### PR TITLE
feat: resolve source display names from metadata (Zotero, PDF, Markdown)

### DIFF
--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -71,7 +71,7 @@ struct SourceDetailView: View {
     }
 
     private var displayName: String {
-        file.filename.isEmpty ? "Untitled" : file.filename
+        file.displayName ?? (file.filename.isEmpty ? "Untitled" : file.filename)
     }
 
     private var alreadyIngested: Bool { hasBeenIngested }

--- a/Sources/WikiFS/SourceRow.swift
+++ b/Sources/WikiFS/SourceRow.swift
@@ -60,7 +60,7 @@ struct SourceRow: View {
             hasBeenIngested: hasBeenIngested)
         Label {
             HStack(spacing: 8) {
-                Text(source.filename.isEmpty ? "Untitled" : source.filename)
+                Text(source.displayName ?? (source.filename.isEmpty ? "Untitled" : source.filename))
                     .font(.body)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/Sources/WikiFSCore/DisplayNameResolver.swift
+++ b/Sources/WikiFSCore/DisplayNameResolver.swift
@@ -1,0 +1,175 @@
+import Foundation
+import PDFKit
+
+/// Resolves the best human-readable display name for a source at ingest time.
+/// Returns `nil` when no richer metadata is available — the caller falls back to
+/// the raw filename via `COALESCE(display_name, filename)`, preserving
+/// backward-compatible link resolution for sources without extracted metadata.
+///
+/// Priority order:
+/// 1. Zotero item title (when the source came from Zotero)
+/// 2. Markdown front matter `title` (for `.md` / `text/markdown` files)
+/// 3. PDF document title (from PDFKit metadata)
+/// 4. `nil` — caller uses the filename
+///
+/// Pure and dependency-free (PDFKit is the only import), so the resolve function
+/// is unit-testable with in-memory Data.
+public enum DisplayNameResolver {
+
+    /// Resolve a display name from the available metadata and file bytes.
+    /// - Parameters:
+    ///   - filename: The original filename (e.g. `"Trip Report.pdf"`).
+    ///   - data: The verbatim file bytes (used for front matter / PDF metadata).
+    ///   - mimeType: Best-effort MIME type (used to skip expensive checks on
+    ///     obviously-wrong types).
+    ///   - zoteroItemTitle: The Zotero parent item title when this source came
+    ///     from the Zotero ingest seam; `nil` otherwise.
+    /// - Returns: A display name string, or `nil` when no richer metadata is
+    ///   available (caller falls back to the filename).
+    public static func resolve(
+        filename: String,
+        data: Data,
+        mimeType: String?,
+        zoteroItemTitle: String?
+    ) -> String? {
+        // 1. Zotero title — the richest metadata we have.
+        if let zoteroTitle = zoteroItemTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !zoteroTitle.isEmpty {
+            return zoteroTitle
+        }
+
+        // 2. Markdown front matter title.
+        if isMarkdown(filename: filename, mimeType: mimeType),
+           let title = extractMarkdownTitle(from: data) {
+            return title
+        }
+
+        // 3. PDF document title.
+        if isPDF(filename: filename, mimeType: mimeType),
+           let title = extractPDFTitle(from: data) {
+            return title
+        }
+
+        // 4. No richer metadata — caller uses the raw filename.
+        return nil
+    }
+
+    // MARK: - Type detection
+
+    private static func isMarkdown(filename: String, mimeType: String?) -> Bool {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        if ext == "md" || ext == "markdown" { return true }
+        if let mime = mimeType?.lowercased(),
+           mime == "text/markdown" || mime == "text/x-markdown" {
+            return true
+        }
+        return false
+    }
+
+    private static func isPDF(filename: String, mimeType: String?) -> Bool {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        if ext == "pdf" { return true }
+        if let mime = mimeType?.lowercased(), mime == "application/pdf" {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Markdown front matter
+
+    /// Extract `title` from YAML front matter (`---\n...\n---` at the start of
+    /// the file). Recognises both `title: "value"` and `title: value` forms;
+    /// handles trailing whitespace and quotes.
+    static func extractMarkdownTitle(from data: Data) -> String? {
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+
+        let scanner = Scanner(string: text)
+        _ = scanner.charactersToBeSkipped = nil  // don't auto-skip whitespace
+
+        // Skip any leading whitespace or newlines before the opening `---`.
+        _ = scanner.scanCharacters(from: .whitespacesAndNewlines)
+
+        // Front matter must start with `---` as the first non-blank line.
+        guard scanner.scanString("---") != nil else { return nil }
+
+        // Scan past the newline after the opening `---`.
+        _ = scanner.scanCharacters(from: .newlines)
+
+        // Scan lines until the closing `---`.
+        while !scanner.isAtEnd {
+            // Check if we've hit the closing `---`.
+            if scanner.scanString("---") != nil {
+                break  // closing delimiter found — stop scanning
+            }
+
+            // Read one line.
+            guard let line = scanner.scanUpToCharacters(from: .newlines) else { break }
+            _ = scanner.scanCharacters(from: .newlines)
+
+            // Try to match `title: "value"` or `title: value`.
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("title:") else { continue }
+
+            let valuePart = String(trimmed.dropFirst("title:".count))
+                .trimmingCharacters(in: .whitespaces)
+
+            // Handle quoted values: `"My Title"` or `'My Title'`.
+            if valuePart.hasPrefix("\"") {
+                let inner = valuePart.dropFirst()
+                // Find closing quote, handling escaped quotes.
+                var result = ""
+                var escaped = false
+                for ch in inner {
+                    if escaped {
+                        result.append(ch)
+                        escaped = false
+                    } else if ch == "\\" {
+                        escaped = true
+                    } else if ch == "\"" {
+                        return result.trimmingCharacters(in: .whitespaces).nilIfEmpty
+                    } else {
+                        result.append(ch)
+                    }
+                }
+                // No closing quote found — return the inner text as-is.
+                let fallback = result.trimmingCharacters(in: .whitespaces)
+                return fallback.nilIfEmpty
+            }
+
+            if valuePart.hasPrefix("'") {
+                let inner = valuePart.dropFirst()
+                if let closeQuote = inner.firstIndex(of: "'") {
+                    let result = String(inner[..<closeQuote])
+                        .trimmingCharacters(in: .whitespaces)
+                    return result.nilIfEmpty
+                }
+            }
+
+            // Unquoted value — take everything until end of line (already trimmed).
+            return valuePart.nilIfEmpty
+        }
+
+        return nil
+    }
+
+    // MARK: - PDF title
+
+    /// Extract the document title from a PDF via PDFKit's document attributes.
+    static func extractPDFTitle(from data: Data) -> String? {
+        guard let document = PDFDocument(data: data),
+              let attrs = document.documentAttributes,
+              let title = attrs[PDFDocumentAttribute.titleAttribute] as? String
+        else { return nil }
+        return title.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+}
+
+// MARK: - String helper
+
+private extension String {
+    /// Returns `nil` when the string is empty after trimming whitespace.
+    var nilIfEmpty: String? {
+        let trimmed = self.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -910,12 +910,15 @@ public final class SQLiteWikiStore: WikiStore {
             ?? ContentSniff.mimeType(of: data)
             ?? (ext.isEmpty ? nil : UTType(filenameExtension: ext)?.preferredMIMEType)
         let now = Date()
+        let displayName = DisplayNameResolver.resolve(
+            filename: filename, data: data, mimeType: mime,
+            zoteroItemTitle: zoteroItemTitle)
 
         let stmt = try statement("""
         INSERT INTO sources
           (id, filename, ext, mime_type, byte_size, content, created_at, updated_at, version,
            zotero_item_key, zotero_item_title, display_name)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, 1, ?8, ?9, ?2);
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, 1, ?8, ?9, ?10);
         """)
         defer { stmt.reset() }
         try stmt.bind(id.rawValue, at: 1)
@@ -927,12 +930,14 @@ public final class SQLiteWikiStore: WikiStore {
         try stmt.bind(now.timeIntervalSince1970, at: 7)
         if let zoteroItemKey { try stmt.bind(zoteroItemKey, at: 8) }  // else leave NULL
         if let zoteroItemTitle { try stmt.bind(zoteroItemTitle, at: 9) }  // else leave NULL
+        if let displayName { try stmt.bind(displayName, at: 10) }  // else leave NULL
         _ = try stmt.step()
 
         return SourceSummary(
             id: id, filename: filename, ext: ext, mimeType: mime,
             byteSize: data.count, createdAt: now, updatedAt: now, version: 1,
-            zoteroItemKey: zoteroItemKey, zoteroItemTitle: zoteroItemTitle
+            zoteroItemKey: zoteroItemKey, zoteroItemTitle: zoteroItemTitle,
+            displayName: displayName
         )
     }
 

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -632,7 +632,8 @@ struct Projection {
             let summary = SourceSummary(
                 id: PageID(rawValue: row.id), filename: row.filename, ext: row.ext,
                 mimeType: row.mime, byteSize: row.byteSize,
-                createdAt: row.createdAt, updatedAt: row.updatedAt, version: row.version)
+                createdAt: row.createdAt, updatedAt: row.updatedAt, version: row.version,
+                displayName: row.displayName)
             let verbatimNode = Self.sourceNode(for: id, file: summary)
             // Sibling eligibility: has a chain AND is NOT markdown-native.
             // Markdown-native sources don't get a sibling — the verbatim .md is the content.

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import CoreGraphics
 import Foundation
 import SQLite3
 import Testing
@@ -250,5 +251,161 @@ struct SourcesTests {
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
         #expect(sqlite3_column_int(stmt, 0) == 11)
         _ = store
+    }
+
+    // MARK: - DisplayNameResolver
+
+    @Test func displayNameFromZoteroTitle() {
+        let result = DisplayNameResolver.resolve(
+            filename: "abc123.pdf", data: Data(),
+            mimeType: "application/pdf",
+            zoteroItemTitle: "A Study in Scarlet")
+        #expect(result == "A Study in Scarlet")
+    }
+
+    @Test func displayNameNilWhenZoteroTitleIsWhitespace() {
+        let result = DisplayNameResolver.resolve(
+            filename: "abc123.pdf", data: Data(),
+            mimeType: "application/pdf",
+            zoteroItemTitle: "   ")
+        #expect(result == nil)
+    }
+
+    @Test func displayNameFromMarkdownFrontMatterDoubleQuoted() {
+        let md = """
+        ---
+        title: "Hello World"
+        ---
+        # Content
+        """
+        let result = DisplayNameResolver.resolve(
+            filename: "note.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == "Hello World")
+    }
+
+    @Test func displayNameFromMarkdownFrontMatterSingleQuoted() {
+        let md = """
+        ---
+        title: 'Single Quoted Title'
+        ---
+        # Body
+        """
+        let result = DisplayNameResolver.resolve(
+            filename: "doc.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == "Single Quoted Title")
+    }
+
+    @Test func displayNameFromMarkdownFrontMatterUnquoted() {
+        let md = """
+        ---
+        title: Plain Title
+        author: Someone
+        ---
+        """
+        let result = DisplayNameResolver.resolve(
+            filename: "page.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == "Plain Title")
+    }
+
+    @Test func displayNameNilForMarkdownWithoutFrontMatter() {
+        let md = "# Just a heading\n\nSome content."
+        let result = DisplayNameResolver.resolve(
+            filename: "plain.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == nil)
+    }
+
+    @Test func displayNameFromMarkdownMimeTypeNotExtension() {
+        let md = """
+        ---
+        title: "From MIME"
+        ---
+        """
+        let result = DisplayNameResolver.resolve(
+            filename: "file.txt", data: Data(md.utf8),
+            mimeType: "text/markdown", zoteroItemTitle: nil)
+        #expect(result == "From MIME")
+    }
+
+    @Test func displayNameFromPDFTitle() throws {
+        // Build a minimal valid PDF with a /Title entry.
+        let title = "My PDF Document"
+        let pdfData = try minimalPDF(title: title)
+        let result = DisplayNameResolver.resolve(
+            filename: "report.pdf", data: pdfData,
+            mimeType: "application/pdf", zoteroItemTitle: nil)
+        #expect(result == "My PDF Document")
+    }
+
+    @Test func displayNameNilForInvalidPDF() {
+        let result = DisplayNameResolver.resolve(
+            filename: "corrupt.pdf", data: Data("not a pdf".utf8),
+            mimeType: "application/pdf", zoteroItemTitle: nil)
+        #expect(result == nil)
+    }
+
+    @Test func displayNameNilForPDFWithoutTitle() throws {
+        // Minimal PDF with no /Title entry.
+        let pdfData = try minimalPDF()
+        let result = DisplayNameResolver.resolve(
+            filename: "untitled.pdf", data: pdfData,
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == nil)
+    }
+
+    @Test func displayNameNilForPlainTextFile() {
+        let result = DisplayNameResolver.resolve(
+            filename: "readme.txt", data: Data("Hello".utf8),
+            mimeType: "text/plain", zoteroItemTitle: nil)
+        #expect(result == nil)
+    }
+
+    @Test func zoteroTitleTakesPriorityOverPDFTitle() throws {
+        let pdfData = try minimalPDF(title: "PDF Title")
+        let result = DisplayNameResolver.resolve(
+            filename: "doc.pdf", data: pdfData,
+            mimeType: "application/pdf",
+            zoteroItemTitle: "Zotero Title")
+        #expect(result == "Zotero Title")
+    }
+
+    @Test func zoteroTitleTakesPriorityOverMarkdownTitle() {
+        let md = """
+        ---
+        title: "MD Title"
+        ---
+        """
+        let result = DisplayNameResolver.resolve(
+            filename: "note.md", data: Data(md.utf8),
+            mimeType: "text/markdown",
+            zoteroItemTitle: "Zotero Title")
+        #expect(result == "Zotero Title")
+    }
+
+    // MARK: - DisplayNameResolver helpers
+
+    /// Build a minimal valid PDF with an optional /Title in the Info dict,
+    /// using CoreGraphics to produce a structurally correct PDF that PDFKit
+    /// can parse.
+    private func minimalPDF(title: String? = nil) throws -> Data {
+        let data = NSMutableData()
+        guard let consumer = CGDataConsumer(data: data as CFMutableData)
+        else { throw NSError(domain: "test", code: 1) }
+        var mediaBox = CGRect(origin: .zero, size: CGSize(width: 612, height: 792))
+
+        var auxInfo: [String: Any] = [:]
+        auxInfo[kCGPDFContextTitle as String] = title as Any?
+
+        guard let ctx = CGContext(consumer: consumer, mediaBox: &mediaBox, auxInfo as CFDictionary) else {
+            throw NSError(domain: "test", code: 2)
+        }
+        ctx.beginPDFPage(nil)
+        ctx.endPDFPage()
+        ctx.closePDF()
+
+        return data as Data
     }
 }


### PR DESCRIPTION
## Summary

Sources now attempt to extract a meaningful **display name** at ingest time instead of defaulting to the raw filename. Users see "A Study in Scarlet" instead of `f24172fb9e.pdf`.

### Priority order

1. **Zotero parent item title** — richest metadata, already threaded through the Zotero ingest seam
2. **Markdown front matter `title:`** — parsed from `---` YAML delimiters (double-quoted, single-quoted, unquoted)
3. **PDF document title** — extracted via PDFKit document attributes
4. **NULL** — `COALESCE(display_name, filename)` falls back to the raw filename, preserving backward-compatible `[[source:filename.pdf]]` link resolution

### Files changed

- **New:** `Sources/WikiFSCore/DisplayNameResolver.swift` — pure resolver, unit-testable
- `Sources/WikiFSCore/SQLiteWikiStore.swift` — `addSource` calls the resolver, binds result (or NULL) to `display_name`
- `Sources/WikiFS/SourceRow.swift` — shows `displayName ?? filename`
- `Sources/WikiFS/SourceDetailView.swift` — same
- `Sources/WikiFSFileProvider/Projection.swift` — threads `displayName` through to File Provider
- `Tests/WikiFSTests/SourcesTests.swift` — 13 new tests covering all extraction paths and priority order

### Design decisions

- Returns **`nil`** (not a computed stem) when no metadata exists, so existing links using the filename keep working
- Migration for existing rows (`display_name = filename`) is unchanged — old sources keep their filename
- Zotero title always wins (if present), over both PDF and Markdown titles