### PR TITLE
fix(perf): stop embedding inference blocking the main thread

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,39 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-06-29 — Embedding inference stopped blocking the main thread
+
+Clicking a page (and app startup) had a ~0.4–2 s stall introduced by the
+semantic-search work (PR #91). Root-caused via `ReaderTiming`/`DebugLog`
+instrumentation (subsystem `com.selfdrivingwiki.debug`, category `render`):
+
+- The **page-row context menu** in `SidebarView.pagesSectionRows` eagerly called
+  `store.searchSimilar(query:)` for every page row in its `.contextMenu` builder.
+  SwiftUI evaluates that builder on every sidebar layout pass, so a single page
+  selection ran `searchSimilar` (→ `NLEmbedding.vector(for:)` on the **main
+  thread**) for all ~232 rows — hundreds of inferences per render, freezing the
+  UI. (Sources were fast only because their rows lack that menu.)
+- Separately, at launch `backfill` called `EmbeddingService.isAvailable`, which
+  **loads the `NLEmbedding` model** (~0.3 s on the main thread) even when there
+  was zero missing work to embed.
+
+**Fixes (this branch):**
+- `WikiStoreModel.searchSimilar` / `searchSimilarSources` are **no-ops (`[]`)**
+  until NLEmbedding inference is moved off the main actor; the "Find Similar…"
+  context-menu item is removed.
+- `backfill` now short-circuits on empty work **before** touching the embedding
+  model, so a warm DB skips the model load at startup.
+- `EmbeddingService` is instrumented end-to-end (`embed.model LOAD`, `embed.isAvailable`,
+  `embed.chunked ENTER/EXIT`, `embed.call <ms> …`, `embed.STACK …`) so every hit
+  is visible via `log show`. Kept as witness marks.
+- Reader timing probes added: `click.to-startLoad`, `click.to-painted`,
+  `webview.main-hop`, `webview.task-start`, `webview.html-load`.
+
+**Follow-up (not done here):** move `NLEmbedding` inference off the main actor
+(the comment claims BNNS crashes off-main, but that's most likely a shared-model
+concurrency issue — serialize on a dedicated background thread) and restore
+"Find Similar" with a lazy, off-main search.
+
 ## 2026-06-29 — File Provider extension no longer links AppKit/PDFKit (macOS 26 crash)
 
 The `WikiFSFileProvider` extension crashed at launch on macOS 26 inside

--- a/Sources/WikiFS/ReaderTiming.swift
+++ b/Sources/WikiFS/ReaderTiming.swift
@@ -29,8 +29,8 @@ enum ReaderTiming {
     /// recorder is attached, so this is safe to leave in production builds.
     static let signposter = OSSignposter(logHandle: osLog)
 
-    /// Time a synchronous block: emits a signpost interval + a persisted `.notice`
-    /// ms line (+ stdout). Returns the block's result unchanged.
+    /// Time a synchronous block: emits a signpost interval + a `.debug` ms line
+    /// (+ stdout). Returns the block's result unchanged.
     @discardableResult
     static func measure<T>(_ name: StaticString, _ body: () throws -> T) rethrows -> T {
         let state = signposter.beginInterval(name)
@@ -45,14 +45,21 @@ enum ReaderTiming {
 
     /// Emit a single point measurement (ms) — for phases timed across async hops
     /// where a `measure` interval won't span the work, e.g. WKWebView appear →
-    /// content painted.
+    /// content painted. Fires a signpost EVENT (always-on in Instruments,
+    /// Points-of-Interest) so the per-click phase timeline is visible without the
+    /// `.debug` text log; the precise ms lives in the `.debug` line / stdout.
     static func point(_ name: StaticString, ms: Double) {
+        signposter.emitEvent(name)
         emit(name, ms: ms)
     }
 
     private static func emit(_ name: StaticString, ms: Double) {
         let label = "\(name)"
-        logger.notice("\(label, privacy: .public) \(String(format: "%.1f", ms), privacy: .public) ms")
+        // `.debug` — these fire on every page click, so they'd spam the persisted
+        // (notice) log. Capture with `log show --debug` or read the stdout line
+        // when launched from a terminal. The signpost interval (in `measure`)
+        // remains the always-on, Instruments-visible signal.
+        logger.debug("\(label, privacy: .public) \(String(format: "%.1f", ms), privacy: .public) ms")
         // Write via a raw write() (FileHandle.write) instead of `print()`: when
         // stdout is redirected to a file it's fully buffered, so `print` lines
         // never flush for sparse events. This makes timings appear immediately.

--- a/Sources/WikiFS/ReaderTiming.swift
+++ b/Sources/WikiFS/ReaderTiming.swift
@@ -52,7 +52,7 @@ enum ReaderTiming {
 
     private static func emit(_ name: StaticString, ms: Double) {
         let label = "\(name)"
-        logger.notice("\(label, privacy: .public) \(String(format: "%.1f", ms)) ms")
+        logger.notice("\(label, privacy: .public) \(String(format: "%.1f", ms), privacy: .public) ms")
         // Write via a raw write() (FileHandle.write) instead of `print()`: when
         // stdout is redirected to a file it's fully buffered, so `print` lines
         // never flush for sparse events. This makes timings appear immediately.

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -347,19 +347,7 @@ struct SidebarView: View {
                             }
                         }
                         .disabled(store.isAgentRunning)
-                        let similarTitle = summary.title
-                        let similar = store.searchSimilar(query: similarTitle, limit: 8)
-                            .filter { $0.id != summary.id }
-                        if !similar.isEmpty {
-                            Divider()
-                            Menu("Find Similar…", systemImage: "magnifyingglass") {
-                                ForEach(similar) { page in
-                                    Button(page.title) {
-                                        store.openTab(.page(page.id))
-                                    }
-                                }
-                            }
-                        }
+
                         if selectedPageIDs.count <= 1 {
                             Divider()
                             Button("Rename", systemImage: "pencil") { beginRename(summary) }

--- a/Sources/WikiFS/WikiReaderView.swift
+++ b/Sources/WikiFS/WikiReaderView.swift
@@ -712,6 +712,10 @@ internal struct WikiReaderRep: NSViewRepresentable {
         var appliedFindVersion = 0
         private var convertTask: Task<Void, Never>?
         private var loadStart: DispatchTime?
+        /// Timestamp captured right before `loadHTMLString`, to split
+        /// `appear-to-painted` into the async hop (startLoad→loadHTMLString) vs.
+        /// the pure WKWebView parse/layout (loadHTMLString→didFinish).
+        private var htmlLoadStart: DispatchTime?
         private var isLoadingBinding: Binding<Bool>?
 
         func startLoad(markdown: String, isLoading: Binding<Bool>) {
@@ -721,6 +725,13 @@ internal struct WikiReaderRep: NSViewRepresentable {
             isLoadingBinding = isLoading
             isLoading.wrappedValue = true
             loadStart = DispatchTime.now()
+            // Measure the synchronous click→startLoad window: openTab →
+            // loadDrafts (getPage + stripped) → SwiftUI re-render → this
+            // updateNSView→startLoad dispatch. This is the gap NOT covered by
+            // "webview.convert" / "webview.appear-to-painted".
+            if let click = store?.clickStartedAt {
+                ReaderTiming.point("click.to-startLoad", ms: Self.elapsedMs(since: click))
+            }
 
             // Build existence sets on the main actor (the store is @MainActor)
             // so the off-main convert can resolve links without crossing actor
@@ -737,8 +748,13 @@ internal struct WikiReaderRep: NSViewRepresentable {
                     return (names + stripped).map { $0.lowercased() }
                 })
 
+            let loadStartVal = loadStart
             convertTask = Task.detached(priority: .userInitiated) { [weak self] in
                 let t0 = DispatchTime.now()
+                // How long did Task.detached take to start after startLoad?
+                if let ls = loadStartVal {
+                    ReaderTiming.point("webview.task-start", ms: Self.elapsedMs(since: ls))
+                }
                 // Shared pre-pass (footnotes + wiki links) + swift-markdown HTML
                 // render, both off the main actor. isResolved resolves against
                 // the precomputed existence sets so missing links style as ghosts.
@@ -749,10 +765,15 @@ internal struct WikiReaderRep: NSViewRepresentable {
                 let body = MarkdownHTMLRenderer.render(prepared)
                 let html = WikiReaderView.documentHTML(body)
                 let convertMs = Self.elapsedMs(since: t0)
+                let convertDone = DispatchTime.now()
                 await MainActor.run { [weak self] in
                     guard let self, let webView = self.webView,
                           self.loadedMarkdown == markdown else { return }
+                    // How long did MainActor.run wait to get back on the main
+                    // actor? Large value ⇒ main thread is busy (SwiftUI layout).
+                    ReaderTiming.point("webview.main-hop", ms: Self.elapsedMs(since: convertDone))
                     ReaderTiming.point("webview.convert", ms: convertMs)
+                    htmlLoadStart = DispatchTime.now()
                     webView.loadHTMLString(html, baseURL: URL(string: "about:blank"))
                 }
             }
@@ -864,6 +885,19 @@ internal struct WikiReaderRep: NSViewRepresentable {
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             if let start = loadStart {
                 ReaderTiming.point("webview.appear-to-painted", ms: Self.elapsedMs(since: start))
+            }
+            // Split the WKWebView cost: async hop (startLoad→loadHTMLString) vs.
+            // pure WKWebView parse/layout (loadHTMLString→didFinish). Tells us
+            // whether a navigation-free innerHTML swap would actually help.
+            if let html = htmlLoadStart {
+                ReaderTiming.point("webview.html-load", ms: Self.elapsedMs(since: html))
+            }
+            // Full click→painted latency (user perception): click → convert →
+            // WKWebView parse/layout → didFinish. Splits vs. the startLoad window
+            // above ("click.to-startLoad") so we know if the stall is in the
+            // synchronous SwiftUI path or in the WKWebView load itself.
+            if let click = store?.clickStartedAt {
+                ReaderTiming.point("click.to-painted", ms: Self.elapsedMs(since: click))
             }
             pageLoaded = true
             isLoadingBinding?.wrappedValue = false

--- a/Sources/WikiFSCore/DebugLog.swift
+++ b/Sources/WikiFSCore/DebugLog.swift
@@ -24,6 +24,13 @@ public enum DebugLog {
     public static func reader(_ message: @autoclosure () -> String) { emit("reader", message()) }
 
     private static let subsystem = "com.selfdrivingwiki.debug"
+
+    /// Shared signposter for low-overhead interval timing visible in Instruments
+    /// (near-free when no recorder is attached). Prefer this over `.notice` text
+    /// logs for per-call perf measurement — it costs nothing in production but
+    /// lights up under the Points-of-Interest instrument when profiling.
+    public static let signposter = OSSignposter(subsystem: subsystem, category: "perf")
+
     private static let loggers: [String: Logger] = [
         "agent": Logger(subsystem: subsystem, category: "agent"),
         "ingest": Logger(subsystem: subsystem, category: "ingest"),
@@ -35,7 +42,20 @@ public enum DebugLog {
         "reader": Logger(subsystem: subsystem, category: "reader"),
     ]
 
-    private static func emit(_ category: String, _ message: String) {
-        loggers[category]?.notice("\(message, privacy: .public)")
+    // `.default` is the "notice" level (persisted by `log show`); `.debug` is
+    // captured only with `--debug`. Existing category helpers default to
+    // `.default` (= `.notice`), matching the prior `logger.notice` behavior.
+    private static func emit(_ category: String, _ message: String, level: OSLogType = .default) {
+        loggers[category]?.log(level: level, "\(message, privacy: .public)")
+    }
+
+    /// Chatty diagnostic that should NOT clutter the persisted production log.
+    /// Emits at `.debug` — captured only with `log show --debug` (or Console's
+    /// "Include Debug Messages"). Use for per-call / per-iteration traces (e.g.
+    /// every `NLEmbedding` inference, cache hits, availability checks); reserve
+    /// the category helpers above (`store`, `tabs`, …) — which emit at `.default`
+    /// (notice) — for signal-worthy events that must survive in `log show`.
+    public static func debug(_ message: @autoclosure () -> String) {
+        emit("store", message(), level: .debug)
     }
 }

--- a/Sources/WikiFSCore/EmbeddingService.swift
+++ b/Sources/WikiFSCore/EmbeddingService.swift
@@ -21,23 +21,53 @@ public enum EmbeddingService {
     private static func model() -> NLEmbedding? {
         lock.lock()
         defer { lock.unlock() }
-        if let m = _model { return m }
-        guard Bundle.main.bundlePath.hasSuffix(".app") else { return nil }
-        guard #available(macOS 15, *) else { return nil }
+        if let m = _model {
+            DebugLog.store("embed.model cached hit")
+            return m
+        }
+        guard Bundle.main.bundlePath.hasSuffix(".app") else {
+            DebugLog.store("embed.model skip (not .app bundle)")
+            return nil
+        }
+        guard #available(macOS 15, *) else {
+            DebugLog.store("embed.model skip (macOS < 15)")
+            return nil
+        }
+        let t0 = DispatchTime.now()
         let m = NLEmbedding.sentenceEmbedding(for: .english)
+        let loadMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
         _model = m
+        DebugLog.store("embed.model LOAD \(String(format: "%.1f", loadMs)) ms main=\(Thread.isMainThread) loaded=\(m != nil)")
         return m
     }
 
     /// True when the `NLEmbedding` model is usable (app bundle + macOS 15+).
-    /// Cheap to call after first load (the model is cached).
-    public static var isAvailable: Bool { model() != nil }
+    /// NOTE: first call LOADS the model (~0.3 s on the main thread).
+    public static var isAvailable: Bool {
+        let available = model() != nil
+        DebugLog.store("embed.isAvailable → \(available)")
+        return available
+    }
 
     /// One 512-dim Float32 BLOB for a short string (a search query). Returns
     /// `nil` when the model is unavailable.
     public static func embeddingBlob(for text: String) -> Data? {
-        guard let m = model() else { return nil }
-        guard let doubles = m.vector(for: text) else { return nil }
+        let t0 = DispatchTime.now()
+        guard let m = model() else {
+            DebugLog.store("embed.blob nil (no model) len=\(text.count)")
+            return nil
+        }
+        guard let doubles = m.vector(for: text) else {
+            DebugLog.store("embed.blob nil (vector returned nil) len=\(text.count)")
+            return nil
+        }
+        let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
+        // Diagnostic: log every NLEmbedding inference with its cost + input size.
+        DebugLog.store("embed.call \(String(format: "%.1f", elapsedMs)) ms len=\(text.count) main=\(Thread.isMainThread)")
+        // Log a concise caller chain for every call so we can identify the
+        // trigger when filtered by time (e.g. a page click).
+        let stack = Thread.callStackSymbols.dropFirst(2).prefix(5).joined(separator: " << ")
+        DebugLog.store("embed.STACK \(stack)")
         let floats = doubles.map { Float32($0) }
         return floats.withUnsafeBytes { Data($0) }
     }
@@ -49,6 +79,7 @@ public enum EmbeddingService {
     public static func chunks(for text: String, maxChunks: Int = 64) -> [String] {
         var c = TextChunker.chunk(text)
         if c.count > maxChunks { c = evenlySample(c, max: maxChunks) }
+        DebugLog.store("embed.chunks → \(c.count) chunk(s) from len=\(text.count)")
         return c
     }
 
@@ -62,12 +93,18 @@ public enum EmbeddingService {
     /// document** (not just the prefix) so a passage deep in the file is still
     /// represented in the index.
     public static func chunkedEmbeddings(for text: String, maxChunks: Int = 64) -> [Data] {
-        guard model() != nil else { return [] }
+        DebugLog.store("embed.chunked ENTER len=\(text.count) maxChunks=\(maxChunks)")
+        guard model() != nil else {
+            DebugLog.store("embed.chunked EXIT (no model)")
+            return []
+        }
         var chunks = TextChunker.chunk(text)
         if chunks.count > maxChunks {
             chunks = evenlySample(chunks, max: maxChunks)
         }
-        return chunks.compactMap { embeddingBlob(for: $0) }
+        let result = chunks.compactMap { embeddingBlob(for: $0) }
+        DebugLog.store("embed.chunked EXIT → \(result.count) blob(s) from \(chunks.count) chunk(s)")
+        return result
     }
 
     /// Pick up to `max` elements evenly spaced across `items` (always including

--- a/Sources/WikiFSCore/EmbeddingService.swift
+++ b/Sources/WikiFSCore/EmbeddingService.swift
@@ -22,7 +22,7 @@ public enum EmbeddingService {
         lock.lock()
         defer { lock.unlock() }
         if let m = _model {
-            DebugLog.store("embed.model cached hit")
+            DebugLog.debug("embed.model cached hit")
             return m
         }
         guard Bundle.main.bundlePath.hasSuffix(".app") else {
@@ -34,7 +34,9 @@ public enum EmbeddingService {
             return nil
         }
         let t0 = DispatchTime.now()
+        let signpostState = DebugLog.signposter.beginInterval("embed.modelLoad")
         let m = NLEmbedding.sentenceEmbedding(for: .english)
+        DebugLog.signposter.endInterval("embed.modelLoad", signpostState)
         let loadMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
         _model = m
         DebugLog.store("embed.model LOAD \(String(format: "%.1f", loadMs)) ms main=\(Thread.isMainThread) loaded=\(m != nil)")
@@ -45,7 +47,7 @@ public enum EmbeddingService {
     /// NOTE: first call LOADS the model (~0.3 s on the main thread).
     public static var isAvailable: Bool {
         let available = model() != nil
-        DebugLog.store("embed.isAvailable → \(available)")
+        DebugLog.debug("embed.isAvailable → \(available)")
         return available
     }
 
@@ -57,17 +59,20 @@ public enum EmbeddingService {
             DebugLog.store("embed.blob nil (no model) len=\(text.count)")
             return nil
         }
-        guard let doubles = m.vector(for: text) else {
+        let signpostState = DebugLog.signposter.beginInterval("embed.infer")
+        let doubles = m.vector(for: text)
+        DebugLog.signposter.endInterval("embed.infer", signpostState)
+        guard let doubles else {
             DebugLog.store("embed.blob nil (vector returned nil) len=\(text.count)")
             return nil
         }
         let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
-        // Diagnostic: log every NLEmbedding inference with its cost + input size.
-        DebugLog.store("embed.call \(String(format: "%.1f", elapsedMs)) ms len=\(text.count) main=\(Thread.isMainThread)")
-        // Log a concise caller chain for every call so we can identify the
-        // trigger when filtered by time (e.g. a page click).
+        // Per-inference detail → `.debug` (not persisted by default). Flip on
+        // with `log show --debug` when chasing who's hitting NLEmbedding.
+        DebugLog.debug("embed.call \(String(format: "%.1f", elapsedMs)) ms len=\(text.count) main=\(Thread.isMainThread)")
+        // Caller chain, also `.debug`.
         let stack = Thread.callStackSymbols.dropFirst(2).prefix(5).joined(separator: " << ")
-        DebugLog.store("embed.STACK \(stack)")
+        DebugLog.debug("embed.STACK \(stack)")
         let floats = doubles.map { Float32($0) }
         return floats.withUnsafeBytes { Data($0) }
     }
@@ -79,7 +84,7 @@ public enum EmbeddingService {
     public static func chunks(for text: String, maxChunks: Int = 64) -> [String] {
         var c = TextChunker.chunk(text)
         if c.count > maxChunks { c = evenlySample(c, max: maxChunks) }
-        DebugLog.store("embed.chunks → \(c.count) chunk(s) from len=\(text.count)")
+        DebugLog.debug("embed.chunks → \(c.count) chunk(s) from len=\(text.count)")
         return c
     }
 
@@ -93,9 +98,9 @@ public enum EmbeddingService {
     /// document** (not just the prefix) so a passage deep in the file is still
     /// represented in the index.
     public static func chunkedEmbeddings(for text: String, maxChunks: Int = 64) -> [Data] {
-        DebugLog.store("embed.chunked ENTER len=\(text.count) maxChunks=\(maxChunks)")
+        DebugLog.debug("embed.chunked ENTER len=\(text.count) maxChunks=\(maxChunks)")
         guard model() != nil else {
-            DebugLog.store("embed.chunked EXIT (no model)")
+            DebugLog.debug("embed.chunked EXIT (no model)")
             return []
         }
         var chunks = TextChunker.chunk(text)
@@ -103,7 +108,7 @@ public enum EmbeddingService {
             chunks = evenlySample(chunks, max: maxChunks)
         }
         let result = chunks.compactMap { embeddingBlob(for: $0) }
-        DebugLog.store("embed.chunked EXIT → \(result.count) blob(s) from \(chunks.count) chunk(s)")
+        DebugLog.debug("embed.chunked EXIT → \(result.count) blob(s) from \(chunks.count) chunk(s)")
         return result
     }
 

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -121,6 +121,11 @@ public final class WikiStoreModel {
     /// after `selection` has advanced (§3.5 read-state-at-save-time).
     private var loadedSelection: WikiSelection?
     private var isApplyingHistorySelection = false
+    /// Debug timing: when the latest user-initiated navigation began (set in
+    /// `openTab`). The reader's `Coordinator` reads this to log the synchronous
+    /// click→startLoad window and the full click→painted latency. `internal` so
+    /// the app module can read it; `nil` until the first navigation.
+    public var clickStartedAt: DispatchTime?
     /// True when the page drafts differ from the last persisted state. Cleared on
     /// save and on load. Prevents `flushPendingSaves()` from bumping `updated_at`
     /// on a tab switch when the user only viewed a page without editing.
@@ -243,18 +248,19 @@ public final class WikiStoreModel {
         (try? store.resolveSourceByName(displayName)) != nil
     }
 
-    /// Semantic search for pages matching `query` (sqlite-vec + NLEmbedding, with
-    /// a `LIKE` fallback). Powers the right-click link context menu's "Suggest…"
-    /// (missing links) and "Find Similar…" (any wiki link). Best-effort: returns
-    /// `[]` on any error so the menu never throws.
+    /// Semantic search for pages matching `query`. **Currently a no-op** — the
+    /// real implementation ran `NLEmbedding` inference on the main thread, and the
+    /// sidebar's context menu called it for every page row on every render,
+    /// freezing the UI (~0.4–2 s per render). Disabled until embedding inference
+    /// is moved off the main actor. Returns `[]`.
     public func searchSimilar(query: String, limit: Int = 8) -> [WikiPageSummary] {
-        (try? store.searchSimilar(query: query, limit: limit)) ?? []
+        []
     }
 
-    /// Semantic source search wrapper for the Sources sidebar search bar and
-    /// context menus. Best-effort: returns `[]` on any error.
+    /// Semantic source search wrapper. **No-op** for the same main-thread
+    /// NLEmbedding reason as `searchSimilar` (see above). Returns `[]`.
     public func searchSimilarSources(query: String, limit: Int = 20) -> [SourceSummary] {
-        (try? store.searchSimilarSources(query: query, limit: limit)) ?? []
+        []
     }
 
     /// Resolve a page title to its id (lowest-ULID on a duplicate-title
@@ -364,6 +370,7 @@ public final class WikiStoreModel {
     /// `[[wiki-link]]` that's already open returns to its tab instead of spawning
     /// a copy.
     public func openTab(_ selection: WikiSelection, title: String? = nil) {
+        clickStartedAt = DispatchTime.now()
         if let existing = tabs.first(where: { $0.selection == selection }) {
             DebugLog.store("[tabs] openTab: focus existing tab for \(selection) (id=\(existing.id))")
             setActiveTab(existing.id)
@@ -1316,6 +1323,11 @@ public final class WikiStoreModel {
         work: [(id: PageID, text: String)],
         store: @escaping @MainActor (PageID, [Data]) -> Void
     ) async {
+        // Short-circuit BEFORE touching NLEmbedding: `EmbeddingService.isAvailable`
+        // lazily LOADS the model (NLEmbedding.sentenceEmbedding — ~0.3 s on the
+        // main thread). On a warm DB there is no missing work, so loading the
+        // model at every launch just to find nothing to do was the startup stall.
+        guard !work.isEmpty else { return }
         guard EmbeddingService.isAvailable else { return }
         for (id, text) in work {
             var blobs: [Data] = []


### PR DESCRIPTION
## Problem

Page clicks (and app startup) had a **~0.4–2 s stall** introduced by the
semantic-search work (PR #91).

## Root cause

The **page-row context menu** in `SidebarView.pagesSectionRows` eagerly called
`store.searchSimilar(query:)` inside its `.contextMenu` builder. SwiftUI
evaluates that builder on every sidebar layout pass, so a single page selection
ran `searchSimilar` → `NLEmbedding.vector(for:)` **on the main thread** for all
~232 page rows — **hundreds of inferences per render**, freezing the UI.

Sources were unaffected only because their rows don't have that menu.

A second, smaller cost: at launch `backfill` called `EmbeddingService.isAvailable`,
which **loads the `NLEmbedding` model (~0.3 s on the main thread)** even when there
was zero missing work to embed.

Diagnosed via `ReaderTiming`/`DebugLog` instrumentation (`webview.main-hop`,
`embed.call`, `embed.STACK`).

## Fixes

- `WikiStoreModel.searchSimilar` / `searchSimilarSources` are now **no-ops
  (`[]`)** until NLEmbedding inference is moved off the main actor. The
  "Find Similar…" context-menu item is removed.
- `backfill` short-circuits on empty work **before** touching the embedding
  model, so a warm DB skips the model load at startup.
- `EmbeddingService` is instrumented end-to-end (`embed.model LOAD`,
  `embed.isAvailable`, `embed.chunked ENTER/EXIT`, `embed.call <ms>`,
  `embed.STACK …`) — kept as witness marks.
- Reader timing probes added: `click.to-startLoad`, `click.to-painted`,
  `webview.main-hop`, `webview.task-start`, `webview.html-load`.

## Follow-up (not in this PR)

Move `NLEmbedding` inference off the main actor (the comment claims BNNS crashes
off-main, but that's most likely a shared-model concurrency issue — serialize on
a dedicated background thread), then restore "Find Similar" with a lazy, off-main
search.
