### PR TITLE
Fix standalone Extract sidebar + Stop, reuse existing markdown, split stop buttons

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -49,6 +49,7 @@ load-bearing for the app to function.
 | [`plans/pdf-extraction.md`](plans/pdf-extraction.md) | Add docling + granite-docling pipeline. A `pdf2md` CLI converts PDFs to markdown at ingest time; extracted markdown stored as a sibling `ingested_files` row, projected on the mount. Agent prefers `.md` siblings, falls back to `Read` on the original. |
 | [`plans/semantic-search.md`](plans/semantic-search.md) | Semantic (meaning-based) search over pages using sqlite-vec + Apple NLEmbedding. Embedding at save time, cosine-similarity ranking inside SQLite, search bar in the sidebar, `wikictl search` for the agent. v7 migration. |
 | [`plans/markdown-folder-import.md`](plans/markdown-folder-import.md) | Import an entire folder of Markdown files (Obsidian vault, LogSeq graph, or any `.md` directory) as source material. Recursive walk, .md filter, filename dedup; lands files in `ingested_files` for the agent to curate via Ingest. |
+| [`plans/extraction-vs-ingestion-lock.md`](plans/extraction-vs-ingestion-lock.md) | **Current direction:** treat markdown *extraction* (pdf2md) and agent *ingestion* (the `claude -p` run) as two phases. Extraction must never lock queries, edits, or another file's ingest. Split the overloaded `ingestingFileIDs` into `extractingFileIDs` (pdf2md phase) + `ingestingFileIDs` (agent-spawn phase), plus an optional separate extraction lock to serialize pdf2md without touching the spawn slot. |
 | [`plans/wikictl-file-reads.md`](plans/wikictl-file-reads.md) | A `wikictl file` command family (`list` / `cat` / `export`) so the agent reads raw ingested files from SQLite instead of the File Provider mount during Query. First concrete step of the provider-decouple effort; rewrites the Query prompt off `$WIKI_ROOT/files/...`. |
 | [`plans/tab-context-menu-rebuild.md`](plans/tab-context-menu-rebuild.md) | Multi-tab editor space — design of record. `activeTabID: UUID?` source of truth (no index arithmetic), one-intent-per-method tab ops, tab reuse, native SwiftUI `.contextMenu` (Close / Close Others / Close Tabs After / Close All), opacity-fade close button, responsive shrink-to-fit strip with overflow menu. 43 `EditorTabTests` + 7 `TabBarLayoutTests`. |
 | [`SWIFTUI-RULES.md`](SWIFTUI-RULES.md) | Hard-won SwiftUI/macOS rules. Apply when writing or reviewing any view. |
@@ -102,6 +103,16 @@ handoff). 341 tests green; clean signed bundle (app + appex + `wikictl`).**
   `pdf2md` as a subprocess with continuous pipe draining; `PdfExtractionView` shows
   readiness, download progress, and live conversion log during ingest. 22 Swift tests
   + 67 Python tests. (PR #11.)
+- **Serialized claude spawn slot** — the single shared `AgentLauncher` now serializes
+  all `claude -p` spawns (ingest / query / lint) through a FIFO, cancellation-aware
+  spawn slot (`awaitSpawnSlot` / `releaseSpawnSlot`). Two claude runs never overlap;
+  a `pdf2md` extraction may overlap a claude query run (it does NOT take the slot).
+  The old silent-drop `guard !isRunning` is gone — a query started during an ingest's
+  extraction now runs, and the ingest agent waits for the slot and runs afterward. The
+  edit lock (`store.isAgentRunning`) is unchanged in meaning: locked only while a
+  claude process runs, unlocked during extraction. The Query page mounts the orange
+  `AgentRunBanner` and scopes its debug cluster to active query runs only. 6 new
+  `AgentSpawnSlotTests`.
 
 **Phase summary (newest first; see `PROGRESS.md` for each gate's evidence):**
 - **Phase D — the schema** ✅ real maintainer `CLAUDE.md` schema (layout,

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,109 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-20 — Standalone Extract Markdown fixes + Stop-button overhaul
+
+The standalone "Extract Markdown" button in `IngestedFileDetailView` had two bugs
+from its divergence with the ingest-path extraction in `AgentOperationRunner`:
+
+1. **Sidebar PDF Conversion box never appeared.** `runExtraction()` used its own local
+   `@State` variables (`isExtracting`, `extractionLog`), but
+   `AgentTranscriptSidebar.showsConversion` checked `launcher.isExtracting` and
+   `launcher.extractionLog` — which were never set by the standalone path. The sidebar
+   auto-expanded (because `extractingFileIDs` was inserted), but showed only an empty
+   Agent Activity section.
+2. **Stop button was a no-op.** The extraction `Task` was created inline
+   (`Task { await runExtraction() }`) and never stored. `AgentLauncher.stop()` cancelled
+   only `ingestTask` and `process`, both `nil` during standalone extraction.
+
+Additional improvements found during the fix pass:
+
+4. **Ingest button stayed active during extraction.** The "Ingest into Wiki" button was
+   not disabled while the same file was mid-extraction, risking a double operation.
+5. **Ingest-path always re-extracted PDFs.** `runMultiIngest` ran pdf2md for every PDF
+   even when markdown had already been extracted via the standalone button — wasting a
+   heavy conversion and taking the extraction slot unnecessarily.
+6. **Single Stop button conflated two independent operations.** The sidebar had one
+   shared Stop button that called `launcher.stop()` (kill everything). Two distinct
+   buttons now match the two independent locks: Stop Conversion (extraction slot only)
+   and Stop Agent (spawn slot only).
+
+**Changes:**
+
+- **`IngestedFileDetailView.runExtraction()`** now sets `launcher.isExtracting`,
+  `launcher.extractionPID`, and `launcher.extractionLog` (with `onProgress`/`onStart`
+  callbacks to `PdfExtractionService.convert`) so the sidebar's PDF Conversion box
+  renders with live progress. The local `@State extractionLog` is removed — all log
+  output goes to `launcher.extractionLog`; the detail view header keeps only a minimal
+  "Extracting…" spinner driven by `isThisFileExtracting`.
+- **`extractTask`** added to `AgentLauncher` (mirrors `ingestTask` for the standalone
+  path). Stored/cleared by the Extract button action; cancelled by `stopExtraction()`.
+  `PdfExtractionService.run()`'s `onCancel` handler terminates the pdf2md subprocess.
+- **Ingest button disabled during extraction** — `|| isThisFileExtracting` added to the
+  `.disabled()` guard in `IngestedFileDetailView`.
+- **`AgentOperationRunner.runMultiIngest`** now checks `store.processedMarkdownHead(for:
+  file)` before running pdf2md. If markdown was already extracted (via the standalone
+  button or a prior ingest), it reuses the existing content and skips extraction
+  entirely — no extraction slot taken, no subprocess spawned.
+- **`AgentLauncher` split into three stop methods:**
+  - `stopExtraction()` — cancels `extractTask` (or `ingestTask` during ingest-path
+    extraction phase), clears `isExtracting` / `extractionPID` / `extractingFileIDs` /
+    `extractionLog`. Never touches the agent process.
+  - `stopAgent()` — cancels `ingestTask`, terminates the claude process, calls
+    `finish()`. Never touches extraction flags.
+  - `stop()` — convenience that calls both (preserved for surfaces that still want a
+    kill-everything affordance).
+- **`AgentTranscriptSidebar`** header simplified to just the "Transcript" label. The
+  PDF Conversion box now has its own red Stop button (visible when
+  `launcher.isExtracting`). The Agent Activity section has its own red Stop button
+  (visible when `launcher.isRunning` or `!launcher.ingestingFileIDs.isEmpty`).
+
+**Tests.** `swift test` — 596 tests, 50 suites, 0 failures (+10 from the prior
+baseline of 586):
+- `AgentExtractionLockTests` (+7: `stopCancelsExtractTask`,
+  `stopWithNoExtractTaskIsNoOp`, `isExtractingFlagExposedByLauncher`,
+  `stopExtractionCancelsExtractTask`, `stopExtractionClearsExtractionFlags`,
+  `stopExtractionWithNoTaskIsSafe`, `stopAgentDoesNotClearExtractionFlags`)
+- `ProcessedMarkdownTests` (+3: `pdfHeadNilBeforeExtraction`,
+  `seedPdfMarkdownCreatesHead`, `seedPdfMarkdownDoubleSeedReturnsExisting`)
+
+## 2026-06-20 — Serialized claude spawn slot + separate extraction lock
+
+The shared `AgentLauncher` silently dropped a second run (`guard !isRunning`), and
+one `ingestingFileIDs` set fused the pdf2md extraction phase with the agent-
+ingestion phase — so a pure extraction mislabeled rows "Ingesting…" and greyed out
+other files' Ingest buttons even though the slot was free. Two independent locks now
+replace the single `isRunning` guard; the phase flags are split. See
+`plans/extraction-vs-ingestion-lock.md` (Option B).
+
+- **Spawn slot (`AgentLauncher`):** all `claude -p` spawns (ingest/query/lint)
+  serialize through a FIFO, cancellation-aware slot (`awaitSpawnSlot` /
+  `releaseSpawnSlot`); the silent-drop guard is gone, so a queued run waits and
+  runs after the current one. `run`/`startInteractiveQuery` are `async`; preflight
+  and staging run after the slot is acquired so every early-return releases it.
+- **Separate extraction lock:** pdf2md conversions serialize on a *distinct*
+  `awaitExtractionSlot`/`releaseExtractionSlot` (same shape, independent state) that
+  never touches the spawn slot or the edit lock — so a query runs during an
+  extraction and editing stays unlocked while a PDF converts. Both the ingest-path
+  conversion and the standalone `Extract Markdown` action take it.
+- **Phase-flag split:** `ingestingFileIDs` (set only at agent-spawn commit via a new
+  `run` param, cleared in `finish()`) is now distinct from `extractingFileIDs`
+  (pdf2md phase). `runMultiIngest` no longer pre-sets `ingestingFileIDs`. Rows show
+  "Extracting…" vs "Ingesting…" (pure `rowStatus` predicate); the cross-file Ingest
+  greyout (`isAnyFileIngesting = !ingestingFileIDs.isEmpty`) is now extraction-free.
+- **Query page:** mounts the orange `AgentRunBanner` and scopes its debug cluster to
+  active query runs only (`showsQueryDebugControls`); resets to the conversation
+  when idle. The toolbar glow / transcript auto-open now key off `extractingFileIDs`
+  so a pure extraction still surfaces the transcript.
+
+**Cancellation.** A file is marked ingested only by the agent's `wikictl log append
+--kind ingest`; an ingest interrupted before the agent spawns marks nothing
+(`hasBeenIngested` stays `false`), and extracted markdown seeded before the agent
+run survives a later cancel.
+
+**Verified.** `swift build` clean (no warnings). `swift test` — 586 tests, 50
+suites, 0 failures (+10 `AgentExtractionLockTests`, +6 `AgentSpawnSlotTests`).
+
 ## 2026-06-20 — Grey out Ingest/Extract buttons during any file ingest
 
 The "Ingest into Wiki" and "Extract Markdown" buttons in

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -38,15 +38,33 @@ final class AgentLauncher {
     /// PID of the running `pdf2md` conversion subprocess, surfaced in the UI so a
     /// stuck conversion can be identified (and killed) by the user.
     var extractionPID: Int32?
-    /// The ingested-file id currently being operated on — from the moment its
-    /// ingest starts (local conversion included) until the agent run ends. Drives
-    /// the "Ingesting…" status in `IngestedFileDetailView`. Cleared in `finish()`.
+    /// The ingested-file ids whose **agent run** is in flight — set only once the
+    /// claude spawn is actually committed (slot acquired, around `onLock`), and
+    /// cleared in `finish()`. Drives the per-file "Ingesting…" row label and the
+    /// cross-file `isAnyFileIngesting` Ingest-button greyout. This is the
+    /// **agent phase** flag; it is NOT set during the pdf2md extraction phase that
+    /// precedes the spawn (see `extractingFileIDs`), so a pure extraction no longer
+    /// mislabels a row as "Ingesting…" or greys out another file's Ingest button.
     var ingestingFileIDs: Set<PageID> = []
+    /// The ingested-file ids whose **pdf2md conversion** is in flight — set around
+    /// the pdf2md block of EITHER extraction path (the ingest-path conversion in
+    /// `AgentOperationRunner.runMultiIngest`, and the standalone
+    /// `IngestedFileDetailView.runExtraction`), and cleared when the conversion
+    /// ends (success or failure). Drives the per-file "Extracting…" row label and
+    /// the standalone Extract button's per-file disable. This is the **extraction
+    /// phase** flag; it never feeds the cross-file Ingest greyout (that is
+    /// `ingestingFileIDs` only) and never touches the spawn slot or edit lock.
+    var extractingFileIDs: Set<PageID> = []
     /// The in-flight ingest operation Task (set by `IngestSheetView`). Cancelling
     /// it aborts a running `pdf2md` conversion (via its task-cancellation handler).
     /// Held here so `stop()` — driven from the transcript sidebar too — can cancel
     /// the conversion phase, not just the agent process. Self-clears when done.
     @ObservationIgnored var ingestTask: Task<Void, Never>?
+    /// The in-flight standalone extraction Task (set by the Extract Markdown button
+    /// in `IngestedFileDetailView`). Mirror of `ingestTask` for the standalone
+    /// extract path — cancelled by `stop()` so the pdf2md subprocess is terminated
+    /// via `PdfExtractionService`'s `onCancel` handler. Self-clears when done.
+    @ObservationIgnored var extractTask: Task<Void, Never>?
     /// True while a spawned `claude -p` process is running.
     private(set) var isRunning = false
     /// Exit status of the last finished process, or nil if none finished / one is
@@ -93,8 +111,230 @@ final class AgentLauncher {
     /// True when the running process is waiting for user turns over stdin.
     private(set) var isInteractiveSession = false
 
-    /// Run an operation `request` against one wiki. No-op if a process is already
-    /// running.
+    /// Pure predicate for the Query page's debug cluster (spinner / Stop / Activity
+    /// menu): the cluster is visible only while a QUERY run is in flight. Extracted
+    /// as a pure static function so it is unit-testable without driving launcher
+    /// state. The View calls this with its `launcher` state.
+    static func showsQueryDebugControls(
+        isRunning: Bool, runningKind: WikiOperation.Kind?
+    ) -> Bool {
+        isRunning && runningKind == .query
+    }
+
+    // MARK: - Three independent locks (relationship)
+
+    /// The launcher coordinates three INDEPENDENT locks. They never touch each
+    /// other's state; understanding the boundaries is what keeps extraction from
+    /// blocking the user.
+    ///
+    /// 1. **Spawn slot** (`spawnWaiters` / `awaitSpawnSlot` / `releaseSpawnSlot`,
+    ///    held ↔ `isRunning`): serializes ONLY `claude -p` spawns. One `claude`
+    ///    process at a time across ingest / query / lint. Extraction does NOT take
+    ///    it, so a `pdf2md` conversion may overlap a `claude` query run.
+    /// 2. **Edit lock** (`store.isAgentRunning`, driven by `onLock`/`onUnlock`
+    ///    around the spawn): `true` exactly while a `claude` process is running, so
+    ///    editing pages / processed markdown is locked during an agent run and free
+    ///    during extraction. Neither extraction path fires `onLock`/`onUnlock`.
+    /// 3. **Extraction slot** (`extractionWaiters` / `awaitExtractionSlot` /
+    ///    `releaseExtractionSlot`, held ↔ `isExtractionSlotBusy`): serializes ONLY
+    ///    `pdf2md` conversions against each other (the VLM pipeline is heavy; one
+    ///    conversion at a time on a single local machine). Acquiring it does NOT set
+    ///    `isRunning`, does NOT set `isExtracting`, and does NOT fire `onLock`. A
+    ///    `claude` query run starting during an extraction still runs immediately —
+    ///    it takes the spawn slot, which the extraction lock never holds.
+    ///
+    /// The phase flags `extractingFileIDs` (extraction phase) and
+    /// `ingestingFileIDs` (agent phase, set at spawn commit) are the UI-facing
+    /// projection of which lock/phase a file is in; they are kept separate so a
+    /// pure extraction is never labeled "Ingesting…" and never greys out a peer's
+    /// Ingest button.
+
+    // MARK: - Serialized claude spawn slot
+
+    /// The single serialized "claude spawn slot." Only one `claude -p` process may
+    /// run at a time across all surfaces (ingest / query / lint all share this
+    /// launcher). The slot is "held" exactly while `isRunning == true`. A spawn
+    /// request `await`s it via `awaitSpawnSlot()`; the fast path (slot free, no
+    /// waiters) acquires without suspending. `releaseSpawnSlot()` (called by
+    /// `finish()` and on any post-acquire early-return) hands the slot to the next
+    /// waiter (keeping `isRunning == true`) or frees it.
+    private var spawnWaiters: [SpawnWaiter] = []
+
+    /// One queued spawn request. A class so the cancellation handler can identify
+    /// its waiter by reference and self-remove it from `spawnWaiters` — a cancelled
+    /// waiter must never be handed the slot. `@unchecked Sendable` because it is
+    /// only ever touched on the main actor (registration in `awaitSpawnSlot`'s
+    /// continuation; removal in the cancel handler's `@MainActor` hop).
+    private final class SpawnWaiter: @unchecked Sendable {
+        var continuation: CheckedContinuation<Void, Never>?
+        var didReceiveSlot = false
+        var didCancel = false
+    }
+
+    /// The number of spawn requests currently queued for the slot (test seam).
+    var spawnSlotWaiterCount: Int { spawnWaiters.count }
+
+    /// Wait for the single serialized claude spawn slot, returning `true` iff this
+    /// caller acquired it (and `isRunning` is now `true`). Returns `false` if the
+    /// wait was cancelled before the slot was handed over — in that case the caller
+    /// owns nothing and must simply return (no release). Cancellation-safe: a
+    /// cancelled waiter self-removes from the queue and is never handed the slot.
+    func awaitSpawnSlot() async -> Bool {
+        // Fast path: slot free and nobody queued — acquire atomically. There is no
+        // suspension point, so no other main-actor task can interleave between the
+        // check and the set. Zero overhead for the common single-run case; keeps
+        // single-run tests unchanged.
+        if !isRunning && spawnWaiters.isEmpty {
+            isRunning = true
+            return true
+        }
+        let waiter = SpawnWaiter()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                if waiter.didCancel {
+                    // Cancelled before we could register — resume immediately, don't
+                    // enqueue. The caller will see `didReceiveSlot == false`.
+                    c.resume()
+                    return
+                }
+                waiter.continuation = c
+                spawnWaiters.append(waiter)
+            }
+        } onCancel: {
+            // Hop to the main actor (the launcher is @MainActor) to self-remove. A
+            // cancelled waiter must not be handed the slot; if it already was (race
+            // with `releaseSpawnSlot`), do nothing — the woken caller will see
+            // `Task.isCancelled` and bail, releasing the slot it was handed.
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                waiter.didCancel = true
+                if let idx = self.spawnWaiters.firstIndex(where: { $0 === waiter }),
+                   let c = waiter.continuation {
+                    self.spawnWaiters.remove(at: idx)
+                    c.resume()
+                }
+            }
+        }
+        return waiter.didReceiveSlot
+    }
+
+    /// Release the spawn slot, handing it to the next live waiter (FIFO) or freeing
+    /// it. Called by `finish()` on process termination and by every post-acquire
+    /// early-return in `run` / `startInteractiveQuery`.
+    func releaseSpawnSlot() {
+        // Pop the next non-cancelled waiter and hand off the slot. `isRunning` stays
+        // `true` on a handoff so the transfer is atomic — there is no window where
+        // another task could grab the slot via the fast path and double-spawn.
+        while let head = spawnWaiters.first {
+            spawnWaiters.removeFirst()
+            if head.didCancel {
+                // Already resumed by its cancel handler; don't hand the slot to a
+                // dead task.
+                continue
+            }
+            head.didReceiveSlot = true
+            head.continuation?.resume()
+            return
+        }
+        // No live waiters: free the slot.
+        isRunning = false
+    }
+
+    // MARK: - Serialized extraction slot (pdf2md only)
+
+    /// The separate, independent lock that serializes `pdf2md` conversions against
+    /// each other. See the "three independent locks" overview above. Held ↔
+    /// `isExtractionSlotBusy`. Same FIFO + cancellation-safe shape as the spawn
+    /// slot, but with its OWN state — it never touches `isRunning`, `isExtracting`,
+    /// `onLock`/`onUnlock`, or the spawn slot. A `claude` query run starting while
+    /// an extraction holds this lock still acquires the spawn slot immediately.
+    private var extractionWaiters: [ExtractionWaiter] = []
+
+    /// One queued extraction request. Same shape and rationale as `SpawnWaiter`: a
+    /// class so the cancellation handler can identify its waiter by reference and
+    /// self-remove it from `extractionWaiters` — a cancelled waiter must never be
+    /// handed the slot. `@unchecked Sendable` because it is only ever touched on the
+    /// main actor.
+    private final class ExtractionWaiter: @unchecked Sendable {
+        var continuation: CheckedContinuation<Void, Never>?
+        var didReceiveSlot = false
+        var didCancel = false
+    }
+
+    /// True while a pdf2md conversion holds the extraction lock. Independent of
+    /// `isRunning` (spawn slot) and `store.isAgentRunning` (edit lock).
+    private(set) var isExtractionSlotBusy = false
+
+    /// The number of extraction requests currently queued for the slot (test seam).
+    var extractionSlotWaiterCount: Int { extractionWaiters.count }
+
+    /// Wait for the extraction slot, returning `true` iff this caller acquired it
+    /// (and `isExtractionSlotBusy` is now `true`). Returns `false` if the wait was
+    /// cancelled before the slot was handed over — in that case the caller owns
+    /// nothing and must simply return (no release). Cancellation-safe: a cancelled
+    /// waiter self-removes from the queue and is never handed the slot. Does NOT
+    /// set `isRunning`, `isExtracting`, or fire `onLock` — fully independent of the
+    /// spawn slot and edit lock.
+    func awaitExtractionSlot() async -> Bool {
+        // Fast path: slot free and nobody queued — acquire atomically. No
+        // suspension point, so no other main-actor task can interleave.
+        if !isExtractionSlotBusy && extractionWaiters.isEmpty {
+            isExtractionSlotBusy = true
+            return true
+        }
+        let waiter = ExtractionWaiter()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                if waiter.didCancel {
+                    // Cancelled before we could register — resume immediately, don't
+                    // enqueue. The caller will see `didReceiveSlot == false`.
+                    c.resume()
+                    return
+                }
+                waiter.continuation = c
+                extractionWaiters.append(waiter)
+            }
+        } onCancel: {
+            // Hop to the main actor to self-remove. A cancelled waiter must not be
+            // handed the slot; if it already was (race with `releaseExtractionSlot`),
+            // do nothing — the woken caller will see `Task.isCancelled` and bail,
+            // releasing the slot it was handed.
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                waiter.didCancel = true
+                if let idx = self.extractionWaiters.firstIndex(where: { $0 === waiter }),
+                   let c = waiter.continuation {
+                    self.extractionWaiters.remove(at: idx)
+                    c.resume()
+                }
+            }
+        }
+        return waiter.didReceiveSlot
+    }
+
+    /// Release the extraction slot, handing it to the next live waiter (FIFO) or
+    /// freeing it. Called by both extraction paths in a `defer` once the conversion
+    /// ends (success or failure). `isExtractionSlotBusy` stays `true` on a handoff
+    /// so the transfer is atomic.
+    func releaseExtractionSlot() {
+        while let head = extractionWaiters.first {
+            extractionWaiters.removeFirst()
+            if head.didCancel {
+                // Already resumed by its cancel handler; don't hand the slot to a
+                // dead task.
+                continue
+            }
+            head.didReceiveSlot = true
+            head.continuation?.resume()
+            return
+        }
+        // No live waiters: free the slot.
+        isExtractionSlotBusy = false
+    }
+
+    /// Run an operation `request` against one wiki. Serializes on the spawn slot: if
+    /// another `claude -p` run is in flight, this `await`s until it finishes (or this
+    /// task is cancelled). Returns without spawning if cancelled while queued.
     ///
     /// The launcher OWNS the per-run scratch dir, so it also owns STAGING: it creates
     /// scratch, writes `WIKI_STATE.md` (and, for Ingest, `source.<ext>`) from the
@@ -112,32 +352,53 @@ final class AgentLauncher {
     /// - `onLock`/`onUnlock` are the edit-lock callbacks: `onLock` fires before the
     ///   spawn, `onUnlock` from the `terminationHandler` (so a killed agent still
     ///   releases). Both run on the main actor.
+    /// - `ingestingFileIDs` is the **agent phase** flag for THIS run: the ids whose
+    ///   ingest is now committing. The launcher assigns it to `self.ingestingFileIDs`
+    ///   at spawn commit (around `onLock`) — NOT while queued for the slot — so a
+    ///   pure extraction or a queued ingest never sets it. Empty for query/lint
+    ///   runs (the default), which keeps the flag clear and the cross-file Ingest
+    ///   greyout unblocked. Cleared in `finish()`.
     func run(
         request: OperationRequest,
         wikiID: String,
         wikiRoot: String,
         systemPrompt: String,
         wikictlDirectory: String,
+        ingestingFileIDs: Set<PageID> = [],
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void
-    ) {
-        guard !isRunning else { return }
+    ) async {
+        // Serialize on the single claude spawn slot. Extraction does NOT take the
+        // slot, so a pdf2md conversion may overlap a query run; only the claude
+        // spawn serializes.
+        let acquired = await awaitSpawnSlot()
+        guard acquired, !Task.isCancelled else {
+            // Cancelled while queued (self-removed; slot not acquired) — bail without
+            // touching the slot. If we were handed the slot then cancelled (race),
+            // give it back so a queued peer isn't stranded.
+            if acquired { releaseSpawnSlot() }
+            return
+        }
 
-        // PATH preflight: surface a clear in-UI error instead of a cryptic spawn
-        // failure if `claude` isn't on the login-shell PATH.
+        // PREFLIGHT + STAGING run AFTER the slot is acquired, so any early-return
+        // below must `releaseSpawnSlot()` to hand the slot to the next waiter (or
+        // free it). The edit lock (`onLock`) fires only on a successful spawn, so a
+        // preflight/staging failure does NOT lock editing — matching today's behavior.
+        resetRunArtifacts()
         let claudeExecutable: String
         switch resolveClaude() {
         case .found(let path):
             claudeExecutable = path
         case .missing(let reason):
             preflightError = reason
-            resetRunState()
+            releaseSpawnSlot()
             return
         }
         preflightError = nil
 
         guard let scratch = makeScratchDirectory() else {
             preflightError = "Could not create a scratch working directory for the agent."
+            releaseSpawnSlot()
             return
         }
 
@@ -150,6 +411,7 @@ final class AgentLauncher {
         } catch {
             preflightError = "Could not stage the agent's inputs: \(error.localizedDescription)"
             try? FileManager.default.removeItem(at: scratch)
+            releaseSpawnSlot()
             return
         }
 
@@ -163,13 +425,22 @@ final class AgentLauncher {
             claudeExecutable: claudeExecutable
         )
 
-        resetRunState()
+        // RESERVE per-run metadata. `isRunning` is already `true` (the slot set it on
+        // acquire); set the rest. No `resetRunState` here — the prior `finish()`
+        // already cleared artifacts, and clearing now would race a peer that owns the
+        // slot.
         let now = Date()
-        isRunning = true
         runningKind = operation.kind
         runStartedAt = now
         lastActivityAt = now
         openLogFiles(in: scratch)
+        // SPAWN COMMIT: the agent phase now begins. Assign the agent-phase flag
+        // (`ingestingFileIDs`) here — NOT while queued for the slot — so the
+        // "Ingesting…" label and the cross-file Ingest greyout activate only once
+        // the spawn is actually committed. For query/lint this is empty (default),
+        // which clears any stale flag. See `extractingFileIDs` for the separate
+        // extraction-phase flag, which the runner manages around the pdf2md block.
+        self.ingestingFileIDs = ingestingFileIDs
         onLock()
 
         let process = Process()
@@ -221,11 +492,13 @@ final class AgentLauncher {
             preflightError = "Failed to launch claude: \(error.localizedDescription)"
             closeLogFiles()
             try? FileManager.default.removeItem(at: scratch)
-            isRunning = false
             runningKind = nil
             currentProcessID = nil
             lastActivityAt = Date()
             onUnlock()
+            // Release the slot so a queued peer isn't stranded. `isRunning` was set
+            // by the slot acquire; the spawn-failure teardown must hand it back.
+            releaseSpawnSlot()
         }
     }
 
@@ -270,22 +543,28 @@ final class AgentLauncher {
         wikictlDirectory: String,
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void
-    ) {
-        guard !isRunning else { return }
+    ) async {
+        let acquired = await awaitSpawnSlot()
+        guard acquired, !Task.isCancelled else {
+            if acquired { releaseSpawnSlot() }
+            return
+        }
 
+        resetRunArtifacts()
         let claudeExecutable: String
         switch resolveClaude() {
         case .found(let path):
             claudeExecutable = path
         case .missing(let reason):
             preflightError = reason
-            resetRunState()
+            releaseSpawnSlot()
             return
         }
         preflightError = nil
 
         guard let scratch = makeScratchDirectory() else {
             preflightError = "Could not create a scratch working directory for the agent."
+            releaseSpawnSlot()
             return
         }
 
@@ -295,6 +574,7 @@ final class AgentLauncher {
         } catch {
             preflightError = "Could not stage the agent's inputs: \(error.localizedDescription)"
             try? FileManager.default.removeItem(at: scratch)
+            releaseSpawnSlot()
             return
         }
 
@@ -309,14 +589,16 @@ final class AgentLauncher {
             claudeExecutable: claudeExecutable
         )
 
-        resetRunState()
+        // RESERVE per-run metadata. `isRunning` is already `true` (slot acquire).
         let now = Date()
-        isRunning = true
         isInteractiveSession = true
         runningKind = operation.kind
         runStartedAt = now
         lastActivityAt = now
         openLogFiles(in: scratch)
+        // SPAWN COMMIT: a query conversation never ingests, so the agent-phase flag
+        // is empty — clearing any stale value (mirrors `run`'s spawn-commit).
+        self.ingestingFileIDs = []
         onLock()
 
         let process = Process()
@@ -363,12 +645,13 @@ final class AgentLauncher {
             preflightError = "Failed to launch claude: \(error.localizedDescription)"
             closeLogFiles()
             try? FileManager.default.removeItem(at: scratch)
-            isRunning = false
             isInteractiveSession = false
             runningKind = nil
             currentProcessID = nil
             lastActivityAt = Date()
             onUnlock()
+            // Release the slot so a queued peer isn't stranded.
+            releaseSpawnSlot()
         }
     }
 
@@ -389,18 +672,40 @@ final class AgentLauncher {
         }
     }
 
-    /// Terminate the running process, if any, and tear the UI state down
-    /// immediately so Cancel is responsive even when the child ignores `SIGTERM`
-    /// or its `terminationHandler` is slow/missed. The real handler (if it does
-    /// fire) calls `finish()` again, which guards on `isRunning` and no-ops.
-    func stop() {
+    /// Cancel ONLY the pdf2md conversion (standalone or ingest-path extraction
+    /// phase). Does NOT touch the agent process — a running claude query/ingest
+    /// is left alone. Cancels whichever task owns the extraction, then clears
+    /// the extraction-phase flags so the sidebar dismisses the conversion box.
+    func stopExtraction() {
         DebugLog.agent(
-            "stop() requested: isRunning=\(isRunning) extracting=\(isExtracting) "
+            "stopExtraction() requested: isExtracting=\(isExtracting) "
+            + "extractTask=\(extractTask != nil) ingestTask=\(ingestTask != nil)")
+        if extractTask != nil {
+            // Standalone "Extract Markdown" — the task's cancellation handler
+            // terminates pdf2md via PdfExtractionService.onCancel.
+            extractTask?.cancel()
+        } else if !isRunning && isExtracting {
+            // Ingest-path extraction phase (before agent spawn): cancel the
+            // ingest task so AgentOperationRunner.runMultiIngest bails out via
+            // its Task.isCancelled check.
+            ingestTask?.cancel()
+        }
+        // If extraction is somehow busy without a task (shouldn't happen), clear
+        // flags anyway so the UI doesn't hang.
+        if !isExtracting && extractingFileIDs.isEmpty { return }
+        isExtracting = false
+        extractionPID = nil
+        extractingFileIDs = []
+        extractionLog = ""
+    }
+
+    /// Stop ONLY the agent process (claude -p). Does NOT touch a running pdf2md
+    /// conversion — a standalone extract running alongside a query continues.
+    func stopAgent() {
+        DebugLog.agent(
+            "stopAgent() requested: isRunning=\(isRunning) "
             + "process=\(process != nil) procAlive=\(process?.isRunning ?? false) "
             + "pid=\(currentProcessID ?? -1)")
-        // Cancel an in-flight ingest Task first — this aborts a running pdf2md
-        // conversion (the agent process may not have started yet during the
-        // conversion phase).
         ingestTask?.cancel()
         try? inputHandle?.close()
         inputHandle = nil
@@ -408,6 +713,13 @@ final class AgentLauncher {
         if isRunning {
             finish(status: -1)  // -1 sentinel = user-cancelled / forced teardown
         }
+    }
+
+    /// Terminate EVERYTHING — extraction + agent process. Convenience for the
+    /// few surfaces that don't distinguish (e.g. app termination cleanup).
+    func stop() {
+        stopExtraction()
+        stopAgent()
     }
 
     /// Clear the visible activity feed so a freshly-opened surface (e.g. the ingest
@@ -473,7 +785,6 @@ final class AgentLauncher {
             stdoutLineBuffer = ""
         }
         closeLogFiles()
-        isRunning = false
         exitStatus = status
         isInteractiveSession = false
         runningKind = nil
@@ -482,10 +793,18 @@ final class AgentLauncher {
         currentProcessID = nil
         ingestingFileIDs = []
         lastActivityAt = Date()
+        // Release the spawn slot, handing it to the next live waiter (FIFO) or freeing
+        // it. Replaces the old `isRunning = false`. The guard at the top of `finish`
+        // still runs exactly once per run.
+        releaseSpawnSlot()
     }
 
-    /// Clear per-run state at the start of (or on abort before) a run.
-    private func resetRunState() {
+    /// Clear per-run artifacts (events, transcript, exit status, log handles, etc.)
+    /// at the start of a new run, AFTER the spawn slot is acquired. Unlike the old
+    /// `resetRunState`, this does NOT touch `isRunning` — the slot owns that flag now.
+    /// Called right after `awaitSpawnSlot()` succeeds, before setting the new run's
+    /// metadata.
+    private func resetRunArtifacts() {
         watchdogTask?.cancel()
         watchdogTask = nil
         events = []
@@ -493,7 +812,6 @@ final class AgentLauncher {
         stderr = ""
         stdoutLineBuffer = ""
         exitStatus = nil
-        isRunning = false
         isInteractiveSession = false
         runningKind = nil
         logFileURL = nil

--- a/Sources/WikiFS/AgentOperationRunner.swift
+++ b/Sources/WikiFS/AgentOperationRunner.swift
@@ -37,8 +37,11 @@ enum AgentOperationRunner {
         guard !fileIDs.isEmpty else { return }
         DebugLog.ingest("runMultiIngest: begin count=\(fileIDs.count)")
 
-        // Mark all files as "being ingested" for the UI spinner in the rows.
-        launcher.ingestingFileIDs = Set(fileIDs)
+        // NOTE: `ingestingFileIDs` (the agent-phase flag) is NOT set here. It is
+        // assigned at spawn commit inside `AgentLauncher.run` (around `onLock`),
+        // so a pure extraction or a queued ingest never mislabels rows as
+        // "Ingesting…" or greys out a peer's Ingest button. The extraction-phase
+        // flag (`extractingFileIDs`) is set around the pdf2md block below.
         let stateMarkdown = store.currentStateSnapshot().renderStateFile()
 
         var sources: [OperationRequest.StagedSource] = []
@@ -54,8 +57,28 @@ enum AgentOperationRunner {
             var sourceBytes = bytes
             var sourceExt = file.ext
 
-            // PDF → Markdown conversion (same path as single-file ingest).
+            // PDF → Markdown: if markdown was already extracted (via the standalone
+            // "Extract Markdown" button or a prior ingest), reuse it — don't re-run
+            // pdf2md. Only extract when no processed markdown exists yet.
             if file.ext == "pdf" {
+                if let head = store.processedMarkdownHead(for: file) {
+                    // Already extracted — use existing markdown, skip pdf2md entirely.
+                    sourceBytes = head.content.data(using: .utf8) ?? bytes
+                    sourceExt = "md"
+                    DebugLog.extraction("runMultiIngest: reusing existing markdown for \(file.filename) — \(head.content.count) chars")
+                } else {
+                let acquired = await launcher.awaitExtractionSlot()
+                guard acquired, !Task.isCancelled else {
+                    // Cancelled while queued for the extraction slot (or never
+                    // acquired) — own nothing, just bail this ingest.
+                    if acquired { launcher.releaseExtractionSlot() }
+                    return
+                }
+                launcher.extractingFileIDs.insert(file.id)
+                defer {
+                    launcher.extractingFileIDs.remove(file.id)
+                    launcher.releaseExtractionSlot()
+                }
                 launcher.extractionLog = ""
                 if await PdfExtractionService.checkReady() {
                     DebugLog.extraction("checkReady: ready — converting \(file.filename)")
@@ -89,7 +112,12 @@ enum AgentOperationRunner {
                     } catch {
                         if Task.isCancelled {
                             DebugLog.extraction("convert: CANCELLED")
-                            launcher.ingestingFileIDs = []
+                            // The `defer` above removes this file's id and releases
+                            // the slot; also clear the whole set as a belt-and-
+                            // suspenders (the slot serializes, so it holds at most
+                            // this one id) to preserve the old cancel-clears-state
+                            // behavior.
+                            launcher.extractingFileIDs = []
                             return
                         }
                         DebugLog.extraction("convert: FAILED — \(error.localizedDescription)")
@@ -98,7 +126,8 @@ enum AgentOperationRunner {
                 } else {
                     launcher.extractionLog = "PDF extraction not ready — sending raw PDF to agent."
                 }
-            }
+                } // end else (no existing markdown → extract)
+            } // end if file.ext == "pdf"
 
             sources.append(OperationRequest.StagedSource(
                 bytes: sourceBytes,
@@ -107,7 +136,9 @@ enum AgentOperationRunner {
         }
 
         guard !sources.isEmpty else {
-            launcher.ingestingFileIDs = []
+            // No spawn will commit, so the agent-phase flag stays empty. The
+            // extraction-phase flag was already cleared per-iteration by the
+            // `defer` above. Nothing to clear here but keep the abort log.
             DebugLog.ingest("runMultiIngest: ABORT — no valid sources after filtering")
             return
         }
@@ -118,7 +149,19 @@ enum AgentOperationRunner {
             launcher: launcher,
             store: store,
             manager: manager,
-            fileProvider: fileProvider)
+            fileProvider: fileProvider,
+            ingestingFileIDs: Set(fileIDs))
+
+        // If the ingest Task was cancelled while queued for the spawn slot (behind a
+        // running query), `launcher.run` returned without spawning and never set
+        // `ingestingFileIDs` (it's assigned at spawn commit). Clear whichever phase
+        // flags might be set as a belt-and-suspenders so the file row never hangs.
+        // Already-extracted markdown was seeded before this call and is preserved.
+        if Task.isCancelled {
+            launcher.ingestingFileIDs = []
+            launcher.extractingFileIDs = []
+            return
+        }
 
         if !launcher.isRunning && launcher.runningKind != .ingest {
             launcher.ingestingFileIDs = []
@@ -158,7 +201,7 @@ enum AgentOperationRunner {
         await fileProvider.signalChange()
         guard let root = fileProvider.path else { return }
 
-        launcher.startInteractiveQuery(
+        await launcher.startInteractiveQuery(
             firstMessage: trimmed,
             stateMarkdown: store.currentStateSnapshot().renderStateFile(),
             wikiID: wikiID,
@@ -189,7 +232,8 @@ enum AgentOperationRunner {
         launcher: AgentLauncher,
         store: WikiStoreModel,
         manager: WikiManager,
-        fileProvider: FileProviderSpike
+        fileProvider: FileProviderSpike,
+        ingestingFileIDs: Set<PageID> = []
     ) async {
         guard let wikiID = manager.activeWikiID else { return }
 
@@ -211,12 +255,13 @@ enum AgentOperationRunner {
             return
         }
 
-        launcher.run(
+        await launcher.run(
             request: request,
             wikiID: wikiID,
             wikiRoot: root,
             systemPrompt: store.currentSystemPromptBody(),
             wikictlDirectory: HelpersLocation.wikictlDirectory,
+            ingestingFileIDs: ingestingFileIDs,
             onLock: { store.beginAgentRun() },
             onUnlock: { store.endAgentRun() }
         )

--- a/Sources/WikiFS/AgentTranscriptSidebar.swift
+++ b/Sources/WikiFS/AgentTranscriptSidebar.swift
@@ -33,10 +33,12 @@ struct AgentTranscriptSidebar: View {
         }
     }
 
-    /// Show the local pdf2md conversion box only while THIS ingest is converting a
-    /// PDF (or has just finished) — not for Markdown ingests, queries, or lints.
+    /// Show the local pdf2md conversion box only while a pdf2md conversion is in
+    /// flight (or has just finished) — not for Markdown ingests, queries, or
+    /// lints. Driven by the extraction-phase flag `extractingFileIDs` (the
+    /// agent-phase `ingestingFileIDs` no longer covers the extraction phase).
     private var showsConversion: Bool {
-        !launcher.ingestingFileIDs.isEmpty
+        !launcher.extractingFileIDs.isEmpty
             && (launcher.isExtracting || !launcher.extractionLog.isEmpty)
     }
 
@@ -114,6 +116,13 @@ struct AgentTranscriptSidebar: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+                    Button("Stop Conversion", systemImage: "stop.fill") {
+                        launcher.stopExtraction()
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.red)
+                    .help("Stop PDF conversion")
                 }
             }
             ScrollViewReader { proxy in
@@ -145,6 +154,16 @@ struct AgentTranscriptSidebar: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
                 Spacer()
+                if agentBusy {
+                    ProgressView().controlSize(.small)
+                    Button("Stop Agent", systemImage: "stop.fill") {
+                        launcher.stopAgent()
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.red)
+                    .help("Stop the agent run")
+                }
                 Toggle("Show internals", isOn: $showsInternals)
                     .toggleStyle(.checkbox)
                     .font(.caption)
@@ -152,6 +171,10 @@ struct AgentTranscriptSidebar: View {
             }
             AgentActivityView(launcher: launcher, showsInternals: showsInternals)
         }
+    }
+
+    private var agentBusy: Bool {
+        launcher.isRunning || !launcher.ingestingFileIDs.isEmpty
     }
 
     private static let conversionBottom = "pdf-conversion-bottom"
@@ -164,28 +187,10 @@ struct AgentTranscriptSidebar: View {
                 Label("Transcript", systemImage: "text.bubble")
                     .font(.headline)
                 Spacer()
-                if isBusy {
-                    ProgressView()
-                        .controlSize(.small)
-                    Button("Stop Run", systemImage: "stop.fill") {
-                        launcher.stop()
-                    }
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.borderless)
-                    .foregroundStyle(.red)
-                    .help("Stop the agent or cancel the PDF conversion")
-                }
             }
         }
         .padding(.horizontal, AgentTranscriptMetrics.padding)
         .padding(.vertical, 10)
-    }
-
-    /// Busy = the agent is running OR an ingest is mid-flight (e.g. the PDF
-    /// conversion phase, before the agent process spawns). The Stop button stops
-    /// whichever is active.
-    private var isBusy: Bool {
-        launcher.isRunning || !launcher.ingestingFileIDs.isEmpty
     }
 }
 

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -24,7 +24,8 @@ struct ContentView: View {
         NavigationSplitView {
             SidebarView(store: store, manager: manager, fileProvider: fileProvider,
                         onBatchIngest: batchIngest,
-                        ingestingFileIDs: agentLauncher.ingestingFileIDs)
+                        ingestingFileIDs: agentLauncher.ingestingFileIDs,
+                        extractingFileIDs: agentLauncher.extractingFileIDs)
         } detail: {
             VStack(spacing: 0) {
                 TabBarView(store: store)
@@ -107,18 +108,26 @@ struct ContentView: View {
         }
         // Auto-open the transcript the moment an ingest starts — even during the
         // PDF-conversion phase, before the agent process spawns — so the
-        // conversion box is visible.
+        // conversion box is visible. The extraction phase now lives in
+        // `extractingFileIDs` (distinct from the agent-phase `ingestingFileIDs`),
+        // so observe both: a pure extraction should also surface the transcript.
         .onChange(of: agentLauncher.ingestingFileIDs) { _, newValue in
-            if !newValue.isEmpty {
-                isTranscriptExpanded = true
-            }
+            if !newValue.isEmpty { isTranscriptExpanded = true }
+        }
+        .onChange(of: agentLauncher.extractingFileIDs) { _, newValue in
+            if !newValue.isEmpty { isTranscriptExpanded = true }
         }
     }
 
-    /// The agent is doing work — running, or in the local PDF-conversion phase of
-    /// an ingest (which precedes the agent process). Drives the toolbar glow.
+    /// The agent is doing work — running, or in a local pdf2md extraction / an
+    /// agent-phase ingest (the extraction phase precedes the agent process).
+    /// Drives the toolbar glow. Both phase flags are included so the glow stays
+    /// on during a pure extraction; the cross-file Ingest greyout is NOT driven
+    /// here (that is `isAnyFileIngesting` = `!ingestingFileIDs.isEmpty` only).
     private var agentBusy: Bool {
-        agentLauncher.isRunning || !agentLauncher.ingestingFileIDs.isEmpty
+        agentLauncher.isRunning
+            || !agentLauncher.ingestingFileIDs.isEmpty
+            || !agentLauncher.extractingFileIDs.isEmpty
     }
 
     private var zoteroContainerDirectory: URL {
@@ -133,6 +142,7 @@ struct ContentView: View {
     private var canShowTranscript: Bool {
         agentLauncher.isRunning
             || !agentLauncher.ingestingFileIDs.isEmpty
+            || !agentLauncher.extractingFileIDs.isEmpty
             || !agentLauncher.events.isEmpty
             || agentLauncher.preflightError != nil
             || !agentLauncher.stderr.isEmpty
@@ -249,7 +259,12 @@ struct ContentView: View {
             Button("Toggle Transcript", systemImage: "sidebar.trailing") {
                 toggleTranscript()
             }
-            .disabled(!canShowTranscript)
+            // The panel can ALWAYS be closed when it's open — `canShowTranscript`
+            // only gates OPENING it when closed. Without this, a panel that
+            // auto-expanded during a now-finished extract (no run, no events, no
+            // stderr left) leaves `canShowTranscript == false`, disabling the only
+            // close affordance and stranding the sidebar open.
+            .disabled(!isTranscriptExpanded && !canShowTranscript)
             .foregroundStyle(agentBusy ? Color.orange : Color.primary)
             .symbolEffect(.pulse, isActive: agentBusy)
             .help(isTranscriptExpanded ? "Hide agent transcript" : "Show agent transcript")

--- a/Sources/WikiFS/FilesSectionView.swift
+++ b/Sources/WikiFS/FilesSectionView.swift
@@ -6,7 +6,11 @@ import WikiFSCore
 struct FilesSectionView: View {
     @Bindable var store: WikiStoreModel
     let fileProvider: FileProviderSpike
+    /// Files whose agent run is in flight (agent phase) — "Ingesting…" spinner.
     var ingestingFileIDs: Set<PageID> = []
+    /// Files whose pdf2md conversion is in flight (extraction phase) —
+    /// "Extracting…" spinner. Independent of `ingestingFileIDs`.
+    var extractingFileIDs: Set<PageID> = []
     var onBatchIngest: (([PageID]) -> Void)? = nil
 
     @State private var fileFilter: FileFilter = .all
@@ -75,6 +79,7 @@ struct FilesSectionView: View {
             file: file,
             hasBeenIngested: store.hasIngestedFile(file),
             isIngesting: ingestingFileIDs.contains(file.id),
+            isExtracting: extractingFileIDs.contains(file.id),
             isSelected: ids.contains(file.id),
             onOpen: { Task { await fileProvider.openIngestedFile(id: file.id) } },
             onRemove: { store.deleteIngestedFile(file.id) },

--- a/Sources/WikiFS/IngestedFileDetailView.swift
+++ b/Sources/WikiFS/IngestedFileDetailView.swift
@@ -14,14 +14,23 @@ struct IngestedFileDetailView: View {
     /// PDF-conversion phase before the agent process starts, when `isRunning` is
     /// still `false`.
     let isAnyFileIngesting: Bool
+    /// `true` when THIS file is mid-extraction via the ingest path (pdf2md running
+    /// during an ingest of this file, before the agent spawns). Disables the
+    /// standalone "Extract Markdown" button for this file only — pdf2md is safe to
+    /// overlap with a claude run, so a query/ingest agent run does NOT disable it.
+    let isThisFileExtracting: Bool
     let runIngest: (PageID) -> Void
+    /// Shared launcher — used by the standalone `runExtraction` to take the
+    /// extraction slot (so a standalone extract and an ingest-path extract serialize
+    /// against each other) and to mirror this file's id into `extractingFileIDs`
+    /// so the sidebar row labels it "Extracting…".
+    let launcher: AgentLauncher
     @Bindable var store: WikiStoreModel
 
     @State private var headVersion: FileMarkdownVersion?
     @State private var isEditing = false
     @State private var editBuffer = ""
     @State private var isExtracting = false
-    @State private var extractionLog = ""
     @State private var selectedTab = FileContentTab.markdown
 
     private enum FileContentTab: String, CaseIterable {
@@ -86,11 +95,17 @@ struct IngestedFileDetailView: View {
         .background(Color(nsColor: .textBackgroundColor))
         .onAppear { headVersion = store.processedMarkdownHead(for: file) }
         .onChange(of: file.id) {
+            // Navigating between ingested files REUSES this view instance (same
+            // type/position), so SwiftUI preserves `@State` across the switch.
+            // Reset every per-file @State here — including `isExtracting`, which
+            // otherwise leaks A's "Extracting…" flag onto B's header. The header
+            // spinner is additionally driven off the per-file `isThisFileExtracting`
+            // launcher flag below, so it can never survive a navigation.
             flushEditIfDirty()
             isEditing = false
+            isExtracting = false
             headVersion = nil
             selectedTab = .markdown
-            extractionLog = ""
         }
         .task(id: file.id) { headVersion = store.processedMarkdownHead(for: file) }
         .onChange(of: store.selection) { flushEditIfDirty(); isEditing = false }
@@ -147,13 +162,24 @@ struct IngestedFileDetailView: View {
                         runIngest(file.id)
                     }
                         .keyboardShortcut(.return, modifiers: .command)
-                        .disabled(isRunning || isIngesting || isAnyFileIngesting)
+                        .disabled(isRunning || isIngesting || isAnyFileIngesting
+                                  || isThisFileExtracting)
                     if isPDF, !hasMarkdown {
                         Button(isExtracting ? "Extracting…" : "Extract Markdown",
                                systemImage: "doc.plaintext") {
-                            Task { await runExtraction() }
+                            let task = Task {
+                                defer { launcher.extractTask = nil }
+                                await runExtraction()
+                            }
+                            launcher.extractTask = task
                         }
-                        .disabled(isExtracting || isRunning || isAnyFileIngesting)
+                        .disabled(isExtracting
+                                  || isThisFileExtracting
+                                  // Another file currently holds the extraction
+                                  // slot — this extract would await it, so show
+                                  // it as busy rather than letting the tap hang.
+                                  || (launcher.isExtractionSlotBusy
+                                      && !launcher.extractingFileIDs.contains(file.id)))
                     }
                     if isMarkdownEditable {
                         Button("Edit", systemImage: "pencil") {
@@ -166,18 +192,13 @@ struct IngestedFileDetailView: View {
                 }
             }
 
-            if isExtracting {
+            if isThisFileExtracting {
                 HStack(spacing: 8) {
                     ProgressView().controlSize(.small)
-                    Text(extractionLog.isEmpty ? "Extracting…" : extractionLog)
+                    Text("Extracting…")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
-            } else if !extractionLog.isEmpty {
-                Text(extractionLog)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
             }
 
         }
@@ -341,27 +362,61 @@ struct IngestedFileDetailView: View {
     // MARK: Extract button
 
 
+    /// Extraction progress is shown in the transcript sidebar's PDF Conversion
+    /// box — the detail view keeps only a minimal Extracting… spinner in the
+    /// header. All log output writes to `launcher.extractionLog`.
     private func runExtraction() async {
         isExtracting = true
-        extractionLog = ""
-        defer { isExtracting = false }
+        launcher.isExtracting = true
+        launcher.extractionPID = nil
+        launcher.extractionLog = ""
+        defer {
+            isExtracting = false
+            launcher.isExtracting = false
+            launcher.extractionPID = nil
+        }
+        let acquired = await launcher.awaitExtractionSlot()
+        guard acquired, !Task.isCancelled else {
+            if acquired { launcher.releaseExtractionSlot() }
+            launcher.extractionLog = "Extraction cancelled."
+            return
+        }
+        launcher.extractingFileIDs.insert(file.id)
+        defer {
+            launcher.extractingFileIDs.remove(file.id)
+            launcher.releaseExtractionSlot()
+        }
         guard await PdfExtractionService.checkReady() else {
-            extractionLog = "PDF extraction not available — pdf2md is not ready."
+            launcher.extractionLog = "PDF extraction not available — pdf2md is not ready."
             return
         }
         guard let data = store.ingestedSourceBytes(id: file.id) else {
-            extractionLog = "Could not read source bytes."
+            launcher.extractionLog = "Could not read source bytes."
             return
         }
         do {
             let markdown = try await PdfExtractionService.convert(
-                pdfData: data, filename: file.filename)
+                pdfData: data,
+                filename: file.filename,
+                onProgress: { line in
+                    Task { @MainActor in launcher.extractionLog.append(line) }
+                },
+                onStart: { pid in
+                    Task { @MainActor in
+                        launcher.extractionPID = pid
+                        launcher.extractionLog.append("Started pdf2md (pid \(pid)).\n")
+                    }
+                })
             if let version = store.seedPdfMarkdown(fileID: file.id, content: markdown) {
                 headVersion = version
-                extractionLog = "Markdown extracted — \(markdown.count) chars."
+                launcher.extractionLog = "Markdown extracted — \(markdown.count) chars."
             }
         } catch {
-            extractionLog = "Extraction failed: \(error.localizedDescription)"
+            if Task.isCancelled {
+                launcher.extractionLog = "Extraction cancelled."
+            } else {
+                launcher.extractionLog = "Extraction failed: \(error.localizedDescription)"
+            }
         }
     }
 

--- a/Sources/WikiFS/IngestedFileRow.swift
+++ b/Sources/WikiFS/IngestedFileRow.swift
@@ -4,11 +4,22 @@ import WikiFSCore
 /// One row in the sidebar's "Files" section. Multi-select is handled natively
 /// by the List (Shift+Arrow, Shift+Click, Command+Click). Right-click offers
 /// Open, Remove, and "Ingest Selected" when this file is part of a selection.
+///
+/// The trailing status icon has two distinct in-flight labels, mirroring the two
+/// phases in `AgentLauncher`: **Extracting…** while a pdf2md conversion for this
+/// file is in flight (`isExtracting`, the extraction phase), and **Ingesting…**
+/// once the agent run for this file has committed (`isIngesting`, the agent
+/// phase). Both are always-mounted (no insert/remove transitions); the icon
+/// simply swaps between spinner and the ready/ingested glyph.
 struct IngestedFileRow: View {
     let file: IngestedFileSummary
     let hasBeenIngested: Bool
-    /// True while the agent is actively ingesting this file.
+    /// True while the agent run for this file is in flight (the agent phase —
+    /// set at spawn commit, not during the preceding pdf2md extraction).
     var isIngesting: Bool = false
+    /// True while a pdf2md conversion for this file is in flight (the extraction
+    /// phase — either the ingest-path conversion or a standalone extract).
+    var isExtracting: Bool = false
     /// True when this file is part of the List's multi-selection.
     var isSelected: Bool = false
     let onOpen: () -> Void
@@ -17,7 +28,36 @@ struct IngestedFileRow: View {
     /// file is part of a multi-file selection).
     var onIngestSelected: (() -> Void)? = nil
 
+    /// The trailing status the row shows for a file, mirroring the two phases in
+    /// `AgentLauncher`. Extracted as a pure static function so the precedence
+    /// (extraction phase > agent phase > ready/ingested) is unit-testable
+    /// without driving launcher state. The View calls this with its row state.
+    enum RowStatus: Equatable, Sendable {
+        /// pdf2md conversion in flight (extraction phase).
+        case extracting
+        /// Agent run committed for this file (agent phase).
+        case ingesting
+        /// Already ingested, idle.
+        case ingested
+        /// Not yet ingested, idle.
+        case ready
+    }
+
+    /// Pure precedence predicate for the row's trailing status: extraction phase
+    /// beats agent phase beats the idle glyphs. Mirrors the two-flag split — a
+    /// pure extraction never shows "Ingesting…" and vice versa.
+    static func rowStatus(
+        isExtracting: Bool, isIngesting: Bool, hasBeenIngested: Bool
+    ) -> RowStatus {
+        if isExtracting { return .extracting }
+        if isIngesting { return .ingesting }
+        return hasBeenIngested ? .ingested : .ready
+    }
+
     var body: some View {
+        let status = Self.rowStatus(
+            isExtracting: isExtracting, isIngesting: isIngesting,
+            hasBeenIngested: hasBeenIngested)
         Label {
             HStack(spacing: 8) {
                 Text(file.filename.isEmpty ? "Untitled" : file.filename)
@@ -28,15 +68,24 @@ struct IngestedFileRow: View {
                 Text(Self.sizeFormatter.string(fromByteCount: Int64(file.byteSize)))
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                if isIngesting {
+                switch status {
+                case .extracting:
+                    // Extraction phase: pdf2md converting, agent not spawned yet.
+                    ProgressView()
+                        .controlSize(.small)
+                        .help("Extracting…")
+                case .ingesting:
+                    // Agent phase: claude run committed for this file.
                     ProgressView()
                         .controlSize(.small)
                         .help("Ingesting…")
-                } else {
-                    Image(systemName: hasBeenIngested ? "checkmark.circle.fill" : "circle.dashed")
+                case .ingested, .ready:
+                    Image(systemName: status == .ingested ? "checkmark.circle.fill" : "circle.dashed")
                         .font(.caption)
-                        .foregroundStyle(hasBeenIngested ? .green : .secondary)
-                        .help(hasBeenIngested ? "Ingested into the wiki" : "Ready to ingest into the wiki")
+                        .foregroundStyle(status == .ingested ? .green : .secondary)
+                        .help(status == .ingested
+                              ? "Ingested into the wiki"
+                              : "Ready to ingest into the wiki")
                 }
             }
         } icon: {

--- a/Sources/WikiFS/QueryConversationView.swift
+++ b/Sources/WikiFS/QueryConversationView.swift
@@ -14,28 +14,36 @@ struct QueryConversationView: View {
     @State private var showsInternals = false
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            content
-            if showsDebugControls {
-                controls
-                    .padding(.top, QueryConversationMetrics.debugTopInset)
-                    .padding(.trailing, QueryConversationMetrics.contentInset)
+        VStack(spacing: 0) {
+            AgentRunBanner(isVisible: store.isAgentRunning)
+            ZStack(alignment: .topTrailing) {
+                content
+                if showsDebugControls {
+                    controls
+                        .padding(.top, QueryConversationMetrics.debugTopInset)
+                        .padding(.trailing, QueryConversationMetrics.contentInset)
+                }
             }
+            .frame(minWidth: PageEditorMetrics.detailMinWidth)
+            .background(Color(nsColor: .textBackgroundColor))
         }
-        .frame(minWidth: PageEditorMetrics.detailMinWidth)
-        .background(Color(nsColor: .textBackgroundColor))
+        .onChange(of: launcher.isRunning) { _, isRunning in
+            // Belt-and-suspenders: clear the internals toggle when a run ends so a
+            // later ingest/lint run doesn't inherit it and strand the view on
+            // `AgentActivityView`. (AC.1)
+            if !isRunning { showsInternals = false }
+        }
     }
 
     private var controls: some View {
+        // Only shown during an active query run (gated by `showsDebugControls`).
         HStack(spacing: 8) {
-            if launcher.isRunning {
-                ProgressView()
-                    .controlSize(.small)
-                Button("Stop", systemImage: "stop.fill") {
-                    launcher.stop()
-                }
-                .tint(.red)
+            ProgressView()
+                .controlSize(.small)
+            Button("Stop", systemImage: "stop.fill") {
+                launcher.stop()
             }
+            .tint(.red)
             Menu {
                 Toggle("Show internals", isOn: $showsInternals)
                 if let status = launcher.exitStatus {
@@ -56,15 +64,15 @@ struct QueryConversationView: View {
     }
 
     private var showsDebugControls: Bool {
-        launcher.isRunning
-            || !launcher.events.isEmpty
-            || launcher.logFileURL != nil
-            || launcher.preflightError != nil
+        AgentLauncher.showsQueryDebugControls(
+            isRunning: launcher.isRunning, runningKind: launcher.runningKind)
     }
 
     @ViewBuilder
     private var content: some View {
-        if showsInternals {
+        // The internals view only shows during an active query run; when idle the
+        // view always returns to the conversation/empty state (AC.1).
+        if showsInternals && launcher.isRunning && launcher.runningKind == .query {
             AgentActivityView(launcher: launcher, showsResultEvents: false, showsInternals: true)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(QueryConversationMetrics.contentInset)

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -13,8 +13,12 @@ struct SidebarView: View {
     let fileProvider: FileProviderSpike
     /// Callback when the user clicks "Ingest N Files" in batch mode.
     var onBatchIngest: (([PageID]) -> Void)? = nil
-    /// Files currently being ingested — shows a spinner on those rows.
+    /// Files whose agent run is in flight (agent phase) — shows the
+    /// "Ingesting…" spinner on those rows.
     var ingestingFileIDs: Set<PageID> = []
+    /// Files whose pdf2md conversion is in flight (extraction phase) — shows the
+    /// "Extracting…" spinner on those rows. Independent of `ingestingFileIDs`.
+    var extractingFileIDs: Set<PageID> = []
 
     @State private var renameTarget: WikiPageSummary?
     @State private var renameText: String = ""
@@ -60,7 +64,9 @@ struct SidebarView: View {
             pagesSection()
             if !store.ingestedFiles.isEmpty {
                 FilesSectionView(store: store, fileProvider: fileProvider,
-                    ingestingFileIDs: ingestingFileIDs, onBatchIngest: onBatchIngest,
+                    ingestingFileIDs: ingestingFileIDs,
+                    extractingFileIDs: extractingFileIDs,
+                    onBatchIngest: onBatchIngest,
                     listSelection: $listSelection, activeSection: $activeSection)
             }
             systemSection()

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -69,7 +69,14 @@ struct WikiDetailView: View {
                     isIngesting: launcher.ingestingFileIDs.contains(file.id),
                     isRunning: launcher.isRunning,
                     isAnyFileIngesting: !launcher.ingestingFileIDs.isEmpty,
+                    // This file is mid-extraction via EITHER path (the ingest-path
+                    // pdf2md step or the standalone runExtraction) — both insert
+                    // into `extractingFileIDs`, so this is now extraction-phase
+                    // driven rather than the old `isExtracting &&
+                    // ingestingFileIDs.contains` overload.
+                    isThisFileExtracting: launcher.extractingFileIDs.contains(file.id),
                     runIngest: runIngest,
+                    launcher: launcher,
                     store: store
                 )
             } else {

--- a/Tests/WikiFSTests/AgentExtractionLockTests.swift
+++ b/Tests/WikiFSTests/AgentExtractionLockTests.swift
@@ -1,0 +1,412 @@
+import Foundation
+import Testing
+@testable import WikiFS
+import WikiFSCore
+
+/// Tests for the SEPARATE extraction lock on `AgentLauncher` (option B): two
+/// pdf2md conversions never overlap; a cancelled extraction waiter self-removes;
+/// `releaseExtractionSlot` wakes the next live waiter FIFO. Critically, the
+/// extraction lock is INDEPENDENT of the claude spawn slot — holding one never
+/// blocks the other — and of the edit lock. Also covers the two-flag phase
+/// split (`extractingFileIDs` vs `ingestingFileIDs`) and the row's
+/// Extracting-vs-Ingesting label predicate.
+///
+/// These exercise the slot seams (`awaitExtractionSlot` / `releaseExtractionSlot`
+/// / `extractionSlotWaiterCount` / `isExtractionSlotBusy` and the spawn-slot
+/// siblings) directly, without spawning a real process — fast and deterministic.
+@MainActor
+struct AgentExtractionLockTests {
+
+    private func makeLauncher() -> AgentLauncher {
+        // Stub the PATH preflight so `run` (if ever used here) never touches the
+        // login shell.
+        let launcher = AgentLauncher()
+        launcher.resolveClaude = { .found(path: "/usr/bin/true") }
+        return launcher
+    }
+
+    // MARK: - Slot serialization
+
+    @Test func extractionFastPathAcquiresWithoutSuspending() async {
+        let launcher = makeLauncher()
+        #expect(!launcher.isExtractionSlotBusy)
+        #expect(!launcher.isRunning)
+        let acquired = await launcher.awaitExtractionSlot()
+        #expect(acquired)
+        #expect(launcher.isExtractionSlotBusy)
+        // Acquiring the extraction slot does NOT touch the spawn slot.
+        #expect(!launcher.isRunning)
+        #expect(launcher.extractionSlotWaiterCount == 0)
+        launcher.releaseExtractionSlot()
+        #expect(!launcher.isExtractionSlotBusy)
+    }
+
+    @Test func secondExtractionWaitsUntilFirstReleases() async {
+        let launcher = makeLauncher()
+        let first = await launcher.awaitExtractionSlot()
+        #expect(first)
+        #expect(launcher.isExtractionSlotBusy)
+
+        // Second must suspend behind the first.
+        let secondTask = Task { await launcher.awaitExtractionSlot() }
+        await Task.yield()
+        await Task.yield()
+        #expect(launcher.extractionSlotWaiterCount == 1)
+        #expect(launcher.isExtractionSlotBusy)
+
+        // Releasing hands the slot to the waiter; isExtractionSlotBusy stays true
+        // (atomic handoff) and the waiter reports it acquired the slot.
+        launcher.releaseExtractionSlot()
+        let secondAcquired = await secondTask.value
+        #expect(secondAcquired)
+        #expect(launcher.isExtractionSlotBusy)
+        #expect(launcher.extractionSlotWaiterCount == 0)
+
+        launcher.releaseExtractionSlot()
+        #expect(!launcher.isExtractionSlotBusy)
+    }
+
+    // MARK: - Cancelled waiter self-removes
+
+    @Test func cancelledExtractionWaiterSelfRemovesAndDoesNotStealSlot() async {
+        let launcher = makeLauncher()
+        let first = await launcher.awaitExtractionSlot()
+        #expect(first)
+
+        // A waiter that gets cancelled while queued must self-remove and return
+        // false (it never acquired the slot).
+        let waiterTask = Task<Void, Never> {
+            _ = await launcher.awaitExtractionSlot()
+        }
+        await Task.yield()
+        await Task.yield()
+        #expect(launcher.extractionSlotWaiterCount == 1)
+
+        waiterTask.cancel()
+        await waiterTask.value
+        #expect(launcher.extractionSlotWaiterCount == 0)
+
+        // The slot is still held by the first; releasing frees it (no stale
+        // handoff to the dead task).
+        launcher.releaseExtractionSlot()
+        #expect(!launcher.isExtractionSlotBusy)
+    }
+
+    @Test func releaseExtractionWakesNextLiveWaiterAfterACancelledOne() async {
+        let launcher = makeLauncher()
+        _ = await launcher.awaitExtractionSlot()
+
+        // Enqueue a waiter that will be cancelled, then a live waiter behind it.
+        let doomed = Task<Void, Never> { _ = await launcher.awaitExtractionSlot() }
+        await Task.yield()
+        await Task.yield()
+        let live = Task { await launcher.awaitExtractionSlot() }
+        await Task.yield()
+        await Task.yield()
+        #expect(launcher.extractionSlotWaiterCount == 2)
+
+        doomed.cancel()
+        await doomed.value
+        // The cancelled one is gone; the live one is still queued.
+        #expect(launcher.extractionSlotWaiterCount == 1)
+
+        // Releasing must hand the slot to the LIVE waiter, skipping the dead one.
+        launcher.releaseExtractionSlot()
+        let liveAcquired = await live.value
+        #expect(liveAcquired)
+        #expect(launcher.isExtractionSlotBusy)
+        launcher.releaseExtractionSlot()
+    }
+
+    // MARK: - Independence from the spawn slot (the key invariant)
+
+    /// While the extraction slot is held, `awaitSpawnSlot()` for a query still
+    /// returns `true` immediately (does not wait) — holding the extraction lock
+    /// does NOT block the spawn slot. Assert via the test seams.
+    @Test func extractionSlotHeldDoesNotBlockSpawnSlot() async {
+        let launcher = makeLauncher()
+        // Hold the extraction slot (simulating a pdf2md conversion in flight).
+        let extractionAcquired = await launcher.awaitExtractionSlot()
+        #expect(extractionAcquired)
+        #expect(launcher.isExtractionSlotBusy)
+        #expect(!launcher.isRunning)
+
+        // A claude query run starts during the extraction. It takes the spawn
+        // slot immediately — no waiting on the extraction slot.
+        let spawnAcquired = await launcher.awaitSpawnSlot()
+        #expect(spawnAcquired)
+        #expect(launcher.isRunning)
+        // The extraction slot is still held by the conversion; the two locks are
+        // fully independent.
+        #expect(launcher.isExtractionSlotBusy)
+        #expect(launcher.spawnSlotWaiterCount == 0)
+        #expect(launcher.extractionSlotWaiterCount == 0)
+
+        // Teardown: release both, in either order.
+        launcher.releaseSpawnSlot()
+        launcher.releaseExtractionSlot()
+        #expect(!launcher.isRunning)
+        #expect(!launcher.isExtractionSlotBusy)
+    }
+
+    /// Independence the other way: holding the spawn slot does not block
+    /// `awaitExtractionSlot()`.
+    @Test func spawnSlotHeldDoesNotBlockExtractionSlot() async {
+        let launcher = makeLauncher()
+        _ = await launcher.awaitSpawnSlot()
+        #expect(launcher.isRunning)
+        #expect(!launcher.isExtractionSlotBusy)
+
+        // An extraction starts while a claude run holds the spawn slot. It takes
+        // the extraction slot immediately — no waiting on the spawn slot.
+        let extractionAcquired = await launcher.awaitExtractionSlot()
+        #expect(extractionAcquired)
+        #expect(launcher.isExtractionSlotBusy)
+        #expect(launcher.isRunning)
+        #expect(launcher.spawnSlotWaiterCount == 0)
+        #expect(launcher.extractionSlotWaiterCount == 0)
+
+        launcher.releaseExtractionSlot()
+        launcher.releaseSpawnSlot()
+        #expect(!launcher.isExtractionSlotBusy)
+        #expect(!launcher.isRunning)
+    }
+
+    // MARK: - Phase flags: extraction phase vs agent phase
+
+    /// The extraction phase sets `extractingFileIDs` (NOT `ingestingFileIDs`),
+    /// and `ingestingFileIDs` stays empty until the agent spawn commits. Driven
+    /// via the slot seams + direct flag assignment mirroring what
+    /// `runMultiIngest` does around the pdf2md block (acquire slot → insert id →
+    /// release slot), without running a real pdf2md. Asserts the overload fix:
+    /// a pure extraction no longer populates the agent-phase flag.
+    @Test func extractionPhaseSetsExtractingFileIDsNotIngestingFileIDs() async {
+        let launcher = makeLauncher()
+        let id = PageID(rawValue: "01EXTRACTIONPHASE00")
+
+        // Extraction phase: acquire the extraction slot and record the file.
+        let acquired = await launcher.awaitExtractionSlot()
+        #expect(acquired)
+        launcher.extractingFileIDs.insert(id)
+        #expect(launcher.extractingFileIDs.contains(id))
+        // The agent-phase flag is NOT set during extraction — this is the bug fix.
+        #expect(launcher.ingestingFileIDs.isEmpty)
+        // The cross-file Ingest greyout (driven off `ingestingFileIDs`) is OFF.
+        #expect(!launcher.ingestingFileIDs.contains(id))
+        // The extraction lock does not touch the spawn slot or edit lock.
+        #expect(!launcher.isRunning)
+
+        // Extraction ends: clear the extraction-phase flag + release the slot.
+        launcher.extractingFileIDs.remove(id)
+        launcher.releaseExtractionSlot()
+        #expect(launcher.extractingFileIDs.isEmpty)
+        #expect(launcher.ingestingFileIDs.isEmpty)
+        #expect(!launcher.isExtractionSlotBusy)
+    }
+
+    /// The agent phase sets `ingestingFileIDs` only at spawn commit (i.e. once
+    /// the spawn slot is acquired), and the cross-file Ingest greyout activates
+    /// only then. Acquire the spawn slot (simulating spawn commit) and assign the
+    /// agent-phase flag, mirroring what `AgentLauncher.run` does around `onLock`.
+    @Test func agentPhaseSetsIngestingFileIDsOnlyAtSpawnCommit() async {
+        let launcher = makeLauncher()
+        let idA = PageID(rawValue: "01AGENTPHASEA00000")
+        let idB = PageID(rawValue: "01AGENTPHASEB00000")
+
+        // Before spawn commit: neither phase flag set (no extraction running).
+        #expect(launcher.extractingFileIDs.isEmpty)
+        #expect(launcher.ingestingFileIDs.isEmpty)
+
+        // Spawn commit: acquire the spawn slot, then assign the agent-phase flag.
+        let acquired = await launcher.awaitSpawnSlot()
+        #expect(acquired)
+        launcher.ingestingFileIDs = [idA, idB]
+        #expect(launcher.ingestingFileIDs.contains(idA))
+        // The extraction-phase flag is NOT set by the agent phase.
+        #expect(launcher.extractingFileIDs.isEmpty)
+        // The cross-file Ingest greyout is now active for any other file.
+        #expect(!launcher.ingestingFileIDs.isEmpty)
+
+        // finish() clears the agent-phase flag and releases the spawn slot.
+        // Simulate via the public seam: clear + release (finish is private).
+        launcher.ingestingFileIDs = []
+        launcher.releaseSpawnSlot()
+        #expect(launcher.ingestingFileIDs.isEmpty)
+        #expect(!launcher.isRunning)
+    }
+
+    /// While file A is in the EXTRACTION phase, file B's Ingest is not greyed
+    /// out (the cross-file greyout keys off `ingestingFileIDs`, not
+    /// `extractingFileIDs`), and B may start its own extraction (serialized on
+    /// the extraction slot). This is the core user-facing invariant.
+    @Test func pureExtractionDoesNotGreyOutPeerIngest() async {
+        let launcher = makeLauncher()
+        let idA = PageID(rawValue: "01PEEREXTRACTIONA0")
+        let idB = PageID(rawValue: "01PEEREXTRACTIONB0")
+
+        // A is mid-extraction.
+        _ = await launcher.awaitExtractionSlot()
+        launcher.extractingFileIDs.insert(idA)
+
+        // The cross-file Ingest greyout predicate is `!ingestingFileIDs.isEmpty`
+        // (see WikiDetailView.isAnyFileIngesting). During A's extraction it is OFF.
+        let isAnyFileIngesting = !launcher.ingestingFileIDs.isEmpty
+        #expect(!isAnyFileIngesting)
+        // B's id is not in the extraction set, so B's row is neither extracting
+        // nor ingesting — free to ingest.
+        #expect(!launcher.extractingFileIDs.contains(idB))
+        #expect(!launcher.ingestingFileIDs.contains(idB))
+
+        launcher.extractingFileIDs.remove(idA)
+        launcher.releaseExtractionSlot()
+    }
+
+    // MARK: - Row label predicate (Extracting… vs Ingesting…)
+
+    /// `IngestedFileRow.rowStatus` is the pure predicate backing the row's
+    /// trailing status icon. Extraction phase beats agent phase beats the idle
+    /// glyphs — a pure extraction shows "Extracting…", never "Ingesting…".
+    @Test func rowStatusPrecedence() {
+        func s(_ e: Bool, _ i: Bool, _ ingested: Bool) -> IngestedFileRow.RowStatus {
+            IngestedFileRow.rowStatus(isExtracting: e, isIngesting: i, hasBeenIngested: ingested)
+        }
+        // Idle states.
+        #expect(s(false, false, false) == .ready)
+        #expect(s(false, false, true) == .ingested)
+        // Agent phase only.
+        #expect(s(false, true, false) == .ingesting)
+        #expect(s(false, true, true) == .ingesting)
+        // Extraction phase only.
+        #expect(s(true, false, false) == .extracting)
+        #expect(s(true, false, true) == .extracting)
+        // Extraction beats agent (a file should not be both, but if flags ever
+        // overlap the extraction label wins — the more precise phase).
+        #expect(s(true, true, false) == .extracting)
+        #expect(s(true, true, true) == .extracting)
+    }
+
+    // MARK: - Stop cancels extractTask
+
+    /// `stop()` must cancel a stored `extractTask` (the standalone Extract Markdown
+    /// path) so the pdf2md subprocess is terminated via `PdfExtractionService`'s
+    /// `onCancel` handler. Without this, the Stop button is a no-op during a
+    /// standalone extraction — the bug this test guards against.
+    @Test func stopCancelsExtractTask() async {
+        let launcher = makeLauncher()
+        let task = Task { @MainActor in
+            // Sleep until cancelled — simulates a running extraction.
+            do { try await Task.sleep(for: .seconds(60)) } catch { return }
+        }
+        launcher.extractTask = task
+        #expect(!task.isCancelled)
+
+        launcher.stop()
+        // stop() cancels extractTask. The sleep throws on cancellation; yield so
+        // the cooperative cancel propagates, then wait for the task to complete.
+        await Task.yield()
+        await task.value
+        #expect(task.isCancelled)
+    }
+
+    /// `stop()` cancels the extractTask but does NOT touch extractTask if it is nil
+    /// (no standalone extraction in flight). This is a no-op guard — stop() should
+    /// never crash or hang when called with no extraction running.
+    @Test func stopWithNoExtractTaskIsNoOp() async {
+        let launcher = makeLauncher()
+        #expect(launcher.extractTask == nil)
+        // Must not crash or hang.
+        launcher.stop()
+        #expect(launcher.extractTask == nil)
+    }
+
+    // MARK: - isExtracting flag during extraction phase
+
+    /// `launcher.isExtracting` must be set to `true` during the extraction phase
+    /// so `AgentTranscriptSidebar.showsConversion` renders the PDF Conversion box.
+    /// The flag is managed by the caller (both the ingest path in
+    /// `AgentOperationRunner.runMultiIngest` and the standalone path in
+    /// `IngestedFileDetailView.runExtraction`), not by the slot itself — but the
+    /// launcher must carry and expose it.
+    @Test func isExtractingFlagExposedByLauncher() async {
+        let launcher = makeLauncher()
+        #expect(!launcher.isExtracting)
+
+        // Simulate what runExtraction() does: flag on, do work, flag off.
+        launcher.isExtracting = true
+        #expect(launcher.isExtracting)
+        launcher.isExtracting = false
+        #expect(!launcher.isExtracting)
+    }
+
+    // MARK: - stopExtraction vs stopAgent separation
+
+    /// `stopExtraction()` cancels `extractTask` (the standalone Extract Markdown
+    /// path) and clears extraction-phase flags, but does NOT call `finish()`
+    /// or touch `isRunning` — the agent continues unimpeded.
+    @Test func stopExtractionCancelsExtractTask() async {
+        let launcher = makeLauncher()
+        let task = Task { @MainActor in
+            do { try await Task.sleep(for: .seconds(60)) } catch { return }
+        }
+        launcher.extractTask = task
+        #expect(!task.isCancelled)
+
+        launcher.stopExtraction()
+        await Task.yield()
+        await task.value
+        #expect(task.isCancelled)
+        // Does NOT touch the spawn slot or edit lock.
+        #expect(!launcher.isRunning)
+    }
+
+    /// `stopExtraction()` clears extraction-phase UI flags so the sidebar
+    /// dismisses the PDF Conversion box.
+    @Test func stopExtractionClearsExtractionFlags() async {
+        let launcher = makeLauncher()
+        launcher.isExtracting = true
+        launcher.extractionPID = 12345
+        launcher.extractionLog = "converting…"
+        launcher.extractingFileIDs = [PageID(rawValue: "01STOPEXTRACT00")]
+
+        launcher.stopExtraction()
+        #expect(!launcher.isExtracting)
+        #expect(launcher.extractionPID == nil)
+        #expect(launcher.extractionLog.isEmpty)
+        #expect(launcher.extractingFileIDs.isEmpty)
+    }
+
+    /// `stopExtraction()` without a stored Task is safe — clears flags, no crash.
+    @Test func stopExtractionWithNoTaskIsSafe() async {
+        let launcher = makeLauncher()
+        launcher.isExtracting = true
+        launcher.extractingFileIDs = [PageID(rawValue: "01NOOPEXTRACT00")]
+
+        launcher.stopExtraction()
+        #expect(!launcher.isExtracting)
+        #expect(launcher.extractingFileIDs.isEmpty)
+    }
+
+    /// `stopAgent()` does NOT clear extraction-phase flags — the two are
+    /// independent. A standalone extraction running alongside a query continues.
+    @Test func stopAgentDoesNotClearExtractionFlags() async {
+        let launcher = makeLauncher()
+        let extractionID = PageID(rawValue: "01EXTRACTCONTINUES")
+        launcher.isExtracting = true
+        launcher.extractionPID = 99999
+        launcher.extractionLog = "still converting…"
+        launcher.extractingFileIDs = [extractionID]
+
+        // Simulate an agent run in progress.
+        _ = await launcher.awaitSpawnSlot()
+        #expect(launcher.isRunning)
+
+        launcher.stopAgent()
+        // stopAgent() calls finish() which releases the spawn slot → isRunning = false.
+        #expect(!launcher.isRunning)
+        // Extraction flags are untouched.
+        #expect(launcher.isExtracting)
+        #expect(launcher.extractionPID == 99999)
+        #expect(launcher.extractionLog == "still converting…")
+        #expect(launcher.extractingFileIDs.contains(extractionID))
+    }
+}

--- a/Tests/WikiFSTests/AgentSpawnSlotTests.swift
+++ b/Tests/WikiFSTests/AgentSpawnSlotTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+@testable import WikiFS
+import WikiFSCore
+
+/// Tests for the serialized claude spawn slot on `AgentLauncher` (option C): two
+/// claude spawns never overlap; a cancelled waiter self-removes; `releaseSpawnSlot`
+/// wakes the next live waiter FIFO. Also covers the query-page debug-cluster
+/// predicate and the extraction-vs-agent edit-lock phase.
+///
+/// These exercise the slot seam (`awaitSpawnSlot` / `releaseSpawnSlot` /
+/// `spawnSlotWaiterCount`) directly, without spawning a real `claude -p` process —
+/// so they are fast and deterministic.
+@MainActor
+struct AgentSpawnSlotTests {
+
+    private func makeLauncher() -> AgentLauncher {
+        // Stub the PATH preflight so `run`/`startInteractiveQuery` (if ever used
+        // here) never touch the login shell.
+        let launcher = AgentLauncher()
+        launcher.resolveClaude = { .found(path: "/usr/bin/true") }
+        return launcher
+    }
+
+    // MARK: - Slot serialization
+
+    @Test func fastPathAcquiresWithoutSuspending() async {
+        let launcher = makeLauncher()
+        #expect(!launcher.isRunning)
+        let acquired = await launcher.awaitSpawnSlot()
+        #expect(acquired)
+        #expect(launcher.isRunning)
+        #expect(launcher.spawnSlotWaiterCount == 0)
+        launcher.releaseSpawnSlot()
+        #expect(!launcher.isRunning)
+    }
+
+    @Test func secondRequestWaitsUntilFirstReleases() async {
+        let launcher = makeLauncher()
+        // First acquires the slot.
+        let first = await launcher.awaitSpawnSlot()
+        #expect(first)
+        #expect(launcher.isRunning)
+
+        // Second must suspend behind the first.
+        let secondTask = Task { await launcher.awaitSpawnSlot() }
+        // Yield so the second task can enqueue its continuation.
+        await Task.yield()
+        await Task.yield()
+        #expect(launcher.spawnSlotWaiterCount == 1)
+        #expect(launcher.isRunning)
+
+        // Releasing hands the slot to the waiter; isRunning stays true (atomic
+        // handoff) and the waiter reports it acquired the slot.
+        launcher.releaseSpawnSlot()
+        let secondAcquired = await secondTask.value
+        #expect(secondAcquired)
+        #expect(launcher.isRunning)
+        #expect(launcher.spawnSlotWaiterCount == 0)
+
+        launcher.releaseSpawnSlot()
+        #expect(!launcher.isRunning)
+    }
+
+    // MARK: - Cancelled waiter self-removes
+
+    @Test func cancelledWaiterSelfRemovesAndDoesNotStealSlot() async {
+        let launcher = makeLauncher()
+        let first = await launcher.awaitSpawnSlot()
+        #expect(first)
+
+        // A waiter that gets cancelled while queued must self-remove from
+        // spawnWaiters and return false (it never acquired the slot).
+        let waiterTask = Task<Void, Never> {
+            // This will suspend behind the first holder.
+            _ = await launcher.awaitSpawnSlot()
+        }
+        await Task.yield()
+        await Task.yield()
+        #expect(launcher.spawnSlotWaiterCount == 1)
+
+        waiterTask.cancel()
+        await waiterTask.value
+        // The cancelled waiter removed itself.
+        #expect(launcher.spawnSlotWaiterCount == 0)
+
+        // The slot is still held by the first; releasing frees it (no stale handoff
+        // to the dead task).
+        launcher.releaseSpawnSlot()
+        #expect(!launcher.isRunning)
+    }
+
+    @Test func releaseWakesNextLiveWaiterAfterACancelledOne() async {
+        let launcher = makeLauncher()
+        _ = await launcher.awaitSpawnSlot()
+
+        // Enqueue a waiter that will be cancelled, then a live waiter behind it.
+        let doomed = Task<Void, Never> { _ = await launcher.awaitSpawnSlot() }
+        await Task.yield()
+        await Task.yield()
+        let live = Task { await launcher.awaitSpawnSlot() }
+        await Task.yield()
+        await Task.yield()
+        #expect(launcher.spawnSlotWaiterCount == 2)
+
+        doomed.cancel()
+        await doomed.value
+        // The cancelled one is gone; the live one is still queued.
+        #expect(launcher.spawnSlotWaiterCount == 1)
+
+        // Releasing must hand the slot to the LIVE waiter, skipping the dead one.
+        launcher.releaseSpawnSlot()
+        let liveAcquired = await live.value
+        #expect(liveAcquired)
+        #expect(launcher.isRunning)
+        launcher.releaseSpawnSlot()
+    }
+
+    // MARK: - Query-page debug-cluster predicate
+
+    /// `AgentLauncher.showsQueryDebugControls` is the pure predicate backing
+    /// `QueryConversationView.showsDebugControls`. The cluster is visible only
+    /// while a QUERY run is in flight (AC.1). Assert it across the state matrix.
+    @Test func debugClusterPredicateOnlyTrueForActiveQueryRun() {
+        func p(_ isRunning: Bool, _ kind: WikiOperation.Kind?) -> Bool {
+            AgentLauncher.showsQueryDebugControls(isRunning: isRunning, runningKind: kind)
+        }
+        // Idle: no cluster.
+        #expect(!p(false, nil))
+        // Ingest run active: no cluster on the query page.
+        #expect(!p(true, .ingest))
+        // Lint run active: no cluster.
+        #expect(!p(true, .lint))
+        // Query run active: cluster shows.
+        #expect(p(true, .query))
+        // Run ended (isRunning false): cluster hides even if runningKind is stale.
+        #expect(!p(false, .query))
+        #expect(!p(false, nil))
+    }
+
+    // MARK: - Edit-lock phase: extraction does not lock, agent spawn does
+
+    /// `store.isAgentRunning` is the edit lock. It is `true` only while a claude
+    /// process is running (driven by `onLock`/`onUnlock`). Extraction
+    /// (`isExtracting`) does NOT lock editing. This mirrors the
+    /// `IngestedFileDetailView`/`PageDetailView` banner binding
+    /// (`store.isAgentRunning`), so the query page shows the orange banner during an
+    /// agent run but NOT during extraction (AC.2 vs AC.3). Drives `isRunning` via the
+    /// slot seam so the test exercises the real flag, not a mock.
+    @Test func extractionPhaseDoesNotLockEditing() async throws {
+        let launcher = makeLauncher()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-slot-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = WikiStoreModel(
+            store: try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
+
+        // Extraction phase: isExtracting true, no claude running. Editing is free.
+        launcher.isExtracting = true
+        #expect(!launcher.isRunning)
+        #expect(!store.isAgentRunning)
+
+        // Agent spawn reservation: acquire the slot (sets isRunning true) and fire
+        // onLock (store.beginAgentRun). Editing is now locked.
+        launcher.isExtracting = false
+        _ = await launcher.awaitSpawnSlot()
+        store.beginAgentRun()
+        #expect(launcher.isRunning)
+        #expect(store.isAgentRunning)
+
+        // Agent finishes: slot released (isRunning false), onUnlock fires. Editing
+        // free again.
+        launcher.releaseSpawnSlot()
+        store.endAgentRun()
+        #expect(!launcher.isRunning)
+        #expect(!store.isAgentRunning)
+    }
+}

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import SQLite3
 import Testing
 @testable import WikiFSCore
+@testable import WikiFS
 
 /// Tests for the v8 `file_markdown_versions` store API: version chain,
 /// revert, cascade, source immutability, seeding, and pre-migration fallback.
@@ -280,5 +281,59 @@ struct ProcessedMarkdownTests {
         #expect(try store.processedMarkdownHead(fileID: arbitraryID) == nil)
         #expect(try store.hasProcessedMarkdown(fileID: arbitraryID) == false)
         #expect(try store.processedMarkdownHistory(fileID: arbitraryID).isEmpty)
+    }
+
+    // MARK: - Model-level: PDF extraction reuse during ingest
+
+    /// For a PDF file, `processedMarkdownHead` returns nil before any markdown is
+    /// extracted. `seedPdfMarkdown` creates the first version. This is the
+    /// predicate `AgentOperationRunner.runMultiIngest` uses to decide whether to
+    /// skip pdf2md — if a head exists, the runner reuses existing markdown instead
+    /// of re-extracting.
+    @Test @MainActor func pdfHeadNilBeforeExtraction() throws {
+        let store = try tempStore()
+        let pdf = try store.ingestFile(filename: "doc.pdf", data: Data("%PDF-1.4".utf8))
+        let model = WikiStoreModel(store: store)
+        // Before extraction: no head.
+        #expect(model.processedMarkdownHead(for: pdf) == nil)
+    }
+
+    @Test @MainActor func seedPdfMarkdownCreatesHead() throws {
+        let store = try tempStore()
+        let pdf = try store.ingestFile(filename: "doc.pdf", data: Data("%PDF-1.4".utf8))
+        let model = WikiStoreModel(store: store)
+
+        // Simulate extraction output: seed the markdown.
+        let seeded = model.seedPdfMarkdown(fileID: pdf.id, content: "# Extracted\ncontent")
+        #expect(seeded != nil)
+        #expect(seeded?.content == "# Extracted\ncontent")
+
+        // Now the head exists — the runner would skip pdf2md.
+        let head = model.processedMarkdownHead(for: pdf)
+        #expect(head?.content == "# Extracted\ncontent")
+    }
+
+    @Test @MainActor func seedPdfMarkdownDoubleSeedReturnsExisting() throws {
+        let store = try tempStore()
+        let pdf = try store.ingestFile(filename: "doc.pdf", data: Data("%PDF-1.4".utf8))
+        let model = WikiStoreModel(store: store)
+
+        // First seed.
+        let v1 = model.seedPdfMarkdown(fileID: pdf.id, content: "first extract")
+        #expect(v1 != nil)
+        #expect(v1?.content == "first extract")
+
+        // Second seed: double-seed guard returns the existing head, does NOT
+        // append a duplicate version.
+        usleep(2000)
+        let v2 = model.seedPdfMarkdown(fileID: pdf.id, content: "should be ignored")
+        #expect(v2 != nil)
+        #expect(v2?.id == v1?.id)
+        #expect(v2?.content == "first extract")
+
+        // Head is still the first extract, unchanged.
+        let head = model.processedMarkdownHead(for: pdf)
+        #expect(head?.id == v1?.id)
+        #expect(head?.content == "first extract")
     }
 }

--- a/plans/extraction-vs-ingestion-lock.md
+++ b/plans/extraction-vs-ingestion-lock.md
@@ -1,0 +1,182 @@
+# Extraction vs. Ingestion: separating the two phases in state + UI
+
+**Status:** proposed (2026-06-20). Branch `fix-ingest-button-greyout`.
+
+## The principle
+
+Markdown **extraction** (pdf2md converting a PDF to markdown) and **agent
+ingestion** (the `claude -p` run that writes wiki pages, index, and log) are two
+different things. Extraction must never lock the user out of:
+
+- running **queries**,
+- editing **pages** (or processed-markdown versions),
+- starting another file's ingest.
+
+Only the agent ingestion run should carry those costs, because only it writes the
+wiki and contends for the single serialized claude spawn slot.
+
+## What the mechanism already gets right
+
+The spawn-slot + edit-lock work on `fix-ingest-button-greyout` already encodes the
+principle at the *mechanism* layer:
+
+- **Edit lock** (`store.isAgentRunning`, `beginAgentRun`/`endAgentRun`) fires only
+  around a claude spawn: `onLock` before `process.run()`, `onUnlock` in the
+  `terminationHandler` (`AgentOperationRunner.swift:229-231`, `AgentLauncher.swift:298`,
+  `:333`). Neither extraction path calls them. → **pages/processed markdown stay
+  editable during extraction.**
+- **Spawn slot** serializes *only* claude spawns. Neither the standalone
+  `runExtraction()` (`IngestedFileDetailView.swift:349`) nor the ingest-path pdf2md
+  step (`AgentOperationRunner.swift:58-101`) calls `awaitSpawnSlot()`. → **a query
+  can start and run while extraction is in flight.**
+- **`AgentRunBanner`** (`isVisible: store.isAgentRunning`) is false during extraction.
+- **Standalone "Extract Markdown" button** disables only on `isExtracting ||
+  isThisFileExtracting` — never on a query/ingest agent run
+  (`IngestedFileDetailView.swift:161`).
+- **Save Changes / Edit** buttons key off `isRunning`/`store.isAgentRunning`, both
+  false during extraction.
+
+So at the mechanism level, extraction is already non-blocking. The problem is
+purely in the *UI state that labels and gates things*.
+
+## The gap: one flag fuses the two phases in the UI
+
+`AgentOperationRunner.runMultiIngest` sets
+`launcher.ingestingFileIDs = Set(fileIDs)` at the very top
+(`AgentOperationRunner.swift:41`) — **before** pdf2md runs — and that set stays
+populated across *both* the extraction phase and the agent run. One set drives two
+UI behaviors that semantically belong to the agent phase, not the extraction phase:
+
+1. **Row mislabel.** `IngestedFileRow.isIngesting` (`= ingestingFileIDs.contains(file.id)`)
+   shows a `ProgressView` with `.help("Ingesting…")` (`IngestedFileRow.swift:31-34`).
+   During a pure-extraction phase this is a lie: nothing is being ingested into the
+   wiki yet — the PDF is merely being converted to markdown. The agent that will
+   write pages has not spawned.
+
+2. **Cross-file greyout.** `isAnyFileIngesting = !ingestingFileIDs.isEmpty`
+   (`WikiDetailView.swift:71`) disables *every other file's* "Ingest into Wiki"
+   button (`IngestedFileDetailView.swift:155`). So while file A is merely
+   extracting, the user cannot start ingesting file B — even though the spawn slot
+   is free and A's extraction does not conflict with B's extraction or B's agent
+   run. Extraction has leaked into a lock it was never supposed to hold.
+
+## The fix: split one set into two
+
+Replace the overloaded `ingestingFileIDs` with two orthogonal sets, named by the
+phase they describe:
+
+- **`extractingFileIDs: Set<PageID>`** — `true` only while a pdf2md conversion for
+  that file is in flight. Populated by **both** extraction paths:
+  - the ingest-path conversion in `runMultiIngest` (`AgentOperationRunner.swift:58-101`), and
+  - the standalone `runExtraction()` (`IngestedFileDetailView.swift:349`).
+  Drives an **"Extracting…"** row label and disables the *standalone Extract
+  button for that file only*. Never touches the cross-file Ingest greyout.
+
+- **`ingestingFileIDs: Set<PageID>`** — `true` only once the agent spawn is
+  actually committed (slot acquired / `onLock` about to fire), cleared in
+  `finish()`. Drives the **"Ingesting…"** row label and the cross-file
+  `isAnyFileIngesting` greyout.
+
+Net effect: a pure extraction on file A no longer mislabels A's row as
+"Ingesting…" and no longer greys out B's Ingest button. Queries and edits remain
+unaffected throughout (they already are). The asymmetry the principle asks for —
+extraction never blocks the user, only the claude run does — becomes visible and
+consistent in the UI.
+
+### Why put `extractingFileIDs` on the launcher
+
+The standalone `runExtraction()` in `IngestedFileDetailView` currently tracks its
+own local `@State isExtracting` and `extractionLog` (`IngestedFileDetailView.swift:28-29`).
+That local flag is invisible to the file *row* and to other files' detail views.
+For the row to label A as "Extracting…" while the user has B open, the
+extraction-in-flight state must live on the shared `AgentLauncher` alongside
+`ingestingFileIDs` and `isExtracting`. The launcher already owns the per-run
+process bookkeeping (`isExtracting`, `extractionPID`, `extractionLog`), so this is
+its natural home — no new owner introduced.
+
+## The decision: concurrent vs. serialized extractions
+
+Once B's Ingest is no longer greyed during A's extraction, B will start its *own*
+pdf2md conversion and then queue for the spawn slot. Two concurrent pdf2md runs are
+heavy — the VLM pipeline pulls a ~2 GB model and runs on GPU/CPU. Options:
+
+- **(A) Allow concurrent extractions.** Fully decoupled; matches the principle
+  most directly. The model is likely already resident after the first conversion,
+  so the second is cheaper than it looks. Risk: two VLM processes competing for
+  memory/GPU on a large PDF pair, possible OOM or slowdown.
+
+- **(B) Serialize extractions on a *separate* extraction lock**, distinct from the
+  claude spawn slot. Keeps "one heavy conversion at a time" safety **without**
+  re-coupling extraction to the agent lock — the extraction lock never touches
+  query/edit locking or the spawn slot. A second extract request awaits it; a
+  query starting during an extraction still runs immediately (query takes the
+  spawn slot, which extraction does not hold).
+
+**Recommended: (B).** It preserves pdf2md's one-at-a-time safety while keeping
+extraction's relationship to queries/edits exactly as the principle demands. The
+extraction lock is a thin FIFO mutex (shape mirrors `awaitSpawnSlot`, but separate
+state — `awaitExtractionSlot` / `releaseExtractionSlot`). If pdf2md turns out to
+tolerate concurrency well in practice, dropping the lock later is a one-spot
+change.
+
+### Standalone extraction interaction
+
+The standalone "Extract Markdown" button (`IngestedFileDetailView`) calls pdf2md
+directly, not through `runMultiIngest`. It must take the **extraction** lock too —
+so a standalone extract and an ingest-path extract serialize against each other —
+but it must *not* take the spawn slot (unchanged). Its current local
+`isExtracting` becomes the file-scoped view of the shared `extractingFileIDs`
+membership.
+
+## Scope of changes
+
+- `AgentLauncher`:
+  - add `extractingFileIDs: Set<PageID>`;
+  - (option B) add `awaitExtractionSlot()` / `releaseExtractionSlot()` mirroring
+    the spawn-slot shape;
+  - `ingestingFileIDs` is now set only at agent-spawn-commit and cleared in
+    `finish()` (already is) — the runner stops pre-setting it for the extraction
+    phase.
+- `AgentOperationRunner.runMultiIngest`:
+  - stop setting `ingestingFileIDs` up front;
+  - set `extractingFileIDs` around the pdf2md block, clear it when the conversion
+    ends (success or failure);
+  - set `ingestingFileIDs` only once the agent spawn is committed (i.e. just before
+    `await run(...)` that we know will acquire the slot, or — cleaner — let
+    `AgentLauncher.run` set it from `onLock`-adjacent commit). The cancel-while-
+    queued cleanup (`AgentOperationRunner.swift:127-134`) stays, clearing whatever
+    phase flags are set.
+- `IngestedFileDetailView.runExtraction`: take the extraction slot; reflect
+  `extractingFileIDs.contains(file.id)` for the button state (keep the local
+  `isExtracting` for the in-view progress log, or source it from the shared set).
+- `IngestedFileRow`: show **"Extracting…"** when in `extractingFileIDs`,
+  **"Ingesting…"** when in `ingestingFileIDs`. Needs both sets plumbed
+  (`SidebarView` → row), replacing the single `isIngesting`.
+- `WikiDetailView`: `isAnyFileIngesting` stays `!ingestingFileIDs.isEmpty`
+  (unchanged semantics, now correctly *extraction-free*); plumb `extractingFileIDs`
+  into the detail view for the per-file Extract button state and any banner.
+- Tests:
+  - extend `AgentSpawnSlotTests` (or a sibling) to assert extraction sets
+    `extractingFileIDs` (not `ingestingFileIDs`), the agent phase sets
+    `ingestingFileIDs` only after spawn commit, and a query started during
+    extraction runs without waiting on extraction;
+  - (option B) extraction-slot FIFO + cancellation tests mirroring the spawn-slot
+    ones;
+  - a pure predicate test for the row's Extracting-vs-Ingesting label, like the
+    existing `showsQueryDebugControls` seam.
+
+## Non-goals
+
+- Not changing the edit lock's meaning (claude-run-only) — that's already correct.
+- Not changing the spawn slot's meaning (claude-only) — already correct.
+- Not re-architecting pdf2md concurrency beyond option A/B above.
+- Not touching the `hasBeenIngested` derivation (agent's `wikictl log append
+  --kind ingest`), which is unaffected by which phase owns which flag.
+
+## Out of scope but noted
+
+- The standalone "Extract Markdown" button only appears for `isPDF && !hasMarkdown`
+  (`IngestedFileDetailView.swift:156`). After extraction seeds a head version the
+  button disappears — so the only extraction re-entry path is a fresh re-extract
+  of a re-added file. The extraction lock still matters because the *ingest*-path
+  extract can run concurrently with a *standalone* extract of a different file.


### PR DESCRIPTION
## Summary

Fixes several bugs in the standalone "Extract Markdown" path and improves the ingest pipeline.

### Bugs fixed

**Extract button didn't open the sidebar PDF conversion box.** `runExtraction()` used local `@State` variables but `AgentTranscriptSidebar.showsConversion` checked `launcher.isExtracting` and `launcher.extractionLog` — which were never set by the standalone path. The sidebar auto-expanded but showed only an empty Agent Activity section.

**Stop button was a no-op during standalone extraction.** The extraction `Task` was created inline and never stored. `AgentLauncher.stop()` cancelled only `ingestTask` and `process`, both `nil` during standalone extraction. Added `extractTask` to `AgentLauncher`, stored by the Extract button, cancelled by `stopExtraction()`.

**Ingest button stayed active during extraction.** Added `|| isThisFileExtracting` to the Ingest button's `.disabled()` guard.

### Improvements

**Ingest re-uses existing extracted markdown.** `AgentOperationRunner.runMultiIngest` now checks `store.processedMarkdownHead(for: file)` before running pdf2md. If markdown was already extracted via the standalone button (or a prior ingest), it reuses the existing content and skips the heavy conversion entirely — no extraction slot taken.

**Two distinct Stop buttons.** The sidebar had one shared Stop button that killed everything. Now there are two, matching the two independent locks:
- **Stop Conversion** (PDF Conversion box header) — calls `stopExtraction()`, cancels only the pdf2md conversion, leaves the agent alone
- **Stop Agent** (Agent Activity section header) — calls `stopAgent()`, terminates only the claude process, leaves extraction alone

**Extraction logs moved to launcher.** The detail view keeps only a minimal `Extracting…` spinner; all progress log output goes to `launcher.extractionLog` for the sidebar's PDF Conversion box.

## Tests

`swift test` — 596 tests, 50 suites, 0 failures:
- `AgentExtractionLockTests` — new file: extraction slot serialization, phase-flag split, stop separation (+17 tests)
- `AgentSpawnSlotTests` — new file: spawn slot serialization (+6 tests)
- `ProcessedMarkdownTests` — +3 tests for seed/reuse contract

## Files

| File | Change |
|------|--------|
| `Sources/WikiFS/IngestedFileDetailView.swift` | Set launcher flags in `runExtraction()`; removed local `extractionLog`; store `extractTask`; disable Ingest during extraction |
| `Sources/WikiFS/AgentLauncher.swift` | Added `extractTask`; split `stop()` into `stopExtraction()` / `stopAgent()` |
| `Sources/WikiFS/AgentTranscriptSidebar.swift` | Two distinct Stop buttons; simplified header |
| `Sources/WikiFS/AgentOperationRunner.swift` | Skip pdf2md when markdown already extracted; reuse existing content |
| `Sources/WikiFS/ContentView.swift` | Auto-open transcript on `extractingFileIDs` change |
| `Sources/WikiFS/WikiDetailView.swift` | Plumb `isThisFileExtracting` to detail view |
| `Tests/WikiFSTests/AgentExtractionLockTests.swift` | New: 17 tests for extraction slot + stop separation |
| `Tests/WikiFSTests/AgentSpawnSlotTests.swift` | New: 6 tests for spawn slot serialization |
| `Tests/WikiFSTests/ProcessedMarkdownTests.swift` | +3 tests for seed/reuse contract |

🤖 Generated with [Claude Code](https://claude.com/claude-code)