### PR TITLE
fix(html): don't let an unclosed <head> swallow the whole document

### DIFF
--- a/Sources/WikiFSCore/HTMLToMarkdown.swift
+++ b/Sources/WikiFSCore/HTMLToMarkdown.swift
@@ -92,6 +92,13 @@ public enum HTMLToMarkdown {
         return denoised
     }
 
+    /// Metadata elements allowed inside `<head>`. Per HTML5 the `</head>` end tag is
+    /// optional: the head is implicitly closed by the first start tag that is NOT one
+    /// of these (in practice `<body>`). We use this to terminate the head-skip below.
+    private static let headMetadata: Set<String> = [
+        "base", "link", "meta", "noscript", "script", "style", "template", "title",
+    ]
+
     /// Remove every token inside (and including) any element whose name is in
     /// `names`. Nesting-aware: tracks a depth counter per opened noise container so
     /// a `<nav>` inside a `<nav>` is fully removed. Void/self-closing noise tags are
@@ -102,16 +109,28 @@ public enum HTMLToMarkdown {
         var skipName: String?
         for token in tokens {
             if skipDepth > 0 {
-                switch token {
-                case let .startTag(name, _, selfClosing) where name == skipName && !selfClosing:
-                    skipDepth += 1
-                case let .endTag(name) where name == skipName:
-                    skipDepth -= 1
-                    if skipDepth == 0 { skipName = nil }
-                default:
-                    break
+                // `<head>` has an OPTIONAL end tag: HTML5 implicitly closes it at the
+                // first non-metadata start tag (normally `<body>`). Bikeshed/W3C pages
+                // omit `</head>` entirely, so a literal "skip until </head>" swallows
+                // the whole document. Detect the implicit close, end the skip, and fall
+                // through so the terminating token (the body) is processed normally.
+                if skipName == "head",
+                   case let .startTag(name, _, _) = token,
+                   !headMetadata.contains(name) {
+                    skipDepth = 0
+                    skipName = nil
+                } else {
+                    switch token {
+                    case let .startTag(name, _, selfClosing) where name == skipName && !selfClosing:
+                        skipDepth += 1
+                    case let .endTag(name) where name == skipName:
+                        skipDepth -= 1
+                        if skipDepth == 0 { skipName = nil }
+                    default:
+                        break
+                    }
+                    continue
                 }
-                continue
             }
             if case let .startTag(name, _, selfClosing) = token, names.contains(name) {
                 if !selfClosing {

--- a/Tests/WikiFSTests/HTMLToMarkdownTests.swift
+++ b/Tests/WikiFSTests/HTMLToMarkdownTests.swift
@@ -167,6 +167,14 @@ struct HTMLToMarkdownTests {
         #expect(md(html) == "visible")
     }
 
+    /// HTML5 makes `</head>` optional; Bikeshed/W3C documents omit it, relying on the
+    /// `<body>` start tag to implicitly close the head. The head-skip must end there
+    /// rather than swallowing the entire document (which yielded an empty file).
+    @Test func unclosedHeadImplicitlyClosedByBody() {
+        let html = "<html><head><meta charset=\"utf-8\"><title>T</title><body><main><p>visible</p></main>"
+        #expect(md(html) == "visible")
+    }
+
     @Test func articlePreferredOverSurroundingChrome() {
         let html = """
         <body><nav>nav</nav><article><h1>Real</h1><p>Body</p></article><aside>ad</aside></body>


### PR DESCRIPTION
## Why

Ingesting a URL whose HTML omits the optional `</head>` tag produced an **empty markdown file**. HTML5 lets `</head>` be omitted (the `<body>` start tag implicitly closes the head), and Bikeshed/W3C-generated specs do exactly that — e.g. https://www.w3.org/TR/2019/REC-webauthn-1-20190304/.

The container-stripping step skipped from `<head>` until a matching `</head>` that never came, so it dropped the entire `<body>` (and the `<main>` content under it) → empty output. The file still got *named* correctly (title extraction runs over the full token stream), which is why it showed up as a titled-but-blank `.md`.

## Fix

End the head-skip at the first non-metadata start tag (per HTML5), then process that token normally. Adds a regression test for the unclosed-`<head>` shape.

`swift test --filter "URLIngest|HTMLToMarkdown"` → all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)