### PR TITLE
Fix citation prompts: agents correctly use [[source:Name#"quote"]] format

### DIFF
--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -72,8 +72,9 @@ final class AgentLauncher {
     private(set) var exitStatus: Int32?
     /// Set when the PATH preflight fails (claude not resolvable) or the spawn
     /// itself throws; shown in the UI instead of spawning. Cleared on the next
-    /// successful run.
-    private(set) var preflightError: String?
+    /// successful run. Settable from `AgentOperationRunner` for silent-failure
+    /// paths where no agent process is spawned.
+    var preflightError: String?
     /// The kind of the operation currently running (drives the UI title / spinner).
     private(set) var runningKind: WikiOperation.Kind?
     /// The per-run `run.jsonl` backend log on disk (raw stream-json), so the UI can
@@ -377,6 +378,11 @@ final class AgentLauncher {
             // touching the slot. If we were handed the slot then cancelled (race),
             // give it back so a queued peer isn't stranded.
             if acquired { releaseSpawnSlot() }
+            if Task.isCancelled {
+                preflightError = "Run cancelled before starting."
+            } else {
+                preflightError = "Another operation is already running. Wait for it to finish and try again."
+            }
             return
         }
 
@@ -547,6 +553,11 @@ final class AgentLauncher {
         let acquired = await awaitSpawnSlot()
         guard acquired, !Task.isCancelled else {
             if acquired { releaseSpawnSlot() }
+            if Task.isCancelled {
+                preflightError = "Query cancelled before starting."
+            } else {
+                preflightError = "Another operation is already running. Wait for it to finish and try again."
+            }
             return
         }
 

--- a/Sources/WikiFS/AgentOperationRunner.swift
+++ b/Sources/WikiFS/AgentOperationRunner.swift
@@ -196,10 +196,20 @@ enum AgentOperationRunner {
         fileProvider: FileProviderSpike
     ) async {
         let trimmed = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let wikiID = manager.activeWikiID else { return }
+        guard !trimmed.isEmpty else { return }
+        guard let wikiID = manager.activeWikiID else {
+            DebugLog.agent("startQueryConversation: no active wiki — bailing")
+            return
+        }
 
         await fileProvider.signalChange()
-        guard let root = fileProvider.path else { return }
+        guard let root = fileProvider.path else {
+            await MainActor.run {
+                launcher.preflightError = "File Provider is not mounted. Open a wiki first."
+            }
+            DebugLog.agent("startQueryConversation: fileProvider.path is nil — bailing")
+            return
+        }
 
         await launcher.startInteractiveQuery(
             firstMessage: trimmed,

--- a/Sources/WikiFSCore/SystemPrompt.swift
+++ b/Sources/WikiFSCore/SystemPrompt.swift
@@ -75,12 +75,16 @@ public struct SystemPrompt: Equatable, Sendable {
       bytes it came from. Prefer passage-level citations with `[[source:Name#"…"]]`
       (see Footnotes & Citations below).
     - **Link to source passages by distinctive quote** —
-      `[[source:Smith2023#"the effect vanishes above 40°C"]]`. Pick a snippet unique
-      to that passage; it survives re-extraction and needs no heading. The quote is
-      whitespace-normalized and case-sensitive.
+      `[[source:Smith2023#"the effect vanishes above 40°C"]]`. The `#"…"` goes AFTER
+      the source name with NO pipe (`|`). The quote makes the link scroll to that
+      exact passage when clicked. Pick a snippet unique to that passage; it survives
+      re-extraction. The quote is whitespace-normalized and case-sensitive.
     - **Link to page sections by heading** — `[[Overview#Methodology]]`. The heading
       text becomes a URL-style slug (lowercase, spaces→`-`, punctuation dropped,
       `-1/-2` suffix on duplicates). Same-page scroll: `[[#Methodology]]`.
+    - **`#` is NOT `|`.** `[[source:X|alias]]` changes the DISPLAY TEXT. `[[source:X#"quote"]]`
+      scrolls to a PASSAGE. They do different things. Never use `|` in a footnote
+      citation — the source's display name IS the link text.
     - **Footnotes** cite evidence at the passage level. Use `[^id]` inline (any label;
       auto-numbered 1,2,3… in output) and `[^id]: definition` on its own line after
       the paragraph that references it. Definitions accept full markdown including
@@ -93,9 +97,24 @@ public struct SystemPrompt: Equatable, Sendable {
       for the original discovery, and [[Calvin Cycle#Regulation]] for regulatory
       mechanisms.
       ```
+
+      WRONG (do NOT do this):
+      ```
+      [^def]: [[source:Bassham1950|Bassham (1950)]], *JACS* 72: 456–460. Anchor: "the dark reactions..."
+      ```
+      This is wrong because: (a) `|` changes display text instead of linking a passage,
+      (b) journal/DOI metadata doesn't belong in a wikilink citation, (c) the quote
+      goes after `#"…"` inside the link, not as "Anchor:" text.
     - **`[[source:Name]]`** (without a passage) navigates to the source and opens its
       extracted/text content — use for general references; add `#"…"` for specific
       passages.
+    - **External sources** (papers, books, URLs NOT ingested into this wiki) get
+      standard academic footnote citations: `[^id]: Author (Year), "Title", Journal/
+      Publisher. DOI or URL`. If only a URL is available, that's fine. External
+      citations go in footnotes just like wiki-source citations — the only difference
+      is the definition format. Example:
+      `[^rosenthal]: Rosenthal (2002), "Explaining Consciousness", in Philosophy of
+      Mind: Classical and Contemporary Readings.`
 
     ## Tooling — write via `wikictl`, never the filesystem
 
@@ -137,7 +156,9 @@ public struct SystemPrompt: Equatable, Sendable {
     **Ingest** — bring one raw source into the wiki:
     1. Read the source (`Read` for PDFs/images, `cat` for text).
     2. Write at least one summary page capturing its key content via
-       `wikictl page upsert`; cite the source by its `sources/…` path.
+       `wikictl page upsert`. FOOTNOTE EVERY CLAIM drawn from the source with
+       `[^id]` + `[^id]: [[source:DisplayName#"distinctive quote"]]` — see the
+       Footnotes convention above for exact syntax.
     3. Create or update the entity/concept pages it mentions, cross-linking with
        `[[wiki links]]`.
     4. Rewrite `index.md` via `wikictl index set` so the catalog lists the pages
@@ -151,8 +172,10 @@ public struct SystemPrompt: Equatable, Sendable {
        search across page bodies. If that misses, fall back to `wikictl page list`,
        then `wikictl page get`; `grep`/`cat` over `index.md`, `log.md`, and
        `WIKI-STRUCTURE.md`.
-    2. Answer concisely, CITING the page titles or `sources/…` paths you drew on. If
-       the wiki lacks the information, say so plainly rather than guessing.
+    2. Answer concisely, CITING page titles with `[[wiki links]]` and source passages
+       with `[^id]` + `[^id]: [[source:Name#"quote"]]` footnotes (see Footnotes
+       convention above). If the wiki lacks the information, say so plainly rather
+       than guessing.
     3. Optionally file a useful answer back as a page via `wikictl page upsert`,
        then `wikictl log append --kind query --title "<the question>"`.
 

--- a/Sources/WikiFSCore/WikiOperation.swift
+++ b/Sources/WikiFSCore/WikiOperation.swift
@@ -255,14 +255,44 @@ extension WikiOperation {
     return lines.joined(separator: "\n")
   }
 
-  /// Ingest-written pages should make provenance visible without making the agent
-  /// chase or construct durable URLs. The reader renders Markdown footnotes.
+  /// Every claim drawn from a source MUST be footnoted. The format depends on
+  /// whether the source lives in the wiki's `sources/` directory.
+  /// - Wiki sources (ANY file in `sources/` — look up display names with
+  ///   `wikictl source list --json` or check `sources.jsonl`): use
+  ///   `[[source:DisplayName#"quote"]]` — a clickable wikilink that navigates to
+  ///   the source and scrolls to the quoted passage.
+  /// - External sources (papers, books, URLs NOT in `sources/`): use a standard
+  ///   academic-style citation: Author (Year), "Title", Journal/Publisher, DOI/URL.
   private static let footnoteConclusionsRule = """
-    FOOTNOTE CONCLUSIONS — When you add synthesized conclusions, interpretations, \
-    or non-obvious facts to wiki pages, footnote them in Markdown using `[^id]` \
-    references and `[^id]: Source filename, page N` definitions. We do NOT need \
-    real links; use concise provenance such as a source file name plus page, \
-    section, heading, line range, or chunk range.
+    FOOTNOTE EVERY CLAIM — When you write a claim, interpretation, or non-obvious \
+    fact drawn from a source, footnote it.
+
+    FOR WIKI SOURCES — i.e. any file in the wiki's `sources/` directory, not just \
+    the files in this ingest batch. Before writing, check whether a source is in \
+    the wiki: search `sources.jsonl` or run `wikictl source list --json` and match \
+    by filename or display name. If it IS a wiki source, cite it with \
+    `[^id]: [[source:DisplayName#"distinctive quote from the passage"]]`. \
+    `DisplayName` is the source's display name from `sources.jsonl` or \
+    `wikictl source list`. The quote goes AFTER `#"` with NO pipe, NO "Anchor:" \
+    text, and NO journal/DOI metadata — the source already has that. Example: \
+    `[^id]: [[source:Bassham1950#"the dark reactions of photosynthesis"]] and \
+    [[Calvin Cycle#Regulation]].`
+
+    FOR EXTERNAL SOURCES — any paper, book, or URL NOT in the wiki's `sources/`: \
+    use `[^id]: Author (Year), "Title", Journal/Publisher. DOI or URL`. Example: \
+    `[^id]: Rosenthal (2002), "Explaining Consciousness", in Philosophy of Mind: \
+    Classical and Contemporary Readings.`
+
+    `#` IS NOT `|`. `[[source:X|alias]]` changes display text. \
+    `[[source:X#"quote"]]` links a PASSAGE. Never use `|` in a footnote citation.
+
+    WRONG — do NOT do any of this: \
+    `[^id]: [[source:X|Author (Year)]], Journal. Anchor: "quote"` \
+    `[^id]: [[source:X]] Author (Year), "Title", Journal.` \
+    `[^id]: Author (Year) — Source (path), page N: "quote"`
+
+    RIGHT: \
+    `[^id]: [[source:DisplayName#"distinctive quote from the passage"]]`
     """
 
   // MARK: - Query / Lint prompts

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -327,12 +327,15 @@ struct OperationCommandTests {
   @Test func ingestPromptsTellOpusToFootnoteConclusionsWithSourceLocations() {
     for operation in [Self.tinyIngest(), Self.curatedIngest()] {
       let prompt = operation.prompt(wikiRoot: Self.resolvedRoot)
-      #expect(prompt.contains("FOOTNOTE CONCLUSIONS"))
-      #expect(prompt.contains("synthesized conclusions"))
-      #expect(prompt.contains("`[^id]`"))
-      #expect(prompt.contains("`[^id]: Source filename, page N`"))
-      #expect(prompt.contains("We do NOT need real links"))
-      #expect(prompt.contains("section, heading, line range, or chunk range"))
+      #expect(prompt.contains("FOOTNOTE EVERY CLAIM"))
+      #expect(prompt.contains("FOR WIKI SOURCES"))
+      #expect(prompt.contains("FOR EXTERNAL SOURCES"))
+      #expect(prompt.contains("wikictl source list --json"))
+      #expect(prompt.contains("[[source:DisplayName#"))
+      #expect(prompt.contains("`[^id]: [[source:"))
+      #expect(prompt.contains("distinctive quote"))
+      #expect(prompt.contains("`#` IS NOT `|`"))
+      #expect(prompt.contains("WRONG — do NOT do any of this"))
     }
   }
 
@@ -343,8 +346,8 @@ struct OperationCommandTests {
       .lint(stateFilePath: Self.stateFile),
     ] {
       let prompt = operation.prompt(wikiRoot: Self.resolvedRoot)
-      #expect(!prompt.contains("FOOTNOTE CONCLUSIONS"))
-      #expect(!prompt.contains("`[^id]: Source filename, page N`"))
+      #expect(!prompt.contains("FOOTNOTE EVERY CLAIM"))
+      #expect(!prompt.contains("`[^id]: [[source:"))
     }
   }
 


### PR DESCRIPTION
Agents were producing wrong citation formats:
```
[^def]: [[source:File.pdf|Author (Year)]], *Journal* Vol: Pages. Anchor: "quote"
```

Instead of the correct passage-level wikilink:
```
[^def]: [[source:File.pdf#"distinctive quote from the passage"]]
```

## Fixes

### 1. `WikiOperation.footnoteConclusionsRule`
- Wiki sources now defined as ANY file in `sources/` (not just current batch)
- Teaches `wikictl source list --json` lookup for display names
- Explicit `# IS NOT |` rule — pipe changes display text, hash links a passage
- WRONG/RIGHT examples showing exact anti-patterns

### 2. SystemPrompt conventions
- Anti-pattern example with the exact wrong format (pipe alias, Anchor: text, journal metadata)
- `#` and `|` distinction explained
- Prefer passage-level citations with `[[source:Name#"..."]]`

### 3. Query silent failure diagnostics
- `AgentLauncher.run` / `startInteractiveQuery` now set `preflightError` when spawn slot acquire fails (was silent `return`)
- `AgentOperationRunner.startQueryConversation` sets `preflightError` when File Provider isn't mounted
- `preflightError` visibility changed from `private(set)` to allow same-module writes

**Tests:** 725 tests, 55 suites, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)