### PR TITLE
Fix source-link resolution + Query answer citations

### DIFF
--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -733,20 +733,38 @@ public final class SQLiteWikiStore: WikiStore {
         return PageID(rawValue: stmt.text(at: 0))
     }
 
-    /// Resolve a `[[source:…]]` target to a source id. Matches display_name first,
-    /// falling back to filename. Case-insensitive. On a multi-match collision, the
-    /// most recently updated source wins.
+    /// Resolve a `[[source:…]]` target to a source id. Case-insensitive; on a
+    /// multi-match collision, the most recently updated source wins.
+    ///
+    /// Two passes: an exact match on `display_name` (falling back to `filename`
+    /// when `display_name` is NULL), then — because legacy rows stored
+    /// `display_name = filename` WITH the file extension while the canonical cite
+    /// target drops it — a scan that matches the query against each candidate's
+    /// name with its last extension removed, so `[[source:Some Paper]]` still
+    /// resolves a row named `Some Paper.pdf`.
     public func resolveSourceByName(_ displayName: String) throws -> PageID? {
-        let stmt = try statement("""
+        let exact = try statement("""
         SELECT id FROM sources
         WHERE COALESCE(display_name, filename) = ?1 COLLATE NOCASE
            OR filename = ?1 COLLATE NOCASE
         ORDER BY updated_at DESC LIMIT 1;
         """)
-        defer { stmt.reset() }
-        try stmt.bind(displayName, at: 1)
-        guard try stmt.step() else { return nil }
-        return PageID(rawValue: stmt.text(at: 0))
+        defer { exact.reset() }
+        try exact.bind(displayName, at: 1)
+        if try exact.step() { return PageID(rawValue: exact.text(at: 0)) }
+
+        let scan = try statement("""
+        SELECT id, COALESCE(display_name, filename) AS name FROM sources
+        ORDER BY updated_at DESC;
+        """)
+        defer { scan.reset() }
+        while try scan.step() {
+            let name = scan.text(at: 1)
+            if (name as NSString).deletingPathExtension.caseInsensitiveCompare(displayName) == .orderedSame {
+                return PageID(rawValue: scan.text(at: 0))
+            }
+        }
+        return nil
     }
 
     public func replaceLinks(from pageID: PageID,

--- a/Sources/WikiFSCore/WikiOperation.swift
+++ b/Sources/WikiFSCore/WikiOperation.swift
@@ -295,6 +295,28 @@ extension WikiOperation {
     `[^id]: [[source:DisplayName#"distinctive quote from the passage"]]`
     """
 
+  /// Citations in a Query ANSWER (chat) — distinct from Ingest's `[^id]` page
+  /// footnotes. The answer is prose, so the agent must both LINK the source and
+  /// SHOW the passage; without this rule it falls back to inert prose like
+  /// `Name.md, "Section" — "quote"` (no link, a `.md` extension, and the passage
+  /// stranded outside any link). Ratified format: a source wikilink followed by
+  /// the quoted passage in plain text.
+  private static let answerCitationRule = """
+    CITE SOURCES IN YOUR ANSWER — When an answer draws on a source, make the \
+    citation a clickable wikilink AND show the passage. Write \
+    `[[source:DisplayName]]` (or `[[source:DisplayName#"distinctive quote"]]` to \
+    deep-link the passage), then put the quoted passage in plain text right after \
+    it so the reader can see exactly what you are citing. `DisplayName` is the \
+    source's display name from `sources.jsonl` / `wikictl source list`, with NO \
+    file extension. \
+    RIGHT: `[[source:Claim File Helper — ProPublica]] ("…human resources \
+    department can help you figure out if that is the case.")`. \
+    WRONG: `Claim File Helper — ProPublica.md, "The Problem" — "quote"` (no link, \
+    a `.md` extension, and the passage stranded outside it). Never wrap a citation \
+    in a pipe alias (`[[source:X|alias]]`) or tack journal/DOI metadata or an \
+    `Anchor:` label onto the link — the source record already has that.
+    """
+
   // MARK: - Query / Lint prompts
 
   /// Query stays single-agent Opus, but still gets the write rule (it may file an
@@ -309,6 +331,8 @@ extension WikiOperation {
 
     \(IngestWriteRule.dontRediscover(stateFilePath: stateFilePath))
 
+    \(answerCitationRule)
+
     TASK — Answer a question from this wiki, following the Query workflow from your \
     instructions. The mount has a root `WIKI-STRUCTURE.md` file that explains the \
     current filesystem layout and `wikictl` cheatsheet; read it when you need to \
@@ -320,8 +344,8 @@ extension WikiOperation {
     with `wikictl source list` (or `--json`), then read it — for text use \
     `wikictl source cat --id <id>`; for a PDF or other binary run \
     `wikictl source export --id <id>` and run `pdftotext` / `Read` / `strings` on the \
-    path it prints. Cite the page titles and any source footnote locations your \
-    answer draws on. If you file a useful answer back as a page, write it via \
+    path it prints. When you cite a source in your answer, follow the CITE SOURCES \
+    rule above. If you file a useful answer back as a page, write it via \
     `wikictl page upsert` and log it with `wikictl log append --kind query`.
 
     WIKI_ROOT (resolved, read-only mount — reference only): \(wikiRoot)
@@ -337,6 +361,8 @@ extension WikiOperation {
 
     \(IngestWriteRule.dontRediscover(stateFilePath: stateFilePath))
 
+    \(answerCitationRule)
+
     ROLE — You are in an interactive Query conversation for this wiki. The user may \
     ask questions, ask follow-ups, ask you to inspect sources, or ask you to update \
     the wiki. Do not assume every answer should be written back. Answer in chat by \
@@ -347,8 +373,8 @@ extension WikiOperation {
     "I'll check the wiki", "I'll consult the sources", "I'll read WIKI_STATE", or \
     "I found this in the wiki" unless the user explicitly asks how you did it. Do \
     not advertise capabilities or ask generic "what would you like me to do" setup \
-    questions. Reply directly and concisely to the user's actual message; cite pages \
-    or sources only when they materially support the answer.
+    questions. Reply directly and concisely to the user's actual message; when a \
+    source materially supports the answer, cite it per the CITE SOURCES rule above.
 
     When answering, use the Query workflow from your instructions. Pull fresh pages \
     with `wikictl page get --title T` (or `--id I`) as needed. If a page contains \

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -351,6 +351,25 @@ struct OperationCommandTests {
     }
   }
 
+  @Test func queryPromptsCarryAnswerCitationRule() {
+    // Query ANSWERS cite sources differently from Ingest footnotes: a source
+    // wikilink plus the visible passage. Both Query surfaces carry that rule.
+    for operation: WikiOperation in [
+      .query(question: "q", stateFilePath: Self.stateFile),
+      .queryConversation(stateFilePath: Self.stateFile),
+    ] {
+      let prompt = operation.prompt(wikiRoot: Self.resolvedRoot)
+      #expect(prompt.contains("CITE SOURCES IN YOUR ANSWER"))
+      #expect(prompt.contains("[[source:DisplayName"))
+      #expect(prompt.contains("[[source:Claim File Helper — ProPublica]]"))
+    }
+    // Lint health-checks; it doesn't cite sources, so it carries neither rule.
+    let lint = WikiOperation.lint(stateFilePath: Self.stateFile)
+      .prompt(wikiRoot: Self.resolvedRoot)
+    #expect(!lint.contains("CITE SOURCES IN YOUR ANSWER"))
+    #expect(!lint.contains("FOOTNOTE EVERY CLAIM"))
+  }
+
   @Test func queryAndLintPromptsNameStateAndForbidRediscovery() {
     for operation: WikiOperation in [
       .query(question: "q", stateFilePath: Self.stateFile),

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -416,6 +416,27 @@ struct SQLiteWikiStoreTests {
         #expect(id != nil)
     }
 
+    @Test func resolveSourceByNameMatchesWithoutExtension() throws {
+        // Legacy rows store display_name = filename WITH the extension, but the
+        // canonical cite target drops it — `[[source:report]]` must resolve
+        // report.pdf, case-insensitively on the stem.
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let source = try store.addSource(filename: "report.pdf", data: Data("pdf".utf8))
+        #expect(try store.resolveSourceByName("report") == source.id)
+        #expect(try store.resolveSourceByName("REPORT") == source.id)
+        // The full name with extension still resolves (fast path).
+        #expect(try store.resolveSourceByName("report.pdf") == source.id)
+    }
+
+    @Test func resolveSourceByNameMatchesMarkdownStem() throws {
+        // The exact regression: a markdown source whose display_name is the
+        // filename with `.md`, cited by its stem.
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let source = try store.addSource(
+            filename: "Claim File Helper — ProPublica.md", data: Data("md".utf8))
+        #expect(try store.resolveSourceByName("Claim File Helper — ProPublica") == source.id)
+    }
+
     @Test func resolveSourceByNameReturnsNilForUnknown() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
         #expect(try store.resolveSourceByName("nonexistent") == nil)


### PR DESCRIPTION
Two citation fixes surfaced while testing ingest-authored pages.

## 1. Source-link resolution (dead clicks)

`resolveSourceByName` was an exact case-insensitive match on `display_name`/`filename`. But every source's `display_name` carries its file extension — the v10 backfill ran `UPDATE sources SET display_name = filename` — while citations use the extension-free name. So `[[source:Claim File Helper — ProPublica]]` never matched `Claim File Helper — ProPublica.md` → the link rendered as `wiki://missing` → clicking did nothing. Confirmed against the live DB: all 48 sources have the extension baked into `display_name`.

**Fix:** keep the exact fast path; add a stem fallback that, on a miss, matches the query against each candidate's name with its last extension removed (case-insensitive, recency-ordered). Fixes every legacy source without a data migration. Verified no false positives on truncated names.

## 2. Query answer citations (wrong format)

The citation rule (`footnoteConclusionsRule`) was wired into the **Ingest** prompts only. The **Query** and **interactive-Query** prompts had no citation guidance beyond a vague "cite the page titles and source footnote locations," so answer citations fell back to inert prose like `Name.md, "Section" — "quote"` (quotes external to the link, a `.md` extension, no clickable link).

**Fix:** add `answerCitationRule` to both Query surfaces — link the source with `[[source:DisplayName]]` (no file extension) **and** show the quoted passage as plain text, e.g. `[[source:Claim File Helper — ProPublica]] ("…human resources department can help you figure out if that is the case.")`, with the old prose form called out as wrong. Lint is unchanged (it doesn't cite). Ingest keeps its own `[^id]` footnote rule.

## Verification
- `swift build` ✅
- `swift test` — 750 pass ✅ (+3 new: stem fallback, markdown-stem regression, query answer-citation rule)
- Manual (live DB): the broken citation now resolves; the Query prompt carries the ratified citation format.
- **Note:** the chat/Query *panel* still renders `[[…]]` as literal text (`AgentMarkdownText` doesn't linkify) — that's a separate, deferred renderer fix. On authored **pages** (MarkdownPreview) both fixes apply end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
