### PR TITLE
Fix sandboxed agent: PATH-independent wikictl + shell seatbelt writes

### DIFF
--- a/Sources/WikiFSCore/ClaudePromptHelp.swift
+++ b/Sources/WikiFSCore/ClaudePromptHelp.swift
@@ -75,6 +75,7 @@ public enum ClaudePromptHelp {
     var envPairs: [(String, String)] = [
       ("WIKI_ROOT", command.environment["WIKI_ROOT"] ?? ""),
       ("WIKI_DB", command.environment["WIKI_DB"] ?? ""),
+      ("WIKICTL", command.environment["WIKICTL"] ?? ""),
       ("PATH", command.environment["PATH"] ?? ""),
     ]
     // When sandboxed, the relocation env is part of the real invocation surface.

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -104,10 +104,7 @@ public struct OperationCommand: Equatable, Sendable {
         }
         environment["WIKI_ROOT"] = wikiRoot
         environment["WIKI_DB"] = wikiID
-        // Prepend the helper dir so `wikictl` resolves; preserve any user PATH.
-        let userPath = environment["PATH"]
-        let existingPath = userPath ?? baseEnvironment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
-        environment["PATH"] = wikictlDirectory + ":" + existingPath
+        resolveWikictl(into: &environment, wikictlDirectory: wikictlDirectory, baseEnvironment: baseEnvironment)
 
         let model = command.modelOverride.isEmpty
             ? operation.topLevelModelAlias : command.modelOverride
@@ -164,9 +161,7 @@ public struct OperationCommand: Equatable, Sendable {
         }
         environment["WIKI_ROOT"] = wikiRoot
         environment["WIKI_DB"] = wikiID
-        let userPath = environment["PATH"]
-        let existingPath = userPath ?? baseEnvironment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
-        environment["PATH"] = wikictlDirectory + ":" + existingPath
+        resolveWikictl(into: &environment, wikictlDirectory: wikictlDirectory, baseEnvironment: baseEnvironment)
 
         let model = command.modelOverride.isEmpty
             ? operation.topLevelModelAlias : command.modelOverride
@@ -196,6 +191,33 @@ public struct OperationCommand: Equatable, Sendable {
             environment: environment,
             currentDirectoryPath: scratchDirectory
         )
+    }
+
+    // MARK: - wikictl resolution
+
+    /// Make the embedded `wikictl` reachable to the agent **without** depending on the
+    /// agent's interactive shell preserving our `PATH`. Sets three things on `environment`:
+    ///
+    /// 1. `WIKICTL` — the absolute path to the binary. Env vars survive the agent's shell
+    ///    init even when `PATH` does not: Claude Code's Bash tool runs the user's login
+    ///    shell, whose startup may rebuild `PATH` from scratch (e.g. nix-darwin's
+    ///    `/etc/zshenv`), discarding our prepend. The system prompt invokes `$WIKICTL`,
+    ///    so resolution no longer rides on `PATH` at all.
+    /// 2. `PATH` — still prepend the helper dir so a bare `wikictl` resolves where the
+    ///    shell leaves our `PATH` intact (preserving any user `PATH`).
+    /// 3. `__NIX_DARWIN_SET_ENVIRONMENT_DONE` — nix-darwin's shell init rebuilds `PATH`
+    ///    only when this guard is unset (the case for a GUI/launchd-spawned app). Setting
+    ///    it makes nix-darwin treat the environment as already initialized, so the `PATH`
+    ///    prepend in (2) survives into the agent's shell. Inert on non-nix systems.
+    static func resolveWikictl(
+        into environment: inout [String: String],
+        wikictlDirectory: String,
+        baseEnvironment: [String: String]
+    ) {
+        environment["WIKICTL"] = wikictlDirectory + "/wikictl"
+        let existingPath = environment["PATH"] ?? baseEnvironment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+        environment["PATH"] = wikictlDirectory + ":" + existingPath
+        environment["__NIX_DARWIN_SET_ENVIRONMENT_DONE"] = "1"
     }
 
     // MARK: - Seatbelt wrapping

--- a/Sources/WikiFSCore/SandboxProfile.swift
+++ b/Sources/WikiFSCore/SandboxProfile.swift
@@ -82,6 +82,7 @@ public enum SandboxProfile {
             // The active wiki DB and its SQLite sidecars are exact files.
             "(allow file-write* (literal (param \"WIKI_DB\")))",
         ]
+        lines.append(contentsOf: agentRuntimeWriteRules())
         for suffix in sqliteSidecarSuffixes {
             lines.append(
                 "(allow file-write* (literal (string-append (param \"WIKI_DB\") \"\(suffix)\")))"
@@ -105,7 +106,7 @@ public enum SandboxProfile {
     /// prevents `wikictl page upsert` / `wikictl index set` / `wikictl log append`
     /// from writing, regardless of prompt instructions.
     public static func generateReadOnly(scratchDir: String) -> String {
-        let lines: [String] = [
+        var lines: [String] = [
             "(version 1)",
             "(allow default)",
             "(deny file-write*)",
@@ -121,6 +122,7 @@ public enum SandboxProfile {
             // Bash tool to function under the sandbox.
             "(allow file-write* (subpath (param \"CLAUDE_TMP\")))",
         ]
+        lines.append(contentsOf: agentRuntimeWriteRules())
         return lines.joined(separator: "\n") + "\n"
     }
 
@@ -194,6 +196,34 @@ public enum SandboxProfile {
                 ("CLAUDE_TMP", resolvedClaudeTemp),
             ]
         )
+    }
+
+    /// Filesystem-write allowances every spawned agent's SHELL and tools need at
+    /// runtime, independent of the wiki write policy — so they belong in BOTH the
+    /// read-write (`generate`) and read-only (`generateReadOnly`) profiles. Shared here
+    /// so the two can't drift. Kept to least privilege — only paths a normal shell run
+    /// actually touches, scoped as narrowly as the use allows:
+    ///
+    /// - **`/dev/null`** — zsh redirects to it during startup; without a write allow the
+    ///   shell prints `operation not permitted: /dev/null` on every command. Only data
+    ///   writes are needed (not chmod/unlink), so `file-write-data`, not `file-write*`.
+    /// - **`/dev/fd`** — the targets of `/dev/stdout`/`/dev/stderr` after symlink
+    ///   canonicalization; aliases the process's own fds, so it can't widen access.
+    ///   Data writes only.
+    /// - **Claude Code's per-shell cwd markers.** Its Bash tool creates a marker dir
+    ///   directly under `/private/tmp` named `claude-<hex>-cwd` — a sibling of, NOT
+    ///   under, the per-session `CLAUDE_TMP` base (`/private/tmp/claude-<uid>`, already
+    ///   allowed separately). Scoped to exactly that marker shape rather than a broad
+    ///   `/private/tmp/claude-*` prefix, so the agent can't write across other uids' or
+    ///   sessions' temp dirs in shared `/private/tmp`. This needs full `file-write*`
+    ///   (mkdir/unlink). `/dev/tty` and `/dev/dtracehelper` are deliberately NOT allowed
+    ///   — they weren't observed as needed (the agent's output is piped, not a tty).
+    private static func agentRuntimeWriteRules() -> [String] {
+        [
+            "(allow file-write-data (literal \"/dev/null\"))",
+            "(allow file-write-data (subpath \"/dev/fd\"))",
+            "(allow file-write* (regex #\"^/private/tmp/claude-[A-Za-z0-9]+-cwd(/|$)\"))",
+        ]
     }
 
     // MARK: - Helpers

--- a/Sources/WikiFSCore/SystemPrompt.swift
+++ b/Sources/WikiFSCore/SystemPrompt.swift
@@ -108,7 +108,7 @@ public struct SystemPrompt: Equatable, Sendable {
     - **`[[source:Name]]`** (without a passage) navigates to the source and opens its
       extracted/text content — use for general references; add `#"…"` for specific
       passages. The canonical cite target is the source's **display name**; you may
-      rename a source with `wikictl source rename --id <id> --to "New Name"` —
+      rename a source with `$WIKICTL source rename --id <id> --to "New Name"` —
       existing `[[source:…]]` links are automatically rewritten, so renames never
       orphan citations.
     - **External sources** (papers, books, URLs NOT ingested into this wiki) get
@@ -150,34 +150,35 @@ public struct SystemPrompt: Equatable, Sendable {
 
     ## Tooling — write via `wikictl`, never the filesystem
 
-    The mount is READ-ONLY. All writes go through the `wikictl` command, which
-    writes straight to the wiki's database. `wikictl` is on your PATH and already
-    targets THIS wiki via the `WIKI_DB` environment variable — do NOT pass
-    `--wiki`.
+    The mount is READ-ONLY. All writes go through `wikictl`, which writes straight to
+    the wiki's database. **Always invoke it as `$WIKICTL`** — that variable holds its
+    absolute path and resolves regardless of your shell's PATH (a bare `wikictl` works
+    in most shells too, but `$WIKICTL` always does). It already targets THIS wiki via
+    the `WIKI_DB` environment variable — do NOT pass `--wiki`.
 
-    **Markdown auto-normalizes on save.** `wikictl page upsert` strips trailing
+    **Markdown auto-normalizes on save.** `$WIKICTL page upsert` strips trailing
     whitespace, converts tabs to spaces, collapses extra blank lines, ensures
     blank lines around headings/fences/lists/tables, and guarantees a single
     trailing newline — automatically. You don't need to hand-format whitespace;
     focus on content and structure.
 
     ```
-    wikictl page list                          list id / title / path per page
-    wikictl page get --title T | --id I        print a page body (instant, authoritative)
-    printf '%s' "<body>" | wikictl page upsert --title T --body-file -   create or update a page
-    wikictl page delete --id I                 delete a page
-    printf '%s' "<body>" | wikictl index set --body-file -               rewrite index.md wholesale
-    wikictl log append --kind ingest|query|lint --title "…" [--note "…"] [--source <file-id>]  record an action (--source marks an ingest done)
-    wikictl search --query "…" [--limit N]    semantic search — find pages by meaning; defaults to 10 results, max 100
-    wikictl source list [--json]               list all sources (TSV, or JSON lines)
-    wikictl source cat --id I | --name N       write raw source bytes to stdout
-    wikictl source export --id I | --name N [--out <path>]
+    $WIKICTL page list                          list id / title / path per page
+    $WIKICTL page get --title T | --id I        print a page body (instant, authoritative)
+    printf '%s' "<body>" | $WIKICTL page upsert --title T --body-file -   create or update a page
+    $WIKICTL page delete --id I                 delete a page
+    printf '%s' "<body>" | $WIKICTL index set --body-file -               rewrite index.md wholesale
+    $WIKICTL log append --kind ingest|query|lint --title "…" [--note "…"] [--source <file-id>]  record an action (--source marks an ingest done)
+    $WIKICTL search --query "…" [--limit N]    semantic search — find pages by meaning; defaults to 10 results, max 100
+    $WIKICTL source list [--json]               list all sources (TSV, or JSON lines)
+    $WIKICTL source cat --id I | --name N       write raw source bytes to stdout
+    $WIKICTL source export --id I | --name N [--out <path>]
                                                 materialize a source to disk, print its path
     ```
 
-    **Read back what you just wrote with `wikictl page get`** — the mount lags a
+    **Read back what you just wrote with `$WIKICTL page get`** — the mount lags a
     few seconds behind the database, so `cat`-ing a path under `$WIKI_ROOT`
-    immediately after a write may show stale bytes. `wikictl page get` reads the
+    immediately after a write may show stale bytes. `$WIKICTL page get` reads the
     database directly and is always current.
 
     ## Sources
@@ -194,36 +195,36 @@ public struct SystemPrompt: Equatable, Sendable {
     **Ingest** — bring one raw source into the wiki:
     1. Read the source (`Read` for PDFs/images, `cat` for text).
     2. Write at least one summary page capturing its key content via
-       `wikictl page upsert`. FOOTNOTE EVERY CLAIM drawn from the source with
+       `$WIKICTL page upsert`. FOOTNOTE EVERY CLAIM drawn from the source with
        `[^id]` + `[^id]: [[source:DisplayName#"distinctive quote"]]` — see the
        Footnotes convention above for exact syntax.
     3. Create or update the entity/concept pages it mentions, cross-linking with
        `[[wiki links]]`.
-    4. Rewrite `index.md` via `wikictl index set` so the catalog lists the pages
-       you just wrote (read the current set with `wikictl page list` first).
-    5. Record it: `wikictl log append --kind ingest --source <file-id> --title "<source>" --note "…"`.
+    4. Rewrite `index.md` via `$WIKICTL index set` so the catalog lists the pages
+       you just wrote (read the current set with `$WIKICTL page list` first).
+    5. Record it: `$WIKICTL log append --kind ingest --source <file-id> --title "<source>" --note "…"`.
        The `--source <file-id>` (given in the ingest task as SOURCE_ID) marks the
        file Ingested in the app — always pass it on a successful ingest.
 
     **Query** — answer a question from the wiki:
-    1. Search: start with `wikictl search --query "…"` for semantic (meaning-based)
-       search across page bodies. If that misses, fall back to `wikictl page list`,
-       then `wikictl page get`; `grep`/`cat` over `index.md`, `log.md`, and
+    1. Search: start with `$WIKICTL search --query "…"` for semantic (meaning-based)
+       search across page bodies. If that misses, fall back to `$WIKICTL page list`,
+       then `$WIKICTL page get`; `grep`/`cat` over `index.md`, `log.md`, and
        `WIKI-STRUCTURE.md`.
     2. Answer concisely, CITING page titles with `[[wiki links]]` and source passages
        with `[^id]` + `[^id]: [[source:Name#"quote"]]` footnotes (see Footnotes
        convention above). If the wiki lacks the information, say so plainly rather
        than guessing.
-    3. Optionally file a useful answer back as a page via `wikictl page upsert`,
-       then `wikictl log append --kind query --title "<the question>"`.
+    3. Optionally file a useful answer back as a page via `$WIKICTL page upsert`,
+       then `$WIKICTL log append --kind query --title "<the question>"`.
 
     **Lint** — health-check the wiki:
-    1. Survey pages (`wikictl page list`/`page get`), the link graph
+    1. Survey pages (`$WIKICTL page list`/`page get`), the link graph
        (`indexes/links.jsonl`), `index.md`, and `log.md`.
     2. Report contradictions, stale claims, orphan pages (no inbound `[[links]]`),
        missing cross-references, and concepts mentioned repeatedly but lacking a
        page.
-    3. Record it: `wikictl log append --kind lint --title "Wiki lint" --note "…"`.
+    3. Record it: `$WIKICTL log append --kind lint --title "Wiki lint" --note "…"`.
        You may also file the report as a page. Only add cross-reference links you
        are confident about; don't rewrite existing page content.
 

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -214,6 +214,19 @@ struct OperationCommandTests {
     #expect(cmd.environment["PATH"] == "/Apps/Self Driving Wiki.app/Contents/Helpers:/usr/bin:/bin")
   }
 
+  @Test func exportsWikictlAbsolutePathSoResolutionSurvivesPathRebuild() {
+    // The agent's login shell may rebuild PATH from scratch (dropping our prepend);
+    // $WIKICTL is an env var (which survives) holding the binary's absolute path.
+    let cmd = build(wikictlDir: "/Apps/Self Driving Wiki.app/Contents/Helpers")
+    #expect(cmd.environment["WIKICTL"] == "/Apps/Self Driving Wiki.app/Contents/Helpers/wikictl")
+  }
+
+  @Test func setsNixDarwinGuardSoInjectedPathSurvivesShellInit() {
+    // nix-darwin's shell init rebuilds PATH unless this guard is already set; setting
+    // it preserves the prepended helper dir (and bare `wikictl`) for the agent's shell.
+    #expect(build().environment["__NIX_DARWIN_SET_ENVIRONMENT_DONE"] == "1")
+  }
+
   @Test func cwdIsTheWritableScratchDirNotTheMount() {
     let cmd = build()
     #expect(cmd.currentDirectoryPath == "/tmp/scratch-xyz")

--- a/Tests/WikiFSTests/SandboxProfileTests.swift
+++ b/Tests/WikiFSTests/SandboxProfileTests.swift
@@ -72,6 +72,34 @@ struct SandboxProfileTests {
     #expect(readOnlyProfile().contains("(allow file-write* (subpath (param \"CLAUDE_TMP\")))"))
   }
 
+  // MARK: - Agent runtime writes (shell devices + Claude cwd markers)
+
+  /// zsh redirects to /dev/null on startup; without a write allow the shell prints
+  /// `operation not permitted: /dev/null` on every command. Scoped to `file-write-data`
+  /// (no chmod/unlink) on only the devices a piped shell actually touches — `/dev/tty`
+  /// and `/dev/dtracehelper` are deliberately excluded as unneeded.
+  @Test func bothProfilesAllowMinimalDeviceDataWrites() {
+    for p in [profile(), readOnlyProfile()] {
+      #expect(p.contains("(allow file-write-data (literal \"/dev/null\"))"))
+      #expect(p.contains("(allow file-write-data (subpath \"/dev/fd\"))"))
+      // Deliberately NOT allowed (least privilege).
+      #expect(!p.contains("/dev/tty"))
+      #expect(!p.contains("/dev/dtracehelper"))
+    }
+  }
+
+  /// Claude Code's Bash tool creates per-shell cwd markers as `/private/tmp/claude-<hex>-cwd`,
+  /// siblings of (not under) the per-session CLAUDE_TMP base. Scoped to exactly that marker
+  /// shape — NOT a broad `/private/tmp/claude-*` prefix — so the agent can't write across
+  /// other uids'/sessions' temp dirs in shared /private/tmp.
+  @Test func bothProfilesAllowOnlyClaudeCwdMarkerShape() {
+    for p in [profile(), readOnlyProfile()] {
+      #expect(p.contains("(allow file-write* (regex #\"^/private/tmp/claude-[A-Za-z0-9]+-cwd(/|$)\"))"))
+      // Not the broad prefix that would open the whole claude-* namespace.
+      #expect(!p.contains("(allow file-write* (regex #\"^/private/tmp/claude-\"))"))
+    }
+  }
+
   @Test func defaultClaudeTempBaseIsPrivateTmpClaudeUid() {
     #expect(SandboxProfile.defaultClaudeTempBase() == "/private/tmp/claude-\(getuid())")
   }

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -37,13 +37,16 @@ struct SystemPromptTests {
     /// schema can't silently regress to a stub.
     @Test func defaultBodyDocumentsTheWikictlCommandReference() {
         let body = SystemPrompt.defaultBody
-        // Every `wikictl` subcommand the agent must know.
-        #expect(body.contains("wikictl page list"))
-        #expect(body.contains("wikictl page get"))
-        #expect(body.contains("wikictl page upsert"))
-        #expect(body.contains("wikictl page delete"))
-        #expect(body.contains("wikictl index set"))
-        #expect(body.contains("wikictl log append"))
+        // Every `wikictl` subcommand the agent must know — invoked via $WIKICTL so
+        // resolution does not depend on the agent's shell preserving PATH.
+        #expect(body.contains("$WIKICTL page list"))
+        #expect(body.contains("$WIKICTL page get"))
+        #expect(body.contains("$WIKICTL page upsert"))
+        #expect(body.contains("$WIKICTL page delete"))
+        #expect(body.contains("$WIKICTL index set"))
+        #expect(body.contains("$WIKICTL log append"))
+        // $WIKICTL holds wikictl's absolute path (PATH-independent resolution).
+        #expect(body.contains("$WIKICTL"))
         // Write-via-wikictl-never-the-filesystem + read-only mount.
         #expect(body.contains("READ-ONLY"))
         // WIKI_DB selects the wiki, so do not pass --wiki.
@@ -88,7 +91,7 @@ struct SystemPromptTests {
         #expect(body.contains("PDF"))
         // Mermaid diagrams: authoring rules + save-time validation note.
         #expect(body.contains("```mermaid"))
-        #expect(body.contains("wikictl page upsert"))
+        #expect(body.contains("$WIKICTL page upsert"))
     }
 
     // MARK: - Update persists + bumps version


### PR DESCRIPTION
The sandboxed agent (`claude -p`) invokes `wikictl` and runs shell commands via the Bash tool. Two issues made Lint/Ingest/Query fail when the app is launched normally (Finder/`open` → launchd):

## 1. `wikictl` not found — PATH doesn't survive the agent's shell

The app prepends the bundled `Helpers` dir to the spawned `claude` process's `PATH`, and the system prompt promised *"`wikictl` is on your PATH."* But Claude Code's Bash tool runs the user's **login shell**, whose startup can rebuild `PATH` from scratch — dropping our prepend — so `wikictl` is `command not found`. This bites any PATH-replacing shell setup (it reproduces cleanly on nix-darwin, where `/etc/zshenv` rebuilds `PATH` when launched without its env guard, i.e. from a GUI app).

Fix — stop depending on `PATH` (env vars *do* survive the shell rebuild, which is why `WIKI_ROOT`/`WIKI_DB` already reach the agent):

- **Export `WIKICTL`** = the binary's absolute path, and invoke it as `$WIKICTL` throughout the system prompt. Resolution no longer rides on `PATH`.
- Keep prepending the helper dir to `PATH` so a bare `wikictl` still resolves where the shell leaves `PATH` intact.
- Set `__NIX_DARWIN_SET_ENVIRONMENT_DONE=1` so nix-darwin's shell init skips its `PATH` rebuild, preserving the prepend. **This one is nix-darwin-specific** (inert on every other system) — happy to drop it if you'd rather not carry an env-specific line; the `$WIKICTL` change alone fixes the failure everywhere.

Factored into `OperationCommand.resolveWikictl`, shared by the one-shot and interactive-query builders.

## 2. Seatbelt blocked the shell's runtime writes

The profile is `(deny file-write*)` by default and was missing two paths the shell needs on every command, which sprayed `operation not permitted` and reset the shell's cwd:

- **`/dev/null`** (zsh redirects to it on startup) and **`/dev/fd/*`** (targets of `/dev/stdout`/`/dev/stderr`) — allowed as `file-write-data` only.
- **Claude Code's per-shell cwd markers** — created directly under `/private/tmp` as `claude-<hex>-cwd`, siblings of the per-session `CLAUDE_TMP` base. Scoped to **exactly** that marker shape (not a broad `/private/tmp/claude-*` prefix), so the agent can't write across other uids'/sessions' temp in shared `/private/tmp`. `/dev/tty` and `/dev/dtracehelper` are intentionally not allowed.

Factored into `SandboxProfile.agentRuntimeWriteRules`, shared by the read-write and read-only profiles.

## Verification
- `swift test` — 1146 tests pass (new tests pin the `$WIKICTL` export, the prompt reference, and the seatbelt rules).
- Real `sandbox-exec` check: `/dev/null` + `/dev/stdout` redirects and the cwd marker work; a cross-uid `claude-*` path **and** an unrelated `/tmp` write are denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
