### PR TITLE
feat/rename page source titles

### DIFF
--- a/Sources/WikiFS/EditableTitle.swift
+++ b/Sources/WikiFS/EditableTitle.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// A large title that can be renamed in place. Shows the title as bold text;
+/// a double-click (or right-click → Rename) swaps it for a focused text field.
+/// Return — or clicking away (focus loss) — commits the trimmed text; Escape
+/// cancels. A commit is a no-op when the text is empty or unchanged, so the
+/// caller's `onCommit` only fires for a real rename.
+///
+/// View-only: the caller owns persistence via `onCommit` (e.g. `store.rename` for
+/// a page, `store.renameSource` for a source). Used by the page and source detail
+/// headers so a title can be edited straight from the detail page.
+struct EditableTitle: View {
+    /// The current title (the committed value). The field seeds from this on edit.
+    let title: String
+    /// Shown when `title` is blank, and used as the baseline so committing the
+    /// placeholder text doesn't count as a change.
+    var placeholder: String = "Untitled"
+    var font: Font = .largeTitle
+    /// Display-mode line cap (the editing field is always single-line). `nil` = no cap.
+    var lineLimit: Int? = nil
+    /// When true, double-click and the Rename menu item are inert (e.g. while the
+    /// agent is updating the wiki).
+    var isDisabled: Bool = false
+    /// Called with the new trimmed title on a real rename (non-empty, changed).
+    let onCommit: (String) -> Void
+
+    @State private var isEditing = false
+    @State private var draft = ""
+    @FocusState private var focused: Bool
+
+    private var display: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? placeholder : title
+    }
+
+    var body: some View {
+        Group {
+            if isEditing {
+                TextField(placeholder, text: $draft)
+                    .font(font)
+                    .fontWeight(.bold)
+                    .textFieldStyle(.plain)
+                    .focused($focused)
+                    .onSubmit(commit)
+                    .onExitCommand(perform: cancel)
+                    .onChange(of: focused) { _, isFocused in
+                        // Clicking away commits whatever is in the field.
+                        if !isFocused { commit() }
+                    }
+            } else {
+                Text(display)
+                    .font(font)
+                    .fontWeight(.bold)
+                    .lineLimit(lineLimit)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) { begin() }
+                    .contextMenu {
+                        Button("Rename") { begin() }
+                            .disabled(isDisabled)
+                        Button("Copy") {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(display, forType: .string)
+                        }
+                    }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        // Bail out of an in-progress edit if the underlying title changes from
+        // outside (e.g. the user navigates to a different page/source — the view
+        // is reused, so @State would otherwise leak the old draft over it).
+        .onChange(of: title) { isEditing = false }
+    }
+
+    private func begin() {
+        guard !isDisabled else { return }
+        draft = title
+        isEditing = true
+        // Focus after the field has mounted, or the binding has nothing to bind to.
+        DispatchQueue.main.async { focused = true }
+    }
+
+    private func commit() {
+        guard isEditing else { return }   // already cancelled / committed
+        isEditing = false
+        if let value = Self.committedValue(draft: draft, current: title) {
+            onCommit(value)
+        }
+    }
+
+    /// Pure decision: the value to hand `onCommit` for a rename, or `nil` to skip.
+    /// Trims surrounding whitespace and skips an empty or unchanged title, so a
+    /// rename only fires for a real change. Extracted so the rule is unit-testable
+    /// without driving SwiftUI state.
+    static func committedValue(draft: String, current: String) -> String? {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != current else { return nil }
+        return trimmed
+    }
+
+    private func cancel() {
+        // Drop the draft without committing. The blur-driven commit that follows
+        // is a no-op because `isEditing` is already false.
+        isEditing = false
+    }
+}

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -22,11 +22,12 @@ struct PageDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header — always visible, same layout in both modes.
             VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
-                Text(displayTitle)
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                EditableTitle(
+                    title: store.draftTitle,
+                    placeholder: "Untitled",
+                    isDisabled: store.isAgentRunning,
+                    onCommit: renameCurrentPage
+                )
 
                 HStack(spacing: 12) {
                     if let date = pageUpdatedAt {
@@ -242,6 +243,13 @@ struct PageDetailView: View {
     private func commitEdit() {
         store.flushPendingSave()
         isEditing = false
+    }
+
+    /// Rename the currently-selected page. `store.rename` flushes pending edits
+    /// first, then updates the title (and the slug, open tabs, and `draftTitle`).
+    private func renameCurrentPage(to newTitle: String) {
+        guard case .page(let id)? = store.selection else { return }
+        store.rename(id, to: newTitle)
     }
 
 }

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -172,11 +172,13 @@ struct SourceDetailView: View {
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
             Label {
-                Text(displayName)
-                    .font(.largeTitle)
-                    .bold()
-                    .lineLimit(2)
-                    .textSelection(.enabled)
+                EditableTitle(
+                    title: displayName,
+                    placeholder: "Untitled",
+                    lineLimit: 2,
+                    isDisabled: store.isAgentRunning || isEditLockedExternally,
+                    onCommit: { store.renameSource(id: file.id, to: $0) }
+                )
             } icon: {
                 Image(systemName: symbol)
                     .foregroundStyle(.secondary)

--- a/Sources/WikiFS/SourceRow.swift
+++ b/Sources/WikiFS/SourceRow.swift
@@ -24,6 +24,8 @@ struct SourceRow: View {
     var isSelected: Bool = false
     let onOpen: () -> Void
     let onRemove: () -> Void
+    /// Begin renaming this source's display name (shown in the context menu).
+    var onRename: (() -> Void)? = nil
     /// Ingest all currently-selected sources (shown in context menu when this
     /// source is part of a multi-source selection).
     var onIngestSelected: (() -> Void)? = nil
@@ -98,6 +100,9 @@ struct SourceRow: View {
                 Divider()
             }
             Button("Open", systemImage: "arrow.up.forward.app", action: onOpen)
+            if let onRename {
+                Button("Rename", systemImage: "pencil", action: onRename)
+            }
             Button("Remove", role: .destructive, action: onRemove)
         }
         .swipeActions(edge: .trailing) {

--- a/Sources/WikiFS/SourcesSectionView.swift
+++ b/Sources/WikiFS/SourcesSectionView.swift
@@ -40,6 +40,10 @@ struct SourcesSectionView: View {
 
     @State private var isSourcesExpanded = true
 
+    // Rename dialog state (mirrors the page-row rename in SidebarView).
+    @State private var renameTarget: SourceSummary?
+    @State private var renameText = ""
+
     var body: some View {
         Section {
             if isSourcesExpanded {
@@ -68,6 +72,29 @@ struct SourcesSectionView: View {
                 .help("Filter sources by ingest status")
             }
         }
+        .alert("Rename Source", isPresented: renamePresented) {
+            TextField("Name", text: $renameText)
+            Button("Cancel", role: .cancel) { renameTarget = nil }
+            Button("Rename") { commitRename() }
+        }
+    }
+
+    private var renamePresented: Binding<Bool> {
+        Binding(get: { renameTarget != nil },
+                set: { if !$0 { renameTarget = nil } })
+    }
+
+    private func beginRename(_ source: SourceSummary) {
+        renameText = source.displayName ?? source.filename
+        renameTarget = source
+    }
+
+    private func commitRename() {
+        if let target = renameTarget {
+            let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { store.renameSource(id: target.id, to: trimmed) }
+        }
+        renameTarget = nil
     }
 
     private func sourceRow(_ source: SourceSummary) -> some View {
@@ -83,6 +110,7 @@ struct SourcesSectionView: View {
             isSelected: ids.contains(source.id),
             onOpen: { Task { await fileProvider.openSource(id: source.id) } },
             onRemove: { store.deleteSource(source.id) },
+            onRename: { beginRename(source) },
             onIngestSelected: ingestAction
         )
         .tag(WikiSelection.source(source.id))

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -783,6 +783,12 @@ public final class WikiStoreModel {
     public func renameSource(id: PageID, to newDisplayName: String) {
         do {
             try store.renameSource(id: id, to: newDisplayName)
+            // Refresh BOTH lists: `sources` so the renamed source's display name
+            // updates in the sidebar + detail view (without this the rename commits
+            // to the DB but the live UI snaps back to the old name), and
+            // `summaries` because the rename rewrites inbound `[[source:…]]` links
+            // in the pages that reference it.
+            reloadSources()
             reloadSummaries()
             for i in tabs.indices where tabs[i].selection == .source(id) {
                 tabs[i].title = newDisplayName

--- a/Tests/WikiFSTests/EditableTitleTests.swift
+++ b/Tests/WikiFSTests/EditableTitleTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import WikiFS
+
+/// Tests for `EditableTitle.committedValue` — the pure rule that decides whether
+/// an inline title edit is a real rename worth committing.
+@MainActor
+struct EditableTitleTests {
+
+    @Test func commitsTrimmedChangedTitle() {
+        #expect(EditableTitle.committedValue(draft: "  New Name  ", current: "Old") == "New Name")
+    }
+
+    @Test func skipsUnchangedTitle() {
+        #expect(EditableTitle.committedValue(draft: "Same", current: "Same") == nil)
+    }
+
+    @Test func skipsUnchangedAfterTrim() {
+        // Re-committing the same title with stray whitespace is not a rename.
+        #expect(EditableTitle.committedValue(draft: "  Same  ", current: "Same") == nil)
+    }
+
+    @Test func skipsEmptyOrWhitespaceOnly() {
+        #expect(EditableTitle.committedValue(draft: "", current: "Old") == nil)
+        #expect(EditableTitle.committedValue(draft: "   ", current: "Old") == nil)
+    }
+
+    @Test func renamingFromBlankTitleCommits() {
+        #expect(EditableTitle.committedValue(draft: "First Title", current: "") == "First Title")
+    }
+}

--- a/Tests/WikiFSTests/WikiStoreModelRenameSourceTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelRenameSourceTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Regression tests for `WikiStoreModel.renameSource`: the rename must refresh the
+/// in-memory `sources` list, or the DB updates but the live UI snaps back to the
+/// old name (the "nothing happens when I rename a source" bug — the model only
+/// reloaded `summaries`, never `sources`).
+@MainActor
+struct WikiStoreModelRenameSourceTests {
+
+    private func makeModel() throws -> WikiStoreModel {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return WikiStoreModel(store: try SQLiteWikiStore(
+            databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
+    }
+
+    @Test func renameSourceRefreshesSourcesList() throws {
+        let model = try makeModel()
+        model.addSource(filename: "old-name.pdf", data: Data("pdf".utf8))
+        let id = try #require(model.sources.first?.id)
+
+        model.renameSource(id: id, to: "Friendly Name")
+
+        let renamed = model.sources.first(where: { $0.id == id })
+        #expect(renamed?.displayName == "Friendly Name")
+    }
+}


### PR DESCRIPTION
Lets users rename a **page** title or **source** display name without leaving the app — straight from the detail page, or via right-click.

## What you can do

**On the detail page (pages + sources):**
- **Double-click the title** → it becomes an editable field in place. Return commits, Esc cancels, clicking away commits.
- **Right-click the title → Rename** (also a Copy item, since the inline-editable title is no longer drag-selectable).

**In the sidebar:**
- **Source rows** gain a right-click **Rename** (small dialog), matching what page rows already had.

## How it works

- New `EditableTitle` view handles the in-place editing. The commit rule (trim, skip empty/unchanged) is a pure, unit-tested `EditableTitle.committedValue`.
- Pages commit via `store.rename` (flushes pending edits, updates the slug + open tabs + `draftTitle`).
- Sources commit via `store.renameSource`, which **transactionally rewrites inbound `[[source:…]]` links** in every referencing page (fragment + alias preserved).
- Title editing is disabled while the agent is updating the wiki.

## Bug fixed along the way

`WikiStoreModel.renameSource` reloaded only `summaries` (pages), never `sources` — so a source rename committed to the DB but the live UI kept deriving its `file` from the stale in-memory `sources` and snapped the title back to the old name ("nothing happens when I rename a source"). Added `reloadSources()` alongside the existing `reloadSummaries()`. A latent bug — nothing exercised it before this branch added source-rename UI.

## Verification

All 1113 tests pass (new: `EditableTitleTests` for the commit rule, `WikiStoreModelRenameSourceTests` regression for the sources-refresh). App builds clean.

⚠️ The GUI interaction itself (double-click focus / commit / Esc) wasn't driven end-to-end — worth a quick manual confirm when running.

## Note on page-title renames

Renaming a **page** leaves inbound `[[wikilinks]]` to the old title stale until each linking page is next saved (they self-heal then) — existing store behavior, unchanged here. Source renames don't have this issue because they rewrite links transactionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)