### PR TITLE
feat(agent): seatbelt write-whitelist sandbox for the spawned agent

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -69,6 +69,7 @@ load-bearing for the app to function.
 | [`SWIFTUI-RULES.md`](SWIFTUI-RULES.md) | Hard-won SwiftUI/macOS rules. Apply when writing or reviewing any view. |
 | [`CLAUDE.md`](CLAUDE.md) | Working agreement (docs, skills to use, PR rules). |
 | [`ISSUES.md`](ISSUES.md) | Known limitations we've chosen to live with (with context to revisit), e.g. the ~5s replicated-File-Provider read-after-write window. |
+| [`plans/sandbox-agent.md`](plans/sandbox-agent.md) | **Agent seatbelt sandbox.** Confines the spawned agent's filesystem WRITES to a strict allowlist (per-run scratch dir + active wiki DB) via macOS's seatbelt (`sandbox-exec`). Provider-agnostic, macOS 15+, opt-in. Reads/network/exec stay open; the provider's config/temp are relocated into the scratch dir. Default-deny writes → no backdoors, no credential tampering, cross-wiki DB confinement. |
 
 ## Status
 
@@ -86,6 +87,16 @@ features below are merged to `main` (single-branch repo, ready for developer
 handoff). 341 tests green; clean signed bundle (app + appex + `wikictl`).**
 
 **Post-completion features (also on `main`):**
+- **Agent seatbelt sandbox (write whitelist)** — opt-in (Settings → Agent → Sandbox)
+  confines the spawned agent's filesystem WRITES to a strict allowlist via macOS's
+  seatbelt (`sandbox-exec`): only the per-run scratch dir + the active wiki's SQLite DB
+  (+ `-wal`/`-shm`/`-journal`) are writable; reads/network/exec stay open. Provider-
+  agnostic (wraps any `AgentCommandConfig` executable). The provider's config/temp are
+  relocated into the scratch dir (`CLAUDE_CONFIG_DIR`, `TMPDIR`). Default-deny writes
+  → no backdoors/credential-tampering, and cross-wiki DB confinement for free. Off by
+  default (byte-identical runs until toggled). New `SandboxConfig` / `SandboxProfile`;
+  `OperationCommand` gains a `sandbox:` param. 19 new tests (989 green). See
+  `plans/sandbox-agent.md`.
 - **File filter + batch ingest** — the Files section has a filter picker
   (All / Ready / Ingested) and a "Select…" button that enables batch mode with
   checkboxes. Selected files are ingested in a SINGLE agent run — all sources staged

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,56 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-24 — Agent seatbelt sandbox (write whitelist)
+
+Implemented `plans/sandbox-agent.md`. Opt-in (off by default) confinement of the
+spawned agent process's filesystem **writes** to a strict allowlist via the macOS
+seatbelt (`/usr/bin/sandbox-exec`). Provider-agnostic; macOS 15+.
+
+- **What's fenced:** when enabled, every agent spawn (Ingest / Query / Lint +
+  interactive Query) runs so the agent AND every child it spawns (`wikictl`, `node`,
+  bash) can write ONLY the per-run scratch dir + the active wiki's `<ulid>.sqlite`
+  (+ `-wal`/`-shm`/`-journal`). Reads, all network, and process exec stay OPEN (the
+  provider still reaches its LLM API and runs `wikictl` unchanged). Default-deny writes
+  → no backdoors/credential-tampering, and cross-wiki DB confinement for free.
+- **Why seatbelt, not Apple Container:** Apple Container needs macOS 26 AND runs a
+  Linux container where the macOS `wikictl` binary cannot run. The seatbelt keeps
+  everything native macOS and is inherited across fork/exec.
+- **Composes around the provider:** the seatbelt wraps whatever
+  `AgentCommandConfig` executable is set (`sandbox-exec -p <profile> -D HOME=… -D
+  SCRATCH_DIR=… -D WIKI_DB=… -- <provider> …`); swapping providers needs no profile
+  change. The profile is **generated in Swift** (`SandboxProfile.generate`, pure) and
+  passed via `sandbox-exec -p`.
+- **Provider self-writes relocated** into the scratch dir (`CLAUDE_CONFIG_DIR`,
+  `TMPDIR`) so the allowlist stays tiny. `WIKI_DB` is NOT conflated: the `-D
+  WIKI_DB=<path>` is a profile param (not in the child env); the `WIKI_DB=<ulid>` env
+  var `wikictl` reads is unchanged.
+- **Byte-identical when off:** `OperationCommand.build`/`buildInteractiveQuery` gained
+  an optional `sandbox: SandboxInvocation? = nil`; nil reproduces today's argv/env
+  exactly. New `SandboxConfig` (`sandbox-config.json`) + `SandboxProfile` mirror the
+  `AgentCommandConfig` config pattern. Settings → Agent has a new "Sandbox" section;
+  Help → Command Template reflects the sandbox when on (profile abbreviated).
+- **Tests:** 19 new (`SandboxConfigTests`, `SandboxProfileTests`,
+  `SandboxedOperationCommandTests` — config round-trip/missing/corrupt, profile
+  skeleton + sidecars + extra-path splicing/tilde/drop, AC.1/AC.2 argv, relocation env
+  present-on/absent-off, prefix-args-after-`--`). 989 tests pass.
+- **Live AC.6 verified:** ran the real generated profile through `/usr/bin/sandbox-exec`
+  — writes inside the scratch dir + to the DB path are ALLOWED; writes to `~/.zshrc` and
+  unrelated dirs are DENIED. This also surfaced and fixed the **symlink trap**: seatbelt
+  `subpath`/`literal` match the canonical path, so a symlinked path (e.g. `/tmp` →
+  `/private/tmp`) makes the allow silently fail. The core layer (`SandboxProfile.invocation`)
+  now canonicalizes the scratch dir, DB path, and every user extra-allowed path with
+  `realpath(3)` — the kernel's own resolver (Foundation's `URL.resolvingSymlinksInPath()`
+  is unreliable and does NOT resolve `/tmp`); 2 regression tests guard it.
+- **Review:** post-hoc `plan-reviewer` pass (on `glm-5.2`, which avoids the thinking-mode
+  `tool_choice` failure that blocked earlier reviews) — no critical/high findings. Fixed:
+  documented `CLAUDE_CONFIG_DIR`/`TMPDIR` as app-owned when sandbox on (Medium); moved
+  symlink resolution into the tested core layer + added tests (Low); added a `WIKI_DB`
+  env-var-not-clobbered assertion (Low). Rebutted the `-D` value-escaping note as latent
+  (app-controlled paths can't contain bad chars; user paths are escaped).
+- **Manual gate pending:** AC.5 — a live `make run` with the sandbox toggled on,
+  confirming a Query completes (scratch + `wikictl` DB writes work end-to-end in-app).
+
 ## 2026-06-24 — SourceWebView (WKWebView) gets the same "Add as Source" menu
 
 Extended `plans/url-context-menu-add.md` to the WKWebView large-source reader,

--- a/Sources/WikiFS/AgentCommandSettingsView.swift
+++ b/Sources/WikiFS/AgentCommandSettingsView.swift
@@ -2,14 +2,17 @@ import SwiftUI
 import WikiFSCore
 
 /// Settings → Agent tab: configure the agent executable, prefix arguments,
-/// model override, and extra environment variables. Mirrors `ZoteroSettingsView`:
-/// a `Form` whose fields persist immediately via `.onChange(of:)` — no explicit
-/// save step, so a value is never lost when the Settings window closes.
+/// model override, extra environment variables, and the optional seatbelt sandbox.
+/// Mirrors `ZoteroSettingsView`: a `Form` whose fields persist immediately via
+/// `.onChange(of:)` — no explicit save step, so a value is never lost when the
+/// Settings window closes.
 struct AgentCommandSettingsView: View {
     @State private var executable: String
     @State private var prefixArguments: String
     @State private var modelOverride: String
     @State private var extraEnvironment: String
+    @State private var sandboxEnabled: Bool
+    @State private var extraAllowedPaths: String
 
     let containerDirectory: URL
 
@@ -20,6 +23,9 @@ struct AgentCommandSettingsView: View {
         _prefixArguments = State(initialValue: config.prefixArguments)
         _modelOverride = State(initialValue: config.modelOverride)
         _extraEnvironment = State(initialValue: config.extraEnvironment)
+        let sandbox = SandboxConfig.load(from: containerDirectory)
+        _sandboxEnabled = State(initialValue: sandbox.enabled)
+        _extraAllowedPaths = State(initialValue: sandbox.extraAllowedPaths)
     }
 
     var body: some View {
@@ -40,10 +46,19 @@ struct AgentCommandSettingsView: View {
                 } header: {
                     Text("Extra Environment")
                 } footer: {
-                    Text("KEY=VALUE, one per line. WIKI_ROOT and WIKI_DB are always set by the app and cannot be overridden.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("KEY=VALUE, one per line. WIKI_ROOT and WIKI_DB are always set by the app and cannot be overridden.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if sandboxEnabled {
+                            Text("While the sandbox is on, the app also sets CLAUDE_CONFIG_DIR and TMPDIR (redirecting the provider's config/temp into the scratch dir); any value you set for those keys here is overridden.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
+
+                sandboxSection
             }
             .formStyle(.grouped)
 
@@ -56,16 +71,54 @@ struct AgentCommandSettingsView: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 10)
         }
-        .onChange(of: executable) { _, _ in save() }
-        .onChange(of: prefixArguments) { _, _ in save() }
-        .onChange(of: modelOverride) { _, _ in save() }
-        .onChange(of: extraEnvironment) { _, _ in save() }
+        .onChange(of: executable) { _, _ in saveCommand() }
+        .onChange(of: prefixArguments) { _, _ in saveCommand() }
+        .onChange(of: modelOverride) { _, _ in saveCommand() }
+        .onChange(of: extraEnvironment) { _, _ in saveCommand() }
+        .onChange(of: sandboxEnabled) { _, _ in saveSandbox() }
+        .onChange(of: extraAllowedPaths) { _, _ in saveSandbox() }
+    }
+
+    // MARK: - Sandbox section
+
+    /// The seatbelt section. The sandbox confines the spawned agent's filesystem
+    /// WRITES to a strict allowlist (the per-run scratch dir + the active wiki's
+    /// database). Reads and network are unaffected. It is provider-agnostic — the
+    /// seatbelt wraps whatever executable is set above.
+    @ViewBuilder private var sandboxSection: some View {
+        Section {
+            Toggle("Confine agent writes (macOS seatbelt)", isOn: $sandboxEnabled)
+
+            if sandboxEnabled {
+                TextEditor(text: $extraAllowedPaths)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(minHeight: 64)
+            }
+        } header: {
+            Text("Sandbox")
+        } footer: {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(sandboxEnabled
+                     ? "The agent can write ONLY the active wiki's database and its per-run scratch directory; the provider's config and temp are redirected into the scratch dir automatically. Reads and network are unaffected."
+                     : "When enabled, the spawned agent is wrapped in macOS's seatbelt (sandbox-exec) so its filesystem writes are confined to the wiki database and a per-run scratch directory.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if sandboxEnabled {
+                    Text("Additional paths the agent may write to — one per line. `~` is expanded to your home. These can only widen the allowlist, never remove the core scratch/database paths.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text("`/usr/bin/sandbox-exec` is Apple's long-stable, widely-used seatbelt CLI (Claude Code, Codex CLI, and SwiftPM depend on it). macOS 15+.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
     }
 
     // MARK: - Actions
 
-    /// Persist the current fields immediately (auto-save).
-    private func save() {
+    /// Persist the command fields immediately (auto-save).
+    private func saveCommand() {
         let config = AgentCommandConfig(
             executable: executable,
             prefixArguments: prefixArguments,
@@ -74,13 +127,27 @@ struct AgentCommandSettingsView: View {
         try? config.save(to: containerDirectory)
     }
 
-    /// Restore the built-in defaults and persist them.
+    /// Persist the sandbox fields immediately (auto-save) to a separate file.
+    private func saveSandbox() {
+        let config = SandboxConfig(
+            enabled: sandboxEnabled,
+            extraAllowedPaths: extraAllowedPaths)
+        try? config.save(to: containerDirectory)
+    }
+
+    /// Restore the built-in defaults and persist both configs.
     private func resetToDefault() {
-        let defaults = AgentCommandConfig.default
-        executable = defaults.executable
-        prefixArguments = defaults.prefixArguments
-        modelOverride = defaults.modelOverride
-        extraEnvironment = defaults.extraEnvironment
-        save()
+        let cmdDefaults = AgentCommandConfig.default
+        executable = cmdDefaults.executable
+        prefixArguments = cmdDefaults.prefixArguments
+        modelOverride = cmdDefaults.modelOverride
+        extraEnvironment = cmdDefaults.extraEnvironment
+
+        let sandboxDefaults = SandboxConfig.default
+        sandboxEnabled = sandboxDefaults.enabled
+        extraAllowedPaths = sandboxDefaults.extraAllowedPaths
+
+        saveCommand()
+        saveSandbox()
     }
 }

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -433,6 +433,7 @@ final class AgentLauncher {
             return
         }
 
+        let sandbox = resolveSandboxInvocation(wikiID: wikiID, scratch: scratch, dir: dir)
         let command = OperationCommand.build(
             operation: operation,
             wikiRoot: wikiRoot,
@@ -441,7 +442,8 @@ final class AgentLauncher {
             scratchDirectory: scratch.path,
             wikictlDirectory: wikictlDirectory,
             resolvedExecutable: resolvedPath,
-            command: agentConfig
+            command: agentConfig,
+            sandbox: sandbox
         )
 
         // RESERVE per-run metadata. `isRunning` is already `true` (the slot set it on
@@ -608,6 +610,7 @@ final class AgentLauncher {
         }
 
         let operation = WikiOperation.queryConversation(stateFilePath: stateFilePath)
+        let sandbox = resolveSandboxInvocation(wikiID: wikiID, scratch: scratch, dir: dir)
         let command = OperationCommand.buildInteractiveQuery(
             operation: operation,
             wikiRoot: wikiRoot,
@@ -616,7 +619,8 @@ final class AgentLauncher {
             scratchDirectory: scratch.path,
             wikictlDirectory: wikictlDirectory,
             resolvedExecutable: resolvedPath,
-            command: agentConfig
+            command: agentConfig,
+            sandbox: sandbox
         )
 
         // RESERVE per-run metadata. `isRunning` is already `true` (slot acquire).
@@ -916,5 +920,63 @@ final class AgentLauncher {
         } catch {
             return nil
         }
+    }
+
+    // MARK: - Seatbelt sandbox
+
+    /// Resolve the seatbelt sandbox invocation for this spawn, or `nil` to run
+    /// un-sandboxed. Loads `SandboxConfig` FRESH at spawn (so Settings changes apply
+    /// on the next run, mirroring `AgentCommandConfig`). When enabled, resolves the
+    /// per-run scratch path + the active wiki's DB path and creates the provider's
+    /// relocation subdirs inside scratch (the app process is unsandboxed; only the
+    /// spawned child is confined). Returns `nil` (fail-open) when disabled OR when a
+    /// required path can't be resolved — logged. Fail-open is acceptable because the
+    /// feature is opt-in and default-off.
+    private func resolveSandboxInvocation(
+        wikiID: String,
+        scratch: URL,
+        dir: URL
+    ) -> SandboxProfile.SandboxInvocation? {
+        let sandboxConfig = SandboxConfig.load(from: dir)
+        guard sandboxConfig.enabled else { return nil }
+
+        // HOME for the `-D HOME` profile param. Read from the environment the child
+        // will inherit (fall back to the process home). Forwarded for forward-compat
+        // and debugging; the current whitelist profile does not reference it.
+        let homePath = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+
+        // The active wiki's SQLite DB path mirrors `WikiResolver.databaseURL(for:)`:
+        // `<container>/<ulid>.sqlite`. `dir` is the App Group container the DB lives in.
+        // Symlink resolution is performed inside `SandboxProfile.invocation` (the
+        // tested core layer) so the canonical path reaches the seatbelt profile.
+        let dbPath = dir.appendingPathComponent("\(wikiID).sqlite", isDirectory: false).path
+
+        // Fail-open if any required path is empty/relative (misconfiguration).
+        guard !scratch.path.isEmpty, scratch.path.hasPrefix("/"),
+              !dbPath.isEmpty, dbPath.hasPrefix("/") else {
+            DebugLog.agent("sandbox: could not resolve scratch/db path — running UNSANDBOXED")
+            return nil
+        }
+
+        createSandboxRelocationDirs(in: scratch)
+
+        let invocation = SandboxProfile.invocation(
+            homePath: homePath,
+            scratchDir: scratch.path,
+            wikiDBPath: dbPath,
+            extraAllowedPaths: sandboxConfig.parsedExtraAllowedPaths()
+        )
+        DebugLog.agent("sandbox: enabled — confining agent writes to scratch + \(dbPath)")
+        return invocation
+    }
+
+    /// Create the provider self-write relocation subdirs inside scratch so they land
+    /// inside the seatbelt allowlist. Best-effort: failure (e.g. scratch unwritable)
+    /// is surfaced later by the provider's own write errors.
+    private func createSandboxRelocationDirs(in scratch: URL) {
+        let claudeConfig = scratch.appendingPathComponent(".claude-config", isDirectory: true)
+        let tmp = scratch.appendingPathComponent(".tmp", isDirectory: true)
+        try? FileManager.default.createDirectory(at: claudeConfig, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
     }
 }

--- a/Sources/WikiFSCore/ClaudePromptHelp.swift
+++ b/Sources/WikiFSCore/ClaudePromptHelp.swift
@@ -59,6 +59,7 @@ public enum ClaudePromptHelp {
   }
 
   public static var commandTemplate: String {
+    let sandbox = currentSandboxInvocation()
     let command = OperationCommand.build(
       operation: curatedIngest,
       wikiRoot: wikiRootPlaceholder,
@@ -68,18 +69,59 @@ public enum ClaudePromptHelp {
       wikictlDirectory: wikictlDirectoryPlaceholder,
       resolvedExecutable: "claude",
       command: AgentCommandConfig.default,
+      sandbox: sandbox,
       baseEnvironment: ["PATH": "<inherited PATH>"])
 
-    return """
-      cwd: \(command.currentDirectoryPath)
-      env:
-        WIKI_ROOT=\(command.environment["WIKI_ROOT"] ?? "")
-        WIKI_DB=\(command.environment["WIKI_DB"] ?? "")
-        PATH=\(command.environment["PATH"] ?? "")
+    var envPairs: [(String, String)] = [
+      ("WIKI_ROOT", command.environment["WIKI_ROOT"] ?? ""),
+      ("WIKI_DB", command.environment["WIKI_DB"] ?? ""),
+      ("PATH", command.environment["PATH"] ?? ""),
+    ]
+    // When sandboxed, the relocation env is part of the real invocation surface.
+    if sandbox != nil {
+      envPairs.append(("CLAUDE_CONFIG_DIR", command.environment["CLAUDE_CONFIG_DIR"] ?? ""))
+      envPairs.append(("TMPDIR", command.environment["TMPDIR"] ?? ""))
+    }
 
-      argv:
-      \(renderCommand(command))
-      """
+    // Build explicitly (no multi-line literal) so the dynamic env list has consistent
+    // indentation regardless of how many keys are present.
+    var lines: [String] = []
+    lines.append("cwd: \(command.currentDirectoryPath)")
+    lines.append("env:")
+    for (key, value) in envPairs {
+      lines.append("    \(key)=\(value)")
+    }
+    lines.append("")
+    lines.append("argv:")
+    lines.append(renderCommandTemplate(command))
+    return lines.joined(separator: "\n")
+  }
+
+  /// The seatbelt sandbox invocation that reflects the user's current SandboxConfig
+  /// (loaded from the App Group container), built with placeholder paths so the Help
+  /// → Command Template previews the real argv shape. `nil` when the sandbox is off.
+  private static func currentSandboxInvocation() -> SandboxProfile.SandboxInvocation? {
+    guard let dir = try? DatabaseLocation.appGroupContainerDirectory() else { return nil }
+    let config = SandboxConfig.load(from: dir)
+    guard config.enabled else { return nil }
+    return SandboxProfile.invocation(
+      homePath: "<HOME>",
+      scratchDir: scratchDirectoryPlaceholder,
+      wikiDBPath: "<container>/\(wikiIDPlaceholder).sqlite",
+      extraAllowedPaths: config.parsedExtraAllowedPaths())
+  }
+
+  /// Render the argv for the Command Template, abbreviating the (long) seatbelt
+  /// profile string to `<profile>` for legibility when the run is sandboxed.
+  private static func renderCommandTemplate(_ command: OperationCommand) -> String {
+    var parts = [command.executable] + command.arguments
+    if command.executable == OperationCommand.sandboxExecutable,
+       let pIndex = parts.firstIndex(of: "-p"),
+       pIndex + 1 < parts.count {
+      // The first `-p` is sandbox-exec's profile arg (it precedes `-D` / `--`).
+      parts[pIndex + 1] = "<profile>"
+    }
+    return parts.map(shellQuoted).joined(separator: " \\\n  ")
   }
 
   private static var tinyIngest: WikiOperation {

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -42,6 +42,11 @@ public struct OperationCommand: Equatable, Sendable {
     ///     (e.g. `/opt/homebrew/bin/claude`). Preflight happens in AgentLauncher.
     ///   - command: the agent command config (prefix args, model override, extra
     ///     env). Default reproduces today's `claude -p …` exactly.
+    ///   - sandbox: when non-nil, wrap the invocation in `/usr/bin/sandbox-exec`
+    ///     with the seatbelt profile that confines writes to the scratch dir + active
+    ///     wiki DB (`plans/sandbox-agent.md`). Default `nil` reproduces today's run
+    ///     byte-for-byte. The relocation env (`CLAUDE_CONFIG_DIR`, `TMPDIR`) is set
+    ///     only when non-nil; it never clobbers `WIKI_ROOT`/`WIKI_DB`/`PATH`.
     ///   - baseEnvironment: the parent environment to inherit (default the current
     ///     process's). Injected so tests can pin a known PATH.
     public static func build(
@@ -53,6 +58,7 @@ public struct OperationCommand: Equatable, Sendable {
         wikictlDirectory: String,
         resolvedExecutable: String = "claude",
         command: AgentCommandConfig = .default,
+        sandbox: SandboxProfile.SandboxInvocation? = nil,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
     ) -> OperationCommand {
         // User env first, then app-owned keys (authoritative).
@@ -85,9 +91,17 @@ public struct OperationCommand: Equatable, Sendable {
             arguments.append(contentsOf: ["--agents", agentsJSON])
         }
 
-        return OperationCommand(
-            executable: resolvedExecutable,
+        let (executable, wrappedArguments) = applySandbox(
+            to: resolvedExecutable,
             arguments: arguments,
+            environment: &environment,
+            scratchDirectory: scratchDirectory,
+            sandbox: sandbox
+        )
+
+        return OperationCommand(
+            executable: executable,
+            arguments: wrappedArguments,
             environment: environment,
             currentDirectoryPath: scratchDirectory
         )
@@ -105,6 +119,7 @@ public struct OperationCommand: Equatable, Sendable {
         wikictlDirectory: String,
         resolvedExecutable: String = "claude",
         command: AgentCommandConfig = .default,
+        sandbox: SandboxProfile.SandboxInvocation? = nil,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
     ) -> OperationCommand {
         var environment = baseEnvironment
@@ -131,11 +146,53 @@ public struct OperationCommand: Equatable, Sendable {
             "--dangerously-skip-permissions",
         ])
 
-        return OperationCommand(
-            executable: resolvedExecutable,
+        let (executable, wrappedArguments) = applySandbox(
+            to: resolvedExecutable,
             arguments: arguments,
+            environment: &environment,
+            scratchDirectory: scratchDirectory,
+            sandbox: sandbox
+        )
+
+        return OperationCommand(
+            executable: executable,
+            arguments: wrappedArguments,
             environment: environment,
             currentDirectoryPath: scratchDirectory
         )
+    }
+
+    // MARK: - Seatbelt wrapping
+
+    /// The macOS seatbelt executable. Always present at this absolute path on macOS
+    /// 15+ (deprecated but functional; no entitlement needed by an un-sandboxed app).
+    static let sandboxExecutable = "/usr/bin/sandbox-exec"
+
+    /// When `sandbox` is non-nil, rewrite the invocation so the provider runs inside
+    /// `/usr/bin/sandbox-exec -p <profile> -D … -- <provider>`, and relocate the
+    /// provider's own config/temp into the scratch dir so they land inside the
+    /// allowlist. When `nil`, returns the inputs unchanged (byte-identical to a
+    /// pre-sandbox run). Pure; mutates `environment` only to add the relocation keys.
+    private static func applySandbox(
+        to resolvedExecutable: String,
+        arguments: [String],
+        environment: inout [String: String],
+        scratchDirectory: String,
+        sandbox: SandboxProfile.SandboxInvocation?
+    ) -> (executable: String, arguments: [String]) {
+        guard let sandbox else { return (resolvedExecutable, arguments) }
+
+        // Relocate the provider's self-writes into the writable scratch zone so the
+        // profile allowlist stays tiny. These keys are distinct from WIKI_ROOT /
+        // WIKI_DB / PATH, so they don't clobber the app-owned block.
+        environment["CLAUDE_CONFIG_DIR"] = scratchDirectory + "/.claude-config"
+        environment["TMPDIR"] = scratchDirectory + "/.tmp"
+
+        var head: [String] = ["-p", sandbox.profile]
+        for (key, value) in sandbox.defines {
+            head.append(contentsOf: ["-D", "\(key)=\(value)"])
+        }
+        head.append(contentsOf: ["--", resolvedExecutable])
+        return (sandboxExecutable, head + arguments)
     }
 }

--- a/Sources/WikiFSCore/SandboxConfig.swift
+++ b/Sources/WikiFSCore/SandboxConfig.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// The macOS seatbelt (`sandbox-exec`) sandbox settings for the spawned agent.
+///
+/// When `enabled`, `AgentLauncher` wraps the provider invocation in
+/// `/usr/bin/sandbox-exec` with a **default-deny write whitelist** profile (generated
+/// by `SandboxProfile`): only the per-run scratch dir and the active wiki's SQLite DB
+/// are writable; reads, network, and process execution stay open. The provider's own
+/// config/temp are relocated into the scratch dir so the allowlist stays tiny and
+/// provider-agnostic. See `plans/sandbox-agent.md`.
+///
+/// App-wide (one config for all wikis) and opt-in (`enabled` defaults to `false`),
+/// exactly like `AgentCommandConfig`. Follows the same `Codable` + atomic
+/// JSON-in-App-Group-container pattern as `ZoteroConfig` / `AgentCommandConfig` /
+/// `WikiRegistry`. Loaded fresh at spawn time so Settings changes apply on the next
+/// run without a restart.
+public struct SandboxConfig: Codable, Equatable, Sendable {
+
+    /// Off by default — the sandbox is opt-in. When `true`, the next agent spawn is
+    /// confined to the write whitelist.
+    public var enabled: Bool
+
+    /// Additional paths the agent may write to, as `KEY`-less `PATH` lines (one
+    /// absolute path per line). These are **additive**: they can only WIDEN the
+    /// allowlist, never remove the scratch-dir / active-DB core (by design — removing
+    /// either would break the agent). `~` is expanded; non-absolute entries are
+    /// dropped (the seatbelt does not understand `~`).
+    public var extraAllowedPaths: String
+
+    public init(enabled: Bool = false, extraAllowedPaths: String = "") {
+        self.enabled = enabled
+        self.extraAllowedPaths = extraAllowedPaths
+    }
+
+    /// The default config reproduces an OFF (un-sandboxed) run exactly. Used when no
+    /// `sandbox-config.json` exists yet.
+    public static let `default` = SandboxConfig()
+
+    /// The config's JSON filename inside the App Group container.
+    public static let fileName = "sandbox-config.json"
+
+    // MARK: - Persistence
+
+    /// Load from `sandbox-config.json` in `directory`. Missing or corrupt file
+    /// degrades to `.default` (sandbox off) rather than throwing — same fresh-install
+    /// behavior as `AgentCommandConfig.load` / `ZoteroConfig.load`.
+    public static func load(from directory: URL) -> SandboxConfig {
+        let url = directory.appendingPathComponent(fileName, isDirectory: false)
+        guard let data = try? Data(contentsOf: url) else { return .default }
+        guard let config = try? JSONDecoder().decode(SandboxConfig.self, from: data) else {
+            print("SandboxConfig: corrupt \(fileName), starting default")
+            return .default
+        }
+        return config
+    }
+
+    /// Persist to `sandbox-config.json` in `directory`, atomically, pretty-printed +
+    /// sorted keys (matches `WikiRegistry.save`'s reviewable-diff rationale).
+    public func save(to directory: URL) throws {
+        let url = directory.appendingPathComponent(SandboxConfig.fileName, isDirectory: false)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try data.write(to: url, options: .atomic)
+    }
+
+    // MARK: - Derived values
+
+    /// Parse `extraAllowedPaths` into absolute path strings ready for the seatbelt
+    /// profile. Blank lines are skipped; a leading `~` (or `~user`) is expanded via
+    /// `AgentCommandConfig.expandTilde`; any entry that is not absolute AFTER
+    /// expansion is dropped (the seatbelt needs a concrete absolute path — a `~` it
+    /// cannot resolve, or a relative path, is meaningless to it).
+    public func parsedExtraAllowedPaths() -> [String] {
+        var paths: [String] = []
+        for line in extraAllowedPaths.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            let expanded = AgentCommandConfig.expandTilde(trimmed)
+            // Drop non-absolute entries (relative paths, or unexpanded `~`).
+            guard expanded.hasPrefix("/") else { continue }
+            paths.append(expanded)
+        }
+        return paths
+    }
+}

--- a/Sources/WikiFSCore/SandboxProfile.swift
+++ b/Sources/WikiFSCore/SandboxProfile.swift
@@ -1,0 +1,155 @@
+import Darwin
+import Foundation
+
+/// Pure generator for the macOS seatbelt (`sandbox-exec`) profile that confines the
+/// spawned agent's filesystem writes to a strict allowlist.
+///
+/// The profile is **allow-by-default for reads, network, and process execution**, but
+/// **default-deny for writes** — `(allow default)` keeps the provider running normally
+/// (it can read, exec, and use the network to reach its LLM API), then `(deny
+/// file-write*)` is overridden by explicit `(allow file-write* …)` rules for ONLY:
+///
+/// - the per-run scratch dir (a directory tree → `subpath`),
+/// - the active wiki's `<ulid>.sqlite` + its SQLite `-wal` / `-shm` / `-journal`
+///   sidecars (exact files → `literal`),
+/// - any user `extraAllowedPaths`.
+///
+/// This is provider-agnostic: the profile never names a provider; it fences the write
+/// channel only. See `plans/sandbox-agent.md` for the threat model and the
+/// `sandbox-exec` syntax research that underpins this.
+public enum SandboxProfile {
+
+    /// The fully-resolved invocation the launcher hands to `OperationCommand` when the
+    /// sandbox is on: the profile text (one string, passed via `sandbox-exec -p`) plus
+    /// the `-D key=value` profile-parameter pairs it references. Equatable so the
+    /// pure argv-assembly in `OperationCommand` is unit-testable.
+    public struct SandboxInvocation: Equatable, Sendable {
+        /// The seatbelt profile text. One argument element (passed via
+        /// `sandbox-exec -p <profile>`).
+        public let profile: String
+        /// `sandbox-exec -D` profile-parameter pairs, in emit order. The profile
+        /// references these by `(param "<key>")`. These are profile variables — they
+        /// are NOT injected into the child process environment (so `-D WIKI_DB=<path>`
+        /// does not collide with the `WIKI_DB=<ulid>` env var `wikictl` uses).
+        public let defines: [(String, String)]
+
+        public init(profile: String, defines: [(String, String)]) {
+            self.profile = profile
+            self.defines = defines
+        }
+
+        // MARK: - Equatable (tuples aren't Equatable by default)
+        public static func == (lhs: SandboxInvocation, rhs: SandboxInvocation) -> Bool {
+            guard lhs.profile == rhs.profile, lhs.defines.count == rhs.defines.count else {
+                return false
+            }
+            return zip(lhs.defines, rhs.defines).allSatisfy { $0.0 == $1.0 && $0.1 == $1.1 }
+        }
+    }
+
+    /// The SQLite journal-mode sidecar suffixes that may be created alongside the
+    /// active wiki DB. `(WAL → -wal/-shm; DELETE/TRUNCATE/PERSIST → -journal.)`
+    static let sqliteSidecarSuffixes = ["-wal", "-shm", "-journal"]
+
+    /// Generate the seatbelt profile text. Pure `String → String` — no shell, no IO.
+    ///
+    /// - Parameters:
+    ///   - scratchDir: the per-run scratch directory absolute path (the writable cwd).
+    ///   - wikiDBPath: the active wiki's `<ulid>.sqlite` absolute file path.
+    ///   - extraAllowedPaths: additional absolute paths to allow writes to (already
+    ///     tilde-expanded and absolute-filtered by `SandboxConfig`).
+    public static func generate(
+        scratchDir: String,
+        wikiDBPath: String,
+        extraAllowedPaths: [String] = []
+    ) -> String {
+        var lines: [String] = [
+            "(version 1)",
+            "(allow default)",
+            "(deny file-write*)",
+            // The scratch dir is a directory tree.
+            "(allow file-write* (subpath (param \"SCRATCH_DIR\")))",
+            // The active wiki DB and its SQLite sidecars are exact files.
+            "(allow file-write* (literal (param \"WIKI_DB\")))",
+        ]
+        for suffix in sqliteSidecarSuffixes {
+            lines.append(
+                "(allow file-write* (literal (string-append (param \"WIKI_DB\") \"\(suffix)\")))"
+            )
+        }
+        // User-widened paths. A path that is an existing directory is matched as a
+        // subtree; anything else is matched as an exact file. Non-absolute entries
+        // are dropped defensively (the caller already filters them, but this stays
+        // robust if invoked directly).
+        for path in extraAllowedPaths {
+            guard path.hasPrefix("/") else { continue }
+            let kind = isDirectory(path) ? "subpath" : "literal"
+            lines.append("(allow file-write* (\(kind) \"\(escape(path))\"))")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Build a `SandboxInvocation` from the three spawn-time paths. The scratch dir,
+    /// DB path, and extra-allowed paths are **symlink-resolved** here, because the
+    /// seatbelt `subpath`/`literal` matchers match the CANONICAL path — a symlinked
+    /// component (e.g. `/tmp` → `/private/tmp`) makes an allow rule silently fail and
+    /// writes get denied. Keeping this resolution in the (tested) core layer guards
+    /// against a launcher regression dropping it. `extraAllowedPaths` should already
+    /// be absolute (tilde-expanded); non-absolute entries are dropped by `generate`.
+    public static func invocation(
+        homePath: String,
+        scratchDir: String,
+        wikiDBPath: String,
+        extraAllowedPaths: [String] = []
+    ) -> SandboxInvocation {
+        func realPath(_ s: String) -> String {
+            Self.canonical(s)
+        }
+        let resolvedScratch = realPath(scratchDir)
+        let resolvedDB = realPath(wikiDBPath)
+        let resolvedExtra = extraAllowedPaths.map(realPath)
+        let profile = generate(
+            scratchDir: resolvedScratch,
+            wikiDBPath: resolvedDB,
+            extraAllowedPaths: resolvedExtra
+        )
+        // NOTE: these are profile parameters, NOT child env vars. `-D WIKI_DB=<path>`
+        // is consumed by `(param "WIKI_DB")`; it does not touch the `WIKI_DB=<ulid>`
+        // env var the agent/wikictl use.
+        return SandboxInvocation(
+            profile: profile,
+            defines: [
+                ("HOME", homePath),
+                ("SCRATCH_DIR", resolvedScratch),
+                ("WIKI_DB", resolvedDB),
+            ]
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `true` if `path` exists and is a directory. Used to pick `subpath` (tree) vs
+    /// `literal` (exact file) for an extra-allowed path.
+    private static func isDirectory(_ path: String) -> Bool {
+        var isDir: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue
+    }
+
+    /// `realpath(3)` — the kernel's own canonical-path resolution, which is exactly
+    /// what the seatbelt `subpath`/`literal` matchers resolve against. Foundation's
+    /// `URL.resolvingSymlinksInPath()` is unreliable for this (it does NOT resolve
+    /// `/tmp` → `/private/tmp`); `realpath` does. Falls back to the input when the
+    /// path doesn't exist yet (`realpath` returns nil for non-existent paths), since
+    /// a non-existent path can't be symlink-resolved and the seatbelt will create it.
+    private static func canonical(_ path: String) -> String {
+        var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard let resolved = realpath(path, &buf) else { return path }
+        return String(cString: resolved)
+    }
+
+    /// Escape a path for a double-quoted SBPL string literal (backslash + quote).
+    private static func escape(_ path: String) -> String {
+        path.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Tests/WikiFSTests/SandboxConfigTests.swift
+++ b/Tests/WikiFSTests/SandboxConfigTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Tests for the seatbelt sandbox config — load/save round-trip, missing/corrupt →
+/// default, and the extra-allowed-paths parser (tilde expansion, blanks, relative
+/// drop). Mirrors `AgentCommandConfigTests`.
+struct SandboxConfigTests {
+
+  // MARK: - Defaults
+
+  @Test func defaultIsDisabledWithEmptyAllowedPaths() {
+    let config = SandboxConfig.default
+    #expect(config.enabled == false)
+    #expect(config.extraAllowedPaths == "")
+  }
+
+  @Test func defaultFileNameIsStable() {
+    #expect(SandboxConfig.fileName == "sandbox-config.json")
+  }
+
+  // MARK: - Persistence
+
+  @Test func roundTripsThroughJSON() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sbconfig-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let original = SandboxConfig(enabled: true, extraAllowedPaths: "/tmp/one\n/tmp/two")
+    try original.save(to: dir)
+
+    let loaded = SandboxConfig.load(from: dir)
+    #expect(loaded == original)
+    #expect(loaded.enabled == true)
+    #expect(loaded.extraAllowedPaths == "/tmp/one\n/tmp/two")
+  }
+
+  @Test func missingFileDegradesToDefault() {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sbconfig-missing-\(UUID().uuidString)")
+    let loaded = SandboxConfig.load(from: dir)
+    #expect(loaded == .default)
+    #expect(loaded.enabled == false)
+  }
+
+  @Test func corruptFileDegradesToDefault() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sbconfig-corrupt-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let url = dir.appendingPathComponent(SandboxConfig.fileName, isDirectory: false)
+    try "{ this is not valid json".data(using: .utf8)!.write(to: url)
+
+    let loaded = SandboxConfig.load(from: dir)
+    #expect(loaded == .default)
+    #expect(loaded.enabled == false)
+  }
+
+  // MARK: - parsedExtraAllowedPaths
+
+  @Test func parsesAbsolutePathsOnePerLine() {
+    let config = SandboxConfig(enabled: true, extraAllowedPaths: "/tmp/a\n/tmp/b\n/tmp/c")
+    #expect(config.parsedExtraAllowedPaths() == ["/tmp/a", "/tmp/b", "/tmp/c"])
+  }
+
+  @Test func skipsBlankAndWhitespaceOnlyLines() {
+    let config = SandboxConfig(enabled: true, extraAllowedPaths: "/tmp/a\n\n   \n/tmp/b")
+    #expect(config.parsedExtraAllowedPaths() == ["/tmp/a", "/tmp/b"])
+  }
+
+  @Test func expandsLeadingTilde() {
+    let config = SandboxConfig(enabled: true, extraAllowedPaths: "~/Documents\n~/.cache")
+    let paths = config.parsedExtraAllowedPaths()
+    #expect(paths.count == 2)
+    // Both must be absolute after expansion.
+    #expect(paths.allSatisfy { $0.hasPrefix("/") })
+    #expect(paths.contains { $0.hasSuffix("/Documents") })
+    #expect(paths.contains { $0.hasSuffix("/.cache") })
+  }
+
+  @Test func dropsRelativeAndUnresolvableEntries() {
+    // A bare `~` that fails to expand stays as `~` (not absolute) → dropped.
+    // Relative paths are dropped. Absolute paths survive.
+    let config = SandboxConfig(
+      enabled: true,
+      extraAllowedPaths: "relative/path\n/tmp/ok\n~/ok-sub")
+    let paths = config.parsedExtraAllowedPaths()
+    #expect(paths.contains("/tmp/ok"))
+    // `~/ok-sub` expands to an absolute path.
+    #expect(paths.contains { $0.hasSuffix("/ok-sub") })
+    // The relative entry never survives.
+    #expect(!paths.contains("relative/path"))
+  }
+}

--- a/Tests/WikiFSTests/SandboxProfileTests.swift
+++ b/Tests/WikiFSTests/SandboxProfileTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Tests for the pure seatbelt profile generator — the exact `(version 1)` /
+/// `(allow default)` / `(deny file-write*)` skeleton, the SCRATCH_DIR subpath allow,
+/// the four WIKI_DB literal allows (base + wal/shm/journal), and extra-path splicing
+/// with tilde expansion + relative junk dropping. Pure; no shell, no IO.
+struct SandboxProfileTests {
+
+  static let scratchDir = "/Users/me/Library/Caches/Self Driving Wiki-agent/UUID"
+  static let wikiDB = "/Users/me/Library/Group Containers/group.x/01WIKI.sqlite"
+
+  private func profile(_ extra: [String] = []) -> String {
+    SandboxProfile.generate(
+      scratchDir: Self.scratchDir,
+      wikiDBPath: Self.wikiDB,
+      extraAllowedPaths: extra)
+  }
+
+  // MARK: - Skeleton
+
+  @Test func startsWithVersionAndAllowDefault() {
+    let p = profile()
+    let lines = p.split(separator: "\n").map(String.init)
+    #expect(lines[0] == "(version 1)")
+    #expect(lines[1] == "(allow default)")
+    #expect(lines[2] == "(deny file-write*)")
+  }
+
+  @Test func deniesAllWritesThenReallowsScratchAndDB() {
+    let p = profile()
+    #expect(p.contains("(deny file-write*)"))
+    #expect(p.contains("(allow file-write* (subpath (param \"SCRATCH_DIR\")))"))
+    #expect(p.contains("(allow file-write* (literal (param \"WIKI_DB\")))"))
+  }
+
+  // MARK: - SQLite sidecars
+
+  @Test func allowsDBPlusWalShmJournalSidecars() {
+    let p = profile()
+    #expect(p.contains("(allow file-write* (literal (string-append (param \"WIKI_DB\") \"-wal\")))"))
+    #expect(p.contains("(allow file-write* (literal (string-append (param \"WIKI_DB\") \"-shm\")))"))
+    #expect(p.contains("(allow file-write* (literal (string-append (param \"WIKI_DB\") \"-journal\")))"))
+  }
+
+  @Test func sidecarSuffixesAreExactlyWalShmJournal() {
+    #expect(SandboxProfile.sqliteSidecarSuffixes == ["-wal", "-shm", "-journal"])
+  }
+
+  // MARK: - Extra allowed paths
+
+  @Test func splicesInValidAbsolutePathAsLiteral() {
+    // A non-existent path (not a directory) → `literal`.
+    let p = profile(["/Users/me/some-file.txt"])
+    #expect(p.contains("(allow file-write* (literal \"/Users/me/some-file.txt\"))"))
+  }
+
+  @Test func splicesInExistingDirectoryAsSubpath() {
+    // `/tmp` exists and is a directory → `subpath`.
+    let p = profile(["/tmp"])
+    #expect(p.contains("(allow file-write* (subpath \"/tmp\"))"))
+  }
+
+  @Test func dropsRelativeAndNonAbsoluteExtraPaths() {
+    let p = profile(["relative/path", "just-a-name"])
+    #expect(!p.contains("relative/path"))
+    #expect(!p.contains("just-a-name"))
+  }
+
+  @Test func escapesQuotesAndBackslashesInExtraPaths() {
+    let p = profile(["/path/with\"quote"])
+    #expect(p.contains("\\\"quote"))
+  }
+
+  // MARK: - SandboxInvocation (Equatable + defines)
+
+  @Test func invocationCarriesHomeScratchAndWikiDBDefines() {
+    let inv = SandboxProfile.invocation(
+      homePath: "/Users/me",
+      scratchDir: Self.scratchDir,
+      wikiDBPath: Self.wikiDB)
+    #expect(inv.defines.count == 3)
+    // Order matters for the argv emit.
+    #expect(inv.defines[0].0 == "HOME")
+    #expect(inv.defines[0].1 == "/Users/me")
+    #expect(inv.defines[1].0 == "SCRATCH_DIR")
+    #expect(inv.defines[1].1 == Self.scratchDir)
+    #expect(inv.defines[2].0 == "WIKI_DB")
+    #expect(inv.defines[2].1 == Self.wikiDB)
+    #expect(inv.profile == profile([]))
+  }
+
+  @Test func invocationEquatableComparesProfileAndDefines() {
+    let a = SandboxProfile.invocation(
+      homePath: "/h", scratchDir: "/s", wikiDBPath: "/d")
+    let b = SandboxProfile.invocation(
+      homePath: "/h", scratchDir: "/s", wikiDBPath: "/d")
+    let c = SandboxProfile.invocation(
+      homePath: "/h2", scratchDir: "/s", wikiDBPath: "/d")
+    #expect(a == b)
+    #expect(a != c)
+  }
+
+  // MARK: - Symlink resolution (the seatbelt matches the canonical path)
+
+  @Test func invocationResolvesSymlinkedScratchToCanonicalPath() throws {
+    // `/tmp` is a symlink to `/private/tmp` on macOS. A scratch dir created under
+    // `/tmp` must surface in the invocation as its canonical `/private/tmp/...` path,
+    // or the seatbelt `subpath` allow silently fails. Create a real dir to make the
+    // resolution observable (resolvingSymlinksInPath only resolves existing paths).
+    let symlinkScratch = "/tmp/sdw-symlink-probe-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(
+      atPath: symlinkScratch, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: symlinkScratch) }
+
+    let inv = SandboxProfile.invocation(
+      homePath: "/Users/me",
+      scratchDir: symlinkScratch,
+      wikiDBPath: "/Users/me/db.sqlite")
+
+    let resolved = try #require(inv.defines.first { $0.0 == "SCRATCH_DIR" }?.1)
+    #expect(resolved.hasPrefix("/private/tmp/"))
+    #expect(resolved.contains("sdw-symlink-probe-"))
+    // The profile references SCRATCH_DIR by param; the resolved canonical value
+    // flows in via the -D define (asserted above).
+    #expect(inv.profile.contains("(subpath (param \"SCRATCH_DIR\"))"))
+  }
+
+  @Test func invocationResolvesExtraAllowedSymlinksToo() throws {
+    let symlinkPath = "/tmp/sdw-extra-probe-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(
+      atPath: symlinkPath, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: symlinkPath) }
+
+    let inv = SandboxProfile.invocation(
+      homePath: "/Users/me",
+      scratchDir: "/Users/me/scratch",
+      wikiDBPath: "/Users/me/db.sqlite",
+      extraAllowedPaths: [symlinkPath])
+    // The canonical /private/tmp path must appear as the allow, not the /tmp form.
+    #expect(inv.profile.contains("/private/tmp/sdw-extra-probe-"))
+    #expect(!inv.profile.contains("(subpath \"\(symlinkPath)\"))"))
+  }
+}

--- a/Tests/WikiFSTests/SandboxedOperationCommandTests.swift
+++ b/Tests/WikiFSTests/SandboxedOperationCommandTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Sandbox-wrapping tests for `OperationCommand.build` / `buildInteractiveQuery`.
+/// Verifies the seatbelt argv shape (AC.2), byte-identical-when-off (AC.1), the
+/// relocation env (`CLAUDE_CONFIG_DIR`/`TMPDIR`) present-on / absent-off, and that
+/// the provider's own prefix args land AFTER `-- <providerExe>`.
+struct SandboxedOperationCommandTests {
+
+  static let resolvedRoot = "/Users/me/Library/CloudStorage/WikiFS-Research"
+  static let scratch = "/tmp/scratch-xyz"
+  static let stateFile = "/tmp/scratch-xyz/WIKI_STATE.md"
+  static let providerExe = "/opt/homebrew/bin/claude"
+  static let wikiDBPath = "/Users/me/Library/Group Containers/group.x/01WIKI.sqlite"
+
+  static let sandbox = SandboxProfile.invocation(
+    homePath: "/Users/me",
+    scratchDir: Self.scratch,
+    wikiDBPath: Self.wikiDBPath)
+
+  private func buildOn(
+    operation: WikiOperation = .query(question: "q?", stateFilePath: Self.stateFile),
+    command: AgentCommandConfig = .default
+  ) -> OperationCommand {
+    OperationCommand.build(
+      operation: operation,
+      wikiRoot: Self.resolvedRoot,
+      wikiID: "01WIKIULID",
+      systemPrompt: "schema",
+      scratchDirectory: Self.scratch,
+      wikictlDirectory: "/helpers",
+      resolvedExecutable: Self.providerExe,
+      command: command,
+      sandbox: Self.sandbox,
+      baseEnvironment: ["PATH": "/usr/bin:/bin", "HOME": "/Users/me"])
+  }
+
+  // MARK: - AC.1: byte-identical when sandbox is nil
+
+  @Test func offPathExecutableIsProviderAndArgumentsStartWithP() {
+    let cmd = OperationCommand.build(
+      operation: .query(question: "q?", stateFilePath: Self.stateFile),
+      wikiRoot: Self.resolvedRoot,
+      wikiID: "01WIKIULID",
+      systemPrompt: "schema",
+      scratchDirectory: Self.scratch,
+      wikictlDirectory: "/helpers",
+      resolvedExecutable: Self.providerExe,
+      baseEnvironment: [:])
+    #expect(cmd.executable == Self.providerExe)
+    #expect(cmd.arguments[0] == "-p")
+    // No relocation env set when sandbox is off.
+    #expect(cmd.environment["CLAUDE_CONFIG_DIR"] == nil)
+    #expect(cmd.environment["TMPDIR"] == nil)
+  }
+
+  // MARK: - AC.2: sandbox-on argv shape
+
+  @Test func onPathUsesSandboxExecutableAndWrappedHead() {
+    let cmd = buildOn()
+    #expect(cmd.executable == OperationCommand.sandboxExecutable)
+    #expect(OperationCommand.sandboxExecutable == "/usr/bin/sandbox-exec")
+
+    let args = cmd.arguments
+    #expect(args[0] == "-p")
+    #expect(args[1] == Self.sandbox.profile)
+    #expect(args[2] == "-D")
+    #expect(args[3] == "HOME=/Users/me")
+    #expect(args[4] == "-D")
+    #expect(args[5] == "SCRATCH_DIR=\(Self.scratch)")
+    #expect(args[6] == "-D")
+    #expect(args[7] == "WIKI_DB=\(Self.wikiDBPath)")
+    #expect(args[8] == "--")
+    #expect(args[9] == Self.providerExe)
+    #expect(args[10] == "-p")
+  }
+
+  @Test func onPathPreservesAppOwnedEnvAndSetsRelocation() {
+    let cmd = buildOn()
+    #expect(cmd.environment["WIKI_ROOT"] == Self.resolvedRoot)
+    #expect(cmd.environment["WIKI_DB"] == "01WIKIULID")
+    #expect(cmd.environment["PATH"] == "/helpers:/usr/bin:/bin")
+    #expect(cmd.environment["CLAUDE_CONFIG_DIR"] == Self.scratch + "/.claude-config")
+    #expect(cmd.environment["TMPDIR"] == Self.scratch + "/.tmp")
+  }
+
+  @Test func prefixArgsLandAfterTheProviderSeparator() {
+    let cfg = AgentCommandConfig(executable: "claude", prefixArguments: "--foo bar")
+    let cmd = buildOn(command: cfg)
+    let sepIndex = cmd.arguments.firstIndex(of: "--")!
+    let providerIndex = sepIndex + 1
+    #expect(cmd.arguments[providerIndex] == Self.providerExe)
+    #expect(cmd.arguments[providerIndex + 1] == "--foo")
+    #expect(cmd.arguments[providerIndex + 2] == "bar")
+    #expect(cmd.arguments[providerIndex + 3] == "-p")
+  }
+
+  // MARK: - Interactive query also wraps
+
+  @Test func interactiveQueryWrapsIdentically() {
+    let cmd = OperationCommand.buildInteractiveQuery(
+      operation: .queryConversation(stateFilePath: Self.stateFile),
+      wikiRoot: Self.resolvedRoot,
+      wikiID: "01WIKIULID",
+      systemPrompt: "schema",
+      scratchDirectory: Self.scratch,
+      wikictlDirectory: "/helpers",
+      resolvedExecutable: Self.providerExe,
+      sandbox: Self.sandbox,
+      baseEnvironment: ["PATH": "/usr/bin:/bin"])
+    #expect(cmd.executable == OperationCommand.sandboxExecutable)
+    #expect(cmd.arguments[0] == "-p")
+    #expect(cmd.arguments[1] == Self.sandbox.profile)
+    #expect(cmd.arguments[8] == "--")
+    #expect(cmd.arguments[9] == Self.providerExe)
+    #expect(cmd.environment["CLAUDE_CONFIG_DIR"] == Self.scratch + "/.claude-config")
+    #expect(cmd.environment["TMPDIR"] == Self.scratch + "/.tmp")
+    // The WIKI_DB env var (the ULID the agent/wikictl use) is NOT clobbered by the
+    // `-D WIKI_DB=<path>` profile param — they are separate channels.
+    #expect(cmd.environment["WIKI_DB"] == "01WIKIULID")
+    #expect(cmd.environment["WIKI_DB"] != Self.wikiDBPath)
+  }
+}

--- a/plans/sandbox-agent.md
+++ b/plans/sandbox-agent.md
@@ -1,0 +1,155 @@
+# Agent seatbelt sandbox (write whitelist)
+
+**Status:** Implemented on `main`. Confines the spawned agent process's filesystem
+**writes** to a strict allowlist via the macOS seatbelt (`/usr/bin/sandbox-exec`).
+Provider-agnostic, macOS 15+, opt-in (off by default).
+
+## What it does
+
+When enabled (Settings → Agent → Sandbox), every agent spawn (Ingest / Query / Lint
+and the interactive Query session) is wrapped so the agent — and **every child it
+spawns** (`wikictl`, `node`, `bash`, …) — can write to ONLY:
+
+- the per-run scratch dir (`~/Library/Caches/Self Driving Wiki-agent/<UUID>/`, the
+  process cwd), and
+- the active wiki's `<ulid>.sqlite` + its SQLite `-wal` / `-shm` / `-journal` sidecars,
+- plus any user-listed extra allowed paths.
+
+Every other filesystem write is denied. **Reads, all network, and process execution
+stay open** — so the provider starts, reaches its LLM API, reads sources, and runs
+`wikictl` unchanged; only the write channel is fenced.
+
+This gives, for free: no persistent backdoors (`LaunchAgents`, shell init), no
+credential tampering (`~/.ssh`, `~/.aws`, keychains), and **cross-wiki DB
+confinement** (the agent of wiki A cannot write wiki B's DB).
+
+## Threat model
+
+Guarded: a prompt-injected agent (driven by ingested content) trying to plant a
+backdoor, overwrite shell init / credentials, or otherwise modify the user's files.
+
+Explicitly NOT guarded (accepted non-goals):
+- **Network exfiltration is still possible** (network is open). A provider-egress
+  allowlist is the natural follow-up.
+- **Reads are open** everywhere.
+
+## How it's invoked
+
+The seatbelt composes *around* the configured provider command, so swapping providers
+needs no profile change. `OperationCommand.build` (when `sandbox` is non-nil) sets
+`executable = /usr/bin/sandbox-exec` and prepends `-p <profile> -D HOME=… -D
+SCRATCH_DIR=… -D WIKI_DB=… -- <providerExe>` to the unchanged provider argv.
+
+The profile is **generated in Swift** (`SandboxProfile.generate`) and passed as one
+argv element via `sandbox-exec -p`:
+
+```scheme
+(version 1)
+(allow default)                                  ; reads/network/exec open
+(deny file-write*)                               ; default-deny writes
+(allow file-write* (subpath (param "SCRATCH_DIR")))
+(allow file-write* (literal (param "WIKI_DB")))
+(allow file-write* (literal (string-append (param "WIKI_DB") "-wal")))
+(allow file-write* (literal (string-append (param "WIKI_DB") "-shm")))
+(allow file-write* (literal (string-append (param "WIKI_DB") "-journal")))
+;; one (allow file-write* (literal|subpath <userPath>)) per extra-allowed line
+```
+
+### Path canonicalization (symlink trap) — verified empirically
+
+The seatbelt `subpath`/`literal` matchers resolve against the **canonical (real)**
+path (the kernel's own `realpath`). If a path passed to the profile contains a symlink
+component (e.g. `/tmp` → `/private/tmp`, or `/etc` → `/private/etc`), the rule
+**silently fails to match** and the write is denied — the allow looks correct but does
+nothing. `SandboxProfile.invocation` therefore canonicalizes the scratch dir, the DB
+path, and every user extra-allowed path with `realpath(3)` (NOT Foundation's
+`URL.resolvingSymlinksInPath()`, which is unreliable and does NOT resolve `/tmp`).
+Keeping this in the tested core layer guards against a regression dropping it (the
+production paths — `~/Library/Caches`, `~/Library/Group Containers` — are real, so this
+is defensive). (Verified: a `/tmp`-based scratch dir is denied; the same profile with
+`/private/tmp`/`$HOME` paths works — scratch + DB writes allowed, everything else denied.)
+
+### Provider self-write relocation
+
+The provider process writes its own config/temp to run. Those are **relocated into the
+scratch dir** so the allowlist stays tiny and provider-agnostic. `OperationCommand`
+sets (only when sandbox is on), as distinct env keys that never clobber
+`WIKI_ROOT`/`WIKI_DB`/`PATH`:
+
+- `CLAUDE_CONFIG_DIR=<scratch>/.claude-config` — Claude Code's config/history.
+- `TMPDIR=<scratch>/.tmp` — node/CLI temp.
+
+The launcher creates both subdirectories before spawn (the app process is unsandboxed;
+only the spawned child is confined).
+
+### `WIKI_DB` is not conflated
+
+The `-D WIKI_DB=<container>/<ulid>.sqlite` is a **sandbox-exec profile parameter**
+(consumed by `(param "WIKI_DB")`). sandbox-exec `-D` params are profile variables and
+are **not** injected into the child environment. The existing `WIKI_DB=<ulid>`
+**environment variable** that `wikictl` reads is set unchanged by
+`OperationCommand.build` — a completely separate channel. They coexist.
+
+## Config
+
+`SandboxConfig` (`sandbox-config.json` in the App Group container) mirrors
+`AgentCommandConfig`:
+
+- `enabled: Bool` (default `false`).
+- `extraAllowedPaths: String` — one path per line; `~` expanded; non-absolute dropped.
+  **Additive only** (can widen, never remove the scratch/DB core).
+
+Loaded fresh at spawn time so Settings changes apply on the next run.
+
+## Adapting for non-claude providers
+
+Claude Code's two write locations are relocated by the two env vars above. A different
+provider may write its state/temp elsewhere. To adapt:
+
+1. Run once with the sandbox on; if the provider errors on a write, it hit a denial.
+2. Find the denied path (see Diagnosing a denied write below).
+3. Either relocate it into the scratch dir via the provider's env var (add the env in
+   `OperationCommand.applySandbox` alongside `CLAUDE_CONFIG_DIR`/`TMPDIR`), or add the
+   path to **extra allowed paths** in Settings → Agent → Sandbox.
+
+This is provider-specific env knowledge, but the seatbelt **profile** is
+provider-agnostic — it never names a provider.
+
+## Diagnosing a denied write
+
+Denied writes are the correct sandbox failure mode. To find what was blocked:
+
+```sh
+log show --predicate 'process == "sandboxd"' --last 5m --info --debug
+```
+
+Look for the `(deny file-write*)` trace naming the path. Then relocate the offending
+env or allowlist the path.
+
+## Why not Apple Container / App Sandbox
+
+- **Apple Container** needs macOS 26 and runs a **Linux** container, where the macOS
+  `wikictl` binary cannot run — it would force re-architecting the write path.
+- **App Sandbox (entitlements)** sandboxes the *app*, not a single spawned subprocess,
+  and conflicts with this local dev-signed, un-sandboxed app's access needs.
+- `sandbox-exec` ships on macOS 15, needs no entitlement, and is inherited by child
+  processes. It is marked deprecated by Apple (they favor App Sandbox), but it is
+  stable and depended on by Claude Code, Codex CLI, SwiftPM, Bazel, and Nix.
+
+## Failure modes
+
+- **Stray writes fail closed.** A provider writing outside scratch/DB that isn't
+  relocated is denied and the run may error. Correct behavior; diagnose + relocate.
+- **Fail-open on misconfiguration** (unresolvable HOME/scratch/DB) skips the sandbox
+  and logs a warning — acceptable because the feature is opt-in and default-off.
+
+## Files
+
+- `Sources/WikiFSCore/SandboxConfig.swift` — config + `parsedExtraAllowedPaths`.
+- `Sources/WikiFSCore/SandboxProfile.swift` — `SandboxInvocation` + pure
+  `generate(...)` / `invocation(...)`.
+- `Sources/WikiFSCore/OperationCommand.swift` — `sandbox:` param + `applySandbox`.
+- `Sources/WikiFS/AgentLauncher.swift` — `resolveSandboxInvocation` + relocation dirs.
+- `Sources/WikiFS/AgentCommandSettingsView.swift` — Sandbox section.
+- `Sources/WikiFSCore/ClaudePromptHelp.swift` — Command Template reflects the sandbox.
+- Tests: `SandboxConfigTests`, `SandboxProfileTests`, `SandboxedOperationCommandTests`.


### PR DESCRIPTION
## Summary

Opt-in confinement of the spawned agent process's filesystem **writes** to a strict allowlist via macOS's seatbelt (`/usr/bin/sandbox-exec`). **Provider-agnostic** — the seatbelt wraps whatever `AgentCommandConfig` executable is set, so swapping providers (claude, deepseek, a wrapper script) needs no profile change. macOS 15+.

When enabled (Settings → Agent → **Sandbox**), every spawn (Ingest / Query / Lint + interactive Query) runs so the agent — and **every child it spawns** (`wikictl`, `node`, bash) — can write **only** the per-run scratch dir + the active wiki's `<ulid>.sqlite` (`+ -wal/-shm/-journal`). Reads, all network, and process exec stay **open** (the provider still reaches its LLM API and runs `wikictl` unchanged); only the write channel is fenced.

**Posture:** default-deny writes → no backdoors (`LaunchAgents`/shell-init), no credential tampering (`~/.ssh`, `~/.aws`), and **cross-wiki DB confinement for free** (wiki A's agent can't write wiki B's DB). The provider's own config/temp are relocated into the scratch dir (`CLAUDE_CONFIG_DIR`, `TMPDIR`) so the allowlist stays tiny.

**Off by default** → byte-identical runs until toggled (`OperationCommand` gains an optional `sandbox:` param; `nil` reproduces today's argv/env exactly).

## Decisions (locked)
- **seatbelt `sandbox-exec`**, not Apple Container (needs macOS 26 + a Linux container where the macOS `wikictl` binary can't run).
- **default-deny writes (whitelist)**, not allow-by-default blacklist.
- **network stays fully open** (reads/network/exec open; only writes fenced).

## Changes
- **New** `Sources/WikiFSCore/SandboxConfig.swift` — config + `parsedExtraAllowedPaths` (mirrors `AgentCommandConfig`).
- **New** `Sources/WikiFSCore/SandboxProfile.swift` — `SandboxInvocation` + pure `generate`/`invocation`; `realpath(3)` canonicalization.
- `Sources/WikiFSCore/OperationCommand.swift` — `sandbox:` param + `applySandbox` (wraps argv, sets relocation env).
- `Sources/WikiFS/AgentLauncher.swift` — `resolveSandboxInvocation` (loads config fresh, builds invocation, fail-open on misconfig, creates relocation dirs).
- `Sources/WikiFS/AgentCommandSettingsView.swift` — Sandbox section (toggle + extra-allowed-paths + footer docs).
- `Sources/WikiFSCore/ClaudePromptHelp.swift` — Command Template reflects the sandbox when on.
- Docs: `plans/sandbox-agent.md`; rows in `PLAN.md` / `PROGRESS.md`.

## Testing
- **991 tests pass** (21 new sandbox tests: config round-trip/missing/corrupt, profile skeleton + sidecars + extra-path splicing/tilde/drop, AC.1/AC.2 argv, relocation env present-on/absent-off, prefix-args-after-`--`, symlink `realpath` resolution).
- **AC.6 verified live** by running the real generated profile through `/usr/bin/sandbox-exec`: writes inside scratch + to the DB path are **allowed**; writes to `~/.zshrc` and unrelated dirs are **denied**.
- **Pending (manual):** AC.5 — a live `make run` with the sandbox toggled on, confirming a Query completes end-to-end in the app.

## Review
Post-hoc `plan-reviewer` pass (on `glm-5.2`, which avoids the thinking-mode `tool_choice` failure that blocked earlier reviews) — no critical/high findings. All Medium/Low findings fixed:
- Documented `CLAUDE_CONFIG_DIR`/`TMPDIR` as app-owned when sandbox on (Medium).
- Moved symlink resolution into the tested core layer — and corrected the mechanism: Foundation's `URL.resolvingSymlinksInPath()` is unreliable (does **not** resolve `/tmp`); switched to `realpath(3)` (the kernel's resolver). +2 regression tests (Low).
- Added `WIKI_DB` env-var-not-clobbered assertion (Low).
- Rebutted `-D` value-escaping note as latent (app-controlled paths; user paths are escaped).

## Notes
- `sandbox-exec` is marked deprecated by Apple (they favor App Sandbox entitlements) but is stable and depended on by Claude Code, Codex CLI, SwiftPM, Bazel, Nix.
- Stray provider writes outside the allowlist **fail closed** (the correct sandbox failure mode); diagnose with `log show --predicate 'process == "sandboxd"'` and relocate or allowlist. Documented in `plans/sandbox-agent.md`.
