### PR TITLE
fix: plain-click navigates current tab; ⌘-click opens new tab (#161)

### DIFF
--- a/Sources/WikiFS/AgentActivityView.swift
+++ b/Sources/WikiFS/AgentActivityView.swift
@@ -10,9 +10,9 @@ struct AgentActivityView: View {
     /// Forwards wiki-link clicks in the transcript to the detail column. Built
     /// where the store lives and threaded down; `nil` when navigation is
     /// impossible (links still render, just don't navigate).
-    var onWikiLink: ((URL) -> Void)? = nil
+    var onWikiLink: ((URL, Bool) -> Void)? = nil
 
-    init(launcher: AgentLauncher, showsResultEvents: Bool = true, showsInternals: Bool = false, onWikiLink: ((URL) -> Void)? = nil) {
+    init(launcher: AgentLauncher, showsResultEvents: Bool = true, showsInternals: Bool = false, onWikiLink: ((URL, Bool) -> Void)? = nil) {
         self.launcher = launcher
         self.showsResultEvents = showsResultEvents
         self.showsInternals = showsInternals

--- a/Sources/WikiFS/AgentTranscriptSidebar.swift
+++ b/Sources/WikiFS/AgentTranscriptSidebar.swift
@@ -10,7 +10,7 @@ struct AgentTranscriptSidebar: View {
     /// Forwards wiki-link clicks in the transcript to the detail column. Built
     /// where the store lives (the owning `ContentView` / `LintView`) and
     /// forwarded unchanged to the activity view.
-    var onWikiLink: ((URL) -> Void)? = nil
+    var onWikiLink: ((URL, Bool) -> Void)? = nil
     @State private var showsInternals = false
     @State private var width: CGFloat = AgentTranscriptMetrics.defaultWidth
     @State private var widthDragOrigin: CGFloat = AgentTranscriptMetrics.defaultWidth

--- a/Sources/WikiFS/AgentTranscriptWebView.swift
+++ b/Sources/WikiFS/AgentTranscriptWebView.swift
@@ -42,7 +42,7 @@ struct AgentTranscriptWebView: NSViewRepresentable {
     /// is built where the store lives (two levels up) and routes to
     /// `selectPage` / `selectSource`. `nil` → links still render but don't
     /// navigate (a strict improvement over literal `[[brackets]]`).
-    var onWikiLink: ((URL) -> Void)? = nil
+    var onWikiLink: ((URL, Bool) -> Void)? = nil
 
     func makeNSView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
@@ -70,7 +70,7 @@ struct AgentTranscriptWebView: NSViewRepresentable {
         var style: VisualStyle = .activityFeed
         /// Routes a clicked `wiki://` link out to the view's `onWikiLink`
         /// closure (built where the store lives). Refreshed each update.
-        var onWikiLink: ((URL) -> Void)?
+        var onWikiLink: ((URL, Bool) -> Void)?
         private var renderedCount = 0
         private var renderedShowsInternals: Bool?
         private var isLoaded = false
@@ -142,7 +142,9 @@ struct AgentTranscriptWebView: NSViewRepresentable {
             if navigationAction.navigationType == .linkActivated,
                let url = navigationAction.request.url {
                 if url.scheme == "wiki" {
-                    onWikiLink?(url)
+                    // ⌘-click opens a new tab; plain click navigates in place.
+                    let openInNewTab = navigationAction.modifierFlags.contains(.command)
+                    onWikiLink?(url, openInNewTab)
                     decisionHandler(.cancel)
                     return
                 }

--- a/Sources/WikiFS/QueryTranscriptView.swift
+++ b/Sources/WikiFS/QueryTranscriptView.swift
@@ -8,7 +8,7 @@ struct QueryTranscriptView: View {
     /// Forwards wiki-link clicks in the transcript to the detail column. Built
     /// where the store lives (the parent `QueryConversationView`) and forwarded
     /// unchanged to the transcript web view.
-    var onWikiLink: ((URL) -> Void)? = nil
+    var onWikiLink: ((URL, Bool) -> Void)? = nil
 
     var body: some View {
         Group {

--- a/Sources/WikiFS/WikiReaderView.swift
+++ b/Sources/WikiFS/WikiReaderView.swift
@@ -116,11 +116,11 @@ struct WikiReaderView: View {
     /// and forwarded unchanged down through the intermediate views to
     /// `AgentTranscriptWebView`. Pass `nil` where navigation is impossible.
     @MainActor
-    static func onWikiLinkHandler(for store: WikiStoreModel) -> (URL) -> Void {
-        { url in
+    static func onWikiLinkHandler(for store: WikiStoreModel) -> (URL, Bool) -> Void {
+        { url, openInNewTab in
             switch WikiReaderView.linkRoute(for: url) {
-            case .page(let title, let frag):   store.selectPage(byTitle: title, anchor: frag)
-            case .source(let title, let frag): store.selectSource(byDisplayName: title, anchor: frag)
+            case .page(let title, let frag):   store.selectPage(byTitle: title, anchor: frag, openInNewTab: openInNewTab)
+            case .source(let title, let frag): store.selectSource(byDisplayName: title, anchor: frag, openInNewTab: openInNewTab)
             case .samePageAnchor, .inert:      break
             }
         }
@@ -967,7 +967,10 @@ internal struct WikiReaderRep: NSViewRepresentable {
             if navigationAction.navigationType == .linkActivated,
                let url = navigationAction.request.url {
                 if url.scheme == "wiki" {
-                    route(url)
+                    // macOS browser convention: plain click navigates the current
+                    // tab in place; ⌘-click opens the target in a new tab.
+                    let openInNewTab = navigationAction.modifierFlags.contains(.command)
+                    route(url, openInNewTab: openInNewTab)
                     decisionHandler(.cancel)
                     return
                 }
@@ -987,7 +990,8 @@ internal struct WikiReaderRep: NSViewRepresentable {
         /// pending-anchor flow (see `consumeAndApplyPendingAnchor`): the resulting
         /// `selectPage`/`selectSource` stash the `#fragment` as a pending anchor
         /// that the *destination* reader's Coordinator later consumes + applies.
-        private func route(_ url: URL) {
+        /// `openInNewTab` mirrors the click's modifier (⌘-click → new tab).
+        private func route(_ url: URL, openInNewTab: Bool = false) {
             switch WikiReaderView.linkRoute(for: url) {
             case .samePageAnchor(let frag):
                 if let webView, let frag {
@@ -996,9 +1000,9 @@ internal struct WikiReaderRep: NSViewRepresentable {
                         #"var e=document.getElementById("\#(s)"); if(e){e.scrollIntoView({block:"start"});}""#)
                 }
             case .page(let title, let frag):
-                store?.selectPage(byTitle: title, anchor: frag)
+                store?.selectPage(byTitle: title, anchor: frag, openInNewTab: openInNewTab)
             case .source(let title, let frag):
-                store?.selectSource(byDisplayName: title, anchor: frag)
+                store?.selectSource(byDisplayName: title, anchor: frag, openInNewTab: openInNewTab)
             case .inert:
                 break
             }

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -279,18 +279,22 @@ public final class WikiStoreModel {
 
     /// Navigate to the page with `title` from a clicked `[[wiki-link]]` in the
     /// preview. Resolves title → id (lowest-ULID on a duplicate-title collision,
-    /// matching the link graph) and opens its tab — REUSING an already-open tab
-    /// for that page rather than spawning a duplicate. Records the jump in
-    /// navigation history first (so back/forward works), then routes through
-    /// `openTab`, whose `setActiveTab` flushes the outgoing page's pending edits
-    /// before loading the target (§3.5). Returns whether navigation happened, so
-    /// the click handler can report `.handled`. A no-op (`false`) if the title has
-    /// no page.
+    /// matching the link graph) and records the jump in navigation history first
+    /// (so back/forward works). Returns whether navigation happened, so the click
+    /// handler can report `.handled`. A no-op (`false`) if the title has no page.
+    ///
+    /// Navigation target depends on the click's modifier (browser convention):
+    /// - **Plain click** (`openInNewTab: false`, the default) → navigate the
+    ///   active tab in place (`navigateCurrentTab`): focus an already-open tab
+    ///   for the target if one exists, otherwise replace the active tab's
+    ///   selection. Never spawns a duplicate tab.
+    /// - **⌘-click** (`openInNewTab: true`) → `openTab`, which focuses an
+    ///   existing tab for the target or appends a new one (current behavior).
     ///
     /// - Parameter anchor: optional `#fragment` from a `[[Page#Section]]` link;
     ///   the destination `WikiReaderView` scrolls to it after load.
     @discardableResult
-    public func selectPage(byTitle title: String, anchor: String? = nil) -> Bool {
+    public func selectPage(byTitle title: String, anchor: String? = nil, openInNewTab: Bool = false) -> Bool {
         guard let id = (try? store.resolveTitleToID(title)) ?? nil else { return false }
         let target = WikiSelection.page(id)
         // Stash the anchor so the destination WikiReaderView can scroll to it
@@ -299,9 +303,14 @@ public final class WikiStoreModel {
         pendingScrollAnchor = anchor.map { (selection: target, fragment: $0) }
         pendingScrollAnchorVersion += 1
         // Record history while `loadedSelection` still points at the outgoing
-        // page (openTab/setActiveTab don't record history themselves).
+        // page (openTab/setActiveTab/navigateCurrentTab don't record history
+        // themselves).
         recordHistoryTransition(from: loadedSelection, to: target)
-        openTab(target)
+        if openInNewTab {
+            openTab(target)
+        } else {
+            navigateCurrentTab(to: target)
+        }
         return true
     }
 
@@ -346,19 +355,25 @@ public final class WikiStoreModel {
 
     /// Navigate to the source with `displayName` from a clicked
     /// `[[source:display-name]]` link in the preview. Resolves display name → id
-    /// (most-recently-updated on collision), records navigation history, and opens
-    /// the source's tab. Returns whether navigation happened.
+    /// (most-recently-updated on collision) and records navigation history. A
+    /// plain click (`openInNewTab: false`) navigates the active tab in place
+    /// (`navigateCurrentTab`); a ⌘-click (`openInNewTab: true`) opens a new tab
+    /// via `openTab`. Returns whether navigation happened.
     ///
     /// - Parameter anchor: optional `#fragment` from a `[[source:Name#"quote"]]`
     ///   link; the destination `WikiReaderView` scrolls to it after load.
     @discardableResult
-    public func selectSource(byDisplayName displayName: String, anchor: String? = nil) -> Bool {
+    public func selectSource(byDisplayName displayName: String, anchor: String? = nil, openInNewTab: Bool = false) -> Bool {
         guard let id = (try? store.resolveSourceByName(displayName)) ?? nil else { return false }
         let target = WikiSelection.source(id)
         pendingScrollAnchor = anchor.map { (selection: target, fragment: $0) }
         pendingScrollAnchorVersion += 1
         recordHistoryTransition(from: loadedSelection, to: target)
-        openTab(target)
+        if openInNewTab {
+            openTab(target)
+        } else {
+            navigateCurrentTab(to: target)
+        }
         return true
     }
 
@@ -428,6 +443,41 @@ public final class WikiStoreModel {
               let newValue else { return }
         tabs[i].selection = newValue
         tabs[i].title = tabTitle(for: newValue)
+    }
+
+    /// Navigate the **active tab in place** to `target` — the plain-click
+    /// (`[[wiki-link]]`) path, matching the macOS browser convention where a
+    /// plain click navigates the current tab rather than spawning a new one.
+    ///
+    /// Resolution order (history is recorded by the caller):
+    /// 1. A tab for `target` is already open → focus it (reuse, never duplicate),
+    ///    via `setActiveTab` (same as `openTab`'s reuse branch).
+    /// 2. No active tab (empty state) → fall back to `openTab` so the first tab
+    ///    is created and focused.
+    /// 3. Otherwise → mutate the active tab's selection/title in place: flush the
+    ///    outgoing selection's pending edits (so nothing in-flight is lost — the
+    ///    reader is read-only in practice, but this keeps the edit path safe),
+    ///    swap the tab's selection, mirror it into `selection`, and reload drafts.
+    ///    The `isApplyingTabSelection` guard mirrors `setActiveTab` so the view's
+    ///    `onChange(of: selection)` bridge no-ops mid-swap.
+    private func navigateCurrentTab(to target: WikiSelection) {
+        if let existing = tabs.first(where: { $0.selection == target }) {
+            setActiveTab(existing.id)
+            return
+        }
+        guard let activeID = activeTabID,
+              let i = tabs.firstIndex(where: { $0.id == activeID }) else {
+            openTab(target)
+            return
+        }
+        flushPendingSaves()
+        isApplyingTabSelection = true
+        tabs[i].selection = target
+        tabs[i].title = tabTitle(for: target)
+        selection = target
+        loadDrafts(for: target)
+        isApplyingTabSelection = false
+        DebugLog.store("[tabs] navigateCurrentTab: in-place to \(target) (id=\(activeID)), \(tabs.count) tabs total")
     }
 
     /// Open the tab for `selection`: if one is already open, focus it (reuse,

--- a/Tests/WikiFSTests/WikiLinkNavigationTests.swift
+++ b/Tests/WikiFSTests/WikiLinkNavigationTests.swift
@@ -68,14 +68,33 @@ struct WikiLinkNavigationTests {
         model.openTab(.page(from.id))
         #expect(model.tabs.count == 2)
 
-        // Clicking a [[To]] link focuses the existing tab — no third tab.
+        // A plain-click [[To]] link focuses the already-open tab — no third tab.
         #expect(model.selectPage(byTitle: "To"))
         #expect(model.tabs.count == 2)
         #expect(model.activeTabID == toTab)
         #expect(model.selection == .page(to.id))
     }
 
-    @Test func selectPageByTitleOpensNewTabWhenNotAlreadyOpen() throws {
+    @Test func selectPageByTitlePlainClickNavigatesCurrentTabInPlace() throws {
+        let (model, store) = try tempModel()
+        let from = try store.createPage(title: "From")
+        let to = try store.createPage(title: "To")
+        model.reloadFromStore()
+
+        model.openTab(.page(from.id))
+        let fromTab = model.activeTabID
+        #expect(model.tabs.count == 1)
+
+        // Plain click (openInNewTab: false) navigates the active tab in place —
+        // the existing tab's selection is replaced, no second tab is created.
+        #expect(model.selectPage(byTitle: "To"))
+        #expect(model.tabs.count == 1)
+        #expect(model.activeTabID == fromTab)
+        #expect(model.selection == .page(to.id))
+        #expect(model.tabs.first?.selection == .page(to.id))
+    }
+
+    @Test func selectPageByTitleCommandClickOpensNewTab() throws {
         let (model, store) = try tempModel()
         let from = try store.createPage(title: "From")
         let to = try store.createPage(title: "To")
@@ -84,21 +103,71 @@ struct WikiLinkNavigationTests {
         model.openTab(.page(from.id))
         #expect(model.tabs.count == 1)
 
-        #expect(model.selectPage(byTitle: "To"))
+        // ⌘-click (openInNewTab: true) opens the target in a new tab.
+        #expect(model.selectPage(byTitle: "To", openInNewTab: true))
         #expect(model.tabs.count == 2)
         #expect(model.selection == .page(to.id))
+        #expect(model.tabs.contains { $0.selection == .page(to.id) })
     }
 
-    @Test func selectPageByTitleDoesNotAutoSavePendingEditsToOutgoingPage() throws {
+    @Test func selectPageByTitleCommandClickReusesAlreadyOpenTab() throws {
         let (model, store) = try tempModel()
         let from = try store.createPage(title: "From")
         let to = try store.createPage(title: "To")
         model.reloadFromStore()
 
-        // Open `from`, type into the body, then navigate to `to`. Edits are
-        // only committed by an explicit save (flushPendingSave); navigating
-        // away must NOT auto-save to the database.
-        model.select(.page(from.id))
+        model.openTab(.page(to.id))
+        let toTab = model.tabs.first { $0.selection == .page(to.id) }!.id
+        model.openTab(.page(from.id))
+        #expect(model.tabs.count == 2)
+
+        // ⌘-clicking an already-open target focuses its tab rather than
+        // duplicating (openTab dedup).
+        #expect(model.selectPage(byTitle: "To", openInNewTab: true))
+        #expect(model.tabs.count == 2)
+        #expect(model.activeTabID == toTab)
+    }
+
+    @Test func selectPageByTitlePlainClickInEmptyStateOpensTab() throws {
+        let (model, store) = try tempModel()
+        let to = try store.createPage(title: "To")
+        model.reloadFromStore()
+
+        #expect(model.tabs.isEmpty)
+
+        // No active tab → plain click falls back to opening a tab.
+        #expect(model.selectPage(byTitle: "To"))
+        #expect(model.tabs.count == 1)
+        #expect(model.selection == .page(to.id))
+    }
+
+    @Test func selectPageByTitleNavigatesInPlaceRecordingHistory() throws {
+        let (model, store) = try tempModel()
+        let from = try store.createPage(title: "From")
+        let to = try store.createPage(title: "To")
+        model.reloadFromStore()
+
+        model.openTab(.page(from.id))
+
+        // Plain-click in-place navigation records a history transition so the
+        // back button can return to the outgoing page.
+        #expect(model.selectPage(byTitle: "To"))
+        #expect(model.selection == .page(to.id))
+        model.navigateBack()
+        #expect(model.selection == .page(from.id))
+    }
+
+    @Test func selectPageByTitleFlushesOutgoingEditsOnInPlaceNavigation() throws {
+        let (model, store) = try tempModel()
+        let from = try store.createPage(title: "From")
+        let to = try store.createPage(title: "To")
+        model.reloadFromStore()
+
+        // In-place navigation replaces the active tab's selection, so the
+        // outgoing page's pending edits are flushed (auto-saved) rather than
+        // silently discarded — the reader is read-only in practice, but this
+        // keeps the edit path safe and matches sidebar `select(_:)`.
+        model.openTab(.page(from.id))
         model.draftBody = "edited body before clicking a link"
         model.bodyChanged()
 
@@ -106,7 +175,7 @@ struct WikiLinkNavigationTests {
         #expect(model.selection == .page(to.id))
 
         let reloaded = try store.getPage(id: from.id)
-        #expect(reloaded.bodyMarkdown == "")  // not auto-saved
+        #expect(reloaded.bodyMarkdown == "edited body before clicking a link")
     }
 
     // MARK: - selectSource(byDisplayName:) (Phase B)
@@ -138,6 +207,38 @@ struct WikiLinkNavigationTests {
 
         #expect(model.selectSource(byDisplayName: "notes.md"))
         #expect(model.tabs.count == 1) // reused, not duplicated
+        #expect(model.selection == .source(source.id))
+    }
+
+    @Test func selectSourceByDisplayNamePlainClickNavigatesInPlace() throws {
+        let (model, store) = try tempModel()
+        let from = try store.createPage(title: "From")
+        let source = try store.addSource(filename: "notes.md", data: Data("md".utf8))
+        model.reloadFromStore()
+
+        model.openTab(.page(from.id))
+        let fromTab = model.activeTabID
+        #expect(model.tabs.count == 1)
+
+        // Plain click on an [[source:…]] link navigates the active tab in place.
+        #expect(model.selectSource(byDisplayName: "notes.md"))
+        #expect(model.tabs.count == 1)
+        #expect(model.activeTabID == fromTab)
+        #expect(model.selection == .source(source.id))
+    }
+
+    @Test func selectSourceByDisplayNameCommandClickOpensNewTab() throws {
+        let (model, store) = try tempModel()
+        let from = try store.createPage(title: "From")
+        let source = try store.addSource(filename: "notes.md", data: Data("md".utf8))
+        model.reloadFromStore()
+
+        model.openTab(.page(from.id))
+        #expect(model.tabs.count == 1)
+
+        // ⌘-click on an [[source:…]] link opens the source in a new tab.
+        #expect(model.selectSource(byDisplayName: "notes.md", openInNewTab: true))
+        #expect(model.tabs.count == 2)
         #expect(model.selection == .source(source.id))
     }
 }


### PR DESCRIPTION
## Summary

Fixes #161. Clicking a `wiki://` link inside the WKWebView reader always opened the target in a **new tab**. This PR implements the standard macOS browser convention:

- **Plain click** → navigate the **current tab** in place (replace the active tab's selection).
- **⌘-click** → open the target in a **new tab** (the previous always-new-tab behavior).

## Changes

**`WikiStoreModel`**
- New private `navigateCurrentTab(to:)`: the plain-click path. If a tab for the target is already open, it focuses it (reuse, never duplicate). If there's no active tab (empty state), it falls back to `openTab`. Otherwise it mutates the active tab's selection/title in place, flushing the outgoing selection's pending edits and reloading drafts — an `setActiveTab`-equivalent that swaps the selection rather than switching tabs.
- Added `openInNewTab: Bool = false` to `selectPage(byTitle:anchor:openInNewTab:)` and `selectSource(byDisplayName:anchor:openInNewTab:)`. `false` (plain click) → `navigateCurrentTab`; `true` (⌘-click) → `openTab`.

**`WikiReaderView`**
- `decidePolicyFor` now reads `navigationAction.modifierFlags.contains(.command)` and threads an `openInNewTab` flag through `route(_:)`.

**Agent transcript chain**
- The `onWikiLink` closure changed from `(URL) -> Void` to `(URL, Bool) -> Void` so the ⌘ flag propagates from `AgentTranscriptWebView`'s `decidePolicyFor` through `AgentActivityView`, `AgentTranscriptSidebar`, `QueryTranscriptView`, `QueryConversationView`, `LintView`, and `ContentView`. Transcript link clicks now get the same plain/cmd semantics as the main reader.

**Tests** (`WikiLinkNavigationTests`)
- Revised the two tests that encoded the old "always new tab" behavior.
- Added: plain-click in-place navigation, ⌘-click new tab, ⌘-click reuse-existing, empty-state fallback, in-place history recording, and in-place edit flushing — for both pages and sources.

## Behavior notes

- The address-bar omnibox (`AddressBarView`) and "Find Similar" context menu (`WikiLinkMenuNSItems`) call `selectPage` without `openInNewTab`, so they now navigate the current tab in place — appropriate for an explicit omnibus/context-menu navigation.
- External `http(s)` links, same-page `#fragment` anchors, and `wiki://missing` ghost links are unaffected.
- In-place navigation flushes (auto-saves) the outgoing page's pending edits rather than discarding them, since the active tab's selection is being replaced. In practice the reader is read-only when links are clickable, so this only matters for the model-level edit path and matches the sidebar `select(_:)` behavior.

## Test plan

- [x] `swift build`
- [x] `swift test --filter WikiLinkNavigationTests` (16 tests)
- [x] `swift test --filter NavigationHistoryTests`
- [x] `swift test` full suite — 1420 tests, 0 failures

Closes #161.
