### PR TITLE
fix(agent): let the agent run without the File Provider mounted

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,28 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-24 — Agent runs without the File Provider mount
+
+The agent (Ingest / Query / Lint + interactive Query) no longer hard-requires a
+mounted File Provider. `fileProvider.path` was a hard gate for Query/Lint/interactive
+(the query conversation bailed with "File Provider is not mounted. Open a wiki
+first."), even though the prompts route ALL reads through `wikictl` (SQLite via
+`WIKI_DB`) and label the mount **reference-only**. Ingest already tolerated a missing
+mount.
+
+- `AgentOperationRunner.run` and `startQueryConversation` now pass
+  `fileProvider.path ?? ""` for every operation (no bail). The mount is still used
+  when available; it's just no longer load-bearing for the agent to start.
+- The closing `WIKI_ROOT` prompt line is now adaptive: when the mount is down it says
+  "File Provider mount is not available for this run — read pages and raw sources via
+  `wikictl` only" (was a dangling empty path). So the agent knows not to read a
+  non-existent mount.
+- Diagnosed live: a `build/`-located app instance can't mount (FP only reliably
+  mounts from the `/Applications` install), which silently blocked every agent op
+  even though the app otherwise worked. This removes that failure mode.
+- Tests: 2 new (`promptsNoteWhenTheMountIsUnavailable`,
+  `promptsKeepTheResolvedMountPathWhenAvailable`); 967 pass.
+
 ## 2026-06-24 — SourceWebView (WKWebView) gets the same "Add as Source" menu
 
 Extended `plans/url-context-menu-add.md` to the WKWebView large-source reader,

--- a/Sources/WikiFS/AgentOperationRunner.swift
+++ b/Sources/WikiFS/AgentOperationRunner.swift
@@ -214,13 +214,11 @@ enum AgentOperationRunner {
         }
 
         await fileProvider.signalChange()
-        guard let root = fileProvider.path else {
-            await MainActor.run {
-                launcher.preflightError = "File Provider is not mounted. Open a wiki first."
-            }
-            DebugLog.agent("startQueryConversation: fileProvider.path is nil — bailing")
-            return
-        }
+        // The mount is reference-only (the agent reads via `wikictl`); proceed even
+        // when it isn't mounted, passing an empty WIKI_ROOT. The prompt tells the
+        // agent to read via `wikictl` only when the mount is unavailable.
+        let root = fileProvider.path ?? ""
+        DebugLog.agent("startQueryConversation: wikiRoot=\(root.isEmpty ? "<mount unavailable>" : root)")
 
         await launcher.startInteractiveQuery(
             firstMessage: trimmed,
@@ -264,17 +262,11 @@ enum AgentOperationRunner {
         case .query, .lint:
             await fileProvider.signalChange()
         }
-        let root: String
-        if let resolvedRoot = fileProvider.path {
-            root = resolvedRoot
-        } else if case .ingest = request {
-            // Ingest stages both the raw source bytes and WIKI_STATE.md from SQLite,
-            // so it can proceed even if the File Provider mount URL is still being
-            // resolved. Query/Lint keep requiring the mount for raw-file reads.
-            root = ""
-        } else {
-            return
-        }
+        // The mount path is reference-only in the prompts (the agent reads pages and
+        // raw sources via `wikictl`/SQLite, not the mount), so every operation can
+        // proceed even when the File Provider isn't mounted — it just gets an empty
+        // WIKI_ROOT, and the prompt tells the agent to read via `wikictl` only.
+        let root = fileProvider.path ?? ""
 
         await launcher.run(
             request: request,

--- a/Sources/WikiFSCore/WikiOperation.swift
+++ b/Sources/WikiFSCore/WikiOperation.swift
@@ -149,6 +149,17 @@ extension WikiOperation {
 
   // MARK: - Ingest prompts
 
+  /// The closing `WIKI_ROOT` line. The mount is **reference-only** (the agent reads
+  /// pages and raw sources via `wikictl`/SQLite, not the mount), so an unavailable
+  /// mount never blocks an operation — but the line tells the agent explicitly when the
+  /// mount is down so it doesn't try to read from a path that isn't there.
+  private static func wikiRootLine(_ wikiRoot: String) -> String {
+    if wikiRoot.isEmpty {
+      return "WIKI_ROOT: (File Provider mount is not available for this run — read pages and raw sources via `wikictl` only.)"
+    }
+    return "WIKI_ROOT (resolved, read-only mount — reference only): \(wikiRoot)"
+  }
+
   /// Single-pass Ingest (tiny total source): one Opus pass does the whole ingest
   /// itself via `wikictl`. No fan-out — Opus reads the small staged source(s) and
   /// writes the pages + index + log. (Opus is the curator even for small sources.)
@@ -181,7 +192,7 @@ extension WikiOperation {
     Each `--source` id is REQUIRED — it marks that file Ingested in the app. \
     Work autonomously to completion; the live app shows your changes as they land.
 
-    WIKI_ROOT (resolved, read-only mount — reference only): \(wikiRoot)
+    \(Self.wikiRootLine(wikiRoot))
     """
   }
 
@@ -240,7 +251,7 @@ extension WikiOperation {
 
     Work autonomously to completion; the live app shows changes as they land.
 
-    WIKI_ROOT (resolved, read-only mount — reference only): \(wikiRoot)
+    \(Self.wikiRootLine(wikiRoot))
     """
   }
 
@@ -348,7 +359,7 @@ extension WikiOperation {
     rule above. If you file a useful answer back as a page, write it via \
     `wikictl page upsert` and log it with `wikictl log append --kind query`.
 
-    WIKI_ROOT (resolved, read-only mount — reference only): \(wikiRoot)
+    \(Self.wikiRootLine(wikiRoot))
     Question: \(question)
     """
   }
@@ -389,7 +400,7 @@ extension WikiOperation {
     query` describing the change. Tell the user what you changed and which pages or \
     source paths you relied on.
 
-    WIKI_ROOT (resolved, read-only mount — reference only): \(wikiRoot)
+    \(Self.wikiRootLine(wikiRoot))
     """
   }
 
@@ -405,7 +416,7 @@ extension WikiOperation {
     Lint workflow from your instructions. Record it with \
     `wikictl log append --kind lint`.
 
-    WIKI_ROOT (resolved, read-only mount — reference only): \(wikiRoot)
+    \(Self.wikiRootLine(wikiRoot))
     """
   }
 }

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -472,6 +472,39 @@ struct OperationCommandTests {
     #expect(WikiOperation.Kind.lint.title == "Lint")
   }
 
+  // MARK: - Mount-unavailable prompts (the agent reads via wikictl, not the mount)
+
+  @Test func promptsNoteWhenTheMountIsUnavailable() {
+    // With an empty WIKI_ROOT (File Provider not mounted), the prompts must tell the
+    // agent to read via `wikictl` only, instead of an empty reference path.
+    for operation: WikiOperation in [
+      Self.tinyIngest(),
+      Self.curatedIngest(),
+      .query(question: "q", stateFilePath: Self.stateFile),
+      .queryConversation(stateFilePath: Self.stateFile),
+      .lint(stateFilePath: Self.stateFile),
+    ] {
+      let prompt = operation.prompt(wikiRoot: "")
+      #expect(prompt.contains("mount is not available"))
+      #expect(prompt.contains("wikictl"))
+      // No dangling empty reference path line.
+      #expect(!prompt.contains("WIKI_ROOT (resolved, read-only mount — reference only): \n"))
+    }
+  }
+
+  @Test func promptsKeepTheResolvedMountPathWhenAvailable() {
+    // A non-empty WIKI_ROOT still renders the reference-only path line.
+    for operation: WikiOperation in [
+      Self.tinyIngest(),
+      .query(question: "q", stateFilePath: Self.stateFile),
+      .lint(stateFilePath: Self.stateFile),
+    ] {
+      let prompt = operation.prompt(wikiRoot: Self.resolvedRoot)
+      #expect(prompt.contains("WIKI_ROOT (resolved, read-only mount — reference only): \(Self.resolvedRoot)"))
+      #expect(!prompt.contains("mount is not available"))
+    }
+  }
+
   // MARK: - PathPreflight
 
   @Test func preflightFindsExecutableOnPath() {


### PR DESCRIPTION
## Summary

The agent (Ingest / Query / Lint + interactive Query) no longer hard-requires a mounted File Provider. Previously Query/Lint/interactive bailed when `fileProvider.path` was `nil` — the query conversation showed *"File Provider is not mounted. Open a wiki first."* — even though the prompts route **all** reads through `wikictl` (SQLite via `WIKI_DB`) and label the mount **reference-only**. Ingest already tolerated a missing mount.

## Why

Diagnosed live: a `build/`-located app instance can't mount the File Provider (it only reliably mounts from the `/Applications` install), which silently blocked **every** agent operation even though the rest of the app worked fine (it reads from SQLite). The mount is genuinely optional for the agent now — it reads pages and raw sources via `wikictl`, not the mount.

## Changes
- `Sources/WikiFS/AgentOperationRunner.swift` — `run(...)` and `startQueryConversation(...)` now pass `fileProvider.path ?? ""` for every operation (no bail). The mount is still used when available; it's just no longer load-bearing for the agent to start.
- `Sources/WikiFSCore/WikiOperation.swift` — the closing `WIKI_ROOT` prompt line is now adaptive: when the mount is down it says *"File Provider mount is not available for this run — read pages and raw sources via `wikictl` only"* (was a dangling empty reference path), so the agent knows not to read a non-existent mount.
- `Tests/WikiFSTests/OperationCommandTests.swift` — 2 new prompt tests (empty-mount note + resolved-path preserved).
- `PROGRESS.md` — entry.

## Testing
- **967 tests pass** (2 new: `promptsNoteWhenTheMountIsUnavailable`, `promptsKeepTheResolvedMountPathWhenAvailable`).
- Manual follow-up: run the app from `build/` (unmounted) → a Query/Lint/interactive session now starts instead of bailing; the prompt tells the agent to read via `wikictl`.

## Notes
- Separate from #54 (sandbox) — independent concern, branched off `main`.
- The File Provider is still the recommended way to browse the wiki in Terminal/Finder; this just makes the agent not depend on it to run.
