### PR TITLE
docs(issues): record large-source reader freeze + directions to investigate

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -83,3 +83,63 @@ domain teardown — but it covers the transient-busy window that was silently
 dropping fresh registrations.
 
 Recorded 2026-06-15 (Phase A write-path live gate); mitigation added 2026-06-16.
+
+## Reader freezes on large source documents (500KB+; pages tend to be smaller)
+
+**Symptom.** Opening a very large **source** document beachballs the app for ~10s
+(the "spinner" is the macOS wait cursor, not an in-app `ProgressView` — the main
+thread is blocked, so the OS shows it). Zooming a large source janks for the same
+reason. In practice this hits ingested/imported/extracted sources, not
+agent-authored wiki pages: pages tend to be short, but a raw source (an imported
+markdown file, a pdf2md extraction) can be 500KB+ and is uncapped. Both surfaces
+render through the same `MarkdownPreview` — the page reader (`PageDetailView`) and
+the source viewer (`SourceDetailView.swift:333`) — so the root cause and fix are
+shared even though the size in practice comes from sources.
+
+**Why.** The reader renders the **entire** document as one Textual node:
+`StructuredText(markdown:)` inside a `ScrollView` + plain `VStack`
+(`Sources/WikiFS/MarkdownPreview.swift`). Two consequences:
+
+- The whole string is parsed and laid out in a single synchronous pass **on the
+  main actor**, inside `body`. Off-screen content is laid out anyway (no
+  virtualization), so cost is proportional to document size, not to what's visible.
+- `.id(renderedBody)` on the `StructuredText` forces a **complete teardown +
+  re-parse + re-layout** on any change to the rendered string — including every
+  zoom tick (`fontScale` is read in-body) and edits that flow back through the
+  reader. The two preprocessing passes (`WikiFootnoteMarkdown`, `WikiLinkMarkdown`)
+  also run on the full string in-body on every evaluation.
+
+**What we tried that does NOT work.** Progressive rendering on the main thread —
+appending blocks across frames. It removes no total work; it spreads the same
+parse+layout across frames, and appending to one growing view tree makes SwiftUI
+re-lay-out the accumulating tree each step (~O(n²)), so the main-thread cost goes
+*up*. One freeze becomes a long stutter.
+
+**Patterns worth investigating.** Two themes underlie any real fix, both
+orthogonal to "progressive": **only render what's on screen** (so cost stops
+scaling with document size), and **keep heavy work off the UI thread** (so the
+main thread never blocks while a document is parsed). Concrete directions to
+explore, each with its own tradeoffs to weigh before committing:
+
+- **Render in chunks rather than as one block.** Split the document into smaller
+  pieces and let the UI instantiate only the visible ones on demand, instead of
+  building the whole document up front. Question to resolve: how splitting affects
+  things that span the whole document, like text selection and search.
+- **Hand rendering to a mature document engine.** Let a system component that
+  already does windowed layout (e.g. a web view, or a native text engine) carry the
+  large-document load, rather than our SwiftUI view tree. Question to resolve: how
+  much of our current styling, links, and theming we'd have to rebuild on top of it.
+- **Do the parsing and preprocessing away from the UI thread**, and avoid throwing
+  away the rendered result on every small change (today any change re-parses and
+  re-lays-out the entire document). This is likely worth doing under any of the
+  above.
+
+These are starting points, not a chosen design — they need prototyping and real
+measurements on a 500KB+ source before we pick one. The manual editor path
+(`TextEditor` in `PageDetailView.swift`) is a separate large-document concern not
+covered here; manual editing is an explicit, rare mode.
+
+**Not implementing now** — recording the diagnosis and directions so we pick an
+approach deliberately rather than re-attempting the main-thread approach.
+
+Recorded 2026-06-22.


### PR DESCRIPTION
## What

Adds an `ISSUES.md` entry documenting a known limitation: opening a very large **source** document (500KB+) freezes the reader for ~10s (macOS beachball — the main thread is blocked). In practice this hits ingested/imported/extracted sources, not agent-authored pages (which stay short); both surfaces render through the same `MarkdownPreview`.

This is **documentation only** — no code changes. It records the diagnosis and directions so we pick an approach deliberately rather than re-attempting the failed main-thread approach.

## Contents of the entry

- **Symptom** — concrete repro: ~10s beachball on opening a large source; the "spinner" is the OS wait cursor, not an in-app `ProgressView`.
- **Why** — the reader builds the entire document as one Textual `StructuredText` in a `ScrollView`/`VStack`, parsed + laid out synchronously on the main actor, with `.id(renderedBody)` forcing a full teardown on any change.
- **What we tried that does NOT work** — progressive rendering on the main thread (spreads the same work, ~O(n²), no virtualization).
- **Patterns worth investigating** — framed as higher-level directions (render in chunks / hand off to a mature document engine / move parsing off the UI thread), each with the open question to resolve. Explicitly starting points, not a chosen design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)