### PR TITLE
Phase 3b: source refresh + Apple Podcasts byteless conversion

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,35 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-06 — Source refresh + Apple Podcasts byteless conversion (Phase 3b)
+
+Shipped two features on the graph-model versioning substrate:
+
+**Source refresh.** A new `SourceRefreshService` (in `WikiFSCore`) reconstructs
+a source's provider from its stored `SourceOrigin` and re-materializes it
+**off-main**, returning a `RefreshMaterial` (`.contentVersion` for website
+sources, `.derivedMarkdown` for byteless podcast sources). The `@MainActor`
+caller (`WikiStoreModel.refreshSource`) performs the store write
+(`appendContentVersion` / `appendProcessedMarkdown`) — preserving the Phase-0
+single-writer-discipline invariant. Import-only providers (local-file, Zotero,
+folder) throw `.notRefreshable`.
+
+**Apple Podcasts byteless conversion (§11).** Retired the Option-A technical
+debt: podcast episodes now store as **byteless sources** (a pointer to the
+external episode with `blob_hash IS NULL`), with the transcript markdown as a
+derived alternative via `appendProcessedMarkdown`. The provider is unchanged;
+only the storage path repoints. New store primitive `addBytelessSource` mirrors
+`addSource`'s transaction discipline minus the blob/hash write, with a dedup on
+`external_identity` (backed by a partial index).
+
+**Surfaces:** UI refresh button in `SourceDetailView` (gated on refreshability),
+`wikictl source refresh` (website-only; async→sync semaphore bridge), the
+`SourceRefreshService` seam (injectable fetchers for CI).
+
+**Deferred:** credentials UX (Phase 7), website sibling `original_path`
+(Phase 4), transcript-level PROV (`apple-ttml` extract agent — Phase 4 when the
+alternatives UI gains a podcast transcript backend).
+
 ## 2026-07-05 — Apple Podcasts transcript ingest (PR #106 rebase + Option-A remodel)
 
 Rebased PR #106 ("Apple Podcasts episode URLs as transcript sources") onto

--- a/Package.swift
+++ b/Package.swift
@@ -98,7 +98,11 @@ let package = Package(
         .target(
             name: "WikiCtlCore",
             dependencies: ["WikiFSCore"],
-            path: "Sources/WikiCtlCore"
+            path: "Sources/WikiCtlCore",
+            // Must match WikiFSCore's PODCAST_TRANSCRIPTS flag so conditional
+            // API in SourceRefreshService (the podcast refresh branch) compiles
+            // consistently across the dependency.
+            swiftSettings: podcastSwiftSettings
         ),
         // wikictl — the agent's write path (plans/llm-wiki.md Phase A). A
         // scriptable CLI that writes straight to a wiki's <ulid>.sqlite in the
@@ -108,7 +112,8 @@ let package = Package(
         .executableTarget(
             name: "wikictl",
             dependencies: ["WikiFSCore", "WikiCtlCore"],
-            path: "Sources/wikictl"
+            path: "Sources/wikictl",
+            swiftSettings: podcastSwiftSettings
         ),
         // podcast-token-helper — the FairPlay/Mescal bearer-token signer for Apple
         // Podcasts transcripts. An ObjC executable ON PURPOSE: it dlopens the private

--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -59,6 +59,8 @@ public enum ArgumentParser {
         case sourceRename(SourceCommand.Selector, to: String)
         /// Nominate a processed-markdown version as the active HEAD (Phase 2).
         case sourceSetActive(SourceCommand.Selector, versionID: PageID)
+        /// Re-fetch a source via its provider, appending a new version (Phase 3b).
+        case sourceRefresh(SourceCommand.Selector)
     }
 
     public enum Failure: Error, Equatable, CustomStringConvertible {
@@ -99,6 +101,8 @@ public enum ArgumentParser {
       source set-active (--id X | --name N) --version <smv-id>
                                               nominate a processed-markdown version
                                               as the active HEAD (extraction alt)
+      source refresh (--id X | --name N)      re-fetch a website source via its
+                                               provider, appending a new version
     """
 
     /// Parse `arguments` (WITHOUT the executable name) plus an env lookup into an
@@ -247,6 +251,9 @@ public enum ArgumentParser {
 
         case "info":
             return .source(.info(try options.requireSourceSelector()))
+
+        case "refresh":
+            return .sourceRefresh(try options.requireSourceSelector())
 
         case "search":
             guard let query = options.value("--query") else {

--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -30,7 +30,7 @@ public enum SourceCommand {
     }
 
     /// How a file is selected for `cat` / `export`.
-    public enum Selector: Equatable {
+    public enum Selector: Equatable, Sendable {
         case id(PageID)
         case name(String)
     }
@@ -44,6 +44,7 @@ public enum SourceCommand {
         case search(query: String, limit: Int)
         case setActive(Selector, versionID: PageID)
         case info(Selector)
+        case refresh(Selector)
     }
 
     public enum Failure: Error, CustomStringConvertible {
@@ -77,6 +78,10 @@ public enum SourceCommand {
             return try setActive(selector, versionID: versionID, in: store)
         case .info(let selector):
             return try info(selector, in: store)
+        case .refresh:
+            // Refresh is async-only — routed via `runRefresh` from `main.swift`.
+            // This case is unreachable through the sync `run` path.
+            throw Failure.message("source refresh requires async execution")
         }
     }
 
@@ -278,5 +283,47 @@ public enum SourceCommand {
             lines.append("fetched_at\t\(date)")
         }
         return Result(payload: .text(lines.joined(separator: "\n")), didCommit: false)
+    }
+
+    // MARK: - refresh
+
+    /// Re-fetch a source via its provider, appending a new version instead of
+    /// overwriting. Unlike the other SourceCommand actions (all sync), this
+    /// needs async network I/O, so it has its own async entry point. `main`
+    /// bridges it to the sync `execute` context via a semaphore.
+    ///
+    /// wikictl is a CLI process (no `@MainActor`), so the store write happens
+    /// directly after the off-main materialize — the Phase-0 `@MainActor`
+    /// invariant applies to the APP process, not wikictl. The service is
+    /// constructed with `podcastFetcher: nil` (no bundled signing helper in the
+    /// CLI context), so podcast refresh throws `.signatureUnavailable` and only
+    /// website sources are refreshable from the CLI. Commits — the caller posts
+    /// the Darwin notification on `didCommit`.
+    public static func runRefresh(
+        _ selector: Selector,
+        in store: WikiStore,
+        fetcher: any URLFetchService.URLResourceFetcher
+    ) async throws -> Result {
+        let id = try resolve(selector, in: store)
+        guard let origin = try store.sourceOrigin(sourceID: id) else {
+            throw Failure.message("source has no origin provenance: \(id.rawValue)")
+        }
+        #if PODCAST_TRANSCRIPTS
+        let service = SourceRefreshService(fetcher: fetcher, podcastFetcher: nil)
+        #else
+        let service = SourceRefreshService(fetcher: fetcher)
+        #endif
+        let material = try await service.materialize(origin: origin)
+        switch material {
+        case .contentVersion(let data, let prov):
+            _ = try store.appendContentVersion(
+                sourceID: id, data: data, mimeType: nil, provenance: prov)
+        case .derivedMarkdown(let content):
+            try store.appendProcessedMarkdown(
+                sourceID: id, content: content, origin: "transcript", note: nil)
+        }
+        return Result(
+            payload: .text("Refreshed \(origin.displayLabel) source."),
+            didCommit: true)
     }
 }

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -43,6 +43,10 @@ struct SourceDetailView: View {
     @State private var isEditing = false
     @State private var editBuffer = ""
     @State private var isExtracting = false
+    /// True while a source refresh (re-fetch via provider) is in flight.
+    @State private var isRefreshing = false
+    /// Set when a refresh fails — surfaced inline below the action row.
+    @State private var refreshError: String?
     /// Tracks the active tab ID as of the last resolved update cycle — used to
     /// distinguish tab switches from in-tab file navigation.
     @State private var lastKnownActiveTabID: UUID? = nil
@@ -82,6 +86,13 @@ struct SourceDetailView: View {
     private var isPDF: Bool { file.mimeType == "application/pdf" }
 
     private var hasMarkdown: Bool { headVersion != nil }
+
+    /// `true` when the source's origin is a refreshable provider (website or
+    /// Apple Podcast). Import-only providers (local-file, Zotero, folder) carry
+    /// no URL to re-fetch.
+    private var isRefreshable: Bool {
+        origin?.agentName == "website" || origin?.agentName == "apple-podcast"
+    }
 
     private var showTabs: Bool { isPDF && hasMarkdown }
 
@@ -160,6 +171,8 @@ struct SourceDetailView: View {
             flushEditIfDirty()
             isEditing = false
             isExtracting = false
+            isRefreshing = false
+            refreshError = nil
             showReingestConfirmation = false
             headVersion = nil
             origin = nil
@@ -371,6 +384,13 @@ struct SourceDetailView: View {
                             store.requestSidebarReveal(.source(file.id))
                         }
                         .help("Reveal this source in the sidebar")
+                        if isRefreshable {
+                            Button("Refresh", systemImage: "arrow.clockwise") {
+                                Task { await runRefresh() }
+                            }
+                            .disabled(isRefreshing || store.isAgentRunning)
+                            .help("Re-fetch this source and append a new version")
+                        }
                         if fileProvider.path != nil {
                             Button("Share", systemImage: "square.and.arrow.up") {
                                 Task {
@@ -415,9 +435,44 @@ struct SourceDetailView: View {
                 }
             }
 
+            if isRefreshing {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Refreshing…")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let refreshError {
+                Text(refreshError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+
         }
         .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
         .padding(PageEditorMetrics.contentInset)
+    }
+
+    // MARK: - Refresh (Phase 3b)
+
+    /// Re-fetch the source via its provider, appending a new version. The
+    /// materialization (network fetch) runs off-main inside the service; the
+    /// store write + `reloadSources` happen on-main inside `refreshSource`.
+    /// On success, reloads the head markdown so the reader updates.
+    private func runRefresh() async {
+        isRefreshing = true
+        refreshError = nil
+        defer { isRefreshing = false }
+        do {
+            _ = try await store.refreshSource(file.id)
+            headVersion = store.processedMarkdownHead(for: file)
+        } catch SourceRefreshService.RefreshError.notRefreshable(let agent) {
+            refreshError = "This \(agent) source can't be refreshed."
+        } catch {
+            refreshError = "Refresh failed: \(error.localizedDescription)"
+        }
     }
 
     // MARK: - Zotero origin

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -473,6 +473,17 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         );
         """)
         try exec("CREATE INDEX IF NOT EXISTS source_versions_source ON source_versions(source_id, id);")
+        // UNIQUE partial index for byteless-source dedup: keeps the
+        // external_identity lookup O(log n) AND provides a DB-level backstop
+        // against the SELECT-then-INSERT TOCTOU (a concurrent wikictl writer
+        // could pass the dedup check and both insert). NULL external_identity
+        // values are not equal in SQLite, so multiple NULLs coexist fine.
+        // Created here (fresh DB) and re-asserted idempotently in
+        // ensureSearchIndexesPopulated so existing v21 DBs pick it up too.
+        try exec("""
+        CREATE UNIQUE INDEX IF NOT EXISTS source_versions_byteless_eid
+            ON source_versions(external_identity) WHERE blob_hash IS NULL;
+        """)
         try exec("""
         CREATE TABLE IF NOT EXISTS refs (
             kind       TEXT NOT NULL,
@@ -2082,6 +2093,149 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         )
     }
 
+    /// Store a **byteless** source — the §11 model for sources whose content is
+    /// an external resource (e.g. an Apple Podcasts episode), not stored bytes.
+    /// The source identity row + v1 content version carry `blob_hash = NULL`,
+    /// `byte_size = 0`, `content_hash = NULL`; the derived alternative (the
+    /// transcript markdown) is stored separately via `appendProcessedMarkdown`.
+    ///
+    /// Mirrors `addSource`'s transaction discipline EXACTLY, minus the blob/
+    /// hash write. Dedups on `external_identity` among byteless sources (the
+    /// partial index `source_versions_byteless_eid` keeps this O(log n)). The
+    /// byteless dedup and `addSource`'s content-hash dedup are disjoint: content
+    /// sources dedup on `content_hash`; byteless sources dedup on
+    /// `external_identity`. SQL `NULL = '…'` is NULL, so `addSource`'s content-
+    /// hash dedup never matches a byteless source.
+    @discardableResult
+    public func addBytelessSource(
+        filename: String,
+        mimeType: String? = nil,
+        provenance: SourceProvenance
+    ) throws -> SourceSummary {
+        lock.lock(); defer { lock.unlock() }
+
+        // Byteless dedup: a byteless source with the same external_identity
+        // already exists → reject (the partial index makes this lookup fast).
+        if let extID = provenance.externalIdentity {
+            let dupStmt = try statement("""
+            SELECT s.id, s.filename, s.ext, s.mime_type, s.byte_size,
+                   s.created_at, s.updated_at, s.version,
+                   s.zotero_item_key, s.zotero_item_title, s.display_name
+            FROM sources s
+            JOIN source_versions sv ON sv.source_id = s.id
+            WHERE sv.external_identity = ?1 AND sv.blob_hash IS NULL
+            LIMIT 1;
+            """)
+            dupStmt.reset()
+            try dupStmt.bind(extID, at: 1)
+            if try dupStmt.step() {
+                let existing = sourceSummary(from: dupStmt)
+                dupStmt.reset()
+                throw WikiStoreError.duplicateContent(existing: existing)
+            }
+            dupStmt.reset()
+        }
+
+        let id = PageID(rawValue: ULID.generate())
+        let ext = (filename as NSString).pathExtension.lowercased()
+        let mime = mimeType
+            ?? (ext.isEmpty ? nil : UTType(filenameExtension: ext)?.preferredMIMEType)
+        let now = Date()
+        // Display-name resolution mirrors addSource — pass empty Data (no bytes
+        // to sniff); the resolver falls back to filename/extension inference.
+        let displayName: String?
+        if let resolved = DisplayNameResolver.resolve(
+            filename: filename, data: Data(), mimeType: mime,
+            zoteroItemTitle: nil) {
+            displayName = WikiNameRules.sanitized(resolved)
+        } else if !WikiNameRules.isLinkable(filename) {
+            displayName = WikiNameRules.sanitized(filename)
+        } else {
+            displayName = nil
+        }
+
+        let insStmt = try statement("""
+        INSERT INTO sources
+          (id, filename, ext, mime_type, byte_size, created_at, updated_at, version,
+           zotero_item_key, zotero_item_title, display_name, content_hash)
+        VALUES (?1, ?2, ?3, ?4, 0, ?5, ?5, 1, NULL, NULL, ?6, NULL);
+        """)
+
+        try withTransaction {
+            let sourceID = id.rawValue
+            let nowTS = now.timeIntervalSince1970
+
+            // 0. The `sources` identity row FIRST (byte_size = 0, content_hash
+            //    = NULL — no blob to hash).
+            insStmt.reset()
+            try insStmt.bind(sourceID, at: 1)
+            try insStmt.bind(filename, at: 2)
+            try insStmt.bind(ext, at: 3)
+            if let mime { try insStmt.bind(mime, at: 4) }
+            try insStmt.bind(nowTS, at: 5)
+            if let displayName { try insStmt.bind(displayName, at: 6) }
+            _ = try insStmt.step()
+
+            // 1. Fetch/import activity + real provider agent (provenance is
+            //    required for byteless sources — there's no meaningful byteless
+            //    source without external identity/provenance).
+            let agentID = try ensureAgent(
+                name: provenance.agentName, kind: provenance.agentKind,
+                version: provenance.agentVersion, externalRef: nil)
+            let activityID = ULID.generate()
+            let insActivity = try statement("""
+            INSERT INTO activities (id, kind, agent_id, plan, external_ref, started_at, ended_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6);
+            """)
+            insActivity.reset()
+            try insActivity.bind(activityID, at: 1)
+            try insActivity.bind(provenance.activityKind, at: 2)
+            try insActivity.bind(agentID, at: 3)
+            if let plan = provenance.plan { try insActivity.bind(plan, at: 4) }
+            if let extRef = provenance.externalRef { try insActivity.bind(extRef, at: 5) }
+            try insActivity.bind(nowTS, at: 6)
+            _ = try insActivity.step()
+
+            // 2. v1 content version (blob_hash = NULL, external_identity set).
+            let versionID = ULID.generate()
+            let insVersion = try statement("""
+            INSERT INTO source_versions (id, source_id, parent_id, blob_hash,
+                                         mime_type, activity_id, external_identity, fetched_at)
+            VALUES (?1, ?2, NULL, NULL, ?3, ?4, ?5, ?6);
+            """)
+            insVersion.reset()
+            try insVersion.bind(versionID, at: 1)
+            try insVersion.bind(sourceID, at: 2)
+            if let mime { try insVersion.bind(mime, at: 3) }
+            try insVersion.bind(activityID, at: 4)
+            if let extID = provenance.externalIdentity { try insVersion.bind(extID, at: 5) }
+            try insVersion.bind(nowTS, at: 6)
+            _ = try insVersion.step()
+
+            // 3. Active ref (generation 1).
+            let insRef = try statement("""
+            INSERT INTO refs (kind, owner_id, version_id, generation, updated_at)
+            VALUES ('source-content', ?1, ?2, 1, ?3);
+            """)
+            insRef.reset()
+            try insRef.bind(sourceID, at: 1)
+            try insRef.bind(versionID, at: 2)
+            try insRef.bind(nowTS, at: 3)
+            _ = try insRef.step()
+        }
+
+        // Name-only FTS index entry (no content text — the transcript lives in
+        // the derived alternative, indexed when appendProcessedMarkdown runs).
+        upsertSourceSearch(sourceID: id, body: "")
+
+        return SourceSummary(
+            id: id, filename: filename, ext: ext, mimeType: mime,
+            byteSize: 0, createdAt: now, updatedAt: now, version: 1,
+            zoteroItemKey: nil, zoteroItemTitle: nil,
+            displayName: displayName
+        )
+    }
+
     /// All source summaries (NO content blob), most-recent-first for the
     /// management list. `id` is a ULID so `created_at DESC` orders by ingest.
     public func listSources() throws -> [SourceSummary] {
@@ -3594,6 +3748,21 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     private func ensureSearchIndexesPopulated() {
         // 0. Wipe chunks if the active embedder changed since the last open.
         ensureEmbedderConsistency()
+
+        // 0a. Ensure the byteless-source dedup UNIQUE partial index exists.
+        //     Fresh DBs get it in createObjectsTablesV20; existing v21 DBs that
+        //     predate Phase 3b need it created here. If an older non-UNIQUE
+        //     version of the index exists (shouldn't happen — it's new), the
+        //     CREATE UNIQUE IF NOT EXISTS is a no-op (the name already exists).
+        //     Idempotent: a no-op once the index exists.
+        do {
+            try exec("""
+            CREATE UNIQUE INDEX IF NOT EXISTS source_versions_byteless_eid
+                ON source_versions(external_identity) WHERE blob_hash IS NULL;
+            """)
+        } catch {
+            DebugLog.store("ensureSearchIndexes: byteless index create failed — \(error)")
+        }
 
         // 1. Seed a v1 processed-markdown version for markdown-native sources
         //    that have none, so their body is searchable (name-only otherwise).

--- a/Sources/WikiFSCore/SourceRefreshService.swift
+++ b/Sources/WikiFSCore/SourceRefreshService.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Phase 3b — reconstructs the provider for a source from its provenance origin
+/// and re-materializes it **off the main actor**. Does NOT write the store — it
+/// returns the materialized bytes/provenance so the `@MainActor` caller
+/// (`WikiStoreModel` in the app) performs the store write, exactly like
+/// `addURL`'s pattern: materialize off-main, store on-main (the Phase-0
+/// single-writer-discipline invariant).
+///
+/// Provider reconstruction keys off `SourceOrigin.agentName`:
+/// - `"website"` → `WebsiteProvider` (refresh appends a content version).
+/// - `"apple-podcast"` → `ApplePodcastProvider` (refresh appends a derived
+///   markdown version — byteless sources have no content to refresh).
+/// - Everything else (`local-file`, `zotero`, `markdown-folder`,
+///   `legacy-import`, `unknown`) → `.notRefreshable` (import-only).
+///
+/// See `plans/graph-model-and-versioning.md` §11–§12.
+public struct SourceRefreshService: Sendable {
+
+    public enum RefreshError: Error, LocalizedError, Equatable {
+        /// The source's provider is import-only (local-file, Zotero, folder) or
+        /// unknown — it carries no URL to re-fetch. Carries the agent name for a
+        /// clear message.
+        case notRefreshable(String)
+        /// The origin has no `plan` (URL) to re-fetch — a data-integrity edge
+        /// case (website sources always record the URL at ingest).
+        case missingPlan
+
+        public var errorDescription: String? {
+            switch self {
+            case .notRefreshable(let agent):
+                return "Sources from \"\(agent)\" can't be refreshed (no URL to re-fetch)."
+            case .missingPlan:
+                return "This source has no recorded URL to re-fetch."
+            }
+        }
+    }
+
+    /// The result of a refresh materialize: what to append and how. The caller
+    /// (on the main actor) switches on this to pick the right store primitive.
+    public enum RefreshMaterial: Sendable {
+        /// Append a new content version (website refresh). Carries the fresh
+        /// bytes + the provider's own provenance.
+        case contentVersion(data: Data, provenance: SourceProvenance)
+        /// Append a new derived markdown version (podcast byteless refresh).
+        /// Provenance is intentionally omitted — `appendProcessedMarkdown` has
+        /// no PROV parameter; the source-level `apple-podcast` agent (recorded
+        /// at v1 creation) remains authoritative. Transcript-level PROV (agent
+        /// `apple-ttml`) is deferred to Phase 4.
+        case derivedMarkdown(content: String)
+    }
+
+    public let fetcher: any URLFetchService.URLResourceFetcher
+    #if PODCAST_TRANSCRIPTS
+    public let podcastFetcher: (any PodcastTranscriptFetching)?
+    #endif
+
+    #if PODCAST_TRANSCRIPTS
+    public init(
+        fetcher: any URLFetchService.URLResourceFetcher,
+        podcastFetcher: (any PodcastTranscriptFetching)? = nil
+    ) {
+        self.fetcher = fetcher
+        self.podcastFetcher = podcastFetcher
+    }
+    #else
+    public init(fetcher: any URLFetchService.URLResourceFetcher) {
+        self.fetcher = fetcher
+    }
+    #endif
+
+    /// Read the origin → reconstruct the provider → materialize OFF-main.
+    /// Returns the material the caller should append. Throws `.notRefreshable`
+    /// for import-only sources and `.missingPlan` when a refreshable source's
+    /// origin has no URL.
+    public func materialize(origin: SourceOrigin) async throws -> RefreshMaterial {
+        switch origin.agentName {
+        case "website":
+            return try await materializeWebsite(origin: origin)
+        case "apple-podcast":
+            return try await materializePodcast(origin: origin)
+        default:
+            throw RefreshError.notRefreshable(origin.agentName)
+        }
+    }
+
+    // MARK: - Website
+
+    private func materializeWebsite(origin: SourceOrigin) async throws -> RefreshMaterial {
+        guard let urlString = origin.plan, let url = URL(string: urlString) else {
+            throw RefreshError.missingPlan
+        }
+        let provider = WebsiteProvider(rawInput: urlString, fetcher: fetcher)
+        let source = try await provider.materialize()
+        guard let prov = source.provenance else {
+            // WebsiteProvider always records provenance — defensive.
+            throw RefreshError.missingPlan
+        }
+        _ = url // validated above; the provider re-normalizes from the raw string
+        return .contentVersion(data: source.data, provenance: prov)
+    }
+
+    // MARK: - Apple Podcast
+
+    #if PODCAST_TRANSCRIPTS
+    private func materializePodcast(origin: SourceOrigin) async throws -> RefreshMaterial {
+        guard let urlString = origin.plan else {
+            throw RefreshError.missingPlan
+        }
+        guard let episode = PodcastEpisodeURL.parse(urlString) else {
+            throw RefreshError.missingPlan
+        }
+        guard let svc = podcastFetcher else {
+            throw PodcastTranscriptError.signatureUnavailable(
+                "Apple Podcasts transcripts need the signing helper, which isn't available in this build.")
+        }
+        guard let pageURL = URL(string: urlString) else {
+            throw RefreshError.missingPlan
+        }
+        // The provider's materialize() runs the transcript fetch off-main
+        // (Task.detached inside). Byteless source → only the derived markdown
+        // (transcript) changes on refresh; the content version never does.
+        let provider = ApplePodcastProvider(episode: episode, pageURL: pageURL, fetcher: svc)
+        let transcript = try await provider.materialize()
+        let markdown = String(data: transcript.data, encoding: .utf8) ?? ""
+        return .derivedMarkdown(content: markdown)
+    }
+    #else
+    private func materializePodcast(origin: SourceOrigin) async throws -> RefreshMaterial {
+        throw RefreshError.notRefreshable(origin.agentName)
+    }
+    #endif
+}

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -87,6 +87,28 @@ public protocol WikiStore: Sendable {
         provenance: SourceProvenance?
     ) throws -> SourceSummary
 
+    /// Store a **byteless** source: a source whose identity row + v1 content
+    /// version carry NO blob (`blob_hash = NULL`, `byte_size = 0`,
+    /// `content_hash = NULL`). The source is a pointer to an external resource
+    /// (e.g. an Apple Podcasts episode); its derived alternative (the transcript
+    /// markdown) is stored separately via `appendProcessedMarkdown`. Mirrors
+    /// `addSource`'s transaction discipline minus the blob/hash write. Dedups on
+    /// `external_identity` (when non-nil) among byteless sources — throws
+    /// `.duplicateContent(existing:)` if one already exists with the same
+    /// identity. See `plans/graph-model-and-versioning.md` §11.
+    ///
+    /// IMPORTANT: `sources.content_hash IS NULL` is used as a one-shot
+    /// "needs backfill" sentinel ONLY inside the schema-version-gated v20
+    /// migration block (already shipped; cannot re-trigger). Byteless rows with
+    /// `content_hash = NULL` are safe, but NO future migration may reuse that
+    /// sentinel — a byteless row would falsely match it.
+    @discardableResult
+    func addBytelessSource(
+        filename: String,
+        mimeType: String?,
+        provenance: SourceProvenance
+    ) throws -> SourceSummary
+
     /// Source summaries (no content blob), most-recent-first.
     func listSources() throws -> [SourceSummary]
 
@@ -122,6 +144,16 @@ public protocol WikiStore: Sendable {
     func markedSourceIDs() throws -> Set<String>
 
     // MARK: - Processed markdown versions (v8, renamed v10)
+
+    /// Append a new content version for a source (the store-level refresh/
+    /// re-ingest primitive). Hashes the bytes → CAS blob → new version row →
+    /// UPSERT the active ref → refresh the denormalized `sources` mirror, all in
+    /// one transaction. Used by the provider refresh path (Phase 3b).
+    @discardableResult
+    func appendContentVersion(
+        sourceID: PageID, data: Data, mimeType: String?,
+        provenance: SourceProvenance?
+    ) throws -> SourceVersion
 
     /// The latest (HEAD) version of the processed markdown for a source, or nil
     /// when no version exists yet (not yet seeded/extracted).

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1326,14 +1326,25 @@ public final class WikiStoreModel {
             let pageURL = URLFetchService.normalizeURL(rawInput)
                 ?? URL(string: "https://podcasts.apple.com")!
             let provider = ApplePodcastProvider(episode: episode, pageURL: pageURL, fetcher: svc)
-            let materialized = try await provider.materialize()
-            let summary = try storeMaterialized(materialized)
+            let transcript = try await provider.materialize()
+            // §11 byteless model: the source is byteless (a pointer to the
+            // external episode), and the transcript markdown is stored as the
+            // derived alternative — NOT as content bytes (Option-A). The
+            // provider is unchanged; only the storage path repoints.
+            guard let prov = transcript.provenance else {
+                throw URLFetchService.FetchError.invalidURL("podcast transcript missing provenance")
+            }
+            let summary = try store.addBytelessSource(
+                filename: transcript.filename, mimeType: transcript.mimeType, provenance: prov)
+            let markdown = String(data: transcript.data, encoding: .utf8) ?? ""
+            try store.appendProcessedMarkdown(
+                sourceID: summary.id, content: markdown, origin: "transcript", note: nil)
             reloadSources()
             openTab(.source(summary.id))
             onPageDidChange?()
             return URLFetchService.FetchOutcome(
-                filename: materialized.filename,
-                byteSize: materialized.data.count,
+                filename: transcript.filename,
+                byteSize: transcript.data.count,
                 kind: .podcastTranscript)
         }
         return try await addURLViaWebsite(rawInput, fetcher: fetcher)
@@ -1357,6 +1368,62 @@ public final class WikiStoreModel {
         onPageDidChange?()
         return URLFetchService.FetchOutcome(
             filename: plan.filename, byteSize: plan.data.count, kind: plan.kind)
+    }
+
+    // MARK: - Source refresh (Phase 3b)
+
+    /// Refresh a source: re-fetch it via its provider (reconstructed from the
+    /// stored origin), appending a new version instead of overwriting. Website
+    /// sources append a content version; podcast (byteless) sources append a
+    /// derived markdown version. Import-only sources (local-file, Zotero,
+    /// folder) throw `.notRefreshable`. Materialization runs off-main (the
+    /// provider's network fetch); the store write happens HERE on the main
+    /// actor, exactly like `addURL`.
+    ///
+    /// Returns a human-readable description for UI surfacing.
+    #if PODCAST_TRANSCRIPTS
+    @discardableResult
+    public func refreshSource(
+        _ id: PageID,
+        fetcher: any URLFetchService.URLResourceFetcher = URLSessionFetcher(),
+        podcastFetcher: (any PodcastTranscriptFetching)? = ApplePodcastTranscriptService.bundled()
+    ) async throws -> String {
+        let service = SourceRefreshService(
+            fetcher: fetcher, podcastFetcher: podcastFetcher)
+        return try await performRefresh(id: id, service: service)
+    }
+    #else
+    @discardableResult
+    public func refreshSource(
+        _ id: PageID,
+        fetcher: any URLFetchService.URLResourceFetcher = URLSessionFetcher()
+    ) async throws -> String {
+        let service = SourceRefreshService(fetcher: fetcher)
+        return try await performRefresh(id: id, service: service)
+    }
+    #endif
+
+    /// Shared refresh body: materialize off-main, append the version on-main,
+    /// reload. Split out so the `#if PODCAST_TRANSCRIPTS` gated inits don't
+    /// duplicate the store-write logic.
+    private func performRefresh(
+        id: PageID, service: SourceRefreshService
+    ) async throws -> String {
+        guard let origin = try store.sourceOrigin(sourceID: id) else {
+            throw SourceRefreshService.RefreshError.notRefreshable("unknown")
+        }
+        let material = try await service.materialize(origin: origin)
+        switch material {
+        case .contentVersion(let data, let prov):
+            _ = try store.appendContentVersion(
+                sourceID: id, data: data, mimeType: nil, provenance: prov)
+        case .derivedMarkdown(let content):
+            try store.appendProcessedMarkdown(
+                sourceID: id, content: content, origin: "transcript", note: nil)
+        }
+        reloadSources()
+        onPageDidChange?()
+        return "Refreshed \(origin.displayLabel) source."
     }
 
     /// Synchronous ingest seam used by tests/verifiers (no drag gesture). Stores

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -111,6 +111,46 @@ func execute(_ command: ArgumentParser.Command, in store: SQLiteWikiStore) throw
         return try SourceCommand.run(
             .setActive(selector, versionID: versionID), in: store,
             cwd: FileManager.default.currentDirectoryPath)
+    case .sourceRefresh(let selector):
+        // `runRefresh` is async (network I/O). Bridge it to the sync `execute`
+        // context via a semaphore — the standard CLI async→sync pattern. Safe
+        // because `DispatchSemaphore.wait()` blocks only the main thread; the
+        // async task signals from its own continuation thread, which never needs
+        // to acquire the main thread to signal (signaling is thread-agnostic).
+        // WebsiteProvider does not hop to the main actor, so no deadlock.
+        let box = RefreshResultBox()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            do {
+                box.result = try await SourceCommand.runRefresh(
+                    selector, in: store, fetcher: URLSessionFetcher())
+            } catch {
+                box.error = error
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        if let error = box.error { throw error }
+        return box.result ?? SourceCommand.Result(payload: .text(""), didCommit: false)
+    }
+}
+
+/// Thread-safe box for the wikictl async→sync semaphore bridge (Phase 3b).
+/// `@unchecked Sendable` — the semaphore guarantees the write (in the async
+/// task) happens-before the read (after `semaphore.wait()` returns), so the
+/// lock is belt-and-suspenders for Swift 6's data-race checker.
+final class RefreshResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _result: SourceCommand.Result?
+    private var _error: Error?
+
+    var result: SourceCommand.Result? {
+        get { lock.lock(); defer { lock.unlock() }; return _result }
+        set { lock.lock(); defer { lock.unlock() }; _result = newValue }
+    }
+    var error: Error? {
+        get { lock.lock(); defer { lock.unlock() }; return _error }
+        set { lock.lock(); defer { lock.unlock() }; _error = newValue }
     }
 }
 

--- a/Tests/WikiFSTests/PodcastIngestRoutingTests.swift
+++ b/Tests/WikiFSTests/PodcastIngestRoutingTests.swift
@@ -52,11 +52,40 @@ struct PodcastIngestRoutingTests {
         #expect(outcome.kind == .podcastTranscript)
         #expect(outcome.filename == "chinatalk-1000774368453-transcript.md")
 
-        // The transcript landed as a real source with the markdown bytes.
+        // §11 byteless model: the source is byteless (no content bytes); the
+        // transcript lives as the processed-markdown derived alternative.
         let sources = try store.listSources()
         let stored = try #require(sources.first { $0.filename == outcome.filename })
-        let content = String(data: try store.sourceContent(id: stored.id), encoding: .utf8)
-        #expect(content == "SPEAKER_1: Hello from the episode.")
+        #expect(stored.byteSize == 0)
+        // sourceContent returns empty Data for a byteless source.
+        #expect(try store.sourceContent(id: stored.id).isEmpty)
+        // The transcript is the processed-markdown head.
+        let head = try #require(try store.processedMarkdownHead(sourceID: stored.id))
+        #expect(head.content == "SPEAKER_1: Hello from the episode.")
+        // Origin provenance: apple-podcast agent + the pasted episode URL.
+        let origin = try #require(try store.sourceOrigin(sourceID: stored.id))
+        #expect(origin.agentName == "apple-podcast")
+        #expect(origin.plan == Self.chinaTalkURL)
+        #expect(origin.externalIdentity == "1000774368453")
+    }
+
+    @Test func pastingSameEpisodeTwiceDedupsAsByteless() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let podcast = FakePodcastFetcher()
+
+        _ = try await model.addURL(
+            Self.chinaTalkURL, fetcher: ExplodingFetcher(), podcastFetcher: podcast)
+
+        // Second paste of the same episode URL → duplicate (byteless dedup on
+        // external_identity).
+        await #expect(throws: WikiStoreError.self) {
+            try await model.addURL(
+                Self.chinaTalkURL, fetcher: ExplodingFetcher(), podcastFetcher: podcast)
+        }
+        // Only one source was created.
+        let sources = try store.listSources()
+        #expect(sources.count == 1)
     }
 
     @Test func missingHelperGivesAClearError() async throws {

--- a/Tests/WikiFSTests/SourceProviderTests.swift
+++ b/Tests/WikiFSTests/SourceProviderTests.swift
@@ -447,4 +447,60 @@ struct SourceProviderTests {
         #expect(origin.displayLabel == "Apple Podcast")
     }
     #endif
+
+    // MARK: - AC.4/AC.9: Byteless source store tests
+
+    @Test func addBytelessSourceCreatesEmptyBytelessSource() throws {
+        let store = try tempStore()
+        let summary = try store.addBytelessSource(
+            filename: "episode-123-transcript.md", mimeType: "text/markdown",
+            provenance: SourceProvenance(
+                agentName: "apple-podcast", activityKind: "fetch",
+                plan: "https://podcasts.apple.com/x?i=123",
+                externalRef: "https://podcasts.apple.com/x?i=123",
+                externalIdentity: "123"))
+
+        #expect(summary.byteSize == 0)
+        // sourceContent returns empty Data for a byteless source.
+        #expect(try store.sourceContent(id: summary.id).isEmpty)
+        // Origin preserved.
+        let origin = try #require(try store.sourceOrigin(sourceID: summary.id))
+        #expect(origin.agentName == "apple-podcast")
+        #expect(origin.externalIdentity == "123")
+    }
+
+    @Test func bytelessSourceDedupsOnExternalIdentity() throws {
+        let store = try tempStore()
+        let prov = SourceProvenance(
+            agentName: "apple-podcast", activityKind: "fetch",
+            plan: "https://podcasts.apple.com/x?i=456",
+            externalIdentity: "456")
+        _ = try store.addBytelessSource(filename: "a.md", mimeType: nil, provenance: prov)
+
+        // Same external_identity → duplicate.
+        #expect(throws: WikiStoreError.self) {
+            _ = try store.addBytelessSource(filename: "b.md", mimeType: nil, provenance: prov)
+        }
+        // Only one source.
+        #expect(try store.listSources().count == 1)
+    }
+
+    @Test func bytelessAndContentSourceCoexistWithSameIdentity() throws {
+        let store = try tempStore()
+        // A byteless source with external_identity "X".
+        _ = try store.addBytelessSource(
+            filename: "ep.md", mimeType: nil,
+            provenance: SourceProvenance(
+                agentName: "apple-podcast", activityKind: "fetch",
+                externalIdentity: "X"))
+        // A content source (different content_hash) — coexists (disjoint dedup).
+        _ = try store.addSource(
+            filename: "doc.txt", data: Data("hello".utf8),
+            zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: nil,
+            provenance: SourceProvenance(
+                agentName: "website", activityKind: "fetch",
+                externalIdentity: "X"))
+        // Both exist — byteless dedup and content dedup are disjoint.
+        #expect(try store.listSources().count == 2)
+    }
 }

--- a/Tests/WikiFSTests/SourceRefreshTests.swift
+++ b/Tests/WikiFSTests/SourceRefreshTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Phase 3b tests: `SourceRefreshService` + `WikiStoreModel.refreshSource`.
+/// Covers website refresh (content version append), podcast refresh (derived
+/// markdown append), and non-refreshable rejection — all via injected fakes.
+@MainActor
+struct SourceRefreshTests {
+
+    /// A controllable fake fetcher: returns different responses on successive
+    /// calls (swap the `response` between refreshes to simulate content change).
+    final class SwapFetcher: URLFetchService.URLResourceFetcher, @unchecked Sendable {
+        var response: URLFetchService.FetchResponse
+        init(_ response: URLFetchService.FetchResponse) { self.response = response }
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse { response }
+    }
+
+    private func tempStore() throws -> SQLiteWikiStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-refresh-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+    }
+
+    private func htmlResponse(_ body: String, url: String) -> URLFetchService.FetchResponse {
+        URLFetchService.FetchResponse(
+            data: Data(body.utf8), contentType: "text/html; charset=utf-8",
+            finalURL: URL(string: url)!)
+    }
+
+    // MARK: - AC.3: Website refresh appends a content version
+
+    @Test func websiteRefreshAppendsNewContentVersion() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let fetcher = SwapFetcher(htmlResponse(
+            "<html><head><title>Test</title></head><body>v1</body></html>",
+            url: "https://example.com/article"))
+
+        // Ingest v1.
+        _ = try await model.addURL("https://example.com/article", fetcher: fetcher)
+        let sources = try store.listSources()
+        let source = try #require(sources.first)
+        let historyBefore = try store.contentVersionHistory(sourceID: source.id)
+        #expect(historyBefore.count == 1)
+
+        // Swap to v2 and refresh.
+        fetcher.response = htmlResponse(
+            "<html><head><title>Test</title></head><body>v2 content</body></html>",
+            url: "https://example.com/article")
+        _ = try await model.refreshSource(source.id, fetcher: fetcher)
+
+        // A new content version was appended.
+        let historyAfter = try store.contentVersionHistory(sourceID: source.id)
+        #expect(historyAfter.count == 2)
+        // HEAD bytes match v2.
+        let head = try store.sourceContent(id: source.id)
+        #expect(String(data: head, encoding: .utf8)?.contains("v2 content") == true)
+        // Origin URL preserved.
+        let origin = try #require(try store.sourceOrigin(sourceID: source.id))
+        #expect(origin.agentName == "website")
+        #expect(origin.plan == "https://example.com/article")
+    }
+
+    @Test func websiteRefreshUnchangedBytesStillAppendsVersion() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let response = htmlResponse(
+            "<html><body>same content</body></html>", url: "https://example.com/page")
+        let fetcher = SwapFetcher(response)
+
+        _ = try await model.addURL("https://example.com/page", fetcher: fetcher)
+        let source = try #require(try store.listSources().first)
+
+        // Refresh with identical bytes — still appends a version ("checked,
+        // unchanged").
+        _ = try await model.refreshSource(source.id, fetcher: fetcher)
+        let history = try store.contentVersionHistory(sourceID: source.id)
+        #expect(history.count == 2)
+    }
+
+    // MARK: - AC.6: Non-refreshable sources
+
+    @Test func localFileSourceIsNotRefreshable() async throws {
+        let store = try tempStore()
+        // A local-file source has no URL to re-fetch.
+        _ = try store.addSource(
+            filename: "notes.txt", data: Data("hello".utf8),
+            zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: nil,
+            provenance: nil)
+        let source = try #require(try store.listSources().first)
+
+        let service = SourceRefreshService(fetcher: SwapFetcher(htmlResponse(
+            "<html></html>", url: "https://example.com")))
+        let origin = try #require(try store.sourceOrigin(sourceID: source.id))
+        await #expect(throws: SourceRefreshService.RefreshError.self) {
+            _ = try await service.materialize(origin: origin)
+        }
+    }
+
+    // MARK: - AC.5: Podcast refresh (guarded)
+
+    #if PODCAST_TRANSCRIPTS
+    @Test func podcastRefreshAppendsDerivedMarkdown() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+
+        // Seed a byteless podcast source via addURL.
+        final class FakePodcast: PodcastTranscriptFetching, @unchecked Sendable {
+            var markdown: String
+            init(_ markdown: String) { self.markdown = markdown }
+            func transcript(for episode: PodcastEpisodeURL.EpisodeRef) async throws -> PodcastTranscript {
+                PodcastTranscript(
+                    episodeID: episode.id, markdown: markdown,
+                    filename: "podcast-\(episode.id)-transcript.md")
+            }
+        }
+        let podcast = FakePodcast("SPEAKER_1: v1 transcript.")
+        let url = "https://podcasts.apple.com/us/podcast/test/id1?i=100"
+        _ = try await model.addURL(url, fetcher: SwapFetcher(htmlResponse("", url: "https://x")), podcastFetcher: podcast)
+        let source = try #require(try store.listSources().first)
+
+        // v1 markdown head.
+        let headBefore = try #require(try store.processedMarkdownHead(sourceID: source.id))
+        #expect(headBefore.content == "SPEAKER_1: v1 transcript.")
+
+        // Swap transcript and refresh (inject the fake podcast fetcher).
+        podcast.markdown = "SPEAKER_1: v2 transcript."
+        _ = try await model.refreshSource(source.id, fetcher: SwapFetcher(htmlResponse("", url: "https://x")), podcastFetcher: podcast)
+
+        // A new derived markdown version was appended.
+        let headAfter = try #require(try store.processedMarkdownHead(sourceID: source.id))
+        #expect(headAfter.content == "SPEAKER_1: v2 transcript.")
+    }
+    #endif
+}

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -756,4 +756,55 @@ struct WikiCtlCommandTests {
         #expect(text.contains("filename\tplain.txt"))
         #expect(text.contains("size\t2"))
     }
+
+    @Test func parsesSourceRefresh() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "refresh", "--id", "01ABC"], env: noEnv)
+        #expect(invocation.command == .sourceRefresh(.id(PageID(rawValue: "01ABC"))))
+    }
+
+    // MARK: - source refresh (Phase 3b)
+
+    /// A fake fetcher returning a canned HTML response.
+    struct RefreshFakeFetcher: URLFetchService.URLResourceFetcher {
+        var response: URLFetchService.FetchResponse
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse { response }
+    }
+
+    @Test func sourceRefreshAppendsVersionAndCommits() async throws {
+        let store = try tempStore()
+        // Seed a website source via a fake fetcher.
+        let fetcher = RefreshFakeFetcher(response: URLFetchService.FetchResponse(
+            data: Data("<html><body>v1</body></html>".utf8),
+            contentType: "text/html", finalURL: URL(string: "https://example.com/p")!))
+        let provider = WebsiteProvider(rawInput: "https://example.com/p", fetcher: fetcher)
+        let source = try await provider.materialize()
+        let summary = try store.addSource(
+            filename: source.filename, data: source.data,
+            zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: nil,
+            provenance: source.provenance)
+        let historyBefore = try store.contentVersionHistory(sourceID: summary.id).count
+
+        // Refresh via wikictl with updated content.
+        let fetcher2 = RefreshFakeFetcher(response: URLFetchService.FetchResponse(
+            data: Data("<html><body>v2</body></html>".utf8),
+            contentType: "text/html", finalURL: URL(string: "https://example.com/p")!))
+        let result = try await SourceCommand.runRefresh(
+            .id(summary.id), in: store, fetcher: fetcher2)
+
+        #expect(result.didCommit)
+        let historyAfter = try store.contentVersionHistory(sourceID: summary.id).count
+        #expect(historyAfter == historyBefore + 1)
+    }
+
+    @Test func sourceRefreshByNameNotFound() async throws {
+        let store = try tempStore()
+        let fetcher = RefreshFakeFetcher(response: URLFetchService.FetchResponse(
+            data: Data("x".utf8), contentType: "text/plain",
+            finalURL: URL(string: "https://x")!))
+        await #expect(throws: SourceCommand.Failure.self) {
+            _ = try await SourceCommand.runRefresh(
+                .name("Nonexistent"), in: store, fetcher: fetcher)
+        }
+    }
 }

--- a/plans/graph-model-and-versioning.md
+++ b/plans/graph-model-and-versioning.md
@@ -757,8 +757,8 @@ verbs) carry over from the draft verbatim. Two grounding notes:
   is reason enough to sequence providers before "refresh" ships (refresh
   needs to know what to re-fetch).
 
-> **Apple Podcasts provider (PR #106).** Podcast transcript ingest already
-> exists as a special case on the URL path (`PodcastEpisodeURL.parse` →
+> **Apple Podcasts provider (PR #106, Phase 3b — SHIPPED).** Podcast transcript
+> ingest exists as a special case on the URL path (`PodcastEpisodeURL.parse` →
 > `ApplePodcastTranscriptService`), built against today's flat source model: it
 > stores the transcript `.md` as source `content` and bakes the episode ID into
 > the filename. When Phase 1–3 land it re-models cleanly — a **byteless source**
@@ -771,6 +771,13 @@ verbs) carry over from the draft verbatim. Two grounding notes:
 > (`#if PODCAST_TRANSCRIPTS`) and stay on the user-initiated UI path — they do
 > not move into the agent surface. Ships independently of this plan; tracked
 > here so it is unified when providers land.
+>
+> **Status (Phase 3b, 2026-07-06):** the byteless conversion has shipped —
+> podcast episodes now store as byteless sources (`addBytelessSource`) with the
+> transcript as a derived markdown alternative (`appendProcessedMarkdown`).
+> Source refresh is live via `SourceRefreshService` + `refreshSource`. The
+> transcript-level `apple-ttml` extract PROV is deferred to Phase 4 (no consumer
+> until the alternatives UI gains a podcast transcript backend).
 
 ## 12. Phases
 


### PR DESCRIPTION
Ship two features on the graph-model versioning substrate:

Source refresh: SourceRefreshService reconstructs a source's provider from its SourceOrigin and re-materializes off-main, returning a RefreshMaterial. The @MainActor caller (WikiStoreModel.refreshSource) performs the store write. Website sources append a content version; byteless podcast sources append a derived markdown version. Import-only providers throw .notRefreshable.

Byteless conversion: podcast episodes now store as byteless sources (addBytelessSource — blob_hash IS NULL, byte_size 0) with the transcript markdown as a derived alternative (appendProcessedMarkdown). The provider is unchanged; only the storage path repoints. Dedup on external_identity backed by a UNIQUE partial index.

Surfaces: UI refresh button in SourceDetailView (gated on refreshability), wikictl source refresh (website-only, async→sync semaphore bridge), and injectable fetcher seams for CI.

Tests: 1572 pass (baseline 1561 + 11 new). Both swift build and WIKIFS_APP_STORE=1 swift build green.