### PR TITLE
fix(links): robust [[wiki-link]] name handling — lookup-driven resolution, name rules, startup self-heal (v18)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -3,6 +3,31 @@
 Running list of known limitations / rough edges. Not bugs to fix right now —
 things we've decided to live with, with enough context to revisit later.
 
+## `[[wiki-link]]` delimiter collisions (residual edges)
+
+The link grammar reserves `#`, `|`, `]`, and the `source:`/`page:` prefixes,
+with no escape syntax. As of 2026-07-04 (v18) this is handled by two
+mechanisms — `WikiLinkResolver` (lookup-driven splitting: every `#` reading of
+a target is tried against the real namespace, longest name first, exact match
+wins) and `WikiNameRules` (names that can NEVER be linked — `|`, `[`/`]`,
+leading `#` — are sanitized at every write boundary and were swept once by the
+v17→18 migration). So `#` anywhere inside a name now just works, including
+with a real anchor after it. What remains:
+
+- **Reserved characters inside a QUOTED PASSAGE:** a `#"…"` fragment containing
+  `]]` terminates the span early, and one containing `|` mis-parses the rest as
+  an alias. Names are sanitized; quote contents can't be (they must match the
+  source text verbatim). Agents' quotes are short prose so this is rare — the
+  fix, if ever needed, is an escape/quoting syntax.
+- **Inherent `#` ambiguity when both readings exist:** if pages "C" AND
+  "C# Guide" both exist, `[[C# Guide]]` links "C# Guide" (longest name wins);
+  there is no way to express "page C, anchor ' Guide'". Contrived, and the
+  longest-name tiebreak is the intended reading in practice.
+- **Ghost links keep the heuristic split:** a target that resolves to nothing
+  renders via the old first-`#`/`#"` split (there's no namespace to consult),
+  so an unresolved `#`-name displays truncated until its page/source exists.
+  Cosmetic only.
+
 ## Read-after-write latency: ~5s replica-invalidation window
 
 **Symptom.** After an in-app edit (page body, system prompt, ingest/remove), a

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,51 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-04 — Robust `[[wiki-link]]` name handling: lookup-driven resolution, name rules, startup self-heal (v18)
+
+A source/page NAME containing `#` (e.g. "Agentic Static Analysis for C#
+Security Auditing") broke every citation to it — the parser split targets on
+the FIRST `#`, truncating labels and orphaning links. Fixed structurally, plus
+the adjacent robustness gaps:
+
+- **`WikiLinkResolver`** (new, pure): a raw target like `C# Guide#Methods` is
+  ambiguous syntactically but not against the real namespace — resolution now
+  tries every `(name, fragment)` reading, longest name first (exact full-target
+  match wins), taking the first that names an existing page/source. Wired into
+  `SQLiteWikiStore.replaceLinks` (link graph), `WikiLinkMarkdown.linkified`
+  (reader links + ghost styling), and `WikiStoreModel.preflightLint`.
+  `WikiLinkParser.splitFragment` prefers the `#"` quote-anchor delimiter for
+  unresolved (ghost) display; `parse` de-dupes by RAW target so two `#`-titles
+  sharing a mis-split base both survive.
+- **`WikiLinkRewriter`**: rename rewriting matches the old name by direct
+  string comparison after `source:` (candidate slices, longest first) instead
+  of delimiter guessing; an `isNameKnown` closure from `renameSource` keeps
+  longest-name-wins (renaming source "C" can't corrupt a citation of
+  "C# Notes").
+- **`WikiNameRules`** (new): names that can NEVER be linked are sanitized at
+  every write boundary (`|` → `-`, `[`/`]` → `(`/`)`, leading `#` dropped) —
+  `createPage`, `updatePage`, `renameSource`, `addSource` (unlinkable FILENAME
+  falls back into `display_name`; the filename stays verbatim), and
+  `PageUpsert` (before the title→id resolve, so repeated upserts of a dirty
+  title can't duplicate pages). `#` inside a name stays legal.
+- **Migration v17→18** (`sanitizeStoredNames`): one-time, data-only sweep of
+  existing titles/display names that violate the rules (slug recomputed,
+  version bumped). Fresh-schema fast path stamps 18.
+- **Lenient source resolution** (`resolveSourceByName` pass 3): unique-only
+  match on `WikiNameRules.looseMatchKey` (one trailing extension + one trailing
+  "(…)" suffix stripped), so a citation of `Some Paper (2026)` finds
+  "Some Paper.pdf"; two candidates → no guess. Mirrored in the reader's
+  ghost-styling sets.
+- **`LinkReconciler`** (new, pure orchestration like `PageUpsert`): re-parses
+  every page and rewrites link rows under current rules; run once per model
+  lifetime from the top of `upgradeSearchIndex()` (scenePhase-`.active` hook,
+  before the MiniLM gates). Heals rows written before a resolution improvement
+  or before their target was ingested — page bodies untouched.
+- Tests: new resolver/name-rules/sanitization suites (incl. a raw-SQL v17
+  tamper/reopen migration test); residual edges (reserved characters inside
+  quoted passages; inherent `#` ambiguity when both readings exist) documented
+  in `ISSUES.md`.
+
 ## 2026-07-03 — Graph-model design: adversarial review hardening (doc-only)
 
 Second-pass adversarial review of [`plans/graph-model-and-versioning.md`](plans/graph-model-and-versioning.md),

--- a/Sources/WikiFS/WikiReaderView.swift
+++ b/Sources/WikiFS/WikiReaderView.swift
@@ -747,6 +747,15 @@ internal struct WikiReaderRep: NSViewRepresentable {
                     let stripped = names.map { ($0 as NSString).deletingPathExtension }
                     return (names + stripped).map { $0.lowercased() }
                 })
+            // Lenient tier, mirroring resolveSourceByName's pass 3 so ghost
+            // styling agrees with navigation: loose keys (extension + trailing
+            // "(…)" stripped) that are UNIQUE across sources.
+            var looseKeyCounts: [String: Int] = [:]
+            for source in store?.sources ?? [] {
+                let effective = source.displayName ?? source.filename
+                looseKeyCounts[WikiNameRules.looseMatchKey(effective), default: 0] += 1
+            }
+            let uniqueLooseKeys = Set(looseKeyCounts.filter { $0.value == 1 }.keys)
 
             let loadStartVal = loadStart
             convertTask = Task.detached(priority: .userInitiated) { [weak self] in
@@ -759,8 +768,10 @@ internal struct WikiReaderRep: NSViewRepresentable {
                 // render, both off the main actor. isResolved resolves against
                 // the precomputed existence sets so missing links style as ghosts.
                 let prepared = ReaderMarkdown.prepared(markdown) { name, kind in
-                    kind == .source ? sourceNames.contains(name.lowercased())
-                                    : pageTitles.contains(name.lowercased())
+                    kind == .source
+                        ? sourceNames.contains(name.lowercased())
+                            || uniqueLooseKeys.contains(WikiNameRules.looseMatchKey(name))
+                        : pageTitles.contains(name.lowercased())
                 }
                 let body = MarkdownHTMLRenderer.render(prepared)
                 let html = WikiReaderView.documentHTML(body)

--- a/Sources/WikiFSCore/LinkReconciler.swift
+++ b/Sources/WikiFSCore/LinkReconciler.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Startup self-heal for the wiki-link graph (`page_links` / `source_links`).
+///
+/// Links resolve at SAVE time (`PageUpsert` → `replaceLinks`), so rows written
+/// before a resolution improvement (the v18 lookup-driven resolver, the lenient
+/// source-name matching) — or before their target page/source existed — stay
+/// stale until each page happens to be edited again. This pass re-parses every
+/// page and rewrites its links under today's resolution rules. It NEVER
+/// touches page bodies; only the derived link tables change. Idempotent — a
+/// consistent graph is rewritten to itself.
+///
+/// Pure orchestration over the `WikiStore` protocol (same pattern as
+/// `PageUpsert`), so the app model, tests, and `wikictl` can all run it.
+/// Cost is one parse + resolve per page, on the caller's (main) thread —
+/// SQLite is never touched off-main (`docs/skills/sqlite-concurrency`).
+public enum LinkReconciler {
+
+    /// Re-resolve every page's outgoing links. Returns the number of pages
+    /// processed (not the number changed — `replaceLinks` rewrites
+    /// unconditionally).
+    @discardableResult
+    public static func reconcileAll(in store: WikiStore) throws -> Int {
+        let summaries = try store.listPages(sortBy: .lastUpdated)
+        for summary in summaries {
+            let page = try store.getPage(id: summary.id)
+            try store.replaceLinks(
+                from: page.id,
+                parsedLinks: WikiLinkParser.parse(page.bodyMarkdown))
+        }
+        return summaries.count
+    }
+}

--- a/Sources/WikiFSCore/PageUpsert.swift
+++ b/Sources/WikiFSCore/PageUpsert.swift
@@ -51,6 +51,11 @@ public enum PageUpsert {
         title: String,
         body: String
     ) throws -> Outcome {
+        // Sanitize BEFORE the title→id resolve, not just in the store's
+        // create/update (which sanitizes again as a backstop): resolving the
+        // raw title against sanitized stored titles would always miss, and
+        // every upsert of the same unlinkable title would create a new page.
+        let title = WikiNameRules.sanitized(title)
         let outcome = try writePage(in: store, id: id, title: title, body: body)
         try store.replaceLinks(from: outcome.id, parsedLinks: WikiLinkParser.parse(body))
         // Compute + store chunk embeddings for the page body. Non-fatal: a

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -142,20 +142,20 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // (version >= 1) — and fresh dbs forced onto the ladder by tests — run
         // `migrate(from:)` so every prior upgrade path is preserved.
         if version == 0 && !forceLadderMigration {
-            try createFreshSchemaV17()
+            try createFreshSchemaV18()
             return
         }
         try migrate(from: &version)
     }
 
-    /// Build the complete current (v17) schema for a fresh database in one
+    /// Build the complete current (v18) schema for a fresh database in one
     /// consolidated block. MUST stay schema-identical to the end state of
     /// `migrate(from:)`; the `freshFastPathMatchesStepwiseLadder` test enforces
     /// that by forcing a fresh db through the ladder and comparing. Legacy index
     /// names (`ingested_files_created`, `file_markdown_versions_file`) are
     /// reproduced verbatim — they survive the table renames in the ladder, so a
     /// fresh db must match.
-    private func createFreshSchemaV17() throws {
+    private func createFreshSchemaV18() throws {
         // Core page model + attachments/links.
         try exec("""
         CREATE TABLE pages (
@@ -383,7 +383,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         """)
         try exec("CREATE INDEX bookmark_nodes_parent ON bookmark_nodes(parent_id, position);")
 
-        try exec("PRAGMA user_version=17;")
+        // v18 is a data-only step (name sanitization) — a fresh DB has no rows
+        // to sweep, so the fast path just stamps the version.
+        try exec("PRAGMA user_version=18;")
     }
 
     /// The stepwise, idempotent migration ladder keyed on `PRAGMA user_version`.
@@ -816,6 +818,70 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try exec("PRAGMA user_version=17;")
             version = 17
         }
+
+        // Step 17 → 18: one-time CONTENT fix, no schema change — sanitize
+        // unlinkable characters out of page titles and source display names
+        // (`|`, `[`/`]`, leading `#` — see WikiNameRules; those break the
+        // `[[wiki-link]]` grammar with no escape, so such names could never be
+        // linked/cited). New writes are sanitized at the store boundary from
+        // v18 on; this sweeps rows that predate the rule. Nothing referenced
+        // the dirty names (they were unlinkable), so no link rewriting is
+        // needed. Versions bump so the File Provider re-syncs; FTS/embeddings
+        // refresh on the row's next save (staleness only for renamed rows).
+        if version < 18 {
+            try sanitizeStoredNames()
+            try exec("PRAGMA user_version=18;")
+            version = 18
+        }
+    }
+
+    /// The v17→18 sweep: rewrite every page title and source display name that
+    /// `WikiNameRules` would change. Pages also get their slug recomputed from
+    /// the sanitized title. Sources with a NULL display_name but an unlinkable
+    /// FILENAME get the sanitized filename as their display name (the filename
+    /// itself stays verbatim — it is the file's identity on the mount).
+    private func sanitizeStoredNames() throws {
+        let now = Date().timeIntervalSince1970
+
+        var pages: [(id: String, title: String)] = []
+        let pageRows = try statement("SELECT id, title FROM pages;")
+        defer { pageRows.reset() }
+        while try pageRows.step() {
+            pages.append((pageRows.text(at: 0), pageRows.text(at: 1)))
+        }
+        for page in pages where !WikiNameRules.isLinkable(page.title) {
+            let clean = WikiNameRules.sanitized(page.title)
+            let slug = try uniqueSlug(from: clean, id: PageID(rawValue: page.id))
+            let update = try statement("""
+            UPDATE pages SET title = ?2, slug = ?3, updated_at = ?4,
+                             version = version + 1 WHERE id = ?1;
+            """)
+            defer { update.reset() }
+            try update.bind(page.id, at: 1)
+            try update.bind(clean, at: 2)
+            try update.bind(slug, at: 3)
+            try update.bind(now, at: 4)
+            _ = try update.step()
+        }
+
+        var sources: [(id: String, effectiveName: String)] = []
+        let sourceRows = try statement(
+            "SELECT id, COALESCE(display_name, filename) FROM sources;")
+        defer { sourceRows.reset() }
+        while try sourceRows.step() {
+            sources.append((sourceRows.text(at: 0), sourceRows.text(at: 1)))
+        }
+        for source in sources where !WikiNameRules.isLinkable(source.effectiveName) {
+            let update = try statement("""
+            UPDATE sources SET display_name = ?2, updated_at = ?3,
+                               version = version + 1 WHERE id = ?1;
+            """)
+            defer { update.reset() }
+            try update.bind(source.id, at: 1)
+            try update.bind(WikiNameRules.sanitized(source.effectiveName), at: 2)
+            try update.bind(now, at: 3)
+            _ = try update.step()
+        }
     }
 
     // MARK: - sqlite-vec registration (statically linked, -DSQLITE_CORE)
@@ -1044,6 +1110,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
     public func createPage(title: String) throws -> WikiPage {
         lock.lock(); defer { lock.unlock() }
+        // Titles must stay linkable (`[[title]]`) — see WikiNameRules.
+        let title = WikiNameRules.sanitized(title)
         let id = PageID(rawValue: ULID.generate())
         let slug = try uniqueSlug(from: title, id: id)
         let now = Date()
@@ -1067,6 +1135,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         // Recompute slug from the (possibly renamed) title, then bump version
         // and updated_at. version bumps support Phase 3 change signaling.
+        // Titles must stay linkable (`[[title]]`) — see WikiNameRules.
+        let title = WikiNameRules.sanitized(title)
         let slug = try uniqueSlug(from: title, id: id)
         let stmt = try statement("""
         UPDATE pages
@@ -1135,12 +1205,16 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// Resolve a `[[source:…]]` target to a source id. Case-insensitive; on a
     /// multi-match collision, the most recently updated source wins.
     ///
-    /// Two passes: an exact match on `display_name` (falling back to `filename`
-    /// when `display_name` is NULL), then — because legacy rows stored
-    /// `display_name = filename` WITH the file extension while the canonical cite
-    /// target drops it — a scan that matches the query against each candidate's
-    /// name with its last extension removed, so `[[source:Some Paper]]` still
-    /// resolves a row named `Some Paper.pdf`.
+    /// Three passes: an exact match on `display_name` (falling back to
+    /// `filename` when `display_name` is NULL); then — because legacy rows
+    /// stored `display_name = filename` WITH the file extension while the
+    /// canonical cite target drops it — a scan that matches the query against
+    /// each candidate's name with its last extension removed, so
+    /// `[[source:Some Paper]]` still resolves a row named `Some Paper.pdf`;
+    /// then a LENIENT pass on `WikiNameRules.looseMatchKey` (extension AND a
+    /// trailing "(…)" suffix stripped) that resolves ONLY when exactly one
+    /// source matches — so an agent citing `Some Paper (2026)` still finds
+    /// `Some Paper.pdf`, but a near-miss never guesses between two candidates.
     public func resolveSourceByName(_ displayName: String) throws -> PageID? {
         lock.lock(); defer { lock.unlock() }
         let exact = try statement("""
@@ -1153,6 +1227,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         try exact.bind(displayName, at: 1)
         if try exact.step() { return PageID(rawValue: exact.text(at: 0)) }
 
+        let queryLooseKey = WikiNameRules.looseMatchKey(displayName)
+        var looseMatches: [PageID] = []
         let scan = try statement("""
         SELECT id, COALESCE(display_name, filename) AS name FROM sources
         ORDER BY updated_at DESC;
@@ -1163,6 +1239,25 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             if (name as NSString).deletingPathExtension.caseInsensitiveCompare(displayName) == .orderedSame {
                 return PageID(rawValue: scan.text(at: 0))
             }
+            if !queryLooseKey.isEmpty, WikiNameRules.looseMatchKey(name) == queryLooseKey {
+                looseMatches.append(PageID(rawValue: scan.text(at: 0)))
+            }
+        }
+        // Pass 3: lenient, unique-only.
+        return looseMatches.count == 1 ? looseMatches[0] : nil
+    }
+
+    /// Resolve a parsed link's target to an id, trying every candidate
+    /// (name, fragment) reading of the raw target — longest name first — via
+    /// `WikiLinkResolver`, so names containing `#` resolve whole. `resolve` is
+    /// `resolveTitleToID` for page links, `resolveSourceByName` for citations.
+    private func resolveLinkTarget(
+        _ link: WikiLinkParser.ParsedLink,
+        using resolve: (String) throws -> PageID?
+    ) throws -> PageID? {
+        let raw = link.fragment.map { "\(link.target)#\($0)" } ?? link.target
+        for split in WikiLinkResolver.candidateSplits(of: raw) {
+            if let id = try resolve(split.base) { return id }
         }
         return nil
     }
@@ -1194,17 +1289,23 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             INSERT OR IGNORE INTO source_links (from_page_id, to_source_id, link_text)
             VALUES (?1, ?2, ?3);
             """)
+            // A `#` inside a page/source NAME mis-splits into base + fragment
+            // at parse time. Resolve via WikiLinkResolver: try every reading
+            // of the raw target (longest name first) and take the first that
+            // names a real page/source.
             for link in parsedLinks {
                 switch link.linkType {
                 case .page:
-                    guard let target = try resolveTitleToID(link.target) else { continue }
+                    guard let target = try resolveLinkTarget(link, using: resolveTitleToID)
+                    else { continue }
                     insPage.reset()
                     try insPage.bind(pageID.rawValue, at: 1)
                     try insPage.bind(target.rawValue, at: 2)
                     try insPage.bind(link.linkText, at: 3)
                     _ = try insPage.step()
                 case .source:
-                    guard let target = try resolveSourceByName(link.target) else { continue }
+                    guard let target = try resolveLinkTarget(link, using: resolveSourceByName)
+                    else { continue }
                     insSource.reset()
                     try insSource.bind(pageID.rawValue, at: 1)
                     try insSource.bind(target.rawValue, at: 2)
@@ -1310,9 +1411,21 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             ?? ContentSniff.mimeType(of: data)
             ?? (ext.isEmpty ? nil : UTType(filenameExtension: ext)?.preferredMIMEType)
         let now = Date()
-        let displayName = DisplayNameResolver.resolve(
+        // The citable name (`[[source:name]]`) must stay linkable — see
+        // WikiNameRules. Sanitize the resolved display name; when metadata
+        // yields none and the raw FILENAME is unlinkable, store its sanitized
+        // form as the display name (the filename itself stays verbatim — it is
+        // the file's identity on the mount).
+        let displayName: String?
+        if let resolved = DisplayNameResolver.resolve(
             filename: filename, data: data, mimeType: mime,
-            zoteroItemTitle: zoteroItemTitle)
+            zoteroItemTitle: zoteroItemTitle) {
+            displayName = WikiNameRules.sanitized(resolved)
+        } else if !WikiNameRules.isLinkable(filename) {
+            displayName = WikiNameRules.sanitized(filename)
+        } else {
+            displayName = nil
+        }
 
         let stmt = try statement("""
         INSERT INTO sources
@@ -1416,6 +1529,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// transaction — it would stall `wikictl`).
     public func renameSource(id: PageID, to newDisplayName: String) throws {
         lock.lock(); defer { lock.unlock() }
+        // Display names must stay citable (`[[source:name]]`) — see WikiNameRules.
+        let newDisplayName = WikiNameRules.sanitized(newDisplayName)
         let renamed = try withTransaction { () -> Bool in
             // Read the old name under the write lock's snapshot.
             let old = try getSource(id: id)
@@ -1432,12 +1547,18 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try stmt.bind(Date().timeIntervalSince1970, at: 3)
             _ = try stmt.step()
 
-            // Rewrite links in every page that points at this source.
+            // Rewrite links in every page that points at this source. The
+            // isNameKnown closure keeps longest-name-wins intact: a span whose
+            // longer reading names some OTHER source is not this rename's to
+            // take. (The row above is already renamed, so oldBase itself
+            // resolves to nothing here — only genuinely different names
+            // answer true.)
             for pageID in try sourceLinkingPages(to: id) {
                 let page = try getPage(id: pageID)
                 guard let rewritten = WikiLinkRewriter.rewriteSourceBase(
                     in: page.bodyMarkdown, matching: oldBase,
-                    to: newDisplayName) else { continue }
+                    to: newDisplayName,
+                    isNameKnown: { (try? self.resolveSourceByName($0)) != nil }) else { continue }
                 try updatePage(id: pageID, title: page.title, body: rewritten)
                 try replaceLinks(from: pageID, parsedLinks: WikiLinkParser.parse(rewritten))
             }

--- a/Sources/WikiFSCore/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSCore/WikiLinkMarkdown.swift
@@ -118,17 +118,27 @@ public enum WikiLinkMarkdown {
                 continue
             }
 
+            // Try every (name, fragment) reading of the target against the
+            // caller's namespace, longest name first — so a `#` INSIDE a
+            // page/source name (e.g. "… for C# …", with or without a real
+            // anchor after it) links the actual page instead of truncating at
+            // the first `#`. Ghost links keep the heuristic split.
+            let raw = fragment.map { "\(bareTarget)#\($0)" } ?? bareTarget
+            let split = WikiLinkResolver.resolvedSplit(of: raw) { isResolved($0, kind) }
+            let resolved = split != nil
+            let linkTarget = split?.base ?? bareTarget
+            let linkFragment = split.map(\.fragment) ?? fragment
+
             let display: String
             if let alias = fixed.alias {
                 let collapsedAlias = collapseWhitespace(alias)
-                display = collapsedAlias.isEmpty ? bareTarget : collapsedAlias
+                display = collapsedAlias.isEmpty ? linkTarget : collapsedAlias
             } else {
-                display = bareTarget
+                display = linkTarget
             }
 
-            let resolved = isResolved(bareTarget, kind)
-            out += markdownLink(display: display, target: bareTarget, kind: kind,
-                                resolved: resolved, fragment: fragment)
+            out += markdownLink(display: display, target: linkTarget, kind: kind,
+                                resolved: resolved, fragment: linkFragment)
         }
         // Tail after the last match.
         if cursor < ns.length {

--- a/Sources/WikiFSCore/WikiLinkParser.swift
+++ b/Sources/WikiFSCore/WikiLinkParser.swift
@@ -19,8 +19,8 @@ import Foundation
 ///   * empty targets (e.g. `[[ ]]`) are skipped;
 ///   * the `source:` / `page:` prefix is stripped from the target *only* (never
 ///     the alias); the remainder is re-normalized;
-///   * duplicate targets are de-duplicated per `(kind, target)`, FIRST occurrence
-///     wins (so the first alias seen for a target is the one kept);
+///   * duplicate targets are de-duplicated per `(kind, raw target)` — base plus
+///     fragment — FIRST occurrence wins (so the first alias seen is kept);
 ///   * unmatched / malformed brackets are ignored.
 public enum WikiLinkParser {
 
@@ -73,14 +73,18 @@ public enum WikiLinkParser {
         return false
     }
 
-    /// Split a raw target on the **first** `#` only. Everything before → `base`
-    /// (may be empty for `[[#Section]]`), everything after → `fragment` (kept
-    /// verbatim; inner `#` characters — e.g. `"C# is a language"` — are preserved
-    /// for substring matching). Returns `(base: "", fragment: "Section")` for a
-    /// same-page anchor `[[#Section]]`. Returns `(base: rawTarget, nil)` when there
-    /// is no `#`.
+    /// Split a raw target into `base` + `fragment`. The delimiter is the first
+    /// `#"` (the start of a quote anchor, `[[source:Name#"quote"]]`) when one is
+    /// present — so a bare `#` inside the NAME (e.g. "Agentic Static Analysis
+    /// for C# Security Auditing") stays part of the base instead of truncating
+    /// it. With no `#"`, the first `#` splits (`[[Page#Section]]`). The base may
+    /// be empty for a same-page anchor `[[#Section]]`; the fragment is kept
+    /// verbatim (inner `#` characters — e.g. `"C# is a language"` — are
+    /// preserved for substring matching). Returns `(base: rawTarget, nil)` when
+    /// there is no `#`.
     public static func splitFragment(_ rawTarget: String) -> (base: String, fragment: String?) {
-        guard let hashIndex = rawTarget.firstIndex(of: "#") else {
+        guard let hashIndex = rawTarget.range(of: "#\"")?.lowerBound
+                ?? rawTarget.firstIndex(of: "#") else {
             return (rawTarget, nil)
         }
         let base = String(rawTarget[..<hashIndex])
@@ -100,9 +104,9 @@ public enum WikiLinkParser {
     // MARK: - Parse
 
     /// Parse all wiki links from `body`, in document order, de-duplicated by
-    /// `(kind, target)` (first alias wins). Same-page anchors (`[[#…]]`, empty
-    /// base) are skipped — they don't name a page or source, so they don't belong
-    /// in the link graph.
+    /// `(kind, raw target)` (first alias wins). Same-page anchors (`[[#…]]`,
+    /// empty base) are skipped — they don't name a page or source, so they don't
+    /// belong in the link graph.
     public static func parse(_ body: String) -> [ParsedLink] {
         let ns = body as NSString
         let matches = regex.matches(in: body, range: NSRange(location: 0, length: ns.length))
@@ -130,7 +134,14 @@ public enum WikiLinkParser {
             guard !bareTarget.isEmpty else { continue } // empty target → skip
             if isEmptyPrefix(base) { continue } // `[[source:]]` → literal
 
-            let dedupKey = "\(kind.rawValue):\(bareTarget)"
+            // De-dupe by the RAW target (base + fragment), not the base alone:
+            // two `#`-containing titles (e.g. `[[C# Guide]]` / `[[C# Notes]]`)
+            // share the mis-split base "C" but are different links. Plain
+            // duplicates (`[[Home]]` twice) still collapse; `[[Page#A]]` +
+            // `[[Page#B]]` both survive and the store's (from,to) primary key
+            // collapses them if they resolve to one page.
+            let raw = fragment.map { "\(bareTarget)#\($0)" } ?? bareTarget
+            let dedupKey = "\(kind.rawValue):\(raw)"
             guard seen.insert(dedupKey).inserted else { continue }
 
             let linkText: String

--- a/Sources/WikiFSCore/WikiLinkResolver.swift
+++ b/Sources/WikiFSCore/WikiLinkResolver.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Lookup-driven disambiguation for `[[wiki-link]]` targets whose NAME may
+/// contain `#`.
+///
+/// The link grammar has no escape syntax, so a raw target like
+/// `C# Guide#Methods` is ambiguous on its face: the name could be
+/// "C# Guide#Methods", "C# Guide" (with a "Methods" anchor), or "C" (with a
+/// "# Guide#Methods" anchor). Guessing from the characters alone can't settle
+/// it — but the consumers that resolve links all KNOW the namespace (the
+/// reader's existence sets, the store's resolve queries). So: try every
+/// possible split, longest name first, and take the first whose name exists.
+/// An exact full-target match beats any anchor reading — the only precedence
+/// that stays correct for names containing `#`, `#"`, or both.
+///
+/// Pure and dependency-free (the namespace arrives as a closure) so it is
+/// trivially unit-testable and shared by the store (`replaceLinks`), the
+/// renderer (`WikiLinkMarkdown.linkified`), and the editor lint
+/// (`WikiStoreModel.preflightLint`). Unresolvable targets fall back to the
+/// caller's heuristic split (`WikiLinkParser.splitFragment`) — there is no
+/// namespace to consult for a ghost link.
+public enum WikiLinkResolver {
+
+    /// One possible reading of a raw target: a normalized base name plus the
+    /// verbatim remainder after the splitting `#` (`nil` = no fragment).
+    public struct Split: Equatable, Sendable {
+        public let base: String
+        public let fragment: String?
+
+        public init(base: String, fragment: String?) {
+            self.base = base
+            self.fragment = fragment
+        }
+    }
+
+    /// All plausible `(base, fragment)` readings of `rawTarget` (whitespace-
+    /// collapsed, prefix-stripped), longest base first: the whole string with
+    /// no fragment, then a split at each `#` from rightmost to leftmost.
+    /// Bases are normalized; a split with an empty base is skipped (that
+    /// reading is a same-page anchor, not a name).
+    public static func candidateSplits(of rawTarget: String) -> [Split] {
+        var out = [Split(base: WikiText.normalized(rawTarget), fragment: nil)]
+        for index in rawTarget.indices.reversed() where rawTarget[index] == "#" {
+            let base = WikiText.normalized(String(rawTarget[..<index]))
+            guard !base.isEmpty else { continue }
+            let fragment = String(rawTarget[rawTarget.index(after: index)...])
+            out.append(Split(base: base, fragment: fragment.isEmpty ? nil : fragment))
+        }
+        return out
+    }
+
+    /// The first candidate reading whose base names something real per
+    /// `isKnown`, or `nil` when none does (a ghost link).
+    public static func resolvedSplit(
+        of rawTarget: String,
+        isKnown: (String) throws -> Bool
+    ) rethrows -> Split? {
+        for split in candidateSplits(of: rawTarget) {
+            if try isKnown(split.base) { return split }
+        }
+        return nil
+    }
+}

--- a/Sources/WikiFSCore/WikiLinkRewriter.swift
+++ b/Sources/WikiFSCore/WikiLinkRewriter.swift
@@ -11,15 +11,24 @@ public enum WikiLinkRewriter {
     /// callers can skip the re-save). Case-insensitive, whitespace-collapsed
     /// base match (same normalization as `WikiLinkParser.classify`).
     ///
-    /// The rewrite splices by structure rather than `replaceOccurrences(of:)`:
-    /// it finds the bare-target byte range after `source:` and before the first
-    /// `#`/`|`, so `[[source:  old base#"quote"|alias]]` correctly matches
-    /// `old base` and replaces only the bare target, leaving everything else
-    /// byte-for-byte intact.
+    /// The match is by DIRECT string comparison, not by delimiter guessing: the
+    /// old name is known, so after the `source:` prefix every candidate slice —
+    /// the whole remainder first, then up to each `#` from rightmost to
+    /// leftmost — is compared (normalized, case-insensitive) against `oldBase`,
+    /// and the first hit is spliced. That way a name CONTAINING `#` (e.g.
+    /// "…for C# Security Auditing"), cited with or without a `#"quote"` anchor,
+    /// matches whole instead of being truncated at its first `#`.
+    ///
+    /// `isNameKnown` mirrors `WikiLinkResolver`'s longest-name-wins rule: when
+    /// a LONGER candidate slice names some OTHER existing source (e.g. old name
+    /// "C", but the span reads `[[source:C# Notes]]` and a source "C# Notes"
+    /// exists), that longer name owns the link and the span is left alone.
+    /// Callers with no namespace can omit it (nothing else is "known").
     public static func rewriteSourceBase(
         in body: String,
         matching oldBase: String,
-        to newBase: String
+        to newBase: String,
+        isNameKnown: (String) -> Bool = { _ in false }
     ) -> String? {
         let ns = body as NSString
         let codeRanges = WikiLinkSpan.protectedCodeRanges(in: body)
@@ -40,73 +49,52 @@ public enum WikiLinkRewriter {
             }
 
             let targetRange = match.range(at: 1)
-            let target = ns.substring(with: targetRange)
+            let target = ns.substring(with: targetRange) as NSString
 
-            // Split on first `#` (fragment), then classify the base part.
-            let (base, _) = WikiLinkParser.splitFragment(target)
-            let (kind, bareTarget) = WikiLinkParser.classify(base)
-
+            // Only `source:` links are rewritten. classify() peels the prefix
+            // off the (normalized) start, so `page:source:foo` stays untouched.
+            let (kind, _) = WikiLinkParser.classify(WikiText.normalized(target as String))
             guard kind == .source else { continue }
-            guard WikiText.normalized(bareTarget).lowercased() == normalizedOld else { continue }
 
-            // Find the byte range of `bareTarget` within the original target text.
-            // `classify` peels `source:` and normalizes; to get the ORIGINAL
-            // un-normalized bare-target slice we find it structurally: after the
-            // `source:` prefix and before the first `#` or `|`.
-            guard let bareRange = bareTargetRange(in: target, for: bareTarget) else {
-                continue
+            // The splice range starts right after the `source:` prefix
+            // (classify confirmed it's at the start, modulo whitespace).
+            let prefix = target.range(of: "source:", options: [.caseInsensitive])
+            guard prefix.location != NSNotFound else { continue }
+            let start = prefix.location + prefix.length
+            guard start < target.length else { continue }
+
+            // Candidate name ends, longest slice first: end-of-target (no
+            // fragment), then each `#` from rightmost to leftmost.
+            var ends: [Int] = [target.length]
+            var i = target.length - 1
+            while i > start {
+                if target.character(at: i) == hashChar { ends.append(i) }
+                i -= 1
             }
 
-            // Map from target-relative to body-absolute byte offsets.
-            let absoluteStart = targetRange.location + bareRange.location
-            let absoluteEnd = absoluteStart + bareRange.length
+            for end in ends {
+                let slice = WikiText.normalized(
+                    target.substring(with: NSRange(location: start, length: end - start)))
+                let isOld = slice.lowercased() == normalizedOld
+                // Neither the old name nor any other known name — keep trying
+                // shorter readings of this span.
+                guard isOld || isNameKnown(slice) else { continue }
+                // A longer KNOWN name owns this span (longest-name-wins, same
+                // rule as WikiLinkResolver) — leave the span untouched.
+                guard isOld else { break }
 
-            guard absoluteStart >= 0, absoluteEnd <= ns.length else { continue }
-
-            let mutable = NSMutableString(string: result)
-            mutable.replaceCharacters(in: NSRange(location: absoluteStart, length: absoluteEnd - absoluteStart), with: newBase)
-            result = mutable as String
-            changed = true
+                let absolute = NSRange(location: targetRange.location + start,
+                                       length: end - start)
+                let mutable = NSMutableString(string: result)
+                mutable.replaceCharacters(in: absolute, with: newBase)
+                result = mutable as String
+                changed = true
+                break
+            }
         }
 
         return changed ? result : nil
     }
 
-    /// Within a source-link target string (everything after `[[` and before the
-    /// first `|` or `]]`), find the byte range to splice — everything between the
-    /// `source:` prefix and the first `#` or `|` (or end of string), including
-    /// any whitespace after `source:`. Replacing this whole range with `newBase`
-    /// normalizes `source:  old base#frag` → `source:new base#frag`.
-    ///
-    /// Returns nil if the structural search fails (shouldn't — `classify` already
-    /// confirmed a `.source` classification, so `source:` must be present).
-    private static func bareTargetRange(
-        in target: String,
-        for bareTarget: String
-    ) -> NSRange? {
-        let ns = target as NSString
-
-        // Find end of `source:` prefix (case-insensitive). The splice range
-        // starts right after the colon.
-        let lower = target.lowercased()
-        guard let prefixEnd = lower.range(of: "source:")?.upperBound else { return nil }
-        let start = target.distance(from: target.startIndex, to: prefixEnd)
-        guard start < ns.length else { return nil }
-
-        // End at the first `#` or `|` after the prefix (or end of string).
-        var end = ns.length
-        for i in start..<ns.length {
-            let c = ns.character(at: i)
-            if c == hashChar || c == pipeChar {
-                end = i
-                break
-            }
-        }
-
-        guard end > start else { return nil }
-        return NSRange(location: start, length: end - start)
-    }
-
     private static let hashChar: unichar = 0x23 // #
-    private static let pipeChar: unichar = 0x7C // |
 }

--- a/Sources/WikiFSCore/WikiNameRules.swift
+++ b/Sources/WikiFSCore/WikiNameRules.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Sanitization rules for page titles and source display names.
+///
+/// The `[[wiki-link]]` grammar reserves characters it cannot escape: `]` ends
+/// the span, `|` starts the alias, and a leading `#` reads as a same-page
+/// anchor. A name containing one of those can NEVER be linked — they break
+/// the bracket regex before any resolution runs — so storing such a name just
+/// plants a silent dead end. A `#` anywhere ELSE in a name is fine:
+/// `WikiLinkResolver` disambiguates it against the real namespace.
+///
+/// Names are sanitized (not rejected) at every write boundary — `createPage`,
+/// `updatePage`, `renameSource`, `addSource`, `PageUpsert` — and once for
+/// pre-existing rows by the v17→18 store migration, so the invariant holds:
+/// **every stored name is linkable**.
+///
+/// `[` alone doesn't break the grammar, but it is mapped alongside `]` so
+/// bracketed names stay paired — "[Editorial] X" becomes "(Editorial) X",
+/// not the mismatched "[Editorial) X".
+public enum WikiNameRules {
+
+    /// `name` with unlinkable characters replaced (`|` → `-`, `[`/`]` →
+    /// `(`/`)`), leading `#`s dropped, and ends trimmed. Idempotent. Returns
+    /// "Untitled" when nothing displayable is left.
+    public static func sanitized(_ name: String) -> String {
+        var s = name
+            .replacingOccurrences(of: "|", with: "-")
+            .replacingOccurrences(of: "[", with: "(")
+            .replacingOccurrences(of: "]", with: ")")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        while s.first == "#" {
+            s.removeFirst()
+            s = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return s.isEmpty ? "Untitled" : s
+    }
+
+    /// True when `name` is already linkable as-is (sanitizing wouldn't change
+    /// it). Used by the migration to find rows that need the one-time fix.
+    public static func isLinkable(_ name: String) -> Bool {
+        sanitized(name) == name
+    }
+
+    /// A LENIENT comparison key for source-name matching: normalized,
+    /// lowercased, with one trailing file extension and one trailing
+    /// parenthesized suffix stripped — so an agent-written citation like
+    /// `[[source:Some Paper (2026)]]` can still find a source named
+    /// "Some Paper.pdf". Both sides of a comparison get the same treatment,
+    /// and callers only act on a UNIQUE match across all sources
+    /// (`resolveSourceByName` pass 3, the reader's ghost-styling sets), so a
+    /// near-miss never silently picks between two plausible sources.
+    public static func looseMatchKey(_ name: String) -> String {
+        var s = WikiText.normalized(name).lowercased()
+        // One trailing ".ext" — only if it looks like a real file extension
+        // (1–5 alphanumerics), so "v2.5" style names lose at most a digit and
+        // both sides lose it identically.
+        let ext = (s as NSString).pathExtension
+        if !ext.isEmpty, ext.count <= 5, ext.allSatisfy({ $0.isLetter || $0.isNumber }) {
+            s = (s as NSString).deletingPathExtension as String
+        }
+        // One trailing "(…)" suffix: "some paper (2026)" → "some paper".
+        if let range = s.range(of: #"\s*\([^()]*\)\s*$"#, options: .regularExpression) {
+            s.removeSubrange(range)
+        }
+        return WikiText.normalized(s)
+    }
+}

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -69,6 +69,7 @@ public final class WikiStoreModel {
     /// sees it true and bails. The check-and-set is main-actor and contains no
     /// suspension, so it is atomic against the scenePhase/activeWikiID hooks.
     @ObservationIgnored private var isUpgrading = false
+    @ObservationIgnored private var didReconcileLinks = false
 
     /// Live SOURCES search query from the Sources search bar. Debounced 300ms.
     /// Mirrors the page `searchQuery` (semantic cosine, LIKE fallback).
@@ -841,10 +842,19 @@ public final class WikiStoreModel {
         let body = didFix ? fixedBody : original
         let links = WikiLinkParser.parse(body)
         let knownTitles = Set(summaries.map { $0.title })
+        // Mirror replaceLinks: a link is broken only when NO candidate reading
+        // of its raw target (per WikiLinkResolver — handles `#` in titles)
+        // names an existing page. Unique the output — two parsed links can
+        // share a base since parse() de-dupes by raw target.
+        var seenBroken = Set<String>()
         let broken = links
             .filter { $0.linkType == .page }
-            .map { $0.target }
-            .filter { !knownTitles.contains($0) }
+            .compactMap { link -> String? in
+                let raw = link.fragment.map { "\(link.target)#\($0)" } ?? link.target
+                guard WikiLinkResolver.resolvedSplit(of: raw, isKnown: { knownTitles.contains($0) }) == nil
+                else { return nil }
+                return seenBroken.insert(link.target).inserted ? link.target : nil
+            }
 
         return LintPreflight(didFixLinks: didFix, brokenPageLinks: broken)
     }
@@ -1386,6 +1396,21 @@ public final class WikiStoreModel {
         guard !isUpgrading else { return }
         isUpgrading = true
         defer { isUpgrading = false }
+
+        // Link-graph self-heal, once per model lifetime, BEFORE the embedder
+        // gates below (it must run even on FTS-only builds). Main-actor SQLite
+        // like everything else here; re-resolves every page's `[[links]]` so
+        // citations that only resolve under newer rules (lookup-driven `#`
+        // splitting, lenient source-name matching) — or whose target was
+        // ingested after the page was last saved — get their link rows without
+        // waiting for the page's next edit.
+        if !didReconcileLinks {
+            didReconcileLinks = true
+            let start = DispatchTime.now()
+            let count = (try? LinkReconciler.reconcileAll(in: store)) ?? 0
+            let ms = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+            DebugLog.store("LinkReconciler: re-resolved links for \(count) page(s) in \(Int(ms))ms")
+        }
 
         guard EmbeddingService.selectedEmbedderIdentifier() == EmbeddingService.miniLMIdentifier else {
             return                                            // no MiniLM model → FTS-only

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -19,7 +19,7 @@ import SQLite3
     @Test func freshDBHasBookmarkNodesTable() throws {
         let url = tempDatabaseURL()
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "17")
+        #expect(store.pragmaValue("user_version") == "18")
 
         // The table exists.
         let nodes = try store.listBookmarkNodes()
@@ -37,7 +37,7 @@ import SQLite3
 
         // Reopen — triggers migration to v16.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "17")
+        #expect(reopened.pragmaValue("user_version") == "18")
 
         // Existing data is intact.
         let pages = try reopened.listPages(sortBy: .lastUpdated)

--- a/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
+++ b/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
@@ -20,7 +20,7 @@ struct EmbeddingMetaCutoverTests {
     @Test func freshDBSeedsNLEmbedderIdentifier() throws {
         let store = try tempStore()
         let stored = store.pragmaValue("user_version")
-        #expect(stored == "17")
+        #expect(stored == "18")
         // ensureEmbedderConsistency with the default identifier (nlembedding-512)
         // is a no-op: the seed matches, so nothing is wiped.
         store.ensureEmbedderConsistency(activeIdentifierOverride: NLEmbedder.identifier)

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import SQLite3
 @testable import WikiFSCore
 
-/// Guards the fresh-DB fast path (`createFreshSchemaV17`) against the stepwise
+/// Guards the fresh-DB fast path (`createFreshSchemaV18`) against the stepwise
 /// `migrate(from:)` ladder. The fast path duplicates the schema definition, so
 /// any drift (a forgotten table/column/index/FK/trigger) would silently make
 /// fresh dbs differ from upgraded ones. This forces a fresh db through the FULL
@@ -120,8 +120,8 @@ import SQLite3
         let ladder = try fingerprint(at: ladderURL)
 
         // Both must report head version 16.
-        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "17")
-        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "17")
+        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "18")
+        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "18")
 
         if fast != ladder {
             Issue.record("fresh fast-path schema drifted from the stepwise ladder:\n--- fast ---\n\(fast)\n--- ladder ---\n\(ladder)")

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -238,7 +238,7 @@ struct LogIndexTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 17)
+        #expect(sqlite3_column_int(stmt, 0) == 18)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -87,7 +87,7 @@ struct ProcessedMarkdownTests {
 
     @Test func freshDBHasV8Schema() throws {
         let store = try tempStore()
-        #expect(store.pragmaValue("user_version") == "17")
+        #expect(store.pragmaValue("user_version") == "18")
     }
 
     @Test func v7DBUpgradesToV8PreservingData() throws {
@@ -103,7 +103,7 @@ struct ProcessedMarkdownTests {
 
         // Opening runs v7→v8→…→v15 migration.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "17")
+        #expect(store.pragmaValue("user_version") == "18")
         // Pre-existing file is intact.
         let content = try store.sourceContent(
             id: PageID(rawValue: "01J00000000000000000000000"))

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -65,7 +65,7 @@ struct SQLiteWikiStoreTests {
         // user_version guard: a fresh DB runs all migration steps → version 16.
         // Reopening must not re-run DDL (no-op bootstrap).
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "17")
+        #expect(userVersion == "18")
         let reopened = try SQLiteWikiStore(databaseURL: url)
         // If bootstrap weren't guarded, the CREATE TABLE would throw here.
         #expect((try? reopened.listPages(sortBy: .lastUpdated)) != nil)
@@ -316,7 +316,7 @@ struct SQLiteWikiStoreTests {
         defer { sqlite3_close(db) }
 
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "17")
+        #expect(userVersion == "18")
 
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"))
@@ -358,9 +358,9 @@ struct SQLiteWikiStoreTests {
         #expect(scalarText(db, "SELECT count(*) FROM source_links WHERE to_source_id = '\(source.id.rawValue)';") == "0")
     }
 
-    @Test func freshDBReachesUserVersion17() throws {
+    @Test func freshDBReachesUserVersion18() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(store.pragmaValue("user_version") == "17")
+        #expect(store.pragmaValue("user_version") == "18")
     }
 
     @Test func v11SourceLinksHasDeleteCascade() throws {

--- a/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
+++ b/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
@@ -49,7 +49,7 @@ struct SourceEmbeddingSearchTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarInt(db, "PRAGMA user_version;") == 17)
+        #expect(scalarInt(db, "PRAGMA user_version;") == 18)
         #expect(tableExists(db, "source_chunks"))
         // page chunk table mirrors the source one.
         #expect(tableExists(db, "page_chunks"))

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -250,7 +250,7 @@ struct SourcesTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 17)
+        #expect(sqlite3_column_int(stmt, 0) == 18)
         _ = store
     }
 

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -234,7 +234,7 @@ struct SystemPromptTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 17)
+        #expect(sqlite3_column_int(stmt, 0) == 18)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
+++ b/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
@@ -43,7 +43,7 @@ struct WikiLinkMarkdownTests {
     @Test func queryMetacharactersInTitleAreEncoded() {
         // The first `#` splits fragment from base (markdown-anchors §1).
         // "A&B=C?D#E+F" → base:"A&B=C?D", fragment:"E+F".
-        let out = WikiLinkMarkdown.linkified("[[A&B=C?D#E+F]]")
+        let out = WikiLinkMarkdown.linkified("[[A&B=C?D#E+F]]") { name, _ in name == "A&B=C?D" }
         let url = URL(string: extractURL(out))!
         let title = WikiLinkMarkdown.target(from: url)
         let frag = WikiLinkMarkdown.fragment(from: url)
@@ -206,17 +206,17 @@ struct WikiLinkMarkdownTests {
     // MARK: - Fragment / anchor rendering (markdown-anchors)
 
     @Test func pageLinkWithHeadingFragmentRendersFragmentInURL() {
-        let out = WikiLinkMarkdown.linkified("[[Overview#Methodology]]") { _, _ in true }
+        let out = WikiLinkMarkdown.linkified("[[Overview#Methodology]]") { name, _ in name == "Overview" }
         #expect(out == "[Overview](wiki://page?title=Overview#Methodology)")
     }
 
     @Test func sourceLinkWithQuoteFragmentRendersFragmentInURL() {
-        let out = WikiLinkMarkdown.linkified("[[source:Paper#the results]]") { _, _ in true }
+        let out = WikiLinkMarkdown.linkified("[[source:Paper#the results]]") { name, _ in name == "Paper" }
         #expect(out == "[Paper](wiki://source?title=Paper#the%20results)")
     }
 
     @Test func fragmentRoundTripsThroughURL() {
-        let out = WikiLinkMarkdown.linkified("[[source:Smith#\"exact passage\"]]") { _, _ in true }
+        let out = WikiLinkMarkdown.linkified("[[source:Smith#\"exact passage\"]]") { name, _ in name == "Smith" }
         let url = URL(string: extractURL(out))!
         let frag = WikiLinkMarkdown.fragment(from: url)
         #expect(frag == "\"exact passage\"")
@@ -229,7 +229,7 @@ struct WikiLinkMarkdownTests {
         // dump the rest as literal text (breaking the renderer). They must be
         // percent-encoded — and still round-trip back to the original fragment.
         let quote = "it is 1.) outside, 2.) uncontrollable (Bargh, 1994)"
-        let out = WikiLinkMarkdown.linkified("[[source:Paper#\"\(quote)\"]]") { _, _ in true }
+        let out = WikiLinkMarkdown.linkified("[[source:Paper#\"\(quote)\"]]") { name, _ in name == "Paper" }
         // No literal parens survive in the emitted link destination.
         #expect(!extractURL(out).contains("("))
         #expect(!extractURL(out).contains(")"))
@@ -282,10 +282,84 @@ struct WikiLinkMarkdownTests {
 
     @Test func fragmentWithInnerHashIsEncoded() {
         // "C# is sharp" → inner # is percent-encoded in the URL.
-        let out = WikiLinkMarkdown.linkified("[[source:Note#C# is sharp]]") { _, _ in true }
+        let out = WikiLinkMarkdown.linkified("[[source:Note#C# is sharp]]") { name, _ in name == "Note" }
         let url = URL(string: extractURL(out))!
         let frag = WikiLinkMarkdown.fragment(from: url)
         #expect(frag == "C# is sharp")
+    }
+
+    // MARK: - `#` inside the NAME
+
+    @Test func sourceNameContainingHashWithQuoteAnchorDisplaysFullName() {
+        // The "C#" in the name no longer truncates the citation to
+        // "…Analysis for C" — the resolver finds the real name.
+        let out = WikiLinkMarkdown.linkified(
+            "[[source:Agentic Static Analysis for C# Security Auditing (2026)#\"the results\"]]"
+        ) { name, _ in name == "Agentic Static Analysis for C# Security Auditing (2026)" }
+        #expect(out.hasPrefix("[Agentic Static Analysis for C# Security Auditing (2026)]"))
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url)
+                == "Agentic Static Analysis for C# Security Auditing (2026)")
+        #expect(WikiLinkMarkdown.fragment(from: url) == "\"the results\"")
+    }
+
+    @Test func pageTitleContainingHashResolvesViaFullTitleFallback() {
+        // No quote anchor, so the parse splits at the `#` in "C#" — but the
+        // FULL target names an existing page, so the fallback links it whole.
+        let out = WikiLinkMarkdown.linkified("[[C# Guide]]") { name, kind in
+            name == "C# Guide" && kind == .page
+        }
+        #expect(out.hasPrefix("[C# Guide]"))
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "C# Guide")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .page)
+        #expect(url.fragment == nil) // the "# Guide" tail is title, not anchor
+    }
+
+    @Test func sourceNameContainingHashWithoutAnchorResolvesViaFallback() {
+        let out = WikiLinkMarkdown.linkified("[[source:C# Notes]]") { name, kind in
+            name == "C# Notes" && kind == .source
+        }
+        #expect(out.hasPrefix("[C# Notes]"))
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "C# Notes")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .source)
+    }
+
+    @Test func hashTitleFallbackKeepsAliasDisplay() {
+        let out = WikiLinkMarkdown.linkified("[[C# Guide|the guide]]") { name, _ in
+            name == "C# Guide"
+        }
+        #expect(out.hasPrefix("[the guide]"))
+    }
+
+    @Test func unresolvedHashTitleKeepsBaseAndFragment() {
+        // Neither the base nor the full target resolves → unchanged legacy
+        // shape: base title + fragment, missing host.
+        let out = WikiLinkMarkdown.linkified("[[C# Ghost]]") { _, _ in false }
+        #expect(out == "[C](wiki://missing?title=C#%20Ghost)")
+    }
+
+    @Test func hashTitleWithRealAnchorResolvesLongestName() {
+        // A `#`-containing title AND a real section anchor after it: the
+        // longest known name wins, the rest is the anchor.
+        let out = WikiLinkMarkdown.linkified("[[C# Guide#Methods]]") { name, _ in
+            name == "C# Guide"
+        }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "C# Guide")
+        #expect(WikiLinkMarkdown.fragment(from: url) == "Methods")
+        #expect(out.hasPrefix("[C# Guide]"))
+    }
+
+    @Test func exactFullTitleBeatsAnchorReading() {
+        // A page literally titled "Page#Section" wins over Page + anchor.
+        let out = WikiLinkMarkdown.linkified("[[Page#Section]]") { name, _ in
+            name == "Page#Section" || name == "Page"
+        }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "Page#Section")
+        #expect(url.fragment == nil)
     }
 
     // MARK: - Code-span protection for source links

--- a/Tests/WikiFSTests/WikiLinkParserTests.swift
+++ b/Tests/WikiFSTests/WikiLinkParserTests.swift
@@ -202,12 +202,28 @@ struct WikiLinkParserTests {
         #expect(links.isEmpty)
     }
 
-    @Test func fragmentDoesNotAffectDedup() {
-        // [[Page#A]] and [[Page#B]] dedup to one entry (first alias wins).
+    @Test func distinctFragmentsDedupSeparately() {
+        // [[Page#A]] and [[Page#B]] are DIFFERENT raw targets — they may be
+        // two distinct `#`-containing titles — so both survive parse. When
+        // they resolve to one page, the store's (from,to) primary key
+        // collapses them (first link text wins, as before).
         let links = WikiLinkParser.parse("[[Page#A|first]] and [[Page#B|second]]")
+        #expect(links.count == 2)
+        #expect(links[0].fragment == "A")
+        #expect(links[1].fragment == "B")
+    }
+
+    @Test func identicalRawTargetsStillDedup() {
+        let links = WikiLinkParser.parse("[[Page#A|first]] and [[Page#A|second]]")
         #expect(links.count == 1)
         #expect(links[0].linkText == "first")
-        #expect(links[0].fragment == "A")
+    }
+
+    @Test func hashTitlesWithSharedMisSplitBaseBothSurvive() {
+        // "C# Guide" and "C# Notes" both mis-split to base "C" — they must not
+        // collapse into one parsed link (each may name a real `#`-title).
+        let links = WikiLinkParser.parse("[[C# Guide]] and [[C# Notes]]")
+        #expect(links.count == 2)
     }
 
     @Test func sourcePrefixFragmentPreservesInnerHash() {
@@ -216,5 +232,42 @@ struct WikiLinkParserTests {
         #expect(links[0].linkType == .source)
         #expect(links[0].target == "Paper")
         #expect(links[0].fragment == "C# is sharp")
+    }
+
+    // MARK: - `#` inside the NAME (quote anchor is the delimiter)
+
+    @Test func splitFragmentQuoteAnchorWinsOverHashInName() {
+        // The NAME contains a bare `#` ("C#"); the quote anchor `#"…"` is the
+        // real delimiter, so the name survives intact.
+        let (base, fragment) = WikiLinkParser.splitFragment(
+            "source:Agentic Static Analysis for C# Security Auditing (2026)#\"the results show\"")
+        #expect(base == "source:Agentic Static Analysis for C# Security Auditing (2026)")
+        #expect(fragment == "\"the results show\"")
+    }
+
+    @Test func splitFragmentBareHashWithoutAnchorStillSplitsAtFirstHash() {
+        // With no `#"` there is nothing to disambiguate — the first `#` splits.
+        // Resolution retries with the fragment re-attached (replaceLinks /
+        // linkified), so a title containing `#` still resolves.
+        let (base, fragment) = WikiLinkParser.splitFragment(
+            "Agentic Static Analysis for C# Security Auditing")
+        #expect(base == "Agentic Static Analysis for C")
+        #expect(fragment == " Security Auditing")
+    }
+
+    @Test func parsesSourceCitationWithHashInName() {
+        let links = WikiLinkParser.parse(
+            "[[source:Agentic Static Analysis for C# Security Auditing (2026)#\"as we show\"]]")
+        #expect(links.count == 1)
+        #expect(links[0].linkType == .source)
+        #expect(links[0].target == "Agentic Static Analysis for C# Security Auditing (2026)")
+        #expect(links[0].fragment == "\"as we show\"")
+    }
+
+    @Test func quotedSamePageAnchorStillHasEmptyBase() {
+        // `#"` at position 0 — quote-anchor preference must not break `[[#"…"]]`.
+        let (base, fragment) = WikiLinkParser.splitFragment("#\"a quote\"")
+        #expect(base == "")
+        #expect(fragment == "\"a quote\"")
     }
 }

--- a/Tests/WikiFSTests/WikiLinkResolverTests.swift
+++ b/Tests/WikiFSTests/WikiLinkResolverTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import WikiFSCore
+
+/// Pure tests for the lookup-driven `[[wiki-link]]` target disambiguation.
+struct WikiLinkResolverTests {
+
+    // MARK: - candidateSplits ordering
+
+    @Test func plainTargetHasSingleCandidate() {
+        let splits = WikiLinkResolver.candidateSplits(of: "Home")
+        #expect(splits == [.init(base: "Home", fragment: nil)])
+    }
+
+    @Test func candidatesGoLongestBaseFirst() {
+        let splits = WikiLinkResolver.candidateSplits(of: "C# Guide#Methods")
+        #expect(splits == [
+            .init(base: "C# Guide#Methods", fragment: nil),
+            .init(base: "C# Guide", fragment: "Methods"),
+            .init(base: "C", fragment: " Guide#Methods"),
+        ])
+    }
+
+    @Test func quoteAnchorTargetSplitsAtEveryHash() {
+        let splits = WikiLinkResolver.candidateSplits(of: "C# Notes#\"a # quote\"")
+        #expect(splits.first == .init(base: "C# Notes#\"a # quote\"", fragment: nil))
+        #expect(splits.contains(.init(base: "C# Notes", fragment: "\"a # quote\"")))
+        #expect(splits.contains(.init(base: "C", fragment: " Notes#\"a # quote\"")))
+    }
+
+    @Test func emptyBaseCandidatesAreSkipped() {
+        // "#Section" has no name-bearing reading other than the whole string —
+        // the split at position 0 (a same-page anchor) is not a candidate.
+        let splits = WikiLinkResolver.candidateSplits(of: "#Section")
+        #expect(splits == [.init(base: "#Section", fragment: nil)])
+    }
+
+    @Test func trailingHashYieldsNilFragment() {
+        let splits = WikiLinkResolver.candidateSplits(of: "Page#")
+        #expect(splits == [
+            .init(base: "Page#", fragment: nil),
+            .init(base: "Page", fragment: nil),
+        ])
+    }
+
+    @Test func basesAreNormalized() {
+        // Split bases get whitespace-collapsed ends ("Foo " → "Foo"); fragments
+        // stay verbatim.
+        let splits = WikiLinkResolver.candidateSplits(of: "Foo #Bar")
+        #expect(splits.contains(.init(base: "Foo", fragment: "Bar")))
+    }
+
+    // MARK: - resolvedSplit
+
+    @Test func resolvesLongestKnownBase() {
+        let known: Set<String> = ["C# Guide"]
+        let split = WikiLinkResolver.resolvedSplit(of: "C# Guide#Methods") { known.contains($0) }
+        #expect(split == .init(base: "C# Guide", fragment: "Methods"))
+    }
+
+    @Test func exactFullTargetBeatsAnchorReading() {
+        // Both "Page#Section" (a literal title) and "Page" exist — the exact
+        // full-target match wins.
+        let known: Set<String> = ["Page#Section", "Page"]
+        let split = WikiLinkResolver.resolvedSplit(of: "Page#Section") { known.contains($0) }
+        #expect(split == .init(base: "Page#Section", fragment: nil))
+    }
+
+    @Test func plainAnchorSplitStillResolves() {
+        let known: Set<String> = ["Page"]
+        let split = WikiLinkResolver.resolvedSplit(of: "Page#Section") { known.contains($0) }
+        #expect(split == .init(base: "Page", fragment: "Section"))
+    }
+
+    @Test func nothingKnownReturnsNil() {
+        let split = WikiLinkResolver.resolvedSplit(of: "Ghost#Section") { _ in false }
+        #expect(split == nil)
+    }
+
+    @Test func throwingLookupPropagates() {
+        struct Boom: Error {}
+        #expect(throws: Boom.self) {
+            try WikiLinkResolver.resolvedSplit(of: "X") { _ in throw Boom() }
+        }
+    }
+}

--- a/Tests/WikiFSTests/WikiLinkRewriterTests.swift
+++ b/Tests/WikiFSTests/WikiLinkRewriterTests.swift
@@ -57,6 +57,51 @@ struct WikiLinkRewriterTests {
         #expect(result == "[[source:New#C# is sharp]]")
     }
 
+    @Test func rewritesNameContainingHashWithQuotedFragment() {
+        // The NAME contains a bare `#` ("C#"); the `#"` quote anchor is the
+        // delimiter, so the whole name is matched and spliced.
+        let result = WikiLinkRewriter.rewriteSourceBase(
+            in: "[[source:Agentic Static Analysis for C# Security Auditing#\"a quote\"]]",
+            matching: "Agentic Static Analysis for C# Security Auditing",
+            to: "New Name")
+        #expect(result == "[[source:New Name#\"a quote\"]]")
+    }
+
+    @Test func rewritesNameContainingHashWithFragmentAndAlias() {
+        let result = WikiLinkRewriter.rewriteSourceBase(
+            in: "[[source:C# Notes#\"q\"|my alias]]",
+            matching: "C# Notes", to: "Renamed")
+        #expect(result == "[[source:Renamed#\"q\"|my alias]]")
+    }
+
+    @Test func rewritesNameContainingHashWithoutAnyFragment() {
+        // Direct string match — no quote anchor needed for a `#`-name to be
+        // recognized and rewritten whole.
+        let result = WikiLinkRewriter.rewriteSourceBase(
+            in: "[[source:C# Notes]]",
+            matching: "C# Notes", to: "Renamed")
+        #expect(result == "[[source:Renamed]]")
+    }
+
+    @Test func longerKnownNameOwnsTheSpan() {
+        // Renaming source "C" must not touch a span whose longer reading names
+        // an EXISTING other source "C# Notes" (longest-name-wins).
+        let result = WikiLinkRewriter.rewriteSourceBase(
+            in: "[[source:C# Notes]]",
+            matching: "C", to: "Renamed",
+            isNameKnown: { $0 == "C# Notes" })
+        #expect(result == nil)
+    }
+
+    @Test func shortNameSplicesWhenNoLongerNameExists() {
+        // With no other source in the namespace, `[[source:C# Notes]]` reads
+        // as source "C" + fragment — renaming "C" rewrites the base.
+        let result = WikiLinkRewriter.rewriteSourceBase(
+            in: "[[source:C# Notes]]",
+            matching: "C", to: "Renamed")
+        #expect(result == "[[source:Renamed# Notes]]")
+    }
+
     // MARK: - Alias preservation
 
     @Test func preservesAlias() {

--- a/Tests/WikiFSTests/WikiLinkStoreTests.swift
+++ b/Tests/WikiFSTests/WikiLinkStoreTests.swift
@@ -123,6 +123,143 @@ struct WikiLinkStoreTests {
         #expect(links.map { "\($0.from)->\($0.to)" } == expected)
     }
 
+    // MARK: - `#` inside a page title / source name
+
+    @Test func replaceLinksResolvesPageTitleContainingHash() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        let sharp = try store.createPage(title: "Agentic Static Analysis for C# Security Auditing")
+
+        // Parsing splits the title at the `#` in "C#"; replaceLinks must retry
+        // with the fragment re-attached and land the row on the real page.
+        try store.replaceLinks(from: a.id, parsedLinks:
+            WikiLinkParser.parse("[[Agentic Static Analysis for C# Security Auditing]]"))
+
+        let links = try store.listAllLinks()
+        #expect(links.count == 1)
+        #expect(links.first?.to == sharp.id.rawValue)
+    }
+
+    @Test func replaceLinksResolvesSourceCitationWithHashInName() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        let src = try store.addSource(filename: "C# Notes.md", data: Data("hi".utf8))
+
+        // The `#"` quote anchor is the delimiter, so the citation's name keeps
+        // its "C#" and resolves (via the extension-stripping fallback).
+        try store.replaceLinks(from: a.id, parsedLinks:
+            WikiLinkParser.parse("[[source:C# Notes#\"a passage\"]]"))
+
+        #expect(try store.sourceLinkingPages(to: src.id) == [a.id])
+    }
+
+    @Test func replaceLinksResolvesHashTitleWithRealAnchor() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        let guide = try store.createPage(title: "C# Guide")
+
+        // `#`-containing title PLUS a real section anchor — the longest name
+        // that resolves wins ("C# Guide"), the rest is the anchor.
+        try store.replaceLinks(from: a.id, parsedLinks:
+            WikiLinkParser.parse("[[C# Guide#Methods]]"))
+
+        let links = try store.listAllLinks()
+        #expect(links.count == 1)
+        #expect(links.first?.to == guide.id.rawValue)
+    }
+
+    @Test func replaceLinksBothHashTitlesLand() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        let guide = try store.createPage(title: "C# Guide")
+        let notes = try store.createPage(title: "C# Notes")
+
+        // Two `#`-titles sharing the mis-split base "C" — parse keeps both
+        // (raw-target dedup) and each resolves to its own page.
+        try store.replaceLinks(from: a.id, parsedLinks:
+            WikiLinkParser.parse("[[C# Guide]] and [[C# Notes]]"))
+
+        let targets = Set(try store.listAllLinks().map(\.to))
+        #expect(targets == [guide.id.rawValue, notes.id.rawValue])
+    }
+
+    @Test func replaceLinksResolvesSourceNameWithHashWithoutQuoteAnchor() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        let src = try store.addSource(filename: "C# Notes.md", data: Data("hi".utf8))
+
+        // No quote anchor → the name mis-splits at "C#"; the fragment-re-attach
+        // fallback must still resolve the source.
+        try store.replaceLinks(from: a.id, parsedLinks:
+            WikiLinkParser.parse("[[source:C# Notes]]"))
+
+        #expect(try store.sourceLinkingPages(to: src.id) == [a.id])
+    }
+
+    // MARK: - Lenient source-name resolution (pass 3)
+
+    @Test func nearMissCitationResolvesUniqueLooseMatch() throws {
+        let store = try tempStore()
+        let src = try store.addSource(
+            filename: "Agentic Static Analysis for C# Security Auditing.pdf",
+            data: Data("%PDF".utf8))
+        // Cited with a "(2026)" suffix the stored name doesn't have, and
+        // without the ".pdf" the stored name does have.
+        let resolved = try store.resolveSourceByName(
+            "Agentic Static Analysis for C# Security Auditing (2026)")
+        #expect(resolved == src.id)
+    }
+
+    @Test func ambiguousLooseMatchDoesNotResolve() throws {
+        let store = try tempStore()
+        _ = try store.addSource(filename: "Report (2025).pdf", data: Data("%PDF".utf8))
+        _ = try store.addSource(filename: "Report (2026).pdf", data: Data("%PDF".utf8))
+        // "Report" loose-matches both → refuse to guess.
+        #expect(try store.resolveSourceByName("Report") == nil)
+    }
+
+    @Test func exactMatchBeatsLooseMatch() throws {
+        let store = try tempStore()
+        _ = try store.addSource(filename: "Paper.pdf", data: Data("%PDF".utf8))
+        let exact = try store.addSource(filename: "Paper (2026).md", data: Data("hi".utf8))
+        // "Paper (2026)" extension-strip-matches the second source exactly;
+        // the loose tier (which would see both) must not be consulted.
+        #expect(try store.resolveSourceByName("Paper (2026)") == exact.id)
+    }
+
+    // MARK: - LinkReconciler (startup self-heal)
+
+    @Test func reconcileHealsCitationSavedBeforeSourceExisted() throws {
+        let store = try tempStore()
+        let page = try store.createPage(title: "P")
+        let body = "cites [[source:Agentic Static Analysis for C# Security Auditing (2026)#\"q\"]]"
+        try store.updatePage(id: page.id, title: "P", body: body)
+        try store.replaceLinks(from: page.id, parsedLinks: WikiLinkParser.parse(body))
+
+        // Source ingested AFTER the page was saved → no link row yet.
+        let src = try store.addSource(
+            filename: "Agentic Static Analysis for C# Security Auditing.pdf",
+            data: Data("%PDF".utf8))
+        #expect(try store.sourceLinkingPages(to: src.id).isEmpty)
+
+        try LinkReconciler.reconcileAll(in: store)
+        #expect(try store.sourceLinkingPages(to: src.id) == [page.id])
+    }
+
+    @Test func reconcileIsIdempotent() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        _ = try store.createPage(title: "B")
+        try store.updatePage(id: a.id, title: "A", body: "see [[B]]")
+        try store.replaceLinks(from: a.id, parsedLinks: WikiLinkParser.parse("see [[B]]"))
+
+        try LinkReconciler.reconcileAll(in: store)
+        try LinkReconciler.reconcileAll(in: store)
+        let links = try store.listAllLinks()
+        #expect(links.count == 1)
+        #expect(links.first?.from == a.id.rawValue)
+    }
+
     // MARK: - deletePage FK safety (the Phase-4 regression)
 
     @Test func deletePageCleansUpLinksAsSourceAndTarget() throws {

--- a/Tests/WikiFSTests/WikiNameRulesTests.swift
+++ b/Tests/WikiFSTests/WikiNameRulesTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import WikiFSCore
+
+/// Pure tests for the page-title / source-display-name sanitization rules.
+struct WikiNameRulesTests {
+
+    @Test func cleanNamesPassThrough() {
+        #expect(WikiNameRules.sanitized("Plain Title") == "Plain Title")
+        #expect(WikiNameRules.isLinkable("Plain Title"))
+    }
+
+    @Test func hashInsideNameIsKept() {
+        // `#` is only unlinkable when LEADING — WikiLinkResolver handles it
+        // elsewhere in a name.
+        #expect(WikiNameRules.sanitized("Agentic Static Analysis for C# Security Auditing")
+                == "Agentic Static Analysis for C# Security Auditing")
+    }
+
+    @Test func pipeBecomesDash() {
+        #expect(WikiNameRules.sanitized("Foo | Bar") == "Foo - Bar")
+        #expect(WikiNameRules.sanitized("A|B") == "A-B")
+    }
+
+    @Test func bracketsBecomeParensAsAPair() {
+        #expect(WikiNameRules.sanitized("[Editorial] Some Paper") == "(Editorial) Some Paper")
+    }
+
+    @Test func leadingHashesAreDropped() {
+        #expect(WikiNameRules.sanitized("#hashtag") == "hashtag")
+        #expect(WikiNameRules.sanitized("# # Deeply Tagged") == "Deeply Tagged")
+    }
+
+    @Test func endsAreTrimmed() {
+        #expect(WikiNameRules.sanitized("  Padded  ") == "Padded")
+    }
+
+    @Test func emptyResultFallsBackToUntitled() {
+        #expect(WikiNameRules.sanitized("#") == "Untitled")
+        #expect(WikiNameRules.sanitized("   ") == "Untitled")
+    }
+
+    @Test func sanitizedIsIdempotent() {
+        for name in ["Foo | Bar", "[Editorial] X", "# #Foo", "C# Guide", "#", "  a  "] {
+            let once = WikiNameRules.sanitized(name)
+            #expect(WikiNameRules.sanitized(once) == once)
+        }
+    }
+
+    // MARK: - looseMatchKey
+
+    @Test func looseKeyStripsExtensionAndParenSuffix() {
+        // The near-miss the lenient pass exists for: an agent cites
+        // "Name (2026)" for a source named "Name.pdf".
+        let cited = WikiNameRules.looseMatchKey("Agentic Static Analysis for C# Security Auditing (2026)")
+        let stored = WikiNameRules.looseMatchKey("Agentic Static Analysis for C# Security Auditing.pdf")
+        #expect(cited == stored)
+        #expect(cited == "agentic static analysis for c# security auditing")
+    }
+
+    @Test func looseKeyIsCaseAndWhitespaceInsensitive() {
+        #expect(WikiNameRules.looseMatchKey("  Some   PAPER ")
+                == WikiNameRules.looseMatchKey("some paper"))
+    }
+
+    @Test func looseKeyStripsOnlyOneParenGroup() {
+        #expect(WikiNameRules.looseMatchKey("A (b) (c)") == "a (b)")
+    }
+
+    @Test func looseKeyKeepsNonExtensionDots() {
+        // A 6+ char or non-alphanumeric tail is not a file extension.
+        #expect(WikiNameRules.looseMatchKey("release.candidate") == "release.candidate")
+    }
+}

--- a/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
+++ b/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import WikiFSCore
+
+/// Store-boundary enforcement of `WikiNameRules` plus the v17→18 one-time
+/// sweep of pre-existing rows.
+struct WikiNameSanitizationStoreTests {
+
+    private func tempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-namerules-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func tempStore() throws -> SQLiteWikiStore {
+        try SQLiteWikiStore(databaseURL: tempDir().appendingPathComponent("WikiFS.sqlite"))
+    }
+
+    // MARK: - Write-boundary enforcement
+
+    @Test func createPageSanitizesTitle() throws {
+        let store = try tempStore()
+        let page = try store.createPage(title: "[Draft] A | B]")
+        #expect(page.title == "(Draft) A - B)")
+        #expect(try store.getPage(id: page.id).title == "(Draft) A - B)")
+    }
+
+    @Test func updatePageSanitizesTitle() throws {
+        let store = try tempStore()
+        let page = try store.createPage(title: "Clean")
+        try store.updatePage(id: page.id, title: "#Now | Tagged", body: "x")
+        #expect(try store.getPage(id: page.id).title == "Now - Tagged")
+    }
+
+    @Test func renameSourceSanitizesDisplayName() throws {
+        let store = try tempStore()
+        let src = try store.addSource(filename: "doc.md", data: Data("hi".utf8))
+        try store.renameSource(id: src.id, to: "New | Name]")
+        let renamed = try store.getSource(id: src.id)
+        #expect(renamed.displayName == "New - Name)")
+    }
+
+    @Test func addSourceWithUnlinkableFilenameGetsSanitizedDisplayName() throws {
+        let store = try tempStore()
+        // No richer metadata → the citable name would fall back to the raw
+        // filename, which is unlinkable — so its sanitized form is stored as
+        // the display name while the filename stays verbatim.
+        let src = try store.addSource(filename: "notes|v1].txt", data: Data("hi".utf8))
+        let stored = try store.getSource(id: src.id)
+        #expect(stored.filename == "notes|v1].txt")
+        #expect(stored.displayName == "notes-v1).txt")
+        #expect(try store.resolveSourceByName("notes-v1).txt") == src.id)
+    }
+
+    @Test func addSourceWithLinkableFilenameKeepsNilDisplayName() throws {
+        let store = try tempStore()
+        let src = try store.addSource(filename: "doc.pdf", data: Data("%PDF".utf8))
+        #expect(try store.getSource(id: src.id).displayName == nil)
+    }
+
+    @Test func upsertOfUnlinkableTitleDoesNotDuplicate() throws {
+        let store = try tempStore()
+        // The raw title sanitizes to the same stored title both times — the
+        // second upsert must UPDATE, not create a second page.
+        let first = try PageUpsert.upsert(in: store, id: nil, title: "A | B", body: "one")
+        let second = try PageUpsert.upsert(in: store, id: nil, title: "A | B", body: "two")
+        #expect(first.didCreate)
+        #expect(!second.didCreate)
+        #expect(second.id == first.id)
+        #expect(try store.getPage(id: first.id).title == "A - B")
+        #expect(try store.getPage(id: first.id).bodyMarkdown == "two")
+    }
+
+    // MARK: - v17 → 18 migration sweep
+
+    @Test func migrationSanitizesPreexistingNames() throws {
+        let dir = try tempDir()
+        let url = dir.appendingPathComponent("WikiFS.sqlite")
+
+        var pageID: PageID?
+        var sourceID: PageID?
+        do {
+            // Fresh v18 store with clean rows, released at scope end so the
+            // raw connection below sees a closed database.
+            let store = try SQLiteWikiStore(databaseURL: url)
+            pageID = try store.createPage(title: "Clean Page").id
+            sourceID = try store.addSource(filename: "doc.md", data: Data("hi".utf8)).id
+        }
+
+        // Tamper via a raw connection: plant pre-rule dirty names and rewind
+        // the stamp to v17, simulating a database written before the rule.
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        for sql in [
+            "UPDATE pages SET title = '[Draft] Bad | #Title';",
+            "UPDATE sources SET display_name = 'Foo | Bar]';",
+            "PRAGMA user_version=17;",
+        ] {
+            #expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK, Comment(rawValue: sql))
+        }
+        sqlite3_close(db)
+
+        // Reopen → the 17→18 step sweeps the dirty names.
+        let reopened = try SQLiteWikiStore(databaseURL: url)
+        #expect(reopened.pragmaValue("user_version") == "18")
+        let page = try reopened.getPage(id: pageID!)
+        #expect(page.title == "(Draft) Bad - #Title") // inner # is fine, kept
+        #expect(try reopened.getSource(id: sourceID!).displayName == "Foo - Bar)")
+    }
+
+    @Test func migrationLeavesCleanNamesUntouched() throws {
+        let dir = try tempDir()
+        let url = dir.appendingPathComponent("WikiFS.sqlite")
+
+        var pageID: PageID?
+        var pageVersion: Int?
+        do {
+            let store = try SQLiteWikiStore(databaseURL: url)
+            let page = try store.createPage(title: "C# Guide") // # inside: linkable
+            pageID = page.id
+            pageVersion = page.version
+        }
+
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        #expect(sqlite3_exec(db, "PRAGMA user_version=17;", nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+
+        let reopened = try SQLiteWikiStore(databaseURL: url)
+        let page = try reopened.getPage(id: pageID!)
+        #expect(page.title == "C# Guide")
+        #expect(page.version == pageVersion!) // no gratuitous version bump
+    }
+}


### PR DESCRIPTION
## Problem

A page/source name containing `#` — e.g. a source named "Agentic Static
Analysis for **C#** Security Auditing" — breaks every citation to it.
`WikiLinkParser` splits link targets at the *first* `#`, so
`[[source:…C# Security Auditing (2026)#"quote"]]` parses as name "…for C"
plus a garbage fragment: footnote labels truncate, and none of the links
resolve. The `[[…]]` grammar has no escape syntax, so `#`, `|`, `]`, and
leading-`#` names all silently collide with delimiters.

## Approach

Character heuristics can't settle where a name ends — but the app always
knows what names *exist*. Resolution is now lookup-driven, and the only
characters banned are the ones no resolver could ever save:

- **`WikiLinkResolver`** (new, pure): tries every `(name, fragment)` reading
  of a target against the real namespace, longest name first, exact
  full-target match wins. `[[C# Guide#Methods]]` resolves to page "C# Guide"
  + anchor "Methods". Wired into `replaceLinks` (link graph),
  `WikiLinkMarkdown.linkified` (reader links + ghost styling), and the
  editor's broken-link lint.
- **`WikiNameRules`** (new): names that can never be linked are sanitized at
  every write boundary (`|` → `-`, `[`/`]` → `(`/`)`, leading `#` dropped);
  `#` inside names stays fully legal. A **v17→18 data-only migration**
  sweeps pre-existing rows once (slugs recomputed, versions bumped).
- **Lenient source resolution:** a third `resolveSourceByName` pass matches
  with one trailing extension and one trailing "(…)" suffix stripped —
  *unique match only* — so an agent citing "Some Paper (2026)" finds
  "Some Paper.pdf" without ever guessing between two candidates.
- **`LinkReconciler`** (new): once per launch (top of `upgradeSearchIndex`,
  before the MiniLM gates), re-parses all pages and rebuilds link rows under
  current rules, so existing content heals without waiting for each page's
  next save. Page bodies are never mutated.
- **`WikiLinkRewriter`** now matches renames by direct string comparison
  with an `isNameKnown` closure, so renaming source "C" can't corrupt a
  citation of "C# Notes".

## Testing

Full suite passes (1363 tests), including `StoreConcurrencyTests` — the new
store code takes the method lock and uses `withTransaction` per the Phase-0
discipline. New suites: `WikiLinkResolverTests`, `WikiNameRulesTests`,
`WikiNameSanitizationStoreTests` (including a raw-SQL v17 tamper/reopen
migration test). Verified end-to-end against a live wiki: all `C#`-name
citations resolve; a cross-wiki audit found the remaining `|`-named sources
fixed by the migration on first open.

Residual edges (reserved characters inside quoted passages; inherent `#`
ambiguity when both readings exist) are documented in `ISSUES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2bJGccRPy5RonE9UsGrcR