### PR TITLE
Grey out Ingest/Extract buttons, fix standalone Extract sidebar + Stop, reuse existing markdown

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,22 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-20 — Grey out Ingest/Extract buttons during any file ingest
+
+The "Ingest into Wiki" and "Extract Markdown" buttons in
+`IngestedFileDetailView` were only disabled when the agent was running or
+the same file was being ingested. During the PDF-conversion phase (before
+agent launch), both buttons were still active — a second ingest could be
+started concurrently.
+
+- **`IngestedFileDetailView`:** added `isAnyFileIngesting` parameter
+  (true when any ingest is in flight, not just this file's). Both buttons
+  now include it in their `.disabled()` guards.
+- **`WikiDetailView`:** plumbed `isAnyFileIngesting` from
+  `!launcher.ingestingFileIDs.isEmpty`.
+
+**Verified.** `swift build` clean. PR #28.
+
 ## 2026-06-20 — Fix transcript sidebar disappearing on tab switch
 
 The `AgentTranscriptSidebar` had Query-specific suppression that forced

--- a/Sources/WikiFS/IngestedFileDetailView.swift
+++ b/Sources/WikiFS/IngestedFileDetailView.swift
@@ -10,6 +10,10 @@ struct IngestedFileDetailView: View {
     let hasBeenIngested: Bool
     let isIngesting: Bool
     let isRunning: Bool
+    /// `true` when any file (not necessarily this one) is mid-ingest — covers the
+    /// PDF-conversion phase before the agent process starts, when `isRunning` is
+    /// still `false`.
+    let isAnyFileIngesting: Bool
     let runIngest: (PageID) -> Void
     @Bindable var store: WikiStoreModel
 
@@ -143,13 +147,13 @@ struct IngestedFileDetailView: View {
                         runIngest(file.id)
                     }
                         .keyboardShortcut(.return, modifiers: .command)
-                        .disabled(isRunning || isIngesting)
+                        .disabled(isRunning || isIngesting || isAnyFileIngesting)
                     if isPDF, !hasMarkdown {
                         Button(isExtracting ? "Extracting…" : "Extract Markdown",
                                systemImage: "doc.plaintext") {
                             Task { await runExtraction() }
                         }
-                        .disabled(isExtracting || isRunning)
+                        .disabled(isExtracting || isRunning || isAnyFileIngesting)
                     }
                     if isMarkdownEditable {
                         Button("Edit", systemImage: "pencil") {

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -68,6 +68,7 @@ struct WikiDetailView: View {
                     hasBeenIngested: store.hasIngestedFile(file),
                     isIngesting: launcher.ingestingFileIDs.contains(file.id),
                     isRunning: launcher.isRunning,
+                    isAnyFileIngesting: !launcher.ingestingFileIDs.isEmpty,
                     runIngest: runIngest,
                     store: store
                 )


### PR DESCRIPTION
## Summary

Fixes several bugs in the standalone "Extract Markdown" path and improves the ingest pipeline.

### Bugs fixed

**Extract button didn't open the sidebar PDF conversion box.** `runExtraction()` used local `@State` variables but `AgentTranscriptSidebar.showsConversion` checked `launcher.isExtracting` and `launcher.extractionLog` — which were never set by the standalone path. The sidebar auto-expanded but showed only an empty Agent Activity section.

**Stop button was a no-op during standalone extraction.** The extraction `Task` was created inline and never stored. `AgentLauncher.stop()` cancelled only `ingestTask` and `process`, both `nil` during standalone extraction. Added `extractTask` to `AgentLauncher`, stored by the Extract button, cancelled by `stopExtraction()`.

**Ingest button stayed active during extraction.** Added `|| isThisFileExtracting` to the Ingest button's `.disabled()` guard so the user can't start an ingest on a file that's mid-extraction.

### Improvements

**Ingest re-uses existing extracted markdown.** `AgentOperationRunner.runMultiIngest` now checks `store.processedMarkdownHead(for: file)` before running pdf2md. If markdown was already extracted via the standalone button (or a prior ingest), it reuses the existing content and skips the heavy conversion entirely — no extraction slot taken.

**Two distinct Stop buttons.** The sidebar had one shared Stop button that killed everything. Now there are two, matching the two independent locks:
- **Stop Conversion** (PDF Conversion box header) — calls `stopExtraction()`, cancels only the pdf2md conversion
- **Stop Agent** (Agent Activity section header) — calls `stopAgent()`, terminates only the claude process

**Extraction logs moved to launcher.** The detail view keeps only a minimal `Extracting…` spinner; all progress log output goes to `launcher.extractionLog` for the sidebar's PDF Conversion box.

### Original change

Grey out "Ingest into Wiki" and "Extract Markdown" buttons while any file is ingesting (`isAnyFileIngesting = !launcher.ingestingFileIDs.isEmpty`), preventing concurrent ingest starts during the PDF-conversion phase.

## Tests

`swift test` — 596 tests, 50 suites, 0 failures (+10):
- `AgentExtractionLockTests` (+7: `stopCancelsExtractTask`, `stopWithNoExtractTaskIsNoOp`, `isExtractingFlagExposedByLauncher`, `stopExtractionCancelsExtractTask`, `stopExtractionClearsExtractionFlags`, `stopExtractionWithNoTaskIsSafe`, `stopAgentDoesNotClearExtractionFlags`)
- `ProcessedMarkdownTests` (+3: `pdfHeadNilBeforeExtraction`, `seedPdfMarkdownCreatesHead`, `seedPdfMarkdownDoubleSeedReturnsExisting`)

## Files

| File | Change |
|------|--------|
| `Sources/WikiFS/IngestedFileDetailView.swift` | Set launcher flags in `runExtraction()`; removed local `extractionLog`; store `extractTask`; disable Ingest button during extraction |
| `Sources/WikiFS/AgentLauncher.swift` | Added `extractTask`; split `stop()` into `stopExtraction()` / `stopAgent()` |
| `Sources/WikiFS/AgentTranscriptSidebar.swift` | Two distinct Stop buttons (conversion box + activity section); simplified header |
| `Sources/WikiFS/AgentOperationRunner.swift` | Skip pdf2md when markdown already extracted; reuse existing content |
| `Tests/WikiFSTests/AgentExtractionLockTests.swift` | +7 tests for stop separation + extractTask cancellation |
| `Tests/WikiFSTests/ProcessedMarkdownTests.swift` | +3 tests for seed/reuse contract |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
