### PR TITLE
fix: wiki-link fragment rendering + split-quote highlight

### DIFF
--- a/Sources/WikiFS/WikiReaderView.swift
+++ b/Sources/WikiFS/WikiReaderView.swift
@@ -774,9 +774,25 @@ internal struct WikiReaderRep: NSViewRepresentable {
           var lo=0, hi=chars.length;
           while(lo<hi&&chars[lo]===" "){ lo++; }
           while(hi>lo&&chars[hi-1]===" "){ hi--; }
-          var at=chars.slice(lo,hi).join("").indexOf(nq);
-          if(at<0){ return; }
-          var s=lo+at, e=lo+at+nq.length-1;
+          var hay=chars.slice(lo,hi).join("");
+          var at=hay.indexOf(nq), mlen=nq.length;
+          if(at<0){
+            // The quote may not appear contiguously: PDF extraction can splice
+            // a footer/marginal block (or a hard-hyphenated word) into the
+            // middle of a sentence. Fall back to the LONGEST contiguous run of
+            // >=4 quote-words that IS present, so we still highlight + scroll to
+            // the passage instead of giving up.
+            var words=nq.split(" ");
+            for(var L=words.length-1; L>=4 && at<0; L--){
+              for(var st=0; st+L<=words.length; st++){
+                var cand=words.slice(st,st+L).join(" ");
+                var p=hay.indexOf(cand);
+                if(p>=0){ at=p; mlen=cand.length; break; }
+              }
+            }
+            if(at<0){ return; }
+          }
+          var s=lo+at, e=lo+at+mlen-1;
           var range=document.createRange();
           range.setStart(map[s].n, map[s].o);
           range.setEnd(map[e].n, map[e].o+1);

--- a/Sources/WikiFSCore/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSCore/WikiLinkMarkdown.swift
@@ -231,18 +231,23 @@ public enum WikiLinkMarkdown {
     /// Allowed characters for the `title=` query value. Start from the URL query
     /// set and remove the sub-delimiters that have query meaning, so a `&`, `=`,
     /// `?`, `#`, `+`, or space in a title is percent-escaped rather than parsed.
+    /// `(` / `)` are also escaped: the whole URL is emitted inside a Markdown
+    /// `[text](url)` destination, where an unbalanced `)` terminates the link.
     private static let titleQueryAllowed: CharacterSet = {
         var set = CharacterSet.urlQueryAllowed
-        set.remove(charactersIn: "&=?#+ ")
+        set.remove(charactersIn: "&=?#+ ()")
         return set
     }()
 
     /// Allowed characters for the URL fragment (everything after `#`). Keeps
     /// alphanumeric + common punctuation; `#`, `"`, space, and `%` are encoded so
-    /// they don't terminate the fragment or confuse URL parsing.
+    /// they don't terminate the fragment or confuse URL parsing. `(` / `)` are
+    /// also escaped: the URL lands inside a Markdown `[text](url)` destination,
+    /// and an unbalanced `)` (e.g. a fragment with `1.) 2.)`) would otherwise end
+    /// the link early and dump the rest of the URL as literal text.
     private static let fragmentAllowed: CharacterSet = {
         var set = CharacterSet.urlFragmentAllowed
-        set.remove(charactersIn: "#\" %")
+        set.remove(charactersIn: "#\" %()")
         return set
     }()
 

--- a/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
@@ -187,6 +187,40 @@ struct QuoteHighlightWebViewTests {
         #expect(await markText(in: webView).isEmpty == false)
     }
 
+    @Test func highlightFallsBackToLongestRunWhenQuoteIsSplit() async throws {
+        // PDF extraction spliced a reprint-address block (and a hard hyphen,
+        // "vo-" / "litional") into the MIDDLE of the sentence, so the full quote
+        // never appears contiguously. The fallback must still highlight the
+        // longest contiguous run that IS present and scroll to it.
+        let webView = WKWebView()
+        let body = """
+        <p>More recently, the vo-</p>\
+        <p>For reprints write to: Irving Kirsch, Ph.D., Department of Psychology, U-20.</p>\
+        <p>litional status of suggested behavior has become a source of intense controversy (Kirsch &amp; Lynn, 1995).</p>
+        """
+        try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
+
+        let quote = "the volitional status of suggested behavior has become a source of intense controversy"
+        await run(webView, WikiReaderRep.highlightJS(quote: quote))
+
+        let all = await allMarksText(in: webView).lowercased()
+        #expect(all.contains("status of suggested behavior has become a source of intense controversy"),
+                "split quote not highlighted via fallback; marks=\"\(all)\"")
+        #expect(await markText(in: webView).isEmpty == false)
+    }
+
+    @Test func noFallbackHighlightForShortUnmatchedQuote() async throws {
+        // A short quote (<4 words) that isn't present must NOT trigger a noisy
+        // partial highlight — the fallback floor is 4 words.
+        let webView = WKWebView()
+        let body = "<p>alpha beta gamma delta epsilon</p>"
+        try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
+
+        await run(webView, WikiReaderRep.highlightJS(quote: "nowhere to be found"))
+
+        #expect(await markText(in: webView).isEmpty)
+    }
+
     @Test func reHighlightClearsThePreviousMark() async throws {
         // A second highlight must remove the first mark, not stack them.
         let webView = WKWebView()

--- a/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
+++ b/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
@@ -222,6 +222,30 @@ struct WikiLinkMarkdownTests {
         #expect(frag == "\"exact passage\"")
     }
 
+    @Test func fragmentWithUnbalancedParensDoesNotBreakMarkdownLink() {
+        // A quoted passage with `1.) 2.) 3.) 4.)` enumerations carries unbalanced
+        // `)` characters. The whole URL is emitted inside a Markdown `(url)`
+        // destination, so an unencoded `)` would terminate the link early and
+        // dump the rest as literal text (breaking the renderer). They must be
+        // percent-encoded — and still round-trip back to the original fragment.
+        let quote = "it is 1.) outside, 2.) uncontrollable (Bargh, 1994)"
+        let out = WikiLinkMarkdown.linkified("[[source:Paper#\"\(quote)\"]]") { _, _ in true }
+        // No literal parens survive in the emitted link destination.
+        #expect(!extractURL(out).contains("("))
+        #expect(!extractURL(out).contains(")"))
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.fragment(from: url) == "\"\(quote)\"")
+    }
+
+    @Test func titleWithParensIsEncoded() {
+        // Parens in the *title* would equally break the `(url)` destination.
+        let out = WikiLinkMarkdown.linkified("[[Title (2024)]]") { _, _ in true }
+        #expect(!extractURL(out).contains("("))
+        #expect(!extractURL(out).contains(")"))
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "Title (2024)")
+    }
+
     @Test func samePageAnchorRendersAsWikiAnchorHost() {
         let out = WikiLinkMarkdown.linkified("[[#Section]]") { _, _ in true }
         #expect(out == "[Section](wiki://anchor#Section)")


### PR DESCRIPTION
Two fixes for `[[source:Name#"quote"]]` links whose fragment is a verbatim passage.

1. Rendering: percent-encode `(` / `)` in the title and fragment of the generated `wiki://` URL. The URL is emitted inside a Markdown `[text](url)` destination, where an unbalanced `)` (e.g. a quoted passage enumerating `1.) 2.) 3.) 4.)`) terminated the link early and dumped the rest as literal text, breaking the renderer.

2. Highlight: when a clicked link lands on a source but the quote isn't contiguous — PDF extraction can splice a footer/marginal block (or a hard hyphen) into the middle of a sentence — fall back to highlighting the longest contiguous run of >=4 quote-words that is present, so the reader still scrolls to the passage instead of giving up. Exact matches are unaffected; the >=4-word floor avoids latching onto noise.

Adds regression tests: paren-encoding round-trips in WikiLinkMarkdown, and a live-WKWebView test reproducing the split-sentence fallback.