### PR TITLE
feat: collapsible sidebar sections + page sort order

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,15 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-18 — Collapsible sidebar sections + page sort order
+
+All four sidebar sections (Tools, System, Pages, Files) are now collapsible via
+chevron toggles. The Pages section gains a sort Picker: Last Updated, Newest
+First, Title A–Z. `WikiPageSummary` now carries `createdAt`. `WikiStore.listPages()`
+accepts a `PageSortOrder` parameter; `WikiStoreModel` holds the user's preference
+and `currentStateSnapshot()` always passes `.lastUpdated` so the agent prompt is
+stable regardless of sidebar sort. 441 tests green. PR #12.
+
 ## 2026-06-18 — PDF extraction pipeline: PdfExtractionService + pdf2md integration
 
 Add pdf2md to integrate docling/granite-docling VLM/spacy pipeline to convert PDF to markdown without going through Claude.  Refactor the ingestion UI to show PDF conversion and ingestion results.

--- a/Sources/WikiCtlCore/PageCommand.swift
+++ b/Sources/WikiCtlCore/PageCommand.swift
@@ -66,7 +66,7 @@ public enum PageCommand {
     // MARK: - list
 
     private static func list(in store: WikiStore, json: Bool) throws -> Result {
-        let summaries = try store.listPages()
+        let summaries = try store.listPages(sortBy: .lastUpdated)
         if json {
             let rows = summaries.map { summary in
                 JSONRow(

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -17,6 +17,11 @@ struct SidebarView: View {
     @State private var showingAddFromURL = false
     /// Drives the "Add from Zotero…" sheet (browse the library → ingested file).
     @State private var showingAddFromZotero = false
+    /// Whether the "Pages" section is expanded. Pure UI state — not persisted.
+    @State private var isPagesExpanded = true
+    @State private var isToolsExpanded = true
+    @State private var isSystemExpanded = true
+    @State private var isFilesExpanded = true
 
     var body: some View {
         List(selection: $store.selection) {
@@ -25,63 +30,142 @@ struct SidebarView: View {
             WikiSwitcher(manager: manager)
                 .listRowSeparator(.hidden)
 
-            Section("Tools") {
-                SidebarModeRow(
-                    title: "Query",
-                    subtitle: "Ask or update",
-                    systemImage: "bubble.left.and.text.bubble.right"
-                )
-                .tag(WikiSelection.query)
-                .help("Ask questions and decide whether Claude should update the wiki")
+            Section {
+                if isToolsExpanded {
+                    SidebarModeRow(
+                        title: "Query",
+                        subtitle: "Ask or update",
+                        systemImage: "bubble.left.and.text.bubble.right"
+                    )
+                    .tag(WikiSelection.query)
+                    .help("Ask questions and decide whether Claude should update the wiki")
+                }
+            } header: {
+                HStack(spacing: 4) {
+                    Image(systemName: isToolsExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Tools")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isToolsExpanded.toggle()
+                    }
+                }
             }
 
-            Section("System") {
-                SidebarModeRow(
-                    title: "Activity",
-                    subtitle: "Operation log",
-                    systemImage: "clock.arrow.circlepath"
-                )
-                .tag(WikiSelection.changeLog)
-                .help("Operation history, projected read-only as log.md")
+            Section {
+                if isSystemExpanded {
+                    SidebarModeRow(
+                        title: "Activity",
+                        subtitle: "Operation log",
+                        systemImage: "clock.arrow.circlepath"
+                    )
+                    .tag(WikiSelection.changeLog)
+                    .help("Operation history, projected read-only as log.md")
 
-                SidebarModeRow(
-                    title: "Instructions",
-                    subtitle: "Agent prompt",
-                    systemImage: "sparkles"
-                )
-                .tag(WikiSelection.systemPrompt)
-                .help("Agent instructions, projected read-only as CLAUDE.md and AGENTS.md")
+                    SidebarModeRow(
+                        title: "Instructions",
+                        subtitle: "Agent prompt",
+                        systemImage: "sparkles"
+                    )
+                    .tag(WikiSelection.systemPrompt)
+                    .help("Agent instructions, projected read-only as CLAUDE.md and AGENTS.md")
+                }
+            } header: {
+                HStack(spacing: 4) {
+                    Image(systemName: isSystemExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("System")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isSystemExpanded.toggle()
+                    }
+                }
             }
 
-            Section("Pages") {
-                ForEach(store.summaries) { summary in
-                    SidebarPageRow(summary: summary)
-                        .tag(WikiSelection.page(summary.id))
-                        .contextMenu {
-                            Button("Rename") { beginRename(summary) }
-                            Button("Delete", role: .destructive) { store.delete(summary.id) }
+            Section {
+                if isPagesExpanded {
+                    ForEach(store.summaries) { summary in
+                        SidebarPageRow(summary: summary)
+                            .tag(WikiSelection.page(summary.id))
+                            .contextMenu {
+                                Button("Rename") { beginRename(summary) }
+                                Button("Delete", role: .destructive) { store.delete(summary.id) }
+                            }
+                            .swipeActions(edge: .trailing) {
+                                Button("Delete", role: .destructive) { store.delete(summary.id) }
+                            }
+                    }
+                }
+            } header: {
+                HStack(spacing: 0) {
+                    HStack(spacing: 4) {
+                        Image(systemName: isPagesExpanded ? "chevron.down" : "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("Pages")
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isPagesExpanded.toggle()
                         }
-                        .swipeActions(edge: .trailing) {
-                            Button("Delete", role: .destructive) { store.delete(summary.id) }
-                        }
+                    }
+                    Spacer()
+                    Picker("Sort", selection: $store.pageSortOrder) {
+                        Text("Last Updated").tag(PageSortOrder.lastUpdated)
+                        Text("Newest First").tag(PageSortOrder.newestFirst)
+                        Text("Title A–Z").tag(PageSortOrder.titleAZ)
+                    }
+                    .pickerStyle(.menu)
+                    .buttonStyle(.borderless)
+                    .labelsHidden()
+                    .fixedSize()
+                    .help("Sort pages by date or title")
                 }
             }
             // Files are most-recently-added first (the store orders by created_at
             // DESC). Selecting one opens a detail pane with direct ingest controls.
             if !store.ingestedFiles.isEmpty {
                 Section {
-                    ForEach(store.ingestedFiles) { file in
-                        IngestedFileRow(
-                            file: file,
-                            hasBeenIngested: store.hasIngestedFile(file),
-                            onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
-                            onRemove: { store.deleteIngestedFile(file.id) }
-                        )
-                        .tag(WikiSelection.ingestedFile(file.id))
+                    if isFilesExpanded {
+                        ForEach(store.ingestedFiles) { file in
+                            IngestedFileRow(
+                                file: file,
+                                hasBeenIngested: store.hasIngestedFile(file),
+                                onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
+                                onRemove: { store.deleteIngestedFile(file.id) }
+                            )
+                            .tag(WikiSelection.ingestedFile(file.id))
+                        }
                     }
                 } header: {
-                    HStack {
-                        Text("Files")
+                    HStack(spacing: 0) {
+                        HStack(spacing: 4) {
+                            Image(systemName: isFilesExpanded ? "chevron.down" : "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text("Files")
+                                .font(.headline)
+                                .foregroundStyle(.primary)
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                isFilesExpanded.toggle()
+                            }
+                        }
                         Spacer()
                         if isZoteroConfigured {
                             Button("Add from Zotero…", systemImage: "books.vertical") {

--- a/Sources/WikiFSCore/PageSortOrder.swift
+++ b/Sources/WikiFSCore/PageSortOrder.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Sort criteria for the sidebar page list.
+/// `rawValue` matches the case name so the enum is trivially `Codable`
+/// should we later persist the preference.
+public enum PageSortOrder: String, CaseIterable, Sendable {
+    /// Most recently edited first (`updated_at DESC`).
+    case lastUpdated
+    /// Most recently created first (`created_at DESC`).
+    case newestFirst
+    /// Case-insensitive alphabetical (`title COLLATE NOCASE ASC`).
+    case titleAZ
+}

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -253,17 +253,27 @@ public final class SQLiteWikiStore: WikiStore {
 
     // MARK: - WikiStore
 
-    public func listPages() throws -> [WikiPageSummary] {
-        let stmt = try statement(
-            "SELECT id, title, updated_at FROM pages ORDER BY updated_at DESC;"
-        )
+    public func listPages(sortBy: PageSortOrder) throws -> [WikiPageSummary] {
+        let orderClause: String
+        switch sortBy {
+        case .lastUpdated:
+            orderClause = "ORDER BY updated_at DESC"
+        case .newestFirst:
+            orderClause = "ORDER BY created_at DESC"
+        case .titleAZ:
+            orderClause = "ORDER BY title COLLATE NOCASE ASC"
+        }
+
+        let sql = "SELECT id, title, updated_at, created_at FROM pages \(orderClause);"
+        let stmt = try statement(sql)
         defer { stmt.reset() }
         var out: [WikiPageSummary] = []
         while try stmt.step() {
             out.append(WikiPageSummary(
                 id: PageID(rawValue: stmt.text(at: 0)),
                 title: stmt.text(at: 1),
-                updatedAt: Date(timeIntervalSince1970: stmt.double(at: 2))
+                updatedAt: Date(timeIntervalSince1970: stmt.double(at: 2)),
+                createdAt: Date(timeIntervalSince1970: stmt.double(at: 3))
             ))
         }
         return out

--- a/Sources/WikiFSCore/WikiPageSummary.swift
+++ b/Sources/WikiFSCore/WikiPageSummary.swift
@@ -7,10 +7,12 @@ public struct WikiPageSummary: Identifiable, Hashable, Sendable {
     public let id: PageID
     public let title: String
     public let updatedAt: Date
+    public let createdAt: Date
 
-    public init(id: PageID, title: String, updatedAt: Date) {
+    public init(id: PageID, title: String, updatedAt: Date, createdAt: Date) {
         self.id = id
         self.title = title
         self.updatedAt = updatedAt
+        self.createdAt = createdAt
     }
 }

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -23,8 +23,8 @@ public enum WikiStoreError: Error, CustomStringConvertible {
 /// implementation is the source of truth; the Phase 2 File Provider extension
 /// will adopt a read-only subset (`WikiReadStore`) of this.
 public protocol WikiStore {
-    /// Page summaries ordered by `updated_at` DESC (most-recently-edited first).
-    func listPages() throws -> [WikiPageSummary]
+    /// Page summaries ordered by the given sort criterion.
+    func listPages(sortBy: PageSortOrder) throws -> [WikiPageSummary]
     func getPage(id: PageID) throws -> WikiPage
     func createPage(title: String) throws -> WikiPage
     func updatePage(id: PageID, title: String, body: String) throws

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -15,6 +15,13 @@ import Observation
 @Observable
 public final class WikiStoreModel {
     public private(set) var summaries: [WikiPageSummary] = []
+    /// Sort order for the sidebar pages list. Changing this triggers a reload.
+    public var pageSortOrder: PageSortOrder = .lastUpdated {
+        didSet {
+            guard pageSortOrder != oldValue else { return }
+            reloadSummaries()
+        }
+    }
     /// The sidebar selection: a page, the system-prompt document, or nothing.
     public var selection: WikiSelection?
     public private(set) var backStack: [WikiSelection] = []
@@ -520,7 +527,7 @@ public final class WikiStoreModel {
     /// read failure degrades to an emptier-but-valid snapshot rather than blocking
     /// the run.
     public func currentStateSnapshot() -> WikiStateSnapshot {
-        let titles = ((try? store.listPages()) ?? []).map(\.title)
+        let titles = ((try? store.listPages(sortBy: .lastUpdated)) ?? []).map(\.title)
         let indexBody = (try? store.getWikiIndex())?.body ?? WikiIndex.defaultBody
         let logEntries = (try? store.recentLogEntries(limit: WikiStateSnapshot.maxLogEntries)) ?? []
         // Render each tail entry with the SAME formatter the `log.md` projection
@@ -565,8 +572,12 @@ public final class WikiStoreModel {
         pruneHistoryToCurrentStore()
     }
 
-    private func reloadSummaries() {
-        summaries = (try? store.listPages()) ?? []
+    /// Rebuild the sidebar page list from the store using the current sort order.
+    /// Public so `SidebarView` can trigger a reload when the sort picker changes
+    /// (via the `pageSortOrder` didSet), and so the Phase A change bridge can
+    /// refresh after an external write.
+    public func reloadSummaries() {
+        summaries = (try? store.listPages(sortBy: pageSortOrder)) ?? []
     }
 
     private func reloadIngestedFiles() {

--- a/Tests/WikiFSTests/NavigationHistoryTests.swift
+++ b/Tests/WikiFSTests/NavigationHistoryTests.swift
@@ -144,4 +144,45 @@ struct NavigationHistoryTests {
 
         #expect(!model.canNavigateBack)
     }
+
+    // MARK: - Sort order integration
+
+    @Test func changingSortOrderReloadsSummaries() throws {
+        let (model, store) = try tempModel()
+        _ = try store.createPage(title: "Banana")
+        Thread.sleep(forTimeInterval: 0.002)
+        _ = try store.createPage(title: "apple")
+        model.reloadFromStore()
+
+        // Default: lastUpdated — both pages have the same updated_at,
+        // so we just verify two pages are loaded.
+        #expect(model.summaries.count == 2)
+
+        // Switch to title A–Z: "apple" then "Banana" (case-insensitive).
+        model.pageSortOrder = .titleAZ
+        #expect(model.summaries.map(\.title) == ["apple", "Banana"])
+
+        // Switch back to lastUpdated.
+        model.pageSortOrder = .lastUpdated
+        #expect(model.summaries.count == 2)
+    }
+
+    @Test func snapshotIgnoresSortPreference() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        Thread.sleep(forTimeInterval: 0.002)
+        let b = try store.createPage(title: "B")
+        // Touch A so it becomes most-recently-edited under lastUpdated.
+        try store.updatePage(id: a.id, title: "A", body: "edited")
+        model.reloadFromStore()
+
+        // User sorts by title A–Z in the sidebar.
+        model.pageSortOrder = .titleAZ
+
+        // Snapshot must still report titles most-recently-edited first.
+        let snapshot = model.currentStateSnapshot()
+        // A was edited last, so it should sort first in the snapshot
+        // regardless of the sidebar's titleAZ preference.
+        #expect(snapshot.pageTitles.first == "A")
+    }
 }

--- a/Tests/WikiFSTests/PageUpsertTests.swift
+++ b/Tests/WikiFSTests/PageUpsertTests.swift
@@ -33,7 +33,7 @@ struct PageUpsertTests {
         // Same page resolved by title, not a second one.
         #expect(updated.id == created.id)
         #expect(try store.getPage(id: created.id).bodyMarkdown == "v2")
-        #expect(try store.listPages().count == 1)
+        #expect(try store.listPages(sortBy: .lastUpdated).count == 1)
     }
 
     @Test func upsertByExplicitIDUpdatesThatPage() throws {

--- a/Tests/WikiFSTests/ReadOnlyStoreTests.swift
+++ b/Tests/WikiFSTests/ReadOnlyStoreTests.swift
@@ -28,7 +28,7 @@ struct ReadOnlyStoreTests {
         #expect(page.title == "Home")
         #expect(page.bodyMarkdown == "# Welcome\n\nlive body")
 
-        let summaries = try reader.listPages()
+        let summaries = try reader.listPages(sortBy: .lastUpdated)
         #expect(summaries.contains { $0.id == id })
 
         let all = try reader.listAllPagesOrderedByID()

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -68,7 +68,7 @@ struct SQLiteWikiStoreTests {
         #expect(userVersion == "6")
         let reopened = try SQLiteWikiStore(databaseURL: url)
         // If bootstrap weren't guarded, the CREATE TABLE would throw here.
-        #expect((try? reopened.listPages()) != nil)
+        #expect((try? reopened.listPages(sortBy: .lastUpdated)) != nil)
         _ = store  // keep first store alive through the test
     }
 
@@ -97,9 +97,51 @@ struct SQLiteWikiStoreTests {
         let b = try store.createPage(title: "B")
         // Touch A last so it should sort first.
         try store.updatePage(id: a.id, title: "A", body: "later edit")
-        let summaries = try store.listPages()
+        let summaries = try store.listPages(sortBy: .lastUpdated)
         #expect(summaries.first?.id == a.id)
         #expect(summaries.contains { $0.id == b.id })
+    }
+
+    @Test func listPagesOrdersByNewestFirst() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        // Insert a tiny sleep so the two pages get distinct created_at timestamps.
+        let a = try store.createPage(title: "A")
+        Thread.sleep(forTimeInterval: 0.002)
+        let b = try store.createPage(title: "B")
+        // B was created later, so it should sort first under newestFirst.
+        let summaries = try store.listPages(sortBy: .newestFirst)
+        #expect(summaries.first?.id == b.id)
+        #expect(summaries.last?.id == a.id)
+    }
+
+    @Test func listPagesOrdersByTitleAZ() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        _ = try store.createPage(title: "Banana")
+        _ = try store.createPage(title: "apple")
+        _ = try store.createPage(title: "Cherry")
+        let summaries = try store.listPages(sortBy: .titleAZ)
+        // Case-insensitive: "apple" < "Banana" < "Cherry"
+        #expect(summaries.map(\.title) == ["apple", "Banana", "Cherry"])
+    }
+
+    @Test func listPagesDefaultIsLastUpdated() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let a = try store.createPage(title: "A")
+        _ = try store.createPage(title: "B")
+        try store.updatePage(id: a.id, title: "A", body: "later edit")
+        // The explicit .lastUpdated call must match the existing ordering expectation.
+        let summaries = try store.listPages(sortBy: .lastUpdated)
+        #expect(summaries.count == 2)
+        #expect(summaries.first?.id == a.id)
+    }
+
+    @Test func pageSortOrderAllCases() {
+        // Guard against accidental reorder / removal.
+        let cases = PageSortOrder.allCases
+        #expect(cases.count == 3)
+        #expect(cases.contains(.lastUpdated))
+        #expect(cases.contains(.newestFirst))
+        #expect(cases.contains(.titleAZ))
     }
 
     // MARK: - Change token (Phase 3 sync anchor)

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -160,7 +160,7 @@ struct WikiCtlCommandTests {
         let id = PageID(rawValue: created.output)
         let result = try PageCommand.run(.delete(id: id), in: store)
         #expect(result.didCommit)
-        #expect(try store.listPages().isEmpty)
+        #expect(try store.listPages(sortBy: .lastUpdated).isEmpty)
     }
 
     // MARK: - Darwin notification naming

--- a/Tests/WikiFSTests/WikiLinkStoreTests.swift
+++ b/Tests/WikiFSTests/WikiLinkStoreTests.swift
@@ -141,6 +141,6 @@ struct WikiLinkStoreTests {
 
         // Deleting A (the former link source) must also succeed.
         try store.deletePage(id: a.id)
-        #expect(try store.listPages().isEmpty)
+        #expect(try store.listPages(sortBy: .lastUpdated).isEmpty)
     }
 }


### PR DESCRIPTION
Collapsible sidebar sections (Tools, System, Pages, Files) with chevron toggles. Pages section gets a sort Picker: Last Updated, Newest First, Title A-Z. 441 tests passing. See commit 372d49b for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)