### PR TITLE
[codex] Surface agent workflows in the UI

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,81 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-16 — Change Log surfaced in the sidebar
+
+Surfaced the append-only operation log in the app UI, next to the other pinned
+wiki-level documents.
+
+**Changed**
+- Added a pinned **Change Log** row beside **System Prompt** in the sidebar.
+- Added `WikiSelection.changeLog` and a read-only `ChangeLogDetailView` that renders
+  the same markdown body as projected `log.md`, including query answers and agent
+  notes.
+- Added `WikiStoreModel.currentLogMarkdown()` as the app-side seam over the existing
+  `LogRenderer`, so the UI and File Provider projection share one formatter.
+
+**Skill pass.** Before and after code: `swiftui-pro` kept the log as a separate
+leaf view with a small model seam; `macos-design` placed it as a pinned sidebar
+document alongside System Prompt; `typography-designer` kept the detail view on
+the existing reader scale (`.largeTitle`, `.callout`, rendered markdown body).
+
+**Verified.** `make check` passes and `make test` passes (**322/322**). Added a
+core regression test that `WikiStoreModel.currentLogMarkdown()` includes query log
+notes via the projection renderer.
+
+## 2026-06-16 — Inline agent transcript inspector
+
+Added an expandable trailing transcript sidebar for inline Query/Ingest runs, so
+the page can remain visible while the wiki is edit-locked and the user can still
+see what the agent is doing.
+
+**Changed**
+- `ContentView` now hosts a trailing inspector pane beside the selected detail
+  content. It auto-expands when an agent run starts and can be toggled from the
+  toolbar or collapsed from inside the pane.
+- `AgentTranscriptSidebar` reuses `AgentActivityView`, the same live transcript
+  renderer used by the dedicated Maintain Wiki sheet, so tool calls, subagent rows,
+  assistant text, diagnostics, and results render consistently.
+- Split selected-detail rendering into `WikiDetailView`, keeping the app shell
+  focused on navigation/chrome and avoiding a growing monolithic view body.
+
+**Skill pass.** Before and after code: `swiftui-pro` favored extracting the detail
+switch and reusing the existing activity view; `macos-design` pointed to a trailing
+inspector rather than a modal; `typography-designer` kept the panel on existing
+semantic macOS styles (`.headline`, `.callout`, `.caption`, monospaced transcript
+rows). The toggle and collapse controls keep text labels for accessibility even
+when rendered as icons.
+
+**Verified.** `make check` passes and `make test` passes (**321/321**).
+
+## 2026-06-16 — Ingestion and query affordances moved into the content flow
+
+Made Ingest and Query discoverable where the user is already working instead of
+requiring the toolbar's Maintain Wiki sheet.
+
+**Changed**
+- The Files list remains most-recently-added first and now shows a per-file status
+  badge: a green check when an ingest log matches that source, otherwise a dashed
+  "ready" indicator.
+- Files are selectable sidebar items. Selecting one opens a file detail pane with
+  **Ingest into Wiki** and **Open File** actions, so a raw source can be processed
+  on the spot.
+- Added a shared `AgentOperationRunner` so the existing operations sheet, the file
+  detail pane, and page-level queries all use the same mount refresh, staging, and
+  edit-lock launch path.
+- Every page reader now has a compact query field pinned below the rendered page,
+  launching the same Query operation without opening the operations sheet.
+
+**Skill pass.** Before code: `swiftui-pro`, `macos-design`, and
+`typography-designer` pointed toward semantic Dynamic Type, standard macOS list
+selection/detail behavior, labeled icon buttons, and progressive disclosure in the
+content area. Post-code review checked the new views against SwiftUI design,
+accessibility, and hygiene guidance: controls keep text labels for VoiceOver, type
+uses system styles, and status is icon+color rather than color-only.
+
+**Verified.** `make check` passes and `make test` passes (**321/321**). Added a
+core regression test for the ingested-file status derived from log entries.
+
 ## 2026-06-16 — Product rename to Self Driving Wiki
 
 Renamed app-facing product copy from WikiFS to **Self Driving Wiki** while leaving

--- a/Sources/WikiFS/AgentOperationRunner.swift
+++ b/Sources/WikiFS/AgentOperationRunner.swift
@@ -1,0 +1,95 @@
+import Foundation
+import WikiFSCore
+
+/// Shared launch seam for UI surfaces that run an agent operation. The toolbar
+/// sheet, file detail pane, and page-bottom query field all gather inputs the
+/// same way, then delegate here so staging, mount refresh, and edit-lock behavior
+/// do not drift.
+@MainActor
+enum AgentOperationRunner {
+    static func runIngest(
+        fileID: PageID,
+        launcher: AgentLauncher,
+        store: WikiStoreModel,
+        manager: WikiManager,
+        fileProvider: FileProviderSpike
+    ) async {
+        let stateMarkdown = store.currentStateSnapshot().renderStateFile()
+        guard let file = store.ingestedFiles.first(where: { $0.id == fileID }),
+              let bytes = store.ingestedSourceBytes(id: fileID)
+        else { return }
+
+        await run(
+            request: .ingest(
+                sourceBytes: bytes,
+                ext: file.ext,
+                sourcePath: ingestSourcePath(for: file),
+                stateMarkdown: stateMarkdown),
+            launcher: launcher,
+            store: store,
+            manager: manager,
+            fileProvider: fileProvider)
+    }
+
+    static func runQuery(
+        question: String,
+        launcher: AgentLauncher,
+        store: WikiStoreModel,
+        manager: WikiManager,
+        fileProvider: FileProviderSpike
+    ) async {
+        let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        await run(
+            request: .query(
+                question: trimmed,
+                stateMarkdown: store.currentStateSnapshot().renderStateFile()),
+            launcher: launcher,
+            store: store,
+            manager: manager,
+            fileProvider: fileProvider)
+    }
+
+    static func runLint(
+        launcher: AgentLauncher,
+        store: WikiStoreModel,
+        manager: WikiManager,
+        fileProvider: FileProviderSpike
+    ) async {
+        await run(
+            request: .lint(stateMarkdown: store.currentStateSnapshot().renderStateFile()),
+            launcher: launcher,
+            store: store,
+            manager: manager,
+            fileProvider: fileProvider)
+    }
+
+    private static func run(
+        request: OperationRequest,
+        launcher: AgentLauncher,
+        store: WikiStoreModel,
+        manager: WikiManager,
+        fileProvider: FileProviderSpike
+    ) async {
+        guard let wikiID = manager.activeWikiID else { return }
+
+        await fileProvider.signalChange()
+        guard let root = fileProvider.path else { return }
+
+        launcher.run(
+            request: request,
+            wikiID: wikiID,
+            wikiRoot: root,
+            systemPrompt: store.currentSystemPromptBody(),
+            wikictlDirectory: HelpersLocation.wikictlDirectory,
+            onLock: { store.beginAgentRun() },
+            onUnlock: { store.endAgentRun() }
+        )
+    }
+
+    private static func ingestSourcePath(for file: IngestedFileSummary) -> String {
+        let leaf = FilenameEscaping.byIDIngestedFilename(fileID: file.id.rawValue, ext: file.ext)
+        return "files/by-id/\(leaf)"
+    }
+}

--- a/Sources/WikiFS/AgentTranscriptSidebar.swift
+++ b/Sources/WikiFS/AgentTranscriptSidebar.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// A trailing inspector for the active agent run. It reuses the operations
+/// sheet's transcript renderer so inline page queries do not disappear into a
+/// silent lock state.
+struct AgentTranscriptSidebar: View {
+    @Bindable var launcher: AgentLauncher
+    let isExpanded: Bool
+    let onCollapse: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().opacity(PageEditorMetrics.dividerOpacity)
+            AgentActivityView(launcher: launcher)
+                .padding(AgentTranscriptMetrics.padding)
+        }
+        .frame(width: isExpanded ? AgentTranscriptMetrics.width : 0)
+        .frame(maxHeight: .infinity)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipped()
+        .accessibilityHidden(!isExpanded)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Label("Transcript", systemImage: "text.bubble")
+                .font(.headline)
+            Spacer()
+            if launcher.isRunning {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Button("Hide Transcript", systemImage: "sidebar.trailing") {
+                onCollapse()
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
+            .help("Hide transcript")
+        }
+        .padding(.horizontal, AgentTranscriptMetrics.padding)
+        .padding(.vertical, 10)
+    }
+}
+
+private enum AgentTranscriptMetrics {
+    static let width: CGFloat = 340
+    static let padding: CGFloat = 12
+}

--- a/Sources/WikiFS/ChangeLogDetailView.swift
+++ b/Sources/WikiFS/ChangeLogDetailView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import WikiFSCore
+
+/// Read-only in-app view of `log.md`, the append-only operation history where
+/// agents record ingests, queries, lints, and their notes.
+struct ChangeLogDetailView: View {
+    @Bindable var store: WikiStoreModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Change Log")
+                    .font(.largeTitle)
+                    .bold()
+                    .textSelection(.enabled)
+                Text("Query answers, ingest notes, and lint results from log.md.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
+            .padding(.horizontal, PageEditorMetrics.contentInset)
+            .padding(.top, PageEditorMetrics.contentInset)
+            .padding(.bottom, PageEditorMetrics.sectionSpacing)
+
+            Divider().opacity(PageEditorMetrics.dividerOpacity)
+
+            if logMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                ContentUnavailableView {
+                    Label("No Log Entries", systemImage: "clock.arrow.circlepath")
+                } description: {
+                    Text("Agent runs will append their notes here.")
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                MarkdownPreview(store: store, markdown: logMarkdown)
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: PageEditorMetrics.previewMinHeight)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private var logMarkdown: String {
+        store.currentLogMarkdown()
+    }
+}

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @Bindable var agentLauncher: AgentLauncher
     @State private var showingPathPopover = false
     @State private var showingAgentSheet = false
+    @State private var isTranscriptExpanded = false
     /// Driven by `.dropDestination`'s `isTargeted` callback to fade in a subtle
     /// accent border while a drag hovers the window (set via the closure param —
     /// no `Binding(get:set:)`).
@@ -22,20 +23,25 @@ struct ContentView: View {
         NavigationSplitView {
             SidebarView(store: store, manager: manager, fileProvider: fileProvider)
         } detail: {
-            switch store.selection {
-            case .none:
-                ContentUnavailableView {
-                    Label("No Page Selected", systemImage: "doc.text")
-                } description: {
-                    Text("Select a page from the sidebar, or create a new one.")
-                } actions: {
-                    Button("New Page", systemImage: "plus") { store.newPage() }
-                }
-            case .systemPrompt:
-                SystemPromptDetailView(store: store)
-            case .page:
-                PageDetailView(store: store)
+            HStack(spacing: 0) {
+                WikiDetailView(
+                    store: store,
+                    launcher: agentLauncher,
+                    manager: manager,
+                    fileProvider: fileProvider,
+                    onIngestFile: runIngest
+                )
+
+                Divider()
+                    .opacity(isTranscriptExpanded ? 1 : 0)
+
+                AgentTranscriptSidebar(
+                    launcher: agentLauncher,
+                    isExpanded: isTranscriptExpanded,
+                    onCollapse: collapseTranscript
+                )
             }
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: isTranscriptExpanded)
         }
         // Drop a file anywhere on the window to ingest it (raw bytes → SQLite →
         // the read-only `files/` projection). The whole content is the target.
@@ -58,6 +64,13 @@ struct ContentView: View {
                 .ignoresSafeArea()
         }
         .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Toggle Transcript", systemImage: "sidebar.trailing") {
+                    toggleTranscript()
+                }
+                .disabled(!canShowTranscript)
+                .help(isTranscriptExpanded ? "Hide agent transcript" : "Show agent transcript")
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button("Maintain Wiki", systemImage: "sparkles") {
                     showingAgentSheet = true
@@ -88,6 +101,37 @@ struct ContentView: View {
         // (§3.5). The view, not the binding, is the right place for this.
         .onChange(of: store.selection) { _, newValue in
             store.handleSelectionChange(to: newValue)
+        }
+        .onChange(of: agentLauncher.isRunning) { _, isRunning in
+            if isRunning {
+                isTranscriptExpanded = true
+            }
+        }
+    }
+
+    private var canShowTranscript: Bool {
+        agentLauncher.isRunning
+            || !agentLauncher.events.isEmpty
+            || agentLauncher.preflightError != nil
+            || !agentLauncher.stderr.isEmpty
+    }
+
+    private func toggleTranscript() {
+        isTranscriptExpanded.toggle()
+    }
+
+    private func collapseTranscript() {
+        isTranscriptExpanded = false
+    }
+
+    private func runIngest(fileID: PageID) {
+        Task {
+            await AgentOperationRunner.runIngest(
+                fileID: fileID,
+                launcher: agentLauncher,
+                store: store,
+                manager: manager,
+                fileProvider: fileProvider)
         }
     }
 }

--- a/Sources/WikiFS/IngestedFileDetailView.swift
+++ b/Sources/WikiFS/IngestedFileDetailView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import WikiFSCore
+
+/// Detail pane for one raw source file. It keeps file management simple and makes
+/// "Ingest this into the wiki" a primary local action instead of a toolbar-only
+/// workflow.
+struct IngestedFileDetailView: View {
+    let file: IngestedFileSummary
+    let hasBeenIngested: Bool
+    let isRunning: Bool
+    let onOpen: () -> Void
+    let onIngest: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
+                Label {
+                    Text(displayName)
+                        .font(.largeTitle)
+                        .bold()
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                } icon: {
+                    Image(systemName: symbol)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack(spacing: 12) {
+                    statusLabel
+                    Text(Self.sizeFormatter.string(fromByteCount: Int64(file.byteSize)))
+                    Text(file.createdAt, style: .date)
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+                HStack(spacing: 10) {
+                    Button("Ingest into Wiki", systemImage: "text.badge.plus", action: onIngest)
+                        .keyboardShortcut(.return, modifiers: .command)
+                        .disabled(isRunning)
+                    Button("Open File", systemImage: "arrow.up.forward.app", action: onOpen)
+                }
+            }
+            .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
+            .padding(PageEditorMetrics.contentInset)
+
+            Divider().opacity(PageEditorMetrics.dividerOpacity)
+
+            ContentUnavailableView {
+                Label("Raw Source", systemImage: symbol)
+            } description: {
+                Text("This file is stored verbatim in the wiki. Ingesting asks the agent to read it, create or update wiki pages, refresh index.md, and append log.md.")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private var displayName: String {
+        file.filename.isEmpty ? "Untitled" : file.filename
+    }
+
+    private var statusLabel: some View {
+        Label(
+            hasBeenIngested ? "Ingested" : "Ready to ingest",
+            systemImage: hasBeenIngested ? "checkmark.circle.fill" : "circle.dashed"
+        )
+        .foregroundStyle(hasBeenIngested ? .green : .secondary)
+    }
+
+    private var symbol: String {
+        switch file.ext {
+        case "pdf": "doc.richtext"
+        case "txt", "md", "markdown": "doc.plaintext"
+        default: "doc"
+        }
+    }
+
+    private static let sizeFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter
+    }()
+}

--- a/Sources/WikiFS/IngestedFileRow.swift
+++ b/Sources/WikiFS/IngestedFileRow.swift
@@ -2,12 +2,11 @@ import SwiftUI
 import WikiFSCore
 
 /// One row in the sidebar's "Files" section: an ingested file's name + size.
-/// Double-clicking (or the "Open" menu item) opens the file in its default app
-/// (e.g. Preview for a PDF); remove is available via context menu and swipe.
-/// The row carries NO `.tag(...)`, so it never participates in the
-/// page-`List(selection:)` binding — clicking it can't load a phantom page.
+/// Selecting the row opens a file detail pane with the agent-ingest affordance;
+/// the context menu keeps direct file actions close at hand.
 struct IngestedFileRow: View {
     let file: IngestedFileSummary
+    let hasBeenIngested: Bool
     let onOpen: () -> Void
     let onRemove: () -> Void
 
@@ -22,14 +21,15 @@ struct IngestedFileRow: View {
                 Text(Self.sizeFormatter.string(fromByteCount: Int64(file.byteSize)))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                Image(systemName: hasBeenIngested ? "checkmark.circle.fill" : "circle.dashed")
+                    .font(.caption)
+                    .foregroundStyle(hasBeenIngested ? .green : .secondary)
+                    .help(hasBeenIngested ? "Ingested into the wiki" : "Ready to ingest into the wiki")
             }
         } icon: {
             Image(systemName: Self.symbol(forExtension: file.ext))
         }
-        // Whole row is the hit target; a double-click opens the file. Use a
-        // simultaneous gesture so it doesn't swallow the context-menu / swipe.
         .contentShape(Rectangle())
-        .onTapGesture(count: 2, perform: onOpen)
         .contextMenu {
             Button("Open", systemImage: "arrow.up.forward.app", action: onOpen)
             Button("Remove", role: .destructive, action: onRemove)

--- a/Sources/WikiFS/OperationsView.swift
+++ b/Sources/WikiFS/OperationsView.swift
@@ -232,64 +232,31 @@ struct OperationsView: View {
     // MARK: - Run
 
     private func run() {
-        guard let wikiID = manager.activeWikiID else { return }
-
         Task {
-            // Refresh the mount + resolve WIKI_ROOT at click time (never hardcoded),
-            // so the agent sees current content before it reads.
-            await fileProvider.signalChange()
-            guard let root = fileProvider.path else { return }
-
-            // Gather the live wiki state HERE, at click time (§3.5), and render it as
-            // the WIKI_STATE.md the launcher stages — so the agent reads the CURRENT
-            // titles / index.md / log tail from local disk and skips orientation.
-            let stateMarkdown = store.currentStateSnapshot().renderStateFile()
-            guard let request = makeRequest(stateMarkdown: stateMarkdown) else { return }
-
-            let systemPrompt = store.currentSystemPromptBody()
-
-            launcher.run(
-                request: request,
-                wikiID: wikiID,
-                wikiRoot: root,
-                systemPrompt: systemPrompt,
-                wikictlDirectory: HelpersLocation.wikictlDirectory,
-                onLock: { store.beginAgentRun() },
-                onUnlock: { store.endAgentRun() }
-            )
+            switch selectedKind {
+            case .ingest:
+                guard let selectedSourceID else { return }
+                await AgentOperationRunner.runIngest(
+                    fileID: selectedSourceID,
+                    launcher: launcher,
+                    store: store,
+                    manager: manager,
+                    fileProvider: fileProvider)
+            case .query:
+                await AgentOperationRunner.runQuery(
+                    question: queryText,
+                    launcher: launcher,
+                    store: store,
+                    manager: manager,
+                    fileProvider: fileProvider)
+            case .lint:
+                await AgentOperationRunner.runLint(
+                    launcher: launcher,
+                    store: store,
+                    manager: manager,
+                    fileProvider: fileProvider)
+            }
         }
-    }
-
-    /// Build the `OperationRequest` from the current selection + input. For Ingest,
-    /// reads the source bytes from SQLite (not the mount) so the launcher can stage
-    /// them; the Ingest mode (single Opus pass vs Opus curator + Sonnet digesters) is
-    /// decided from the staged source size at stage time.
-    private func makeRequest(stateMarkdown: String) -> OperationRequest? {
-        switch selectedKind {
-        case .ingest:
-            guard let id = selectedSourceID,
-                  let file = store.ingestedFiles.first(where: { $0.id == id }),
-                  let bytes = store.ingestedSourceBytes(id: id)
-            else { return nil }
-            return .ingest(
-                sourceBytes: bytes,
-                ext: file.ext,
-                sourcePath: ingestSourcePath(for: file),
-                stateMarkdown: stateMarkdown)
-        case .query:
-            let trimmed = queryText.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : .query(question: trimmed, stateMarkdown: stateMarkdown)
-        case .lint:
-            return .lint(stateMarkdown: stateMarkdown)
-        }
-    }
-
-    /// The mount-relative path of an ingested file's `files/by-id` projection, so
-    /// the agent can Read it directly. Uses the SAME `FilenameEscaping` helper the
-    /// projection uses for the leaf filename, so it can't drift.
-    private func ingestSourcePath(for file: IngestedFileSummary) -> String {
-        let leaf = FilenameEscaping.byIDIngestedFilename(fileID: file.id.rawValue, ext: file.ext)
-        return "files/by-id/\(leaf)"
     }
 }
 

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -6,6 +6,9 @@ import WikiFSCore
 /// editor and keeps the existing autosave buffers intact.
 struct PageDetailView: View {
     @Bindable var store: WikiStoreModel
+    @Bindable var launcher: AgentLauncher
+    @Bindable var manager: WikiManager
+    let fileProvider: FileProviderSpike
     @State private var isEditing = false
 
     var body: some View {
@@ -15,7 +18,11 @@ struct PageDetailView: View {
             if isEditing {
                 PageEditorView(store: store)
             } else {
-                PageReaderView(store: store)
+                PageReaderView(
+                    store: store,
+                    isRunning: launcher.isRunning,
+                    onQuery: runQuery
+                )
             }
         }
         .frame(minWidth: PageEditorMetrics.detailMinWidth)
@@ -44,5 +51,16 @@ struct PageDetailView: View {
             store.flushPendingSave()
         }
         isEditing.toggle()
+    }
+
+    private func runQuery(_ question: String) {
+        Task {
+            await AgentOperationRunner.runQuery(
+                question: question,
+                launcher: launcher,
+                store: store,
+                manager: manager,
+                fileProvider: fileProvider)
+        }
     }
 }

--- a/Sources/WikiFS/PageQueryPrompt.swift
+++ b/Sources/WikiFS/PageQueryPrompt.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Compact query composer shown at the bottom of every page reader. It mirrors a
+/// native search/question field: always visible, modest in scale, and submit-on-
+/// Return without sending the user hunting through the toolbar.
+struct PageQueryPrompt: View {
+    let isRunning: Bool
+    let onSubmit: (String) -> Void
+    @State private var queryText = ""
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            TextField("Ask this wiki a question…", text: $queryText, axis: .vertical)
+                .font(.callout)
+                .textFieldStyle(.plain)
+                .lineLimit(1...4)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                .onSubmit(submit)
+                .disabled(isRunning)
+
+            Button("Query", systemImage: "arrow.up.circle.fill", action: submit)
+                .labelStyle(.iconOnly)
+                .font(.title3)
+                .disabled(isRunning || trimmedQuery.isEmpty)
+                .help("Query the wiki")
+        }
+        .frame(maxWidth: PageEditorMetrics.readableContentWidth)
+        .padding(.horizontal, PageEditorMetrics.contentInset)
+        .padding(.vertical, PageEditorMetrics.sectionSpacing)
+    }
+
+    private var trimmedQuery: String {
+        queryText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func submit() {
+        let question = trimmedQuery
+        guard !question.isEmpty else { return }
+        onSubmit(question)
+        queryText = ""
+    }
+}

--- a/Sources/WikiFS/PageReaderView.swift
+++ b/Sources/WikiFS/PageReaderView.swift
@@ -5,6 +5,8 @@ import WikiFSCore
 /// agent maintains; manual source editing lives behind PageDetailView's Edit action.
 struct PageReaderView: View {
     @Bindable var store: WikiStoreModel
+    let isRunning: Bool
+    let onQuery: (String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -25,6 +27,9 @@ struct PageReaderView: View {
             MarkdownPreview(store: store, markdown: readerMarkdown)
                 .frame(maxWidth: .infinity)
                 .frame(minHeight: PageEditorMetrics.previewMinHeight)
+
+            Divider().opacity(PageEditorMetrics.dividerOpacity)
+            PageQueryPrompt(isRunning: isRunning, onSubmit: onQuery)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(nsColor: .textBackgroundColor))

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -32,6 +32,12 @@ struct SidebarView: View {
                 .tag(WikiSelection.systemPrompt)
                 .help("Agent instructions, projected read-only as CLAUDE.md and AGENTS.md")
 
+            Label("Change Log", systemImage: "clock.arrow.circlepath")
+                .font(.body)
+                .lineLimit(1)
+                .tag(WikiSelection.changeLog)
+                .help("Operation history, projected read-only as log.md")
+
             Section("Pages") {
                 ForEach(store.summaries) { summary in
                     Text(summary.title.isEmpty ? "Untitled" : summary.title)
@@ -48,19 +54,18 @@ struct SidebarView: View {
                         }
                 }
             }
-            // Files section appears only once at least one file is ingested. The
-            // rows are management-only (no `.tag`), so they never feed the page
-            // selection binding above — clicking one is a no-op on the detail pane.
-            // The header carries an inline "Add from URL…" button so the affordance
-            // sits right next to the content it produces.
+            // Files are most-recently-added first (the store orders by created_at
+            // DESC). Selecting one opens a detail pane with direct ingest controls.
             if !store.ingestedFiles.isEmpty {
                 Section {
                     ForEach(store.ingestedFiles) { file in
                         IngestedFileRow(
                             file: file,
+                            hasBeenIngested: store.hasIngestedFile(file),
                             onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
                             onRemove: { store.deleteIngestedFile(file.id) }
                         )
+                        .tag(WikiSelection.ingestedFile(file.id))
                     }
                 } header: {
                     HStack {

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import WikiFSCore
+
+/// The main content pane for the current selection. Kept separate from
+/// `ContentView` so the app shell owns layout/chrome while this view owns the
+/// selected document/source surface.
+struct WikiDetailView: View {
+    @Bindable var store: WikiStoreModel
+    @Bindable var launcher: AgentLauncher
+    @Bindable var manager: WikiManager
+    let fileProvider: FileProviderSpike
+    let onIngestFile: (PageID) -> Void
+
+    var body: some View {
+        switch store.selection {
+        case .none:
+            ContentUnavailableView {
+                Label("No Page Selected", systemImage: "doc.text")
+            } description: {
+                Text("Select a page from the sidebar, or create a new one.")
+            } actions: {
+                Button("New Page", systemImage: "plus") { store.newPage() }
+            }
+        case .systemPrompt:
+            SystemPromptDetailView(store: store)
+        case .changeLog:
+            ChangeLogDetailView(store: store)
+        case .page:
+            PageDetailView(
+                store: store,
+                launcher: launcher,
+                manager: manager,
+                fileProvider: fileProvider)
+        case .ingestedFile(let id):
+            if let file = store.ingestedFiles.first(where: { $0.id == id }) {
+                IngestedFileDetailView(
+                    file: file,
+                    hasBeenIngested: store.hasIngestedFile(file),
+                    isRunning: launcher.isRunning,
+                    onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
+                    onIngest: { onIngestFile(file.id) }
+                )
+            } else {
+                ContentUnavailableView {
+                    Label("File Missing", systemImage: "doc.badge.questionmark")
+                } description: {
+                    Text("This ingested file is no longer available.")
+                }
+            }
+        }
+    }
+}

--- a/Sources/WikiFSCore/WikiSelection.swift
+++ b/Sources/WikiFSCore/WikiSelection.swift
@@ -1,11 +1,13 @@
 /// What the sidebar currently has selected. The sidebar is a single
 /// `List(selection:)`, so its selection must be ONE `Hashable` type — this enum
-/// unifies the singleton system-prompt document with the wiki pages. Ingested
-/// files are intentionally NOT a case: their rows carry no tag and never feed
-/// the selection (they open in their default app instead).
+/// unifies the singleton system-prompt document, wiki pages, and ingested files.
 public enum WikiSelection: Hashable, Sendable {
     /// The user-editable system-prompt document (`CLAUDE.md` / `AGENTS.md`).
     case systemPrompt
+    /// The append-only operation log (`log.md`).
+    case changeLog
     /// A wiki page, by id.
     case page(PageID)
+    /// A raw source file stored in the wiki, by id.
+    case ingestedFile(PageID)
 }

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -22,6 +22,11 @@ public final class WikiStoreModel {
     /// ALWAYS rebuilt from `store.listIngestedFiles()` after a change, never
     /// incrementally patched (§3.1). Most-recent-first.
     public private(set) var ingestedFiles: [IngestedFileSummary] = []
+    /// Best-effort UI status for whether a raw source has already been processed
+    /// by an agent Ingest run. The source of truth is the append-only log; agents
+    /// can choose their log title, so matching accepts the filename, id, by-id
+    /// projection leaf, or path in either the log title or note.
+    private var ingestedFileStatus: [PageID: Bool] = [:]
 
     /// Invoked on the main actor after any successful persisted mutation
     /// (save / new / rename / delete). The app wires this to the File Provider
@@ -124,6 +129,14 @@ public final class WikiStoreModel {
             loadedPage = id
         case .systemPrompt:
             draftSystemPrompt = (try? store.getSystemPrompt())?.body ?? SystemPrompt.defaultBody
+            loadedPage = nil
+        case .changeLog:
+            draftTitle = ""
+            draftBody = ""
+            loadedPage = nil
+        case .ingestedFile:
+            draftTitle = ""
+            draftBody = ""
             loadedPage = nil
         case nil:
             draftTitle = ""
@@ -391,6 +404,10 @@ public final class WikiStoreModel {
     public func deleteIngestedFile(_ id: PageID) {
         do {
             try store.deleteIngestedFile(id: id)
+            if selection == .ingestedFile(id) {
+                selection = nil
+                loadDrafts(for: nil)
+            }
             reloadIngestedFiles()
             onPageDidChange?()
         } catch {
@@ -427,6 +444,15 @@ public final class WikiStoreModel {
         return WikiStateSnapshot.make(allTitles: titles, indexBody: indexBody, logLines: logLines)
     }
 
+    /// Render the operation log exactly as the File Provider's `log.md` does, so
+    /// the in-app document and filesystem projection show the same query/ingest/
+    /// lint history. Bounded generously for UI responsiveness; entries remain in
+    /// chronological order so newest activity sits at the bottom.
+    public func currentLogMarkdown(limit: Int = 10_000) -> String {
+        let entries = (try? store.recentLogEntries(limit: limit)) ?? []
+        return LogRenderer.render(entries)
+    }
+
     /// The verbatim bytes of one ingested source, read from SQLite at click time so
     /// the agent run can STAGE it onto reliable local disk (`source.<ext>`) rather
     /// than reading from the ~5s-laggy read-only mount. `nil` if the read fails;
@@ -434,6 +460,10 @@ public final class WikiStoreModel {
     /// would fall back to probing the mount.
     public func ingestedSourceBytes(id: PageID) -> Data? {
         try? store.ingestedFileContent(id: id)
+    }
+
+    public func hasIngestedFile(_ file: IngestedFileSummary) -> Bool {
+        ingestedFileStatus[file.id] ?? false
     }
 
     // MARK: - Source-of-truth rebuild
@@ -454,5 +484,23 @@ public final class WikiStoreModel {
 
     private func reloadIngestedFiles() {
         ingestedFiles = (try? store.listIngestedFiles()) ?? []
+        let entries = (try? store.recentLogEntries(limit: 10_000)) ?? []
+        let ingestTexts = entries
+            .filter { $0.kind == .ingest }
+            .map { "\($0.title) \($0.note ?? "")".lowercased() }
+
+        ingestedFileStatus = Dictionary(uniqueKeysWithValues: ingestedFiles.map { file in
+            let filename = file.filename.lowercased()
+            let byIDLeaf = FilenameEscaping
+                .byIDIngestedFilename(fileID: file.id.rawValue, ext: file.ext)
+                .lowercased()
+            let path = "files/by-id/\(byIDLeaf)"
+            let matchers = [filename, file.id.rawValue.lowercased(), byIDLeaf, path]
+                .filter { !$0.isEmpty }
+            let hasLogEntry = ingestTexts.contains { text in
+                matchers.contains { text.contains($0) }
+            }
+            return (file.id, hasLogEntry)
+        })
     }
 }

--- a/Tests/WikiFSTests/IngestedFilesTests.swift
+++ b/Tests/WikiFSTests/IngestedFilesTests.swift
@@ -114,6 +114,23 @@ struct IngestedFilesTests {
         #expect(list.last?.id == first.id)
     }
 
+    @MainActor
+    @Test func modelTracksWhetherFileHasBeenAgentIngested() throws {
+        let store = try tempStore()
+        let raw = try store.ingestFile(filename: "source.pdf", data: Data("%PDF".utf8))
+        let untouched = try store.ingestFile(filename: "notes.txt", data: Data("notes".utf8))
+
+        let model = WikiStoreModel(store: store)
+        #expect(model.hasIngestedFile(raw) == false)
+        #expect(model.hasIngestedFile(untouched) == false)
+
+        try store.appendLog(kind: .ingest, title: "files/by-id/\(raw.id.rawValue).pdf", note: nil)
+        model.reloadFromStore()
+
+        #expect(model.hasIngestedFile(raw) == true)
+        #expect(model.hasIngestedFile(untouched) == false)
+    }
+
     // MARK: - Stepwise migration (v1 DB with pages → v2, pages intact)
 
     @Test func migratesV1DatabaseToV2PreservingPages() throws {

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -93,6 +93,18 @@ struct LogIndexTests {
         #expect(LogRenderer.render([]).isEmpty)
     }
 
+    @MainActor
+    @Test func modelCurrentLogMarkdownUsesProjectionRenderer() throws {
+        let store = try tempStore()
+        _ = try store.appendLog(kind: .query, title: "What changed?", note: "The agent answered from the wiki.")
+        let model = WikiStoreModel(store: store)
+        let markdown = model.currentLogMarkdown()
+
+        #expect(markdown.contains("## ["))
+        #expect(markdown.contains("query | What changed?"))
+        #expect(markdown.contains("The agent answered from the wiki."))
+    }
+
     // MARK: - index set (UPSERT)
 
     @Test func updateWikiIndexPersistsAndBumpsVersion() throws {


### PR DESCRIPTION
## Summary

- surface file ingestion directly from selectable file rows with status indicators
- add an inline page query prompt plus an expandable live agent transcript sidebar
- expose the append-only Change Log next to System Prompt in the sidebar
- share agent launch/staging through AgentOperationRunner and add focused model tests

## Validation

- make check
- make test (322/322)

## Notes

AGENTS.md remains untracked and is intentionally excluded from this PR.