### PR TITLE
Replace always-on ".already ingested" banner with an ingest confirmation dialog

### DIFF
--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -40,6 +40,10 @@ struct SourceDetailView: View {
     @State private var isEditing = false
     @State private var editBuffer = ""
     @State private var isExtracting = false
+    /// Raised when the user taps Ingest on a document that has already been
+    /// ingested — prompts before re-ingesting, since that may create duplicate
+    /// pages. (Replaces the old always-on "already ingested" warning banner.)
+    @State private var showReingestConfirmation = false
     @State private var selectedTab = FileContentTab.markdown
     /// Quote to highlight in the PDF view, set when a `[[source:Name#"…"]]` link
     /// targets an un-extracted PDF. Consumed from `store.pendingScrollAnchor`.
@@ -101,30 +105,10 @@ struct SourceDetailView: View {
     /// navigation targets distinct occurrences instead of always the first.
     private var findOccurrence: Int { findModel.currentMatchIndex }
 
-    private var alreadyIngested: Bool { hasBeenIngested }
-
-    private var alreadyIngestedBanner: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-            Text("This document has already been ingested. Running ingest again may create duplicate pages.")
-                .font(.subheadline)
-                .fontWeight(.medium)
-            Spacer()
-        }
-        .padding(.horizontal, 16)
-        .frame(height: 32)
-        .frame(maxWidth: .infinity)
-        .background(.yellow.opacity(0.18))
-        .clipped()
-    }
-
     // MARK: - Body
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if alreadyIngested {
-                alreadyIngestedBanner
-            }
             headerSection
             if showTabs, !isEditing {
                 tabPicker
@@ -145,6 +129,7 @@ struct SourceDetailView: View {
             flushEditIfDirty()
             isEditing = false
             isExtracting = false
+            showReingestConfirmation = false
             headVersion = nil
             selectedTab = .markdown
             pdfQuote = nil
@@ -227,11 +212,27 @@ struct SourceDetailView: View {
                     Button(isIngesting ? "Ingesting…" : "Ingest into Wiki",
                            systemImage: "text.badge.plus") {
                         DebugLog.ingest("SourceDetailView: Ingest tapped — id=\(file.id.rawValue)")
-                        runIngest(file.id)
+                        if hasBeenIngested {
+                            showReingestConfirmation = true
+                        } else {
+                            runIngest(file.id)
+                        }
                     }
                         .keyboardShortcut(.return, modifiers: .command)
                         .disabled(isRunning || isIngesting || isAnySourceIngesting
                                   || isThisFileExtracting || isEditLockedExternally)
+                        .confirmationDialog(
+                            "Ingest Again?",
+                            isPresented: $showReingestConfirmation,
+                            titleVisibility: .visible
+                        ) {
+                            Button("Ingest Again", role: .destructive) {
+                                runIngest(file.id)
+                            }
+                            Button("Cancel", role: .cancel) {}
+                        } message: {
+                            Text("This document has already been ingested. Running ingest again may create duplicate pages.")
+                        }
                     if isPDF, !hasMarkdown {
                         Button(isExtracting ? "Extracting…" : "Extract Markdown",
                                systemImage: "doc.plaintext") {


### PR DESCRIPTION
## What

On **Sources** that have already been ingested, the static yellow warning banner
(\"This document has already been ingested. Running ingest again may create
duplicate pages.\") is removed. Tapping the **Ingest** button on an already-
ingested source now raises a native macOS confirmation dialog explaining the
duplicate-pages risk, with a destructive **Ingest Again** and a **Cancel**.

Sources that have **not** yet been ingested continue to ingest immediately on the
first tap — unchanged.

## Why

The always-on banner was visual noise for the common case and didn't gate the
action. A confirmation prompt is the right macOS pattern for a
potentially-destructive re-run, surfacing the tradeoff exactly when the user is
about to commit to it.

## Changes

- `Sources/WikiFS/SourceDetailView.swift`
  - Removed `alreadyIngestedBanner`, the `if alreadyIngested` block in `body`,
    and the now-dead `alreadyIngested` computed property.
  - Added `@State showReingestConfirmation`; the Ingest button now checks
    `hasBeenIngested` and either ingests directly (fresh) or shows the dialog.
  - Attached a \`.confirmationDialog\` (\`Ingest Again?\`, destructive confirm +
    \`Cancel\`, explanatory message) to the Ingest button.
  - Reset \`showReingestConfirmation\` in the per-file navigation \`.onChange\` so it
    can't leak across source switches.

## Verification

- \`swift build\` passes clean.
- Behavior is UI-only; the confirmation presentation is not covered by the
  existing unit-test harness.

## Notes

- Based directly on \`main\` (not on \`feature/separate-query-launcher\`); this is an
  independent UI change.