### PR TITLE
fix(sandbox): deny agent exec/read of bundled pdf2md (#116 items 1+5)

### DIFF
--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -587,7 +587,9 @@ final class AgentLauncher {
             return
         }
 
-        let sandbox = resolveSandboxInvocation(wikiID: wikiID, scratch: scratch, dir: dir)
+        let pdf2mdScriptPath = resolvePdf2mdScriptPath()
+        let sandbox = resolveSandboxInvocation(
+            wikiID: wikiID, scratch: scratch, dir: dir, pdf2mdScriptPath: pdf2mdScriptPath)
         if sandbox != nil { createSandboxTmpDir(in: scratch) }
         let command = OperationCommand.build(
             operation: operation,
@@ -783,10 +785,12 @@ final class AgentLauncher {
         // When on, use the existing opt-in sandbox behavior (which may itself be
         // `nil`, i.e. fail-open un-sandboxed). Resolved separately then handed to the
         // pure selector so the invariant is unit-testable.
-        let editSandbox = resolveSandboxInvocation(wikiID: wikiID, scratch: scratch, dir: dir)
+        let pdf2mdScriptPath = resolvePdf2mdScriptPath()
+        let editSandbox = resolveSandboxInvocation(
+            wikiID: wikiID, scratch: scratch, dir: dir, pdf2mdScriptPath: pdf2mdScriptPath)
         let homePath = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
         let readOnlySandbox = SandboxProfile.readOnlyInvocation(
-            homePath: homePath, scratchDir: scratch.path)
+            homePath: homePath, scratchDir: scratch.path, pdf2mdScriptPath: pdf2mdScriptPath)
         let sandbox = Self.selectQuerySandbox(
             allowWikiEdits: allowWikiEdits,
             editSandbox: editSandbox,
@@ -1250,10 +1254,16 @@ final class AgentLauncher {
 
     /// Resolve the write-confinement seatbelt sandbox for an Ingest or Edit spawn.
     /// The sandbox is **always on** for these paths — it confines the agent's
-    /// filesystem writes to the wiki DB + scratch + `~/.claude` (reads, network, and
-    /// process execution stay open; see `SandboxProfile`). Returns `nil` (fail-open,
-    /// logged) only when a required path can't be resolved, so a misconfiguration
-    /// never blocks agent work entirely.
+    /// filesystem writes to the wiki DB + scratch + `~/.claude`, AND denies exec/read
+    /// of the resolved `pdf2md` script so a compromised agent can't run the bundled
+    /// extractor (reads, network, and all other exec stay open; see `SandboxProfile`).
+    /// Returns `nil` (fail-open, logged) only when a required path can't be resolved,
+    /// so a misconfiguration never blocks agent work entirely.
+    ///
+    /// - Parameter pdf2mdScriptPath: the resolved `pdf2md` script path (or nil if the
+    ///   app couldn't resolve one). Threaded into the profile as the `PDF2MD_SCRIPT`
+    ///   deny target. When nil, no exec/read deny is emitted (the agent has nothing
+    ///   bundled to run; generic `uv`/`python3` is still reachable — issue #116 item 2).
     ///
     /// This does NOT affect the Ask session, which is always forced into the stricter
     /// read-only sandbox by `selectQuerySandbox` regardless of this result.
@@ -1265,7 +1275,8 @@ final class AgentLauncher {
     private func resolveSandboxInvocation(
         wikiID: String,
         scratch: URL,
-        dir: URL
+        dir: URL,
+        pdf2mdScriptPath: String?
     ) -> SandboxProfile.SandboxInvocation? {
         // HOME for the `-D HOME` profile param. Read from the environment the child
         // will inherit (fall back to the process home). Forwarded for forward-compat
@@ -1288,10 +1299,25 @@ final class AgentLauncher {
         let invocation = SandboxProfile.invocation(
             homePath: homePath,
             scratchDir: scratch.path,
-            wikiDBPath: dbPath
+            wikiDBPath: dbPath,
+            pdf2mdScriptPath: pdf2mdScriptPath
         )
-        DebugLog.agent("sandbox: confining Ingest/Edit agent writes to scratch + \(dbPath)")
+        let pdf2mdNote = pdf2mdScriptPath.map { " + denying pdf2md @ \($0)" } ?? ""
+        DebugLog.agent("sandbox: confining Ingest/Edit agent writes to scratch + \(dbPath)\(pdf2mdNote)")
         return invocation
+    }
+
+    /// Resolve the bundled `pdf2md` script path to deny in the agent seatbelt, or nil
+    /// if no script is resolvable. Delegates to `PdfExtractionService.resolveScript()`
+    /// (the same canonical resolver the APP process uses to run the script) so the deny
+    /// always targets the exact file the agent would otherwise reach. Resolved once per
+    /// spawn and handed to BOTH the edit and read-only invocations.
+    private func resolvePdf2mdScriptPath() -> String? {
+        let path = PdfExtractionService.resolveScript()?.path
+        if path == nil {
+            DebugLog.agent("sandbox: pdf2md not resolved — no PDF2MD_SCRIPT deny rule emitted")
+        }
+        return path
     }
 
     /// Create the `scratch/.tmp` directory that `OperationCommand.applySandbox`

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -249,8 +249,11 @@ public struct OperationCommand: Equatable, Sendable {
         // Relocate temp writes into scratch so they land inside the seatbelt allowlist.
         // CLAUDE_CONFIG_DIR is intentionally NOT redirected: Claude Code reads its
         // credentials from ~/.claude/.credentials.json, and pointing it at an empty
-        // scratch dir hides those credentials. The sandbox's (deny file-write*) rule
-        // already blocks writes to ~/.claude/ — Claude Code handles the EPERM quietly.
+        // scratch dir hides those credentials. The seatbelt profile DOES allow writes
+        // to ~/.claude/ + ~/.claude.json (`SandboxProfile.generate`/`generateReadOnly`)
+        // so a sandboxed session can persist its transcript — that subtree is a known
+        // persistence vector (issue #116 item 4); narrowing it is a follow-up, not
+        // something this redirection changes.
         environment["TMPDIR"] = scratchDirectory + "/" + Self.tmpRelocationLeaf
 
         var head: [String] = ["-p", sandbox.profile]

--- a/Sources/WikiFSCore/SandboxProfile.swift
+++ b/Sources/WikiFSCore/SandboxProfile.swift
@@ -16,6 +16,11 @@ import Foundation
 /// This is provider-agnostic: the profile never names a provider; it fences the write
 /// channel only. See `plans/sandbox-agent.md` for the threat model and the
 /// `sandbox-exec` syntax research that underpins this.
+///
+/// The ONE read/exec carve-out: the resolved `pdf2md` script is denied for both
+/// `process-exec*` and `file-read*` (`pdf2mdDenyRules()`), so a sandboxed agent can't
+/// run the bundled extractor or feed it to `uv --script`. Everything else stays
+/// allow-default. Generic `uv`/`python3` exec is NOT yet denied (issue #116 item 2).
 public enum SandboxProfile {
 
     /// The fully-resolved invocation the launcher hands to `OperationCommand` when the
@@ -55,9 +60,16 @@ public enum SandboxProfile {
     /// - Parameters:
     ///   - scratchDir: the per-run scratch directory absolute path (the writable cwd).
     ///   - wikiDBPath: the active wiki's `<ulid>.sqlite` absolute file path.
+    ///   - pdf2mdScriptPath: when non-nil, the resolved absolute path to the bundled
+    ///     `pdf2md` PEP 723 script. Emits `process-exec*` + `file-read*` denies (by
+    ///     `literal` on the script file) so a sandboxed agent can't run it or feed it
+    ///     to `uv --script`. See `pdf2mdDenyRules()` for why this is `literal`, not
+    ///     `subpath`. Nil (default) emits nothing — byte-identical to the pre-denial
+    ///     profile, so call sites that don't care are unaffected.
     public static func generate(
         scratchDir: String,
-        wikiDBPath: String
+        wikiDBPath: String,
+        pdf2mdScriptPath: String? = nil
     ) -> String {
         var lines: [String] = [
             "(version 1)",
@@ -84,6 +96,13 @@ public enum SandboxProfile {
                 "(allow file-write* (literal (string-append (param \"WIKI_DB\") \"\(suffix)\")))"
             )
         }
+        // The deny rules reference only the `PDF2MD_SCRIPT` param NAME; the resolved
+        // value flows in via `-D` at sandbox-exec time. Guard just to avoid emitting
+        // rules with nothing to deny (and to keep the default-nil profile identical to
+        // the pre-denial one).
+        if let pdf2mdScriptPath, !pdf2mdScriptPath.isEmpty {
+            lines.append(contentsOf: pdf2mdDenyRules())
+        }
         return lines.joined(separator: "\n") + "\n"
     }
 
@@ -92,7 +111,15 @@ public enum SandboxProfile {
     /// Used when the query agent runs without "Allow wiki edits" — it physically
     /// prevents `wikictl page upsert` / `wikictl index set` / `wikictl log append`
     /// from writing, regardless of prompt instructions.
-    public static func generateReadOnly(scratchDir: String) -> String {
+    ///
+    /// - Parameter pdf2mdScriptPath: when non-nil, emits the same `pdf2md` exec/read
+    ///   denies as `generate(...)` so the deny holds for the read-only query path too.
+    ///   See `generate(...)` / `pdf2mdDenyRules()` for details. Nil (default) emits
+    ///   nothing.
+    public static func generateReadOnly(
+        scratchDir: String,
+        pdf2mdScriptPath: String? = nil
+    ) -> String {
         var lines: [String] = [
             "(version 1)",
             "(allow default)",
@@ -110,6 +137,11 @@ public enum SandboxProfile {
             "(allow file-write* (subpath (param \"CLAUDE_TMP\")))",
         ]
         lines.append(contentsOf: agentRuntimeWriteRules())
+        // Mirror `generate`: deny exec/read of the resolved pdf2md script when a path
+        // is supplied. The rules reference only the `PDF2MD_SCRIPT` param name.
+        if let pdf2mdScriptPath, !pdf2mdScriptPath.isEmpty {
+            lines.append(contentsOf: pdf2mdDenyRules())
+        }
         return lines.joined(separator: "\n") + "\n"
     }
 
@@ -124,20 +156,26 @@ public enum SandboxProfile {
     public static func readOnlyInvocation(
         homePath: String,
         scratchDir: String,
-        claudeTempBase: String = defaultClaudeTempBase()
+        claudeTempBase: String = defaultClaudeTempBase(),
+        pdf2mdScriptPath: String? = nil
     ) -> SandboxInvocation {
         let resolvedHome = Self.canonical(homePath)
         let resolvedScratch = Self.canonical(scratchDir)
         let resolvedClaudeTemp = Self.canonical(claudeTempBase)
-        let profile = generateReadOnly(scratchDir: resolvedScratch)
-        return SandboxInvocation(
-            profile: profile,
-            defines: [
-                ("HOME", resolvedHome),
-                ("SCRATCH_DIR", resolvedScratch),
-                ("CLAUDE_TMP", resolvedClaudeTemp),
-            ]
+        let resolvedPdf2md = pdf2mdScriptPath.map { Self.canonical($0) }
+        let profile = generateReadOnly(
+            scratchDir: resolvedScratch,
+            pdf2mdScriptPath: resolvedPdf2md
         )
+        var defines: [(String, String)] = [
+            ("HOME", resolvedHome),
+            ("SCRATCH_DIR", resolvedScratch),
+            ("CLAUDE_TMP", resolvedClaudeTemp),
+        ]
+        if let resolvedPdf2md, !resolvedPdf2md.isEmpty {
+            defines.append(("PDF2MD_SCRIPT", resolvedPdf2md))
+        }
+        return SandboxInvocation(profile: profile, defines: defines)
     }
 
     /// Build a `SandboxInvocation` from the three spawn-time paths. The scratch dir and
@@ -150,7 +188,8 @@ public enum SandboxProfile {
         homePath: String,
         scratchDir: String,
         wikiDBPath: String,
-        claudeTempBase: String = defaultClaudeTempBase()
+        claudeTempBase: String = defaultClaudeTempBase(),
+        pdf2mdScriptPath: String? = nil
     ) -> SandboxInvocation {
         func realPath(_ s: String) -> String {
             Self.canonical(s)
@@ -163,22 +202,32 @@ public enum SandboxProfile {
         let resolvedScratch = realPath(scratchDir)
         let resolvedDB = realPath(wikiDBPath)
         let resolvedClaudeTemp = realPath(claudeTempBase)
+        // The script file exists when the launcher hands it to us (it probed
+        // `isExecutableFile`), so `realpath` fully resolves it — important because
+        // the seatbelt `literal` matcher resolves the exec'd/read path the same way.
+        // A dev script under `/tmp/…` surfaces as `/private/tmp/…`, matching how the
+        // kernel resolves the agent's exec attempt.
+        let resolvedPdf2md = pdf2mdScriptPath.map { realPath($0) }
         let profile = generate(
             scratchDir: resolvedScratch,
-            wikiDBPath: resolvedDB
+            wikiDBPath: resolvedDB,
+            pdf2mdScriptPath: resolvedPdf2md
         )
         // NOTE: these are profile parameters, NOT child env vars. `-D WIKI_DB=<path>`
         // is consumed by `(param "WIKI_DB")`; it does not touch the `WIKI_DB=<ulid>`
-        // env var the agent/wikictl use.
-        return SandboxInvocation(
-            profile: profile,
-            defines: [
-                ("HOME", resolvedHome),
-                ("SCRATCH_DIR", resolvedScratch),
-                ("WIKI_DB", resolvedDB),
-                ("CLAUDE_TMP", resolvedClaudeTemp),
-            ]
-        )
+        // env var the agent/wikictl use. `PDF2MD_SCRIPT` is appended ONLY when a path
+        // was supplied, so the default-nil invocation stays byte-identical to the
+        // pre-denial build (call sites and argv-index tests unaffected).
+        var defines: [(String, String)] = [
+            ("HOME", resolvedHome),
+            ("SCRATCH_DIR", resolvedScratch),
+            ("WIKI_DB", resolvedDB),
+            ("CLAUDE_TMP", resolvedClaudeTemp),
+        ]
+        if let resolvedPdf2md, !resolvedPdf2md.isEmpty {
+            defines.append(("PDF2MD_SCRIPT", resolvedPdf2md))
+        }
+        return SandboxInvocation(profile: profile, defines: defines)
     }
 
     /// Filesystem-write allowances every spawned agent's SHELL and tools need at
@@ -206,6 +255,36 @@ public enum SandboxProfile {
             "(allow file-write-data (literal \"/dev/null\"))",
             "(allow file-write-data (subpath \"/dev/fd\"))",
             "(allow file-write* (regex #\"^/private/tmp/claude-[A-Za-z0-9]+-cwd(/|$)\"))",
+        ]
+    }
+
+    /// The `pdf2md` exec/read deny rules, emitted by BOTH `generate` and
+    /// `generateReadOnly` when a resolved script path is supplied. Shared here so the
+    /// two profiles can't drift — the deny must hold for every spawn path (Ingest /
+    /// Edit / read-only Query) regardless of "Allow wiki edits".
+    ///
+    /// **Why `literal` on the script FILE, not `subpath` on its directory.** `wikictl`
+    /// (the agent's ONLY sanctioned exec) and `pdf2md` ship in the SAME directory in
+    /// every production/dev candidate — `Contents/Helpers/` in the bundle, `build/`,
+    /// and the `swift run` exe-sibling (`HelpersLocation.wikictlDirectory` vs
+    /// `PdfExtractionService.candidateLocations()`). A `subpath` deny on that dir would
+    /// deny exec of `wikictl` too, breaking the agent. `literal` on the exact script
+    /// path denies only `pdf2md` and never collides with `wikictl`.
+    ///
+    /// **Why `file-read*` as well as `process-exec*`.** `uv run --script pdf2md` must
+    /// `open()` the script to parse its PEP 723 inline deps; denying the read closes
+    /// that angle for the bundled-script case (issue #116 item 1's "ideally deny-read").
+    /// The agent never legitimately reads `pdf2md` — only the unsandboxed APP process
+    /// (`PdfExtractionService`) does — so this is safe. This does NOT stop generic
+    /// `uv`/`python3` use (item 2, a follow-up).
+    ///
+    /// Precedence: these are filtered rules, so they win over the generic
+    /// `(allow default)` at the top of the profile — same last-specific-match-wins
+    /// semantics the `(deny file-write*)` + `(allow file-write* …)` pair relies on.
+    private static func pdf2mdDenyRules() -> [String] {
+        [
+            "(deny process-exec* (literal (param \"PDF2MD_SCRIPT\")))",
+            "(deny file-read* (literal (param \"PDF2MD_SCRIPT\")))",
         ]
     }
 

--- a/Tests/WikiFSTests/SandboxProfileTests.swift
+++ b/Tests/WikiFSTests/SandboxProfileTests.swift
@@ -204,4 +204,103 @@ struct SandboxProfileTests {
     // flows in via the -D define (asserted above).
     #expect(inv.profile.contains("(subpath (param \"SCRATCH_DIR\"))"))
   }
+
+  // MARK: - pdf2md exec/read deny (issue #116 item 1)
+
+  /// Both profiles deny exec AND read of the resolved pdf2md script when a path is
+  /// supplied — closes both the direct `pdf2md` exec and the `uv run --script` angle
+  /// (uv must `open()` the script to parse its PEP 723 deps).
+  @Test func bothProfilesDenyExecAndReadOfResolvedPdf2md() {
+    let script = "/Applications/Self Driving Wiki.app/Contents/Helpers/pdf2md"
+    let rw = SandboxProfile.generate(
+      scratchDir: Self.scratchDir, wikiDBPath: Self.wikiDB, pdf2mdScriptPath: script)
+    let ro = SandboxProfile.generateReadOnly(
+      scratchDir: Self.scratchDir, pdf2mdScriptPath: script)
+    for p in [rw, ro] {
+      #expect(p.contains("(deny process-exec* (literal (param \"PDF2MD_SCRIPT\")))"))
+      #expect(p.contains("(deny file-read* (literal (param \"PDF2MD_SCRIPT\")))"))
+    }
+  }
+
+  /// Regression guard: the deny MUST be `literal` on the script file, NOT `subpath`
+  /// on its directory. `wikictl` and `pdf2md` are collocated in `Contents/Helpers/`
+  /// (and in `build/`, and beside the swift-run exe) — a `subpath` deny would block
+  /// `wikictl`, the agent's only sanctioned exec. See `SandboxProfile.pdf2mdDenyRules`.
+  @Test func pdf2mdDenyUsesLiteralNotSubpath() {
+    let script = "/Applications/Self Driving Wiki.app/Contents/Helpers/pdf2md"
+    let p = SandboxProfile.generate(
+      scratchDir: Self.scratchDir, wikiDBPath: Self.wikiDB, pdf2mdScriptPath: script)
+    #expect(!p.contains("(deny process-exec* (subpath"))
+    #expect(!p.contains("(deny file-read* (subpath"))
+    // No directory-shaped param either — the collocation trap would name a dir.
+    #expect(!p.contains("PDF2MD_DIR"))
+  }
+
+  /// Default-nil emission: when no pdf2md path is supplied, neither the deny rules
+  /// nor the `PDF2MD_SCRIPT` param reference appear — the profile is byte-identical
+  /// to the pre-denial build, so call sites and argv-index tests that don't care about
+  /// pdf2md are unaffected (the load-bearing non-breaking guard).
+  @Test func defaultNilEmitsNoPdf2mdDeny() {
+    let gen = SandboxProfile.generate(scratchDir: Self.scratchDir, wikiDBPath: Self.wikiDB)
+    let ro = SandboxProfile.generateReadOnly(scratchDir: Self.scratchDir)
+    for p in [gen, ro] {
+      #expect(!p.contains("PDF2MD_SCRIPT"))
+    }
+  }
+
+  @Test func emptyPdf2mdPathEmitsNoDeny() {
+    let p = SandboxProfile.generate(
+      scratchDir: Self.scratchDir, wikiDBPath: Self.wikiDB, pdf2mdScriptPath: "")
+    #expect(!p.contains("PDF2MD_SCRIPT"))
+  }
+
+  @Test func invocationCarriesPdf2mdDefineWhenSupplied() {
+    let inv = SandboxProfile.invocation(
+      homePath: "/Users/me",
+      scratchDir: Self.scratchDir,
+      wikiDBPath: Self.wikiDB,
+      claudeTempBase: "/private/tmp/claude-999",
+      pdf2mdScriptPath: "/Users/me/app/Contents/Helpers/pdf2md")
+    #expect(inv.defines.count == 5)
+    // Order matters for the argv emit — PDF2MD_SCRIPT is appended last.
+    #expect(inv.defines[4].0 == "PDF2MD_SCRIPT")
+    #expect(inv.defines[4].1 == "/Users/me/app/Contents/Helpers/pdf2md")
+    // The define alone is useless without the deny rules in the profile text.
+    #expect(inv.profile.contains("(deny process-exec* (literal (param \"PDF2MD_SCRIPT\")))"))
+    #expect(inv.profile.contains("(deny file-read* (literal (param \"PDF2MD_SCRIPT\")))"))
+  }
+
+  @Test func readOnlyInvocationCarriesPdf2mdDefineWhenSupplied() {
+    let inv = SandboxProfile.readOnlyInvocation(
+      homePath: "/Users/me",
+      scratchDir: Self.scratchDir,
+      claudeTempBase: "/private/tmp/claude-999",
+      pdf2mdScriptPath: "/Users/me/app/Contents/Helpers/pdf2md")
+    #expect(inv.defines.count == 4)  // HOME, SCRATCH_DIR, CLAUDE_TMP, PDF2MD_SCRIPT
+    #expect(inv.defines[3].0 == "PDF2MD_SCRIPT")
+    #expect(inv.profile.contains("(deny process-exec* (literal (param \"PDF2MD_SCRIPT\")))"))
+  }
+
+  /// `/tmp` is a symlink to `/private/tmp`. A pdf2md script resolved under `/tmp`
+  /// must surface in the define as its canonical `/private/tmp/...` path, or the
+  /// seatbelt `literal` deny would silently fail to match the agent's exec attempt
+  /// (the kernel resolves the path it execs). Mirrors the SCRATCH_DIR symlink test.
+  @Test func invocationResolvesSymlinkedPdf2mdToCanonicalPath() throws {
+    let symlinkScript = "/tmp/sdw-pdf2md-probe-\(UUID().uuidString)"
+    // Create a real file so realpath resolves it (realpath returns nil for
+    // non-existent paths, falling back to the input — which would hide the
+    // /tmp → /private/tmp resolution).
+    try "#!/bin/sh\n".write(toFile: symlinkScript, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(atPath: symlinkScript) }
+
+    let inv = SandboxProfile.invocation(
+      homePath: "/Users/me",
+      scratchDir: "/Users/me/scratch",
+      wikiDBPath: "/Users/me/db.sqlite",
+      pdf2mdScriptPath: symlinkScript)
+
+    let resolved = try #require(inv.defines.first { $0.0 == "PDF2MD_SCRIPT" }?.1)
+    #expect(resolved.hasPrefix("/private/tmp/"))
+    #expect(resolved.contains("sdw-pdf2md-probe-"))
+  }
 }


### PR DESCRIPTION
## Summary

Addresses **#116, items 1 + 5** — the first read/exec carve-out in the agent seatbelt. Items 2/3/4/6 remain open follow-ups; this does **not** close the issue.

The agent seatbelt (`SandboxProfile`) was a **write fence only**: reads, network, and process execution were all `(allow default)`, and both spawns pass `--dangerously-skip-permissions` (`OperationCommand.swift:120,177`). The agent's sole sanctioned job is to call `wikictl`, but the bundled `pdf2md` PEP 723 script — resolved and run unsandboxed by the **app process** (`PdfExtractionService`) — was discoverable on disk and runnable by a prompt-injected agent, directly or via `uv run --script`.

## Changes

**Item 1 — deny exec/read of the resolved `pdf2md` script in the agent profile.**
- `SandboxProfile.swift`: `generate` / `generateReadOnly` / `invocation` / `readOnlyInvocation` take an optional `pdf2mdScriptPath: String? = nil`. When supplied, both profiles emit:
  - `(deny process-exec* (literal (param "PDF2MD_SCRIPT")))` — blocks `execve` of the script.
  - `(deny file-read* (literal (param "PDF2MD_SCRIPT")))` — blocks `uv run --script pdf2md` too, since uv must `open()` the script to parse its PEP 723 deps. The agent never legitimately reads `pdf2md`, so deny-read is safe.
  - The resolved path is canonicalized via `realpath` (seatbelt matches the canonical path — the `/tmp` → `/private/tmp` trap).
- `AgentLauncher.swift`: resolves the path once per spawn via `PdfExtractionService.resolveScript()` (the same resolver the app uses) and threads it into **both** the edit (`run`) and read-only (`startInteractiveQuery`) invocations, so the deny holds regardless of "Allow wiki edits".

**Item 5 — fix the stale comment** at `OperationCommand.swift:250` that claimed `(deny file-write*)` blocks writes to `~/.claude/`. Untrue since `48fbcb2`, which allowed the `~/.claude` subtree + `~/.claude.json` so a sandboxed session can persist its transcript. Rewritten to describe reality and flag item 4 as the follow-up that actually narrows it.

## Design note: `literal`, not `subpath`

The issue suggested `(deny … (subpath (param "PDF2MD_DIR")))`. That would **break the agent**: `wikictl` and `pdf2md` are collocated in the same directory in every production/dev candidate — `Contents/Helpers/` in the bundle, `build/`, and the `swift run` exe-sibling (`HelpersLocation.wikictlDirectory` vs `PdfExtractionService.candidateLocations()`). A `subpath` deny on that directory would deny exec of `wikictl` too. Denying the **script file by `literal`** is correct in every case and never collides with `wikictl`.

## Non-breaking

The new param defaults to `nil`, and `nil` emits **no rule and no define** — so every call site and the argv-index / define-count tests stay byte-identical when `pdf2md` is absent. If `resolveScript()` returns `nil` (pdf2md not bundled), no deny is emitted and the spawn still succeeds (fail-open for this rule only).

## Verification

- `swift test` — **1279 passed**, including 7 new `SandboxProfileTests`: conditional emission (with/without path), `literal`-not-`subpath` regression guard, define counts (5 for `invocation`, 4 for `readOnlyInvocation`), and `/tmp` → `/private/tmp` canonicalization.
- Existing `SandboxedOperationCommandTests` argv-index assertions pass unchanged (proves the default-nil path adds no `-D PDF2MD_SCRIPT`).
- **Live `sandbox-exec` probe** on macOS 26.5: the deny fires on the canonical script path (`read script: DENIED`, `exec script: DENIED`) while unrelated exec/read stays `ALLOWED`. Also re-confirmed canonicalization is load-bearing — raw `/tmp/...` literals match nothing.

## Out of scope (issue #116 follow-ups)

- **Item 2**: real `process-exec*` allowlist (default-deny exec, allow only `wikictl`) — the actual fix for "agent can run generic `uv`/`python3`".
- **Item 3**: drop `--dangerously-skip-permissions` for a `Bash(wikictl:*)`-only perms block.
- **Item 4**: narrow the `~/.claude` write-allow to just the transcript path.
- **Item 6**: network egress allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
