### PR TITLE
Finish the CAS-only drop: drop source_markdown_versions.content (v26)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,7 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-## 2026-07-07 — Graph-model v24: finish the CAS-only drop (`source_markdown_versions.content`)
+## 2026-07-07 — Graph-model v26: derived markdown is CAS-only (drop `source_markdown_versions.content`)
 
 **Shipped (on `fix/finish-smv-cas-drop`; tests green).** Completes the
 content-addressed-storage model for derived markdown: the dead inline
@@ -10,14 +10,12 @@ content-addressed-storage model for derived markdown: the dead inline
 markdown body lives ONLY in `blobs` (CAS), joined via `blob_hash`. The fresh
 schema omits the column; the ladder drops it idempotently at v25→26 (appended at the top — a DB already at v25 would skip a `version < 24` step).
 
-**Why.** The store's blob-join readers (`smvSelectColumns`) still selected
-`smv.content` as a fallback — but the column had already been dropped on the
-live wiki DB (v25), so every read of a derived-markdown HEAD threw
-`no such column: smv.content`. Byteless sources — the two Apple Podcast
-transcripts — project their `.md` from exactly that HEAD read, so they
-materialized as **0-byte files** while their ~69 KB + ~31 KB transcripts sat
-intact (and unreadable) in `blobs`. Non-byteless sources project their own raw
-bytes via a different path, so only podcasts were visibly broken.
+**Appended at the top (append-only).** The drop is v26 — the newest version,
+not inserted at the reserved v24 slot — so it runs on every DB < 26 (a step
+guarded `version < 24` would be skipped by DBs already at v25). Idempotent: a
+no-op where the column is already gone (fresh DBs never create it; DBs already
+migrated past it). DBs still carrying the column drop it after the v21 backfill
+has CAS'd every row into `blobs`.
 
 **What shipped:**
 - **Fresh `CREATE TABLE source_markdown_versions`** — `content` removed (the
@@ -39,9 +37,9 @@ bytes via a different path, so only podcasts were visibly broken.
 - **`FreshSchemaParityTests.v20ToV21MigrationLossless`** — re-creates the
   `content` column when rewinding to v20 (to seed genuine legacy inline rows),
   and now asserts the column is **dropped** (was: "cleared to ''").
-- **New `ProcessedMarkdownTests.transcriptResolvesFromBlobOnCasOnlyDB`** — pins
-  the fix: a `transcript`-origin body round-trips through `processedMarkdownHead`
-  on a column-less DB, with the body in `blobs`.
+- **New `ProcessedMarkdownTests.transcriptResolvesFromBlobOnCasOnlyDB`** — a
+  `transcript`-origin body round-trips through `processedMarkdownHead` on a
+  column-less DB, body in `blobs`.
 
 **Gate:** full suite green — **1895 tests** (156 suites); migration parity
 (`freshFastPathMatchesStepwiseLadder`) holds (fresh == stepwise, both
@@ -49,7 +47,8 @@ column-less at v26).
 
 **Files:** `Sources/WikiFSCore/SQLiteWikiStore.swift`,
 `Tests/WikiFSTests/FreshSchemaParityTests.swift`,
-`Tests/WikiFSTests/ProcessedMarkdownTests.swift`.
+`Tests/WikiFSTests/ProcessedMarkdownTests.swift` (+ max-version assertions
+updated across the test target).
 
 ## 2026-07-07 — #129 slice 2b, Phase B: generic flat projection (pages + sources)
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,53 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-07 — Graph-model v24: finish the CAS-only drop (`source_markdown_versions.content`)
+
+**Shipped (on `fix/finish-smv-cas-drop`; tests green).** Completes the
+content-addressed-storage model for derived markdown: the dead inline
+`source_markdown_versions.content` column is dropped (v24), so every derived-
+markdown body lives ONLY in `blobs` (CAS), joined via `blob_hash`. The fresh
+schema omits the column; the ladder drops it idempotently at v23→24.
+
+**Why.** The store's blob-join readers (`smvSelectColumns`) still selected
+`smv.content` as a fallback — but the column had already been dropped on the
+live wiki DB (v25), so every read of a derived-markdown HEAD threw
+`no such column: smv.content`. Byteless sources — the two Apple Podcast
+transcripts — project their `.md` from exactly that HEAD read, so they
+materialized as **0-byte files** while their ~69 KB + ~31 KB transcripts sat
+intact (and unreadable) in `blobs`. Non-byteless sources project their own raw
+bytes via a different path, so only podcasts were visibly broken.
+
+**What shipped:**
+- **Fresh `CREATE TABLE source_markdown_versions`** — `content` removed (the
+  body is CAS'd in `blobs`).
+- **`smvSelectColumns`** — `COALESCE(CAST(b.content AS TEXT), smv.content)` →
+  `COALESCE(CAST(b.content AS TEXT), '')` (blob-only; no inline fallback).
+- **The three smv INSERTs** (`appendProcessedMarkdown`,
+  `recordMarkdownExtraction`, `revertProcessedMarkdown`) — `content` column +
+  the literal `''` value removed; `appendProcessedMarkdown` bind indices
+  renumbered (the other two used literal origins, so binds were unchanged).
+- **v24 ladder step** (between v23 and v25) — `ALTER TABLE … DROP COLUMN
+  content`, guarded idempotent (`pragma_table_info` check → no-op where the
+  column is already gone: fresh DBs, DBs already at v24+). The live DB (v25,
+  column already dropped) is fixed with NO migration run — the new blob-only
+  reads simply resolve. DBs still carrying the column (≤v23) drop it after the
+  v21 backfill has CAS'd every row.
+- **`FreshSchemaParityTests.v20ToV21MigrationLossless`** — re-creates the
+  `content` column when rewinding to v20 (to seed genuine legacy inline rows),
+  and now asserts the column is **dropped** (was: "cleared to ''").
+- **New `ProcessedMarkdownTests.transcriptResolvesFromBlobOnCasOnlyDB`** — pins
+  the fix: a `transcript`-origin body round-trips through `processedMarkdownHead`
+  on a column-less DB, with the body in `blobs`.
+
+**Gate:** full suite green — **1895 tests** (156 suites); migration parity
+(`freshFastPathMatchesStepwiseLadder`) holds (fresh == stepwise, both
+column-less at v25).
+
+**Files:** `Sources/WikiFSCore/SQLiteWikiStore.swift`,
+`Tests/WikiFSTests/FreshSchemaParityTests.swift`,
+`Tests/WikiFSTests/ProcessedMarkdownTests.swift`.
+
 ## 2026-07-07 — #129 slice 2b, Phase B: generic flat projection (pages + sources)
 
 **Shipped (on `feature/129-2b-phase-b-flat-projection`; tests green).** Phase B:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,9 +6,9 @@ Newest first. To get up to speed: read `PLAN.md` then this file.
 
 **Shipped (on `fix/finish-smv-cas-drop`; tests green).** Completes the
 content-addressed-storage model for derived markdown: the dead inline
-`source_markdown_versions.content` column is dropped (v24), so every derived-
+`source_markdown_versions.content` column is dropped (v26), so every derived-
 markdown body lives ONLY in `blobs` (CAS), joined via `blob_hash`. The fresh
-schema omits the column; the ladder drops it idempotently at v23→24.
+schema omits the column; the ladder drops it idempotently at v25→26 (appended at the top — a DB already at v25 would skip a `version < 24` step).
 
 **Why.** The store's blob-join readers (`smvSelectColumns`) still selected
 `smv.content` as a fallback — but the column had already been dropped on the
@@ -28,12 +28,14 @@ bytes via a different path, so only podcasts were visibly broken.
   `recordMarkdownExtraction`, `revertProcessedMarkdown`) — `content` column +
   the literal `''` value removed; `appendProcessedMarkdown` bind indices
   renumbered (the other two used literal origins, so binds were unchanged).
-- **v24 ladder step** (between v23 and v25) — `ALTER TABLE … DROP COLUMN
-  content`, guarded idempotent (`pragma_table_info` check → no-op where the
-  column is already gone: fresh DBs, DBs already at v24+). The live DB (v25,
-  column already dropped) is fixed with NO migration run — the new blob-only
-  reads simply resolve. DBs still carrying the column (≤v23) drop it after the
-  v21 backfill has CAS'd every row.
+- **v26 ladder step** (appended at the top — NOT inserted at the reserved v24
+  slot) — `ALTER TABLE … DROP COLUMN content`, guarded idempotent
+  (`pragma_table_info` check → no-op where the column is already gone: fresh
+  DBs, a DB already migrated past it). Appended rather than v24 because a step
+  guarded `version < 24` would be skipped by DBs already at v25 (the live DB);
+  v26 runs on every DB < 26. The live DB (v25, column already dropped) runs it
+  as a no-op and stamps 26; DBs still carrying the column drop it after the v21
+  backfill has CAS'd every row.
 - **`FreshSchemaParityTests.v20ToV21MigrationLossless`** — re-creates the
   `content` column when rewinding to v20 (to seed genuine legacy inline rows),
   and now asserts the column is **dropped** (was: "cleared to ''").
@@ -43,7 +45,7 @@ bytes via a different path, so only podcasts were visibly broken.
 
 **Gate:** full suite green — **1895 tests** (156 suites); migration parity
 (`freshFastPathMatchesStepwiseLadder`) holds (fresh == stepwise, both
-column-less at v25).
+column-less at v26).
 
 **Files:** `Sources/WikiFSCore/SQLiteWikiStore.swift`,
 `Tests/WikiFSTests/FreshSchemaParityTests.swift`,

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -258,7 +258,6 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             id                TEXT PRIMARY KEY,
             file_id           TEXT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
             parent_id         TEXT,
-            content           TEXT NOT NULL,
             origin            TEXT NOT NULL,
             note              TEXT,
             created_at        REAL NOT NULL,
@@ -461,10 +460,10 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // no schema change, and a fresh DB has no rows to sweep. Shared with
         // the v22→23 migration step.
         //
-        // v24 (graph-model Phase 2 close-out, NOT yet merged from main): drops
-        // the dead `source_markdown_versions.content` column. This branch still
-        // has the column in the fresh CREATE TABLE above (writes set it to '');
-        // it is harmless and will be dropped when main's v24 is merged.
+        // v24 (graph-model Phase 2 close-out): drops the dead
+        // `source_markdown_versions.content` column — the body lives only in
+        // `blobs` (CAS-only). The fresh path omits the column entirely (matching
+        // the ladder's post-v24 state); the ladder drops it in the v23→24 step.
         //
         // v25 (issue #119 phase 1): persisted chat history — `chats` +
         // `chat_messages`. Purely additive. Bumped above main's v24 so a DB
@@ -1106,15 +1105,28 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             version = 23
         }
 
-        // Step 23 → 25 (issue #119 phase 1): persisted chat history — `chats` +
-        // `chat_messages`. Purely additive. Bumped above main's v24
-        // (`source_markdown_versions.content` DROP COLUMN, not yet merged into
-        // this branch) so a DB opened by main (v24) still creates the chats
-        // tables. `IF NOT EXISTS` — a no-op on a DB that already has them
-        // (e.g. a v23 DB from an earlier build of this branch that created
-        // them at v23). v24 is intentionally absent here; it will be merged
-        // from main separately (and is a no-op for fresh DBs whose `content`
-        // column is already gone — or, in this branch, still present-but-dead).
+        // Step 23 → 24 (graph-model Phase 2 close-out): drop the now-dead
+        // `source_markdown_versions.content` column. Post-v21 every derived-
+        // markdown row is content-addressed in `blobs` (the inline column was
+        // `''` and unread), so finishing the CAS-only model removes it
+        // entirely. Idempotent: a no-op where the column is already gone (fresh
+        // DBs never create it; a DB already at v24+). Without this, the store's
+        // blob-only readers throw `no such column: smv.content` against a
+        // column-less DB — the bug that left byteless podcast transcripts
+        // projecting as empty `.md` files.
+        if version < 24 {
+            let hasSMVContent = try queryScalarText(
+                "SELECT COUNT(*) FROM pragma_table_info('source_markdown_versions') WHERE name='content';") != "0"
+            if hasSMVContent {
+                try exec("ALTER TABLE source_markdown_versions DROP COLUMN content;")
+            }
+            try exec("PRAGMA user_version=24;")
+            version = 24
+        }
+
+        // Step 24 → 25 (issue #119 phase 1): persisted chat history — `chats` +
+        // `chat_messages`. Purely additive. `IF NOT EXISTS` — a no-op on a DB
+        // that already has them.
         if version < 25 {
             try createChatTablesV23()
             try exec("PRAGMA user_version=25;")
@@ -4943,10 +4955,11 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     ///   6 created_at, 7 activity_id, 8 source_version_id, 9 blob_hash, 10 mime_type.
     ///
     /// The `content` column passed in MUST be the resolved body — i.e. the
-    /// SELECT computes `COALESCE(CAST(blobs.content AS TEXT), smv.content)` so
-    /// CAS rows (whose inline column is `''`) decode to real markdown. This keeps
-    /// `.content` always the full text (the resolved-body invariant) without
-    /// issuing a per-row blob read inside the caller's cursor.
+    /// SELECT computes `COALESCE(CAST(blobs.content AS TEXT), '')` (CAS-only:
+    /// the inline `source_markdown_versions.content` column was dropped at v24,
+    /// so the body lives only in `blobs`). This keeps `.content` always the full
+    /// text (the resolved-body invariant) without a per-row blob read inside the
+    /// caller's cursor.
     private func sourceMarkdownVersion(from stmt: SQLiteStatement) -> SourceMarkdownVersion {
         func textOrNull(_ col: Int32) -> String? {
             sqlite3_column_type(stmt.handle, col) == SQLITE_NULL ? nil : stmt.text(at: col)
@@ -4972,7 +4985,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// every Swift-decode reader so they all honor the resolved-body invariant.
     private static let smvSelectColumns = """
     smv.id, smv.file_id, smv.parent_id,
-    COALESCE(CAST(b.content AS TEXT), smv.content),
+    COALESCE(CAST(b.content AS TEXT), ''),
     smv.origin, smv.note, smv.created_at,
     smv.activity_id, smv.source_version_id, smv.blob_hash, smv.mime_type
     """
@@ -5270,18 +5283,18 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
         let stmt = try statement("""
         INSERT INTO source_markdown_versions
-          (id, file_id, parent_id, content, origin, note, created_at,
+          (id, file_id, parent_id, origin, note, created_at,
            blob_hash, mime_type)
-        VALUES (?1, ?2, ?3, '', ?5, ?6, ?7, ?8, 'text/markdown');
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'text/markdown');
         """)
         defer { stmt.reset() }
         try stmt.bind(id.rawValue, at: 1)
         try stmt.bind(sourceID.rawValue, at: 2)
         if let parentID { try stmt.bind(parentID.rawValue, at: 3) }
-        try stmt.bind(origin, at: 5)
-        if let note { try stmt.bind(note, at: 6) }
-        try stmt.bind(now.timeIntervalSince1970, at: 7)
-        try stmt.bind(blobHash, at: 8)
+        try stmt.bind(origin, at: 4)
+        if let note { try stmt.bind(note, at: 5) }
+        try stmt.bind(now.timeIntervalSince1970, at: 6)
+        try stmt.bind(blobHash, at: 7)
         _ = try stmt.step()
 
         // Re-embed the source from the just-written content + its name so content
@@ -5351,9 +5364,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             storedBlobHash = blobHash
             let ins = try statement("""
             INSERT INTO source_markdown_versions
-              (id, file_id, parent_id, content, origin, note, created_at,
+              (id, file_id, parent_id, origin, note, created_at,
                activity_id, source_version_id, blob_hash, mime_type)
-            VALUES (?1, ?2, ?3, '', 'extraction', ?4, ?5, ?6, ?7, ?8, 'text/markdown');
+            VALUES (?1, ?2, ?3, 'extraction', ?4, ?5, ?6, ?7, ?8, 'text/markdown');
             """)
             ins.reset()
             try ins.bind(id.rawValue, at: 1)
@@ -5439,9 +5452,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         try withTransaction {
             let ins = try statement("""
             INSERT INTO source_markdown_versions
-              (id, file_id, parent_id, content, origin, note, created_at,
+              (id, file_id, parent_id, origin, note, created_at,
                activity_id, source_version_id, blob_hash, mime_type)
-            VALUES (?1, ?2, ?3, '', 'revert', ?4, ?5, ?6, ?7, ?8, ?9);
+            VALUES (?1, ?2, ?3, 'revert', ?4, ?5, ?6, ?7, ?8, ?9);
             """)
             ins.reset()
             try ins.bind(id.rawValue, at: 1)

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -460,18 +460,19 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // no schema change, and a fresh DB has no rows to sweep. Shared with
         // the v22→23 migration step.
         //
-        // v24 (graph-model Phase 2 close-out): drops the dead
-        // `source_markdown_versions.content` column — the body lives only in
-        // `blobs` (CAS-only). The fresh path omits the column entirely (matching
-        // the ladder's post-v24 state); the ladder drops it in the v23→24 step.
+        // v24: reserved slot, never stamped. The `source_markdown_versions.content`
+        // drop lands as v26 below — appended at the top (not inserted here) so a
+        // DB already at v25 actually runs it (`version < 24` would skip v25 DBs).
         //
         // v25 (issue #119 phase 1): persisted chat history — `chats` +
-        // `chat_messages`. Purely additive. Bumped above main's v24 so a DB
-        // opened by main (v24) still creates the chats tables. Shared with the
-        // v23→25 migration step. `IF NOT EXISTS` (idempotent).
+        // `chat_messages`. Purely additive. `IF NOT EXISTS` (idempotent).
         try createChatTablesV23()
 
-        try exec("PRAGMA user_version=25;")
+        // v26 (graph-model Phase 2 close-out): drops the dead
+        // `source_markdown_versions.content` column — the body lives only in
+        // `blobs` (CAS-only). The fresh path omits the column entirely (nothing
+        // to drop); the ladder drops it in the v25→26 step.
+        try exec("PRAGMA user_version=26;")
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -1105,32 +1106,35 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             version = 23
         }
 
-        // Step 23 → 24 (graph-model Phase 2 close-out): drop the now-dead
+        // Step 23 → 25 (issue #119 phase 1): persisted chat history — `chats` +
+        // `chat_messages`. Purely additive. `IF NOT EXISTS` — a no-op on a DB
+        // that already has them. (v24 is a reserved slot, never stamped; the
+        // smv.content drop is appended as v26 below so DBs already at v25 run it.)
+        if version < 25 {
+            try createChatTablesV23()
+            try exec("PRAGMA user_version=25;")
+            version = 25
+        }
+
+        // Step 25 → 26 (graph-model Phase 2 close-out): drop the now-dead
         // `source_markdown_versions.content` column. Post-v21 every derived-
         // markdown row is content-addressed in `blobs` (the inline column was
         // `''` and unread), so finishing the CAS-only model removes it
-        // entirely. Idempotent: a no-op where the column is already gone (fresh
-        // DBs never create it; a DB already at v24+). Without this, the store's
-        // blob-only readers throw `no such column: smv.content` against a
-        // column-less DB — the bug that left byteless podcast transcripts
-        // projecting as empty `.md` files.
-        if version < 24 {
+        // entirely. Appended at the TOP — not inserted at the reserved v24 slot
+        // — because a DB already at v25 would skip a `version < 24` step; the
+        // drop must be the newest version to run on every existing DB. Idempotent:
+        // a no-op where the column is already gone (fresh DBs never create it).
+        // Without this, the store's blob-only readers throw
+        // `no such column: smv.content` against a column-less DB — the bug that
+        // left byteless podcast transcripts projecting as empty `.md` files.
+        if version < 26 {
             let hasSMVContent = try queryScalarText(
                 "SELECT COUNT(*) FROM pragma_table_info('source_markdown_versions') WHERE name='content';") != "0"
             if hasSMVContent {
                 try exec("ALTER TABLE source_markdown_versions DROP COLUMN content;")
             }
-            try exec("PRAGMA user_version=24;")
-            version = 24
-        }
-
-        // Step 24 → 25 (issue #119 phase 1): persisted chat history — `chats` +
-        // `chat_messages`. Purely additive. `IF NOT EXISTS` — a no-op on a DB
-        // that already has them.
-        if version < 25 {
-            try createChatTablesV23()
-            try exec("PRAGMA user_version=25;")
-            version = 25
+            try exec("PRAGMA user_version=26;")
+            version = 26
         }
     }
 

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -19,7 +19,7 @@ import SQLite3
     @Test func freshDBHasBookmarkNodesTable() throws {
         let url = tempDatabaseURL()
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "25")
+        #expect(store.pragmaValue("user_version") == "26")
 
         // The table exists.
         let nodes = try store.listBookmarkNodes()
@@ -37,7 +37,7 @@ import SQLite3
 
         // Reopen — triggers migration to v16.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "25")
+        #expect(reopened.pragmaValue("user_version") == "26")
 
         // Existing data is intact.
         let pages = try reopened.listPages(sortBy: .lastUpdated)

--- a/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
+++ b/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
@@ -20,7 +20,7 @@ struct EmbeddingMetaCutoverTests {
     @Test func freshDBSeedsNLEmbedderIdentifier() throws {
         let store = try tempStore()
         let stored = store.pragmaValue("user_version")
-        #expect(stored == "25")
+        #expect(stored == "26")
         // ensureEmbedderConsistency with the default identifier (nlembedding-512)
         // is a no-op: the seed matches, so nothing is wiped.
         store.ensureEmbedderConsistency(activeIdentifierOverride: NLEmbedder.identifier)

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -125,8 +125,8 @@ import SQLite3
         let ladder = try fingerprint(at: ladderURL)
 
         // Both must report head version 22.
-        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "25")
-        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "25")
+        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "26")
+        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "26")
 
         if fast != ladder {
             Issue.record("fresh fast-path schema drifted from the stepwise ladder:\n--- fast ---\n\(fast)\n--- ladder ---\n\(ladder)")
@@ -206,7 +206,7 @@ import SQLite3
         // 3. Reopen → runs the v20→v21 backfill.
         sqlite3_close(db)
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "25")
+        #expect(migrated.pragmaValue("user_version") == "26")
 
         // 4. The legacy extraction row was backfilled: blob_hash + activity_id + source_version_id set.
         #expect(migrated.scalarText(
@@ -268,7 +268,7 @@ import SQLite3
         sqlite3_close(db)
 
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "25")
+        #expect(migrated.pragmaValue("user_version") == "26")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
         let roleCol = columns(db2, "sources").first { $0.name == "role" }
@@ -343,7 +343,7 @@ import SQLite3
 
         // Reopen → v22 migration rebuilds source_links.
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "25")
+        #expect(migrated.pragmaValue("user_version") == "26")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -185,6 +185,10 @@ import SQLite3
         let db = try open(url)
         defer { sqlite3_close(db) }
         exec(db, "PRAGMA user_version=20;")
+        // The fresh schema no longer has the `content` column (dropped at v24,
+        // CAS-only). Re-create it to faithfully simulate a genuine v20-era smv
+        // row with inline content, so the v20→v21 backfill has something to CAS.
+        exec(db, "ALTER TABLE source_markdown_versions ADD COLUMN content TEXT NOT NULL DEFAULT '';")
         let legacyID = "01JLEGACY0000000000000000V"
         exec(db, """
         INSERT INTO source_markdown_versions (id, file_id, parent_id, content, origin, note, created_at)
@@ -212,16 +216,17 @@ import SQLite3
         #expect(migrated.scalarText(
             "SELECT source_version_id FROM source_markdown_versions WHERE id='\(legacyID)';")
             == (contentVersionID ?? ""))
-        // Inline content was cleared.
+        // The inline `content` column is dropped entirely (v24, CAS-only): the
+        // body lives only in `blobs`, so there is no per-row content to clear.
         #expect(migrated.scalarText(
-            "SELECT content FROM source_markdown_versions WHERE id='\(legacyID)';") == "")
+            "SELECT COUNT(*) FROM pragma_table_info('source_markdown_versions') WHERE name='content';") == "0")
 
         // 4b. The user-edit row IS CAS'd (blob_hash set, content cleared) but has
         //     NO activity_id — it must not be mislabeled as a legacy extraction.
         #expect(migrated.scalarText(
             "SELECT blob_hash FROM source_markdown_versions WHERE id='\(editID)';") != "")
-        #expect(migrated.scalarText(
-            "SELECT content FROM source_markdown_versions WHERE id='\(editID)';") == "")
+        // (The edit row's inline `content` is gone with the column — asserted
+        // DB-wide above; its body is in `blobs` like every other row.)
         #expect(migrated.scalarText(
             "SELECT activity_id FROM source_markdown_versions WHERE id='\(editID)';") == "")
 

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -238,7 +238,7 @@ struct LogIndexTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 25)
+        #expect(sqlite3_column_int(stmt, 0) == 26)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
+++ b/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
@@ -191,7 +191,7 @@ struct Phase5StoreCanonicalizationTests {
 
         // Reopen → v23 sweep runs.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "25")
+        #expect(reopened.pragmaValue("user_version") == "26")
 
         let migrated = try reopened.getPage(id: linkerID)
         // Resolvable link canonicalized; forward link left verbatim.

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -22,6 +22,31 @@ struct ProcessedMarkdownTests {
         try store.addSource(filename: filename, data: data)
     }
 
+    /// Regression for the byteless-podcast bug: on a CAS-only DB (the
+    /// `source_markdown_versions.content` column dropped at v24), a derived
+    /// transcript written via `appendProcessedMarkdown(origin: "transcript")`
+    /// lives ONLY in `blobs` and must round-trip through `processedMarkdownHead`.
+    /// Previously the blob-join reader still selected the dropped `smv.content`
+    /// column → `no such column: smv.content` → byteless sources (Apple Podcast
+    /// transcripts) projected as empty `.md` files. This pins the fix: no inline
+    /// column, body resolves from the blob.
+    @Test func transcriptResolvesFromBlobOnCasOnlyDB() throws {
+        let store = try tempStore()
+        let source = try seedSource(in: store)
+        let body = "SPEAKER_1: transcript body that must survive the CAS-only round-trip."
+
+        _ = try store.appendProcessedMarkdown(
+            sourceID: source.id, content: body, origin: "transcript", note: nil)
+
+        // The inline `content` column is gone (CAS-only, v24).
+        #expect(store.scalarText(
+            "SELECT COUNT(*) FROM pragma_table_info('source_markdown_versions') WHERE name='content';") == "0")
+        // ... yet the body resolves through the blob join.
+        let head = try store.processedMarkdownHead(sourceID: source.id)
+        #expect(head?.content == body)
+        #expect(head?.blobHash?.isEmpty == false)
+    }
+
     /// Build a v7 DB by hand (pages + sources + system_prompt + log +
     /// wiki_index + page_embeddings), then open it with SQLiteWikiStore — the
     /// store runs the v7→v8 migration step. Used to verify stepwise upgrade.

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -112,7 +112,7 @@ struct ProcessedMarkdownTests {
 
     @Test func freshDBHasV8Schema() throws {
         let store = try tempStore()
-        #expect(store.pragmaValue("user_version") == "25")
+        #expect(store.pragmaValue("user_version") == "26")
     }
 
     @Test func v7DBUpgradesToV8PreservingData() throws {
@@ -128,7 +128,7 @@ struct ProcessedMarkdownTests {
 
         // Opening runs v7→v8→…→v15 migration.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "25")
+        #expect(store.pragmaValue("user_version") == "26")
         // Pre-existing file is intact.
         let content = try store.sourceContent(
             id: PageID(rawValue: "01J00000000000000000000000"))

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -66,7 +66,7 @@ struct SQLiteWikiStoreTests {
         // user_version guard: a fresh DB runs all migration steps → version 16.
         // Reopening must not re-run DDL (no-op bootstrap).
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "25")
+        #expect(userVersion == "26")
         let reopened = try SQLiteWikiStore(databaseURL: url)
         // If bootstrap weren't guarded, the CREATE TABLE would throw here.
         #expect((try? reopened.listPages(sortBy: .lastUpdated)) != nil)
@@ -323,7 +323,7 @@ struct SQLiteWikiStoreTests {
         defer { sqlite3_close(db) }
 
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "25")
+        #expect(userVersion == "26")
 
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"))
@@ -367,7 +367,7 @@ struct SQLiteWikiStoreTests {
 
     @Test func freshDBReachesUserVersion18() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(store.pragmaValue("user_version") == "25")
+        #expect(store.pragmaValue("user_version") == "26")
     }
 
     @Test func v11SourceLinksHasDeleteCascade() throws {
@@ -623,7 +623,7 @@ struct SQLiteWikiStoreTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarText(db, "PRAGMA user_version;") == "25")
+        #expect(scalarText(db, "PRAGMA user_version;") == "26")
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"))
         for expected in ["blobs", "agents", "activities", "source_versions", "refs"] {
@@ -684,7 +684,7 @@ struct SQLiteWikiStoreTests {
 
         // Reopen → migrates 19→20.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "25")
+        #expect(store.pragmaValue("user_version") == "26")
 
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)

--- a/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
+++ b/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
@@ -49,7 +49,7 @@ struct SourceEmbeddingSearchTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarInt(db, "PRAGMA user_version;") == 25)
+        #expect(scalarInt(db, "PRAGMA user_version;") == 26)
         #expect(tableExists(db, "source_chunks"))
         // page chunk table mirrors the source one.
         #expect(tableExists(db, "page_chunks"))

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -279,7 +279,7 @@ struct SourcesTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 25)
+        #expect(sqlite3_column_int(stmt, 0) == 26)
         _ = store
     }
 

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -234,7 +234,7 @@ struct SystemPromptTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 25)
+        #expect(sqlite3_column_int(stmt, 0) == 26)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
+++ b/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
@@ -104,7 +104,7 @@ struct WikiNameSanitizationStoreTests {
 
         // Reopen → the 17→18 step sweeps the dirty names.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "25")
+        #expect(reopened.pragmaValue("user_version") == "26")
         let page = try reopened.getPage(id: pageID!)
         #expect(page.title == "(Draft) Bad - #Title") // inner # is fine, kept
         #expect(try reopened.getSource(id: sourceID!).displayName == "Foo - Bar)")


### PR DESCRIPTION
## What

Finishes the CAS-only storage model for derived markdown: drops the dead inline `source_markdown_versions.content` column (schema **v26**), so every derived-markdown body lives **only** in `blobs` (content-addressed), joined via `blob_hash`. The fresh schema omits the column; the ladder drops it idempotently at v25→26.

## Why — the empty Apple Podcast sources

The store's blob-join readers (`smvSelectColumns`) still selected `smv.content` as a fallback — but the column had **already been dropped** on the live wiki DB (v25), so every read of a derived-markdown HEAD threw `no such column: smv.content`.

Byteless sources — the two Apple Podcast transcripts — project their `.md` from exactly that HEAD read, so they materialized as **0-byte files** while their transcripts (~69 KB + ~31 KB) sat intact and unreadable in `blobs`. Non-byteless sources project their own raw bytes via a different path, so only podcasts were visibly broken. (Diagnosed live: removing the `smv.content` reference from the HEAD select made it return the full 69 KB transcript.)

This is the `source_markdown_versions` analog of the v20 `sources.content` drop — the last step of "commit to content-addressed storage."

## The drop is v26, appended at the top (append-only)

The drop is a **new** schema change on top of a shipped v25, so it's appended as **v26** (the next version) — *not* inserted at the reserved v24 slot. A step guarded `version < 24` would be **skipped by DBs already at v25** (the live DB), so it could never drop the column on them. As v26, the drop runs on every DB < 26; the idempotent `pragma_table_info` guard makes it a no-op where the column is already gone.

- **Live DB** (v25, column already dropped): runs the v26 step as a no-op, stamps 26; the new blob-only reads resolve the transcripts.
- **DBs still carrying the column** (≤ v25 from older code): drop it, after the v21 backfill has CAS'd every row (the empty-content guard still protects against data loss).

## Changes (store-layer only; no projection change)

- **Fresh `CREATE TABLE source_markdown_versions`** — `content` column removed.
- **`smvSelectColumns`** — `COALESCE(CAST(b.content AS TEXT), smv.content)` → `COALESCE(CAST(b.content AS TEXT), '')` (blob-only; no inline fallback).
- **The three smv INSERTs** (`appendProcessedMarkdown`, `recordMarkdownExtraction`, `revertProcessedMarkdown`) — `content` column + the literal `''` removed; `appendProcessedMarkdown` bind indices renumbered (the other two used literal origins, so binds were unchanged).
- **v26 ladder step** (after v25 chats) — `ALTER TABLE … DROP COLUMN content`, guarded idempotent.
- **Fresh-path stamp** → 26; max-version test assertions → 26.
- **`FreshSchemaParityTests.v20ToV21MigrationLossless`** — re-creates the `content` column when rewinding to v20 (to seed genuine legacy inline rows), and now asserts the column is **dropped** (was: "cleared to ''").
- **New `ProcessedMarkdownTests.transcriptResolvesFromBlobOnCasOnlyDB`** — pins the fix: a `transcript`-origin body round-trips through `processedMarkdownHead` on a column-less DB, body in `blobs`.

## Verification

- Full suite green: **1895 tests** (156 suites).
- Migration parity holds: `freshFastPathMatchesStepwiseLadder` — fresh schema == stepwise ladder, both column-less at v26.
- `v20ToV21MigrationLossless` — the v21 inline→CAS backfill still works, then v26 drops the column.

## Notes

- Rebased onto `main` (carries #222). The projection read path (#222's `contentForLeaf`) is **unaffected** — it calls the public `processedMarkdownHead` API, which now resolves correctly; it neither caused nor fixes this.
- Branch renamed from `fix/restore-smv-content-column` → `fix/finish-smv-cas-drop` to match the chosen direction (finish the drop, not restore the column).
