### PR TITLE
Reader-first system prompt with Cmd+E edit mode

### DIFF
--- a/Sources/WikiFS/SystemPromptDetailView.swift
+++ b/Sources/WikiFS/SystemPromptDetailView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 import WikiFSCore
 
-/// Editor + live preview for the singleton system-prompt document — the agent's
+/// Reader-first surface for the singleton system-prompt document — the agent's
 /// instructions, projected read-only at the wiki root as `CLAUDE.md` and
-/// `AGENTS.md`. Mirrors `PageDetailView` but there is no editable title (it is a
-/// singleton); instead a fixed header explains where the document surfaces. The
-/// editor binds to the model's `draftSystemPrompt`; autosave fires via
-/// `.onChange` (not a `Binding(get:set:)`, per swiftui-pro).
+/// `AGENTS.md`. Like `PageDetailView`, the default state renders the prompt as
+/// formatted markdown; manual editing is an explicit mode (Cmd+E) that reveals a
+/// monospaced source editor and keeps the existing system-prompt autosave intact.
+/// There is no editable title (it is a singleton); a fixed header explains where
+/// the document surfaces and stays visible in both modes.
 struct SystemPromptDetailView: View {
     @Bindable var store: WikiStoreModel
+    @State private var isEditing = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -29,23 +31,62 @@ struct SystemPromptDetailView: View {
 
             Divider().opacity(PageEditorMetrics.dividerOpacity)
 
-            TextEditor(text: $store.draftSystemPrompt)
-                .font(.system(.body, design: .monospaced))
-                .scrollContentBackground(.hidden)
-                .padding(.horizontal, PageEditorMetrics.contentInset - 5)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .frame(minHeight: PageEditorMetrics.editorMinHeight)
-                .onChange(of: store.draftSystemPrompt) { store.systemPromptChanged() }
-
-            Divider().opacity(PageEditorMetrics.dividerOpacity)
-
-            MarkdownPreview(store: store, markdown: store.draftSystemPrompt)
-                .frame(maxWidth: .infinity)
-                .frame(minHeight: PageEditorMetrics.previewMinHeight)
-                .background(.quaternary.opacity(0.25))
+            if isEditing {
+                editor
+            } else {
+                reader
+            }
         }
         // Read-only while the agent runs (decision #6); autosave paused in the model.
         .disabled(store.isAgentRunning)
         .frame(minWidth: PageEditorMetrics.detailMinWidth)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(isEditing ? "Done Editing" : "Edit Instructions",
+                       systemImage: isEditing ? "checkmark" : "pencil") {
+                    toggleEditing()
+                }
+                .keyboardShortcut("e", modifiers: .command)
+                .disabled(store.isAgentRunning)
+                .help(isEditing ? "Return to the rendered instructions"
+                                : "Edit the system prompt source")
+            }
+        }
+        .onChange(of: store.selection) {
+            isEditing = false
+        }
+        .onChange(of: store.isAgentRunning) { _, isRunning in
+            if isRunning {
+                isEditing = false
+            }
+        }
+    }
+
+    // MARK: - Modes
+
+    /// Default mode: the prompt rendered as formatted, read-only markdown.
+    private var reader: some View {
+        MarkdownPreview(store: store, markdown: store.draftSystemPrompt)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(minHeight: PageEditorMetrics.previewMinHeight)
+    }
+
+    /// Edit mode: the monospaced source editor, bound to the live draft buffer.
+    /// Autosave fires via `.onChange` (not a `Binding(get:set:)`, per swiftui-pro).
+    private var editor: some View {
+        TextEditor(text: $store.draftSystemPrompt)
+            .font(.system(.body, design: .monospaced))
+            .scrollContentBackground(.hidden)
+            .padding(.horizontal, PageEditorMetrics.contentInset - 5)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(minHeight: PageEditorMetrics.editorMinHeight)
+            .onChange(of: store.draftSystemPrompt) { store.systemPromptChanged() }
+    }
+
+    private func toggleEditing() {
+        if isEditing {
+            store.flushPendingSystemPromptSave()
+        }
+        isEditing.toggle()
     }
 }


### PR DESCRIPTION
## Summary

Reworks `SystemPromptDetailView` to be reader-first, mirroring `PageDetailView`:

- **Default state** renders the system prompt as formatted, read-only markdown instead of always showing the raw monospaced editor + live preview split.
- **Editing is now an explicit mode** toggled with **Cmd+E** (toolbar button: "Edit Instructions" / "Done Editing"), revealing the monospaced source editor.
- The **fixed header** explaining where the document surfaces (`CLAUDE.md` / `AGENTS.md`) stays visible in both modes.
- Existing **system-prompt autosave is preserved** — `flushPendingSystemPromptSave()` runs when leaving edit mode.
- Edit mode **resets** on selection change and when the agent starts running (the view is already read-only while the agent runs).

## Notes

- Autosave continues to fire via `.onChange` rather than a `Binding(get:set:)`, per swiftui-pro.
- No editable title since the system prompt is a singleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)