### PR TITLE
[codex] Fix reader link navigation

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,70 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-16 — Reader links no longer use Textual's stale selection overlay
+
+- Reproduced the page shape from Test Wiki 4 in SQLite: `Missing Heritability
+  Revisited (Gusev Talk)` starts with ordinary `**[[Alexander Gusev]]**` markup,
+  and the target page exists, so the failed click was not an unresolved/malformed
+  wiki link.
+- Traced the hover/click failure to Textual's macOS document-selection overlay:
+  its AppKit `TextSelectionModel` owns both the hand cursor and URL hit testing,
+  and can get stale after reader navigation.
+- Removed document-wide Textual text selection from the rendered Markdown page
+  body so wiki links use Textual's per-fragment tap path instead of the stale
+  selection overlay. The page title remains selectable, and full source
+  selection is still available in Edit mode.
+
+**Skill pass.** Before code: `swiftui-pro` kept the fix local to the leaf
+renderer and avoided changing the model/navigation path, which was already
+unit-tested; `macos-design` prioritized reliable direct link interaction over
+document-wide text selection in the reader. After code: no new state or custom
+gesture stack was introduced, and the reader-first layout is unchanged.
+
+**Verified.** `make check` passes, focused `swift test --filter WikiLink`
+passes (**40/40**), and full `swift test` passes (**344/344**).
+
+## 2026-06-16 — Reader navigation has Back/Forward history
+
+- Added per-wiki navigation history to `WikiStoreModel`, shared by sidebar
+  selection, `[[wiki-link]]` clicks, and programmatic page creation.
+- Added Back/Forward toolbar controls with standard macOS shortcuts: `Cmd-[` and
+  `Cmd-]`. Buttons disable when their stack is empty.
+- Preserved the existing selection-switch invariant: navigating history flushes
+  pending edits for the outgoing page before loading the destination.
+- Pruned deleted pages/files from history on UI deletes and external store
+  reloads, so agent/CLI deletes do not leave stale Back/Forward destinations.
+
+**Skill pass.** Before code: `swiftui-pro` kept history in the existing
+`@MainActor @Observable` model rather than view-local state, preserving the
+single selection source of truth and autosave-on-switch path; `macos-design`
+favored standard toolbar chevrons plus conventional macOS shortcuts. After code:
+the controls are discoverable, disabled states are model-driven, and history
+navigation uses the same draft-loading path as sidebar/wiki-link navigation.
+
+**Verified.** `make check` passes, focused `swift test --filter NavigationHistory`
+passes (**7/7**), and full `swift test` passes (**344/344**).
+
+## 2026-06-16 — Wiki links stay clickable after reader navigation
+
+- Diagnosed a reader-only link interaction regression after the Textual Markdown
+  renderer landed: following links could leave subsequent links visually rendered
+  but unresponsive in the current wiki.
+- Keyed the `StructuredText` subtree by the fully rendered Markdown body so
+  Textual's macOS text-selection/link overlay is rebuilt when navigation swaps
+  the selected page's document content, instead of reusing stale hit-test state.
+
+**Skill pass.** Before code: `swiftui-pro` pointed to the existing
+`openURL`/model selection seam as the right navigation path and to keeping the
+fix local to the leaf renderer; `macos-design` kept links as direct in-document
+navigation without adding extra UI. After code: the change preserves the
+reader-first layout, keeps parsing/link transforms outside SwiftUI view logic,
+and only resets the third-party renderer subtree when its rendered document
+changes.
+
+**Verified.** `make check` passes, focused `swift test --filter WikiLink`
+passes (**40/40**), and full `swift test` passes (**337/337**).
+
 ## 2026-06-16 — Agent runs show quiet-live status and can be stopped inline
 
 - Diagnosed a Query run that appeared hung: the spawned `claude -p` process was

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -65,6 +65,18 @@ struct ContentView: View {
                 .ignoresSafeArea()
         }
         .toolbar {
+            ToolbarItemGroup(placement: .navigation) {
+                Button("Back", systemImage: "chevron.left", action: navigateBack)
+                    .disabled(!store.canNavigateBack)
+                    .keyboardShortcut("[", modifiers: .command)
+                    .help("Go back")
+
+                Button("Forward", systemImage: "chevron.right", action: navigateForward)
+                    .disabled(!store.canNavigateForward)
+                    .keyboardShortcut("]", modifiers: .command)
+                    .help("Go forward")
+            }
+
             ToolbarItem(placement: .primaryAction) {
                 Button("Toggle Transcript", systemImage: "sidebar.trailing") {
                     toggleTranscript()
@@ -125,6 +137,14 @@ struct ContentView: View {
 
     private func collapseTranscript() {
         isTranscriptExpanded = false
+    }
+
+    private func navigateBack() {
+        store.navigateBack()
+    }
+
+    private func navigateForward() {
+        store.navigateForward()
     }
 
     private func runIngest(fileID: PageID) {

--- a/Sources/WikiFS/MarkdownPreview.swift
+++ b/Sources/WikiFS/MarkdownPreview.swift
@@ -24,6 +24,8 @@ struct MarkdownPreview: View {
     let markdown: String
 
     var body: some View {
+        let renderedBody = renderedMarkdown
+
         ScrollView {
             VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
                 if markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -31,8 +33,10 @@ struct MarkdownPreview: View {
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 } else {
-                    StructuredText(markdown: renderedMarkdown)
-                        .textual.textSelection(.enabled)
+                    StructuredText(markdown: renderedBody)
+                        .id(renderedBody)
+                        // Textual's macOS document-selection overlay owns cursor/link hit-testing
+                        // and can get stale after navigation; keep links on the fragment tap path.
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -17,6 +17,11 @@ public final class WikiStoreModel {
     public private(set) var summaries: [WikiPageSummary] = []
     /// The sidebar selection: a page, the system-prompt document, or nothing.
     public var selection: WikiSelection?
+    public private(set) var backStack: [WikiSelection] = []
+    public private(set) var forwardStack: [WikiSelection] = []
+
+    public var canNavigateBack: Bool { !backStack.isEmpty }
+    public var canNavigateForward: Bool { !forwardStack.isEmpty }
 
     /// The removable list of ingested files (Phase 5). Like `summaries`, this is
     /// ALWAYS rebuilt from `store.listIngestedFiles()` after a change, never
@@ -58,6 +63,8 @@ public final class WikiStoreModel {
     /// What the drafts currently hold, so a flush saves the RIGHT document even
     /// after `selection` has advanced (§3.5 read-state-at-save-time).
     private var loadedSelection: WikiSelection?
+    private var isApplyingHistorySelection = false
+    private static let navigationHistoryLimit = 100
 
     public init(store: WikiStore) {
         self.store = store
@@ -76,6 +83,7 @@ public final class WikiStoreModel {
     public func select(_ newValue: WikiSelection?) {
         guard newValue != selection else { return }
         flushPendingSaves()
+        recordHistoryTransition(from: loadedSelection, to: newValue)
         selection = newValue
         loadDrafts(for: newValue)
     }
@@ -88,7 +96,25 @@ public final class WikiStoreModel {
     public func handleSelectionChange(to newValue: WikiSelection?) {
         guard newValue != loadedSelection else { return }
         flushPendingSaves()     // persists drafts to loadedSelection
+        recordHistoryTransition(from: loadedSelection, to: newValue)
         loadDrafts(for: newValue)
+    }
+
+    public func navigateBack() {
+        guard let destination = backStack.popLast() else { return }
+        if let current = loadedSelection {
+            forwardStack.append(current)
+        }
+        applyHistorySelection(destination)
+    }
+
+    public func navigateForward() {
+        guard let destination = forwardStack.popLast() else { return }
+        if let current = loadedSelection {
+            backStack.append(current)
+        }
+        trimBackStackIfNeeded()
+        applyHistorySelection(destination)
     }
 
     /// True if `title` resolves to an existing page. Drives the in-app preview's
@@ -143,6 +169,36 @@ public final class WikiStoreModel {
             draftBody = ""
             loadedPage = nil
         }
+    }
+
+    private func recordHistoryTransition(from oldValue: WikiSelection?, to newValue: WikiSelection?) {
+        guard !isApplyingHistorySelection, oldValue != newValue else { return }
+        if let oldValue {
+            backStack.append(oldValue)
+            trimBackStackIfNeeded()
+        }
+        forwardStack.removeAll()
+    }
+
+    private func applyHistorySelection(_ newValue: WikiSelection) {
+        guard newValue != selection else { return }
+        flushPendingSaves()
+        isApplyingHistorySelection = true
+        selection = newValue
+        loadDrafts(for: newValue)
+        isApplyingHistorySelection = false
+    }
+
+    private func trimBackStackIfNeeded() {
+        let overflow = backStack.count - Self.navigationHistoryLimit
+        if overflow > 0 {
+            backStack.removeFirst(overflow)
+        }
+    }
+
+    private func removeFromHistory(_ value: WikiSelection) {
+        backStack.removeAll { $0 == value }
+        forwardStack.removeAll { $0 == value }
     }
 
     // MARK: - Editing / autosave
@@ -274,8 +330,10 @@ public final class WikiStoreModel {
             // create-with-body wouldn't silently skip link indexing).
             try store.replaceLinks(from: page.id, parsedLinks: WikiLinkParser.parse(page.bodyMarkdown))
             reloadSummaries()
-            selection = .page(page.id)
-            loadDrafts(for: .page(page.id))
+            let newSelection = WikiSelection.page(page.id)
+            recordHistoryTransition(from: loadedSelection, to: newSelection)
+            selection = newSelection
+            loadDrafts(for: newSelection)
             onPageDidChange?()
         } catch {
             print("WikiStoreModel.newPage failed: \(error)")
@@ -299,6 +357,7 @@ public final class WikiStoreModel {
     public func delete(_ id: PageID) {
         do {
             try store.deletePage(id: id)
+            removeFromHistory(.page(id))
             if selection == .page(id) {
                 autosaveTask?.cancel()
                 autosaveTask = nil
@@ -404,6 +463,7 @@ public final class WikiStoreModel {
     public func deleteIngestedFile(_ id: PageID) {
         do {
             try store.deleteIngestedFile(id: id)
+            removeFromHistory(.ingestedFile(id))
             if selection == .ingestedFile(id) {
                 selection = nil
                 loadDrafts(for: nil)
@@ -476,6 +536,7 @@ public final class WikiStoreModel {
     public func reloadFromStore() {
         reloadSummaries()
         reloadIngestedFiles()
+        pruneHistoryToCurrentStore()
     }
 
     private func reloadSummaries() {
@@ -502,5 +563,27 @@ public final class WikiStoreModel {
             }
             return (file.id, hasLogEntry)
         })
+    }
+
+    private func pruneHistoryToCurrentStore() {
+        let pageIDs = Set(summaries.map(\.id))
+        let fileIDs = Set(ingestedFiles.map(\.id))
+        backStack.removeAll { !isAvailableHistorySelection($0, pageIDs: pageIDs, fileIDs: fileIDs) }
+        forwardStack.removeAll { !isAvailableHistorySelection($0, pageIDs: pageIDs, fileIDs: fileIDs) }
+    }
+
+    private func isAvailableHistorySelection(
+        _ value: WikiSelection,
+        pageIDs: Set<PageID>,
+        fileIDs: Set<PageID>
+    ) -> Bool {
+        switch value {
+        case .page(let id):
+            pageIDs.contains(id)
+        case .ingestedFile(let id):
+            fileIDs.contains(id)
+        case .systemPrompt, .changeLog:
+            true
+        }
     }
 }

--- a/Tests/WikiFSTests/NavigationHistoryTests.swift
+++ b/Tests/WikiFSTests/NavigationHistoryTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+@MainActor
+struct NavigationHistoryTests {
+
+    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-history-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        return (WikiStoreModel(store: store), store)
+    }
+
+    @Test func programmaticSelectionBuildsBackAndForwardHistory() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        model.reloadFromStore()
+
+        model.select(.page(a.id))
+        model.select(.page(b.id))
+        model.select(.page(c.id))
+
+        #expect(model.selection == .page(c.id))
+        #expect(model.canNavigateBack)
+        #expect(!model.canNavigateForward)
+
+        model.navigateBack()
+        #expect(model.selection == .page(b.id))
+        #expect(model.canNavigateForward)
+
+        model.navigateBack()
+        #expect(model.selection == .page(a.id))
+        #expect(!model.canNavigateBack)
+
+        model.navigateForward()
+        #expect(model.selection == .page(b.id))
+    }
+
+    @Test func listSelectionBuildsHistoryThroughChangeHandler() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.selection = .page(b.id)
+        model.handleSelectionChange(to: .page(b.id))
+
+        #expect(model.selection == .page(b.id))
+        model.navigateBack()
+        #expect(model.selection == .page(a.id))
+    }
+
+    @Test func wikiLinkSelectionParticipatesInHistory() throws {
+        let (model, store) = try tempModel()
+        let from = try store.createPage(title: "From")
+        let to = try store.createPage(title: "To")
+        model.reloadFromStore()
+
+        model.select(.page(from.id))
+        #expect(model.selectPage(byTitle: "To"))
+
+        #expect(model.selection == .page(to.id))
+        model.navigateBack()
+        #expect(model.selection == .page(from.id))
+    }
+
+    @Test func historyNavigationFlushesOutgoingDraft() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.select(.page(a.id))
+        model.select(.page(b.id))
+        model.draftBody = "edited before back"
+        model.bodyChanged()
+
+        model.navigateBack()
+        #expect(model.selection == .page(a.id))
+        #expect(try store.getPage(id: b.id).bodyMarkdown == "edited before back")
+    }
+
+    @Test func newSelectionClearsForwardHistory() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        model.reloadFromStore()
+
+        model.select(.page(a.id))
+        model.select(.page(b.id))
+        model.navigateBack()
+        #expect(model.canNavigateForward)
+
+        model.select(.page(c.id))
+        #expect(!model.canNavigateForward)
+    }
+
+    @Test func deletingSelectionRemovesItFromHistory() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.select(.page(a.id))
+        model.select(.page(b.id))
+        model.delete(a.id)
+
+        #expect(!model.canNavigateBack)
+    }
+
+    @Test func reloadPrunesExternallyDeletedHistoryItems() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.select(.page(a.id))
+        model.select(.page(b.id))
+        try store.deletePage(id: a.id)
+
+        model.reloadFromStore()
+
+        #expect(!model.canNavigateBack)
+    }
+}


### PR DESCRIPTION
## What changed
- Keep reader wiki links on Textual's per-fragment tap path by disabling the stale macOS document-selection overlay in rendered Markdown.
- Add per-wiki Back/Forward history shared by sidebar selection, wiki-link clicks, and page creation.
- Add toolbar chevrons with Cmd-[ and Cmd-] shortcuts.
- Prune deleted pages/files from navigation history and add regression coverage.

## Why
Links in the reader could stop showing the hand cursor and stop responding after navigation because Textual's AppKit document-selection overlay could hold stale hit-test state. The navigation history work also gives users standard browser-style recovery while moving through wiki pages.

## Validation
- make check
- swift test --filter WikiLink (40/40)
- swift test --filter NavigationHistory (7/7)
- swift test (344/344)
- make install
