### PR TITLE
Fix page delete failing on FK constraint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
+* For all coding tasks use your judgement to decide an appropriate lower
+  power model and run that in a subagent.
+
 * Keep a master PLAN.md as an index to the documentation you make for this codebase.
 
 * Store specific in-depth documentation in plans/whatever.md.

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -100,6 +100,15 @@ struct ContentView: View {
         } message: {
             Text("You're in edit mode. Unsaved changes will be discarded.")
         }
+        .alert("Couldn't Delete Page",
+               isPresented: Binding(get: { store.storeError != nil },
+                                    set: { if !$0 { store.dismissStoreError() } })) {
+            Button("OK", role: .cancel) { store.dismissStoreError() }
+        } message: {
+            if let error = store.storeError {
+                Text(error.message)
+            }
+        }
     }
 
     /// NavigationSplitView + drop / overlay / toolbar. Split out of `body` so the

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -1086,18 +1086,30 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
     public func deletePage(id: PageID) throws {
         lock.lock(); defer { lock.unlock() }
-        // FK safety (Phase 4): `page_links` has FKs onto `pages(id)` for BOTH
-        // `from_page_id` and `to_page_id`, and `foreign_keys=ON`. Once links are
-        // populated, deleting a page referenced as a link SOURCE or TARGET would
-        // throw a constraint violation. So clear every link touching this page
-        // first, then delete the row — in ONE transaction so a failure can't
-        // leave dangling link rows.
+        // FK safety: `page_links`, `attachments`, and `source_links` all have
+        // FKs onto `pages(id)` WITHOUT `ON DELETE CASCADE` (unlike `page_chunks`
+        // which cascades). With `foreign_keys=ON`, deleting a page that still has
+        // rows in any of those tables throws a constraint violation. So clear
+        // every dependent row first, then delete the page — all in ONE
+        // transaction so a failure can't leave dangling rows.
         try withTransaction {
             let unlink = try statement(
                 "DELETE FROM page_links WHERE from_page_id = ?1 OR to_page_id = ?1;")
             unlink.reset()
             try unlink.bind(id.rawValue, at: 1)
             _ = try unlink.step()
+
+            let deleteSourceLinks = try statement(
+                "DELETE FROM source_links WHERE from_page_id = ?1;")
+            deleteSourceLinks.reset()
+            try deleteSourceLinks.bind(id.rawValue, at: 1)
+            _ = try deleteSourceLinks.step()
+
+            let deleteAttachments = try statement(
+                "DELETE FROM attachments WHERE page_id = ?1;")
+            deleteAttachments.reset()
+            try deleteAttachments.bind(id.rawValue, at: 1)
+            _ = try deleteAttachments.step()
 
             let stmt = try statement("DELETE FROM pages WHERE id = ?1;")
             stmt.reset()

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -53,6 +53,15 @@ public final class WikiStoreModel {
     /// runs when MiniLM is the selected embedder AND there is missing content
     /// (first run, an NLEmbedding→MiniLM cutover, or `wikictl`-written content);
     /// the common launch is an instant no-op and shows nothing.
+    /// A user-facing error from a store mutation (e.g. a delete that violated a
+    /// foreign-key constraint). Surfaced via an alert in `ContentView`; `nil`-ing
+    /// it dismisses the alert.
+    public struct StoreError: Identifiable {
+        public let id = UUID()
+        public let message: String
+    }
+    public private(set) var storeError: StoreError?
+
     public private(set) var searchUpgrade: SearchUpgradeState?
     /// Synchronous single-flight guard for ``upgradeSearchIndex``. Set BEFORE any
     /// `await` (unlike `searchUpgrade`, which is only set after `configure()`),
@@ -1024,7 +1033,13 @@ public final class WikiStoreModel {
             onPageDidChange?()
         } catch {
             DebugLog.store("WikiStoreModel.delete failed: \(error)")
+            storeError = StoreError(message: "Could not delete the page: \(error.localizedDescription)")
         }
+    }
+
+    /// Dismiss the current store error (called when the user taps OK on the alert).
+    public func dismissStoreError() {
+        storeError = nil
     }
 
     // MARK: - File ingestion (Phase 5)

--- a/Tests/WikiFSTests/WikiLinkStoreTests.swift
+++ b/Tests/WikiFSTests/WikiLinkStoreTests.swift
@@ -143,4 +143,45 @@ struct WikiLinkStoreTests {
         try store.deletePage(id: a.id)
         #expect(try store.listPages(sortBy: .lastUpdated).isEmpty)
     }
+
+    @Test func deletePageCleansUpSourceLinks() throws {
+        let store = try tempStore()
+
+        // Create page A (independent, should survive)
+        let pageA = try store.createPage(title: "A")
+
+        // Ingest a source file
+        let source = try store.addSource(filename: "test.txt", data: Data("test content".utf8))
+
+        // Create page B that links to the source
+        let pageB = try store.createPage(title: "B")
+
+        // Create a source link from B to the source
+        try store.replaceLinks(from: pageB.id, parsedLinks: [
+            .init(linkType: .source, target: source.filename, linkText: source.filename)
+        ])
+
+        // Verify the source link was created
+        let sourceLinksBefore = try store.listAllSourceLinks()
+        #expect(sourceLinksBefore.count == 1)
+        #expect(sourceLinksBefore[0].from == pageB.id.rawValue)
+        #expect(sourceLinksBefore[0].to == source.id.rawValue)
+
+        // Delete page B — this must NOT throw (this was the bug: FK constraint on source_links.from_page_id)
+        try store.deletePage(id: pageB.id)
+
+        // Verify the source link was cleaned up
+        #expect(try store.listAllSourceLinks().isEmpty)
+
+        // Verify page A still exists
+        let remainingPages = try store.listPages(sortBy: .lastUpdated)
+        #expect(remainingPages.count == 1)
+        #expect(remainingPages[0].id == pageA.id)
+
+        // Verify the source still exists (deletePage should only clean source_links, not sources table)
+        let sources = try store.listSources()
+        #expect(sources.count == 1)
+        #expect(sources[0].id == source.id)
+        #expect(sources[0].filename == "test.txt")
+    }
 }


### PR DESCRIPTION
## Problem

Deleting a page did nothing — the UI appeared unresponsive. Logs showed:

```
WikiStoreModel.delete failed: SQLite error 19: FOREIGN KEY constraint failed
```

## Root Cause

`deletePage` only cleared `page_links` before deleting from `pages`, but two other tables have non-cascading FKs onto `pages(id)`:

- **`attachments`** — `FOREIGN KEY(page_id) REFERENCES pages(id)` (no cascade)
- **`source_links`** — `from_page_id REFERENCES pages(id)` (no cascade)

Any page with attachments or source links hit a constraint violation. The error was swallowed by `WikiStoreModel.delete` (just logged), so nothing happened visually.

## Fix

Added `DELETE FROM source_links` and `DELETE FROM attachments` inside the existing `withTransaction` block, before the page row is deleted. Keeps cleanup atomic.

