### PR TITLE
Remove Save button from Zotero settings; auto-save on change

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,13 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-22 — Zotero settings auto-save
+
+Removed the explicit "Save" button from `ZoteroSettingsView`. API key, library ID,
+and directory override now persist immediately via `.onChange(of:)` on each field
+— no data can be lost on window close (`⌘W` / red button). Also removed the
+redundant save calls from `testConnection()`.
+
 ## 2026-06-22 — Pluggable PDF→Markdown extraction backends (Claude, Gemini, Docling Serve)
 
 Implemented `plans/pdf-extraction-backends.md`. PDF→Markdown extraction is no

--- a/Sources/WikiFS/ZoteroSettingsView.swift
+++ b/Sources/WikiFS/ZoteroSettingsView.swift
@@ -8,11 +8,9 @@ import WikiFSCore
 /// failures via `.alert`, mirroring `WikiFSApp`'s `FileProviderSetupWarning`
 /// pattern.
 ///
-/// Saving is a single explicit action (the "Save" button), not an implicit
-/// on-blur/on-submit side effect: a field that loses focus because the WINDOW
-/// closed (red close button, `⌘W`) never fires `onSubmit`/focus-change, so an
-/// implicit save would silently drop the just-typed value. "Save" closes the
-/// window itself, so there's one unambiguous way edits land.
+/// Changes persist immediately via `.onChange(of:)` — no explicit save step.
+/// The Keychain-backed API key is written on every keystroke; the config JSON
+/// is written whenever the library ID or directory override change.
 struct ZoteroSettingsView: View {
     let containerDirectory: URL
     let credentialStore: any ZoteroCredentialStore
@@ -22,7 +20,6 @@ struct ZoteroSettingsView: View {
     @State private var libraryIDText = ""
     @State private var zoteroDirText = ""
     @State private var testPhase: TestPhase = .idle
-    @Environment(\.dismiss) private var dismiss
 
     private enum TestPhase: Equatable {
         case idle
@@ -71,12 +68,7 @@ struct ZoteroSettingsView: View {
             }
 
             Section {
-                HStack {
-                    testConnectionRow
-                    Spacer()
-                    Button("Save") { saveAndClose() }
-                        .keyboardShortcut(.defaultAction)
-                }
+                testConnectionRow
             }
         }
         .formStyle(.grouped)
@@ -91,6 +83,9 @@ struct ZoteroSettingsView: View {
         } message: { message in
             Text(message)
         }
+        .onChange(of: apiKeyText) { _, _ in saveCredential() }
+        .onChange(of: libraryIDText) { _, _ in saveConfig() }
+        .onChange(of: zoteroDirText) { _, _ in saveConfig() }
     }
 
     // MARK: - Test Connection row
@@ -146,17 +141,6 @@ struct ZoteroSettingsView: View {
         try? config.save(to: containerDirectory)
     }
 
-    /// Save both the secret (Keychain) and non-secret (JSON) halves, then close
-    /// the Settings window. `dismiss` covers a sheet-presented case; the
-    /// `NSApp.keyWindow` fallback covers the `Settings` scene itself, which
-    /// isn't a SwiftUI "presentation" `dismiss` necessarily unwinds.
-    private func saveAndClose() {
-        saveCredential()
-        saveConfig()
-        dismiss()
-        NSApp.keyWindow?.close()
-    }
-
     private func chooseDirectory() {
         guard let url = WikiFilePanels.chooseDirectory(
             title: "Choose Zotero Folder", prompt: "Choose"
@@ -165,8 +149,6 @@ struct ZoteroSettingsView: View {
     }
 
     private func testConnection() {
-        saveCredential()
-        saveConfig()
         let config = ZoteroClient.Config(
             libraryID: libraryIDText.trimmingCharacters(in: .whitespacesAndNewlines),
             apiKey: apiKeyText)

--- a/Sources/WikiFS/ZoteroSettingsView.swift
+++ b/Sources/WikiFS/ZoteroSettingsView.swift
@@ -167,6 +167,6 @@ struct ZoteroSettingsView: View {
     }
 
     private enum Metrics {
-        static let width: CGFloat = 420
+        static let width: CGFloat = 460
     }
 }


### PR DESCRIPTION
## Summary

Removes the explicit "Save" button from `ZoteroSettingsView` and replaces it with `.onChange(of:)` modifiers that persist each field immediately as the user types.

## Changes

- **Auto-save**: `.onChange(of: apiKeyText)` writes to Keychain on every keystroke; `.onChange(of: libraryIDText)` and `.onChange(of: zoteroDirText)` write to the config JSON
- **Removed** `saveAndClose()` method and the "Save" button (including `.keyboardShortcut(.defaultAction)`)
- **Removed** `@Environment(\.dismiss)` (only used by `saveAndClose()`)
- **Cleaned up** `testConnection()` — no longer calls redundant `saveCredential()` / `saveConfig()` since the fields are already persisted
- **Updated** the doc comment to describe the new auto-save behavior

## Motivation

No data can be lost on window close (`⌘W` / red close button) — every edit is committed immediately. The UX mirrors modern macOS settings where changes take effect without an explicit save step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)