### PR TITLE
fix: remove CLAUDE_CONFIG_DIR sandbox redirect and sandbox UI

### DIFF
--- a/Sources/WikiFS/AgentCommandSettingsView.swift
+++ b/Sources/WikiFS/AgentCommandSettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import WikiFSCore
 
 /// Settings → Agent tab: configure the agent executable, prefix arguments,
-/// model override, extra environment variables, and the optional seatbelt sandbox.
+/// model override, and extra environment variables.
 /// Mirrors `ZoteroSettingsView`: a `Form` whose fields persist immediately via
 /// `.onChange(of:)` — no explicit save step, so a value is never lost when the
 /// Settings window closes.
@@ -11,8 +11,6 @@ struct AgentCommandSettingsView: View {
     @State private var prefixArguments: String
     @State private var modelOverride: String
     @State private var extraEnvironment: String
-    @State private var sandboxEnabled: Bool
-    @State private var extraAllowedPaths: String
 
     let containerDirectory: URL
 
@@ -23,9 +21,6 @@ struct AgentCommandSettingsView: View {
         _prefixArguments = State(initialValue: config.prefixArguments)
         _modelOverride = State(initialValue: config.modelOverride)
         _extraEnvironment = State(initialValue: config.extraEnvironment)
-        let sandbox = SandboxConfig.load(from: containerDirectory)
-        _sandboxEnabled = State(initialValue: sandbox.enabled)
-        _extraAllowedPaths = State(initialValue: sandbox.extraAllowedPaths)
     }
 
     var body: some View {
@@ -46,19 +41,10 @@ struct AgentCommandSettingsView: View {
                 } header: {
                     Text("Extra Environment")
                 } footer: {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("KEY=VALUE, one per line. WIKI_ROOT and WIKI_DB are always set by the app and cannot be overridden.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        if sandboxEnabled {
-                            Text("While the sandbox is on, the app also sets CLAUDE_CONFIG_DIR and TMPDIR (redirecting the provider's config/temp into the scratch dir); any value you set for those keys here is overridden.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
+                    Text("KEY=VALUE, one per line. WIKI_ROOT and WIKI_DB are always set by the app and cannot be overridden.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-
-                sandboxSection
             }
             .formStyle(.grouped)
 
@@ -75,49 +61,10 @@ struct AgentCommandSettingsView: View {
         .onChange(of: prefixArguments) { _, _ in saveCommand() }
         .onChange(of: modelOverride) { _, _ in saveCommand() }
         .onChange(of: extraEnvironment) { _, _ in saveCommand() }
-        .onChange(of: sandboxEnabled) { _, _ in saveSandbox() }
-        .onChange(of: extraAllowedPaths) { _, _ in saveSandbox() }
-    }
-
-    // MARK: - Sandbox section
-
-    /// The seatbelt section. The sandbox confines the spawned agent's filesystem
-    /// WRITES to a strict allowlist (the per-run scratch dir + the active wiki's
-    /// database). Reads and network are unaffected. It is provider-agnostic — the
-    /// seatbelt wraps whatever executable is set above.
-    @ViewBuilder private var sandboxSection: some View {
-        Section {
-            Toggle("Confine agent writes (macOS seatbelt)", isOn: $sandboxEnabled)
-
-            if sandboxEnabled {
-                TextEditor(text: $extraAllowedPaths)
-                    .font(.system(.body, design: .monospaced))
-                    .frame(minHeight: 64)
-            }
-        } header: {
-            Text("Sandbox")
-        } footer: {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(sandboxEnabled
-                     ? "The agent can write ONLY the active wiki's database and its per-run scratch directory; the provider's config and temp are redirected into the scratch dir automatically. Reads and network are unaffected."
-                     : "When enabled, the spawned agent is wrapped in macOS's seatbelt (sandbox-exec) so its filesystem writes are confined to the wiki database and a per-run scratch directory.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                if sandboxEnabled {
-                    Text("Additional paths the agent may write to — one per line. `~` is expanded to your home. These can only widen the allowlist, never remove the core scratch/database paths.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Text("`/usr/bin/sandbox-exec` is Apple's long-stable, widely-used seatbelt CLI (Claude Code, Codex CLI, and SwiftPM depend on it). macOS 15+.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-        }
     }
 
     // MARK: - Actions
 
-    /// Persist the command fields immediately (auto-save).
     private func saveCommand() {
         let config = AgentCommandConfig(
             executable: executable,
@@ -127,27 +74,12 @@ struct AgentCommandSettingsView: View {
         try? config.save(to: containerDirectory)
     }
 
-    /// Persist the sandbox fields immediately (auto-save) to a separate file.
-    private func saveSandbox() {
-        let config = SandboxConfig(
-            enabled: sandboxEnabled,
-            extraAllowedPaths: extraAllowedPaths)
-        try? config.save(to: containerDirectory)
-    }
-
-    /// Restore the built-in defaults and persist both configs.
     private func resetToDefault() {
         let cmdDefaults = AgentCommandConfig.default
         executable = cmdDefaults.executable
         prefixArguments = cmdDefaults.prefixArguments
         modelOverride = cmdDefaults.modelOverride
         extraEnvironment = cmdDefaults.extraEnvironment
-
-        let sandboxDefaults = SandboxConfig.default
-        sandboxEnabled = sandboxDefaults.enabled
-        extraAllowedPaths = sandboxDefaults.extraAllowedPaths
-
         saveCommand()
-        saveSandbox()
     }
 }

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1145,9 +1145,7 @@ final class AgentLauncher {
     /// inside the seatbelt allowlist. Best-effort: failure (e.g. scratch unwritable)
     /// is surfaced later by the provider's own write errors.
     private func createSandboxRelocationDirs(in scratch: URL) {
-        let claudeConfig = scratch.appendingPathComponent(".claude-config", isDirectory: true)
         let tmp = scratch.appendingPathComponent(".tmp", isDirectory: true)
-        try? FileManager.default.createDirectory(at: claudeConfig, withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
     }
 

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -222,10 +222,11 @@ public struct OperationCommand: Equatable, Sendable {
     ) -> (executable: String, arguments: [String]) {
         guard let sandbox else { return (resolvedExecutable, arguments) }
 
-        // Relocate the provider's self-writes into the writable scratch zone so the
-        // profile allowlist stays tiny. These keys are distinct from WIKI_ROOT /
-        // WIKI_DB / PATH, so they don't clobber the app-owned block.
-        environment["CLAUDE_CONFIG_DIR"] = scratchDirectory + "/.claude-config"
+        // Relocate temp writes into scratch so they land inside the seatbelt allowlist.
+        // CLAUDE_CONFIG_DIR is intentionally NOT redirected: Claude Code reads its
+        // credentials from ~/.claude/.credentials.json, and pointing it at an empty
+        // scratch dir hides those credentials. The sandbox's (deny file-write*) rule
+        // already blocks writes to ~/.claude/ — Claude Code handles the EPERM quietly.
         environment["TMPDIR"] = scratchDirectory + "/.tmp"
 
         var head: [String] = ["-p", sandbox.profile]

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -32,15 +32,11 @@ public struct OperationCommand: Equatable, Sendable {
     /// legible and free of wiki content), and only the auth/resolution-relevant
     /// environment keys — never the whole environment, which may carry API keys.
     ///
-    /// The headline diagnostic for claude's "Not logged in · Please run /login":
-    /// `CLAUDE_CONFIG_DIR` is relocated into an empty per-run scratch dir whenever
-    /// the run is sandboxed (the read-only query default), so the child can't see
-    /// the user's `~/.claude` credentials. `authSet` lists which API-key env vars
-    /// are present (NAMES ONLY, never values) — an empty list plus a relocated
-    /// `CLAUDE_CONFIG_DIR` is the fingerprint of that failure.
+    /// `authSet` lists which API-key env vars are present (NAMES ONLY, never values) —
+    /// an empty list means Claude Code will fall back to ~/.claude credential lookup.
     public var debugSummary: String {
         let redactedArgs = arguments.map { Self.redactArgument($0) }.joined(separator: " ")
-        let reportedEnvKeys = ["CLAUDE_CONFIG_DIR", "HOME", "TMPDIR", "PATH", "WIKI_ROOT", "WIKI_DB"]
+        let reportedEnvKeys = ["HOME", "TMPDIR", "PATH", "WIKI_ROOT", "WIKI_DB"]
         let env = reportedEnvKeys
             .compactMap { key in environment[key].map { "\(key)=\($0)" } }
             .joined(separator: " ")
@@ -85,8 +81,8 @@ public struct OperationCommand: Equatable, Sendable {
     ///   - sandbox: when non-nil, wrap the invocation in `/usr/bin/sandbox-exec`
     ///     with the seatbelt profile that confines writes to the scratch dir + active
     ///     wiki DB (`plans/sandbox-agent.md`). Default `nil` reproduces today's run
-    ///     byte-for-byte. The relocation env (`CLAUDE_CONFIG_DIR`, `TMPDIR`) is set
-    ///     only when non-nil; it never clobbers `WIKI_ROOT`/`WIKI_DB`/`PATH`.
+    ///     byte-for-byte. `TMPDIR` is relocated into scratch when non-nil; it never
+    ///     clobbers `WIKI_ROOT`/`WIKI_DB`/`PATH`.
     ///   - baseEnvironment: the parent environment to inherit (default the current
     ///     process's). Injected so tests can pin a known PATH.
     public static func build(

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -248,9 +248,10 @@ struct OperationCommandTests {
     #expect(!summary.contains(String(repeating: "x", count: 200)))
   }
 
-  @Test func debugSummaryReportsRelocatedConfigDirButNeverSecretValues() {
-    // Sandboxed build relocates CLAUDE_CONFIG_DIR — the "Not logged in" fingerprint —
-    // and the env carries an API key whose VALUE must never appear in the summary.
+  @Test func debugSummaryReportsAuthSetButNeverSecretValues() {
+    // Sandboxed build; the env carries an API key whose VALUE must never appear in
+    // the summary. CLAUDE_CONFIG_DIR is intentionally NOT set (fixing the auth bug
+    // where redirecting it to an empty scratch dir hid ~/.claude credentials).
     let cmd = OperationCommand.build(
       operation: Self.tinyIngest(),
       wikiRoot: Self.resolvedRoot,
@@ -263,7 +264,8 @@ struct OperationCommandTests {
       baseEnvironment: ["PATH": "/usr/bin", "HOME": "/Users/me",
                         "ANTHROPIC_API_KEY": "sk-ant-supersecret"])
     let summary = cmd.debugSummary
-    #expect(summary.contains("CLAUDE_CONFIG_DIR=/tmp/scratch-xyz/.claude-config"))
+    // CLAUDE_CONFIG_DIR must NOT appear — we no longer redirect it.
+    #expect(!summary.contains("CLAUDE_CONFIG_DIR"))
     #expect(summary.contains("sandboxed=true"))
     // The key's PRESENCE is reported by name; its value is never logged.
     #expect(summary.contains("authSet=[ANTHROPIC_API_KEY]"))

--- a/Tests/WikiFSTests/SandboxedOperationCommandTests.swift
+++ b/Tests/WikiFSTests/SandboxedOperationCommandTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 /// Sandbox-wrapping tests for `OperationCommand.build` / `buildInteractiveQuery`.
 /// Verifies the seatbelt argv shape (AC.2), byte-identical-when-off (AC.1), the
-/// relocation env (`CLAUDE_CONFIG_DIR`/`TMPDIR`) present-on / absent-off, and that
+/// relocation env (`TMPDIR`) present-on / absent-off, and that
 /// the provider's own prefix args land AFTER `-- <providerExe>`.
 struct SandboxedOperationCommandTests {
 
@@ -81,7 +81,9 @@ struct SandboxedOperationCommandTests {
     #expect(cmd.environment["WIKI_ROOT"] == Self.resolvedRoot)
     #expect(cmd.environment["WIKI_DB"] == "01WIKIULID")
     #expect(cmd.environment["PATH"] == "/helpers:/usr/bin:/bin")
-    #expect(cmd.environment["CLAUDE_CONFIG_DIR"] == Self.scratch + "/.claude-config")
+    // CLAUDE_CONFIG_DIR is intentionally NOT set: redirecting it to an empty scratch
+    // dir hid ~/.claude/.credentials.json and caused "Not logged in" auth failures.
+    #expect(cmd.environment["CLAUDE_CONFIG_DIR"] == nil)
     #expect(cmd.environment["TMPDIR"] == Self.scratch + "/.tmp")
   }
 
@@ -114,7 +116,7 @@ struct SandboxedOperationCommandTests {
     #expect(cmd.arguments[1] == Self.sandbox.profile)
     #expect(cmd.arguments[8] == "--")
     #expect(cmd.arguments[9] == Self.providerExe)
-    #expect(cmd.environment["CLAUDE_CONFIG_DIR"] == Self.scratch + "/.claude-config")
+    #expect(cmd.environment["CLAUDE_CONFIG_DIR"] == nil)
     #expect(cmd.environment["TMPDIR"] == Self.scratch + "/.tmp")
     // The WIKI_DB env var (the ULID the agent/wikictl use) is NOT clobbered by the
     // `-D WIKI_DB=<path>` profile param — they are separate channels.


### PR DESCRIPTION
## Summary
- **fix:** Removed `CLAUDE_CONFIG_DIR` redirect from `applySandbox` — it pointed Claude Code at an empty scratch dir, hiding `~/.claude/.credentials.json` and causing auth failures. The sandbox's `(deny file-write*)` rule already blocks writes to `~/.claude/` so the redirect was redundant as a write guard and harmful as a read guard.
- **feat:** Removed sandbox toggle/extra-paths UI from `AgentCommandSettingsView`. `SandboxConfig` and `SandboxProfile` remain for programmatic use; the launcher still loads the config at spawn time.

## Test plan
- [ ] Launch a query conversation — Claude Code authenticates and responds
- [ ] `TMPDIR` is still redirected to scratch (temp files stay inside sandbox allowlist)
- [ ] Settings → Agent no longer shows a Sandbox section

🤖 Generated with Claude Code