### PR TITLE
Phase B: [[source:display-name]] wikilinks

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -88,50 +88,19 @@ baseline of 601):
 
 On branch `feature/phase-b-source-wikilinks`. PR #33.
 
-## 2026-06-21 — Phase A: rename "ingested file" → "source" throughout (PR #31, #32)
+## 2026-06-21 — Phase A: rename "ingested file" → "source" throughout (PR #31)
 
-Full rename across database, types, UI, CLI, File Provider, and agent prompts.
+Full rename across database, types, UI, CLI, File Provider, and agent prompts. v10
+migration renames `ingested_files` → `sources` and `file_markdown_versions` →
+`source_markdown_versions`; adds `display_name` column (backfilled from `filename`);
+creates `source_links` table. All Swift types renamed (`IngestedFileSummary` →
+`SourceSummary`, etc.), all views renamed (`IngestedFileDetailView` →
+`SourceDetailView`, `IngestedFileRow` → `SourceRow`, `FilesSectionView` →
+`SourcesSectionView`), CLI renamed (`wikictl file` → `wikictl source`), mount paths
+renamed (`files/` → `sources/`), agent prompts updated. Six extension-check bugs
+fixed (use `mimeType` instead of `ext` for behavioral decisions). 596 tests green.
 
-**Migration:** v10 renames `ingested_files` → `sources` and `file_markdown_versions`
-→ `source_markdown_versions`; adds `display_name` column (backfilled from
-`filename`); creates `source_links` table (for future `[[source:…]]` links).
-
-**Type/UI/CLI renames:** `IngestedFileSummary` → `SourceSummary`, `FileMarkdownVersion`
-→ `SourceMarkdownVersion`, `IngestedFileDetailView` → `SourceDetailView`,
-`IngestedFileRow` → `SourceRow`, `FilesSectionView` → `SourcesSectionView`,
-`wikictl file` → `wikictl source`, `WikiSelection.ingestedFile` → `.source`, etc.
-Mount paths: `files/` → `sources/`, `indexes/files.jsonl` → `indexes/sources.jsonl`.
-Agent prompts (system prompt, operation prompts, TREE.md) all updated.
-
-**Extension-check bugs fixed (6 sites):** `isPDF`, `isMarkdownNative`, `symbol`, and
-the PDF extraction gate in `AgentOperationRunner` now use `mimeType` (content-sniffed)
-instead of `ext` (filename-derived), so a PDF without a `.pdf` extension still gets
-PDF viewer, extraction, and correct icons.
-
-**Variable renames:** `ingestingFileIDs` → `ingestingSourceIDs`, `extractingFileIDs`
-→ `extractingSourceIDs`, `selectedFileIDs` → `selectedSourceIDs`, `fileFilter` →
-`sourceFilter`, `isFilesExpanded` → `isSourcesExpanded`, `isAnyFileIngesting` →
-`isAnySourceIngesting`, `openIngestedFile` → `openSource`. View parameters and local
-variables updated throughout.
-
-**Follow-up bug fixes (PR #32):** two shipped bugs caught by Phase B review and fixed
-before Phase B landed:
-
-- **`source_links` missing `ON DELETE CASCADE`:** latent until Phase B populates the
-  table. v10→v11 migration rebuilds `source_links` with the cascade via
-  rename→create→copy→drop (data-preserving, idempotent).
-- **File Provider projected `files.jsonl` / `files/`:** the Phase A rename updated
-  enum cases but missed display strings in `Projection.swift`. The on-disk tree still
-  showed `indexes/files.jsonl` and a top-level `files/` folder, contradicting
-  `manifest.json`. Fixed to `sources.jsonl` / `sources`.
-
-**Tests.** `swift test` — 601 tests, 50 suites, 0 failures (+5 for bug fixes):
-`deleteSourceCascadesToSourceLinksAfterV11Migration`,
-`freshDBReachesUserVersion11`, `v11SourceLinksHasDeleteCascade`,
-`sourcesJSONLPathIsCorrect`, `manifestAdvertisesSourcePaths`.
-All `user_version` assertions bumped from 9→10→11 across the two PRs.
-
-Branches `feature/sources-redesign` (PR #31) → `fix-source-bugs` (PR #32).
+Branches `feature/sources-redesign` (PR #31) → `feature/phase-b-source-wikilinks` (PR #33).
 
 ## 2026-06-21 — Phase B review + two follow-up plans
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -66,22 +66,7 @@ serves both link kinds.
   running `wikictl file` from its prompt instructions and getting "unknown
   command". Three commits pushed to the PR to stamp this out.
 
-**Tests.** `swift test` — 635 tests, 50 suites, 0 failures (+39 from Phase A's
-baseline of 596):
-
-- `WikiLinkParserTests` (+11): `source:` prefix, alias preservation, whitespace
-  normalization, empty-prefix skip, `page:` escape, dedup across kinds, `classify`
-  edge cases.
-- `WikiLinkMarkdownTests` (+10): source host on resolve/missing, alias display,
-  `resolvedKind(from:)` / `target(from:)` round-trip, mixed page+source rendering,
-  `[[source:]]` literal emission, code-span and fenced-block protection.
-- `SQLiteWikiStoreTests` (+7): `resolveSourceByName` (display name hit, filename
-  fallback, case-insensitive, nil on unknown), `replaceLinks` mixed+atomic,
-  case-insensitive title resolution.
-- `IndexGeneratorTests` (+3): `linksJSONL` `type` field, byte stability,
-  manifest advertises source paths.
-- `WikiLinkNavigationTests` (+3): `selectSource(byDisplayName:)` navigation,
-  no-op on missing, tab reuse.
+**Tests.** `swift test` — 635 tests, 50 suites, 0 failures.
 
 On branch `feature/phase-b-source-wikilinks`. PR #33.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,17 +4,10 @@ Newest first. To get up to speed: read `PLAN.md` then this file.
 
 ## 2026-06-21 — Phase B: `[[source:display-name]]` wikilinks
 
-An adversarial multi-agent review of the parent design (`sources-redesign.md`) found
-23 issues: a self-contradictory render contract (`?id=` needs a ULID at render time
-but the closure is Bool), no shared normalizer, case-sensitive page resolution that
-diverged from the spec, and a claim that the rename would add a "general" link-rewrite
-scanner when none existed. A new grounded plan (`phase-b-source-wikilinks.md`) resolved
-all findings, then the implementation followed.
-
 Wiki pages can now link to sources with `[[source:display-name]]` syntax. Clicking a
 source link in the preview navigates to that source's detail view — the same seam
 page links use. Source links render as `wiki://source?title=<display-name>`
-(not `?id=<ulid>`), resolution happens at click time via
+(mirroring `wiki://page?title=…`), resolution happens at click time via
 `selectSource(byDisplayName:)`, and a single `(String, LinkType) -> Bool` closure
 serves both link kinds.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,15 +4,19 @@ Newest first. To get up to speed: read `PLAN.md` then this file.
 
 ## 2026-06-21 — Phase B: `[[source:display-name]]` wikilinks
 
+An adversarial multi-agent review of the parent design (`sources-redesign.md`) found
+23 issues: a self-contradictory render contract (`?id=` needs a ULID at render time
+but the closure is Bool), no shared normalizer, case-sensitive page resolution that
+diverged from the spec, and a claim that the rename would add a "general" link-rewrite
+scanner when none existed. A new grounded plan (`phase-b-source-wikilinks.md`) resolved
+all findings, then the implementation followed.
+
 Wiki pages can now link to sources with `[[source:display-name]]` syntax. Clicking a
 source link in the preview navigates to that source's detail view — the same seam
-page links use. The implementation spans the full stack: parser → renderer → resolver
-→ navigator → persistence → agent index.
-
-The architecture mirrors page links: source links render as
-`wiki://source?title=<display-name>` (not `?id=<ulid>`), resolution happens at click
-time via a new `selectSource(byDisplayName:)`, and the resolution closure stays
-uniform — a single `(String, LinkType) -> Bool` for both link kinds.
+page links use. Source links render as `wiki://source?title=<display-name>`
+(not `?id=<ulid>`), resolution happens at click time via
+`selectSource(byDisplayName:)`, and a single `(String, LinkType) -> Bool` closure
+serves both link kinds.
 
 **Changes:**
 
@@ -69,8 +73,8 @@ uniform — a single `(String, LinkType) -> Bool` for both link kinds.
   running `wikictl file` from its prompt instructions and getting "unknown
   command". Three commits pushed to the PR to stamp this out.
 
-**Tests.** `swift test` — 635 tests, 50 suites, 0 failures (+34 from the prior
-baseline of 601):
+**Tests.** `swift test` — 635 tests, 50 suites, 0 failures (+39 from Phase A's
+baseline of 596):
 
 - `WikiLinkParserTests` (+11): `source:` prefix, alias preservation, whitespace
   normalization, empty-prefix skip, `page:` escape, dedup across kinds, `classify`
@@ -101,37 +105,6 @@ renamed (`files/` → `sources/`), agent prompts updated. Six extension-check bu
 fixed (use `mimeType` instead of `ext` for behavioral decisions). 596 tests green.
 
 Branches `feature/sources-redesign` (PR #31) → `feature/phase-b-source-wikilinks` (PR #33).
-
-## 2026-06-21 — Phase B review + two follow-up plans
-
-Reviewed Phase B ("Wiki links to sources") of `plans/sources-redesign.md` against the
-actual codebase (adversarial multi-agent review; 23 findings, all verified real). Headline
-issues: (1) the render contract is self-contradictory — the plan injects a
-`(String, LinkType) -> Bool` closure but renders `wiki://source?id=<ulid>`, which needs the
-ULID at render time a Bool closure can't supply (page links render `?title=` and resolve at
-click time); (2) `source_links` shipped without `ON DELETE CASCADE`
-(`SQLiteWikiStore.swift:330`), so `deleteSource` will FK-violate once the table is
-populated; (3) "same normalization as page titles" is false — page resolution is
-case-sensitive and no shared normalizer exists. Also found a stale Phase A rename:
-`Projection.swift:407,409` still projects `files.jsonl`/`files/` instead of
-`sources.jsonl`/`sources/`.
-
-Wrote two implementation plans (both indexed in `PLAN.md`):
-
-- **`plans/fix-phase-a-source-bugs.md`** — the two shipped bugs, scoped tight so they land
-  first. v11 migration rebuilds `source_links` with `ON DELETE CASCADE` (data-preserving
-  rename→create→copy→drop); `Projection.swift` projected names corrected to
-  `sources.jsonl`/`sources/`. Blocks Phase B.
-- **`plans/phase-b-source-wikilinks.md`** — Phase B re-grounded. Adopts the review's
-  recommended architecture: render source links as `wiki://source?title=<display-name>`
-  (mirror pages, resolve at click time via new `selectSource(byDisplayName:)`), one shared
-  whitespace normalizer (consolidating the 3 `collapseWhitespace` copies), case-insensitive
-  resolution for both pages and sources, a `LinkType` enum with a `.page` default + a
-  `page:` escape for the `source:` namespace collision, a single-transaction `replaceLinks`
-  over both link tables, and a unified `links.jsonl` with a `type` field. Resolves all 23
-  findings and corrects the rename spec in `sources-redesign.md`.
-
-No code changed this session — planning only, on branch `feature/source-wikilinks`.
 
 ## 2026-06-20 — Standalone Extract Markdown fixes + Stop-button overhaul
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -88,42 +88,48 @@ baseline of 601):
 
 On branch `feature/phase-b-source-wikilinks`. PR #33.
 
-## 2026-06-21 — Phase A bug fixes: source_links cascade + stale File Provider names
+## 2026-06-21 — Phase A: rename "ingested file" → "source" throughout (PR #31, #32)
 
-Two shipped bugs from Phase A (PR #31) fixed before Phase B builds on top:
+Full rename across database, types, UI, CLI, File Provider, and agent prompts.
 
-**Bug A — `source_links` missing `ON DELETE CASCADE`:** the v10 migration created
-`source_links` without cascade, latent until Phase B populates the table.
-**Fix:** v10→v11 migration rebuilds `source_links` with `ON DELETE CASCADE` via
-rename→create→copy→drop (data-preserving, idempotent). `deleteSource` needs no
-change — the cascade is the single source of truth.
+**Migration:** v10 renames `ingested_files` → `sources` and `file_markdown_versions`
+→ `source_markdown_versions`; adds `display_name` column (backfilled from
+`filename`); creates `source_links` table (for future `[[source:…]]` links).
 
-**Bug B — File Provider projected `files.jsonl` / `files/`:** the Phase A rename
-updated enum cases and `IndexGenerators` paths but missed the display strings the
-File Provider projects. The on-disk tree still showed `indexes/files.jsonl` and a
-top-level `files/` folder, contradicting `manifest.json`.
-**Fix:** display names updated in `Projection.swift` to `sources.jsonl` / `sources`.
-Stale comment in `SourceCommand.swift` fixed.
+**Type/UI/CLI renames:** `IngestedFileSummary` → `SourceSummary`, `FileMarkdownVersion`
+→ `SourceMarkdownVersion`, `IngestedFileDetailView` → `SourceDetailView`,
+`IngestedFileRow` → `SourceRow`, `FilesSectionView` → `SourcesSectionView`,
+`wikictl file` → `wikictl source`, `WikiSelection.ingestedFile` → `.source`, etc.
+Mount paths: `files/` → `sources/`, `indexes/files.jsonl` → `indexes/sources.jsonl`.
+Agent prompts (system prompt, operation prompts, TREE.md) all updated.
 
-**Tests.** `swift test` — 601 tests, 50 suites, 0 failures (+5):
+**Extension-check bugs fixed (6 sites):** `isPDF`, `isMarkdownNative`, `symbol`, and
+the PDF extraction gate in `AgentOperationRunner` now use `mimeType` (content-sniffed)
+instead of `ext` (filename-derived), so a PDF without a `.pdf` extension still gets
+PDF viewer, extraction, and correct icons.
+
+**Variable renames:** `ingestingFileIDs` → `ingestingSourceIDs`, `extractingFileIDs`
+→ `extractingSourceIDs`, `selectedFileIDs` → `selectedSourceIDs`, `fileFilter` →
+`sourceFilter`, `isFilesExpanded` → `isSourcesExpanded`, `isAnyFileIngesting` →
+`isAnySourceIngesting`, `openIngestedFile` → `openSource`. View parameters and local
+variables updated throughout.
+
+**Follow-up bug fixes (PR #32):** two shipped bugs caught by Phase B review and fixed
+before Phase B landed:
+
+- **`source_links` missing `ON DELETE CASCADE`:** latent until Phase B populates the
+  table. v10→v11 migration rebuilds `source_links` with the cascade via
+  rename→create→copy→drop (data-preserving, idempotent).
+- **File Provider projected `files.jsonl` / `files/`:** the Phase A rename updated
+  enum cases but missed display strings in `Projection.swift`. The on-disk tree still
+  showed `indexes/files.jsonl` and a top-level `files/` folder, contradicting
+  `manifest.json`. Fixed to `sources.jsonl` / `sources`.
+
+**Tests.** `swift test` — 601 tests, 50 suites, 0 failures (+5 for bug fixes):
 `deleteSourceCascadesToSourceLinksAfterV11Migration`,
 `freshDBReachesUserVersion11`, `v11SourceLinksHasDeleteCascade`,
 `sourcesJSONLPathIsCorrect`, `manifestAdvertisesSourcePaths`.
-All `user_version` assertions bumped from 10→11.
-
-Branches `fix-source-bugs` (PR #32) → `feature/phase-b-source-wikilinks` (PR #33).
-
-## 2026-06-21 — Phase A: rename "ingested file" → "source" throughout (PR #31)
-
-Full rename across database, types, UI, CLI, File Provider, and agent prompts. v10
-migration renames `ingested_files` → `sources` and `file_markdown_versions` →
-`source_markdown_versions`; adds `display_name` column (backfilled from `filename`);
-creates `source_links` table. All Swift types renamed (`IngestedFileSummary` →
-`SourceSummary`, etc.), all views renamed (`IngestedFileDetailView` →
-`SourceDetailView`, `IngestedFileRow` → `SourceRow`, `FilesSectionView` →
-`SourcesSectionView`), CLI renamed (`wikictl file` → `wikictl source`), mount paths
-renamed (`files/` → `sources/`), agent prompts updated. Six extension-check bugs
-fixed (use `mimeType` instead of `ext` for behavioral decisions). 596 tests green.
+All `user_version` assertions bumped from 9→10→11 across the two PRs.
 
 Branches `feature/sources-redesign` (PR #31) → `fix-source-bugs` (PR #32).
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,131 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-21 — Phase B: `[[source:display-name]]` wikilinks
+
+Wiki pages can now link to sources with `[[source:display-name]]` syntax. Clicking a
+source link in the preview navigates to that source's detail view — the same seam
+page links use. The implementation spans the full stack: parser → renderer → resolver
+→ navigator → persistence → agent index.
+
+The architecture mirrors page links: source links render as
+`wiki://source?title=<display-name>` (not `?id=<ulid>`), resolution happens at click
+time via a new `selectSource(byDisplayName:)`, and the resolution closure stays
+uniform — a single `(String, LinkType) -> Bool` for both link kinds.
+
+**Changes:**
+
+- **Parser (`WikiLinkParser`):** `ParsedLink` gains a `LinkType` enum (`.page` /
+  `.source`) with a `.page` default so every existing call site compiles unchanged.
+  A new `classify()` method extracts the `source:` / `page:` prefix and re-normalizes
+  the remainder (`[[source: X]]` → target `"X"`). `parse()` deduplicates per
+  `(kind, target)`; `[[source:]]` (empty prefix target) is skipped as a non-link.
+  The `page:` prefix is an explicit escape: `[[page:source:foo]]` links to a page
+  literally titled "source:foo".
+
+- **Shared normalizer (`WikiText`):** `WikiText.normalized()` replaces three private
+  `collapseWhitespace` copies (in `WikiLinkParser`, `WikiLinkMarkdown`,
+  `HTMLToMarkdown`). One source of truth for whitespace collapsing across the wiki
+  subsystem.
+
+- **Renderer (`WikiLinkMarkdown`):** `linkified` closure signature changed to
+  `(String, LinkType) -> Bool`; source links render as
+  `wiki://source?title=<display-name>` when resolved, `wiki://missing?title=…` when
+  not. `markdownLink` is now kind-aware; `resolvedKind(from:)` returns `.page` /
+  `.source` / `nil` for the click handler. `isEmptyPrefix()` skips `[[source:]]`
+  in both parser and renderer.
+
+- **Resolution (`SQLiteWikiStore`):** `resolveTitleToID` is now case-insensitive
+  (`COLLATE NOCASE`) for parity with source resolution. `resolveSourceByName`
+  matches `display_name` first, falling back to `filename`; multi-match tiebreak
+  by `updated_at DESC`. `WikiStore` protocol extended with `resolveSourceByName`.
+
+- **Navigation (`WikiStoreModel`):** `sourceExists(displayName:)` mirrors
+  `pageExists(title:)` for the render closure. `selectSource(byDisplayName:)`
+  mirrors `selectPage(byTitle:)` line for line — resolves display name → ULID,
+  records navigation history, opens the source's tab (reusing an already-open
+  tab). `MarkdownPreview`'s `OpenURLAction` dispatches by kind.
+
+- **Persistence (`SQLiteWikiStore.replaceLinks`):** extended to write BOTH
+  `page_links` and `source_links` in ONE `BEGIN IMMEDIATE` transaction. Wipes
+  both tables for the page, then re-inserts resolved subsets atomically.
+  `listAllSourceLinks()` added with `type: "source"`.
+
+- **Index (`IndexGenerators`, `Projection`):** `LinkRow` gains `type: String`
+  (default `"page"`). `linksJSONL` emits `type` in fixed key order
+  (`from, to, link_text, type`). The File Provider projection merges
+  `listAllLinks()` + `listAllSourceLinks()` — page rows first, then source rows,
+  each sorted by `(from, to)`.
+
+- **Agent prompts:** `SystemPrompt` cheatsheet now lists `wikictl source` commands
+  and documents the `type` field in `links.jsonl`. `WikiOperation` Ingest/Query
+  prompts updated from `wikictl file` to `wikictl source`. `wikictl --help`
+  usage string updated in `ArgumentParser`.
+
+- **Stale help text + prompt references fixed:** `ArgumentParser` usage string,
+  `main.swift` comment, `WikiOperation` Ingest/Query prompts, and `SystemPrompt`
+  cheatsheet all said `wikictl file` instead of `wikictl source`. The agent was
+  running `wikictl file` from its prompt instructions and getting "unknown
+  command". Three commits pushed to the PR to stamp this out.
+
+**Tests.** `swift test` — 635 tests, 50 suites, 0 failures (+34 from the prior
+baseline of 601):
+
+- `WikiLinkParserTests` (+11): `source:` prefix, alias preservation, whitespace
+  normalization, empty-prefix skip, `page:` escape, dedup across kinds, `classify`
+  edge cases.
+- `WikiLinkMarkdownTests` (+10): source host on resolve/missing, alias display,
+  `resolvedKind(from:)` / `target(from:)` round-trip, mixed page+source rendering,
+  `[[source:]]` literal emission, code-span and fenced-block protection.
+- `SQLiteWikiStoreTests` (+7): `resolveSourceByName` (display name hit, filename
+  fallback, case-insensitive, nil on unknown), `replaceLinks` mixed+atomic,
+  case-insensitive title resolution.
+- `IndexGeneratorTests` (+3): `linksJSONL` `type` field, byte stability,
+  manifest advertises source paths.
+- `WikiLinkNavigationTests` (+3): `selectSource(byDisplayName:)` navigation,
+  no-op on missing, tab reuse.
+
+On branch `feature/phase-b-source-wikilinks`. PR #33.
+
+## 2026-06-21 — Phase A bug fixes: source_links cascade + stale File Provider names
+
+Two shipped bugs from Phase A (PR #31) fixed before Phase B builds on top:
+
+**Bug A — `source_links` missing `ON DELETE CASCADE`:** the v10 migration created
+`source_links` without cascade, latent until Phase B populates the table.
+**Fix:** v10→v11 migration rebuilds `source_links` with `ON DELETE CASCADE` via
+rename→create→copy→drop (data-preserving, idempotent). `deleteSource` needs no
+change — the cascade is the single source of truth.
+
+**Bug B — File Provider projected `files.jsonl` / `files/`:** the Phase A rename
+updated enum cases and `IndexGenerators` paths but missed the display strings the
+File Provider projects. The on-disk tree still showed `indexes/files.jsonl` and a
+top-level `files/` folder, contradicting `manifest.json`.
+**Fix:** display names updated in `Projection.swift` to `sources.jsonl` / `sources`.
+Stale comment in `SourceCommand.swift` fixed.
+
+**Tests.** `swift test` — 601 tests, 50 suites, 0 failures (+5):
+`deleteSourceCascadesToSourceLinksAfterV11Migration`,
+`freshDBReachesUserVersion11`, `v11SourceLinksHasDeleteCascade`,
+`sourcesJSONLPathIsCorrect`, `manifestAdvertisesSourcePaths`.
+All `user_version` assertions bumped from 10→11.
+
+Branches `fix-source-bugs` (PR #32) → `feature/phase-b-source-wikilinks` (PR #33).
+
+## 2026-06-21 — Phase A: rename "ingested file" → "source" throughout (PR #31)
+
+Full rename across database, types, UI, CLI, File Provider, and agent prompts. v10
+migration renames `ingested_files` → `sources` and `file_markdown_versions` →
+`source_markdown_versions`; adds `display_name` column (backfilled from `filename`);
+creates `source_links` table. All Swift types renamed (`IngestedFileSummary` →
+`SourceSummary`, etc.), all views renamed (`IngestedFileDetailView` →
+`SourceDetailView`, `IngestedFileRow` → `SourceRow`, `FilesSectionView` →
+`SourcesSectionView`), CLI renamed (`wikictl file` → `wikictl source`), mount paths
+renamed (`files/` → `sources/`), agent prompts updated. Six extension-check bugs
+fixed (use `mimeType` instead of `ext` for behavioral decisions). 596 tests green.
+
+Branches `feature/sources-redesign` (PR #31) → `fix-source-bugs` (PR #32).
+
 ## 2026-06-21 — Phase B review + two follow-up plans
 
 Reviewed Phase B ("Wiki links to sources") of `plans/sources-redesign.md` against the

--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -79,10 +79,10 @@ public enum ArgumentParser {
       index set --body-file <path|->         rewrite the curated index.md body
       search --query X [--limit N]           semantic search (cosine similarity);
                                              falls back to LIKE title match
-      file list [--json]                     list ingested files (TSV, or JSON lines)
-      file cat  (--id X | --name N)          write raw file bytes to stdout
-      file export (--id X | --name N) [--out <path>]
-                                             materialize a file to disk, print its path
+      source list [--json]                    list sources (TSV, or JSON lines)
+      source cat  (--id X | --name N)         write raw source bytes to stdout
+      source export (--id X | --name N) [--out <path>]
+                                              materialize a source to disk, print its path
     """
 
     /// Parse `arguments` (WITHOUT the executable name) plus an env lookup into an
@@ -272,7 +272,7 @@ public enum ArgumentParser {
             }
         }
 
-        /// A `--id Y` or `--name N` file selector (exactly one required).
+        /// A `--id Y` or `--name N` source selector (exactly one required).
         func requireSourceSelector() throws -> SourceCommand.Selector {
             switch (values["--id"], values["--name"]) {
             case (let id?, nil):

--- a/Sources/WikiFS/MarkdownPreview.swift
+++ b/Sources/WikiFS/MarkdownPreview.swift
@@ -57,8 +57,10 @@ struct MarkdownPreview: View {
                 }
                 return .systemAction
             }
-            if WikiLinkMarkdown.isResolvedURL(url) {
-                store.selectPage(byTitle: title)
+            switch WikiLinkMarkdown.resolvedKind(from: url) {
+            case .page:   store.selectPage(byTitle: title)
+            case .source: store.selectSource(byDisplayName: title)
+            case nil:     break // unresolved ("missing") → inert
             }
             return .handled
         })
@@ -76,7 +78,9 @@ struct MarkdownPreview: View {
     }
 
     private func linkified(_ body: String) -> String {
-        WikiLinkMarkdown.linkified(body) { store.pageExists(title: $0) }
+        WikiLinkMarkdown.linkified(body) { name, kind in
+            kind == .source ? store.sourceExists(displayName: name) : store.pageExists(title: name)
+        }
     }
 }
 

--- a/Sources/WikiFSCore/IndexGenerators.swift
+++ b/Sources/WikiFSCore/IndexGenerators.swift
@@ -17,16 +17,19 @@ import Foundation
 /// byte-for-byte stable, which lets the extension cache size==content by token.
 public enum IndexGenerators {
 
-    /// A single wiki link row, as read back from `page_links`.
+    /// A single wiki link row, as read back from `page_links` or `source_links`.
     public struct LinkRow: Equatable, Sendable {
         public let from: String
         public let to: String
         public let linkText: String
+        /// `"page"` or `"source"` — so the unified `links.jsonl` spans both kinds.
+        public let type: String
 
-        public init(from: String, to: String, linkText: String) {
+        public init(from: String, to: String, linkText: String, type: String = "page") {
             self.from = from
             self.to = to
             self.linkText = linkText
+            self.type = type
         }
     }
 
@@ -121,15 +124,16 @@ public enum IndexGenerators {
     }
 
     /// `indexes/links.jsonl` — one JSON object per line, one line per link,
-    /// ordered as given (the caller passes links ordered by (from,to)). Keys in
-    /// fixed order: from, to, link_text.
+    /// ordered as given (page rows first, then source rows, each sorted by
+    /// (from,to)). Keys in fixed order: from, to, link_text, type.
     public static func linksJSONL(links: [LinkRow]) -> Data {
         var out = ""
         for link in links {
             let from = jsonString(link.from)
             let to = jsonString(link.to)
             let text = jsonString(link.linkText)
-            out += "{\"from\":\(from),\"to\":\(to),\"link_text\":\(text)}\n"
+            let type = jsonString(link.type)
+            out += "{\"from\":\(from),\"to\":\(to),\"link_text\":\(text),\"type\":\(type)}\n"
         }
         return Data(out.utf8)
     }

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -712,38 +712,75 @@ public final class SQLiteWikiStore: WikiStore {
 
     public func resolveTitleToID(_ title: String) throws -> PageID? {
         // Lowest ULID == oldest page on a duplicate-title collision.
+        // COLLATE NOCASE: case-insensitive ASCII folding so [[home]] → "Home".
         let stmt = try statement(
-            "SELECT id FROM pages WHERE title = ?1 ORDER BY id ASC LIMIT 1;")
+            "SELECT id FROM pages WHERE title = ?1 COLLATE NOCASE ORDER BY id ASC LIMIT 1;")
         defer { stmt.reset() }
         try stmt.bind(title, at: 1)
         guard try stmt.step() else { return nil }
         return PageID(rawValue: stmt.text(at: 0))
     }
 
+    /// Resolve a `[[source:…]]` target to a source id. Matches display_name first,
+    /// falling back to filename. Case-insensitive. On a multi-match collision, the
+    /// most recently updated source wins.
+    public func resolveSourceByName(_ displayName: String) throws -> PageID? {
+        let stmt = try statement("""
+        SELECT id FROM sources
+        WHERE COALESCE(display_name, filename) = ?1 COLLATE NOCASE
+           OR filename = ?1 COLLATE NOCASE
+        ORDER BY updated_at DESC LIMIT 1;
+        """)
+        defer { stmt.reset() }
+        try stmt.bind(displayName, at: 1)
+        guard try stmt.step() else { return nil }
+        return PageID(rawValue: stmt.text(at: 0))
+    }
+
     public func replaceLinks(from pageID: PageID,
                              parsedLinks: [WikiLinkParser.ParsedLink]) throws {
-        // One transaction: wipe this page's outgoing links, then insert the
-        // resolved subset. Unresolved targets are OMITTED (NULL to_page_id is
-        // forbidden by the schema). `INSERT OR IGNORE` collapses duplicate
-        // (from,to) pairs from distinct titles that resolve to the same page.
+        // One transaction: wipe this page's outgoing links in BOTH tables, then
+        // insert the resolved subsets. Unresolved targets are OMITTED.
+        // `INSERT OR IGNORE` collapses duplicate (from,to) pairs.
+        // `source_links` inherits the same alias-collapsing behavior as
+        // `page_links` via its PRIMARY KEY (from_page_id, to_source_id).
         try exec("BEGIN IMMEDIATE;")
         do {
-            let del = try statement("DELETE FROM page_links WHERE from_page_id = ?1;")
-            del.reset()
-            try del.bind(pageID.rawValue, at: 1)
-            _ = try del.step()
+            let delPage = try statement("DELETE FROM page_links WHERE from_page_id = ?1;")
+            delPage.reset()
+            try delPage.bind(pageID.rawValue, at: 1)
+            _ = try delPage.step()
 
-            let ins = try statement("""
+            let delSource = try statement("DELETE FROM source_links WHERE from_page_id = ?1;")
+            delSource.reset()
+            try delSource.bind(pageID.rawValue, at: 1)
+            _ = try delSource.step()
+
+            let insPage = try statement("""
             INSERT OR IGNORE INTO page_links (from_page_id, to_page_id, link_text)
             VALUES (?1, ?2, ?3);
             """)
+            let insSource = try statement("""
+            INSERT OR IGNORE INTO source_links (from_page_id, to_source_id, link_text)
+            VALUES (?1, ?2, ?3);
+            """)
             for link in parsedLinks {
-                guard let target = try resolveTitleToID(link.target) else { continue }
-                ins.reset()
-                try ins.bind(pageID.rawValue, at: 1)
-                try ins.bind(target.rawValue, at: 2)
-                try ins.bind(link.linkText, at: 3)
-                _ = try ins.step()
+                switch link.linkType {
+                case .page:
+                    guard let target = try resolveTitleToID(link.target) else { continue }
+                    insPage.reset()
+                    try insPage.bind(pageID.rawValue, at: 1)
+                    try insPage.bind(target.rawValue, at: 2)
+                    try insPage.bind(link.linkText, at: 3)
+                    _ = try insPage.step()
+                case .source:
+                    guard let target = try resolveSourceByName(link.target) else { continue }
+                    insSource.reset()
+                    try insSource.bind(pageID.rawValue, at: 1)
+                    try insSource.bind(target.rawValue, at: 2)
+                    try insSource.bind(link.linkText, at: 3)
+                    _ = try insSource.step()
+                }
             }
             try exec("COMMIT;")
         } catch {
@@ -752,9 +789,9 @@ public final class SQLiteWikiStore: WikiStore {
         }
     }
 
-    /// All link rows, ordered by `(from_page_id, to_page_id)`. Read-side helper
-    /// for the File Provider projection's `links.jsonl` generator. Not on the
-    /// `WikiStore` protocol — like `listAllPagesOrderedByID`, it is a
+    /// All page→page link rows, ordered by `(from_page_id, to_page_id)`. Read-side
+    /// helper for the File Provider projection's `links.jsonl` generator. Not on
+    /// the `WikiStore` protocol — like `listAllPagesOrderedByID`, it is a
     /// read-projection helper, not part of the editing API.
     public func listAllLinks() throws -> [IndexGenerators.LinkRow] {
         let stmt = try statement("""
@@ -767,13 +804,35 @@ public final class SQLiteWikiStore: WikiStore {
             out.append(IndexGenerators.LinkRow(
                 from: stmt.text(at: 0),
                 to: stmt.text(at: 1),
-                linkText: stmt.text(at: 2)
+                linkText: stmt.text(at: 2),
+                type: "page"
             ))
         }
         return out
     }
 
-    // MARK: - Ingested files (Phase 5)
+    /// All page→source link rows, ordered by `(from_page_id, to_source_id)`. Same
+    /// shape as `listAllLinks` so the projection merges them into a unified
+    /// `links.jsonl` (page rows first, then source rows).
+    public func listAllSourceLinks() throws -> [IndexGenerators.LinkRow] {
+        let stmt = try statement("""
+        SELECT from_page_id, to_source_id, link_text
+        FROM source_links ORDER BY from_page_id, to_source_id;
+        """)
+        defer { stmt.reset() }
+        var out: [IndexGenerators.LinkRow] = []
+        while try stmt.step() {
+            out.append(IndexGenerators.LinkRow(
+                from: stmt.text(at: 0),
+                to: stmt.text(at: 1),
+                linkText: stmt.text(at: 2),
+                type: "source"
+            ))
+        }
+        return out
+    }
+
+    // MARK: - Sources (Phase 5, renamed v10)
 
     /// Reject any single dropped file larger than this. A soft guard so the
     /// verbatim-bytes-in-SQLite model can't be handed a multi-GB blob that would

--- a/Sources/WikiFSCore/SystemPrompt.swift
+++ b/Sources/WikiFSCore/SystemPrompt.swift
@@ -52,7 +52,8 @@ public struct SystemPrompt: Equatable, Sendable {
     - `WIKI-STRUCTURE.md` — an orientation map of this layout plus live page/file counts.
     - `TREE.md` — legacy alias for `WIKI-STRUCTURE.md`.
     - `indexes/*.jsonl` — machine-readable indexes (`pages.jsonl`, `links.jsonl`,
-      `sources.jsonl`) for cheap programmatic navigation.
+      `sources.jsonl`) for cheap programmatic navigation. `links.jsonl` has a
+      `type` field (`"page"` or `"source"`) — the unified link graph spans both.
     - `manifest.json` — the generated wiki manifest.
     - `CLAUDE.md` / `AGENTS.md` — this document (identical bytes).
 

--- a/Sources/WikiFSCore/SystemPrompt.swift
+++ b/Sources/WikiFSCore/SystemPrompt.swift
@@ -89,6 +89,10 @@ public struct SystemPrompt: Equatable, Sendable {
     printf '%s' "<body>" | wikictl index set --body-file -               rewrite index.md wholesale
     wikictl log append --kind ingest|query|lint --title "…" [--note "…"] [--source <file-id>]  record an action (--source marks an ingest done)
     wikictl search --query "…" [--limit N]    semantic search — find pages by meaning; defaults to 10 results, max 100
+    wikictl source list [--json]               list all sources (TSV, or JSON lines)
+    wikictl source cat --id I | --name N       write raw source bytes to stdout
+    wikictl source export --id I | --name N [--out <path>]
+                                                materialize a source to disk, print its path
     ```
 
     **Read back what you just wrote with `wikictl page get`** — the mount lags a

--- a/Sources/WikiFSCore/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSCore/WikiLinkMarkdown.swift
@@ -18,8 +18,8 @@ import Foundation
 ///
 /// Resolution is injected as a closure (`isResolved`) rather than reaching for a
 /// store, so the function stays pure and the caller decides what "exists" means:
-///   * a target that resolves → `wiki://page?title=<encoded>` (a live link);
-///   * a target that does NOT  → `wiki://missing?title=<encoded>` (still a link
+///   * a target that resolves → `wiki://page?title=…` or `wiki://source?title=…`
+///   * a target that does NOT  → `wiki://missing?title=…` (still a link
 ///     so the view can style it dimmed, but the click handler no-ops on it).
 public enum WikiLinkMarkdown {
 
@@ -28,7 +28,7 @@ public enum WikiLinkMarkdown {
     public static let scheme = "wiki"
     /// Host for a link whose target resolves to a real page (navigates).
     public static let resolvedHost = "page"
-    /// Host for a link whose target has no page (rendered dimmed, inert).
+    /// Host for a link whose target has no page/source (rendered dimmed, inert).
     public static let unresolvedHost = "missing"
 
     // Same grammar as WikiLinkParser.pattern: [[ target (no ] or |) (| alias)? ]]
@@ -43,13 +43,13 @@ public enum WikiLinkMarkdown {
     ///
     /// - Parameters:
     ///   - body: the raw page Markdown (with literal `[[…]]`).
-    ///   - isResolved: returns `true` if a target title maps to an existing page.
-    ///                 Receives the whitespace-collapsed target (same form
-    ///                 `WikiLinkParser` and `resolveTitleToID` use).
+    ///   - isResolved: returns `true` if a (target, LinkType) pair maps to an
+    ///                 existing page/source. Receives the whitespace-collapsed,
+    ///                 prefix-stripped target.
     /// - Returns: Markdown safe to hand to `AttributedString(markdown:)`.
     public static func linkified(
         _ body: String,
-        isResolved: (String) -> Bool = { _ in true }
+        isResolved: (String, WikiLinkParser.ParsedLink.LinkType) -> Bool = { _, _ in true }
     ) -> String {
         let ns = body as NSString
         let codeRanges = protectedCodeRanges(in: body)
@@ -73,9 +73,16 @@ public enum WikiLinkMarkdown {
             }
             cursor = full.location + full.length
 
-            let target = collapseWhitespace(ns.substring(with: match.range(at: 1)))
-            guard !target.isEmpty else {
+            let rawTarget = collapseWhitespace(ns.substring(with: match.range(at: 1)))
+            guard !rawTarget.isEmpty else {
                 // Empty target (e.g. `[[ ]]`): leave the literal text in place.
+                out += ns.substring(with: full)
+                continue
+            }
+
+            let (kind, bareTarget) = WikiLinkParser.classify(rawTarget)
+            guard !bareTarget.isEmpty else {
+                // Empty bare target after prefix strip (e.g. `[[source:]]`): literal.
                 out += ns.substring(with: full)
                 continue
             }
@@ -84,12 +91,13 @@ public enum WikiLinkMarkdown {
             let display: String
             if aliasRange.location != NSNotFound {
                 let alias = collapseWhitespace(ns.substring(with: aliasRange))
-                display = alias.isEmpty ? target : alias
+                display = alias.isEmpty ? bareTarget : alias
             } else {
-                display = target
+                display = bareTarget
             }
 
-            out += markdownLink(display: display, target: target, resolved: isResolved(target))
+            let resolved = isResolved(bareTarget, kind)
+            out += markdownLink(display: display, target: bareTarget, kind: kind, resolved: resolved)
         }
         // Tail after the last match.
         if cursor < ns.length {
@@ -99,11 +107,12 @@ public enum WikiLinkMarkdown {
     }
 
     /// The `wiki://…` URL for a given target title, or nil if `url` is not one of
-    /// ours. Used by the view's `OpenURLAction` to pull the title back out.
+    /// ours. Accepts hosts `"page"`, `"source"`, or `"missing"`. Used by the view's
+    /// `OpenURLAction` to pull the title back out.
     public static func target(from url: URL) -> String? {
         guard url.scheme == scheme,
               let host = url.host,
-              host == resolvedHost || host == unresolvedHost,
+              host == resolvedHost || host == "source" || host == unresolvedHost,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let title = components.queryItems?.first(where: { $0.name == "title" })?.value,
               !title.isEmpty
@@ -111,16 +120,34 @@ public enum WikiLinkMarkdown {
         return title
     }
 
+    /// `.page` / `.source` for a resolved link; `nil` for unresolved (`missing`) or
+    /// non-wiki. Used by the view's `OpenURLAction` to route the click.
+    public static func resolvedKind(from url: URL) -> WikiLinkParser.ParsedLink.LinkType? {
+        guard url.scheme == scheme, let host = url.host else { return nil }
+        switch host {
+        case resolvedHost:   return .page     // "page"
+        case "source":       return .source
+        default:             return nil       // "missing" or anything else → inert
+        }
+    }
+
     /// True if `url` points at a page that resolved (i.e. should navigate). An
     /// unresolved (`missing`) link is one of ours but inert.
     public static func isResolvedURL(_ url: URL) -> Bool {
-        url.scheme == scheme && url.host == resolvedHost
+        resolvedKind(from: url) != nil
     }
 
     // MARK: - Helpers
 
-    private static func markdownLink(display: String, target: String, resolved: Bool) -> String {
-        let host = resolved ? resolvedHost : unresolvedHost
+    private static func markdownLink(display: String, target: String,
+                                     kind: WikiLinkParser.ParsedLink.LinkType,
+                                     resolved: Bool) -> String {
+        let host: String
+        if resolved {
+            host = kind == .source ? "source" : resolvedHost
+        } else {
+            host = unresolvedHost
+        }
         // Encode the title for the query value, and escape any `]`/`)` in the
         // display text so it can't break the Markdown `[text](url)` grammar.
         let encodedTitle = target.addingPercentEncoding(withAllowedCharacters: titleQueryAllowed)
@@ -132,10 +159,10 @@ public enum WikiLinkMarkdown {
         return "[\(safeDisplay)](\(scheme)://\(host)?title=\(encodedTitle))"
     }
 
-    /// Collapse whitespace runs to one space and trim — identical to
-    /// `WikiLinkParser` so a target linkifies to the same title it resolves to.
+    /// Collapse whitespace runs to one space and trim — delegates to the single
+    /// shared normalizer.
     private static func collapseWhitespace(_ s: String) -> String {
-        s.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        WikiText.normalized(s)
     }
 
     /// Allowed characters for the `title=` query value. Start from the URL query

--- a/Sources/WikiFSCore/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSCore/WikiLinkMarkdown.swift
@@ -82,7 +82,13 @@ public enum WikiLinkMarkdown {
 
             let (kind, bareTarget) = WikiLinkParser.classify(rawTarget)
             guard !bareTarget.isEmpty else {
-                // Empty bare target after prefix strip (e.g. `[[source:]]`): literal.
+                // Empty bare target after prefix strip: literal text.
+                out += ns.substring(with: full)
+                continue
+            }
+            // `[[source:]]` / `[[page:]]` — reserved prefix with no meaningful
+            // remainder: emit literal text (consistent with the parser's skip).
+            if WikiLinkParser.isEmptyPrefix(rawTarget) {
                 out += ns.substring(with: full)
                 continue
             }

--- a/Sources/WikiFSCore/WikiLinkParser.swift
+++ b/Sources/WikiFSCore/WikiLinkParser.swift
@@ -11,22 +11,32 @@ import Foundation
 /// Supported forms:
 ///   * `[[Title]]`            → target = "Title",  linkText = "Title"
 ///   * `[[Target|alias]]`     → target = "Target", linkText = "alias"
+///   * `[[source:Name]]`      → linkType = .source, target = "Name"
+///   * `[[page:Title]]`       → linkType = .page (explicit; escape hatch)
 ///
 /// Rules:
 ///   * the target has its internal whitespace collapsed and ends trimmed;
 ///   * empty targets (e.g. `[[ ]]`) are skipped;
-///   * duplicate targets are de-duplicated, FIRST occurrence wins (so the first
-///     alias seen for a target is the one kept);
+///   * the `source:` / `page:` prefix is stripped from the target *only* (never
+///     the alias); the remainder is re-normalized;
+///   * duplicate targets are de-duplicated per `(kind, target)`, FIRST occurrence
+///     wins (so the first alias seen for a target is the one kept);
 ///   * unmatched / malformed brackets are ignored.
 public enum WikiLinkParser {
 
-    /// A single parsed link reference: the raw target *title* (not yet resolved
-    /// to a page id) and the display text to record in `page_links.link_text`.
+    /// A single parsed link reference: the kind + the bare target (prefix-stripped)
+    /// and the display text to record in the link tables.
     public struct ParsedLink: Equatable, Sendable {
-        public let target: String
-        public let linkText: String
+        public enum LinkType: String, Equatable, Sendable { case page, source }
 
-        public init(target: String, linkText: String) {
+        public let linkType: LinkType
+        public let target: String       // prefix-stripped, whitespace-collapsed
+        public let linkText: String     // alias verbatim (never prefix-stripped)
+
+        /// `linkType` defaults to `.page` so every existing `ParsedLink(target:linkText:)`
+        /// call site compiles unchanged and equality holds (both sides default to `.page`).
+        public init(linkType: LinkType = .page, target: String, linkText: String) {
+            self.linkType = linkType
             self.target = target
             self.linkText = linkText
         }
@@ -36,38 +46,70 @@ public enum WikiLinkParser {
     private static let pattern = #"\[\[([^\]\|]+)(?:\|([^\]]+))?\]\]"#
     private static let regex = try! NSRegularExpression(pattern: pattern)
 
+    // MARK: - Prefix classification
+
+    /// Split a whitespace-collapsed target into its (kind, bare-target). Reserved
+    /// prefixes: `page:` (explicit page link / escape) takes precedence over `source:`,
+    /// so a page literally titled "source:foo" is linkable as `[[page:source:foo]]`.
+    /// The remainder is re-normalized so `[[source: X]]` → ("X"), not (" X").
+    public static func classify(_ target: String) -> (ParsedLink.LinkType, String) {
+        if let rest = peel(prefix: "page:", off: target)   { return (.page,   WikiText.normalized(rest)) }
+        if let rest = peel(prefix: "source:", off: target) { return (.source, WikiText.normalized(rest)) }
+        return (.page, target) // target already normalized by the caller
+    }
+
+    private static func peel(prefix: String, off s: String) -> String? {
+        guard s.hasPrefix(prefix) else { return nil }
+        let rest = String(s.dropFirst(prefix.count))
+        return rest.allSatisfy(\.isWhitespace) ? nil : rest // `[[source:]]` → not a source link
+    }
+
+    // MARK: - Parse
+
     /// Parse all wiki links from `body`, in document order, de-duplicated by
-    /// target (first alias wins).
+    /// `(kind, target)` (first alias wins).
     public static func parse(_ body: String) -> [ParsedLink] {
         let ns = body as NSString
         let matches = regex.matches(in: body, range: NSRange(location: 0, length: ns.length))
 
-        var seenTargets = Set<String>()
+        var seen = Set<String>()
         var out: [ParsedLink] = []
 
         for match in matches {
             let rawTarget = ns.substring(with: match.range(at: 1))
             let target = collapseWhitespace(rawTarget)
             guard !target.isEmpty else { continue }
-            guard seenTargets.insert(target).inserted else { continue }
+
+            let (kind, bareTarget) = classify(target)
+            guard !bareTarget.isEmpty else { continue } // empty target → skip
+            // `[[source:]]` / `[[page:   ]]` — reserved prefix with no meaningful
+            // remainder: skip the link entirely (consistent with `[[ ]]`).
+            if target.hasPrefix("source:") || target.hasPrefix("page:") {
+                let afterPrefix: String
+                if target.hasPrefix("page:") { afterPrefix = String(target.dropFirst(5)) }
+                else { afterPrefix = String(target.dropFirst(7)) }
+                if afterPrefix.allSatisfy(\.isWhitespace) { continue }
+            }
+
+            let dedupKey = "\(kind.rawValue):\(bareTarget)"
+            guard seen.insert(dedupKey).inserted else { continue }
 
             let aliasRange = match.range(at: 2)
             let linkText: String
             if aliasRange.location != NSNotFound {
                 let alias = collapseWhitespace(ns.substring(with: aliasRange))
-                linkText = alias.isEmpty ? target : alias
+                linkText = alias.isEmpty ? bareTarget : alias
             } else {
-                linkText = target
+                linkText = bareTarget
             }
-            out.append(ParsedLink(target: target, linkText: linkText))
+            out.append(ParsedLink(linkType: kind, target: bareTarget, linkText: linkText))
         }
         return out
     }
 
-    /// Collapse runs of whitespace to a single space and trim the ends — the
-    /// same normalization the title escaping uses, so `[[ Home ]]` resolves to
-    /// the `Home` page.
+    /// Collapse runs of whitespace to a single space and trim the ends — delegates
+    /// to the single shared normalizer.
     private static func collapseWhitespace(_ s: String) -> String {
-        s.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        WikiText.normalized(s)
     }
 }

--- a/Sources/WikiFSCore/WikiLinkParser.swift
+++ b/Sources/WikiFSCore/WikiLinkParser.swift
@@ -58,6 +58,18 @@ public enum WikiLinkParser {
         return (.page, target) // target already normalized by the caller
     }
 
+    /// True when `target` starts with a reserved prefix (`source:` or `page:`) but
+    /// the remainder is empty/whitespace (e.g. `[[source:]]`, `[[page:   ]]`). Both
+    /// parse() and WikiLinkMarkdown.linkified() use this to emit literal text.
+    public static func isEmptyPrefix(_ target: String) -> Bool {
+        for prefix in ["page:", "source:"] {
+            guard target.hasPrefix(prefix) else { continue }
+            let rest = String(target.dropFirst(prefix.count))
+            return rest.allSatisfy(\.isWhitespace)
+        }
+        return false
+    }
+
     private static func peel(prefix: String, off s: String) -> String? {
         guard s.hasPrefix(prefix) else { return nil }
         let rest = String(s.dropFirst(prefix.count))
@@ -82,14 +94,7 @@ public enum WikiLinkParser {
 
             let (kind, bareTarget) = classify(target)
             guard !bareTarget.isEmpty else { continue } // empty target → skip
-            // `[[source:]]` / `[[page:   ]]` — reserved prefix with no meaningful
-            // remainder: skip the link entirely (consistent with `[[ ]]`).
-            if target.hasPrefix("source:") || target.hasPrefix("page:") {
-                let afterPrefix: String
-                if target.hasPrefix("page:") { afterPrefix = String(target.dropFirst(5)) }
-                else { afterPrefix = String(target.dropFirst(7)) }
-                if afterPrefix.allSatisfy(\.isWhitespace) { continue }
-            }
+            if isEmptyPrefix(target) { continue } // `[[source:]]` → literal
 
             let dedupKey = "\(kind.rawValue):\(bareTarget)"
             guard seen.insert(dedupKey).inserted else { continue }

--- a/Sources/WikiFSCore/WikiOperation.swift
+++ b/Sources/WikiFSCore/WikiOperation.swift
@@ -287,9 +287,9 @@ extension WikiOperation {
     To answer, pull wiki pages from SQLite with `wikictl page get --title T` (or \
     `--id I`) so you see fresh authoritative content. If a page contains Markdown \
     footnotes (`[^id]: ...`) that cite a raw source, FOLLOW THEM: resolve the source \
-    with `wikictl file list` (or `--json`), then read it — for text use \
-    `wikictl file cat --id <id>`; for a PDF or other binary run \
-    `wikictl file export --id <id>` and run `pdftotext` / `Read` / `strings` on the \
+    with `wikictl source list` (or `--json`), then read it — for text use \
+    `wikictl source cat --id <id>`; for a PDF or other binary run \
+    `wikictl source export --id <id>` and run `pdftotext` / `Read` / `strings` on the \
     path it prints. Cite the page titles and any source footnote locations your \
     answer draws on. If you file a useful answer back as a page, write it via \
     `wikictl page upsert` and log it with `wikictl log append --kind query`.
@@ -323,9 +323,9 @@ extension WikiOperation {
     When answering, use the Query workflow from your instructions. Pull fresh pages \
     with `wikictl page get --title T` (or `--id I`) as needed. If a page contains \
     Markdown footnotes (`[^id]: ...`) that cite a raw source, resolve it with \
-    `wikictl file list` (or `--json`), then read it — for text use \
-    `wikictl file cat --id <id>`; for a PDF or other binary run \
-    `wikictl file export --id <id>` and run `pdftotext` / `Read` / `strings` on \
+    `wikictl source list` (or `--json`), then read it — for text use \
+    `wikictl source cat --id <id>`; for a PDF or other binary run \
+    `wikictl source export --id <id>` and run `pdftotext` / `Read` / `strings` on \
     the path it prints.
 
     If the user asks you to update the wiki, write via `wikictl page upsert`, update \

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -35,6 +35,12 @@ public protocol WikiStore {
     /// `[[wiki-link]]` resolution (INITIAL §4 v1).
     func resolveTitleToID(_ title: String) throws -> PageID?
 
+    /// Resolve a `[[source:…]]` target to a source id. Matches display_name first,
+    /// falling back to filename (so a retired display name still resolves via its
+    /// original filename). Case-insensitive (COLLATE NOCASE). On a multi-match
+    /// collision, the most recently updated source wins.
+    func resolveSourceByName(_ displayName: String) throws -> PageID?
+
     /// Replace ALL outgoing links for `pageID` with the resolved subset of
     /// `parsedLinks`, in one transaction. Targets that don't resolve to a page
     /// are omitted (the schema forbids a NULL `to_page_id`). Self-links allowed.

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -213,6 +213,27 @@ public final class WikiStoreModel {
         return true
     }
 
+    // MARK: - Source link resolution
+
+    /// Existence check for `[[source:…]]` linkification: returns `true` when a
+    /// source with the given display name (or filename fallback) exists.
+    public func sourceExists(displayName: String) -> Bool {
+        (try? store.resolveSourceByName(displayName)) != nil
+    }
+
+    /// Navigate to the source with `displayName` from a clicked
+    /// `[[source:display-name]]` link in the preview. Resolves display name → id
+    /// (most-recently-updated on collision), records navigation history, and opens
+    /// the source's tab. Returns whether navigation happened.
+    @discardableResult
+    public func selectSource(byDisplayName displayName: String) -> Bool {
+        guard let id = (try? store.resolveSourceByName(displayName)) ?? nil else { return false }
+        let target = WikiSelection.source(id)
+        recordHistoryTransition(from: loadedSelection, to: target)
+        openTab(target)
+        return true
+    }
+
     // MARK: - Tab operations
 
     /// The single seam every tab switch routes through: flush the outgoing tab's

--- a/Sources/WikiFSCore/WikiText.swift
+++ b/Sources/WikiFSCore/WikiText.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Pure text transforms shared across the wiki subsystem. Home of the single
+/// whitespace normalizer (replaces the three private `collapseWhitespace` copies
+/// that previously lived in WikiLinkParser, WikiLinkMarkdown, and HTMLToMarkdown).
+public enum WikiText {
+
+    /// Collapse whitespace runs to one space and trim ends. The same
+    /// normalization the title escaping and link resolution use, so
+    /// `[[ Home ]]` resolves to the `Home` page.
+    public static func normalized(_ s: String) -> String {
+        s.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+    }
+}

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -206,8 +206,10 @@ struct Projection {
             guard let pages = try? store.listAllPagesOrderedByID() else { return nil }
             return IndexGenerators.pagesJSONL(pages: pages)
         case Identity.indexLinksJSONL:
-            guard let links = try? store.listAllLinks() else { return nil }
-            return IndexGenerators.linksJSONL(links: links)
+            guard let pageLinks = try? store.listAllLinks(),
+                  let sourceLinks = try? store.listAllSourceLinks() else { return nil }
+            // Page rows first, then source rows — each already sorted by (from,to).
+            return IndexGenerators.linksJSONL(links: pageLinks + sourceLinks)
         case Identity.indexSourcesJSONL:
             // Resilient to the table not existing yet → empty index, never nil,
             // so enumeration of `indexes/` never errors pre-migration.

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -63,7 +63,7 @@ func run() -> Int32 {
 
 /// Execute a parsed `Command`, dispatching to `PageCommand` (the `page …` family),
 /// `LogIndexCommand` (the Phase-B `log append` / `index set`), or `SourceCommand`
-/// (the `file …` family for raw source reads). The deferred body read (`-` = stdin,
+/// (the `source …` family for raw source reads). The deferred body read (`-` = stdin,
 /// else a file path) happens here — the only I/O the parser left for `main`.
 func execute(_ command: ArgumentParser.Command, in store: SQLiteWikiStore) throws -> SourceCommand.Result {
     switch command {

--- a/Tests/WikiFSTests/IndexGeneratorTests.swift
+++ b/Tests/WikiFSTests/IndexGeneratorTests.swift
@@ -83,6 +83,30 @@ struct IndexGeneratorTests {
         #expect(first?["from"] as? String == "A")
         #expect(first?["to"] as? String == "B")
         #expect(first?["link_text"] as? String == "File Provider")
+        #expect(first?["type"] as? String == "page")
+    }
+
+    // MARK: - links.jsonl type field (Phase B)
+
+    @Test func linksJSONLIncludesTypeField() {
+        let links = [
+            IndexGenerators.LinkRow(from: "A", to: "B", linkText: "x", type: "page"),
+            IndexGenerators.LinkRow(from: "A", to: "S1", linkText: "src", type: "source"),
+        ]
+        let data = IndexGenerators.linksJSONL(links: links)
+        let lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+        #expect(lines.count == 2)
+
+        let first = try! JSONSerialization.jsonObject(with: Data(lines[0].utf8)) as? [String: Any]
+        #expect(first?["type"] as? String == "page")
+
+        let second = try! JSONSerialization.jsonObject(with: Data(lines[1].utf8)) as? [String: Any]
+        #expect(second?["type"] as? String == "source")
+    }
+
+    @Test func linksJSONLIsByteStable() {
+        let links = [IndexGenerators.LinkRow(from: "A", to: "B", linkText: "x", type: "page")]
+        #expect(IndexGenerators.linksJSONL(links: links) == IndexGenerators.linksJSONL(links: links))
     }
 
     // MARK: - sources.jsonl (Phase 5)

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -373,9 +373,9 @@ struct OperationCommandTests {
     #expect(prompt.contains("Markdown footnotes"))
     #expect(prompt.contains("FOLLOW THEM"))
     // The Query prompt now routes raw-file reads through wikictl, not the mount.
-    #expect(prompt.contains("wikictl file list"))
-    #expect(prompt.contains("wikictl file cat --id"))
-    #expect(prompt.contains("wikictl file export --id"))
+    #expect(prompt.contains("wikictl source list"))
+    #expect(prompt.contains("wikictl source cat --id"))
+    #expect(prompt.contains("wikictl source export --id"))
     #expect(prompt.contains("Read"))
     #expect(prompt.contains("pdftotext"))
     #expect(prompt.contains("strings"))

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -309,6 +309,85 @@ struct SQLiteWikiStoreTests {
         _ = store
     }
 
+    // MARK: - Phase B: resolveSourceByName + mixed replaceLinks
+
+    @Test func resolveSourceByNameMatchesDisplayName() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let source = try store.addSource(filename: "report.pdf", data: Data("pdf".utf8))
+        // display_name defaults to filename.
+        let id = try store.resolveSourceByName("report.pdf")
+        #expect(id == source.id)
+    }
+
+    @Test func resolveSourceByNameMatchesFilenameFallback() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let source = try store.addSource(filename: "data.csv", data: Data("csv".utf8))
+        // Even without a custom display_name, filename match works.
+        let id = try store.resolveSourceByName("data.csv")
+        #expect(id == source.id)
+    }
+
+    @Test func resolveSourceByNameIsCaseInsensitive() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        _ = try store.addSource(filename: "My Report.PDF", data: Data("pdf".utf8))
+        let id = try store.resolveSourceByName("my report.pdf")
+        #expect(id != nil)
+    }
+
+    @Test func resolveSourceByNameReturnsNilForUnknown() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        #expect(try store.resolveSourceByName("nonexistent") == nil)
+    }
+
+    @Test func replaceLinksWritesBothPageAndSourceLinks() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let page = try store.createPage(title: "Test Page")
+        let source = try store.addSource(filename: "note.md", data: Data("md".utf8))
+
+        // Mixed links: one page link, one source link.
+        let links: [WikiLinkParser.ParsedLink] = [
+            .init(linkType: .page, target: "Test Page", linkText: "self"),
+            .init(linkType: .source, target: source.filename, linkText: "the note"),
+        ]
+        try store.replaceLinks(from: page.id, parsedLinks: links)
+
+        // Both tables are populated.
+        let pageLinks = try store.listAllLinks()
+        #expect(pageLinks.count == 1)
+        #expect(pageLinks[0].type == "page")
+
+        let sourceLinks = try store.listAllSourceLinks()
+        #expect(sourceLinks.count == 1)
+        #expect(sourceLinks[0].type == "source")
+        #expect(sourceLinks[0].linkText == "the note")
+    }
+
+    @Test func replaceLinksIsAtomicAcrossBothTables() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let page = try store.createPage(title: "P")
+        let source = try store.addSource(filename: "s.txt", data: Data("x".utf8))
+
+        // First write a page link.
+        try store.replaceLinks(from: page.id, parsedLinks: [
+            .init(linkType: .page, target: "P", linkText: "p"),
+        ])
+        #expect(try store.listAllLinks().count == 1)
+
+        // Re-write with only source links — page links should be wiped.
+        try store.replaceLinks(from: page.id, parsedLinks: [
+            .init(linkType: .source, target: source.filename, linkText: "src"),
+        ])
+        #expect(try store.listAllLinks().isEmpty)
+        #expect(try store.listAllSourceLinks().count == 1)
+    }
+
+    @Test func resolveTitleToIDIsCaseInsensitive() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        _ = try store.createPage(title: "Home Page")
+        let id = try store.resolveTitleToID("home page")
+        #expect(id != nil)
+    }
+
     // MARK: - Helpers
 
     private func rows(_ db: OpaquePointer?, _ sql: String) -> [String] {

--- a/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
+++ b/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
@@ -55,12 +55,12 @@ struct WikiLinkMarkdownTests {
     // MARK: - Resolution / styling host
 
     @Test func unresolvedTargetUsesMissingHost() {
-        let out = WikiLinkMarkdown.linkified("[[Ghost]]") { _ in false }
+        let out = WikiLinkMarkdown.linkified("[[Ghost]]") { _, _ in false }
         #expect(out == "[Ghost](wiki://missing?title=Ghost)")
     }
 
     @Test func mixedResolutionPicksHostPerLink() {
-        let out = WikiLinkMarkdown.linkified("[[Real]] vs [[Fake]]") { $0 == "Real" }
+        let out = WikiLinkMarkdown.linkified("[[Real]] vs [[Fake]]") { name, _ in name == "Real" }
         #expect(out == "[Real](wiki://page?title=Real) vs "
             + "[Fake](wiki://missing?title=Fake)")
     }
@@ -137,6 +137,49 @@ struct WikiLinkMarkdownTests {
     @Test func targetRejectsForeignURLs() {
         #expect(WikiLinkMarkdown.target(from: URL(string: "https://example.com?title=X")!) == nil)
         #expect(WikiLinkMarkdown.target(from: URL(string: "wiki://page")!) == nil)
+    }
+
+    // MARK: - source: link rendering (Phase B)
+
+    @Test func resolvedSourceLinkUsesSourceHost() {
+        let out = WikiLinkMarkdown.linkified("[[source:My Notes]]") { _, _ in true }
+        #expect(out == "[My Notes](wiki://source?title=My%20Notes)")
+    }
+
+    @Test func unresolvedSourceLinkUsesMissingHost() {
+        let out = WikiLinkMarkdown.linkified("[[source:Ghost]]") { _, _ in false }
+        #expect(out == "[Ghost](wiki://missing?title=Ghost)")
+    }
+
+    @Test func sourceLinkWithAliasPreservesDisplay() {
+        let out = WikiLinkMarkdown.linkified("[[source:My Notes|the notes]]") { _, _ in true }
+        // Display text is the alias, URL carries the target.
+        #expect(out.contains("the notes"))
+        #expect(out.contains("wiki://source?title=My%20Notes"))
+    }
+
+    @Test func resolvedKindReturnsSourceForSourceHost() {
+        let url = URL(string: "wiki://source?title=X")!
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .source)
+    }
+
+    @Test func resolvedKindReturnsPageForPageHost() {
+        let url = URL(string: "wiki://page?title=X")!
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .page)
+    }
+
+    @Test func resolvedKindReturnsNilForMissingHost() {
+        let url = URL(string: "wiki://missing?title=X")!
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == nil)
+    }
+
+    @Test func targetFromAcceptsSourceHost() {
+        let url = URL(string: "wiki://source?title=My%20Notes")!
+        #expect(WikiLinkMarkdown.target(from: url) == "My Notes")
+    }
+
+    @Test func isResolvedURLTrueForSourceHost() {
+        #expect(WikiLinkMarkdown.isResolvedURL(URL(string: "wiki://source?title=X")!))
     }
 
     // Pull the URL substring out of a single `[text](url)` for assertions.

--- a/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
+++ b/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
@@ -182,6 +182,39 @@ struct WikiLinkMarkdownTests {
         #expect(WikiLinkMarkdown.isResolvedURL(URL(string: "wiki://source?title=X")!))
     }
 
+    // MARK: - Mixed page + source links
+
+    @Test func mixedPageAndSourceLinksRenderWithCorrectHosts() {
+        let out = WikiLinkMarkdown.linkified("[[Home]] and [[source:Paper]]") { name, kind in
+            kind == .source ? name == "Paper" : name == "Home"
+        }
+        #expect(out.contains("wiki://page?title=Home"))
+        #expect(out.contains("wiki://source?title=Paper"))
+    }
+
+    @Test func emptySourcePrefixRendersAsLiteral() {
+        // [[source:]] should stay verbatim, not become a link.
+        let out = WikiLinkMarkdown.linkified("before [[source:]] after") { _, _ in true }
+        #expect(out.contains("[[source:]]"))
+        #expect(!out.contains("wiki://"))
+    }
+
+    // MARK: - Code-span protection for source links
+
+    @Test func sourceLinkInsideCodeSpanIsLiteral() {
+        let out = WikiLinkMarkdown.linkified("`[[source:Paper]]` is a code span") { _, _ in true }
+        #expect(out.contains("[[source:Paper]]"))
+        #expect(!out.contains("wiki://source"))
+    }
+
+    @Test func sourceLinkInsideFencedCodeBlockIsLiteral() {
+        let out = WikiLinkMarkdown.linkified(
+            "```\n[[source:Paper]]\n```\n\nOutside [[source:Notes]]") { _, _ in true }
+        #expect(out.contains("[[source:Paper]]"))   // inside fence → verbatim
+        #expect(!out.contains("wiki://source?title=Paper"))
+        #expect(out.contains("wiki://source?title=Notes")) // outside fence → linkified
+    }
+
     // Pull the URL substring out of a single `[text](url)` for assertions.
     private func extractURL(_ markdownLink: String) -> String {
         guard let open = markdownLink.lastIndex(of: "("),

--- a/Tests/WikiFSTests/WikiLinkNavigationTests.swift
+++ b/Tests/WikiFSTests/WikiLinkNavigationTests.swift
@@ -108,4 +108,36 @@ struct WikiLinkNavigationTests {
         let reloaded = try store.getPage(id: from.id)
         #expect(reloaded.bodyMarkdown == "edited body before clicking a link")
     }
+
+    // MARK: - selectSource(byDisplayName:) (Phase B)
+
+    @Test func selectSourceByDisplayNameNavigatesToThatSource() throws {
+        let (model, store) = try tempModel()
+        let source = try store.addSource(filename: "Paper.pdf", data: Data("pdf".utf8))
+        model.reloadFromStore()
+
+        let navigated = model.selectSource(byDisplayName: "Paper.pdf")
+        #expect(navigated)
+        #expect(model.selection == .source(source.id))
+        #expect(model.tabs.contains { $0.selection == .source(source.id) })
+    }
+
+    @Test func selectSourceByDisplayNameNoOpsOnMissingName() throws {
+        let (model, _) = try tempModel()
+        let navigated = model.selectSource(byDisplayName: "Ghost.pdf")
+        #expect(!navigated)
+    }
+
+    @Test func selectSourceByDisplayNameReusesAlreadyOpenTab() throws {
+        let (model, store) = try tempModel()
+        let source = try store.addSource(filename: "notes.md", data: Data("md".utf8))
+        model.reloadFromStore()
+
+        model.openTab(.source(source.id))
+        #expect(model.tabs.count == 1)
+
+        #expect(model.selectSource(byDisplayName: "notes.md"))
+        #expect(model.tabs.count == 1) // reused, not duplicated
+        #expect(model.selection == .source(source.id))
+    }
 }

--- a/Tests/WikiFSTests/WikiLinkParserTests.swift
+++ b/Tests/WikiFSTests/WikiLinkParserTests.swift
@@ -50,4 +50,73 @@ struct WikiLinkParserTests {
     @Test func returnsEmptyForNoLinks() {
         #expect(WikiLinkParser.parse("just some plain markdown text").isEmpty)
     }
+
+    // MARK: - source: prefix (Phase B)
+
+    @Test func parsesSourcePrefixLink() {
+        let links = WikiLinkParser.parse("See [[source:My Notes]].")
+        #expect(links.count == 1)
+        #expect(links[0].linkType == .source)
+        #expect(links[0].target == "My Notes")
+        #expect(links[0].linkText == "My Notes")
+    }
+
+    @Test func sourceLinkWithAliasPreservesAlias() {
+        let links = WikiLinkParser.parse("[[source:My Notes|my notes]]")
+        #expect(links[0].linkType == .source)
+        #expect(links[0].target == "My Notes")
+        #expect(links[0].linkText == "my notes")
+    }
+
+    @Test func sourcePrefixNormalizesRemainder() {
+        let links = WikiLinkParser.parse("[[source:  X  ]]")
+        #expect(links[0].target == "X") // no leading/trailing space
+    }
+
+    @Test func emptySourceTargetIsSkipped() {
+        let links = WikiLinkParser.parse("[[source:]] and [[source:   ]]")
+        #expect(links.isEmpty)
+    }
+
+    @Test func pagePrefixEscapesSourcePrefixTitle() {
+        // A page literally titled "source:foo" is reachable via [[page:source:foo]].
+        let links = WikiLinkParser.parse("[[page:source:foo]]")
+        #expect(links[0].linkType == .page)
+        #expect(links[0].target == "source:foo")
+    }
+
+    @Test func sourceAndPageLinksDedupSeparately() {
+        let links = WikiLinkParser.parse("[[source:X|a]] [[source:X|b]] [[X]] [[source:X]]")
+        #expect(links.count == 2) // one page link "X" + one source link "X"
+        let sourceLink = links.first { $0.linkType == .source }
+        #expect(sourceLink?.linkText == "a") // first alias wins
+    }
+
+    // MARK: - classify
+
+    @Test func classifyDefaultsToPage() {
+        let (kind, target) = WikiLinkParser.classify("Plain Title")
+        #expect(kind == .page)
+        #expect(target == "Plain Title")
+    }
+
+    @Test func classifySourcePrefix() {
+        let (kind, target) = WikiLinkParser.classify("source:My Notes")
+        #expect(kind == .source)
+        #expect(target == "My Notes") // prefix stripped, remainder normalized
+    }
+
+    @Test func classifyPagePrefixTakesPrecedence() {
+        let (kind, target) = WikiLinkParser.classify("page:source:foo")
+        #expect(kind == .page)
+        #expect(target == "source:foo")
+    }
+
+    @Test func classifyEmptySourceTargetFallsBackToPage() {
+        // peel returns nil (rest is empty), so classify falls through → .page with
+        // the original string. The parser's skip logic handles the empty-prefix case.
+        let (kind, target) = WikiLinkParser.classify("source:")
+        #expect(kind == .page)
+        #expect(target == "source:")
+    }
 }


### PR DESCRIPTION
## Summary

Implements `[[source:display-name]]` wikilinks so wiki pages can link to sources. Clicking a source link in the preview navigates to that source's detail view.

## What changed

### Parser
- `ParsedLink` gains `LinkType` enum (`.page` / `.source`) with defaulted init for backward compatibility
- `classify()` extracts `source:` / `page:` prefix, strips and re-normalizes the remainder
- `parse()` deduplicates per `(kind, target)`; `[[source:]]` (empty target) is skipped
- `page:` prefix escapes a page literally titled `source:foo` → `[[page:source:foo]]`

### Resolution
- `resolveSourceByName`: matches `display_name` first, falls back to `filename`, case-insensitive
- Page title resolution is now case-insensitive too (COLLATE NOCASE) for parity
- `sourceExists(displayName:)` + `selectSource(byDisplayName:)` on `WikiStoreModel`

### Rendering
- Source links render as `wiki://source?title=...` (mirroring `wiki://page?title=...`)
- `resolvedKind(from:)` dispatches `.page` / `.source` / `nil`

### Navigation
- `MarkdownPreview` OpenURLAction dispatches by kind → `selectPage` or `selectSource`

### Persistence
- `replaceLinks` writes both `page_links` and `source_links` in ONE transaction
- `listAllSourceLinks()` added; projection merges page + source links in `links.jsonl`

### Index
- `links.jsonl` now emits a `type` field (`"page"` or `"source"`)
- `LinkRow` gains `type` with default `"page"`
- System prompt documents the `type` field for the managing agent

### Shared normalizer
- New `WikiText.normalized()` replaces three private `collapseWhitespace` copies

### Gates
- ✅ `swift build` — clean
- ✅ `swift test` — 628 tests, 0 failures (+27 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)