### PR TITLE
Fix #211: Edit button focuses markdown editor from PDF tab

### DIFF
--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -404,6 +404,13 @@ struct SourceDetailView: View {
                             Button("Edit", systemImage: "pencil") {
                                 editBuffer = headVersion?.content ?? ""
                                 isEditing = true
+                                // #211: focus the editor even if the user had
+                                // switched to the PDF tab, where the markdown
+                                // editor isn't rendered. Leave Split alone —
+                                // the editor is already visible there.
+                                if selectedTab == .pdf {
+                                    selectedTab = .markdown
+                                }
                             }
                             .keyboardShortcut("e", modifiers: .command)
                             .disabled(isRunning)


### PR DESCRIPTION
## Problem

Fixes #211. In the source detail view, if you're on the **PDF** tab and click **Edit**, the editor never appears — the tab doesn't switch to the markdown editor.

## Root cause

The source detail view tracks the PDF/Split/Markdown sub-tab (`selectedTab`) separately from the `isEditing` flag. The Edit button only set `isEditing = true`, but the markdown `TextEditor` is rendered *solely* inside `markdownContent`. On the PDF tab, `tabbedContent` renders `pdfView` unconditionally, so the editor stayed invisible.

## Fix

When Edit is clicked, switch `selectedTab` away from `.pdf` to `.markdown`. `.split` is left alone since its editor is already visible (`splitContent` embeds `markdownContent`). The ⌘E shortcut shares the same action, so it's covered too.

## Verification

`swift build --target WikiFS` completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)