### PR TITLE
Restore in-app wiki switcher in sidebar

### DIFF
--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -74,6 +74,11 @@ struct SidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            WikiSwitcher(manager: manager)
+                .padding(.horizontal, 12)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+            Divider()
             sectionSelectorBar
                 .padding(.top, 8)
             Divider()


### PR DESCRIPTION
The `WikiSwitcher` view was wired into the sidebar in `8c378ea` ("Phase 0: one FP domain per wiki + in-app switcher"), but the `WikiSwitcher(manager:)` line was dropped during the UI refactor in #74 (`0bb7662`). That left `WikiSwitcher.swift` in the tree as dead code — defined but never referenced anywhere — so there's currently no way to switch wikis from the app.

This re-adds it to the top of the sidebar in the new `VStack` layout so users can switch between wikis again.

## Test plan
- `swift build` passes.
- Switcher appears at the top of the sidebar, above the section selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
