### PR TITLE
fix(extraction): find Homebrew-installed uv when launching pdf2md

### DIFF
--- a/Sources/WikiFS/PdfExtractionService.swift
+++ b/Sources/WikiFS/PdfExtractionService.swift
@@ -57,6 +57,18 @@ enum PdfExtractionService {
 
     private static nonisolated let processRegistry = ProcessRegistry()
 
+    /// Directories prepended to a subprocess PATH so the `pdf2md` shebang
+    /// (`env -S uv run --script`) can find `uv`. A Finder-launched app inherits
+    /// the bare system PATH (`/usr/bin:/bin:…`), so cover every place uv
+    /// actually lands: `~/.local/bin` (the official installer),
+    /// `/opt/homebrew/bin` (Homebrew on Apple silicon), and `/usr/local/bin`
+    /// (Homebrew on Intel).
+    static nonisolated var uvSearchPATH: String {
+        let localBin = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/bin", isDirectory: true).path
+        return "\(localBin):/opt/homebrew/bin:/usr/local/bin"
+    }
+
     /// Thread-safe byte accumulator for a pipe drained on a background queue.
     /// The pipe `readabilityHandler` fires off-actor, so the buffer it appends to
     /// must be its own lock-guarded box (not actor state).
@@ -88,10 +100,7 @@ enum PdfExtractionService {
             process.standardOutput = FileHandle.nullDevice
             process.standardError = FileHandle.nullDevice
             var env = ProcessInfo.processInfo.environment
-            let localBin = FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".local/bin", isDirectory: true).path
-            let existing = env["PATH"] ?? ""
-            env["PATH"] = "\(localBin):\(existing)"
+            env["PATH"] = "\(uvSearchPATH):\(env["PATH"] ?? "")"
             process.environment = env
             process.terminationHandler = { proc in
                 processRegistry.untrack(proc)
@@ -131,9 +140,7 @@ enum PdfExtractionService {
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         var env = ProcessInfo.processInfo.environment
-        let localBin = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".local/bin", isDirectory: true).path
-        env["PATH"] = "\(localBin):\(env["PATH"] ?? "")"
+        env["PATH"] = "\(uvSearchPATH):\(env["PATH"] ?? "")"
         process.environment = env
 
         return await withTaskGroup(of: Bool.self) { group in
@@ -222,20 +229,17 @@ enum PdfExtractionService {
         guard let script = resolveScript() else {
             throw ExtractionError.scriptNotFound
         }
-        let localBin = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".local/bin", isDirectory: true).path
-
         onProgress("Installing Python packages (docling, torch, spacy)…\n")
         try await streamProcess(
             executable: script, arguments: ["--help"],
-            extraPATH: localBin, onProgress: onProgress)
+            extraPATH: uvSearchPATH, onProgress: onProgress)
 
         onProgress("\nDownloading model weights (\(graniteModelRepoID))…\n")
         try await streamProcess(
             executable: URL(fileURLWithPath: "/usr/bin/env"),
             arguments: ["uv", "run", "--quiet", "--with", "huggingface_hub",
                         "python", "-c", modelDownloadProgram, graniteModelRepoID],
-            extraPATH: localBin, onProgress: onProgress)
+            extraPATH: uvSearchPATH, onProgress: onProgress)
     }
 
     /// Inline Python that fetches a repo into the HF hub cache, emitting tqdm
@@ -371,14 +375,8 @@ enum PdfExtractionService {
         process.arguments = [input.path]
         process.currentDirectoryURL = input.deletingLastPathComponent()
 
-        // Prepend ~/.local/bin to PATH so the pdf2md shebang can find `uv`.
-        // The system PATH (used when the app is launched from Finder) does not
-        // include ~/.local/bin, but that is where `uv` installs itself.
         var env = ProcessInfo.processInfo.environment
-        let localBin = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".local/bin", isDirectory: true).path
-        let existing = env["PATH"] ?? ""
-        env["PATH"] = "\(localBin):\(existing)"
+        env["PATH"] = "\(uvSearchPATH):\(env["PATH"] ?? "")"
         process.environment = env
 
         let stdoutPipe = Pipe()


### PR DESCRIPTION
## Problem

With `uv` installed via Homebrew rather than the official installer, local PDF extraction never works: the `pdf2md --help` readiness probe exits 127 and every ingest falls back to sending the raw PDF to the agent.

```
[pdf2md] checkReady: probing /Applications/Self Driving Wiki.app/Contents/Helpers/pdf2md
[pdf2md] checkReady: probe exit=127 ready=false
readiness: not ready — Local pdf2md dependencies aren't installed. ...
```

A Finder-launched app inherits the bare system PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), and the four subprocess sites in `PdfExtractionService` only prepended `~/.local/bin` (where the official uv installer puts it). The script's shebang is `env -S uv run --script`, so `env` can't find a Homebrew uv at `/opt/homebrew/bin` and exits 127.

## Fix

Extract the duplicated PATH construction (checkReady, probeReady, preDownload, run) into a single `uvSearchPATH` helper that prepends `~/.local/bin`, `/opt/homebrew/bin` (Apple silicon Homebrew), and `/usr/local/bin` (Intel Homebrew).

## Verification

- Reproduced outside the app: bundled `pdf2md --help` with the old PATH construction exits 127, with the new one exits 0 (uv at `/opt/homebrew/bin/uv` only).
- Confirmed end-to-end in the installed app: probe now reports `exit=0 ready=true` and a 3.8 MB arXiv PDF converted to 102k chars of markdown via local pdf2md.
- `swift test`: 1478 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2bJGccRPy5RonE9UsGrcR