### PR TITLE
refactor: rename SourceProvider → SourceMaterializer + all conforming types

### DIFF
--- a/Sources/WikiFSCore/SourceMaterializer.swift
+++ b/Sources/WikiFSCore/SourceMaterializer.swift
@@ -1,23 +1,23 @@
 import Foundation
 import UniformTypeIdentifiers
 
-/// Phase 3a — the provider protocol that owns *materialization* (bytes +
+/// Phase 3a — the materializer protocol that owns *materialization* (bytes +
 /// filename + mime + PROV provenance) for every ingest entry point. The four
-/// ingest paths (drag-drop, URL, Zotero, Markdown-folder) each build a provider,
+/// ingest paths (drag-drop, URL, Zotero, Markdown-folder) each build a materializer,
 /// `materialize()` into a `MaterializedSource`, and flow through the single
 /// `WikiStoreModel.storeMaterialized(_:)` → `store.addSource(provenance:)` seam.
 ///
-/// A provider materializes bytes/provenance **only** — it never writes the store
+/// A materializer produces bytes/provenance **only** — it never writes the store
 /// (single-writer discipline: the `@MainActor` model owns the write, exactly as
 /// today). Network/file I/O inside `materialize()` runs off the main actor.
 ///
-/// See `plans/graph-model-and-versioning.md` §11 (provider protocol).
+/// See `plans/graph-model-and-versioning.md` §11 (materializer protocol).
 
 // MARK: - Provenance descriptor
 
 /// The PROV-DM descriptor threaded into `addSource`/`appendContentVersion`. When
 /// present, the store swaps the synthetic `legacy-import` agent/activity stub for
-/// a **real** provider agent + a `fetch`/`import` activity carrying `plan`/
+/// a **real** materializer agent + a `fetch`/`import` activity carrying `plan`/
 /// `external_ref`, and writes `external_identity` on the v1 version.
 ///
 /// Every column this populates already exists and was previously stubbed NULL
@@ -29,14 +29,14 @@ public struct SourceProvenance: Sendable, Equatable {
     public let agentName: String
     /// `agents.kind` (PROV agent kind). Defaults to `"software"`.
     public let agentKind: String
-    /// `agents.version` — a tool/model version, if known. `nil` for local providers.
+    /// `agents.version` — a tool/model version, if known. `nil` for local materializers.
     public let agentVersion: String?
     /// `activities.kind` — `"fetch"` for URL/website, `"import"` for local/
     /// Zotero/folder.
     public let activityKind: String
     /// `activities.plan` — the recipe. For website = the request URL string.
     public let plan: String?
-    /// `activities.external_ref` — provider-scoped stable identity for this
+    /// `activities.external_ref` — materializer-scoped stable identity for this
     /// *activity* (e.g. the final resolved URL). Per-ingest, NOT per-agent.
     public let externalRef: String?
     /// `source_versions.external_identity` — the canonical external id (resolved
@@ -64,10 +64,10 @@ public struct SourceProvenance: Sendable, Equatable {
 
 // MARK: - Materialized source
 
-/// A provider's output: the bytes to store + the provenance to record. Carries
+/// A materializer's output: the bytes to store + the provenance to record. Carries
 /// **no store handle** — the store owns the write (`storeMaterialized` →
 /// `addSource`). Also carries the retained Zotero legacy columns so the
-/// `ZoteroProvider` can populate both the PROV layer and the legacy columns in
+/// `ZoteroMaterializer` can populate both the PROV layer and the legacy columns in
 /// one call (§4.2: zotero columns are "legacy provenance, retained").
 public struct MaterializedSource: Sendable {
     public let filename: String
@@ -96,11 +96,11 @@ public struct MaterializedSource: Sendable {
 
 // MARK: - Provider protocol
 
-/// Materializes bytes + provenance for one ingest. Each provider turns its input
+/// Materializes bytes + provenance for one ingest. Each materializer turns its input
 /// into a `MaterializedSource`; the caller then stores it through the shared
-/// `storeMaterialized(_:)` seam. A provider NEVER writes the store.
-public protocol SourceProvider: Sendable {
-    /// The agent name this provider records (`"local-file"`, `"website"`, …).
+/// `storeMaterialized(_:)` seam. A materializer NEVER writes the store.
+public protocol SourceMaterializer: Sendable {
+    /// The agent name this materializer records (`"local-file"`, `"website"`, …).
     var agentName: String { get }
     /// Produce the bytes + provenance. Network/file I/O here may run off-main.
     func materialize() async throws -> MaterializedSource
@@ -151,12 +151,12 @@ public struct SourceOrigin: Sendable, Equatable {
     }
 }
 
-// MARK: - LocalFileProvider
+// MARK: - LocalFileMaterializer
 
 /// Materializes a drag-dropped / picked file: reads the bytes (off-main), sniffs
 /// the MIME type, and records `agentName = "local-file"` with an `import`
 /// activity (no external identity).
-public struct LocalFileProvider: SourceProvider {
+public struct LocalFileMaterializer: SourceMaterializer {
     public let agentName = "local-file"
     public let fileURL: URL
 
@@ -188,7 +188,7 @@ public struct LocalFileProvider: SourceProvider {
     }
 }
 
-// MARK: - WebsiteProvider
+// MARK: - WebsiteMaterializer
 
 /// Materializes a fetched URL: normalizes → fetches → dispatches by content type
 /// (HTML→Markdown / PDF / text / binary), reusing `URLFetchService.plan(for:)`
@@ -200,7 +200,7 @@ public struct LocalFileProvider: SourceProvider {
 /// computed dispatch `StorePlan`, so `addURL` can build its `FetchOutcome`
 /// (kind/size) without a second fetch. A pure struct — `materialize()` is the
 /// protocol-conformant projection that discards the plan.
-public struct WebsiteProvider: SourceProvider {
+public struct WebsiteMaterializer: SourceMaterializer {
     public let agentName = "website"
     public let rawInput: String
     public let fetcher: any URLFetchService.URLResourceFetcher
@@ -331,7 +331,7 @@ public struct WebsiteSnapshot: Sendable {
     }
 }
 
-// MARK: - ApplePodcastProvider
+// MARK: - ApplePodcastMaterializer
 
 #if PODCAST_TRANSCRIPTS
 /// Materializes an Apple Podcasts episode transcript: the fetch (token signing →
@@ -339,14 +339,14 @@ public struct WebsiteSnapshot: Sendable {
 /// `MaterializedSource` with `agentName = "apple-podcast"`, `activityKind = "fetch"`,
 /// `plan`/`externalRef` = the episode's `podcasts.apple.com` URL, and
 /// `externalIdentity` = the numeric episode ID (`i=` value). This is the first real
-/// consumer of the `SourceProvider` protocol; `addURL` routes recognized episode
-/// URLs here instead of `WebsiteProvider`.
+/// consumer of the `SourceMaterializer` protocol; `addURL` routes recognized episode
+/// URLs here instead of `WebsiteMaterializer`.
 ///
 /// Holds the page URL separately from `EpisodeRef` so the provenance records the
 /// canonical `podcasts.apple.com` link (not the episode ID alone) — the ID is what
 /// the AMP endpoint wants, but the URL is what the user pasted and what the Origin
 /// row should surface.
-public struct ApplePodcastProvider: SourceProvider {
+public struct ApplePodcastMaterializer: SourceMaterializer {
     public let agentName = "apple-podcast"
     public let episode: PodcastEpisodeURL.EpisodeRef
     public let pageURL: URL
@@ -366,7 +366,7 @@ public struct ApplePodcastProvider: SourceProvider {
         let episode = self.episode
         let fetcher = self.fetcher
         // The transcript fetch (helper subprocess + two HTTP round-trips) is
-        // off-main; the provider never touches the store.
+        // off-main; the materializer never touches the store.
         let transcript = try await Task.detached(priority: .userInitiated) {
             try await fetcher.transcript(for: episode)
         }.value
@@ -387,13 +387,13 @@ public struct ApplePodcastProvider: SourceProvider {
 }
 #endif
 
-// MARK: - ZoteroProvider
+// MARK: - ZoteroMaterializer
 
 /// Materializes a Zotero attachment: resolves its local file (off-main read),
 /// recording `agentName = "zotero"`, `activityKind = "import"`,
 /// `externalIdentity` = the parent item key. Also populates the retained legacy
 /// `zoteroItemKey`/`zoteroItemTitle` columns (§4.2).
-public struct ZoteroProvider: SourceProvider {
+public struct ZoteroMaterializer: SourceMaterializer {
     public let agentName = "zotero"
     public let attachment: ZoteroAttachment
     public let parentItem: ZoteroItem
@@ -429,15 +429,15 @@ public struct ZoteroProvider: SourceProvider {
     }
 }
 
-// MARK: - MarkdownFolderProvider
+// MARK: - MarkdownFolderMaterializer
 
 /// Materializes one `.md`/`.markdown` file from a folder import: the
 /// `MarkdownFolderReader.walk` does the batch off-main discovery + read, and this
-/// provider adapts each walked file into a `MaterializedSource` with
+/// materializer adapts each walked file into a `MaterializedSource` with
 /// `agentName = "markdown-folder"` (so "everything from a folder import" is a
 /// join). Takes the pre-read `(filename, data)` from the walk to avoid a
 /// double-read.
-public struct MarkdownFolderProvider: SourceProvider {
+public struct MarkdownFolderMaterializer: SourceMaterializer {
     public let agentName = "markdown-folder"
     public let filename: String
     public let data: Data

--- a/Sources/WikiFSCore/SourceRefreshService.swift
+++ b/Sources/WikiFSCore/SourceRefreshService.swift
@@ -8,8 +8,8 @@ import Foundation
 /// single-writer-discipline invariant).
 ///
 /// Provider reconstruction keys off `SourceOrigin.agentName`:
-/// - `"website"` → `WebsiteProvider` (refresh appends a content version).
-/// - `"apple-podcast"` → `ApplePodcastProvider` (refresh appends a derived
+/// - `"website"` → `WebsiteMaterializer` (refresh appends a content version).
+/// - `"apple-podcast"` → `ApplePodcastMaterializer` (refresh appends a derived
 ///   markdown version — byteless sources have no content to refresh).
 /// - Everything else (`local-file`, `zotero`, `markdown-folder`,
 ///   `legacy-import`, `unknown`) → `.notRefreshable` (import-only).
@@ -97,10 +97,10 @@ public struct SourceRefreshService: Sendable {
         guard let urlString = origin.plan, let url = URL(string: urlString) else {
             throw RefreshError.missingPlan
         }
-        let provider = WebsiteProvider(rawInput: urlString, fetcher: fetcher)
+        let provider = WebsiteMaterializer(rawInput: urlString, fetcher: fetcher)
         let source = try await provider.materialize()
         guard let prov = source.provenance else {
-            // WebsiteProvider always records provenance — defensive.
+            // WebsiteMaterializer always records provenance — defensive.
             throw RefreshError.missingPlan
         }
         _ = url // validated above; the provider re-normalizes from the raw string
@@ -127,7 +127,7 @@ public struct SourceRefreshService: Sendable {
         // The provider's materialize() runs the transcript fetch off-main
         // (Task.detached inside). Byteless source → only the derived markdown
         // (transcript) changes on refresh; the content version never does.
-        let provider = ApplePodcastProvider(episode: episode, pageURL: pageURL, fetcher: svc)
+        let provider = ApplePodcastMaterializer(episode: episode, pageURL: pageURL, fetcher: svc)
         let transcript = try await provider.materialize()
         let markdown = String(data: transcript.data, encoding: .utf8) ?? ""
         return .derivedMarkdown(content: markdown)

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1429,7 +1429,7 @@ public final class WikiStoreModel {
                 continue
             }
             // Materialize off-main (read + dispatch), store on the main actor.
-            let provider = LocalFileProvider(fileURL: url)
+            let provider = LocalFileMaterializer(fileURL: url)
             let materialized: MaterializedSource
             do {
                 materialized = try await provider.materialize()
@@ -1522,7 +1522,7 @@ public final class WikiStoreModel {
             }
             let pageURL = URLFetchService.normalizeURL(rawInput)
                 ?? URL(string: "https://podcasts.apple.com")!
-            let provider = ApplePodcastProvider(episode: episode, pageURL: pageURL, fetcher: svc)
+            let provider = ApplePodcastMaterializer(episode: episode, pageURL: pageURL, fetcher: svc)
             let transcript = try await provider.materialize()
             // §11 byteless model: the source is byteless (a pointer to the
             // external episode), and the transcript markdown is stored as the
@@ -1592,7 +1592,7 @@ public final class WikiStoreModel {
 
     /// The web-fetch ingest path (HTML→md / PDF / text / binary), shared by both
     /// the feature-on and feature-off `addURL` overloads. Validate + fetch OFF the
-    /// main actor (the GET shouldn't stall the UI); the WebsiteProvider owns
+    /// main actor (the GET shouldn't stall the UI); the WebsiteMaterializer owns
     /// normalize→fetch→dispatch (materialization). Then store the result HERE on
     /// the main actor, where we own `store`.
     ///
@@ -1603,7 +1603,7 @@ public final class WikiStoreModel {
         _ rawInput: String,
         fetcher: any URLFetchService.URLResourceFetcher
     ) async throws -> URLFetchService.FetchOutcome {
-        let provider = WebsiteProvider(rawInput: rawInput, fetcher: fetcher)
+        let provider = WebsiteMaterializer(rawInput: rawInput, fetcher: fetcher)
         let snapshot = try await provider.materializeSnapshot()
         // Pre-resolve the page's display name off the main actor so a PDF
         // source's PDFKit parse doesn't block the UI or delay the store write
@@ -1760,7 +1760,7 @@ public final class WikiStoreModel {
         parentItem: ZoteroItem,
         zoteroDir: URL
     ) async throws {
-        let provider = ZoteroProvider(
+        let provider = ZoteroMaterializer(
             attachment: attachment, parentItem: parentItem, zoteroDir: zoteroDir)
         // Resolve + read off the main actor (the provider materializes, throwing
         // ZoteroFetchError.unavailable when the attachment isn't local).
@@ -1807,7 +1807,7 @@ public final class WikiStoreModel {
         for file in result.files {
             let ext = (file.filename as NSString).pathExtension.lowercased()
             let mimeType = UTType(filenameExtension: ext)?.preferredMIMEType
-            let provider = MarkdownFolderProvider(
+            let provider = MarkdownFolderMaterializer(
                 filename: file.filename, data: file.data, mimeType: mimeType)
             do {
                 let materialized = try await provider.materialize()

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -117,7 +117,7 @@ func execute(_ command: ArgumentParser.Command, in store: SQLiteWikiStore) throw
         // because `DispatchSemaphore.wait()` blocks only the main thread; the
         // async task signals from its own continuation thread, which never needs
         // to acquire the main thread to signal (signaling is thread-agnostic).
-        // WebsiteProvider does not hop to the main actor, so no deadlock.
+        // WebsiteMaterializer does not hop to the main actor, so no deadlock.
         let box = RefreshResultBox()
         let semaphore = DispatchSemaphore(value: 0)
         Task {

--- a/Tests/WikiFSTests/SourceMaterializerTests.swift
+++ b/Tests/WikiFSTests/SourceMaterializerTests.swift
@@ -7,7 +7,7 @@ import CryptoKit
 /// Phase 3a tests: provider materialization + real provenance persistence.
 /// Covers AC.1–AC.5 (website/Zotero/local/folder provenance, agent idempotency,
 /// and the legacy nil-provenance fallback regression).
-struct SourceProviderTests {
+struct SourceMaterializerTests {
 
     // MARK: - Test doubles
 
@@ -43,13 +43,13 @@ struct SourceProviderTests {
         return try #require(origin)
     }
 
-    // MARK: - AC.1: WebsiteProvider + store provenance
+    // MARK: - AC.1: WebsiteMaterializer + store provenance
 
     @Test func websiteProviderRecordsOriginURL() async throws {
         let fetcher = FakeFetcher(response: htmlResponse(
             "<html><head><title>Example</title></head><body><p>Hi</p></body></html>",
             url: "https://example.com/page"))
-        let provider = WebsiteProvider(rawInput: "example.com/page", fetcher: fetcher)
+        let provider = WebsiteMaterializer(rawInput: "example.com/page", fetcher: fetcher)
         let (source, _) = try await provider.materializeWithPlan()
         let prov = try #require(source.provenance)
         #expect(prov.agentName == "website")
@@ -64,7 +64,7 @@ struct SourceProviderTests {
         let fetcher = FakeFetcher(response: htmlResponse(
             "<html><head><title>Test</title></head><body>x</body></html>",
             url: "https://example.com/article"))
-        let provider = WebsiteProvider(rawInput: "https://example.com/article", fetcher: fetcher)
+        let provider = WebsiteMaterializer(rawInput: "https://example.com/article", fetcher: fetcher)
         let (source, _) = try await provider.materializeWithPlan()
         let summary = try store.addSource(
             filename: source.filename, data: source.data,
@@ -87,10 +87,10 @@ struct SourceProviderTests {
         let html = { (title: String) in
             "<html><head><title>\(title)</title></head><body>x</body></html>"
         }
-        let p1 = WebsiteProvider(rawInput: "https://a.com/one", fetcher: FakeFetcher(
+        let p1 = WebsiteMaterializer(rawInput: "https://a.com/one", fetcher: FakeFetcher(
             response: htmlResponse(html("One").replacingOccurrences(of: "x", with: "alpha"),
                                    url: "https://a.com/one")))
-        let p2 = WebsiteProvider(rawInput: "https://b.com/two", fetcher: FakeFetcher(
+        let p2 = WebsiteMaterializer(rawInput: "https://b.com/two", fetcher: FakeFetcher(
             response: htmlResponse(html("Two").replacingOccurrences(of: "x", with: "beta"),
                                    url: "https://b.com/two")))
 
@@ -120,9 +120,9 @@ struct SourceProviderTests {
         let html = { (title: String, body: String) in
             "<html><head><title>\(title)</title></head><body>\(body)</body></html>"
         }
-        let p1 = WebsiteProvider(rawInput: "https://a.com", fetcher: FakeFetcher(
+        let p1 = WebsiteMaterializer(rawInput: "https://a.com", fetcher: FakeFetcher(
             response: htmlResponse(html("A", "alpha"), url: "https://a.com")))
-        let p2 = WebsiteProvider(rawInput: "https://b.com", fetcher: FakeFetcher(
+        let p2 = WebsiteMaterializer(rawInput: "https://b.com", fetcher: FakeFetcher(
             response: htmlResponse(html("B", "beta"), url: "https://b.com")))
         let (m1, _) = try await p1.materializeWithPlan()
         let (m2, _) = try await p2.materializeWithPlan()
@@ -143,7 +143,7 @@ struct SourceProviderTests {
         #expect(actCount == "2")
     }
 
-    // MARK: - AC.3: LocalFileProvider + MarkdownFolderProvider
+    // MARK: - AC.3: LocalFileMaterializer + MarkdownFolderMaterializer
 
     @Test func localFileProviderReadsBytesAndSetsProvenance() async throws {
         let dir = FileManager.default.temporaryDirectory
@@ -153,7 +153,7 @@ struct SourceProviderTests {
         let fileURL = dir.appendingPathComponent("note.md")
         try Data("# Hello".utf8).write(to: fileURL)
 
-        let provider = LocalFileProvider(fileURL: fileURL)
+        let provider = LocalFileMaterializer(fileURL: fileURL)
         let source = try await provider.materialize()
         #expect(source.data == Data("# Hello".utf8))
         let prov = try #require(source.provenance)
@@ -163,7 +163,7 @@ struct SourceProviderTests {
     }
 
     @Test func markdownFolderProviderSetsFolderProvenance() async throws {
-        let provider = MarkdownFolderProvider(
+        let provider = MarkdownFolderMaterializer(
             filename: "Note.md", data: Data("# Body".utf8), mimeType: "text/markdown")
         let source = try await provider.materialize()
         let prov = try #require(source.provenance)
@@ -174,9 +174,9 @@ struct SourceProviderTests {
 
     @Test func addSourceLocalAndFolderRecordDistinctAgents() async throws {
         let store = try tempStore()
-        let local = try await LocalFileProvider(fileURL: writeTempFile(
+        let local = try await LocalFileMaterializer(fileURL: writeTempFile(
             "local.txt", Data("x".utf8))).materialize()
-        let folder = try await MarkdownFolderProvider(
+        let folder = try await MarkdownFolderMaterializer(
             filename: "f.md", data: Data("y".utf8)).materialize()
         let s1 = try store.addSource(
             filename: local.filename, data: local.data, zoteroItemKey: nil, zoteroItemTitle: nil,
@@ -189,7 +189,7 @@ struct SourceProviderTests {
         #expect(try store.sourceOrigin(sourceID: s2.id)?.agentName == "markdown-folder")
     }
 
-    // MARK: - AC.2: ZoteroProvider
+    // MARK: - AC.2: ZoteroMaterializer
 
     @Test func zoteroProviderSetsItemKeyProvenance() async throws {
         let dir = FileManager.default.temporaryDirectory
@@ -209,7 +209,7 @@ struct SourceProviderTests {
         let parent = ZoteroItem(
             key: "PARENT1", version: 1, itemType: "journalArticle",
             title: "My Paper", creatorSummary: "Doe", date: "2024")
-        let provider = ZoteroProvider(
+        let provider = ZoteroMaterializer(
             attachment: attachment, parentItem: parent, zoteroDir: dir)
         let source = try await provider.materialize()
         let prov = try #require(source.provenance)
@@ -415,12 +415,12 @@ struct SourceProviderTests {
     private static let chinaTalkEpisode = PodcastEpisodeURL.EpisodeRef(id: "1000774368453", slug: "chinatalk")
     private static let chinaTalkPageURL = URL(string: "https://podcasts.apple.com/us/podcast/chinatalk/id1289062927?i=1000774368453")!
 
-    /// AC.5 — `ApplePodcastProvider.materialize()` produces provenance that
+    /// AC.5 — `ApplePodcastMaterializer.materialize()` produces provenance that
     /// survives a store round-trip: agentName, externalIdentity (episode ID),
     /// plan (the page URL), and the displayLabel.
     @Test func applePodcastProviderPersistsProvenance() async throws {
         let store = try tempStore()
-        let provider = ApplePodcastProvider(
+        let provider = ApplePodcastMaterializer(
             episode: Self.chinaTalkEpisode,
             pageURL: Self.chinaTalkPageURL,
             fetcher: FakePodcastFetcher())

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -777,7 +777,7 @@ struct WikiCtlCommandTests {
         let fetcher = RefreshFakeFetcher(response: URLFetchService.FetchResponse(
             data: Data("<html><body>v1</body></html>".utf8),
             contentType: "text/html", finalURL: URL(string: "https://example.com/p")!))
-        let provider = WebsiteProvider(rawInput: "https://example.com/p", fetcher: fetcher)
+        let provider = WebsiteMaterializer(rawInput: "https://example.com/p", fetcher: fetcher)
         let source = try await provider.materialize()
         let summary = try store.addSource(
             filename: source.filename, data: source.data,


### PR DESCRIPTION
Pure rename — no behavior change. The protocol's sole method is `materialize()`, it returns `MaterializedSource`, and every doc comment already says "materializes." The codebase uses "materialize" vocabulary throughout (`materialize()`, `MaterializedSource`, `materializeSnapshot()`, `storeMaterialized()`) — the protocol name was the one holdout.

**Renames:**
- `SourceProvider` → `SourceMaterializer` (protocol)
- `LocalFileProvider` → `LocalFileMaterializer`
- `WebsiteProvider` → `WebsiteMaterializer`
- `ApplePodcastProvider` → `ApplePodcastMaterializer`
- `ZoteroProvider` → `ZoteroMaterializer`
- `MarkdownFolderProvider` → `MarkdownFolderMaterializer`
- `SourceProviderTests` → `SourceMaterializerTests`
- `SourceProvider.swift` → `SourceMaterializer.swift`
- `SourceProviderTests.swift` → `SourceMaterializerTests.swift`

**Test plan:**
- [x] `swift build` clean
- [x] `swift test` — 1933 tests pass

**Follow-up:** #263 (separate source origin from materialized format — `PdfMaterializer`, `MarkdownMaterializer`, etc.)