### PR TITLE
Fix stale cursor/link hit-testing in the page reader

### DIFF
--- a/Sources/WikiFS/MarkdownPreview.swift
+++ b/Sources/WikiFS/MarkdownPreview.swift
@@ -2,10 +2,18 @@ import SwiftUI
 import Textual
 import WikiFSCore
 
-/// Live, read-only render of the page body. Regex preprocessing (footnote
-/// expansion + wiki-link linkification) runs in a detached task so the view
-/// shell appears immediately and the rendered text fills in after. For large
-/// documents this avoids blocking the main thread during body evaluation.
+/// Live, read-only render of the page body. Footnote expansion + wiki-link
+/// linkification run SYNCHRONOUSLY in `body` so `StructuredText` is built with
+/// its final content during the first layout pass.
+///
+/// Why synchronous (reverts the `95d237f` `Task.yield()` deferral): Textual's
+/// macOS text-selection overlay owns both the cursor and link hit-testing — both
+/// gate on the selection model's laid-out link geometry (`model.url(for:)`).
+/// When `StructuredText` is swapped in AFTER the first layout pass (the old
+/// `ProgressView` → rendered swap), that geometry is stale until a scroll forces
+/// relayout, so links are unclickable and the cursor stays the I-beam everywhere
+/// until you scroll. Rendering in `body` attaches the model to final, laid-out
+/// content up front.
 ///
 /// Anchor scrolling: `StructuredText.Heading` already applies `.id(slug)` via
 /// Textual (`Heading.swift:24`); `NumberedParagraphStyle` applies `.id("p\(n)")`
@@ -18,8 +26,6 @@ struct MarkdownPreview: View {
     /// Used to match against `store.pendingScrollAnchor`.
     var currentSelection: WikiSelection? = nil
 
-    @State private var renderedBody: String?
-    @State private var renderTaskKey: String?
     @State private var blocks: [AnchorBlock] = []
 
     var body: some View {
@@ -30,16 +36,17 @@ struct MarkdownPreview: View {
                         Text("Nothing to preview yet.")
                             .font(.callout)
                             .foregroundStyle(.secondary)
-                    } else if let body = renderedBody {
-                        StructuredText(markdown: body)
-                            .id(body)
+                    } else {
+                        // Render synchronously so StructuredText is built with
+                        // its final content during the first layout pass (see the
+                        // type doc). `renderNumbered` resets the paragraph counter
+                        // and returns the rendered markdown in one call.
+                        let rendered = renderNumbered(markdown)
+                        StructuredText(markdown: rendered)
+                            .id(rendered)
                             .textual.paragraphStyle(NumberedParagraphStyle())
                             .textual.textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                    } else {
-                        ProgressView()
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(.vertical, 40)
                     }
                 }
                 .frame(maxWidth: contentInset ? PageEditorMetrics.readableContentWidth : .infinity,
@@ -70,16 +77,10 @@ struct MarkdownPreview: View {
                 return .handled
             })
             .task(id: markdown) {
-                let captured = markdown
-                let key = UUID().uuidString
-                renderTaskKey = key
-                await Task.yield()
-                guard renderTaskKey == key else { return }
-                NumberedParagraphStyle.resetCounter()
-                renderedBody = renderMarkdown(captured)
-                blocks = AnchorBlock.parse(renderedBody ?? captured)
-                await Task.yield()
-                // Consume pending scroll anchor (set by selectPage/Source).
+                // Display is rendered synchronously in `body`; this task only
+                // derives the anchor block list (post-layout) and consumes any
+                // pending scroll anchor set by selectPage/Source.
+                blocks = AnchorBlock.parse(renderMarkdown(markdown))
                 if let frag = store.consumePendingScrollAnchor(for: currentSelection),
                    let id = resolveAnchor(frag, in: blocks) {
                     try? await Task.sleep(for: .milliseconds(50))
@@ -87,6 +88,16 @@ struct MarkdownPreview: View {
                 }
             }
         }
+    }
+
+    /// Reset the paragraph counter and return the rendered markdown, together,
+    /// so both run in `body` before `StructuredText`'s layout pass consumes the
+    /// counter. (A bare `resetCounter()` statement isn't valid inside a
+    /// `@ViewBuilder`, so it's bundled into this one-call helper.)
+    @MainActor
+    private func renderNumbered(_ raw: String) -> String {
+        NumberedParagraphStyle.resetCounter()
+        return renderMarkdown(raw)
     }
 
     @MainActor


### PR DESCRIPTION
## Problem

When opening a page, the cursor showed the I-beam ("select") over the whole markdown body and `[[wiki-links]]` were not clickable. It only corrected after scrolling — then the cursor became the arrow over text and the pointing hand over links, and links became clickable.

## Root cause

`MarkdownPreview` deferred `StructuredText` rendering into a `.task`, swapping it in **after** the first layout pass (`95d237f`). Textual's macOS text-selection overlay owns **both** the cursor and link-click hit-testing — and both gate on the same thing: the selection model's laid-out link geometry (`model.url(for:)`):

- cursor — `AppKitTextSelectionInteraction.updateCursor`: `model.url(for:) != nil ? pointingHand : iBeam`
- click — `NSTextInteractionView.mouseDown`: opens the link only if `model.url(for:)` returns a URL

Because the `StructuredText` appeared after the first layout pass, the model's link geometry was stale until a scroll forced relayout — so `model.url(for:)` returned `nil` everywhere → I-beam everywhere and clicks swallowed. This was a known issue: the code used to carry a comment ("Textual's macOS document-selection overlay owns cursor/link hit-testing and can get stale after navigation") that was dropped when the redundant `.textual.textSelection(.enabled)` was added in `a303278`.

## Fix

Render **synchronously in `body`** so `StructuredText` is built with its final content during the first layout pass; the selection model attaches to laid-out content up front. Reverts the `95d237f` `Task.yield()` deferral.

- Removed `renderedBody` / `renderTaskKey` state and the `ProgressView` → `StructuredText` swap.
- Added `renderNumbered(_:)`, which resets the `NumberedParagraphStyle` paragraph counter and renders in one call (a bare `resetCounter()` statement isn't valid inside a `@ViewBuilder`).
- `.task(id: markdown)` now only derives the anchor block list and consumes the pending scroll anchor — display no longer depends on it.

Text selection/copy and the pointing-hand cursor are preserved.

## Verification

- `swift build` ✅
- `swift test` — 747 tests pass ✅
- Manual (`make run`): opening a page no longer needs a scroll — cursor is the hand over links and links are clickable immediately; verified across page→page navigation; paragraph numbering still restarts at 1 per page. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
