### PR TITLE
[codex] Add Claude prompt help reference

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,53 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-16 — Prompt help made navigable
+
+Changed the Claude Prompt Templates Help window from one long scroll into a
+sidebar/detail view listing each prompt artifact directly: Command, Ingest
+variants, Query, Lint, Agents, and appended System Prompt. The window now defaults
+to **Query -p Prompt**, so Query is visible immediately instead of buried below
+the long ingest prompt. The detail body still renders from `ClaudePromptHelp`,
+which renders from the production prompt builders.
+
+**Verified.** `make check` passes and `swift test` passes (**325/325**).
+
+## 2026-06-16 — Fan-out prompt names Sonnet for raw ingestion
+
+Tightened the large-source Ingest curator prompt so it explicitly tells Opus to
+use **Sonnet `source-reader` workers, not Opus**, for raw source ingestion. Opus
+still curates/synthesizes and writes pages/index/log; Sonnet handles the bulk
+read/digest work. Added a regression assertion in `OperationCommandTests`, and
+the Help-menu prompt reference picks this up automatically from the production
+`WikiOperation` builder.
+
+**Verified.** `make check` passes and `swift test` passes (**325/325**).
+
+## 2026-06-16 — Claude prompt templates added to Help
+
+Added a secondary Help-menu reference for the actual `claude -p` command surface:
+the argv/env/cwd template, each operation's `-p` prompt, the large-ingest
+`--agents` JSON, and a pointer to the active wiki's editable System Prompt body.
+
+**Changed**
+- Added `ClaudePromptHelp` in `WikiFSCore`, rendering Help documents from the
+  production `OperationCommand`, `WikiOperation`, and `IngestPlan` builders using
+  placeholder paths/inputs so the reference tracks the real launch payload.
+- Added a **Help → Claude Prompt Templates** window with selectable monospaced
+  prompt blocks. The window is secondary UI, separate from the main wiki/editor
+  flow.
+- Added `ClaudePromptHelpTests` to assert the Help reference includes command,
+  operation, subagent, and system-prompt sections and that the operation prompt
+  bodies come from the production builders.
+
+**Skill pass.** Before and after code: `swiftui-pro` kept the renderer pure and
+the SwiftUI views split into leaf types; `macos-design` placed the reference in
+the Help menu rather than primary navigation; `typography-designer` kept semantic
+system styles for prose and monospaced body text only for literal prompt/code
+content.
+
+**Verified.** `make check` passes and `swift test` passes (**325/325**).
+
 ## 2026-06-16 — Change Log surfaced in the sidebar
 
 Surfaced the append-only operation log in the app UI, next to the other pinned

--- a/Sources/WikiFS/ClaudePromptHelpCommands.swift
+++ b/Sources/WikiFS/ClaudePromptHelpCommands.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// Help menu command for the secondary prompt reference window.
+struct ClaudePromptHelpCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(after: .help) {
+            Button("Claude Prompt Templates") {
+                openWindow(id: "claudePromptHelp")
+            }
+            .keyboardShortcut("/", modifiers: [.command, .option])
+        }
+    }
+}

--- a/Sources/WikiFS/ClaudePromptHelpView.swift
+++ b/Sources/WikiFS/ClaudePromptHelpView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import WikiFSCore
+
+/// Secondary Help-menu surface for the exact `claude -p` command and prompts.
+struct ClaudePromptHelpView: View {
+    private let documents = ClaudePromptHelp.documents
+    @State private var selectedDocumentID: ClaudePromptHelpDocument.ID? = "query"
+
+    var body: some View {
+        NavigationSplitView {
+            List(documents, selection: $selectedDocumentID) { document in
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(document.title)
+                        .font(.body)
+                        .lineLimit(1)
+                    Text(document.summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                .padding(.vertical, 3)
+            }
+            .listStyle(.sidebar)
+            .navigationTitle("Prompts")
+            .navigationSplitViewColumnWidth(min: 220, ideal: 260)
+        } detail: {
+            if let selectedDocument {
+                ScrollView {
+                    PromptHelpSectionView(document: selectedDocument)
+                        .padding(PageEditorMetrics.contentInset)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(Color(nsColor: .textBackgroundColor))
+                .navigationTitle(selectedDocument.title)
+            } else {
+                ContentUnavailableView {
+                    Label("No Prompt Selected", systemImage: "text.page")
+                } description: {
+                    Text("Choose a prompt from the sidebar.")
+                }
+            }
+        }
+        .navigationTitle("Claude Prompt Templates")
+        .frame(minWidth: 720, minHeight: 560)
+    }
+
+    private var selectedDocument: ClaudePromptHelpDocument? {
+        let selectedID = selectedDocumentID ?? "query"
+        return documents.first { $0.id == selectedID } ?? documents.first
+    }
+}
+
+#Preview {
+    ClaudePromptHelpView()
+}

--- a/Sources/WikiFS/PromptCodeBlockView.swift
+++ b/Sources/WikiFS/PromptCodeBlockView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Selectable monospace text for command and prompt templates.
+struct PromptCodeBlockView: View {
+    let text: String
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            Text(text)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/Sources/WikiFS/PromptHelpSectionView.swift
+++ b/Sources/WikiFS/PromptHelpSectionView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import WikiFSCore
+
+/// One titled prompt block in the Help-menu prompt reference.
+struct PromptHelpSectionView: View {
+    let document: ClaudePromptHelpDocument
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(document.title)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                Text(document.summary)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            PromptCodeBlockView(text: document.body)
+        }
+    }
+}

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -58,6 +58,9 @@ struct WikiFSApp: App {
                 }
         }
         .windowToolbarStyle(.unified)
+        .commands {
+            ClaudePromptHelpCommands()
+        }
         .onChange(of: scenePhase) { _, phase in
             if phase != .active { manager.activeStore?.flushPendingSaves() }
         }
@@ -67,6 +70,11 @@ struct WikiFSApp: App {
         .onChange(of: manager.wikis) { _, _ in
             changeBridge?.refreshObservations()
         }
+
+        Window("Claude Prompt Templates", id: "claudePromptHelp") {
+            ClaudePromptHelpView()
+        }
+        .defaultSize(width: 880, height: 680)
     }
 }
 

--- a/Sources/WikiFSCore/ClaudePromptHelp.swift
+++ b/Sources/WikiFSCore/ClaudePromptHelp.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Renders the exact `claude -p` command/prompt templates for the Help menu.
+///
+/// This intentionally calls the production prompt builders (`WikiOperation`,
+/// `OperationCommand`, and `IngestPlan`) using placeholder paths, so the help
+/// window stays coupled to the real invocation surface instead of a stale copy.
+public enum ClaudePromptHelp {
+  public static let wikiRootPlaceholder = "<resolved WIKI_ROOT mount path>"
+  public static let wikiIDPlaceholder = "<active wiki ULID>"
+  public static let systemPromptPlaceholder = "<active wiki System Prompt body>"
+  public static let scratchDirectoryPlaceholder = "<per-run writable scratch directory>"
+  public static let wikictlDirectoryPlaceholder = "<app bundle Contents/Helpers>"
+  public static let stagedSourcePlaceholder = "<scratch>/source"
+  public static let stateFilePlaceholder = "<scratch>/WIKI_STATE.md"
+
+  public static var documents: [ClaudePromptHelpDocument] {
+    [
+      ClaudePromptHelpDocument(
+        id: "command",
+        title: "Command Template",
+        summary: "The argv, cwd, and environment used when the app launches Claude.",
+        body: commandTemplate),
+      ClaudePromptHelpDocument(
+        id: "ingest-single",
+        title: "Ingest -p Prompt (Single Opus)",
+        summary: "Used for tiny sources below the ingest fan-out threshold.",
+        body: tinyIngest.prompt(wikiRoot: wikiRootPlaceholder)),
+      ClaudePromptHelpDocument(
+        id: "ingest-curator",
+        title: "Ingest -p Prompt (Opus Curator)",
+        summary: "Used for larger sources; Opus writes while Sonnet workers digest chunks.",
+        body: curatedIngest.prompt(wikiRoot: wikiRootPlaceholder)),
+      ClaudePromptHelpDocument(
+        id: "query",
+        title: "Query -p Prompt",
+        summary: "Used when answering a question from the wiki.",
+        body: WikiOperation
+          .query(question: "<question typed in the Query sheet>", stateFilePath: stateFilePlaceholder)
+          .prompt(wikiRoot: wikiRootPlaceholder)),
+      ClaudePromptHelpDocument(
+        id: "lint",
+        title: "Lint -p Prompt",
+        summary: "Used when health-checking the wiki.",
+        body: WikiOperation
+          .lint(stateFilePath: stateFilePlaceholder)
+          .prompt(wikiRoot: wikiRootPlaceholder)),
+      ClaudePromptHelpDocument(
+        id: "agents",
+        title: "Large Ingest --agents JSON",
+        summary: "The inline source-reader subagent template passed only for large-source ingest.",
+        body: IngestPlan.opusCurator.agentsJSON() ?? "{}"),
+      ClaudePromptHelpDocument(
+        id: "append-system-prompt",
+        title: "--append-system-prompt",
+        summary: "This is not duplicated here because it is the editable System Prompt document.",
+        body: systemPromptPlaceholder),
+    ]
+  }
+
+  public static var commandTemplate: String {
+    let command = OperationCommand.build(
+      operation: curatedIngest,
+      wikiRoot: wikiRootPlaceholder,
+      wikiID: wikiIDPlaceholder,
+      systemPrompt: systemPromptPlaceholder,
+      scratchDirectory: scratchDirectoryPlaceholder,
+      wikictlDirectory: wikictlDirectoryPlaceholder,
+      claudeExecutable: "claude",
+      baseEnvironment: ["PATH": "<inherited PATH>"])
+
+    return """
+      cwd: \(command.currentDirectoryPath)
+      env:
+        WIKI_ROOT=\(command.environment["WIKI_ROOT"] ?? "")
+        WIKI_DB=\(command.environment["WIKI_DB"] ?? "")
+        PATH=\(command.environment["PATH"] ?? "")
+
+      argv:
+      \(renderCommand(command))
+      """
+  }
+
+  private static var tinyIngest: WikiOperation {
+    .ingest(
+      sourcePath: "files/by-id/<file-id>",
+      stagedSourcePath: stagedSourcePlaceholder,
+      stateFilePath: stateFilePlaceholder,
+      plan: .singleOpus)
+  }
+
+  private static var curatedIngest: WikiOperation {
+    .ingest(
+      sourcePath: "files/by-id/<file-id>",
+      stagedSourcePath: stagedSourcePlaceholder,
+      stateFilePath: stateFilePlaceholder,
+      plan: .opusCurator)
+  }
+
+  private static func renderCommand(_ command: OperationCommand) -> String {
+    ([command.executable] + command.arguments)
+      .map(shellQuoted)
+      .joined(separator: " \\\n  ")
+  }
+
+  private static func shellQuoted(_ value: String) -> String {
+    if value.range(of: #"^[A-Za-z0-9_@%+=:,./-]+$"#, options: .regularExpression) != nil {
+      return value
+    }
+    return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+  }
+}

--- a/Sources/WikiFSCore/ClaudePromptHelpDocument.swift
+++ b/Sources/WikiFSCore/ClaudePromptHelpDocument.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// One readable prompt/command artifact shown in the app's Help menu.
+public struct ClaudePromptHelpDocument: Equatable, Identifiable, Sendable {
+  public let id: String
+  public let title: String
+  public let summary: String
+  public let body: String
+
+  public init(id: String, title: String, summary: String, body: String) {
+    self.id = id
+    self.title = title
+    self.summary = summary
+    self.body = body
+  }
+}

--- a/Sources/WikiFSCore/WikiOperation.swift
+++ b/Sources/WikiFSCore/WikiOperation.swift
@@ -157,9 +157,9 @@ extension WikiOperation {
     """
   }
 
-  /// Large-source Ingest: an Opus CURATOR orchestrates reading the large source via
-  /// Sonnet `source-reader` digesters, then DECIDES the page set and WRITES every
-  /// page + index.md + the log entry itself. The 2..19 digester guardrail and the
+  /// Large-source Ingest: an Opus CURATOR delegates raw source ingestion to Sonnet
+  /// `source-reader` digesters, then DECIDES the page set and WRITES every page +
+  /// index.md + the log entry itself. The 2..19 digester guardrail and the
   /// "fork more for follow-up questions / pull pages to double-check" affordances are
   /// stated prompt-level. Leads with the write rule because Opus is the writer.
   private static func ingestCuratorPrompt(
@@ -174,14 +174,15 @@ extension WikiOperation {
 
     TASK — Ingest this one source into the wiki, following the Ingest workflow from \
     your instructions. You are the CURATOR: you decide what goes in the wiki and you \
-    write everything. The source is LARGE — use Sonnet `source-reader` workers to \
-    read its bulk for you so you don't have to read the whole thing yourself. Act \
-    immediately; do not explore the mount first.
+    write everything. The source is LARGE — use Sonnet `source-reader` workers, not \
+    Opus, to do the raw source ingestion: they read the bulk source chunks and return \
+    structured digests for you to synthesize. Act immediately; do not explore the \
+    mount first.
 
     1. INSPECT the staged source's size and structure WITHOUT reading the whole bulk \
        — e.g. `wc -l`/`head` for text, or count pages for a PDF — then split it into \
        chunks (byte/line ranges, sections, or page ranges).
-    2. FAN OUT the READING to `source-reader` subagents via the Task tool — \
+    2. FAN OUT RAW INGESTION to Sonnet `source-reader` subagents via the Task tool — \
        use MORE THAN 1 and FEWER THAN 20 workers (between 2 and 19). Size the fan-out \
        to the material: do NOT spawn 15 workers for 3 pages; one worker can digest \
        adjacent chunks. In each worker's task, give it the staged source path \

--- a/Tests/WikiFSTests/ClaudePromptHelpTests.swift
+++ b/Tests/WikiFSTests/ClaudePromptHelpTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import WikiFSCore
+
+struct ClaudePromptHelpTests {
+  @Test func exposesCommandOperationPromptsAgentsAndSystemPromptPlaceholder() {
+    let documents = ClaudePromptHelp.documents
+    #expect(documents.map(\.id) == [
+      "command",
+      "ingest-single",
+      "ingest-curator",
+      "query",
+      "lint",
+      "agents",
+      "append-system-prompt",
+    ])
+  }
+
+  @Test func commandTemplateUsesTheRealOperationCommandSurface() {
+    let template = ClaudePromptHelp.commandTemplate
+    #expect(template.contains("claude"))
+    #expect(template.contains("-p"))
+    #expect(template.contains("--model"))
+    #expect(template.contains("opus"))
+    #expect(template.contains("--output-format"))
+    #expect(template.contains("stream-json"))
+    #expect(template.contains("--append-system-prompt"))
+    #expect(template.contains("--dangerously-skip-permissions"))
+    #expect(template.contains("--agents"))
+    #expect(template.contains("WIKI_ROOT=<resolved WIKI_ROOT mount path>"))
+    #expect(template.contains("WIKI_DB=<active wiki ULID>"))
+    #expect(!template.contains("\\\n+"))
+  }
+
+  @Test func promptDocumentsComeFromProductionPromptBuilders() {
+    let byID = Dictionary(uniqueKeysWithValues: ClaudePromptHelp.documents.map { ($0.id, $0.body) })
+    let tiny = WikiOperation.ingest(
+      sourcePath: "files/by-id/<file-id>",
+      stagedSourcePath: ClaudePromptHelp.stagedSourcePlaceholder,
+      stateFilePath: ClaudePromptHelp.stateFilePlaceholder,
+      plan: .singleOpus)
+    let curated = WikiOperation.ingest(
+      sourcePath: "files/by-id/<file-id>",
+      stagedSourcePath: ClaudePromptHelp.stagedSourcePlaceholder,
+      stateFilePath: ClaudePromptHelp.stateFilePlaceholder,
+      plan: .opusCurator)
+
+    #expect(byID["ingest-single"] == tiny.prompt(wikiRoot: ClaudePromptHelp.wikiRootPlaceholder))
+    #expect(byID["ingest-curator"] == curated.prompt(wikiRoot: ClaudePromptHelp.wikiRootPlaceholder))
+    #expect(byID["agents"] == IngestPlan.opusCurator.agentsJSON())
+  }
+}

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -288,6 +288,8 @@ struct OperationCommandTests {
     #expect(prompt.contains("MORE THAN 1 and FEWER THAN 20"))
     #expect(prompt.contains("between 2 and 19"))
     #expect(prompt.contains("source-reader"))
+    #expect(prompt.contains("use Sonnet `source-reader` workers, not Opus"))
+    #expect(prompt.contains("FAN OUT RAW INGESTION to Sonnet `source-reader` subagents"))
     // Size the fan-out to the material.
     #expect(prompt.contains("do NOT spawn 15 workers for 3 pages"))
     // Opus may fork MORE workers for follow-up questions, and may pull pages to


### PR DESCRIPTION
## Summary

- Adds a secondary Help menu window that renders the exact `claude -p` command template, operation prompts, large-ingest `--agents` JSON, and appended system-prompt placeholder from the production builders.
- Makes the prompt help navigable with a sidebar and defaults to the Query prompt so it is not buried below the long ingest prompt.
- Tightens the large-source ingest prompt to explicitly tell Opus to use Sonnet `source-reader` workers, not Opus, for raw source ingestion.

## Validation

- `make check`
- `swift test` (325/325)

## Notes

Left the untracked root `AGENTS.md` out of this PR.