### PR TITLE
Hide the tab bar when there are 0 or 1 tabs (Safari-style)

### DIFF
--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -200,9 +200,18 @@ struct ContentView: View {
             // window. It shares the detail column's full height, so it sits at
             // the same height as the leading sidebar rather than under the tab bar.
             VStack(spacing: 0) {
-                TabBarView(store: store)
+                // Safari-style: the tab strip is only shown when there are 2+
+                // tabs. With 0 or 1 tabs there's nothing to switch, so the strip
+                // is removed (the detail pane reclaims the vertical space). New
+                // tabs are still created from the sidebar / shortcuts, which
+                // crosses the 1→2 threshold and re-shows the strip.
+                if store.tabs.count > 1 {
+                    TabBarView(store: store)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
                 wikiDetailPane
             }
+            .animation(.easeInOut(duration: 0.18), value: store.tabs.count > 1)
 
             if isTranscriptExpanded {
                 Divider()


### PR DESCRIPTION
## What

Hide the tab bar when there are 0 or 1 tabs, so it only appears with 2+ tabs — like Safari.

## Why

With a single page/source (or none) open there is nothing to switch between, so the tab strip is just dead chrome. Safari hides its tab bar in the same situation.

## Change

`ContentView.swift` — conditionally render `TabBarView` only when `store.tabs.count > 1`:

```swift
if store.tabs.count > 1 {
    TabBarView(store: store)
        .transition(.move(edge: .top).combined(with: .opacity))
}
wikiDetailPane
```

- The animation is scoped to the `1 ↔ 2` threshold (`value: store.tabs.count > 1`), so opening/closing tabs beyond that doesn't trigger spurious layout animation — only the bar's appear/disappear does.
- Creating new tabs is unaffected: they're opened from the sidebar / keyboard shortcuts, which crosses the `1 → 2` threshold and re-shows the strip.

## Verification

- `swift build` clean.
- `EditorTabTests` (50 tests) pass.
