### PR TITLE
fix(tabs): sidebar drag-drop onto detail tabs and the WKWebView body (#133)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,40 +2,48 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-## 2026-07-04 — Drag sidebar rows onto the welcome screen to open them (#133)
+## 2026-07-04 — Drag sidebar rows onto the welcome screen or any detail tab to open it (#133)
 
-The welcome/empty-state screen only accepted external **file** drops (URL
-ingest). Sidebar rows (pages, sources, bookmarks) weren't draggable at all.
-Now any of them can be dragged onto the welcome screen to open its detail view
-directly, instead of requiring a sidebar click. Implements
-[#133](https://github.com/tqbf/selfdrivingwiki/issues/133).
+Sidebar rows (pages, sources, bookmarks) weren't draggable. Now any of them can
+be dragged onto the welcome screen **or onto any open detail tab** (including
+the rendered markdown body) to open its target as a new focused tab.
+Implements [#133](https://github.com/tqbf/selfdrivingwiki/issues/133).
 
 - **`SidebarDragPayload`** (`WikiFSCore`, new) — a `Codable` value carrying a
   `kind` (page/source) + id, with a computed `selection: WikiSelection`. Kept in
   the model layer (no `Transferable`) so it's unit-testable; the app layer adds
-  the `Transferable` conformance + a programmatic `UTType.wikiSidebarItem`
-  (`exportedAs:conformingTo: .data`). No Info.plist UTType registration — the
-  payload only round-trips within the process, matched by identifier string.
+  `Transferable` + a `UTType.wikiSidebarItem` declared in the app's Info.plist
+  (`UTExportedTypeDeclarations`, conforms to `public.item`). The Info.plist
+  declaration is mandatory — without it, AppKit can't match the drag to the drop
+  target and the gesture silently no-ops.
 - **Drag sources** — `PagesListView`/`SourcesListView` gain
-  `pasteboardWriterForRow` (returning a custom `NSPasteboardWriting` with the
-  payload JSON) plus `.copy` local drag-source mask.
-  `BookmarksOutlineView.pasteboardWriterForItem` now dual-registers: the
-  `.string` node id (so intra-tree **reorder** keeps working — `acceptDrop`
-  reads `pb.string(forType: .string)`) AND the resolved-target payload
-  (`pageRef`→page, `sourceRef`→source). Folders carry the node id only.
-  Bookmarks resolve to what they point at at drag-start, so the drop target
-  doesn't need to know bookmarks exist.
-- **Drop target** — `WikiDetailView`'s welcome (`.none`) case gets
-  `.dropDestination(for: SidebarDragPayload.self)` that calls
-  `store.openTab(payload.selection)`. It's the innermost drop target, so it
-  takes priority over the window-level URL-ingest destination for sidebar
-  payloads; URL drops still fall through to ingest. A subtle accent tint
-  highlights the drop zone while targeted.
-- **Tests** — `SidebarDragPayloadTests` (Codable round-trip + selection
-  mapping) and `SidebarDragPasteboardBridgeTests` (pasteboard-level bridge:
-  writer → `NSPasteboard` → decodable JSON, including the bookmark
-  dual-representation and folder node-id-only cases). 1378-test suite green
-  except for one pre-existing flake in unrelated pdf-pipe code.
+  `pasteboardWriterForRow` (a custom `NSPasteboardWriting` carrying the payload
+  JSON) + `.copy` local drag-source mask. `BookmarksOutlineView` dual-registers
+  the `.string` node id (intra-tree **reorder** still works) AND the
+  resolved-target payload (`pageRef`→page, `sourceRef`→source); folders carry
+  the node id only. Bookmarks resolve at drag-start, so the drop target is
+  bookmark-agnostic.
+- **Drop target — SwiftUI chrome** — `WikiDetailView` wraps its whole
+  `detailContent` in `.dropDestination(for: SidebarDragPayload.self)` →
+  `store.openTab(payload.selection)`. Covers the welcome screen, header, and
+  banners. Innermost target, so URL/file drops still fall through to the
+  window-level ingest destination.
+- **Drop target — WKWebView body** — the rendered markdown is a `WKWebView`, and
+  SwiftUI's `.dropDestination` does NOT receive drags over an embedded
+  `NSViewRepresentable`'s NSView (AppKit delivers them into the web view's own
+  subtree). So `WikiReaderWebView` is itself the `NSDraggingDestination` for its
+  body: it overrides `registerForDraggedTypes` to register ONLY the sidebar-item
+  type, plus `draggingEntered`/`draggingUpdated`/`performDragOperation` to decode
+  the payload and call `store.openTab`. WebKit's internal subviews still register
+  their own broad types for web-content drag/drop, but a sidebar payload doesn't
+  conform to those, so AppKit walks up to the WKWebView subclass. This is the
+  fix that made drops work on the markdown body, not just the top portion.
+- **Tests** — `SidebarDragPayloadTests` (Codable round-trip + selection mapping)
+  and `SidebarDragPasteboardBridgeTests` (pasteboard-level bridge: writer →
+  `NSPasteboard` → decodable JSON, including the bookmark dual-representation and
+  folder node-id-only cases). Full 1378-test suite green. Live DnD verified via
+  `os_log` traces: drops land on the welcome screen, the SwiftUI chrome, and the
+  WKWebView markdown body.
 
 ## 2026-07-04 — Sources default-open opens an in-app tab; "Open With" submenu for external editors (#139)
 

--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -280,6 +280,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             let kind: SidebarDragPayload.Kind = (node.kind == .pageRef) ? .page : .source
             payload = SidebarDragPayload(kind: kind, id: targetID.rawValue)
         }
+        DebugLog.tabs("[drag] bookmark pasteboardWriterForItem node=\(node.id) kind=\(node.kind) hasPayload=\(payload != nil)")
         return SidebarDragPasteboardItem(payload: payload, bookmarkNodeID: node.id)
     }
 

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -188,7 +188,9 @@ extension PagesListViewController: NSTableViewDataSource {
 
     func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
         guard row >= 0, row < items.count else { return nil }
-        return SidebarDragPayload(kind: .page, id: items[row].id.rawValue).makePasteboardWriter()
+        let id = items[row].id.rawValue
+        DebugLog.tabs("[drag] page pasteboardWriterForRow row=\(row) id=\(id)")
+        return SidebarDragPayload(kind: .page, id: id).makePasteboardWriter()
     }
 }
 

--- a/Sources/WikiFS/SidebarDragPayloadTransferable.swift
+++ b/Sources/WikiFS/SidebarDragPayloadTransferable.swift
@@ -27,12 +27,19 @@ extension UTType {
     /// Internal pasteboard identifier for a sidebar drag payload. The AppKit
     /// drag source writes JSON under this identifier; the SwiftUI
     /// `.dropDestination(for: SidebarDragPayload.self)` reads it back via the
-    /// matching `CodableRepresentation`. Both sides reference the same identifier
-    /// string, so it round-trips within the process without an Info.plist
-    /// `UTExportedTypeDeclarations` entry.
+    /// matching `CodableRepresentation`.
+    ///
+    /// Conforms to `public.item` (the root), NOT `public.data`: WKWebView and its
+    /// private internal subviews auto-register broad types like `public.data` and
+    /// re-register them asynchronously after load. Since AppKit routes a drag to
+    /// the deepest descendant whose registered types the drag conforms to, a
+    /// `public.data`-conforming payload gets intercepted by the WKWebView
+    /// rendering the markdown body. A sibling under `public.item` doesn't conform
+    /// to any of those broad types, so the drag bubbles past the WKWebView to the
+    /// SwiftUI drop target (#133).
     static let wikiSidebarItem = UTType(
         exportedAs: "com.selfdrivingwiki.sidebar-item",
-        conformingTo: .data
+        conformingTo: .item
     )
 }
 

--- a/Sources/WikiFS/SourcesListView.swift
+++ b/Sources/WikiFS/SourcesListView.swift
@@ -315,7 +315,9 @@ extension SourcesListViewController: NSTableViewDataSource {
 
     func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
         guard row >= 0, row < items.count else { return nil }
-        return SidebarDragPayload(kind: .source, id: items[row].id.rawValue).makePasteboardWriter()
+        let id = items[row].id.rawValue
+        DebugLog.tabs("[drag] source pasteboardWriterForRow row=\(row) id=\(id)")
+        return SidebarDragPayload(kind: .source, id: id).makePasteboardWriter()
     }
 }
 

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -23,6 +23,28 @@ struct WikiDetailView: View {
     @State private var isSidebarDropTargeted = false
 
     var body: some View {
+        detailContent
+            // Accept an internal sidebar drag anywhere in the detail column —
+            // dropping a page/source/bookmark onto the welcome screen OR onto any
+            // open detail tab opens it as a tab and focuses it (openTab reuses an
+            // existing tab if one is already open). Innermost drop target, so
+            // URL/file drops still fall through to the window-level ingest
+            // destination in ContentView.
+            .dropDestination(for: SidebarDragPayload.self) { payloads, _ in
+                guard let payload = payloads.first else {
+                    DebugLog.tabs("[drop] detail action fired with NO payload")
+                    return false
+                }
+                DebugLog.tabs("[drop] detail action fired: kind=\(payload.kind) id=\(payload.id)")
+                store.openTab(payload.selection)
+                return true
+            } isTargeted: { targeted in
+                isSidebarDropTargeted = targeted
+            }
+    }
+
+    @ViewBuilder
+    private var detailContent: some View {
         switch store.selection {
         case .none:
             ScrollView {
@@ -103,18 +125,6 @@ struct WikiDetailView: View {
             .background {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(Color.accentColor.opacity(isSidebarDropTargeted ? 0.08 : 0))
-            }
-            // Accept an internal sidebar drag (page/source, or a bookmark
-            // resolved to its target) and open it as a tab. This is the innermost
-            // drop target, so it takes priority over the window-level URL ingest
-            // destination in ContentView for sidebar-item payloads. URL drops
-            // (external files) still fall through to ingest.
-            .dropDestination(for: SidebarDragPayload.self) { payloads, _ in
-                guard let payload = payloads.first else { return false }
-                store.openTab(payload.selection)
-                return true
-            } isTargeted: { targeted in
-                isSidebarDropTargeted = targeted
             }
         case .ask:
             QueryConversationView(

--- a/Sources/WikiFS/WikiReaderView.swift
+++ b/Sources/WikiFS/WikiReaderView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 import WebKit
 import WikiFSCore
 
@@ -322,6 +323,40 @@ final class WikiReaderWebView: WKWebView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Handle sidebar drag-and-drop directly on the WKWebView. SwiftUI's
+    /// `.dropDestination` overlay covers the SwiftUI chrome (header, banners) and
+    /// the welcome screen, but it does NOT cover the AppKit WKWebView's own frame
+    /// — so drops on the rendered markdown body never reach the SwiftUI target
+    /// (#133). The WKWebView subclass is the drop target for its own body:
+    /// register ONLY the sidebar-item type, and AppKit routes a sidebar drag over
+    /// the body here (WebKit's internal subviews still register their own broad
+    /// types for web-content drag/drop, but a sidebar payload doesn't conform to
+    /// those, so they don't match and the drag bubbles up to this view).
+    override func registerForDraggedTypes(_ newTypes: [NSPasteboard.PasteboardType]) {
+        super.registerForDraggedTypes([NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)])
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        sidebarPayload(from: sender.draggingPasteboard) == nil ? [] : .copy
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        sidebarPayload(from: sender.draggingPasteboard) == nil ? [] : .copy
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let payload = sidebarPayload(from: sender.draggingPasteboard) else { return false }
+        DebugLog.tabs("[drop] wikiReader body action fired: kind=\(payload.kind) id=\(payload.id)")
+        store?.openTab(payload.selection)
+        return true
+    }
+
+    private func sidebarPayload(from pb: NSPasteboard) -> SidebarDragPayload? {
+        let type = NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
+        guard let data = pb.data(forType: type) else { return nil }
+        return try? JSONDecoder().decode(SidebarDragPayload.self, from: data)
+    }
 
     override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
         super.willOpenMenu(menu, with: event)

--- a/build.sh
+++ b/build.sh
@@ -194,6 +194,33 @@ cat > "${CONTENTS}/Info.plist" <<PLIST
 	<!-- Per-developer ids read at runtime by WikiIdentifiers (Bundle.main path). -->
 	<key>WIKIAppGroupID</key><string>${APP_GROUP}</string>
 	<key>WIKIFileProviderID</key><string>${EXT_BUNDLE_ID}</string>
+	<!-- Internal pasteboard type for sidebar drag-and-drop onto the welcome
+	     screen / detail view (#133). Conforms to public.item (NOT public.data):
+	     WKWebView and its internal subviews auto-register broad types like
+	     public.data and re-register them after load, which intercepts any
+	     payload that conforms to public.data before SwiftUI's dropDestination
+	     sees it. A sibling under public.item doesn't conform to those broad
+	     types, so sidebar drags bubble past the WKWebView to the drop target. -->
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.selfdrivingwiki.sidebar-item</string>
+			<key>UTTypeDescription</key>
+			<string>Self Driving Wiki sidebar item</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.item</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sdw-sidebar-item</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## Summary

Implements #133. Drag any sidebar row (page, source, or bookmark) onto the **welcome screen, any open detail tab, or the rendered markdown body** to open its target as a new focused tab.

## What changed

**Payload type — `SidebarDragPayload` (`WikiFSCore`)**
A `Codable` kind + id resolving to a `WikiSelection`. The app layer adds `Transferable` + a `UTType.wikiSidebarItem` declared in the app bundle's Info.plist (`UTExportedTypeDeclarations`, conforms to `public.item`).

**Drag sources (AppKit `NSTableView`/`NSOutlineView`)**
- `PagesListView` / `SourcesListView`: `pasteboardWriterForRow` returns a custom `NSPasteboardWriting` (`SidebarDragPasteboardItem`) carrying the payload JSON; `.copy` local drag-source mask.
- `BookmarksOutlineView`: dual-registers the `.string` node id (intra-tree **reorder** still works — `acceptDrop` reads `pb.string(forType: .string)`) AND the resolved-target payload. Folders carry the node id only. Bookmarks resolve to their target at drag-start.

**Drop target — SwiftUI chrome (`WikiDetailView`)**
`.dropDestination(for: SidebarDragPayload.self)` wraps the entire `detailContent`, so drops land on the welcome screen, page header, banners — anywhere except the embedded WKWebView. Calls `store.openTab(payload.selection)`.

**Drop target — WKWebView body (`WikiReaderWebView`)**
SwiftUI's `.dropDestination` does NOT receive drags over an embedded `NSViewRepresentable`'s NSView — AppKit delivers them into the web view's own subtree. So the `WKWebView` subclass is itself the `NSDraggingDestination` for its body: it overrides `registerForDraggedTypes` to register ONLY the sidebar-item type, plus `draggingEntered`/`draggingUpdated`/`performDragOperation` to decode the payload and call `store.openTab`. WebKit's internal subviews register broad types for web-content drag/drop, but a sidebar payload doesn't conform to those, so AppKit walks up to the subclass.

## Why these three pieces are all required

1. **Info.plist UTType declaration** — without LaunchServices registration, AppKit can't match the drag to the drop target and the gesture silently no-ops. (Verified by hosted introspection: SwiftUI registered `public.data` instead of the specific identifier until the type was declared.)
2. **Wrapper `.dropDestination`** — covers all the SwiftUI-rendered detail area (welcome screen + chrome).
3. **WKWebView `NSDraggingDestination`** — covers the rendered markdown body, which the SwiftUI drop target structurally cannot see.

## Test plan

- [x] `SidebarDragPayloadTests` — Codable round-trip + selection mapping (page/source); `Kind` encodes as raw string.
- [x] `SidebarDragPasteboardBridgeTests` — pasteboard-level bridge: writer → `NSPasteboard` → decodable JSON, including the bookmark dual-representation and folder node-id-only cases.
- [x] `swift build` clean; full **1378-test suite green**.
- [x] **Live DnD verified via `os_log` traces** — drops land on the welcome screen (`[drop] detail action fired`), the SwiftUI chrome, and the WKWebView markdown body (`[drop] wikiReader body action fired`), for both pages and sources.
