### PR TITLE
fix: move PDF title extraction off main actor and out of locked path (#229)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5879,3 +5879,33 @@ once" cross-view signal (issue #183 design):
 
 **Build/tests:** `swift build` clean; `swift test` — 1466 tests pass.
 
+---
+
+### Issue #229 — PDF source add by URL can fail "database is locked" (PR #247)
+
+**Problem.** `DisplayNameResolver.resolve()` — which invokes PDFKit's
+whole-file parse for PDFs — ran **inside** `SQLiteWikiStore.addSource`'s
+`mutate()` closure, under the recursive lock and before the write transaction
+opened. For a large PDF this parse can take seconds, delaying the `BEGIN` long
+enough for another writer (File Provider, daemon, concurrent write) to hold the
+DB write lock past the 5 s `busy_timeout`, surfacing as "database is locked".
+
+**Fix.** Two-part:
+1. **Out of the locked path:** `addSource` (and `addSnapshotImage`) now compute
+   `ext` / `mime` / `displayName` **before** `mutate()` acquires the recursive
+   lock. The locked body keeps only the dup-check SELECT + INSERT transaction.
+   Added a `resolvedDisplayName: String??` parameter to `addSource` (and a
+   `WikiStore` protocol-extension convenience overload since protocol methods
+   can't have default args) so callers can skip the in-method parse entirely.
+2. **Off the main actor:** `WikiStoreModel.preResolveDisplayName()` runs
+   `DisplayNameResolver.resolve()` on a `Task.detached` for **PDFs only**
+   (non-PDFs return `nil` → resolve inline). Wired into `addURLViaWebsite`,
+   `addFiles`, and `ingestFromZotero`.
+
+**Key files:** `SQLiteWikiStore.swift` (`addSource` / `addSnapshotImage`),
+`WikiStore.swift` (protocol + extension), `WikiStoreModel.swift`
+(`preResolveDisplayName`, `storeMaterialized`, three ingest paths).
+
+**Build/tests:** `swift build` clean; `swift test` — 1930 tests pass
+(1927 existing + 3 new for the `resolvedDisplayName` tri-state bypass).
+

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -2383,9 +2383,43 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         provenance: SourceProvenance? = nil,
         role: SourceRole = .primary,
         originalPath: String? = nil,
-        activityID: String? = nil
+        activityID: String? = nil,
+        /// Pre-resolved display name from ``DisplayNameResolver/resolve``.
+        /// `nil` (default) → resolve in-method (still before the locked path).
+        /// Non-`nil` → use directly, skipping the (potentially expensive PDFKit)
+        /// parse — callers that pre-resolve off-main pass this to keep the
+        /// store write fast (issue #229).
+        resolvedDisplayName: String?? = nil
     ) throws -> SourceSummary {
-        try mutate(event: { source in localEvent(.source, id: source.id.rawValue, change: .created) }) {
+        // Resolve the display name BEFORE entering the locked ``mutate`` path.
+        // For PDFs, ``DisplayNameResolver`` invokes PDFKit — a multi-second,
+        // whole-file parse. Running it under the recursive lock delays the
+        // write transaction long enough to collide with another connection
+        // (File Provider, daemon, concurrent write) holding the DB write lock
+        // past the 5 s ``busy_timeout``, surfacing as "database is locked".
+        // Callers that pre-resolve off-main (addURL, addFiles, Zotero) pass
+        // ``resolvedDisplayName`` to skip the in-method parse entirely (#229).
+        let ext = (filename as NSString).pathExtension.lowercased()
+        let mime = mimeType
+            ?? ContentSniff.mimeType(of: data)
+            ?? (ext.isEmpty ? nil : UTType(filenameExtension: ext)?.preferredMIMEType)
+        // The citable name (`[[source:name]]`) must stay linkable — see
+        // WikiNameRules. Sanitize the resolved display name; when metadata
+        // yields none and the raw FILENAME is unlinkable, store its sanitized
+        // form as the display name (the filename itself stays verbatim — it is
+        // the file's identity on the mount).
+        let displayName: String?
+        if let resolved = resolvedDisplayName ?? DisplayNameResolver.resolve(
+            filename: filename, data: data, mimeType: mime,
+            zoteroItemTitle: zoteroItemTitle) {
+            displayName = WikiNameRules.sanitized(resolved)
+        } else if !WikiNameRules.isLinkable(filename) {
+            displayName = WikiNameRules.sanitized(filename)
+        } else {
+            displayName = nil
+        }
+
+        return try mutate(event: { source in localEvent(.source, id: source.id.rawValue, change: .created) }) {
         guard data.count <= Self.ingestByteCap else {
             throw WikiStoreError.unexpected(
                 "source \(data.count) bytes exceeds cap \(Self.ingestByteCap)")
@@ -2406,26 +2440,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         dupStmt.reset()
 
         let id = PageID(rawValue: ULID.generate())
-        let ext = (filename as NSString).pathExtension.lowercased()
-        let mime = mimeType
-            ?? ContentSniff.mimeType(of: data)
-            ?? (ext.isEmpty ? nil : UTType(filenameExtension: ext)?.preferredMIMEType)
         let now = Date()
-        // The citable name (`[[source:name]]`) must stay linkable — see
-        // WikiNameRules. Sanitize the resolved display name; when metadata
-        // yields none and the raw FILENAME is unlinkable, store its sanitized
-        // form as the display name (the filename itself stays verbatim — it is
-        // the file's identity on the mount).
-        let displayName: String?
-        if let resolved = DisplayNameResolver.resolve(
-            filename: filename, data: data, mimeType: mime,
-            zoteroItemTitle: zoteroItemTitle) {
-            displayName = WikiNameRules.sanitized(resolved)
-        } else if !WikiNameRules.isLinkable(filename) {
-            displayName = WikiNameRules.sanitized(filename)
-        } else {
-            displayName = nil
-        }
+
 
         let stmt = try statement("""
         INSERT INTO sources
@@ -2604,7 +2620,22 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         activityID: String,
         role: SourceRole = .media
     ) throws -> SourceSummary {
-        try mutate(event: { source in localEvent(.source, id: source.id.rawValue, change: .created) }) {
+        // Resolve display name BEFORE the locked path (same discipline as
+        // addSource — issue #229). Snapshot images are never PDFs, so this is
+        // always fast, but the pattern is identical for consistency.
+        let ext = (filename as NSString).pathExtension.lowercased()
+        let mime = ContentSniff.mimeType(of: data) ?? mimeType
+        let displayName: String?
+        if let resolved = DisplayNameResolver.resolve(
+            filename: filename, data: data, mimeType: mime, zoteroItemTitle: nil) {
+            displayName = WikiNameRules.sanitized(resolved)
+        } else if !WikiNameRules.isLinkable(filename) {
+            displayName = WikiNameRules.sanitized(filename)
+        } else {
+            displayName = nil
+        }
+
+        return try mutate(event: { source in localEvent(.source, id: source.id.rawValue, change: .created) }) {
         guard data.count <= Self.ingestByteCap else {
             throw WikiStoreError.unexpected(
                 "source \(data.count) bytes exceeds cap \(Self.ingestByteCap)")
@@ -2612,18 +2643,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let contentHash = SHA256.hash(data: data)
             .map { String(format: "%02x", $0) }.joined()
         let id = PageID(rawValue: ULID.generate())
-        let ext = (filename as NSString).pathExtension.lowercased()
-        let mime = ContentSniff.mimeType(of: data) ?? mimeType
         let now = Date()
-        let displayName: String? = {
-            if let resolved = DisplayNameResolver.resolve(
-                filename: filename, data: data, mimeType: mime, zoteroItemTitle: nil) {
-                return WikiNameRules.sanitized(resolved)
-            } else if !WikiNameRules.isLinkable(filename) {
-                return WikiNameRules.sanitized(filename)
-            }
-            return nil
-        }()
 
         try withTransaction {
             let sourceID = id.rawValue

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -95,7 +95,8 @@ public protocol WikiStore: Sendable {
         provenance: SourceProvenance?,
         role: SourceRole,
         originalPath: String?,
-        activityID: String?
+        activityID: String?,
+        resolvedDisplayName: String??
     ) throws -> SourceSummary
 
     /// Store a **byteless** source: a source whose identity row + v1 content
@@ -397,4 +398,32 @@ public protocol WikiStore: Sendable {
     /// Delete a chat. `ON DELETE CASCADE` removes its messages. No error if
     /// `id` doesn't exist.
     func deleteChat(id: PageID) throws
+}
+
+// MARK: - addSource default-argument convenience
+
+extension WikiStore {
+    /// Convenience overload so existing callers that don't pre-resolve a
+    /// display name can omit `resolvedDisplayName` (defaults to `nil` → resolve
+    /// in-method). Protocol requirements can't have default arguments, so this
+    /// extension provides the zero-arg-by-default entry point.
+    @discardableResult
+    func addSource(
+        filename: String,
+        data: Data,
+        zoteroItemKey: String?,
+        zoteroItemTitle: String?,
+        mimeType: String?,
+        provenance: SourceProvenance?,
+        role: SourceRole,
+        originalPath: String?,
+        activityID: String?
+    ) throws -> SourceSummary {
+        try addSource(
+            filename: filename, data: data,
+            zoteroItemKey: zoteroItemKey, zoteroItemTitle: zoteroItemTitle,
+            mimeType: mimeType, provenance: provenance, role: role,
+            originalPath: originalPath, activityID: activityID,
+            resolvedDisplayName: nil)
+    }
 }

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1365,18 +1365,46 @@ public final class WikiStoreModel {
 
     // MARK: - Provider-backed ingest seam (Phase 3a)
 
+    /// Pre-resolve a source's display name off the main actor. Only PDFs
+    /// trigger the expensive PDFKit whole-file parse, so this is a no-op
+    /// (returns `nil` → ``SQLiteWikiStore/addSource`` resolves inline) for all
+    /// other types whose metadata parsing is fast. For PDFs, the result is
+    /// computed on a detached task and handed to ``storeMaterialized`` via
+    /// ``resolvedDisplayName``, keeping the PDFKit work off the main actor and
+    /// out of the store's locked write path (issue #229).
+    ///
+    /// Returns `String??`:
+    /// - `nil` → "resolve in-method" (non-PDF or caller chose not to pre-resolve)
+    /// - `.some(result)` → use `result` as the ``DisplayNameResolver`` output
+    private func preResolveDisplayName(
+        filename: String, data: Data, mimeType: String?, zoteroItemTitle: String?
+    ) async -> String?? {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        let isPDF = ext == "pdf" || mimeType?.lowercased() == "application/pdf"
+        guard isPDF else { return nil }
+        return await Task.detached(priority: .userInitiated) {
+            DisplayNameResolver.resolve(
+                filename: filename, data: data, mimeType: mimeType,
+                zoteroItemTitle: zoteroItemTitle)
+        }.value
+    }
+
     /// The single store-write seam every provider-backed ingest flows through.
     /// Materialization (bytes + provenance) happens off-main inside the provider;
     /// this does the main-actor `store.addSource` write, threading the
     /// `MaterializedSource`'s provenance + retained Zotero columns through. Each
     /// caller wraps its OWN duplicate/error handling around this throw.
     @discardableResult
-    private func storeMaterialized(_ m: MaterializedSource) throws -> SourceSummary {
+    private func storeMaterialized(
+        _ m: MaterializedSource,
+        resolvedDisplayName: String?? = nil
+    ) throws -> SourceSummary {
         try store.addSource(
             filename: m.filename, data: m.data,
             zoteroItemKey: m.zoteroItemKey, zoteroItemTitle: m.zoteroItemTitle,
             mimeType: m.mimeType, provenance: m.provenance, role: .primary,
-            originalPath: nil, activityID: nil)
+            originalPath: nil, activityID: nil,
+            resolvedDisplayName: resolvedDisplayName)
     }
 
     /// Ingest dropped files. For each URL: reject directories (a recursive
@@ -1410,8 +1438,13 @@ public final class WikiStoreModel {
                 continue
             }
 
+            // Pre-resolve display name off-main for PDFs (issue #229).
+            let resolvedDisplayName = await preResolveDisplayName(
+                filename: materialized.filename, data: materialized.data,
+                mimeType: materialized.mimeType, zoteroItemTitle: materialized.zoteroItemTitle)
+
             do {
-                let summary = try storeMaterialized(materialized)
+                let summary = try storeMaterialized(materialized, resolvedDisplayName: resolvedDisplayName)
                 lastSourceID = summary.id
             } catch WikiStoreError.duplicateContent(let existing) {
                 // Byte-identical to an already-stored source — skip rather than
@@ -1572,11 +1605,17 @@ public final class WikiStoreModel {
     ) async throws -> URLFetchService.FetchOutcome {
         let provider = WebsiteProvider(rawInput: rawInput, fetcher: fetcher)
         let snapshot = try await provider.materializeSnapshot()
+        // Pre-resolve the page's display name off the main actor so a PDF
+        // source's PDFKit parse doesn't block the UI or delay the store write
+        // (issue #229). Non-PDFs are unaffected (helper returns nil → inline).
+        let resolvedDisplayName = await preResolveDisplayName(
+            filename: snapshot.page.filename, data: snapshot.page.data,
+            mimeType: snapshot.page.mimeType, zoteroItemTitle: snapshot.page.zoteroItemTitle)
         var summary: SourceSummary
         if snapshot.plan.kind == .htmlConverted && !snapshot.images.isEmpty {
             summary = try storeSnapshot(snapshot)
         } else {
-            summary = try storeMaterialized(snapshot.page)
+            summary = try storeMaterialized(snapshot.page, resolvedDisplayName: resolvedDisplayName)
         }
         // HTML-converted sources have ".md" appended to the storage filename;
         // set a clean display name (the page title without the extension) so
@@ -1726,8 +1765,12 @@ public final class WikiStoreModel {
         // Resolve + read off the main actor (the provider materializes, throwing
         // ZoteroFetchError.unavailable when the attachment isn't local).
         let materialized = try await provider.materialize()
+        // Pre-resolve display name off-main for PDFs (issue #229).
+        let resolvedDisplayName = await preResolveDisplayName(
+            filename: materialized.filename, data: materialized.data,
+            mimeType: materialized.mimeType, zoteroItemTitle: materialized.zoteroItemTitle)
         do {
-            let summary = try storeMaterialized(materialized)
+            let summary = try storeMaterialized(materialized, resolvedDisplayName: resolvedDisplayName)
             reloadSources()
             openTab(.source(summary.id))
         } catch {

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -458,6 +458,50 @@ struct SourcesTests {
         #expect(result == "Zotero Title")
     }
 
+    // MARK: - resolvedDisplayName bypass (issue #229)
+
+    @Test func resolvedDisplayNameBypassesInMethodResolve() throws {
+        // PDF data WITH a /Title — DisplayNameResolver.resolve would return
+        // "My PDF Document" if called. Passing resolvedDisplayName: .some("Pre")
+        // must bypass that entirely and use the pre-resolved value.
+        let pdfData = try minimalPDF(title: "My PDF Document")
+        let store = try tempStore()
+        let summary = try store.addSource(
+            filename: "report.pdf", data: pdfData,
+            zoteroItemKey: nil, zoteroItemTitle: nil,
+            mimeType: "application/pdf", provenance: nil, role: .primary,
+            originalPath: nil, activityID: nil,
+            resolvedDisplayName: .some("Pre-Resolved Title"))
+        #expect(summary.displayName == "Pre-Resolved Title")
+    }
+
+    @Test func resolvedDisplayNameNilBypassSkipsResolve() throws {
+        // PDF data WITH a /Title, but caller passes .some(nil) → store must
+        // NOT call DisplayNameResolver.resolve (which would return "My PDF
+        // Document"); it uses nil → display_name stays NULL (filename fallback).
+        let pdfData = try minimalPDF(title: "My PDF Document")
+        let store = try tempStore()
+        let summary = try store.addSource(
+            filename: "report.pdf", data: pdfData,
+            zoteroItemKey: nil, zoteroItemTitle: nil,
+            mimeType: "application/pdf", provenance: nil, role: .primary,
+            originalPath: nil, activityID: nil,
+            resolvedDisplayName: .some(nil))
+        #expect(summary.displayName == nil)
+    }
+
+    @Test func resolvedDisplayNameDefaultsToInMethodResolve() throws {
+        // resolvedDisplayName: nil (default) → resolve in-method as before.
+        let md = "# Inline Title\nbody"
+        let store = try tempStore()
+        let summary = try store.addSource(
+            filename: "note.md", data: Data(md.utf8),
+            zoteroItemKey: nil, zoteroItemTitle: nil,
+            mimeType: nil, provenance: nil, role: .primary,
+            originalPath: nil, activityID: nil)
+        #expect(summary.displayName == "Inline Title")
+    }
+
     // MARK: - DisplayNameResolver helpers
 
     /// Build a minimal valid PDF with an optional /Title in the Info dict,


### PR DESCRIPTION
## Summary

Fixes #229 — adding a PDF source via **Add from URL** could fail with "database is locked".

### Root cause

`DisplayNameResolver.resolve()` — which invokes PDFKit's whole-file parse for PDFs — ran **inside** `SQLiteWikiStore.addSource`'s `mutate()` closure, under the recursive lock and before the write transaction opened. For a large academic PDF this parse can take seconds, delaying the `BEGIN` long enough for another writer (File Provider extension, daemon, concurrent write) to grab and hold the DB write lock past the 5 s `busy_timeout`.

### Fix

**1. Move display-name resolution out of the locked path** (`SQLiteWikiStore.addSource`, `addSnapshotImage`)

`ext` / `mime` / `displayName` computation (all pure — no SQLite) now runs **before** `mutate()` acquires the recursive lock. The locked body keeps only the dup-check SELECT + INSERT transaction, which are fast.

**2. Add `resolvedDisplayName: String??` parameter** so callers that pre-resolve off-main can skip the in-method parse entirely:

| Value | Meaning |
|-------|---------|
| `nil` (default) | Resolve in-method (before `mutate`, but still synchronous) |
| `.some("Title")` | Use this; skip `DisplayNameResolver.resolve()` |
| `.some(nil)` | No metadata found; skip resolve, fall back to filename |

Protocol methods can't have default arguments, so a `WikiStore` extension provides a convenience overload preserving the old 9-arg signature — all existing callers are unchanged.

**3. Pre-resolve off-main in async ingest paths** (`WikiStoreModel`)

New `preResolveDisplayName()` helper runs `DisplayNameResolver.resolve()` on a `Task.detached` for **PDFs only** (non-PDFs return `nil` → resolve inline, since markdown/text parsing is fast). Wired into:
- `addURLViaWebsite` (the URL repro)
- `addFiles` (drag-drop)
- `ingestFromZotero`

### Test plan

- [x] `swift build` — compiles clean
- [x] `swift test` — all 1930 tests pass (1927 existing + 3 new)
- [x] 3 new tests verify the `resolvedDisplayName` tri-state bypass (pre-resolved name used, `.some(nil)` skips resolve, default resolves in-method)
- [x] `StoreEmissionExhaustivenessTests` still pass (both methods still route through `mutate()`)
