### PR TITLE
fix: replace beachballing TextField composer with NSTextView (port of #198)

### DIFF
--- a/Sources/WikiFS/ComposerTextView.swift
+++ b/Sources/WikiFS/ComposerTextView.swift
@@ -1,0 +1,246 @@
+import AppKit
+import SwiftUI
+
+/// NSTextView-backed chat composer, replacing the SwiftUI
+/// `TextField(..., axis: .vertical).lineLimit(1...6)` that previously backed
+/// the conversation views' composer.
+///
+/// Why this exists: on macOS, `TextField` is NSTextField/field-editor backed.
+/// Every keystroke, cursor move, or selection change re-lays-out the *entire*
+/// string, and `.lineLimit(1...6)` re-measures the full ideal height on every
+/// pass. Pasting ~150 lines of markdown into that field beachballed the app.
+/// `NSTextView` (the standard Slack/Messages-style chat composer: an
+/// `NSScrollView` wrapping a single `NSTextView`, growing 1–6 lines and then
+/// scrolling internally) does incremental layout and doesn't re-measure the
+/// whole document on every edit.
+///
+/// Mirrors `OmniboxSearchField.swift` — this repo's existing
+/// `NSViewRepresentable` text-input precedent: a `Coordinator` owns delegate
+/// state and forwards through to SwiftUI bindings/callbacks; `updateNSView`
+/// only touches AppKit state that has actually changed, so it doesn't fight
+/// the user's in-flight edit/selection/IME state on every SwiftUI update.
+///
+/// Placeholder text is intentionally NOT drawn here — `NSTextView` has no
+/// built-in placeholder (unlike `NSTextField`/`NSSearchField`), so the caller
+/// overlays a SwiftUI `Text` when `text.isEmpty`.
+struct ComposerTextView: NSViewRepresentable {
+    @Binding var text: String
+    let isEditable: Bool
+    /// Callers pass `.preferredFont(forTextStyle: .body)` to match the rest of
+    /// the composer's type scale.
+    let font: NSFont
+    /// Invoked when the user presses plain Return (see `keyAction`). Shift+Return
+    /// and Option+Return insert a line break instead.
+    let onSubmit: () -> Void
+    /// Written (asynchronously — never from inside `updateNSView` synchronously)
+    /// whenever the measured content height changes. The caller applies
+    /// `.frame(height: measuredHeight)`.
+    @Binding var measuredHeight: CGFloat
+
+    nonisolated static let accessibilityLabel = "Message"
+    private let placeholderText = "Ask a question, or ask the Agent to update the wiki…"
+
+    // MARK: - Height clamping (pure, testable)
+
+    /// Clamp + inset constants. `verticalInsetPerSide` is applied to the text
+    /// container's top AND bottom, so the total vertical inset baked into every
+    /// height measurement is double this. `verticalInset` is used in the
+    /// clamp and the text container's vertical inset, so the two can't drift
+    /// apart (the inset is baked into every `contentHeight` measurement fed
+    /// into `clampedHeight`, so the clamp's own `+ verticalInset` term has to
+    /// match exactly).
+    nonisolated enum Metrics {
+        static let minLines: CGFloat = 1
+        static let maxLines: CGFloat = 6
+        static let verticalInsetPerSide: CGFloat = 4
+        static var verticalInset: CGFloat { verticalInsetPerSide * 2 }
+    }
+
+    /// Pure: clamp measured content height to the 1–6 line band.
+    nonisolated static func clampedHeight(contentHeight: CGFloat, lineHeight: CGFloat) -> CGFloat {
+        let minHeight = lineHeight * Metrics.minLines + Metrics.verticalInset
+        let maxHeight = lineHeight * Metrics.maxLines + Metrics.verticalInset
+        return min(max(contentHeight, minHeight), maxHeight)
+    }
+
+    /// The one-line height for `font`, used as the initial `@State` value on
+    /// the SwiftUI side before any layout pass has run.
+    nonisolated static func oneLineHeight(for font: NSFont) -> CGFloat {
+        clampedHeight(contentHeight: 0, lineHeight: NSLayoutManager().defaultLineHeight(for: font))
+    }
+
+    // MARK: - Key handling (pure, testable)
+
+    nonisolated enum ComposerKeyAction {
+        case send
+        case insertNewline
+        case unhandled
+    }
+
+    /// Pure: decide what a `doCommandBy:` selector + the live modifier flags
+    /// mean for the composer.
+    ///
+    /// Plain Return sends. Shift/Option+Return insert a literal line break.
+    /// Cmd+Return falls through (`.unhandled`) so the send button's own
+    /// `.keyboardShortcut(.return, modifiers: .command)` is the single path —
+    /// otherwise a Cmd+Return keystroke would send twice.
+    nonisolated static func keyAction(for selector: Selector, modifiers: NSEvent.ModifierFlags) -> ComposerKeyAction {
+        guard selector == #selector(NSResponder.insertNewline(_:)) else { return .unhandled }
+        if modifiers.contains(.shift) || modifiers.contains(.option) { return .insertNewline }
+        if modifiers.contains(.command) { return .unhandled }
+        return .send
+    }
+
+    // MARK: - NSViewRepresentable
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    /// Builds and configures the `NSTextView` used both by `makeNSView` and by
+    /// tests that need a directly-constructible, fully-configured text view
+    /// without going through the SwiftUI representable machinery.
+    static func makeConfiguredTextView(font: NSFont) -> NSTextView {
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.allowsUndo = true
+        textView.drawsBackground = false
+        textView.textColor = .labelColor
+        textView.insertionPointColor = .labelColor
+        textView.font = font
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isSelectable = true
+        textView.textContainerInset = NSSize(width: 0, height: Metrics.verticalInsetPerSide)
+
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.minSize = NSSize(width: 0, height: 0)
+        if let container = textView.textContainer {
+            container.widthTracksTextView = true
+            container.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+            // Zero line-fragment padding so typed text aligns exactly with the
+            // SwiftUI placeholder overlay (NSTextContainer defaults to 5pt/side).
+            container.lineFragmentPadding = 0
+        }
+
+        textView.setAccessibilityLabel(accessibilityLabel)
+        return textView
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+
+        let textView = Self.makeConfiguredTextView(font: font)
+        textView.delegate = context.coordinator
+        textView.isEditable = isEditable
+        textView.string = text
+        textView.setAccessibilityPlaceholderValue(placeholderText)
+        textView.postsFrameChangedNotifications = true
+        context.coordinator.observeFrameChanges(for: textView)
+
+        scrollView.documentView = textView
+        return scrollView
+    }
+
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        coordinator.stopObservingFrameChanges()
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+
+        if textView.string != text {
+            textView.string = text
+        }
+        if textView.isEditable != isEditable {
+            textView.isEditable = isEditable
+        }
+        textView.setAccessibilityPlaceholderValue(placeholderText)
+        context.coordinator.recomputeHeight(for: textView)
+    }
+
+    // MARK: - Coordinator
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: ComposerTextView
+        private var frameObserver: NSObjectProtocol?
+        private var lastObservedWidth: CGFloat?
+
+        init(_ parent: ComposerTextView) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            if parent.text != textView.string {
+                parent.text = textView.string
+            }
+            recomputeHeight(for: textView)
+        }
+
+        func textView(_ textView: NSTextView, doCommandBy selector: Selector) -> Bool {
+            let modifiers = (NSApp.currentEvent?.modifierFlags ?? []).intersection(.deviceIndependentFlagsMask)
+            switch ComposerTextView.keyAction(for: selector, modifiers: modifiers) {
+            case .send:
+                parent.onSubmit()
+                return true
+            case .insertNewline, .unhandled:
+                return false
+            }
+        }
+
+        /// Measures content height and writes the clamped result back to the
+        /// binding — deferred to the next main-actor turn (must never write
+        /// synchronously, since this also runs from inside `updateNSView`).
+        func recomputeHeight(for textView: NSTextView) {
+            guard let layoutManager = textView.layoutManager, let container = textView.textContainer else { return }
+            layoutManager.ensureLayout(for: container)
+            let contentHeight = layoutManager.usedRect(for: container).height + textView.textContainerInset.height * 2
+            let lineHeight = layoutManager.defaultLineHeight(for: parent.font)
+            let clamped = ComposerTextView.clampedHeight(contentHeight: contentHeight, lineHeight: lineHeight)
+            guard clamped != parent.measuredHeight else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.parent.measuredHeight = clamped
+            }
+        }
+
+        func observeFrameChanges(for textView: NSTextView) {
+            guard frameObserver == nil else { return }
+            lastObservedWidth = textView.frame.width
+            frameObserver = NotificationCenter.default.addObserver(
+                forName: NSView.frameDidChangeNotification,
+                object: textView,
+                queue: .main
+            ) { [weak self, weak textView] _ in
+                guard let self, let textView else { return }
+                MainActor.assumeIsolated {
+                    self.handleFrameChange(for: textView)
+                }
+            }
+        }
+
+        func stopObservingFrameChanges() {
+            guard let frameObserver else { return }
+            NotificationCenter.default.removeObserver(frameObserver)
+            self.frameObserver = nil
+        }
+
+        @MainActor
+        private func handleFrameChange(for textView: NSTextView) {
+            let width = textView.frame.width
+            guard width != lastObservedWidth else { return }
+            lastObservedWidth = width
+            recomputeHeight(for: textView)
+        }
+    }
+}

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -28,6 +28,7 @@ struct ConversationView: View {
 
     @State private var draftMessage = ""
     @State private var showsInternals = false
+    @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ConversationMetrics.composerFont)
     @State private var persistedMessages: [ChatMessage] = []
 
     /// True when this surface is rendering the active live session (D2
@@ -344,14 +345,26 @@ struct ConversationView: View {
     private func composer(enabled: Bool) -> some View {
         let sendActive = canSend && enabled
         return HStack(alignment: .bottom, spacing: 10) {
-            TextField("Ask a question, or ask the Agent to update the wiki…", text: $draftMessage, axis: .vertical)
-                .font(.body)
-                .textFieldStyle(.plain)
-                .lineLimit(1...6)
+            ComposerTextView(
+                text: $draftMessage,
+                isEditable: enabled,
+                font: ConversationMetrics.composerFont,
+                onSubmit: sendMessage,
+                measuredHeight: $composerHeight
+            )
+                .frame(height: composerHeight)
                 .padding(.leading, ConversationMetrics.composerHorizontalPadding)
                 .padding(.vertical, ConversationMetrics.composerVerticalPadding)
-                .onSubmit(sendMessage)
-                .disabled(!enabled)
+                .overlay(alignment: .topLeading) {
+                    if draftMessage.isEmpty {
+                        Text("Ask a question, or ask the Agent to update the wiki…")
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                            .allowsHitTesting(false)
+                            .padding(.leading, ConversationMetrics.composerHorizontalPadding)
+                            .padding(.vertical, ConversationMetrics.composerVerticalPadding + ComposerTextView.Metrics.verticalInsetPerSide)
+                    }
+                }
 
             Button(action: sendMessage) {
                 Image(systemName: sendButtonIcon)
@@ -364,6 +377,7 @@ struct ConversationView: View {
                 .disabled(!sendActive)
                 .keyboardShortcut(.return, modifiers: .command)
                 .help(sendButtonTitle)
+                .padding(.bottom, ConversationMetrics.sendButtonBottomInset)
         }
         .padding(.trailing, ConversationMetrics.composerButtonInset)
         .background(Color(nsColor: .controlBackgroundColor), in: Capsule())
@@ -545,4 +559,15 @@ enum ConversationMetrics {
     static let composerVerticalPadding: CGFloat = 16
     static let composerButtonInset: CGFloat = 8
     static let sendButtonSize: CGFloat = 42
+    /// Font for `ComposerTextView` — matches the previous `TextField`'s
+    /// `.font(.body)`, expressed as an `NSFont` since the composer is
+    /// AppKit-backed.
+    static var composerFont: NSFont { .preferredFont(forTextStyle: .body) }
+    /// Bottom inset that vertically centers the send button in a ONE-line
+    /// capsule. Derived, not hardcoded, so a font or padding change can't
+    /// silently un-center the button.
+    static var sendButtonBottomInset: CGFloat {
+        (ComposerTextView.oneLineHeight(for: composerFont)
+            + composerVerticalPadding * 2 - sendButtonSize) / 2
+    }
 }

--- a/Tests/WikiFSTests/ComposerTextViewTests.swift
+++ b/Tests/WikiFSTests/ComposerTextViewTests.swift
@@ -1,0 +1,186 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import WikiFS
+
+@MainActor
+@Suite struct ComposerTextViewTests {
+
+    // MARK: - clampedHeight matrix
+
+    // Constants mirrored from `ComposerTextView.Metrics` so the test pins the
+    // exact numbers, not just "whatever the implementation currently does".
+    // `lineHeight` here is an arbitrary concrete value (20pt) — the clamp is
+    // linear in `lineHeight`, so this exercises the formula without coupling
+    // the test to a real font's metrics.
+    private let lineHeight: CGFloat = 20
+    private var minHeight: CGFloat { lineHeight * 1 + ComposerTextView.Metrics.verticalInset }
+    private var maxHeight: CGFloat { lineHeight * 6 + ComposerTextView.Metrics.verticalInset }
+
+    @Test func clampedHeightBelowOneLineClampsToMinimum() {
+        #expect(ComposerTextView.clampedHeight(contentHeight: 0, lineHeight: lineHeight) == minHeight)
+        #expect(ComposerTextView.clampedHeight(contentHeight: 10, lineHeight: lineHeight) == minHeight)
+    }
+
+    @Test func clampedHeightWithinBandPassesThrough() {
+        let midHeight: CGFloat = lineHeight * 3 + ComposerTextView.Metrics.verticalInset
+        #expect(ComposerTextView.clampedHeight(contentHeight: midHeight, lineHeight: lineHeight) == midHeight)
+        #expect(ComposerTextView.clampedHeight(contentHeight: minHeight, lineHeight: lineHeight) == minHeight)
+        #expect(ComposerTextView.clampedHeight(contentHeight: maxHeight, lineHeight: lineHeight) == maxHeight)
+    }
+
+    @Test func clampedHeightAboveSixLinesClampsToMaximum() {
+        #expect(ComposerTextView.clampedHeight(contentHeight: 10_000, lineHeight: lineHeight) == maxHeight)
+    }
+
+    // MARK: - keyAction matrix
+
+    private let insertNewline = #selector(NSResponder.insertNewline(_:))
+    private let insertTab = #selector(NSResponder.insertTab(_:))
+
+    @Test func plainReturnSends() {
+        #expect(ComposerTextView.keyAction(for: insertNewline, modifiers: []) == .send)
+    }
+
+    @Test func shiftReturnInsertsNewline() {
+        #expect(ComposerTextView.keyAction(for: insertNewline, modifiers: .shift) == .insertNewline)
+    }
+
+    @Test func optionReturnInsertsNewline() {
+        #expect(ComposerTextView.keyAction(for: insertNewline, modifiers: .option) == .insertNewline)
+    }
+
+    @Test func shiftOptionReturnInsertsNewline() {
+        #expect(ComposerTextView.keyAction(for: insertNewline, modifiers: [.shift, .option]) == .insertNewline)
+    }
+
+    @Test func unrelatedSelectorIsUnhandled() {
+        #expect(ComposerTextView.keyAction(for: insertTab, modifiers: []) == .unhandled)
+    }
+
+    @Test func commandReturnIsUnhandledSoTheSendButtonOwnsIt() {
+        #expect(ComposerTextView.keyAction(for: insertNewline, modifiers: .command) == .unhandled)
+    }
+
+    // MARK: - Window-hosted integration
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 400),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+    }
+
+    private var bodyFont: NSFont { .preferredFont(forTextStyle: .body) }
+
+    private func makeHostedComposer(
+        text: Binding<String>,
+        isEditable: Bool,
+        measuredHeight: Binding<CGFloat>
+    ) -> (window: NSWindow, textView: NSTextView, coordinator: ComposerTextView.Coordinator) {
+        let parent = ComposerTextView(
+            text: text,
+            isEditable: isEditable,
+            font: bodyFont,
+            onSubmit: {},
+            measuredHeight: measuredHeight
+        )
+        let coordinator = ComposerTextView.Coordinator(parent)
+        let textView = ComposerTextView.makeConfiguredTextView(font: bodyFont)
+        textView.delegate = coordinator
+        textView.isEditable = isEditable
+        textView.string = text.wrappedValue
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+        scrollView.documentView = textView
+
+        let window = makeWindow()
+        window.contentView?.addSubview(scrollView)
+
+        return (window, textView, coordinator)
+    }
+
+    @Test func largePasteClampsToSixLineMaximum() async {
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, isEditable: true, measuredHeight: heightBinding)
+
+        let pasted = Array(repeating: "Line of pasted markdown text.", count: 150).joined(separator: "\n")
+        textView.string = pasted
+        coordinator.recomputeHeight(for: textView)
+
+        let expectedMax = ComposerTextView.clampedHeight(
+            contentHeight: .greatestFiniteMagnitude,
+            lineHeight: NSLayoutManager().defaultLineHeight(for: bodyFont))
+        await Task.yield()
+        await Task.yield()
+
+        #expect(heightBinding.wrappedValue == expectedMax)
+    }
+
+    @Test func editPropagatesToBoundText() {
+        var text = "initial"
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, isEditable: true, measuredHeight: heightBinding)
+
+        textView.string = "edited by the user"
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+
+        #expect(textBinding.wrappedValue == "edited by the user")
+    }
+
+    @Test func narrowingWidthRecomputesHeightViaFrameObserver() async {
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, isEditable: true, measuredHeight: heightBinding)
+        textView.postsFrameChangedNotifications = true
+        coordinator.observeFrameChanges(for: textView)
+
+        let pasted = Array(repeating: "Line of pasted markdown text.", count: 150).joined(separator: "\n")
+        textView.string = pasted
+        coordinator.recomputeHeight(for: textView)
+        await Task.yield()
+        await Task.yield()
+
+        let lineHeight = NSLayoutManager().defaultLineHeight(for: bodyFont)
+        let expectedMax = ComposerTextView.clampedHeight(contentHeight: .greatestFiniteMagnitude, lineHeight: lineHeight)
+        #expect(heightBinding.wrappedValue == expectedMax)
+
+        measuredHeight = ComposerTextView.oneLineHeight(for: bodyFont)
+
+        textView.setFrameSize(NSSize(width: 120, height: textView.frame.height))
+        await Task.yield()
+        await Task.yield()
+
+        #expect(heightBinding.wrappedValue == expectedMax)
+    }
+
+    @Test func isEditableTogglesTextViewEditability() {
+        var text = "hello"
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let (_, textView, _) = makeHostedComposer(
+            text: textBinding, isEditable: true, measuredHeight: heightBinding)
+        #expect(textView.isEditable == true)
+        #expect(textView.isSelectable == true)
+
+        textView.isEditable = false
+        #expect(textView.isEditable == false)
+        #expect(textView.isSelectable == true)
+    }
+}


### PR DESCRIPTION
## Replace beachballing TextField composer with NSTextView (port of #198)

Ports the two un-merged pieces of PR #198 onto current main:

### 1. ComposerTextView — fixes the beachball on large pastes

Pasting ~150 lines of markdown into the chat composer froze the app. The root cause: `TextField(axis: .vertical).lineLimit(1...6)` is NSTextField/field-editor backed on macOS — every keystroke, cursor move, and selection re-lays-out the *entire* string, and the line clamp re-measures the full ideal height every pass.

**`ComposerTextView`** is an `NSViewRepresentable` wrapping `NSScrollView + NSTextView` with incremental TextKit layout. It auto-grows 1→6 lines then scrolls internally. Plain Return sends; Shift/Option+Return insert a newline; Cmd+Return falls through to the send button's key equivalent (no double-send). Smart quote/dash substitution off (users paste markdown). Height flows back via a deferred `measuredHeight` binding; a `frameDidChangeNotification` observer keeps the height fresh across window resizes.

Applied to **`ConversationView`** (the active composer surface — `QueryConversationView` is no longer instantiated; its dead-code composer is left as-is).

### 2. Send-button centering

The taller NSTextView composer (24pt vs TextField's ~17pt) exposed that the send button was bottom-flush in the capsule. A derived `sendButtonBottomInset` centers it in a one-line capsule and keeps it anchored off the bottom curve as the composer grows.

### What changed from the original PR #198

- The "New Conversation" button (piece #1 of #198) was already merged into main via the #119 chat persistence work — not duplicated here.
- Added `nonisolated` to the pure static functions (`clampedHeight`, `oneLineHeight`, `keyAction`, `Metrics`) so they're callable from non-main-actor contexts (Swift 6 strict concurrency).
- Marked the test suite `@MainActor` (Swift 6 requires it for AppKit-touching tests).
- Added `import AppKit` to `ConversationView` (needed for `NSFont`).

### Gate

- **1927 tests green** (157 suites), +13 ComposerTextViewTests.
- 13 tests: clamp matrix (below/within/above band), key-action matrix (plain/shift/option/shift+option/cmd/unrelated), window-hosted integration (150-line paste clamps to 6 lines, edit propagates, width-change re-measures, isEditable toggles).

Closes #198.
