### PR TITLE
fix(find): wire Find on Page menu item to shared FindModel (#157)

### DIFF
--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -41,6 +41,10 @@ struct AddressBarView: View {
     /// Pointer is over the omnibox — reveals the trailing "add to bookmarks" plus.
     @State private var isHovering = false
     @State private var showReaderMenu = false
+    /// The shared find model (injected via environment by `ContentView`). The
+    /// "Find on Page…" menu item toggles this, matching Cmd+F in the detail
+    /// views — both drive the same `FindBarView` overlay (issue #157).
+    @Environment(FindModel.self) private var findModel
     /// Fired when the omnibox "+" is clicked. `ContentView` presents the
     /// `BookmarkTargetPickerSheet` (sheets can't be reliably presented from a
     /// toolbar item's SwiftUI hierarchy).
@@ -294,14 +298,13 @@ struct AddressBarView: View {
         }
     }
 
-    /// Show the system find bar by sending the standard Text Finder action down
-    /// the responder chain (`to: nil`) to the focused view. Works in the text
-    /// editors today; the web reader depends on macOS's built-in support.
+    /// Open the find bar by toggling the shared `FindModel` — the same model
+    /// Cmd+F toggles inside the active detail view. Previously this sent the
+    /// legacy `performTextFinderAction` down the responder chain, which no view
+    /// implemented, so the menu item was a no-op (issue #157).
     private func findOnPage() {
         showReaderMenu = false
-        let sender = NSMenuItem()
-        sender.tag = Int(NSTextFinder.Action.showFindInterface.rawValue)
-        NSApp.sendAction(#selector(NSResponder.performTextFinderAction(_:)), to: nil, from: sender)
+        findModel.toggle()
     }
 
     // MARK: - Address string

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -43,6 +43,10 @@ struct ContentView: View {
     /// lives here (not on `AddressBarView`) because toolbar items can't reliably
     /// present SwiftUI sheets.
     @State private var omniboxBookmarkContext: BookmarkTargetPickerContext?
+    /// Shared find-bar model. Hoisted here (out of per-view `@State`) so both the
+    /// toolbar's "Find on Page…" menu item (`AddressBarView`) and the active
+    /// detail view's Cmd+F drive the same `FindBarView` overlay (issue #157).
+    @State private var findModel = FindModel()
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
@@ -125,6 +129,10 @@ struct ContentView: View {
                 }
             )
         }
+        // Inject the shared find model so the toolbar's "Find on Page…" menu item
+        // (`AddressBarView`, in a `ToolbarItem`) and the detail views' Cmd+F both
+        // reach the same `FindModel` instance (#157).
+        .environment(findModel)
     }
 
     /// NavigationSplitView + drop / overlay / toolbar. Split out of `body` so the

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -20,8 +20,10 @@ struct PageDetailView: View {
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
     @AppStorage("isOutlineExpanded") private var isOutlineExpanded = false
 
-    // Find bar state.
-    @State private var findModel = FindModel()
+    // Find bar state. The model is shared (hoisted to `ContentView` and injected
+    // via environment) so the address bar's "Find on Page…" menu item can drive
+    // the same find bar that Cmd+F toggles here (issue #157).
+    @Environment(FindModel.self) private var findModel
     @State private var findVersion = 0
 
     var body: some View {

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -58,8 +58,9 @@ struct SourceDetailView: View {
     /// targets an un-extracted PDF. Consumed from `store.pendingScrollAnchor`.
     @State private var pdfQuote: String?
 
-    // Find bar state.
-    @State private var findModel = FindModel()
+    // Find bar state. Shared via environment (see `ContentView`) so the address
+    // bar's "Find on Page…" menu item and Cmd+F drive the same model (#157).
+    @Environment(FindModel.self) private var findModel
     @State private var findVersion = 0
 
     private enum FileContentTab: String, CaseIterable {

--- a/Tests/WikiFSTests/FindModelTests.swift
+++ b/Tests/WikiFSTests/FindModelTests.swift
@@ -1,0 +1,177 @@
+import Testing
+@testable import WikiFS
+
+/// `FindModel` is the shared find-bar state that BOTH Cmd+F (in the detail
+/// views) and the address bar's "Find on Page…" menu item now drive (issue
+/// #157). These tests pin down the toggle / search / navigation contract those
+/// two entry points rely on, independent of any SwiftUI wiring.
+@MainActor
+@Suite struct FindModelTests {
+
+    // MARK: - Toggle (the action both entry points call)
+
+    @Test func toggleOpensAndRunsFindWhenContentPresent() {
+        let model = FindModel()
+        model.content = "hello world hello"
+
+        // Closed by default.
+        #expect(model.isShowing == false)
+
+        model.query = "hello"
+        model.toggle()
+        #expect(model.isShowing == true)
+        // Toggling open runs the search immediately (FindModel.toggle contract).
+        #expect(model.matches.count == 2)
+        #expect(model.currentMatchIndex == 1)
+    }
+
+    @Test func toggleClosesAndClearsOnSecondToggle() {
+        let model = FindModel()
+        model.content = "abc abc"
+        model.query = "abc"
+        model.toggle() // open
+        #expect(model.isShowing == true)
+        #expect(model.matches.count == 2)
+
+        model.toggle() // close
+        #expect(model.isShowing == false)
+        // Closing clears matches so no stale highlighting lingers.
+        #expect(model.matches.isEmpty)
+        #expect(model.currentMatchIndex == 0)
+    }
+
+    @Test func toggleIsANoopWhenThereIsNoContent() {
+        let model = FindModel()
+        // No content set.
+        model.query = "anything"
+        model.toggle()
+        #expect(model.isShowing == true)
+        #expect(model.matches.isEmpty)
+        #expect(model.currentMatchIndex == 0)
+    }
+
+    // MARK: - Search semantics
+
+    @Test func searchIsCaseInsensitiveByDefault() {
+        let model = FindModel()
+        model.content = "Foo foo FOO"
+        model.query = "foo"
+        model.search()
+        #expect(model.matches.count == 3)
+    }
+
+    @Test func searchRespectsCaseSensitiveToggle() {
+        let model = FindModel()
+        model.content = "Foo foo FOO"
+        model.caseSensitive = true
+        model.query = "foo"
+        model.search()
+        #expect(model.matches.count == 1)
+    }
+
+    @Test func emptyQueryYieldsNoMatches() {
+        let model = FindModel()
+        model.content = "some content"
+        model.query = ""
+        model.search()
+        #expect(model.matches.isEmpty)
+        #expect(model.currentMatchIndex == 0)
+    }
+
+    @Test func noContentYieldsNoMatchesEvenWithQuery() {
+        let model = FindModel()
+        model.content = nil
+        model.query = "x"
+        model.search()
+        #expect(model.matches.isEmpty)
+    }
+
+    // MARK: - Next / previous navigation
+
+    @Test func nextMatchWrapsAround() {
+        let model = FindModel()
+        model.content = "a a a"
+        model.query = "a"
+        model.search() // 3 matches, index 1
+        #expect(model.currentMatchIndex == 1)
+
+        model.nextMatch()
+        #expect(model.currentMatchIndex == 2)
+        model.nextMatch()
+        #expect(model.currentMatchIndex == 3)
+        // Wraps from last back to first.
+        model.nextMatch()
+        #expect(model.currentMatchIndex == 1)
+    }
+
+    @Test func previousMatchWrapsAround() {
+        let model = FindModel()
+        model.content = "a a a"
+        model.query = "a"
+        model.search() // index 1
+        // Wraps from first back to last.
+        model.previousMatch()
+        #expect(model.currentMatchIndex == 3)
+        model.previousMatch()
+        #expect(model.currentMatchIndex == 2)
+    }
+
+    @Test func navigationIsNoopWithNoMatches() {
+        let model = FindModel()
+        model.content = "abc"
+        model.query = "zzz"
+        model.search()
+        model.nextMatch()
+        model.previousMatch()
+        #expect(model.currentMatchIndex == 0)
+    }
+
+    // MARK: - Navigation callback
+
+    @Test func toggleNotifiesCurrentMatchViaCallback() {
+        let model = FindModel()
+        model.content = "x y x"
+        model.query = "x"
+
+        var visited: [String] = []
+        model.onNavigateToMatch = { range in
+            visited.append(String(model.content![range]))
+        }
+
+        model.toggle() // open -> match 1
+        #expect(visited == ["x"])
+        model.nextMatch() // -> match 2
+        #expect(visited == ["x", "x"])
+    }
+
+    // MARK: - Count label
+
+    @Test func countLabelFormats() {
+        let model = FindModel()
+        #expect(model.countLabel == "") // empty query
+
+        model.query = "q"
+        model.content = "q q q"
+        model.search()
+        #expect(model.countLabel == "1 of 3")
+
+        model.content = "no match here"
+        model.search()
+        #expect(model.countLabel == "0 matches")
+    }
+
+    // MARK: - Dismiss
+
+    @Test func dismissHidesAndClears() {
+        let model = FindModel()
+        model.content = "abc"
+        model.query = "a"
+        model.toggle()
+        #expect(model.isShowing == true)
+
+        model.dismiss()
+        #expect(model.isShowing == false)
+        #expect(model.matches.isEmpty)
+        #expect(model.currentMatchIndex == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #157 — the **Find on Page…** menu item in the address bar's page-controls popover did nothing; it should open the find bar like Cmd+F.

## Root cause

`AddressBarView.findOnPage()` sent the legacy AppKit action `performTextFinderAction(_:)` with `NSTextFinder.Action.showFindInterface` down the responder chain. But neither reader view implements that action. Cmd+F was wired to a completely separate mechanism: a private per-view `@State` `FindModel` toggled by a hidden button, which drives the custom `FindBarView` overlay. So the menu item touched a system no view handled → no-op.

## Fix

Hoisted `FindModel` out of per-view `@State` into a single shared instance owned by `ContentView`, injected via SwiftUI environment (`.environment(findModel)`). Both entry points now reach the same model:

- **`AddressBarView`** reads `@Environment(FindModel.self)`; `findOnPage()` now just calls `findModel.toggle()` (removed the `NSTextFinder` responder-chain round-trip).
- **`PageDetailView` / `SourceDetailView`** swapped `@State private var findModel = FindModel()` → `@Environment(FindModel.self)`. Their Cmd+F button, find-bar overlay, and content-search wiring are unchanged.
- **`ContentView`** owns `@State private var findModel = FindModel()` and injects it on `baseContent`, so it reaches both the `ToolbarItem` (address bar) and the detail column.

Navigation safety is preserved: the detail views still call `findModel.dismiss()` on selection change, so the shared bar never leaks across an unrelated view, and clicking Find while on a non-findable selection (e.g. Activity) is a harmless no-op (dismissed on next navigation, matching prior behavior).

## Tests

Added `Tests/WikiFSTests/FindModelTests.swift` — 13 Swift Testing cases (`@MainActor`) pinning the `FindModel` contract both entry points depend on: open/close toggle, immediate-search-on-open, case-sensitive vs insensitive matching, next/prev wrap-around, the `onNavigateToMatch` callback, count-label formatting, and dismiss. All pass.

## Checklist

- [x] `swift build` clean
- [x] `swift test --filter FindModelTests` — 13/13 pass
- [x] No behavior change to Cmd+F
