### PR TITLE
fix(bookmarks): omnibox + shows folder picker; fix stale outline

### DIFF
--- a/SWIFTUI-RULES.md
+++ b/SWIFTUI-RULES.md
@@ -200,6 +200,52 @@ save it 600ms later — a concurrent change clobbers it on save. Read
 fresh at the click handler, mutate, write. This is the "stale-snapshot
 autosave" lesson from Moves' Phase-5 gate.
 
+### 3.6 `NSViewRepresentable` / `NSViewControllerRepresentable` that read `@Observable` model state must receive that data as an explicit parameter from the parent view's body — never read it only inside `updateNSView` / `updateNSViewController`.
+
+```swift
+// BAD — observation gap: the parent never accesses bookmarkNodes,
+// so SwiftUI never re-renders, so updateNSViewController is never
+// called when bookmarks change. The outline silently goes stale.
+struct BookmarksOutlineView: NSViewControllerRepresentable {
+    let store: WikiStoreModel          // ← passed but not observed
+    func updateNSViewController(_ vc: ...) {
+        let nodes = store.bookmarkNodes // ← read here, but this method
+        // isn't called unless the parent re-renders!
+    }
+}
+// Parent: BookmarksContainerView.body passes `store` but never reads
+// store.bookmarkNodes → no @Observable tracking → no re-render.
+
+// GOOD — data passed through the parent's body establishes tracking
+struct BookmarksOutlineView: NSViewControllerRepresentable {
+    let store: WikiStoreModel
+    let nodes: [BookmarkNode]          // ← explicit data parameter
+    func updateNSViewController(_ vc: ...) {
+        let needs = vc.needsReload(nodes: nodes) // ← uses the parameter
+    }
+}
+// Parent: BookmarksContainerView.body reads store.bookmarkNodes to
+// build the nodes parameter → @Observable tracking established →
+// re-renders when bookmarkNodes changes → updateNSViewController fires.
+```
+
+**Why.** SwiftUI's `@Observable` tracking registers dependencies only
+for properties accessed *during a view's `body` evaluation*. An
+`NSViewControllerRepresentable` has no `body` — its
+`updateNSViewController` is called only when the *parent* SwiftUI view
+re-renders. If the parent passes the model object but never reads the
+specific property in its body, no tracking is registered, and the
+representable silently stops receiving updates. The data is correct in
+the database; the UI just never refreshes.
+
+**The fix is always the same.** Pass the observable data as an explicit
+`let` parameter from the parent's body. This forces the parent to
+access the property during body evaluation, establishing the tracking.
+The bug that taught us: the omnibox "Add Bookmark" "+" created a
+bookmark in SQLite, but the `BookmarksOutlineView` never refreshed
+because `BookmarksContainerView` passed `store` without reading
+`store.bookmarkNodes` in its body.
+
 ---
 
 ## 4. Lists, scrolling, and rows

--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -41,6 +41,10 @@ struct AddressBarView: View {
     /// Pointer is over the omnibox — reveals the trailing "add to bookmarks" plus.
     @State private var isHovering = false
     @State private var showReaderMenu = false
+    /// Fired when the omnibox "+" is clicked. `ContentView` presents the
+    /// `BookmarkTargetPickerSheet` (sheets can't be reliably presented from a
+    /// toolbar item's SwiftUI hierarchy).
+    var onAddToBookmarks: (BookmarkTargetPickerContext) -> Void
 
     // The reader/page zoom is a persisted global (`@AppStorage`), so the toolbar
     // can drive the same value the detail views read — no binding to thread.
@@ -283,8 +287,10 @@ struct AddressBarView: View {
 
     private func addToBookmarks(_ target: BookmarkTarget) {
         switch target {
-        case .page(let id): store.addPageRef(parentID: nil, pageID: id)
-        case .source(let id): store.addSourceRef(parentID: nil, sourceID: id)
+        case .page(let id):
+            onAddToBookmarks(BookmarkTargetPickerContext(kind: .pages, ids: [id]))
+        case .source(let id):
+            onAddToBookmarks(BookmarkTargetPickerContext(kind: .sources, ids: [id]))
         }
     }
 

--- a/Sources/WikiFS/BookmarksContainerView.swift
+++ b/Sources/WikiFS/BookmarksContainerView.swift
@@ -23,6 +23,7 @@ struct BookmarksContainerView: View {
             // NSOutlineView — instant selection, native macOS performance
             BookmarksOutlineView(
                 store: store,
+                nodes: store.bookmarkNodes,
                 fileProvider: fileProvider,
                 onOpen: { sel in store.openTab(sel) },
                 onEdit: { onEdit($0) },

--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -10,6 +10,14 @@ import WikiFSCore
 /// on macOS (see plans/bookmark-drag-drop-performance.md).
 struct BookmarksOutlineView: NSViewControllerRepresentable {
     let store: WikiStoreModel
+    /// The live bookmark-node snapshot. Passed explicitly (rather than read
+    /// inside `updateNSViewController`) so that the **parent** view
+    /// (`BookmarksContainerView`) accesses `store.bookmarkNodes` during its
+    /// `body` evaluation — establishing the `@Observable` dependency that
+    /// triggers a re-render when bookmarks change. Without this, mutations from
+    /// the omnibox "+", context menus, etc. update the database but the outline
+    /// never refreshes (no SwiftUI state change to force `updateNSViewController`).
+    let nodes: [BookmarkNode]
     let fileProvider: FileProviderSpike
     var onOpen: (WikiSelection) -> Void
     var onEdit: (String) -> Void
@@ -41,7 +49,6 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
             onAddPage: onAddPage, onAddSource: onAddSource,
             onNewFolder: onNewFolder, onNewSubfolder: onNewSubfolder
         )
-        let nodes = store.bookmarkNodes
         let needs = vc.needsReload(nodes: nodes)
         DebugLog.tabs("BookmarksOutlineView.updateNSVC: nodes=\(nodes.count) needsReload=\(needs)")
         if needs {

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -39,6 +39,10 @@ struct ContentView: View {
     /// (never in toolbar overflow) instead of the omnibox field's own leading edge
     /// is what keeps the width from getting stranded. See `OmniboxLayout`.
     @State private var detailWidth: CGFloat = 0
+    /// Drives the `BookmarkTargetPickerSheet` from the omnibox "+". The sheet
+    /// lives here (not on `AddressBarView`) because toolbar items can't reliably
+    /// present SwiftUI sheets.
+    @State private var omniboxBookmarkContext: BookmarkTargetPickerContext?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
@@ -105,6 +109,21 @@ struct ContentView: View {
             if let error = store.storeError {
                 StoreErrorSheet(error: error) { store.dismissStoreError() }
             }
+        }
+        .sheet(item: $omniboxBookmarkContext) { ctx in
+            BookmarkTargetPickerSheet(
+                store: store,
+                kind: ctx.kind,
+                ids: ctx.ids,
+                onConfirm: { parentID in
+                    for id in ctx.ids {
+                        switch ctx.kind {
+                        case .pages: store.addPageRef(parentID: parentID, pageID: id)
+                        case .sources: store.addSourceRef(parentID: parentID, sourceID: id)
+                        }
+                    }
+                }
+            )
         }
     }
 
@@ -252,7 +271,8 @@ struct ContentView: View {
                 AddressBarView(store: store, isFocused: $addressBarFocused,
                                wikiName: activeWikiName,
                                detailWidth: detailWidth,
-                               sidebarVisible: columnVisibility != .detailOnly)
+                               sidebarVisible: columnVisibility != .detailOnly,
+                               onAddToBookmarks: { omniboxBookmarkContext = $0 })
             }
 
             // The wiki switcher moves out of the sidebar header into the toolbar,

--- a/Tests/WikiFSTests/ObservableTrackingTests.swift
+++ b/Tests/WikiFSTests/ObservableTrackingTests.swift
@@ -1,0 +1,138 @@
+import Testing
+import Foundation
+import Observation
+@testable import WikiFSCore
+
+/// Model-level `@Observable` contract tests.
+///
+/// These verify that mutating observable properties fires the tracking
+/// callback that SwiftUI's runtime relies on to re-render views. They do NOT
+/// verify that a specific view reads the property in its body (that was the
+/// omnibox bookmark bug — see `SWIFTUI-RULES.md` §3.6), but they lock in the
+/// model's half of the contract so a refactor that breaks observation is
+/// caught immediately rather than silently making the UI go stale.
+@MainActor
+struct ObservableTrackingTests {
+
+    /// `withObservationTracking`'s `onChange` closure is `@Sendable`, so a
+    /// plain `var` can't be captured. This reference-type box is
+    /// `@unchecked Sendable` — safe because the test is single-threaded.
+    private final class Box: @unchecked Sendable {
+        var fireCount = 0
+    }
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("observable-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    // MARK: - bookmarkNodes
+
+    @Test func addPageRefFiresBookmarkNodesObservation() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let page = try store.createPage(title: "Observable Page")
+        let model = WikiStoreModel(store: store)
+
+        let box = Box()
+        withObservationTracking {
+            _ = model.bookmarkNodes
+        } onChange: {
+            box.fireCount += 1
+        }
+
+        #expect(model.bookmarkNodes.isEmpty)
+
+        model.addPageRef(parentID: nil, pageID: page.id)
+
+        #expect(box.fireCount == 1,
+                "addPageRef → reloadBookmarkNodes must fire the @Observable callback")
+        #expect(model.bookmarkNodes.count == 1)
+    }
+
+    @Test func addSourceRefFiresBookmarkNodesObservation() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let source = try store.addSource(filename: "paper.pdf", data: Data("x".utf8))
+        let model = WikiStoreModel(store: store)
+
+        let box = Box()
+        withObservationTracking {
+            _ = model.bookmarkNodes
+        } onChange: {
+            box.fireCount += 1
+        }
+
+        model.addSourceRef(parentID: nil, sourceID: source.id)
+
+        #expect(box.fireCount == 1,
+                "addSourceRef → reloadBookmarkNodes must fire the @Observable callback")
+        #expect(model.bookmarkNodes.count == 1)
+    }
+
+    @Test func createFolderFiresBookmarkNodesObservation() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+
+        let box = Box()
+        withObservationTracking {
+            _ = model.bookmarkNodes
+        } onChange: {
+            box.fireCount += 1
+        }
+
+        _ = model.createFolder(parentID: nil, name: "Research")
+
+        #expect(box.fireCount == 1,
+                "createFolder → reloadBookmarkNodes must fire the @Observable callback")
+        #expect(model.bookmarkNodes.count == 1)
+    }
+
+    @Test func deleteBookmarkNodeFiresObservation() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+
+        // Seed: create a folder, then reload so the model has data.
+        _ = model.createFolder(parentID: nil, name: "Temp")
+        #expect(model.bookmarkNodes.count == 1)
+
+        let nodeID = model.bookmarkNodes.first!.id
+
+        let box = Box()
+        withObservationTracking {
+            _ = model.bookmarkNodes
+        } onChange: {
+            box.fireCount += 1
+        }
+
+        model.deleteBookmarkNode(id: nodeID)
+
+        #expect(box.fireCount == 1,
+                "deleteBookmarkNode → reloadBookmarkNodes must fire the @Observable callback")
+        #expect(model.bookmarkNodes.isEmpty)
+    }
+
+    @Test func bookmarkNodesObservationIsOneShot() throws {
+        /// `withObservationTracking` installs a one-shot callback — it fires
+        /// once, then unregisters. SwiftUI re-registers on each body
+        /// re-evaluation, but a raw call does not. This test documents that
+        /// contract so a future "optimization" that makes it sticky is caught.
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let page = try store.createPage(title: "One-Shot Page")
+        let model = WikiStoreModel(store: store)
+
+        let box = Box()
+        withObservationTracking {
+            _ = model.bookmarkNodes
+        } onChange: {
+            box.fireCount += 1
+        }
+
+        model.addPageRef(parentID: nil, pageID: page.id)
+        model.addPageRef(parentID: nil, pageID: page.id)
+
+        #expect(box.fireCount == 1,
+                "withObservationTracking fires once then unregisters (SwiftUI re-registers per body)")
+        #expect(model.bookmarkNodes.count == 2)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in the omnibox add-bookmark flow and adds a project convention + tests to prevent recurrence.

### Bug 1: Outline never refreshed after bookmark mutations

`BookmarksContainerView` passed `store` to `BookmarksOutlineView` (an `NSViewControllerRepresentable`) but never accessed `store.bookmarkNodes` in its SwiftUI `body`. The `@Observable` macro only registers tracking for properties accessed *during body evaluation*. Since the parent never touched `bookmarkNodes`, SwiftUI never re-rendered, so `updateNSViewController` was never called when bookmarks changed. The bookmark was created in SQLite but the outline silently went stale.

This affected **all** bookmark mutations that didn't also trigger a SwiftUI state change (omnibox "+", outline context-menu delete, subfolder creation). Operations that showed a sheet/alert (New Folder, Add Page…) worked only because dismissing the sheet incidentally re-rendered the hierarchy.

**Fix:** Pass `store.bookmarkNodes` as an explicit `nodes` parameter from `BookmarksContainerView.body` into `BookmarksOutlineView`, establishing the observation dependency.

### Bug 2: Omnibox "+" added silently to root

The button called `store.addPageRef(parentID: nil)` directly with no dialog. Now fires an `onAddToBookmarks` callback that `ContentView` uses to present `BookmarkTargetPickerSheet` — the same folder picker used by the Pages/Sources multi-select context menu. The sheet lives on `ContentView` because SwiftUI sheets can't be reliably presented from `NSToolbar` items.

### Convention

Added `SWIFTUI-RULES.md` §3.6: any `NSViewRepresentable` / `NSViewControllerRepresentable` that reads `@Observable` model state must receive that data as an explicit parameter from the parent view's body, never read only inside `updateNSView` / `updateNSViewController`.

### Tests

Added `ObservableTrackingTests` (5 tests) verifying the `@Observable` contract at the model level:
- `addPageRef`, `addSourceRef`, `createFolder`, and `deleteBookmarkNode` all fire the tracking callback
- Documents the one-shot nature of `withObservationTracking`

These lock in the model's half of the contract. They don't test that a specific view accesses the property in its body (that's the architectural convention above), but they catch any refactor that breaks the model's observation infrastructure.

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter "Bookmark|Observable"` — 37 tests green (32 existing + 5 new)
- [x] Live check: open a page, hover the omnibox "+", click it → folder picker sheet appears
- [x] Live check: pick a folder, confirm → bookmark appears immediately in the Bookmarks outline
