### PR TITLE
refactor(#178): rename ingest(fileURLs:)/ingestURL to addFiles/addURL

### DIFF
--- a/Sources/WikiFS/AddFromURLSheet.swift
+++ b/Sources/WikiFS/AddFromURLSheet.swift
@@ -147,7 +147,7 @@ struct AddFromURLSheet: View {
         phase = .fetching
         Task {
             do {
-                _ = try await store.ingestURL(input)
+                _ = try await store.addURL(input)
                 dismiss()  // success: the new file is already in store.sources
             } catch {
                 let message = (error as? URLIngestService.IngestError)?.errorDescription

--- a/Sources/WikiFS/AddFromZoteroSheet.swift
+++ b/Sources/WikiFS/AddFromZoteroSheet.swift
@@ -323,7 +323,7 @@ struct AddFromZoteroSheet: View {
     }
 
     /// Ingest every selected attachment, collect-and-continue on a per-item
-    /// failure (mirrors `WikiStoreModel.ingest(fileURLs:)`) — one bad attachment
+    /// failure (mirrors `WikiStoreModel.addFiles(_:)`) — one bad attachment
     /// shouldn't block the others. Dismisses only on full success.
     private func addSelected() {
         let toIngest = attachmentRows.filter { selectedAttachmentKeys.contains($0.id) }.map(\.attachment)

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -156,7 +156,7 @@ struct ContentView: View {
         // Drop a file anywhere on the window to ingest it (raw bytes → SQLite →
         // the read-only `files/` projection). The whole content is the target.
         .dropDestination(for: URL.self) { urls, _ in
-            Task { await store.ingest(fileURLs: urls) }
+            Task { await store.addFiles(urls) }
             return true
         } isTargeted: { targeted in
             // Fade, not bounce; skip the animation entirely under Reduce Motion.

--- a/Sources/WikiFS/SourcesContainerView.swift
+++ b/Sources/WikiFS/SourcesContainerView.swift
@@ -156,7 +156,7 @@ struct SourcesContainerView: View {
 
     private func addFile() {
         if let url = WikiFilePanels.chooseFile(title: "Add File", prompt: "Import") {
-            Task { await store.ingest(fileURLs: [url]) }
+            Task { await store.addFiles([url]) }
         }
     }
 

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -91,7 +91,7 @@ struct WikiDetailView: View {
                             Button {
                                 if let url = WikiFilePanels.chooseFile(title: "Add File", prompt: "Add File") {
                                     Task {
-                                        await store.ingest(fileURLs: [url])
+                                        await store.addFiles([url])
                                     }
                                 }
                             } label: {

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1117,20 +1117,24 @@ public final class WikiStoreModel {
 
     // MARK: - File ingestion (Phase 5)
 
-    /// Ingest dropped files. For each URL: reject directories (a recursive
-    /// directory ingest is out of scope), read the bytes OFF the main thread
-    /// (big files shouldn't stall the UI), then hop back to the main actor to
-    /// store + reload. Per-file failures are logged and skipped so one bad drop
+    /// Add dropped/imported files as sources. For each URL: reject directories
+    /// (a recursive directory add is out of scope), read the bytes OFF the main
+    /// thread (big files shouldn't stall the UI), then hop back to the main actor
+    /// to store + reload. Per-file failures are logged and skipped so one bad drop
     /// doesn't abort the batch. `onPageDidChange?()` fires ONCE at the end so the
     /// daemon re-enumerates the `sources/` tree exactly once for the whole batch.
-    public func ingest(fileURLs: [URL]) async {
+    ///
+    /// Named `addFiles` (not `ingest`) because it only adds sources — it does NOT
+    /// run the agent "Ingest into wiki" phase (see `AgentLauncher` /
+    /// `ingestingSourceIDs`). Issue #178.
+    public func addFiles(_ fileURLs: [URL]) async {
         var lastSourceID: PageID?
         var duplicateNames: [String] = []
         for url in fileURLs {
             // Skip directories — only flat files are ingested.
             let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
             if isDir {
-                DebugLog.store("WikiStoreModel.ingest skipping directory: \(url.lastPathComponent)")
+                DebugLog.store("WikiStoreModel.addFiles skipping directory: \(url.lastPathComponent)")
                 continue
             }
             let filename = url.lastPathComponent
@@ -1141,7 +1145,7 @@ public final class WikiStoreModel {
                     try Data(contentsOf: url)
                 }.value
             } catch {
-                DebugLog.store("WikiStoreModel.ingest read failed for \(filename): \(error)")
+                DebugLog.store("WikiStoreModel.addFiles read failed for \(filename): \(error)")
                 continue
             }
 
@@ -1160,7 +1164,7 @@ public final class WikiStoreModel {
                 // left wondering why the file didn't show up.
                 duplicateNames.append("\(filename) (already added as \(existing.effectiveName))")
             } catch {
-                DebugLog.store("WikiStoreModel.ingest store failed for \(filename): \(error)")
+                DebugLog.store("WikiStoreModel.addFiles store failed for \(filename): \(error)")
             }
         }
         reloadSources()
@@ -1177,17 +1181,21 @@ public final class WikiStoreModel {
         }
     }
 
-    /// Ingest a resource by URL: fetch it, convert HTML→Markdown (or store a PDF /
-    /// text / binary verbatim), and land it as an ingested file — exactly like a
-    /// drag-dropped file, so the existing "Ingest into wiki" `claude -p` operation
-    /// can summarize it afterward. Lands through the SAME `store.ingestFile` path as
-    /// drag-ingest, so it appears under Sources + `sources/by-{id,name}` immediately and
-    /// is pickable in Operations → Ingest. Returns the outcome on success; throws a
-    /// user-readable `URLIngestService.IngestError` on a bad URL, non-2xx, empty
-    /// body, or store failure (the caller surfaces it in the sheet). The store write
-    /// hops to the main actor (this type is `@MainActor`); the fetch runs off it.
+    /// Add a resource by URL as a source: fetch it, convert HTML→Markdown (or
+    /// store a PDF / text / binary verbatim), and land it as a source file —
+    /// exactly like a drag-dropped file, so the existing **"Ingest into wiki"**
+    /// `claude -p` operation can summarize it afterward. Lands through the SAME
+    /// `store.addSource` path as `addFiles`, so it appears under Sources +
+    /// `sources/by-{id,name}` immediately and is pickable in Operations → Ingest.
+    /// Returns the outcome on success; throws a user-readable
+    /// `URLIngestService.IngestError` on a bad URL, non-2xx, empty body, or store
+    /// failure (the caller surfaces it in the sheet). The store write hops to the
+    /// main actor (this type is `@MainActor`); the fetch runs off it.
+    ///
+    /// Named `addURL` (not `ingestURL`) because it only adds a source — the agent
+    /// "Ingest into wiki" phase is a separate, later step. Issue #178.
     @discardableResult
-    public func ingestURL(
+    public func addURL(
         _ rawInput: String,
         fetcher: any URLIngestService.URLResourceFetcher = URLSessionFetcher()
     ) async throws -> URLIngestService.IngestOutcome {
@@ -1249,7 +1257,7 @@ public final class WikiStoreModel {
     ) async throws {
         switch ZoteroLocalStorage.resolve(attachment, zoteroDir: zoteroDir) {
         case .local(let path):
-            // Read off the main actor — same rationale as `ingest(fileURLs:)`:
+            // Read off the main actor — same rationale as `addFiles(_:)`:
             // `Data(contentsOf:)` is blocking I/O and shouldn't stall the UI.
             let data = try await Task.detached(priority: .userInitiated) {
                 try Data(contentsOf: path)

--- a/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
@@ -2,11 +2,11 @@ import Foundation
 import Testing
 @testable import WikiFSCore
 
-/// Verifies `WikiStoreModel.ingestURL` lands a fetched resource through the SAME
-/// store path as drag-ingest, so it appears under `sources` immediately and
+/// Verifies `WikiStoreModel.addURL` lands a fetched resource through the SAME
+/// store path as `addFiles`, so it appears under `sources` immediately and
 /// is byte-correct. Uses a fake fetcher — no real network.
 @MainActor
-struct WikiStoreModelURLIngestTests {
+struct WikiStoreModelAddURLTests {
 
     struct FakeFetcher: URLIngestService.URLResourceFetcher {
         let response: URLIngestService.FetchResponse
@@ -15,7 +15,7 @@ struct WikiStoreModelURLIngestTests {
 
     private func tempStore() throws -> SQLiteWikiStore {
         let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("wikifs-urlingest-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("wikifs-addurl-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
     }
@@ -31,7 +31,7 @@ struct WikiStoreModelURLIngestTests {
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/doc")!))
 
-        let outcome = try await model.ingestURL("example.com/doc", fetcher: fetcher)
+        let outcome = try await model.addURL("example.com/doc", fetcher: fetcher)
 
         #expect(outcome.kind == .htmlConverted)
         #expect(outcome.filename == "My Doc.md")
@@ -55,7 +55,7 @@ struct WikiStoreModelURLIngestTests {
             data: pdf, contentType: "application/pdf",
             finalURL: URL(string: "https://example.com/files/paper.pdf")!))
 
-        let outcome = try await model.ingestURL("https://example.com/files/paper.pdf", fetcher: fetcher)
+        let outcome = try await model.addURL("https://example.com/files/paper.pdf", fetcher: fetcher)
         #expect(outcome.kind == .pdf)
         #expect(model.sources.first?.filename == "paper.pdf")
         let id = model.sources.first!.id
@@ -69,7 +69,7 @@ struct WikiStoreModelURLIngestTests {
             data: Data(), contentType: "text/html",
             finalURL: URL(string: "https://example.com")!))
         await #expect(throws: URLIngestService.IngestError.empty) {
-            try await model.ingestURL("https://example.com", fetcher: fetcher)
+            try await model.addURL("https://example.com", fetcher: fetcher)
         }
         #expect(model.sources.isEmpty)
     }


### PR DESCRIPTION
## Summary

Closes #178.

Renames the legacy `WikiStoreModel` add-source methods so the verb **"ingest"** refers only to the agent-reads-source-and-generates-pages phase, not to fetching/storing a source:

- `WikiStoreModel.ingest(fileURLs:)` → **`addFiles(_:)`**
- `WikiStoreModel.ingestURL(_:)` → **`addURL(_:)`**

## Why

The codebase conflated two distinct operations under "ingest": (1) **adding a source** (fetch/store bytes so a file appears under Sources), and (2) **agent ingestion** (the model reading a source to generate new wiki pages — `AgentLauncher` / `ingestingSourceIDs` / the "Ingest into wiki" `claude -p` operation). The add-source methods were misleadingly named `ingest…`. The #163 drop router already used the `add*` verb to avoid this; the older methods now follow suit.

## Changes

**Renamed methods** (`Sources/WikiFSCore/WikiStoreModel.swift`):
- `ingest(fileURLs:)` → `addFiles(_:)`
- `ingestURL(_:)` → `addURL(_:)`
- Updated doc comments (clarified these only *add* a source; the agent "Ingest into wiki" phase is a separate, later step) and the `DebugLog` strings.
- Fixed a stale doc reference (`store.ingestFile` → `store.addSource`) and the `ingestFromZotero` comment that referenced `ingest(fileURLs:)`.

**Call sites updated:**
- `ContentView.swift` — window-level `.dropDestination`
- `SourcesContainerView.swift` — "Add File" picker
- `WikiDetailView.swift` — welcome-screen "Add File"
- `AddFromURLSheet.swift` — "Add from URL" fetch
- `AddFromZoteroSheet.swift` — doc comment reference

**Tests:** renamed `WikiStoreModelURLIngestTests.swift` → `WikiStoreModelAddURLTests.swift` (struct + doc comment + temp-dir prefix + 3 call sites). History preserved via `git mv`.

## Scope decision

Per the issue's **non-goal**, left untouched:
- The agent phase (`ingestingSourceIDs`, "Ingest into wiki") — that *is* ingestion.
- The lower-level `URLIngestService` fetch service and its test file. Renaming that deeper type is a larger, separate effort beyond this issue's explicit proposal; the two `WikiStoreModel` methods named here are the public seam call sites use.

## Verification
- `swift build` green
- `WikiStoreModelAddURLTests` (3) + `URLIngestServiceTests` (26) pass — 29 total
- grep confirms no remaining `ingest(fileURLs` / `.ingestURL` references in `Sources` or `Tests`

## Checklist
- [x] no behavior change — pure rename
- [x] all call sites updated
- [x] doc comments + DebugLog strings updated
- [x] test file renamed to match (history preserved)
- [x] agent-phase "ingest" terminology preserved
