### PR TITLE
feat(tabs): drag sidebar rows onto the welcome screen to open them (#133)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,41 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-04 — Drag sidebar rows onto the welcome screen to open them (#133)
+
+The welcome/empty-state screen only accepted external **file** drops (URL
+ingest). Sidebar rows (pages, sources, bookmarks) weren't draggable at all.
+Now any of them can be dragged onto the welcome screen to open its detail view
+directly, instead of requiring a sidebar click. Implements
+[#133](https://github.com/tqbf/selfdrivingwiki/issues/133).
+
+- **`SidebarDragPayload`** (`WikiFSCore`, new) — a `Codable` value carrying a
+  `kind` (page/source) + id, with a computed `selection: WikiSelection`. Kept in
+  the model layer (no `Transferable`) so it's unit-testable; the app layer adds
+  the `Transferable` conformance + a programmatic `UTType.wikiSidebarItem`
+  (`exportedAs:conformingTo: .data`). No Info.plist UTType registration — the
+  payload only round-trips within the process, matched by identifier string.
+- **Drag sources** — `PagesListView`/`SourcesListView` gain
+  `pasteboardWriterForRow` (returning a custom `NSPasteboardWriting` with the
+  payload JSON) plus `.copy` local drag-source mask.
+  `BookmarksOutlineView.pasteboardWriterForItem` now dual-registers: the
+  `.string` node id (so intra-tree **reorder** keeps working — `acceptDrop`
+  reads `pb.string(forType: .string)`) AND the resolved-target payload
+  (`pageRef`→page, `sourceRef`→source). Folders carry the node id only.
+  Bookmarks resolve to what they point at at drag-start, so the drop target
+  doesn't need to know bookmarks exist.
+- **Drop target** — `WikiDetailView`'s welcome (`.none`) case gets
+  `.dropDestination(for: SidebarDragPayload.self)` that calls
+  `store.openTab(payload.selection)`. It's the innermost drop target, so it
+  takes priority over the window-level URL-ingest destination for sidebar
+  payloads; URL drops still fall through to ingest. A subtle accent tint
+  highlights the drop zone while targeted.
+- **Tests** — `SidebarDragPayloadTests` (Codable round-trip + selection
+  mapping) and `SidebarDragPasteboardBridgeTests` (pasteboard-level bridge:
+  writer → `NSPasteboard` → decodable JSON, including the bookmark
+  dual-representation and folder node-id-only cases). 1378-test suite green
+  except for one pre-existing flake in unrelated pdf-pipe code.
+
 ## 2026-07-04 — Sources default-open opens an in-app tab; "Open With" submenu for external editors (#139)
 
 The default-open gestures on **sources** (double-click + the "Open" / "Open N

--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -265,10 +265,22 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
         return node.kind == .folder
     }
 
-    // Drag and drop
+    // Drag and drop.
+    // The writer carries TWO representations so one drag can serve two drop
+    // targets: the `.string` node id powers intra-tree reorder (`acceptDrop`
+    // reads `pb.string(forType: .string)`), and the resolved-target payload lets
+    // the row be dropped onto the welcome screen to open whatever the bookmark
+    // points at (issue #133). Folders have no target, so they carry only the
+    // reorder id.
     func outlineView(_ outlineView: NSOutlineView, pasteboardWriterForItem item: Any) -> NSPasteboardWriting? {
         guard let node = item as? BookmarkNode else { return nil }
-        return node.id as NSString
+        var payload: SidebarDragPayload?
+        if let targetID = node.targetID,
+           node.kind == .pageRef || node.kind == .sourceRef {
+            let kind: SidebarDragPayload.Kind = (node.kind == .pageRef) ? .page : .source
+            payload = SidebarDragPayload(kind: kind, id: targetID.rawValue)
+        }
+        return SidebarDragPasteboardItem(payload: payload, bookmarkNodeID: node.id)
     }
 
     func outlineView(_ outlineView: NSOutlineView,

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -107,6 +107,12 @@ final class PagesListViewController: NSViewController {
         tableView.backgroundColor = .clear
         tableView.doubleAction = #selector(onDoubleClick)
         tableView.target = self
+        // Implementing `pasteboardWriterForRow` opts the table into drag-out; the
+        // source operation mask still has to be set explicitly or the default
+        // (empty/multi-bit) mask blocks the drag from starting. `.copy` because
+        // dragging a page row onto the welcome screen opens a reference, not a
+        // move (the row isn't removed).
+        tableView.setDraggingSourceOperationMask(.copy, forLocal: true)
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("page"))
         tableView.addTableColumn(column)
@@ -179,6 +185,11 @@ final class PagesListViewController: NSViewController {
 
 extension PagesListViewController: NSTableViewDataSource {
     func numberOfRows(in tableView: NSTableView) -> Int { items.count }
+
+    func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
+        guard row >= 0, row < items.count else { return nil }
+        return SidebarDragPayload(kind: .page, id: items[row].id.rawValue).makePasteboardWriter()
+    }
 }
 
 // MARK: - Delegate

--- a/Sources/WikiFS/SidebarDragPayloadTransferable.swift
+++ b/Sources/WikiFS/SidebarDragPayloadTransferable.swift
@@ -1,0 +1,79 @@
+import AppKit
+import CoreTransferable
+import UniformTypeIdentifiers
+import WikiFSCore
+
+/// App-layer `Transferable` conformance for `SidebarDragPayload`, plus the
+/// pasteboard wiring. Kept out of `WikiFSCore` so the model layer stays
+/// UI-framework-agnostic; the AppKit drag sources and the SwiftUI drop target
+/// (both in this target) share these definitions.
+extension SidebarDragPayload: Transferable {
+    public static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .wikiSidebarItem)
+    }
+
+    /// An `NSPasteboardWriting` carrying this payload as JSON, suitable for
+    /// returning from an `NSTableView`/`NSOutlineView` pasteboard-writer
+    /// callback. (`NSItemProvider` is not `NSPasteboardWriting` on this SDK, so
+    /// the AppKit drag source needs a real writer object; the SwiftUI
+    /// `.dropDestination(for: SidebarDragPayload.self)` reads the JSON back via
+    /// the matching `CodableRepresentation`.)
+    func makePasteboardWriter() -> NSPasteboardWriting {
+        SidebarDragPasteboardItem(payload: self)
+    }
+}
+
+extension UTType {
+    /// Internal pasteboard identifier for a sidebar drag payload. The AppKit
+    /// drag source writes JSON under this identifier; the SwiftUI
+    /// `.dropDestination(for: SidebarDragPayload.self)` reads it back via the
+    /// matching `CodableRepresentation`. Both sides reference the same identifier
+    /// string, so it round-trips within the process without an Info.plist
+    /// `UTExportedTypeDeclarations` entry.
+    static let wikiSidebarItem = UTType(
+        exportedAs: "com.selfdrivingwiki.sidebar-item",
+        conformingTo: .data
+    )
+}
+
+/// `NSPasteboardWriting` for a sidebar drag. Carries the resolved-target payload
+/// (page/source) and, for bookmark rows, the node id as `.string` so the existing
+/// intra-tree reorder (`BookmarksOutlineView.acceptDrop` reads
+/// `pb.string(forType: .string)`) keeps working alongside the welcome-screen
+/// drop. Bookmark folders pass a nil payload (no target to open).
+final class SidebarDragPasteboardItem: NSObject {
+    let payload: SidebarDragPayload?
+    let bookmarkNodeID: String?
+
+    init(payload: SidebarDragPayload? = nil, bookmarkNodeID: String? = nil) {
+        self.payload = payload
+        self.bookmarkNodeID = bookmarkNodeID
+    }
+
+    private var sidebarType: NSPasteboard.PasteboardType {
+        NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
+    }
+}
+
+extension SidebarDragPasteboardItem: NSPasteboardWriting {
+    func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
+        var types: [NSPasteboard.PasteboardType] = []
+        if bookmarkNodeID != nil { types.append(.string) }
+        if payload != nil { types.append(sidebarType) }
+        return types
+    }
+
+    func pasteboardPropertyList(forType type: NSPasteboard.PasteboardType) -> Any? {
+        if type == .string { return bookmarkNodeID }
+        if type == sidebarType, let payload,
+           let data = try? JSONEncoder().encode(payload) {
+            return data as NSData
+        }
+        return nil
+    }
+
+    func writingOptions(forType type: NSPasteboard.PasteboardType,
+                        pasteboard: NSPasteboard) -> NSPasteboard.WritingOptions {
+        []
+    }
+}

--- a/Sources/WikiFS/SourcesListView.swift
+++ b/Sources/WikiFS/SourcesListView.swift
@@ -243,6 +243,9 @@ final class SourcesListViewController: NSViewController {
         tableView.backgroundColor = .clear
         tableView.doubleAction = #selector(onDoubleClick)
         tableView.target = self
+        // Enable drag-out (see PagesListView for the mask rationale). `.copy`
+        // because dragging a source row opens a reference rather than moving it.
+        tableView.setDraggingSourceOperationMask(.copy, forLocal: true)
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("source"))
         tableView.addTableColumn(column)
@@ -309,6 +312,11 @@ final class SourcesListViewController: NSViewController {
 
 extension SourcesListViewController: NSTableViewDataSource {
     func numberOfRows(in tableView: NSTableView) -> Int { items.count }
+
+    func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
+        guard row >= 0, row < items.count else { return nil }
+        return SidebarDragPayload(kind: .source, id: items[row].id.rawValue).makePasteboardWriter()
+    }
 }
 
 // MARK: - Delegate

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -18,6 +18,10 @@ struct WikiDetailView: View {
     let isZoteroConfigured: Bool
     @Environment(\.addURLHandler) private var addURLHandler
 
+    /// Highlights the welcome screen as a drop target while an internal
+    /// sidebar row (page/source/bookmark) is dragged over it.
+    @State private var isSidebarDropTargeted = false
+
     var body: some View {
         switch store.selection {
         case .none:
@@ -95,6 +99,22 @@ struct WikiDetailView: View {
                 }
                 .padding(.horizontal, 40)
                 .frame(maxWidth: .infinity)
+            }
+            .background {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.accentColor.opacity(isSidebarDropTargeted ? 0.08 : 0))
+            }
+            // Accept an internal sidebar drag (page/source, or a bookmark
+            // resolved to its target) and open it as a tab. This is the innermost
+            // drop target, so it takes priority over the window-level URL ingest
+            // destination in ContentView for sidebar-item payloads. URL drops
+            // (external files) still fall through to ingest.
+            .dropDestination(for: SidebarDragPayload.self) { payloads, _ in
+                guard let payload = payloads.first else { return false }
+                store.openTab(payload.selection)
+                return true
+            } isTargeted: { targeted in
+                isSidebarDropTargeted = targeted
             }
         case .ask:
             QueryConversationView(

--- a/Sources/WikiFSCore/SidebarDragPayload.swift
+++ b/Sources/WikiFSCore/SidebarDragPayload.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Internal drag payload for a sidebar row dragged onto the welcome screen
+/// (issue #133). Carries just enough to resolve the drop to a `WikiSelection`:
+/// a kind (page or source) and the target's stable id.
+///
+/// This type lives in the model layer (no `Transferable` conformance here) so it
+/// can be unit-tested directly; the app layer adds the `Transferable` conformance
+/// plus the pasteboard wiring. It is `Codable` so the AppKit drag source and the
+/// SwiftUI drop destination round-trip the value through JSON on the pasteboard.
+///
+/// Bookmarks are not a kind here: a bookmark row resolves to whatever it points at
+/// (a page or a source) at drag-start time, then carries that resolved kind+id —
+/// so the drop target doesn't need to know bookmarks exist.
+public struct SidebarDragPayload: Codable, Sendable, Hashable {
+    public enum Kind: String, Sendable, Codable {
+        case page
+        case source
+    }
+
+    /// Whether the target is a page or a source.
+    public let kind: Kind
+    /// `PageID.rawValue` of the target page/source.
+    public let id: String
+
+    public init(kind: Kind, id: String) {
+        self.kind = kind
+        self.id = id
+    }
+
+    /// The selection the drop target should open.
+    public var selection: WikiSelection {
+        let pageID = PageID(rawValue: id)
+        switch kind {
+        case .page:   return .page(pageID)
+        case .source: return .source(pageID)
+        }
+    }
+}

--- a/Tests/WikiFSTests/SidebarDragPasteboardBridgeTests.swift
+++ b/Tests/WikiFSTests/SidebarDragPasteboardBridgeTests.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+@testable import WikiFSCore
+@testable import WikiFS
+
+/// Verifies the AppKit→SwiftUI drag bridge at the pasteboard level: an
+/// `NSPasteboardWriting` produced by the sidebar lists must put valid JSON under
+/// the sidebar-item type identifier (so SwiftUI's `.dropDestination(for:)` can
+/// decode it), and the bookmark writer must keep the `.string` node id for
+/// intra-tree reorder alongside the payload.
+@MainActor
+struct SidebarDragPasteboardBridgeTests {
+
+    private func write(_ writer: NSPasteboardWriting) -> NSPasteboard {
+        let pb = NSPasteboard(name: .init("sidebar-drag-test"))
+        pb.clearContents()
+        pb.writeObjects([writer])
+        return pb
+    }
+
+    private var sidebarType: NSPasteboard.PasteboardType {
+        NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
+    }
+
+    @Test func pageWriterRoundTripsThroughPasteboard() throws {
+        let payload = SidebarDragPayload(kind: .page, id: "page-1")
+        let pb = write(payload.makePasteboardWriter())
+
+        let data = try #require(pb.data(forType: sidebarType))
+        let decoded = try JSONDecoder().decode(SidebarDragPayload.self, from: data)
+        #expect(decoded == payload)
+        // A page row must not advertise a reorder id (no bookmark node).
+        #expect(pb.string(forType: .string) == nil)
+    }
+
+    @Test func sourceWriterRoundTripsThroughPasteboard() throws {
+        let payload = SidebarDragPayload(kind: .source, id: "src-9")
+        let pb = write(payload.makePasteboardWriter())
+
+        let decoded = try JSONDecoder().decode(
+            SidebarDragPayload.self,
+            from: try #require(pb.data(forType: sidebarType))
+        )
+        #expect(decoded == payload)
+    }
+
+    @Test func bookmarkRefCarriesBothNodeIDAndPayload() throws {
+        let payload = SidebarDragPayload(kind: .page, id: "page-7")
+        let pb = write(SidebarDragPasteboardItem(payload: payload, bookmarkNodeID: "node-42"))
+
+        // Intra-tree reorder reads this (BookmarksOutlineView.acceptDrop).
+        #expect(pb.string(forType: .string) == "node-42")
+        // The welcome-screen drop reads this.
+        let decoded = try JSONDecoder().decode(
+            SidebarDragPayload.self,
+            from: try #require(pb.data(forType: sidebarType))
+        )
+        #expect(decoded == payload)
+    }
+
+    @Test func bookmarkFolderCarriesNodeIDOnly() {
+        // A folder has no target to open, so it carries only the reorder id.
+        let pb = write(SidebarDragPasteboardItem(payload: nil, bookmarkNodeID: "folder-1"))
+
+        #expect(pb.string(forType: .string) == "folder-1")
+        #expect(pb.data(forType: sidebarType) == nil)
+    }
+
+    @Test func bookmarkRefResolvesToSourceTarget() throws {
+        // A sourceRef bookmark must resolve to kind=.source in the payload.
+        let payload = SidebarDragPayload(kind: .source, id: "src-3")
+        let pb = write(SidebarDragPasteboardItem(payload: payload, bookmarkNodeID: "node-99"))
+
+        let decoded = try JSONDecoder().decode(
+            SidebarDragPayload.self,
+            from: try #require(pb.data(forType: sidebarType))
+        )
+        #expect(decoded.kind == .source)
+    }
+}

--- a/Tests/WikiFSTests/SidebarDragPayloadTests.swift
+++ b/Tests/WikiFSTests/SidebarDragPayloadTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+@Test func sidebarDragPayloadRoundTripsThroughJSON_page() throws {
+    let payload = SidebarDragPayload(kind: .page, id: "01JKKK PAGE")
+    let encoded = try JSONEncoder().encode(payload)
+    let decoded = try JSONDecoder().decode(SidebarDragPayload.self, from: encoded)
+
+    #expect(decoded == payload)
+    #expect(decoded.kind == .page)
+    #expect(decoded.id == "01JKKK PAGE")
+}
+
+@Test func sidebarDragPayloadRoundTripsThroughJSON_source() throws {
+    let payload = SidebarDragPayload(kind: .source, id: "01HK SOURCE")
+    let encoded = try JSONEncoder().encode(payload)
+    let decoded = try JSONDecoder().decode(SidebarDragPayload.self, from: encoded)
+
+    #expect(decoded.kind == .source)
+    #expect(decoded.id == "01HK SOURCE")
+}
+
+@Test func sidebarDragPayloadSelection_page() {
+    let payload = SidebarDragPayload(kind: .page, id: "abc123")
+    #expect(payload.selection == .page(PageID(rawValue: "abc123")))
+}
+
+@Test func sidebarDragPayloadSelection_source() {
+    let payload = SidebarDragPayload(kind: .source, id: "xyz789")
+    #expect(payload.selection == .source(PageID(rawValue: "xyz789")))
+}
+
+/// The pasteboard JSON carries a stable, human-readable shape: the enum cases
+/// encode as their raw string ("page"/"source"), not numeric indices, so a drag
+/// started by one build can be decoded by another without index drift.
+@Test func sidebarDragPayloadKindEncodesAsRawString() throws {
+    let payload = SidebarDragPayload(kind: .source, id: "x")
+    let encoded = try JSONEncoder().encode(payload)
+
+    guard let json = try JSONSerialization.jsonObject(with: encoded) as? [String: String] else {
+        Issue.record("expected a flat string-keyed JSON object")
+        return
+    }
+    #expect(json["kind"] == "source")
+    #expect(json["id"] == "x")
+}


### PR DESCRIPTION
## Summary

Implements #133.

The welcome/empty-state screen only accepted external **file** drops (URL ingest) — no sidebar row was draggable. Now pages, sources, and bookmarks can be dragged onto the welcome screen to open their detail view directly, instead of requiring a sidebar click.

## What changed

**New payload type — `SidebarDragPayload` (`WikiFSCore`)**
A `Codable` value carrying a `kind` (`.page` / `.source`) and an id, with a computed `selection: WikiSelection`. Kept in the model layer (no `Transferable`) so it's unit-testable; the app layer (`WikiFS`) adds the `Transferable` conformance plus a programmatic `UTType.wikiSidebarItem` (`exportedAs:conformingTo: .data`). No Info.plist UTType registration is needed — the payload only round-trips within the process, matched by identifier string.

**Drag sources (AppKit)**
- `PagesListView` / `SourcesListView`: implement `pasteboardWriterForRow` returning a custom `NSPasteboardWriting` (`SidebarDragPasteboardItem`) that writes the payload as JSON, and set the local drag-source mask to `.copy`.
- `BookmarksOutlineView.pasteboardWriterForItem`: dual-registers **two** representations on one drag — the `.string` node id (so intra-tree **reorder** keeps working; `acceptDrop` reads `pb.string(forType: .string)`) AND the resolved-target payload. `pageRef`→page, `sourceRef`→source; folders carry the node id only.

Bookmarks resolve to what they point at **at drag-start**, so the drop target doesn't need to know bookmarks exist.

**Drop target (SwiftUI)**
`WikiDetailView`'s welcome (`.none`) case gains `.dropDestination(for: SidebarDragPayload.self)` that calls `store.openTab(payload.selection)`. It's the innermost drop target, so it takes priority over the window-level URL-ingest destination for sidebar payloads; external URL/file drops still fall through to ingest. A subtle accent tint highlights the drop zone while targeted.

## Why the AppKit + custom-writer approach

All three sidebar lists are `NSTableView`/`NSOutlineView` (not SwiftUI `List`), so `.draggable` isn't available — drag-out goes through `pasteboardWriterForRowAt/Item`. `NSItemProvider` is **not** `NSPasteboardWriting` on this SDK, so the source is a small `NSObject + NSPasteboardWriting` wrapper. There's no public `Transferable → NSItemProvider` bridge, so the AppKit side writes raw JSON under the custom UTType identifier and the SwiftUI side reads it back via `CodableRepresentation` — they meet on the identifier string.

## Test plan

- [x] `SidebarDragPayloadTests` — Codable round-trip + selection mapping (page/source); `Kind` encodes as raw string (build-stable across versions).
- [x] `SidebarDragPasteboardBridgeTests` — pasteboard-level bridge: writer → `NSPasteboard` → decodable JSON, for pages, sources, bookmark refs (both `.string` + payload), and folders (node id only, no payload).
- [x] `swift build` clean.
- [x] Full suite (1378 tests) green except one pre-existing flake in unrelated pdf-extraction pipe code (`PdfExtractionServiceTests.streamProcessCapturesStderrLines`, passes in isolation).
- [ ] **Manual check needed** (I can't drive the mouse): drag a page / source / bookmark row onto the welcome screen and confirm the detail view opens. Drag a bookmark within the Bookmarks tree and confirm reorder still works.

## Files

- `Sources/WikiFSCore/SidebarDragPayload.swift` (new)
- `Sources/WikiFS/SidebarDragPayloadTransferable.swift` (new)
- `Sources/WikiFS/PagesListView.swift`, `SourcesListView.swift`, `BookmarksOutlineView.swift`, `WikiDetailView.swift`
- `Tests/WikiFSTests/SidebarDragPayloadTests.swift` (new), `SidebarDragPasteboardBridgeTests.swift` (new)
