### PR TITLE
Fix #154: scope sidebar Cmd+A select-all to the table first-responder

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,27 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-05 — Stop sidebar tables stealing Cmd+A from the omnibox (#154)
+
+`PagesNSTableView` and `SourcesNSTableView` overrode `performKeyEquivalent(with:)`
+to map Cmd+A → "select all rows". But `performKeyEquivalent` is dispatched across
+the *entire* window view hierarchy for every key-down (not just to the first
+responder), so the override unconditionally consumed Cmd+A even when the omnibox
+field editor — not the table — was first responder. Result: Cmd+A in the address
+bar selected all sidebar rows instead of the omnibox text. Fixes
+[#154](https://github.com/tqbf/selfdrivingwiki/issues/154).
+
+- **`NSView.isFirstResponder(_:selfOrDescendantOf:)`** (`WikiFS/NSView+FirstResponder.swift`,
+  new) — a pure predicate (nil / self / descendant / unrelated) that the tables
+  now consult before acting on Cmd+A. Split out as a static function so the
+  gating decision is testable without depending on window key/visibility state,
+  which AppKit does not reliably commit in a headless test environment.
+- **Both table overrides** now `guard isSelfOrDescendantFirstResponder()` before
+  calling `selectAll(self)`; otherwise they defer to `super`.
+- **`SidebarSelectAllShortcutTests`** — pure-predicate coverage plus integration
+  regression guards: with an omnibox `NSTextField` holding focus (field editor
+  first responder), neither table consumes Cmd+A, and non-Cmd+A keys always defer.
+
 ## 2026-07-04 — Multi-select pages/sources → bookmark them all into a chosen folder (#151)
 
 Bookmarking was folder-first: the only entry point was from inside the Bookmarks

--- a/Sources/WikiFS/NSView+FirstResponder.swift
+++ b/Sources/WikiFS/NSView+FirstResponder.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+extension NSView {
+    /// Pure predicate: would `firstResponder` make `view` the active target —
+    /// i.e. is it `view` itself, or a descendant such as an inline field editor
+    /// hosted by an `NSTableView`?
+    ///
+    /// `performKeyEquivalent(with:)` is dispatched across the window's entire
+    /// view hierarchy for every key-down event — not just to the first
+    /// responder — so view-scoped shortcuts must consult this before acting,
+    /// otherwise they steal key equivalents from other first responders in the
+    /// same window (e.g. Cmd+A in the omnibox, issue #154).
+    ///
+    /// Split out as a pure function so the gating decision can be tested
+    /// without depending on window key/visibility state, which AppKit does not
+    /// reliably commit in a headless test environment.
+    static func isFirstResponder(
+        _ firstResponder: NSResponder?,
+        selfOrDescendantOf view: NSView
+    ) -> Bool {
+        guard let firstResponder else { return false }
+        if firstResponder === view { return true }
+        if let responderView = firstResponder as? NSView,
+           responderView.isDescendant(of: view) {
+            return true
+        }
+        return false
+    }
+
+    /// Convenience: true when this view (or a descendant) is the window's
+    /// current first responder.
+    func isSelfOrDescendantFirstResponder() -> Bool {
+        Self.isFirstResponder(window?.firstResponder, selfOrDescendantOf: self)
+    }
+}

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -411,15 +411,23 @@ final class PagesNSTableView: NSTableView {
         return (self.delegate as? PagesListViewController)?.menuForRow(row)
     }
 
-    /// Cmd+A → select all rows, scoped to this table (only the visible
-    /// section's table is in the responder chain). Replaces the cross-section
-    /// `handleSelectAll` hack from the shared-List era.
+    /// Cmd+A → select all rows, scoped to this table.
+    ///
+    /// `performKeyEquivalent(with:)` is dispatched across the window's entire
+    /// view hierarchy for every key-down event — not just to the current first
+    /// responder — so a naive override here would steal Cmd+A from other first
+    /// responders in the same window (notably the omnibox/address bar). We
+    /// therefore only act when this table view (or a descendant, e.g. an inline
+    /// field editor) is actually the current first responder.
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if event.modifierFlags.contains(.command),
-           event.charactersIgnoringModifiers == "a" {
-            self.selectAll(self)
-            return true
+        guard event.modifierFlags.contains(.command),
+              event.charactersIgnoringModifiers == "a" else {
+            return super.performKeyEquivalent(with: event)
         }
-        return super.performKeyEquivalent(with: event)
+        guard isSelfOrDescendantFirstResponder() else {
+            return super.performKeyEquivalent(with: event)
+        }
+        self.selectAll(self)
+        return true
     }
 }

--- a/Sources/WikiFS/SourcesListView.swift
+++ b/Sources/WikiFS/SourcesListView.swift
@@ -540,12 +540,20 @@ final class SourcesNSTableView: NSTableView {
         return (self.delegate as? SourcesListViewController)?.menuForRow(row)
     }
 
+    /// Cmd+A → select all rows, scoped to this table. See the matching note on
+    /// `PagesNSTableView`: `performKeyEquivalent(with:)` runs for the whole
+    /// view hierarchy, so we must confirm this table is the first responder
+    /// (or hosts it) before hijacking Cmd+A — otherwise we steal it from the
+    /// omnibox and other fields in the same window.
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if event.modifierFlags.contains(.command),
-           event.charactersIgnoringModifiers == "a" {
-            self.selectAll(self)
-            return true
+        guard event.modifierFlags.contains(.command),
+              event.charactersIgnoringModifiers == "a" else {
+            return super.performKeyEquivalent(with: event)
         }
-        return super.performKeyEquivalent(with: event)
+        guard isSelfOrDescendantFirstResponder() else {
+            return super.performKeyEquivalent(with: event)
+        }
+        self.selectAll(self)
+        return true
     }
 }

--- a/Tests/WikiFSTests/SidebarSelectAllShortcutTests.swift
+++ b/Tests/WikiFSTests/SidebarSelectAllShortcutTests.swift
@@ -1,0 +1,121 @@
+import AppKit
+import CoreGraphics
+import Testing
+@testable import WikiFS
+
+/// Verifies the Cmd+A "select all rows" shortcut on the sidebar table views is
+/// scoped to when the table (or a descendant) is the first responder, so it
+/// does not steal Cmd+A from the omnibox or other text fields that share the
+/// window (issue #154).
+///
+/// `performKeyEquivalent(with:)` is dispatched across the window's entire view
+/// hierarchy for every key-down, not just to the first responder — so the table
+/// must confirm it actually owns focus before consuming Cmd+A.
+@MainActor
+@Suite struct SidebarSelectAllShortcutTests {
+
+    // MARK: - Helpers
+
+    /// A Cmd+A key-down event, matching what AppKit dispatches for ⌘A.
+    private func cmdAEvent() -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "a",
+            charactersIgnoringModifiers: "a",
+            isARepeat: false,
+            keyCode: 0)
+    }
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 400),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+    }
+
+    // MARK: - Pure gating predicate (no window/visibility dependency)
+
+    @Test func predicateReturnsFalseForNilFirstResponder() {
+        let table = PagesNSTableView()
+        #expect(NSView.isFirstResponder(nil, selfOrDescendantOf: table) == false)
+    }
+
+    @Test func predicateReturnsTrueWhenViewIsItselfFirstResponder() {
+        let table = PagesNSTableView()
+        #expect(NSView.isFirstResponder(table, selfOrDescendantOf: table))
+    }
+
+    @Test func predicateReturnsTrueForDescendantFirstResponder() {
+        // Mimics an inline field editor hosted inside the table: a subview of
+        // the table being first responder still counts as "table owns focus".
+        let table = PagesNSTableView()
+        let hosted = NSView()
+        table.addSubview(hosted)
+        #expect(NSView.isFirstResponder(hosted, selfOrDescendantOf: table))
+    }
+
+    @Test func predicateReturnsFalseForUnrelatedFirstResponder() {
+        // The omnibox is a sibling in the window, not a descendant of the table.
+        let table = PagesNSTableView()
+        let omnibox = NSTextField(string: "query")
+        #expect(NSView.isFirstResponder(omnibox, selfOrDescendantOf: table) == false)
+    }
+
+    // MARK: - Integration: the reported bug (issue #154)
+
+    @Test func pagesTableDoesNotStealCmdAFromOmniboxField() throws {
+        let event = try #require(cmdAEvent())
+        let window = makeWindow()
+        let table = PagesNSTableView()
+        window.contentView?.addSubview(table)
+        let omnibox = NSTextField(string: "omnibox text")
+        window.contentView?.addSubview(omnibox)
+
+        // The omnibox owns focus. AppKit swaps in the window's shared field
+        // editor (an NSTextView) as first responder — it is NOT a descendant of
+        // the table, exactly the scenario in issue #154.
+        #expect(window.makeFirstResponder(omnibox))
+        #expect(window.firstResponder !== table)
+        #expect(table.isSelfOrDescendantFirstResponder() == false)
+
+        // Cmd+A must fall through so the field can select its own text.
+        #expect(table.performKeyEquivalent(with: event) == false)
+    }
+
+    @Test func sourcesTableDoesNotStealCmdAFromOmniboxField() throws {
+        let event = try #require(cmdAEvent())
+        let window = makeWindow()
+        let table = SourcesNSTableView()
+        window.contentView?.addSubview(table)
+        let omnibox = NSTextField(string: "omnibox text")
+        window.contentView?.addSubview(omnibox)
+
+        #expect(window.makeFirstResponder(omnibox))
+        #expect(window.firstResponder !== table)
+        #expect(table.isSelfOrDescendantFirstResponder() == false)
+
+        #expect(table.performKeyEquivalent(with: event) == false)
+    }
+
+    // MARK: - Only Cmd+A is intercepted
+
+    @Test func pagesTableDoesNotInterceptOtherCommandKeys() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: .command, timestamp: 0,
+            windowNumber: 0, context: nil, characters: "b",
+            charactersIgnoringModifiers: "b", isARepeat: false, keyCode: 11))
+        let window = makeWindow()
+        let table = PagesNSTableView()
+        window.contentView?.addSubview(table)
+        // Anything that isn't Cmd+A defers to super regardless of focus.
+        window.makeFirstResponder(table)
+
+        #expect(table.performKeyEquivalent(with: event) == false)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #154.

Cmd+A while focused in the omnibox was selecting all rows in the sidebar tree instead of selecting the omnibox text.

### Root cause

`PagesNSTableView` and `SourcesNSTableView` both overrode `performKeyEquivalent(with:)` to map Cmd+A → "select all rows":

```swift
override func performKeyEquivalent(with event: NSEvent) -> Bool {
    if event.modifierFlags.contains(.command),
       event.charactersIgnoringModifiers == "a" {
        self.selectAll(self)
        return true
    }
    return super.performKeyEquivalent(with: event)
}
```

`performKeyEquivalent(with:)` is dispatched down the window's **entire** view hierarchy for every key-down event — not just to the current first responder — so this override unconditionally intercepted Cmd+A even when the omnibox's field editor, not the table, was first responder. The sidebar table "won" the shortcut and the omnibox never ran its own select-all.

### Fix

Both tables now confirm they (or a descendant, e.g. an inline field editor) are actually the current first responder before consuming Cmd+A, and defer to `super` otherwise:

- New `NSView.isFirstResponder(_:selfOrDescendantOf:)` (`Sources/WikiFS/NSView+FirstResponder.swift`) — a pure predicate covering the nil / self / descendant / unrelated cases.
- `isSelfOrDescendantFirstResponder()` convenience wraps it against `window?.firstResponder`.
- Both `performKeyEquivalent` overrides `guard` on it before calling `selectAll(self)`.

The predicate is split out as a static function so the gating decision can be tested without depending on window key/visibility state, which AppKit does not reliably commit in a headless test environment.

## Testing

New `Tests/WikiFSTests/SidebarSelectAllShortcutTests.swift` (Swift Testing, all passing):

- **Pure predicate** — nil → false, self → true, descendant subview → true, unrelated view → false.
- **Integration regression guards** (the reported bug) — with an omnibox `NSTextField` holding focus (AppKit swaps in its field editor `NSTextView` as first responder, which is not a descendant of the table), neither table consumes Cmd+A.
- **Non-Cmd-A keys** always defer to `super`.

Verified locally:

```
swift test --filter SidebarSelectAllShortcutTests   # 7/7 pass
swift test --filter "Omnibox|Sidebar|BookmarksMultiSelect"  # 56/56 pass
```

Against the original (unconditional) code, the integration guards fail (the tables return `true`), confirming they catch the regression.

## Files

- `Sources/WikiFS/NSView+FirstResponder.swift` (new)
- `Sources/WikiFS/PagesListView.swift`
- `Sources/WikiFS/SourcesListView.swift`
- `Tests/WikiFSTests/SidebarSelectAllShortcutTests.swift` (new)
