### PR TITLE
[codex] Rename app to Self Driving Wiki

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# WikiFS — native macOS SwiftUI wiki with a filesystem projection
+# Self Driving Wiki — native macOS SwiftUI wiki with a filesystem projection
 #
 # Quick start:
-#   make           # debug-builds via SwiftPM into ./build/WikiFS.app
+#   make           # debug-builds via SwiftPM into ./build/Self Driving Wiki.app
 #   make run       # build + launch
 #   make check     # compile only, no bundling/signing (agent / CI gate)
 #   make install   # copy to /Applications/ and register with LaunchServices
@@ -14,12 +14,12 @@
 # release zip.
 
 CONFIG       := debug
-APP          := build/WikiFS.app
+APP_NAME      := Self Driving Wiki
+APP          := build/$(APP_NAME).app
 LSREGISTER   := /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister
 MIN_MACOS    := 14
 MIN_SWIFT    := 6.0
 
-APP_NAME      := WikiFS
 ENTITLEMENTS  := WikiFS/WikiFS.entitlements
 
 # ---------------------------------------------------------------------------
@@ -162,15 +162,15 @@ run: build
 
 install: build
 	@if [ ! -d "$(APP)" ]; then echo "✗ $(APP) missing — build failed?"; exit 1; fi
-	rm -rf /Applications/$(APP_NAME).app
+	rm -rf "/Applications/$(APP_NAME).app"
 	cp -R "$(APP)" /Applications/
 	@echo "✓ copied to /Applications/$(APP_NAME).app"
-	$(LSREGISTER) -f /Applications/$(APP_NAME).app
+	$(LSREGISTER) -f "/Applications/$(APP_NAME).app"
 	@echo "✓ registered /Applications/$(APP_NAME).app with LaunchServices"
 
 uninstall:
-	@if [ -d /Applications/$(APP_NAME).app ]; then \
-	  rm -rf /Applications/$(APP_NAME).app 2>/dev/null || sudo rm -rf /Applications/$(APP_NAME).app; \
+	@if [ -d "/Applications/$(APP_NAME).app" ]; then \
+	  rm -rf "/Applications/$(APP_NAME).app" 2>/dev/null || sudo rm -rf "/Applications/$(APP_NAME).app"; \
 	  echo "✓ removed /Applications/$(APP_NAME).app"; \
 	else \
 	  echo "  (no /Applications/$(APP_NAME).app to remove)"; \
@@ -280,7 +280,7 @@ zip-release: staple
 	@echo "✓ wrote $(RELEASE_ZIP)"
 
 checksum: zip-release
-	cd "$(DIST_DIR)" && shasum -a 256 "$$(basename $(RELEASE_ZIP))" > "$$(basename $(RELEASE_ZIP)).sha256"
+	cd "$(DIST_DIR)" && shasum -a 256 "$$(basename "$(RELEASE_ZIP)")" > "$$(basename "$(RELEASE_ZIP)").sha256"
 	@echo "✓ wrote $(RELEASE_ZIP).sha256"
 
 verify-release: zip-release

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,12 +1,13 @@
-# WikiFS
+# Self Driving Wiki
 
 **What this is.** A native macOS SwiftUI wiki backed by SQLite, mirrored
 read-only onto the filesystem by a **File Provider extension** so the same
 content can be browsed by Unix tools and agents (`find`, `cat`, `grep`) under
-`~/Library/CloudStorage/WikiFS-WikiFS`. You edit in the app; the mount reflects
-every change. It also ingests dropped files (verbatim bytes under `files/`) and
-projects a singleton agent system prompt as `CLAUDE.md` + `AGENTS.md` at the
-root. Runs locally only — free, local dev signing; no Developer ID / notarization.
+`~/Library/CloudStorage/Self Driving Wiki-<wiki name>`. You edit in the app; the
+mount reflects every change. It also ingests dropped files (verbatim bytes under
+`files/`) and projects a singleton agent system prompt as `CLAUDE.md` +
+`AGENTS.md` at the root. Runs locally only — free, local dev signing; no Developer
+ID / notarization.
 
 **Core goal (non-negotiable).** This is a proof-of-concept of the macOS **File
 Provider API**. The extension is essential, not optional — do **not** replace it
@@ -29,10 +30,10 @@ with a plain-folder export, even though that would dodge the signing requirement
 
 | Doc | What it covers |
 | --- | --- |
-| [`README.md`](README.md) | **Start here (new developers).** What WikiFS is, the non-negotiable read-only-mount / write-via-`wikictl` invariant, quick start (`make` targets + the runtime gotchas), repo layout, and a tour of how it works. |
+| [`README.md`](README.md) | **Start here (new developers).** What Self Driving Wiki is, the non-negotiable read-only-mount / write-via-`wikictl` invariant, quick start (`make` targets + the runtime gotchas), repo layout, and a tour of how it works. |
 | [`plans/architecture.md`](plans/architecture.md) | **The system map.** Components/targets, the per-wiki SQLite data model + migration ladder + `changeToken()`, the File Provider projection, the read/write split + change bridge, the `claude -p` operations (Ingest tiering, Query, Lint), URL ingest, and the key invariants/gotchas. Read after the README to go deep. |
 | [`plans/INITIAL.md`](plans/INITIAL.md) | Original full product/architecture plan (milestones, schema, File Provider design, definition of done). Source of truth for *what we're building*. |
-| [`plans/llm-wiki.md`](plans/llm-wiki.md) | **Next major effort:** turning WikiFS into a self-maintaining LLM Wiki — **many** wikis (one SQLite DB + one File Provider domain each), with `claude -p` authoring/maintaining each one by writing via a new `wikictl` CLI (read via the mount, write via the CLI). Locked decisions, components, and the Phase 0 → A–D plan. Read before Phase 0. |
+| [`plans/llm-wiki.md`](plans/llm-wiki.md) | **Next major effort:** turning Self Driving Wiki into a self-maintaining LLM Wiki — **many** wikis (one SQLite DB + one File Provider domain each), with `claude -p` authoring/maintaining each one by writing via a new `wikictl` CLI (read via the mount, write via the CLI). Locked decisions, components, and the Phase 0 → A–D plan. Read before Phase 0. |
 | [`plans/page-reader-ui.md`](plans/page-reader-ui.md) | **Current UI direction:** page detail is reader-first because the agent should maintain wiki content; manual source editing is an explicit, rare mode. |
 | [`plans/BRINGUP.md`](plans/BRINGUP.md) | The 4-phase bring-up plan from skeleton to v0 (groups INITIAL.md's M0–M6). Source of truth for *the order we build in*. |
 | [`plans/build-environment.md`](plans/build-environment.md) | How the app is built: SwiftPM + `build.sh` + `Makefile`, signing, icon generation, app-bundle layout. Source of truth for *how we build and run*. |
@@ -45,7 +46,7 @@ with a plain-folder export, even though that would dodge the signing requirement
 ## Status
 
 See `PROGRESS.md` for the running log. Current: **🎉 LLM Wiki COMPLETE ✅ — all
-five phases (0, A, B, C, D) gate-passed.** WikiFS is now a self-maintaining LLM
+five phases (0, A, B, C, D) gate-passed.** Self Driving Wiki is now a self-maintaining LLM
 wiki: a user keeps **many** wikis (one SQLite DB + one File Provider domain
 each); an LLM (`claude -p`, run as **Ingest / Query / Lint** from the app)
 authors and maintains each one — reading the read-only mount and writing via the
@@ -136,7 +137,7 @@ gate's evidence and the known v0 gaps.
 ## Build quick reference
 
 ```sh
-make          # debug build → build/WikiFS.app
+make          # debug build → build/Self Driving Wiki.app
 make run      # build + launch
 make check    # compile-only gate (no bundle/sign)
 make help     # all targets

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,11 +2,34 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-16 — Product rename to Self Driving Wiki
+
+Renamed app-facing product copy from WikiFS to **Self Driving Wiki** while leaving
+bundle identifiers, SwiftPM target/module names, signing assets, and legacy
+database filenames intact.
+
+**Changed**
+- `build.sh` and `Makefile` now produce/install `Self Driving Wiki.app`, with the
+  SwiftPM executable target still built from `WikiFS` and copied into the renamed
+  bundle.
+- App/File Provider display strings, projection README/root labels, default legacy
+  wiki display name, manifest product name, agent scratch/log cache directory, and
+  the read-only error now say Self Driving Wiki.
+- `README.md` and `PLAN.md` now present Self Driving Wiki as the product name while
+  keeping technical identifiers such as `WikiFSCore`, `WikiFSFileProvider`, and
+  `org.sockpuppet.WikiFS` explicit where they remain true.
+
+**Skill pass.** Before code: `swiftui-pro`, `macos-design`, and
+`typography-designer` pointed toward preserving semantic SwiftUI text and native
+macOS naming surfaces rather than adding custom typography or visual treatment.
+Post-code review kept the rename to visible strings/build metadata only, with no
+new UI layout or type-scale changes.
+
 ## 2026-06-16 — Reader-first page detail UI
 
 Started correcting the app's main interface: page selection now defaults to a
 rendered reader instead of an always-visible markdown editor + preview split. The
-product principle is that WikiFS is agent-maintained first; users should rarely
+product principle is that Self Driving Wiki is agent-maintained first; users should rarely
 need manual source editing.
 
 **Changed**

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
 // swift-tools-version: 6.0
 import PackageDescription
 
-// WikiFS — native macOS SwiftUI wiki with a File Provider filesystem
+// Self Driving Wiki — native macOS SwiftUI wiki with a File Provider filesystem
 // projection. Built with SwiftPM (no Xcode IDE, no xcodebuild); ./build.sh
-// bundles the executable produced here into build/WikiFS.app and codesigns it.
+// bundles the executable produced here into build/Self Driving Wiki.app and codesigns it.
 let package = Package(
     name: "WikiFS",
     platforms: [.macOS(.v14)],
@@ -46,7 +46,7 @@ let package = Package(
             path: "Tests/WikiFSTests"
         ),
         // The File Provider extension binary. build.sh repackages this into a
-        // .appex bundle under WikiFS.app/Contents/PlugIns and signs it.
+        // .appex bundle under Self Driving Wiki.app/Contents/PlugIns and signs it.
         .executableTarget(
             name: "WikiFSFileProvider",
             dependencies: ["WikiFSCore"],

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WikiFS
+# Self Driving Wiki
 
 A native **macOS SwiftUI wiki**, backed by **SQLite**, mirrored **read-only** onto
 the filesystem by a **File Provider extension** — and now a **self-maintaining LLM
@@ -60,7 +60,7 @@ that the project exists to demonstrate. The split is deliberate:
 From the repo root (full detail in [`plans/build-environment.md`](plans/build-environment.md)):
 
 ```sh
-make            # debug build → build/WikiFS.app (also builds + embeds wikictl)
+make            # debug build → build/Self Driving Wiki.app (also builds + embeds wikictl)
 make run        # build + open the app
 make check      # compile-only gate, no bundle/sign (CI / agent verification)
 make test       # the SwiftPM test suite (320 tests)
@@ -100,8 +100,8 @@ Defined in [`Package.swift`](Package.swift):
 | Target | Kind | Purpose |
 | --- | --- | --- |
 | **`WikiFSCore`** | library | The dependency-free core: data model, hand-rolled SQLite store, multi-wiki registry, the `claude -p` operation seams, log/index/TREE rendering, URL-ingest + HTML→Markdown. Shared by the app, the extension, the CLI, and the tests. |
-| **`WikiFS`** | executable | The SwiftUI app — the editor/viewer, the wiki switcher, the Operations panel (Ingest/Query/Lint), domain registration + change bridge. |
-| **`WikiFSFileProvider`** | executable* | The File Provider extension — the read-only SQLite→filesystem projection. (*Built as an executable, then repackaged into a `.appex` by `build.sh`; entry point overridden to `_NSExtensionMain`.) |
+| **`WikiFS`** | executable | The SwiftUI app target for Self Driving Wiki — the editor/viewer, the wiki switcher, the Operations panel (Ingest/Query/Lint), domain registration + change bridge. |
+| **`WikiFSFileProvider`** | executable* | The File Provider extension target — the read-only SQLite→filesystem projection. (*Built as an executable, then repackaged into a `.appex` by `build.sh`; entry point overridden to `_NSExtensionMain`.) |
 | **`WikiCtlCore`** | library | `wikictl`'s logic: arg parsing, command dispatch, wiki resolution, the Darwin post. Library-split so it's unit-testable. |
 | **`wikictl`** | executable | The agent's **write path** — a scriptable CLI that writes straight to a wiki's `<ulid>.sqlite` and posts a per-wiki Darwin notification. A thin shell over `WikiCtlCore`. |
 
@@ -125,7 +125,7 @@ A deeper map is in [`plans/architecture.md`](plans/architecture.md); the short v
 - **Many wikis.** A `wikis.json` registry lists the user's wikis. Each wiki is one
   self-contained `<ulid>.sqlite` file in the App Group container **plus one File
   Provider domain** (`NSFileProviderDomain`), mounting at its own
-  `~/Library/CloudStorage/WikiFS-<name>`. A wiki's stable identity is its **ULID**,
+  `~/Library/CloudStorage/Self Driving Wiki-<name>`. A wiki's stable identity is its **ULID**,
   never its display name (rename-safe). The extension is instantiated per domain;
   `domain.identifier` *is* the wiki ULID, which selects the DB to open.
 

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -75,7 +75,7 @@ final class AgentLauncher {
     /// - `wikiID`/`wikiRoot`/`systemPrompt` come from the active wiki at click time
     ///   (`wikiRoot` resolved from the FP manager — never hardcoded).
     /// - `wikictlDirectory` is the dir holding the embedded `wikictl`
-    ///   (`WikiFS.app/Contents/Helpers`), prepended to the child's PATH so the
+    ///   (`Self Driving Wiki.app/Contents/Helpers`), prepended to the child's PATH so the
     ///   agent's `wikictl` calls resolve.
     /// - `onLock`/`onUnlock` are the edit-lock callbacks: `onLock` fires before the
     ///   spawn, `onUnlock` from the `terminationHandler` (so a killed agent still
@@ -285,7 +285,7 @@ final class AgentLauncher {
             .urls(for: .cachesDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
         let scratch = base
-            .appendingPathComponent("WikiFS-agent", isDirectory: true)
+            .appendingPathComponent("Self Driving Wiki-agent", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         do {
             try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)

--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -12,7 +12,7 @@ import WikiFSCore
 /// **Domain identity = the wiki's ULID.** `domainFor(id:displayName:)` builds an
 /// `NSFileProviderDomain(identifier: <ulid>, displayName: <name>)`; the extension
 /// reads `domain.identifier` to pick `<ulid>.sqlite`. The display name only sets
-/// the Finder mount label (`~/Library/CloudStorage/WikiFS-<name>`), so a rename
+/// the Finder mount label (`~/Library/CloudStorage/Self Driving Wiki-<name>`), so a rename
 /// is cosmetic and never breaks the DB mapping.
 @MainActor
 @Observable
@@ -27,7 +27,7 @@ final class FileProviderSpike {
     private var activeDisplayName: String?
 
     /// Build the File Provider domain for a wiki. Identifier is the ULID (stable
-    /// across rename); displayName drives the `WikiFS-<name>` mount label.
+    /// across rename); displayName drives the `Self Driving Wiki-<name>` mount label.
     private func domain(id: String, displayName: String) -> NSFileProviderDomain {
         NSFileProviderDomain(
             identifier: NSFileProviderDomainIdentifier(rawValue: id),

--- a/Sources/WikiFS/HelpersLocation.swift
+++ b/Sources/WikiFS/HelpersLocation.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// Locates the embedded `wikictl` helper so the spawned agent can invoke it
 /// (`plans/llm-wiki.md` Phase C — "ensure `wikictl` is resolvable: prepend
-/// `WikiFS.app/Contents/Helpers` to the child's PATH").
+/// `Self Driving Wiki.app/Contents/Helpers` to the child's PATH").
 ///
-/// `build.sh` embeds + codesigns `wikictl` at `WikiFS.app/Contents/Helpers/wikictl`
-/// and ALSO drops a copy at `build/wikictl` next to the dev binaries. We resolve
-/// the directory in priority order so it works both from the signed bundle and
-/// from a `swift run` dev launch.
+/// `build.sh` embeds + codesigns `wikictl` at
+/// `Self Driving Wiki.app/Contents/Helpers/wikictl` and ALSO drops a copy at
+/// `build/wikictl` next to the dev binaries. We resolve the directory in priority
+/// order so it works both from the signed bundle and from a `swift run` dev launch.
 enum HelpersLocation {
     /// The directory that should be prepended to the agent's PATH so `wikictl`
     /// resolves. Returns the first directory that actually contains an executable

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -112,8 +112,8 @@ struct SidebarView: View {
     /// The active wiki's display name for the window title (falls back to the app
     /// name when no wiki is selected yet).
     private var activeWikiName: String {
-        guard let id = manager.activeWikiID else { return "WikiFS" }
-        return manager.wikis.first { $0.id == id }?.displayName ?? "WikiFS"
+        guard let id = manager.activeWikiID else { return "Self Driving Wiki" }
+        return manager.wikis.first { $0.id == id }?.displayName ?? "Self Driving Wiki"
     }
 
     private func beginRename(_ summary: WikiPageSummary) {

--- a/Sources/WikiFSCore/IndexGenerators.swift
+++ b/Sources/WikiFSCore/IndexGenerators.swift
@@ -83,7 +83,7 @@ public enum IndexGenerators {
         let iso = iso8601(generatedAt)
         let json = """
         {
-          "name": "WikiFS",
+          "name": "Self Driving Wiki",
           "version": 1,
           "generated_at": "\(iso)",
           "page_count": \(pages.count),

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -36,7 +36,7 @@ public struct OperationCommand: Equatable, Sendable {
     ///     `--append-system-prompt`. No `CLAUDE.md` is written onto the mount.
     ///   - scratchDirectory: a per-run writable dir (under the app caches). The cwd.
     ///   - wikictlDirectory: the directory containing the `wikictl` binary
-    ///     (`WikiFS.app/Contents/Helpers`). PREPENDED to the child's PATH so the
+    ///     (`Self Driving Wiki.app/Contents/Helpers`). PREPENDED to the child's PATH so the
     ///     agent's `Bash(wikictl:*)` calls resolve.
     ///   - claudeExecutable: the `claude` binary name (default `"claude"`; the
     ///     PATH preflight confirms it resolves on the login shell).

--- a/Sources/WikiFSCore/SystemPrompt.swift
+++ b/Sources/WikiFSCore/SystemPrompt.swift
@@ -36,7 +36,7 @@ public struct SystemPrompt: Equatable, Sendable {
 
     You read this document at the start of every run: it is projected read-only at
     the wiki root as both `CLAUDE.md` and `AGENTS.md`. The user co-evolves it in
-    the WikiFS app over time. Do not edit it through the filesystem.
+    the Self Driving Wiki app over time. Do not edit it through the filesystem.
 
     ## Layout
 

--- a/Sources/WikiFSCore/WikiDescriptor.swift
+++ b/Sources/WikiFSCore/WikiDescriptor.swift
@@ -15,7 +15,7 @@ public struct WikiDescriptor: Codable, Identifiable, Equatable, Sendable {
     public let id: String
 
     /// Human-facing label, shown in the switcher and used to name the Finder
-    /// mount (`~/Library/CloudStorage/WikiFS-<displayName>`). Mutable — a rename
+    /// mount (`~/Library/CloudStorage/Self Driving Wiki-<displayName>`). Mutable — a rename
     /// changes ONLY this, never `id`.
     public var displayName: String
 

--- a/Sources/WikiFSCore/WikiManager.swift
+++ b/Sources/WikiFSCore/WikiManager.swift
@@ -255,7 +255,7 @@ public final class WikiManager {
         // Mint the descriptor for the migrated wiki and move the file to its
         // ULID-keyed name. If the move fails, leave everything as-is (the app
         // can retry next launch).
-        let descriptor = WikiDescriptor.make(displayName: "WikiFS")
+        let descriptor = WikiDescriptor.make(displayName: "Self Driving Wiki")
         let target = databaseURL(forWikiID: descriptor.id)
         guard !fm.fileExists(atPath: target.path) else { return }
 

--- a/Sources/WikiFSCore/WikiTreeRenderer.swift
+++ b/Sources/WikiFSCore/WikiTreeRenderer.swift
@@ -24,7 +24,7 @@ public enum WikiTreeRenderer {
         """
         # Wiki Layout (TREE.md)
 
-        A read-only map of this WikiFS wiki. Everything under the mount is served
+        A read-only map of this Self Driving Wiki wiki. Everything under the mount is served
         read-only — WRITE only through the `wikictl` command (see the cheatsheet
         below). `wikictl` already targets THIS wiki via the `$WIKI_DB` environment
         variable, so never pass `--wiki`.

--- a/Sources/WikiFSFileProvider/FileProviderExtension.swift
+++ b/Sources/WikiFSFileProvider/FileProviderExtension.swift
@@ -96,6 +96,6 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     private var readOnly: NSError {
         NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError,
-                userInfo: [NSLocalizedDescriptionKey: "WikiFS is read-only"])
+                userInfo: [NSLocalizedDescriptionKey: "Self Driving Wiki is read-only"])
     }
 }

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -115,9 +115,9 @@ struct Projection {
     /// The generated `README.md` (INITIAL §5). Static across the DB lifetime, so
     /// a constant version is correct.
     static let readmeBytes = Data("""
-    # WikiFS
+    # Self Driving Wiki
 
-    This is a read-only filesystem projection of the WikiFS database.
+    This is a read-only filesystem projection of the Self Driving Wiki database.
 
     Useful paths:
 
@@ -367,7 +367,7 @@ struct Projection {
     /// Resolve a single item's metadata by identifier.
     func node(for id: NSFileProviderItemIdentifier) -> ProjectedNode? {
         if id == .rootContainer {
-            return .folder(id: .rootContainer, parent: .rootContainer, name: "WikiFS")
+            return .folder(id: .rootContainer, parent: .rootContainer, name: "Self Driving Wiki")
         }
         switch id {
         case Identity.readme:

--- a/Tests/WikiFSTests/IndexGeneratorTests.swift
+++ b/Tests/WikiFSTests/IndexGeneratorTests.swift
@@ -26,7 +26,7 @@ struct IndexGeneratorTests {
         let data = IndexGenerators.manifest(pages: pages, fileCount: 3,
                                             generatedAt: Date(timeIntervalSince1970: 0))
         let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        #expect(obj?["name"] as? String == "WikiFS")
+        #expect(obj?["name"] as? String == "Self Driving Wiki")
         #expect(obj?["version"] as? Int == 1)
         #expect(obj?["page_count"] as? Int == 2)
         #expect(obj?["file_count"] as? Int == 3)

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -39,7 +39,7 @@ struct OperationCommandTests {
 
   private func build(
     operation: WikiOperation = OperationCommandTests.curatedIngest(),
-    wikictlDir: String = "/Apps/WikiFS.app/Contents/Helpers",
+    wikictlDir: String = "/Apps/Self Driving Wiki.app/Contents/Helpers",
     basePATH: String = "/usr/bin:/bin"
   ) -> OperationCommand {
     OperationCommand.build(
@@ -157,8 +157,8 @@ struct OperationCommandTests {
   }
 
   @Test func prependsWikictlDirectoryToChildPATH() {
-    let cmd = build(wikictlDir: "/Apps/WikiFS.app/Contents/Helpers", basePATH: "/usr/bin:/bin")
-    #expect(cmd.environment["PATH"] == "/Apps/WikiFS.app/Contents/Helpers:/usr/bin:/bin")
+    let cmd = build(wikictlDir: "/Apps/Self Driving Wiki.app/Contents/Helpers", basePATH: "/usr/bin:/bin")
+    #expect(cmd.environment["PATH"] == "/Apps/Self Driving Wiki.app/Contents/Helpers:/usr/bin:/bin")
   }
 
   @Test func cwdIsTheWritableScratchDirNotTheMount() {

--- a/Tests/WikiFSTests/WikiManagerTests.swift
+++ b/Tests/WikiFSTests/WikiManagerTests.swift
@@ -145,7 +145,7 @@ struct WikiManagerTests {
 
         #expect(manager.wikis.count == 1)
         let descriptor = manager.wikis[0]
-        #expect(descriptor.displayName == "WikiFS")
+        #expect(descriptor.displayName == "Self Driving Wiki")
 
         // The legacy file was renamed to <ulid>.sqlite; the old name is gone.
         #expect(!FileManager.default.fileExists(atPath: legacy.path))
@@ -181,7 +181,7 @@ struct WikiManagerTests {
     /// import must be strictly one-time — gated on an EMPTY registry — so a legacy
     /// file reappearing alongside a non-empty registry adds ZERO wikis and keeps
     /// the same wiki #1 active. This reproduces the duplication loop the gate
-    /// caught (1 wiki → 2, both "WikiFS").
+    /// caught (1 wiki → 2, both named from the legacy product default).
     @Test func legacyFileReappearingAfterFirstLaunchDoesNotDuplicate() throws {
         let dir = tempDirectory()
         let legacy = dir.appendingPathComponent(DatabaseLocation.legacyDatabaseFileName)

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# build.sh — compile WikiFS + its File Provider extension, bundle them into a
-# proper macOS .app (with the .appex nested under Contents/PlugIns), embed
-# provisioning profiles, and codesign inside-out.
+# build.sh — compile Self Driving Wiki + its File Provider extension, bundle
+# them into a proper macOS .app (with the .appex nested under Contents/PlugIns),
+# embed provisioning profiles, and codesign inside-out.
 #
 #   ./build.sh [debug|release]
 #
@@ -20,7 +20,8 @@ set -euo pipefail
 
 CONFIG="${1:-debug}"
 
-APP_NAME="WikiFS"
+APP_NAME="Self Driving Wiki"
+APP_TARGET_NAME="WikiFS"
 EXT_NAME="WikiFSFileProvider"
 CTL_NAME="wikictl"
 BUNDLE_ID="org.sockpuppet.WikiFS"
@@ -55,7 +56,7 @@ VERSION="${VERSION:-0.0.0-dev}"
 echo "→ swift build -c ${CONFIG}"
 swift build -c "${CONFIG}"
 BIN_DIR="$(swift build -c "${CONFIG}" --show-bin-path)"
-APP_BIN="${BIN_DIR}/${APP_NAME}"
+APP_BIN="${BIN_DIR}/${APP_TARGET_NAME}"
 EXT_BIN="${BIN_DIR}/${EXT_NAME}"
 CTL_BIN="${BIN_DIR}/${CTL_NAME}"
 for b in "${APP_BIN}" "${EXT_BIN}" "${CTL_BIN}"; do
@@ -104,7 +105,7 @@ cat > "${APPEX_CONTENTS}/Info.plist" <<PLIST
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key><string>${EXT_NAME}</string>
-	<key>CFBundleDisplayName</key><string>WikiFS File Provider</string>
+	<key>CFBundleDisplayName</key><string>Self Driving Wiki File Provider</string>
 	<key>CFBundleExecutable</key><string>${EXT_NAME}</string>
 	<key>CFBundleIdentifier</key><string>${EXT_BUNDLE_ID}</string>
 	<key>CFBundlePackageType</key><string>XPC!</string>

--- a/plans/architecture.md
+++ b/plans/architecture.md
@@ -48,7 +48,7 @@ Five SwiftPM targets ([`Package.swift`](../Package.swift)):
   the wiki switcher, domain registration, and the change bridge.
 - **`WikiFSFileProvider`** is the `NSFileProviderReplicatedExtension`. Built as an
   executable, then `build.sh` repackages it into a `.appex` under
-  `WikiFS.app/Contents/PlugIns`. Its Mach-O entry point is overridden to
+  `Self Driving Wiki.app/Contents/PlugIns`. Its Mach-O entry point is overridden to
   `_NSExtensionMain` via a linker flag — a Swift `main()` that calls
   `NSExtensionMain()` recurses infinitely on re-invocation and SIGSEGVs (see the
   comment in `Package.swift` and the appex-entry memory).

--- a/plans/build-environment.md
+++ b/plans/build-environment.md
@@ -1,6 +1,6 @@
 # Build environment
 
-How WikiFS is compiled, bundled, signed, and run. This is the source of truth
+How Self Driving Wiki is compiled, bundled, signed, and run. This is the source of truth
 for *how we build*; `plans/INITIAL.md` is the source of truth for *what we
 build*.
 
@@ -28,7 +28,7 @@ WikiFS/
 scripts/make-icon.swift       renders build/AppIcon.iconset from an SF Symbol
 build.sh                      swift build → assemble .app → write Info.plist → codesign
 Makefile                      orchestration (adapted from Makefile.example)
-build/                        output (gitignored): WikiFS.app, AppIcon.icns, .iconset
+build/                        output (gitignored): Self Driving Wiki.app, AppIcon.icns, .iconset
 .build/                       SwiftPM intermediate (gitignored)
 dist/                         release zips (gitignored)
 ```
@@ -45,7 +45,7 @@ dist/                         release zips (gitignored)
    icon sizes into `build/AppIcon.iconset`; `iconutil -c icns` packs it.
 3. **`build.sh <config>`**:
    - `swift build -c <config>` produces the executable.
-   - Assembles `build/WikiFS.app/Contents/{MacOS,Resources}`, copies the
+   - Assembles `build/Self Driving Wiki.app/Contents/{MacOS,Resources}`, copies the
      binary and `AppIcon.icns`.
    - Writes `Info.plist` (bundle id `org.sockpuppet.WikiFS`, min macOS 14,
      `NSHighResolutionCapable`, productivity category). Version resolves from
@@ -58,7 +58,7 @@ dist/                         release zips (gitignored)
 
 | Target | Effect |
 | --- | --- |
-| `make` / `make build` | Debug build → `build/WikiFS.app` |
+| `make` / `make build` | Debug build → `build/Self Driving Wiki.app` |
 | `make run` | Build + `open` the app |
 | `make check` | `swift build` only — no bundle/sign. **The CI / agent gate.** |
 | `make test` | `swift test` (no test target yet) |
@@ -83,7 +83,7 @@ change, run it and confirm the process survives the first display cycle:
 
 ```sh
 make run
-sleep 4 && pgrep -x WikiFS && echo alive
+sleep 4 && pgrep -x "Self Driving Wiki" && echo alive
 ```
 
 ## What's deliberately deferred

--- a/plans/file-provider.md
+++ b/plans/file-provider.md
@@ -58,7 +58,7 @@ signs are non-interactive.
 - **Two SwiftPM executable targets**: `WikiFS` (app) and `WikiFSFileProvider`
   (extension binary), the latter with `.linkedFramework("FileProvider")` and the
   `-e _NSExtensionMain` entry override.
-- **`build.sh`** assembles `WikiFS.app/Contents/PlugIns/WikiFSFileProvider.appex`
+- **`build.sh`** assembles `Self Driving Wiki.app/Contents/PlugIns/WikiFSFileProvider.appex`
   by hand: copies the binary, writes the appex `Info.plist`
   (`CFBundlePackageType = XPC!`, `NSExtension` dict with point id
   `com.apple.fileprovider-nonui`, principal class `FileProviderExtension`,

--- a/plans/llm-wiki.md
+++ b/plans/llm-wiki.md
@@ -1,10 +1,10 @@
-# LLM Wiki — WikiFS as a self-maintaining knowledge base
+# LLM Wiki — Self Driving Wiki as a self-maintaining knowledge base
 
-**What this adds.** Turns WikiFS from a hand-edited wiki into the
+**What this adds.** Turns Self Driving Wiki from a hand-edited wiki into the
 [LLM Wiki pattern](../problems/): an LLM (`claude -p`) *writes and maintains* the
 wiki — ingesting raw sources, authoring summary/entity/concept pages,
 cross-linking, and keeping a curated index + chronological log current. The human
-curates sources and asks questions; the agent does the bookkeeping. WikiFS is the
+curates sources and asks questions; the agent does the bookkeeping. Self Driving Wiki is the
 "Obsidian" in the pattern (the live viewer) and the storage; `claude -p` is the
 maintainer.
 
@@ -18,10 +18,10 @@ This doc is the source of truth for *what we're adding and in what order*. Read
 
 ## How the pattern maps onto what we already have
 
-The pattern's three layers already exist in WikiFS — only the wiki's **write
+The pattern's three layers already exist in Self Driving Wiki — only the wiki's **write
 path** is missing.
 
-| Pattern layer | WikiFS today | Work |
+| Pattern layer | Self Driving Wiki today | Work |
 | --- | --- | --- |
 | **Raw sources** (immutable) | `files/` ingestion — verbatim bytes in SQLite, read-only under `files/by-{id,name}` | none — done |
 | **The schema** (`CLAUDE.md`/`AGENTS.md`) | `system_prompt` singleton projected read-only at root as both names | rewrite the *content* (Phase D) |
@@ -65,7 +65,7 @@ A user has **N independent wikis**. Each is fully self-contained:
   `wiki_id` columns and no per-query filtering. A wiki is a single portable,
   git-able file; deleting one = drop the file + remove its domain.
 - **One `NSFileProviderDomain` per wiki** — each mounts at its own
-  `~/Library/CloudStorage/WikiFS-<name>` in Finder's sidebar. `NSFileProviderManager`
+  `~/Library/CloudStorage/Self Driving Wiki-<name>` in Finder's sidebar. `NSFileProviderManager`
   is built for multiple domains; this leans *harder* into the File Provider API
   than v0 did (v0 registered exactly one domain).
 - **A registry** — the set of wikis (id, display name, DB filename, domain
@@ -279,7 +279,7 @@ Stacked, unmerged branches off the current line, like v0 / the post-v0 features.
   domain per wiki** and gains a switcher to **create / select / delete** wikis
   (each new wiki = fresh DB seeded with the default schema + a new domain). The
   existing single v0 wiki migrates into the registry as wiki #1. *Gate:* create a
-  second wiki in-app → it mounts as its own `~/Library/CloudStorage/WikiFS-<name>`;
+  second wiki in-app → it mounts as its own `~/Library/CloudStorage/Self Driving Wiki-<name>`;
   pages written in wiki A never appear in wiki B's mount; both DBs are independent
   files; deleting a wiki removes its domain + file; v0 single-wiki content
   preserved as wiki #1.

--- a/plans/page-reader-ui.md
+++ b/plans/page-reader-ui.md
@@ -1,6 +1,6 @@
 # Page Reader UI
 
-WikiFS is agent-maintained first and manually edited only occasionally. The main
+Self Driving Wiki is agent-maintained first and manually edited only occasionally. The main
 page surface should therefore behave like a wiki reader, not a source editor.
 
 ## Product Direction

--- a/plans/signing.md
+++ b/plans/signing.md
@@ -75,7 +75,7 @@ the certificate, device registration, App IDs, App Group, provisioning
 profiles, and any macOS approval prompts.
 
 **`build.sh` / app code handles** (automated): assembling the `.appex` under
-`WikiFS.app/Contents/PlugIns/`, the extension `NSExtension` Info.plist keys,
+`Self Driving Wiki.app/Contents/PlugIns/`, the extension `NSExtension` Info.plist keys,
 both `.entitlements` files, embedding the downloaded `.provisionprofile`s,
 inside-out codesigning, and `NSFileProviderManager.add(domain:)` at runtime.
 

--- a/scripts/make-icon.swift
+++ b/scripts/make-icon.swift
@@ -1,6 +1,6 @@
 #!/usr/bin/env swift
 //
-// make-icon.swift — render the WikiFS app icon at every macOS icon size into
+// make-icon.swift — render the Self Driving Wiki app icon at every macOS icon size into
 // build/AppIcon.iconset, which the Makefile then packs with `iconutil`.
 //
 // The icon: a rounded-rect "squircle" with a blue→indigo gradient and a white


### PR DESCRIPTION
## Summary

Renames the app-facing product from WikiFS to Self Driving Wiki while preserving the existing bundle identifiers, SwiftPM targets, modules, signing assets, and legacy database filenames.

This updates the app bundle/display names, File Provider display strings, projection copy, generated manifest name, default migrated wiki display name, agent cache directory, README, PLAN, and supporting docs/tests.

## Validation

- `make check`
- `make test` (320/320)
- `make build` produced and signed `build/Self Driving Wiki.app`
- Verified generated plists keep `org.sockpuppet.WikiFS` / `org.sockpuppet.WikiFS.FileProvider` bundle identifiers while showing Self Driving Wiki display names
