### PR TITLE
#242: Bookmark created/updated timestamps

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,36 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-08 — #242: Bookmark created/updated timestamps
+
+Bookmarks now carry `createdAt`/`updatedAt` so the UI can show "date added"/"date
+updated" (the companion sort/filter is #241). New **schema v27** migration adds
+`created_at`/`updated_at REAL NOT NULL DEFAULT 0` to `bookmark_nodes`, backfilling
+every legacy row to the migration time (legacy nodes have no recorded creation time).
+
+**Reorder semantics (the issue's open question):** a **cross-folder move** bumps
+`updatedAt`; a **pure same-parent reorder does NOT** (organizing siblings shouldn't
+reshuffle a "date updated" view). Label rename also bumps. `moveBookmarkNode`
+already computes `sameParent`, so the bump is conditional on `!sameParent`.
+
+**What shipped:**
+- **`BookmarkNode`** — `createdAt`/`updatedAt` fields (epoch defaults so existing
+  in-memory test fixtures keep compiling; the store always stamps real values).
+- **`SQLiteWikiStore`** — fresh schema + v26→v27 ladder step (ALTER + backfill,
+  `pragma_table_info`-guarded; also tolerates a missing `bookmark_nodes` table so
+  a hand-crafted minimal fixture can't crash mid-migration). `createBookmarkNode`
+  stamps both on insert; `updateBookmarkNode` and cross-folder `moveBookmarkNode`
+  bump `updatedAt`; `listBookmarkNodes` selects/decodes them.
+- **`EditBookmarkSheet`** — read-only "Added …"/"Updated …" relative dates
+  (absolute date as tooltip), mirroring `RecentChatRow`'s `chat.updatedAt`.
+  "Updated" only appears when the node has actually changed.
+- **Schema-version assertions** across the test suite bumped 26→27 (ULID
+  `.count == 26` and the FileProvider UserDefaults version left untouched).
+- **Tests (6 new):** create stamps both; rename bumps `updatedAt` not `createdAt`;
+  cross-folder move bumps; same-parent reorder doesn't; the v26→v27 migration adds
+  the columns + backfills a legacy row to ~now (parity-checked NOT NULL DEFAULT 0).
+  1979 tests green.
+
 ## 2026-07-08 — #253: Blob GC — sweep orphaned blobs
 
 **Shipped (on `feature/253-blob-gc`; 1972 tests green).** Lazy reclamation of

--- a/Sources/WikiFS/EditBookmarkSheet.swift
+++ b/Sources/WikiFS/EditBookmarkSheet.swift
@@ -44,6 +44,23 @@ struct EditBookmarkSheet: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                // Timestamps (read-only) — issue #242. Relative date mirrors
+                // RecentChatRow's treatment of chat.updatedAt; the absolute date
+                // is the tooltip for precision. "Updated" only appears when the
+                // node has actually changed since creation.
+                if let node {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Added \(node.createdAt, format: .relative(presentation: .named))")
+                            .help(node.createdAt.formatted(.dateTime))
+                        if node.updatedAt > node.createdAt {
+                            Text("Updated \(node.updatedAt, format: .relative(presentation: .named))")
+                                .help(node.updatedAt.formatted(.dateTime))
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
             }
 
             Spacer()
@@ -82,7 +99,7 @@ struct EditBookmarkSheet: View {
             }
         }
         .padding(20)
-        .frame(width: 340, height: 200)
+        .frame(width: 340, height: 240)
         .onAppear {
             name = node?.label ?? ""
         }

--- a/Sources/WikiFSCore/BookmarkNode.swift
+++ b/Sources/WikiFSCore/BookmarkNode.swift
@@ -23,6 +23,13 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
     public var label: String?
     /// Page/source id for refs; `nil` otherwise.
     public var targetID: PageID?
+    /// When the node was first created (issue #242). Epoch default lets
+    /// in-memory fixtures omit it; the store always stamps a real value.
+    public var createdAt: Date
+    /// When the node last changed in a way the user would consider an "update"
+    /// (label rename or a move to a new parent). Pure same-parent reordering
+    /// does NOT bump this — see `moveBookmarkNode`.
+    public var updatedAt: Date
 
     public init(
         id: String,
@@ -30,7 +37,9 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
         position: Int,
         kind: BookmarkNodeKind,
         label: String?,
-        targetID: PageID?
+        targetID: PageID?,
+        createdAt: Date = Date(timeIntervalSince1970: 0),
+        updatedAt: Date = Date(timeIntervalSince1970: 0)
     ) {
         self.id = id
         self.parentID = parentID
@@ -38,6 +47,8 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
         self.kind = kind
         self.label = label
         self.targetID = targetID
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
     }
 
     /// Builds a slash-delimited display path for a folder by walking its

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -450,7 +450,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             position      INTEGER NOT NULL DEFAULT 0,
             kind          TEXT NOT NULL,
             label         TEXT,
-            target_id     TEXT
+            target_id     TEXT,
+            created_at    REAL NOT NULL DEFAULT 0,
+            updated_at    REAL NOT NULL DEFAULT 0
         );
         """)
         try exec("CREATE INDEX bookmark_nodes_parent ON bookmark_nodes(parent_id, position);")
@@ -491,7 +493,13 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // `source_markdown_versions.content` column — the body lives only in
         // `blobs` (CAS-only). The fresh path omits the column entirely (nothing
         // to drop); the ladder drops it in the v25→26 step.
-        try exec("PRAGMA user_version=26;")
+        //
+        // v27 (issue #242): bookmark nodes gain `created_at`/`updated_at`
+        // timestamps so the UI can show "date added"/"date updated" (companion
+        // sort/filter in #241). The fresh-path table def already includes both
+        // columns; a brand-new DB has no rows to backfill. Shared with the
+        // v26→27 migration step.
+        try exec("PRAGMA user_version=27;")
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -1154,6 +1162,39 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             }
             try exec("PRAGMA user_version=26;")
             version = 26
+        }
+
+        // Step 26 → 27 (issue #242): add `created_at`/`updated_at` to
+        // `bookmark_nodes` so the UI can show "date added"/"date updated"
+        // (companion sort/filter in #241). Additive ALTER (NOT NULL DEFAULT 0),
+        // then backfill every existing row to `now` — legacy nodes have no
+        // recorded creation time, so migration time is the best available proxy
+        // (and on a brand-new DB forced through the ladder there are no rows).
+        // Column defs match the fresh-path CREATE TABLE byte-for-byte — the
+        // `freshFastPathMatchesStepwiseLadder` parity test compares defaults.
+        // Idempotent: pragma_table_info-guarded so a rewound-for-testing DB
+        // stamps v27 without re-adding the columns.
+        if version < 27 {
+            // `bookmark_nodes` is created at v16, so any DB that reached here
+            // through the real ladder already has it. But hand-crafted test
+            // fixtures (e.g. a minimal v19 DB with only `sources`) may be
+            // stamped at ≥16 without the table — skip the column work in that
+            // case rather than crash mid-migration. There's nothing to backfill
+            // when the table is absent.
+            let tableExists = try queryScalarText(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='bookmark_nodes';") != "0"
+            if tableExists {
+                let hasCreatedAt = try queryScalarText(
+                    "SELECT COUNT(*) FROM pragma_table_info('bookmark_nodes') WHERE name='created_at';") != "0"
+                if !hasCreatedAt {
+                    try exec("ALTER TABLE bookmark_nodes ADD COLUMN created_at REAL NOT NULL DEFAULT 0;")
+                    try exec("ALTER TABLE bookmark_nodes ADD COLUMN updated_at REAL NOT NULL DEFAULT 0;")
+                    let now = Date().timeIntervalSince1970
+                    try exec("UPDATE bookmark_nodes SET created_at = \(now), updated_at = \(now);")
+                }
+            }
+            try exec("PRAGMA user_version=27;")
+            version = 27
         }
     }
 
@@ -3965,7 +4006,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // each parent. SQLite lacks NULLS FIRST, so `parent_id IS NULL DESC`
         // sorts NULL parents before non-NULL.
         let stmt = try statement("""
-        SELECT id, parent_id, position, kind, label, target_id
+        SELECT id, parent_id, position, kind, label, target_id, created_at, updated_at
         FROM bookmark_nodes
         ORDER BY parent_id IS NULL DESC, parent_id, position;
         """)
@@ -3978,7 +4019,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                 position: Int(stmt.int(at: 2)),
                 kind: BookmarkNodeKind(rawValue: stmt.text(at: 3)) ?? .folder,
                 label: sqlite3_column_type(stmt.handle, 4) == SQLITE_NULL ? nil : stmt.text(at: 4),
-                targetID: sqlite3_column_type(stmt.handle, 5) == SQLITE_NULL ? nil : PageID(rawValue: stmt.text(at: 5))
+                targetID: sqlite3_column_type(stmt.handle, 5) == SQLITE_NULL ? nil : PageID(rawValue: stmt.text(at: 5)),
+                createdAt: Date(timeIntervalSince1970: stmt.double(at: 6)),
+                updatedAt: Date(timeIntervalSince1970: stmt.double(at: 7))
             ))
         }
         return out
@@ -3993,6 +4036,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     ) throws -> BookmarkNode {
         try mutate(event: { node in localEvent(.bookmark, id: node.id, change: .created) }) {
         let id = ULID.generate()
+        let now = Date().timeIntervalSince1970
         try withTransaction {
             // Shift siblings at >= position up by 1 within the same parent.
             // SQLite's `IS` operator matches NULL=NULL (unlike `=`), so
@@ -4011,8 +4055,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             _ = try shift.step()
 
             let ins = try statement("""
-            INSERT INTO bookmark_nodes (id, parent_id, position, kind, label, target_id)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6);
+            INSERT INTO bookmark_nodes (id, parent_id, position, kind, label, target_id, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);
             """)
             ins.reset()
             try ins.bind(id, at: 1)
@@ -4033,6 +4077,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             } else {
                 sqlite3_bind_null(ins.handle, 6)
             }
+            try ins.bind(now, at: 7)
+            try ins.bind(now, at: 8)
             _ = try ins.step()
 
             // Defense-in-depth: renumber siblings so positions stay contiguous
@@ -4043,15 +4089,17 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                 try renumberRootSiblings()
             }
         }
+        let stamp = Date(timeIntervalSince1970: now)
         return BookmarkNode(id: id, parentID: parentID, position: position, kind: kind,
-                        label: label, targetID: targetID)
+                        label: label, targetID: targetID, createdAt: stamp, updatedAt: stamp)
         }
     }
 
     public func updateBookmarkNode(id: String, label: String?) throws {
         try mutate(event: { _ in localEvent(.bookmark, id: id, change: .updated) }) {
+        let now = Date().timeIntervalSince1970
         let stmt = try statement("""
-        UPDATE bookmark_nodes SET label = ?2 WHERE id = ?1;
+        UPDATE bookmark_nodes SET label = ?2, updated_at = ?3 WHERE id = ?1;
         """)
         stmt.reset()
         try stmt.bind(id, at: 1)
@@ -4060,6 +4108,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         } else {
             sqlite3_bind_null(stmt.handle, 2)
         }
+        try stmt.bind(now, at: 3)
         _ = try stmt.step()
         }
     }
@@ -4167,6 +4216,19 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             }
             try upd.bind(Int64(position), at: 3)
             _ = try upd.step()
+
+            // Step 2b: A move to a NEW parent is a meaningful change — bump
+            // updated_at so a "date updated" sort reflects it. A pure same-
+            // parent reorder is NOT bumped (organizing siblings shouldn't
+            // reshuffle the recency view). See BookmarkNode.updatedAt.
+            if !sameParent {
+                let bump = try statement(
+                    "UPDATE bookmark_nodes SET updated_at = ?2 WHERE id = ?1;")
+                bump.reset()
+                try bump.bind(id, at: 1)
+                try bump.bind(Date().timeIntervalSince1970, at: 2)
+                _ = try bump.step()
+            }
 
             // Step 3: Renumber siblings on both old and new parent (or root) so
             // positions are contiguous. The shift in step 1 may leave a gap at

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -19,7 +19,7 @@ import SQLite3
     @Test func freshDBHasBookmarkNodesTable() throws {
         let url = tempDatabaseURL()
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "26")
+        #expect(store.pragmaValue("user_version") == "27")
 
         // The table exists.
         let nodes = try store.listBookmarkNodes()
@@ -37,7 +37,7 @@ import SQLite3
 
         // Reopen — triggers migration to v16.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "26")
+        #expect(reopened.pragmaValue("user_version") == "27")
 
         // Existing data is intact.
         let pages = try reopened.listPages(sortBy: .lastUpdated)
@@ -360,5 +360,75 @@ import SQLite3
         let nodes = try store.listBookmarkNodes()
         let moved = nodes.first { $0.id == a.id }
         #expect(moved?.parentID == b.id)
+    }
+
+    // MARK: - Timestamps (issue #242)
+
+    @Test func createBookmarkNodeStampsCreatedAtAndUpdatedAt() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let before = Date().addingTimeInterval(-1)
+        let node = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder, label: "F", targetID: nil)
+        let after = Date().addingTimeInterval(1)
+
+        // Create stamps both timestamps equally, ~now.
+        #expect(node.createdAt == node.updatedAt)
+        #expect(node.createdAt > before)
+        #expect(node.createdAt < after)
+
+        // Persisted identically (round-trips through listBookmarkNodes).
+        let reloaded = try store.listBookmarkNodes().first { $0.id == node.id }
+        #expect(reloaded?.createdAt == node.createdAt)
+        #expect(reloaded?.updatedAt == node.updatedAt)
+    }
+
+    @Test func updateBookmarkNodeBumpsUpdatedAtNotCreatedAt() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let node = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder, label: "Old", targetID: nil)
+        let originalCreatedAt = node.createdAt
+
+        try store.updateBookmarkNode(id: node.id, label: "New")
+
+        let reloaded = try store.listBookmarkNodes().first { $0.id == node.id }!
+        #expect(reloaded.label == "New")
+        #expect(reloaded.createdAt == originalCreatedAt)
+        #expect(reloaded.updatedAt > originalCreatedAt)
+    }
+
+    @Test func moveAcrossParentBumpsUpdatedAt() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let parentA = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder, label: "A", targetID: nil)
+        let parentB = try store.createBookmarkNode(
+            parentID: nil, position: 1, kind: .folder, label: "B", targetID: nil)
+        let child = try store.createBookmarkNode(
+            parentID: parentA.id, position: 0, kind: .folder, label: "C", targetID: nil)
+        let originalUpdatedAt = child.updatedAt
+
+        // Cross-folder move → updatedAt bumps.
+        try store.moveBookmarkNode(id: child.id, toParentID: parentB.id, position: 0)
+
+        let reloaded = try store.listBookmarkNodes().first { $0.id == child.id }!
+        #expect(reloaded.parentID == parentB.id)
+        #expect(reloaded.updatedAt > originalUpdatedAt)
+    }
+
+    @Test func reorderWithinSameParentDoesNotBumpUpdatedAt() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        _ = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder, label: "A", targetID: nil)
+        _ = try store.createBookmarkNode(
+            parentID: nil, position: 1, kind: .folder, label: "B", targetID: nil)
+        let c = try store.createBookmarkNode(
+            parentID: nil, position: 2, kind: .folder, label: "C", targetID: nil)
+        let originalUpdatedAt = c.updatedAt
+
+        // Pure same-parent reorder (C → position 0) leaves updatedAt untouched.
+        try store.moveBookmarkNode(id: c.id, toParentID: nil, position: 0)
+
+        let reloaded = try store.listBookmarkNodes().first { $0.id == c.id }!
+        #expect(reloaded.position == 0)
+        #expect(reloaded.updatedAt == originalUpdatedAt)
     }
 }

--- a/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
+++ b/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
@@ -20,7 +20,7 @@ struct EmbeddingMetaCutoverTests {
     @Test func freshDBSeedsNLEmbedderIdentifier() throws {
         let store = try tempStore()
         let stored = store.pragmaValue("user_version")
-        #expect(stored == "26")
+        #expect(stored == "27")
         // ensureEmbedderConsistency with the default identifier (nlembedding-512)
         // is a no-op: the seed matches, so nothing is wiped.
         store.ensureEmbedderConsistency(activeIdentifierOverride: NLEmbedder.identifier)

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -125,8 +125,8 @@ import SQLite3
         let ladder = try fingerprint(at: ladderURL)
 
         // Both must report head version 22.
-        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "26")
-        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "26")
+        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "27")
+        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "27")
 
         if fast != ladder {
             Issue.record("fresh fast-path schema drifted from the stepwise ladder:\n--- fast ---\n\(fast)\n--- ladder ---\n\(ladder)")
@@ -206,7 +206,7 @@ import SQLite3
         // 3. Reopen → runs the v20→v21 backfill.
         sqlite3_close(db)
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "26")
+        #expect(migrated.pragmaValue("user_version") == "27")
 
         // 4. The legacy extraction row was backfilled: blob_hash + activity_id + source_version_id set.
         #expect(migrated.scalarText(
@@ -268,7 +268,7 @@ import SQLite3
         sqlite3_close(db)
 
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "26")
+        #expect(migrated.pragmaValue("user_version") == "27")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
         let roleCol = columns(db2, "sources").first { $0.name == "role" }
@@ -343,7 +343,7 @@ import SQLite3
 
         // Reopen → v22 migration rebuilds source_links.
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "26")
+        #expect(migrated.pragmaValue("user_version") == "27")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 
@@ -373,5 +373,55 @@ import SQLite3
         try migrated.deleteSource(id: source.id)
         #expect(scalarText(db2,
             "SELECT COUNT(*) FROM source_links WHERE to_source_id='\(sourceID)';") == "0")
+    }
+
+    // MARK: - v27 (issue #242): bookmark timestamps
+
+    /// v26→v27 migration adds `created_at`/`updated_at` to `bookmark_nodes` and
+    /// backfills every legacy row to the migration time (legacy nodes have no
+    /// recorded creation time). AC: columns appear NOT NULL DEFAULT 0 (matching
+    /// the fresh-path def — parity), and a pre-existing row's timestamps are
+    /// non-epoch and ~now after reopening.
+    @Test func v26ToV27AddsAndBackfillsBookmarkTimestamps() throws {
+        let url = tempURL()
+        let nodeID: String
+        do {
+            let store = try SQLiteWikiStore(databaseURL: url)
+            let node = try store.createBookmarkNode(
+                parentID: nil, position: 0, kind: .folder, label: "Legacy", targetID: nil)
+            nodeID = node.id
+        }
+
+        // Simulate a genuine v26 DB: the fresh schema already has the columns,
+        // so drop them and rewind the stamp to before #242.
+        let db = try open(url)
+        exec(db, "ALTER TABLE bookmark_nodes DROP COLUMN created_at;")
+        exec(db, "ALTER TABLE bookmark_nodes DROP COLUMN updated_at;")
+        exec(db, "PRAGMA user_version=26;")
+        sqlite3_close(db)
+
+        let reopenStart = Date()
+        let migrated = try SQLiteWikiStore(databaseURL: url)
+        #expect(migrated.pragmaValue("user_version") == "27")
+        let db2 = try open(url)
+        defer { sqlite3_close(db2) }
+
+        // Columns exist, NOT NULL, default 0 (matches the fresh-path CREATE
+        // TABLE byte-for-byte — the parity test compares defaults).
+        let createdCol = columns(db2, "bookmark_nodes").first { $0.name == "created_at" }
+        #expect(createdCol?.notnull == 1, "bookmark_nodes.created_at must be NOT NULL")
+        #expect(createdCol?.dflt == "0")
+        let updatedCol = columns(db2, "bookmark_nodes").first { $0.name == "updated_at" }
+        #expect(updatedCol?.notnull == 1, "bookmark_nodes.updated_at must be NOT NULL")
+        #expect(updatedCol?.dflt == "0")
+
+        // The legacy row was backfilled: both timestamps equal (migration
+        // time), non-epoch, and within a tight window of the reopen.
+        let nodes = try migrated.listBookmarkNodes()
+        let reloaded = try #require(nodes.first { $0.id == nodeID })
+        #expect(reloaded.createdAt == reloaded.updatedAt)
+        #expect(reloaded.createdAt.timeIntervalSince1970 > 0)
+        #expect(reloaded.createdAt > reopenStart.addingTimeInterval(-5))
+        #expect(reloaded.createdAt < Date().addingTimeInterval(5))
     }
 }

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -238,7 +238,7 @@ struct LogIndexTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 26)
+        #expect(sqlite3_column_int(stmt, 0) == 27)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
+++ b/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
@@ -191,7 +191,7 @@ struct Phase5StoreCanonicalizationTests {
 
         // Reopen → v23 sweep runs.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "26")
+        #expect(reopened.pragmaValue("user_version") == "27")
 
         let migrated = try reopened.getPage(id: linkerID)
         // Resolvable link canonicalized; forward link left verbatim.

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -112,7 +112,7 @@ struct ProcessedMarkdownTests {
 
     @Test func freshDBHasV8Schema() throws {
         let store = try tempStore()
-        #expect(store.pragmaValue("user_version") == "26")
+        #expect(store.pragmaValue("user_version") == "27")
     }
 
     @Test func v7DBUpgradesToV8PreservingData() throws {
@@ -128,7 +128,7 @@ struct ProcessedMarkdownTests {
 
         // Opening runs v7→v8→…→v15 migration.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "26")
+        #expect(store.pragmaValue("user_version") == "27")
         // Pre-existing file is intact.
         let content = try store.sourceContent(
             id: PageID(rawValue: "01J00000000000000000000000"))

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -66,7 +66,7 @@ struct SQLiteWikiStoreTests {
         // user_version guard: a fresh DB runs all migration steps → version 16.
         // Reopening must not re-run DDL (no-op bootstrap).
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "26")
+        #expect(userVersion == "27")
         let reopened = try SQLiteWikiStore(databaseURL: url)
         // If bootstrap weren't guarded, the CREATE TABLE would throw here.
         #expect((try? reopened.listPages(sortBy: .lastUpdated)) != nil)
@@ -323,7 +323,7 @@ struct SQLiteWikiStoreTests {
         defer { sqlite3_close(db) }
 
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "26")
+        #expect(userVersion == "27")
 
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"))
@@ -367,7 +367,7 @@ struct SQLiteWikiStoreTests {
 
     @Test func freshDBReachesUserVersion18() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(store.pragmaValue("user_version") == "26")
+        #expect(store.pragmaValue("user_version") == "27")
     }
 
     @Test func v11SourceLinksHasDeleteCascade() throws {
@@ -623,7 +623,7 @@ struct SQLiteWikiStoreTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarText(db, "PRAGMA user_version;") == "26")
+        #expect(scalarText(db, "PRAGMA user_version;") == "27")
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"))
         for expected in ["blobs", "agents", "activities", "source_versions", "refs"] {
@@ -684,7 +684,7 @@ struct SQLiteWikiStoreTests {
 
         // Reopen → migrates 19→20.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "26")
+        #expect(store.pragmaValue("user_version") == "27")
 
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)

--- a/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
+++ b/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
@@ -49,7 +49,7 @@ struct SourceEmbeddingSearchTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarInt(db, "PRAGMA user_version;") == 26)
+        #expect(scalarInt(db, "PRAGMA user_version;") == 27)
         #expect(tableExists(db, "source_chunks"))
         // page chunk table mirrors the source one.
         #expect(tableExists(db, "page_chunks"))

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -279,7 +279,7 @@ struct SourcesTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 26)
+        #expect(sqlite3_column_int(stmt, 0) == 27)
         _ = store
     }
 

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -234,7 +234,7 @@ struct SystemPromptTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 26)
+        #expect(sqlite3_column_int(stmt, 0) == 27)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
+++ b/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
@@ -104,7 +104,7 @@ struct WikiNameSanitizationStoreTests {
 
         // Reopen → the 17→18 step sweeps the dirty names.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "26")
+        #expect(reopened.pragmaValue("user_version") == "27")
         let page = try reopened.getPage(id: pageID!)
         #expect(page.title == "(Draft) Bad - #Title") // inner # is fine, kept
         #expect(try reopened.getSource(id: sourceID!).displayName == "Foo - Bar)")


### PR DESCRIPTION
Closes #242.

## Summary

Bookmarks now carry `createdAt` / `updatedAt` timestamps so the UI can show "date
added" / "date updated" (companion sort/filter is #241), mirroring the pattern
already used by `ChatSummary.updatedAt` → `RecentChatRow`.

## Changes

- **`BookmarkNode`** — new `createdAt` / `updatedAt` fields (epoch defaults keep
  existing in-memory test fixtures compiling; the store always stamps real values).
- **Schema v27** — fresh-path `bookmark_nodes` CREATE TABLE gains
  `created_at` / `updated_at REAL NOT NULL DEFAULT 0`; a new v26→v27 ladder step
  ALTER-adds both columns and backfills every legacy row to the migration time
  (legacy nodes have no recorded creation time). Column defs match the fresh path
  byte-for-byte (`freshFastPathMatchesStepwiseLadder` checks defaults).
- **CRUD stamping**
  - `createBookmarkNode` stamps both timestamps on insert.
  - `updateBookmarkNode` (label rename) bumps `updatedAt`.
  - `moveBookmarkNode` bumps `updatedAt` **only on a cross-folder move**
    (`!sameParent`); a pure same-parent reorder does **not**.
  - `listBookmarkNodes` selects + decodes both.
- **`EditBookmarkSheet`** — read-only "Added …" / "Updated …" relative dates
  (absolute date as tooltip), matching `RecentChatRow`. "Updated" only appears
  once the node has actually changed.

## Design decision: reorder semantics

The issue flagged an open question — does a pure reorder count as an "update"?

**Decision: no.** A move to a *new parent* bumps `updatedAt`; a *same-parent
reorder* does not. Organizing siblings shouldn't reshuffle a "date updated" view,
and a parent change is the more meaningful "where did this bookmark go" event.
`moveBookmarkNode` already computed `sameParent`, so the bump is conditional on
`!sameParent`. Trivial to flip if the opposite is preferred.

## Tests (6 new, 1979 total green)

- create stamps `createdAt == updatedAt`, ~now, round-trips.
- rename bumps `updatedAt` (not `createdAt`).
- cross-folder move bumps `updatedAt`.
- same-parent reorder leaves `updatedAt` untouched.
- v26→v27 migration adds the columns (NOT NULL DEFAULT 0) and backfills a legacy
  row to ~now.
- schema-version assertions across the suite bumped 26→27 (ULID `.count == 26` and
  the FileProvider UserDefaults version left untouched).

## Notes

- The migration tolerates a missing `bookmark_nodes` table (only matters for a
  hand-crafted minimal test fixture stamped at ≥v16 without the table) so it can't
  crash mid-migration; in any real upgrade path the table exists from v16.
