### PR TITLE
Fix editor tab title

### DIFF
--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -86,7 +86,8 @@ struct SourceDetailView: View {
     }
 
     private var displayName: String {
-        file.displayName ?? (file.filename.isEmpty ? "Untitled" : file.filename)
+        let name = file.effectiveName
+        return name.isEmpty ? "Untitled" : name
     }
 
     /// The markdown content currently shown (from processed head or native

--- a/Sources/WikiFSCore/EditorTab.swift
+++ b/Sources/WikiFSCore/EditorTab.swift
@@ -40,8 +40,8 @@ extension WikiStoreModel {
             return summaries.first { $0.id == id }?.title
                 .nonEmpty ?? "Untitled"
         case .source(let id):
-            return sources.first { $0.id == id }?.filename
-                .nonEmpty ?? "Source"
+            guard let source = sources.first(where: { $0.id == id }) else { return "Source" }
+            return source.effectiveName.nonEmpty ?? "Source"
         }
     }
 

--- a/Sources/WikiFSCore/SourceSummary.swift
+++ b/Sources/WikiFSCore/SourceSummary.swift
@@ -34,6 +34,13 @@ public struct SourceSummary: Identifiable, Hashable, Sendable {
     /// resolution and sidebar/file-provider presentation.
     public let displayName: String?
 
+    /// Best human-readable name: `displayName` when set and non-empty, otherwise `filename`.
+    /// Use this everywhere a label is needed instead of branching on `displayName` at the call site.
+    public var effectiveName: String {
+        if let name = displayName, !name.isEmpty { return name }
+        return filename
+    }
+
     public init(
         id: PageID,
         filename: String,

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -727,11 +727,30 @@ struct EditorTabTests {
         #expect(model.tabTitle(for: .changeLog) == "Activity")
     }
 
-    @Test func tabTitleForSource() throws {
+    @Test func tabTitleForSourceFallsBackToFilenameWhenNoDisplayName() throws {
         let (model, store) = try tempModel()
         let f1 = try store.addSource(filename: "report.pdf", data: Data("pdf".utf8))
         model.reloadFromStore()
         #expect(model.tabTitle(for: .source(f1.id)) == "report.pdf")
+    }
+
+    @Test func tabTitleForSourcePrefersDisplayNameOverFilename() throws {
+        let (model, store) = try tempModel()
+        let f1 = try store.addSource(filename: "report.pdf", data: Data("pdf".utf8))
+        model.reloadFromStore()
+        model.renameSource(id: f1.id, to: "My Custom Title")
+        #expect(model.tabTitle(for: .source(f1.id)) == "My Custom Title")
+    }
+
+    @Test func sourceTabTitleUpdatesOnRename() throws {
+        let (model, store) = try tempModel()
+        let f1 = try store.addSource(filename: "doc.pdf", data: Data("pdf".utf8))
+        model.reloadFromStore()
+        model.openTab(.source(f1.id))
+        #expect(model.tabs[0].title == "doc.pdf")
+
+        model.renameSource(id: f1.id, to: "Annual Report")
+        #expect(model.tabs[0].title == "Annual Report")
     }
 
     // MARK: - tabIcon helper


### PR DESCRIPTION
## Summary

- Tab titles for sources now show the user-set display name instead of the raw filename
- Centralized the display-name fallback logic into `SourceSummary.effectiveName` (used by both the tab bar and the detail view header)
- Added three tests covering the filename fallback, displayName precedence, and live tab title update on rename

## Details

**Root cause:** `EditorTab.tabTitle(for:)` was reading `source.filename` directly, while `SourceDetailView` already used the `displayName ?? filename` fallback chain. The two code paths were independent.

**Fix:**
- Added `SourceSummary.effectiveName` — single computed property encoding "displayName if set and non-empty, otherwise filename"
- `EditorTab.tabTitle(.source)` now delegates to `source.effectiveName`
- `SourceDetailView.displayName` now delegates to `file.effectiveName`

**Tests added** (`EditorTabTests`):
- `tabTitleForSourceFallsBackToFilenameWhenNoDisplayName` — filename used when no displayName set
- `tabTitleForSourcePrefersDisplayNameOverFilename` — displayName wins after `renameSource`
- `sourceTabTitleUpdatesOnRename` — live open tab title string also updates on rename

## Test plan

- [ ] Open a source that has no display name set — tab title should show filename
- [ ] Rename a source via the detail view header — tab title should update to the new display name
- [ ] Run `swift test --filter EditorTabTests` — all 50 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)