### PR TITLE
[codex] Add wiki backup and restore

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -56,9 +56,13 @@ maintainer schema projected as `CLAUDE.md`/`AGENTS.md`. Agent runs stream live
 (tool calls + text, `--output-format stream-json`) with per-run backend
 `run.jsonl` logs and an editor edit-lock. **All five phases plus the post-completion
 features below are merged to `main` (single-branch repo, ready for developer
-handoff). 320 tests green; clean signed bundle (app + appex + `wikictl`).**
+handoff). 341 tests green; clean signed bundle (app + appex + `wikictl`).**
 
 **Post-completion features (also on `main`):**
+- **Wiki backup/restore management** — the wiki switcher can rename the active
+  wiki, export its checkpointed standalone SQLite file, and import a SQLite wiki
+  backup under a new display name/new ULID. Rename refreshes the File Provider
+  display name while preserving identity; export refuses to overwrite its source.
 - **Ingest model-tiering** — Ingest is now **Opus-curated**: Opus decides what goes
   in the wiki and writes every page; for a large source it fans out **2–19 Sonnet
   `source-reader` subagents** (via `claude -p --agents`) that only *digest* the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,32 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-16 — Wiki rename plus SQLite backup/restore
+
+- Added wiki-level management actions to the switcher menu: rename the active
+  wiki, export it as a `.sqlite` backup, and import a `.sqlite` backup as a new
+  wiki with a new display name.
+- `WikiManager.exportWiki(id:to:)` flushes pending active edits, checkpoints the
+  WAL into the main DB, copies a single portable SQLite file, and refuses to
+  overwrite the source backing database.
+- `WikiManager.importWiki(from:displayName:)` copies the selected SQLite file to
+  a fresh ULID-backed DB, opens it once to validate/migrate the schema, adds it
+  to the registry, registers its File Provider domain, and selects it.
+- Rename remains identity-stable (`<ulid>.sqlite` unchanged) and now refreshes
+  the File Provider domain display name so Finder can pick up the new label.
+- Added native macOS open/save panels for choosing backup files, plus an import
+  naming sheet that uses the existing compact `.headline`/body hierarchy.
+
+**Skill pass.** Before code: `swiftui-pro` kept stateful backup/restore logic in
+the existing `@MainActor @Observable` manager and left the switcher as a thin UI
+surface; `macos-design` put the actions in the wiki/account menu and used system
+file panels; `typography-designer` kept semantic system type rather than adding a
+new scale. After code: import/export are covered by manager tests, the UI uses
+native controls and SF Symbols, and rename/delete/import remain progressive
+wiki-level actions rather than page chrome.
+
+**Verified.** Full `swift test` passes (**341/341**) and `make check` passes.
+
 ## 2026-06-16 — Agent runs show quiet-live status and can be stopped inline
 
 - Diagnosed a Query run that appeared hung: the spawned `claude -p` process was

--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -151,6 +151,17 @@ final class FileProviderSpike {
         }
     }
 
+    /// Refresh a registered domain's display name after a wiki rename. The
+    /// identifier stays stable, so remove+add is cosmetic from the extension's
+    /// point of view: both old and new domains map to the same `<ulid>.sqlite`.
+    func renameDomain(id: String, displayName: String) async {
+        let wasActive = activeWikiID == id
+        await removeDomain(id: id)
+        if await registerDomain(id: id, displayName: displayName), wasActive {
+            await activate(id: id, displayName: displayName)
+        }
+    }
+
     /// Make `id` the active wiki for path/signal purposes and resolve its mount
     /// path. Called when the user switches wikis.
     func activate(id: String, displayName: String) async {

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -155,6 +155,9 @@ extension FileProviderSpike {
         manager.removeDomain = { [weak self] id in
             await self?.removeDomain(id: id)
         }
+        manager.renameDomain = { [weak self] id, name in
+            await self?.renameDomain(id: id, displayName: name)
+        }
         manager.onActiveStoreDidChange = { [weak self, weak manager] in
             guard let self, let manager else { return }
             // Re-point the freshly-swapped store's change hook at the active

--- a/Sources/WikiFS/WikiFilePanels.swift
+++ b/Sources/WikiFS/WikiFilePanels.swift
@@ -1,0 +1,33 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// Native macOS file panels for wiki backup/restore. Kept out of the switcher
+/// view so the menu stays declarative and testable manager logic stays in core.
+@MainActor
+enum WikiFilePanels {
+    private static var sqliteType: UTType {
+        UTType(filenameExtension: "sqlite") ?? .data
+    }
+
+    static func exportURL(defaultName: String) -> URL? {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [sqliteType]
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+        panel.nameFieldStringValue = "\(defaultName).sqlite"
+        panel.prompt = "Export"
+        panel.title = "Export Wiki Backup"
+        return panel.runModal() == .OK ? panel.url : nil
+    }
+
+    static func importURL() -> URL? {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [sqliteType]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.prompt = "Import"
+        panel.title = "Import Wiki Backup"
+        return panel.runModal() == .OK ? panel.url : nil
+    }
+}

--- a/Sources/WikiFS/WikiSwitcher.swift
+++ b/Sources/WikiFS/WikiSwitcher.swift
@@ -17,6 +17,9 @@ struct WikiSwitcher: View {
     @State private var renameTarget: WikiDescriptor?
     @State private var renameText = ""
     @State private var deleteTarget: WikiDescriptor?
+    @State private var importSourceURL: URL?
+    @State private var importWikiName = ""
+    @State private var failureMessage: String?
 
     var body: some View {
         Menu {
@@ -41,9 +44,18 @@ struct WikiSwitcher: View {
                     renameText = active.displayName
                     renameTarget = active
                 }
+                Button("Export “\(active.displayName)”…", systemImage: "square.and.arrow.up") {
+                    exportWiki(active)
+                }
                 Button("Delete “\(active.displayName)”…", systemImage: "trash", role: .destructive) {
                     deleteTarget = active
                 }
+            }
+
+            Divider()
+
+            Button("Import Wiki Backup…", systemImage: "square.and.arrow.down") {
+                importWiki()
             }
         } label: {
             HStack(spacing: 6) {
@@ -68,8 +80,20 @@ struct WikiSwitcher: View {
             TextField("Name", text: $renameText)
             Button("Cancel", role: .cancel) { renameTarget = nil }
             Button("Rename") {
-                manager.renameWiki(id: target.id, to: renameText)
+                Task { await manager.renameWiki(id: target.id, to: renameText) }
                 renameTarget = nil
+            }
+        }
+        .sheet(isPresented: importPresented) {
+            ImportWikiSheet(name: $importWikiName) { name in
+                guard let sourceURL = importSourceURL else { return }
+                Task {
+                    do {
+                        _ = try await manager.importWiki(from: sourceURL, displayName: name)
+                    } catch {
+                        failureMessage = String(describing: error)
+                    }
+                }
             }
         }
         .alert("Delete Wiki?", isPresented: deletePresented, presenting: deleteTarget) { target in
@@ -80,6 +104,11 @@ struct WikiSwitcher: View {
             }
         } message: { target in
             Text("“\(target.displayName)” and all its pages, files, and its filesystem mount will be permanently deleted. This cannot be undone.")
+        }
+        .alert("Wiki Operation Failed", isPresented: failurePresented) {
+            Button("OK", role: .cancel) { failureMessage = nil }
+        } message: {
+            Text(failureMessage ?? "An unknown error occurred.")
         }
     }
 
@@ -98,6 +127,37 @@ struct WikiSwitcher: View {
 
     private var deletePresented: Binding<Bool> {
         Binding(get: { deleteTarget != nil }, set: { if !$0 { deleteTarget = nil } })
+    }
+
+    private var importPresented: Binding<Bool> {
+        Binding(
+            get: { importSourceURL != nil },
+            set: {
+                if !$0 {
+                    importSourceURL = nil
+                    importWikiName = ""
+                }
+            }
+        )
+    }
+
+    private var failurePresented: Binding<Bool> {
+        Binding(get: { failureMessage != nil }, set: { if !$0 { failureMessage = nil } })
+    }
+
+    private func exportWiki(_ wiki: WikiDescriptor) {
+        guard let destinationURL = WikiFilePanels.exportURL(defaultName: wiki.displayName) else { return }
+        do {
+            try manager.exportWiki(id: wiki.id, to: destinationURL)
+        } catch {
+            failureMessage = String(describing: error)
+        }
+    }
+
+    private func importWiki() {
+        guard let sourceURL = WikiFilePanels.importURL() else { return }
+        importSourceURL = sourceURL
+        importWikiName = sourceURL.deletingPathExtension().lastPathComponent
     }
 }
 
@@ -135,6 +195,43 @@ private struct NewWikiSheet: View {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         onCreate(trimmed)
+        dismiss()
+    }
+}
+
+/// Names a restored wiki after the user chooses a SQLite backup. The source file
+/// already exists; this sheet only asks for the new display name.
+private struct ImportWikiSheet: View {
+    @Binding var name: String
+    let onImport: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Import Wiki Backup")
+                .font(.headline)
+
+            TextField("Wiki name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 260)
+                .onSubmit(importBackup)
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Import", action: importBackup)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(20)
+    }
+
+    private func importBackup() {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onImport(trimmed)
         dismiss()
     }
 }

--- a/Sources/WikiFSCore/WikiManager.swift
+++ b/Sources/WikiFSCore/WikiManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SQLite3
 
 /// Owns the multi-wiki foundation at the app layer (`plans/llm-wiki.md` Phase 0):
 /// the registry of wikis, the currently-active store/model, and the create /
@@ -41,6 +42,8 @@ public final class WikiManager {
     /// `removeDomain(id:)` tears it down on delete.
     @ObservationIgnored public var registerDomain: ((_ id: String, _ displayName: String) async -> Void)?
     @ObservationIgnored public var removeDomain: ((_ id: String) async -> Void)?
+    /// Update a wiki domain's user-visible display name. Identity stays the ULID.
+    @ObservationIgnored public var renameDomain: ((_ id: String, _ displayName: String) async -> Void)?
 
     /// Invoked after the active store swaps (select / create / migrate). The app
     /// re-wires `onPageDidChange` to the new store's File Provider signaling.
@@ -146,14 +149,62 @@ public final class WikiManager {
         openActive(id)
     }
 
-    /// Rename a wiki: change ONLY its display name (identity/DB/domain untouched).
-    public func renameWiki(id: String, to displayName: String) {
+    /// Rename a wiki: change ONLY its display name (identity/DB untouched).
+    public func renameWiki(id: String, to displayName: String) async {
         let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         var registry = WikiRegistry.load(from: containerDirectory)
         registry.rename(id: id, to: trimmed)
         try? registry.save(to: containerDirectory)
         wikis = registry.wikis
+        await renameDomain?(id, trimmed)
+    }
+
+    /// Export one wiki as a single SQLite file. A WAL checkpoint runs first so
+    /// the copied `.sqlite` contains the latest committed pages, files, prompt,
+    /// index, and log without requiring `-wal` / `-shm` sidecars.
+    public func exportWiki(id: String, to destinationURL: URL) throws {
+        guard descriptorExists(id) else { throw WikiManagerError.unknownWiki(id) }
+        if id == activeWikiID { activeStore?.flushPendingSaves() }
+        let sourceURL = databaseURL(forWikiID: id)
+        guard sourceURL.standardizedFileURL != destinationURL.standardizedFileURL else {
+            throw WikiManagerError.exportWouldOverwriteSource
+        }
+        try checkpointDatabase(at: sourceURL)
+
+        let fm = FileManager.default
+        if fm.fileExists(atPath: destinationURL.path) {
+            try fm.removeItem(at: destinationURL)
+        }
+        try fm.copyItem(at: sourceURL, to: destinationURL)
+    }
+
+    /// Import a standalone SQLite wiki file as a new wiki with a new ULID and a
+    /// caller-provided display name. The source file is copied, opened once to
+    /// validate/migrate it, registered, and selected.
+    @discardableResult
+    public func importWiki(from sourceURL: URL, displayName: String) async throws -> WikiDescriptor {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw WikiManagerError.emptyDisplayName }
+
+        let descriptor = WikiDescriptor.make(displayName: trimmed)
+        let destinationURL = databaseURL(forWikiID: descriptor.id)
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+            _ = try makeStore(destinationURL)
+        } catch {
+            deleteDatabaseFiles(forWikiID: descriptor.id)
+            throw error
+        }
+
+        var registry = WikiRegistry.load(from: containerDirectory)
+        registry.add(descriptor)
+        try registry.save(to: containerDirectory)
+        wikis = registry.wikis
+
+        await registerDomain?(descriptor.id, descriptor.displayName)
+        select(descriptor.id)
+        return descriptor
     }
 
     /// Delete a wiki: remove its File Provider domain, its registry entry, and its
@@ -229,6 +280,25 @@ public final class WikiManager {
     private func makeModelIfEmpty(_ store: WikiStore) -> WikiStoreModel? {
         let model = WikiStoreModel(store: store)
         return model.summaries.isEmpty ? model : nil
+    }
+
+    /// Force any committed WAL pages back into the main database file so backup
+    /// export can be a single portable `.sqlite` file.
+    private func checkpointDatabase(at url: URL) throws {
+        var handle: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        let rc = sqlite3_open_v2(url.path, &handle, flags, nil)
+        guard rc == SQLITE_OK, let handle else {
+            let message = handle.map { String(cString: sqlite3_errmsg($0)) } ?? "rc \(rc)"
+            if let handle { sqlite3_close(handle) }
+            throw WikiManagerError.sqlite(message)
+        }
+        defer { sqlite3_close(handle) }
+
+        let checkpoint = sqlite3_exec(handle, "PRAGMA wal_checkpoint(TRUNCATE);", nil, nil, nil)
+        guard checkpoint == SQLITE_OK else {
+            throw WikiManagerError.sqlite(String(cString: sqlite3_errmsg(handle)))
+        }
     }
 
     // MARK: - v0 migration

--- a/Sources/WikiFSCore/WikiManagerError.swift
+++ b/Sources/WikiFSCore/WikiManagerError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum WikiManagerError: Error, Equatable, CustomStringConvertible {
+    case emptyDisplayName
+    case exportWouldOverwriteSource
+    case sqlite(String)
+    case unknownWiki(String)
+
+    public var description: String {
+        switch self {
+        case .emptyDisplayName:
+            return "Wiki name cannot be empty."
+        case .exportWouldOverwriteSource:
+            return "Choose a backup location outside the wiki's backing database file."
+        case .sqlite(let message):
+            return "SQLite checkpoint failed: \(message)"
+        case .unknownWiki(let id):
+            return "No wiki exists with id \(id)."
+        }
+    }
+}

--- a/Tests/WikiFSTests/WikiManagerTests.swift
+++ b/Tests/WikiFSTests/WikiManagerTests.swift
@@ -117,11 +117,90 @@ struct WikiManagerTests {
         let path = dir.appendingPathComponent("\(id).sqlite").path
         #expect(FileManager.default.fileExists(atPath: path))
 
-        manager.renameWiki(id: id, to: "Renamed")
+        await manager.renameWiki(id: id, to: "Renamed")
         // Same file, same id — only the label changed.
         #expect(FileManager.default.fileExists(atPath: path))
         #expect(manager.activeWikiID == id)
         #expect(manager.wikis.first { $0.id == id }?.displayName == "Renamed")
+    }
+
+    @Test func renameRefreshesTheFileProviderDomainName() async throws {
+        let manager = WikiManager(containerDirectory: tempDirectory())
+        manager.bootstrap()
+        let id = try #require(manager.activeWikiID)
+        var renamedDomain: (id: String, displayName: String)?
+        manager.renameDomain = { id, displayName in
+            renamedDomain = (id, displayName)
+        }
+
+        await manager.renameWiki(id: id, to: "Readable Name")
+
+        #expect(renamedDomain?.id == id)
+        #expect(renamedDomain?.displayName == "Readable Name")
+    }
+
+    // MARK: - Backup / restore
+
+    @Test func exportWritesAPortableSQLiteFileWithCurrentContent() throws {
+        let dir = tempDirectory()
+        let manager = WikiManager(containerDirectory: dir)
+        manager.bootstrap()
+        let id = try #require(manager.activeWikiID)
+
+        manager.activeStore?.newPage(title: "Exported Page")
+        manager.activeStore?.draftBody = "backup body"
+        manager.activeStore?.flushPendingSaves()
+
+        let backupURL = dir.appendingPathComponent("backup.sqlite")
+        try manager.exportWiki(id: id, to: backupURL)
+
+        let restoredStore = try SQLiteWikiStore(databaseURL: backupURL)
+        let resolvedPageID = try restoredStore.resolveTitleToID("Exported Page")
+        let pageID = try #require(resolvedPageID)
+        let page = try restoredStore.getPage(id: pageID)
+        #expect(page.bodyMarkdown == "backup body")
+    }
+
+    @Test func exportRefusesToOverwriteTheSourceDatabase() throws {
+        let dir = tempDirectory()
+        let manager = WikiManager(containerDirectory: dir)
+        manager.bootstrap()
+        let id = try #require(manager.activeWikiID)
+        let sourceURL = dir.appendingPathComponent("\(id).sqlite")
+
+        #expect(throws: WikiManagerError.exportWouldOverwriteSource) {
+            try manager.exportWiki(id: id, to: sourceURL)
+        }
+        #expect(FileManager.default.fileExists(atPath: sourceURL.path))
+    }
+
+    @Test func importCopiesSQLiteFileAsANewNamedWiki() async throws {
+        let dir = tempDirectory()
+        let manager = WikiManager(containerDirectory: dir)
+        manager.bootstrap()
+        let originalID = try #require(manager.activeWikiID)
+
+        manager.activeStore?.newPage(title: "Restored Page")
+        manager.activeStore?.draftBody = "restored body"
+        manager.activeStore?.flushPendingSaves()
+
+        let backupURL = dir.appendingPathComponent("restore-source.sqlite")
+        try manager.exportWiki(id: originalID, to: backupURL)
+
+        let imported = try await manager.importWiki(from: backupURL, displayName: "Restored Wiki")
+
+        #expect(imported.id != originalID)
+        #expect(imported.displayName == "Restored Wiki")
+        #expect(manager.activeWikiID == imported.id)
+        #expect(manager.wikis.first?.id == imported.id)
+        #expect(FileManager.default.fileExists(
+            atPath: dir.appendingPathComponent("\(imported.id).sqlite").path))
+
+        let restoredPage = try #require(manager.activeStore?.summaries.first {
+            $0.title == "Restored Page"
+        })
+        manager.activeStore?.select(.page(restoredPage.id))
+        #expect(manager.activeStore?.draftBody == "restored body")
     }
 
     // MARK: - v0 migration: legacy WikiFS.sqlite becomes wiki #1, content intact


### PR DESCRIPTION
## Summary

Adds wiki-level backup and restore management to the macOS app.

- Rename now refreshes the File Provider domain display name while preserving the stable wiki ULID and backing database filename.
- Export writes a standalone `.sqlite` backup after flushing pending edits and checkpointing WAL contents into the main database file.
- Import restores a selected SQLite wiki file under a new display name and fresh ULID, registers its File Provider domain, and selects it.
- The wiki switcher now exposes Rename, Export, Import, and Delete as compact wiki/account-level actions using native macOS panels.

## Why

Users need a straightforward backup/restore path for individual wikis, plus the ability to rename a wiki without breaking identity, database lookup, or the File Provider mount.

## Validation

- `swift test` passed: 341/341
- `make check` passed
