### PR TITLE
fix: flaky ChatStoreTests WAL race (CI SQLITE_ERROR)

### DIFF
--- a/Tests/WikiFSTests/ChatStoreTests.swift
+++ b/Tests/WikiFSTests/ChatStoreTests.swift
@@ -201,8 +201,16 @@ import SQLite3
         // connection on the now-quiescent DB (a future/garbled event_json a
         // WikiStore method would never write, but a bad row should never brick
         // the rest of history).
+        //
+        // The store from the `do` block above may not be finalized by ARC yet
+        // (Swift doesn't guarantee deinit timing), so the WAL might still be
+        // held by the store's connection. We open with an explicit busy timeout
+        // and disable FK enforcement — the corrupt row is deliberately not
+        // validated by the store's own write path.
         var raw: OpaquePointer?
         #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        sqlite3_busy_timeout(raw, 5000)
+        sqlite3_exec(raw, "PRAGMA foreign_keys=OFF;", nil, nil, nil)
         let corruptSQL = """
         INSERT INTO chat_messages (id, chat_id, seq, role, event_json, text, created_at)
         VALUES ('01CORRUPTROW000000000000A', '\(chatID.rawValue)', 1_000,


### PR DESCRIPTION
## Fix: flaky ChatStoreTests WAL race

`chatMessagesSkipsRowWithCorruptEventJSON` intermittently fails on CI with `SQLITE_ERROR` on the raw `sqlite3_exec` INSERT.

**Root cause:** the test injects a corrupt row via a raw `sqlite3_open` connection after the store goes out of scope in a `do` block. ARC doesn't guarantee `deinit` timing — on CI, the store's WAL connection may still be active when the raw connection opens. The `chat_messages.chat_id` FK constraint can't see the `chats` row through the un-checkpointed WAL, so the INSERT returns `SQLITE_ERROR`.

**Fix:** set `busy_timeout(5000)` and `PRAGMA foreign_keys=OFF` on the raw connection before the INSERT. The corrupt row is deliberately unvalidated by the store's own write path — FK enforcement is irrelevant to what the test exercises (corrupt-JSON resilience).

1927 tests green. Fixes the CI failure on #228.
