### PR TITLE
fix(fileprovider): isolate PDFKit/AppKit out of WikiFSCore (macOS 26 crash)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ run: install
 
 install: build prune-provider-registrations
 	@if [ ! -d "$(APP)" ]; then echo "✗ $(APP) missing — build failed?"; exit 1; fi
+	@pkill -f "$(EXT_NAME).appex" 2>/dev/null && echo "✓ killed stale $(EXT_NAME) process" || true
 	rm -rf "$(INSTALLED_APP)"
 	cp -R "$(APP)" /Applications/
 	@echo "✓ copied to $(INSTALLED_APP)"

--- a/PLAN.md
+++ b/PLAN.md
@@ -226,6 +226,20 @@ gate's evidence and the known v0 gaps.
 - **M5 — Change signaling** ✅ edits increment version; Terminal reads see updates (no relaunch).
 - **M6 — Agent launch** ✅ spawn agent with `WIKI_ROOT` env pointing at the projection.
 
+### Target-linking constraint (File Provider extension)
+
+The `WikiFSFileProvider` extension is `com.apple.fileprovider-nonui` and
+**must not link AppKit** (or PDFKit/AVFoundation/Metal/Accelerate/CoreML) —
+macOS 26 asserts against it and the extension crashes on launch in
+`_EXRunningExtension._start`. The extension links `WikiFSCore` read-only as its
+sole dependency, so **`WikiFSCore` itself must stay free of those frameworks**.
+Anything framework-backed that `WikiFSCore` needs (currently PDF-title extraction
+via PDFKit) is exposed behind an injectable seam (`DisplayNameResolver.pdfTitle-
+Extractor`) whose default is framework-free; the real implementation lives in the
+**app** target (`Sources/WikiFS/`), which the extension does not link, and is
+installed at launch. Verified by `otool -L` on the built extension binary.
+See `plans/file-provider.md`.
+
 ## Build quick reference
 
 ```sh

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,38 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-29 — File Provider extension no longer links AppKit/PDFKit (macOS 26 crash)
+
+The `WikiFSFileProvider` extension crashed at launch on macOS 26 inside
+`_EXRunningExtension._start` because its binary linked **AppKit** — forbidden
+for a `com.apple.fileprovider-nonui` extension.
+
+**Root cause.** `DisplayNameResolver` (in `WikiFSCore`) `import`s PDFKit, and
+PDFKit transitively links AppKit. The extension links `WikiFSCore` as its sole
+read-only dependency, so it inherited AppKit linkage even though it never runs
+the PDF-title path.
+
+**Fix (injectable seam).** PDF-title extraction is now injected:
+`DisplayNameResolver.pdfTitleExtractor` defaults to a `nil`-returning closure,
+keeping `WikiFSCore` — and therefore the extension — free of PDFKit/AppKit at
+link time. The real PDFKit implementation lives in the **app** target
+(`Sources/WikiFS/PDFTitleExtractor.swift`), which the extension does **not**
+link, and is installed at launch via `DisplayNameResolver.installPDFTitleExtractor()`
+(called from `WikiFSApp.init`). Non-app contexts (extension, `wikictl`, tests)
+keep the default and fall through to the filename.
+
+**MLX note.** This branch was originally built on top of a MiniLM/MLX embedding
+feature series; that MLX work was **dropped** (it was a separate concern and
+also pulled Metal/Accelerate/CoreML into the extension). The fix now stands on
+`main` alone, where isolating PDFKit is *sufficient* to remove AppKit from the
+extension. NL-based embeddings (PR #91) remain unaffected.
+
+**Evidence.** `swift build` clean; 1211 tests pass; `otool -L` on the rebuilt
+`WikiFSFileProvider` binary shows **no** AppKit/PDFKit/AVFoundation/Metal (only
+FileProvider/Foundation/NaturalLanguage/JavaScriptCore/CFNetwork/Security). The
+app binary still links PDFKit/AppKit, so PDF display-name resolution is
+preserved. See PR #93.
+
 ## 2026-06-29 — Fresh-DB fast path (migration consolidation)
 
 The stepwise ladder (v0→v14) is correct but does heavy create→mutate→drop churn

--- a/Sources/WikiFS/PDFTitleExtractor.swift
+++ b/Sources/WikiFS/PDFTitleExtractor.swift
@@ -1,0 +1,40 @@
+import Foundation
+import PDFKit
+import WikiFSCore
+
+/// PDFKit-based PDF document-title extraction for the **app** target only.
+///
+/// `import PDFKit` transitively links **AppKit** (and AVFoundation). The
+/// read-only File Provider extension (`WikiFSFileProvider`) also links
+/// `WikiFSCore`, so if `WikiFSCore` imported PDFKit the extension would pull
+/// AppKit — which macOS 26 (`com.apple.fileprovider-nonui`) asserts against in
+/// `_EXRunningExtension._start`, crashing the extension on launch.
+///
+/// To keep `WikiFSCore` (and thus the extension) free of PDFKit/AppKit, the PDF
+/// extraction is **injectable** via `DisplayNameResolver.pdfTitleExtractor`.
+/// Core's default is a `nil`-returning closure; the app installs this real
+/// PDFKit implementation at launch (`WikiFSApp.init`). Every non-app context
+/// (the extension, `wikictl`, tests by default) leaves the default and simply
+/// falls through to the filename.
+public enum PDFTitleExtractor {
+    /// Extract the document title from a PDF via PDFKit's document attributes.
+    /// Returns `nil` for non-PDF data, PDFs with no `/Title`, or an empty title.
+    public static func extract(_ data: Data) -> String? {
+        guard let document = PDFDocument(data: data),
+              let attrs = document.documentAttributes,
+              let title = attrs[PDFDocumentAttribute.titleAttribute] as? String
+        else { return nil }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+extension DisplayNameResolver {
+    /// Install the app-only PDFKit title extractor into Core's injectable seam.
+    /// Called once at launch from `WikiFSApp.init`. Non-app contexts never call
+    /// this, so they keep the default `nil`-returning closure and stay free of
+    /// PDFKit/AppKit.
+    public static func installPDFTitleExtractor() {
+        pdfTitleExtractor = PDFTitleExtractor.extract
+    }
+}

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -33,6 +33,13 @@ struct WikiFSApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
+        // Install the app-only PDFKit title extractor into Core's injectable
+        // seam. Core must not import PDFKit (it pulls AppKit into the File
+        // Provider extension on macOS 26), so the real implementation lives in
+        // this app target and is injected here. Non-app contexts (the
+        // extension, wikictl, tests) keep the nil-returning default.
+        DisplayNameResolver.installPDFTitleExtractor()
+
         let warning = LaunchLocationWarning.current()
         launchLocationWarning = warning
         _showingLaunchLocationWarning = State(initialValue: warning != nil)

--- a/Sources/WikiFSCore/DisplayNameResolver.swift
+++ b/Sources/WikiFSCore/DisplayNameResolver.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PDFKit
 
 /// Resolves the best human-readable display name for a source at ingest time.
 /// Returns `nil` when no richer metadata is available — the caller falls back to
@@ -9,12 +8,25 @@ import PDFKit
 /// Priority order:
 /// 1. Zotero item title (when the source came from Zotero)
 /// 2. Markdown front matter `title` (for `.md` / `text/markdown` files)
-/// 3. PDF document title (from PDFKit metadata)
+/// 3. PDF document title (via PDFKit metadata)
 /// 4. `nil` — caller uses the filename
 ///
-/// Pure and dependency-free (PDFKit is the only import), so the resolve function
-/// is unit-testable with in-memory Data.
+/// The Zotero + markdown paths are pure Foundation. The PDF-title step needs
+/// PDFKit, which transitively links **AppKit** — forbidden in the read-only
+/// File Provider extension (`WikiFSFileProvider`) that also links `WikiFSCore`
+/// on macOS 26 (`com.apple.fileprovider-nonui`). So PDF extraction is
+/// **injectable**: ``pdfTitleExtractor`` defaults to a `nil`-returning closure
+/// (used by the extension, `wikictl`, and tests by default) and the app installs
+/// the real PDFKit implementation at launch. This keeps `WikiFSCore` — and
+/// therefore the extension — free of PDFKit/AppKit at link time.
 public enum DisplayNameResolver {
+
+    /// PDF document-title extractor. Defaults to "no metadata" (`{ _ in nil }`)
+    /// so this type stays free of PDFKit/AppKit. The app installs the real PDFKit
+    /// implementation at launch (`WikiFS.PDFTitleExtractor.extract`); every
+    /// non-app context (extension, CLI, tests) leaves the default and simply
+    /// falls through to the filename.
+    public nonisolated(unsafe) static var pdfTitleExtractor: (Data) -> String? = { _ in nil }
 
     /// Resolve a display name from the available metadata and file bytes.
     /// - Parameters:
@@ -44,9 +56,10 @@ public enum DisplayNameResolver {
             return title
         }
 
-        // 3. PDF document title.
+        // 3. PDF document title (via the injectable extractor — nil-returning
+        //    unless the app installed the PDFKit implementation).
         if isPDF(filename: filename, mimeType: mimeType),
-           let title = extractPDFTitle(from: data) {
+           let title = pdfTitleExtractor(data) {
             return title
         }
 
@@ -154,14 +167,10 @@ public enum DisplayNameResolver {
 
     // MARK: - PDF title
 
-    /// Extract the document title from a PDF via PDFKit's document attributes.
-    static func extractPDFTitle(from data: Data) -> String? {
-        guard let document = PDFDocument(data: data),
-              let attrs = document.documentAttributes,
-              let title = attrs[PDFDocumentAttribute.titleAttribute] as? String
-        else { return nil }
-        return title.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-    }
+    // PDF title extraction is injected via ``pdfTitleExtractor`` so that this
+    // target does not import PDFKit (which pulls AppKit into the File Provider
+    // extension). The PDFKit implementation lives in the app target
+    // (`WikiFS.PDFTitleExtractor`) and is installed at launch.
 }
 
 // MARK: - String helper

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -3,6 +3,7 @@ import CoreGraphics
 import Foundation
 import SQLite3
 import Testing
+import WikiFS
 @testable import WikiFSCore
 
 /// Phase 5 file-ingestion tests: ingest/list/get/delete, byte-identical content
@@ -331,6 +332,12 @@ struct SourcesTests {
     }
 
     @Test func displayNameFromPDFTitle() throws {
+        // Core no longer links PDFKit (it would pull AppKit into the File
+        // Provider extension). Install the app-only extractor so this test
+        // exercises the real PDF-title path, then restore the nil default.
+        DisplayNameResolver.pdfTitleExtractor = PDFTitleExtractor.extract
+        defer { DisplayNameResolver.pdfTitleExtractor = { _ in nil } }
+
         // Build a minimal valid PDF with a /Title entry.
         let title = "My PDF Document"
         let pdfData = try minimalPDF(title: title)


### PR DESCRIPTION
## Problem

The `WikiFSFileProvider` extension (`.appex`) crashed on launch at macOS 26
inside `_EXRunningExtension._start` because its binary linked **AppKit** —
forbidden for a `com.apple.fileprovider-nonui` extension.

## Root cause

`DisplayNameResolver` (in `WikiFSCore`) does `import PDFKit`, and **PDFKit
transitively links AppKit**. The extension links `WikiFSCore` as its sole
read-only dependency, so it inherited AppKit linkage even though it never
executes the PDF-title path. (This is independent of any embedding backend — it
exists on `main` with NL-only embeddings.)

## Fix — injectable seam

Make PDF-title extraction injectable so `WikiFSCore` (and therefore the
extension) stays free of PDFKit/AppKit:

- `DisplayNameResolver.pdfTitleExtractor` — a `(Data) -> String?` closure that
  **defaults to `{ _ in nil }`** (framework-free).
- The real PDFKit implementation lives in the **app** target
  (`Sources/WikiFS/PDFTitleExtractor.swift`), which the extension does **not**
  link, and is installed at launch via
  `DisplayNameResolver.installPDFTitleExtractor()` (`WikiFSApp.init`).
- Non-app contexts (extension, `wikictl`, tests) keep the default and fall
  through to the filename. The one test that exercises the PDF-title path
  installs the real extractor locally.

> Note: this branch originally carried a MiniLM/**MLX** embedding feature
> series (which also pulled Metal/Accelerate/CoreML into the extension). That
> work was **dropped** as a separate concern. On `main`'s no-MLX base, isolating
> PDFKit alone is *sufficient* to remove AppKit from the extension.

## Verification

- `swift build` clean
- **1211 tests pass**
- `otool -L` on the rebuilt `WikiFSFileProvider` binary — **no**
  AppKit/PDFKit/AVFoundation/Metal/CoreML/Accelerate; only FileProvider /
  Foundation / NaturalLanguage / JavaScriptCore / CFNetwork / Security remain
- The app binary **still links** PDFKit/AppKit, so PDF display-name resolution
  is preserved

## Bonus

`make install` now kills a stale `WikiFSFileProvider.appex` process before
reinstall — a resident old extension can survive `rm -rf` and mask the fix.
