### PR TITLE
Add "Show in List" sidebar reveal for pages & sources (#183)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4784,3 +4784,40 @@ the window hit the generic file-drop path (`addFiles`), ingesting the
 **Tests:** `WikiStoreModelDropRoutingTests` (5) — webloc→md, http url→md, local
 txt→verbatim, mixed batch, unresolvable webloc skipped. All pass; existing
 `WikiStoreModelAddURLTests` still green.
+
+## #183 — "Show In List" sidebar reveal for pages & sources
+
+A "Show in List" button (next to "Reveal in Finder") in `PageDetailView` and
+`SourceDetailView` that surfaces the current page/source in the sidebar: opens
+the sidebar if collapsed, switches to the right section, clears a search that
+would hide the row, then scrolls to + selects it.
+
+**Mechanism** — mirrors the existing `pendingScrollAnchor` "set once, consume
+once" cross-view signal (issue #183 design):
+
+- `WikiStoreModel` — `pendingSidebarReveal: WikiSelection?` +
+  `pendingSidebarRevealVersion: Int` (monotonic, observed via `.onChange` so a
+  repeat request re-fires even when the value is unchanged), with
+  `requestSidebarReveal(_:)` (producer) and `consumePendingSidebarReveal()`
+  (consumer, called by the list view after scroll+select).
+- `ContentView` — `.onChange(of: pendingSidebarRevealVersion)` un-collapses the
+  sidebar (`columnVisibility = .all`) when it's `.detailOnly`, so the target
+  section's list is actually mounted.
+- `SidebarView` — `.onChange(of: pendingSidebarRevealVersion)` sets
+  `selectedSection` to `.pages`/`.sources` from the `WikiSelection` case and
+  clears the section's search query (`searchQuery`/`sourceSearchQuery`) only
+  when the target isn't in the filtered results (clearing resets
+  `searchResults`/`sourceSearchResults` synchronously, so the full list is
+  visible for row lookup).
+- `PagesListViewController` / `SourcesListViewController` — new
+  `revealAndSelect(id:)`: looks up the row, selects it (bypassing the
+  `reconcileHighlight` multi-select guard — an explicit user action wins over a
+  Cmd/Shift selection), and `scrollRowToVisible(_:)`. Driven from
+  `updateNSViewController`, which reads `pendingSidebarReveal` (also registers
+  the observation so the method re-runs on change), then consumes.
+- `PageDetailView` / `SourceDetailView` — `Button("Show in List",
+  systemImage: "sidebar.left")` calling `requestSidebarReveal(.page(id))` /
+  `.source(id)`. Works without a mounted File Provider (unlike Reveal in Finder).
+
+**Build/tests:** `swift build` clean; `swift test` — 1466 tests pass.
+

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -79,6 +79,14 @@ struct ContentView: View {
         .onChange(of: store.selection) { _, newValue in
             store.handleSelectionChange(to: newValue)
         }
+        // "Show In List" reveal (issue #183): a detail-view button requested the
+        // sidebar reveal a page/source. Un-collapse the sidebar so the target list
+        // is actually mounted (SidebarView only mounts the active section).
+        .onChange(of: store.pendingSidebarRevealVersion) { _, _ in
+            if columnVisibility == .detailOnly {
+                columnVisibility = .all
+            }
+        }
         .onChange(of: agentLauncher.isRunning) { _, isRunning in
             if isRunning {
                 isTranscriptExpanded = true

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -85,6 +85,12 @@ struct PageDetailView: View {
                             .disabled(store.isAgentRunning)
                             .help("Fix [[wiki-link]] syntax and run LLM lint on this page")
                         }
+                        if case .page(let pageID) = store.selection {
+                            Button("Show in List", systemImage: "sidebar.left") {
+                                store.requestSidebarReveal(.page(pageID))
+                            }
+                            .help("Reveal this page in the sidebar")
+                        }
                         if fileProvider.path != nil, case .page(let pageID) = store.selection {
                             Button("Share", systemImage: "square.and.arrow.up") {
                                 Task {
@@ -107,7 +113,6 @@ struct PageDetailView: View {
                             }
                             .help("Reveal this page file in Finder")
                         }
-
                         Button {
                             isOutlineExpanded.toggle()
                         } label: {

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -45,6 +45,14 @@ struct PagesListView: NSViewControllerRepresentable {
         if needs { vc.reloadData(from: visible) }
         // Always reconcile highlight to the active tab (cheap; guarded inside).
         vc.reconcileHighlight(activeSelection: store.activeTab?.selection)
+        // Explicit "Show In List" reveal (issue #183): the pending target is
+        // read here so SwiftUI re-invokes this method when it changes. When the
+        // target matches this section, scroll to + select the row (bypassing the
+        // multi-select guard) and consume so it fires once.
+        if let pending = store.pendingSidebarReveal, case .page(let id) = pending {
+            _ = vc.revealAndSelect(id: id)
+            store.consumePendingSidebarReveal()
+        }
     }
 }
 
@@ -172,6 +180,22 @@ final class PagesListViewController: NSViewController {
                 isReconcilingHighlight = false
             }
         }
+    }
+
+    // MARK: - Reveal ("Show In List")
+
+    /// Explicit "Show In List" reveal: select the target row and scroll it into
+    /// view. Unlike ``reconcileHighlight``, this bypasses the multi-select guard
+    /// (an explicit user action should win over a Cmd/Shift selection) and always
+    /// scrolls. Returns whether the row was found in the current items.
+    @discardableResult
+    func revealAndSelect(id: PageID) -> Bool {
+        guard let row = items.firstIndex(where: { $0.id == id }) else { return false }
+        isReconcilingHighlight = true
+        tableView.selectRowIndexes(IndexSet([row]), byExtendingSelection: false)
+        isReconcilingHighlight = false
+        tableView.scrollRowToVisible(row)
+        return true
     }
 
     // MARK: - Double-click

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -94,6 +94,32 @@ struct SidebarView: View {
                 store.createFolder(parentID: nil, name: name)
             }
         }
+        // "Show In List" reveal (issue #183): a detail-view button asked the
+        // sidebar to surface a page/source. Switch to the matching section and
+        // drop any active search that would hide the target row. The actual
+        // scroll + select happens in the list view once it mounts.
+        .onChange(of: store.pendingSidebarRevealVersion) { _, _ in
+            guard let target = store.pendingSidebarReveal else { return }
+            switch target {
+            case .page(let id):
+                selectedSection = .pages
+                // Clearing to "" resets searchResults synchronously (scheduleSearch
+                // sets [] on empty), so the full list is visible when the row is
+                // looked up.
+                if !store.searchQuery.isEmpty,
+                   !store.searchResults.contains(where: { $0.id == id }) {
+                    store.searchQuery = ""
+                }
+            case .source(let id):
+                selectedSection = .sources
+                if !store.sourceSearchQuery.isEmpty,
+                   !store.sourceSearchResults.contains(where: { $0.id == id }) {
+                    store.sourceSearchQuery = ""
+                }
+            default:
+                break
+            }
+        }
     }
 
     /// A row of evenly-spaced icons — one per section — that selects which

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -330,6 +330,10 @@ struct SourceDetailView: View {
                     // canonical URL from the daemon (like openSource) so the
                     // filename is human-readable and the URL is guaranteed
                     // to resolve.
+                    Button("Show in List", systemImage: "sidebar.left") {
+                        store.requestSidebarReveal(.source(file.id))
+                    }
+                    .help("Reveal this source in the sidebar")
                     if fileProvider.path != nil {
                         Button("Share", systemImage: "square.and.arrow.up") {
                             Task {

--- a/Sources/WikiFS/SourcesListView.swift
+++ b/Sources/WikiFS/SourcesListView.swift
@@ -50,6 +50,12 @@ struct SourcesListView: NSViewControllerRepresentable {
         DebugLog.tabs("SourcesListView.updateNSVC: count=\(sources.count) needsReload=\(needs)")
         if needs { vc.reloadData(from: sources) }
         vc.reconcileHighlight(activeSelection: store.activeTab?.selection)
+        // Explicit "Show In List" reveal (issue #183). See PagesListView for the
+        // rationale; the pending read also re-triggers this method on change.
+        if let pending = store.pendingSidebarReveal, case .source(let id) = pending {
+            _ = vc.revealAndSelect(id: id)
+            store.consumePendingSidebarReveal()
+        }
     }
 }
 
@@ -302,6 +308,22 @@ final class SourcesListViewController: NSViewController {
                 isReconcilingHighlight = false
             }
         }
+    }
+
+    // MARK: - Reveal ("Show In List")
+
+    /// Explicit "Show In List" reveal: select the target row and scroll it into
+    /// view. Unlike ``reconcileHighlight``, this bypasses the multi-select guard
+    /// (an explicit user action should win over a Cmd/Shift selection) and always
+    /// scrolls. Returns whether the row was found in the current items.
+    @discardableResult
+    func revealAndSelect(id: PageID) -> Bool {
+        guard let row = items.firstIndex(where: { $0.id == id }) else { return false }
+        isReconcilingHighlight = true
+        tableView.selectRowIndexes(IndexSet([row]), byExtendingSelection: false)
+        isReconcilingHighlight = false
+        tableView.scrollRowToVisible(row)
+        return true
     }
 
     @objc private func onDoubleClick() {

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -411,6 +411,35 @@ public final class WikiStoreModel {
         return pending.fragment
     }
 
+    // MARK: - Sidebar reveal ("Show In List")
+
+    /// The pending "Show In List" reveal target set by a detail view's button
+    /// (`requestSidebarReveal(_:)`) and consumed by the sidebar list view once it
+    /// has scrolled to + selected the row. Follows the same "set once, consume
+    /// once" producer/consumer discipline as `pendingScrollAnchor` (issue #183).
+    public private(set) var pendingSidebarReveal: WikiSelection?
+
+    /// Monotonic counter bumped each time `pendingSidebarReveal` is assigned. The
+    /// sidebar host (`SidebarView`) and `ContentView` observe it via `.onChange`
+    /// so a repeat request for an already-mounted section still fires the switch
+    /// / un-collapse / scroll path (the value itself may be identical to the
+    /// previous one).
+    public private(set) var pendingSidebarRevealVersion: Int = 0
+
+    /// Request that the sidebar reveal `selection` in its list: open the sidebar
+    /// if collapsed, switch to the matching section (Pages vs. Sources), clear any
+    /// active search that would hide the target, then scroll to + select the row.
+    public func requestSidebarReveal(_ selection: WikiSelection) {
+        pendingSidebarReveal = selection
+        pendingSidebarRevealVersion += 1
+    }
+
+    /// Called by the sidebar list view AFTER it has scrolled to + selected the
+    /// target row, so the reveal fires exactly once. Clears the pending target.
+    public func consumePendingSidebarReveal() {
+        pendingSidebarReveal = nil
+    }
+
     // MARK: - Tab operations
 
     /// The single seam every tab switch routes through: flush the outgoing tab's


### PR DESCRIPTION
## Summary

Adds a **"Show in List"** button to `PageDetailView` and `SourceDetailView` that reveals the currently-viewed page/source in the sidebar — the in-app counterpart to the existing "Reveal in Finder." Closes #183.

Pressing it:
1. Opens the sidebar if it's collapsed.
2. Switches the sidebar to the matching section (Pages vs. Sources).
3. Clears any active search that would hide the target row.
4. Scrolls to + selects the row in the list.

## How it works

Mirrors the existing `pendingScrollAnchor` "set once, consume once" cross-view signal described in the issue:

- **`WikiStoreModel`** — `pendingSidebarReveal: WikiSelection?` + a monotonic `pendingSidebarRevealVersion`, with `requestSidebarReveal(_:)` (producer) and `consumePendingSidebarReveal()` (consumer, called by the list view after scroll+select). The version counter lets a repeat request re-fire even when the target value is unchanged.
- **`ContentView`** — `.onChange(of: pendingSidebarRevealVersion)` un-collapses the sidebar (`columnVisibility = .all`) when it's `.detailOnly`, so the target section's list is actually mounted.
- **`SidebarView`** — `.onChange(of: pendingSidebarRevealVersion)` sets `selectedSection` to `.pages`/`.sources` and clears the section's search query (`searchQuery`/`sourceSearchQuery`) only when the target isn't in the filtered results. (Clearing resets `searchResults`/`sourceSearchResults` synchronously, so the full list is visible for row lookup.)
- **`PagesListViewController` / `SourcesListViewController`** — new `revealAndSelect(id:)`: looks up the row, selects it (bypassing the `reconcileHighlight` multi-select guard — an explicit user action wins over a Cmd/Shift selection), and `scrollRowToVisible(_:)`. Driven from `updateNSViewController`, which reads `pendingSidebarReveal` (registering the observation so the method re-runs on change), then consumes.
- **`PageDetailView` / `SourceDetailView`** — `Button("Show in List", systemImage: "sidebar.left")` calling `requestSidebarReveal(.page(id))` / `.source(id)`. Works without a mounted File Provider (unlike Reveal in Finder).

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 1466 tests pass
- [ ] Manual: with sidebar collapsed, viewing a page → "Show in List" opens sidebar to Pages and selects/scrolls to the page
- [ ] Manual: same for a source → switches to Sources section
- [ ] Manual: with an active search that hides the target → search clears, row revealed
- [ ] Manual: repeat click on an already-revealed row still scrolls/highlights (version counter)
