### PR TITLE
Phase C: source markdown projection + self-seed (MIME-keyed)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,10 +4,11 @@ Newest first. To get up to speed: read `PLAN.md` then this file.
 
 ## 2026-06-21 — Phase C: source markdown in the File Provider
 
-Implemented `plans/phase-c-source-markdown-projection.md`. Sources with a processed-markdown
-chain (PDFs that have been extracted) now project a `.md` sibling alongside the verbatim
-file in both `sources/by-id/` and `sources/by-name/`. The change bridge now sees chain
-edits, so extraction / edit / revert refresh the mount without a relaunch.
+Implemented `plans/phase-c-source-markdown-projection.md`. PDFs with extraction output now
+project a `.md` sibling alongside the verbatim file in both `sources/by-id/` and
+`sources/by-name/`. The change bridge now sees chain edits, so extraction / edit / revert
+refresh the mount without a relaunch. Every source gets a chain: markdown-native sources
+self-seed v1 from verbatim bytes (origin `"source"`), PDFs seed from extraction.
 
 **Changes:**
 
@@ -22,17 +23,19 @@ edits, so extraction / edit / revert refresh the mount without a relaunch.
   source identity). `sourceMarkdownNode(for:source:head:)` versions the sibling off the
   HEAD row (`contentVersion = Data(head.id.rawValue.utf8)`), naturally distinct from
   the verbatim node's version. `sourceNodes(byName:)` fetches all HEADs in one query
-  (`processedMarkdownHeadsBySource()`) and emits a sibling for every source with a
-  chain — no N+1. `contents(for:)` serves the HEAD content for markdown-sibling ids.
+  (`processedMarkdownHeadsBySource()`) and emits a sibling only for non-markdown-native
+  sources with a chain — markdown-native sources don't need a sibling (the verbatim
+  `<id>.md` is the content). `contents(for:)` serves HEAD content for sibling ids.
 
 - **One-query HEAD read (`SQLiteWikiStore`):** `processedMarkdownHeadsBySource()` joins
   `source_markdown_versions` against `MAX(id) GROUP BY file_id` in a single query.
   Returns `[String: SourceMarkdownVersion]` keyed by source id; empty dict on failure.
 
-- **Lazy-seed removal (`WikiStoreModel`):** `processedMarkdownHead(for:)` no longer
-  seeds a v1 chain from a markdown source's verbatim bytes. Only PDFs get chains now
-  (seeded by extraction via `seedPdfMarkdown`). This removes the collision risk where a
-  markdown source had both a verbatim `<id>.md` and a seeded sibling with the same name.
+- **Self-seed, MIME-keyed (`WikiStoreModel`):** `processedMarkdownHead(for:)` self-seeds
+  v1 from verbatim bytes for markdown-native sources (`mimeType.hasPrefix("text/")`,
+  not `file.ext`). Origin `"source"` (distinct from `"extraction"` and `"user"`).
+  Double-seed guard prevents duplicates. `headVersion` is never nil — every source has
+  a chain, and the original content is always available as the baseline.
 
 - **CLI (`wikictl source edit-markdown`):** New subcommand appends a `"user"` version
   to an existing chain. Accepts `--content` or `--file`. Refuses with a clear error
@@ -40,11 +43,12 @@ edits, so extraction / edit / revert refresh the mount without a relaunch.
 
 - **Index (`IndexGenerators`):** `SourceIndexRow` gains `has_markdown: Bool`.
   `sourcesJSONL` emits it in fixed key order (`id, name, path, size, mime, has_markdown`).
-  True only for sources with at least one row in `source_markdown_versions`.
+  True for every source (all have chains after self-seed). The agent uses `mime` to
+  distinguish PDFs (have a `.md` sibling) from markdown-native sources (verbatim is content).
 
 - **Agent prompt (`SystemPrompt`):** One line documenting the `.md` sibling convention.
 
-**Tests.** `swift test` — 683 tests, 54 suites, 0 failures.
+**Tests.** `swift test` — 684 tests, 54 suites, 0 failures.
 
 On branch `feature/phase-c-source-markdown-projection`.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,53 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-## 2026-06-21 — Content-type over extension (implemented)
+## 2026-06-21 — Phase C: source markdown in the File Provider
+
+Implemented `plans/phase-c-source-markdown-projection.md`. Sources with a processed-markdown
+chain (PDFs that have been extracted) now project a `.md` sibling alongside the verbatim
+file in both `sources/by-id/` and `sources/by-name/`. The change bridge now sees chain
+edits, so extraction / edit / revert refresh the mount without a relaunch.
+
+**Changes:**
+
+- **Change bridge (`SQLiteWikiStore`):** `sourceMarkdownVersionCount()` helper added
+  (resilient `COUNT(*)` over `source_markdown_versions`, mirrors `logRowCount`).
+  `changeToken()` gains an 8th component (`smvCount`), so any append to the versions
+  table advances the File Provider sync anchor. Previously `appendProcessedMarkdown`
+  and `revertProcessedMarkdown` left the token unchanged.
+
+- **Projection (`Projection`):** `sourceMarkdownByID` / `sourceMarkdownByName` identity
+  prefixes with constructors and a `sourceMarkdownULID` parser (parity with verbatim
+  source identity). `sourceMarkdownNode(for:source:head:)` versions the sibling off the
+  HEAD row (`contentVersion = Data(head.id.rawValue.utf8)`), naturally distinct from
+  the verbatim node's version. `sourceNodes(byName:)` fetches all HEADs in one query
+  (`processedMarkdownHeadsBySource()`) and emits a sibling for every source with a
+  chain — no N+1. `contents(for:)` serves the HEAD content for markdown-sibling ids.
+
+- **One-query HEAD read (`SQLiteWikiStore`):** `processedMarkdownHeadsBySource()` joins
+  `source_markdown_versions` against `MAX(id) GROUP BY file_id` in a single query.
+  Returns `[String: SourceMarkdownVersion]` keyed by source id; empty dict on failure.
+
+- **Lazy-seed removal (`WikiStoreModel`):** `processedMarkdownHead(for:)` no longer
+  seeds a v1 chain from a markdown source's verbatim bytes. Only PDFs get chains now
+  (seeded by extraction via `seedPdfMarkdown`). This removes the collision risk where a
+  markdown source had both a verbatim `<id>.md` and a seeded sibling with the same name.
+
+- **CLI (`wikictl source edit-markdown`):** New subcommand appends a `"user"` version
+  to an existing chain. Accepts `--content` or `--file`. Refuses with a clear error
+  when no extraction baseline exists (exit 1). `signalChange()` so the mount refreshes.
+
+- **Index (`IndexGenerators`):** `SourceIndexRow` gains `has_markdown: Bool`.
+  `sourcesJSONL` emits it in fixed key order (`id, name, path, size, mime, has_markdown`).
+  True only for sources with at least one row in `source_markdown_versions`.
+
+- **Agent prompt (`SystemPrompt`):** One line documenting the `.md` sibling convention.
+
+**Tests.** `swift test` — 683 tests, 54 suites, 0 failures.
+
+On branch `feature/phase-c-source-markdown-projection`.
+
+## 2026-06-21 — Content-type over extension
 
 Implemented `plans/content-type-over-extension.md` — made `mime_type` content-authoritative
 rather than extension-derived. This closes the circularity bug where a PDF renamed `.txt`
@@ -28,40 +74,6 @@ was mis-typed and skipped extraction.
 **Tests.** `swift test` — 653 tests, 53 suites, 0 failures.
 
 On branch `feature/content-type-over-extension`.
-
-## 2026-06-21 — Phase C review + content-type + Phase C plans
-
-Reviewed Phase C ("Source Markdown in the File Provider") of `plans/sources-redesign.md`
-against the post-Phase-B tree. Two load-bearing assumptions in the parent design are false
-in the code: (1) the change bridge can't see processed-markdown edits — `changeToken()`
-(`SQLiteWikiStore.swift:564`) folds `COUNT`/`SUM(version)` over `sources` but not
-`source_markdown_versions`, and `appendProcessedMarkdown`/`revertProcessedMarkdown` don't
-bump `sources.version`, so extraction/edit/revert don't move the sync anchor and the
-projected `.md` sibling never refreshes; (2) markdown sources *do* get chains today via the
-lazy-seed in `WikiStoreModel.processedMarkdownHead(for:)` (`:865-877`), which contradicts
-the intended model (only PDFs have chains) and would project a colliding `<id>.md` sibling.
-Design intent confirmed: the chain is a git-lite history of PDF→markdown conversions
-(revert shipped, compare future); only HEAD is projected; the agent sees the latest only.
-
-Also surfaced the root extension-check bug: `addSource` (`SQLiteWikiStore.swift:861`)
-derives `mime_type` from the filename extension, making every downstream "trust MIME" check
-circular (a PDF named `.txt` is mis-typed and skips extraction). `URLIngestService` already
-content-sniffs but the result is discarded and re-derived from ext.
-
-Wrote three plans (all indexed in `PLAN.md`):
-
-- **`plans/content-type-over-extension.md`** — cross-cutting fix making `mime_type`
-  content-authoritative: extract a `ContentSniff` helper, `addSource` sniffs bytes,
-  MIME-first `WikiFSItem.contentType`, Zotero filter, and a grep guard. Standalone; Phase C
-  depends on it.
-- **`plans/phase-c-source-markdown-projection.md`** — Phase C re-grounded. Folds
-  `source_markdown_versions` into `changeToken()` + versions the sibling off the HEAD row;
-  removes the markdown lazy-seed; projects the `.md` sibling in by-id and by-name with
-  proper identity prefixes; one-query HEAD read to avoid N+1; `wikictl source edit-markdown`
-  (appends a `user` version, requires an existing extraction baseline). Defers all
-  MIME-authority work to the content-type plan (no duplicated edits between the two).
-
-No code changed — planning only, on branch `feature/source-wikilinks`.
 
 ## 2026-06-21 — Phase B: `[[source:display-name]]` wikilinks
 

--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -50,6 +50,11 @@ public enum ArgumentParser {
         case search(query: String, limit: Int)
         /// Source commands: list, read, export sources from SQLite.
         case source(SourceCommand.Action)
+        /// Edit processed markdown for a source. When `isFile` is true,
+        /// `contentOrFile` is a file path (or `-` for stdin); when false it is
+        /// the literal markdown content. `main` resolves the file in the former
+        /// case before appending.
+        case sourceEditMarkdown(SourceCommand.Selector, contentOrFile: String, isFile: Bool)
     }
 
     public enum Failure: Error, Equatable, CustomStringConvertible {
@@ -83,6 +88,8 @@ public enum ArgumentParser {
       source cat  (--id X | --name N)         write raw source bytes to stdout
       source export (--id X | --name N) [--out <path>]
                                               materialize a source to disk, print its path
+      source edit-markdown (--id X | --name N) (--content <md> | --file <path|->)
+                                              replace the processed-markdown HEAD
     """
 
     /// Parse `arguments` (WITHOUT the executable name) plus an env lookup into an
@@ -211,8 +218,29 @@ public enum ArgumentParser {
             let selector = try options.requireSourceSelector()
             return .source(.export(selector, out: options.value("--out")))
 
+        case "edit-markdown":
+            return try parseSourceEditMarkdown(options)
+
         default:
             throw Failure.usage("source: unknown subcommand \(sub.debugDescription)")
+        }
+    }
+
+    private static func parseSourceEditMarkdown(_ options: Options) throws -> Command {
+        let selector = try options.requireSourceSelector()
+
+        let contentValue = options.value("--content")
+        let fileValue = options.value("--file")
+
+        switch (contentValue, fileValue) {
+        case (.some, .some):
+            throw Failure.usage("source edit-markdown: pass exactly one of --content / --file, not both")
+        case (.none, .none):
+            throw Failure.usage("source edit-markdown: pass --content <text> or --file <path>")
+        case (let content?, nil):
+            return .sourceEditMarkdown(selector, contentOrFile: content, isFile: false)
+        case (nil, let file?):
+            return .sourceEditMarkdown(selector, contentOrFile: file, isFile: true)
         }
     }
 

--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -39,6 +39,7 @@ public enum SourceCommand {
         case list(json: Bool)
         case cat(Selector)
         case export(Selector, out: String?)
+        case editMarkdown(Selector, content: String)
     }
 
     public enum Failure: Error, CustomStringConvertible {
@@ -62,6 +63,8 @@ public enum SourceCommand {
             return try cat(selector, in: store)
         case .export(let selector, let out):
             return try export(selector, out: out, in: store, cwd: cwd)
+        case .editMarkdown(let selector, let content):
+            return try editMarkdown(selector, content: content, in: store)
         }
     }
 
@@ -168,5 +171,19 @@ public enum SourceCommand {
                 )
             }
         }
+    }
+
+    // MARK: - edit-markdown
+
+    /// Replace the processed-markdown HEAD for a source. Errors when no markdown
+    /// chain exists yet (extract first). Commits — the caller posts the Darwin
+    /// notification on `didCommit`.
+    private static func editMarkdown(_ selector: Selector, content: String, in store: WikiStore) throws -> Result {
+        let id = try resolve(selector, in: store)
+        guard try store.hasProcessedMarkdown(sourceID: id) else {
+            throw Failure.message("no processed markdown for this source")
+        }
+        try store.appendProcessedMarkdown(sourceID: id, content: content, origin: "user", note: nil)
+        return Result(payload: .text(""), didCommit: true)
     }
 }

--- a/Sources/WikiFSCore/IndexGenerators.swift
+++ b/Sources/WikiFSCore/IndexGenerators.swift
@@ -36,8 +36,8 @@ public enum IndexGenerators {
     /// A single source row (no content), as read for `sources.jsonl` and for
     /// the projection's `sources/` enumeration. Carries the stable
     /// version/timestamps too so the File Provider can derive stable item
-    /// versions during enumeration (only `id/name/path/size/mime` reach the
-    /// JSONL — the rest are projection-only).
+    /// versions during enumeration (only `id/name/path/size/mime/has_markdown`
+    /// reach the JSONL — the rest are projection-only).
     public struct SourceIndexRow: Equatable, Sendable {
         public let id: String
         public let filename: String
@@ -48,6 +48,7 @@ public enum IndexGenerators {
         public let updatedAt: Date
         public let version: Int
         public let displayName: String?
+        public let hasMarkdown: Bool
 
         public init(
             id: String,
@@ -58,7 +59,8 @@ public enum IndexGenerators {
             createdAt: Date = Date(timeIntervalSince1970: 0),
             updatedAt: Date = Date(timeIntervalSince1970: 0),
             version: Int = 1,
-            displayName: String? = nil
+            displayName: String? = nil,
+            hasMarkdown: Bool = false
         ) {
             self.id = id
             self.filename = filename
@@ -69,6 +71,7 @@ public enum IndexGenerators {
             self.updatedAt = updatedAt
             self.version = version
             self.displayName = displayName
+            self.hasMarkdown = hasMarkdown
         }
     }
 
@@ -140,9 +143,11 @@ public enum IndexGenerators {
 
     /// `indexes/sources.jsonl` — one JSON object per line, one line per source,
     /// ordered as given (the caller passes sources ordered by id == ingest
-    /// order). Keys in fixed order: id, name, path, size, mime. `path` points at
-    /// the canonical `sources/by-id/<id>.<ext>` location (no dot when extension-
-    /// less); `mime` is JSON `null` when unknown.
+    /// order). Keys in fixed order: id, name, path, size, mime, has_markdown.
+    /// `path` points at the canonical `sources/by-id/<id>.<ext>` location (no
+    /// dot when extension-less); `mime` is JSON `null` when unknown;
+    /// `has_markdown` is `true` when at least one processed-markdown version
+    /// exists (from `source_markdown_versions`).
     public static func sourcesJSONL(sources: [SourceIndexRow]) -> Data {
         var out = ""
         for source in sources {
@@ -154,7 +159,8 @@ public enum IndexGenerators {
             let path = jsonString(relPath)
             let size = String(source.byteSize)
             let mime = source.mime.map { jsonString($0) } ?? "null"
-            out += "{\"id\":\(id),\"name\":\(name),\"path\":\(path),\"size\":\(size),\"mime\":\(mime)}\n"
+            let hasMarkdown = source.hasMarkdown ? "true" : "false"
+            out += "{\"id\":\(id),\"name\":\(name),\"path\":\(path),\"size\":\(size),\"mime\":\(mime),\"has_markdown\":\(hasMarkdown)}\n"
         }
         return Data(out.utf8)
     }

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -564,14 +564,15 @@ public final class SQLiteWikiStore: WikiStore {
     public func changeToken() throws -> String {
         let pages = try statement("SELECT COUNT(*), COALESCE(SUM(version), 0) FROM pages;")
         defer { pages.reset() }
-        guard try pages.step() else { return "0:0:0:0:0:0:0" }
+        guard try pages.step() else { return "0:0:0:0:0:0:0:0" }
         let pCount = pages.int(at: 0)
         let pSum = pages.int(at: 1)
         let (fCount, fSum) = sourceCountSum()
         let spVersion = systemPromptVersion()
         let logCount = logRowCount()
         let idxVersion = wikiIndexVersion()
-        return "\(pCount):\(pSum):\(fCount):\(fSum):\(spVersion):\(logCount):\(idxVersion)"
+        let smvCount = sourceMarkdownVersionCount()
+        return "\(pCount):\(pSum):\(fCount):\(fSum):\(spVersion):\(logCount):\(idxVersion):\(smvCount)"
     }
 
     /// COUNT/SUM(version) over `sources`, resilient to the table not
@@ -618,6 +619,17 @@ public final class SQLiteWikiStore: WikiStore {
             "SELECT COALESCE(version, 0) FROM wiki_index WHERE id = 1;") else {
             return 0
         }
+        defer { stmt.reset() }
+        guard (try? stmt.step()) == true else { return 0 }
+        return stmt.int(at: 0)
+    }
+
+    /// The `source_markdown_versions` table's row COUNT, resilient to the table
+    /// not existing yet (a read connection opened against a pre-v8 DB). On any
+    /// failure returns `0` so `changeToken()` still answers.
+    private func sourceMarkdownVersionCount() -> Int64 {
+        guard let stmt = try? statement(
+            "SELECT COUNT(*) FROM source_markdown_versions;") else { return 0 }
         defer { stmt.reset() }
         guard (try? stmt.step()) == true else { return 0 }
         return stmt.int(at: 0)
@@ -963,8 +975,10 @@ public final class SQLiteWikiStore: WikiStore {
     /// Read-side projection helper (like `listAllPagesOrderedByID`).
     public func listAllSourcesOrderedByID() throws -> [IndexGenerators.SourceIndexRow] {
         let stmt = try statement("""
-        SELECT id, filename, ext, mime_type, byte_size, created_at, updated_at, version, display_name
-        FROM sources ORDER BY id ASC;
+        SELECT s.id, s.filename, s.ext, s.mime_type, s.byte_size,
+               s.created_at, s.updated_at, s.version, s.display_name,
+               (SELECT 1 FROM source_markdown_versions WHERE file_id = s.id LIMIT 1) IS NOT NULL AS has_markdown
+        FROM sources s ORDER BY s.id ASC;
         """)
         defer { stmt.reset() }
         var out: [IndexGenerators.SourceIndexRow] = []
@@ -982,7 +996,8 @@ public final class SQLiteWikiStore: WikiStore {
                 createdAt: Date(timeIntervalSince1970: stmt.double(at: 5)),
                 updatedAt: Date(timeIntervalSince1970: stmt.double(at: 6)),
                 version: Int(stmt.int(at: 7)),
-                displayName: displayName
+                displayName: displayName,
+                hasMarkdown: stmt.int(at: 9) != 0
             ))
         }
         return out
@@ -1410,6 +1425,25 @@ public final class SQLiteWikiStore: WikiStore {
             out.append(sourceMarkdownVersion(from: stmt))
         }
         return out
+    }
+
+    /// All processed markdown heads keyed by sourceID. Returns empty dict when
+    /// the table doesn't exist yet (pre-migration read connection) so the caller
+    /// never errors — the sources list simply has no markdown siblings.
+    /// Single GROUP BY query avoids N+1 across the full source enumeration.
+    public func processedMarkdownHeadsBySource() throws -> [String: SourceMarkdownVersion] {
+        guard let stmt = try? statement("""
+        SELECT id, file_id, parent_id, content, origin, note, created_at
+        FROM source_markdown_versions
+        WHERE id IN (SELECT MAX(id) FROM source_markdown_versions GROUP BY file_id);
+        """) else { return [:] }
+        defer { stmt.reset() }
+        var result: [String: SourceMarkdownVersion] = [:]
+        while try stmt.step() {
+            let version = sourceMarkdownVersion(from: stmt)
+            result[version.sourceID.rawValue] = version
+        }
+        return result
     }
 
     @discardableResult

--- a/Sources/WikiFSCore/SystemPrompt.swift
+++ b/Sources/WikiFSCore/SystemPrompt.swift
@@ -105,6 +105,9 @@ public struct SystemPrompt: Equatable, Sendable {
     Raw files under `sources/` may be PDFs or images, not just text. Use the `Read`
     tool on them directly — it handles text, images, and PDFs. For a PDF, read the
     text first; if it references figures you need, view those images separately.
+    `sources.jsonl` includes a `has_markdown` flag — sources with processed markdown
+    have a `<id>.md` sibling in `sources/by-id/` holding the latest conversion or
+    edit; prefer it over the raw PDF when reading.
 
     ## Workflows
 

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -860,10 +860,20 @@ public final class WikiStoreModel {
 
     // MARK: - Processed markdown versions (v8)
 
-    /// The latest (HEAD) processed markdown version for a file.
-    /// Returns `nil` when the source has no processed-markdown chain yet.
+    /// The latest (HEAD) processed markdown version for a file. Every source has a
+    /// chain: PDFs are seeded from extraction, markdown-native sources self-seed
+    /// v1 from their verbatim bytes (origin `"source"`). After seeding, new
+    /// versions are appended by edits (`"user"`) or re-extraction (`"extraction"`).
     public func processedMarkdownHead(for file: SourceSummary) -> SourceMarkdownVersion? {
-        try? store.processedMarkdownHead(sourceID: file.id)
+        if let head = try? store.processedMarkdownHead(sourceID: file.id) {
+            return head
+        }
+        // Seed v1 from verbatim bytes for markdown-native sources (MIME-keyed).
+        guard let mime = file.mimeType, mime.hasPrefix("text/") else { return nil }
+        guard let bytes = try? store.sourceContent(id: file.id),
+              let text = String(data: bytes, encoding: .utf8) else { return nil }
+        return try? store.appendProcessedMarkdown(
+            sourceID: file.id, content: text, origin: "source", note: nil)
     }
 
     /// True when at least one processed-markdown version exists for this source.

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -860,21 +860,10 @@ public final class WikiStoreModel {
 
     // MARK: - Processed markdown versions (v8)
 
-    /// The latest (HEAD) processed markdown version for a file. For native
-    /// md/txt files without an existing version chain, lazily seeds v1 from
-    /// the source bytes (double-seed guard prevents duplicates).
+    /// The latest (HEAD) processed markdown version for a file.
+    /// Returns `nil` when the source has no processed-markdown chain yet.
     public func processedMarkdownHead(for file: SourceSummary) -> SourceMarkdownVersion? {
-        if let head = try? store.processedMarkdownHead(sourceID: file.id) {
-            return head
-        }
-        // Lazy seed: native md/txt → decode source bytes as v1.
-        guard file.ext == "md" || file.ext == "markdown" || file.ext == "txt" else {
-            return nil
-        }
-        guard let bytes = try? store.sourceContent(id: file.id),
-              let text = String(data: bytes, encoding: .utf8) else { return nil }
-        return try? store.appendProcessedMarkdown(
-            sourceID: file.id, content: text, origin: "extraction", note: nil)
+        try? store.processedMarkdownHead(sourceID: file.id)
     }
 
     /// True when at least one processed-markdown version exists for this source.

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -629,7 +629,10 @@ struct Projection {
                 mimeType: row.mime, byteSize: row.byteSize,
                 createdAt: row.createdAt, updatedAt: row.updatedAt, version: row.version)
             let verbatimNode = Self.sourceNode(for: id, file: summary)
-            guard let head = heads[row.id] else { return [verbatimNode] }
+            // Sibling eligibility: has a chain AND is NOT markdown-native.
+            // Markdown-native sources don't get a sibling — the verbatim .md is the content.
+            guard let head = heads[row.id],
+                  let mime = row.mime, !mime.hasPrefix("text/") else { return [verbatimNode] }
             let markdownID = byName
                 ? Identity.sourceMarkdownByName(row.id)
                 : Identity.sourceMarkdownByID(row.id)

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -75,6 +75,8 @@ struct Projection {
         // it in the default app), so the two sides build the identical identifier.
         static let sourceByIDPrefix = WikiFSContainerID.sourceByIDPrefix
         static let sourceByNamePrefix = "source-by-name:"
+        static let sourceMarkdownByIDPrefix = "source-markdown-by-id:"
+        static let sourceMarkdownByNamePrefix = "source-markdown-by-name:"
 
         static func pageByID(_ ulid: String) -> NSFileProviderItemIdentifier {
             NSFileProviderItemIdentifier(byIDPrefix + ulid)
@@ -90,6 +92,14 @@ struct Projection {
 
         static func sourceByName(_ ulid: String) -> NSFileProviderItemIdentifier {
             NSFileProviderItemIdentifier(sourceByNamePrefix + ulid)
+        }
+
+        static func sourceMarkdownByID(_ ulid: String) -> NSFileProviderItemIdentifier {
+            NSFileProviderItemIdentifier(sourceMarkdownByIDPrefix + ulid)
+        }
+
+        static func sourceMarkdownByName(_ ulid: String) -> NSFileProviderItemIdentifier {
+            NSFileProviderItemIdentifier(sourceMarkdownByNamePrefix + ulid)
         }
 
         /// Extract the embedded ULID from a `page-by-id:` / `page-by-title:`
@@ -108,6 +118,16 @@ struct Projection {
             let raw = id.rawValue
             if raw.hasPrefix(sourceByIDPrefix) { return String(raw.dropFirst(sourceByIDPrefix.count)) }
             if raw.hasPrefix(sourceByNamePrefix) { return String(raw.dropFirst(sourceByNamePrefix.count)) }
+            return nil
+        }
+
+        /// Extract the embedded ULID from a `source-markdown-by-id:` /
+        /// `source-markdown-by-name:` identifier, or nil if it isn't a processed
+        /// markdown head identifier.
+        static func sourceMarkdownULID(from id: NSFileProviderItemIdentifier) -> String? {
+            let raw = id.rawValue
+            if raw.hasPrefix(sourceMarkdownByIDPrefix) { return String(raw.dropFirst(sourceMarkdownByIDPrefix.count)) }
+            if raw.hasPrefix(sourceMarkdownByNamePrefix) { return String(raw.dropFirst(sourceMarkdownByNamePrefix.count)) }
             return nil
         }
     }
@@ -416,6 +436,17 @@ struct Projection {
         default:
             break
         }
+        // Processed markdown head (source-markdown-by-id: / source-markdown-by-name:).
+        // Must come before the verbatim-source check below so the two identifier
+        // families don't collide.
+        if let ulid = Identity.sourceMarkdownULID(from: id) {
+            guard let store = openReadStore(),
+                  let file = try? store.getSource(id: PageID(rawValue: ulid)),
+                  let head = try? store.processedMarkdownHead(sourceID: PageID(rawValue: ulid)) else {
+                return nil
+            }
+            return Self.sourceMarkdownNode(for: id, source: file, head: head)
+        }
         // Ingested-file leaf (file-by-id: / file-by-name:). Resolve the embedded
         // ULID and look up the summary; resilient to a missing table (the read
         // throws → nil → the node simply isn't found, never an enumeration error).
@@ -432,6 +463,32 @@ struct Projection {
             return nil
         }
         return Self.pageFileNode(for: id, page: page)
+    }
+
+    /// Build a file node for a processed markdown head (the `.md` sibling of a
+    /// verbatim source, projected under both `by-id` and `by-name` views).
+    /// Always has `ingestedExt:"md"`; versioned by the head's ULID so any
+    /// edit/revert bumps the item version and invalidates the daemon's cache.
+    static func sourceMarkdownNode(
+        for id: NSFileProviderItemIdentifier,
+        source: SourceSummary,
+        head: SourceMarkdownVersion
+    ) -> ProjectedNode {
+        let raw = id.rawValue
+        let isByName = raw.hasPrefix(Identity.sourceMarkdownByNamePrefix)
+        let name = isByName
+            ? FilenameEscaping.byNameSourceFilename(
+                filename: source.filename, ext: "md", sourceID: source.id.rawValue)
+            : FilenameEscaping.byIDSourceFilename(sourceID: source.id.rawValue, ext: "md")
+        let parent = isByName ? Identity.sourcesByName : Identity.sourcesByID
+        return .file(
+            id: id, parent: parent, name: name, size: head.content.utf8.count,
+            version: Data(head.id.rawValue.utf8),
+            metadataVersion: Data(head.id.rawValue.utf8),
+            created: head.createdAt, modified: head.createdAt,
+            ingestedExt: "md",
+            mimeType: "text/markdown"
+        )
     }
 
     /// Build a file node for an ingested-file row, under whichever view `id`
@@ -557,16 +614,26 @@ struct Projection {
     /// All ingested-file rows projected as file nodes under the given view,
     /// ordered by id (ULID == ingest order). Resilient to the table not existing
     /// yet (pre-migration) → empty, so enumeration never errors.
+    /// When a source has a processed markdown head (from `source_markdown_versions`),
+    /// emits BOTH the verbatim source node AND a `.md` sibling — the processed
+    /// markdown version — under both `by-id` and `by-name` views. Single bulk
+    /// head query avoids N+1 across the source list.
     private func sourceNodes(byName: Bool) -> [ProjectedNode] {
         guard let store = openReadStore(),
               let files = try? store.listAllSourcesOrderedByID() else { return [] }
-        return files.map { row in
+        let heads = (try? store.processedMarkdownHeadsBySource()) ?? [:]
+        return files.flatMap { row in
             let id = byName ? Identity.sourceByName(row.id) : Identity.sourceByID(row.id)
             let summary = SourceSummary(
                 id: PageID(rawValue: row.id), filename: row.filename, ext: row.ext,
                 mimeType: row.mime, byteSize: row.byteSize,
                 createdAt: row.createdAt, updatedAt: row.updatedAt, version: row.version)
-            return Self.sourceNode(for: id, file: summary)
+            let verbatimNode = Self.sourceNode(for: id, file: summary)
+            guard let head = heads[row.id] else { return [verbatimNode] }
+            let markdownID = byName
+                ? Identity.sourceMarkdownByName(row.id)
+                : Identity.sourceMarkdownByID(row.id)
+            return [verbatimNode, Self.sourceMarkdownNode(for: markdownID, source: summary, head: head)]
         }
     }
 
@@ -597,6 +664,16 @@ struct Projection {
         if id == Identity.manifest || id == Identity.indexPagesJSONL
             || id == Identity.indexLinksJSONL || id == Identity.indexSourcesJSONL {
             return indexData(for: id)
+        }
+        // Processed markdown head: serve the head content from
+        // `source_markdown_versions`. Must come before the verbatim-source check
+        // so the two identifier families don't collide.
+        if let sourceULID = Identity.sourceMarkdownULID(from: id) {
+            guard let store = openReadStore(),
+                  let head = try? store.processedMarkdownHead(sourceID: PageID(rawValue: sourceULID)) else {
+                return nil
+            }
+            return Data(head.content.utf8)
         }
         // Ingested sources: serve the verbatim bytes from SQLite (raw, no
         // conversion). Resilient to a missing row/table → nil (noSuchItem).

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -93,6 +93,16 @@ func execute(_ command: ArgumentParser.Command, in store: SQLiteWikiStore) throw
     case .source(let action):
         return try SourceCommand.run(action, in: store,
                                    cwd: FileManager.default.currentDirectoryPath)
+    case .sourceEditMarkdown(let selector, let contentOrFile, let isFile):
+        let content: String
+        if isFile {
+            content = try readBody(from: contentOrFile)
+        } else {
+            content = contentOrFile
+        }
+        return try SourceCommand.run(
+            .editMarkdown(selector, content: content), in: store,
+            cwd: FileManager.default.currentDirectoryPath)
     }
 }
 

--- a/Tests/WikiFSTests/IndexGeneratorTests.swift
+++ b/Tests/WikiFSTests/IndexGeneratorTests.swift
@@ -131,12 +131,33 @@ struct IndexGeneratorTests {
         #expect(first?["path"] as? String == "sources/by-id/F1.pdf")
         #expect(first?["size"] as? Int == 1024)
         #expect(first?["mime"] as? String == "application/pdf")
+        #expect(first?["has_markdown"] as? Bool == false)
 
         // Extension-less + nil mime: path omits the dot; mime is JSON null.
         let second = try JSONSerialization.jsonObject(with: Data(lines[1].utf8)) as? [String: Any]
         #expect(second?["path"] as? String == "sources/by-id/F2")
         #expect(second?["size"] as? Int == 0)
         #expect(second?["mime"] is NSNull)
+        #expect(second?["has_markdown"] as? Bool == false)
+    }
+
+    @Test func sourcesJSONLIncludesHasMarkdown() throws {
+        let files = [
+            IndexGenerators.SourceIndexRow(id: "F1", filename: "a.pdf", ext: "pdf",
+                                    mime: "application/pdf", byteSize: 100,
+                                    hasMarkdown: true),
+            IndexGenerators.SourceIndexRow(id: "F2", filename: "b.txt", ext: "txt",
+                                    mime: "text/plain", byteSize: 50,
+                                    hasMarkdown: false),
+        ]
+        let data = IndexGenerators.sourcesJSONL(sources: files)
+        let lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+
+        let first = try JSONSerialization.jsonObject(with: Data(lines[0].utf8)) as? [String: Any]
+        #expect(first?["has_markdown"] as? Bool == true)
+
+        let second = try JSONSerialization.jsonObject(with: Data(lines[1].utf8)) as? [String: Any]
+        #expect(second?["has_markdown"] as? Bool == false)
     }
 
     @Test func sourcesJSONLIsByteStable() {

--- a/Tests/WikiFSTests/IndexGeneratorTests.swift
+++ b/Tests/WikiFSTests/IndexGeneratorTests.swift
@@ -114,9 +114,11 @@ struct IndexGeneratorTests {
     @Test func sourcesJSONLEachLineValidWithCorrectCount() throws {
         let files = [
             IndexGenerators.SourceIndexRow(id: "F1", filename: "Report.pdf", ext: "pdf",
-                                    mime: "application/pdf", byteSize: 1024),
+                                    mime: "application/pdf", byteSize: 1024,
+                                    hasMarkdown: false),
             IndexGenerators.SourceIndexRow(id: "F2", filename: "notes", ext: "",
-                                    mime: nil, byteSize: 0),
+                                    mime: nil, byteSize: 0,
+                                    hasMarkdown: false),
         ]
         let data = IndexGenerators.sourcesJSONL(sources: files)
         let text = String(decoding: data, as: UTF8.self)
@@ -162,9 +164,42 @@ struct IndexGeneratorTests {
 
     @Test func sourcesJSONLIsByteStable() {
         let files = [IndexGenerators.SourceIndexRow(id: "F1", filename: "x.txt", ext: "txt",
-                                             mime: "text/plain", byteSize: 5)]
+                                             mime: "text/plain", byteSize: 5,
+                                             hasMarkdown: false)]
         #expect(IndexGenerators.sourcesJSONL(sources: files)
                 == IndexGenerators.sourcesJSONL(sources: files))
+    }
+
+    // MARK: - sources.jsonl has_markdown with/without chain (integration with the store)
+
+    @Test func sourcesJSONLHasMarkdownTrueWhenChainExists() throws {
+        let store = try tempStore()
+        // Add a source and append a processed-markdown version to create a chain.
+        let ingested = try store.addSource(filename: "doc.md", data: Data("hello".utf8))
+        try store.appendProcessedMarkdown(
+            sourceID: ingested.id, content: "v1", origin: "extraction", note: nil)
+        let sources = try store.listAllSourcesOrderedByID()
+        #expect(sources.count == 1)
+        #expect(sources[0].hasMarkdown == true)
+
+        let data = IndexGenerators.sourcesJSONL(sources: sources)
+        let lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+        let obj = try JSONSerialization.jsonObject(with: Data(lines[0].utf8)) as? [String: Any]
+        #expect(obj?["has_markdown"] as? Bool == true)
+    }
+
+    @Test func sourcesJSONLHasMarkdownFalseWhenNoChain() throws {
+        let store = try tempStore()
+        // Add a source without any processed-markdown version.
+        let ingested = try store.addSource(filename: "plain.pdf", data: Data("%PDF".utf8))
+        let sources = try store.listAllSourcesOrderedByID()
+        #expect(sources.count == 1)
+        #expect(sources[0].hasMarkdown == false)
+
+        let data = IndexGenerators.sourcesJSONL(sources: sources)
+        let lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+        let obj = try JSONSerialization.jsonObject(with: Data(lines[0].utf8)) as? [String: Any]
+        #expect(obj?["has_markdown"] as? Bool == false)
     }
 
     // MARK: - Determinism
@@ -177,6 +212,11 @@ struct IndexGeneratorTests {
         #expect(IndexGenerators.pagesJSONL(pages: pages) == IndexGenerators.pagesJSONL(pages: pages))
         let links = [IndexGenerators.LinkRow(from: "A", to: "B", linkText: "x")]
         #expect(IndexGenerators.linksJSONL(links: links) == IndexGenerators.linksJSONL(links: links))
+        let sources = [IndexGenerators.SourceIndexRow(id: "S1", filename: "r.pdf", ext: "pdf",
+                                               mime: "application/pdf", byteSize: 100,
+                                               hasMarkdown: true)]
+        #expect(IndexGenerators.sourcesJSONL(sources: sources)
+                == IndexGenerators.sourcesJSONL(sources: sources))
     }
 
     // MARK: - Counts match a seeded DB (integration with the store)

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -158,20 +158,20 @@ struct LogIndexTests {
     @Test func changeTokenAdvancesOnLogOnlyWrite() throws {
         let store = try tempStore()
         // Fresh DB: no pages/files, system_prompt + wiki_index at v1, no log rows.
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
         // Appending ONLY a log entry must still advance the token (logCount fold).
         _ = try store.appendLog(kind: .ingest, title: "x", note: nil)
-        #expect(try store.changeToken() == "0:0:0:0:1:1:1")
+        #expect(try store.changeToken() == "0:0:0:0:1:1:1:0")
         _ = try store.appendLog(kind: .lint, title: "y", note: nil)
-        #expect(try store.changeToken() == "0:0:0:0:1:2:1")
+        #expect(try store.changeToken() == "0:0:0:0:1:2:1:0")
     }
 
     @Test func changeTokenAdvancesOnIndexOnlyWrite() throws {
         let store = try tempStore()
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
         // Editing ONLY the index must still advance the token (idxVersion fold).
         try store.updateWikiIndex(body: "edited")
-        #expect(try store.changeToken() == "0:0:0:0:1:0:2")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:2:0")
     }
 
     // MARK: - v3 → v4 → v5 migration (preserves prior data, seeds index)

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -283,6 +283,48 @@ struct ProcessedMarkdownTests {
         #expect(try store.processedMarkdownHistory(sourceID: arbitraryID).isEmpty)
     }
 
+    // MARK: - Bulk head lookup (processedMarkdownHeadsBySource)
+
+    @Test func processedMarkdownHeadsBySourceReturnsHeadsBySourceID() throws {
+        let store = try tempStore()
+        let fileA = try seedSource(in: store, filename: "alpha.txt")
+        let fileB = try seedSource(in: store, filename: "beta.txt")
+        let fileC = try seedSource(in: store, filename: "gamma.txt") // no head
+        let headA = try store.appendProcessedMarkdown(
+            sourceID: fileA.id, content: "alpha head", origin: "extraction", note: nil)
+        usleep(2000)
+        let headB = try store.appendProcessedMarkdown(
+            sourceID: fileB.id, content: "beta head", origin: "extraction", note: nil)
+        let heads = try store.processedMarkdownHeadsBySource()
+        #expect(heads.count == 2) // fileC has no head
+        #expect(heads[fileA.id.rawValue]?.content == "alpha head")
+        #expect(heads[fileB.id.rawValue]?.content == "beta head")
+        #expect(heads[fileC.id.rawValue] == nil)
+        #expect(heads[fileA.id.rawValue]?.id == headA.id)
+        #expect(heads[fileB.id.rawValue]?.id == headB.id)
+    }
+
+    @Test func processedMarkdownHeadsBySourceReturnsLatestPerSource() throws {
+        let store = try tempStore()
+        let file = try seedSource(in: store)
+        _ = try store.appendProcessedMarkdown(
+            sourceID: file.id, content: "v1", origin: "extraction", note: nil)
+        usleep(2000)
+        let v2 = try store.appendProcessedMarkdown(
+            sourceID: file.id, content: "v2", origin: "user", note: nil)
+        let heads = try store.processedMarkdownHeadsBySource()
+        #expect(heads.count == 1)
+        #expect(heads[file.id.rawValue]?.content == "v2")
+        #expect(heads[file.id.rawValue]?.id == v2.id)
+    }
+
+    @Test func processedMarkdownHeadsBySourceReturnsEmptyForPreV8DB() throws {
+        let url = try tempV7DatabaseURL()
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let heads = try store.processedMarkdownHeadsBySource()
+        #expect(heads.isEmpty)
+    }
+
     // MARK: - Model-level: PDF extraction reuse during ingest
 
     /// For a PDF file, `processedMarkdownHead` returns nil before any markdown is

--- a/Tests/WikiFSTests/ProjectionTests.swift
+++ b/Tests/WikiFSTests/ProjectionTests.swift
@@ -1,0 +1,164 @@
+import FileProvider
+import Foundation
+import Testing
+import WikiFSCore
+@testable import WikiFSFileProvider
+
+/// Tests for `Projection.Identity` identifier construction and ULID extraction,
+/// and `Projection.sourceMarkdownNode` construction — all of which are pure
+/// functions testable without the File Provider runtime.
+struct ProjectionTests {
+
+    // MARK: - sourceMarkdownByID / sourceMarkdownByName round-trip
+
+    @Test func sourceMarkdownByIDRoundTrip() {
+        let ulid = "01KV6EAH410NWC9K9ZM44DNMXT"
+        let id = Projection.Identity.sourceMarkdownByID(ulid)
+        let extracted = Projection.Identity.sourceMarkdownULID(from: id)
+        #expect(extracted == ulid)
+    }
+
+    @Test func sourceMarkdownByNameRoundTrip() {
+        let ulid = "01KV6EAH410NWC9K9ZM44DNMXT"
+        let id = Projection.Identity.sourceMarkdownByName(ulid)
+        let extracted = Projection.Identity.sourceMarkdownULID(from: id)
+        #expect(extracted == ulid)
+    }
+
+    // MARK: - sourceMarkdownULID extraction (non-matching identifiers)
+
+    @Test func sourceMarkdownULIDReturnsNilForPageByID() {
+        let pageID = Projection.Identity.pageByID("01KV6EAH410NWC9K9ZM44DNMXT")
+        #expect(Projection.Identity.sourceMarkdownULID(from: pageID) == nil)
+    }
+
+    @Test func sourceMarkdownULIDReturnsNilForPageByTitle() {
+        let pageTitle = Projection.Identity.pageByTitle("01KV6EAH410NWC9K9ZM44DNMXT")
+        #expect(Projection.Identity.sourceMarkdownULID(from: pageTitle) == nil)
+    }
+
+    @Test func sourceMarkdownULIDReturnsNilForSourceByID() {
+        let sourceID = Projection.Identity.sourceByID("01KV6EAH410NWC9K9ZM44DNMXT")
+        #expect(Projection.Identity.sourceMarkdownULID(from: sourceID) == nil)
+    }
+
+    @Test func sourceMarkdownULIDReturnsNilForSourceByName() {
+        let sourceName = Projection.Identity.sourceByName("01KV6EAH410NWC9K9ZM44DNMXT")
+        #expect(Projection.Identity.sourceMarkdownULID(from: sourceName) == nil)
+    }
+
+    @Test func sourceMarkdownULIDReturnsNilForArbitraryIdentifier() {
+        let arbitrary = NSFileProviderItemIdentifier("something-else")
+        #expect(Projection.Identity.sourceMarkdownULID(from: arbitrary) == nil)
+    }
+
+    @Test func sourceMarkdownULIDReturnsNilForRootContainer() {
+        #expect(Projection.Identity.sourceMarkdownULID(from: .rootContainer) == nil)
+    }
+
+    // MARK: - sourceMarkdownNode construction (by-id)
+
+    @Test func sourceMarkdownNodeByIDFilenameIsULIDDotMD() {
+        let sourceID = "01KV6EAH410NWC9K9ZM44DNMXT"
+        let headID = "01KV9ABC410NWC9K9ZM44DNMXX"
+        let createdAt = Date(timeIntervalSince1970: 1728000000)
+
+        let source = SourceSummary(
+            id: PageID(rawValue: sourceID),
+            filename: "report.pdf",
+            ext: "pdf",
+            mimeType: "application/pdf",
+            byteSize: 1000,
+            createdAt: createdAt,
+            updatedAt: createdAt,
+            version: 1
+        )
+
+        let head = SourceMarkdownVersion(
+            id: PageID(rawValue: headID),
+            sourceID: PageID(rawValue: sourceID),
+            parentID: nil,
+            content: "# Processed Report\n\nThis is the extracted markdown.",
+            origin: "extraction",
+            note: nil,
+            createdAt: createdAt
+        )
+
+        let identifier = Projection.Identity.sourceMarkdownByID(sourceID)
+        let node = Projection.sourceMarkdownNode(for: identifier, source: source, head: head)
+
+        // by-id filename is "<ulid>.md"
+        #expect(node.name == "01KV6EAH410NWC9K9ZM44DNMXT.md")
+        // parent is sourcesByID
+        #expect(node.parent == Projection.Identity.sourcesByID)
+        // contentVersion is Data(head.id.rawValue.utf8)
+        #expect(node.contentVersion == Data(headID.utf8))
+        // metadataVersion is also Data(head.id.rawValue.utf8)
+        #expect(node.metadataVersion == Data(headID.utf8))
+        // ingestedExt is "md"
+        #expect(node.ingestedExt == "md")
+        // mimeType is "text/markdown"
+        #expect(node.mimeType == "text/markdown")
+        // size is head.content.utf8.count
+        #expect(node.size == head.content.utf8.count)
+        // created and modified are head.createdAt
+        #expect(node.created == createdAt)
+        #expect(node.modified == createdAt)
+        // not a folder
+        #expect(!node.isFolder)
+    }
+
+    // MARK: - sourceMarkdownNode construction (by-name)
+
+    @Test func sourceMarkdownNodeByNameUsesFilenameEscaping() {
+        let sourceID = "01JABCDEFGHJKMNPQRSTVWXYZ0"
+        let headID = "01JABCDEFGHJKMNPQRSTVWXYZ9"
+        let createdAt = Date(timeIntervalSince1970: 1728000000)
+
+        let source = SourceSummary(
+            id: PageID(rawValue: sourceID),
+            filename: "Trip Report.pdf",
+            ext: "pdf",
+            mimeType: "application/pdf",
+            byteSize: 2000,
+            createdAt: createdAt,
+            updatedAt: createdAt,
+            version: 1
+        )
+
+        let head = SourceMarkdownVersion(
+            id: PageID(rawValue: headID),
+            sourceID: PageID(rawValue: sourceID),
+            parentID: nil,
+            content: "Extracted content from Trip Report.",
+            origin: "extraction",
+            note: nil,
+            createdAt: createdAt
+        )
+
+        let identifier = Projection.Identity.sourceMarkdownByName(sourceID)
+        let node = Projection.sourceMarkdownNode(for: identifier, source: source, head: head)
+
+        // by-name uses FilenameEscaping.byNameSourceFilename(filename:ext:sourceID:)
+        let expectedName = FilenameEscaping.byNameSourceFilename(
+            filename: source.filename, ext: "md", sourceID: sourceID)
+        #expect(node.name == expectedName)
+        // parent is sourcesByName
+        #expect(node.parent == Projection.Identity.sourcesByName)
+        // contentVersion is Data(head.id.rawValue.utf8)
+        #expect(node.contentVersion == Data(headID.utf8))
+        // metadataVersion is also Data(head.id.rawValue.utf8)
+        #expect(node.metadataVersion == Data(headID.utf8))
+        // ingestedExt is "md"
+        #expect(node.ingestedExt == "md")
+        // mimeType is "text/markdown"
+        #expect(node.mimeType == "text/markdown")
+        // size is head.content.utf8.count
+        #expect(node.size == head.content.utf8.count)
+        // created and modified are head.createdAt
+        #expect(node.created == createdAt)
+        #expect(node.modified == createdAt)
+        // not a folder
+        #expect(!node.isFolder)
+    }
+}

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -149,11 +149,11 @@ struct SQLiteWikiStoreTests {
     @Test func changeTokenAdvancesOnEveryMutation() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
 
-        // v5 format:
-        //   "<pCount>:<pSum>:<fCount>:<fSum>:<spVersion>:<logCount>:<idxVersion>".
+        // Current format:
+        //   "<pCount>:<pSum>:<fCount>:<fSum>:<spVersion>:<logCount>:<idxVersion>:<smvCount>".
         // A fresh DB seeds the system_prompt AND wiki_index singletons at version
-        // 1, has no log rows, and no source_markdown_versions →
-        // trailing ":1:0:1:0".
+        // 1, has no log rows, no source_markdown_versions, and no processed
+        // markdown → trailing ":1:0:1:0".
         #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
 
         // Create bumps page COUNT and SUM (version starts at 1).
@@ -195,6 +195,87 @@ struct SQLiteWikiStoreTests {
         // Delete the first → file COUNT and SUM drop.
         try store.deleteSource(id: f.id)
         #expect(try store.changeToken() == "0:0:1:1:1:0:1:0")
+    }
+
+    /// The token MUST advance when a processed markdown version is appended,
+    /// or the `sources/` tree would never learn of new extracts.
+    @Test func changeTokenAdvancesOnAppendProcessedMarkdown() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
+
+        // Add a source first.
+        let source = try store.addSource(filename: "doc.pdf", data: Data("pdf content".utf8))
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:0")
+
+        // Append processed markdown — smvCount goes 0 → 1.
+        _ = try store.appendProcessedMarkdown(
+            sourceID: source.id, content: "# Extracted", origin: "test", note: nil)
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:1")
+
+        // Append another version — smvCount advances again.
+        _ = try store.appendProcessedMarkdown(
+            sourceID: source.id, content: "# Edited", origin: "test", note: "edit")
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:2")
+
+        // Deleting the source removes its markdown versions (CASCADE).
+        try store.deleteSource(id: source.id)
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
+    }
+
+    /// processedMarkdownHeadsBySource returns one row per source, keyed by
+    /// sourceID, with the head version for each.
+    @Test func processedMarkdownHeadsBySourceReturnsCorrectHeads() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+
+        // No sources → empty dict.
+        #expect(try store.processedMarkdownHeadsBySource().isEmpty)
+
+        // Add two sources.
+        let a = try store.addSource(filename: "a.pdf", data: Data("a".utf8))
+        let b = try store.addSource(filename: "b.pdf", data: Data("b".utf8))
+
+        // No markdown yet → still empty.
+        #expect(try store.processedMarkdownHeadsBySource().isEmpty)
+
+        // Append markdown for source a only.
+        let v1 = try store.appendProcessedMarkdown(
+            sourceID: a.id, content: "# A", origin: "test", note: nil)
+        var heads = try store.processedMarkdownHeadsBySource()
+        #expect(heads.count == 1)
+        #expect(heads[a.id.rawValue]?.id == v1.id)
+        #expect(heads[a.id.rawValue]?.content == "# A")
+
+        // Append markdown for source b.
+        let v2 = try store.appendProcessedMarkdown(
+            sourceID: b.id, content: "# B", origin: "test", note: nil)
+        heads = try store.processedMarkdownHeadsBySource()
+        #expect(heads.count == 2)
+        #expect(heads[a.id.rawValue]?.id == v1.id)
+        #expect(heads[b.id.rawValue]?.id == v2.id)
+
+        // Append a new head for source a — only that source's entry changes.
+        let v3 = try store.appendProcessedMarkdown(
+            sourceID: a.id, content: "# A Edited", origin: "test", note: "edit")
+        heads = try store.processedMarkdownHeadsBySource()
+        #expect(heads.count == 2)
+        #expect(heads[a.id.rawValue]?.id == v3.id)
+        #expect(heads[a.id.rawValue]?.content == "# A Edited")
+        #expect(heads[b.id.rawValue]?.id == v2.id)
+    }
+
+    // MARK: - Processed markdown head returns nil when empty (lazy-seed regression)
+
+    @Test func processedMarkdownHeadReturnsNilWhenNoVersionsExist() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let source = try store.addSource(filename: "doc.pdf", data: Data("pdf".utf8))
+
+        // Head is nil when no markdown has been appended.
+        let head = try store.processedMarkdownHead(sourceID: source.id)
+        #expect(head == nil)
+
+        // No chain row was created by the nil read (lazy-seed regression).
+        #expect(try !store.hasProcessedMarkdown(sourceID: source.id))
+        #expect(try store.processedMarkdownHistory(sourceID: source.id).isEmpty)
     }
 
     // MARK: - ULID ordering

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -152,48 +152,49 @@ struct SQLiteWikiStoreTests {
         // v5 format:
         //   "<pCount>:<pSum>:<fCount>:<fSum>:<spVersion>:<logCount>:<idxVersion>".
         // A fresh DB seeds the system_prompt AND wiki_index singletons at version
-        // 1 and has no log rows → trailing ":1:0:1".
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1")
+        // 1, has no log rows, and no source_markdown_versions →
+        // trailing ":1:0:1:0".
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
 
         // Create bumps page COUNT and SUM (version starts at 1).
         let a = try store.createPage(title: "Alpha")
-        #expect(try store.changeToken() == "1:1:0:0:1:0:1")
+        #expect(try store.changeToken() == "1:1:0:0:1:0:1:0")
 
         // Update bumps that row's version by 1 → SUM increments.
         try store.updatePage(id: a.id, title: "Alpha", body: "edited")
-        #expect(try store.changeToken() == "1:2:0:0:1:0:1")
+        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0")
 
         // A SECOND page that is NOT the global-max version must STILL advance the
         // token — the MAX-vs-SUM correctness lock. b starts at version 1, yet
         // count:sum changes (2 pages, sum 2+1=3).
         let b = try store.createPage(title: "Beta")
-        #expect(try store.changeToken() == "2:3:0:0:1:0:1")
+        #expect(try store.changeToken() == "2:3:0:0:1:0:1:0")
 
         try store.updatePage(id: b.id, title: "Beta", body: "beta edit")
-        #expect(try store.changeToken() == "2:4:0:0:1:0:1")
+        #expect(try store.changeToken() == "2:4:0:0:1:0:1:0")
 
         // Delete changes page COUNT and SUM.
         try store.deletePage(id: b.id)
-        #expect(try store.changeToken() == "1:2:0:0:1:0:1")
+        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0")
     }
 
     /// The token MUST advance on ingest AND on delete (else the `files/` tree
     /// would never refresh — the orchestrator-critical fold-in).
     @Test func changeTokenAdvancesOnIngestAndDelete() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
 
         // Ingest bumps the file COUNT and SUM (version 1).
         let f = try store.addSource(filename: "a.txt", data: Data("hi".utf8))
-        #expect(try store.changeToken() == "0:0:1:1:1:0:1")
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:0")
 
         // A second file.
         _ = try store.addSource(filename: "b.txt", data: Data("yo".utf8))
-        #expect(try store.changeToken() == "0:0:2:2:1:0:1")
+        #expect(try store.changeToken() == "0:0:2:2:1:0:1:0")
 
         // Delete the first → file COUNT and SUM drop.
         try store.deleteSource(id: f.id)
-        #expect(try store.changeToken() == "0:0:1:1:1:0:1")
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:0")
     }
 
     // MARK: - ULID ordering

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -147,9 +147,9 @@ struct SystemPromptTests {
     @Test func changeTokenAdvancesOnSystemPromptEdit() throws {
         let store = try tempStore()
         // No pages, no sources: only the system-prompt version moves.
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0")
         try store.updateSystemPrompt(body: "edited")
-        #expect(try store.changeToken() == "0:0:0:0:2:0:1")
+        #expect(try store.changeToken() == "0:0:0:0:2:0:1:0")
     }
 
     // MARK: - UPSERT recreates a missing singleton row (defensive)

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -332,6 +332,7 @@ struct WikiCtlCommandTests {
             #expect(obj?["size"] != nil)
             // mime key always present (null for unknown types)
             #expect(obj?.keys.contains("mime") ?? false)
+            #expect(obj?.keys.contains("has_markdown") ?? false)
         }
     }
 

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -471,6 +471,34 @@ struct WikiCtlCommandTests {
 
     // MARK: - edit-markdown dispatch
 
+    @Test func editMarkdownAppendsUserVersion() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "doc.md", data: Data("hello".utf8))
+        // Append first version (extraction).
+        _ = try store.appendProcessedMarkdown(
+            sourceID: ingested.id, content: "original", origin: "extraction", note: nil)
+        // Small delay ensures the next ULID is strictly later.
+        usleep(2000)
+        // Run edit-markdown which appends a "user" version.
+        let result = try SourceCommand.run(
+            .editMarkdown(.id(ingested.id), content: "edited"), in: store, cwd: "/tmp")
+        #expect(result.didCommit)
+
+        // Verify the chain has 2 versions.
+        let history = try store.processedMarkdownHistory(sourceID: ingested.id)
+        #expect(history.count == 2)
+
+        // Head (first, newest) is the user-edited version.
+        #expect(history[0].content == "edited")
+        #expect(history[0].origin == "user")
+        #expect(history[0].parentID == history[1].id)
+
+        // Second is the extraction baseline.
+        #expect(history[1].content == "original")
+        #expect(history[1].origin == "extraction")
+        #expect(history[1].parentID == nil)
+    }
+
     @Test func editMarkdownCommitsAndAppends() throws {
         let store = try tempStore()
         let ingested = try store.addSource(filename: "doc.md", data: Data("hello".utf8))
@@ -486,12 +514,17 @@ struct WikiCtlCommandTests {
         #expect(head?.origin == "user")
     }
 
-    @Test func editMarkdownFailsWhenNoMarkdownExists() throws {
+    @Test func editMarkdownFailsWhenNoChainExists() throws {
         let store = try tempStore()
         let ingested = try store.addSource(filename: "doc.pdf", data: Data("%PDF".utf8))
-        #expect(throws: SourceCommand.Failure.self) {
+        do {
             try SourceCommand.run(
                 .editMarkdown(.id(ingested.id), content: "edited"), in: store, cwd: "/tmp")
+            Issue.record("expected SourceCommand.Failure")
+        } catch let error as SourceCommand.Failure {
+            #expect(error.description == "no processed markdown for this source")
+        } catch {
+            Issue.record("unexpected error: \(error)")
         }
     }
 

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -427,6 +427,88 @@ struct WikiCtlCommandTests {
         }
     }
 
+    // MARK: - edit-markdown parsing
+
+    @Test func parsesEditMarkdownWithContent() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "edit-markdown", "--id", "01ABC", "--content", "new body"], env: noEnv)
+        #expect(invocation.command == .sourceEditMarkdown(.id(PageID(rawValue: "01ABC")), contentOrFile: "new body", isFile: false))
+    }
+
+    @Test func parsesEditMarkdownWithFile() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "edit-markdown", "--id", "01ABC", "--file", "edit.md"], env: noEnv)
+        #expect(invocation.command == .sourceEditMarkdown(.id(PageID(rawValue: "01ABC")), contentOrFile: "edit.md", isFile: true))
+    }
+
+    @Test func parsesEditMarkdownByName() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "edit-markdown", "--name", "report.md", "--content", "updated"], env: noEnv)
+        #expect(invocation.command == .sourceEditMarkdown(.name("report.md"), contentOrFile: "updated", isFile: false))
+    }
+
+    @Test func editMarkdownRejectsBothContentAndFile() {
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(
+                ["--wiki", "W", "source", "edit-markdown", "--id", "x", "--content", "a", "--file", "b.md"],
+                env: noEnv)
+        }
+    }
+
+    @Test func editMarkdownRequiresContentOrFile() {
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(
+                ["--wiki", "W", "source", "edit-markdown", "--id", "x"], env: noEnv)
+        }
+    }
+
+    @Test func editMarkdownRequiresSelector() {
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(
+                ["--wiki", "W", "source", "edit-markdown", "--content", "x"], env: noEnv)
+        }
+    }
+
+    // MARK: - edit-markdown dispatch
+
+    @Test func editMarkdownCommitsAndAppends() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "doc.md", data: Data("hello".utf8))
+        _ = try store.appendProcessedMarkdown(
+            sourceID: ingested.id, content: "original", origin: "extraction", note: nil)
+        // Small delay ensures the next ULID is strictly later.
+        usleep(2000)
+        let result = try SourceCommand.run(
+            .editMarkdown(.id(ingested.id), content: "edited"), in: store, cwd: "/tmp")
+        #expect(result.didCommit)
+        let head = try store.processedMarkdownHead(sourceID: ingested.id)
+        #expect(head?.content == "edited")
+        #expect(head?.origin == "user")
+    }
+
+    @Test func editMarkdownFailsWhenNoMarkdownExists() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "doc.pdf", data: Data("%PDF".utf8))
+        #expect(throws: SourceCommand.Failure.self) {
+            try SourceCommand.run(
+                .editMarkdown(.id(ingested.id), content: "edited"), in: store, cwd: "/tmp")
+        }
+    }
+
+    @Test func editMarkdownByNameResolvesAndCommits() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "unique.md", data: Data("hello".utf8))
+        _ = try store.appendProcessedMarkdown(
+            sourceID: ingested.id, content: "v1", origin: "extraction", note: nil)
+        // Small delay ensures the next ULID is strictly later.
+        usleep(2000)
+        let result = try SourceCommand.run(
+            .editMarkdown(.name("unique.md"), content: "v2"), in: store, cwd: "/tmp")
+        #expect(result.didCommit)
+        let head = try store.processedMarkdownHead(sourceID: ingested.id)
+        #expect(head?.content == "v2")
+    }
+
     // MARK: - Darwin notification naming
 
     @Test func darwinNotificationNameCarriesWikiID() {

--- a/Tests/WikiFSTests/WikiStoreModelMarkdownImportTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelMarkdownImportTests.swift
@@ -236,29 +236,47 @@ struct WikiStoreModelMarkdownImportTests {
         #expect(result.imported == 2)
     }
 
-    // MARK: - Lazy-seed regression
+    // MARK: - Self-seed (MIME-keyed)
 
-    /// processedMarkdownHead(for:) on an .md source MUST return nil when no
-    /// markdown has been appended, and MUST NOT create a chain row as a side
-    /// effect of the nil read. This guards against a lazy-seed regression where
-    /// merely querying a source's processed-markdown head would auto-create a
-    /// version row, cluttering the history with empty/extraneous entries.
-    @Test func processedMarkdownHeadOnMdSourceReturnsNilNoSideEffect() throws {
+    /// processedMarkdownHead(for:) on a markdown-native source self-seeds v1 from
+    /// the verbatim bytes (origin "source"). Every source has a chain: PDFs are
+    /// seeded from extraction, markdown-native sources self-seed. The seed means
+    /// headVersion is never nil — the original content is always available as v1.
+    @Test func processedMarkdownHeadOnMdSourceSelfSeedsV1() throws {
         let store = try tempStore()
         let model = WikiStoreModel(store: store)
 
-        // Add an .md source via the model.
         model.addSource(filename: "note.md", data: Data("# Hello".utf8))
         #expect(model.sources.count == 1)
         let source = model.sources[0]
 
-        // Head must be nil — no processed markdown has been appended.
+        // Self-seeds: the verbatim bytes become v1 (origin "source").
         let head = model.processedMarkdownHead(for: source)
-        #expect(head == nil)
+        #expect(head != nil)
+        #expect(head?.content == "# Hello")
+        #expect(head?.origin == "source")
 
-        // No chain row was created by the nil read (lazy-seed regression).
-        // We verify at the store level, bypassing the model's nil-coalescing.
+        // Chain row was created.
+        #expect(try store.hasProcessedMarkdown(sourceID: source.id))
+        #expect(try store.processedMarkdownHistory(sourceID: source.id).count == 1)
+
+        // Second call returns the same head — no double-seed.
+        let head2 = model.processedMarkdownHead(for: source)
+        #expect(head2?.id == head?.id)
+        #expect(try store.processedMarkdownHistory(sourceID: source.id).count == 1)
+    }
+
+    /// Binary sources (non-text MIME) do NOT self-seed — only markdown-native
+    /// sources get a chain from their verbatim bytes.
+    @Test func processedMarkdownHeadOnBinarySourceReturnsNil() throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+
+        model.addSource(filename: "data.bin", data: Data([0x00, 0x01, 0x02]))
+        #expect(model.sources.count == 1)
+        let source = model.sources[0]
+
+        #expect(model.processedMarkdownHead(for: source) == nil)
         #expect(try !store.hasProcessedMarkdown(sourceID: source.id))
-        #expect(try store.processedMarkdownHistory(sourceID: source.id).isEmpty)
     }
 }

--- a/Tests/WikiFSTests/WikiStoreModelMarkdownImportTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelMarkdownImportTests.swift
@@ -235,4 +235,30 @@ struct WikiStoreModelMarkdownImportTests {
         let result = await model.importFromMarkdownFolder(directory: dir)
         #expect(result.imported == 2)
     }
+
+    // MARK: - Lazy-seed regression
+
+    /// processedMarkdownHead(for:) on an .md source MUST return nil when no
+    /// markdown has been appended, and MUST NOT create a chain row as a side
+    /// effect of the nil read. This guards against a lazy-seed regression where
+    /// merely querying a source's processed-markdown head would auto-create a
+    /// version row, cluttering the history with empty/extraneous entries.
+    @Test func processedMarkdownHeadOnMdSourceReturnsNilNoSideEffect() throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+
+        // Add an .md source via the model.
+        model.addSource(filename: "note.md", data: Data("# Hello".utf8))
+        #expect(model.sources.count == 1)
+        let source = model.sources[0]
+
+        // Head must be nil — no processed markdown has been appended.
+        let head = model.processedMarkdownHead(for: source)
+        #expect(head == nil)
+
+        // No chain row was created by the nil read (lazy-seed regression).
+        // We verify at the store level, bypassing the model's nil-coalescing.
+        #expect(try !store.hasProcessedMarkdown(sourceID: source.id))
+        #expect(try store.processedMarkdownHistory(sourceID: source.id).isEmpty)
+    }
 }

--- a/plans/phase-c-source-markdown-projection.md
+++ b/plans/phase-c-source-markdown-projection.md
@@ -18,19 +18,23 @@ It supersedes the Phase C portion of `sources-redesign.md` wherever they conflic
 - **Plan 2** (`phase-b-source-wikilinks.md`) — the rename and `source_markdown_versions`
   table are in place (Phase A/B merged). Phase C builds on those names.
 
-## The model (from design intent — load-bearing)
+## The model (corrected — 2026-06-21)
 
-1. **Only PDF sources have a processing chain.** The `source_markdown_versions` table holds
-   the git-lite history of a PDF→markdown *conversion* and the user's edits to it. Markdown
-   sources are verbatim-only — there is no "processed markdown" for a file that is already
-   markdown.
-2. **The chain is internal history; everyone else sees only HEAD.** The File Provider, the
-   agent, and the CLI see the latest version (`MAX(id)`). The version history powers revert
-   (shipped: `revertProcessedMarkdown`) and compare (future UI feature, out of scope here).
-3. **Content type drives behavior, never the filename extension.** `mime_type` is the
-   behavioral authority; `ext` is a display/filename hint only. This is the plan's own
-   "Content-Type Over Extension" principle (`sources-redesign.md:419-475`) — and it must
-   hold at the *source* of the data, not just at the branch sites.
+1. **Every source has a processing chain.** The `source_markdown_versions` table holds the
+   git-lite history of all revisions. Markdown-native sources self-seed v1 from verbatim
+   bytes (origin `"source"`) — the original content is always available as the baseline.
+   PDFs are seeded from extraction output (origin `"extraction"`). Edits append `"user"`
+   versions. `headVersion` is never nil.
+2. **The chain is internal history; the UI and agent see only HEAD.** The File Provider, the
+   agent, the CLI, and the in-app preview all see the latest version (`MAX(id)`). The
+   version history powers revert (shipped: `revertProcessedMarkdown`) and compare (future).
+3. **The `.md` sibling in the File Provider is a PDF-only concept.** It projects the
+   extraction output alongside the verbatim PDF. For markdown-native sources, the verbatim
+   file *is* the content — there is no sibling. No collision: PDF verbatim is `<id>.pdf`,
+   sibling is `<id>.md`; markdown verbatim is `<id>.md`, no sibling.
+4. **Content type drives behavior, never the filename extension.** `mime_type` is the
+   behavioral authority; `ext` is a display/filename hint only. This applies to the seed
+   (MIME-keyed, not ext-keyed) and to the sibling eligibility gate.
 
 ## Decisions (locked)
 
@@ -41,18 +45,19 @@ These overturn or sharpen the parent design.
    `addSource` sniff the bytes and `WikiFSItem.contentType` MIME-first. Phase C's "only PDFs
    have chains" model (Decision 2) and the sibling eligibility (Decision 4) are only
    trustworthy once `mime_type` is content-derived, so **land that plan first**.
-2. **Remove the markdown lazy-seed.** `WikiStoreModel.processedMarkdownHead(for:)`
-   (`:865-877`) seeds a v1 from a markdown source's own verbatim bytes. That contradicts the
-   model (no chain for markdown) and is the one ext-check bug that, under the parent
-   design's projection rule, would project a colliding `<id>.md` sibling next to the
-   verbatim `<id>.md`. Removing it makes "only PDFs have chains" true by construction.
+2. **Restore the markdown seed, MIME-keyed.** `WikiStoreModel.processedMarkdownHead(for:)`
+   self-seeds v1 from verbatim bytes for markdown-native sources (`mimeType.hasPrefix("text/")`,
+   not `file.ext`). Origin is `"source"` (distinct from `"extraction"` and `"user"`).
+   Double-seed guard prevents duplicates. Every source has a chain; `headVersion` is
+   never nil.
 3. **The change bridge must see chain edits.** Fold `source_markdown_versions` into
    `changeToken()` and version the sibling node off the HEAD row, so extraction / edit /
    revert refresh the mount. The parent design's "change bridge signals → File Provider
    refreshes the `.md` sibling" (`sources-redesign.md:206`) is false without this.
-4. **Eligibility for the projected sibling is `hasProcessedMarkdown`** (after Decision 2,
-   only PDFs can satisfy it). Project the sibling in **both** `by-id` and `by-name`, with
-   proper identity prefixes (the parent design specified only the by-id prefix).
+4. **Eligibility for the projected sibling: has a chain AND is NOT markdown-native.**
+   Every source has a chain (Decision 2), but the `.md` sibling is only for sources whose
+   verbatim bytes aren't already markdown — i.e. PDFs with extraction output. Markdown-native
+   sources don't get a sibling (the verbatim file is the content).
 5. **The sibling serves HEAD only**, as `text/markdown`, size and version derived from the
    HEAD version row — never from the `sources` row.
 
@@ -66,10 +71,9 @@ the extension (`SQLiteWikiStore.swift:861`), MIME-first `WikiFSItem.contentType`
 guard against new extension checks — is owned by
 [`content-type-over-extension.md`](content-type-over-extension.md). **Land it first.**
 
-The one extension check Phase C *does* own is the markdown lazy-seed
-(`WikiStoreModel.swift:870`), removed in §4 for model reasons — it's an extension check, but
-its removal is about the chain model (no chains for markdown), not about MIME-vs-ext, so it
-stays here. The other surviving checks (the stale `AgentOperationRunner.swift:130` comment,
+The one extension check Phase C *does* own is the markdown seed. The old `file.ext` check
+is replaced with a MIME-keyed `hasPrefix("text/")` gate (§4) — same seed behavior, correct
+authority. The other surviving checks (the stale `AgentOperationRunner.swift:130` comment,
 `ZoteroClient.swift:284`) belong to the content-type plan.
 
 ---
@@ -197,9 +201,9 @@ private func sourceNodes(byName: Bool) -> [ProjectedNode] {
 }
 ```
 
-Eligibility is simply "has a HEAD" (after Decision 2, only PDFs can). `heads` is keyed by
-source id; the verbatim node is always emitted, so the original bytes remain reachable
-(satisfying `sources-redesign.md:185`).
+Eligibility: has a HEAD AND is NOT markdown-native. The sibling is only for PDFs with
+extraction output — markdown-native sources never project a sibling (the verbatim `<id>.md`
+is the content). `heads` is keyed by source id; the verbatim node is always emitted.
 
 ### 3.4 `contents(for:)` serves HEAD; contentType is explicit
 
@@ -232,24 +236,30 @@ public func processedMarkdownHeadsBySource() throws -> [String: SourceMarkdownVe
 
 ---
 
-## 4. Delete the markdown lazy-seed (Decision 2, detail)
+## 4. Restore the markdown seed, MIME-keyed (Decision 2, corrected)
 
-`WikiStoreModel.processedMarkdownHead(for:)` (`:865-877`) becomes:
+`WikiStoreModel.processedMarkdownHead(for:)` self-seeds v1 from verbatim bytes for
+markdown-native sources, keyed on `mimeType.hasPrefix("text/")` instead of the old
+`file.ext` check:
 
 ```swift
 public func processedMarkdownHead(for file: SourceSummary) -> SourceMarkdownVersion? {
-    try? store.processedMarkdownHead(sourceID: file.id)
+    if let head = try? store.processedMarkdownHead(sourceID: file.id) {
+        return head
+    }
+    // Seed v1 for markdown-native sources (MIME-keyed).
+    guard let mime = file.mimeType, mime.hasPrefix("text/") else { return nil }
+    guard let bytes = try? store.sourceContent(id: file.id),
+          let text = String(data: bytes, encoding: .utf8) else { return nil }
+    return try? store.appendProcessedMarkdown(
+        sourceID: file.id, content: text, origin: "source", note: nil)
 }
 ```
 
-No seeding branch. A markdown source now has no chain (matching the model); a PDF source
-gets its chain from extraction (`seedPdfMarkdown`, `:894-903`, origin `"extraction"`).
-`saveProcessedMarkdown` (`:886-891`, origin `"user"`) still appends user edits to a PDF's
-existing chain. **Collision is impossible by construction**: PDF verbatim is `<id>.pdf`,
-sibling is `<id>.md`.
-
-> If a future extraction target is itself markdown-ext, revisit the sibling filename then.
-> Do not pre-engineer a disambiguator now.
+Origin `"source"` distinguishes self-seeds from extraction (`"extraction"`) and user
+edits (`"user"`). Double-seed guard: if a head already exists, it returns immediately.
+`seedPdfMarkdown` is unchanged — PDFs still get their chain from extraction output.
+`headVersion` is never nil.
 
 ---
 
@@ -280,9 +290,10 @@ how other commands read `--file <path>` into a string). The app's in-app editor
 
 ## 6. Index + agent prompt (locked)
 
-- **`sources.jsonl`** (`IndexGenerators.swift:142-`): add a `has_markdown` boolean so the
-  agent can discover which sources have a `.md` sibling without `ls`-ing. Additive; update
-  `IndexGeneratorTests`. (After Decision 2, `has_markdown` is true only for extracted PDFs.)
+- **`sources.jsonl`** (`IndexGenerators.swift:142-`): add a `has_markdown` boolean. After
+  the self-seed (Decision 2 corrected), this is true for EVERY source. The agent can use
+  `mime` (already in the JSONL) to distinguish PDFs (have a `.md` sibling from extraction)
+  from markdown-native sources (verbatim `.md` is the content, no sibling needed).
 - **`SystemPrompt`** (`SystemPrompt.swift`): document the `.md`-sibling convention — for a
   source with processed markdown, a `<id>.md` sibling holds the latest conversion/edit and
   is the one to `Read` in preference to the raw PDF. One line in the prompt's sources
@@ -298,12 +309,13 @@ how other commands read `--file <path>` into a string). The app's in-app editor
   - `addSource` sets `mime_type` from bytes (sniff), e.g. a PDF fed with a `.txt` filename
     still stores `application/pdf`.
   - `processedMarkdownHeadsBySource` returns the right HEAD per source.
-- **`WikiStoreModelTests`** (or equivalent): `processedMarkdownHead(for:)` for a `.md`
-  source returns nil and creates **no** chain (regression test for the lazy-seed removal).
-- **Projection** (File Provider test target): a PDF source with a chain projects TWO nodes
-  in `by-id` and `by-name` (`<id>.pdf` + `<id>.md`); a PDF without a chain projects one; a
-  `.md` source projects one (no sibling). `contents(for: <md sibling id>)` serves the HEAD
-  text; editing the chain changes the node's `contentVersion`.
+- **`WikiStoreModelTests`**: `processedMarkdownHead(for:)` for a markdown-native source
+  self-seeds v1 from verbatim bytes (origin `"source"`). Double-seed guard prevents
+  duplicate rows. Binary (non-text) sources return nil and create no chain.
+- **Projection** (File Provider test target): a PDF source projects TWO nodes in `by-id`
+  and `by-name` (`<id>.pdf` + `<id>.md` sibling); a markdown-native source projects ONE
+  node (the verbatim `<id>.md`, no sibling). `contents(for: <md sibling id>)` serves the
+  HEAD text; editing the chain changes the node's `contentVersion`.
 - **`SourceCommandTests`**: `edit-markdown` appends a `"user"` version; refuses when no
   chain exists.
 
@@ -326,8 +338,8 @@ how other commands read `--file <path>` into a string). The app's in-app editor
 - **Phase D** display-name editing — when it lands, the by-name sibling switches from
   `filename` to `display_name` for its stem (one-line change in §3.2).
 - A backfill migration to re-sniff existing rows' `mime_type` (§1.2 note) — optional.
-- Generalizing extraction beyond PDF — the design leaves room (eligibility keys on
-  `hasProcessedMarkdown`, not on `ext`/`mime`), but only PDFs produce chains today.
+- Generalizing extraction beyond PDF — the design leaves room. Every source already has a
+  chain; the sibling eligibility gate (§3.3) determines whether a `.md` sibling is projected.
 
 ## Open decisions (all locked)
 

--- a/plans/phase-c-source-markdown-projection.md
+++ b/plans/phase-c-source-markdown-projection.md
@@ -78,11 +78,11 @@ stays here. The other surviving checks (the stale `AgentOperationRunner.swift:13
 
 ### 2.1 Fold `source_markdown_versions` into `changeToken()`
 
-`SQLiteWikiStore.swift:564-570` returns
+`SQLiteWikiStore.swift:564-570` returns a 7-component token
 `pCount:pSum:fCount:fSum:spVersion:logCount:idxVersion`. None of those move when
 `appendProcessedMarkdown` (`:1412`) or `revertProcessedMarkdown` (`:1440`) inserts a version
 row, because neither touches `sources.version`/`sources.updated_at`. Add a resilient count
-helper (mirroring `logRowCount`, `:600-607`) and a 7th token component:
+helper (mirroring `logRowCount`, `:600-607`) as an 8th token component.
 
 ```swift
 private func sourceMarkdownVersionCount() -> Int64 {
@@ -162,6 +162,12 @@ static func sourceMarkdownNode(
 > Why both `version` and `metadataVersion` off HEAD: the anchor (§2.1) tells the enumerator
 > *something* in the DB changed; the per-item `contentVersion` tells it *this* sibling's
 > bytes changed. Both are needed — anchor alone leaves the daemon serving stale contents.
+>
+> **The sibling's `contentVersion` must differ from the verbatim node's `contentVersion`.**
+> The verbatim node versions off `Data(String(file.version).utf8)` — the source row version.
+> The sibling versions off `Data(head.id.rawValue.utf8)` — the HEAD version id. These are
+> naturally distinct (different types, different values), so the daemon can tell them apart
+> and re-fetches the sibling when a new HEAD row is appended.
 
 ### 3.3 Enumeration — emit the sibling for eligible sources, without N+1
 
@@ -272,7 +278,7 @@ how other commands read `--file <path>` into a string). The app's in-app editor
 
 ---
 
-## 6. Index + agent prompt (recommended)
+## 6. Index + agent prompt (locked)
 
 - **`sources.jsonl`** (`IndexGenerators.swift:142-`): add a `has_markdown` boolean so the
   agent can discover which sources have a `.md` sibling without `ls`-ing. Additive; update
@@ -323,11 +329,11 @@ how other commands read `--file <path>` into a string). The app's in-app editor
 - Generalizing extraction beyond PDF — the design leaves room (eligibility keys on
   `hasProcessedMarkdown`, not on `ext`/`mime`), but only PDFs produce chains today.
 
-## Open decisions
+## Open decisions (all locked)
 
-1. **`smvCount` vs `MAX(id)` in the token.** `COUNT(*)` (recommended) is simpler and matches
-   `logRowCount`; `MAX(id)` is marginally more discriminating. Either moves on any append.
-2. **`edit-markdown` when no chain exists.** Recommended: refuse ("extract first"). Alt:
-   allow it to seed a `"user"` v1 — but that muddies the "extraction is the baseline" model.
-3. **`has_markdown` in `sources.jsonl`.** Recommended yes (cheap, helps the agent). If you'd
-   rather keep the index minimal, drop §6's first bullet.
+1. **`smvCount` vs `MAX(id)` in the token.** ✅ `COUNT(*)` — simpler, matches `logRowCount`.
+   Either moves on any append.
+2. **`edit-markdown` when no chain exists.** ✅ Refuse ("extract first"). Seeding a `"user"` v1
+   muddies the "extraction is the baseline" model.
+3. **`has_markdown` in `sources.jsonl`.** ✅ Yes. One boolean, cheap to compute, saves the agent
+   from `ls`-ing sources to discover which have processed markdown.


### PR DESCRIPTION
Implements [`plans/phase-c-source-markdown-projection.md`](plans/phase-c-source-markdown-projection.md) (corrected 2026-06-21).

## Model (corrected)

Every source has a chain. Markdown-native sources self-seed v1 from verbatim bytes (origin `"source"`, MIME-keyed). PDFs seed from extraction output. `headVersion` is never nil. The `.md` sibling in the File Provider is PDF-only — markdown-native sources don't need one (the verbatim `<id>.md` is the content).

## Changes

- **Change bridge:** `sourceMarkdownVersionCount()` + 8th `smvCount` component in `changeToken()`. Chain edits now move the File Provider sync anchor.
- **Projection:** `sourceMarkdownByID` / `sourceMarkdownByName` identity prefixes. `sourceMarkdownNode` versions the sibling off the HEAD row. `sourceNodes` emits a sibling only for non-markdown-native sources with a chain. `contents(for:)` serves HEAD content for sibling ids.
- **One-query HEAD read:** `processedMarkdownHeadsBySource()` — joins against `MAX(id) GROUP BY file_id`, avoids N+1.
- **Self-seed, MIME-keyed:** `processedMarkdownHead(for:)` self-seeds v1 from verbatim bytes for markdown-native sources (`mimeType.hasPrefix("text/")`, not `file.ext`). Origin `"source"`. Double-seed guard.
- **CLI:** `wikictl source edit-markdown <selector> --content "..."` appends a `"user"` version. Refuses when no chain exists.
- **Index:** `has_markdown` boolean in `sources.jsonl`. True for every source (all have chains). Agent uses `mime` to differentiate.
- **Agent prompt:** Documents the `.md` sibling convention.

## Tests

684 tests, 54 suites, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)