### PR TITLE
fix(ingest): deliver wiki bodies via file, refuse empty bodies

### DIFF
--- a/Sources/WikiCtlCore/LogIndexCommand.swift
+++ b/Sources/WikiCtlCore/LogIndexCommand.swift
@@ -27,6 +27,13 @@ public enum LogIndexCommand {
             if let source { try store.markSourceIngested(id: source) }
             return PageCommand.Result(output: entry.id.rawValue, didCommit: true)
         case .indexSet(let body):
+            guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw PageCommand.Failure.message(
+                    "refusing to set an empty index body — nothing was delivered. "
+                    + "Under the sandbox a piped or heredoc'd body can arrive empty; "
+                    + "write the body to a file in your cwd and pass --body-file <path>."
+                )
+            }
             try store.updateWikiIndex(body: body)
             return PageCommand.Result(output: "", didCommit: true)
         }

--- a/Sources/WikiCtlCore/PageCommand.swift
+++ b/Sources/WikiCtlCore/PageCommand.swift
@@ -145,6 +145,13 @@ public enum PageCommand {
         validator: MermaidValidator?,
         linter: MarkdownLinter?
     ) throws -> Result {
+        guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw Failure.message(
+                "refusing to upsert an empty body for \(title.debugDescription) — nothing "
+                + "was delivered. Under the sandbox a piped or heredoc'd body can arrive "
+                + "empty; write the body to a file in your cwd and pass --body-file <path>."
+            )
+        }
         // 1. Auto-fix cosmetic markdown issues BEFORE the write (trailing
         //    whitespace, hard tabs, blank-line spacing, etc.). Skipped silently
         //    when the linter is nil (no bundle → dev / swift test). If any

--- a/Sources/WikiFSCore/IngestWriteRule.swift
+++ b/Sources/WikiFSCore/IngestWriteRule.swift
@@ -30,9 +30,13 @@ public enum IngestWriteRule {
     is writable — writing the mount fails ON PURPOSE; do not probe it. The ONLY way \
     to create or update content is the `wikictl` command. It is already on your PATH \
     and already targets THIS wiki via the $WIKI_DB environment variable — do NOT \
-    pass --wiki. Write with:
-      printf '%s' "<body>" | wikictl page upsert --title T --body-file -
-      printf '%s' "<body>" | wikictl index set --body-file -
+    pass --wiki. Deliver the body via FILE, not a shell pipe or heredoc: write the \
+    body to a file in your current working directory, then pass `--body-file <path>`. \
+    Do NOT use `printf '<body>' | wikictl … --body-file -` or a `<<EOF` heredoc — \
+    under the sandbox the body can arrive empty (a heredoc stages a temp file the \
+    sandbox denies), and `wikictl` refuses an empty body. Write with:
+      wikictl page upsert --title T --body-file ./body.md
+      wikictl index set --body-file ./index.md
       wikictl log append --kind ingest --title "…" --note "…"
     After a write, read it back with `wikictl page get` (the mount lags the database \
     by ~5s, so cat-ing the mount right after a write shows stale bytes). Cross-link \

--- a/Sources/WikiFSCore/SystemPrompt.swift
+++ b/Sources/WikiFSCore/SystemPrompt.swift
@@ -162,12 +162,17 @@ public struct SystemPrompt: Equatable, Sendable {
     trailing newline — automatically. You don't need to hand-format whitespace;
     focus on content and structure.
 
+    Write page and index bodies to a FILE in your current working directory, then \
+    pass `--body-file <path>`. NEVER pipe or heredoc the body (`printf '<body>' | … \
+    --body-file -`, `wikictl … <<EOF`): the sandbox blocks the heredoc's temp file, \
+    the body arrives empty, and `wikictl` refuses an empty body.
+
     ```
     $WIKICTL page list                          list id / title / path per page
     $WIKICTL page get --title T | --id I        print a page body (instant, authoritative)
-    printf '%s' "<body>" | $WIKICTL page upsert --title T --body-file -   create or update a page
+    $WIKICTL page upsert --title T --body-file ./body.md   create or update a page
     $WIKICTL page delete --id I                 delete a page
-    printf '%s' "<body>" | $WIKICTL index set --body-file -               rewrite index.md wholesale
+    $WIKICTL index set --body-file ./index.md   rewrite index.md wholesale
     $WIKICTL log append --kind ingest|query|lint --title "…" [--note "…"] [--source <file-id>]  record an action (--source marks an ingest done)
     $WIKICTL search --query "…" [--limit N]    semantic search — find pages by meaning; defaults to 10 results, max 100
     $WIKICTL source list [--json]               list all sources (TSV, or JSON lines)

--- a/Sources/WikiFSCore/WikiTreeRenderer.swift
+++ b/Sources/WikiFSCore/WikiTreeRenderer.swift
@@ -52,12 +52,14 @@ public enum WikiTreeRenderer {
 
         - `wikictl page list`                         — id / title / path per page.
         - `wikictl page get --title T` (or `--id I`)  — print a page body (instant, authoritative).
-        - `printf '%s' "<body>" | wikictl page upsert --title T --body-file -`  — create/update a page.
-        - `printf '%s' "<body>" | wikictl index set --body-file -`              — rewrite index.md.
+        - `wikictl page upsert --title T --body-file ./body.md`  — create/update a page.
+        - `wikictl index set --body-file ./index.md`             — rewrite index.md.
         - `wikictl log append --kind ingest|query|lint --title "…" [--note "…"]` — record an action.
 
-        After any write, read it back with `wikictl page get` — the read-only mount
-        lags a few seconds, so don't `cat` the mount to verify a fresh write.
+        Pass page/index bodies via a FILE (`--body-file <path>`), never a shell pipe
+        or heredoc — the sandbox drops a piped/heredoc'd body and `wikictl` refuses an
+        empty body. After any write, read it back with `wikictl page get` — the
+        read-only mount lags a few seconds, so don't `cat` the mount to verify a fresh write.
 
         """
     }

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -352,8 +352,8 @@ struct OperationCommandTests {
       // prompt itself (not only the appended system prompt).
       #expect(prompt.contains("READ-ONLY BY DESIGN"))
       #expect(prompt.contains("NEVER search for a \"mutation tool\""))
-      #expect(prompt.contains("wikictl page upsert --title T --body-file -"))
-      #expect(prompt.contains("wikictl index set --body-file -"))
+      #expect(prompt.contains("wikictl page upsert --title T --body-file ./body.md"))
+      #expect(prompt.contains("wikictl index set --body-file ./index.md"))
       #expect(prompt.contains("wikictl log append --kind ingest"))
       #expect(prompt.contains("$WIKI_DB"))
       #expect(prompt.contains("[[Page Title]]"))

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -163,7 +163,7 @@ struct WikiCtlCommandTests {
 
     @Test func listTSVHasIDTitlePathPerLine() throws {
         let store = try tempStore()
-        _ = try PageCommand.run(.upsert(id: nil, title: "Alpha", body: ""), in: store)
+        _ = try PageCommand.run(.upsert(id: nil, title: "Alpha", body: "stub"), in: store)
         let result = try PageCommand.run(.list(json: false), in: store)
         #expect(!result.didCommit)
         let columns = result.output.split(separator: "\t")
@@ -174,8 +174,8 @@ struct WikiCtlCommandTests {
 
     @Test func listJSONIsOneObjectPerLine() throws {
         let store = try tempStore()
-        _ = try PageCommand.run(.upsert(id: nil, title: "One", body: ""), in: store)
-        _ = try PageCommand.run(.upsert(id: nil, title: "Two", body: ""), in: store)
+        _ = try PageCommand.run(.upsert(id: nil, title: "One", body: "stub"), in: store)
+        _ = try PageCommand.run(.upsert(id: nil, title: "Two", body: "stub"), in: store)
         let result = try PageCommand.run(.list(json: true), in: store)
         let lines = result.output.split(separator: "\n")
         #expect(lines.count == 2)
@@ -189,7 +189,7 @@ struct WikiCtlCommandTests {
 
     @Test func deleteCommitsAndRemovesPage() throws {
         let store = try tempStore()
-        let created = try PageCommand.run(.upsert(id: nil, title: "Doomed", body: ""), in: store)
+        let created = try PageCommand.run(.upsert(id: nil, title: "Doomed", body: "stub"), in: store)
         let id = PageID(rawValue: created.output)
         let result = try PageCommand.run(.delete(id: id), in: store)
         #expect(result.didCommit)
@@ -650,5 +650,29 @@ struct WikiCtlCommandTests {
         }
         // No page was written.
         #expect(try store.listPages(sortBy: .lastUpdated).isEmpty)
+    }
+
+    // MARK: - Empty-body refusal at the CLI boundary
+
+    @Test func testPageUpssertRefusesEmptyBody() throws {
+        let store = try tempStore()
+        // 1. Empty body is refused at the CLI boundary.
+        do {
+            _ = try PageCommand.run(.upsert(id: nil, title: "X", body: ""), in: store)
+            Issue.record("expected empty-body upsert to throw")
+        } catch let PageCommand.Failure.message(text) {
+            #expect(text.contains("empty body"))
+        }
+        // 2. Whitespace-only body is also refused.
+        do {
+            _ = try PageCommand.run(.upsert(id: nil, title: "X", body: "  \n\t "), in: store)
+            Issue.record("expected whitespace-only upsert to throw")
+        } catch let PageCommand.Failure.message(text) {
+            #expect(text.contains("empty body"))
+        }
+        // 3. A non-empty body succeeds, commits, and returns a non-empty id.
+        let result = try PageCommand.run(.upsert(id: nil, title: "Y", body: "hello"), in: store)
+        #expect(result.didCommit)
+        #expect(!result.output.isEmpty)
     }
 }

--- a/Tests/WikiFSTests/WikiCtlLogIndexTests.swift
+++ b/Tests/WikiFSTests/WikiCtlLogIndexTests.swift
@@ -133,4 +133,24 @@ struct WikiCtlLogIndexTests {
         #expect(index.body == "# Catalog")
         #expect(index.version == 2)  // seed 1, +1
     }
+
+    // MARK: - Empty-body refusal at the CLI boundary
+
+    @Test func testIndexSetRefusesEmptyBody() throws {
+        let store = try tempStore()
+        // Empty body is refused.
+        do {
+            _ = try LogIndexCommand.run(.indexSet(body: ""), in: store)
+            Issue.record("expected empty-body indexSet to throw")
+        } catch let PageCommand.Failure.message(text) {
+            #expect(text.contains("empty index body"))
+        }
+        // Whitespace-only body is also refused.
+        do {
+            _ = try LogIndexCommand.run(.indexSet(body: "  \n\t "), in: store)
+            Issue.record("expected whitespace-only indexSet to throw")
+        } catch let PageCommand.Failure.message(text) {
+            #expect(text.contains("empty index body"))
+        }
+    }
 }

--- a/Tests/WikiFSTests/WikiTreeRendererTests.swift
+++ b/Tests/WikiFSTests/WikiTreeRendererTests.swift
@@ -23,9 +23,9 @@ struct WikiTreeRendererTests {
         #expect(body.contains("sources/by-name/"))
         #expect(body.contains("sources/by-id/"))
         #expect(body.contains("indexes/"))
-        // The wikictl cheatsheet, including the exact stdin-piped upsert form.
-        #expect(body.contains("printf '%s' \"<body>\" | wikictl page upsert --title T --body-file -"))
-        #expect(body.contains("wikictl index set"))
+        // The wikictl cheatsheet uses the file-first body delivery form.
+        #expect(body.contains("wikictl page upsert --title T --body-file ./body.md"))
+        #expect(body.contains("wikictl index set --body-file ./index.md"))
         #expect(body.contains("wikictl log append"))
         // Mount discipline.
         #expect(body.contains("read-only"))


### PR DESCRIPTION
## Why

The spawned ingest agent (the `claude -p` run launched from `AgentOperationRunner`) runs under a macOS seatbelt sandbox that denies the shell's heredoc temp file — `$TMPDIR` is not allow-listed (only cwd / `SCRATCH_DIR`, `WIKI_DB`, `~/.claude`, and `/private/tmp/claude-<uid>/` are writable). The agent-facing prompts taught a `printf '<body>' | wikictl … --body-file -` pipe pattern. Piping a multi-KB markdown body as a single shell argument is infeasible, so a sensible agent reaches for a heredoc — whose temp file the sandbox denies → empty stdin → `wikictl` wrote a **0-byte page and returned an id**. Silent success. In a real ingest run this cost a multi-page recovery loop before the empty pages were noticed.

## What changed

**Fix 1 — teach file-first body delivery (root cause), across all three agent-facing surfaces:**
- `Sources/WikiFSCore/IngestWriteRule.swift` — the load-bearing `writes` block that leads every writer op (the `-p` prompt).
- `Sources/WikiFSCore/SystemPrompt.swift` — `defaultBody` (projected as `CLAUDE.md` / `AGENTS.md`).
- `Sources/WikiFSCore/WikiTreeRenderer.swift` — the `wikictl` cheatsheet in `WIKI-STRUCTURE.md` / `TREE.md` projected to the wiki root.

All three now show `wikictl page upsert --title T --body-file ./body.md` (and the `index set` equivalent) and warn that a pipe/heredoc delivers empty under the sandbox.

**Fix 2 — refuse an empty body loudly at the CLI boundary (defense in depth):**
- `Sources/WikiCtlCore/PageCommand.swift` — `upsert` throws on empty / whitespace-only body.
- `Sources/WikiCtlCore/LogIndexCommand.swift` — symmetric guard on `indexSet`.

The guard sits at the CLI path only; the shared `PageUpsert.upsert` seam is untouched, so the in-app editor can still save a title-only stub. The diagnostic names the cause, so an agent that ignores the prompt learns on its first failed upsert instead of after five.

## Tests
- New: `testPageUpssertRefusesEmptyBody` (empty + whitespace-only refuse; non-empty succeeds and commits), `testIndexSetRefusesEmptyBody`.
- Updated: four `body: ""` setup calls → `"stub"`; `OperationCommandTests` and `WikiTreeRendererTests` assertions moved to the file-first command strings.
- `swift build` green; full `swift test` suite **1272/1272**; filtered runs — `WikiCtlCommandTests` 59/59, `LogIndex` 27/27, `WikiTreeRendererTests` 4/4.

## Caveat for review
`SystemPrompt.defaultBody` only seeds **fresh** wikis — existing wikis keep their own prompt row in the DB, so to retro this guidance into a wiki that already exists, paste the updated Tooling paragraph into the in-app system-prompt editor. The `wikictl` empty-body guard and `IngestWriteRule.writes` take effect for every wiki on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
