### PR TITLE
Source detail: show PDF-conversion timestamp and other metadata

### DIFF
--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -239,12 +239,12 @@ struct SourceDetailView: View {
             HStack(spacing: 12) {
                 statusLabel
                 Text(Self.sizeFormatter.string(fromByteCount: Int64(file.byteSize)))
-                Text("Added \(file.createdAt, style: .date)")
+                Text("Added \(file.createdAt, style: .date) at \(file.createdAt, style: .time)")
                 if file.updatedAt != file.createdAt {
-                    Text("Updated \(file.updatedAt, style: .date)")
+                    Text("Updated \(file.updatedAt, style: .date) at \(file.updatedAt, style: .time)")
                 }
-                if let head = headVersion {
-                    Text("\(Self.markdownOriginLabel(for: head.origin)) \(head.createdAt, style: .date)")
+                if let head = headVersion, let label = Self.markdownOriginLabel(for: head.origin) {
+                    Text("\(label) \(head.createdAt, style: .date) at \(head.createdAt, style: .time)")
                 }
             }
             .font(.callout)
@@ -687,13 +687,15 @@ struct SourceDetailView: View {
     }()
 
     /// Human label for a `SourceMarkdownVersion.origin` value, describing how
-    /// the currently-displayed markdown version came to exist.
-    private static func markdownOriginLabel(for origin: String) -> String {
+    /// the currently-displayed markdown version came to exist. `nil` for
+    /// "source" (the as-ingested seed version of a native markdown file,
+    /// which the added-date row above already covers) so the row is omitted.
+    private static func markdownOriginLabel(for origin: String) -> String? {
         switch origin {
         case "extraction": return "Converted"
         case "user": return "Edited"
         case "revert": return "Reverted"
-        default: return "Updated"
+        default: return nil
         }
     }
 }

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -239,7 +239,13 @@ struct SourceDetailView: View {
             HStack(spacing: 12) {
                 statusLabel
                 Text(Self.sizeFormatter.string(fromByteCount: Int64(file.byteSize)))
-                Text(file.createdAt, style: .date)
+                Text("Added \(file.createdAt, style: .date)")
+                if file.updatedAt != file.createdAt {
+                    Text("Updated \(file.updatedAt, style: .date)")
+                }
+                if let head = headVersion {
+                    Text("\(Self.markdownOriginLabel(for: head.origin)) \(head.createdAt, style: .date)")
+                }
             }
             .font(.callout)
             .foregroundStyle(.secondary)
@@ -679,6 +685,17 @@ struct SourceDetailView: View {
         formatter.countStyle = .file
         return formatter
     }()
+
+    /// Human label for a `SourceMarkdownVersion.origin` value, describing how
+    /// the currently-displayed markdown version came to exist.
+    private static func markdownOriginLabel(for origin: String) -> String {
+        switch origin {
+        case "extraction": return "Converted"
+        case "user": return "Edited"
+        case "revert": return "Reverted"
+        default: return "Updated"
+        }
+    }
 }
 
 /// Keys the PDF-only anchor consume task so it re-fires on repeat quote clicks

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -52,14 +52,6 @@ struct WikiDetailView: View {
 
                         FlowLayout(spacing: 12) {
                             Button {
-                                store.newPageInNewTab()
-                            } label: {
-                                Label("New Page", systemImage: "plus")
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.large)
-
-                            Button {
                                 addURLHandler?("")
                             } label: {
                                 Label("Add from URL", systemImage: "link.badge.plus")


### PR DESCRIPTION
Closes #134.

- Header metadata row now shows Added/Updated dates (with times) instead of just an unlabeled added-date.
- Added a Converted/Edited/Reverted label (with timestamp) sourced from `SourceMarkdownVersion.headVersion.origin`/`.createdAt`, shown only when the head version is more than the plain as-ingested seed (origin `"source"` is suppressed since it's redundant with "Added").

## Test plan
- [x] `swift build` passes
- [x] Manually verified in the running app: opened a native-markdown source and confirmed Added/Updated timestamps render with date+time in the local time zone, and that the origin label is correctly suppressed for `origin: "source"`.