### PR TITLE
fix(chat): prevent titled-but-empty orphan chats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,54 @@ codegen'd into the checked-in `Sources/WikiFSCore/GeneratedPrompts.swift` by
 the `.md` and the regenerated `.swift`. CI runs `make check-prompts` and fails
 on drift, so a stale generated file blocks the build.
 
+## Local data — finding the SQLite wiki databases
+
+**The SQLite DB is the source of truth.** Every wiki is one `<ulid>.sqlite` file in
+the **App Group container** (`~/Library/Group Containers/<appGroupID>/`). The
+`pages/`, `sources/`, `indexes/` folders you may see elsewhere (e.g. an iCloud
+Drive folder) are the **File Provider's read-only filesystem projection** — a
+mirror of the DB, not the data store. Don't dig through those for chat/page data;
+read the DB.
+
+**The container path is per-developer.** `appGroupID` resolves at runtime
+(`Sources/WikiFSCore/WikiIdentifiers.swift`), first hit wins:
+
+1. env `WIKI_APP_GROUP_ID`
+2. Info.plist key `WIKIAppGroupID` (injected by `build.sh`)
+3. sidecar `wiki-identifiers.env` beside the executable
+4. `signing/local.config` key `APP_GROUP` (gitignored, per-developer)
+5. compiled default `group.org.sockpuppet.wiki`
+
+So the literal path is `~/Library/Group Containers/<that id>/<ulid>.sqlite`.
+`wikis.json` in the same container is the registry: it maps display name → ULID
+(see `Sources/WikiFSCore/WikiRegistry.swift`). The legacy single-wiki DB is
+`WikiFS.sqlite`. The DB runs in WAL mode, so expect `<ulid>.sqlite`,
+`-wal`, and `-shm` sidecars.
+
+**⚠️ TCC gotcha — the container is protected.** A plain shell gets
+`Operation not permitted` / `authorization denied` on `ls`, `cat`, and even
+`sqlite3` against files in the container. To read the DB you must either give the
+terminal/daemon process **Full Disk Access** (System Settings → Privacy &
+Security), or read it through the app / bundled `wikictl` (which has access).
+
+**Quick locator that works regardless of developer** (needs FDA on the shell):
+
+```bash
+# Resolve THIS machine's app-group id from the built app (or signing/local.config).
+defaults read "$(mdfind -name WikiFS.app | head -1)/Contents/Info" WIKIAppGroupID \
+  2>/dev/null || grep '^APP_GROUP=' signing/local.config | cut -d= -f2 | tr -d '"'
+# Then list the wikis and open one.
+C="$HOME/Library/Group Containers/$(…resolved id…)"
+cat "$C/wikis.json"                      # registry: name → ULID
+sqlite3 "$C/<ulid>.sqlite" ".tables"     # pages, chats, chat_messages, …
+```
+
+Schema lives in `Sources/WikiFSCore/SQLiteWikiStore.swift`
+(`createFreshSchemaV20` / `createChatTablesV23` / the `migrate(from:)` ladder).
+Persistent chats are two tables: `chats` (one row per conversation) and
+`chat_messages` (one row per persistable `AgentEvent`) — see
+`plans/chat-and-persistence.md`.
+
 ## Testing
 
 **Swift** (from repo root):

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,35 +2,6 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-## 2026-07-08 — Fix: prevent titled-but-empty orphan chats (PR #265)
-
-**Problem:** a persisted chat could appear in Recent Chats with a title but be
-empty when opened — a `chats` row with zero `chat_messages`. Confirmed live:
-one `edit` chat with `created_at == updated_at` and 0 messages.
-
-**Root cause:** `WikiStoreModel.startChat` created the row eagerly at session
-start (title from the first message), but `chat_messages` were written lazily —
-only at turn boundaries / `finish()`, and the first `.userText` wasn't appended
-to `events[]` until the generation gate was acquired. A session that died before
-its first turn (preflight/spawn failure, immediate exit) left a titled-but-empty
-orphan.
-
-**Fix (`fix/orphan-chat-empty`):**
-- `startChat` now **seeds** the first user message as `chat_messages` seq 0 at
-  creation → a chat is never titled-but-empty even if the agent never responds.
-- `AgentLauncher` gains `firstMessagePrePersisted` (fresh-chat path) → marks the
-  seeded event already-flushed (`persistedEventCount` bumped past it) so the
-  first `flushTranscript()` doesn't double-insert it.
-- `AgentOperationRunner` **rolls back** the chat (`rollbackChatCreation`) on
-  preflight/spawn failure — deletes the row, reverts the retargeted tab to draft.
-- **Data:** deleted the orphan row from the live Malleable Software DB; WAL
-  checkpointed.
-- **Docs:** `AGENTS.md` gains a **Local data** section (App Group container path,
-  per-dev `appGroupID` resolution, `wikis.json` registry, TCC/FDA caveat).
-- **Tests:** `OrphanChatSeedingTests` (7); full suite 1940 green. Chat mutators
-  stay plain lock-guarded (not `mutate()`-emitting) — chats aren't File Provider
-  resources, so `StoreEmissionExhaustivenessTests` still holds.
-
 ## 2026-07-08 — #129 Phase E: model subscribes to ALL events; `origin` removed
 
 **Shipped (on `feature/129-phase-e-reload-on-self-write`; tests green).** The

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,35 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-08 — Fix: prevent titled-but-empty orphan chats (PR #265)
+
+**Problem:** a persisted chat could appear in Recent Chats with a title but be
+empty when opened — a `chats` row with zero `chat_messages`. Confirmed live:
+one `edit` chat with `created_at == updated_at` and 0 messages.
+
+**Root cause:** `WikiStoreModel.startChat` created the row eagerly at session
+start (title from the first message), but `chat_messages` were written lazily —
+only at turn boundaries / `finish()`, and the first `.userText` wasn't appended
+to `events[]` until the generation gate was acquired. A session that died before
+its first turn (preflight/spawn failure, immediate exit) left a titled-but-empty
+orphan.
+
+**Fix (`fix/orphan-chat-empty`):**
+- `startChat` now **seeds** the first user message as `chat_messages` seq 0 at
+  creation → a chat is never titled-but-empty even if the agent never responds.
+- `AgentLauncher` gains `firstMessagePrePersisted` (fresh-chat path) → marks the
+  seeded event already-flushed (`persistedEventCount` bumped past it) so the
+  first `flushTranscript()` doesn't double-insert it.
+- `AgentOperationRunner` **rolls back** the chat (`rollbackChatCreation`) on
+  preflight/spawn failure — deletes the row, reverts the retargeted tab to draft.
+- **Data:** deleted the orphan row from the live Malleable Software DB; WAL
+  checkpointed.
+- **Docs:** `AGENTS.md` gains a **Local data** section (App Group container path,
+  per-dev `appGroupID` resolution, `wikis.json` registry, TCC/FDA caveat).
+- **Tests:** `OrphanChatSeedingTests` (7); full suite 1940 green. Chat mutators
+  stay plain lock-guarded (not `mutate()`-emitting) — chats aren't File Provider
+  resources, so `StoreEmissionExhaustivenessTests` still holds.
+
 ## 2026-07-08 — #129 Phase E: model subscribes to ALL events; `origin` removed
 
 **Shipped (on `feature/129-phase-e-reload-on-self-write`; tests green).** The

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -185,6 +185,14 @@ final class AgentLauncher {
     /// `flushTranscript()` incremental — each call only sends events appended since
     /// the last flush — and idempotent when nothing new arrived since the last call.
     private var persistedEventCount = 0
+    /// One-shot: true when the first user message of this session was already
+    /// persisted at chat-creation time (by `WikiStoreModel.startChat`). The first
+    /// `sendInteractiveMessage` consumes it — after appending `.userText` to
+    /// `events` for live display, it bumps `persistedEventCount` past it so the
+    /// next `flushTranscript()` skips it (no duplicate `chat_messages` row).
+    /// Reset by `resetRunArtifacts()`. Only set on the fresh-chat path; the
+    /// continue path (D3) leaves it false (no seeding for an existing chat).
+    private var firstMessagePrePersisted = false
     /// Backstop poller that reconciles the UI if the process `terminationHandler`
     /// is ever missed (see `startCompletionWatchdog`). Cancelled on teardown.
     private var watchdogTask: Task<Void, Never>?
@@ -799,6 +807,7 @@ final class AgentLauncher {
         wikictlDirectory: String,
         allowWikiEdits: Bool = false,
         chatID: String? = nil,
+        firstMessagePrePersisted: Bool = false,
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
         onTurnBoundary: @escaping @MainActor (Bool) -> Void,
@@ -810,6 +819,9 @@ final class AgentLauncher {
 
         // Preflight (no gate held — early returns here don't need gate release).
         resetRunArtifacts()
+        // Consumed by the first `sendInteractiveMessage` to skip re-persisting
+        // the user message the model already seeded at chat creation.
+        self.firstMessagePrePersisted = firstMessagePrePersisted
 
         // Load agent command config fresh at spawn time.
         let dir = containerDirectory ?? (try? DatabaseLocation.appGroupContainerDirectory()) ?? FileManager.default.temporaryDirectory
@@ -1002,6 +1014,14 @@ final class AgentLauncher {
             // (preamble) is sent to the backend below.
             let visible = (displayText ?? trimmed).trimmingCharacters(in: .whitespacesAndNewlines)
             self.events.append(.userText(visible))
+            // The fresh-chat path seeds this first user message at chat-creation
+            // time (WikiStoreModel.startChat). Mark it flushed so the next
+            // flushTranscript() doesn't double-insert it — the row already exists
+            // at seq 0; it stays in `events` only for live transcript display.
+            if self.firstMessagePrePersisted {
+                self.persistedEventCount = self.events.count
+                self.firstMessagePrePersisted = false
+            }
             self.setGenerating(true)    // fires onTurnBoundary(true) → edit lock (Edit only)
             self.lastActivityAt = Date()
             // Send the turn and consume the per-turn stream. The backend writes
@@ -1310,6 +1330,7 @@ final class AgentLauncher {
         // session's events (issue #119).
         transcriptSink = nil
         persistedEventCount = 0
+        firstMessagePrePersisted = false
         // D2: a stale active chat association must never survive into a new run.
         // (startInteractiveQuery sets the fresh value right after this reset.)
         activeChatID = nil

--- a/Sources/WikiFS/AgentOperationRunner.swift
+++ b/Sources/WikiFS/AgentOperationRunner.swift
@@ -258,6 +258,9 @@ enum AgentOperationRunner {
             // activeChatID — ConversationView's source-of-truth switch. `nil`
             // when startChat failed (session runs unpersisted, no live tab).
             chatID: chat?.id.rawValue,
+            // The model seeded the first user message at chat creation; tell the
+            // launcher so it skips double-inserting it on the first flush.
+            firstMessagePrePersisted: chat != nil,
             onLock: { if allowWikiEdits { store.beginAgentRun() } },
             onUnlock: { if allowWikiEdits { store.endAgentRun() } },
             // Per-turn edit lock: release between turns (re-acquire on the next
@@ -272,6 +275,18 @@ enum AgentOperationRunner {
                 return { [weak store] events in store?.appendChatEvents(chatID: chat.id, events: events) }
             }
         )
+
+        // If the session never started — a preflight failure (e.g. the agent
+        // binary wasn't found) or a spawn failure — `startInteractiveQuery` sets
+        // `preflightError` synchronously before returning. The chat row the model
+        // just created (with its seeded first message) would otherwise linger in
+        // history as a dead conversation. Roll it back: drop the row and revert
+        // the tab to the draft composer. (A process that spawns OK then dies
+        // immediately isn't caught here, but seeding guarantees that chat still
+        // holds its first message — never titled-but-empty.)
+        if let chat, launcher.preflightError != nil {
+            store.rollbackChatCreation(id: chat.id, toDraft: allowWikiEdits ? .edit : .ask)
+        }
     }
 
     // MARK: - Continue a persisted conversation (D3, seeded-fallback)

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -33,6 +33,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// Current `withTransaction` nesting depth. 0 = no open transaction.
     /// Only ever touched while holding `lock`.
     private var transactionDepth = 0
+    /// Guards against double-close (`close()` then `deinit`). `sqlite3_close`
+    /// on an already-closed handle returns SQLITE_MISUSE; the flag keeps it clean.
+    private var closed = false
     /// `mutate()`'s OWN nesting depth — distinct from `transactionDepth`.
     /// `mutate()` flushes its buffered event to `eventBus` only when this returns
     /// to 0 (the outermost `mutate()` call), AFTER releasing the lock, so no
@@ -131,6 +134,22 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     deinit {
         // Finalize every cached statement before closing the connection,
         // otherwise sqlite3_close returns SQLITE_BUSY and leaks the handle.
+        guard !closed else { return }
+        closed = true
+        statements.removeAll()
+        sqlite3_close(db)
+    }
+
+    /// Explicitly close the database connection. After calling this, the store
+    /// must not be used further. `deinit` normally handles this, but ARC does not
+    /// guarantee deinit timing — callers that need a second raw connection on the
+    /// same file (e.g. tests inserting corrupt data) must call this to quiesce the
+    /// WAL before opening the new connection.
+    public func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !closed else { return }
+        closed = true
         statements.removeAll()
         sqlite3_close(db)
     }

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -2435,11 +2435,37 @@ public final class WikiStoreModel {
         do {
             let title = ChatSummary.title(fromFirstMessage: firstMessage)
             let chat = try store.createChat(kind: kind, title: title)
+            // Seed the first user message immediately (seq 0) so a chat is never
+            // titled-but-empty — even if the agent session dies before its first
+            // turn produces any events (the orphan-chat bug: a `chats` row with a
+            // title but zero `chat_messages`). The launcher is told the message is
+            // already persisted (firstMessagePrePersisted) so it marks the event as
+            // flushed and does NOT double-insert it on the first transcript flush.
+            try store.appendChatMessages(chatID: chat.id, events: [.userText(firstMessage)])
             reloadChats()
             return chat
         } catch {
             DebugLog.store("WikiStoreModel.startChat failed: \(error)")
             return nil
+        }
+    }
+
+    /// Roll back a chat created by `startChat` when its session never started
+    /// (preflight/spawn failure in `startQueryConversation`). Deletes the row
+    /// (and its seeded first message, via `ON DELETE CASCADE`) and reverts the
+    /// tab that was retargeted to it back to the draft composer — so the user
+    /// isn't left on a dead `.chat` selection. Best-effort: a store failure is
+    /// logged, never thrown.
+    public func rollbackChatCreation(id: PageID, toDraft draft: WikiSelection) {
+        do {
+            try store.deleteChat(id: id)
+        } catch {
+            DebugLog.store("WikiStoreModel.rollbackChatCreation failed: \(error)")
+        }
+        reloadChats()
+        // Revert the tab we retargeted to `.chat(id)` back to the draft composer.
+        if let tab = tabs.first(where: { $0.selection == .chat(id) }) {
+            retargetTab(id: tab.id, to: draft)
         }
     }
 

--- a/Tests/WikiFSTests/ChatStoreTests.swift
+++ b/Tests/WikiFSTests/ChatStoreTests.swift
@@ -179,34 +179,28 @@ import SQLite3
     @Test func chatMessagesSkipsRowWithCorruptEventJSON() throws {
         let url = tempDatabaseURL()
 
-        // Seed via the store in a scope, then let it CLOSE before the raw insert.
-        // The original opened a second raw connection while the store stayed open
-        // on the same WAL file; under CI load that raw INSERT intermittently
-        // returned SQLITE_ERROR (a second connection can fail to read the WAL
-        // sidecars / schema while the writer is active). Closing the store first
-        // checkpoints + quiesces the DB so the raw write runs against a clean
-        // file. (`SQLiteWikiStore.deinit` closes the connection.)
-        let chatID: PageID
-        do {
-            let store = try SQLiteWikiStore(databaseURL: url)
-            let chat = try store.createChat(kind: .ask, title: "Conversation")
-            let inserted = try store.appendChatMessages(chatID: chat.id, events: [
-                .userText("before"), .assistantText("after"),
-            ])
-            #expect(inserted.count == 2)
-            chatID = chat.id
-        }
+        // Seed via the store, then explicitly close the connection before the
+        // raw insert. Opening a second raw connection while the store's WAL-holding
+        // connection is still live intermittently returned SQLITE_ERROR under CI
+        // load (the raw INSERT can fail to acquire the write lock). Previous fixes
+        // (#223, #234) relied on the store leaving a `do { }` scope to trigger
+        // `deinit` — but ARC does not guarantee deinit timing, so the race
+        // recurred. `store.close()` closes the connection synchronously:
+        // `sqlite3_close` checkpoints + quiesces the WAL when it's the last open
+        // connection, so the raw write runs against a clean file.
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let chat = try store.createChat(kind: .ask, title: "Conversation")
+        let inserted = try store.appendChatMessages(chatID: chat.id, events: [
+            .userText("before"), .assistantText("after"),
+        ])
+        #expect(inserted.count == 2)
+        let chatID = chat.id
+        store.close()
 
         // Hand-insert a corrupt row between the two valid ones via a raw
         // connection on the now-quiescent DB (a future/garbled event_json a
         // WikiStore method would never write, but a bad row should never brick
         // the rest of history).
-        //
-        // The store from the `do` block above may not be finalized by ARC yet
-        // (Swift doesn't guarantee deinit timing), so the WAL might still be
-        // held by the store's connection. We open with an explicit busy timeout
-        // and disable FK enforcement — the corrupt row is deliberately not
-        // validated by the store's own write path.
         var raw: OpaquePointer?
         #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
         sqlite3_busy_timeout(raw, 5000)
@@ -220,8 +214,8 @@ import SQLite3
         sqlite3_close(raw)
 
         // Reopen and read: the corrupt row is skipped, the two valid ones survive.
-        let store = try SQLiteWikiStore(databaseURL: url)
-        let messages = try store.chatMessages(chatID: chatID)
+        let reader = try SQLiteWikiStore(databaseURL: url)
+        let messages = try reader.chatMessages(chatID: chatID)
         #expect(messages.count == 2)
         #expect(messages.map(\.event) == [.userText("before"), .assistantText("after")])
     }

--- a/Tests/WikiFSTests/OrphanChatSeedingTests.swift
+++ b/Tests/WikiFSTests/OrphanChatSeedingTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+
+/// Tests for the orphan-chat fix: a persisted chat must never be
+/// titled-but-empty (a `chats` row with a title but zero `chat_messages`).
+///
+/// Root cause being fixed: `WikiStoreModel.startChat` created the `chats` row
+/// eagerly at session start (title from the first message), but `chat_messages`
+/// were written lazily — only when `AgentLauncher.flushTranscript()` ran at a
+/// turn boundary or in `finish()`. If the agent session died before its first
+/// turn produced any events, the row was orphaned: a title with no messages.
+///
+/// Fix: `startChat` now seeds the first user message as `chat_messages` seq 0
+/// immediately, and `rollbackChatCreation` deletes a chat whose session never
+/// started (preflight/spawn failure). The launcher's
+/// `firstMessagePrePersisted` flag keeps the seeded row from being
+/// double-inserted on the first transcript flush (modeled here at the model
+/// level: a post-seed append continues from seq 1, not 0).
+@MainActor
+struct OrphanChatSeedingTests {
+
+    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-orphan-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        return (WikiStoreModel(store: store), store)
+    }
+
+    // MARK: - Seeding: a chat is never titled-but-empty
+
+    @Test func startChatSeedsFirstUserMessageImmediately() throws {
+        let (model, store) = try tempModel()
+
+        let chat = try #require(model.startChat(kind: .edit, firstMessage: "Set up the home page"))
+
+        // The title is still derived from the first message (unchanged behavior).
+        #expect(chat.title.contains("Set up the home page"))
+
+        // The chat is NOT titled-but-empty: the first user message is already
+        // persisted at seq 0, so opening it shows the user's prompt even if the
+        // agent never responds.
+        let messages = try store.chatMessages(chatID: chat.id)
+        #expect(messages.count == 1)
+        #expect(messages[0].seq == 0)
+        #expect(messages[0].event == .userText("Set up the home page"))
+    }
+
+    @Test func startChatUpdatesChatsListWithOneMessage() throws {
+        let (model, _) = try tempModel()
+
+        let chat = try #require(model.startChat(kind: .ask, firstMessage: "Hello"))
+
+        // reloadChats() ran inside startChat, so the model's list reflects the
+        // seeded message (count 1, not 0).
+        let listed = try #require(model.chats.first { $0.id == chat.id })
+        #expect(listed.messageCount == 1)
+    }
+
+    // MARK: - No duplicate: a post-seed flush continues from seq 1
+
+    @Test func appendAfterSeedContinuesFromSeq1WithoutDuplicatingUserMessage() throws {
+        let (model, store) = try tempModel()
+
+        let chat = try #require(model.startChat(kind: .ask, firstMessage: "first"))
+
+        // Simulate the launcher's first transcript flush AFTER it has marked the
+        // seeded user message as already-persisted (firstMessagePrePersisted →
+        // persistedEventCount bumped past it). The flush therefore sends only the
+        // agent's response tail — which must land at seq 1+, not duplicate the
+        // user message at seq 0.
+        model.appendChatEvents(chatID: chat.id, events: [
+            .assistantText("here is the answer"),
+            .result(isError: false, text: "done"),
+        ])
+
+        let messages = try store.chatMessages(chatID: chat.id)
+        #expect(messages.count == 3)
+        #expect(messages.map(\.seq) == [0, 1, 2])
+        // seq 0 is still the seeded user message; no duplicate.
+        #expect(messages[0].event == .userText("first"))
+        #expect(messages[1].event == .assistantText("here is the answer"))
+    }
+
+    @Test func seedingThenAppendingManyTurnsKeepsDenseUniqueSeq() throws {
+        let (model, store) = try tempModel()
+
+        let chat = try #require(model.startChat(kind: .edit, firstMessage: "q1"))
+
+        // Turn 1 response.
+        model.appendChatEvents(chatID: chat.id, events: [.assistantText("a1")])
+        // Turn 2: user + response (the continue path appends the user message,
+        // since seeding only happens at creation, not on continue).
+        model.appendChatEvents(chatID: chat.id, events: [.userText("q2"), .assistantText("a2")])
+
+        let messages = try store.chatMessages(chatID: chat.id)
+        // Dense, gap-free, unique seqs — the UNIQUE(chat_id, seq) index holds.
+        #expect(messages.map(\.seq) == [0, 1, 2, 3])
+        #expect(messages.map(\.event) == [
+            .userText("q1"), .assistantText("a1"),
+            .userText("q2"), .assistantText("a2"),
+        ])
+    }
+
+    // MARK: - Rollback: a session that never started leaves no trace
+
+    @Test func rollbackChatCreationDeletesRowAndSeededMessage() throws {
+        let (model, store) = try tempModel()
+
+        let chat = try #require(model.startChat(kind: .edit, firstMessage: "doomed"))
+        #expect(try store.chatMessages(chatID: chat.id).count == 1)
+        #expect(model.chats.contains { $0.id == chat.id })
+
+        // The session never started (preflight/spawn failure) → roll back.
+        model.rollbackChatCreation(id: chat.id, toDraft: .edit)
+
+        // Row + cascaded message both gone; the model's chat list no longer
+        // contains the orphan.
+        #expect(try store.chatMessages(chatID: chat.id).isEmpty)
+        #expect(try store.listChats().isEmpty)
+        #expect(model.chats.isEmpty)
+    }
+
+    @Test func rollbackRevertsRetargetedTabToDraftComposer() throws {
+        let (model, _) = try tempModel()
+
+        model.openTab(.edit)
+        let activeID = try #require(model.activeTabID)
+
+        let chat = try #require(model.startChat(kind: .edit, firstMessage: "doomed"))
+        model.retargetActiveTabToChat(chatID: chat.id)
+        // The draft-state morph retargeted the tab to .chat(id).
+        let retargeted = try #require(model.tabs.first { $0.id == activeID })
+        #expect(retargeted.selection == .chat(chat.id))
+
+        model.rollbackChatCreation(id: chat.id, toDraft: .edit)
+
+        // The tab is reverted to the draft composer, not left on a dead .chat.
+        let reverted = try #require(model.tabs.first { $0.id == activeID })
+        #expect(reverted.selection == .edit)
+    }
+
+    @Test func rollbackIsHarmlessWhenChatAlreadyAbsent() throws {
+        let (model, store) = try tempModel()
+        // No chat created — rolling back a never-created id must not throw and
+        // must leave the store untouched.
+        let phantom = PageID(rawValue: "01PHANTOMCHAT0000000000Z")
+        model.rollbackChatCreation(id: phantom, toDraft: .ask)
+        #expect(try store.listChats().isEmpty)
+        #expect(model.chats.isEmpty)
+    }
+}


### PR DESCRIPTION
## Problem

A persisted chat could appear in **Recent Chats** with a title but be empty when opened — a `chats` row with zero `chat_messages`. Confirmed in the live Malleable Software DB: one chat (`01KX17ZY7H2M…`, kind `edit`, title "Please set up the home page with an overview and organizati…") with `created_at == updated_at` and **0** messages.

## Root cause

- `WikiStoreModel.startChat` created the `chats` row **eagerly** at session start, titled from the first user message — *before the agent did anything*.
- But `chat_messages` were written **lazily** — only when `AgentLauncher.flushTranscript()` ran at a turn boundary (`.messageStop`/`.result`) or in `finish()`.
- The first `.userText` wasn't even appended to `events[]` until **after** the generation gate was acquired (`sendInteractiveMessage`).

So a session that died before its first turn started (preflight failure / spawn failure / immediate process exit) left a **titled-but-empty orphan**: `onExit` → `finish()` flushed an empty `events[]`, the queued turn task bailed on the `isInteractiveSession` guard, and the already-created row survived with a title but no messages.

The mismatch: **row creation is eager and unconditional; message persistence is gated on the turn actually running.**

## Fix

1. **Seed the first user message at creation.** `startChat` now persists the first message as `chat_messages` seq 0 immediately, so a chat is never titled-but-empty even if the agent never responds.
2. **No double-insert.** `AgentLauncher` gains a `firstMessagePrePersisted` flag (fresh-chat path only); on the first turn it marks the seeded event as already-flushed (`persistedEventCount` bumped past it), so the next `flushTranscript()` skips it. The message stays in `events[]` for live transcript display.
3. **Rollback on confirmed failure.** `AgentOperationRunner` calls `rollbackChatCreation` when `startInteractiveQuery` reports a preflight/spawn failure (`preflightError` set) — deleting the row and reverting the retargeted tab to the draft composer. A process that spawns OK then dies immediately isn't caught here, but seeding guarantees that chat still holds its first message (never empty).

## Data cleanup

Deleted the orphan row `01KX17ZY7H2M…` from the live Malleable Software DB (`01KX1367BPBE2161MMGMPGWQAD.sqlite`); it had 0 messages so cascade was a no-op. WAL checkpointed.

## Docs

`AGENTS.md` gains a **Local data** section documenting how to locate the per-wiki SQLite DBs: the App Group container path, per-developer `appGroupID` resolution (`WikiIdentifiers`), the `wikis.json` registry, and the **TCC / Full-Disk-Access caveat** (a plain shell gets "Operation not permitted" on the container).

## Tests

New `OrphanChatSeedingTests` (7): seeding at creation, no-duplicate seq continuation, multi-turn dense/unique seq, rollback (data + tab revert), and harmless-when-absent. Full suite **1940 green** (incl. `StoreEmissionExhaustivenessTests` — chat mutators are plain lock-guarded, not `mutate()`-emitting, since chats aren't File Provider resources).
