### PR TITLE
fix: query chat "Not logged in" + debug-log the claude invocation

### DIFF
--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -136,6 +136,11 @@ final class AgentLauncher {
     private var stderrLogHandle: FileHandle?
     /// Writable stdin for an interactive stream-json query session.
     private var inputHandle: FileHandle?
+    /// The per-run copy of the user's `.credentials.json` seeded into the relocated
+    /// `CLAUDE_CONFIG_DIR` (sandboxed runs only), or nil. Tracked so `finish()` can
+    /// delete it — the scratch dir is kept for debugging, so the OAuth token must
+    /// not outlive the run there.
+    @ObservationIgnored private var seededCredentialFile: URL?
     /// True when the running process is waiting for user turns over stdin.
     private(set) var isInteractiveSession = false
 
@@ -500,6 +505,10 @@ final class AgentLauncher {
             sandbox: sandbox
         )
 
+        // Seed the user's credentials into the relocated CLAUDE_CONFIG_DIR (sandboxed
+        // runs only) so the child authenticates without an interactive /login.
+        seedSandboxCredentials(for: command, scratch: scratch)
+
         // RESERVE per-run metadata. `isRunning` is already `true` (the slot set it on
         // acquire); set the rest. No `resetRunState` here — the prior `finish()`
         // already cleared artifacts, and clearing now would race a peer that owns the
@@ -562,6 +571,7 @@ final class AgentLauncher {
 
         do {
             DebugLog.agent("run: spawning kind=\(operation.kind.rawValue) wikiID=\(wikiID) exe=\(command.executable)")
+            DebugLog.agent("run: command \(command.debugSummary)")
             try process.run()
             self.process = process
             currentProcessID = process.processIdentifier
@@ -701,6 +711,10 @@ final class AgentLauncher {
             sandbox: sandbox
         )
 
+        // Seed the user's credentials into the relocated CLAUDE_CONFIG_DIR (sandboxed
+        // runs only) so the query session authenticates without an interactive /login.
+        seedSandboxCredentials(for: command, scratch: scratch)
+
         // RESERVE per-run metadata. `isRunning` is already `true` (slot acquire).
         let now = Date()
         isInteractiveSession = true
@@ -760,6 +774,7 @@ final class AgentLauncher {
         }
 
         do {
+            DebugLog.agent("startInteractiveQuery: command \(command.debugSummary)")
             try process.run()
             self.process = process
             inputHandle = stdinPipe.fileHandleForWriting
@@ -948,6 +963,9 @@ final class AgentLauncher {
             stdoutLineBuffer = ""
         }
         closeLogFiles()
+        // Delete the per-run seeded credential copy so the user's OAuth token does
+        // not linger in the persisted scratch dir.
+        removeSeededCredentials()
         exitStatus = status
         isInteractiveSession = false
         runningKind = nil
@@ -1131,5 +1149,76 @@ final class AgentLauncher {
         let tmp = scratch.appendingPathComponent(".tmp", isDirectory: true)
         try? FileManager.default.createDirectory(at: claudeConfig, withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Sandbox credential seeding
+
+    /// Pure decision for credential seeding. Given the built command's
+    /// `CLAUDE_CONFIG_DIR` (set only when the spawn is sandboxed) and the run's
+    /// `scratchPath`, return the `(source, target)` `.credentials.json` copy to
+    /// perform — or nil when no seeding applies. Seeds ONLY when the config dir was
+    /// relocated INTO our scratch, so a user who set their OWN `CLAUDE_CONFIG_DIR`
+    /// is never touched, and unsandboxed runs (which read the real `~/.claude`)
+    /// are no-ops. Pure + injectable so the path logic is unit-testable.
+    static func relocatedCredentialPlan(
+        configDir: String?,
+        scratchPath: String,
+        home: String
+    ) -> (source: String, target: String)? {
+        guard let configDir, configDir.hasPrefix(scratchPath) else { return nil }
+        return (source: home + "/.claude/.credentials.json",
+                target: configDir + "/.credentials.json")
+    }
+
+    /// Seed the relocated `CLAUDE_CONFIG_DIR` a sandboxed spawn points at so the
+    /// child can authenticate without an interactive `/login`.
+    /// `OperationCommand.applySandbox` redirects claude's config dir into the
+    /// per-run scratch zone; that dir starts empty, so when the spawn can't reach
+    /// the login Keychain (the headless, sandboxed GUI-spawn case observed in the
+    /// app) claude finds no credentials and reports "Not logged in · Please run
+    /// /login". Copying the user's `.credentials.json` into the relocated dir gives
+    /// it a file-based credential to read instead. (An expired access token in that
+    /// file self-heals via its refresh token on first use.)
+    ///
+    /// Best-effort and reversible: records the seeded path in `seededCredentialFile`
+    /// so `finish()` deletes it when the run ends — the scratch dir is kept for
+    /// debugging, so a copy of the user's OAuth token must not accumulate there. A
+    /// missing source file or a copy failure just leaves the child to whatever else
+    /// it can reach (e.g. an `ANTHROPIC_API_KEY` in the env).
+    private func seedSandboxCredentials(for command: OperationCommand, scratch: URL) {
+        let fm = FileManager.default
+        // Ensure the relocated dirs we own exist — the read-only query path doesn't
+        // run `createSandboxRelocationDirs`, and claude writes its config + temp here.
+        for key in ["CLAUDE_CONFIG_DIR", "TMPDIR"] {
+            if let dir = command.environment[key], dir.hasPrefix(scratch.path) {
+                try? fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            }
+        }
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+        guard let plan = Self.relocatedCredentialPlan(
+            configDir: command.environment["CLAUDE_CONFIG_DIR"],
+            scratchPath: scratch.path,
+            home: home) else { return }
+        guard fm.fileExists(atPath: plan.source) else {
+            DebugLog.agent("seedSandboxCredentials: no \(plan.source) to copy — child may report Not logged in")
+            return
+        }
+        do {
+            if fm.fileExists(atPath: plan.target) { try fm.removeItem(atPath: plan.target) }
+            try fm.copyItem(atPath: plan.source, toPath: plan.target)
+            try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: plan.target)
+            seededCredentialFile = URL(fileURLWithPath: plan.target)
+            DebugLog.agent("seedSandboxCredentials: seeded credentials into relocated CLAUDE_CONFIG_DIR")
+        } catch {
+            DebugLog.agent("seedSandboxCredentials: copy failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Delete the per-run seeded credential copy (if any). Called from `finish()` so
+    /// the OAuth-token copy never outlives the run in the persisted scratch dir.
+    private func removeSeededCredentials() {
+        guard let file = seededCredentialFile else { return }
+        try? FileManager.default.removeItem(at: file)
+        seededCredentialFile = nil
     }
 }

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -24,6 +24,46 @@ public struct OperationCommand: Equatable, Sendable {
     /// mount.
     public let currentDirectoryPath: String
 
+    // MARK: - Debug summary
+
+    /// A single-line, redacted summary of this invocation for `DebugLog`. Surfaces
+    /// the executable, the full FLAG surface (long payloads like the system prompt
+    /// and the query prompt are truncated to a length marker so the log stays
+    /// legible and free of wiki content), and only the auth/resolution-relevant
+    /// environment keys — never the whole environment, which may carry API keys.
+    ///
+    /// The headline diagnostic for claude's "Not logged in · Please run /login":
+    /// `CLAUDE_CONFIG_DIR` is relocated into an empty per-run scratch dir whenever
+    /// the run is sandboxed (the read-only query default), so the child can't see
+    /// the user's `~/.claude` credentials. `authSet` lists which API-key env vars
+    /// are present (NAMES ONLY, never values) — an empty list plus a relocated
+    /// `CLAUDE_CONFIG_DIR` is the fingerprint of that failure.
+    public var debugSummary: String {
+        let redactedArgs = arguments.map { Self.redactArgument($0) }.joined(separator: " ")
+        let reportedEnvKeys = ["CLAUDE_CONFIG_DIR", "HOME", "TMPDIR", "PATH", "WIKI_ROOT", "WIKI_DB"]
+        let env = reportedEnvKeys
+            .compactMap { key in environment[key].map { "\(key)=\($0)" } }
+            .joined(separator: " ")
+        // Presence-only (no values): an API key or OAuth token in the child env
+        // bypasses interactive /login, so knowing which are set explains the auth
+        // path without ever logging a secret.
+        let authKeys = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"]
+        let authSet = authKeys.filter { (environment[$0]?.isEmpty == false) }
+        let sandboxed = (executable == Self.sandboxExecutable)
+        return "exe=\(executable) sandboxed=\(sandboxed) "
+            + "args=[\(redactedArgs)] env={\(env)} "
+            + "authSet=[\(authSet.joined(separator: ","))] cwd=\(currentDirectoryPath)"
+    }
+
+    /// Truncate one argument to a head + length marker when it's long. The system
+    /// prompt and query prompt run to thousands of characters (and may carry wiki
+    /// content), so dumping them whole would bury the flags and leak page text;
+    /// short flags and values pass through unchanged.
+    static func redactArgument(_ arg: String, limit: Int = 80) -> String {
+        guard arg.count > limit else { return arg }
+        return "\(arg.prefix(limit))…(\(arg.count) chars)"
+    }
+
     /// Build the invocation for `operation` against one wiki.
     ///
     /// - Parameters:

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -232,6 +232,44 @@ struct OperationCommandTests {
     #expect(!cmd.arguments.contains { $0.contains("Bash(wikictl") })
   }
 
+  // MARK: - Debug summary (redacted, secret-safe)
+
+  @Test func debugSummaryTruncatesLongPayloadArgsButKeepsFlags() {
+    let longPrompt = String(repeating: "x", count: 5000)
+    let cmd = build(operation: .query(question: longPrompt, stateFilePath: Self.stateFile))
+    let summary = cmd.debugSummary
+    // Flags survive verbatim…
+    #expect(summary.contains("--model"))
+    #expect(summary.contains("--output-format"))
+    #expect(summary.contains("--dangerously-skip-permissions"))
+    // …but the multi-thousand-char prompt is collapsed to a length marker, not dumped.
+    #expect(!summary.contains(longPrompt))
+    #expect(summary.contains(" chars)"))   // a truncation marker is present
+    #expect(!summary.contains(String(repeating: "x", count: 200)))
+  }
+
+  @Test func debugSummaryReportsRelocatedConfigDirButNeverSecretValues() {
+    // Sandboxed build relocates CLAUDE_CONFIG_DIR — the "Not logged in" fingerprint —
+    // and the env carries an API key whose VALUE must never appear in the summary.
+    let cmd = OperationCommand.build(
+      operation: Self.tinyIngest(),
+      wikiRoot: Self.resolvedRoot,
+      wikiID: "01WIKIULID",
+      systemPrompt: "You are the maintainer.",
+      scratchDirectory: "/tmp/scratch-xyz",
+      wikictlDirectory: "/Apps/Self Driving Wiki.app/Contents/Helpers",
+      resolvedExecutable: "/opt/homebrew/bin/claude",
+      sandbox: .init(profile: "(version 1)", defines: []),
+      baseEnvironment: ["PATH": "/usr/bin", "HOME": "/Users/me",
+                        "ANTHROPIC_API_KEY": "sk-ant-supersecret"])
+    let summary = cmd.debugSummary
+    #expect(summary.contains("CLAUDE_CONFIG_DIR=/tmp/scratch-xyz/.claude-config"))
+    #expect(summary.contains("sandboxed=true"))
+    // The key's PRESENCE is reported by name; its value is never logged.
+    #expect(summary.contains("authSet=[ANTHROPIC_API_KEY]"))
+    #expect(!summary.contains("sk-ant-supersecret"))
+  }
+
   @Test func eachOperationKindBuildsAValidCommand() {
     for operation: WikiOperation in [
       Self.tinyIngest(),

--- a/Tests/WikiFSTests/RelocatedCredentialPlanTests.swift
+++ b/Tests/WikiFSTests/RelocatedCredentialPlanTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import WikiFS
+
+/// Tests for the pure `AgentLauncher.relocatedCredentialPlan` decision: WHEN to
+/// seed the user's `.credentials.json` into a sandboxed spawn's relocated
+/// `CLAUDE_CONFIG_DIR`. The seed must fire ONLY when the config dir was relocated
+/// into the run's own scratch (so a user's own `CLAUDE_CONFIG_DIR` is never touched
+/// and unsandboxed runs are no-ops).
+@MainActor
+struct RelocatedCredentialPlanTests {
+
+    private static let scratch = "/Users/me/Library/Caches/Self Driving Wiki-agent/01ABC"
+    private static let home = "/Users/me"
+
+    @Test func seedsWhenConfigDirIsRelocatedIntoScratch() {
+        let plan = AgentLauncher.relocatedCredentialPlan(
+            configDir: Self.scratch + "/.claude-config",
+            scratchPath: Self.scratch,
+            home: Self.home)
+        #expect(plan?.source == "/Users/me/.claude/.credentials.json")
+        #expect(plan?.target == Self.scratch + "/.claude-config/.credentials.json")
+    }
+
+    @Test func noSeedWhenUnsandboxed() {
+        // Unsandboxed runs never relocate CLAUDE_CONFIG_DIR — nil → no copy.
+        #expect(AgentLauncher.relocatedCredentialPlan(
+            configDir: nil, scratchPath: Self.scratch, home: Self.home) == nil)
+    }
+
+    @Test func noSeedWhenConfigDirIsOutsideOurScratch() {
+        // A user's OWN CLAUDE_CONFIG_DIR (not under our scratch) must never be
+        // overwritten with a credential copy.
+        #expect(AgentLauncher.relocatedCredentialPlan(
+            configDir: "/Users/me/.config/claude",
+            scratchPath: Self.scratch,
+            home: Self.home) == nil)
+    }
+}


### PR DESCRIPTION
## Problem

The interactive **query chat** runs `claude` under a read-only seatbelt sandbox, which relocates `CLAUDE_CONFIG_DIR` into an empty per-run scratch dir. In the app's headless GUI-spawn context the child can't reach the login Keychain, so it finds no credentials and reports **"Not logged in · Please run /login"**.

## Changes

- **Seed credentials into the relocated config dir.** Copy the user's `~/.claude/.credentials.json` into `$CLAUDE_CONFIG_DIR/.credentials.json` for sandboxed spawns so the child authenticates from a file instead of the Keychain. (An expired access token self-heals via its refresh token on first use.)
  - Gated by the pure, unit-tested `AgentLauncher.relocatedCredentialPlan` — only seeds when the config dir is **inside our scratch**, so a user's own `CLAUDE_CONFIG_DIR` is never touched and unsandboxed runs are no-ops.
  - `chmod 0600`, and `finish()` deletes the copy so the OAuth token never lingers in the persisted scratch dir.

- **Debug-log the exact claude invocation.** New `OperationCommand.debugSummary` — a redacted, secret-safe one-line summary (executable, full flag surface with long prompt payloads truncated, auth/resolution-relevant env keys only, API-key presence by **name** never value) emitted at every spawn. The relocated `CLAUDE_CONFIG_DIR` + empty `authSet` is the fingerprint of the login failure.

  Read with:
  ```
  log show --predicate 'subsystem == "com.selfdrivingwiki.debug"' \
           --style compact --info --debug --last 30m
  ```

## Verification

All 1112 tests pass (3 new for `relocatedCredentialPlan`, 2 for `debugSummary` redaction/secret-safety).

⚠️ **Caveat:** the exact "Not logged in" failure could not be reproduced from a shell — a terminal is a trusted Keychain context, whereas the failure is specific to the headless GUI spawn. The fix is sound in principle (file credential bypasses the Keychain) but its end-to-end proof is running the query chat in the app; the new debug log confirms seeding + auth outcome there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)