### PR TITLE
fix(#173): show concise tool-call summaries in Ask/Edit chat

### DIFF
--- a/Sources/WikiFS/AgentTranscriptWebView.swift
+++ b/Sources/WikiFS/AgentTranscriptWebView.swift
@@ -236,10 +236,9 @@ struct AgentTranscriptWebView: NSViewRepresentable {
 
         /// The Query page chat look: a right-aligned capsule for the user, plain
         /// prose for the assistant (matching `QueryMessageBubble`'s prior
-        /// SwiftUI rendering), no row labels. Other event kinds never reach a
-        /// chat-styled transcript (the caller's `events` is pre-filtered to
-        /// user/assistant/result), but render nothing rather than crash if one
-        /// slips through.
+        /// SwiftUI rendering), no row labels. Tool calls render as a concise,
+        /// muted one-line progress indicator (issue #173) — independent of the
+        /// "Show internals" toggle, which still gates the full raw feed.
         static func chatRowHTML(for event: AgentEvent) -> String {
             switch event {
             case .userText(let text):
@@ -255,9 +254,29 @@ struct AgentTranscriptWebView: NSViewRepresentable {
                 return """
                 <div class="row chat-row chat-assistant"><div class="bubble">\(renderedMarkdown(text))</div></div>
                 """
-            case .systemInit, .toolUse, .toolResult, .subagent, .messageStop, .raw, .assistantTextDelta:
+            case .toolUse(let name, let summary):
+                return chatToolRowHTML(name: name, summary: summary, isError: false)
+            case .toolResult(let isError, let summary):
+                // Only error results reach a chat-styled transcript (successes are
+                // filtered out upstream in `QueryTranscriptView.visibleEvents`).
+                guard isError else { return "" }
+                return chatToolRowHTML(name: nil, summary: summary, isError: true)
+            case .systemInit, .subagent, .messageStop, .raw, .assistantTextDelta:
                 return ""
             }
+        }
+
+        /// A single muted, left-aligned progress line for a tool call — the
+        /// lightweight in-transcript indicator (issue #173). Not a chat bubble:
+        /// it reads like a status line, so it stays subordinate to the prose.
+        private static func chatToolRowHTML(name: String?, summary: String, isError: Bool) -> String {
+            let nameHTML = name.map { "<span class=\"chat-tool-name\">\(escape($0))</span>" } ?? ""
+            let body = summary.isEmpty ? (isError ? "(error)" : "") : summary
+            let summaryHTML = body.isEmpty ? "" : "<span class=\"chat-tool-summary\">\(escape(body))</span>"
+            return """
+            <div class="row chat-row chat-tool\(isError ? " is-error" : "")">\
+            \(nameHTML)\(summaryHTML)</div>
+            """
         }
 
         private static func escape(_ s: String) -> String {
@@ -326,6 +345,20 @@ struct AgentTranscriptWebView: NSViewRepresentable {
             background: var(--code-bg); border-radius: 14px;
             padding: 11px 16px; white-space: pre-wrap; font-size: 13.5px;
           }
+          .chat-tool {
+            justify-content: flex-start; align-items: baseline;
+            gap: 6px; font-size: 11.5px; color: var(--muted);
+            padding: 1px 2px;
+          }
+          .chat-tool-name {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-weight: 600; color: var(--text);
+          }
+          .chat-tool-summary {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+          }
+          .chat-tool.is-error { color: #ff453a; }
+          .chat-tool.is-error .chat-tool-name { color: #ff453a; }
           p { margin: 0 0 0.6em; }
           p:last-child { margin-bottom: 0; }
           h1, h2, h3, h4, h5, h6 { line-height: 1.25; font-weight: 600; margin: 0.7em 0 0.3em; }

--- a/Sources/WikiFS/QueryTranscriptView.swift
+++ b/Sources/WikiFS/QueryTranscriptView.swift
@@ -27,6 +27,16 @@ struct QueryTranscriptView: View {
             switch event {
             case .result(_, let text):
                 return !hasAssistantText(matching: text)
+            case .toolUse:
+                // A concise one-line progress summary per tool call (issue #173):
+                // lets the user see the agent reading/searching/editing without
+                // opting into the full internals view. Full raw detail still lives
+                // behind "Show internals".
+                return true
+            case .toolResult(let isError, _):
+                // Surface failed tool calls (a useful stall/error signal); successes
+                // are implied by the agent's next action or final answer.
+                return isError
             default:
                 return !event.isInternalTranscriptEvent
             }
@@ -50,7 +60,7 @@ struct QueryTranscriptView: View {
                 .font(.headline)
                 .fontWeight(.medium)
                 .foregroundStyle(.primary)
-            Text("Answers appear here; tool calls and scratch-work stay hidden unless you show internals.")
+            Text("Answers appear here; one-line tool-call summaries show as the agent works. Full detail is available under “Show internals.”")
                 .font(.callout)
                 .foregroundStyle(.secondary)
         }

--- a/Tests/WikiFSTests/AgentTranscriptLinkifyTests.swift
+++ b/Tests/WikiFSTests/AgentTranscriptLinkifyTests.swift
@@ -53,4 +53,33 @@ struct AgentTranscriptLinkifyTests {
         let html = Transcript.chatRowHTML(for: .result(isError: false, text: "See [[Page]] here."))
         #expect(html.contains("wiki://"))
     }
+
+    // MARK: - Concise tool-call summaries (issue #173)
+
+    @Test func chatToolUseRowRendersConciseSummary() {
+        let html = Transcript.chatRowHTML(for: .toolUse(name: "Read", inputSummary: "page.md"))
+        #expect(html.contains("chat-tool"))
+        #expect(html.contains("Read"))
+        #expect(html.contains("page.md"))
+        // Not a chat bubble — it's a status line.
+        #expect(!html.contains("bubble"))
+    }
+
+    @Test func chatToolUseRowWithoutSummaryStillShowsName() {
+        let html = Transcript.chatRowHTML(for: .toolUse(name: "Grep", inputSummary: ""))
+        #expect(html.contains("Grep"))
+        #expect(html.contains("chat-tool"))
+    }
+
+    @Test func chatToolResultErrorRowRenders() {
+        let html = Transcript.chatRowHTML(for: .toolResult(isError: true, summary: "file not found"))
+        #expect(html.contains("chat-tool"))
+        #expect(html.contains("is-error"))
+        #expect(html.contains("file not found"))
+    }
+
+    @Test func chatToolResultSuccessRowIsEmpty() {
+        let html = Transcript.chatRowHTML(for: .toolResult(isError: false, summary: "ok"))
+        #expect(html.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #173.

With "Show internals" off (the default), the Ask/Edit chat transcript filtered out **every** `toolUse`/`toolResult` event. So during a long-running turn the user saw nothing between their question and the final answer — no indication the agent was reading files, running a search, or editing the wiki. The only way to see progress was to opt into the full internals view, which dumps raw stream-json detail.

This adds a **concise, one-line progress summary per tool call** to the normal chat transcript, independent of the "Show internals" toggle.

## What changed

- **`QueryTranscriptView.visibleEvents`** — now keeps `.toolUse` events (always) and error `.toolResult` events (failures are a useful stall/error signal). Successful results stay hidden — they're implied by the agent's next action or final answer. All other internals (`systemInit`, `subagent`, `raw`, `messageStop`, `assistantTextDelta`) remain filtered.
- **`AgentTranscriptWebView.chatRowHTML`** — renders a tool call as a muted, left-aligned status line (not a chat bubble): monospace tool name + concise input summary, e.g. `Read  page.md`. Error results render in red. Reuses the existing `ToolInputSummary` one-liner rendering.
- **Empty-state copy** updated to reflect the new behavior.
- Full raw event detail is unchanged behind "Show internals" (`AgentActivityView`).

## Design notes

- Tool rows are deliberately **not** bubbles — they read as a subordinate status line so the assistant's prose stays the visual focus.
- Only **errors** among tool results are surfaced; surfacing every successful result would add noise without adding signal (the next action/answer confirms success).

## Testing

- `swift build` ✅
- New tests in `AgentTranscriptLinkifyTests`: chat tool-use row (with/without summary), error result row, success result row is empty.
- Full `AgentTranscriptLinkifyTests` + `AgentEventParserTests` suites pass (50 tests).
