### PR TITLE
v24: drop dead source_markdown_versions.content column

### DIFF
--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -258,7 +258,6 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             id                TEXT PRIMARY KEY,
             file_id           TEXT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
             parent_id         TEXT,
-            content           TEXT NOT NULL,
             origin            TEXT NOT NULL,
             note              TEXT,
             created_at        REAL NOT NULL,
@@ -461,7 +460,12 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // schema change, and a fresh DB has no rows to sweep. The run-once guard
         // is the only effect on a fresh DB. Shared with the v22→23 migration step.
 
-        try exec("PRAGMA user_version=23;")
+        // v24 (graph-model Phase 2 close-out): the inline
+        // `source_markdown_versions.content` column is dropped — it's already
+        // absent from the fresh CREATE TABLE above (blob-only). Shared with the
+        // v23→24 migration step, which drops it from an upgraded DB.
+
+        try exec("PRAGMA user_version=24;")
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -1059,6 +1063,20 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try exec("PRAGMA user_version=23;")
             version = 23
         }
+
+        // Step 23 → 24 (graph-model Phase 2 close-out, §4.5): the v21 step
+        // CAS-moved every legacy `source_markdown_versions.content` into a blob
+        // and set `content=''`; every write path now writes `blob_hash` +
+        // `content=''`, and every reader resolves the body from the blob. The
+        // inline `content` column and its "prefer blob, fall back to inline"
+        // read path are dead — DROP the column (mirrors the v20 `sources.content`
+        // DROP COLUMN, same pre-drop silent-data-loss guard). See
+        // `migrateV23ToV24`.
+        if version < 24 {
+            try migrateV23ToV24()
+            try exec("PRAGMA user_version=24;")
+            version = 24
+        }
     }
 
     /// The v19→20 migration step. Creates the objects tables, then — for every
@@ -1485,6 +1503,45 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                 _ = try update.step()
             }
             update.reset()
+        }
+    }
+
+    /// The v23→v24 migration step (graph-model Phase 2 close-out, §4.5). Drops
+    /// the now-dead inline `source_markdown_versions.content` column — the v21
+    /// step already CAS-moved every legacy row's inline body into a blob and set
+    /// `content=''`, and every write path writes `blob_hash` + `content=''`
+    /// since. Mirrors the v20 `sources.content` DROP COLUMN exactly: one
+    /// `withTransaction`, a pre-drop silent-data-loss guard, then DROP COLUMN.
+    private func migrateV23ToV24() throws {
+        try withTransaction {
+            // Guard: a DB rewound from v24 for testing, an artificial fixture
+            // that never created `source_markdown_versions`, or a fresh DB whose
+            // content column is already gone has nothing to drop. Skip + stamp.
+            let hasSMV = try queryScalarText(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='source_markdown_versions';") != "0"
+            guard hasSMV else { return }
+            let hasContentColumn = try queryScalarText(
+                "SELECT COUNT(*) FROM pragma_table_info('source_markdown_versions') WHERE name='content';") != "0"
+            guard hasContentColumn else { return }
+
+            // Pre-drop silent-data-loss guard (parallels the v20 content guard).
+            // Every row MUST have a blob_hash — the resolved body lives in the
+            // blob, so a NULL hash means dropping `content` would lose bytes. In
+            // practice impossible post-v21, but never silently drop content.
+            let unmigrated = try statement("""
+            SELECT id FROM source_markdown_versions WHERE blob_hash IS NULL LIMIT 1;
+            """)
+            defer { unmigrated.reset() }
+            unmigrated.reset()
+            if try unmigrated.step() {
+                let badID = unmigrated.text(at: 0)
+                throw WikiStoreError.unexpected(
+                    "v24 migration: source_markdown_versions row \(badID) has NULL blob_hash — refusing to drop content column")
+            }
+
+            // Drop the dead inline column. macOS 15 ships SQLite ≥ 3.43
+            // (`DROP COLUMN` since 3.35) — same precedent as the v20 step.
+            try exec("ALTER TABLE source_markdown_versions DROP COLUMN content;")
         }
     }
 
@@ -4667,11 +4724,12 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     }
 
     /// The shared SELECT-list + LEFT JOIN that resolves a CAS'd row's content from
-    /// its blob (falling back to the inline column for any unmigrated row). Used by
-    /// every Swift-decode reader so they all honor the resolved-body invariant.
+    /// its blob. The inline `content` column was dropped in v24; the empty-string
+    /// default is defensive null handling for a row whose blob is somehow absent.
+    /// Used by every Swift-decode reader so they all honor the resolved-body invariant.
     private static let smvSelectColumns = """
     smv.id, smv.file_id, smv.parent_id,
-    COALESCE(CAST(b.content AS TEXT), smv.content),
+    COALESCE(CAST(b.content AS TEXT), ''),
     smv.origin, smv.note, smv.created_at,
     smv.activity_id, smv.source_version_id, smv.blob_hash, smv.mime_type
     """
@@ -4969,18 +5027,18 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
         let stmt = try statement("""
         INSERT INTO source_markdown_versions
-          (id, file_id, parent_id, content, origin, note, created_at,
+          (id, file_id, parent_id, origin, note, created_at,
            blob_hash, mime_type)
-        VALUES (?1, ?2, ?3, '', ?5, ?6, ?7, ?8, 'text/markdown');
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'text/markdown');
         """)
         defer { stmt.reset() }
         try stmt.bind(id.rawValue, at: 1)
         try stmt.bind(sourceID.rawValue, at: 2)
         if let parentID { try stmt.bind(parentID.rawValue, at: 3) }
-        try stmt.bind(origin, at: 5)
-        if let note { try stmt.bind(note, at: 6) }
-        try stmt.bind(now.timeIntervalSince1970, at: 7)
-        try stmt.bind(blobHash, at: 8)
+        try stmt.bind(origin, at: 4)
+        if let note { try stmt.bind(note, at: 5) }
+        try stmt.bind(now.timeIntervalSince1970, at: 6)
+        try stmt.bind(blobHash, at: 7)
         _ = try stmt.step()
 
         // Re-embed the source from the just-written content + its name so content
@@ -5050,9 +5108,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             storedBlobHash = blobHash
             let ins = try statement("""
             INSERT INTO source_markdown_versions
-              (id, file_id, parent_id, content, origin, note, created_at,
+              (id, file_id, parent_id, origin, note, created_at,
                activity_id, source_version_id, blob_hash, mime_type)
-            VALUES (?1, ?2, ?3, '', 'extraction', ?4, ?5, ?6, ?7, ?8, 'text/markdown');
+            VALUES (?1, ?2, ?3, 'extraction', ?4, ?5, ?6, ?7, ?8, 'text/markdown');
             """)
             ins.reset()
             try ins.bind(id.rawValue, at: 1)
@@ -5138,9 +5196,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         try withTransaction {
             let ins = try statement("""
             INSERT INTO source_markdown_versions
-              (id, file_id, parent_id, content, origin, note, created_at,
+              (id, file_id, parent_id, origin, note, created_at,
                activity_id, source_version_id, blob_hash, mime_type)
-            VALUES (?1, ?2, ?3, '', 'revert', ?4, ?5, ?6, ?7, ?8, ?9);
+            VALUES (?1, ?2, ?3, 'revert', ?4, ?5, ?6, ?7, ?8, ?9);
             """)
             ins.reset()
             try ins.bind(id.rawValue, at: 1)

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -19,7 +19,7 @@ import SQLite3
     @Test func freshDBHasBookmarkNodesTable() throws {
         let url = tempDatabaseURL()
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "23")
+        #expect(store.pragmaValue("user_version") == "24")
 
         // The table exists.
         let nodes = try store.listBookmarkNodes()
@@ -37,7 +37,7 @@ import SQLite3
 
         // Reopen — triggers migration to v16.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "23")
+        #expect(reopened.pragmaValue("user_version") == "24")
 
         // Existing data is intact.
         let pages = try reopened.listPages(sortBy: .lastUpdated)

--- a/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
+++ b/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
@@ -20,7 +20,7 @@ struct EmbeddingMetaCutoverTests {
     @Test func freshDBSeedsNLEmbedderIdentifier() throws {
         let store = try tempStore()
         let stored = store.pragmaValue("user_version")
-        #expect(stored == "23")
+        #expect(stored == "24")
         // ensureEmbedderConsistency with the default identifier (nlembedding-512)
         // is a no-op: the seed matches, so nothing is wiped.
         store.ensureEmbedderConsistency(activeIdentifierOverride: NLEmbedder.identifier)

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -124,9 +124,9 @@ import SQLite3
         let fast = try fingerprint(at: fastURL)
         let ladder = try fingerprint(at: ladderURL)
 
-        // Both must report head version 22.
-        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "23")
-        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "23")
+        // Both must report head version 24.
+        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "24")
+        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "24")
 
         if fast != ladder {
             Issue.record("fresh fast-path schema drifted from the stepwise ladder:\n--- fast ---\n\(fast)\n--- ladder ---\n\(ladder)")
@@ -185,6 +185,10 @@ import SQLite3
         let db = try open(url)
         defer { sqlite3_close(db) }
         exec(db, "PRAGMA user_version=20;")
+        // A genuine v20 DB still has the inline `content` column (dropped at v24).
+        // The fresh store built it at v24 (no `content`), so re-add it to
+        // faithfully simulate a v20 table before seeding legacy inline rows.
+        exec(db, "ALTER TABLE source_markdown_versions ADD COLUMN content TEXT NOT NULL DEFAULT '';")
         let legacyID = "01JLEGACY0000000000000000V"
         exec(db, """
         INSERT INTO source_markdown_versions (id, file_id, parent_id, content, origin, note, created_at)
@@ -202,7 +206,7 @@ import SQLite3
         // 3. Reopen → runs the v20→v21 backfill.
         sqlite3_close(db)
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "23")
+        #expect(migrated.pragmaValue("user_version") == "24")
 
         // 4. The legacy extraction row was backfilled: blob_hash + activity_id + source_version_id set.
         #expect(migrated.scalarText(
@@ -212,16 +216,15 @@ import SQLite3
         #expect(migrated.scalarText(
             "SELECT source_version_id FROM source_markdown_versions WHERE id='\(legacyID)';")
             == (contentVersionID ?? ""))
-        // Inline content was cleared.
+        // The inline `content` column was CAS-cleared at v21 and DROPPED at v24 —
+        // it must no longer exist on the table.
         #expect(migrated.scalarText(
-            "SELECT content FROM source_markdown_versions WHERE id='\(legacyID)';") == "")
+            "SELECT COUNT(*) FROM pragma_table_info('source_markdown_versions') WHERE name='content';") == "0")
 
-        // 4b. The user-edit row IS CAS'd (blob_hash set, content cleared) but has
-        //     NO activity_id — it must not be mislabeled as a legacy extraction.
+        // 4b. The user-edit row IS CAS'd (blob_hash set) but has NO activity_id —
+        //     it must not be mislabeled as a legacy extraction.
         #expect(migrated.scalarText(
             "SELECT blob_hash FROM source_markdown_versions WHERE id='\(editID)';") != "")
-        #expect(migrated.scalarText(
-            "SELECT content FROM source_markdown_versions WHERE id='\(editID)';") == "")
         #expect(migrated.scalarText(
             "SELECT activity_id FROM source_markdown_versions WHERE id='\(editID)';") == "")
 
@@ -263,7 +266,7 @@ import SQLite3
         sqlite3_close(db)
 
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "23")
+        #expect(migrated.pragmaValue("user_version") == "24")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
         let roleCol = columns(db2, "sources").first { $0.name == "role" }
@@ -338,7 +341,7 @@ import SQLite3
 
         // Reopen → v22 migration rebuilds source_links.
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "23")
+        #expect(migrated.pragmaValue("user_version") == "24")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -238,7 +238,7 @@ struct LogIndexTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 23)
+        #expect(sqlite3_column_int(stmt, 0) == 24)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
+++ b/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
@@ -191,7 +191,7 @@ struct Phase5StoreCanonicalizationTests {
 
         // Reopen → v23 sweep runs.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "23")
+        #expect(reopened.pragmaValue("user_version") == "24")
 
         let migrated = try reopened.getPage(id: linkerID)
         // Resolvable link canonicalized; forward link left verbatim.

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -87,7 +87,7 @@ struct ProcessedMarkdownTests {
 
     @Test func freshDBHasV8Schema() throws {
         let store = try tempStore()
-        #expect(store.pragmaValue("user_version") == "23")
+        #expect(store.pragmaValue("user_version") == "24")
     }
 
     @Test func v7DBUpgradesToV8PreservingData() throws {
@@ -103,7 +103,7 @@ struct ProcessedMarkdownTests {
 
         // Opening runs v7→v8→…→v15 migration.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "23")
+        #expect(store.pragmaValue("user_version") == "24")
         // Pre-existing file is intact.
         let content = try store.sourceContent(
             id: PageID(rawValue: "01J00000000000000000000000"))

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -66,7 +66,7 @@ struct SQLiteWikiStoreTests {
         // user_version guard: a fresh DB runs all migration steps → version 16.
         // Reopening must not re-run DDL (no-op bootstrap).
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "23")
+        #expect(userVersion == "24")
         let reopened = try SQLiteWikiStore(databaseURL: url)
         // If bootstrap weren't guarded, the CREATE TABLE would throw here.
         #expect((try? reopened.listPages(sortBy: .lastUpdated)) != nil)
@@ -323,7 +323,7 @@ struct SQLiteWikiStoreTests {
         defer { sqlite3_close(db) }
 
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "23")
+        #expect(userVersion == "24")
 
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"))
@@ -367,7 +367,7 @@ struct SQLiteWikiStoreTests {
 
     @Test func freshDBReachesUserVersion18() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(store.pragmaValue("user_version") == "23")
+        #expect(store.pragmaValue("user_version") == "24")
     }
 
     @Test func v11SourceLinksHasDeleteCascade() throws {
@@ -623,7 +623,7 @@ struct SQLiteWikiStoreTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarText(db, "PRAGMA user_version;") == "23")
+        #expect(scalarText(db, "PRAGMA user_version;") == "24")
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"))
         for expected in ["blobs", "agents", "activities", "source_versions", "refs"] {
@@ -684,7 +684,7 @@ struct SQLiteWikiStoreTests {
 
         // Reopen → migrates 19→20.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "23")
+        #expect(store.pragmaValue("user_version") == "24")
 
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)

--- a/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
+++ b/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
@@ -49,7 +49,7 @@ struct SourceEmbeddingSearchTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarInt(db, "PRAGMA user_version;") == 23)
+        #expect(scalarInt(db, "PRAGMA user_version;") == 24)
         #expect(tableExists(db, "source_chunks"))
         // page chunk table mirrors the source one.
         #expect(tableExists(db, "page_chunks"))

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -279,7 +279,7 @@ struct SourcesTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 23)
+        #expect(sqlite3_column_int(stmt, 0) == 24)
         _ = store
     }
 

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -234,7 +234,7 @@ struct SystemPromptTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 23)
+        #expect(sqlite3_column_int(stmt, 0) == 24)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
+++ b/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
@@ -104,7 +104,7 @@ struct WikiNameSanitizationStoreTests {
 
         // Reopen → the 17→18 step sweeps the dirty names.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "23")
+        #expect(reopened.pragmaValue("user_version") == "24")
         let page = try reopened.getPage(id: pageID!)
         #expect(page.title == "(Draft) Bad - #Title") // inner # is fine, kept
         #expect(try reopened.getSource(id: sourceID!).displayName == "Foo - Bar)")


### PR DESCRIPTION
## Summary

Drops the now-unused inline `content` column from `source_markdown_versions`. The v21 migration moved all legacy inline content to blobs and set `content=''`; every write path since then writes `blob_hash` + `content=''`. The inline column and its "prefer blob, fall back to inline" read path are dead code.

Mirrors the v20 `sources.content` DROP COLUMN pattern exactly: one `withTransaction`, a pre-drop safety guard ensuring all rows have `blob_hash` set, then DROP COLUMN.

## Changes

- **Fresh schema (v24)**: Removed `content TEXT NOT NULL` from `CREATE TABLE source_markdown_versions` (blob-only).
- **Migration step `migrateV23ToV24()`**: 
  - Guards against tables/columns that don't exist (rewound DBs, test fixtures, fresh DBs).
  - Pre-drop safety check: verifies every row has `blob_hash` set before dropping the column.
  - Executes `ALTER TABLE source_markdown_versions DROP COLUMN content;`.
- **Read path**: Updated `smvSelectColumns` to fall back to empty string `''` instead of `smv.content` (defensive for missing blobs).
- **Write paths**: Removed `content` parameter from INSERT statements; adjusted parameter indices to match the new column order.
- **Tests**: Updated all version assertions from 23 to 24; fixed `FreshSchemaParityTests` to re-add the `content` column when simulating a v20 DB (so the migration ladder faithfully represents legacy table structure before re-seeding).