### PR TITLE
fix(sandbox): narrow ~/.claude writes — deny hooks/agents/skills/plug…

### DIFF
--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -325,11 +325,12 @@ public struct OperationCommand: Equatable, Sendable {
         // Relocate temp writes into scratch so they land inside the seatbelt allowlist.
         // CLAUDE_CONFIG_DIR is intentionally NOT redirected: Claude Code reads its
         // credentials from ~/.claude/.credentials.json, and pointing it at an empty
-        // scratch dir hides those credentials. The seatbelt profile DOES allow writes
-        // to ~/.claude/ + ~/.claude.json (`SandboxProfile.generate`/`generateReadOnly`)
-        // so a sandboxed session can persist its transcript — that subtree is a known
-        // persistence vector (issue #116 item 4); narrowing it is a follow-up, not
-        // something this redirection changes.
+        // scratch dir hides those credentials. The seatbelt profile allows writes to
+        // ~/.claude/ + ~/.claude.json (`SandboxProfile.generate`/`generateReadOnly`) so
+        // a sandboxed session can persist its transcript; `claudeHomeDenyRules()` narrows
+        // that allow by denying the execution-vector / credential paths (issue #116
+        // item 4) — so CLAUDE_CONFIG_DIR redirection stays unnecessary AND the subtree
+        // is no longer a persistence hole.
         environment["TMPDIR"] = scratchDirectory + "/" + Self.tmpRelocationLeaf
 
         var head: [String] = ["-p", sandbox.profile]

--- a/Sources/WikiFSCore/SandboxProfile.swift
+++ b/Sources/WikiFSCore/SandboxProfile.swift
@@ -21,6 +21,13 @@ import Foundation
 /// `process-exec*` and `file-read*` (`pdf2mdDenyRules()`), so a sandboxed agent can't
 /// run the bundled extractor or feed it to `uv --script`. Everything else stays
 /// allow-default. Generic `uv`/`python3` exec is NOT yet denied (issue #116 item 2).
+///
+/// `~/.claude` write narrowing (issue #116 item 4): the `~/.claude` subtree is broadly
+/// allowed (the transcript under `projects/` needs it), but `claudeHomeDenyRules()`
+/// layers narrower denies over the execution-vector / credential paths (`hooks/`,
+/// `commands/`, `agents/`, `skills/`, `plugins/`, `.credentials.json`, `settings.json`,
+/// `settings.local.json`, `CLAUDE.md`) so a sandboxed agent can't plant files a future
+/// unsandboxed session would execute.
 public enum SandboxProfile {
 
     /// The fully-resolved invocation the launcher hands to `OperationCommand` when the
@@ -77,9 +84,11 @@ public enum SandboxProfile {
             "(deny file-write*)",
             // The scratch dir is a directory tree.
             "(allow file-write* (subpath (param \"SCRATCH_DIR\")))",
-            // Claude Code writes its session transcript and config under ~/.claude/ and
-            // to ~/.claude.json — allow the subtree and the top-level file so sandboxed
-            // runs can record their transcript without EPERM.
+            // Claude Code writes its session transcript under ~/.claude/projects/ and its
+            // top-level state to ~/.claude.json. The subtree allow is deliberately broad
+            // so benign runtime paths (projects/, shell-snapshots/, sessions/, …) keep
+            // working; the execution-vector / credential subpaths are carved out by
+            // claudeHomeDenyRules() below (issue #116 item 4).
             "(allow file-write* (subpath (string-append (param \"HOME\") \"/.claude\")))",
             "(allow file-write* (literal (string-append (param \"HOME\") \"/.claude.json\")))",
             // Claude Code derives a per-session temp dir from the cwd and places it under
@@ -90,6 +99,8 @@ public enum SandboxProfile {
             // The active wiki DB and its SQLite sidecars are exact files.
             "(allow file-write* (literal (param \"WIKI_DB\")))",
         ]
+        // Layer the ~/.claude execution-vector / credential denies over the subtree allow.
+        lines.append(contentsOf: claudeHomeDenyRules())
         lines.append(contentsOf: agentRuntimeWriteRules())
         for suffix in sqliteSidecarSuffixes {
             lines.append(
@@ -126,9 +137,11 @@ public enum SandboxProfile {
             "(deny file-write*)",
             // The scratch dir is writable — the agent needs a cwd.
             "(allow file-write* (subpath (param \"SCRATCH_DIR\")))",
-            // Claude Code writes its session transcript and config under ~/.claude/ and
-            // to ~/.claude.json — allow the subtree and the top-level file so sandboxed
-            // runs can record their transcript without EPERM.
+            // Claude Code writes its session transcript under ~/.claude/projects/ and its
+            // top-level state to ~/.claude.json. The subtree allow is deliberately broad
+            // so benign runtime paths (projects/, shell-snapshots/, sessions/, …) keep
+            // working; the execution-vector / credential subpaths are carved out by
+            // claudeHomeDenyRules() below (issue #116 item 4).
             "(allow file-write* (subpath (string-append (param \"HOME\") \"/.claude\")))",
             "(allow file-write* (literal (string-append (param \"HOME\") \"/.claude.json\")))",
             // See `generate` — Claude Code's per-session temp dir lives under
@@ -136,6 +149,8 @@ public enum SandboxProfile {
             // Bash tool to function under the sandbox.
             "(allow file-write* (subpath (param \"CLAUDE_TMP\")))",
         ]
+        // Layer the ~/.claude execution-vector / credential denies over the subtree allow.
+        lines.append(contentsOf: claudeHomeDenyRules())
         lines.append(contentsOf: agentRuntimeWriteRules())
         // Mirror `generate`: deny exec/read of the resolved pdf2md script when a path
         // is supplied. The rules reference only the `PDF2MD_SCRIPT` param name.
@@ -256,6 +271,39 @@ public enum SandboxProfile {
             "(allow file-write-data (subpath \"/dev/fd\"))",
             "(allow file-write* (regex #\"^/private/tmp/claude-[A-Za-z0-9]+-cwd(/|$)\"))",
         ]
+    }
+
+    /// `~/.claude` write-deny rules layered OVER the broad `~/.claude` subtree allow, so
+    /// a sandboxed agent can't tamper files that a FUTURE, unsandboxed Claude Code session
+    /// would load and execute (issue #116 item 4). The subtree allow is kept broad for
+    /// robustness — Claude Code writes the session transcript under `~/.claude/projects/`
+    /// and touches other benign runtime paths (`shell-snapshots/`, `sessions/`, `cache/`,
+    /// …) that vary by version; carving them all out individually would be brittle. Instead
+    /// the dangerous subpaths are denied here, and a narrower filtered deny wins over the
+    /// broader allow (same specificity semantics the `(deny file-write*)` fence and
+    /// `pdf2mdDenyRules()` rely on — verified live with `sandbox-exec`).
+    ///
+    /// Two categories, both under `~/.claude/`:
+    /// - **Execution vectors** (subtree `deny`): `hooks/`, `commands/`, `agents/`,
+    ///   `skills/`, `plugins/` — each can run code or define behavior a future session
+    ///   loads. (`commands/` is denied defensively even when absent — it's a known vector.)
+    /// - **Credentials + config + memory** (literal `deny`): `.credentials.json`,
+    ///   `settings.json`, `settings.local.json`, `CLAUDE.md` — credential swap, settings
+    ///   tamper (e.g. enabling `bypassPermissions`), or user-level instruction injection.
+    ///
+    /// Emitted in BOTH profiles; references only `(param "HOME")` (already a define), so
+    /// no new `-D` parameter is threaded through the invocation builders.
+    private static func claudeHomeDenyRules() -> [String] {
+        let dirSubtrees = ["hooks", "commands", "agents", "skills", "plugins"]
+        let literalFiles = [".credentials.json", "settings.json", "settings.local.json", "CLAUDE.md"]
+        var rules: [String] = []
+        for d in dirSubtrees {
+            rules.append("(deny file-write* (subpath (string-append (param \"HOME\") \"/.claude/\(d)\")))")
+        }
+        for f in literalFiles {
+            rules.append("(deny file-write* (literal (string-append (param \"HOME\") \"/.claude/\(f)\")))")
+        }
+        return rules
     }
 
     /// The `pdf2md` exec/read deny rules, emitted by BOTH `generate` and

--- a/Tests/WikiFSTests/SandboxProfileTests.swift
+++ b/Tests/WikiFSTests/SandboxProfileTests.swift
@@ -303,4 +303,50 @@ struct SandboxProfileTests {
     #expect(resolved.hasPrefix("/private/tmp/"))
     #expect(resolved.contains("sdw-pdf2md-probe-"))
   }
+
+  // MARK: - ~/.claude write-narrowing (issue #116 item 4)
+
+  /// The execution-vector / credential paths under ~/.claude are denied EVEN THOUGH the
+  /// subtree is broadly allowed — a compromised agent can't plant hooks/commands/agents/
+  /// skills/plugins or swap credentials/settings/CLAUDE.md for a future unsandboxed session.
+  @Test func bothProfilesDenyClaudeHomeExecutionAndCredentialPaths() {
+    let rw = SandboxProfile.generate(scratchDir: Self.scratchDir, wikiDBPath: Self.wikiDB)
+    let ro = SandboxProfile.generateReadOnly(scratchDir: Self.scratchDir)
+    for p in [rw, ro] {
+      // Subtree denies (execution vectors).
+      for d in ["hooks", "commands", "agents", "skills", "plugins"] {
+        #expect(p.contains("(deny file-write* (subpath (string-append (param \"HOME\") \"/.claude/\(d)\")))"))
+      }
+      // Literal denies (credentials + settings + user-level memory).
+      for f in [".credentials.json", "settings.json", "settings.local.json", "CLAUDE.md"] {
+        #expect(p.contains("(deny file-write* (literal (string-append (param \"HOME\") \"/.claude/\(f)\")))"))
+      }
+    }
+  }
+
+  /// Regression guard: the broad ~/.claude subtree allow stays (the transcript under
+  /// projects/ and other benign runtime writes still need it); only the dangerous
+  /// subpaths are carved out. Narrowing the ALLOW itself would break the transcript.
+  @Test func bothProfilesStillBroadlyAllowClaudeHomeSubtree() {
+    let rw = SandboxProfile.generate(scratchDir: Self.scratchDir, wikiDBPath: Self.wikiDB)
+    let ro = SandboxProfile.generateReadOnly(scratchDir: Self.scratchDir)
+    for p in [rw, ro] {
+      #expect(p.contains("(allow file-write* (subpath (string-append (param \"HOME\") \"/.claude\")))"))
+      // The transcript dir is NOT separately denied — it rides the broad allow.
+      #expect(!p.contains("\"/.claude/projects"))
+    }
+  }
+
+  /// Regression guard: dirs use `subpath` (whole subtree), files use `literal` (exact).
+  /// Swapping them would either over-deny (a literal on a dir misses new files) or
+  /// under-deny (a subpath on a file is equivalent but inconsistent).
+  @Test func claudeHomeDenyUsesSubpathForDirsLiteralForFiles() {
+    let p = SandboxProfile.generate(scratchDir: Self.scratchDir, wikiDBPath: Self.wikiDB)
+    // settings.json is a FILE → literal, not subpath.
+    #expect(p.contains("(deny file-write* (literal (string-append (param \"HOME\") \"/.claude/settings.json\")))"))
+    #expect(!p.contains("(deny file-write* (subpath (string-append (param \"HOME\") \"/.claude/settings.json\")))"))
+    // hooks is a DIR → subpath, not literal.
+    #expect(p.contains("(deny file-write* (subpath (string-append (param \"HOME\") \"/.claude/hooks\")))"))
+    #expect(!p.contains("(deny file-write* (literal (string-append (param \"HOME\") \"/.claude/hooks\")))"))
+  }
 }


### PR DESCRIPTION
Fix the sandbox from having ~/.claude/ availability.  Partial fix for #116 

The seatbelt broadly allowed the whole ~/.claude subtree (added in https://github.com/tqbf/selfdrivingwiki/commit/48fbcb2658fa8c36d2121859afa8095eda27efe9 so a
sandboxed session could persist its transcript under projects/). That made
~/.claude a persistence hole: a prompt-injected agent could plant hooks/,
commands/, agents/, skills/, plugins/, or swap .credentials.json / settings /
CLAUDE.md — files a FUTURE unsandboxed Claude Code session would load and execute.

Item 4 layers narrower denies over the broad allow (the issue's recommended
approach — robust to new benign runtime paths that an allow-narrowing would
break). `claudeHomeDenyRules()` emits, in BOTH generate and generateReadOnly:

```
  (deny file-write* (subpath .../.claude/<dir>))   for hooks/commands/agents/skills/plugins
  (deny file-write* (literal .../.claude/<file>))  for .credentials.json /
                                                   settings.json / settings.local.json / CLAUDE.md
```

The transcript dir (~/.claude/projects/) and other benign runtime writes
(~/.claude.json, shell-snapshots/, sessions/, cache/) stay writable via the
broad subtree allow.