### PR TITLE
Fix transcript sidebar disappearing on tab switch

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-20 — Fix transcript sidebar disappearing on tab switch
+
+The `AgentTranscriptSidebar` had Query-specific suppression that forced
+`isTranscriptExpanded = false` when entering the Query tab and guarded
+visibility/auto-open/toggle-enable with `!isQuerySelected`. This caused the
+sidebar to collapse on entry to Query and stay collapsed when switching back to
+other tabs — the state didn't recover.
+
+- **`ContentView`:** removed `!isQuerySelected` from the sidebar visibility
+  guard, the auto-open-on-agent-start guard, the auto-open-on-ingest guard,
+  and `canShowTranscript`. Removed the forced `isTranscriptExpanded = false`
+  in `onChange(of: store.selection)`. Removed the now-unused
+  `isQuerySelected` computed property. (-16/+8)
+
+The sidebar now persists across all tab switches and works consistently
+regardless of which detail view is active.
+
+**Verified.** `swift build` clean; `swift test` — 570 tests, 48 suites, 0
+failures. PR #27.
+
 ## 2026-06-20 — Fix Zotero "View in Zotero" link + PageDetailView markdown alignment
 
 Fixed two bugs found in live use after the Zotero source-link feature landed:

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -43,7 +43,7 @@ struct ContentView: View {
                     )
                     .frame(maxWidth: .infinity)
 
-                    if isTranscriptExpanded && !isQuerySelected {
+                    if isTranscriptExpanded {
                         Divider()
                         AgentTranscriptSidebar(launcher: agentLauncher)
                         .transition(.move(edge: .trailing).combined(with: .opacity))
@@ -99,12 +99,9 @@ struct ContentView: View {
         // (§3.5). The view, not the binding, is the right place for this.
         .onChange(of: store.selection) { _, newValue in
             store.handleSelectionChange(to: newValue)
-            if newValue == .query {
-                isTranscriptExpanded = false
-            }
         }
         .onChange(of: agentLauncher.isRunning) { _, isRunning in
-            if isRunning && !isQuerySelected {
+            if isRunning {
                 isTranscriptExpanded = true
             }
         }
@@ -112,7 +109,7 @@ struct ContentView: View {
         // PDF-conversion phase, before the agent process spawns — so the
         // conversion box is visible.
         .onChange(of: agentLauncher.ingestingFileIDs) { _, newValue in
-            if !newValue.isEmpty && !isQuerySelected {
+            if !newValue.isEmpty {
                 isTranscriptExpanded = true
             }
         }
@@ -134,16 +131,11 @@ struct ContentView: View {
     }
 
     private var canShowTranscript: Bool {
-        !isQuerySelected
-            && (agentLauncher.isRunning
-                || !agentLauncher.ingestingFileIDs.isEmpty
-                || !agentLauncher.events.isEmpty
-                || agentLauncher.preflightError != nil
-                || !agentLauncher.stderr.isEmpty)
-    }
-
-    private var isQuerySelected: Bool {
-        store.selection == .query
+        agentLauncher.isRunning
+            || !agentLauncher.ingestingFileIDs.isEmpty
+            || !agentLauncher.events.isEmpty
+            || agentLauncher.preflightError != nil
+            || !agentLauncher.stderr.isEmpty
     }
 
     private func toggleTranscript() {


### PR DESCRIPTION
## Summary

The AgentTranscriptSidebar had Query-specific suppression that caused it to collapse when switching to the Query tab and stay collapsed on subsequent tab switches. Removed all Query-specific guards so the sidebar behaves consistently across every detail view.

## Changes

- **Sidebar visibility**: removed `!isQuerySelected` guard — sidebar now shows alongside any view
- **State persistence**: removed forced `isTranscriptExpanded = false` when entering Query — sidebar state survives all tab switches
- **Auto-open**: removed `!isQuerySelected` from agent-start and ingest-start auto-open behaviors
- **Toggle button**: `canShowTranscript` no longer excludes Query
- Removed now-unused `isQuerySelected` computed property

## Files

| File | Change |
|------|--------|
| `Sources/WikiFS/ContentView.swift` | Removed 5 Query-specific sidebar guards (-16/+8) |

## Verified

- `swift build`: clean
- `swift test`: 570 tests, 48 suites, 0 failures