### PR TITLE
[codex] Show agent run heartbeat and stop inline runs

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,28 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-16 — Agent runs show quiet-live status and can be stopped inline
+
+- Diagnosed a Query run that appeared hung: the spawned `claude -p` process was
+  still alive, but `run.jsonl` had not changed since the last tool result, so the
+  transcript only showed a spinner with no heartbeat.
+- `AgentLauncher` now records run start time, last stdout/stderr activity, and
+  the child process ID for the current run.
+- The operation transcript and inline transcript sidebar now show a live status
+  line such as "Running · last output 12s ago · elapsed 1m 4s · pid 12345"; after
+  60 seconds without output it explicitly says the process is still running but
+  quiet.
+- Added a Stop button to the inline transcript header, matching the modal sheet's
+  existing stop control, so a wedged inline query can be terminated without
+  leaving the page.
+- Fixed a follow-on beachball when collapsing the transcript sidebar. The sidebar
+  had been kept alive at width 0, leaving selectable transcript text and live
+  timeline/status views in a zero-width layout loop. Collapsing now removes the
+  transcript subtree entirely; visible sidebars use a stable fixed width.
+
+**Verified.** `make check` passes, `swift test` passes (**337/337**), and
+`make install` installs the fixed app into `/Applications`.
+
 ## 2026-06-16 — Reader renders full Markdown blocks with Textual
 
 - Replaced the reader's inline-only Markdown preview with

--- a/Sources/WikiFS/AgentActivityView.swift
+++ b/Sources/WikiFS/AgentActivityView.swift
@@ -20,6 +20,11 @@ struct AgentActivityView: View {
             if let error = launcher.preflightError {
                 preflightBanner(error)
             }
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                AgentRunStatusView(launcher: launcher, now: context.date)
+                    .padding(.horizontal, ActivityMetrics.padding)
+                    .padding(.top, ActivityMetrics.padding)
+            }
             activityList
             if !launcher.stderr.isEmpty {
                 stderrBanner

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -45,6 +45,15 @@ final class AgentLauncher {
     /// The per-run `run.jsonl` backend log on disk (raw stream-json), so the UI can
     /// offer a "Reveal log" affordance. Its sibling `run.stderr.log` holds stderr.
     private(set) var logFileURL: URL?
+    /// Wall-clock start time for the current/last run. Used by the UI to show a
+    /// heartbeat instead of a context-free spinner.
+    private(set) var runStartedAt: Date?
+    /// Last time stdout/stderr produced bytes, or the run state changed. A live
+    /// process with an old `lastActivityAt` is not necessarily dead, but the UI can
+    /// name that it is quiet.
+    private(set) var lastActivityAt: Date?
+    /// The spawned process ID while running, useful context when a run looks quiet.
+    private(set) var currentProcessID: Int32?
 
     /// Builds the login-shell PATH-resolved `claude` path. Injected so tests can
     /// stub it; the app uses the real login-shell preflight.
@@ -132,8 +141,11 @@ final class AgentLauncher {
         )
 
         resetRunState()
+        let now = Date()
         isRunning = true
         runningKind = operation.kind
+        runStartedAt = now
+        lastActivityAt = now
         openLogFiles(in: scratch)
         onLock()
 
@@ -176,12 +188,15 @@ final class AgentLauncher {
         do {
             try process.run()
             self.process = process
+            currentProcessID = process.processIdentifier
         } catch {
             preflightError = "Failed to launch claude: \(error.localizedDescription)"
             closeLogFiles()
             try? FileManager.default.removeItem(at: scratch)
             isRunning = false
             runningKind = nil
+            currentProcessID = nil
+            lastActivityAt = Date()
             onUnlock()
         }
     }
@@ -197,6 +212,7 @@ final class AgentLauncher {
     /// Append a raw stdout chunk: mirror it to the transcript + `run.jsonl`, then
     /// split into complete lines and feed each to the parser.
     private func ingestStdout(_ chunk: String) {
+        lastActivityAt = Date()
         rawTranscript.append(chunk)
         writeLog(chunk, to: logHandle)
 
@@ -215,6 +231,7 @@ final class AgentLauncher {
     /// Append a raw stderr chunk: surface it in `stderr`, mirror to the transcript +
     /// `run.stderr.log`.
     private func ingestStderr(_ chunk: String) {
+        lastActivityAt = Date()
         stderr.append(chunk)
         rawTranscript.append(chunk)
         writeLog(chunk, to: stderrLogHandle)
@@ -233,6 +250,8 @@ final class AgentLauncher {
         exitStatus = status
         runningKind = nil
         process = nil
+        currentProcessID = nil
+        lastActivityAt = Date()
     }
 
     /// Clear per-run state at the start of (or on abort before) a run.
@@ -245,6 +264,9 @@ final class AgentLauncher {
         isRunning = false
         runningKind = nil
         logFileURL = nil
+        runStartedAt = nil
+        lastActivityAt = nil
+        currentProcessID = nil
     }
 
     // MARK: - Backend log files

--- a/Sources/WikiFS/AgentRunStatusView.swift
+++ b/Sources/WikiFS/AgentRunStatusView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct AgentRunStatusView: View {
+    @Bindable var launcher: AgentLauncher
+    let now: Date
+
+    var body: some View {
+        if launcher.isRunning, let startedAt = launcher.runStartedAt {
+            HStack(spacing: 6) {
+                Image(systemName: isQuiet ? "hourglass" : "waveform.path")
+                    .font(.caption)
+                    .foregroundStyle(isQuiet ? .orange : .secondary)
+                    .frame(width: 14)
+                Text(statusText(startedAt: startedAt))
+                    .font(.caption)
+                    .foregroundStyle(isQuiet ? .orange : .secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .accessibilityLabel(accessibilityText(startedAt: startedAt))
+        }
+    }
+
+    private var isQuiet: Bool {
+        guard let lastActivityAt = launcher.lastActivityAt else { return false }
+        return now.timeIntervalSince(lastActivityAt) >= Self.quietThreshold
+    }
+
+    private func statusText(startedAt: Date) -> String {
+        let elapsed = durationString(now.timeIntervalSince(startedAt))
+        let lastOutput = launcher.lastActivityAt.map { durationString(now.timeIntervalSince($0)) } ?? "unknown"
+        let pid = launcher.currentProcessID.map { " · pid \($0)" } ?? ""
+        if isQuiet {
+            return "Still running · no output for \(lastOutput) · elapsed \(elapsed)\(pid)"
+        }
+        return "Running · last output \(lastOutput) ago · elapsed \(elapsed)\(pid)"
+    }
+
+    private func accessibilityText(startedAt: Date) -> String {
+        statusText(startedAt: startedAt)
+    }
+
+    private func durationString(_ interval: TimeInterval) -> String {
+        let seconds = max(0, Int(interval.rounded(.down)))
+        if seconds < 60 {
+            return "\(seconds)s"
+        }
+        let minutes = seconds / 60
+        let remainingSeconds = seconds % 60
+        if minutes < 60 {
+            return remainingSeconds == 0 ? "\(minutes)m" : "\(minutes)m \(remainingSeconds)s"
+        }
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+        return remainingMinutes == 0 ? "\(hours)h" : "\(hours)h \(remainingMinutes)m"
+    }
+
+    private static let quietThreshold: TimeInterval = 60
+}

--- a/Sources/WikiFS/AgentTranscriptSidebar.swift
+++ b/Sources/WikiFS/AgentTranscriptSidebar.swift
@@ -5,7 +5,6 @@ import SwiftUI
 /// silent lock state.
 struct AgentTranscriptSidebar: View {
     @Bindable var launcher: AgentLauncher
-    let isExpanded: Bool
     let onCollapse: () -> Void
 
     var body: some View {
@@ -15,28 +14,39 @@ struct AgentTranscriptSidebar: View {
             AgentActivityView(launcher: launcher)
                 .padding(AgentTranscriptMetrics.padding)
         }
-        .frame(width: isExpanded ? AgentTranscriptMetrics.width : 0)
+        .frame(width: AgentTranscriptMetrics.width)
         .frame(maxHeight: .infinity)
         .background(Color(nsColor: .controlBackgroundColor))
         .clipped()
-        .accessibilityHidden(!isExpanded)
     }
 
     private var header: some View {
-        HStack(spacing: 8) {
-            Label("Transcript", systemImage: "text.bubble")
-                .font(.headline)
-            Spacer()
-            if launcher.isRunning {
-                ProgressView()
-                    .controlSize(.small)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Label("Transcript", systemImage: "text.bubble")
+                    .font(.headline)
+                Spacer()
+                if launcher.isRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                    Button("Stop Run", systemImage: "stop.fill") {
+                        launcher.stop()
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.red)
+                    .help("Stop the running agent")
+                }
+                Button("Hide Transcript", systemImage: "sidebar.trailing") {
+                    onCollapse()
+                }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .help("Hide transcript")
             }
-            Button("Hide Transcript", systemImage: "sidebar.trailing") {
-                onCollapse()
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                AgentRunStatusView(launcher: launcher, now: context.date)
             }
-            .labelStyle(.iconOnly)
-            .buttonStyle(.borderless)
-            .help("Hide transcript")
         }
         .padding(.horizontal, AgentTranscriptMetrics.padding)
         .padding(.vertical, 10)

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -33,14 +33,14 @@ struct ContentView: View {
                     onIngestFile: runIngest
                 )
 
-                Divider()
-                    .opacity(isTranscriptExpanded ? 1 : 0)
-
-                AgentTranscriptSidebar(
-                    launcher: agentLauncher,
-                    isExpanded: isTranscriptExpanded,
-                    onCollapse: collapseTranscript
-                )
+                if isTranscriptExpanded {
+                    Divider()
+                    AgentTranscriptSidebar(
+                        launcher: agentLauncher,
+                        onCollapse: collapseTranscript
+                    )
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
             }
             .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: isTranscriptExpanded)
         }


### PR DESCRIPTION
## Summary

- track agent run start time, last stdout/stderr activity, and child process id
- show a live heartbeat in the operation transcript and inline transcript sidebar, including a quiet-running warning after 60 seconds without output
- add an inline Stop Run button so a wedged page query can be terminated without opening Terminal

## Diagnosis

A live Query run had an active `claude -p` child process, but `run.jsonl` stopped changing after the last tool result. The UI only showed a spinner, so there was no way to tell whether the process was alive, quiet, exited, or wedged.

## Validation

- make check
- swift test (337 tests)
- make install