### PR TITLE
Agent env: bash-style parsing (export/$VAR); remove Sandbox toggle

### DIFF
--- a/Sources/WikiFS/AgentCommandSettingsView.swift
+++ b/Sources/WikiFS/AgentCommandSettingsView.swift
@@ -11,7 +11,6 @@ struct AgentCommandSettingsView: View {
     @State private var prefixArguments: String
     @State private var modelOverride: String
     @State private var extraEnvironment: String
-    @State private var sandboxEnabled: Bool
 
     let containerDirectory: URL
 
@@ -22,7 +21,6 @@ struct AgentCommandSettingsView: View {
         _prefixArguments = State(initialValue: config.prefixArguments)
         _modelOverride = State(initialValue: config.modelOverride)
         _extraEnvironment = State(initialValue: config.extraEnvironment)
-        _sandboxEnabled = State(initialValue: SandboxConfig.load(from: containerDirectory).enabled)
     }
 
     var body: some View {
@@ -43,17 +41,7 @@ struct AgentCommandSettingsView: View {
                 } header: {
                     Text("Extra Environment")
                 } footer: {
-                    Text("KEY=VALUE, one per line. WIKI_ROOT and WIKI_DB are always set by the app and cannot be overridden.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Section {
-                    Toggle("Run agent in sandbox", isOn: $sandboxEnabled)
-                } header: {
-                    Text("Sandbox")
-                } footer: {
-                    Text("When on, the main agent and Edit sessions run under a seatbelt that confines writes to the wiki DB and scratch directory (plus ~/.claude). The Ask session is always read-only sandboxed regardless of this setting.")
+                    Text("bash-style, one per line. `export KEY=VALUE` and `$VAR` / `${VAR}` expansion are supported (single quotes are taken literally). WIKI_ROOT and WIKI_DB are always set by the app and cannot be overridden.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -73,7 +61,6 @@ struct AgentCommandSettingsView: View {
         .onChange(of: prefixArguments) { _, _ in saveCommand() }
         .onChange(of: modelOverride) { _, _ in saveCommand() }
         .onChange(of: extraEnvironment) { _, _ in saveCommand() }
-        .onChange(of: sandboxEnabled) { _, _ in saveSandbox() }
     }
 
     // MARK: - Actions
@@ -87,17 +74,6 @@ struct AgentCommandSettingsView: View {
         try? config.save(to: containerDirectory)
     }
 
-    private func saveSandbox() {
-        // Load fresh to PRESERVE extraAllowedPaths — we only mutate `enabled` here.
-        // Safe because this view is currently the sole writer of sandbox-config.json;
-        // revisit if an extraAllowedPaths editor is added. A corrupt file degrades to
-        // .default (empty paths), which is accepted.
-        var config = SandboxConfig.load(from: containerDirectory)
-        config.enabled = sandboxEnabled
-        // try? is deliberate: the view has no error-reporting surface. Matches saveCommand().
-        try? config.save(to: containerDirectory)
-    }
-
     private func resetToDefault() {
         let cmdDefaults = AgentCommandConfig.default
         executable = cmdDefaults.executable
@@ -105,12 +81,5 @@ struct AgentCommandSettingsView: View {
         modelOverride = cmdDefaults.modelOverride
         extraEnvironment = cmdDefaults.extraEnvironment
         saveCommand()
-        // Also reset the sandbox toggle so "Reset to Default" is fully consistent.
-        sandboxEnabled = SandboxConfig.default.enabled
-        // Explicit save mirrors saveCommand() above: persistence-on-reset is
-        // unconditional regardless of .onChange timing. The .onChange(of: sandboxEnabled)
-        // would also fire and call saveSandbox(), but the explicit call here is
-        // intentional — do not remove it as "redundant".
-        saveSandbox()
     }
 }

--- a/Sources/WikiFSCore/AgentCommandConfig.swift
+++ b/Sources/WikiFSCore/AgentCommandConfig.swift
@@ -83,20 +83,117 @@ public struct AgentCommandConfig: Codable, Equatable, Sendable {
         AgentCommandConfig.tokenize(prefixArguments)
     }
 
-    /// Parse `extraEnvironment` into a `[String: String]` dictionary. Lines
-    /// without `=` are skipped; blank lines are skipped.
+    /// Parse `extraEnvironment` into a `[String: String]` dictionary, accepting
+    /// bash-style assignment lines:
+    ///
+    /// - A leading `export ` keyword is stripped (`export FOO=bar` ≡ `FOO=bar`).
+    /// - One surrounding layer of quotes is removed: double quotes (`FOO="a b"`)
+    ///   or unquoted values get `$VAR`/`${VAR}` expansion; single quotes
+    ///   (`FOO='$HOME'`) are taken literally (no expansion), like bash.
+    /// - `$NAME` and `${NAME}` references expand against the app process
+    ///   environment (bash-style: a referenced-but-unset variable → empty string).
+    /// - Lines without `=` and blank lines are skipped.
+    ///
+    /// App-owned keys (`WIKI_ROOT`, `WIKI_DB`) are not filtered here — the spawn
+    /// site merges this dictionary under the app-owned keys so they always win.
     public func parsedExtraEnv() -> [String: String] {
         var env: [String: String] = [:]
-        for line in extraEnvironment.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
+        for rawLine in extraEnvironment.components(separatedBy: "\n") {
+            var trimmed = rawLine.trimmingCharacters(in: .whitespaces)
             guard !trimmed.isEmpty else { continue }
+            // Strip a leading `export` keyword. Require whitespace after it so a
+            // key literally named `export` (e.g. `export=foo`, a normal
+            // assignment) is not mangled.
+            if trimmed.hasPrefix("export"),
+               let firstAfter = trimmed.dropFirst("export".count).first,
+               firstAfter.isWhitespace {
+                trimmed = trimmed.dropFirst("export".count)
+                    .trimmingCharacters(in: .whitespaces)
+            }
             guard let eq = trimmed.firstIndex(of: "=") else { continue }
             let key = String(trimmed[..<eq]).trimmingCharacters(in: .whitespaces)
-            let value = String(trimmed[trimmed.index(after: eq)...])
             guard !key.isEmpty else { continue }
+            var value = String(trimmed[trimmed.index(after: eq)...])
+                .trimmingCharacters(in: .whitespaces)
+            // One layer of surrounding quotes. Single-quoted → literal; double-
+            // quoted / unquoted → expand variable references.
+            let expand: Bool
+            if value.count >= 2, value.first == "'", value.last == "'" {
+                value = String(value.dropFirst().dropLast())
+                expand = false
+            } else if value.count >= 2, value.first == "\"", value.last == "\"" {
+                value = String(value.dropFirst().dropLast())
+                expand = true
+            } else {
+                expand = true
+            }
+            if expand {
+                value = Self.expandEnvironmentVariables(in: value)
+            }
             env[key] = value
         }
         return env
+    }
+
+    /// Expand `$NAME` and `${NAME}` references against the current process
+    /// environment, bash-style. A reference whose variable is unset expands to
+    /// the empty string (matching `export FOO=$UNSET` → `FOO=`). Names follow the
+    /// shell rule: start with a letter or `_`, continue with letters/digits/`_`.
+    private static func expandEnvironmentVariables(in value: String) -> String {
+        let env = ProcessInfo.processInfo.environment
+        var output = ""
+        var i = value.startIndex
+        while i < value.endIndex {
+            let ch = value[i]
+            guard ch == "$" else {
+                output.append(ch)
+                i = value.index(after: i)
+                continue
+            }
+            let afterDollar = value.index(after: i)
+            if afterDollar < value.endIndex, value[afterDollar] == "{" {
+                // ${NAME}
+                let nameStart = value.index(after: afterDollar)
+                var nameEnd = nameStart
+                while nameEnd < value.endIndex, isShellNameChar(value[nameEnd], isStart: false) {
+                    nameEnd = value.index(after: nameEnd)
+                }
+                if nameEnd < value.endIndex, value[nameEnd] == "}", nameStart < nameEnd {
+                    let name = String(value[nameStart..<nameEnd])
+                    output.append(env[name] ?? "")
+                    i = value.index(after: nameEnd)   // consume the '}'
+                } else {
+                    // Malformed `${…` — emit the '$' literally and continue.
+                    output.append("$")
+                    i = afterDollar
+                }
+            } else {
+                // $NAME (greedy run of name chars)
+                var nameEnd = afterDollar
+                while nameEnd < value.endIndex, isShellNameChar(value[nameEnd], isStart: nameEnd == afterDollar) {
+                    nameEnd = value.index(after: nameEnd)
+                }
+                if nameEnd > afterDollar {
+                    let name = String(value[afterDollar..<nameEnd])
+                    output.append(env[name] ?? "")
+                    i = nameEnd
+                } else {
+                    // Lone '$' not followed by a name char (e.g. `$$`, `$1`) — literal.
+                    output.append("$")
+                    i = afterDollar
+                }
+            }
+        }
+        return output
+    }
+
+    /// Shell variable-name character test: first char is ASCII letter or `_`;
+    /// subsequent chars may also be ASCII digits.
+    private static func isShellNameChar(_ c: Character, isStart: Bool) -> Bool {
+        guard c.isASCII else { return false }
+        if c == "_" { return true }
+        if c.isLetter { return true }
+        return !isStart && c.isNumber
     }
 
     // MARK: - Tokenizer (public for testing)

--- a/Tests/WikiFSTests/AgentCommandConfigTests.swift
+++ b/Tests/WikiFSTests/AgentCommandConfigTests.swift
@@ -150,6 +150,77 @@ struct AgentCommandConfigTests {
         #expect(env["comment"] == nil)
     }
 
+    @Test func parsedExtraEnvStripsExportKeyword() {
+        let config = AgentCommandConfig(extraEnvironment: "export FOO=bar\nexport   BAZ=qux")
+        let env = config.parsedExtraEnv()
+        #expect(env["FOO"] == "bar")
+        #expect(env["BAZ"] == "qux")
+    }
+
+    @Test func parsedExtraEnvExportWithoutEqualsIsSkipped() {
+        // `export FOO` (no assignment) is not a key=value line.
+        let config = AgentCommandConfig(extraEnvironment: "export FOO\nBAR=1")
+        let env = config.parsedExtraEnv()
+        #expect(env["FOO"] == nil)
+        #expect(env["BAR"] == "1")
+    }
+
+    @Test func parsedExtraEnvDoesNotMangleKeyNamedExport() {
+        // `export=foo` is a normal assignment to a key literally named "export".
+        let config = AgentCommandConfig(extraEnvironment: "export=foo")
+        let env = config.parsedExtraEnv()
+        #expect(env["export"] == "foo")
+    }
+
+    @Test func parsedExtraEnvStripsDoubleQuotes() {
+        let config = AgentCommandConfig(extraEnvironment: #"export CLAUDE_MODEL="sonnet""#)
+        let env = config.parsedExtraEnv()
+        #expect(env["CLAUDE_MODEL"] == "sonnet")
+    }
+
+    @Test func parsedExtraEnvExpandsBraceVar() {
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? ""
+        let config = AgentCommandConfig(extraEnvironment: "DOCS=${HOME}/docs")
+        let env = config.parsedExtraEnv()
+        #expect(env["DOCS"] == "\(home)/docs")
+    }
+
+    @Test func parsedExtraEnvExpandsBareVar() {
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? ""
+        let config = AgentCommandConfig(extraEnvironment: "DOCS=$HOME/docs")
+        let env = config.parsedExtraEnv()
+        #expect(env["DOCS"] == "\(home)/docs")
+    }
+
+    @Test func parsedExtraEnvExpandsVarInsideDoubleQuotes() {
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? ""
+        let config = AgentCommandConfig(extraEnvironment: #"DOCS="$HOME/docs""#)
+        let env = config.parsedExtraEnv()
+        #expect(env["DOCS"] == "\(home)/docs")
+    }
+
+    @Test func parsedExtraEnvSingleQuotesAreLiteral() {
+        // Single quotes suppress expansion, like bash.
+        let config = AgentCommandConfig(extraEnvironment: "DOCS='$HOME/docs'")
+        let env = config.parsedExtraEnv()
+        #expect(env["DOCS"] == "$HOME/docs")
+    }
+
+    @Test func parsedExtraEnvUnsetVarExpandsToEmpty() {
+        let config = AgentCommandConfig(extraEnvironment: "X=${WIKI_TEST_UNSET_VAR_42}/y\nZ=$WIKI_TEST_UNSET_VAR_42")
+        let env = config.parsedExtraEnv()
+        #expect(env["X"] == "/y")
+        #expect(env["Z"] == "")
+    }
+
+    @Test func parsedExtraEnvLoneDollarIsLiteral() {
+        // `$1` is not a valid name (names can't start with a digit), so the `$`
+        // is kept literally rather than treated as a variable reference.
+        let config = AgentCommandConfig(extraEnvironment: "FOO=$1")
+        let env = config.parsedExtraEnv()
+        #expect(env["FOO"] == "$1")
+    }
+
     // MARK: - expandTilde
 
     @Test func expandTildeReturnsNonTildePathsUnchanged() {


### PR DESCRIPTION
## What

Two changes to **Settings → Agent**:

1. The **Extra Environment** field now accepts bash-style assignment lines.
2. The **Sandbox** section was removed from this view.

## Extra Environment — bash-style parsing

`AgentCommandConfig.parsedExtraEnv()` now handles:

- **`export` keyword** — `export CLAUDE_MODEL="sonnet"` works the same as `CLAUDE_MODEL="sonnet"`. A leading `export ` is stripped (requires trailing whitespace, so a key literally named `export` in `export=foo` is not mangled).
- **Quotes** — one surrounding layer of double or single quotes is removed.
- **`$VAR` / `${VAR}` expansion** — against the app process environment, bash-style. e.g. `DOCS=${HOME}/docs` resolves to `/Users/you/docs`.
- **Single quotes suppress expansion** (literal), like bash: `DOCS='$HOME/docs'` stays `$HOME/docs`.
- Unset variables expand to the empty string (bash semantics).

The footer text was updated to describe the supported syntax.

## Sandbox section — removed

Removed the "Run agent in sandbox" toggle and its persistence (`saveSandbox`), state, and reset logic from `AgentCommandSettingsView`. The underlying sandbox machinery (`SandboxConfig`, `SandboxProfile`, the always-on read-only query sandbox) is untouched — only this Settings toggle is gone.

## Verification

- `swift build` clean.
- Full test suite: **1275 tests pass** (10 new env-parsing tests added).
