### PR TITLE
Add streaming to chat

### DIFF
--- a/Sources/WikiFS/AgentActivityView.swift
+++ b/Sources/WikiFS/AgentActivityView.swift
@@ -119,7 +119,7 @@ private enum ActivityMetrics {
 extension AgentEvent {
     var isInternalTranscriptEvent: Bool {
         switch self {
-        case .systemInit, .toolUse, .toolResult, .subagent, .raw, .messageStop:
+        case .systemInit, .toolUse, .toolResult, .subagent, .raw, .messageStop, .assistantTextDelta:
             true
         case .userText, .assistantText, .result:
             false

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -149,6 +149,11 @@ final class AgentLauncher {
     /// Carries-over bytes from a stdout read that ended mid-line, so the parser only
     /// ever sees complete NDJSON lines.
     private var stdoutLineBuffer = ""
+    /// True while the last row in `events` is an in-progress `.assistantText` row
+    /// being grown by streamed `.assistantTextDelta` chunks (issue #121). Reset by
+    /// any other event (a tool call, a turn boundary, …) so unrelated `.assistantText`
+    /// rows are never merged together.
+    private var isStreamingAssistantRow = false
     /// Append-only handle to the per-run `run.jsonl` (raw stream-json).
     private var logHandle: FileHandle?
     /// Append-only handle to the per-run `run.stderr.log`.
@@ -1037,6 +1042,7 @@ final class AgentLauncher {
     func resetActivityIfIdle() {
         guard !isRunning && !isExtracting else { return }
         events = []
+        isStreamingAssistantRow = false
         rawTranscript = ""
         stderr = ""
         stdoutLineBuffer = ""
@@ -1062,7 +1068,7 @@ final class AgentLauncher {
             let line = String(stdoutLineBuffer[..<newlineIndex])
             stdoutLineBuffer.removeSubrange(...newlineIndex)
             if let event = AgentEventParser.parse(line: line) {
-                events.append(event)
+                mergeOrAppend(event)
                 // `.result` fires at session end (one-shot runs, or when the
                 // interactive session terminates). `.messageStop` fires at the
                 // end of EACH turn in an interactive session — Claude emits it
@@ -1091,6 +1097,39 @@ final class AgentLauncher {
         }
     }
 
+    /// Route one parsed event into `events`: either grow the in-progress streamed
+    /// assistant row in place, or append a new row (the existing, non-streaming
+    /// behavior). This is what lets `AgentTranscriptWebView` patch a live row
+    /// instead of only ever appending (issue #121).
+    private func mergeOrAppend(_ event: AgentEvent) {
+        switch event {
+        case .assistantTextDelta(let delta):
+            if isStreamingAssistantRow, case .assistantText(let existing) = events.last {
+                events[events.count - 1] = .assistantText(existing + delta)
+            } else {
+                events.append(.assistantText(delta))
+                isStreamingAssistantRow = true
+            }
+
+        case .assistantText:
+            // The complete/final text for a block already being streamed — replace
+            // the in-progress row with the authoritative full text rather than
+            // appending a duplicate. Any other `.assistantText` (no streaming in
+            // flight, e.g. a run without `--include-partial-messages`) appends as
+            // it always has.
+            if isStreamingAssistantRow, case .assistantText = events.last {
+                events[events.count - 1] = event
+            } else {
+                events.append(event)
+            }
+            isStreamingAssistantRow = false
+
+        default:
+            events.append(event)
+            isStreamingAssistantRow = false
+        }
+    }
+
     /// Append a raw stderr chunk: surface it in `stderr`, mirror to the transcript +
     /// `run.stderr.log`.
     private func ingestStderr(_ chunk: String) {
@@ -1113,7 +1152,7 @@ final class AgentLauncher {
         watchdogTask = nil
         if !stdoutLineBuffer.isEmpty {
             if let event = AgentEventParser.parse(line: stdoutLineBuffer) {
-                events.append(event)
+                mergeOrAppend(event)
             }
             stdoutLineBuffer = ""
         }
@@ -1165,6 +1204,7 @@ final class AgentLauncher {
         watchdogTask?.cancel()
         watchdogTask = nil
         events = []
+        isStreamingAssistantRow = false
         rawTranscript = ""
         stderr = ""
         stdoutLineBuffer = ""

--- a/Sources/WikiFS/AgentTranscriptWebView.swift
+++ b/Sources/WikiFS/AgentTranscriptWebView.swift
@@ -13,12 +13,14 @@ import WikiFSCore
 /// sibling one — every message was an island. Folding the whole feed into one
 /// document removes that boundary entirely.
 ///
-/// `events` is expected to be append-only except for an explicit reset to
-/// `[]` (`AgentLauncher.events`'s contract): new events are inserted into the
-/// live DOM via `appendRows` rather than a full reload, so an in-progress
-/// text selection survives a streaming run. A count *decrease* (a reset) or a
-/// `showsInternals` change (which changes which underlying events are
-/// visible) forces a full rebuild.
+/// `events` is expected to only grow in length, or have its LAST element mutated
+/// in place (a streamed text delta merged into an in-progress `.assistantText`,
+/// issue #121), except for an explicit reset to `[]` (`AgentLauncher.events`'s
+/// contract): new events are inserted into the live DOM via `appendRows`, and an
+/// in-place growth of the last row is patched via `replaceLastRow`, rather than a
+/// full reload — so an in-progress text selection survives a streaming run. A
+/// count *decrease* (a reset) or a `showsInternals` change (which changes which
+/// underlying events are visible) forces a full rebuild.
 struct AgentTranscriptWebView: NSViewRepresentable {
     /// `.activityFeed` is the inspector look (labeled rows, tool calls,
     /// diagnostics). `.chat` is the Query page look (right-aligned capsule
@@ -73,10 +75,15 @@ struct AgentTranscriptWebView: NSViewRepresentable {
         private var renderedShowsInternals: Bool?
         private var isLoaded = false
         private var pendingEvents: [AgentEvent] = []
+        /// The last event actually rendered, so `apply` can detect "no new row, but
+        /// `AgentLauncher` grew the last one in place" (a streamed `.assistantText`
+        /// delta merge, issue #121) and patch that row instead of no-op'ing.
+        private var renderedLastEvent: AgentEvent?
 
         func reload(events: [AgentEvent], showsInternals: Bool) {
             renderedCount = 0
             renderedShowsInternals = showsInternals
+            renderedLastEvent = nil
             isLoaded = false
             pendingEvents = events
             webView?.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
@@ -95,9 +102,20 @@ struct AgentTranscriptWebView: NSViewRepresentable {
                 reload(events: events, showsInternals: showsInternals)
                 return
             }
-            guard events.count > renderedCount else { return }
+            guard events.count > renderedCount else {
+                // Same row count: `AgentLauncher` may have grown the last row in
+                // place (streamed text deltas merged into an in-progress
+                // `.assistantText`, issue #121) rather than appending a new one —
+                // patch that row's HTML instead of treating this as a no-op.
+                if let last = events.last, last != renderedLastEvent {
+                    replaceLastRow(last)
+                    renderedLastEvent = last
+                }
+                return
+            }
             appendRows(Array(events[renderedCount...]))
             renderedCount = events.count
+            renderedLastEvent = events.last
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -108,6 +126,7 @@ struct AgentTranscriptWebView: NSViewRepresentable {
                 appendRows(toRender)
             }
             renderedCount = toRender.count
+            renderedLastEvent = toRender.last
         }
 
         /// Open external links in the default browser instead of navigating
@@ -143,6 +162,17 @@ struct AgentTranscriptWebView: NSViewRepresentable {
                   let jsonString = String(data: data, encoding: .utf8)
             else { return }
             webView?.evaluateJavaScript("appendRows(\(jsonString))", completionHandler: nil)
+        }
+
+        /// Re-render the already-rendered last row in place (a streaming delta grew
+        /// its content without adding a new `AgentEvent`) instead of appending a
+        /// duplicate — the DOM equivalent of `apply`'s same-count branch.
+        private func replaceLastRow(_ event: AgentEvent) {
+            let html = Self.rowHTML(for: event, style: style)
+            guard let data = try? JSONSerialization.data(withJSONObject: html, options: [.fragmentsAllowed]),
+                  let jsonString = String(data: data, encoding: .utf8)
+            else { return }
+            webView?.evaluateJavaScript("replaceLastRow(\(jsonString))", completionHandler: nil)
         }
 
         // MARK: - Row rendering
@@ -195,8 +225,8 @@ struct AgentTranscriptWebView: NSViewRepresentable {
                 return """
                 <div class="row row-result\(isError ? " is-error" : "")"><div class="row-label">\(label)</div>\(bodyHTML)</div>
                 """
-            case .messageStop:
-                return ""  // internal — not rendered
+            case .messageStop, .assistantTextDelta:
+                return ""  // internal — not rendered (deltas are merged into `.assistantText` upstream)
             case .raw(let line):
                 return "<pre class=\"row row-raw\">\(escape(line))</pre>"
             }
@@ -223,7 +253,7 @@ struct AgentTranscriptWebView: NSViewRepresentable {
                 return """
                 <div class="row chat-row chat-assistant"><div class="bubble">\(renderedMarkdown(text))</div></div>
                 """
-            case .systemInit, .toolUse, .toolResult, .subagent, .messageStop, .raw:
+            case .systemInit, .toolUse, .toolResult, .subagent, .messageStop, .raw, .assistantTextDelta:
                 return ""
             }
         }
@@ -322,6 +352,14 @@ struct AgentTranscriptWebView: NSViewRepresentable {
         <script>
           function appendRows(html) {
             document.body.insertAdjacentHTML('beforeend', html);
+            window.scrollTo(0, document.body.scrollHeight);
+          }
+          function replaceLastRow(html) {
+            if (document.body.lastElementChild) {
+              document.body.lastElementChild.outerHTML = html;
+            } else {
+              document.body.insertAdjacentHTML('beforeend', html);
+            }
             window.scrollTo(0, document.body.scrollHeight);
           }
         </script>

--- a/Sources/WikiFS/QueryConversationView.swift
+++ b/Sources/WikiFS/QueryConversationView.swift
@@ -232,7 +232,7 @@ struct QueryConversationView: View {
                 return true
             case .assistantText(let text), .result(_, let text):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            case .systemInit, .toolUse, .toolResult, .subagent, .messageStop, .raw:
+            case .systemInit, .toolUse, .toolResult, .subagent, .messageStop, .raw, .assistantTextDelta:
                 return false
             }
         }

--- a/Sources/WikiFSCore/AgentEvent.swift
+++ b/Sources/WikiFSCore/AgentEvent.swift
@@ -20,6 +20,15 @@ public enum AgentEvent: Equatable, Sendable {
     /// A block of assistant prose (`assistant` message → `text` content block).
     case assistantText(String)
 
+    /// One incremental chunk of assistant prose (`stream_event` →
+    /// `content_block_delta` → `text_delta`), emitted only when the run requests
+    /// `--include-partial-messages`. Never stored in `AgentLauncher.events` directly —
+    /// `AgentLauncher` merges each delta into the in-progress `.assistantText` row (or
+    /// starts one) so the transcript keeps its "one row per turn" shape while still
+    /// growing incrementally (issue #121). Not rendered on its own; treated as
+    /// internal/not-directly-renderable like `.messageStop`.
+    case assistantTextDelta(String)
+
     /// The agent invoked a tool (`assistant` message → `tool_use` content block).
     /// `inputSummary` is a concise human-readable rendering of the tool's input
     /// (e.g. a `Bash` command, a `Read` path) so the line reads like
@@ -69,6 +78,8 @@ public enum AgentEvent: Equatable, Sendable {
             return "Started · \(model)"
         case .assistantText(let text):
             return text
+        case .assistantTextDelta:
+            return ""  // internal — merged into `.assistantText` before it's rendered
         case .toolUse(let name, let inputSummary):
             return inputSummary.isEmpty ? name : "\(name)  \(inputSummary)"
         case .toolResult(let isError, let summary):
@@ -112,9 +123,11 @@ public enum AgentEvent: Equatable, Sendable {
 /// not a guess: a `system`/`init` event, `assistant` messages whose `content` holds
 /// `text` and `tool_use` blocks, `user` messages whose `content` holds
 /// `tool_result` blocks, and a final `result` event with `is_error`. Partial-message
-/// `stream_event` deltas and other bookkeeping types (`rate_limit_event`,
-/// `system`/`status`) are intentionally NOT surfaced — the complete `assistant`/`user`
-/// events carry the same content cleanly, so deltas would only duplicate noise.
+/// `stream_event` → `content_block_delta` → `text_delta` chunks are surfaced as
+/// `.assistantTextDelta` (issue #121 — the interactive chat path needs them to
+/// stream incrementally instead of buffering); other bookkeeping types
+/// (`rate_limit_event`, `system`/`status`, non-text-delta `stream_event`s) are still
+/// NOT surfaced.
 public enum AgentEventParser {
     /// Parse one NDJSON line into an `AgentEvent`. Never throws: an empty line
     /// returns `nil` (skip it); anything that fails to decode into a known shape
@@ -167,11 +180,27 @@ public enum AgentEventParser {
         case "message_stop":
             return .messageStop
 
+        case "stream_event":
+            return streamEventDelta(from: envelope)
+
         default:
-            // Unmodeled event types (stream_event deltas, status, rate_limit_event,
-            // post_turn_summary, …) are not rendered as their own lines.
+            // Unmodeled event types (status, rate_limit_event, post_turn_summary, …)
+            // are not rendered as their own lines.
             return nil
         }
+    }
+
+    /// Map a `stream_event` envelope to a text delta. Only `content_block_delta` →
+    /// `text_delta` is modeled — other inner event kinds (`message_start`,
+    /// `content_block_start`/`_stop`, `input_json_delta` for streamed tool input,
+    /// `message_delta`) carry nothing the transcript renders, so they fall through
+    /// to `nil` same as any other unmodeled line.
+    private static func streamEventDelta(from envelope: Envelope) -> AgentEvent? {
+        guard let inner = envelope.event, inner.type == "content_block_delta",
+              let delta = inner.delta, delta.type == "text_delta",
+              let text = delta.text, !text.isEmpty
+        else { return nil }
+        return .assistantTextDelta(text)
     }
 
     // MARK: - Content-block mapping
@@ -230,11 +259,26 @@ extension AgentEventParser {
         let description: String?
         let status: String?
         let summary: String?
+        // Present on `stream_event` lines: the nested partial-message event.
+        let event: StreamEvent?
 
         enum CodingKeys: String, CodingKey {
-            case type, subtype, model, message, result, description, status, summary
+            case type, subtype, model, message, result, description, status, summary, event
             case isError = "is_error"
             case subagentType = "subagent_type"
+        }
+    }
+
+    /// The `event` payload of a `stream_event` line — `{"type":"content_block_delta",
+    /// "delta":{"type":"text_delta","text":"…"}}` is the only shape we render;
+    /// other inner types decode with `delta == nil` and are ignored by the caller.
+    private struct StreamEvent: Decodable {
+        let type: String
+        let delta: Delta?
+
+        struct Delta: Decodable {
+            let type: String
+            let text: String?
         }
     }
 

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -182,6 +182,7 @@ public struct OperationCommand: Equatable, Sendable {
             "--input-format", "stream-json",
             "--output-format", "stream-json",
             "--verbose",
+            "--include-partial-messages",
             "--model", model,
             "--append-system-prompt", systemPrompt + "\n\n" + operation.prompt(wikiRoot: wikiRoot),
             // Scope the agent to wikictl + read-only inspection tools (issue #116 item 3),

--- a/Tests/WikiFSTests/AgentEventParserTests.swift
+++ b/Tests/WikiFSTests/AgentEventParserTests.swift
@@ -109,16 +109,31 @@ struct AgentEventParserTests {
     }
 
     @Test func unmodeledEventTypesAreSkipped() {
-        // stream_event deltas, status, rate_limit_event, post_turn_summary carry no
-        // line of their own — they return nil rather than cluttering the feed.
+        // status, rate_limit_event, post_turn_summary, and non-text-delta
+        // stream_events carry no line of their own — they return nil rather than
+        // cluttering the feed. (Text deltas ARE modeled — see
+        // `contentBlockTextDeltaBecomesAssistantTextDelta` below, issue #121.)
         for line in [
-            #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"he"}}}"#,
+            #"{"type":"stream_event","event":{"type":"content_block_start"}}"#,
+            #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{"}}}"#,
             #"{"type":"rate_limit_event"}"#,
             #"{"type":"system","subtype":"status"}"#,
             #"{"type":"system","subtype":"post_turn_summary"}"#,
         ] {
             #expect(AgentEventParser.parse(line: line) == nil)
         }
+    }
+
+    // MARK: - Partial-message streaming (issue #121)
+
+    @Test func contentBlockTextDeltaBecomesAssistantTextDelta() {
+        let line = #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"he"}}}"#
+        #expect(AgentEventParser.parse(line: line) == .assistantTextDelta("he"))
+    }
+
+    @Test func emptyTextDeltaIsSkipped() {
+        let line = #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":""}}}"#
+        #expect(AgentEventParser.parse(line: line) == nil)
     }
 
     @Test func assistantWithNoRenderableBlockIsSkipped() {

--- a/Tests/WikiFSTests/OperationCommandTests.swift
+++ b/Tests/WikiFSTests/OperationCommandTests.swift
@@ -154,6 +154,9 @@ struct OperationCommandTests {
     let outputIndex = cmd.arguments.firstIndex(of: "--output-format")!
     #expect(cmd.arguments[outputIndex + 1] == "stream-json")
     #expect(cmd.arguments.contains("--verbose"))
+    // issue #121: without this flag the CLI never emits stream_event/content_block_delta
+    // for the interactive chat path, so Ask/Edit responses buffer instead of streaming.
+    #expect(cmd.arguments.contains("--include-partial-messages"))
     #expect(cmd.arguments.contains("--allowed-tools"))
     #expect(!cmd.arguments.contains("--dangerously-skip-permissions"))
     #expect(!cmd.arguments.contains { $0.hasPrefix("Question:") })


### PR DESCRIPTION
Fixes https://github.com/tqbf/selfdrivingwiki/issues/121

★ Insight ─────────────────────────────────────
The trickiest part here wasn’t the parsing — it was the “row” abstraction leaking across three layers (parser → AgentLauncher.events → WKWebView DOM), each with its own append-only assumption baked in as an invariant (a doc comment, a count-based diff, insertAdjacentHTML('beforeend')). Fixing streaming required threading one new concept (“the last row can grow in place”) consistently through all three without breaking any of their existing exhaustive-switch or identity assumptions.
─────────────────────────────────────────────────

Implemented issue #121 end to end:
1.
OperationCommand.buildInteractiveQuery now passes --include-partial-messages, so the CLI actually emits stream_event/content_block_delta deltas for Ask/Edit chat (previously only build() requested this).
2.
AgentEventParser decodes stream_event → content_block_delta → text_delta into a new AgentEvent.assistantTextDelta(String) case instead of silently dropping it.
3.
AgentLauncher gained a mergeOrAppend step: a delta grows the in-progress 
[.assistantText](paseo://app/h/srv_1dK8dOWytkYf/workspace/.assistantText)
 row in place (tracked via isStreamingAssistantRow); the eventual complete assistant event replaces that row with the authoritative full text instead of duplicating it; any other event (tool call, turn boundary) resets the streaming flag so unrelated rows never get merged.
4.
AgentTranscriptWebView’s Coordinator.apply gained a same-count branch that detects the last row grew and calls a new replaceLastRow JS function (outerHTML swap) instead of no-op’ing, so the DOM updates incrementally as text streams in.