### PR TITLE
Enforce page body contract

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -39,6 +39,7 @@ load-bearing for the app to function.
 | [`plans/INITIAL.md`](plans/INITIAL.md) | Original full product/architecture plan (milestones, schema, File Provider design, definition of done). Source of truth for *what we're building*. |
 | [`plans/llm-wiki.md`](plans/llm-wiki.md) | **Next major effort:** turning Self Driving Wiki into a self-maintaining LLM Wiki — **many** wikis (one SQLite DB + one File Provider domain each), with `claude -p` authoring/maintaining each one by writing via a new `wikictl` CLI (read via the mount, write via the CLI). Locked decisions, components, and the Phase 0 → A–D plan. Read before Phase 0. |
 | [`plans/page-reader-ui.md`](plans/page-reader-ui.md) | **Current UI direction:** page detail is reader-first because the agent should maintain wiki content; manual source editing is an explicit, rare mode. |
+| [`plans/page-body-contract.md`](plans/page-body-contract.md) | **Page body contract:** `body_markdown` in SQLite stores clean body only (no H1, no frontmatter); the file provider generates both on the fly via `PageMarkdownFormat`. Covers the outline-flicker fix, migration strategy, frontmatter schema, and editor warning. |
 | [`plans/query-conversation.md`](plans/query-conversation.md) | **Current Query direction:** a dedicated sidebar page with an interactive Claude session; output-first chat by default, hidden tool/internal rows behind a checkbox, and writes via `wikictl` only when the user asks to persist changes. |
 | [`plans/BRINGUP.md`](plans/BRINGUP.md) | The 4-phase bring-up plan from skeleton to v0 (groups INITIAL.md's M0–M6). Source of truth for *the order we build in*. |
 | [`plans/build-environment.md`](plans/build-environment.md) | How the app is built: SwiftPM + `build.sh` + `Makefile`, signing, icon generation, app-bundle layout. Source of truth for *how we build and run*. |
@@ -148,6 +149,11 @@ handoff). 341 tests green; clean signed bundle (app + appex + `wikictl`).**
   `AgentSpawnSlotTests`.
 
 **Phase summary (newest first; see `PROGRESS.md` for each gate's evidence):**
+- **Page body contract** ✅ `body_markdown` in SQLite now stores clean body only
+  (no H1, no frontmatter); `PageMarkdownFormat` strips both on load/rename and
+  regenerates them in the file provider (`Projection`); outline flicker
+  eliminated; editor warns immediately when the user types frontmatter.
+  See `plans/page-body-contract.md`.
 - **Phase D — the schema** ✅ real maintainer `CLAUDE.md` schema (layout,
   conventions, `wikictl` reference, read-after-write rule, Ingest/Query/Lint
   playbooks); `-p` prompts slimmed to rely on it; new wikis seed it, existing

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,51 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-28 — Page body contract: clean body in SQLite, decoration via file provider
+
+`body_markdown` in SQLite now stores only the prose body — no H1, no YAML
+frontmatter. The File Provider extension generates both on the fly when serving
+`.md` files to Finder and external tools. This fixes the outline-panel flicker
+and makes renames safe.
+
+**Root cause of the flicker.** `PageDetailView` had a `readerMarkdown` computed
+property that stripped the leading H1 from `draftBody` before passing it to
+`PageOutlineView`. Because `draftTitle` and `draftBody` are set sequentially in
+`loadDrafts`, there was a render window where the new title was live but the old
+body was still in place. The guard inside `readerMarkdown` failed to match,
+returning the full old body (H1 included), which briefly appeared in the outline.
+
+**New contract.** A shared `PageMarkdownFormat` enum in `WikiFSCore` owns both
+directions:
+- `stripped(body:title:)` — removes leading YAML frontmatter block, matching H1,
+  and the blank lines that separate them from the body. Used in `loadDrafts` and
+  `rename(_:to:)` so the editor and SQLite always hold clean body.
+- `fileContent(for:)` — generates `---\ntitle/date frontmatter---\n\n# Title\n\n
+  body` for the file provider. Calls `stripped` internally, so pages whose
+  `body_markdown` still has an embedded H1 (pre-migration) produce correct
+  single-title output without a DB migration.
+
+**`Projection` changes.** Both `pageFileNode` (reported `documentSize`) and
+`contents(for:)` call `PageMarkdownFormat.fileContent(for:)`, so the file size
+the daemon caches and the bytes it serves are always derived from the same
+formula. Frontmatter schema: `title` (double-quoted, `"` escaped) and `date`
+(local `YYYY-MM-DD` from `updatedAt`).
+
+**Editor warning.** `saveWarningBanner` in `PageDetailView` now shows an orange
+warning when `draftBody` starts with `---`, pointing the user to the title field
+above.
+
+**`readerMarkdown` deleted.** The three call sites in `PageDetailView` now
+reference `store.draftBody` directly; no stripping is needed because the body is
+always clean.
+
+**Migration.** Automatic and zero-downtime: stripping in `loadDrafts` is
+backwards-compatible; pages converge to the new format on first load + save.
+
+**Tests.** 12 new `PageMarkdownFormatTests` covering `stripped` (H1 match/miss,
+frontmatter only, frontmatter + H1, mismatch, empty) and `fileContent` (format,
+no-double-H1, empty body, title escaping). 1170 tests total, all passing.
+
 ## 2026-06-28 — Clean up link context menus and sidebar context menus
 
 Removed redundant actions and reorganized the right-click link context menu

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -126,7 +126,7 @@ struct PageDetailView: View {
                             .zoomShortcuts($editorZoom)
                             .zoomScroll($editorZoom)
                     } else {
-                        WikiReaderView(markdown: readerMarkdown,
+                        WikiReaderView(markdown: store.draftBody,
                                         currentSelection: store.selection,
                                         store: store,
                                         fileProvider: fileProvider,
@@ -140,7 +140,7 @@ struct PageDetailView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 
                 if isOutlineExpanded {
-                    PageOutlineView(markdown: readerMarkdown) { slug in
+                    PageOutlineView(markdown: store.draftBody) { slug in
                         store.jumpToAnchorInCurrentSelection(slug)
                     }
                 }
@@ -157,13 +157,13 @@ struct PageDetailView: View {
         .background { findShortcutButton }
         .overlay(alignment: .top) { findBarOverlay }
         .onChange(of: store.selection) { findModel.dismiss() }
-        .onChange(of: readerMarkdown) { _, newMarkdown in
+        .onChange(of: store.draftBody) { _, newMarkdown in
             findModel.content = newMarkdown
             findModel.search()
         }
         .onChange(of: findModel.isShowing) { _, showing in
             if showing {
-                findModel.content = readerMarkdown
+                findModel.content = store.draftBody
                 findModel.search()
             }
         }
@@ -213,19 +213,6 @@ struct PageDetailView: View {
             ? "Untitled" : store.draftTitle
     }
 
-    private var readerMarkdown: String {
-        let trimmedTitle = displayTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        let lines = store.draftBody.split(separator: "\n", omittingEmptySubsequences: false)
-        guard let firstLine = lines.first else { return store.draftBody }
-        let firstHeading = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard firstHeading == "# \(trimmedTitle)" else { return store.draftBody }
-        let remainingLines = lines.dropFirst()
-        let withoutDuplicateHeading = remainingLines
-            .drop(while: { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
-            .joined(separator: "\n")
-        return withoutDuplicateHeading
-    }
-
     private var pageUpdatedAt: Date? {
         guard let selection = store.selection,
               case .page(let id) = selection else { return nil }
@@ -235,8 +222,13 @@ struct PageDetailView: View {
     // MARK: - Subviews
 
     @ViewBuilder private var saveWarningBanner: some View {
-        if store.mermaidSaveWarning != nil || store.markdownSaveWarning != nil {
+        let hasFrontmatter = store.draftBody.hasPrefix("---")
+        if store.mermaidSaveWarning != nil || store.markdownSaveWarning != nil || hasFrontmatter {
             VStack(alignment: .leading, spacing: 6) {
+                if hasFrontmatter {
+                    Text("Frontmatter (---) is generated automatically and will be stripped from this field on next load. Set the title using the field above.")
+                        .foregroundStyle(.orange)
+                }
                 if let mermaid = store.mermaidSaveWarning {
                     Text(mermaid)
                         .foregroundStyle(.orange)

--- a/Sources/WikiFSCore/PageMarkdownFormat.swift
+++ b/Sources/WikiFSCore/PageMarkdownFormat.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Shared logic for the page-markdown contract: the editor stores only the
+/// body (no H1, no frontmatter); the file-provider generates both on the fly.
+public enum PageMarkdownFormat {
+
+    /// Strip leading YAML frontmatter, a matching H1, and the blank lines that
+    /// follow them from a stored page body. Called on load so the editor never
+    /// sees generated decoration, and on rename so SQLite stays clean.
+    public static func stripped(body: String, title: String) -> String {
+        let lines = body.components(separatedBy: "\n")
+        var i = 0
+
+        // Strip YAML frontmatter block (opening --- … closing ---)
+        if lines.first?.trimmingCharacters(in: .whitespaces) == "---" {
+            i = 1
+            while i < lines.count && lines[i].trimmingCharacters(in: .whitespaces) != "---" {
+                i += 1
+            }
+            if i < lines.count { i += 1 } // consume closing ---
+        }
+
+        // Skip blank lines between frontmatter and body
+        while i < lines.count && lines[i].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            i += 1
+        }
+
+        // Strip leading H1 when it matches the page title exactly
+        if i < lines.count && lines[i] == "# \(title)" {
+            i += 1
+        }
+
+        // Skip blank lines that followed the H1
+        while i < lines.count && lines[i].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            i += 1
+        }
+
+        guard i > 0 else { return body }
+        return lines[i...].joined(separator: "\n")
+    }
+
+    /// Generate the complete on-disk content served by the file provider:
+    /// YAML frontmatter + blank line + H1 + blank line + body.
+    /// `body_markdown` in SQLite must already be clean (no frontmatter, no H1)
+    /// before calling this; pass through `stripped(body:title:)` if unsure.
+    public static func fileContent(for page: WikiPage) -> String {
+        let dateStr = localDateString(from: page.updatedAt)
+        let escapedTitle = page.title.replacingOccurrences(of: "\\", with: "\\\\")
+                                     .replacingOccurrences(of: "\"", with: "\\\"")
+        let cleanBody = stripped(body: page.bodyMarkdown, title: page.title)
+
+        var result = "---\ntitle: \"\(escapedTitle)\"\ndate: \(dateStr)\n---\n\n# \(page.title)"
+        if !cleanBody.isEmpty {
+            result += "\n\n\(cleanBody)"
+        }
+        return result
+    }
+
+    // MARK: - Private
+
+    private static func localDateString(from date: Date) -> String {
+        let c = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+}

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -461,7 +461,7 @@ public final class WikiStoreModel {
                 return
             }
             draftTitle = page.title
-            draftBody = page.bodyMarkdown
+            draftBody = PageMarkdownFormat.stripped(body: page.bodyMarkdown, title: page.title)
             loadedPage = id
         case .systemPrompt:
             draftSystemPrompt = (try? store.getSystemPrompt())?.body ?? SystemPrompt.defaultBody
@@ -827,7 +827,8 @@ public final class WikiStoreModel {
         flushPendingSave()
         do {
             let page = try store.getPage(id: id)
-            try store.updatePage(id: id, title: newTitle, body: page.bodyMarkdown)
+            let cleanBody = PageMarkdownFormat.stripped(body: page.bodyMarkdown, title: page.title)
+            try store.updatePage(id: id, title: newTitle, body: cleanBody)
             reloadSummaries()
             if selection == .page(id) { draftTitle = newTitle }
             // Update any tab showing this renamed page.

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -529,9 +529,9 @@ struct Projection {
             ? FilenameEscaping.byTitleFilename(title: page.title, pageID: page.id.rawValue)
             : FilenameEscaping.byIDFilename(pageID: page.id.rawValue)
         let parent = isByTitle ? Identity.pagesByTitle : Identity.pagesByID
-        let body = Data(page.bodyMarkdown.utf8)
+        let fileData = Data(PageMarkdownFormat.fileContent(for: page).utf8)
         return .file(
-            id: id, parent: parent, name: name, size: body.count,
+            id: id, parent: parent, name: name, size: fileData.count,
             version: Data(String(page.version).utf8),
             metadataVersion: Data(
                 "\(page.title)|\(page.updatedAt.timeIntervalSince1970)|\(page.version)".utf8),
@@ -698,7 +698,7 @@ struct Projection {
               let page = try? store.getPage(id: PageID(rawValue: ulid)) else {
             return nil
         }
-        return Data(page.bodyMarkdown.utf8)
+        return Data(PageMarkdownFormat.fileContent(for: page).utf8)
     }
 }
 

--- a/Tests/WikiFSTests/PageMarkdownFormatTests.swift
+++ b/Tests/WikiFSTests/PageMarkdownFormatTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+import WikiFSCore
+
+struct PageMarkdownFormatTests {
+
+    // MARK: - stripped: H1 present
+
+    @Test func stripsMatchingH1() {
+        let body = "# My Page\n\nSome content here."
+        let result = PageMarkdownFormat.stripped(body: body, title: "My Page")
+        #expect(result == "Some content here.")
+    }
+
+    @Test func stripsMatchingH1WithMultipleBlankLines() {
+        let body = "# My Page\n\n\n\nSome content here."
+        let result = PageMarkdownFormat.stripped(body: body, title: "My Page")
+        #expect(result == "Some content here.")
+    }
+
+    @Test func doesNotStripH1WhenTitleMismatches() {
+        let body = "# Other Title\n\nSome content here."
+        let result = PageMarkdownFormat.stripped(body: body, title: "My Page")
+        #expect(result == body)
+    }
+
+    // MARK: - stripped: frontmatter present
+
+    @Test func stripsFrontmatterAndH1() {
+        let body = "---\ntitle: \"My Page\"\ndate: 2026-06-28\n---\n\n# My Page\n\nSome content here."
+        let result = PageMarkdownFormat.stripped(body: body, title: "My Page")
+        #expect(result == "Some content here.")
+    }
+
+    @Test func stripsFrontmatterWithoutH1() {
+        let body = "---\ntitle: \"My Page\"\n---\n\nSome content here."
+        let result = PageMarkdownFormat.stripped(body: body, title: "My Page")
+        #expect(result == "Some content here.")
+    }
+
+    @Test func stripsFrontmatterWhenH1Mismatches() {
+        let body = "---\ntitle: \"Old Title\"\n---\n\n# Old Title\n\nSome content here."
+        let result = PageMarkdownFormat.stripped(body: body, title: "My Page")
+        // frontmatter is stripped; H1 doesn't match so it stays
+        #expect(result == "# Old Title\n\nSome content here.")
+    }
+
+    // MARK: - stripped: no decoration
+
+    @Test func returnsBodyUnchangedWhenNothingToStrip() {
+        let body = "Some content here.\n\n## A section"
+        let result = PageMarkdownFormat.stripped(body: body, title: "My Page")
+        #expect(result == body)
+    }
+
+    @Test func returnsEmptyStringUnchanged() {
+        let result = PageMarkdownFormat.stripped(body: "", title: "My Page")
+        #expect(result == "")
+    }
+
+    // MARK: - fileContent
+
+    @Test func fileContentContainsFrontmatterAndH1() {
+        let page = WikiPage(
+            id: PageID(rawValue: "01KW6BDW000000000000000000"),
+            title: "My Page",
+            slug: "my-page",
+            bodyMarkdown: "Some content here.",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            version: 1
+        )
+        let content = PageMarkdownFormat.fileContent(for: page)
+        #expect(content.hasPrefix("---\n"))
+        #expect(content.contains("title: \"My Page\""))
+        #expect(content.contains("# My Page"))
+        #expect(content.contains("Some content here."))
+    }
+
+    @Test func fileContentStripsExistingH1BeforeGenerating() {
+        let page = WikiPage(
+            id: PageID(rawValue: "01KW6BDW000000000000000000"),
+            title: "My Page",
+            slug: "my-page",
+            bodyMarkdown: "# My Page\n\nSome content here.",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            version: 1
+        )
+        let content = PageMarkdownFormat.fileContent(for: page)
+        // H1 appears exactly once (the generated one)
+        let h1Count = content.components(separatedBy: "# My Page").count - 1
+        #expect(h1Count == 1)
+        #expect(content.contains("Some content here."))
+    }
+
+    @Test func fileContentEscapesDoubleQuoteInTitle() {
+        let page = WikiPage(
+            id: PageID(rawValue: "01KW6BDW000000000000000000"),
+            title: "It's a \"Test\"",
+            slug: "its-a-test",
+            bodyMarkdown: "Body.",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            version: 1
+        )
+        let content = PageMarkdownFormat.fileContent(for: page)
+        #expect(content.contains("\\\"Test\\\""))
+    }
+
+    @Test func fileContentHandlesEmptyBody() {
+        let page = WikiPage(
+            id: PageID(rawValue: "01KW6BDW000000000000000000"),
+            title: "Empty Page",
+            slug: "empty-page",
+            bodyMarkdown: "",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            version: 1
+        )
+        let content = PageMarkdownFormat.fileContent(for: page)
+        #expect(content.hasSuffix("# Empty Page"))
+    }
+}

--- a/plans/page-body-contract.md
+++ b/plans/page-body-contract.md
@@ -1,0 +1,120 @@
+# Page Body Contract
+
+## Problem
+
+Wiki page files as served by the File Provider extension contain three layers of
+decoration that belong to the format, not the content: a YAML frontmatter block,
+an H1 title, and the body prose. Historically all three could end up mixed
+together inside the SQLite `body_markdown` column, which caused several problems:
+
+**Outline flicker.** `PageDetailView` had a `readerMarkdown` computed property
+that stripped the H1 from `draftBody` before passing it to the outline. Because
+`draftTitle` and `draftBody` are separate `@Observable` properties set
+sequentially in `loadDrafts`, there was a render window where the new title was
+set but the old body was still in place. `readerMarkdown` would then fail its
+match guard and return the old body—including its H1—producing a transient wrong
+heading in the outline panel.
+
+**H1 duplication in the file provider.** The file provider served
+`page.bodyMarkdown` verbatim. If a page had been created with `# Title` in its
+body (common for older pages), the external file contained the H1 once. After
+any rename it fell out of sync silently.
+
+**Frontmatter exposure in the editor.** Nothing prevented a user from typing a
+YAML frontmatter block at the top of the editor. That content would be saved
+into `body_markdown`, round-tripped into future loads, and interpreted as content
+rather than metadata—confusing the renderer and the outline parser.
+
+## Decision
+
+**The SQLite `body_markdown` column is the canonical body only — no H1, no
+frontmatter.** The file provider is the sole place where the full, decorated
+markdown file is assembled. A new shared helper (`PageMarkdownFormat`) owns both
+directions:
+
+- **Stripping** (SQLite ← external): remove frontmatter and any leading H1 that
+  matches the page title before storing or exposing to the editor.
+- **Generation** (SQLite → file provider): prepend YAML frontmatter and an H1
+  before serving to the file system.
+
+This makes `draftBody` always clean, eliminating both the outline flicker
+(nothing to strip means no mismatched intermediate state) and the H1/frontmatter
+duplication.
+
+## Frontmatter schema
+
+```yaml
+---
+title: "Page Title"
+date: YYYY-MM-DD        # updatedAt in local timezone
+---
+```
+
+Minimal and compatible with standard static-site generators (Jekyll, Hugo) and
+Obsidian. The title is double-quoted with `"` → `\"` escaping. The date is the
+page's `updatedAt` formatted as `YYYY-MM-DD` in the user's local timezone,
+matching what the in-app date display shows.
+
+## Implementation
+
+### `Sources/WikiFSCore/PageMarkdownFormat.swift` (new)
+
+Public `enum PageMarkdownFormat` with two entry points shared by the app and the
+file provider extension:
+
+- `stripped(body: String, title: String) -> String` — strips leading YAML
+  frontmatter (opening `---` through closing `---`), skips blank lines, strips
+  the H1 if it matches the title exactly, skips blank lines again. Returns the
+  body unchanged if none of those patterns are present.
+- `fileContent(for page: WikiPage) -> String` — generates
+  `frontmatter + blank line + # Title + blank line + stripped(body)`. Calls
+  `stripped` internally so bodies that still contain an embedded H1 (from before
+  this change) produce correct output with no double title.
+
+### `Sources/WikiFSCore/WikiStoreModel.swift`
+
+- `loadDrafts`: passes `page.bodyMarkdown` through
+  `PageMarkdownFormat.stripped(body:title:)` before assigning to `draftBody`.
+  Migration is automatic: the next save after loading persists the clean body.
+- `rename(_:to:)`: reads `page.bodyMarkdown` from SQLite and strips before
+  saving with the new title, so a rename also cleans up any embedded H1 from an
+  old format.
+
+### `Sources/WikiFSFileProvider/Projection.swift`
+
+- `pageFileNode(for:page:)`: sizes the node using `PageMarkdownFormat.fileContent`
+  instead of the raw body, so the reported `documentSize` and the served bytes are
+  derived from the same formula.
+- `contents(for:)`: returns `Data(PageMarkdownFormat.fileContent(for: page).utf8)`.
+
+Both call the same function; size == content is guaranteed for any given DB
+snapshot.
+
+### `Sources/WikiFS/PageDetailView.swift`
+
+- Deleted the `readerMarkdown` computed property (which existed solely to strip
+  the H1 before passing to the reader and outline). All three call sites now
+  reference `store.draftBody` directly.
+- `saveWarningBanner`: when `store.draftBody.hasPrefix("---")`, shows an orange
+  warning explaining that frontmatter is generated automatically and will be
+  stripped on next load, directing the user to the title field.
+
+## Migration
+
+No schema migration required. The stripping in `loadDrafts` is backward-
+compatible: pages whose `body_markdown` was stored without an H1 are unaffected;
+pages that do contain `# Title` are silently cleaned on first load, and the
+cleaned body is persisted on the next save. All pages converge to the new
+contract within one load/edit cycle.
+
+## Tests
+
+`Tests/WikiFSTests/PageMarkdownFormatTests.swift` covers:
+
+- `stripped` with H1 matching and not matching the title
+- `stripped` with frontmatter only, frontmatter + H1, and neither
+- `stripped` when the H1 is present but does not match (H1 is preserved)
+- `fileContent` containing correct frontmatter and H1
+- `fileContent` with a body that already has an embedded H1 (no duplication)
+- `fileContent` with an empty body
+- `fileContent` with a title containing `"` characters (escaping)


### PR DESCRIPTION
## Summary

- `body_markdown` in SQLite now stores clean prose only — no H1, no YAML frontmatter. The File Provider generates both on the fly when serving `.md` files to Finder and external tools.
- New `PageMarkdownFormat` enum (in `WikiFSCore`) owns stripping on load/rename and generation for the file provider, shared across both targets.
- Eliminates the outline-panel flicker caused by the two-step `draftTitle`/`draftBody` update producing a mismatched intermediate render.
- Editor warns immediately (orange banner) when the user types a `---` frontmatter block, directing them to the title field instead.

## What changed

**`PageMarkdownFormat.swift` (new, `WikiFSCore`)**
- `stripped(body:title:)` — removes leading YAML frontmatter, a matching H1, and the blank lines around them. Used on every load and rename so `draftBody` is always decoration-free.
- `fileContent(for:)` — generates `---\ntitle/date frontmatter\n---\n\n# Title\n\nbody`. Calls `stripped` internally, so pages with a legacy embedded H1 produce single-title output with no DB migration needed.

**`WikiStoreModel.swift`**
- `loadDrafts`: passes `page.bodyMarkdown` through `PageMarkdownFormat.stripped` before assigning to `draftBody`.
- `rename(_:to:)`: strips before saving so a rename also cleans up any legacy H1 read directly from SQLite.

**`Projection.swift`**
- Both `pageFileNode` (reported `documentSize`) and `contents(for:)` call `PageMarkdownFormat.fileContent(for:)`, so the size the daemon caches and the bytes served are always derived from the same formula.
- Frontmatter schema: `title` (double-quoted, `"` escaped) and `date` (local `YYYY-MM-DD` from `updatedAt`).

**`PageDetailView.swift`**
- `readerMarkdown` computed property deleted — it existed solely to strip the H1 before passing to the reader and outline. All three call sites now use `store.draftBody` directly.
- `saveWarningBanner`: shows an orange warning when `draftBody.hasPrefix("---")`.

## Migration

Automatic and zero-downtime. `stripped` in `loadDrafts` is backwards-compatible: pages with a legacy `# Title` in `body_markdown` are cleaned on first load; the cleaned body is persisted on the next save. No schema change required.

## Test plan

- [ ] Open a page whose `body_markdown` starts with `# Title` — confirm the H1 does not appear in the editor body or the outline
- [ ] Rename a page — confirm the file in the File Provider mount reflects the new title in both the H1 and the frontmatter `title:` field
- [ ] Open a page in the File Provider (`cat` or Finder Quick Look) — confirm it starts with `---\ntitle:` and contains a single `# Title`
- [ ] In edit mode, type `---` at the start of the body — confirm the orange frontmatter warning appears immediately
- [ ] Delete the `---` — confirm the warning disappears
- [ ] Switch between pages rapidly with the outline panel open — confirm no spurious headings flash in the outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
