### PR TITLE
fix(#169): drag wiki link onto Bookmarks to create a bookmark at drop position

### DIFF
--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -128,7 +128,9 @@ final class BookmarksOutlineViewController: NSViewController {
         outlineView.delegate = self
         // Required for the outline view to act as a drop target at all — without
         // this, validateDrop/acceptDrop are never called and no highlight shows.
-        outlineView.registerForDraggedTypes([.string])
+        // `.string` powers intra-tree reorder (a node id); `.url` lets a
+        // `wiki://` link dragged out of a page/source body land here (issue #169).
+        outlineView.registerForDraggedTypes([.string, .init("public.url")])
         // NSTableView/NSOutlineView is its own NSDraggingSource; there is no
         // delegate callback for this — the mask is configured imperatively.
         // Without it, the default local-drag mask is a multi-bit value that
@@ -325,11 +327,84 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
         }
     }
 
+    // MARK: - Wiki-link drop (issue #169)
+
+    /// Read the first `wiki://…` href from a drag pasteboard. WebKit's default
+    /// link drag may offer the href under `.url`, `.string`, or both, so check
+    /// each. Returns nil for an intra-tree bookmark reorder (whose `.string` is a
+    /// node id, not a `wiki://` URL).
+    private static func firstWikiLinkURL(from pb: NSPasteboard) -> URL? {
+        let schemePrefix = "\(WikiLinkMarkdown.scheme)://"
+        for type in [NSPasteboard.PasteboardType("public.url"), NSPasteboard.PasteboardType.string] {
+            guard let raw = pb.string(forType: type),
+                  raw.hasPrefix(schemePrefix),
+                  let url = URL(string: raw) else { continue }
+            return url
+        }
+        return nil
+    }
+
+    /// Resolve a dropped `wiki://` link to a page/source and insert a bookmark
+    /// node for it at the drop position. Mirrors `WikiReaderView.linkRoute(for:)`'s
+    /// resolution: title from `WikiLinkMarkdown.target`, kind from `resolvedKind`,
+    /// then the same `pageID(forTitle:)` / `sourceID(forDisplayName:)` lookups the
+    /// click handler uses. The insertion position follows the same rules as the
+    /// intra-tree reorder: a precise `index >= 0` lands between siblings (the
+    /// store shifts later siblings down); `-1` (drop *on* an item) appends.
+    @discardableResult
+    private func acceptWikiLinkDrop(url: URL, onto item: Any?, atIndex index: Int,
+                                    store: WikiStoreModel) -> Bool {
+        guard let title = WikiLinkMarkdown.target(from: url),
+              let kind = WikiLinkMarkdown.resolvedKind(from: url) else {
+            DebugLog.tabs("[drop] wiki-link bookmark drop: not a resolvable wiki URL \(url.absoluteString)")
+            return false
+        }
+        let targetID: PageID? = (kind == .page)
+            ? store.pageID(forTitle: title)
+            : store.sourceID(forDisplayName: title)
+        guard let resolved = targetID else {
+            DebugLog.tabs("[drop] wiki-link bookmark drop: title \"\(title)\" did not resolve to a \(kind) id")
+            return false
+        }
+        // Resolve parent + insertion index. `index == -1` (NSOutlineViewDropOnItemIndex)
+        // means "drop on the item", so append inside it (or, for a leaf, at the
+        // leaf's own slot); `index >= 0` means "insert between siblings".
+        let parentID: String?
+        let position: Int
+        if let folder = item as? BookmarkNode, folder.kind == .folder {
+            parentID = folder.id
+            position = index >= 0 ? index : children(of: folder.id).count
+        } else if let leaf = item as? BookmarkNode {
+            parentID = leaf.parentID
+            position = index >= 0 ? index : leaf.position
+        } else {
+            // Root.
+            parentID = nil
+            position = index >= 0 ? index : children(of: nil).count
+        }
+        switch kind {
+        case .page:   store.addPageRef(parentID: parentID, pageID: resolved, position: position)
+        case .source: store.addSourceRef(parentID: parentID, sourceID: resolved, position: position)
+        }
+        DebugLog.tabs("[drop] wiki-link bookmark created: kind=\(kind) title=\"\(title)\" parentID=\(parentID ?? "root") position=\(position)")
+        return true
+    }
+
     func outlineView(_ outlineView: NSOutlineView,
                      validateDrop info: NSDraggingInfo,
                      proposedItem item: Any?,
                      proposedChildIndex index: Int) -> NSDragOperation {
         DebugLog.tabs("BookmarksOutlineView.validateDrop: mask=\(info.draggingSourceOperationMask.rawValue) item=\((item as? BookmarkNode)?.id ?? "root") index=\(index)")
+        // Wiki-link drop: a `wiki://page?title=…` / `wiki://source?title=…`
+        // anchor dragged out of rendered page/source content (issue #169). The
+        // default WKWebView link drag vends the href as `.url`/`.string`; accept
+        // it as `.copy` so `acceptDrop` creates a bookmark at the target.
+        if Self.firstWikiLinkURL(from: info.draggingPasteboard) != nil {
+            if item == nil { return .copy }                       // root
+            if (item as? BookmarkNode)?.kind == .folder { return .copy }
+            if item is BookmarkNode { return .copy }              // leaf → sibling
+            return []
+        }
         guard info.draggingSourceOperationMask.contains(.move) else { return [] }
         // Allow drop onto folders or between rows.
         if let folder = item as? BookmarkNode, folder.kind == .folder {
@@ -351,6 +426,14 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
                      childIndex index: Int) -> Bool {
         DebugLog.tabs("BookmarksOutlineView.acceptDrop: item=\((item as? BookmarkNode)?.id ?? "root") index=\(index)")
         guard let store else { return false }
+
+        // Wiki-link drop → create a bookmark pointing at the link's target
+        // (issue #169). Resolved before the intra-tree reorder path, which reads
+        // `.string` as a bookmark *node id* and would no-op on a `wiki://` URL.
+        if let url = Self.firstWikiLinkURL(from: info.draggingPasteboard) {
+            return acceptWikiLinkDrop(url: url, onto: item, atIndex: index, store: store)
+        }
+
         // Multi-selection is allowed, so a reorder drag can carry more than one
         // node id — one pasteboard item per dragged row.
         let draggedIDs = (info.draggingPasteboard.pasteboardItems ?? [])

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1660,13 +1660,14 @@ public final class WikiStoreModel {
         }
     }
 
-    /// Add a page reference to a folder.
-    public func addPageRef(parentID: String?, pageID: PageID) {
+    /// Add a page reference to a folder. Pass `position` to insert at a specific
+    /// sibling index (the store shifts later siblings down); omit it to append.
+    public func addPageRef(parentID: String?, pageID: PageID, position: Int? = nil) {
         let t0 = DispatchTime.now()
-        let position = bookmarkNodes.filter { $0.parentID == parentID }.count
+        let pos = position ?? bookmarkNodes.filter { $0.parentID == parentID }.count
         do {
             _ = try store.createBookmarkNode(
-                parentID: parentID, position: position, kind: .pageRef,
+                parentID: parentID, position: pos, kind: .pageRef,
                 label: nil, targetID: pageID)
             reloadBookmarkNodes()
             let ms = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
@@ -1676,12 +1677,13 @@ public final class WikiStoreModel {
         }
     }
 
-    /// Add a source reference to a folder.
-    public func addSourceRef(parentID: String?, sourceID: PageID) {
-        let position = bookmarkNodes.filter { $0.parentID == parentID }.count
+    /// Add a source reference to a folder. Pass `position` to insert at a specific
+    /// sibling index (the store shifts later siblings down); omit it to append.
+    public func addSourceRef(parentID: String?, sourceID: PageID, position: Int? = nil) {
+        let pos = position ?? bookmarkNodes.filter { $0.parentID == parentID }.count
         do {
             _ = try store.createBookmarkNode(
-                parentID: parentID, position: position, kind: .sourceRef,
+                parentID: parentID, position: pos, kind: .sourceRef,
                 label: nil, targetID: sourceID)
             reloadBookmarkNodes()
         } catch {

--- a/Tests/WikiFSTests/BookmarkInsertPositionTests.swift
+++ b/Tests/WikiFSTests/BookmarkInsertPositionTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// Model-level tests for the `position` parameter on `addPageRef` /
+/// `addSourceRef`, added so a wiki-link dragged onto the Bookmarks outline lands
+/// *between* siblings (issue #169) rather than always appending at the end.
+///
+/// These cover the ordering contract the drop handler relies on; the AppKit
+/// drag/drop wiring itself is exercised manually (it needs a live WKWebView).
+@MainActor
+struct BookmarkInsertPositionTests {
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "bookmark-insert-position-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    /// nil `position` (the default / append path) is unchanged by the new
+    /// parameter — this guards the existing callers.
+    @Test func addPageRefWithNilPositionAppends() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let p1 = try store.createPage(title: "One")
+        let p2 = try store.createPage(title: "Two")
+        let model = WikiStoreModel(store: store)
+
+        model.addPageRef(parentID: nil, pageID: p1.id)
+        model.addPageRef(parentID: nil, pageID: p2.id)
+
+        let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
+        #expect(nodes.map(\.position) == [0, 1])
+        #expect(nodes.map(\.targetID) == [p1.id, p2.id])
+    }
+
+    /// Inserting at position 0 pushes the existing first node down.
+    @Test func addPageRefAtPositionZeroPrepends() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let first = try store.createPage(title: "First")
+        let model = WikiStoreModel(store: store)
+        model.addPageRef(parentID: nil, pageID: first.id) // position 0
+
+        let earlier = try store.createPage(title: "Earlier")
+        model.addPageRef(parentID: nil, pageID: earlier.id, position: 0)
+
+        let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
+        #expect(nodes.map(\.position) == [0, 1])
+        #expect(nodes.first?.targetID == earlier.id,
+                "position: 0 must land before the previously-first node")
+    }
+
+    /// Inserting in the middle shifts only the nodes at/after the index.
+    @Test func addPageRefAtMiddlePositionShiftsLaterSiblings() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        let model = WikiStoreModel(store: store)
+        model.addPageRef(parentID: nil, pageID: a.id) // 0
+        model.addPageRef(parentID: nil, pageID: b.id) // 1
+        model.addPageRef(parentID: nil, pageID: c.id) // 2
+
+        let mid = try store.createPage(title: "MID")
+        model.addPageRef(parentID: nil, pageID: mid.id, position: 1)
+
+        let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
+        #expect(nodes.map(\.position) == [0, 1, 2, 3])
+        // A, MID, B, C
+        let titles = nodes.compactMap { $0.targetID }
+            .compactMap { id in [a, b, c, mid].first { $0.id == id }?.title }
+        #expect(titles == ["A", "MID", "B", "C"])
+    }
+
+    /// Source refs honor the same position contract as page refs.
+    @Test func addSourceRefAtPositionInsertsBetweenSiblings() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let s1 = try store.addSource(filename: "a.pdf", data: Data("x".utf8))
+        let s2 = try store.addSource(filename: "b.pdf", data: Data("y".utf8))
+        let model = WikiStoreModel(store: store)
+        model.addSourceRef(parentID: nil, sourceID: s1.id) // 0
+        model.addSourceRef(parentID: nil, sourceID: s2.id) // 1
+
+        let between = try store.addSource(filename: "mid.pdf", data: Data("z".utf8))
+        model.addSourceRef(parentID: nil, sourceID: between.id, position: 1)
+
+        let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
+        #expect(nodes.map(\.position) == [0, 1, 2])
+        #expect(nodes[1].targetID == between.id,
+                "source ref inserted at position 1 must land between the two siblings")
+    }
+
+    /// A positioned insert is scoped to its folder — it must not disturb root
+    /// ordering or a sibling folder's children.
+    @Test func positionedInsertIsScopedToParent() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let folder = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder, label: "F", targetID: nil)
+        let model = WikiStoreModel(store: store)
+
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.addPageRef(parentID: folder.id, pageID: a.id) // 0
+        model.addPageRef(parentID: folder.id, pageID: b.id) // 1
+
+        // Also a root-level ref, to confirm it's untouched.
+        let root = try store.createPage(title: "Root")
+        model.addPageRef(parentID: nil, pageID: root.id) // 0 at root
+
+        let mid = try store.createPage(title: "MID")
+        model.addPageRef(parentID: folder.id, pageID: mid.id, position: 0)
+
+        let folderChildren = model.bookmarkNodes
+            .filter { $0.parentID == folder.id }
+            .sorted { $0.position < $1.position }
+        #expect(folderChildren.map(\.position) == [0, 1, 2])
+        #expect(folderChildren.first?.targetID == mid.id)
+
+        let rootChildren = model.bookmarkNodes
+            .filter { $0.parentID == nil && $0.kind == .pageRef }
+        #expect(rootChildren.count == 1)
+        #expect(rootChildren.first?.targetID == root.id)
+    }
+
+    /// Inserting past the end (a stale/out-of-range index) still yields a
+    /// contiguous, correct ordering — the store's renumber pass defends this.
+    @Test func outOfRangePositionClampsViaRenumber() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let a = try store.createPage(title: "A")
+        let model = WikiStoreModel(store: store)
+        model.addPageRef(parentID: nil, pageID: a.id) // 0
+
+        let b = try store.createPage(title: "B")
+        // No siblings exist beyond position 0; position 5 is out of range.
+        model.addPageRef(parentID: nil, pageID: b.id, position: 5)
+
+        let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
+        #expect(nodes.map(\.position) == [0, 1],
+                "renumber pass must keep positions contiguous on an out-of-range insert")
+        #expect(nodes.last?.targetID == b.id)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #169.

Dragging a wiki link rendered inside a page/source body (`wiki://page?title=…` / `wiki://source?title=…` anchors) onto the Bookmarks tab now creates a bookmark pointing at that link's target — landing **between** siblings at the exact drop position, not appended at the end of the folder.

## Problem

Wiki links in rendered content are plain `<a href>` elements in the `WKWebView`. WebKit's default link-drag vends the href as `.url`/`.string`, but `BookmarksOutlineView` only accepted intra-tree reorder drags:

- `validateDrop` gated on the `.move` source operation mask; a link drag carries `.copy`, so it was rejected.
- `acceptDrop` read `.string` off the pasteboard as a bookmark *node id* — a `wiki://` URL would no-op.

## Changes

**`Sources/WikiFS/BookmarksOutlineView.swift`**
- Registered the `public.url` pasteboard type so the outline accepts link drags (alongside `.string`).
- `validateDrop`: detects a `wiki://` href on the drag pasteboard and returns `.copy` for drops onto the root, a folder, or a leaf row.
- `acceptDrop`: short-circuits wiki-link drops before the reorder path.
- `firstWikiLinkURL(from:)`: reads the href from `.url` then `.string` (WebKit may vend either).
- `acceptWikiLinkDrop`: resolves title → `PageID` via the same `WikiLinkMarkdown.target`/`resolvedKind` + `pageID(forTitle:)`/`sourceID(forDisplayName:)` lookups the click handler uses, then inserts at the precise drop index. Position mirrors the reorder rules: `index >= 0` inserts between siblings; `-1` (`NSOutlineViewDropOnItemIndex`) appends.

**`Sources/WikiFSCore/WikiStoreModel.swift`**
- `addPageRef` / `addSourceRef` now accept an optional `position: Int? = nil`. When provided, the node inserts at that sibling index (the store's `createBookmarkNode` shifts later siblings down and renumbers). `nil` preserves the previous append behavior, so all existing callers are unaffected.

## Tests

New `Tests/WikiFSTests/BookmarkInsertPositionTests.swift` (model-level, 6 tests):
- `addPageRefWithNilPositionAppends` — default/append path unchanged
- `addPageRefAtPositionZeroPrepends`
- `addPageRefAtMiddlePositionShiftsLaterSiblings`
- `addSourceRefAtPositionInsertsBetweenSiblings` — source-ref parity
- `positionedInsertIsScopedToParent` — folder scoping doesn't disturb root/other folders
- `outOfRangePositionClampsViaRenumber`

All 6 pass; the broader bookmark suite (51 tests) passes. Build is green.

> Note: the AppKit drag/drop wiring itself (pasteboard round-trip from a live `WKWebView` link drag) isn't unit-tested — it needs a running app. The model-level ordering contract it relies on is covered by the new suite.

## Checklist
- [x] `swift build` green
- [x] bookmark tests pass
- [x] no change to existing `addPageRef`/`addSourceRef` callers (default `position` is nil)
- [x] unresolved `wiki://missing` links are filtered out (`resolvedKind` returns `nil`)
