### PR TITLE
refactor(#178): rename URLIngestService to URLFetchService

### DIFF
--- a/Sources/WikiFS/AddFromURLSheet.swift
+++ b/Sources/WikiFS/AddFromURLSheet.swift
@@ -135,7 +135,7 @@ struct AddFromURLSheet: View {
     private var isFetching: Bool { phase == .fetching }
 
     private var canFetch: Bool {
-        !isFetching && URLIngestService.normalizeURL(urlText) != nil
+        !isFetching && URLFetchService.normalizeURL(urlText) != nil
     }
 
     // MARK: - Action
@@ -143,14 +143,14 @@ struct AddFromURLSheet: View {
     private func fetch() {
         // Read the field fresh at click time (§3.5), not a captured-early copy.
         let input = urlText
-        guard URLIngestService.normalizeURL(input) != nil else { return }
+        guard URLFetchService.normalizeURL(input) != nil else { return }
         phase = .fetching
         Task {
             do {
                 _ = try await store.addURL(input)
                 dismiss()  // success: the new file is already in store.sources
             } catch {
-                let message = (error as? URLIngestService.IngestError)?.errorDescription
+                let message = (error as? URLFetchService.FetchError)?.errorDescription
                     ?? error.localizedDescription
                 phase = .failed(message)
             }

--- a/Sources/WikiFSCore/ContentSniff.swift
+++ b/Sources/WikiFSCore/ContentSniff.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Pure, dependency-free content-type detection from magic bytes (the leading
-/// bytes of a data blob). Extracted from `URLIngestService` so the store,
+/// bytes of a data blob). Extracted from `URLFetchService` so the store,
 /// ingest paths, and any future caller can sniff without depending on the
 /// URL-fetch layer.
 ///

--- a/Sources/WikiFSCore/MarkdownFolderReader.swift
+++ b/Sources/WikiFSCore/MarkdownFolderReader.swift
@@ -7,7 +7,7 @@ import Foundation
 /// Pure + injectable filesystem via the `FileOperations` protocol, so the entire
 /// walk is unit-testable without touching the real disk. Mirrors
 /// `ZoteroLocalStorage`'s injection shape (`fileExists` closure) and
-/// `URLIngestService`'s injectable-fetcher pattern.
+/// `URLFetchService`'s injectable-fetcher pattern.
 public enum MarkdownFolderReader {
 
     // MARK: - File operations protocol (injectable)

--- a/Sources/WikiFSCore/URLFetchService.swift
+++ b/Sources/WikiFSCore/URLFetchService.swift
@@ -1,14 +1,17 @@
 import Foundation
 
-/// Fetches a URL and lands its content as an ingested file in the active wiki —
+/// Fetches a URL and lands its content as a source file in the active wiki —
 /// exactly like a drag-dropped file, so the existing "Ingest into wiki" `claude -p`
 /// operation can summarize it afterward.
+///
+/// Named `URLFetchService` (not `URLIngestService`) because it only fetches and
+/// stores bytes — it does NOT run the agent "Ingest into wiki" phase. Issue #178.
 ///
 /// Design for testability: the network is behind an injected `URLResourceFetcher`,
 /// and the store write is an injected closure (`store:`). So the whole
 /// dispatch / filename / store pipeline is unit-tested with a FAKE fetcher and an
 /// in-memory store — no real network, deterministic. The app wires the real
-/// `URLSessionFetcher` + the active `WikiStoreModel.ingestFile`.
+/// `URLSessionFetcher` + the active `WikiStoreModel.addSource`.
 ///
 /// Dispatch by `Content-Type`:
 /// - `text/html` / `application/xhtml+xml` → `HTMLToMarkdown` → store the **markdown**
@@ -17,7 +20,7 @@ import Foundation
 /// - other `text/*` (plain, markdown, csv…) → store the raw text as-is.
 /// - anything else (images, binaries) → store raw bytes with an extension inferred
 ///   from the MIME type or the URL.
-public struct URLIngestService {
+public struct URLFetchService {
 
     /// The bytes + metadata returned by a fetch. `finalURL` reflects redirects, so
     /// the filename derives from where we ended up, not where we asked.
@@ -34,7 +37,7 @@ public struct URLIngestService {
     }
 
     /// What was stored, surfaced to the UI for the success message.
-    public struct IngestOutcome: Sendable, Equatable {
+    public struct FetchOutcome: Sendable, Equatable {
         public let filename: String
         public let byteSize: Int
         /// The detected kind, for a human-readable confirmation.
@@ -60,7 +63,7 @@ public struct URLIngestService {
     }
 
     /// Errors surfaced to the UI with user-readable messages.
-    public enum IngestError: LocalizedError, Equatable {
+    public enum FetchError: LocalizedError, Equatable {
         case invalidURL(String)
         case httpStatus(Int)
         case empty
@@ -78,7 +81,7 @@ public struct URLIngestService {
 
     private let fetcher: any URLResourceFetcher
     /// Stores `(filename, data)` into the active wiki and returns nothing. The app
-    /// passes `WikiStoreModel.ingestFile`; tests pass an in-memory collector.
+    /// passes `WikiStoreModel.addSource`; tests pass an in-memory collector.
     private let store: @Sendable (_ filename: String, _ data: Data) throws -> Void
 
     public init(
@@ -111,12 +114,12 @@ public struct URLIngestService {
     }
 
     /// Fetch `rawInput`, dispatch by content type, and store the result in the
-    /// active wiki. Returns what was stored. Throws `IngestError` on a bad URL,
+    /// active wiki. Returns what was stored. Throws `FetchError` on a bad URL,
     /// non-2xx status (the fetcher reports it), empty body, or a store failure.
     @discardableResult
-    public func ingest(rawInput: String) async throws -> IngestOutcome {
+    public func fetch(_ rawInput: String) async throws -> FetchOutcome {
         guard let url = Self.normalizeURL(rawInput) else {
-            throw IngestError.invalidURL(rawInput.trimmingCharacters(in: .whitespacesAndNewlines))
+            throw FetchError.invalidURL(rawInput.trimmingCharacters(in: .whitespacesAndNewlines))
         }
         let response = try await fetcher.fetch(url)
         return try store(response: response)
@@ -125,15 +128,15 @@ public struct URLIngestService {
     /// The PURE dispatch + filename + store step (no network), so tests can drive it
     /// directly with a hand-built `FetchResponse`.
     @discardableResult
-    public func store(response: FetchResponse) throws -> IngestOutcome {
-        guard !response.data.isEmpty else { throw IngestError.empty }
+    public func store(response: FetchResponse) throws -> FetchOutcome {
+        guard !response.data.isEmpty else { throw FetchError.empty }
         let plan = Self.plan(for: response)
         do {
             try store(plan.filename, plan.data)
         } catch {
-            throw IngestError.network("Couldn't save the fetched file: \(error.localizedDescription)")
+            throw FetchError.network("Couldn't save the fetched file: \(error.localizedDescription)")
         }
-        return IngestOutcome(filename: plan.filename, byteSize: plan.data.count, kind: plan.kind)
+        return FetchOutcome(filename: plan.filename, byteSize: plan.data.count, kind: plan.kind)
     }
 
     // MARK: - Dispatch plan (pure)
@@ -144,7 +147,7 @@ public struct URLIngestService {
     public struct StorePlan: Equatable, Sendable {
         public let filename: String
         public let data: Data
-        public let kind: IngestOutcome.Kind
+        public let kind: FetchOutcome.Kind
     }
 
     public static func plan(for response: FetchResponse) -> StorePlan {
@@ -162,7 +165,7 @@ public struct URLIngestService {
             let ext = binaryExtension(forMIME: sniffed, url: response.finalURL)
             let stem = stemFromURL(response.finalURL, droppingExtension: ext)
             let filename = ext.isEmpty ? sanitizeStem(stem) : ensureExtension(sanitizeStem(stem), ext: ext)
-            let kind: IngestOutcome.Kind = sniffed == "application/pdf" ? .pdf : .binary
+            let kind: FetchOutcome.Kind = sniffed == "application/pdf" ? .pdf : .binary
             return StorePlan(filename: filename, data: response.data, kind: kind)
         }
 

--- a/Sources/WikiFSCore/URLSessionFetcher.swift
+++ b/Sources/WikiFSCore/URLSessionFetcher.swift
@@ -12,9 +12,9 @@ import FoundationNetworking
 ///   so the filename derives from where we landed;
 /// - send a desktop browser `User-Agent` so sites that 403 unknown agents serve us;
 /// - use a bounded timeout so a dead host fails cleanly instead of hanging the sheet;
-/// - translate a non-2xx status into `IngestError.httpStatus` and a transport error
-///   into `IngestError.network`, both with user-readable messages.
-public struct URLSessionFetcher: URLIngestService.URLResourceFetcher {
+/// - translate a non-2xx status into `FetchError.httpStatus` and a transport error
+///   into `FetchError.network`, both with user-readable messages.
+public struct URLSessionFetcher: URLFetchService.URLResourceFetcher {
 
     /// A current desktop Safari UA — generic enough that content sites serve full
     /// HTML rather than a bot challenge.
@@ -32,7 +32,7 @@ public struct URLSessionFetcher: URLIngestService.URLResourceFetcher {
         self.session = URLSession(configuration: config)
     }
 
-    public func fetch(_ url: URL) async throws -> URLIngestService.FetchResponse {
+    public func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse {
         // Rewrite recognized file-share preview links (e.g. a Dropbox `www.dropbox.com`
         // share URL) to their direct-download host BEFORE the request — otherwise the
         // host serves a non-browser an HTML JS interstitial instead of the file. Pure +
@@ -53,13 +53,13 @@ public struct URLSessionFetcher: URLIngestService.URLResourceFetcher {
         do {
             (data, response) = try await session.data(for: request)
         } catch {
-            throw URLIngestService.IngestError.network(
+            throw URLFetchService.FetchError.network(
                 "Couldn't reach that URL: \(error.localizedDescription)")
         }
 
         guard let http = response as? HTTPURLResponse else {
             // Non-HTTP (e.g. file://) — accept the bytes as-is.
-            return URLIngestService.FetchResponse(
+            return URLFetchService.FetchResponse(
                 data: data,
                 contentType: response.mimeType,
                 finalURL: response.url ?? fetchURL
@@ -67,11 +67,11 @@ public struct URLSessionFetcher: URLIngestService.URLResourceFetcher {
         }
 
         guard (200..<300).contains(http.statusCode) else {
-            throw URLIngestService.IngestError.httpStatus(http.statusCode)
+            throw URLFetchService.FetchError.httpStatus(http.statusCode)
         }
 
         let contentType = http.value(forHTTPHeaderField: "Content-Type") ?? response.mimeType
-        return URLIngestService.FetchResponse(
+        return URLFetchService.FetchResponse(
             data: data,
             contentType: contentType,
             finalURL: http.url ?? fetchURL

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1151,8 +1151,8 @@ public final class WikiStoreModel {
 
             let ext = (filename as NSString).pathExtension.lowercased()
             let mimeType = UTType(filenameExtension: ext)?.preferredMIMEType
-            let response = URLIngestService.FetchResponse(data: data, contentType: mimeType, finalURL: url)
-            let plan = URLIngestService.plan(for: response)
+            let response = URLFetchService.FetchResponse(data: data, contentType: mimeType, finalURL: url)
+            let plan = URLFetchService.plan(for: response)
 
             do {
                 let summary = try store.addSource(
@@ -1188,7 +1188,7 @@ public final class WikiStoreModel {
     /// `store.addSource` path as `addFiles`, so it appears under Sources +
     /// `sources/by-{id,name}` immediately and is pickable in Operations → Ingest.
     /// Returns the outcome on success; throws a user-readable
-    /// `URLIngestService.IngestError` on a bad URL, non-2xx, empty body, or store
+    /// `URLFetchService.FetchError` on a bad URL, non-2xx, empty body, or store
     /// failure (the caller surfaces it in the sheet). The store write hops to the
     /// main actor (this type is `@MainActor`); the fetch runs off it.
     ///
@@ -1197,29 +1197,29 @@ public final class WikiStoreModel {
     @discardableResult
     public func addURL(
         _ rawInput: String,
-        fetcher: any URLIngestService.URLResourceFetcher = URLSessionFetcher()
-    ) async throws -> URLIngestService.IngestOutcome {
+        fetcher: any URLFetchService.URLResourceFetcher = URLSessionFetcher()
+    ) async throws -> URLFetchService.FetchOutcome {
         // Validate + fetch OFF the main actor (the GET shouldn't stall the UI);
         // `fetch` is `Sendable` and the service is stateless. Then store the result
         // back HERE on the main actor, where we own `store`. Splitting fetch (async,
         // off-actor) from store (main-actor) keeps the @Sendable boundary honest —
         // no `assumeIsolated` gamble on which thread a continuation resumes.
-        guard let url = URLIngestService.normalizeURL(rawInput) else {
-            throw URLIngestService.IngestError.invalidURL(
+        guard let url = URLFetchService.normalizeURL(rawInput) else {
+            throw URLFetchService.FetchError.invalidURL(
                 rawInput.trimmingCharacters(in: .whitespacesAndNewlines))
         }
         let response = try await fetcher.fetch(url)
-        guard !response.data.isEmpty else { throw URLIngestService.IngestError.empty }
+        guard !response.data.isEmpty else { throw URLFetchService.FetchError.empty }
 
         // Pure dispatch decides the filename + bytes; we store directly on the main
         // actor (no @Sendable store closure crossing the actor boundary).
-        let plan = URLIngestService.plan(for: response)
+        let plan = URLFetchService.plan(for: response)
         let summary = try store.addSource(
             filename: plan.filename, data: plan.data, zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: nil)
         reloadSources()
         openTab(.source(summary.id))
         onPageDidChange?()
-        return URLIngestService.IngestOutcome(
+        return URLFetchService.FetchOutcome(
             filename: plan.filename, byteSize: plan.data.count, kind: plan.kind)
     }
 
@@ -1245,11 +1245,11 @@ public final class WikiStoreModel {
     /// parent item's key + title into the row as provenance so the detail view
     /// can show "From Zotero" and link back. We already know the filename and
     /// bytes from Zotero's metadata, so this goes straight to the
-    /// `addSource(filename:data:)` seam rather than `URLIngestService`'s
+    /// `addSource(filename:data:)` seam rather than `URLFetchService`'s
     /// content-type dispatch (that dispatch exists for the unknown-bytes-from-a-
     /// URL case, which doesn't apply here). No network fallback in v1: an
     /// attachment that isn't synced to `~/Zotero/storage` yet throws
-    /// `ZoteroIngestError.unavailable` rather than downloading it.
+    /// `ZoteroFetchError.unavailable` rather than downloading it.
     public func ingestFromZotero(
         _ attachment: ZoteroAttachment,
         parentItem: ZoteroItem,
@@ -1275,7 +1275,7 @@ public final class WikiStoreModel {
                 throw error
             }
         case .unavailable(let reason):
-            throw ZoteroIngestError.unavailable(reason)
+            throw ZoteroFetchError.unavailable(reason)
         }
     }
 
@@ -1759,7 +1759,7 @@ public final class WikiStoreModel {
 /// Thrown by `WikiStoreModel.ingestFromZotero` when an attachment can't be
 /// ingested — currently just the "not synced locally yet" case, since v1 has no
 /// network-download fallback (see `ZoteroLocalStorage`).
-public enum ZoteroIngestError: LocalizedError, Equatable {
+public enum ZoteroFetchError: LocalizedError, Equatable {
     case unavailable(String)
 
     public var errorDescription: String? {

--- a/Sources/WikiFSCore/ZoteroClient.swift
+++ b/Sources/WikiFSCore/ZoteroClient.swift
@@ -11,12 +11,12 @@ import FoundationNetworking
 /// directly). This keeps the picker's search-as-you-type loop to one cheap JSON
 /// round trip per keystroke, with no file transfer in the hot path.
 ///
-/// Design for testability, mirroring `URLIngestService`: the network is behind an
+/// Design for testability, mirroring `URLFetchService`: the network is behind an
 /// injected `RequestFetcher`, and every decode/request-building step is a pure
 /// static function — the actual unit-test target.
 public struct ZoteroClient: Sendable {
 
-    /// Abstracts the network call. Unlike `URLIngestService.URLResourceFetcher`
+    /// Abstracts the network call. Unlike `URLFetchService.URLResourceFetcher`
     /// (which takes a bare `URL`), this takes a fully-formed `URLRequest` because
     /// every Zotero call needs `Zotero-API-Key` / `Zotero-API-Version` headers
     /// attached by THIS client, not by the fetcher — the fetcher stays

--- a/Sources/WikiFSCore/ZoteroCredentialStore.swift
+++ b/Sources/WikiFSCore/ZoteroCredentialStore.swift
@@ -74,7 +74,7 @@ public struct KeychainZoteroCredentialStore: ZoteroCredentialStore {
     }
 }
 
-/// In-memory test double — mirrors `URLIngestServiceTests.StoreCollector`'s
+/// In-memory test double — mirrors `URLFetchServiceTests.StoreCollector`'s
 /// `@unchecked Sendable` shape. NOT for production use.
 public final class InMemoryZoteroCredentialStore: ZoteroCredentialStore, @unchecked Sendable {
     private var key: String?

--- a/Tests/WikiFSTests/ContentSniffTests.swift
+++ b/Tests/WikiFSTests/ContentSniffTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import WikiFSCore
 
 /// Direct tests for the shared `ContentSniff.mimeType(of:)` helper. Previously
-/// these were only exercised through `URLIngestService.sniffContentType`, but
+/// these were only exercised through `URLFetchService.sniffContentType`, but
 /// `addSource` now depends on `ContentSniff` directly for the MIME-first path
 /// (content-type-over-extension plan).
 struct ContentSniffTests {

--- a/Tests/WikiFSTests/ExtensionCheckGuardTests.swift
+++ b/Tests/WikiFSTests/ExtensionCheckGuardTests.swift
@@ -12,7 +12,7 @@ import Testing
 /// - `WikiFSItem` — generated-doc suffixes (`.md`, `.json`, `.jsonl` on names we control)
 /// - `EmbeddingService` — `Bundle.main.bundlePath.hasSuffix(".app")` (runtime path)
 /// - `SQLiteWikiStore` — same bundle-path guard + ext fallback in `addSource` (last resort)
-/// - `URLIngestService` — `ensureExtension` (filename construction, not behavior)
+/// - `URLFetchService` — `ensureExtension` (filename construction, not behavior)
 /// - `ZoteroClient` — `isIngestable` fallback heuristic (MIME-first already)
 /// - `WikiStoreModel` — markdown lazy-seed ext check (owned by Phase C)
 struct ExtensionCheckGuardTests {
@@ -32,7 +32,7 @@ struct ExtensionCheckGuardTests {
         "WikiFSItem",             // generated-doc suffixes on names we control
         "EmbeddingService",       // Bundle.main.bundlePath.hasSuffix(".app")
         "SQLiteWikiStore",        // bundle-path guard + ext fallback in addSource
-        "URLIngestService",       // ensureExtension (filename construction)
+        "URLFetchService",       // ensureExtension (filename construction)
         "ZoteroClient",           // isIngestable fallback (MIME-first already)
         "WikiStoreModel",         // markdown lazy-seed (Phase C owns removal)
     ]

--- a/Tests/WikiFSTests/URLFetchServiceTests.swift
+++ b/Tests/WikiFSTests/URLFetchServiceTests.swift
@@ -6,7 +6,7 @@ import Testing
 /// by a FAKE fetcher and an in-memory store collector — no real network. Covers
 /// html→.md, pdf→.pdf (raw bytes preserved), text/plain→as-is, non-2xx error,
 /// redirect→final-URL filename, missing-scheme→https, and the pure plan/helpers.
-struct URLIngestServiceTests {
+struct URLFetchServiceTests {
 
     // MARK: - Test doubles
 
@@ -24,15 +24,15 @@ struct URLIngestServiceTests {
     }
 
     /// A fetcher returning a canned response (or throwing a canned error).
-    struct FakeFetcher: URLIngestService.URLResourceFetcher {
-        var response: URLIngestService.FetchResponse?
-        var error: URLIngestService.IngestError?
+    struct FakeFetcher: URLFetchService.URLResourceFetcher {
+        var response: URLFetchService.FetchResponse?
+        var error: URLFetchService.FetchError?
         /// Captures the URL the service actually requested.
         let requested = Box()
 
         final class Box: @unchecked Sendable { var url: URL? }
 
-        func fetch(_ url: URL) async throws -> URLIngestService.FetchResponse {
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse {
             requested.url = url
             if let error { throw error }
             return response!
@@ -41,16 +41,16 @@ struct URLIngestServiceTests {
 
     private func makeService(
         _ fetcher: FakeFetcher, _ collector: StoreCollector
-    ) -> URLIngestService {
-        URLIngestService(fetcher: fetcher) { name, data in
+    ) -> URLFetchService {
+        URLFetchService(fetcher: fetcher) { name, data in
             try collector.store(name, data)
         }
     }
 
     private func response(
         _ body: String, mime: String?, url: String
-    ) -> URLIngestService.FetchResponse {
-        URLIngestService.FetchResponse(
+    ) -> URLFetchService.FetchResponse {
+        URLFetchService.FetchResponse(
             data: Data(body.utf8), contentType: mime, finalURL: URL(string: url)!)
     }
 
@@ -65,7 +65,7 @@ struct URLIngestServiceTests {
         ))
         let service = makeService(fetcher, collector)
 
-        let outcome = try await service.ingest(rawInput: "https://example.com/article")
+        let outcome = try await service.fetch( "https://example.com/article")
 
         #expect(outcome.kind == .htmlConverted)
         #expect(collector.filename == "Cool Page.md")
@@ -83,7 +83,7 @@ struct URLIngestServiceTests {
         ))
         let service = makeService(fetcher, collector)
 
-        try await service.ingest(rawInput: "example.com/guides/photosynthesis")
+        try await service.fetch( "example.com/guides/photosynthesis")
         #expect(collector.filename == "photosynthesis.md")
     }
 
@@ -94,7 +94,7 @@ struct URLIngestServiceTests {
             mime: "application/xhtml+xml",
             url: "https://example.com/x"
         ))
-        try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/x")
+        try await makeService(fetcher, collector).fetch( "https://example.com/x")
         #expect(collector.filename == "X.md")
     }
 
@@ -106,12 +106,12 @@ struct URLIngestServiceTests {
         var pdf = Data("%PDF-1.7\n".utf8)
         pdf.append(contentsOf: [0x00, 0x01, 0x02, 0xFF, 0xFE])
         pdf.append(contentsOf: Data("trailer".utf8))
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: pdf, contentType: "application/pdf",
             finalURL: URL(string: "https://example.com/docs/report.pdf")!))
         let service = makeService(fetcher, collector)
 
-        let outcome = try await service.ingest(rawInput: "https://example.com/docs/report.pdf")
+        let outcome = try await service.fetch( "https://example.com/docs/report.pdf")
         #expect(outcome.kind == .pdf)
         #expect(collector.filename == "report.pdf")
         #expect(collector.data == pdf)  // byte-identical
@@ -119,10 +119,10 @@ struct URLIngestServiceTests {
 
     @Test func pdfFilenameGetsExtensionWhenURLLacksIt() async throws {
         let collector = StoreCollector()
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data("%PDF".utf8), contentType: "application/pdf",
             finalURL: URL(string: "https://example.com/download?id=99")!))
-        try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/download?id=99")
+        try await makeService(fetcher, collector).fetch( "https://example.com/download?id=99")
         #expect(collector.filename?.hasSuffix(".pdf") == true)
     }
 
@@ -136,7 +136,7 @@ struct URLIngestServiceTests {
             url: "https://example.com/notes.txt"))
         let service = makeService(fetcher, collector)
 
-        let outcome = try await service.ingest(rawInput: "https://example.com/notes.txt")
+        let outcome = try await service.fetch( "https://example.com/notes.txt")
         #expect(outcome.kind == .text)
         #expect(collector.filename == "notes.txt")
         #expect(String(data: collector.data!, encoding: .utf8) == body)
@@ -147,7 +147,7 @@ struct URLIngestServiceTests {
         let fetcher = FakeFetcher(response: response(
             "# Heading\n\nbody", mime: "text/markdown",
             url: "https://example.com/raw/doc"))
-        try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/raw/doc")
+        try await makeService(fetcher, collector).fetch( "https://example.com/raw/doc")
         #expect(collector.filename == "doc.md")
     }
 
@@ -156,10 +156,10 @@ struct URLIngestServiceTests {
     @Test func imageStoredWithInferredExtension() async throws {
         let collector = StoreCollector()
         let bytes = Data([0x89, 0x50, 0x4E, 0x47])  // PNG magic
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: bytes, contentType: "image/png",
             finalURL: URL(string: "https://example.com/logo")!))
-        let outcome = try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/logo")
+        let outcome = try await makeService(fetcher, collector).fetch( "https://example.com/logo")
         #expect(outcome.kind == .binary)
         #expect(collector.filename == "logo.png")
         #expect(collector.data == bytes)
@@ -174,12 +174,12 @@ struct URLIngestServiceTests {
         var pdf = Data("%PDF-1.3\n".utf8)
         pdf.append(contentsOf: [0x00, 0x01, 0xFF, 0xFE])
         pdf.append(contentsOf: Data("trailer".utf8))
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: pdf, contentType: "text/html; charset=utf-8",
             finalURL: URL(string: "https://dl.dropboxusercontent.com/scl/fi/x/CPP_behaviorgen.pdf?rlkey=k")!))
 
-        let outcome = try await makeService(fetcher, collector).ingest(
-            rawInput: "https://dl.dropboxusercontent.com/scl/fi/x/CPP_behaviorgen.pdf?rlkey=k")
+        let outcome = try await makeService(fetcher, collector).fetch(
+            "https://dl.dropboxusercontent.com/scl/fi/x/CPP_behaviorgen.pdf?rlkey=k")
 
         #expect(outcome.kind == .pdf)
         #expect(collector.filename == "CPP_behaviorgen.pdf")
@@ -189,11 +189,11 @@ struct URLIngestServiceTests {
     @Test func octetStreamPNGBytesSniffedToImage() async throws {
         let collector = StoreCollector()
         let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])  // PNG magic
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: png, contentType: "application/octet-stream",
             finalURL: URL(string: "https://example.com/blob")!))
 
-        let outcome = try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/blob")
+        let outcome = try await makeService(fetcher, collector).fetch( "https://example.com/blob")
         #expect(outcome.kind == .binary)
         #expect(collector.filename == "blob.png")
         #expect(collector.data == png)
@@ -205,7 +205,7 @@ struct URLIngestServiceTests {
         let fetcher = FakeFetcher(response: response(
             "<html><head><title>Real Page</title></head><body><p>hi</p></body></html>",
             mime: "text/html", url: "https://example.com/page"))
-        let outcome = try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/page")
+        let outcome = try await makeService(fetcher, collector).fetch( "https://example.com/page")
         #expect(outcome.kind == .htmlConverted)
         #expect(collector.filename == "Real Page.md")
     }
@@ -214,35 +214,35 @@ struct URLIngestServiceTests {
         // A correctly-labeled PDF takes the application/pdf path (not sniffed away).
         let collector = StoreCollector()
         let pdf = Data("%PDF-1.7\nbody".utf8)
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: pdf, contentType: "application/pdf",
             finalURL: URL(string: "https://example.com/docs/report.pdf")!))
-        let outcome = try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/docs/report.pdf")
+        let outcome = try await makeService(fetcher, collector).fetch( "https://example.com/docs/report.pdf")
         #expect(outcome.kind == .pdf)
         #expect(collector.filename == "report.pdf")
         #expect(collector.data == pdf)
     }
 
     @Test func sniffContentTypeMagicNumbers() {
-        #expect(URLIngestService.sniffContentType(Data("%PDF-1.4".utf8)) == "application/pdf")
-        #expect(URLIngestService.sniffContentType(Data([0x89, 0x50, 0x4E, 0x47])) == "image/png")
-        #expect(URLIngestService.sniffContentType(Data([0xFF, 0xD8, 0xFF, 0xE0])) == "image/jpeg")
-        #expect(URLIngestService.sniffContentType(Data("GIF89a".utf8)) == "image/gif")
-        #expect(URLIngestService.sniffContentType(Data([0x50, 0x4B, 0x03, 0x04])) == "application/zip")
+        #expect(URLFetchService.sniffContentType(Data("%PDF-1.4".utf8)) == "application/pdf")
+        #expect(URLFetchService.sniffContentType(Data([0x89, 0x50, 0x4E, 0x47])) == "image/png")
+        #expect(URLFetchService.sniffContentType(Data([0xFF, 0xD8, 0xFF, 0xE0])) == "image/jpeg")
+        #expect(URLFetchService.sniffContentType(Data("GIF89a".utf8)) == "image/gif")
+        #expect(URLFetchService.sniffContentType(Data([0x50, 0x4B, 0x03, 0x04])) == "application/zip")
         // Plain text / HTML carries no magic → nil (falls back to declared type).
-        #expect(URLIngestService.sniffContentType(Data("<!DOCTYPE html>".utf8)) == nil)
-        #expect(URLIngestService.sniffContentType(Data("hello".utf8)) == nil)
-        #expect(URLIngestService.sniffContentType(Data()) == nil)
+        #expect(URLFetchService.sniffContentType(Data("<!DOCTYPE html>".utf8)) == nil)
+        #expect(URLFetchService.sniffContentType(Data("hello".utf8)) == nil)
+        #expect(URLFetchService.sniffContentType(Data()) == nil)
     }
 
     @Test func shouldSniffOnlyAmbiguousTypes() {
-        #expect(URLIngestService.shouldSniff(nil))
-        #expect(URLIngestService.shouldSniff("text/html"))
-        #expect(URLIngestService.shouldSniff("application/octet-stream"))
+        #expect(URLFetchService.shouldSniff(nil))
+        #expect(URLFetchService.shouldSniff("text/html"))
+        #expect(URLFetchService.shouldSniff("application/octet-stream"))
         // A specific declared type is trusted, not sniffed.
-        #expect(!URLIngestService.shouldSniff("application/pdf"))
-        #expect(!URLIngestService.shouldSniff("image/png"))
-        #expect(!URLIngestService.shouldSniff("text/plain"))
+        #expect(!URLFetchService.shouldSniff("application/pdf"))
+        #expect(!URLFetchService.shouldSniff("image/png"))
+        #expect(!URLFetchService.shouldSniff("text/plain"))
     }
 
     // MARK: - Errors
@@ -251,19 +251,19 @@ struct URLIngestServiceTests {
         let collector = StoreCollector()
         let fetcher = FakeFetcher(error: .httpStatus(404))
         let service = makeService(fetcher, collector)
-        await #expect(throws: URLIngestService.IngestError.httpStatus(404)) {
-            try await service.ingest(rawInput: "https://example.com/missing")
+        await #expect(throws: URLFetchService.FetchError.httpStatus(404)) {
+            try await service.fetch( "https://example.com/missing")
         }
         #expect(collector.filename == nil)  // nothing stored on error
     }
 
     @Test func emptyBodyIsError() async throws {
         let collector = StoreCollector()
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data(), contentType: "text/html",
             finalURL: URL(string: "https://example.com")!))
-        await #expect(throws: URLIngestService.IngestError.empty) {
-            try await makeService(fetcher, collector).ingest(rawInput: "https://example.com")
+        await #expect(throws: URLFetchService.FetchError.empty) {
+            try await makeService(fetcher, collector).fetch( "https://example.com")
         }
     }
 
@@ -271,7 +271,7 @@ struct URLIngestServiceTests {
         let collector = StoreCollector()
         let fetcher = FakeFetcher(response: response("x", mime: "text/html", url: "https://x.com"))
         await #expect(throws: (any Error).self) {
-            try await makeService(fetcher, collector).ingest(rawInput: "   ")
+            try await makeService(fetcher, collector).fetch( "   ")
         }
     }
 
@@ -280,7 +280,7 @@ struct URLIngestServiceTests {
         collector.failNext = true
         let fetcher = FakeFetcher(response: response("<p>x</p>", mime: "text/html", url: "https://x.com"))
         await #expect(throws: (any Error).self) {
-            try await makeService(fetcher, collector).ingest(rawInput: "https://x.com")
+            try await makeService(fetcher, collector).fetch( "https://x.com")
         }
     }
 
@@ -289,10 +289,10 @@ struct URLIngestServiceTests {
     @Test func filenameDerivesFromFinalURLAfterRedirect() async throws {
         let collector = StoreCollector()
         // Asked for /short, fetcher reports it landed on /real-article.pdf.
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data("%PDF".utf8), contentType: "application/pdf",
             finalURL: URL(string: "https://cdn.example.com/files/real-article.pdf")!))
-        try await makeService(fetcher, collector).ingest(rawInput: "https://example.com/short")
+        try await makeService(fetcher, collector).fetch( "https://example.com/short")
         #expect(collector.filename == "real-article.pdf")
     }
 
@@ -300,7 +300,7 @@ struct URLIngestServiceTests {
         let collector = StoreCollector()
         let fetcher = FakeFetcher(response: response("<title>T</title>", mime: "text/html", url: "https://example.com"))
         let service = makeService(fetcher, collector)
-        try await service.ingest(rawInput: "example.com/page")
+        try await service.fetch( "example.com/page")
         #expect(fetcher.requested.url?.scheme == "https")
         #expect(fetcher.requested.url?.absoluteString == "https://example.com/page")
     }
@@ -309,47 +309,47 @@ struct URLIngestServiceTests {
         let collector = StoreCollector()
         let fetcher = FakeFetcher(response: response("<title>T</title>", mime: "text/html", url: "https://example.com"))
         let service = makeService(fetcher, collector)
-        try await service.ingest(rawInput: "  https://example.com/x  ")
+        try await service.fetch( "  https://example.com/x  ")
         #expect(fetcher.requested.url?.absoluteString == "https://example.com/x")
     }
 
     // MARK: - normalizeURL (pure)
 
     @Test func normalizeURLForms() {
-        #expect(URLIngestService.normalizeURL("https://a.com")?.absoluteString == "https://a.com")
-        #expect(URLIngestService.normalizeURL("http://a.com")?.absoluteString == "http://a.com")
-        #expect(URLIngestService.normalizeURL("a.com/path")?.absoluteString == "https://a.com/path")
-        #expect(URLIngestService.normalizeURL("//a.com")?.absoluteString == "https://a.com")
-        #expect(URLIngestService.normalizeURL("") == nil)
-        #expect(URLIngestService.normalizeURL("   ") == nil)
+        #expect(URLFetchService.normalizeURL("https://a.com")?.absoluteString == "https://a.com")
+        #expect(URLFetchService.normalizeURL("http://a.com")?.absoluteString == "http://a.com")
+        #expect(URLFetchService.normalizeURL("a.com/path")?.absoluteString == "https://a.com/path")
+        #expect(URLFetchService.normalizeURL("//a.com")?.absoluteString == "https://a.com")
+        #expect(URLFetchService.normalizeURL("") == nil)
+        #expect(URLFetchService.normalizeURL("   ") == nil)
         // A bare word with no dot is not a valid host-bearing URL.
-        #expect(URLIngestService.normalizeURL("ftp://a.com") == nil)  // unsupported scheme
+        #expect(URLFetchService.normalizeURL("ftp://a.com") == nil)  // unsupported scheme
     }
 
     // MARK: - Pure helpers
 
     @Test func normalizedMIMEStripsCharset() {
-        #expect(URLIngestService.normalizedMIME("text/html; charset=UTF-8") == "text/html")
-        #expect(URLIngestService.normalizedMIME("  APPLICATION/PDF ") == "application/pdf")
-        #expect(URLIngestService.normalizedMIME(nil) == nil)
+        #expect(URLFetchService.normalizedMIME("text/html; charset=UTF-8") == "text/html")
+        #expect(URLFetchService.normalizedMIME("  APPLICATION/PDF ") == "application/pdf")
+        #expect(URLFetchService.normalizedMIME(nil) == nil)
     }
 
     @Test func ensureExtensionDoesNotDouble() {
-        #expect(URLIngestService.ensureExtension("file", ext: "md") == "file.md")
-        #expect(URLIngestService.ensureExtension("file.md", ext: "md") == "file.md")
-        #expect(URLIngestService.ensureExtension("file.MD", ext: "md") == "file.MD")
+        #expect(URLFetchService.ensureExtension("file", ext: "md") == "file.md")
+        #expect(URLFetchService.ensureExtension("file.md", ext: "md") == "file.md")
+        #expect(URLFetchService.ensureExtension("file.MD", ext: "md") == "file.MD")
     }
 
     @Test func stemFromURLPrefersPathThenHost() {
-        #expect(URLIngestService.stemFromURL(URL(string: "https://a.com/x/report.pdf")!) == "report")
-        #expect(URLIngestService.stemFromURL(URL(string: "https://a.com/")!) == "a.com")
-        #expect(URLIngestService.stemFromURL(URL(string: "https://a.com")!) == "a.com")
+        #expect(URLFetchService.stemFromURL(URL(string: "https://a.com/x/report.pdf")!) == "report")
+        #expect(URLFetchService.stemFromURL(URL(string: "https://a.com/")!) == "a.com")
+        #expect(URLFetchService.stemFromURL(URL(string: "https://a.com")!) == "a.com")
     }
 
     @Test func sanitizeStemCapsAndCleans() {
         let long = String(repeating: "x", count: 200)
-        #expect(URLIngestService.sanitizeStem(long).count <= 80)
-        #expect(URLIngestService.sanitizeStem("a/b:c") == "a-b-c")
-        #expect(URLIngestService.sanitizeStem("   ") == "untitled")
+        #expect(URLFetchService.sanitizeStem(long).count <= 80)
+        #expect(URLFetchService.sanitizeStem("a/b:c") == "a-b-c")
+        #expect(URLFetchService.sanitizeStem("   ") == "untitled")
     }
 }

--- a/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
@@ -8,9 +8,9 @@ import Testing
 @MainActor
 struct WikiStoreModelAddURLTests {
 
-    struct FakeFetcher: URLIngestService.URLResourceFetcher {
-        let response: URLIngestService.FetchResponse
-        func fetch(_ url: URL) async throws -> URLIngestService.FetchResponse { response }
+    struct FakeFetcher: URLFetchService.URLResourceFetcher {
+        let response: URLFetchService.FetchResponse
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse { response }
     }
 
     private func tempStore() throws -> SQLiteWikiStore {
@@ -26,7 +26,7 @@ struct WikiStoreModelAddURLTests {
         var didSignal = false
         model.onPageDidChange = { didSignal = true }
 
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data("<title>My Doc</title><body><h1>Heading</h1><p>Body.</p></body>".utf8),
             contentType: "text/html",
             finalURL: URL(string: "https://example.com/doc")!))
@@ -51,7 +51,7 @@ struct WikiStoreModelAddURLTests {
         let model = WikiStoreModel(store: store)
         var pdf = Data("%PDF-1.7".utf8)
         pdf.append(contentsOf: [0x00, 0xFF, 0x10])
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: pdf, contentType: "application/pdf",
             finalURL: URL(string: "https://example.com/files/paper.pdf")!))
 
@@ -65,10 +65,10 @@ struct WikiStoreModelAddURLTests {
     @Test func errorLeavesListUnchanged() async throws {
         let store = try tempStore()
         let model = WikiStoreModel(store: store)
-        let fetcher = FakeFetcher(response: URLIngestService.FetchResponse(
+        let fetcher = FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data(), contentType: "text/html",
             finalURL: URL(string: "https://example.com")!))
-        await #expect(throws: URLIngestService.IngestError.empty) {
+        await #expect(throws: URLFetchService.FetchError.empty) {
             try await model.addURL("https://example.com", fetcher: fetcher)
         }
         #expect(model.sources.isEmpty)

--- a/Tests/WikiFSTests/WikiStoreModelZoteroIngestTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelZoteroIngestTests.swift
@@ -93,7 +93,7 @@ struct WikiStoreModelZoteroIngestTests {
         let model = WikiStoreModel(store: store)
         let zoteroDir = try tempZoteroDir()  // no fixture written — file doesn't exist
 
-        await #expect(throws: ZoteroIngestError.self) {
+        await #expect(throws: ZoteroFetchError.self) {
             try await model.ingestFromZotero(
                 attachment(key: "MISSING1", filename: "ghost.pdf"),
                 parentItem: parentItem(), zoteroDir: zoteroDir)
@@ -108,7 +108,7 @@ struct WikiStoreModelZoteroIngestTests {
         try writeFixture(
             zoteroDir: zoteroDir, key: "L1", filename: "stray.pdf", data: Data("%PDF".utf8))
 
-        await #expect(throws: ZoteroIngestError.self) {
+        await #expect(throws: ZoteroFetchError.self) {
             try await model.ingestFromZotero(
                 attachment(key: "L1", linkMode: "linked_file", filename: "stray.pdf"),
                 parentItem: parentItem(), zoteroDir: zoteroDir)
@@ -135,17 +135,17 @@ struct WikiStoreModelZoteroIngestTests {
         #expect(filenames == ["paper.pdf", "notes.md"])
     }
 
-    // MARK: - ZoteroIngestError
+    // MARK: - ZoteroFetchError
 
-    @Test func zoteroIngestErrorDescriptionReturnsReason() {
-        let error = ZoteroIngestError.unavailable("Not synced to this Mac yet")
+    @Test func zoteroFetchErrorDescriptionReturnsReason() {
+        let error = ZoteroFetchError.unavailable("Not synced to this Mac yet")
         #expect(error.errorDescription == "Not synced to this Mac yet")
     }
 
-    @Test func zoteroIngestErrorIsEquatable() {
-        let a = ZoteroIngestError.unavailable("msg")
-        let b = ZoteroIngestError.unavailable("msg")
-        let c = ZoteroIngestError.unavailable("different")
+    @Test func zoteroFetchErrorIsEquatable() {
+        let a = ZoteroFetchError.unavailable("msg")
+        let b = ZoteroFetchError.unavailable("msg")
+        let c = ZoteroFetchError.unavailable("different")
         #expect(a == b)
         #expect(a != c)
     }

--- a/Tests/WikiFSTests/ZoteroClientTests.swift
+++ b/Tests/WikiFSTests/ZoteroClientTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 /// Tests for `ZoteroClient`'s request-building, decoding, and status-code mapping
 /// — driven entirely by a FAKE fetcher returning canned `(Data, Int)` pairs, no
-/// real network. Mirrors `URLIngestServiceTests`'s fake-fetcher pattern.
+/// real network. Mirrors `URLFetchServiceTests`'s fake-fetcher pattern.
 struct ZoteroClientTests {
 
     // MARK: - Test double


### PR DESCRIPTION
## Summary

Follow-up to #180 (merged). Renames the lower-level fetch+plan service so "ingest" refers only to the agent phase, completing #178.

Closes #178.

## Why a follow-up

#180 renamed the `WikiStoreModel` add-source methods (`ingest(fileURLs:)` → `addFiles(_:)`, `ingestURL(_:)` → `addURL(_:)`) but intentionally **deferred** the deeper `URLIngestService`. On reflection that left the job half-done: `addURL` delegated to `URLIngestService.ingest(...)`, recreating exactly the confusion #178 was filed to fix. The service fetches bytes and plans storage — it does **not** run the agent "Ingest into wiki" phase — so by #178's own principle its name is wrong too.

## Changes

`Sources/WikiFSCore/URLIngestService.swift` → **`URLFetchService.swift`** (history preserved via `git mv`):

| Before | After |
|---|---|
| `URLIngestService` | `URLFetchService` |
| `IngestOutcome` | `FetchOutcome` |
| `IngestError` | `FetchError` |
| `ingest(rawInput:)` | `fetch(_:)` |

Already carried no "ingest" — left unchanged: `FetchResponse`, `URLResourceFetcher`, `StorePlan`, `normalizeURL`, `plan`, `store(response:)`.

**References updated** (all symbol + doc-comment occurrences): `URLSessionFetcher`, `AddFromURLSheet`, `WikiStoreModel`, and cross-file doc pointers in `ContentSniff`, `MarkdownFolderReader`, `ZoteroClient`, `ZoteroCredentialStore`.

**Tests renamed to match** (via `git mv`): `URLIngestServiceTests` → `URLFetchServiceTests`.

## Untouched (per #178's non-goal)
The genuine agent-phase ingestion terminology stays: `AgentLauncher.ingestingSourceIDs`, `WikiOperation.ingest` (the "Ingest into wiki" operation), and `DebugLog.ingest`.

## Verification
- `swift build` green
- `URLFetchServiceTests` + `WikiStoreModelAddURLTests` pass (29 tests)
- grep confirms zero remaining `URLIngestService` / `IngestError` / `IngestOutcome` references

## Checklist
- [x] no behavior change — pure rename
- [x] all references updated (symbols + doc comments)
- [x] test files renamed (history preserved)
- [x] agent-phase "ingest" terminology preserved
