### PR TITLE
fix(sources): fall back to leading H1 heading for display name

### DIFF
--- a/Sources/WikiFSCore/DisplayNameResolver.swift
+++ b/Sources/WikiFSCore/DisplayNameResolver.swift
@@ -8,8 +8,9 @@ import Foundation
 /// Priority order:
 /// 1. Zotero item title (when the source came from Zotero)
 /// 2. Markdown front matter `title` (for `.md` / `text/markdown` files)
-/// 3. PDF document title (via PDFKit metadata)
-/// 4. `nil` — caller uses the filename
+/// 3. Markdown leading `# ` ATX heading (when front matter is absent or has no `title`)
+/// 4. PDF document title (via PDFKit metadata)
+/// 5. `nil` — caller uses the filename
 ///
 /// The Zotero + markdown paths are pure Foundation. The PDF-title step needs
 /// PDFKit, which transitively links **AppKit** — forbidden in the read-only
@@ -50,10 +51,15 @@ public enum DisplayNameResolver {
             return zoteroTitle
         }
 
-        // 2. Markdown front matter title.
-        if isMarkdown(filename: filename, mimeType: mimeType),
-           let title = extractMarkdownTitle(from: data) {
-            return title
+        // 2. Markdown front matter title, falling back to a leading H1 heading
+        //    when front matter is absent or has no `title:` key.
+        if isMarkdown(filename: filename, mimeType: mimeType) {
+            if let title = extractMarkdownTitle(from: data) {
+                return title
+            }
+            if let heading = extractMarkdownHeading(from: data) {
+                return heading
+            }
         }
 
         // 3. PDF document title (via the injectable extractor — nil-returning
@@ -163,6 +169,42 @@ public enum DisplayNameResolver {
         }
 
         return nil
+    }
+
+    // MARK: - Markdown leading heading
+
+    /// Extract the text of a leading `# ` ATX heading — the first non-blank
+    /// line of content (after skipping past any front-matter block, whether
+    /// or not it had a `title:` key). Deeper headings (`##` and beyond) do
+    /// not count; the heading must be the first line of content.
+    static func extractMarkdownHeading(from data: Data) -> String? {
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        var lines = ArraySlice(text.components(separatedBy: .newlines))
+
+        // Skip leading blank lines.
+        while let first = lines.first, first.trimmingCharacters(in: .whitespaces).isEmpty {
+            lines = lines.dropFirst()
+        }
+
+        // Skip a front-matter block, if present, regardless of whether it
+        // contained a `title:` key.
+        if lines.first?.trimmingCharacters(in: .whitespaces) == "---" {
+            lines = lines.dropFirst()
+            while let line = lines.first, line.trimmingCharacters(in: .whitespaces) != "---" {
+                lines = lines.dropFirst()
+            }
+            if !lines.isEmpty { lines = lines.dropFirst() }  // drop closing `---`
+
+            // Skip blank lines between the closing `---` and the heading.
+            while let first = lines.first, first.trimmingCharacters(in: .whitespaces).isEmpty {
+                lines = lines.dropFirst()
+            }
+        }
+
+        guard let headingLine = lines.first else { return nil }
+        let trimmed = headingLine.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("# "), !trimmed.hasPrefix("##") else { return nil }
+        return String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces).nilIfEmpty
     }
 
     // MARK: - PDF title

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -340,12 +340,49 @@ struct SourcesTests {
         #expect(result == "Plain Title")
     }
 
-    @Test func displayNameNilForMarkdownWithoutFrontMatter() {
+    @Test func displayNameFromMarkdownH1WithoutFrontMatter() {
         let md = "# Just a heading\n\nSome content."
         let result = DisplayNameResolver.resolve(
             filename: "plain.md", data: Data(md.utf8),
             mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == "Just a heading")
+    }
+
+    @Test func displayNameFromMarkdownH1WithLeadingBlankLines() {
+        let md = "\n\n\n# Heading After Blanks\n\nBody."
+        let result = DisplayNameResolver.resolve(
+            filename: "plain.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == "Heading After Blanks")
+    }
+
+    @Test func displayNameFromMarkdownH1WhenFrontMatterHasNoTitle() {
+        let md = """
+        ---
+        author: Someone
+        ---
+        # Fallback Heading
+        """
+        let result = DisplayNameResolver.resolve(
+            filename: "page.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == "Fallback Heading")
+    }
+
+    @Test func displayNameNilForMarkdownH2Only() {
+        let md = "## Not An H1\n\nSome content."
+        let result = DisplayNameResolver.resolve(
+            filename: "plain.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
         #expect(result == nil)
+    }
+
+    @Test func displayNameFromMarkdownH1WithInlineFormatting() {
+        let md = "# `Code` in a Title\n\nBody."
+        let result = DisplayNameResolver.resolve(
+            filename: "plain.md", data: Data(md.utf8),
+            mimeType: nil, zoteroItemTitle: nil)
+        #expect(result == "`Code` in a Title")
     }
 
     @Test func displayNameFromMarkdownMimeTypeNotExtension() {


### PR DESCRIPTION
Fixes #113

## Summary
- `DisplayNameResolver.resolve()` only checked YAML front matter for a Markdown title. Plain Markdown files with no front matter but a leading `# Heading` (Obsidian exports, scraped docs, Apple developer-doc mirrors, etc.) fell through to `nil`, so `sources.display_name` stayed `NULL` and every surface (Sources sidebar, `sources/by-name/`, `indexes/sources.jsonl`, `[[source:DisplayName]]` links) showed the raw ingest filename instead.
- Added `DisplayNameResolver.extractMarkdownHeading(from:)`: after skipping leading blank lines and any front-matter block (whether or not it had a `title:` key), it looks for a single `# ` ATX heading as the next line of content and uses its text verbatim.
- Wired into `resolve()` between front-matter and PDF-title lookup (priority: Zotero title → front matter `title` → leading H1 → PDF title → filename).

## Test plan
- [x] Replaced the test that locked in the old "returns nil for H1-only Markdown" behavior with one asserting the H1 is now used.
- [x] Added tests: leading blank lines before H1, front matter present but no `title:` falling through to H1, `##`/deeper headings NOT counting, H1 with inline formatting preserved verbatim.
- [x] `swift build` and `swift test --filter SourcesTests` pass (35/35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)