### PR TITLE
Fix app launching in background + recurring 'access data from other apps' TCC prompt

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,33 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-02 — Fix app launching in the background + "access data from other apps" prompt
+
+Both symptoms were one bug. At cold launch the app appeared behind other windows
+and popped a recurring **"Self Driving Wiki would like to access data from other
+apps"** TCC prompt. Root cause: `FileProviderSpike.warmCaches(root:)` eagerly
+listed the File Provider mount top-down via `FileManager.contentsOfDirectory`
+during the launch `.task`. The File Provider runs in the sandboxed **extension**
+(separate bundle id), so reading the domain's directory data tripped
+`kTCCServiceSystemPolicyAppData` (the `FileProviderDomainID` indirect object) on
+every cold launch. That pending prompt held the app in the background until
+dismissed. See [`plans/fileprovider-schema-migration-and-cache-warming.md`](plans/fileprovider-schema-migration-and-cache-warming.md).
+
+- **Removed `warmCaches`** entirely (`Sources/WikiFS/FileProviderSpike.swift`) and
+  its two `Task.detached` call sites in `resolvePath`. All leaf-resolution methods
+  (`openSource`, `resolveSourceByNameURL`, `resolvePageByTitleURL`) resolve by
+  **identifier** via `getUserVisibleURL` through the daemon, so they never needed
+  the parent pre-enumerated — verified: no prompt, app foregrounds,
+  `FileProviderSpikeMountPathTests` pass. If a path-*traversal* access ever needs a
+  warm cache, reintroduce warming lazily at that user-initiated call site only.
+- **App Group entitlement** (`build.sh`) — added
+  `com.apple.security.application-groups = [${APP_GROUP}]` to the **app** target's
+  entitlements (previously only the extension had it). The app accesses the group
+  container at launch; the entitlement makes that legitimate (the app's
+  provisioning profile already authorizes the group) and avoids a slow TCC/sandbox
+  evaluation at launch. Parameterized via `${APP_GROUP}` per-developer like the
+  existing extension entitlement.
+
 ## 2026-07-01 — Bookmarks sidebar section (folders, refs, drag-drop)
 
 A user-defined hierarchical tree of folders, page references, and source

--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -249,10 +249,6 @@ final class FileProviderSpike {
                 timeout: .seconds(5))
             path = url.path
             status = "Mounted"
-            let rootURL = url
-            Task.detached(priority: .background) { [weak self] in
-                await self?.warmCaches(root: rootURL)
-            }
         } catch {
             status = "Resolving mount timed out; retrying domain registration…"
             if await registerDomain(id: id, displayName: displayName) {
@@ -264,55 +260,12 @@ final class FileProviderSpike {
                         timeout: .seconds(5))
                     path = url.path
                     status = "Mounted"
-                    let rootURL = url
-                    Task.detached(priority: .background) { [weak self] in
-                        await self?.warmCaches(root: rootURL)
-                    }
                     return
                 } catch {
                     status = "Mount unavailable: \(error.localizedDescription)"
                 }
             } else {
                 status = "Mount unavailable: \(error.localizedDescription)"
-            }
-        }
-    }
-
-    /// Force the File Provider daemon to enumerate the directory hierarchy
-    /// top-down so the leaf container cache is warm before the share sheet
-    /// or Finder needs to resolve a path inside it.  The daemon enumerates
-    /// lazily; a cold parent means the child directory doesn't exist yet.
-    /// Listing each level with `FileManager` triggers synchronous
-    /// enumeration.  Best-effort — failures are logged.
-    private func warmCaches(root url: URL) async {
-        // List the root first — the daemon may have an incomplete cache
-        // from a previous enumeration and needs a fresh one that includes
-        // every container.  Then walk top-down so each parent is
-        // enumerated before its children.
-        DebugLog.fileprovider("warmCaches: listing root…")
-        if let rootItems = try? FileManager.default.contentsOfDirectory(
-            at: url, includingPropertiesForKeys: nil) {
-            let names = rootItems.map { $0.lastPathComponent }.sorted()
-            DebugLog.fileprovider("warmCaches: root → \(rootItems.count) items: \(names)")
-        } else {
-            DebugLog.fileprovider("warmCaches: root listing failed")
-        }
-
-        let walks: [(containers: [String], label: String)] = [
-            (["sources", "sources/by-name"], "source share"),
-            (["pages",   "pages/by-title"],   "page share"),
-        ]
-        for (containers, _) in walks {
-            for relative in containers {
-                let dirURL = url.appendingPathComponent(relative, isDirectory: true)
-                DebugLog.fileprovider("warmCaches: listing \(relative)…")
-                do {
-                    let contents = try FileManager.default.contentsOfDirectory(
-                        at: dirURL, includingPropertiesForKeys: nil)
-                    DebugLog.fileprovider("warmCaches: \(relative) → \(contents.count) items")
-                } catch {
-                    DebugLog.fileprovider("warmCaches: \(relative) error=\(error.localizedDescription)")
-                }
             }
         }
     }

--- a/build.sh
+++ b/build.sh
@@ -257,6 +257,17 @@ if [ "${REAL_SIGNING}" = "1" ]; then
 	<string>${TEAM_ID}.${BUNDLE_ID}</string>
 	<key>com.apple.developer.team-identifier</key>
 	<string>${TEAM_ID}</string>
+	<!-- App Group container holds the SQLite DB shared with the sandboxed File
+	     Provider extension. The app accesses it via a LITERAL path (see
+	     DatabaseLocation.appGroupContainerDirectory), but WITHOUT this entitlement
+	     macOS treats the group container as "another app's data" and shows a
+	     "would like to access data from other apps" privacy prompt at every cold
+	     launch — which also holds the app in the background until dismissed. The
+	     app's provisioning profile already authorizes this group. -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>${APP_GROUP}</string>
+	</array>
 </dict>
 </plist>
 PLIST

--- a/plans/fileprovider-schema-migration-and-cache-warming.md
+++ b/plans/fileprovider-schema-migration-and-cache-warming.md
@@ -34,15 +34,29 @@ History:
 - **v2** — `files` container renamed to `sources`; `source-by-name:` prefix shared via `WikiFSContainerID`
 - **v1** — initial schema
 
-## Cache warming (`FileProviderSpike.warmCaches(root:)`)
+## Cache warming — REMOVED (caused launch-time TCC prompt)
 
-Called from `resolvePath` after the mount URL is resolved. Lists directories top-down with `FileManager.default.contentsOfDirectory`:
+`FileProviderSpike.warmCaches(root:)` and its calls in `resolvePath` were
+**removed**. The method listed the File Provider mount top-down with
+`FileManager.default.contentsOfDirectory`. Because the File Provider runs in the
+sandboxed **extension** process (a separate bundle id from the host app), reading
+the domain's directory data tripped `kTCCServiceSystemPolicyAppData` — the
+**"Self Driving Wiki would like to access data from other apps"** privacy prompt
+— on every cold launch. That pending prompt also **held the app in the
+background** at startup (the app never reached the front until the user dealt
+with the prompt).
 
-1. List `sources/` — daemon enumerates the `sources` container, discovers `by-id` and `by-name` children
-2. List `sources/by-name/` — daemon enumerates all source file nodes, caches filenames
-3. Same for `pages/` → `pages/by-title/`
+`warmCaches` was written for an older path-traversal share flow, but the current
+leaf-resolution methods (`openSource`, `resolveSourceByNameURL`,
+`resolvePageByTitleURL`) all resolve via `getUserVisibleURL` by **identifier**,
+which goes straight through the daemon and does **not** require the parent
+container to be pre-enumerated. So removing `warmCaches` does not regress those
+paths (verified: launch foregrounds, no prompt, `FileProviderSpikeMountPathTests`
+pass).
 
-Errors are logged but never surfaced to the user — the cache warming is best-effort; the share button's `resourceValues(forKeys:)` call is the safety net for individual file access.
+If a future path-*traversal* access (e.g. Finder resolving a path by walking the
+hierarchy) needs a warm cache, reintroduce warming **lazily at that user-initiated
+call site** — never eagerly from `resolvePath`/launch.
 
 ## Source mount path (`FileProviderSpike.sourceMountPath(for:)`)
 


### PR DESCRIPTION
## Problem

At cold launch the app appeared **behind other windows** and popped a recurring **"Self Driving Wiki would like to access data from other apps"** TCC prompt. Both symptoms were one bug.

## Root cause

`FileProviderSpike.warmCaches(root:)` eagerly listed the File Provider mount top-down via `FileManager.contentsOfDirectory` during the launch `.task`. The File Provider runs in the sandboxed **extension** (a separate bundle id from the host app), so reading the domain's directory data tripped `kTCCServiceSystemPolicyAppData` (the `FileProviderDomainID` indirect object) on every cold launch. That pending privacy prompt held the app in the background until the user dismissed it — which is why it only came forward after being clicked.

Confirmed via the unified log: `AUTHREQ_PROMPTING: service=kTCCServiceSystemPolicyAppData, subject=com.willsargent.WikiFS`, and disabling the directory reads eliminated the prompt.

## Fix

1. **Removed `warmCaches`** (`Sources/WikiFS/FileProviderSpike.swift`) and its two `Task.detached` call sites in `resolvePath`. All leaf-resolution methods (`openSource`, `resolveSourceByNameURL`, `resolvePageByTitleURL`) resolve by **identifier** via `getUserVisibleURL` through the daemon, so they never needed the parent container pre-enumerated. `warmCaches` was vestigial — written for an older path-traversal share flow. If a future path-*traversal* access (Finder walking the hierarchy) needs a warm cache, warming should be reintroduced **lazily at that user-initiated call site**, never eagerly from launch.

2. **`build.sh`** — added `com.apple.security.application-groups = [${APP_GROUP}]` to the **app** target's entitlements (previously only the extension had it). The app reads the App Group container at launch; the entitlement makes that legitimate and avoids a slow TCC/sandbox evaluation at launch. The app's provisioning profile already authorizes the group, so no portal change is needed. Parameterized via `${APP_GROUP}` per-developer, matching the existing extension entitlement.

## Verification

- Cold launch: no prompt, app comes to the foreground.
- `swift build` clean.
- Full test suite: **1265 tests pass**.
- `FileProviderSpikeMountPathTests` pass.

## Docs

Updated `plans/fileprovider-schema-migration-and-cache-warming.md` (cache-warming section marked REMOVED with rationale) and `PROGRESS.md`.
