### PR TITLE
fix(sidebar): keep Sources tab enabled with zero sources

### DIFF
--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -110,9 +110,6 @@ struct SidebarView: View {
 
     private func sectionSelectorButton(_ section: SidebarSection) -> some View {
         let isSelected = selectedSection == section
-        // Nothing to show for an empty Sources list — disable rather than select
-        // an empty window.
-        let isDisabled = section == .sources && store.sources.isEmpty
         return Button {
             selectedSection = section
         } label: {
@@ -126,7 +123,6 @@ struct SidebarView: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(isDisabled)
         .help(section.title)
     }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/tqbf/selfdrivingwiki/issues/149

Removes the logic that disabled the Sources sidebar tab when the sources list was empty. Users can now access and interact with the Sources tab regardless of whether sources exist.

## Changes

- Removed the `isDisabled` variable that blocked the Sources tab based on `store.sources.isEmpty`
- Removed the `.disabled(isDisabled)` modifier from the section selector button
- Cleaned up the associated comment

## Rationale

Keeping the tab accessible even with zero sources improves the UX — users can navigate to the Sources section, see that it's empty, and understand where to add sources. Disabling the tab creates an odd experience where the UI suggests the feature is unavailable rather than simply empty.