### PR TITLE
Show Refresh only when applicable; one content affordance per source (#218)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,31 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-07 — Refresh button only when applicable + on the action row (#218)
+
+**Shipped.** The source detail view no longer offers Refresh on sources that
+can't actually be refreshed, and Refresh now lives on the primary action row
+(with Extract/Ingest) instead of the utility row.
+
+- **Authoritative gate.** Added `WikiStoreModel.isSourceRefreshable(for:)` — the
+  single source of truth the UI gates on. It mirrors what
+  `SourceRefreshService.materialize` + the `performRefresh` snapshot guard will
+  actually do: `website` is refreshable *unless* it's a snapshot with image
+  siblings (the D3 guard); `apple-podcast` only when the build compiled
+  `PODCAST_TRANSCRIPTS` **and** the `podcast-token-helper` binary is present at
+  runtime; everything else (local-file, Zotero, folder, unknown, missing
+  origin/plan) is not. This fixes the prior gap where the view's own string
+  check (`agentName == website|apple-podcast`) showed Refresh for podcast
+  sources with no helper and for image snapshots — both of which always errored.
+- **View.** `SourceDetailView.isRefreshable` is now `@State` loaded per-file in
+  `.task(id:)`/`.onAppear` and reset in `.onChange(of: file.id)` (alongside
+  `origin`), so `body` stays free of DB/filesystem probes. The Refresh button
+  moved from the utility `HStack` (Edit/Show in List/Share/Reveal/Outline) to
+  the primary action `HStack`, right after Ingest.
+- **Tests.** Gate coverage in `SourceRefreshTests` (website = true, local-file =
+  false) and `SnapshotRefreshGuardTests` (image snapshot = false, imageless
+  website = true). Build + 10 refresh-suite tests green.
+
 ## 2026-07-08 — Chat UI + persistent chat (issue #119)
 
 **Shipped.** Ask/Edit conversations persist to the wiki's SQLite store, render

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -47,6 +47,12 @@ struct SourceDetailView: View {
     @State private var isRefreshing = false
     /// Set when a refresh fails — surfaced inline below the action row.
     @State private var refreshError: String?
+    /// Whether THIS source can actually be refreshed — the authoritative gate
+    /// from `store.isSourceRefreshable(for:)` (mirrors the refresh service's real
+    /// decision, incl. the snapshot-with-images guard and podcast-helper
+    /// availability). Loaded per-file alongside `origin` so `body` stays free of
+    /// DB/filesystem probes.
+    @State private var isRefreshable = false
     /// Tracks the active tab ID as of the last resolved update cycle — used to
     /// distinguish tab switches from in-tab file navigation.
     @State private var lastKnownActiveTabID: UUID? = nil
@@ -103,13 +109,6 @@ struct SourceDetailView: View {
         if let pinID = store.consumePendingPinnedExtraction(for: store.selection) {
             pinnedExtraction = store.processedMarkdownVersion(for: pinID)
         }
-    }
-
-    /// `true` when the source's origin is a refreshable provider (website or
-    /// Apple Podcast). Import-only providers (local-file, Zotero, folder) carry
-    /// no URL to re-fetch.
-    private var isRefreshable: Bool {
-        origin?.agentName == "website" || origin?.agentName == "apple-podcast"
     }
 
     private var showTabs: Bool { isPDF && hasMarkdown }
@@ -177,6 +176,7 @@ struct SourceDetailView: View {
         .onAppear {
             headVersion = store.processedMarkdownHead(for: file)
             origin = store.sourceOrigin(for: file.id)
+            isRefreshable = store.isSourceRefreshable(for: file.id)
             lastKnownActiveTabID = store.activeTabID
             consumePinnedExtraction()
         }
@@ -195,6 +195,7 @@ struct SourceDetailView: View {
             showReingestConfirmation = false
             headVersion = nil
             origin = nil
+            isRefreshable = false
             selectedTab = .markdown
             pdfQuote = nil
             pinnedExtraction = nil
@@ -205,6 +206,7 @@ struct SourceDetailView: View {
         .task(id: file.id) {
             headVersion = store.processedMarkdownHead(for: file)
             origin = store.sourceOrigin(for: file.id)
+            isRefreshable = store.isSourceRefreshable(for: file.id)
         }
         .task(id: PDFTaskKey(sourceID: file.id, anchorVersion: store.pendingScrollAnchorVersion)) {
             // Only consume for un-extracted PDFs (the markdown side handles
@@ -396,6 +398,17 @@ struct SourceDetailView: View {
                                           && !launcher.extractingSourceIDs.contains(file.id)))
                         }
                         ingestButton
+                        // Refresh lives on the primary action row (with Extract /
+                        // Ingest), not the utility row — re-fetching is a primary
+                        // source action. Only shown when the source can actually be
+                        // refreshed (see `isRefreshable`).
+                        if isRefreshable {
+                            Button("Refresh", systemImage: "arrow.clockwise") {
+                                Task { await runRefresh() }
+                            }
+                            .disabled(isRefreshing || store.isAgentRunning)
+                            .help("Re-fetch this source and append a new version")
+                        }
                     }
                     // Row 2 — secondary / utility actions: Edit, Show in List,
                     // Share, Reveal in Finder, Outline.
@@ -422,13 +435,6 @@ struct SourceDetailView: View {
                             store.requestSidebarReveal(.source(file.id))
                         }
                         .help("Reveal this source in the sidebar")
-                        if isRefreshable {
-                            Button("Refresh", systemImage: "arrow.clockwise") {
-                                Task { await runRefresh() }
-                            }
-                            .disabled(isRefreshing || store.isAgentRunning)
-                            .help("Re-fetch this source and append a new version")
-                        }
                         if fileProvider.path != nil {
                             Button("Share", systemImage: "square.and.arrow.up") {
                                 Task {

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -113,6 +113,13 @@ struct SourceDetailView: View {
 
     private var showTabs: Bool { isPDF && hasMarkdown }
 
+    /// A PDF with no markdown derivation yet — the gate for the prominent
+    /// "Extract" call-to-action. Also the exclusivity guard for the source's
+    /// single "act on this source's content" affordance: an unextracted PDF
+    /// shows Extract, so Refresh is suppressed until it has a derivation
+    /// (one affordance per source).
+    private var needsExtraction: Bool { isPDF && !hasMarkdown }
+
     /// `true` when this source has ≥2 extraction alternatives — the gate for the
     /// "Compare Extractions…" button (compare is meaningless with one).
     private var hasMultipleExtractions: Bool {
@@ -376,7 +383,7 @@ struct SourceDetailView: View {
                         if isPDF, hasMarkdown, let head = headVersion {
                             extractionProvenanceChip(head: head)
                         }
-                        if isPDF, !hasMarkdown {
+                        if needsExtraction {
                             // No derivation yet → Extract is the call-to-action:
                             // prominent and leftmost, with Ingest stepped down to
                             // secondary until there's markdown worth ingesting.
@@ -398,11 +405,12 @@ struct SourceDetailView: View {
                                           && !launcher.extractingSourceIDs.contains(file.id)))
                         }
                         ingestButton
-                        // Refresh lives on the primary action row (with Extract /
-                        // Ingest), not the utility row — re-fetching is a primary
-                        // source action. Only shown when the source can actually be
-                        // refreshed (see `isRefreshable`).
-                        if isRefreshable {
+                        // The source's content affordance is one-per-source: an
+                        // unextracted PDF shows Extract (above) to gain a readable
+                        // derivation, so Refresh is suppressed until it has one.
+                        // Every other refreshable (live) source offers Refresh to
+                        // re-fetch and append a new version.
+                        if isRefreshable, !needsExtraction {
                             Button("Refresh", systemImage: "arrow.clockwise") {
                                 Task { await runRefresh() }
                             }
@@ -534,8 +542,9 @@ struct SourceDetailView: View {
     // MARK: - Provider origin (Phase 3a)
 
     /// Inline origin tag for non-Zotero providers, shown on the metadata line:
-    /// website → a clickable link to the origin URL; local-file → "File";
-    /// markdown-folder → "Folder". Mirrors the inline Zotero tag's styling.
+    /// website → a clickable link to the origin URL; apple-podcast → a clickable
+    /// link to the episode; markdown-folder → "Folder"; local-file → "File".
+    /// Mirrors the inline Zotero tag's styling.
     @ViewBuilder
     private func providerOriginTag(_ origin: SourceOrigin) -> some View {
         switch origin.agentName {
@@ -554,6 +563,21 @@ struct SourceDetailView: View {
             }
         case "markdown-folder":
             Label("Folder", systemImage: "folder")
+        case "apple-podcast":
+            // Byteless source (a transcript) — link to the episode page, like the
+            // website tag. Never "File": a podcast source carries no file bytes.
+            let urlString = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
+            if let url = URL(string: urlString), url.scheme != nil {
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    Label("Apple Podcast", systemImage: "waveform")
+                }
+                .buttonStyle(.link)
+                .help("Open episode: \(urlString)")
+            } else {
+                Label("Apple Podcast", systemImage: "waveform")
+            }
         default:
             Label("File", systemImage: "doc")
         }

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1855,6 +1855,32 @@ public final class WikiStoreModel {
         try? store.sourceOrigin(sourceID: id)
     }
 
+    /// `true` iff `refreshSource(_:)` would actually succeed for this source —
+    /// the single source of truth the detail view gates the Refresh button on.
+    /// Mirrors `SourceRefreshService.materialize` + the `performRefresh` snapshot
+    /// guard so the UI only offers Refresh when it can work:
+    /// - `"website"` → refreshable, unless it's a snapshot with image siblings
+    ///   (the single-source refresh guard, D3, would orphan them).
+    /// - `"apple-podcast"` → refreshable only when this build compiled podcast
+    ///   support AND the `podcast-token-helper` binary is present at runtime.
+    /// - Everything else (local-file, Zotero, folder, unknown, missing origin)
+    ///   is import-only and not refreshable.
+    public func isSourceRefreshable(for id: PageID) -> Bool {
+        guard let origin = sourceOrigin(for: id), origin.plan != nil else { return false }
+        switch origin.agentName {
+        case "website":
+            return !((try? store.hasImageSiblings(sourceID: id)) ?? false)
+        case "apple-podcast":
+            #if PODCAST_TRANSCRIPTS
+            return ApplePodcastTranscriptService.bundled() != nil
+            #else
+            return false
+            #endif
+        default:
+            return false
+        }
+    }
+
     // MARK: - Processed markdown versions (v8)
 
     /// The latest (HEAD) processed markdown version for a file. Every source has a

--- a/Tests/WikiFSTests/SnapshotRefreshGuardTests.swift
+++ b/Tests/WikiFSTests/SnapshotRefreshGuardTests.swift
@@ -103,4 +103,45 @@ struct SnapshotRefreshGuardTests {
         let versionAfter = try #require(verAfter)
         #expect(versionAfter.id != versionBefore.id)
     }
+
+    // MARK: - Refreshability gate (#218): a snapshot with image siblings hides
+    // Refresh entirely (the single-source refresh guard would orphan the images).
+
+    @Test func snapshotWithImagesIsNotRefreshableGate() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+
+        let html = """
+        <html><head><title>Guarded</title></head><body><article>
+        <p>v1 content</p>
+        <img src="images/logo.png">
+        </article></body></html>
+        """
+        let fetcher = MultiURLFetcher(responses: [
+            "https://example.com/g": URLFetchService.FetchResponse(
+                data: Data(html.utf8), contentType: "text/html",
+                finalURL: URL(string: "https://example.com/g")!),
+            "https://example.com/images/logo.png": pngResponse(url: "https://example.com/images/logo.png"),
+        ])
+        _ = try await model.addURL("https://example.com/g", fetcher: fetcher)
+
+        let pageID = try store.listSources().first { $0.role == .primary }!.id
+        #expect(model.isSourceRefreshable(for: pageID) == false)
+    }
+
+    @Test func imagelessWebsiteSourceIsRefreshableGate() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+
+        let html = "<html><head><title>Plain</title></head><body><p>v1</p></body></html>"
+        let fetcher = MultiURLFetcher(responses: [
+            "https://example.com/p": URLFetchService.FetchResponse(
+                data: Data(html.utf8), contentType: "text/html",
+                finalURL: URL(string: "https://example.com/p")!),
+        ])
+        _ = try await model.addURL("https://example.com/p", fetcher: fetcher)
+
+        let pageID = try store.listSources().first { $0.role == .primary }!.id
+        #expect(model.isSourceRefreshable(for: pageID) == true)
+    }
 }

--- a/Tests/WikiFSTests/SourceRefreshTests.swift
+++ b/Tests/WikiFSTests/SourceRefreshTests.swift
@@ -134,4 +134,29 @@ struct SourceRefreshTests {
         #expect(headAfter.content == "SPEAKER_1: v2 transcript.")
     }
     #endif
+
+    // MARK: - Refreshability gate (#218): the detail view should only offer
+    // Refresh when `refreshSource(_:)` would actually succeed.
+
+    @Test func websiteSourceIsRefreshable() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let fetcher = SwapFetcher(htmlResponse(
+            "<html><body>plain</body></html>", url: "https://example.com/a"))
+        _ = try await model.addURL("https://example.com/a", fetcher: fetcher)
+        let source = try #require(try store.listSources().first { $0.role == .primary })
+        #expect(model.isSourceRefreshable(for: source.id) == true)
+    }
+
+    @Test func localFileSourceIsNotRefreshableGate() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        // A local-file source has no URL to re-fetch.
+        _ = try store.addSource(
+            filename: "notes.txt", data: Data("hello".utf8),
+            zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: nil,
+            provenance: nil)
+        let source = try #require(try store.listSources().first)
+        #expect(model.isSourceRefreshable(for: source.id) == false)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #218 — the source detail view no longer offers **Refresh** on sources that can't actually be refreshed, and Refresh is presented as the single per-source content affordance alongside Extract/Ingest.

## Problems

1. **Refresh showed where it couldn't work.** The view gated Refresh on a bare `agentName` string check (`website | apple-podcast`). That's necessary but not sufficient — it offered Refresh for:
   - Apple Podcast sources with no `podcast-token-helper` at runtime (or app-store builds without `PODCAST_TRANSCRIPTS`) → always errored `.notRefreshable`.
   - Website snapshots with image siblings → always errored `.snapshotWithImages` (the D3 orphan guard).
2. **Refresh was on the wrong row.** It sat on the utility row (Edit / Show in List / Share / Reveal / Outline) instead of with the primary actions.
3. **Extract vs Refresh could overlap** for a PDF fetched via URL (a refreshable source that's also an unextracted PDF).
4. **Podcast sources were mislabeled** "File" in the origin tag — a podcast source is byteless (a transcript).

## Changes

- **Authoritative gate.** New `WikiStoreModel.isSourceRefreshable(for:)` — the single source of truth, mirroring `SourceRefreshService.materialize` + the `performRefresh` snapshot guard:
  - `website` → refreshable, *unless* it's a snapshot with image siblings.
  - `apple-podcast` → only when the build compiled `PODCAST_TRANSCRIPTS` **and** the helper binary is present at runtime.
  - everything else (local-file, Zotero, folder, unknown, missing origin/plan) → not refreshable.
- **One content affordance per source.** `isRefreshable` is now `@State` loaded per-file (alongside `origin`), so `body` does no DB/FS probes. Added a `needsExtraction` guard (`isPDF && !hasMarkdown`) so Extract and Refresh are mutually exclusive — an unextracted PDF shows Extract; any other refreshable source shows Refresh. Never both.
- **Refresh moved to the primary action row** (with Extract / Ingest), after Ingest.
- **Podcast origin tag.** `providerOriginTag` now renders `apple-podcast` as a clickable "Apple Podcast" link (waveform icon) to the episode URL, matching the website tag and `SourceOrigin.displayLabel`.

## Tests

- Gate coverage in `SourceRefreshTests` (website = true, local-file = false) and `SnapshotRefreshGuardTests` (image snapshot = false, imageless website = true).
- `swift build` clean; 10 refresh-suite tests green.

## Notes

- The view/mutator partition is unaffected — `isSourceRefreshable` is read-only and routes through the existing `sourceOrigin`/`hasImageSiblings` seams (no new store mutator, so no new `mutate()`/emit obligation).
