### PR TITLE
feat: native List multi-select, context-aware Cmd+A, transcript layout fix, remove button cruft

### DIFF
--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -33,6 +33,7 @@ struct ContentView: View {
                     fileProvider: fileProvider,
                     runIngest: runIngest
                 )
+                .frame(maxWidth: .infinity)
 
                 if isTranscriptExpanded && !isQuerySelected {
                     Divider()

--- a/Sources/WikiFS/FilesSectionView.swift
+++ b/Sources/WikiFS/FilesSectionView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import WikiFSCore
+
+/// The Files section of the sidebar — filter picker, native multi-select rows,
+/// and right-click → Ingest Selected.
+struct FilesSectionView: View {
+    @Bindable var store: WikiStoreModel
+    let fileProvider: FileProviderSpike
+    var ingestingFileIDs: Set<PageID> = []
+    var onBatchIngest: (([PageID]) -> Void)? = nil
+
+    @State private var fileFilter: FileFilter = .all
+    @Binding var listSelection: Set<WikiSelection>
+    @Binding var activeSection: SidebarView.ActiveSection
+
+    enum FileFilter: String, CaseIterable {
+        case all = "All"
+        case ready = "Ready"
+        case ingested = "Ingested"
+    }
+
+    private var filteredFiles: [IngestedFileSummary] {
+        switch fileFilter {
+        case .all: return store.ingestedFiles
+        case .ready: return store.ingestedFiles.filter { !store.hasIngestedFile($0) }
+        case .ingested: return store.ingestedFiles.filter { store.hasIngestedFile($0) }
+        }
+    }
+
+    private var selectedFileIDs: Set<PageID> {
+        Set(listSelection.compactMap { sel in
+            if case .ingestedFile(let id) = sel { return id }
+            return nil
+        })
+    }
+
+    @State private var isFilesExpanded = true
+
+    var body: some View {
+        Section {
+            if isFilesExpanded {
+                ForEach(filteredFiles) { file in
+                    fileRow(file)
+                }
+            }
+        } header: {
+            HStack(spacing: 0) {
+                HStack(spacing: 4) {
+                    Image(systemName: isFilesExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Text("Files").font(.headline).foregroundStyle(.primary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.2)) { isFilesExpanded.toggle() }
+                }
+                Spacer()
+                Picker("Filter", selection: $fileFilter) {
+                    ForEach(FileFilter.allCases, id: \.self) { filter in
+                        Text(filter.rawValue).tag(filter)
+                    }
+                }
+                .pickerStyle(.menu).buttonStyle(.borderless).labelsHidden().fixedSize()
+                .help("Filter files by ingest status")
+            }
+        }
+    }
+
+    private func fileRow(_ file: IngestedFileSummary) -> some View {
+        let ids = selectedFileIDs
+        let ingestAction: (() -> Void)? = ids.isEmpty ? nil : {
+            onBatchIngest?(Array(ids))
+        }
+        return IngestedFileRow(
+            file: file,
+            hasBeenIngested: store.hasIngestedFile(file),
+            isIngesting: ingestingFileIDs.contains(file.id),
+            isSelected: ids.contains(file.id),
+            onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
+            onRemove: { store.deleteIngestedFile(file.id) },
+            onIngestSelected: ingestAction
+        )
+        .tag(WikiSelection.ingestedFile(file.id))
+    }
+}

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -243,14 +243,6 @@ struct SidebarView: View {
                             }
                         }
                         Spacer()
-                        if !selectedFileIDs.isEmpty {
-                            Button("Ingest Selected") {
-                                let ids = Array(selectedFileIDs)
-                                onBatchIngest?(ids)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                        }
                         Picker("Filter", selection: $fileFilter) {
                             ForEach(FileFilter.allCases, id: \.self) { filter in
                                 Text(filter.rawValue).tag(filter)

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -179,6 +179,7 @@ struct SidebarView: View {
     }
 
     private func selectionDidChange(_ newValue: Set<WikiSelection>) {
+        // Track which section was last interacted with.
         for item in newValue {
             switch item {
             case .page: activeSection = .pages
@@ -186,6 +187,15 @@ struct SidebarView: View {
             default: break
             }
         }
+
+        // Cmd+A selects everything — filter to the active section only.
+        let hasPage = newValue.contains(where: { if case .page = $0 { true } else { false } })
+        let hasFile = newValue.contains(where: { if case .ingestedFile = $0 { true } else { false } })
+        if hasPage && hasFile {
+            handleSelectAll()
+            return
+        }
+
         if newValue.count == 1, let first = newValue.first {
             store.selection = first
         }

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -28,302 +28,53 @@ struct SidebarView: View {
     @State private var isPagesExpanded = true
     @State private var isToolsExpanded = true
     @State private var isSystemExpanded = true
-    @State private var isFilesExpanded = true
 
-    // MARK: - File filter & batch select
+    // MARK: - Multi-select
 
-    @State private var fileFilter: FileFilter = .all
     /// Native multi-select binding for the List — supports Shift+Arrow,
     /// Shift+Click, and Command+Click. Synced to `store.selection` for
     /// single-item navigation.
     @State private var listSelection: Set<WikiSelection> = []
 
-    /// File IDs currently selected in the list (extracted from listSelection).
-    private var selectedFileIDs: Set<PageID> {
-        Set(listSelection.compactMap { sel in
-            if case .ingestedFile(let id) = sel { return id }
-            return nil
-        })
-    }
+    /// Tracks which section was last clicked, so Cmd+A selects only that section.
+    @State private var activeSection: ActiveSection = .pages
 
-    private enum FileFilter: String, CaseIterable {
-        case all = "All"
-        case ready = "Ready"
-        case ingested = "Ingested"
-    }
-
-    private var filteredFiles: [IngestedFileSummary] {
-        switch fileFilter {
-        case .all: return store.ingestedFiles
-        case .ready: return store.ingestedFiles.filter { !store.hasIngestedFile($0) }
-        case .ingested: return store.ingestedFiles.filter { store.hasIngestedFile($0) }
-        }
-    }
+    enum ActiveSection { case pages, files }
 
     var body: some View {
+        listContent
+            .listStyle(.inset)
+            .scrollContentBackground(.hidden)
+            .navigationTitle(activeWikiName)
+            .onChange(of: listSelection) { _, newValue in selectionDidChange(newValue) }
+            .onChange(of: store.selection) { _, newValue in
+                if let sel = newValue, !listSelection.contains(sel) { listSelection = [sel] }
+            }
+            .navigationSplitViewColumnWidth(min: PageEditorMetrics.sidebarMinWidth,
+                                             ideal: PageEditorMetrics.sidebarIdealWidth)
+            .toolbar { sidebarToolbar() }
+            .sheet(isPresented: $showingAddFromURL) { AddFromURLSheet(store: store) }
+            .sheet(isPresented: $showingAddFromZotero) {
+                AddFromZoteroSheet(store: store, containerDirectory: zoteroContainerDirectory)
+            }
+            .sheet(isPresented: $showingImportMarkdown) { ImportMarkdownSheet(store: store) }
+            .alert("Rename Page", isPresented: renamePresented) {
+                TextField("Title", text: $renameText)
+                Button("Cancel", role: .cancel) { renameTarget = nil }
+                Button("Rename") { commitRename() }
+            }
+    }
+
+    private var listContent: some View {
         List(selection: $listSelection) {
-            // The wiki switcher — the top-level container switch (which knowledge
-            // base am I in). No `.tag`, so it never feeds the page selection.
-            WikiSwitcher(manager: manager)
-                .listRowSeparator(.hidden)
-
-            Section {
-                if isToolsExpanded {
-                    SidebarModeRow(
-                        title: "Query",
-                        subtitle: "Ask or update",
-                        systemImage: "bubble.left.and.text.bubble.right"
-                    )
-                    .tag(WikiSelection.query)
-                    .help("Ask questions and decide whether Claude should update the wiki")
-                }
-            } header: {
-                HStack(spacing: 4) {
-                    Image(systemName: isToolsExpanded ? "chevron.down" : "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text("Tools")
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isToolsExpanded.toggle()
-                    }
-                }
-            }
-
-            Section {
-                if isSystemExpanded {
-                    SidebarModeRow(
-                        title: "Activity",
-                        subtitle: "Operation log",
-                        systemImage: "clock.arrow.circlepath"
-                    )
-                    .tag(WikiSelection.changeLog)
-                    .help("Operation history, projected read-only as log.md")
-
-                    SidebarModeRow(
-                        title: "Instructions",
-                        subtitle: "Agent prompt",
-                        systemImage: "sparkles"
-                    )
-                    .tag(WikiSelection.systemPrompt)
-                    .help("Agent instructions, projected read-only as CLAUDE.md and AGENTS.md")
-                }
-            } header: {
-                HStack(spacing: 4) {
-                    Image(systemName: isSystemExpanded ? "chevron.down" : "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text("System")
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isSystemExpanded.toggle()
-                    }
-                }
-            }
-
-            Section {
-                if isPagesExpanded {
-                    // Search bar
-                    HStack(spacing: 6) {
-                        Image(systemName: "magnifyingglass")
-                            .foregroundStyle(.secondary)
-                            .font(.callout)
-                        TextField("Search pages…", text: $store.searchQuery)
-                            .textFieldStyle(.plain)
-                            .font(.callout)
-                            .disableAutocorrection(true)
-                        if !store.searchQuery.isEmpty {
-                            Button {
-                                store.searchQuery = ""
-                            } label: {
-                                Image(systemName: "xmark.circle.fill")
-                                    .foregroundStyle(.secondary)
-                            }
-                            .buttonStyle(.borderless)
-                        }
-                    }
-                    .padding(.vertical, 4)
-                    .padding(.horizontal, 2)
-
-                    // Results or full list
-                    let source = store.searchQuery.isEmpty
-                        ? store.summaries : store.searchResults
-                    if source.isEmpty, !store.searchQuery.isEmpty {
-                        Text("No matching pages")
-                            .foregroundStyle(.secondary)
-                            .font(.callout)
-                            .padding(.vertical, 8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    ForEach(source) { summary in
-                        SidebarPageRow(summary: summary)
-                            .tag(WikiSelection.page(summary.id))
-                            .contextMenu {
-                                Button("Rename") { beginRename(summary) }
-                                Button("Delete", role: .destructive) { store.delete(summary.id) }
-                            }
-                            .swipeActions(edge: .trailing) {
-                                Button("Delete", role: .destructive) { store.delete(summary.id) }
-                            }
-                    }
-                }
-            } header: {
-                HStack(spacing: 0) {
-                    HStack(spacing: 4) {
-                        Image(systemName: isPagesExpanded ? "chevron.down" : "chevron.right")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text("Pages")
-                            .font(.headline)
-                            .foregroundStyle(.primary)
-                    }
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            isPagesExpanded.toggle()
-                        }
-                    }
-                    Spacer()
-                    Picker("Sort", selection: $store.pageSortOrder) {
-                        Text("Last Updated").tag(PageSortOrder.lastUpdated)
-                        Text("Newest First").tag(PageSortOrder.newestFirst)
-                        Text("Title A–Z").tag(PageSortOrder.titleAZ)
-                    }
-                    .pickerStyle(.menu)
-                    .buttonStyle(.borderless)
-                    .labelsHidden()
-                    .fixedSize()
-                    .help("Sort pages by date or title")
-                }
-            }
-            // Files are most-recently-added first (the store orders by created_at
-            // DESC). Selecting one opens a detail pane with direct ingest controls.
+            WikiSwitcher(manager: manager).listRowSeparator(.hidden)
+            toolsSection()
+            systemSection()
+            pagesSection()
             if !store.ingestedFiles.isEmpty {
-                Section {
-                    if isFilesExpanded {
-                        let files = filteredFiles
-                        ForEach(files) { file in
-                            IngestedFileRow(
-                                file: file,
-                                hasBeenIngested: store.hasIngestedFile(file),
-                                isIngesting: ingestingFileIDs.contains(file.id),
-                                isSelected: selectedFileIDs.contains(file.id),
-                                onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
-                                onRemove: { store.deleteIngestedFile(file.id) },
-                                onIngestSelected: selectedFileIDs.isEmpty ? nil : {
-                                    let ids = Array(selectedFileIDs)
-                                    onBatchIngest?(ids)
-                                }
-                            )
-                            .tag(WikiSelection.ingestedFile(file.id))
-                        }
-                    }
-                } header: {
-                    HStack(spacing: 0) {
-                        HStack(spacing: 4) {
-                            Image(systemName: isFilesExpanded ? "chevron.down" : "chevron.right")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text("Files")
-                                .font(.headline)
-                                .foregroundStyle(.primary)
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                isFilesExpanded.toggle()
-                            }
-                        }
-                        Spacer()
-                        Picker("Filter", selection: $fileFilter) {
-                            ForEach(FileFilter.allCases, id: \.self) { filter in
-                                Text(filter.rawValue).tag(filter)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .buttonStyle(.borderless)
-                        .labelsHidden()
-                        .fixedSize()
-                        .help("Filter files by ingest status")
-                    }
-                }
-            }
-        }
-        .listStyle(.inset)
-        .scrollContentBackground(.hidden)
-        .navigationTitle(activeWikiName)
-        .onChange(of: listSelection) { _, newValue in
-            // Forward single-item selection to the store for detail navigation.
-            if newValue.count == 1, let first = newValue.first {
-                store.selection = first
-            }
-        }
-        .onChange(of: store.selection) { _, newValue in
-            // Programmatic navigation (back/forward) updates the list.
-            if let sel = newValue, !listSelection.contains(sel) {
-                listSelection = [sel]
-            }
-        }
-        .navigationSplitViewColumnWidth(
-            min: PageEditorMetrics.sidebarMinWidth,
-            ideal: PageEditorMetrics.sidebarIdealWidth
-        )
-        .toolbar {
-            if isZoteroConfigured {
-                ToolbarItem {
-                    Button("Add from Zotero…", systemImage: "books.vertical") {
-                        showingAddFromZotero = true
-                    }
-                    .help("Browse your Zotero library and ingest a PDF or Markdown attachment")
-                }
-            }
-            ToolbarItem {
-                Button("Add from URL…", systemImage: "link.badge.plus") {
-                    showingAddFromURL = true
-                }
-                .help("Fetch a web page or PDF by URL and ingest it into this wiki")
-            }
-            ToolbarItem {
-                Button("Import Markdown Folder…", systemImage: "doc.badge.plus") {
-                    showingImportMarkdown = true
-                }
-                .help("Import all .md files from a folder as source material")
-            }
-            ToolbarItem {
-                Button("New Page", systemImage: "plus") { store.newPage() }
-            }
-            ToolbarItem {
-                Button("Reindex Search", systemImage: "arrow.triangle.2.circlepath") {
-                    _ = store.recomputeMissingEmbeddings()
-                }
-                .help("Recompute embeddings for all pages that are missing one, so semantic search covers pre‑v7 pages.")
-            }
-        }
-        .sheet(isPresented: $showingAddFromURL) {
-            AddFromURLSheet(store: store)
-        }
-        .sheet(isPresented: $showingAddFromZotero) {
-            AddFromZoteroSheet(store: store, containerDirectory: zoteroContainerDirectory)
-        }
-        .sheet(isPresented: $showingImportMarkdown) {
-            ImportMarkdownSheet(store: store)
-        }
-        .alert("Rename Page", isPresented: renamePresented) {
-            TextField("Title", text: $renameText)
-            Button("Cancel", role: .cancel) { renameTarget = nil }
-            Button("Rename") {
-                if let target = renameTarget {
-                    store.rename(target.id, to: renameText)
-                }
-                renameTarget = nil
+                FilesSectionView(store: store, fileProvider: fileProvider,
+                    ingestingFileIDs: ingestingFileIDs, onBatchIngest: onBatchIngest,
+                    listSelection: $listSelection, activeSection: $activeSection)
             }
         }
     }
@@ -349,6 +100,140 @@ struct SidebarView: View {
         return manager.wikis.first { $0.id == id }?.displayName ?? "Self Driving Wiki"
     }
 
+    private func toolsSection() -> some View {
+        Section {
+            if isToolsExpanded {
+                SidebarModeRow(title: "Query", subtitle: "Ask or update",
+                    systemImage: "bubble.left.and.text.bubble.right")
+                    .tag(WikiSelection.query)
+                    .help("Ask questions and decide whether Claude should update the wiki")
+            }
+        } header: { SidebarSectionHeader(title: "Tools", isExpanded: $isToolsExpanded) }
+    }
+
+    private func systemSection() -> some View {
+        Section {
+            if isSystemExpanded {
+                SidebarModeRow(title: "Activity", subtitle: "Operation log",
+                    systemImage: "clock.arrow.circlepath")
+                    .tag(WikiSelection.changeLog)
+                    .help("Operation history, projected read-only as log.md")
+                SidebarModeRow(title: "Instructions", subtitle: "Agent prompt",
+                    systemImage: "sparkles")
+                    .tag(WikiSelection.systemPrompt)
+                    .help("Agent instructions, projected read-only as CLAUDE.md and AGENTS.md")
+            }
+        } header: { SidebarSectionHeader(title: "System", isExpanded: $isSystemExpanded) }
+    }
+
+    private func pagesSection() -> some View {
+        Section {
+            if isPagesExpanded { pagesSectionRows() }
+        } header: {
+            HStack(spacing: 0) {
+                SidebarSectionHeader(title: "Pages", isExpanded: $isPagesExpanded)
+                Spacer()
+                Picker("Sort", selection: $store.pageSortOrder) {
+                    Text("Last Updated").tag(PageSortOrder.lastUpdated)
+                    Text("Newest First").tag(PageSortOrder.newestFirst)
+                    Text("Title A–Z").tag(PageSortOrder.titleAZ)
+                }
+                .pickerStyle(.menu).buttonStyle(.borderless).labelsHidden().fixedSize()
+                .help("Sort pages by date or title")
+            }
+        }
+    }
+
+    /// Extracted to keep the `body` type-checkable.
+    private func pagesSectionRows() -> some View {
+        Group {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary).font(.callout)
+                TextField("Search pages…", text: $store.searchQuery)
+                    .textFieldStyle(.plain).font(.callout).disableAutocorrection(true)
+                if !store.searchQuery.isEmpty {
+                    Button { store.searchQuery = "" } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                    }.buttonStyle(.borderless)
+                }
+            }
+            .padding(.vertical, 4).padding(.horizontal, 2)
+            let source = store.searchQuery.isEmpty ? store.summaries : store.searchResults
+            if source.isEmpty, !store.searchQuery.isEmpty {
+                Text("No matching pages").foregroundStyle(.secondary).font(.callout)
+                    .padding(.vertical, 8).frame(maxWidth: .infinity, alignment: .leading)
+            }
+            ForEach(source) { summary in
+                SidebarPageRow(summary: summary)
+                    .tag(WikiSelection.page(summary.id))
+                    .contextMenu {
+                        Button("Rename") { beginRename(summary) }
+                        Button("Delete", role: .destructive) { store.delete(summary.id) }
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button("Delete", role: .destructive) { store.delete(summary.id) }
+                    }
+            }
+        }
+    }
+
+    private func selectionDidChange(_ newValue: Set<WikiSelection>) {
+        for item in newValue {
+            switch item {
+            case .page: activeSection = .pages
+            case .ingestedFile: activeSection = .files
+            default: break
+            }
+        }
+        if newValue.count == 1, let first = newValue.first {
+            store.selection = first
+        }
+    }
+
+    private func handleSelectAll() {
+        switch activeSection {
+        case .files:
+            listSelection = Set(store.ingestedFiles.map { WikiSelection.ingestedFile($0.id) })
+        case .pages:
+            listSelection = Set(store.summaries.map { WikiSelection.page($0.id) })
+        }
+    }
+
+    @ToolbarContentBuilder
+    private func sidebarToolbar() -> some ToolbarContent {
+        if isZoteroConfigured {
+            ToolbarItem {
+                Button("Add from Zotero…", systemImage: "books.vertical") {
+                    showingAddFromZotero = true
+                }.help("Browse your Zotero library and ingest a PDF or Markdown attachment")
+            }
+        }
+        ToolbarItem {
+            Button("Add from URL…", systemImage: "link.badge.plus") {
+                showingAddFromURL = true
+            }.help("Fetch a web page or PDF by URL and ingest it into this wiki")
+        }
+        ToolbarItem {
+            Button("Import Markdown Folder…", systemImage: "doc.badge.plus") {
+                showingImportMarkdown = true
+            }.help("Import all .md files from a folder as source material")
+        }
+        ToolbarItem {
+            Button("New Page", systemImage: "plus") { store.newPage() }
+        }
+        ToolbarItem {
+            Button("Reindex Search", systemImage: "arrow.triangle.2.circlepath") {
+                _ = store.recomputeMissingEmbeddings()
+            }.help("Recompute embeddings for all missing pages for semantic search")
+        }
+    }
+
+    private func commitRename() {
+        if let target = renameTarget { store.rename(target.id, to: renameText) }
+        renameTarget = nil
+    }
+
     private func beginRename(_ summary: WikiPageSummary) {
         renameText = summary.title
         renameTarget = summary
@@ -361,5 +246,23 @@ struct SidebarView: View {
             get: { renameTarget != nil },
             set: { if !$0 { renameTarget = nil } }
         )
+    }
+}
+
+/// A collapsible section header with chevron + title.
+struct SidebarSectionHeader: View {
+    let title: String
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                .font(.caption).foregroundStyle(.secondary)
+            Text(title).font(.headline).foregroundStyle(.primary)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+        }
     }
 }

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -179,15 +179,6 @@ struct SidebarView: View {
     }
 
     private func selectionDidChange(_ newValue: Set<WikiSelection>) {
-        // Track which section was last interacted with.
-        for item in newValue {
-            switch item {
-            case .page: activeSection = .pages
-            case .ingestedFile: activeSection = .files
-            default: break
-            }
-        }
-
         // Cmd+A selects everything — filter to the active section only.
         let hasPage = newValue.contains(where: { if case .page = $0 { true } else { false } })
         let hasFile = newValue.contains(where: { if case .ingestedFile = $0 { true } else { false } })
@@ -196,7 +187,13 @@ struct SidebarView: View {
             return
         }
 
+        // Only update activeSection from single clicks (not mass selections).
         if newValue.count == 1, let first = newValue.first {
+            switch first {
+            case .page: activeSection = .pages
+            case .ingestedFile: activeSection = .files
+            default: break
+            }
             store.selection = first
         }
     }


### PR DESCRIPTION
## Summary

Post-merge fixes and polish on top of PR #16.

### Native multi-select
- `List(selection:)` uses `Set<WikiSelection>` for native Shift+Arrow, Shift+Click, Command+Click
- Removed custom checkbox/toggle code from `IngestedFileRow`
- Removed "Ingest Selected" header button (right-click context menu only)
- **Cmd+A** selects only the active section (pages or files), not everything

### Layout fix
- `WikiDetailView` fills available width so the transcript sidebar pins to the right edge

### Code health
- `FilesSectionView` extracted from `SidebarView` for compiler type-check limits
- `SidebarSectionHeader` reusable component
- Section helpers keep `body` type-checkable

🤖 Generated with [Claude Code](https://claude.com/claude-code)