### PR TITLE
feat: multi-tab editor space (Obsidian-style)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -44,6 +44,7 @@ with a plain-folder export, even though that would dodge the signing requirement
 | [`plans/pdf-extraction.md`](plans/pdf-extraction.md) | Add docling + granite-docling pipeline. A `pdf2md` CLI converts PDFs to markdown at ingest time; extracted markdown stored as a sibling `ingested_files` row, projected on the mount. Agent prefers `.md` siblings, falls back to `Read` on the original. |
 | [`plans/semantic-search.md`](plans/semantic-search.md) | Semantic (meaning-based) search over pages using sqlite-vec + Apple NLEmbedding. Embedding at save time, cosine-similarity ranking inside SQLite, search bar in the sidebar, `wikictl search` for the agent. v7 migration. |
 | [`plans/markdown-folder-import.md`](plans/markdown-folder-import.md) | Import an entire folder of Markdown files (Obsidian vault, LogSeq graph, or any `.md` directory) as source material. Recursive walk, .md filter, filename dedup; lands files in `ingested_files` for the agent to curate via Ingest. |
+| [`plans/multi-tab-editor.md`](plans/multi-tab-editor.md) | Multi-tab editor space (Obsidian-style): horizontal tab bar, openTab/closeTab/selectTab/reopen, singleton-type reuse, keyboard shortcuts, 31 tab model tests. |
 | [`SWIFTUI-RULES.md`](SWIFTUI-RULES.md) | Hard-won SwiftUI/macOS rules. Apply when writing or reviewing any view. |
 | [`CLAUDE.md`](CLAUDE.md) | Working agreement (docs, skills to use, PR rules). |
 | [`ISSUES.md`](ISSUES.md) | Known limitations we've chosen to live with (with context to revisit), e.g. the ~5s replicated-File-Provider read-after-write window. |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,53 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-19 — Multi-tab editor space (Obsidian-style)
+
+Added a multi-tab editor space: a horizontal tab bar above the detail pane lets
+users keep multiple pages, Query, Instructions, and Activity open simultaneously.
+Obsidian-style — clicking a page in the sidebar opens it in a new tab.
+
+- **EditorTab** (`WikiFSCore/EditorTab.swift`) — `Identifiable, Hashable, Sendable`
+  value type holding a `UUID` identity, a `WikiSelection`, and a display `title`.
+  Plus `WikiStoreModel` helpers `tabTitle(for:)` and `tabIcon(for:)` that derive
+  labels/icons from the live summaries/ingestedFiles arrays.
+- **Tab management** on `WikiStoreModel`:
+  - `tabs: [EditorTab]`, `activeTabIndex: Int`, `recentlyClosedTabs: [EditorTab]`
+  - `openTab(_:title:)` — create or focus a tab. Singleton types (`.query`,
+    `.systemPrompt`, `.changeLog`) reuse existing; pages/files always create new
+    (Obsidian-style).
+  - `selectTab(at:)` — switch tabs, flushing outgoing drafts
+  - `closeTab(at:)` — close tab, push to recently-closed stack, activate neighbor
+  - `reopenLastClosedTab()` — Cmd+Shift+T support
+  - `newPageInNewTab(title:)` — create page + open in new tab
+  - `handleSelectionChange`, `delete`, `deleteIngestedFile`, `rename`, `newPage`,
+    `select`, `selectPage`, `applyHistorySelection` all updated for tab awareness
+- **TabBarView** (`WikiFS/TabBarView.swift`) — horizontal `ScrollView` tab strip
+  with `.regularMaterial` background, 34pt height
+- **TabBarItemView** (`WikiFS/TabBarItemView.swift`) — icon + truncated title +
+  hover-revealed close button; active tab: accent underline + control background;
+  inactive: subtle hover highlight. Semantic typography (`.caption`, `.semibold`).
+- **ContentView** — tab bar integrated above detail content; hidden keyboard
+  shortcut buttons (Cmd+W close, Cmd+Shift+T reopen, Cmd+1–9 switch, Cmd+N new
+  page); New Tab toolbar menu (New Page / Query / Instructions / Activity)
+- **SidebarView** — single-click calls `store.openTab(_:)` (Obsidian-style)
+
+**Tests** — `EditorTabTests` (31 tests): initial state, tab creation, open/close/
+switch/reopen, singleton reuse, delete-page-closes-tab, rename-updates-title,
+ingested-file-tab-close, history-preserves-tab-metadata, tabTitle/tabIcon helpers.
+
+**Verified.** `make check` clean; `swift test` **510/510** green (31 new, 0
+regressions); `make` produces a clean signed bundle.
+
+**Post-merge fix:** Opening a file (switching tabs) was bumping `updated_at` on the
+outgoing page because `flushPendingSaves()` called `save()` unconditionally, and
+`PageUpsert.upsert` always writes. Added `isDraftDirty` / `isSystemPromptDirty`
+flags — set by `didSet` on `draftTitle`/`draftBody`/`draftSystemPrompt` (and by
+`bodyChanged`/`titleChanged`/`systemPromptChanged`), cleared by `loadDrafts` and
+after a successful save. `flushPendingSave()` and `flushPendingSystemPromptSave()`
+now skip the save when the draft is clean, so viewing a page without editing no
+longer touches its timestamp.
+
 ## 2026-06-19 — File filter + native multi-select + batch ingest in single agent run
 
 Added a filter picker and native multi-select to the Files section, and generalized

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -25,23 +25,29 @@ struct ContentView: View {
                         onBatchIngest: batchIngest,
                         ingestingFileIDs: agentLauncher.ingestingFileIDs)
         } detail: {
-            HStack(spacing: 0) {
-                WikiDetailView(
-                    store: store,
-                    launcher: agentLauncher,
-                    manager: manager,
-                    fileProvider: fileProvider,
-                    runIngest: runIngest
-                )
-                .frame(maxWidth: .infinity)
+            VStack(spacing: 0) {
+                TabBarView(store: store)
 
-                if isTranscriptExpanded && !isQuerySelected {
-                    Divider()
-                    AgentTranscriptSidebar(launcher: agentLauncher)
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                HStack(spacing: 0) {
+                    WikiDetailView(
+                        store: store,
+                        launcher: agentLauncher,
+                        manager: manager,
+                        fileProvider: fileProvider,
+                        runIngest: runIngest
+                    )
+                    .frame(maxWidth: .infinity)
+
+                    if isTranscriptExpanded && !isQuerySelected {
+                        Divider()
+                        AgentTranscriptSidebar(launcher: agentLauncher)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                    }
                 }
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: isTranscriptExpanded)
             }
-            .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: isTranscriptExpanded)
+            // Hidden buttons for keyboard shortcuts.
+            .background { keyboardShortcutButtons }
         }
         // Drop a file anywhere on the window to ingest it (raw bytes → SQLite →
         // the read-only `files/` projection). The whole content is the target.
@@ -103,6 +109,26 @@ struct ContentView: View {
                 .popover(isPresented: $showingPathPopover, arrowEdge: .bottom) {
                     VerificationPopover(fileProvider: fileProvider)
                 }
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    Button("New Page", systemImage: "doc.badge.plus") {
+                        store.newPageInNewTab()
+                    }
+                    .keyboardShortcut("n", modifiers: .command)
+                    Button("Query", systemImage: "bubble.left.and.text.bubble.right") {
+                        store.openTab(.query)
+                    }
+                    Button("Instructions", systemImage: "sparkles") {
+                        store.openTab(.systemPrompt)
+                    }
+                    Button("Activity", systemImage: "clock.arrow.circlepath") {
+                        store.openTab(.changeLog)
+                    }
+                } label: {
+                    Label("New Tab", systemImage: "plus.square.on.square")
+                }
+                .help("Open a new tab")
             }
         }
         .sheet(isPresented: $showingMaintainSheet) {
@@ -194,5 +220,37 @@ struct ContentView: View {
                 fileProvider: fileProvider)
         }
         agentLauncher.ingestTask = task
+    }
+
+    // MARK: - Keyboard shortcuts
+
+    /// Hidden buttons that provide Cmd+W, Cmd+Shift+T, and Cmd+1–9 shortcuts.
+    /// Placed in the detail background so they're always in the responder chain.
+    @ViewBuilder
+    private var keyboardShortcutButtons: some View {
+        // Cmd+W: Close active tab
+        Button("") { store.closeTab(at: store.activeTabIndex) }
+            .keyboardShortcut("w", modifiers: .command)
+            .opacity(0).allowsHitTesting(false)
+            .disabled(store.tabs.isEmpty)
+
+        // Cmd+Shift+T: Reopen last closed tab
+        Button("") { store.reopenLastClosedTab() }
+            .keyboardShortcut("t", modifiers: [.command, .shift])
+            .opacity(0).allowsHitTesting(false)
+            .disabled(store.recentlyClosedTabs.isEmpty)
+
+        // Cmd+1 through Cmd+9: Switch to tab by index
+        let keys: [KeyEquivalent] = [
+            "1", "2", "3", "4", "5", "6", "7", "8", "9"
+        ]
+        ForEach(Array(zip(keys.indices, keys)), id: \.0) { i, key in
+            Button("") {
+                guard store.tabs.indices.contains(i) else { return }
+                store.selectTab(at: i)
+            }
+            .keyboardShortcut(key, modifiers: .command)
+            .opacity(0).allowsHitTesting(false)
+        }
     }
 }

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -194,7 +194,8 @@ struct SidebarView: View {
             case .ingestedFile: activeSection = .files
             default: break
             }
-            store.selection = first
+            // Obsidian-style: single-click opens/activates a tab.
+            store.openTab(first)
         }
     }
 

--- a/Sources/WikiFS/TabBarItemView.swift
+++ b/Sources/WikiFS/TabBarItemView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import WikiFSCore
+
+/// One tab button in the tab bar. Shows icon + truncated title + close button.
+/// Active tab has an accent underline; inactive tabs have a subtle background on hover.
+struct TabBarItemView: View {
+    let tab: EditorTab
+    let isActive: Bool
+    let iconName: String
+    let onClick: () -> Void
+    let onClose: () -> Void
+
+    @State private var isHovering = false
+    @State private var isCloseHovering = false
+
+    var body: some View {
+        Button(action: onClick) {
+            HStack(spacing: 4) {
+                closeButton
+                icon
+                titleText
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .frame(maxHeight: .infinity)
+            .background(background)
+            .overlay(alignment: .bottom) {
+                if isActive {
+                    Capsule()
+                        .fill(Color.accentColor)
+                        .frame(height: 2)
+                        .padding(.horizontal, 2)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in isHovering = hovering }
+        .help(tab.title)
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var closeButton: some View {
+        Group {
+            if isHovering || isActive {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 14, height: 14)
+                        .background(isCloseHovering ? Color.primary.opacity(0.1) : .clear)
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .onHover { h in isCloseHovering = h }
+            } else {
+                Color.clear.frame(width: 14, height: 14)
+            }
+        }
+    }
+
+    private var icon: some View {
+        Image(systemName: iconName)
+            .font(.caption)
+            .foregroundStyle(isActive ? Color.accentColor : .secondary)
+    }
+
+    private var titleText: some View {
+        Text(tab.title)
+            .font(.caption)
+            .fontWeight(isActive ? .semibold : .regular)
+            .foregroundStyle(isActive ? .primary : .secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: ItemMetrics.maxTitleWidth, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        if isActive {
+            Color(nsColor: .controlBackgroundColor)
+        } else if isHovering {
+            Color.primary.opacity(0.06)
+        } else {
+            Color.clear
+        }
+    }
+}
+
+private enum ItemMetrics {
+    static let maxTitleWidth: CGFloat = 160
+}

--- a/Sources/WikiFS/TabBarView.swift
+++ b/Sources/WikiFS/TabBarView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import WikiFSCore
+
+/// Horizontal tab strip displayed at the top of the detail pane. Mirrors
+/// Obsidian's tab bar: each tab shows icon + truncated title + close button.
+/// Scrolls horizontally when there are many tabs.
+struct TabBarView: View {
+    @Bindable var store: WikiStoreModel
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 0) {
+                ForEach(Array(store.tabs.enumerated()), id: \.element.id) { index, tab in
+                    TabBarItemView(
+                        tab: tab,
+                        isActive: index == store.activeTabIndex,
+                        iconName: store.tabIcon(for: tab.selection),
+                        onClick: { store.selectTab(at: index) },
+                        onClose: { store.closeTab(at: index) }
+                    )
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+        .frame(height: TabBarMetrics.height)
+        .background(.regularMaterial)
+        .overlay(alignment: .bottom) {
+            Divider().opacity(PageEditorMetrics.dividerOpacity)
+        }
+    }
+}
+
+enum TabBarMetrics {
+    static let height: CGFloat = 34
+}

--- a/Sources/WikiFSCore/EditorTab.swift
+++ b/Sources/WikiFSCore/EditorTab.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// A single editor tab. Each tab tracks which wiki content it displays and a
+/// display label for the tab bar. `Hashable` + `Sendable` so it can live in the
+/// `@Observable` store.
+public struct EditorTab: Hashable, Sendable, Identifiable {
+    /// Stable identity — survives selection changes within the tab.
+    public let id: UUID
+    /// The wiki content this tab is showing.
+    public var selection: WikiSelection
+    /// Display label in the tab bar (page title, "Query", "Instructions", etc.).
+    public var title: String
+
+    public init(selection: WikiSelection, title: String) {
+        self.id = UUID()
+        self.selection = selection
+        self.title = title
+    }
+}
+
+extension WikiStoreModel {
+    /// Display title for a `WikiSelection`, used as the tab bar label.
+    /// Reads from the live `summaries` / `ingestedFiles` arrays (rebuild from store
+    /// after mutations, per SWIFTUI-RULES §3.1).
+    public func tabTitle(for selection: WikiSelection) -> String {
+        switch selection {
+        case .query: return "Query"
+        case .systemPrompt: return "Instructions"
+        case .changeLog: return "Activity"
+        case .page(let id):
+            return summaries.first { $0.id == id }?.title
+                .nonEmpty ?? "Untitled"
+        case .ingestedFile(let id):
+            return ingestedFiles.first { $0.id == id }?.filename
+                .nonEmpty ?? "File"
+        }
+    }
+
+    /// SF Symbol name for a `WikiSelection`, used as the tab icon.
+    public func tabIcon(for selection: WikiSelection) -> String {
+        switch selection {
+        case .query: return "bubble.left.and.text.bubble.right"
+        case .systemPrompt: return "sparkles"
+        case .changeLog: return "clock.arrow.circlepath"
+        case .page: return "doc.text"
+        case .ingestedFile(let id):
+            guard let file = ingestedFiles.first(where: { $0.id == id }) else {
+                return "doc"
+            }
+            switch file.ext.lowercased() {
+            case "pdf": return "doc.richtext"
+            case "txt", "md", "markdown": return "doc.plaintext"
+            default: return "doc"
+            }
+        }
+    }
+}
+
+private extension String {
+    var nonEmpty: Self? { isEmpty ? nil : self }
+}

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -37,6 +37,15 @@ public final class WikiStoreModel {
     public var canNavigateBack: Bool { !backStack.isEmpty }
     public var canNavigateForward: Bool { !forwardStack.isEmpty }
 
+    // MARK: - Tab management
+
+    /// All open editor tabs, in display order (left to right).
+    public private(set) var tabs: [EditorTab] = []
+    /// Index into `tabs` for the active tab. 0 when `tabs` is empty.
+    public var activeTabIndex: Int = 0
+    /// Stack of recently-closed tabs for Cmd+Shift+T reopen. Max 10.
+    public private(set) var recentlyClosedTabs: [EditorTab] = []
+
     /// The removable list of ingested files (Phase 5). Like `summaries`, this is
     /// ALWAYS rebuilt from `store.listIngestedFiles()` after a change, never
     /// incrementally patched (§3.1). Most-recent-first.
@@ -55,13 +64,19 @@ public final class WikiStoreModel {
     @ObservationIgnored public var onPageDidChange: (@MainActor () -> Void)?
 
     /// Live editing buffers — the single source of in-flight text.
-    public var draftTitle: String = ""
-    public var draftBody: String = ""
+    public var draftTitle: String = "" {
+        didSet { if draftTitle != oldValue { isDraftDirty = true } }
+    }
+    public var draftBody: String = "" {
+        didSet { if draftBody != oldValue { isDraftDirty = true } }
+    }
 
     /// Live editing buffer for the system-prompt document (the singleton
     /// `CLAUDE.md`/`AGENTS.md`). Separate track from the page drafts above so the
     /// well-tested page autosave path is untouched.
-    public var draftSystemPrompt: String = ""
+    public var draftSystemPrompt: String = "" {
+        didSet { if draftSystemPrompt != oldValue { isSystemPromptDirty = true } }
+    }
 
     /// True while a `claude -p` operation is running against THIS wiki (Phase C /
     /// decision #6). The editor binds this to go read-only with a banner, and
@@ -78,7 +93,17 @@ public final class WikiStoreModel {
     /// after `selection` has advanced (§3.5 read-state-at-save-time).
     private var loadedSelection: WikiSelection?
     private var isApplyingHistorySelection = false
+    /// True when the page drafts differ from the last persisted state. Cleared on
+    /// save and on load. Prevents `flushPendingSaves()` from bumping `updated_at`
+    /// on a tab switch when the user only viewed a page without editing.
+    private var isDraftDirty = false
+    /// Same for the system prompt draft (separate track).
+    private var isSystemPromptDirty = false
+    /// Suppresses double-processing in `handleSelectionChange` during tab switches.
+    /// Follows the same pattern as `isApplyingHistorySelection`.
+    @ObservationIgnored private var isSwitchingTab = false
     private static let navigationHistoryLimit = 100
+    private static let maxRecentlyClosedTabs = 10
 
     public init(store: WikiStore) {
         self.store = store
@@ -94,12 +119,18 @@ public final class WikiStoreModel {
     /// Switch the selection programmatically. Flushes any pending save
     /// SYNCHRONOUSLY first (§3.5 immediate-on-switch) so the outgoing document
     /// can't lose buffered edits, then loads the new selection's text.
+    /// Updates the active tab's metadata to stay in sync.
     public func select(_ newValue: WikiSelection?) {
         guard newValue != selection else { return }
         flushPendingSaves()
         recordHistoryTransition(from: loadedSelection, to: newValue)
         selection = newValue
         loadDrafts(for: newValue)
+        // Keep the active tab in sync.
+        if tabs.indices.contains(activeTabIndex), let newValue {
+            tabs[activeTabIndex].selection = newValue
+            tabs[activeTabIndex].title = tabTitle(for: newValue)
+        }
     }
 
     /// Bridge for SwiftUI's `List(selection:)`, which writes `selection`
@@ -108,10 +139,22 @@ public final class WikiStoreModel {
     /// belong to `loadedSelection`, so the outgoing document's edits are
     /// persisted before we load the incoming one (§3.5).
     public func handleSelectionChange(to newValue: WikiSelection?) {
-        guard newValue != loadedSelection else { return }
+        // Skip if triggered programmatically by a tab switch.
+        guard !isSwitchingTab, newValue != loadedSelection else { return }
         flushPendingSaves()     // persists drafts to loadedSelection
         recordHistoryTransition(from: loadedSelection, to: newValue)
         loadDrafts(for: newValue)
+
+        // Keep the active tab's metadata in sync after a sidebar-driven change.
+        // If no tabs exist yet, create the initial tab.
+        if tabs.isEmpty {
+            let label = tabTitle(for: newValue ?? .query)
+            tabs.append(EditorTab(selection: newValue ?? .query, title: label))
+            activeTabIndex = 0
+        } else if tabs.indices.contains(activeTabIndex), let newValue {
+            tabs[activeTabIndex].selection = newValue
+            tabs[activeTabIndex].title = tabTitle(for: newValue)
+        }
     }
 
     public func navigateBack() {
@@ -153,6 +196,107 @@ public final class WikiStoreModel {
         return true
     }
 
+    // MARK: - Tab operations
+
+    /// Open a new tab with the given selection. For singleton selection types
+    /// (.query, .systemPrompt, .changeLog), switches to their existing tab instead
+    /// of creating a duplicate. Flushes the current tab's drafts first.
+    public func openTab(_ selection: WikiSelection, title: String? = nil) {
+        // Singleton types: switch to existing tab if one exists.
+        switch selection {
+        case .query, .systemPrompt, .changeLog:
+            if let existingIndex = tabs.firstIndex(where: { $0.selection == selection }) {
+                selectTab(at: existingIndex)
+                return
+            }
+        default:
+            // Page/file tabs: always create new (Obsidian-style).
+            break
+        }
+
+        flushPendingSaves()
+        let label = title ?? tabTitle(for: selection)
+        let tab = EditorTab(selection: selection, title: label)
+        tabs.append(tab)
+        activeTabIndex = tabs.count - 1
+
+        // Switch to the new tab without recording history.
+        isSwitchingTab = true
+        self.selection = selection
+        loadDrafts(for: selection)
+        isSwitchingTab = false
+    }
+
+    /// Switch to a specific tab by index. Flushes the outgoing tab's drafts and
+    /// loads the incoming tab's content. Does NOT record in navigation history.
+    public func selectTab(at index: Int) {
+        guard tabs.indices.contains(index), index != activeTabIndex else { return }
+        flushPendingSaves()
+        isSwitchingTab = true
+        activeTabIndex = index
+        selection = tabs[index].selection
+        loadDrafts(for: selection)
+        isSwitchingTab = false
+    }
+
+    /// Close the tab at the given index. Preserves it in `recentlyClosedTabs`
+    /// for Cmd+Shift+T. Activates the right-neighbor tab (or left if closing the
+    /// rightmost). Closing the last tab shows the empty state.
+    public func closeTab(at index: Int) {
+        guard tabs.indices.contains(index) else { return }
+        flushPendingSaves()
+
+        // Save to recently-closed stack.
+        let closedTab = tabs[index]
+        recentlyClosedTabs.append(closedTab)
+        if recentlyClosedTabs.count > Self.maxRecentlyClosedTabs {
+            recentlyClosedTabs.removeFirst()
+        }
+
+        let wasActive = index == activeTabIndex
+        tabs.remove(at: index)
+
+        if tabs.isEmpty {
+            // Last tab closed: show the empty state.
+            activeTabIndex = 0
+            isSwitchingTab = true
+            selection = nil
+            loadDrafts(for: nil)
+            isSwitchingTab = false
+        } else if wasActive {
+            // Activate the right neighbor, or left if removing the rightmost.
+            let newIndex = min(index, tabs.count - 1)
+            isSwitchingTab = true
+            activeTabIndex = newIndex
+            selection = tabs[newIndex].selection
+            loadDrafts(for: selection)
+            isSwitchingTab = false
+        } else if index < activeTabIndex {
+            // A tab to the left of the active one was closed — shift the index.
+            activeTabIndex -= 1
+        }
+    }
+
+    /// Reopen the last closed tab.
+    public func reopenLastClosedTab() {
+        guard let lastClosed = recentlyClosedTabs.popLast() else { return }
+        openTab(lastClosed.selection, title: lastClosed.title)
+    }
+
+    /// Create a new page and open it in a new tab.
+    public func newPageInNewTab(title: String = "Untitled") {
+        flushPendingSaves()
+        do {
+            let page = try store.createPage(title: title)
+            try store.replaceLinks(from: page.id, parsedLinks: WikiLinkParser.parse(page.bodyMarkdown))
+            reloadSummaries()
+            openTab(.page(page.id), title: title)
+            onPageDidChange?()
+        } catch {
+            print("WikiStoreModel.newPageInNewTab failed: \(error)")
+        }
+    }
+
     private func loadDrafts(for newValue: WikiSelection?) {
         loadedSelection = newValue
         switch newValue {
@@ -187,6 +331,8 @@ public final class WikiStoreModel {
             draftBody = ""
             loadedPage = nil
         }
+        isDraftDirty = false
+        isSystemPromptDirty = false
     }
 
     private func recordHistoryTransition(from oldValue: WikiSelection?, to newValue: WikiSelection?) {
@@ -205,6 +351,11 @@ public final class WikiStoreModel {
         selection = newValue
         loadDrafts(for: newValue)
         isApplyingHistorySelection = false
+        // Update the active tab's metadata so the tab bar stays in sync.
+        if tabs.indices.contains(activeTabIndex) {
+            tabs[activeTabIndex].selection = newValue
+            tabs[activeTabIndex].title = tabTitle(for: newValue)
+        }
     }
 
     private func trimBackStackIfNeeded() {
@@ -223,8 +374,8 @@ public final class WikiStoreModel {
 
     /// Called on each keystroke in the title or body. Cancels and restarts a
     /// 500ms debounce; when it fires it reads the live drafts and saves.
-    public func bodyChanged() { scheduleAutosave() }
-    public func titleChanged() { scheduleAutosave() }
+    public func bodyChanged() { isDraftDirty = true; scheduleAutosave() }
+    public func titleChanged() { isDraftDirty = true; scheduleAutosave() }
 
     private func scheduleAutosave() {
         // Paused while an agent runs (decision #6): an in-app autosave must never
@@ -242,8 +393,8 @@ public final class WikiStoreModel {
     /// belong to) + `draftTitle` + `draftBody` AT CALL TIME (§3.5 live read) so
     /// a debounce that fires after further typing — or a flush triggered once
     /// `selection` has already advanced to the next page — still writes the
-    /// freshest text to the RIGHT page. No-op when nothing is loaded. Always
-    /// rebuilds `summaries` from source on success.
+    /// freshest text to the RIGHT page. No-op when nothing is loaded.
+    /// Always rebuilds `summaries` from source on success.
     public func save() {
         guard let id = loadedPage else { return }
         do {
@@ -255,6 +406,7 @@ public final class WikiStoreModel {
             // that targeted the old title go stale until the linking page is next
             // saved (they self-heal then).
             try PageUpsert.upsert(in: store, id: id, title: draftTitle, body: draftBody)
+            isDraftDirty = false
             reloadSummaries()
             onPageDidChange?()
         } catch {
@@ -265,9 +417,12 @@ public final class WikiStoreModel {
 
     /// Cancel any pending debounce and save synchronously. Called on page
     /// switch and on app backgrounding (§3.5 immediate-on-background).
+    /// No-op when the draft hasn't been modified since the last load/save
+    /// (prevents bumping `updated_at` on a tab switch for a view-only page).
     public func flushPendingSave() {
         autosaveTask?.cancel()
         autosaveTask = nil
+        guard isDraftDirty else { return }
         save()
     }
 
@@ -278,6 +433,7 @@ public final class WikiStoreModel {
     public func systemPromptChanged() {
         // Paused while an agent runs (decision #6), same as the page autosave.
         guard !isAgentRunning else { return }
+        isSystemPromptDirty = true
         systemPromptAutosaveTask?.cancel()
         systemPromptAutosaveTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(500))
@@ -288,12 +444,14 @@ public final class WikiStoreModel {
 
     /// Persist the system-prompt draft. Guarded on `loadedSelection` so a flush
     /// triggered once selection has moved off the prompt doesn't clobber it with
-    /// stale text (mirrors `save()`'s `loadedPage` guard). Bumps the row version,
-    /// which advances `changeToken()` so `CLAUDE.md`/`AGENTS.md` refresh.
+    /// stale text (mirrors `save()`'s `loadedPage` guard). No-op when the draft
+    /// hasn't been modified (prevents bumping the row version on a tab switch
+    /// when the user only viewed the Instructions page).
     public func saveSystemPrompt() {
         guard loadedSelection == .systemPrompt else { return }
         do {
             try store.updateSystemPrompt(body: draftSystemPrompt)
+            isSystemPromptDirty = false
             onPageDidChange?()
         } catch {
             print("WikiStoreModel.saveSystemPrompt failed: \(error)")
@@ -301,9 +459,12 @@ public final class WikiStoreModel {
     }
 
     /// Cancel the system-prompt debounce and save synchronously.
+    /// No-op when the draft hasn't been modified (prevents bumping the row
+    /// version on a tab switch when the user only viewed the Instructions page).
     public func flushPendingSystemPromptSave() {
         systemPromptAutosaveTask?.cancel()
         systemPromptAutosaveTask = nil
+        guard isSystemPromptDirty else { return }
         saveSystemPrompt()
     }
 
@@ -350,8 +511,7 @@ public final class WikiStoreModel {
             reloadSummaries()
             let newSelection = WikiSelection.page(page.id)
             recordHistoryTransition(from: loadedSelection, to: newSelection)
-            selection = newSelection
-            loadDrafts(for: newSelection)
+            openTab(newSelection, title: title)
             onPageDidChange?()
         } catch {
             print("WikiStoreModel.newPage failed: \(error)")
@@ -366,6 +526,10 @@ public final class WikiStoreModel {
             try store.updatePage(id: id, title: newTitle, body: page.bodyMarkdown)
             reloadSummaries()
             if selection == .page(id) { draftTitle = newTitle }
+            // Update any tab showing this renamed page.
+            for i in tabs.indices where tabs[i].selection == .page(id) {
+                tabs[i].title = newTitle
+            }
             onPageDidChange?()
         } catch {
             print("WikiStoreModel.rename failed: \(error)")
@@ -376,11 +540,9 @@ public final class WikiStoreModel {
         do {
             try store.deletePage(id: id)
             removeFromHistory(.page(id))
-            if selection == .page(id) {
-                autosaveTask?.cancel()
-                autosaveTask = nil
-                selection = nil
-                loadDrafts(for: nil)
+            // Close any tab showing this deleted page.
+            if let tabIndex = tabs.firstIndex(where: { $0.selection == .page(id) }) {
+                closeTab(at: tabIndex)
             }
             reloadSummaries()
             onPageDidChange?()
@@ -542,9 +704,9 @@ public final class WikiStoreModel {
         do {
             try store.deleteIngestedFile(id: id)
             removeFromHistory(.ingestedFile(id))
-            if selection == .ingestedFile(id) {
-                selection = nil
-                loadDrafts(for: nil)
+            // Close any tab showing this deleted file.
+            if let tabIndex = tabs.firstIndex(where: { $0.selection == .ingestedFile(id) }) {
+                closeTab(at: tabIndex)
             }
             reloadIngestedFiles()
             onPageDidChange?()

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -1,0 +1,485 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+@MainActor
+struct EditorTabTests {
+
+    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-tabs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        return (WikiStoreModel(store: store), store)
+    }
+
+    // MARK: - Initial state
+
+    @Test func startsWithNoTabs() throws {
+        let (model, _) = try tempModel()
+        #expect(model.tabs.isEmpty)
+        #expect(model.activeTabIndex == 0)
+        #expect(model.recentlyClosedTabs.isEmpty)
+    }
+
+    // MARK: - Sidebar-driven selection creates tabs
+
+    @Test func firstSidebarSelectionCreatesInitialTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        #expect(model.tabs.isEmpty)
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+
+        #expect(model.tabs.count == 1)
+        #expect(model.tabs[0].selection == .page(a.id))
+        #expect(model.tabs[0].title == "A")
+        #expect(model.activeTabIndex == 0)
+    }
+
+    @Test func sidebarSingleClickReplacesActiveTabContent() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        #expect(model.tabs.count == 1)
+        #expect(model.tabs[0].title == "A")
+
+        model.selection = .page(b.id)
+        model.handleSelectionChange(to: .page(b.id))
+
+        #expect(model.tabs.count == 1)  // Still one tab — content replaced
+        #expect(model.tabs[0].selection == .page(b.id))
+        #expect(model.tabs[0].title == "B")
+    }
+
+    // MARK: - openTab
+
+    @Test func openTabAddsNewTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        // Seed the first tab via selection.
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        #expect(model.tabs.count == 1)
+
+        // Open B in a new tab (Obsidian-style).
+        model.openTab(.page(b.id))
+
+        #expect(model.tabs.count == 2)
+        #expect(model.tabs[0].selection == .page(a.id))
+        #expect(model.tabs[1].selection == .page(b.id))
+        #expect(model.activeTabIndex == 1)  // New tab is active
+        #expect(model.selection == .page(b.id))
+    }
+
+    @Test func openTabForExistingPageCreatesNewTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        #expect(model.tabs.count == 1)
+
+        // Opening the same page again creates a new tab (Obsidian-style).
+        model.openTab(.page(a.id))
+        #expect(model.tabs.count == 2)
+        #expect(model.tabs[0].selection == .page(a.id))
+        #expect(model.tabs[1].selection == .page(a.id))
+    }
+
+    // MARK: - Singleton reuse
+
+    @Test func singletonSelectionReusesExistingTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.query)
+        #expect(model.tabs.count == 2)
+
+        // Opening query again should switch to the existing query tab.
+        model.openTab(.query)
+        #expect(model.tabs.count == 2)  // No duplicate
+        #expect(model.activeTabIndex == 1)  // Query tab is active
+    }
+
+    @Test func singletonSystemPromptReusesExistingTab() throws {
+        let (model, _) = try tempModel()
+        model.openTab(.systemPrompt)
+        #expect(model.tabs.count == 1)
+        model.openTab(.systemPrompt)
+        #expect(model.tabs.count == 1)
+    }
+
+    @Test func singletonChangeLogReusesExistingTab() throws {
+        let (model, _) = try tempModel()
+        model.openTab(.changeLog)
+        #expect(model.tabs.count == 1)
+        model.openTab(.changeLog)
+        #expect(model.tabs.count == 1)
+    }
+
+    // MARK: - selectTab
+
+    @Test func selectTabSwitchesContent() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        // Both tabs open, B is active (index 1).
+
+        model.selectTab(at: 0)
+        #expect(model.activeTabIndex == 0)
+        #expect(model.selection == .page(a.id))
+    }
+
+    @Test func selectTabFlushesOutgoingDraft() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        model.draftBody = "B content has been edited"
+        model.bodyChanged()
+        model.flushPendingSave()
+
+        // Switch back to tab A. B's draft should have been persisted.
+        model.selectTab(at: 0)
+        let bPage = try store.getPage(id: b.id)
+        #expect(bPage.bodyMarkdown == "B content has been edited")
+    }
+
+    @Test func selectTabWithSameIndexIsNoOp() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.draftBody = "some text"
+
+        // Selecting the already-active tab should not flush/change anything.
+        model.selectTab(at: 0)
+        #expect(model.activeTabIndex == 0)
+        #expect(model.draftBody == "some text")
+    }
+
+    // MARK: - closeTab
+
+    @Test func closeTabActivatesRightNeighbor() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        model.openTab(.page(c.id))
+        #expect(model.tabs.count == 3)
+        #expect(model.activeTabIndex == 2)
+
+        // Close tab 1 (B). Active is 2 > 1, stays at 1 (C shifts left).
+        model.closeTab(at: 1)
+        #expect(model.tabs.count == 2)
+        #expect(model.tabs[1].selection == .page(c.id))
+        #expect(model.activeTabIndex == 1)
+    }
+
+    @Test func closeTabRightmostActivatesLeftNeighbor() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        #expect(model.activeTabIndex == 1)
+
+        // Close tab 1 (rightmost, active).
+        model.closeTab(at: 1)
+        #expect(model.tabs.count == 1)
+        #expect(model.activeTabIndex == 0)
+        #expect(model.tabs[0].selection == .page(a.id))
+    }
+
+    @Test func closeLastTabShowsEmptyState() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        #expect(model.tabs.count == 1)
+
+        model.closeTab(at: 0)
+        #expect(model.tabs.isEmpty)
+        #expect(model.selection == nil)
+    }
+
+    @Test func closeNonActiveTabDoesNotChangeSelection() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        model.openTab(.page(c.id))
+        // Active is tab 2 (C).
+
+        // Close tab 0 (A, not active, to the left of active).
+        model.closeTab(at: 0)
+        #expect(model.tabs.count == 2)
+        #expect(model.activeTabIndex == 1)  // Shifted from 2 → 1
+        #expect(model.selection == .page(c.id))
+    }
+
+    // MARK: - Reopen closed tab
+
+    @Test func reopenLastClosedTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.closeTab(at: 0)
+        #expect(model.tabs.isEmpty)
+
+        model.reopenLastClosedTab()
+        #expect(model.tabs.count == 1)
+        #expect(model.tabs[0].selection == .page(a.id))
+        #expect(model.activeTabIndex == 0)
+    }
+
+    @Test func closeTabPreservesInRecentlyClosedStack() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.closeTab(at: 0)
+
+        #expect(model.recentlyClosedTabs.count == 1)
+        #expect(model.recentlyClosedTabs[0].title == "A")
+    }
+
+    @Test func reopenWhenStackIsEmptyIsNoOp() throws {
+        let (model, _) = try tempModel()
+        #expect(model.recentlyClosedTabs.isEmpty)
+        model.reopenLastClosedTab()
+        #expect(model.tabs.isEmpty)
+    }
+
+    // MARK: - Delete page closes affected tab
+
+    @Test func deletePage_closesAffectedTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        #expect(model.tabs.count == 2)
+        #expect(model.activeTabIndex == 1)  // B is active
+
+        model.delete(a.id)
+        #expect(model.tabs.count == 1)
+        #expect(model.tabs[0].selection == .page(b.id))
+    }
+
+    @Test func deleteActivePageActivatesNeighbor() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        // Active is tab 1 (B).
+
+        model.delete(b.id)
+        #expect(model.tabs.count == 1)
+        #expect(model.activeTabIndex == 0)
+        #expect(model.tabs[0].selection == .page(a.id))
+    }
+
+    @Test func deletePage_notInAnyTab_doesNotAffectTabs() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+
+        // Delete C — not open in any tab.
+        model.delete(c.id)
+        #expect(model.tabs.count == 2)
+    }
+
+    // MARK: - Delete ingested file closes affected tab
+
+    @Test func deleteIngestedFile_closesAffectedTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let f1 = try store.ingestFile(filename: "doc.pdf", data: Data("pdf".utf8))
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.ingestedFile(f1.id))
+        #expect(model.tabs.count == 2)
+
+        model.deleteIngestedFile(f1.id)
+        #expect(model.tabs.count == 1)
+        #expect(model.tabs[0].selection == .page(a.id))
+    }
+
+    // MARK: - Rename updates tab titles
+
+    @Test func renameUpdatesTabTitles() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        #expect(model.tabs[0].title == "A")
+
+        model.rename(a.id, to: "Renamed A")
+        #expect(model.tabs[0].title == "Renamed A")
+    }
+
+    @Test func renamePageOnlyAffectsMatchingTabs() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.openTab(.page(b.id))
+        model.openTab(.query)
+        #expect(model.tabs.count == 3)
+
+        model.rename(a.id, to: "Renamed A")
+        // Tab 0 (page A) should be renamed.
+        #expect(model.tabs[0].title == "Renamed A")
+        // Tab 1 (page B) should be unchanged.
+        #expect(model.tabs[1].title == "B")
+        // Tab 2 (Query) should be unchanged.
+        #expect(model.tabs[2].title == "Query")
+    }
+
+    // MARK: - newPageInNewTab
+
+    @Test func newPageInNewTab_createsPageAndOpensTab() throws {
+        let (model, store) = try tempModel()
+        model.reloadFromStore()
+
+        model.newPageInNewTab(title: "Fresh Page")
+        #expect(model.tabs.count == 1)
+        if case .page = model.tabs[0].selection {
+            // OK
+        } else {
+            #expect(Bool(false), "Expected tab selection to be a page")
+        }
+        #expect(model.tabs[0].title == "Fresh Page")
+        #expect(model.activeTabIndex == 0)
+
+        let summaries = (try? store.listPages(sortBy: .lastUpdated)) ?? []
+        #expect(summaries.contains(where: { $0.title == "Fresh Page" }))
+    }
+
+    // MARK: - History navigation preserves tab metadata
+
+    @Test func historyBackUpdatesActiveTabMetadata() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+
+        model.selection = .page(a.id)
+        model.handleSelectionChange(to: .page(a.id))
+        model.selection = .page(b.id)
+        model.handleSelectionChange(to: .page(b.id))
+
+        #expect(model.tabs.count == 1)
+        #expect(model.tabs[0].title == "B")
+
+        model.navigateBack()
+        #expect(model.selection == .page(a.id))
+        #expect(model.tabs[0].title == "A")
+        #expect(model.tabs[0].selection == .page(a.id))
+    }
+
+    // MARK: - tabTitle helper
+
+    @Test func tabTitleForPage() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "My Page")
+        model.reloadFromStore()
+        #expect(model.tabTitle(for: .page(a.id)) == "My Page")
+    }
+
+    @Test func tabTitleForMissingPageReturnsUntitled() throws {
+        let (model, _) = try tempModel()
+        #expect(model.tabTitle(for: .page(PageID(rawValue: "nonexistent"))) == "Untitled")
+    }
+
+    @Test func tabTitleForSpecialSelections() throws {
+        let (model, _) = try tempModel()
+        #expect(model.tabTitle(for: .query) == "Query")
+        #expect(model.tabTitle(for: .systemPrompt) == "Instructions")
+        #expect(model.tabTitle(for: .changeLog) == "Activity")
+    }
+
+    @Test func tabTitleForIngestedFile() throws {
+        let (model, store) = try tempModel()
+        let f1 = try store.ingestFile(filename: "report.pdf", data: Data("pdf".utf8))
+        model.reloadFromStore()
+        #expect(model.tabTitle(for: .ingestedFile(f1.id)) == "report.pdf")
+    }
+
+    // MARK: - tabIcon helper
+
+    @Test func tabIconReturnsExpectedSymbols() throws {
+        let (model, _) = try tempModel()
+        #expect(model.tabIcon(for: .query) == "bubble.left.and.text.bubble.right")
+        #expect(model.tabIcon(for: .systemPrompt) == "sparkles")
+        #expect(model.tabIcon(for: .changeLog) == "clock.arrow.circlepath")
+        #expect(model.tabIcon(for: .page(PageID(rawValue: "any"))) == "doc.text")
+    }
+}

--- a/plans/multi-tab-editor.md
+++ b/plans/multi-tab-editor.md
@@ -1,0 +1,132 @@
+# Multi-Tab Editor Space
+
+## Context
+
+SelfDrivingWiki currently has a single-content navigation model: one `WikiSelection` at a time, with browser-like back/forward history. The user wants an Obsidian-like multi-tab editor where each opened page (or Query, Instructions, etc.) gets its own tab in a horizontal tab bar above the content area.
+
+**Why**: Users need to work with multiple pages simultaneously — referencing one while editing another, keeping Query open alongside pages, etc. The current single-selection model forces constant back/forward navigation.
+
+**What changes**: A custom SwiftUI tab bar inside the detail pane. Each tab tracks a `WikiSelection`. The existing draft/autosave system stays on `WikiStoreModel` (shared) — switching tabs flushes and loads via the existing `flushPendingSaves()` / `loadDrafts()` infrastructure. A future phase can move drafts into tabs for true multi-edit.
+
+**Click behavior**: Obsidian-style — single-clicking a page in the sidebar opens/activates it in a tab. If a tab for that page already exists, focus it; otherwise create a new tab. Singleton types (Query, Instructions, Activity) have at most one tab each.
+
+## Approach
+
+### New Types
+
+**`EditorTab`** (`Sources/WikiFSCore/EditorTab.swift`):
+```swift
+public struct EditorTab: Hashable, Sendable, Identifiable {
+    public let id: UUID
+    public var selection: WikiSelection
+    public var title: String
+}
+```
+Plus `WikiStoreModel` helpers `tabTitle(for:)` and `tabIcon(for:)` that derive display strings/icons from the live summaries/ingestedFiles arrays.
+
+### WikiStoreModel Changes
+
+Add tab management properties:
+- `tabs: [EditorTab]` — all open tabs, in display order
+- `activeTabIndex: Int` — index into tabs (0 when empty)
+- `recentlyClosedTabs: [EditorTab]` — max 10, for Cmd+Shift+T
+- `isSwitchingTab: Bool` (private) — suppresses double-processing in `handleSelectionChange`
+
+New methods:
+- **`openTab(_:title:)`** — create or focus a tab. Singleton types reuse existing. Non-singleton always creates new.
+- **`selectTab(at:)`** — switch to tab by index, flush outgoing drafts, load incoming
+- **`closeTab(at:)`** — close tab, preserve in recently-closed stack, activate right-neighbor (or left if rightmost), show empty state if last tab
+- **`reopenLastClosedTab()`** — pop from recently-closed stack, call `openTab`
+- **`newPageInNewTab(title:)`** — create page + open in new tab
+
+Modified methods:
+- **`handleSelectionChange(to:)`** — skip during tab switches (`isSwitchingTab` guard). Update active tab's metadata on sidebar-driven change.
+- **`delete(_:)`** / **`deleteIngestedFile(_:)`** — close any tab showing the deleted item
+- **`rename(_:to:)`** — update tab titles for renamed page
+
+The existing `draftTitle`/`draftBody` buffers remain on the model. The `selection` property stays and always mirrors the active tab's selection.
+
+### New Views
+
+**`TabBarView`** (`Sources/WikiFS/TabBarView.swift`):
+- Horizontal `ScrollView` with `HStack` of `TabBarItemView` items
+- `.regularMaterial` background, bottom divider
+- 34pt height
+
+**`TabBarItemView`** (`Sources/WikiFS/TabBarItemView.swift`):
+- Icon + truncated title + hover-revealed close button
+- Active tab: accent underline + `.controlBackgroundColor` fill
+- Inactive tab: subtle background on hover
+- Close button: 14pt circle with xmark, visible on hover or when active
+
+### ContentView Changes
+
+- Wrap detail content in `VStack` with `TabBarView` at top
+- Add hidden keyboard shortcut buttons: Cmd+W (close tab), Cmd+Shift+T (reopen), Cmd+1-9 (switch to tab N)
+- Add "New Tab" toolbar menu (New Page, Query, Instructions, Activity)
+
+### SidebarView Changes
+
+- All single-clicks call `store.openTab(first)` instead of `store.selection = first`
+- Singleton types (.query, .systemPrompt, .changeLog) open inline — the sidebar highlight follows the active tab
+- No explicit Cmd+click handling needed for v1 (Obsidian-style makes single-click the tab-opening action)
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Page deleted while open in tab | `delete(_:)` calls `closeTab(at:)` for affected tab |
+| Wiki switched | `RootView.id(activeWikiID)` forces clean rebuild with empty tabs |
+| Last tab closed | `selection = nil`, empty state shown |
+| Singleton tab already open | `openTab` switches to existing instead of duplicating |
+| Many tabs | ScrollView handles overflow |
+
+### Files
+
+**New**: `EditorTab.swift`, `TabBarView.swift`, `TabBarItemView.swift`, `EditorTabTests.swift`
+**Modified**: `WikiStoreModel.swift`, `ContentView.swift`, `SidebarView.swift`
+**Unchanged**: `WikiDetailView.swift`, `RootView.swift`, `PageDetailView.swift`, `QueryConversationView.swift`, all other detail views
+
+## Implementation Order
+
+1. Add `EditorTab` type + `WikiStoreModel` extensions (`EditorTab.swift`)
+2. Add tab properties + methods to `WikiStoreModel`
+3. Write and pass unit tests (`EditorTabTests.swift`)
+4. Run full test suite, verify no regressions
+5. Build `TabBarView` + `TabBarItemView`
+6. Wire tab bar into `ContentView` detail VStack
+7. Update `SidebarView.selectionDidChange` to use `openTab`
+8. Add keyboard shortcut hidden buttons
+9. Update `delete`/`rename`/`deleteIngestedFile` for tab awareness
+10. Full manual verification (see below)
+11. Skill pass: `swiftui-pro`, `macos-design`, `typography-designer`
+
+## Verification
+
+### Automated
+```sh
+swift test --filter EditorTabTests    # new tab model tests
+swift test                            # full suite — must be green, no regressions
+make check                            # compile gate
+```
+
+### Manual (live app)
+1. Open app → empty state with no tabs
+2. Click a page → one tab appears, content loads
+3. Click another page → second tab opens, becomes active
+4. Click first page in sidebar → focuses existing tab (no duplicate)
+5. Click tab X button → tab closes, neighbor activates
+6. Close last tab → empty state
+7. Cmd+W → closes active tab
+8. Cmd+Shift+T → reopens last closed tab
+9. Cmd+1-9 → switches between tabs
+10. Open Query in a tab, type → switch away → switch back → conversation preserved
+11. Delete a page open in a tab → tab closes
+12. Rename a page open in a tab → tab title updates
+13. Switch wikis → tabs reset
+14. Create new page → opens in new tab
+
+### Gate
+- `make check` clean
+- `swift test` all green
+- Signed `make` bundle launches and passes manual checks above


### PR DESCRIPTION
Adds a horizontal tab bar above the detail pane so users can keep multiple pages, Query, Instructions, and Activity open simultaneously — like Obsidian tabs.

## What

- **EditorTab** (`WikiFSCore/EditorTab.swift`) — value type with UUID identity, `WikiSelection`, and display title. Plus `tabTitle(for:)` / `tabIcon(for:)` helpers.
- **Tab management** on `WikiStoreModel`: `openTab`, `selectTab`, `closeTab`, `reopenLastClosedTab`, `newPageInNewTab`. Singleton types (Query, Instructions, Activity) reuse existing tabs; pages/files always create new tabs (Obsidian-style).
- **TabBarView + TabBarItemView** — horizontal scrollable tab strip with `.regularMaterial` background, icon + truncated title + hover-revealed close button, active accent underline.
- **Keyboard shortcuts**: `Cmd+W` close tab, `Cmd+Shift+T` reopen, `Cmd+1–9` switch, `Cmd+N` new page in new tab.
- **Dirty-flag tracking**: opening a page without editing no longer bumps its `updated_at` timestamp (`isDraftDirty` guard in `flushPendingSave`).
- **Sidebar** single-click calls `openTab` (Obsidian-style navigation).

## Tested

- `swift test`: **510/510 green** (31 new `EditorTabTests`, 0 regressions)
- `make check`: clean compile
- `make`: clean signed bundle

## Files

| Type | File |
|------|------|
| New | `Sources/WikiFSCore/EditorTab.swift` |
| New | `Sources/WikiFS/TabBarView.swift` |
| New | `Sources/WikiFS/TabBarItemView.swift` |
| New | `Tests/WikiFSTests/EditorTabTests.swift` |
| New | `plans/multi-tab-editor.md` |
| Modified | `Sources/WikiFSCore/WikiStoreModel.swift` |
| Modified | `Sources/WikiFS/ContentView.swift` |
| Modified | `Sources/WikiFS/SidebarView.swift` |
| Modified | `PLAN.md`, `PROGRESS.md` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)