### PR TITLE
fix(tabs): focus new tab when Open in Background fires on empty bar (#138)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,22 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-04 — "Open in Background" focuses the tab when the bar is empty (#138)
+
+"Open in Background" appended a tab without activating it — correct when other
+tabs exist, but a no-op when the bar was empty (nothing stayed focused, so the
+user clicked and saw no visible change). Fixes
+[#138](https://github.com/tqbf/selfdrivingwiki/issues/138).
+
+- **`WikiStoreModel.openTabInBackground`** now delegates to `openTab` when
+  `tabs.isEmpty`, so the first tab is opened *and* activated instead of appended
+  to an empty bar. Non-empty-bar behavior is unchanged (background = keep current
+  focus). All five call sites (`SourcesContainerView`, `PagesContainerView`,
+  `BookmarksOutlineView`, `WikiLinkMenuNSItems`, `WikiReaderView`) route through
+  this single method, so no view changes were needed.
+- **Regression test** `backgroundOpenOnEmptyBarFocusesTheNewTab` in
+  `EditorTabTests` asserts the empty-bar path sets `activeTabID` to the new tab.
+
 ## 2026-07-04 — Sources default-open opens an in-app tab; "Open With" submenu for external editors (#139)
 
 The default-open gestures on **sources** (double-click + the "Open" / "Open N

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -450,7 +450,16 @@ public final class WikiStoreModel {
     /// Open a tab for `selection` without switching focus to it. If a tab for
     /// `selection` is already open, this is a no-op (avoid duplicates). The
     /// active tab remains unchanged; the new tab appears at the end of the bar.
+    ///
+    /// When the tab bar is empty there is nothing to keep focused, so "background"
+    /// would leave the user on a dead surface with no signal the action fired.
+    /// Fall back to the foreground path (`openTab`) so the first tab is opened
+    /// and focused like a normal Open.
     public func openTabInBackground(_ selection: WikiSelection, title: String? = nil) {
+        if tabs.isEmpty {
+            openTab(selection, title: title)
+            return
+        }
         guard !tabs.contains(where: { $0.selection == selection }) else { return }
         let tab = EditorTab(selection: selection, title: title ?? tabTitle(for: selection))
         tabs.append(tab)

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -829,4 +829,21 @@ struct EditorTabTests {
         #expect(model.tabs.count == 2)
         #expect(model.tabs.map(\.title).sorted() == ["A", "B"])
     }
+
+    @Test func backgroundOpenOnEmptyBarFocusesTheNewTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        // No tabs open yet — "Open in Background" has nothing to keep focused,
+        // so it must fall back to opening AND activating the tab (issue #138).
+        #expect(model.tabs.isEmpty)
+        #expect(model.activeTabID == nil)
+
+        model.openTabInBackground(.page(a.id))
+
+        #expect(model.tabs.count == 1)
+        #expect(model.tabs.first?.selection == .page(a.id))
+        #expect(model.activeTabID == model.tabs.first?.id)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #138.

"Open in Background" created a tab but never focused it — correct when other tabs exist ("background" = keep current focus), but a no-op when the tab bar was empty. With nothing to keep focused, the new tab was appended to an empty bar and the user saw no visible change from the action.

## Change

`WikiStoreModel.openTabInBackground` now falls back to the foreground path (`openTab`) when `tabs.isEmpty`, so the first tab is opened **and** activated instead of appended to an empty bar. Non-empty-bar behavior is unchanged.

All five call sites route through this single method, so no view changes were needed:
- `SourcesContainerView`
- `PagesContainerView`
- `BookmarksOutlineView`
- `WikiLinkMenuNSItems`
- `WikiReaderView`

## Root cause

`openTabInBackground` appended a tab but never called `setActiveTab`:

```swift
// Sources/WikiFSCore/WikiStoreModel.swift
public func openTabInBackground(_ selection: WikiSelection, title: String? = nil) {
    guard !tabs.contains(where: { $0.selection == selection }) else { return }
    let tab = EditorTab(selection: selection, title: title ?? tabTitle(for: selection))
    tabs.append(tab)
    // ← never activated; correct when tabs is non-empty, a dead end when empty
}
```

## Test plan

- [x] New regression test `backgroundOpenOnEmptyBarFocusesTheNewTab` asserts the empty-bar path sets `activeTabID` to the new tab.
- [x] `swift test --filter EditorTabTests` — 51/51 pass (including pre-existing background-open tests, which still assert non-empty-bar behavior is unchanged).
- [x] `swift build` clean.
