### PR TITLE
feat: pointing-hand cursor on link hover in markdown preview

### DIFF
--- a/Sources/WikiFS/MarkdownPreview.swift
+++ b/Sources/WikiFS/MarkdownPreview.swift
@@ -35,8 +35,7 @@ struct MarkdownPreview: View {
                 } else {
                     StructuredText(markdown: renderedBody)
                         .id(renderedBody)
-                        // Textual's macOS document-selection overlay owns cursor/link hit-testing
-                        // and can get stale after navigation; keep links on the fragment tap path.
+                        .textual.textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }


### PR DESCRIPTION
Enables Textual's `.textSelection(.enabled)` on `StructuredText` in `MarkdownPreview` so that `AppKitTextSelectionInteraction` activates its `.onContinuousHover` cursor tracking.

**Before:** Links in the preview always showed the default arrow cursor.

**After:** 
- `NSCursor.pointingHand` when hovering over wiki links, external URLs, and footnotes
- `NSCursor.iBeam` when hovering over selectable text

The `.id(renderedBody)` modifier already forces a full view recreation on navigation, so the text selection overlay stays fresh across page changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)