### PR TITLE
fix: surface open-file errors in IngestedFileDetailView

### DIFF
--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -227,6 +227,7 @@ final class FileProviderSpike {
     /// drift), then hands it to `NSWorkspace`. URL asked at click time.
     func openIngestedFile(id: PageID) async {
         DebugLog.agent("openIngestedFile: id=\(id.rawValue) activeWiki=\(activeWikiID ?? "nil")")
+        status = ""   // clear any stale error from a prior attempt
         guard let wikiID = activeWikiID else {
             DebugLog.agent("openIngestedFile: ABORT — no active wiki")
             status = "Can’t open file — no active wiki."

--- a/Sources/WikiFS/IngestedFileDetailView.swift
+++ b/Sources/WikiFS/IngestedFileDetailView.swift
@@ -10,6 +10,7 @@ struct IngestedFileDetailView: View {
     /// True while THIS file's ingest is in flight (local conversion + agent run).
     let isIngesting: Bool
     let isRunning: Bool
+    let fileProvider: FileProviderSpike
     let onOpen: () -> Void
     let onIngest: () -> Void
 
@@ -40,7 +41,16 @@ struct IngestedFileDetailView: View {
                            systemImage: "text.badge.plus", action: onIngest)
                         .keyboardShortcut(.return, modifiers: .command)
                         .disabled(isRunning || isIngesting)
-                    Button("Open File", systemImage: "arrow.up.forward.app", action: onOpen)
+                    Button("Open File", systemImage: "arrow.up.forward.app") {
+                        DebugLog.agent("IngestedFileDetailView: Open File tapped — id=\(file.id.rawValue)")
+                        onOpen()
+                    }
+                }
+
+                if !fileProvider.status.isEmpty, fileProvider.status != "Not registered" {
+                    Label(fileProvider.status, systemImage: "exclamationmark.triangle")
+                        .font(.callout)
+                        .foregroundStyle(.orange)
                 }
             }
             .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -45,6 +45,7 @@ struct WikiDetailView: View {
                     hasBeenIngested: store.hasIngestedFile(file),
                     isIngesting: launcher.ingestingFileID == file.id,
                     isRunning: launcher.isRunning,
+                    fileProvider: fileProvider,
                     onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
                     onIngest: { onIngestFile(file.id) }
                 )


### PR DESCRIPTION
The Open File button called `fileProvider.openIngestedFile()` which sets status on failure but `IngestedFileDetailView` never showed it, so errors were invisible — the button appeared to do nothing.

**Fixes:**
- `IngestedFileDetailView` now accepts `fileProvider` and displays its `status` as an orange warning
- `openIngestedFile()` resets `status` on entry so a successful open clears stale errors
- `DebugLog.agent` call on button tap for Console.app diagnostics

**Files:** `IngestedFileDetailView.swift`, `WikiDetailView.swift`, `FileProviderSpike.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)