### PR TITLE
fix(omnibox): arrow keys navigate suggestions panel (#155)

### DIFF
--- a/Sources/WikiFS/OmniboxSearchField.swift
+++ b/Sources/WikiFS/OmniboxSearchField.swift
@@ -112,19 +112,28 @@ struct OmniboxSearchField: NSViewRepresentable {
         coordinator.hidePanel()
     }
 
-    final class Coordinator: NSObject, NSSearchFieldDelegate {
+    final class Coordinator: NSObject, NSSearchFieldDelegate, @unchecked Sendable {
         var parent: OmniboxSearchField
         var lastFocusToken = 0
         private var panel: SuggestionsPanel?
 
-        // Keyboard-driven highlight. The arrow keys arrive here (the field editor
-        // has first responder, not the non-key panel), so the "which row is
-        // selected" state must live on the AppKit side and be pushed into the
-        // SwiftUI list for rendering.
+        // Keyboard-driven highlight. The arrow keys never reliably reach
+        // `control(_:textView:doCommandBy:)` when the field lives inside an
+        // `NSToolbar` item (the toolbar hosts its field editor in a responder
+        // chain isolated from the window), so arrow navigation is handled by a
+        // local `NSEvent` key monitor (`handleArrowKey`) that intercepts the
+        // event ahead of the responder chain. The "which row is selected" state
+        // still lives here and is pushed into the SwiftUI list for rendering.
+        //
+        // `@unchecked Sendable`: the coordinator is touched only on the main
+        // thread — SwiftUI's `updateNSView`/delegate callbacks and local event
+        // monitors both deliver there — so the cross-isolation capture in
+        // `handleArrowKey` is race-free.
         private var selectedIndex: Int?
         private var results: [WikiPageSummary] = []
         private var cachedResultIDs: [PageID] = []
         private weak var anchor: NSSearchField?
+        private var keyMonitor: Any?
 
         init(_ parent: OmniboxSearchField) { self.parent = parent }
 
@@ -158,34 +167,14 @@ struct OmniboxSearchField: NSViewRepresentable {
                 parent.onEscape()
                 control.window?.makeFirstResponder(nil)
                 return true
-            case #selector(NSResponder.moveDown(_:)):
-                // Only hijack the arrow keys while suggestions are showing; with
-                // no panel, let the caret move normally in the field.
-                guard !results.isEmpty else { return false }
-                moveSelection(1)
-                return true
-            case #selector(NSResponder.moveUp(_:)):
-                guard !results.isEmpty else { return false }
-                moveSelection(-1)
-                return true
+            // Arrow keys are handled by the local key monitor (`handleArrowKey`),
+            // not here: the field editor for an `NSSearchField` inside an
+            // `NSToolbar` item lives in a responder chain isolated from the
+            // window, so `moveDown:`/`moveUp:` don't reliably reach this delegate
+            // method in the running app (issue #155).
             default:
                 return false
             }
-        }
-
-        /// Advance the keyboard highlight by `delta` (clamped to the list), then
-        /// re-render the panel so the new row lights up.
-        @MainActor
-        private func moveSelection(_ delta: Int) {
-            guard !results.isEmpty else { return }
-            let count = results.count
-            switch selectedIndex {
-            case nil:
-                selectedIndex = delta > 0 ? 0 : count - 1
-            case .some(let current):
-                selectedIndex = max(0, min(count - 1, current + delta))
-            }
-            presentPanel()
         }
 
         @MainActor
@@ -212,14 +201,80 @@ struct OmniboxSearchField: NSViewRepresentable {
                 anchor?.window?.makeFirstResponder(nil)
             }
             panel.present(under: anchor)
+            installKeyMonitor()
         }
 
         @MainActor
         func hidePanel() {
+            removeKeyMonitor()
             guard let panel else { return }
             panel.parent?.removeChildWindow(panel)
             panel.orderOut(nil)
         }
+
+        // MARK: - Arrow-key monitor
+
+        /// Installs a local keyDown monitor (idempotent). Removed in
+        /// `hidePanel` so arrows fall through to the field normally when the
+        /// panel isn't showing.
+        private func installKeyMonitor() {
+            guard keyMonitor == nil else { return }
+            keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self else { return event }
+                return self.handleArrowKey(event)
+            }
+        }
+
+        private func removeKeyMonitor() {
+            guard let keyMonitor else { return }
+            NSEvent.removeMonitor(keyMonitor)
+            self.keyMonitor = nil
+        }
+
+        /// Consumes up/down arrow keys while the suggestions panel is showing;
+        /// passes every other event through untouched. The monitor is installed
+        /// only while the panel is up (and removed in `hidePanel`, which runs
+        /// when the field blurs / results clear), so by the time we're here the
+        /// omnibox field editor holds first responder. The consume/pass-through
+        /// decision is made here from nonisolated state + the (Sendable) key
+        /// code; the `@MainActor` panel update runs synchronously via
+        /// `assumeIsolated` (local monitors deliver on the main thread).
+        private func handleArrowKey(_ event: NSEvent) -> NSEvent? {
+            guard !results.isEmpty else { return event }
+            let delta: Int
+            switch event.keyCode {
+            case 125: delta = 1   // Down arrow
+            case 126: delta = -1  // Up arrow
+            default: return event
+            }
+            MainActor.assumeIsolated { self.applyArrow(delta: delta) }
+            return nil
+        }
+
+        /// Advances the keyboard highlight and pushes the new row into the panel.
+        @MainActor
+        private func applyArrow(delta: Int) {
+            guard let next = OmniboxSelection.advance(current: selectedIndex,
+                                                     count: results.count,
+                                                     delta: delta) else { return }
+            selectedIndex = next
+            presentPanel()
+        }
+    }
+}
+
+/// Pure, testable keyboard-highlight advancement for the omnibox suggestions
+/// list. `current == nil` means nothing is selected yet; `delta > 0` moves toward
+/// the end of the list, `delta < 0` toward the start. Clamps at the ends (no
+/// wrap), matching the caret-free behavior of a browser address-bar dropdown.
+enum OmniboxSelection {
+    /// Returns the new selected index, or `nil` if there is nothing to select
+    /// (empty list). When `current == nil`, the first down selects row 0 and the
+    /// first up selects the last row.
+    static func advance(current: Int?, count: Int, delta: Int) -> Int? {
+        guard count > 0 else { return nil }
+        guard let current else { return delta > 0 ? 0 : count - 1 }
+        return max(0, min(count - 1, current + delta))
     }
 }
 

--- a/Tests/WikiFSTests/OmniboxSelectionTests.swift
+++ b/Tests/WikiFSTests/OmniboxSelectionTests.swift
@@ -1,0 +1,77 @@
+import Testing
+@testable import WikiFS
+
+/// Pure logic behind omnibox arrow-key navigation (issue #155). The actual
+/// AppKit event interception lives in `OmniboxSearchField.Coordinator`
+/// (`NSEvent` local monitor); these tests lock the selection-advancement math
+/// it drives — the first-down selects the top row, up/down step and clamp at
+/// the ends, and an empty list yields nothing.
+@Suite struct OmniboxSelectionTests {
+
+    // MARK: - First press (nothing selected yet)
+
+    @Test func firstDownSelectsTheTopRow() {
+        #expect(OmniboxSelection.advance(current: nil, count: 5, delta: 1) == 0)
+    }
+
+    @Test func firstUpSelectsTheLastRow() {
+        #expect(OmniboxSelection.advance(current: nil, count: 5, delta: -1) == 4)
+    }
+
+    @Test func firstUpOnASingleItemSelectsIt() {
+        #expect(OmniboxSelection.advance(current: nil, count: 1, delta: -1) == 0)
+    }
+
+    // MARK: - Stepping
+
+    @Test func downStepsTowardTheEnd() {
+        var index: Int? = OmniboxSelection.advance(current: nil, count: 4, delta: 1)
+        index = OmniboxSelection.advance(current: index, count: 4, delta: 1)
+        #expect(index == 1)
+        index = OmniboxSelection.advance(current: index, count: 4, delta: 1)
+        #expect(index == 2)
+        index = OmniboxSelection.advance(current: index, count: 4, delta: 1)
+        #expect(index == 3)
+    }
+
+    @Test func upStepsTowardTheStart() {
+        var index: Int? = OmniboxSelection.advance(current: nil, count: 4, delta: -1) // 3
+        index = OmniboxSelection.advance(current: index, count: 4, delta: -1) // 2
+        index = OmniboxSelection.advance(current: index, count: 4, delta: -1) // 1
+        index = OmniboxSelection.advance(current: index, count: 4, delta: -1) // 0
+        #expect(index == 0)
+    }
+
+    // MARK: - Clamping (no wrap)
+
+    @Test func downClampsAtTheLastRow() {
+        // Already at the end: stays put, never wraps to the top.
+        #expect(OmniboxSelection.advance(current: 3, count: 4, delta: 1) == 3)
+        #expect(OmniboxSelection.advance(current: 3, count: 4, delta: 5) == 3)
+    }
+
+    @Test func upClampsAtTheFirstRow() {
+        // Already at the start: stays put, never wraps to the bottom.
+        #expect(OmniboxSelection.advance(current: 0, count: 4, delta: -1) == 0)
+        #expect(OmniboxSelection.advance(current: 0, count: 4, delta: -5) == 0)
+    }
+
+    @Test func clampsPastTheEndInOneStep() {
+        // A single large delta never overshoots the bounds.
+        #expect(OmniboxSelection.advance(current: 1, count: 4, delta: 100) == 3)
+        #expect(OmniboxSelection.advance(current: 2, count: 4, delta: -100) == 0)
+    }
+
+    // MARK: - Empty list
+
+    @Test func emptyListYieldsNoSelection() {
+        #expect(OmniboxSelection.advance(current: nil, count: 0, delta: 1) == nil)
+        #expect(OmniboxSelection.advance(current: 0, count: 0, delta: 1) == nil)
+    }
+
+    @Test func singleItemListClampsImmediately() {
+        #expect(OmniboxSelection.advance(current: nil, count: 1, delta: 1) == 0)
+        #expect(OmniboxSelection.advance(current: 0, count: 1, delta: 1) == 0)
+        #expect(OmniboxSelection.advance(current: 0, count: 1, delta: -1) == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #155 — arrow up/down did nothing while the omnibox suggestions panel was open.

## Root cause

The omnibox is an `NSSearchField` hosted inside an `NSToolbar` item. The toolbar hosts its field editor in a responder chain isolated from the window, so `moveDown:`/`moveUp:` selectors never reliably reach `control(_:textView:doCommandBy:)` on the coordinator. The existing arrow-highlight code was correct but never ran. `insertNewline:`/`cancelOperation:` (Enter/Escape) were unaffected, which is why only arrows were broken.

## Fix

- Handle arrow keys via a **local `NSEvent` keyDown monitor** that intercepts up/down *ahead of the responder chain*. It's installed only while the suggestions panel is showing (`presentPanel`) and removed on hide (`hidePanel`, also run on dismantle), so arrows fall through to the field normally otherwise.
- The monitor consumes the event (`return nil`) and advances the keyboard highlight; `selectedIndex` updates synchronously (rapid presses accumulate correctly) and the panel is re-rendered to light up the new row.
- Enter/Escape continue to flow through `doCommandBy:` — those selectors *do* reach the delegate.
- Swift 6: the consume/pass-through decision is made from nonisolated state + the Sendable key code; the `@MainActor` panel update runs synchronously via `MainActor.assumeIsolated` (local monitors deliver on the main thread). The coordinator is `@unchecked Sendable`, justified because all access is main-thread — the same discipline as the existing `ZoomScrollMonitor`.

## Tests

Extracted the selection-advance math into a pure, unit-tested `OmniboxSelection` type (`Tests/WikiFSTests/OmniboxSelectionTests.swift`):

- first down → top row; first up → last row
- stepping up/down
- clamping at both ends (no wrap), including large single deltas
- empty list → no selection; single-item list clamps immediately

`swift test` — 1443 tests pass (10 new).

## Verification

- `swift build` ✅
- `swift test` ✅

## Notes

The arrow handling was removed from `control(_:textView:doCommandBy:)` since the monitor now owns it (and consumes those events before they could reach the delegate anyway).
