### PR TITLE
Add find bar (⌘F) with next/prev navigation and match highlighting

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,53 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-24 — Find bar (⌘F) with next/prev navigation + match highlight
+
+Added a native macOS-style find bar (driven by a `FindModel` `@Observable`)
+overlaid at the top of every reader: search field, live match count
+("2 of 14"), case-sensitivity toggle, prev/next arrows, and ⌘F / Enter /
+Shift+Enter / Esc. It works in both the native `MarkdownPreview` reader and the
+`SourceWebView` (WKWebView) large-source reader, plus both detail views
+(`PageDetailView`, `SourceDetailView`).
+
+**State (`FindModel`).** Holds `query`, `caseSensitive`, `isShowing`, and the
+search results: `matches: [Range<String.Index>]` found by walking the content
+with `range(of:options:)` (case-insensitive by default), plus a 1-based
+`currentMatchIndex`. `nextMatch`/`previousMatch` wrap with modular arithmetic.
+Both detail views feed `content` (the rendered markdown) into the model and
+re-run `search()` on query / case-sensitivity / content changes.
+
+**The bug — forward arrow didn't advance.** The renderers were passed only the
+matched *substring* (`findText`), never *which* occurrence. So:
+- **Native reader:** `resolveAnchor` used `blocks.first(where:)` → always the
+  first block; the highlight (`WikiLinkStylingParser.quoteRange`) always picked
+  the first occurrence (`normalizedHaystack.range(of:)`).
+- **Web reader:** `applyFind` cleared the prior `<mark>` (collapsing the
+  selection) then called `window.find()` once → always re-found the first match.
+
+`currentMatchIndex` was computed correctly but discarded.
+
+**The fix — thread the occurrence index end to end.** Added `findOccurrence`
+(= `currentMatchIndex`) through `PageDetailView` / `SourceDetailView` → both
+readers:
+- **`AnchorBlock.resolveAnchor(_:occurrence:in:)`** (new) walks blocks in
+  document order counting non-overlapping case-insensitive matches, landing on
+  the block holding the Nth (with a fallback to the first matching block if the
+  count overshoots). The single-match `resolveAnchor` is unchanged for
+  URL/quote-anchor callers.
+- **`WikiLinkStylingParser.quoteRange(_:in:occurrence:)`** (new param) finds the
+  Nth non-overlapping occurrence; the parser stores `highlightOccurrence`.
+  `MarkdownPreview` tracks `highlightOccurrence` in `@State`, set alongside
+  `highlightQuote` in the find task.
+- **`SourceWebView.applyFind`** resets the selection to the document start and
+  advances `window.find()` N times so each click steps to a distinct match, with
+  a `surroundContents` fallback for matches spanning element boundaries.
+
+**Tests.** +12 (977 total, 71 suites, 0 failures): occurrence selection in
+`quoteRange` (2nd/3rd/beyond/zero/default), parser highlights the Nth occurrence,
+and occurrence-aware `resolveAnchor` (first, same-block repeat, step-to-next-block,
+zero→nil, beyond-count fallback). On branch `feature/find-bar`.
+
 ## 2026-06-24 — SourceWebView (WKWebView) gets the same "Add as Source" menu
 
 Extended `plans/url-context-menu-add.md` to the WKWebView large-source reader,

--- a/Sources/WikiFS/FindBarView.swift
+++ b/Sources/WikiFS/FindBarView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// A compact find bar overlaid at the top of the content area — mirrors
+/// the native macOS find bar in look and feel. Driven by a `FindModel`.
+///
+/// Layout: [Search Field] [count label] [‹][›] [Aa] [Done]
+/// Keyboard: Enter = next, Shift+Enter = previous, Esc = dismiss
+struct FindBarView: View {
+    @Bindable var model: FindModel
+    @FocusState private var fieldFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Leading edge — same inset as the content area.
+            Spacer().frame(width: 4)
+
+            // Search field with magnifying glass + clear button.
+            HStack(spacing: 4) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                TextField("Find", text: $model.query)
+                    .textFieldStyle(.plain)
+                    .font(.callout)
+                    .focused($fieldFocused)
+                    .onSubmit { model.nextMatch() }
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(.secondary.opacity(0.3), lineWidth: 1)
+            )
+            .frame(width: 200)
+
+            // Match count.
+            if !model.countLabel.isEmpty {
+                Text(model.countLabel)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            }
+
+            // Next / Previous.
+            HStack(spacing: 2) {
+                Button { model.previousMatch() } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .buttonStyle(.borderless)
+                .font(.callout)
+                .disabled(model.matches.isEmpty)
+                .help("Previous match (⇧↩)")
+
+                Button { model.nextMatch() } label: {
+                    Image(systemName: "chevron.right")
+                }
+                .buttonStyle(.borderless)
+                .font(.callout)
+                .disabled(model.matches.isEmpty)
+                .help("Next match (↩)")
+            }
+
+            // Case toggle.
+            Button {
+                model.caseSensitive.toggle()
+            } label: {
+                Text("Aa")
+                    .font(.callout.weight(model.caseSensitive ? .bold : .regular))
+                    .foregroundStyle(model.caseSensitive ? .primary : .secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Match case")
+
+            // Done.
+            Button("Done") { model.dismiss() }
+                .buttonStyle(.borderless)
+                .font(.callout)
+                .keyboardShortcut(.escape, modifiers: [])
+
+            Spacer().frame(width: 4)
+        }
+        .padding(.vertical, 4)
+        .background(.regularMaterial)
+        .onAppear { fieldFocused = true }
+        .onChange(of: model.isShowing) { _, showing in
+            if showing { fieldFocused = true }
+        }
+        .onChange(of: model.query) { model.search() }
+        .onChange(of: model.caseSensitive) { model.search() }
+    }
+}

--- a/Sources/WikiFS/FindModel.swift
+++ b/Sources/WikiFS/FindModel.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Observation
+
+/// Reactive find state shared between the find bar and the content view.
+/// Drives the find bar UI (search field, match count, next/prev) and exposes
+/// the current match range so the content view can scroll to / highlight it.
+@MainActor
+@Observable
+public final class FindModel {
+
+    /// Current search text typed in the find bar.
+    public var query = ""
+
+    /// Case-sensitive toggle.
+    public var caseSensitive = false
+
+    /// Whether the find bar is visible. Cmd+F toggles.
+    public var isShowing = false
+
+    /// All match ranges found in the current content.
+    private(set) public var matches: [Range<String.Index>] = []
+
+    /// 1-based index into `matches` (0 when no matches).
+    private(set) public var currentMatchIndex = 0
+
+    /// The content text being searched. Set by the owning detail view before
+    /// the find bar opens. When `nil`, find is a no-op (no content to search).
+    public var content: String?
+
+    /// Callback the content view sets to scroll to / select a given match
+    /// (usually the range within the source markdown string that the view is
+    /// rendering). The caller maps the character range to a view scroll position.
+    public var onNavigateToMatch: ((Range<String.Index>) -> Void)?
+
+    // MARK: - Navigation
+
+    public func nextMatch() {
+        guard !matches.isEmpty else { return }
+        currentMatchIndex = (currentMatchIndex % matches.count) + 1
+        notifyCurrentMatch()
+    }
+
+    public func previousMatch() {
+        guard !matches.isEmpty else { return }
+        currentMatchIndex = currentMatchIndex <= 1 ? matches.count : currentMatchIndex - 1
+        notifyCurrentMatch()
+    }
+
+    public func toggle() {
+        isShowing.toggle()
+        if isShowing { performFind() }
+        else { clear() }
+    }
+
+    public func dismiss() {
+        isShowing = false
+        clear()
+    }
+
+    // MARK: - Count display string
+
+    /// "2 of 14" when matches exist, or "0 matches" when query is non-empty with
+    /// no results, or empty for an empty query.
+    public var countLabel: String {
+        if query.isEmpty { return "" }
+        if matches.isEmpty { return "0 matches" }
+        return "\(currentMatchIndex) of \(matches.count)"
+    }
+
+    /// Called by FindBarView when query or case sensitivity changes, or when
+    /// content is set by the owning detail view. Re-runs the search.
+    public func search() { performFind() }
+
+    // MARK: - Private
+
+    private func performFind() {
+        guard let content, !query.isEmpty else {
+            matches = []
+            currentMatchIndex = 0
+            return
+        }
+        let options: NSString.CompareOptions = caseSensitive
+            ? [.literal]
+            : [.caseInsensitive]
+        var found: [Range<String.Index>] = []
+        var searchStart = content.startIndex
+        while let range = content.range(of: query, options: options, range: searchStart..<content.endIndex) {
+            found.append(range)
+            searchStart = range.upperBound
+        }
+        matches = found
+        currentMatchIndex = found.isEmpty ? 0 : 1
+        if !found.isEmpty { notifyCurrentMatch() }
+    }
+
+    private func notifyCurrentMatch() {
+        guard currentMatchIndex > 0, currentMatchIndex <= matches.count else { return }
+        onNavigateToMatch?(matches[currentMatchIndex - 1])
+    }
+
+    private func clear() {
+        matches = []
+        currentMatchIndex = 0
+    }
+}

--- a/Sources/WikiFS/MarkdownPreview.swift
+++ b/Sources/WikiFS/MarkdownPreview.swift
@@ -44,6 +44,9 @@ struct MarkdownPreview: View {
     /// The quote to highlight, set after consuming a `pendingScrollAnchor` with
     /// a `#"quoted passage"` fragment. Nil when there's no active highlight.
     @State private var highlightQuote: String?
+    /// Occurrence (1-based) of `highlightQuote` to highlight — tracks find-bar
+    /// navigation so the highlight steps through successive matches.
+    @State private var highlightOccurrence: Int = 1
     /// Bumped each time `highlightQuote` changes. Used in the versioned markup
     /// to force `StructuredText` to re-parse without changing its view identity.
     @State private var highlightVersion: Int = 0
@@ -51,6 +54,15 @@ struct MarkdownPreview: View {
     /// `ContentView` so the right-click "Add as Source" item works in every
     /// reader (pages, sources, system prompt, changelog) without per-view wiring.
     @Environment(\.addURLHandler) private var addURLHandler
+
+    /// When set, scrolls to the anchor block containing this text and highlights
+    /// it. Bumped by the find bar as the user navigates through matches.
+    var findText: String? = nil
+    var findVersion: Int = 0
+    /// 1-based index of the current match within the content (from
+    /// `FindModel.currentMatchIndex`). Lets the scroll task target the Nth
+    /// occurrence rather than always the first.
+    var findOccurrence: Int = 1
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -70,7 +82,7 @@ struct MarkdownPreview: View {
                         let versioned = highlightVersion > 0
                             ? rendered + String(repeating: "\n", count: highlightVersion)
                             : rendered
-                        StructuredText(versioned, parser: WikiLinkStylingParser(highlightQuote: highlightQuote))
+                        StructuredText(versioned, parser: WikiLinkStylingParser(highlightQuote: highlightQuote, highlightOccurrence: highlightOccurrence))
                             .textual.paragraphStyle(NumberedParagraphStyle())
                             .textual.textSelection(.enabled)
                             .textual.fontScale(CGFloat(readerZoom))
@@ -134,6 +146,20 @@ struct MarkdownPreview: View {
                 highlightQuote = nil
                 highlightVersion = 0
             }
+            // Find bar scrolling: resolve the matched text to an anchor block,
+            // scroll to it, then highlight. Task(id:) re-fires on version bumps
+            // so repeated clicks on the same match still scroll.
+            .task(id: FindScrollKey(text: findText, version: findVersion, occurrence: findOccurrence)) {
+                guard let text = findText, !text.isEmpty else { return }
+                blocks = AnchorBlock.parse(markdown)
+                if let id = resolveAnchor(text, occurrence: findOccurrence, in: blocks) {
+                    try? await Task.sleep(for: .milliseconds(50))
+                    proxy.scrollTo(id, anchor: .top)
+                    highlightQuote = text.wikiNormalized
+                    highlightOccurrence = findOccurrence
+                    highlightVersion += 1
+                }
+            }
         }
     }
 
@@ -163,6 +189,14 @@ struct MarkdownPreview: View {
 private struct RenderKey: Hashable {
     let markdown: String
     let anchorVersion: Int
+}
+
+/// Keys the find-scroll task so it re-fires on version bumps (same text,
+/// bumped version = user clicked Next again for the same match).
+private struct FindScrollKey: Hashable {
+    let text: String?
+    let version: Int
+    let occurrence: Int
 }
 
 #Preview {

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -14,6 +14,10 @@ struct PageDetailView: View {
     @AppStorage("editor.zoom") private var editorZoom = Double(ZoomScale.defaultScale)
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
 
+    // Find bar state.
+    @State private var findModel = FindModel()
+    @State private var findVersion = 0
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             AgentRunBanner(isVisible: store.isAgentRunning)
@@ -82,7 +86,8 @@ struct PageDetailView: View {
             } else {
                 MarkdownPreview(store: store, markdown: readerMarkdown,
                                 currentSelection: store.selection,
-                                fileProvider: fileProvider)
+                                fileProvider: fileProvider,
+                                findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
                     .frame(maxWidth: .infinity)
                     .frame(minHeight: PageEditorMetrics.previewMinHeight)
                     .zoomShortcuts($readerZoom)
@@ -98,9 +103,59 @@ struct PageDetailView: View {
         .onChange(of: store.isAgentRunning) { _, isRunning in
             if isRunning { isEditing = false }
         }
+        .background { findShortcutButton }
+        .overlay(alignment: .top) { findBarOverlay }
+        .onChange(of: store.selection) { findModel.dismiss() }
+        .onChange(of: readerMarkdown) { _, newMarkdown in
+            findModel.content = newMarkdown
+            findModel.search()
+        }
+        .onChange(of: findModel.isShowing) { _, showing in
+            if showing {
+                findModel.content = readerMarkdown
+                findModel.search()
+            }
+        }
+        .onChange(of: findModel.currentMatchIndex) { _, _ in
+            guard findModel.currentMatchIndex > 0 else { return }
+            findVersion &+= 1
+        }
+    }
+
+    // MARK: - Find bar
+
+    @ViewBuilder
+    private var findBarOverlay: some View {
+        if findModel.isShowing {
+            VStack(spacing: 0) {
+                FindBarView(model: findModel)
+                Divider()
+            }
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    private var findShortcutButton: some View {
+        Button("") { findModel.toggle() }
+            .keyboardShortcut("f", modifiers: .command)
+            .opacity(0).allowsHitTesting(false)
     }
 
     // MARK: - Computed
+
+    private var findText: String? {
+        guard findModel.isShowing,
+              let content = findModel.content,
+              findModel.currentMatchIndex > 0,
+              findModel.currentMatchIndex <= findModel.matches.count
+        else { return nil }
+        let range = findModel.matches[findModel.currentMatchIndex - 1]
+        return String(content[range])
+    }
+
+    /// 1-based current match index, forwarded to the reader so next/previous
+    /// navigation targets distinct occurrences instead of always the first.
+    private var findOccurrence: Int { findModel.currentMatchIndex }
 
     private var displayTitle: String {
         store.draftTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -47,6 +47,10 @@ struct SourceDetailView: View {
     /// `defaults write` (set very high to effectively disable).
     @AppStorage("reader.webThresholdKB") private var webThresholdKB: Int = 96
 
+    // Find bar state.
+    @State private var findModel = FindModel()
+    @State private var findVersion = 0
+
     private enum FileContentTab: String, CaseIterable {
         case markdown = "Markdown"
         case pdf = "PDF"
@@ -73,6 +77,31 @@ struct SourceDetailView: View {
     private var displayName: String {
         file.filename.isEmpty ? "Untitled" : file.filename
     }
+
+    /// The markdown content currently shown (from processed head or native
+    /// markdown source). Used as the find bar's search content.
+    private var currentMarkdownContent: String? {
+        if isEditing { return editBuffer }
+        if let head = headVersion { return head.content }
+        if isMarkdownNative, let data = store.sourceBytes(id: file.id) {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+
+    private var findText: String? {
+        guard findModel.isShowing,
+              let content = findModel.content,
+              findModel.currentMatchIndex > 0,
+              findModel.currentMatchIndex <= findModel.matches.count
+        else { return nil }
+        let range = findModel.matches[findModel.currentMatchIndex - 1]
+        return String(content[range])
+    }
+
+    /// 1-based current match index, forwarded to the reader so next/previous
+    /// navigation targets distinct occurrences instead of always the first.
+    private var findOccurrence: Int { findModel.currentMatchIndex }
 
     private var alreadyIngested: Bool { hasBeenIngested }
 
@@ -136,6 +165,23 @@ struct SourceDetailView: View {
         .onChange(of: store.selection) { flushEditIfDirty(); isEditing = false }
         .onChange(of: store.isAgentRunning) {
             if $1 { flushEditIfDirty(); isEditing = false }
+        }
+        .background { findShortcutButton }
+        .overlay(alignment: .top) { findBarOverlay }
+        .onChange(of: file.id) { findModel.dismiss() }
+        .onChange(of: currentMarkdownContent) { _, newContent in
+            findModel.content = newContent
+            findModel.search()
+        }
+        .onChange(of: findModel.isShowing) { _, showing in
+            if showing {
+                findModel.content = currentMarkdownContent
+                findModel.search()
+            }
+        }
+        .onChange(of: findModel.currentMatchIndex) { _, _ in
+            guard findModel.currentMatchIndex > 0 else { return }
+            findVersion &+= 1
         }
     }
 
@@ -362,10 +408,12 @@ struct SourceDetailView: View {
             if useWeb {
                 SourceWebView(markdown: head.content,
                               currentSelection: store.selection,
-                              store: store)
+                              store: store,
+                              findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
             } else {
                 MarkdownPreview(store: store, markdown: head.content,
-                                currentSelection: store.selection)
+                                currentSelection: store.selection,
+                                findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
                     .zoomShortcuts($readerZoom)
                     .zoomScroll($readerZoom)
             }
@@ -517,6 +565,25 @@ struct SourceDetailView: View {
         if file.mimeType == "application/pdf" { return "doc.richtext" }
         if let mime = file.mimeType, mime.hasPrefix("text/") { return "doc.plaintext" }
         return "doc"
+    }
+
+    // MARK: - Find bar
+
+    @ViewBuilder
+    private var findBarOverlay: some View {
+        if findModel.isShowing {
+            VStack(spacing: 0) {
+                FindBarView(model: findModel)
+                Divider()
+            }
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    private var findShortcutButton: some View {
+        Button("") { findModel.toggle() }
+            .keyboardShortcut("f", modifiers: .command)
+            .opacity(0).allowsHitTesting(false)
     }
 
     private static let sizeFormatter: ByteCountFormatter = {

--- a/Sources/WikiFS/SourceWebView.swift
+++ b/Sources/WikiFS/SourceWebView.swift
@@ -39,6 +39,15 @@ struct SourceWebView: View {
     /// (covers re-clicking the same `[[…#"quote"]]` on an already-open source).
     @State private var scrollVersion = 0
 
+    /// Find bar: when set, the matched text is passed to the web view for
+    /// `window.find()` highlighting and scrolling.
+    var findText: String? = nil
+    var findVersion: Int = 0
+    /// 1-based index of the current match (`FindModel.currentMatchIndex`).
+    /// `applyFind` advances `window.find()` this many times so next/previous
+    /// navigation lands on distinct matches instead of always the first.
+    var findOccurrence: Int = 1
+
     var body: some View {
         ZStack {
             WebViewRep(markdown: markdown,
@@ -46,7 +55,8 @@ struct SourceWebView: View {
                        isLoading: $isLoading,
                        pendingScroll: pendingScroll,
                        scrollVersion: scrollVersion,
-                       addURLHandler: addURLHandler)
+                       addURLHandler: addURLHandler,
+                       findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
             if isLoading {
                 ProgressView()
                     .controlSize(.large)
@@ -250,6 +260,9 @@ private struct WebViewRep: NSViewRepresentable {
     let pendingScroll: PendingScroll?
     let scrollVersion: Int
     let addURLHandler: ((String) -> Void)?
+    let findText: String?
+    let findVersion: Int
+    let findOccurrence: Int
 
     func makeNSView(context: Context) -> SourceDetailWebView {
         let webView = SourceDetailWebView(frame: .zero, configuration: WKWebViewConfiguration())
@@ -273,6 +286,13 @@ private struct WebViewRep: NSViewRepresentable {
         } else {
             context.coordinator.applyPendingScrollIfNeeded(in: webView)
         }
+        // Find: apply to the loaded page.
+        if context.coordinator.appliedFindVersion != findVersion {
+            context.coordinator.appliedFindVersion = findVersion
+            if let text = findText, !text.isEmpty {
+                context.coordinator.applyFind(text, occurrence: findOccurrence, in: webView)
+            }
+        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -286,6 +306,7 @@ private struct WebViewRep: NSViewRepresentable {
         var pendingScroll: PendingScroll?
         var pendingScrollVersion = 0
         var appliedScrollVersion = 0
+        var appliedFindVersion = 0
         private var convertTask: Task<Void, Never>?
         private var loadStart: DispatchTime?
         private var isLoadingBinding: Binding<Bool>?
@@ -325,6 +346,51 @@ private struct WebViewRep: NSViewRepresentable {
                   appliedScrollVersion != pendingScrollVersion else { return }
             appliedScrollVersion = pendingScrollVersion
             WebViewRep.apply(target, in: webView)
+        }
+
+        /// Highlight and scroll to the find match using `window.find()`.
+        /// `occurrence` is 1-based: the selection is reset to the document start
+        /// and `window.find()` is advanced that many times, so repeated next/prev
+        /// clicks step through distinct matches instead of re-finding the first.
+        func applyFind(_ text: String, occurrence: Int, in webView: WKWebView) {
+            guard pageLoaded else { return }
+            let q = WebViewRep.jsString(text)
+            let n = max(1, occurrence)
+            webView.evaluateJavaScript("""
+            (function(q, n){
+              // Clear any previous highlight, collapsing the selection.
+              document.querySelectorAll("mark.sdwhl").forEach(function(m){
+                var p=m.parentNode; while(m.firstChild) p.insertBefore(m.firstChild,m);
+                p.removeChild(m); p.normalize();
+              });
+              // Reset the selection to the start of the body so window.find()
+              // walks matches in order from the top — making occurrence N
+              // deterministic instead of resuming from the previous highlight.
+              var sel=window.getSelection();
+              sel.removeAllRanges();
+              var body=document.body;
+              if(body){
+                var r0=document.createRange();
+                r0.setStart(body,0);
+                r0.collapse(true);
+                sel.addRange(r0);
+              }
+              // Advance forward N times to land on the requested occurrence.
+              for(var i=0;i<n;i++){ window.find(q,false,false,false,false); }
+              if(sel.rangeCount>0 && !sel.isCollapsed){
+                var r=sel.getRangeAt(0); var mark=document.createElement("mark");
+                mark.className="sdwhl";
+                try{ r.surroundContents(mark); }catch(e){
+                  // surroundContents fails across element boundaries; fall back
+                  // to a plain node at the selection start and scroll to it.
+                  mark.appendChild(document.createTextNode(q));
+                  r.insertNode(mark);
+                }
+                var mk=document.querySelector("mark.sdwhl");
+                if(mk){ mk.scrollIntoView({block:"center"}); }
+              }
+            })("\(q)", \(n));
+            """)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/Sources/WikiFS/WikiLinkStylingParser.swift
+++ b/Sources/WikiFS/WikiLinkStylingParser.swift
@@ -28,12 +28,12 @@ import WikiFSCore
 /// parser does not receive. `NSColor.linkColor` is SwiftUI's self-adapting
 /// semantic link color and is visually equivalent to Textual's link blue.
 ///
-/// **Quote highlighting.** When `highlightQuote` is non-nil, the parser finds
-/// the first whitespace-normalized occurrence of the quote in the rendered
-/// markdown and sets its `.backgroundColor` — exactly the same normalization
-/// `resolveAnchor` uses (`wikiNormalized`). The highlight color is the semantic
-/// Find color (`NSColor.findHighlightColor`), matching native macOS reader
-/// behavior.
+/// **Quote highlighting.** When `highlightQuote` is non-nil, the parser finds the
+/// whitespace-normalized occurrence of the quote (selected by
+/// `highlightOccurrence`, 1-based) in the rendered markdown and sets its
+/// `.backgroundColor` — exactly the same normalization `resolveAnchor` uses
+/// (`wikiNormalized`). The highlight color is the semantic Find color
+/// (`NSColor.findHighlightColor`), matching native macOS reader behavior.
 @MainActor
 struct WikiLinkStylingParser: MarkupParser {
     private let base: AttributedStringMarkdownParser = .init(baseURL: nil)
@@ -41,9 +41,14 @@ struct WikiLinkStylingParser: MarkupParser {
     /// An optional quote to highlight in the rendered output. Whitespace-normalized
     /// before matching (mirrors `wikiNormalized`). `nil` → no highlight.
     private let highlightQuote: String?
+    /// 1-based occurrence of the quote to highlight — lets find-bar next/previous
+    /// navigation step the highlight through distinct matches instead of always
+    /// highlighting the first one.
+    private let highlightOccurrence: Int
 
-    init(highlightQuote: String? = nil) {
+    init(highlightQuote: String? = nil, highlightOccurrence: Int = 1) {
         self.highlightQuote = highlightQuote
+        self.highlightOccurrence = max(1, highlightOccurrence)
     }
 
     func attributedString(for input: String) throws -> AttributedString {
@@ -81,7 +86,7 @@ struct WikiLinkStylingParser: MarkupParser {
     /// Uses a dynamic color that adapts to light/dark mode: the system Find color in
     /// light mode, and a lower-opacity warm tint in dark mode so white text stays readable.
     private func highlightQuote(_ quote: String, in string: inout AttributedString) {
-        guard let range = Self.quoteRange(quote, in: string) else { return }
+        guard let range = Self.quoteRange(quote, in: string, occurrence: highlightOccurrence) else { return }
         string[range].backgroundColor = Self.highlightColor
     }
 
@@ -102,15 +107,18 @@ struct WikiLinkStylingParser: MarkupParser {
 
     // MARK: - Pure, testable quote range
 
-    /// Find the first whitespace-normalized occurrence of `quote` in `string`,
-    /// returning the original `AttributedString` range, or `nil` on no match.
+    /// Find the whitespace-normalized occurrence `occurrence` (1-based) of `quote`
+    /// in `string`, returning the original `AttributedString` range, or `nil` on no
+    /// match.
     ///
     /// Whitespace in `string` is collapsed to single spaces (mirrors
     /// `wikiNormalized`), then an index map translates the normalized match
     /// bounds back to the original `AttributedString.Index` positions. The match
-    /// is case-sensitive and always picks the first occurrence.
-    static func quoteRange(_ quote: String, in string: AttributedString) -> Range<AttributedString.Index>? {
-        guard !quote.isEmpty else { return nil }
+    /// is case-sensitive; `occurrence` selects which non-overlapping match to use
+    /// (defaulting to the first), so find-bar navigation can step the highlight
+    /// through successive matches.
+    static func quoteRange(_ quote: String, in string: AttributedString, occurrence: Int = 1) -> Range<AttributedString.Index>? {
+        guard !quote.isEmpty, occurrence > 0 else { return nil }
 
         let chars = string.characters
         guard !chars.isEmpty else { return nil }
@@ -142,7 +150,20 @@ struct WikiLinkStylingParser: MarkupParser {
         while normalizedChars.last == " " { normalizedChars.removeLast(); indexMap.removeLast() }
 
         let normalizedHaystack = String(normalizedChars)
-        guard let matchRange = normalizedHaystack.range(of: quote) else { return nil }
+
+        // Find the Nth non-overlapping occurrence of quote.
+        var remaining = occurrence
+        var searchStart = normalizedHaystack.startIndex
+        var matchRange: Range<String.Index>?
+        while searchStart < normalizedHaystack.endIndex {
+            guard let r = normalizedHaystack.range(of: quote, range: searchStart..<normalizedHaystack.endIndex) else {
+                break
+            }
+            remaining -= 1
+            if remaining == 0 { matchRange = r; break }
+            searchStart = r.upperBound
+        }
+        guard let matchRange else { return nil }
 
         // Convert String.Index offsets in the normalized haystack to array indices.
         let lo = normalizedHaystack.distance(from: normalizedHaystack.startIndex, to: matchRange.lowerBound)

--- a/Sources/WikiFSCore/AnchorBlock.swift
+++ b/Sources/WikiFSCore/AnchorBlock.swift
@@ -169,6 +169,62 @@ public func resolveAnchor(_ fragment: String, in blocks: [AnchorBlock]) -> Strin
     return nil
 }
 
+// MARK: - Find-bar match resolution (occurrence-aware)
+
+/// Resolve a find-bar match to its anchor block, accounting for match order.
+/// `occurrence` is 1-based — which match, in document order, to scroll to.
+///
+/// Unlike the single-match `resolveAnchor`, this walks blocks counting
+/// non-overlapping matches so next/previous navigation steps through distinct
+/// blocks instead of always landing on the first one that contains the text.
+public func resolveAnchor(
+    _ fragment: String,
+    occurrence: Int,
+    in blocks: [AnchorBlock]
+) -> String? {
+    guard occurrence > 0 else { return nil }
+    let needle = fragment.wikiNormalized.lowercased()
+    guard !needle.isEmpty else { return nil }
+
+    // A heading slug is unique, so it can only ever be the first match.
+    if occurrence == 1 {
+        let slug = fragment.wikiNormalized
+        if let h = blocks.first(where: { $0.kind == .heading && $0.id == slug }) {
+            return h.id
+        }
+    }
+
+    // Walk blocks in document order, accumulating non-overlapping
+    // case-insensitive occurrences until we reach the target one.
+    var seen = 0
+    var firstMatching: String?
+    for block in blocks {
+        let c = countOccurrences(of: needle, in: block.text.wikiNormalized.lowercased())
+        if c > 0, firstMatching == nil { firstMatching = block.id }
+        seen += c
+        if seen >= occurrence {
+            return block.id
+        }
+    }
+    // Occurrence overshoots the block-level count (match straddles a block
+    // boundary, or rendered-text normalization differs from the raw content the
+    // find bar searched) — fall back to the first block that held any match.
+    return firstMatching
+}
+
+/// Count non-overlapping, case-sensitive occurrences of `needle` in `haystack`.
+private func countOccurrences(of needle: String, in haystack: String) -> Int {
+    guard !needle.isEmpty else { return 0 }
+    var count = 0
+    var searchStart = haystack.startIndex
+    while searchStart < haystack.endIndex,
+          let range = haystack.range(of: needle, range: searchStart..<haystack.endIndex) {
+        count += 1
+        searchStart = range.upperBound
+    }
+    return count
+}
+
 // MARK: - wikiNormalized (shared with WikiText)
 
 extension String {

--- a/Tests/WikiFSTests/AnchorBlockTests.swift
+++ b/Tests/WikiFSTests/AnchorBlockTests.swift
@@ -176,6 +176,39 @@ struct AnchorBlockTests {
         #expect(id == "p1")
     }
 
+    // MARK: - resolveAnchor(occurrence:) — find-bar next/prev navigation
+
+    @Test func resolveAnchorOccurrenceFirstMatchesFirstBlock() {
+        let blocks = AnchorBlock.parse("# Intro\n\nThe cat sat. The cat napped.")
+        let id = resolveAnchor("cat", occurrence: 1, in: blocks)
+        #expect(id == "p1")
+    }
+
+    @Test func resolveAnchorOccurrenceStaysInSameBlock() {
+        // Both "cat" occurrences are in the same paragraph, so occurrence 2
+        // still resolves to p1.
+        let blocks = AnchorBlock.parse("# Intro\n\nThe cat sat. The cat napped.")
+        #expect(resolveAnchor("cat", occurrence: 2, in: blocks) == "p1")
+    }
+
+    @Test func resolveAnchorOccurrenceStepsToNextBlock() {
+        let blocks = AnchorBlock.parse("# Intro\n\nThe cat sat.\n\nThe cat napped.")
+        #expect(resolveAnchor("cat", occurrence: 1, in: blocks) == "p1")
+        #expect(resolveAnchor("cat", occurrence: 2, in: blocks) == "p2")
+    }
+
+    @Test func resolveAnchorOccurrenceZeroReturnsNil() {
+        let blocks = AnchorBlock.parse("# Intro\n\nThe cat sat.")
+        #expect(resolveAnchor("cat", occurrence: 0, in: blocks) == nil)
+    }
+
+    @Test func resolveAnchorOccurrenceBeyondCountFallsBack() {
+        // Only one "cat" total; occurrence 5 falls back to the only matching
+        // block (p1) rather than nil, so the view still lands somewhere useful.
+        let blocks = AnchorBlock.parse("# Intro\n\nThe cat sat.")
+        #expect(resolveAnchor("cat", occurrence: 5, in: blocks) == "p1")
+    }
+
     // MARK: - Regression: anchors parse the RAW markdown (#1 dedupe)
     // MarkdownPreview's consume task now parses the RAW markdown instead of the
     // fully preprocessed (footnote-expanded + linkified) string, to avoid

--- a/Tests/WikiFSTests/QuoteHighlightTests.swift
+++ b/Tests/WikiFSTests/QuoteHighlightTests.swift
@@ -104,6 +104,66 @@ struct QuoteHighlightTests {
         #expect(range.lowerBound == attributed.startIndex)
     }
 
+    // MARK: - quoteRange: occurrence selection (find-bar next/prev navigation)
+
+    @Test func occurrenceDefaultsToFirst() throws {
+        let input = "cat dog cat dog"
+        let attributed = try attributedString(input)
+        let range = try #require(WikiLinkStylingParser.quoteRange("cat", in: attributed))
+        let offset = attributed.characters.distance(from: attributed.startIndex, to: range.lowerBound)
+        #expect(offset == 0)
+    }
+
+    @Test func occurrencePicksSecond() throws {
+        let input = "cat dog cat dog"
+        let attributed = try attributedString(input)
+        let range = try #require(WikiLinkStylingParser.quoteRange("cat", in: attributed, occurrence: 2))
+        let matched = String(attributed[range].characters)
+        #expect(matched == "cat")
+        let offset = attributed.characters.distance(from: attributed.startIndex, to: range.lowerBound)
+        #expect(offset == 8)
+    }
+
+    @Test func occurrencePicksThird() throws {
+        let input = "cat cat cat"
+        let attributed = try attributedString(input)
+        let range = try #require(WikiLinkStylingParser.quoteRange("cat", in: attributed, occurrence: 3))
+        let offset = attributed.characters.distance(from: attributed.startIndex, to: range.lowerBound)
+        #expect(offset == 8)
+    }
+
+    @Test func occurrenceBeyondCountReturnsNil() throws {
+        let attributed = try attributedString("only one match here")
+        #expect(WikiLinkStylingParser.quoteRange("match", in: attributed, occurrence: 5) == nil)
+    }
+
+    @Test func occurrenceZeroReturnsNil() throws {
+        let attributed = try attributedString("cat cat")
+        #expect(WikiLinkStylingParser.quoteRange("cat", in: attributed, occurrence: 0) == nil)
+    }
+
+    // MARK: - Integration: parser highlights the Nth occurrence
+
+    @Test func parserHighlightsNthOccurrence() throws {
+        let input = "cat dog cat dog"
+        let parser = WikiLinkStylingParser(highlightQuote: "cat", highlightOccurrence: 2)
+        let attributed = try parser.attributedString(for: input)
+        let bgRuns = attributed.runs.filter { $0.backgroundColor != nil }
+        let highlighted = try #require(bgRuns.first)
+        let text = String(attributed[highlighted.range].characters)
+        #expect(text == "cat")
+        let offset = attributed.characters.distance(from: attributed.startIndex, to: highlighted.range.lowerBound)
+        #expect(offset == 8)
+    }
+
+    @Test func parserDefaultOccurrenceHighlightsFirst() throws {
+        let parser = WikiLinkStylingParser(highlightQuote: "cat")
+        let attributed = try parser.attributedString(for: "cat dog cat dog")
+        let highlighted = try #require(attributed.runs.first { $0.backgroundColor != nil })
+        let offset = attributed.characters.distance(from: attributed.startIndex, to: highlighted.range.lowerBound)
+        #expect(offset == 0)
+    }
+
     // MARK: - Integration: parser applies backgroundColor
 
     @Test func parserAppliesBackgroundColor() throws {


### PR DESCRIPTION
## Summary

Adds a native macOS-style find bar to every reader, plus fixes two navigation bugs where the forward arrow did not advance to the next match.

## Find bar

`FindModel` (an `@Observable`) + `FindBarView`, overlaid at the top of every reader (`PageDetailView`, `SourceDetailView`):

- Search field with live match count ("2 of 14")
- Case-sensitivity toggle
- Prev / next arrows
- Keyboard: **⌘F** toggle, **Enter** next, **Shift+Enter** previous, **Esc** dismiss

Works in both the native `MarkdownPreview` reader and the `SourceWebView` (WKWebView) large-source reader.

## Bug fix — forward arrow did not advance

The renderers were passed only the matched *substring* (`findText`), never *which* occurrence. `currentMatchIndex` was computed correctly but discarded, so both renderers always jumped to the **first** match:

- **Native reader:** `resolveAnchor` used `blocks.first(where:)`; the highlight (`quoteRange`) always picked the first occurrence.
- **Web reader:** `applyFind` cleared the prior highlight (collapsing the selection) then called `window.find()` once.

**Fix:** thread the occurrence index (`currentMatchIndex`) end to end as `findOccurrence`:

| Layer | Change |
|---|---|
| `AnchorBlock` | New `resolveAnchor(_:occurrence:in:)` walks blocks in document order counting matches, lands on the Nth |
| `WikiLinkStylingParser` | `quoteRange` takes an `occurrence` param; parser stores `highlightOccurrence` |
| `SourceWebView` | `applyFind` resets selection to document start and advances `window.find()` N times |

## Tests

+12 tests (977 total, 71 suites, 0 failures):

- Occurrence selection in `quoteRange` (2nd/3rd/beyond/zero/default)
- Parser highlights the Nth occurrence (integration)
- Occurrence-aware `resolveAnchor` (first, same-block repeat, step-to-next-block, zero→nil, beyond-count fallback)

`swift build` and `swift test` both clean.