### PR TITLE
Fix stale-selection crash in vendored Textual (localCharacterRange OOB)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -106,6 +106,12 @@ make three localized edits (`plans/link-context-menus.md`).
 - `…/AppKit/NSTextInteractionView.swift` — right-click whole-link selection +
   link-menu builder; refactored `makeContextMenu`.
 - `…/AppKit/AppKitTextInteractionOverlay.swift` — threads the env value.
+- `…/TextLayout/TextLayoutCollection+Positioning.swift` — `localCharacterRange(at:)`
+  clamps each IndexPath level instead of trapping when a stale selection (held
+  across a markdown re-render / text replacement) indexes past the layout
+  structure. Fixes an `EXC_BREAKPOINT` crash from `setLayoutCollection` →
+  `reconcileRange` → `reconcilePosition` reaching the primitive with a stale
+  `IndexPath`. Only the out-of-bounds path changes; valid indexes are unchanged.
 - The manifest is byte-identical to upstream (no `testTarget` patch).
 
 **Why it's probably fine.** The diff is tiny and isolated to the link-menu
@@ -113,8 +119,9 @@ feature; it does not change Textual's rendering or selection behavior for
 non-link right-clickes. The vendored tree is a faithful copy of upstream minus
 `.git`, build artifacts, and the `Examples/` tree.
 
-**To re-sync upstream.** Diff the six files above against a fresh checkout of the
+**To re-sync upstream.** Diff the seven files above against a fresh checkout of the
 new version, port the edits, bump the recorded rev here. Do NOT re-point
 `Package.swift` at a remote — carrying the fork is the point.
 
-Recorded 2026-06-22 (link-context-menus PR).
+Recorded 2026-06-22 (link-context-menus PR). `localCharacterRange` bounds clamp
+added 2026-06-23 (stale-selection crash fix).

--- a/Packages/Textual/Sources/Textual/Internal/TextInteraction/Shared/TextLayout/TextLayoutCollection+Positioning.swift
+++ b/Packages/Textual/Sources/Textual/Internal/TextInteraction/Shared/TextLayout/TextLayoutCollection+Positioning.swift
@@ -75,10 +75,20 @@
     }
 
     func localCharacterRange(at indexPath: IndexPath) -> Range<Int> {
-      let line = layouts[indexPath.layout].lines[indexPath.line]
-      return line.runs[indexPath.run]
-        .slices[indexPath.runSlice]
-        .characterRange
+      // A stale IndexPath — e.g. a selection held across a text replacement —
+      // can point past the current layout structure (same layout count, but
+      // fewer lines/runs/slices). Clamp each level rather than trap on an
+      // out-of-bounds subscript. Selection reconciliation then lands on a
+      // nearby valid position instead of crashing.
+      guard !layouts.isEmpty else { return 0..<0 }
+      let layout = layouts[min(indexPath.layout, layouts.count - 1)]
+      guard !layout.lines.isEmpty else { return 0..<0 }
+      let line = layout.lines[min(indexPath.line, layout.lines.count - 1)]
+      guard !line.runs.isEmpty else { return 0..<0 }
+      let run = line.runs[min(indexPath.run, line.runs.count - 1)]
+      guard !run.slices.isEmpty else { return 0..<0 }
+      let slice = run.slices[min(indexPath.runSlice, run.slices.count - 1)]
+      return slice.characterRange
     }
 
     func layoutDirection(at indexPath: IndexPath) -> LayoutDirection {


### PR DESCRIPTION
Crash: EXC_BREAKPOINT in TextLayoutCollection.localCharacterRange(at:)
reached via setLayoutCollection -> reconcileRange -> reconcilePosition.
A selection held across a markdown re-render keeps an IndexPath for the
old text; when the layout collection is replaced, reconciling that stale
IndexPath indexes past the (fewer) lines/runs/slices and traps.
reconcileRange only guarded layout count, not the per-slice structure.

Fix: make localCharacterRange(at:) bounds-safe — clamp each IndexPath
level instead of subscripting blindly. Valid indexes are unchanged; an
out-of-bounds index now lands on a nearby valid slice (and an empty
collection yields 0..<0, which position(at:localCharacterIndex:) handles
via its existing > 0 early return). Documented in ISSUES.md (fork list).

Co-Authored-By: Claude <noreply@anthropic.com>
