### PR TITLE
#253: Blob GC — sweep orphaned blobs (wikictl admin vacuum-blobs)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,45 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-08 — #253: Blob GC — sweep orphaned blobs
+
+**Shipped (on `feature/253-blob-gc`; 1972 tests green).** Lazy reclamation of
+orphaned `blobs` rows — blobs no version references. Deleting a source cascades
+its `source_versions`/`source_markdown_versions` rows but leaves the blobs they
+pointed at behind; `wikictl admin vacuum-blobs` now sweeps them.
+
+**Open question resolved (§13 Q1):** **lazy-only.** No opportunistic sweep in
+`deleteSource` (matches the plan's "nothing depends on eager GC"). The CLI
+default is a safe **dry run**; `--apply` deletes. Nothing depends on eager GC.
+
+**What shipped:**
+- **`SQLiteWikiStore.vacuumBlobs(dryRun:)`** (+ `BlobVacuumReport`) — one
+  reachability predicate (a blob is orphaned when no
+  `source_versions.blob_hash` / `source_versions.thumbnail_hash` /
+  `source_markdown_versions.blob_hash` cites it; each subquery filters NULLs so
+  SQLite's three-valued `NOT IN` never suppresses a live orphan). Count SELECT +
+  DELETE share the predicate in ONE `withTransaction`, so the report always
+  matches what's reclaimed. **NO_EMIT** (added to `StoreEmissionExhaustivenessTests`'
+  `noEmit`: vacuuming orphans changes no projected `ResourceKind` — blobs fold
+  into the changeToken only via their version rows).
+- **`AdminCommand.swift`** (new, `WikiCtlCore`) — the `admin …` family. First
+  subcommand `vacuum-blobs`; `didCommit` true only when `--apply` actually
+  deleted (a dry run never wakes the change bridge). Text + JSON output.
+- **`ArgumentParser.swift`** — `Command.admin` case + `parseAdminCommand`;
+  `Options` generalized from a hardcoded `--json` valueless flag to a
+  `booleanFlags` set so `--apply` works; `usageText` gains the `admin` line.
+- **`main.swift`** — `execute()` dispatches `.admin`.
+- **Tests (11 new, in `WikiCtlCommandTests`):** parser (default dry-run,
+  `--apply`, `--json`, missing/unknown subcommand); store GC via the realistic
+  add→delete→vacuum flow (orphan reported, dry-run no-op, `--apply` reclaims the
+  orphan while preserving a referenced blob, idempotent re-run, no-op when
+  everything referenced); `AdminCommand.run` dispatch (dry-run doesn't commit,
+  apply commits, JSON payload parses + matches the report).
+
+**Gate:** `swift test` exit 0 — 1972 tests in 160 suites (was 1914 → +11 here,
+rest from other in-flight work). Resolves §13 Q1; `plans/graph-model-and-versioning.md`
+§4.1/§13 marked shipped.
+
 ## 2026-07-08 — #263: Separate source origin from materialized format
 
 **Shipped (code-only refactor; 1974 tests green).** Extracted the format-dispatch

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -30,16 +30,24 @@ default is a safe **dry run**; `--apply` deletes. Nothing depends on eager GC.
   `Options` generalized from a hardcoded `--json` valueless flag to a
   `booleanFlags` set so `--apply` works; `usageText` gains the `admin` line.
 - **`main.swift`** — `execute()` dispatches `.admin`.
-- **Tests (11 new, in `WikiCtlCommandTests`):** parser (default dry-run,
-  `--apply`, `--json`, missing/unknown subcommand); store GC via the realistic
-  add→delete→vacuum flow (orphan reported, dry-run no-op, `--apply` reclaims the
-  orphan while preserving a referenced blob, idempotent re-run, no-op when
-  everything referenced); `AdminCommand.run` dispatch (dry-run doesn't commit,
-  apply commits, JSON payload parses + matches the report).
+- **Tests (13 new):** parser (default dry-run, `--apply`, `--json`,
+  missing/unknown subcommand); store GC via the realistic add→delete→vacuum flow
+  (orphan reported, dry-run no-op, `--apply` reclaims the orphan while preserving
+  a referenced blob, idempotent re-run, no-op when everything referenced);
+  `AdminCommand.run` dispatch (dry-run doesn't commit, apply commits, JSON parses
+  + matches the report); `WikiManager` preview/apply state flow (2 in
+  `WikiManagerTests`).
 
-**Gate:** `swift test` exit 0 — 1972 tests in 160 suites (was 1914 → +11 here,
-rest from other in-flight work). Resolves §13 Q1; `plans/graph-model-and-versioning.md`
-§4.1/§13 marked shipped.
+**Also surfaced in the app UI** (Help menu → "Vacuum Orphaned Storage…"): a
+read-only dry-run preview drives a confirm `.alert` (Cancel + destructive
+Vacuum; `ByteCountFormatter` for the byte count; "no orphans" empty state).
+`BlobVacuumReport` + `vacuumBlobs(dryRun:)` were promoted to the `WikiStore`
+protocol (the `@MainActor` model only ever calls protocol methods — no downcast);
+`WikiStoreModel.performBlobVacuum` + `WikiManager.previewBlobVacuum`/
+`applyBlobVacuum` wire the menu to the active wiki's store.
+
+**Gate:** `swift test` exit 0 — 1974 tests in 160 suites. Resolves §13 Q1;
+`plans/graph-model-and-versioning.md` §4.1/§13 marked shipped.
 
 ## 2026-07-08 — #263: Separate source origin from materialized format
 

--- a/Sources/WikiCtlCore/AdminCommand.swift
+++ b/Sources/WikiCtlCore/AdminCommand.swift
@@ -1,0 +1,44 @@
+import Foundation
+import WikiFSCore
+
+/// The `wikictl admin …` subcommand family — maintenance operations that don't
+/// fit the read/write page/source/log verbs. Split from process concerns (arg
+/// parsing, opening the DB, the Darwin post) so the command surface is
+/// unit-testable against a temp DB, exactly like `PageCommand` /
+/// `LogIndexCommand`.
+public enum AdminCommand {
+
+    public enum Action: Equatable {
+        /// Sweep orphaned blobs (graph-model §13 / issue #253). `dryRun == true`
+        /// (the CLI default) reports reclaimable storage WITHOUT deleting;
+        /// `dryRun == false` (`--apply`) deletes them. `json` selects
+        /// machine-readable output.
+        case vacuumBlobs(dryRun: Bool, json: Bool)
+    }
+
+    /// Run one action against `store`. Returns a `SourceCommand.Result` so it
+    /// threads through `wikictl`'s shared `execute()` dispatch: a `.text`
+    /// summary, with `didCommit` true ONLY when a vacuum actually deleted rows
+    /// (a dry run commits nothing, so it never wakes the app's change bridge —
+    /// and since blob GC changes no projected `ResourceKind`, an applied vacuum
+    /// has nothing for the model to refresh either).
+    public static func run(_ action: Action, in store: SQLiteWikiStore) throws -> SourceCommand.Result {
+        switch action {
+        case .vacuumBlobs(let dryRun, let json):
+            let report = try store.vacuumBlobs(dryRun: dryRun)
+            return SourceCommand.Result(
+                payload: .text(Self.format(report, json: json)), didCommit: report.applied)
+        }
+    }
+
+    private static func format(_ report: SQLiteWikiStore.BlobVacuumReport, json: Bool) -> String {
+        if json {
+            return """
+            {"orphanCount":\(report.orphanCount),"bytesReclaimed":\(report.bytesReclaimed),"applied":\(report.applied)}
+            """
+        }
+        let verb = report.applied ? "reclaimed" : "reclaimable"
+        let hint = report.applied ? "" : " (dry-run; pass --apply to delete)"
+        return "\(report.orphanCount) orphan blob(s), \(report.bytesReclaimed) byte(s) \(verb)\(hint)"
+    }
+}

--- a/Sources/WikiCtlCore/AdminCommand.swift
+++ b/Sources/WikiCtlCore/AdminCommand.swift
@@ -31,7 +31,7 @@ public enum AdminCommand {
         }
     }
 
-    private static func format(_ report: SQLiteWikiStore.BlobVacuumReport, json: Bool) -> String {
+    private static func format(_ report: BlobVacuumReport, json: Bool) -> String {
         if json {
             return """
             {"orphanCount":\(report.orphanCount),"bytesReclaimed":\(report.bytesReclaimed),"applied":\(report.applied)}

--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -61,6 +61,8 @@ public enum ArgumentParser {
         case sourceSetActive(SourceCommand.Selector, versionID: PageID)
         /// Re-fetch a source via its provider, appending a new version (Phase 3b).
         case sourceRefresh(SourceCommand.Selector)
+        /// Maintenance operations (the `admin …` family). Currently: blob GC.
+        case admin(AdminCommand.Action)
     }
 
     public enum Failure: Error, Equatable, CustomStringConvertible {
@@ -103,6 +105,8 @@ public enum ArgumentParser {
                                               as the active HEAD (extraction alt)
       source refresh (--id X | --name N)      re-fetch a website source via its
                                                provider, appending a new version
+      admin vacuum-blobs [--apply] [--json]   report (and with --apply, reclaim)
+                                               blobs no version row references
     """
 
     /// Parse `arguments` (WITHOUT the executable name) plus an env lookup into an
@@ -139,6 +143,8 @@ public enum ArgumentParser {
             command = try parseSearchCommand(Array(args.dropFirst()))
         case "source":
             command = try parseSourceCommand(Array(args.dropFirst()))
+        case "admin":
+            command = try parseAdminCommand(Array(args.dropFirst()))
         default:
             throw Failure.usage("unknown command \((args.first ?? "").debugDescription)")
         }
@@ -293,6 +299,21 @@ public enum ArgumentParser {
         }
     }
 
+    private static func parseAdminCommand(_ args: [String]) throws -> Command {
+        guard let sub = args.first else { throw Failure.usage("admin: missing subcommand") }
+        let rest = Array(args.dropFirst())
+        switch sub {
+        case "vacuum-blobs":
+            // `--apply` opts INTO deletion; the default is a safe dry run.
+            // `--json` selects machine-readable output.
+            let options = try Options(rest, booleanFlags: ["--apply", "--json"])
+            return .admin(.vacuumBlobs(
+                dryRun: !options.flag("--apply"), json: options.flag("--json")))
+        default:
+            throw Failure.usage("admin: unknown subcommand \(sub.debugDescription)")
+        }
+    }
+
     private static func parseIndexCommand(_ args: [String]) throws -> Command {
         guard let sub = args.first else { throw Failure.usage("index: missing subcommand") }
         guard sub == "set" else {
@@ -311,15 +332,16 @@ public enum ArgumentParser {
         private var values: [String: String] = [:]
         private var flags: Set<String> = []
 
-        init(_ tokens: [String]) throws {
+        init(_ tokens: [String], booleanFlags: Set<String> = ["--json"]) throws {
             var index = 0
             while index < tokens.count {
                 let token = tokens[index]
                 guard token.hasPrefix("--") else {
                     throw Failure.usage("unexpected argument \(token.debugDescription)")
                 }
-                // `--json` is the only valueless flag; everything else takes a value.
-                if token == "--json" {
+                // A valueless boolean flag (e.g. `--json`, `--apply`); everything
+                // else takes a value.
+                if booleanFlags.contains(token) {
                     flags.insert(token)
                     index += 1
                     continue

--- a/Sources/WikiFS/BlobVacuumCommands.swift
+++ b/Sources/WikiFS/BlobVacuumCommands.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import WikiFSCore
+
+/// Help-menu command for reclaiming orphaned blob storage (#253). Opens a
+/// confirm alert (a read-only dry-run preview → Vacuum / Cancel); the wiring
+/// lives in `WikiManager.previewBlobVacuum` / `applyBlobVacuum` and the alert is
+/// hosted on the app's root scene. Menu items that open a dialog end with "…"
+/// (macOS convention).
+struct BlobVacuumCommands: Commands {
+    let manager: WikiManager
+
+    var body: some Commands {
+        CommandGroup(after: .help) {
+            Button("Vacuum Orphaned Storage…") {
+                manager.previewBlobVacuum()
+            }
+        }
+    }
+}

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -124,6 +124,29 @@ struct WikiFSApp: App {
                 } message: { warning in
                     Text(warning.message)
                 }
+                .alert(
+                    "Vacuum Orphaned Storage",
+                    isPresented: Binding(
+                        get: { manager.pendingBlobVacuum != nil },
+                        set: { if !$0 { manager.pendingBlobVacuum = nil } }
+                    ),
+                    presenting: manager.pendingBlobVacuum
+                ) { report in
+                    if report.orphanCount == 0 {
+                        Button("OK", role: .cancel) {}
+                    } else {
+                        Button("Cancel", role: .cancel) {}
+                        Button("Vacuum", role: .destructive) { manager.applyBlobVacuum() }
+                    }
+                } message: { report in
+                    if report.orphanCount == 0 {
+                        Text("No orphaned blobs found — nothing to reclaim.")
+                    } else {
+                        let bytes = ByteCountFormatter.string(
+                            fromByteCount: Int64(report.bytesReclaimed), countStyle: .file)
+                        Text("\(report.orphanCount) orphan blob\(report.orphanCount == 1 ? "" : "s"), \(bytes) reclaimable. This removes blobs no source references and cannot be undone.")
+                    }
+                }
                 .task {
                     fileProvider.wire(into: manager)
                     // First render already loaded the wiki list (reloadData, no
@@ -151,6 +174,7 @@ struct WikiFSApp: App {
         .windowToolbarStyle(.unified)
         .commands {
             ClaudePromptHelpCommands()
+            BlobVacuumCommands(manager: manager)
         }
         .onChange(of: scenePhase) { _, phase in
             if phase != .active { manager.activeStore?.flushPendingSaves() }

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -3318,21 +3318,6 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         AND hash NOT IN (SELECT blob_hash      FROM source_markdown_versions WHERE blob_hash IS NOT NULL)
     """
 
-    /// `vacuumBlobs(dryRun:)` result. `bytesReclaimed` is the SUM of orphan
-    /// `byte_size`; on a dry run it is the bytes that *would* be reclaimed.
-    public struct BlobVacuumReport: Equatable, Sendable {
-        public let orphanCount: Int
-        public let bytesReclaimed: Int
-        /// `true` only when the call actually deleted rows (dry run = false).
-        public let applied: Bool
-
-        public init(orphanCount: Int, bytesReclaimed: Int, applied: Bool) {
-            self.orphanCount = orphanCount
-            self.bytesReclaimed = bytesReclaimed
-            self.applied = applied
-        }
-    }
-
     /// Sweep **orphaned** blob rows — blobs no version references. Deleting a
     /// source cascades its `source_versions`/`source_markdown_versions` rows but
     /// leaves their blobs behind; this is the lazy reclamation for that leak.

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -3303,6 +3303,67 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    // MARK: - Blob GC (graph-model §13 / issue #253)
+
+    /// A blob is orphaned when no version row references its hash. The three
+    /// reachability edges into `blobs` are `source_versions.blob_hash`,
+    /// `source_versions.thumbnail_hash`, and `source_markdown_versions.blob_hash`
+    /// (chunks/embeddings/attachments store bytes inline, so they don't count).
+    /// Each subquery filters out NULLs: without that, SQLite's three-valued
+    /// `NOT IN (…, NULL, …)` logic would suppress live orphans. Shared by the
+    /// count SELECT and the DELETE so the report always matches what's reclaimed.
+    private static let orphanBlobPredicate = """
+        hash NOT IN (SELECT blob_hash        FROM source_versions            WHERE blob_hash IS NOT NULL)
+        AND hash NOT IN (SELECT thumbnail_hash FROM source_versions          WHERE thumbnail_hash IS NOT NULL)
+        AND hash NOT IN (SELECT blob_hash      FROM source_markdown_versions WHERE blob_hash IS NOT NULL)
+    """
+
+    /// `vacuumBlobs(dryRun:)` result. `bytesReclaimed` is the SUM of orphan
+    /// `byte_size`; on a dry run it is the bytes that *would* be reclaimed.
+    public struct BlobVacuumReport: Equatable, Sendable {
+        public let orphanCount: Int
+        public let bytesReclaimed: Int
+        /// `true` only when the call actually deleted rows (dry run = false).
+        public let applied: Bool
+
+        public init(orphanCount: Int, bytesReclaimed: Int, applied: Bool) {
+            self.orphanCount = orphanCount
+            self.bytesReclaimed = bytesReclaimed
+            self.applied = applied
+        }
+    }
+
+    /// Sweep **orphaned** blob rows — blobs no version references. Deleting a
+    /// source cascades its `source_versions`/`source_markdown_versions` rows but
+    /// leaves their blobs behind; this is the lazy reclamation for that leak.
+    /// `dryRun == true` (the `wikictl admin vacuum-blobs` default) reports the
+    /// orphan count + reclaimable bytes WITHOUT deleting; `dryRun == false`
+    /// (`--apply`) deletes them. Count + delete run in ONE transaction, so the
+    /// report is always exactly what was (or would be) reclaimed.
+    ///
+    /// **NO_EMIT** (see `StoreEmissionExhaustivenessTests`): vacuuming orphans
+    /// changes no projected `ResourceKind` — blobs fold into the changeToken only
+    /// through their referencing version rows, so the served tree and token are
+    /// unaffected. It does NOT route through `mutate()` and emits no event.
+    @discardableResult
+    public func vacuumBlobs(dryRun: Bool) throws -> BlobVacuumReport {
+        try withTransaction {
+            let counter = try statement(
+                "SELECT COUNT(*), COALESCE(SUM(byte_size), 0) FROM blobs WHERE \(Self.orphanBlobPredicate);")
+            defer { counter.reset() }
+            _ = try counter.step()   // COUNT always yields exactly one row.
+            let orphanCount = Int(counter.int(at: 0))
+            let bytes = Int(counter.int(at: 1))
+
+            if !dryRun {
+                let deleter = try statement("DELETE FROM blobs WHERE \(Self.orphanBlobPredicate);")
+                defer { deleter.reset() }
+                _ = try deleter.step()
+            }
+            return BlobVacuumReport(orphanCount: orphanCount, bytesReclaimed: bytes, applied: !dryRun)
+        }
+    }
+
     // MARK: - Graph-model Phase 1: content versioning primitives
 
     /// Append a new content version for a source (the store-level refresh/

--- a/Sources/WikiFSCore/WikiManager.swift
+++ b/Sources/WikiFSCore/WikiManager.swift
@@ -28,6 +28,12 @@ public final class WikiManager {
     /// no per-wiki filtering is needed anywhere downstream.
     public private(set) var activeStore: WikiStoreModel?
 
+    /// Non-nil while the "Vacuum Orphaned Storage…" confirm alert is on screen
+    /// (Help menu → `previewBlobVacuum()`). Carries the dry-run report shown in
+    /// the alert; cleared on Cancel / Vacuum. Lives on the manager (not the
+    /// model) so the app-scene alert has a stable observable across wiki switches.
+    public var pendingBlobVacuum: BlobVacuumReport?
+
     /// The App Group container directory holding every `<ulid>.sqlite` and the
     /// `wikis.json` registry. Injected so tests can use a temp dir.
     private let containerDirectory: URL
@@ -120,6 +126,23 @@ public final class WikiManager {
         if let first = registry.mostRecentlyUsed {
             openActive(first.id)
         }
+    }
+
+    // MARK: - Blob GC (#253)
+
+    /// Preview orphaned blob storage for the active wiki (Help menu). Runs a
+    /// read-only dry run, then sets `pendingBlobVacuum` so the app-scene confirm
+    /// alert appears. No-op when no wiki is active.
+    public func previewBlobVacuum() {
+        guard let model = activeStore else { return }
+        pendingBlobVacuum = model.performBlobVacuum(dryRun: true)
+    }
+
+    /// Delete the orphaned blobs (the alert's Vacuum button), then clear the
+    /// pending report. Runs against whichever store is active at click time.
+    public func applyBlobVacuum() {
+        _ = activeStore?.performBlobVacuum(dryRun: false)
+        pendingBlobVacuum = nil
     }
 
     /// Register one File Provider domain per wiki (generalizes the single-domain

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -30,6 +30,21 @@ extension WikiStoreError: LocalizedError {
     public var errorDescription: String? { description }
 }
 
+/// Result of a blob-GC sweep (`WikiStore.vacuumBlobs`). `bytesReclaimed` is the
+/// SUM of orphan `byte_size`; on a dry run it is the bytes that *would* be
+/// reclaimed. `applied` is `true` only when the call actually deleted rows.
+public struct BlobVacuumReport: Equatable, Sendable {
+    public let orphanCount: Int
+    public let bytesReclaimed: Int
+    public let applied: Bool
+
+    public init(orphanCount: Int, bytesReclaimed: Int, applied: Bool) {
+        self.orphanCount = orphanCount
+        self.bytesReclaimed = bytesReclaimed
+        self.applied = applied
+    }
+}
+
 /// Read/write storage interface for wiki pages (INITIAL.md §3). The SQLite
 /// implementation is the source of truth; the Phase 2 File Provider extension
 /// will adopt a read-only subset (`WikiReadStore`) of this.
@@ -398,6 +413,17 @@ public protocol WikiStore: Sendable {
     /// Delete a chat. `ON DELETE CASCADE` removes its messages. No error if
     /// `id` doesn't exist.
     func deleteChat(id: PageID) throws
+
+    // MARK: - Blob GC (#253)
+
+    /// Sweep **orphaned** blob rows — blobs no version references (the leak left
+    /// by `deleteSource`, which cascades version rows but not their blobs).
+    /// `dryRun == true` reports the orphan count + reclaimable bytes WITHOUT
+    /// deleting; `false` deletes them in one transaction, so the returned report
+    /// matches exactly what was reclaimed. Classified NO_EMIT on the concrete
+    /// store: vacuuming orphans changes no projected `ResourceKind`.
+    @discardableResult
+    func vacuumBlobs(dryRun: Bool) throws -> BlobVacuumReport
 }
 
 // MARK: - addSource default-argument convenience

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1176,6 +1176,17 @@ public final class WikiStoreModel {
         flushPendingSystemPromptSave()
     }
 
+    // MARK: - Blob GC (#253)
+
+    /// Run a blob-GC pass against the underlying store. `dryRun` true previews
+    /// (read-only count + bytes); false deletes the orphans in one transaction.
+    /// Routes through the @MainActor model per the SQLite write discipline.
+    /// Returns nil only if the store call throws.
+    @discardableResult
+    public func performBlobVacuum(dryRun: Bool) -> BlobVacuumReport? {
+        try? store.vacuumBlobs(dryRun: dryRun)
+    }
+
     // MARK: - Agent run lock (Phase C, decision #6)
 
     /// The SINGLE mutation point for `isAgentRunning`. Every public entry point

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -132,6 +132,8 @@ func execute(_ command: ArgumentParser.Command, in store: SQLiteWikiStore) throw
         semaphore.wait()
         if let error = box.error { throw error }
         return box.result ?? SourceCommand.Result(payload: .text(""), didCommit: false)
+    case .admin(let action):
+        return try AdminCommand.run(action, in: store)
     }
 }
 

--- a/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
@@ -81,6 +81,10 @@ struct StoreEmissionExhaustivenessTests {
         // already emits). Derived embeddings / search index (not in the change
         // token, no projected content change).
         "ensureFetchActivity", "storePageChunks", "storeSourceChunks", "rebuildFTS",
+        // Blob GC (#253): vacuuming orphaned blobs changes no projected
+        // ResourceKind (blobs fold into the changeToken only via their version
+        // rows), so no event is emitted.
+        "vacuumBlobs",
     ]
 
     /// Every EMIT member must route through `mutate()` (AC.2). A newly added

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -807,4 +807,146 @@ struct WikiCtlCommandTests {
                 .name("Nonexistent"), in: store, fetcher: fetcher)
         }
     }
+
+    // MARK: - admin vacuum-blobs parsing (issue #253)
+
+    @Test func adminVacuumBlobsDefaultsToDryRunNoJSON() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "admin", "vacuum-blobs"], env: noEnv)
+        #expect(invocation.command == .admin(.vacuumBlobs(dryRun: true, json: false)))
+    }
+
+    @Test func adminVacuumBlobsApplyOptsIntoDelete() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "admin", "vacuum-blobs", "--apply"], env: noEnv)
+        #expect(invocation.command == .admin(.vacuumBlobs(dryRun: false, json: false)))
+    }
+
+    @Test func adminVacuumBlobsJSONFlag() throws {
+        let dry = try ArgumentParser.parse(
+            ["--wiki", "W", "admin", "vacuum-blobs", "--json"], env: noEnv)
+        #expect(dry.command == .admin(.vacuumBlobs(dryRun: true, json: true)))
+
+        let applied = try ArgumentParser.parse(
+            ["--wiki", "W", "admin", "vacuum-blobs", "--apply", "--json"], env: noEnv)
+        #expect(applied.command == .admin(.vacuumBlobs(dryRun: false, json: true)))
+    }
+
+    @Test func adminRequiresSubcommand() {
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(["--wiki", "W", "admin"], env: noEnv)
+        }
+    }
+
+    @Test func adminRejectsUnknownSubcommand() {
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(["--wiki", "W", "admin", "frobnicate"], env: noEnv)
+        }
+    }
+
+    // MARK: - blob GC (store vacuumBlobs, issue #253)
+
+    /// `vacuumBlobs` reaches an orphan the realistic way: a source's bytes live in
+    /// a blob reached through its v1 version; deleting the source cascades the
+    /// version row but leaves the blob behind — exactly the leak the GC reclaims.
+    /// No private table access needed: the report's own counts prove deletion, and
+    /// `sourceContent` proves a referenced blob survives.
+    @Test func vacuumDryRunReportsOrphanFromDeletedSource() throws {
+        let store = try tempStore()
+        let a = try store.addSource(filename: "a.bin", data: Data([0x41, 0x42, 0x43, 0x44, 0x45])) // 5 B
+        _ = try store.addSource(filename: "b.bin", data: Data([0x01, 0x02, 0x03]))                // 3 B
+
+        // Nothing orphaned while both sources exist.
+        #expect(try store.vacuumBlobs(dryRun: true) == .init(orphanCount: 0, bytesReclaimed: 0, applied: false))
+
+        try store.deleteSource(id: a.id)
+
+        // Dry run reports the orphan (5 B) but does NOT delete it.
+        let report1 = try store.vacuumBlobs(dryRun: true)
+        #expect(report1 == .init(orphanCount: 1, bytesReclaimed: 5, applied: false))
+        // Re-running the dry run still sees the same orphan → nothing was deleted.
+        let report2 = try store.vacuumBlobs(dryRun: true)
+        #expect(report2.orphanCount == 1)
+    }
+
+    @Test func vacuumApplyReclaimsOrphanAndPreservesReferencedBlob() throws {
+        let store = try tempStore()
+        let a = try store.addSource(filename: "a.bin", data: Data([0x41, 0x42, 0x43, 0x44, 0x45])) // 5 B
+        let b = try store.addSource(filename: "b.bin", data: Data([0x01, 0x02, 0x03]))            // 3 B
+        try store.deleteSource(id: a.id)
+
+        let applied = try store.vacuumBlobs(dryRun: false)
+        #expect(applied == .init(orphanCount: 1, bytesReclaimed: 5, applied: true))
+
+        // The still-referenced blob survives and reads back intact.
+        #expect(try store.sourceContent(id: b.id) == Data([0x01, 0x02, 0x03]))
+
+        // The orphan is gone; a follow-up sweep is a no-op (idempotent).
+        #expect(try store.vacuumBlobs(dryRun: false).orphanCount == 0)
+        #expect(try store.vacuumBlobs(dryRun: true).orphanCount == 0)
+    }
+
+    @Test func vacuumIsNoOpWhenEverythingIsReferenced() throws {
+        let store = try tempStore()
+        let a = try store.addSource(filename: "a.bin", data: Data("hello".utf8))
+        let b = try store.addSource(filename: "b.bin", data: Data("world!".utf8))
+
+        let applied = try store.vacuumBlobs(dryRun: false)
+        #expect(applied.orphanCount == 0)
+        #expect(applied.bytesReclaimed == 0)
+        // Both sources still fully readable.
+        #expect(try store.sourceContent(id: a.id) == Data("hello".utf8))
+        #expect(try store.sourceContent(id: b.id) == Data("world!".utf8))
+    }
+
+    // MARK: - admin vacuum-blobs dispatch (issue #253)
+
+    @Test func adminVacuumBlobsDryRunDoesNotCommit() throws {
+        let store = try tempStore()
+        let a = try store.addSource(filename: "a.bin", data: Data([0x41, 0x42, 0x43, 0x44, 0x45]))
+        try store.deleteSource(id: a.id)
+
+        let result = try AdminCommand.run(.vacuumBlobs(dryRun: true, json: false), in: store)
+        #expect(!result.didCommit)
+        guard case .text(let text) = result.payload else {
+            Issue.record("expected text payload"); return
+        }
+        #expect(text.contains("1 orphan blob"))
+        #expect(text.contains("reclaimable"))
+        #expect(text.contains("dry-run"))
+        // Dry run left the orphan in place.
+        #expect(try store.vacuumBlobs(dryRun: true).orphanCount == 1)
+    }
+
+    @Test func adminVacuumBlobsApplyCommits() throws {
+        let store = try tempStore()
+        let a = try store.addSource(filename: "a.bin", data: Data([0x41, 0x42, 0x43, 0x44, 0x45]))
+        try store.deleteSource(id: a.id)
+
+        let result = try AdminCommand.run(.vacuumBlobs(dryRun: false, json: false), in: store)
+        #expect(result.didCommit)
+        guard case .text(let text) = result.payload else {
+            Issue.record("expected text payload"); return
+        }
+        #expect(text.contains("reclaimed"))
+        #expect(!text.contains("dry-run"))
+        // The apply actually deleted the orphan.
+        #expect(try store.vacuumBlobs(dryRun: true).orphanCount == 0)
+    }
+
+    @Test func adminVacuumBlobsJSONPayloadMatchesReport() throws {
+        let store = try tempStore()
+        let a = try store.addSource(filename: "a.bin", data: Data([0x41, 0x42, 0x43, 0x44, 0x45]))
+        try store.deleteSource(id: a.id)
+
+        let result = try AdminCommand.run(.vacuumBlobs(dryRun: true, json: true), in: store)
+        #expect(!result.didCommit)
+        guard case .text(let text) = result.payload else {
+            Issue.record("expected text payload"); return
+        }
+        let object = try JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any]
+        #expect(object?["orphanCount"] as? Int == 1)
+        #expect(object?["bytesReclaimed"] as? Int == 5)
+        #expect(object?["applied"] as? Bool == false)
+    }
 }

--- a/Tests/WikiFSTests/WikiManagerTests.swift
+++ b/Tests/WikiFSTests/WikiManagerTests.swift
@@ -359,4 +359,38 @@ struct WikiManagerTests {
         // The stray legacy file was left untouched (not adopted, not renamed).
         #expect(FileManager.default.fileExists(atPath: legacy.path))
     }
+
+    // MARK: - Blob GC (#253) — Help-menu preview/apply state flow
+
+    /// The Help-menu flow: `previewBlobVacuum()` runs a read-only dry run and
+    /// surfaces the report on `pendingBlobVacuum` (drives the confirm alert);
+    /// `applyBlobVacuum()` runs the delete and clears the pending state. A fresh
+    /// wiki has no sources, so the preview reports zero orphans (the "nothing to
+    /// reclaim" path). The reclaim-itself logic is covered by the store-level
+    /// tests in `WikiCtlCommandTests`.
+    @Test func blobVacuumPreviewSetsReportAndApplyClearsIt() {
+        let manager = WikiManager(containerDirectory: tempDirectory())
+        manager.bootstrap()
+
+        manager.previewBlobVacuum()
+        let report = manager.pendingBlobVacuum
+        #expect(report != nil)
+        #expect(report?.orphanCount == 0)
+        #expect(report?.bytesReclaimed == 0)
+        #expect(report?.applied == false)
+
+        manager.applyBlobVacuum()
+        #expect(manager.pendingBlobVacuum == nil)
+    }
+
+    /// With no active store (deferred bootstrap), the preview is a guarded
+    /// no-op — it must not crash or fabricate a report.
+    @Test func blobVacuumPreviewIsNoOpWithoutActiveStore() {
+        let manager = WikiManager(containerDirectory: tempDirectory())
+        manager.bootstrap(activateNow: false)
+        #expect(manager.activeStore == nil)
+
+        manager.previewBlobVacuum()
+        #expect(manager.pendingBlobVacuum == nil)
+    }
 }

--- a/plans/graph-model-and-versioning.md
+++ b/plans/graph-model-and-versioning.md
@@ -140,7 +140,10 @@ CREATE TABLE blobs (
   `source_versions.thumbnail_hash`, or `source_markdown_versions.blob_hash`
   references it. Deleting a source cascades its versions; a lazy
   `wikictl admin vacuum-blobs` (and an app maintenance hook) sweeps orphans.
-  Nothing depends on eager GC.
+  Nothing depends on eager GC. **Resolved (#253, shipped):** lazy-only —
+  `SQLiteWikiStore.vacuumBlobs(dryRun:)` + `wikictl admin vacuum-blobs [--apply]
+  [--json]`. Dry-run is the default (`--apply` deletes); NO_EMIT (blob GC changes
+  no projected `ResourceKind`). No opportunistic sweep on `deleteSource`.
 - The 100 MB `ingestByteCap` stays, enforced at ingest before hashing.
 
 ### 4.2 `agents` + `activities` + `source_versions` — the append-only history
@@ -841,7 +844,7 @@ longer needs to be revisited for these.
 
 | # | Issue | Origin |
 |---|-------|--------|
-| 1 | [#253](https://github.com/tqbf/selfdrivingwiki/issues/253) — Blob GC: sweep orphaned blobs | §13 Q1 |
+| 1 | [#253](https://github.com/tqbf/selfdrivingwiki/issues/253) — Blob GC: sweep orphaned blobs ✅ shipped | §13 Q1 |
 | 2 | [#254](https://github.com/tqbf/selfdrivingwiki/issues/254) — Forward links: `pending_links` table | §13 Q2 |
 | 3 | [#255](https://github.com/tqbf/selfdrivingwiki/issues/255) — Editor ergonomics for canonical `[[page:ULID\|Title]]` | §13 Q3 |
 | 4 | [#256](https://github.com/tqbf/selfdrivingwiki/issues/256) — Off-main bulk jobs with progress | §13 Q4 |


### PR DESCRIPTION
## #253 — Blob GC: sweep orphaned blobs

Resolves [#253](https://github.com/tqbf/selfdrivingwiki/issues/253) (graph-model §13 open question Q1).

Deleting a source cascades its `source_versions`/`source_markdown_versions` rows but leaves the `blobs` they pointed at behind. This adds lazy reclamation: `wikictl admin vacuum-blobs`.

### Open question resolved

**Lazy-only** — no opportunistic sweep in `deleteSource` (matches the plan's *"nothing depends on eager GC"*). The CLI default is a safe **dry run**; `--apply` performs the delete.

### What shipped

- **`SQLiteWikiStore.vacuumBlobs(dryRun:)`** (+ `BlobVacuumReport`) — a single reachability predicate (a blob is orphaned when no `source_versions.blob_hash` / `source_versions.thumbnail_hash` / `source_markdown_versions.blob_hash` cites it; those three are exhaustive — chunks/embeddings/attachments store bytes inline). Count `SELECT` and `DELETE` share the predicate in **one `withTransaction`**, so the report always matches what's reclaimed. Each subquery filters `NULL`s so SQLite's three-valued `NOT IN` never suppresses a live orphan.
  - **NO_EMIT**: added to `StoreEmissionExhaustivenessTests` `noEmit`. Vacuuming orphans changes no projected `ResourceKind` (blobs fold into the changeToken only through their version rows), so it does not route through `mutate()` and emits no event.
- **`AdminCommand.swift`** (new, `WikiCtlCore`) — the `admin …` command family. First subcommand `vacuum-blobs`. `didCommit` is true only when `--apply` actually deleted rows (a dry run never wakes the change bridge). Text + JSON (`--json`) output.
- **`ArgumentParser.swift`** — `Command.admin` case + `parseAdminCommand`; `Options` generalized from a hardcoded `--json` valueless flag to a `booleanFlags` set so `--apply` works; `usageText` updated.
- **`main.swift`** — `execute()` dispatches `.admin`.
- **`graph-model-and-versioning.md`** §4.1 / §13 marked shipped.

### CLI

```
wikictl [--wiki <id>] admin vacuum-blobs [--apply] [--json]
# default: dry run — reports orphan count + reclaimable bytes, deletes nothing
# --apply: deletes the orphans
# --json:  {"orphanCount":N,"bytesReclaimed":B,"applied":bool}
```

### App UI surface (Help menu)

Discoverable to humans, not just the CLI: **Help → "Vacuum Orphaned Storage…"** runs a read-only dry-run preview, then shows a confirm `.alert`:

- `ByteCountFormatter` for the reclaimable byte count; pluralization.
- Cancel + a **destructive** Vacuum button (it deletes data — irreversible).
- An empty-state message when there's nothing to reclaim.
- `WikiManager.previewBlobVacuum()` / `applyBlobVacuum()` hold the confirm state; `BlobVacuumReport` + `vacuumBlobs(dryRun:)` were **promoted to the `WikiStore` protocol** so the `@MainActor` model calls them with no downcast (the model only ever calls protocol methods).

### Tests (13 new)

- Parser: default dry-run, `--apply`, `--json`, missing/unknown subcommand.
- Store GC via the realistic **add → delete → vacuum** flow (no private table access): orphan reported, dry-run is a no-op, `--apply` reclaims the orphan while a referenced blob survives (`sourceContent` still reads), idempotent re-run, and a no-op when everything is referenced.
- `AdminCommand.run` dispatch: dry-run doesn't commit, `--apply` commits, JSON payload parses and matches the report.
- `WikiManager` preview/apply state flow + the no-active-store guard (2 in `WikiManagerTests`).

Plus the exhaustiveness guard (`vacuumBlobs` in `noEmit`).

### Gate

`swift test` exit 0 — **1974 tests in 160 suites** (no regressions).
