### PR TITLE
fix(#163): route .webloc/remote-URL drops through Add-from-URL ingest

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4766,23 +4766,21 @@ hello-world WikiFS SwiftUI app building, signing, and launching.
 ## #163 — Drop routing for .webloc / remote URLs (2026-07-05)
 
 **Problem:** dragging a `.webloc` file or an `http(s)` URL from a browser onto
-the window hit the generic file-drop path (`ingest(fileURLs:)`), ingesting the
+the window hit the generic file-drop path (`addFiles`), ingesting the
 `.webloc` plist's raw bytes instead of fetching the linked page.
 
 **Fix**
 - `WikiStoreModel.addDroppedURLs(_:fetcher:)` — partitions dropped URLs:
   `http(s)` URLs and `.webloc` shortcuts (resolved to their target) route through
-  `ingestURL` (the "Add from URL" fetch + HTML→Markdown path); other `file://`
-  URLs still ingest as raw bytes via `ingest(fileURLs:)`. Supports multi-URL drops;
+  `addURL` (the "Add from URL" fetch + HTML→Markdown path); other `file://`
+  URLs still ingest as raw bytes via `addFiles`. Supports multi-URL drops;
   an unresolvable `.webloc` is skipped (its bytes aren't a useful source).
   Named `add*` (not `ingest*`) since it only adds a source — agent ingestion
-  (read source → generate pages) is a separate `AgentLauncher` phase. The older
-  `ingest(fileURLs:)` / `ingestURL` carry the same misnomer; tracked for a later
-  rename.
+  (read source → generate pages) is a separate `AgentLauncher` phase.
 - `WikiStoreModel.resolveWeblocURL(_:)` — reads the plist (XML or binary) off the
   main actor via `PropertyListSerialization`.
 - `ContentView` `.dropDestination` now calls `store.addDroppedURLs(_:)`.
 
 **Tests:** `WikiStoreModelDropRoutingTests` (5) — webloc→md, http url→md, local
 txt→verbatim, mixed batch, unresolvable webloc skipped. All pass; existing
-`WikiStoreModelURLIngestTests` still green.
+`WikiStoreModelAddURLTests` still green.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4762,3 +4762,27 @@ hello-world WikiFS SwiftUI app building, signing, and launching.
 - Add a `WikiFSTests` target so `make test` does something.
 - Begin SQLite store + page model (Milestone 0 deliverables in `plans/INITIAL.md`
   also include persistence; the build skeleton is done, the data layer is not).
+
+## #163 — Drop routing for .webloc / remote URLs (2026-07-05)
+
+**Problem:** dragging a `.webloc` file or an `http(s)` URL from a browser onto
+the window hit the generic file-drop path (`ingest(fileURLs:)`), ingesting the
+`.webloc` plist's raw bytes instead of fetching the linked page.
+
+**Fix**
+- `WikiStoreModel.addDroppedURLs(_:fetcher:)` — partitions dropped URLs:
+  `http(s)` URLs and `.webloc` shortcuts (resolved to their target) route through
+  `ingestURL` (the "Add from URL" fetch + HTML→Markdown path); other `file://`
+  URLs still ingest as raw bytes via `ingest(fileURLs:)`. Supports multi-URL drops;
+  an unresolvable `.webloc` is skipped (its bytes aren't a useful source).
+  Named `add*` (not `ingest*`) since it only adds a source — agent ingestion
+  (read source → generate pages) is a separate `AgentLauncher` phase. The older
+  `ingest(fileURLs:)` / `ingestURL` carry the same misnomer; tracked for a later
+  rename.
+- `WikiStoreModel.resolveWeblocURL(_:)` — reads the plist (XML or binary) off the
+  main actor via `PropertyListSerialization`.
+- `ContentView` `.dropDestination` now calls `store.addDroppedURLs(_:)`.
+
+**Tests:** `WikiStoreModelDropRoutingTests` (5) — webloc→md, http url→md, local
+txt→verbatim, mixed batch, unresolvable webloc skipped. All pass; existing
+`WikiStoreModelURLIngestTests` still green.

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -153,10 +153,12 @@ struct ContentView: View {
         } detail: {
             detailColumn
         }
-        // Drop a file anywhere on the window to ingest it (raw bytes → SQLite →
-        // the read-only `files/` projection). The whole content is the target.
+        // Drop a file or link anywhere on the window. Remote links (an http(s)
+        // URL dragged from a browser, or a `.webloc` resolved to one) route
+        // through the "Add from URL" fetch path; local files ingest as raw
+        // bytes. The whole content is the target. (#163)
         .dropDestination(for: URL.self) { urls, _ in
-            Task { await store.addFiles(urls) }
+            Task { await store.ingest(droppedURLs: urls) }
             return true
         } isTargeted: { targeted in
             // Fade, not bounce; skip the animation entirely under Reduce Motion.

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -158,7 +158,7 @@ struct ContentView: View {
         // through the "Add from URL" fetch path; local files ingest as raw
         // bytes. The whole content is the target. (#163)
         .dropDestination(for: URL.self) { urls, _ in
-            Task { await store.ingest(droppedURLs: urls) }
+            Task { await store.addDroppedURLs(urls) }
             return true
         } isTargeted: { targeted in
             // Fade, not bounce; skip the animation entirely under Reduce Motion.

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1122,7 +1122,7 @@ public final class WikiStoreModel {
     /// run the agent "ingestion" that reads a source and generates pages; that is
     /// a separate `AgentLauncher` phase.)
     /// - An `http(s)` URL (a link dragged from a browser) **or** a `.webloc`
-    ///   shortcut that resolves to one → `ingestURL` — the fetch + HTML→Markdown
+    ///   shortcut that resolves to one → `addURL` — the fetch + HTML→Markdown
     ///   "Add from URL" path. This avoids reading a `.webloc` plist's raw bytes,
     ///   which would capture the wrapper XML rather than the linked page.
     /// - Any other `file://` URL → `addFiles` (raw bytes, as before).
@@ -1133,7 +1133,7 @@ public final class WikiStoreModel {
     /// default performs a real network GET.
     public func addDroppedURLs(
         _ droppedURLs: [URL],
-        fetcher: any URLIngestService.URLResourceFetcher = URLSessionFetcher()
+        fetcher: any URLFetchService.URLResourceFetcher = URLSessionFetcher()
     ) async {
         var remoteInputs: [String] = []
         var localFiles: [URL] = []

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1117,7 +1117,10 @@ public final class WikiStoreModel {
 
     // MARK: - File ingestion (Phase 5)
 
-    /// Route dropped URLs to the correct ingest path (#163):
+    /// Route dropped URLs to the correct **add-source** path (#163). (This adds
+    /// a source — fetches/stores bytes so it appears under Sources — it does *not*
+    /// run the agent "ingestion" that reads a source and generates pages; that is
+    /// a separate `AgentLauncher` phase.)
     /// - An `http(s)` URL (a link dragged from a browser) **or** a `.webloc`
     ///   shortcut that resolves to one → `ingestURL` — the fetch + HTML→Markdown
     ///   "Add from URL" path. This avoids reading a `.webloc` plist's raw bytes,
@@ -1128,8 +1131,8 @@ public final class WikiStoreModel {
     /// own source. A `.webloc` whose `URL` key can't be parsed is skipped (its
     /// bytes aren't useful as a source). `fetcher` is injectable for tests; the
     /// default performs a real network GET.
-    public func ingest(
-        droppedURLs: [URL],
+    public func addDroppedURLs(
+        _ droppedURLs: [URL],
         fetcher: any URLIngestService.URLResourceFetcher = URLSessionFetcher()
     ) async {
         var remoteInputs: [String] = []
@@ -1141,7 +1144,7 @@ public final class WikiStoreModel {
                 if let resolved = await Self.resolveWeblocURL(url) {
                     remoteInputs.append(resolved)
                 } else {
-                    DebugLog.store("WikiStoreModel.ingest(droppedURLs:) could not resolve .webloc: \(url.lastPathComponent)")
+                    DebugLog.store("WikiStoreModel.addDroppedURLs could not resolve .webloc: \(url.lastPathComponent)")
                 }
             } else {
                 localFiles.append(url)
@@ -1151,7 +1154,7 @@ public final class WikiStoreModel {
             do {
                 _ = try await addURL(input, fetcher: fetcher)
             } catch {
-                DebugLog.store("WikiStoreModel.ingest(droppedURLs:) URL ingest failed for \(input): \(error)")
+                DebugLog.store("WikiStoreModel.addDroppedURLs URL ingest failed for \(input): \(error)")
             }
         }
         if !localFiles.isEmpty {

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1117,10 +1117,66 @@ public final class WikiStoreModel {
 
     // MARK: - File ingestion (Phase 5)
 
-    /// Add dropped/imported files as sources. For each URL: reject directories
-    /// (a recursive directory add is out of scope), read the bytes OFF the main
-    /// thread (big files shouldn't stall the UI), then hop back to the main actor
-    /// to store + reload. Per-file failures are logged and skipped so one bad drop
+    /// Route dropped URLs to the correct ingest path (#163):
+    /// - An `http(s)` URL (a link dragged from a browser) **or** a `.webloc`
+    ///   shortcut that resolves to one → `ingestURL` — the fetch + HTML→Markdown
+    ///   "Add from URL" path. This avoids reading a `.webloc` plist's raw bytes,
+    ///   which would capture the wrapper XML rather than the linked page.
+    /// - Any other `file://` URL → `addFiles` (raw bytes, as before).
+    ///
+    /// Several links / `.webloc` files dropped together are each added as their
+    /// own source. A `.webloc` whose `URL` key can't be parsed is skipped (its
+    /// bytes aren't useful as a source). `fetcher` is injectable for tests; the
+    /// default performs a real network GET.
+    public func ingest(
+        droppedURLs: [URL],
+        fetcher: any URLIngestService.URLResourceFetcher = URLSessionFetcher()
+    ) async {
+        var remoteInputs: [String] = []
+        var localFiles: [URL] = []
+        for url in droppedURLs {
+            if let scheme = url.scheme, scheme == "http" || scheme == "https" {
+                remoteInputs.append(url.absoluteString)
+            } else if url.isFileURL, url.pathExtension.lowercased() == "webloc" {
+                if let resolved = await Self.resolveWeblocURL(url) {
+                    remoteInputs.append(resolved)
+                } else {
+                    DebugLog.store("WikiStoreModel.ingest(droppedURLs:) could not resolve .webloc: \(url.lastPathComponent)")
+                }
+            } else {
+                localFiles.append(url)
+            }
+        }
+        for input in remoteInputs {
+            do {
+                _ = try await addURL(input, fetcher: fetcher)
+            } catch {
+                DebugLog.store("WikiStoreModel.ingest(droppedURLs:) URL ingest failed for \(input): \(error)")
+            }
+        }
+        if !localFiles.isEmpty {
+            await addFiles(localFiles)
+        }
+    }
+
+    /// Read a `.webloc` property list (XML or binary) off the main actor and
+    /// return its `URL` string, or `nil` if the file isn't a valid webloc. (#163)
+    private static func resolveWeblocURL(_ fileURL: URL) async -> String? {
+        await Task.detached(priority: .userInitiated) {
+            guard let data = try? Data(contentsOf: fileURL),
+                  let plist = try? PropertyListSerialization.propertyList(
+                      from: data, options: [], format: nil),
+                  let urlString = (plist as? [String: Any])?["URL"] as? String,
+                  !urlString.isEmpty
+            else { return nil }
+            return urlString
+        }.value
+    }
+
+    /// Ingest dropped files. For each URL: reject directories (a recursive
+    /// directory ingest is out of scope), read the bytes OFF the main thread
+    /// (big files shouldn't stall the UI), then hop back to the main actor to
+    /// store + reload. Per-file failures are logged and skipped so one bad drop
     /// doesn't abort the batch. `onPageDidChange?()` fires ONCE at the end so the
     /// daemon re-enumerates the `sources/` tree exactly once for the whole batch.
     ///

--- a/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Verifies the window-wide drop routing (#163): an `http(s)` URL dragged from
+/// a browser, and a `.webloc` shortcut that resolves to one, flow through the
+/// "Add from URL" fetch path (`ingestURL` → HTML→Markdown), while genuine local
+/// files still ingest as raw bytes (`ingest(fileURLs:)`). Uses a fake fetcher —
+/// no real network.
+@MainActor
+struct WikiStoreModelDropRoutingTests {
+
+    struct FakeFetcher: URLIngestService.URLResourceFetcher {
+        let response: URLIngestService.FetchResponse
+        func fetch(_ url: URL) async throws -> URLIngestService.FetchResponse { response }
+    }
+
+    private func tempStore() throws -> SQLiteWikiStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-droproute-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+    }
+
+    /// Write a real `.webloc` plist (XML) wrapping `urlString` and return its URL.
+    private func writeWebloc(in dir: URL, named: String, urlString: String) throws -> URL {
+        let fileURL = dir.appendingPathComponent("\(named).webloc")
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["URL": urlString], format: .xml, options: 0)
+        try data.write(to: fileURL)
+        return fileURL
+    }
+
+    /// Write a plain local file and return its URL.
+    private func writeLocalFile(in dir: URL, named: String, contents: String) throws -> URL {
+        let fileURL = dir.appendingPathComponent(named)
+        try Data(contents.utf8).write(to: fileURL)
+        return fileURL
+    }
+
+    @Test func weblocRoutesThroughURLIngestAsMarkdown() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-droproute-files-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let webloc = try writeWebloc(
+            in: dir, named: "Link",
+            urlString: "https://example.com/article")
+
+        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+            data: Data("<title>Article</title><body><p>Body.</p></body>".utf8),
+            contentType: "text/html",
+            finalURL: URL(string: "https://example.com/article")!))
+
+        await model.ingest(droppedURLs: [webloc], fetcher: fetcher)
+
+        // Routed through ingestURL → converted markdown, NOT the raw plist bytes.
+        #expect(model.sources.count == 1)
+        #expect(model.sources.first?.filename == "Article.md")
+        let id = model.sources.first!.id
+        let bytes = try store.sourceContent(id: id)
+        #expect(String(data: bytes, encoding: .utf8) == "Body.")
+    }
+
+    @Test func remoteHTTPURLRoutesThroughURLIngest() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+
+        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+            data: Data("<title>Page</title><body><h1>Hi</h1></body>".utf8),
+            contentType: "text/html",
+            finalURL: URL(string: "https://example.com/page")!))
+
+        await model.ingest(
+            droppedURLs: [URL(string: "https://example.com/page")!],
+            fetcher: fetcher)
+
+        #expect(model.sources.count == 1)
+        #expect(model.sources.first?.filename == "Page.md")
+    }
+
+    @Test func localFileStillIngestsAsRawBytes() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-droproute-files-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = try writeLocalFile(in: dir, named: "notes.txt", contents: "plain text body")
+
+        await model.ingest(droppedURLs: [file], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
+            data: Data(), contentType: nil, finalURL: URL(string: "https://unused.example")!)))
+
+        #expect(model.sources.count == 1)
+        #expect(model.sources.first?.filename == "notes.txt")
+        let id = model.sources.first!.id
+        #expect(String(data: try store.sourceContent(id: id), encoding: .utf8) == "plain text body")
+    }
+
+    @Test func mixedBatchRoutesEachURLCorrectly() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-droproute-files-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let webloc = try writeWebloc(
+            in: dir, named: "Web",
+            urlString: "https://example.com/web")
+        let txt = try writeLocalFile(in: dir, named: "doc.txt", contents: "file bytes")
+
+        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+            data: Data("<title>Web</title><body><p>Web body.</p></body>".utf8),
+            contentType: "text/html",
+            finalURL: URL(string: "https://example.com/web")!))
+
+        await model.ingest(droppedURLs: [webloc, txt], fetcher: fetcher)
+
+        let names = model.sources.map(\.filename).sorted()
+        #expect(names == ["Web.md", "doc.txt"])
+    }
+
+    @Test func unresolvableWeblocIsSkippedNotIngestedAsBytes() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-droproute-files-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // A .webloc whose plist has no URL key — must NOT be ingested as raw bytes.
+        let badWebloc = dir.appendingPathComponent("Broken.webloc")
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["Foo": "bar"], format: .xml, options: 0)
+        try data.write(to: badWebloc)
+
+        await model.ingest(droppedURLs: [badWebloc], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
+            data: Data(), contentType: nil, finalURL: URL(string: "https://unused.example")!)))
+
+        #expect(model.sources.isEmpty)
+    }
+}

--- a/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
@@ -4,15 +4,15 @@ import Testing
 
 /// Verifies the window-wide drop routing (#163): an `http(s)` URL dragged from
 /// a browser, and a `.webloc` shortcut that resolves to one, flow through the
-/// "Add from URL" fetch path (`ingestURL` → HTML→Markdown), while genuine local
-/// files still ingest as raw bytes (`ingest(fileURLs:)`). Uses a fake fetcher —
+/// "Add from URL" fetch path (`addURL` → HTML→Markdown), while genuine local
+/// files still ingest as raw bytes (`addFiles`). Uses a fake fetcher —
 /// no real network.
 @MainActor
 struct WikiStoreModelDropRoutingTests {
 
-    struct FakeFetcher: URLIngestService.URLResourceFetcher {
-        let response: URLIngestService.FetchResponse
-        func fetch(_ url: URL) async throws -> URLIngestService.FetchResponse { response }
+    struct FakeFetcher: URLFetchService.URLResourceFetcher {
+        let response: URLFetchService.FetchResponse
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse { response }
     }
 
     private func tempStore() throws -> SQLiteWikiStore {
@@ -50,14 +50,14 @@ struct WikiStoreModelDropRoutingTests {
             in: dir, named: "Link",
             urlString: "https://example.com/article")
 
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data("<title>Article</title><body><p>Body.</p></body>".utf8),
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/article")!))
 
         await model.addDroppedURLs([webloc], fetcher: fetcher)
 
-        // Routed through ingestURL → converted markdown, NOT the raw plist bytes.
+        // Routed through addURL → converted markdown, NOT the raw plist bytes.
         #expect(model.sources.count == 1)
         #expect(model.sources.first?.filename == "Article.md")
         let id = model.sources.first!.id
@@ -69,7 +69,7 @@ struct WikiStoreModelDropRoutingTests {
         let store = try tempStore()
         let model = WikiStoreModel(store: store)
 
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data("<title>Page</title><body><h1>Hi</h1></body>".utf8),
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/page")!))
@@ -92,7 +92,7 @@ struct WikiStoreModelDropRoutingTests {
 
         let file = try writeLocalFile(in: dir, named: "notes.txt", contents: "plain text body")
 
-        await model.addDroppedURLs([file], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
+        await model.addDroppedURLs([file], fetcher: FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data(), contentType: nil, finalURL: URL(string: "https://unused.example")!)))
 
         #expect(model.sources.count == 1)
@@ -114,7 +114,7 @@ struct WikiStoreModelDropRoutingTests {
             urlString: "https://example.com/web")
         let txt = try writeLocalFile(in: dir, named: "doc.txt", contents: "file bytes")
 
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data("<title>Web</title><body><p>Web body.</p></body>".utf8),
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/web")!))
@@ -139,7 +139,7 @@ struct WikiStoreModelDropRoutingTests {
             fromPropertyList: ["Foo": "bar"], format: .xml, options: 0)
         try data.write(to: badWebloc)
 
-        await model.addDroppedURLs([badWebloc], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
+        await model.addDroppedURLs([badWebloc], fetcher: FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data(), contentType: nil, finalURL: URL(string: "https://unused.example")!)))
 
         #expect(model.sources.isEmpty)

--- a/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
@@ -55,7 +55,7 @@ struct WikiStoreModelDropRoutingTests {
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/article")!))
 
-        await model.ingest(droppedURLs: [webloc], fetcher: fetcher)
+        await model.addDroppedURLs([webloc], fetcher: fetcher)
 
         // Routed through ingestURL → converted markdown, NOT the raw plist bytes.
         #expect(model.sources.count == 1)
@@ -74,8 +74,8 @@ struct WikiStoreModelDropRoutingTests {
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/page")!))
 
-        await model.ingest(
-            droppedURLs: [URL(string: "https://example.com/page")!],
+        await model.addDroppedURLs(
+            [URL(string: "https://example.com/page")!],
             fetcher: fetcher)
 
         #expect(model.sources.count == 1)
@@ -92,7 +92,7 @@ struct WikiStoreModelDropRoutingTests {
 
         let file = try writeLocalFile(in: dir, named: "notes.txt", contents: "plain text body")
 
-        await model.ingest(droppedURLs: [file], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
+        await model.addDroppedURLs([file], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
             data: Data(), contentType: nil, finalURL: URL(string: "https://unused.example")!)))
 
         #expect(model.sources.count == 1)
@@ -119,7 +119,7 @@ struct WikiStoreModelDropRoutingTests {
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/web")!))
 
-        await model.ingest(droppedURLs: [webloc, txt], fetcher: fetcher)
+        await model.addDroppedURLs([webloc, txt], fetcher: fetcher)
 
         let names = model.sources.map(\.filename).sorted()
         #expect(names == ["Web.md", "doc.txt"])
@@ -139,7 +139,7 @@ struct WikiStoreModelDropRoutingTests {
             fromPropertyList: ["Foo": "bar"], format: .xml, options: 0)
         try data.write(to: badWebloc)
 
-        await model.ingest(droppedURLs: [badWebloc], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
+        await model.addDroppedURLs([badWebloc], fetcher: FakeFetcher(response: URLIngestService.FetchResponse(
             data: Data(), contentType: nil, finalURL: URL(string: "https://unused.example")!)))
 
         #expect(model.sources.isEmpty)


### PR DESCRIPTION
## Summary

Fixes #163.

Dragging a `.webloc` file (or an `http(s)` URL) from Safari/a browser onto the window previously hit the generic file-drop path (`ingest(fileURLs:)`), which read the `.webloc`'s raw plist bytes instead of fetching the linked page.

## Changes

- **`WikiStoreModel.addDroppedURLs(_:fetcher:)`** — new router that partitions dropped URLs:
  - `http(s)` URLs **and** `.webloc` shortcuts (resolved to their target URL) → `ingestURL`, the existing **Add from URL** fetch + HTML→Markdown path.
  - Other `file://` URLs → `ingest(fileURLs:)` (raw bytes, unchanged behavior).
  - Supports multi-URL drops (each remote link added as its own source). An unresolvable `.webloc` is skipped rather than ingested as bytes.
- **`WikiStoreModel.resolveWeblocURL(_:)`** — reads the plist (XML or binary) off the main actor via `PropertyListSerialization`.
- **`ContentView`** `.dropDestination` now calls `store.addDroppedURLs(_:)`.

### Naming note

The new method is named `addDroppedURLs` (not `ingest…`) because it only **adds a source** — fetches/stores bytes so the file appears under Sources. Agent **ingestion** (the model reading a source and generating new pages) is a separate `AgentLauncher` phase. The older `ingest(fileURLs:)` / `ingestURL` carry the same misnomer; that cleanup is tracked in a separate issue.

## Why not pop the `AddFromURLSheet`?

The sheet's `fetch()` just calls `store.ingestURL(input)`. For a drop the user has already committed to the URL, so going straight to `ingestURL` is equivalent to "submitting that link" without a redundant modal step.

## Tests

New `WikiStoreModelDropRoutingTests` (5, all passing, no network — fake fetcher):
- `.webloc` → converted markdown (not raw plist)
- `http(s)` URL → converted markdown
- local `.txt` → verbatim bytes
- mixed batch (`.webloc` + `.txt`) → both land correctly
- unresolvable `.webloc` → skipped, nothing ingested

Existing `WikiStoreModelURLIngestTests` still green. `swift build` clean.

## Checklist
- [x] Routes `.webloc`/remote URLs through Add-from-URL ingest
- [x] Supports multiple URLs/`.webloc` dropped at once
- [x] Local file ingest behavior unchanged
- [x] New method named `add*` (accurate — adds a source, not agent-ingests)
