### PR TITLE
fix(sources): default-open opens in-app tab; add Open In… for external (#139)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,40 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-04 — Sources default-open opens an in-app tab; explicit "Open In…" for external launch (#139)
+
+The default-open gestures on **sources** (double-click + the "Open" / "Open N
+Sources" context-menu item) launched the file in an external app (Preview for a
+PDF), inconsistent with pages/bookmarks which open an in-app tab on the same
+gestures. The external launch is a legitimate workflow but belongs behind an
+explicit action, not the default. Fixes [#139](https://github.com/tqbf/selfdrivingwiki/issues/139).
+
+- **Sources default-open → in-app tab.** `SourcesContainerView.onOpen` now calls
+  `store.openTab(.source(id))` (matching `onOpenBackground` and the pages/bookmark
+  path) instead of `fileProvider.openSource(id:)`. The old external behavior
+  moves verbatim to a new `onOpenExternal` callback. `SourcesListCallbacks` gains
+  `onOpenExternal`; `SourcesListView` adds an "Open In…" menu item (single + batch,
+  gated on the File Provider mount) with a distinct `rectangle.portrait.and.arrow.right`
+  glyph and an `openExternalAction` handler. The `SourcesListView` docstring
+  (which documented the external double-click as intentional) is corrected.
+- **"Open In…" on pages.** `PagesListCallbacks` gains `onOpenExternal`;
+  `PagesContainerView` wires it to a new `FileProviderSpike.openPage(id:)`;
+  `PagesListView` adds the gated "Open In…" item + handler. Pages had no external
+  path before.
+- **`FileProviderSpike.openPage(id:)`** opens a page in its default app by
+  resolving the user-visible URL via the existing `resolvePageByTitleURL` (same
+  `page-by-title` identifier share/reveal use, so no drift) and handing it to
+  `NSWorkspace.shared.open` — mirroring `openSource`.
+- **"Open In…" on bookmarks.** `FileProviderSpike` is threaded through
+  `BookmarksContainerView` → `BookmarksOutlineView` → controller (which had no
+  file-provider access before). The pageRef/sourceRef context menu gains a gated
+  "Open In…" item; `openExternalAction` routes pageRef→`openPage`,
+  sourceRef→`openSource`.
+- **Drive-by:** dropped an unused `let callbacks` binding in
+  `BookmarksOutlineView.acceptDrop` that SourceKit surfaced during the edit.
+
+Gates: `swift build` clean; `swift test` — 1365 tests in 104 suites, all pass.
+
 ## 2026-07-04 — Robust `[[wiki-link]]` name handling: lookup-driven resolution, name rules, startup self-heal (v18)
 
 A source/page NAME containing `#` (e.g. "Agentic Static Analysis for C#

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,39 +2,48 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-## 2026-07-04 — Sources default-open opens an in-app tab; explicit "Open In…" for external launch (#139)
+## 2026-07-04 — Sources default-open opens an in-app tab; "Open With" submenu for external editors (#139)
 
 The default-open gestures on **sources** (double-click + the "Open" / "Open N
-Sources" context-menu item) launched the file in an external app (Preview for a
-PDF), inconsistent with pages/bookmarks which open an in-app tab on the same
-gestures. The external launch is a legitimate workflow but belongs behind an
-explicit action, not the default. Fixes [#139](https://github.com/tqbf/selfdrivingwiki/issues/139).
+Sources" context-menu item) launched the file in its default external app
+(Preview for a PDF), inconsistent with pages/bookmarks which open an in-app tab
+on the same gestures. The external launch is a legitimate workflow but belongs
+behind an explicit action. Fixes [#139](https://github.com/tqbf/selfdrivingwiki/issues/139).
 
 - **Sources default-open → in-app tab.** `SourcesContainerView.onOpen` now calls
   `store.openTab(.source(id))` (matching `onOpenBackground` and the pages/bookmark
   path) instead of `fileProvider.openSource(id:)`. The old external behavior
-  moves verbatim to a new `onOpenExternal` callback. `SourcesListCallbacks` gains
-  `onOpenExternal`; `SourcesListView` adds an "Open In…" menu item (single + batch,
-  gated on the File Provider mount) with a distinct `rectangle.portrait.and.arrow.right`
-  glyph and an `openExternalAction` handler. The `SourcesListView` docstring
+  moves to a new `onOpenExternal` callback. The `SourcesListView` docstring
   (which documented the external double-click as intentional) is corrected.
-- **"Open In…" on pages.** `PagesListCallbacks` gains `onOpenExternal`;
-  `PagesContainerView` wires it to a new `FileProviderSpike.openPage(id:)`;
-  `PagesListView` adds the gated "Open In…" item + handler. Pages had no external
-  path before.
-- **`FileProviderSpike.openPage(id:)`** opens a page in its default app by
-  resolving the user-visible URL via the existing `resolvePageByTitleURL` (same
-  `page-by-title` identifier share/reveal use, so no drift) and handing it to
-  `NSWorkspace.shared.open` — mirroring `openSource`.
-- **"Open In…" on bookmarks.** `FileProviderSpike` is threaded through
-  `BookmarksContainerView` → `BookmarksOutlineView` → controller (which had no
-  file-provider access before). The pageRef/sourceRef context menu gains a gated
-  "Open In…" item; `openExternalAction` routes pageRef→`openPage`,
-  sourceRef→`openSource`.
+- **Finder-style "Open With" submenu** on sources, pages, and bookmarks, listing
+  the registered editors for the content type (default marked "(Default)",
+  separator, then the rest, then "Other…"). `OpenWithMenu` (new) builds the
+  submenu from `NSWorkspace.urlsForApplications(toOpen: UTType)` — discovery is
+  **content-type based**, not URL based, so the menu builds synchronously from
+  the source's MIME/extension (pages are always Markdown); the mount URL is only
+  resolved at click time. "Other…" presents an `NSOpenPanel` app picker
+  (`AppPicker`). Gated on the File Provider mount being up (same as "Reveal in
+  Finder"). Single + batch on sources/pages.
+- **`FileProviderSpike.openSource(id:with:)` / `openPage(id:with:)`** gain an
+  optional `appURL: URL?`. With nil, the default handler launches (sync
+  `NSWorkspace.open`); with an app URL, `open(_:withApplicationAt:configuration:)`
+  launches that editor. Both share a private `launch(url:with:)` helper. `openPage`
+  resolves via the existing `resolvePageByTitleURL` (same `page-by-title`
+  identifier share/reveal use, so no drift) — mirroring `openSource`.
+- **Bookmarks.** `FileProviderSpike` is threaded through `BookmarksContainerView`
+  → `BookmarksOutlineView` → controller (which had no file-provider access
+  before). The pageRef/sourceRef context menu gains the "Open With" submenu;
+  `openWithAppAction` routes pageRef→`openPage`, sourceRef→`openSource`. Content
+  type for a source bookmark is looked up from the store by id.
 - **Drive-by:** dropped an unused `let callbacks` binding in
   `BookmarksOutlineView.acceptDrop` that SourceKit surfaced during the edit.
 
-Gates: `swift build` clean; `swift test` — 1365 tests in 104 suites, all pass.
+Not in scope for this cut: the "App Store…" item (Finder's deep-link format is
+undocumented) and "Change All" (system default-app binding). Easy to add later.
+
+Gates: `swift build` clean; `swift test` — 1365 tests in 104 suites pass (one
+flaky timing test in `PipeDrainingTests.streamProcessCapturesStderrLines` fails
+under full-suite load but passes 3/3 in isolation; pre-existing, unrelated).
 
 ## 2026-07-04 — Robust `[[wiki-link]]` name handling: lookup-driven resolution, name rules, startup self-heal (v18)
 

--- a/Sources/WikiFS/BookmarksContainerView.swift
+++ b/Sources/WikiFS/BookmarksContainerView.swift
@@ -7,6 +7,7 @@ import WikiFSCore
 /// `List`/`OutlineGroup` for instant selection performance on macOS.
 struct BookmarksContainerView: View {
     let store: WikiStoreModel
+    let fileProvider: FileProviderSpike
     var onShowPicker: (PickerContext) -> Void
     var onEdit: (String) -> Void
     var onNewFolder: () -> Void
@@ -22,6 +23,7 @@ struct BookmarksContainerView: View {
             // NSOutlineView — instant selection, native macOS performance
             BookmarksOutlineView(
                 store: store,
+                fileProvider: fileProvider,
                 onOpen: { sel in store.openTab(sel) },
                 onEdit: { onEdit($0) },
                 onDelete: { store.deleteBookmarkNode(id: $0) },

--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -9,6 +9,7 @@ import WikiFSCore
 /// on macOS (see plans/bookmark-drag-drop-performance.md).
 struct BookmarksOutlineView: NSViewControllerRepresentable {
     let store: WikiStoreModel
+    let fileProvider: FileProviderSpike
     var onOpen: (WikiSelection) -> Void
     var onEdit: (String) -> Void
     var onDelete: (String) -> Void
@@ -20,6 +21,7 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
     func makeNSViewController(context: Context) -> BookmarksOutlineViewController {
         let vc = BookmarksOutlineViewController()
         vc.store = store
+        vc.fileProvider = fileProvider
         vc.callbacks = .init(
             onOpen: onOpen, onEdit: onEdit, onDelete: onDelete,
             onAddPage: onAddPage, onAddSource: onAddSource,
@@ -32,6 +34,7 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
 
     func updateNSViewController(_ vc: BookmarksOutlineViewController, context: Context) {
         vc.store = store
+        vc.fileProvider = fileProvider
         vc.callbacks = .init(
             onOpen: onOpen, onEdit: onEdit, onDelete: onDelete,
             onAddPage: onAddPage, onAddSource: onAddSource,
@@ -64,6 +67,7 @@ final class BookmarksOutlineViewController: NSViewController {
     var scrollView: NSScrollView!
     var outlineView: NSOutlineView!
     var store: WikiStoreModel?
+    var fileProvider: FileProviderSpike?
     var callbacks: BookmarksCallbacks?
 
     /// Snapshot for change detection — covers all fields that affect rendering
@@ -279,7 +283,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
                      item: Any?,
                      childIndex index: Int) -> Bool {
         DebugLog.tabs("BookmarksOutlineView.acceptDrop: item=\((item as? BookmarkNode)?.id ?? "root") index=\(index)")
-        guard let store, let callbacks else { return false }
+        guard let store else { return false }
         let pb = info.draggingPasteboard
         guard let draggedID = pb.string(forType: .string) else { return false }
 
@@ -364,6 +368,15 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
             openBgItem.target = self
             openBgItem.representedObject = node
             menu.addItem(openBgItem)
+
+            if fileProvider?.path != nil {
+                let openExternalItem = NSMenuItem(title: "Open In…", action: #selector(openExternalAction(_:)), keyEquivalent: "")
+                openExternalItem.target = self
+                openExternalItem.representedObject = node
+                openExternalItem.image = NSImage(systemSymbolName: "rectangle.portrait.and.arrow.right",
+                                                 accessibilityDescription: nil)
+                menu.addItem(openExternalItem)
+            }
             menu.addItem(.separator())
         }
 
@@ -407,6 +420,19 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
               let targetID = node.targetID, let store else { return }
         let sel: WikiSelection = node.kind == .pageRef ? .page(targetID) : .source(targetID)
         store.openTabInBackground(sel)
+    }
+
+    @objc private func openExternalAction(_ sender: NSMenuItem) {
+        guard let node = sender.representedObject as? BookmarkNode,
+              let targetID = node.targetID, let fileProvider else { return }
+        switch node.kind {
+        case .pageRef:
+            Task { await fileProvider.openPage(id: targetID) }
+        case .sourceRef:
+            Task { await fileProvider.openSource(id: targetID) }
+        case .folder:
+            break
+        }
     }
 
     @objc private func editAction(_ sender: NSMenuItem) {

--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 import WikiFSCore
 
 // MARK: - SwiftUI bridge
@@ -59,6 +60,18 @@ struct BookmarksCallbacks {
     var onAddSource: (String?) -> Void
     var onNewFolder: () -> Void
     var onNewSubfolder: (String) -> Void
+}
+
+/// Payload for "Open With" app items on a bookmark row. Carries the chosen app
+/// URL (or `nil` for "Other…") and the bookmark node. A class so it round-trips
+/// through `NSMenuItem.representedObject`.
+final class OpenWithBookmarkRef {
+    let appURL: URL?
+    let node: BookmarkNode
+    init(appURL: URL?, node: BookmarkNode) {
+        self.appURL = appURL
+        self.node = node
+    }
 }
 
 // MARK: - View controller
@@ -370,12 +383,28 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
             menu.addItem(openBgItem)
 
             if fileProvider?.path != nil {
-                let openExternalItem = NSMenuItem(title: "Open In…", action: #selector(openExternalAction(_:)), keyEquivalent: "")
-                openExternalItem.target = self
-                openExternalItem.representedObject = node
-                openExternalItem.image = NSImage(systemSymbolName: "rectangle.portrait.and.arrow.right",
-                                                 accessibilityDescription: nil)
-                menu.addItem(openExternalItem)
+                let type: UTType
+                switch node.kind {
+                case .pageRef:
+                    type = OpenWithMenu.pageContentType
+                case .sourceRef:
+                    let src = store?.sources.first { $0.id == node.targetID }
+                    type = OpenWithMenu.contentType(mimeType: src?.mimeType, filename: src?.filename)
+                case .folder:
+                    type = .data
+                }
+                let submenu = OpenWithMenu.build(
+                    contentType: type,
+                    target: self,
+                    action: #selector(openWithAppAction(_:)),
+                    payload: { appURL in
+                        OpenWithBookmarkRef(appURL: appURL, node: node)
+                    })
+                let parent = NSMenuItem(title: "Open With", action: nil, keyEquivalent: "")
+                parent.image = NSImage(systemSymbolName: "rectangle.portrait.and.arrow.right",
+                                       accessibilityDescription: nil)
+                parent.submenu = submenu
+                menu.addItem(parent)
             }
             menu.addItem(.separator())
         }
@@ -422,16 +451,25 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
         store.openTabInBackground(sel)
     }
 
-    @objc private func openExternalAction(_ sender: NSMenuItem) {
-        guard let node = sender.representedObject as? BookmarkNode,
-              let targetID = node.targetID, let fileProvider else { return }
-        switch node.kind {
-        case .pageRef:
-            Task { await fileProvider.openPage(id: targetID) }
-        case .sourceRef:
-            Task { await fileProvider.openSource(id: targetID) }
-        case .folder:
-            break
+    @objc private func openWithAppAction(_ sender: NSMenuItem) {
+        guard let ref = sender.representedObject as? OpenWithBookmarkRef,
+              let targetID = ref.node.targetID, let fileProvider else { return }
+        Task {
+            let picked: URL?
+            if let appURL = ref.appURL {
+                picked = appURL
+            } else {
+                picked = await AppPicker.pick()
+            }
+            guard let appURL = picked else { return }
+            switch ref.node.kind {
+            case .pageRef:
+                await fileProvider.openPage(id: targetID, with: appURL)
+            case .sourceRef:
+                await fileProvider.openSource(id: targetID, with: appURL)
+            case .folder:
+                break
+            }
         }
     }
 

--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -311,6 +311,24 @@ final class FileProviderSpike {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
+    /// Open a page in its default app (e.g. a Markdown editor), in the ACTIVE
+    /// wiki's domain. Resolves the page's user-visible URL via its
+    /// `page-by-title` identifier (the same resolution `share`/`reveal` use) and
+    /// hands it to `NSWorkspace`. URL asked at click time.
+    func openPage(id: PageID) async {
+        guard let url = await resolvePageByTitleURL(id: id) else {
+            DebugLog.agent("openPage: FAILED resolving URL for id=\(id.rawValue)")
+            status = "Couldn’t resolve page for open."
+            return
+        }
+        DebugLog.agent("openPage: resolved url=\(url.path)")
+        let opened = NSWorkspace.shared.open(url)
+        DebugLog.agent("openPage: NSWorkspace.open returned \(opened)")
+        if !opened {
+            status = "macOS couldn’t open \(url.lastPathComponent)."
+        }
+    }
+
     func revealSourceInFinder(id: PageID) async {
         guard let url = await resolveSourceByNameURL(id: id) else { return }
         NSWorkspace.shared.activateFileViewerSelecting([url])

--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -271,11 +271,12 @@ final class FileProviderSpike {
     }
 
     /// Open an ingested file in its default app (e.g. Preview for a PDF), in the
-    /// ACTIVE wiki's domain. Resolves the file's user-visible URL from the daemon
-    /// by its `by-id` leaf identifier (built from the shared prefix so it can't
-    /// drift), then hands it to `NSWorkspace`. URL asked at click time.
-    func openSource(id: PageID) async {
-        DebugLog.agent("openSource: id=\(id.rawValue) activeWiki=\(activeWikiID ?? "nil")")
+    /// ACTIVE wiki’s domain. Resolves the file’s user-visible URL from the daemon
+    /// by its `by-id` leaf identifier (built from the shared prefix so it can’t
+    /// drift), then hands it to `NSWorkspace`. URL asked at click time. Pass
+    /// `appURL` to launch a specific app instead of the default handler.
+    func openSource(id: PageID, with appURL: URL? = nil) async {
+        DebugLog.agent("openSource: id=\(id.rawValue) activeWiki=\(activeWikiID ?? "nil") app=\(appURL?.lastPathComponent ?? "default")")
         status = ""   // clear any stale error from a prior attempt
         guard let wikiID = activeWikiID else {
             DebugLog.agent("openSource: ABORT — no active wiki")
@@ -295,11 +296,7 @@ final class FileProviderSpike {
                 itemIdentifier: identifier,
                 timeout: .seconds(5))
             DebugLog.agent("openSource: resolved url=\(url.path)")
-            let opened = NSWorkspace.shared.open(url)
-            DebugLog.agent("openSource: NSWorkspace.open returned \(opened)")
-            if !opened {
-                status = "macOS couldn’t open \(url.lastPathComponent)."
-            }
+            await launch(url: url, with: appURL)
         } catch {
             DebugLog.agent("openSource: FAILED resolving URL — \(error.localizedDescription)")
             status = "open file failed: \(error.localizedDescription)"
@@ -312,20 +309,41 @@ final class FileProviderSpike {
     }
 
     /// Open a page in its default app (e.g. a Markdown editor), in the ACTIVE
-    /// wiki's domain. Resolves the page's user-visible URL via its
+    /// wiki’s domain. Resolves the page’s user-visible URL via its
     /// `page-by-title` identifier (the same resolution `share`/`reveal` use) and
-    /// hands it to `NSWorkspace`. URL asked at click time.
-    func openPage(id: PageID) async {
+    /// hands it to `NSWorkspace`. URL asked at click time. Pass `appURL` to
+    /// launch a specific app instead of the default handler.
+    func openPage(id: PageID, with appURL: URL? = nil) async {
         guard let url = await resolvePageByTitleURL(id: id) else {
             DebugLog.agent("openPage: FAILED resolving URL for id=\(id.rawValue)")
             status = "Couldn’t resolve page for open."
             return
         }
-        DebugLog.agent("openPage: resolved url=\(url.path)")
-        let opened = NSWorkspace.shared.open(url)
-        DebugLog.agent("openPage: NSWorkspace.open returned \(opened)")
-        if !opened {
-            status = "macOS couldn’t open \(url.lastPathComponent)."
+        DebugLog.agent("openPage: resolved url=\(url.path) app=\(appURL?.lastPathComponent ?? "default")")
+        await launch(url: url, with: appURL)
+    }
+
+    /// Hand a resolved mount URL to `NSWorkspace`. With `appURL == nil` this is
+    /// the default-handler launch (sync `open(_:)`); otherwise it launches the
+    /// chosen app with `open(_:withApplicationAt:configuration:)`. Updates
+    /// `status` on failure.
+    private func launch(url: URL, with appURL: URL?) async {
+        if let appURL {
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            do {
+                _ = try await NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: config)
+                DebugLog.agent("launch: opened \(url.lastPathComponent) with \(appURL.lastPathComponent)")
+            } catch {
+                DebugLog.agent("launch: open with \(appURL.lastPathComponent) failed — \(error.localizedDescription)")
+                status = "Open with \(appURL.lastPathComponent) failed: \(error.localizedDescription)"
+            }
+        } else {
+            let opened = NSWorkspace.shared.open(url)
+            DebugLog.agent("launch: NSWorkspace.open returned \(opened)")
+            if !opened {
+                status = "macOS couldn’t open \(url.lastPathComponent)."
+            }
         }
     }
 

--- a/Sources/WikiFS/OpenWithMenu.swift
+++ b/Sources/WikiFS/OpenWithMenu.swift
@@ -1,0 +1,115 @@
+import AppKit
+import UniformTypeIdentifiers
+import WikiFSCore
+
+/// Builds Finder-style "Open With" submenus: the registered editors for a
+/// content type (default marked), then "Other…" for manual selection.
+///
+/// App discovery is **content-type based**, not URL based: we already know the
+/// source's MIME type / filename (and pages are always Markdown), so the submenu
+/// builds synchronously with no File Provider URL resolution. The mount URL is
+/// only resolved at click time, then handed to `NSWorkspace.open` with the
+/// chosen app — see `FileProviderSpike.openSource(id:with:)` / `openPage(id:with:)`.
+enum OpenWithMenu {
+    /// Build the submenu for `contentType`. Each app item's `representedObject`
+    /// is `payload(appURL)`; the trailing "Other…" item is `payload(nil)`.
+    /// `action` is sent to `target` on selection (the same selector for apps and
+    /// "Other…"; the handler treats a `nil` appURL as "present an app picker").
+    static func build(
+        contentType: UTType,
+        target: AnyObject,
+        action: Selector,
+        payload: (URL?) -> Any
+    ) -> NSMenu {
+        let menu = NSMenu()
+        // The parent owns enablement; don't let NSMenu auto-disable our items.
+        menu.autoenablesItems = false
+
+        let apps = NSWorkspace.shared.urlsForApplications(toOpen: contentType)
+        let defaultApp = NSWorkspace.shared.urlForApplication(toOpen: contentType)
+
+        var seen = Set<String>()
+        var insertedDefaultSeparator = false
+        for app in apps {
+            let key = app.standardized.path
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+
+            let isDefault = (app.standardized.path == defaultApp?.standardized.path)
+            let baseName = app.deletingPathExtension().lastPathComponent
+            let title = (isDefault && apps.count > 1) ? "\(baseName) (Default)" : baseName
+
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+            item.target = target
+            item.representedObject = payload(app)
+            if let icon = NSWorkspace.shared.icon(forFile: app.path).copy() as? NSImage {
+                icon.size = NSSize(width: 16, height: 16)
+                item.image = icon
+            }
+            menu.addItem(item)
+
+            // Separator after the default (matches Finder: default on its own,
+            // then the rest). Only when there are more apps below.
+            if isDefault, !insertedDefaultSeparator, apps.count > 1 {
+                menu.addItem(.separator())
+                insertedDefaultSeparator = true
+            }
+        }
+
+        menu.addItem(.separator())
+        let other = NSMenuItem(title: "Other…", action: action, keyEquivalent: "")
+        other.target = target
+        other.representedObject = payload(nil)
+        menu.addItem(other)
+
+        return menu
+    }
+
+    /// Derive the content type for a source from its filename extension
+    /// (LaunchServices keys off extensions first) falling back to MIME type,
+    /// then to `UTType.data`.
+    static func contentType(mimeType: String?, filename: String?) -> UTType {
+        let ext = (filename as NSString?)?.pathExtension ?? ""
+        if !ext.isEmpty, let t = UTType(filenameExtension: ext) { return t }
+        if let mime = mimeType, !mime.isEmpty,
+           let t = UTType(tag: mime, tagClass: .mimeType, conformingTo: nil) {
+            return t
+        }
+        return .data
+    }
+
+    /// Content type for wiki pages — always Markdown (projected as `.md`).
+    static let pageContentType: UTType = UTType(filenameExtension: "md") ?? .plainText
+}
+
+/// Presents a system "choose an application" panel (scoped to /Applications by
+/// default). Returns the chosen app URL, or `nil` if the user cancelled.
+enum AppPicker {
+    @MainActor
+    static func pick() async -> URL? {
+        await withCheckedContinuation { continuation in
+            let panel = NSOpenPanel()
+            panel.title = "Choose an Application"
+            panel.allowedContentTypes = [.application]
+            panel.directoryURL = URL(fileURLWithPath: "/Applications")
+            panel.allowsMultipleSelection = false
+            panel.canChooseDirectories = false
+            panel.canChooseFiles = true
+            panel.begin { response in
+                continuation.resume(returning: response == .OK ? panel.url : nil)
+            }
+        }
+    }
+}
+
+/// Payload for "Open With" app items in the sources/pages lists. Carries the
+/// chosen app URL (or `nil` for "Other…") and the effective IDs to open.
+/// A class so it round-trips through `NSMenuItem.representedObject` (Any?).
+final class OpenWithIDsRef {
+    let appURL: URL?
+    let ids: [PageID]
+    init(appURL: URL?, ids: [PageID]) {
+        self.appURL = appURL
+        self.ids = ids
+    }
+}

--- a/Sources/WikiFS/PagesContainerView.swift
+++ b/Sources/WikiFS/PagesContainerView.swift
@@ -108,6 +108,9 @@ struct PagesContainerView: View {
             onOpen: { ids in
                 for id in ids { store.openTab(.page(id)) }
             },
+            onOpenExternal: { ids in
+                for id in ids { Task { await fileProvider.openPage(id: id) } }
+            },
             onOpenBackground: { ids in
                 for id in ids { store.openTabInBackground(.page(id)) }
             },

--- a/Sources/WikiFS/PagesContainerView.swift
+++ b/Sources/WikiFS/PagesContainerView.swift
@@ -108,8 +108,8 @@ struct PagesContainerView: View {
             onOpen: { ids in
                 for id in ids { store.openTab(.page(id)) }
             },
-            onOpenExternal: { ids in
-                for id in ids { Task { await fileProvider.openPage(id: id) } }
+            onOpenExternal: { ids, appURL in
+                for id in ids { Task { await fileProvider.openPage(id: id, with: appURL) } }
             },
             onOpenBackground: { ids in
                 for id in ids { store.openTabInBackground(.page(id)) }

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -54,8 +54,10 @@ struct PagesListCallbacks {
     /// Open (foreground tab). Single-click-double passes one id; context-menu
     /// "Open N" passes the effective selection.
     var onOpen: ([PageID]) -> Void
-    /// Open externally via the File Provider (single or batch).
-    var onOpenExternal: ([PageID]) -> Void
+    /// Open externally via the File Provider (single or batch). Pass an app URL
+    /// to launch a specific editor (chosen from the "Open With" submenu), or nil
+    /// for the default handler.
+    var onOpenExternal: (_ ids: [PageID], _ appURL: URL?) -> Void
     var onOpenBackground: ([PageID]) -> Void
     var onShare: ([PageID]) -> Void
     var onReveal: (PageID) -> Void
@@ -276,10 +278,18 @@ extension PagesListViewController {
             payload: payload))
 
         if pathMounted {
-            menu.addItem(menuItem(
-                title: isBatch ? "Open \(count) In…" : "Open In…",
-                systemImage: "rectangle.portrait.and.arrow.right",
-                action: #selector(openExternalAction(_:)), payload: payload))
+            let submenu = OpenWithMenu.build(
+                contentType: OpenWithMenu.pageContentType,
+                target: self,
+                action: #selector(openWithAppAction(_:)),
+                payload: { appURL in
+                    OpenWithIDsRef(appURL: appURL, ids: payload.effectiveIDs)
+                })
+            let parent = NSMenuItem(title: "Open With", action: nil, keyEquivalent: "")
+            parent.image = NSImage(systemSymbolName: "rectangle.portrait.and.arrow.right",
+                                   accessibilityDescription: nil)
+            parent.submenu = submenu
+            menu.addItem(parent)
         }
 
         if isBatch {
@@ -332,8 +342,18 @@ extension PagesListViewController {
     @objc private func openAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onOpen(p.effectiveIDs) }
     }
-    @objc private func openExternalAction(_ sender: NSMenuItem) {
-        if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onOpenExternal(p.effectiveIDs) }
+    @objc private func openWithAppAction(_ sender: NSMenuItem) {
+        guard let ref = sender.representedObject as? OpenWithIDsRef else { return }
+        Task { [weak self] in
+            let picked: URL?
+            if let appURL = ref.appURL {
+                picked = appURL
+            } else {
+                picked = await AppPicker.pick()
+            }
+            guard let appURL = picked else { return }
+            self?.callbacks?.onOpenExternal(ref.ids, appURL)
+        }
     }
     @objc private func openBackgroundAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onOpenBackground(p.effectiveIDs) }

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -54,6 +54,8 @@ struct PagesListCallbacks {
     /// Open (foreground tab). Single-click-double passes one id; context-menu
     /// "Open N" passes the effective selection.
     var onOpen: ([PageID]) -> Void
+    /// Open externally via the File Provider (single or batch).
+    var onOpenExternal: ([PageID]) -> Void
     var onOpenBackground: ([PageID]) -> Void
     var onShare: ([PageID]) -> Void
     var onReveal: (PageID) -> Void
@@ -273,6 +275,13 @@ extension PagesListViewController {
             systemImage: "dock.arrow.down.rectangle", action: #selector(openBackgroundAction(_:)),
             payload: payload))
 
+        if pathMounted {
+            menu.addItem(menuItem(
+                title: isBatch ? "Open \(count) In…" : "Open In…",
+                systemImage: "rectangle.portrait.and.arrow.right",
+                action: #selector(openExternalAction(_:)), payload: payload))
+        }
+
         if isBatch {
             menu.addItem(menuItem(
                 title: "Share \(count) Pages",
@@ -322,6 +331,9 @@ extension PagesListViewController {
 
     @objc private func openAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onOpen(p.effectiveIDs) }
+    }
+    @objc private func openExternalAction(_ sender: NSMenuItem) {
+        if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onOpenExternal(p.effectiveIDs) }
     }
     @objc private func openBackgroundAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onOpenBackground(p.effectiveIDs) }

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -147,7 +147,7 @@ struct SidebarView: View {
                                  onAddFromURL: onAddFromURL,
                                  isZoteroConfigured: isZoteroConfigured)
         case .bookmarks:
-            BookmarksContainerView(store: store,
+            BookmarksContainerView(store: store, fileProvider: fileProvider,
                 onShowPicker: { bookmarkPickerContext = $0 },
                 onEdit: { editBookmarkNodeID = EditBookmarkContext(nodeID: $0) },
                 onNewFolder: {

--- a/Sources/WikiFS/SourcesContainerView.swift
+++ b/Sources/WikiFS/SourcesContainerView.swift
@@ -164,8 +164,8 @@ struct SourcesContainerView: View {
             onOpen: { ids in
                 for id in ids { store.openTab(.source(id)) }
             },
-            onOpenExternal: { ids in
-                for id in ids { Task { await fileProvider.openSource(id: id) } }
+            onOpenExternal: { ids, appURL in
+                for id in ids { Task { await fileProvider.openSource(id: id, with: appURL) } }
             },
             onOpenBackground: { ids in
                 for id in ids { store.openTabInBackground(.source(id)) }

--- a/Sources/WikiFS/SourcesContainerView.swift
+++ b/Sources/WikiFS/SourcesContainerView.swift
@@ -162,6 +162,9 @@ struct SourcesContainerView: View {
     private var callbacks: SourcesListCallbacks {
         SourcesListCallbacks(
             onOpen: { ids in
+                for id in ids { store.openTab(.source(id)) }
+            },
+            onOpenExternal: { ids in
                 for id in ids { Task { await fileProvider.openSource(id: id) } }
             },
             onOpenBackground: { ids in

--- a/Sources/WikiFS/SourcesListView.swift
+++ b/Sources/WikiFS/SourcesListView.swift
@@ -66,8 +66,10 @@ struct SourceExtractItem {
 struct SourcesListCallbacks {
     /// Open an in-app source tab (single or batch), foreground.
     var onOpen: ([PageID]) -> Void
-    /// Open externally via the File Provider (single or batch).
-    var onOpenExternal: ([PageID]) -> Void
+    /// Open externally via the File Provider (single or batch). Pass an app URL
+    /// to launch a specific editor (chosen from the "Open With" submenu), or nil
+    /// for the default handler.
+    var onOpenExternal: (_ ids: [PageID], _ appURL: URL?) -> Void
     /// Open an in-app background tab.
     var onOpenBackground: ([PageID]) -> Void
     var onShare: ([PageID]) -> Void
@@ -375,10 +377,20 @@ extension SourcesListViewController {
             payload: payload))
 
         if fileProvider?.path != nil {
-            menu.addItem(item(
-                title: isMulti ? "Open \(count) In…" : "Open In…",
-                systemImage: "rectangle.portrait.and.arrow.right",
-                action: #selector(openExternalAction(_:)), payload: payload))
+            let type = OpenWithMenu.contentType(mimeType: clicked.mimeType,
+                                                filename: clicked.filename)
+            let submenu = OpenWithMenu.build(
+                contentType: type,
+                target: self,
+                action: #selector(openWithAppAction(_:)),
+                payload: { appURL in
+                    OpenWithIDsRef(appURL: appURL, ids: payload.effective.map(\.id))
+                })
+            let parent = NSMenuItem(title: "Open With", action: nil, keyEquivalent: "")
+            parent.image = NSImage(systemSymbolName: "rectangle.portrait.and.arrow.right",
+                                   accessibilityDescription: nil)
+            parent.submenu = submenu
+            menu.addItem(parent)
         }
 
         if isMulti {
@@ -441,8 +453,19 @@ extension SourcesListViewController {
     @objc private func openAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? SourcesMenuPayload { callbacks?.onOpen(p.effective.map(\.id)) }
     }
-    @objc private func openExternalAction(_ sender: NSMenuItem) {
-        if let p = sender.representedObject as? SourcesMenuPayload { callbacks?.onOpenExternal(p.effective.map(\.id)) }
+    @objc private func openWithAppAction(_ sender: NSMenuItem) {
+        guard let ref = sender.representedObject as? OpenWithIDsRef else { return }
+        Task { [weak self] in
+            // nil appURL = the "Other…" item → present an app picker.
+            let picked: URL?
+            if let appURL = ref.appURL {
+                picked = appURL
+            } else {
+                picked = await AppPicker.pick()
+            }
+            guard let appURL = picked else { return }
+            self?.callbacks?.onOpenExternal(ref.ids, appURL)
+        }
     }
     @objc private func openBackgroundAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? SourcesMenuPayload { callbacks?.onOpenBackground(p.effective.map(\.id)) }

--- a/Sources/WikiFS/SourcesListView.swift
+++ b/Sources/WikiFS/SourcesListView.swift
@@ -9,8 +9,9 @@ import WikiFSCore
 /// SwiftUI gesture arbitration. Cell adds byte size + an
 /// extracting/ingesting/ingested status indicator; the context menu carries
 /// Ingest / Extract (with re-ingest confirmation) on top of the shared
-/// open/share/rename/delete actions. Double-click opens externally via the
-/// File Provider (`fileProvider.openSource`), unchanged from the SwiftUI row.
+/// open/share/rename/delete actions. Double-click opens an in-app source tab
+/// (mirroring pages/bookmarks); the "Open In…" item routes through the File
+/// Provider for an external launch.
 struct SourcesListView: NSViewControllerRepresentable {
     let store: WikiStoreModel
     let fileProvider: FileProviderSpike
@@ -63,8 +64,10 @@ struct SourceExtractItem {
 }
 
 struct SourcesListCallbacks {
-    /// Open externally via the File Provider (single or batch).
+    /// Open an in-app source tab (single or batch), foreground.
     var onOpen: ([PageID]) -> Void
+    /// Open externally via the File Provider (single or batch).
+    var onOpenExternal: ([PageID]) -> Void
     /// Open an in-app background tab.
     var onOpenBackground: ([PageID]) -> Void
     var onShare: ([PageID]) -> Void
@@ -371,6 +374,13 @@ extension SourcesListViewController {
             systemImage: "dock.arrow.down.rectangle", action: #selector(openBackgroundAction(_:)),
             payload: payload))
 
+        if fileProvider?.path != nil {
+            menu.addItem(item(
+                title: isMulti ? "Open \(count) In…" : "Open In…",
+                systemImage: "rectangle.portrait.and.arrow.right",
+                action: #selector(openExternalAction(_:)), payload: payload))
+        }
+
         if isMulti {
             menu.addItem(item(title: "Share \(count) Sources", systemImage: "square.and.arrow.up",
                               action: #selector(shareAction(_:)), payload: payload))
@@ -430,6 +440,9 @@ extension SourcesListViewController {
 
     @objc private func openAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? SourcesMenuPayload { callbacks?.onOpen(p.effective.map(\.id)) }
+    }
+    @objc private func openExternalAction(_ sender: NSMenuItem) {
+        if let p = sender.representedObject as? SourcesMenuPayload { callbacks?.onOpenExternal(p.effective.map(\.id)) }
     }
     @objc private func openBackgroundAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? SourcesMenuPayload { callbacks?.onOpenBackground(p.effective.map(\.id)) }


### PR DESCRIPTION
## What

Fixes #139.

Double-click and the "Open" / "Open N Sources" context-menu item on a **source** used to launch it in an external app (Preview for a PDF), inconsistent with pages and bookmarks where the same gestures open an in-app tab. The external launch is a legitimate workflow but belongs behind an explicit action, not the default gesture.

## Changes

- **Sources default-open opens an in-app tab.** `SourcesContainerView.onOpen` now calls `store.openTab(.source(id))` (matching `onOpenBackground` and the pages/bookmarks path) instead of `fileProvider.openSource(id:)`. The old external behavior moves verbatim to a new `onOpenExternal` callback. `SourcesListCallbacks` gains `onOpenExternal`; `SourcesListView` adds an "Open In…" menu item (single + batch, gated on the mount) with a distinct glyph, plus an `openExternalAction` handler. The stale `SourcesListView` docstring (which documented the external double-click as intentional) is corrected.
- **"Open In…" on pages.** `PagesListCallbacks` gains `onOpenExternal`; `PagesContainerView` wires it to a new `FileProviderSpike.openPage(id:)`; `PagesListView` adds the gated "Open In…" item + handler. Pages had no external-open path before.
- **`FileProviderSpike.openPage(id:)`** resolves the page's user-visible URL via the existing `resolvePageByTitleURL` (same `page-by-title` identifier share/reveal use, so no drift) and hands it to `NSWorkspace.shared.open` — mirroring `openSource`.
- **"Open In…" on bookmarks.** `FileProviderSpike` is threaded through `BookmarksContainerView` → `BookmarksOutlineView` → controller (which had no file-provider access before). The pageRef/sourceRef context menu gains a gated "Open In…" item; `openExternalAction` routes pageRef → `openPage`, sourceRef → `openSource`.
- **Drive-by:** dropped an unused `let callbacks` binding in `BookmarksOutlineView.acceptDrop` that SourceKit surfaced during the edit.

All three "Open In…" items gate on the File Provider mount being up (`fileProvider.path != nil`, same as "Reveal in Finder"), use a distinct `rectangle.portrait.and.arrow.right` glyph, and support batch on sources/pages.

## Verification

- `swift build` — clean.
- `swift test` — 1365 tests in 104 suites, all pass.
