### PR TITLE
Fix outline clicks being no-op while editing (#268)

### DIFF
--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -11,6 +11,10 @@ struct PageDetailView: View {
     @Bindable var manager: WikiManager
     let fileProvider: FileProviderSpike
     @State private var isEditing = false
+    /// Pending scroll-to-heading for the editor (outline click while editing).
+    @State private var editorScrollRequest: EditorScrollRequest?
+    /// Caret position in the editor, for outline cursor tracking (issue #268).
+    @State private var caretCharIndex: Int?
     /// Tracks the active tab ID at the end of the last resolved update cycle.
     /// Used to distinguish tab switches (activeTabID changes) from in-tab
     /// navigation (activeTabID stays, selection changes) when deciding whether
@@ -135,39 +139,7 @@ struct PageDetailView: View {
             // both are present to avoid stacked notification noise.
             saveWarningBanner
 
-            HStack(spacing: 0) {
-                Group {
-                    // Content — swaps between reader and editor, header stays put.
-                    if isEditing {
-                        TextEditor(text: $store.draftBody)
-                            .font(.system(size: 13 * editorZoom, design: .monospaced))
-                            .scrollContentBackground(.hidden)
-                            .padding(.horizontal, PageEditorMetrics.contentInset)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .frame(minHeight: PageEditorMetrics.editorMinHeight)
-                            .onChange(of: store.draftBody) { store.bodyChanged() }
-                            .zoomShortcuts($editorZoom)
-                            .zoomScroll($editorZoom)
-                    } else {
-                        WikiReaderView(markdown: store.draftBody,
-                                        currentSelection: store.selection,
-                                        store: store,
-                                        fileProvider: fileProvider,
-                                        findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
-                            .frame(maxWidth: .infinity)
-                            .frame(minHeight: PageEditorMetrics.previewMinHeight)
-                            .zoomShortcuts($readerZoom)
-                            .zoomScroll($readerZoom)
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                
-                if isOutlineExpanded {
-                    PageOutlineView(markdown: store.draftBody) { slug in
-                        store.jumpToAnchorInCurrentSelection(slug)
-                    }
-                }
-            }
+            contentAndOutline
         }
         .background(Color(nsColor: .textBackgroundColor))
         .frame(minWidth: PageEditorMetrics.detailMinWidth)
@@ -189,6 +161,7 @@ struct PageDetailView: View {
             if let id = store.activeTabID {
                 store.setTabEditing(tabID: id, isEditing: newValue)
             }
+            if !newValue { caretCharIndex = nil }
         }
         .onChange(of: store.isAgentRunning) { _, isRunning in
             if isRunning { isEditing = false }
@@ -210,6 +183,67 @@ struct PageDetailView: View {
             guard findModel.currentMatchIndex > 0 else { return }
             findVersion &+= 1
         }
+    }
+
+    // MARK: - Content + Outline
+
+    /// The main content area (reader or editor) plus the optional outline
+    /// sidebar. Extracted from `body` so the type-checker can resolve each
+    /// subtree independently.
+    @ViewBuilder
+    private var contentAndOutline: some View {
+        HStack(spacing: 0) {
+            Group {
+                if isEditing {
+                    editorContent
+                } else {
+                    readerContent
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            if isOutlineExpanded {
+                PageOutlineView(markdown: store.draftBody,
+                                caretCharIndex: caretCharIndex) { heading in
+                    if isEditing {
+                        editorScrollRequest = EditorScrollRequest(
+                            charOffset: heading.charOffset,
+                            version: (editorScrollRequest?.version ?? 0) + 1)
+                    } else {
+                        store.jumpToAnchorInCurrentSelection(heading.id)
+                    }
+                }
+            }
+        }
+    }
+
+    private var editorContent: some View {
+        ScrollableTextEditor(
+            text: $store.draftBody,
+            font: NSFont.monospacedSystemFont(
+                ofSize: CGFloat(13 * editorZoom), weight: .regular),
+            scrollRequest: editorScrollRequest,
+            onCaretChange: { caretCharIndex = $0 }
+        )
+        .padding(.horizontal, PageEditorMetrics.contentInset)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(minHeight: PageEditorMetrics.editorMinHeight)
+        .onChange(of: store.draftBody) { store.bodyChanged() }
+        .zoomShortcuts($editorZoom)
+        .zoomScroll($editorZoom)
+    }
+
+    private var readerContent: some View {
+        WikiReaderView(markdown: store.draftBody,
+                        currentSelection: store.selection,
+                        store: store,
+                        fileProvider: fileProvider,
+                        findText: findText, findVersion: findVersion,
+                        findOccurrence: findOccurrence)
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: PageEditorMetrics.previewMinHeight)
+            .zoomShortcuts($readerZoom)
+            .zoomScroll($readerZoom)
     }
 
     // MARK: - Find bar
@@ -328,15 +362,43 @@ struct HeadingItem: Identifiable, Hashable {
     let id: String // The anchor slug
     let text: String
     let level: Int
+    /// NSString (UTF-16) character offset of this heading's line start within
+    /// the source markdown. Used by the editor to scroll to this heading
+    /// (issue #268) and by the outline to determine which heading the caret
+    /// is currently inside.
+    let charOffset: Int
 }
 
 struct PageOutlineView: View {
     let markdown: String
-    let onSelect: (String) -> Void
+    /// The caret's character index within the source text, or `nil` when not
+    /// editing. When non-nil, the heading containing the caret is highlighted
+    /// and the outline scrolls to keep it visible (issue #268).
+    var caretCharIndex: Int? = nil
+    let onSelect: (HeadingItem) -> Void
     
     @State private var headings: [HeadingItem] = []
     @AppStorage("outlineWidth") private var outlineWidth: Double = 75.0
     @State private var dragStartWidth: Double? = nil
+    /// Tracks which heading the outline last scrolled itself to, so we only
+    /// auto-scroll when the active heading actually changes (not on every
+    /// keystroke that stays within the same heading).
+    @State private var scrolledToHeadingID: String? = nil
+    
+    /// The id of the heading whose `charOffset` is closest to (but not after)
+    /// the caret, or `nil` if there is no caret or no preceding heading.
+    private var activeHeadingID: String? {
+        guard let caret = caretCharIndex, !headings.isEmpty else { return nil }
+        var active: HeadingItem?
+        for heading in headings {
+            if heading.charOffset <= caret {
+                active = heading
+            } else {
+                break
+            }
+        }
+        return active?.id
+    }
     
     var body: some View {
         HStack(spacing: 0) {
@@ -379,32 +441,52 @@ struct PageOutlineView: View {
                     
                 Divider()
                 
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 6) {
-                        ForEach(headings) { heading in
-                            Button(action: {
-                                onSelect(heading.id)
-                            }) {
-                                Text(heading.text)
-                                    .font(.system(size: 13))
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-                                    .padding(.leading, CGFloat((heading.level - 1) * 12))
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundStyle(.secondary)
-                            .onHover { isHovering in
-                                if isHovering {
-                                    NSCursor.pointingHand.push()
-                                } else {
-                                    NSCursor.pop()
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 6) {
+                            ForEach(headings) { heading in
+                                let isActive = heading.id == activeHeadingID
+                                Button(action: {
+                                    onSelect(heading)
+                                }) {
+                                    Text(heading.text)
+                                        .font(.system(size: 13))
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                        .padding(.leading, CGFloat((heading.level - 1) * 12))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .foregroundStyle(isActive ? .primary : .secondary)
+                                .background(
+                                    isActive
+                                        ? Color.accentColor.opacity(0.12)
+                                        : Color.clear,
+                                    in: RoundedRectangle(cornerRadius: 4)
+                                )
+                                .id(heading.id)
+                                .onHover { isHovering in
+                                    if isHovering {
+                                        NSCursor.pointingHand.push()
+                                    } else {
+                                        NSCursor.pop()
+                                    }
                                 }
                             }
                         }
+                        .padding()
                     }
-                    .padding()
+                    .onChange(of: caretCharIndex) { _, _ in
+                        let target = activeHeadingID
+                        guard target != scrolledToHeadingID else { return }
+                        scrolledToHeadingID = target
+                        if let target {
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                proxy.scrollTo(target, anchor: .center)
+                            }
+                        }
+                    }
                 }
             }
             .frame(width: outlineWidth)
@@ -421,17 +503,22 @@ struct PageOutlineView: View {
     private func parseHeadings() {
         var items: [HeadingItem] = []
         var slugCounts: [String: Int] = [:]
-        
-        let lines = markdown.components(separatedBy: .newlines)
         var inFence = false
         
-        for line in lines {
+        // charOffset tracks the NSString (UTF-16) character offset of each
+        // line's start — the same coordinate space NSTextView uses for ranges.
+        var charOffset = 0
+        
+        for line in markdown.components(separatedBy: .newlines) {
+            let lineUTF16Length = (line as NSString).length
+            defer { charOffset += lineUTF16Length + 1 } // +1 for the \n
+            
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix("```") {
                 inFence.toggle()
                 continue
             }
-            if inFence { continue }
+            guard !inFence else { continue }
             
             if trimmed.hasPrefix("#") {
                 let level = trimmed.prefix(while: { $0 == "#" }).count
@@ -444,7 +531,8 @@ struct PageOutlineView: View {
                 guard !text.isEmpty else { continue }
                 
                 let slug = AnchorBlock.makeSlug(text, counts: &slugCounts)
-                items.append(HeadingItem(id: slug, text: text, level: level))
+                items.append(HeadingItem(id: slug, text: text, level: level,
+                                         charOffset: charOffset))
             }
         }
         

--- a/Sources/WikiFS/ScrollableTextEditor.swift
+++ b/Sources/WikiFS/ScrollableTextEditor.swift
@@ -1,0 +1,163 @@
+import AppKit
+import SwiftUI
+
+/// A programmatic scroll request for `ScrollableTextEditor`. When `version`
+/// changes, the editor scrolls so the character at `charOffset` is visible and
+/// places the caret there.
+///
+/// `charOffset` is an `NSString` (UTF-16 code-unit) index into the editor's
+/// text — the same coordinate space `NSTextView` uses for ranges. This matches
+/// the `charOffset` computed by `PageOutlineView.parseHeadings`.
+struct EditorScrollRequest: Equatable {
+    let charOffset: Int
+    /// Monotonic counter. The editor only acts when this value changes, so
+    /// re-clicking the same heading re-fires the scroll + caret move.
+    let version: Int
+}
+
+/// `NSTextView`-backed plain-text editor that supports programmatic
+/// scroll-to-heading and caret reporting. Replaces SwiftUI's `TextEditor` in
+/// page/source edit mode so that outline clicks can scroll the cursor to a
+/// heading (issue #268).
+///
+/// SwiftUI's built-in `TextEditor` has no public API for scrolling to an
+/// arbitrary character offset or reading the caret position — both needed for
+/// outline-click navigation and live "which heading is the caret in?"
+/// highlighting. This `NSViewRepresentable` wraps an `NSScrollView` +
+/// `NSTextView` (the same backing `TextEditor` uses internally) and exposes
+/// those capabilities.
+///
+/// Mirrors `ComposerTextView` — this repo's existing `NSViewRepresentable`
+/// text-input precedent: a `Coordinator` owns delegate state and forwards
+/// through to SwiftUI bindings; `updateNSView` only touches AppKit state that
+/// has actually changed, so it doesn't fight the user's in-flight edit /
+/// selection / IME state on every SwiftUI update.
+struct ScrollableTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    let font: NSFont
+    /// When `version` changes, the editor scrolls to `charOffset` and sets the
+    /// caret there. Pass `nil` when no scroll is pending.
+    var scrollRequest: EditorScrollRequest?
+    /// Fires with the caret's character index whenever it changes — used by the
+    /// caller to highlight the heading the caret is currently inside.
+    var onCaretChange: ((Int) -> Void)?
+
+    // MARK: - NSViewRepresentable
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+
+        let textView = Self.makeConfiguredTextView(font: font)
+        textView.delegate = context.coordinator
+        textView.string = text
+
+        scrollView.documentView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+
+        // Sync text only when it changed externally (avoids clobbering the
+        // user's in-flight edit). Setting `.string` resets undo + selection,
+        // so we must skip it when the text view is already in sync.
+        if textView.string != text {
+            textView.string = text
+        }
+        if textView.font?.fontName != font.fontName
+            || textView.font?.pointSize != font.pointSize {
+            textView.font = font
+        }
+
+        // Consume a pending scroll request.
+        if let request = scrollRequest,
+           context.coordinator.appliedScrollVersion != request.version {
+            context.coordinator.appliedScrollVersion = request.version
+            let length = (textView.string as NSString).length
+            let clamped = min(max(0, request.charOffset), length)
+            let range = NSRange(location: clamped, length: 0)
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
+            textView.window?.makeFirstResponder(textView)
+        }
+    }
+
+    // MARK: - Text view factory (shared with tests)
+
+    static func makeConfiguredTextView(font: NSFont) -> NSTextView {
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.allowsUndo = true
+        textView.drawsBackground = false
+        textView.textColor = .labelColor
+        textView.insertionPointColor = .labelColor
+        textView.font = font
+        // Disable automatic substitutions so pasted/typed markdown is not
+        // silently rewritten (smart quotes, dashes, etc.).
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isSelectable = true
+        textView.isEditable = true
+
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                  height: CGFloat.greatestFiniteMagnitude)
+        textView.minSize = NSSize(width: 0, height: 0)
+
+        if let container = textView.textContainer {
+            container.widthTracksTextView = true
+            container.containerSize = NSSize(width: 0,
+                                              height: CGFloat.greatestFiniteMagnitude)
+        }
+
+        return textView
+    }
+
+    // MARK: - Coordinator
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: ScrollableTextEditor
+        /// The last `EditorScrollRequest.version` this coordinator applied.
+        var appliedScrollVersion: Int?
+        /// Avoids redundant SwiftUI updates: only reports the caret when its
+        /// index actually changed.
+        private var lastReportedCaret: Int?
+
+        init(_ parent: ScrollableTextEditor) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            if parent.text != textView.string {
+                parent.text = textView.string
+            }
+            reportCaret(in: textView)
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            reportCaret(in: textView)
+        }
+
+        private func reportCaret(in textView: NSTextView) {
+            let caret = textView.selectedRange().location
+            guard caret != lastReportedCaret else { return }
+            lastReportedCaret = caret
+            parent.onCaretChange?(caret)
+        }
+    }
+}

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -42,6 +42,10 @@ struct SourceDetailView: View {
     @State private var origin: SourceOrigin?
     @State private var isEditing = false
     @State private var editBuffer = ""
+    /// Pending scroll-to-heading for the editor (outline click while editing).
+    @State private var editorScrollRequest: EditorScrollRequest?
+    /// Caret position in the editor, for outline cursor tracking (issue #268).
+    @State private var caretCharIndex: Int?
     @State private var isExtracting = false
     /// True while a source refresh (re-fetch via provider) is in flight.
     @State private var isRefreshing = false
@@ -169,14 +173,7 @@ struct SourceDetailView: View {
                 tabPicker
             }
             Divider().opacity(PageEditorMetrics.dividerOpacity)
-            HStack(spacing: 0) {
-                contentArea
-                if isOutlineExpanded, let markdown = currentMarkdownContent {
-                    PageOutlineView(markdown: markdown) { slug in
-                        store.jumpToAnchorInCurrentSelection(slug)
-                    }
-                }
-            }
+            contentAndOutline
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(nsColor: .textBackgroundColor))
@@ -283,7 +280,7 @@ struct SourceDetailView: View {
             if let id = store.activeTabID {
                 store.setTabEditing(tabID: id, isEditing: newValue)
             }
-            if !newValue { shouldRestoreEditing = false }
+            if !newValue { shouldRestoreEditing = false; caretCharIndex = nil }
         }
     }
 
@@ -583,6 +580,33 @@ struct SourceDetailView: View {
         }
     }
 
+    // MARK: - Content + Outline
+
+    /// The content area plus the optional outline sidebar. Extracted from
+    /// `body` so the type-checker can resolve each subtree independently.
+    @ViewBuilder
+    private var contentAndOutline: some View {
+        HStack(spacing: 0) {
+            contentArea
+            if isOutlineExpanded, let markdown = currentMarkdownContent {
+                outlineView(markdown: markdown)
+            }
+        }
+    }
+
+    private func outlineView(markdown: String) -> some View {
+        PageOutlineView(markdown: markdown,
+                        caretCharIndex: caretCharIndex) { heading in
+            if isEditing {
+                editorScrollRequest = EditorScrollRequest(
+                    charOffset: heading.charOffset,
+                    version: (editorScrollRequest?.version ?? 0) + 1)
+            } else {
+                store.jumpToAnchorInCurrentSelection(heading.id)
+            }
+        }
+    }
+
     // MARK: - Content area
 
     @ViewBuilder
@@ -652,9 +676,13 @@ struct SourceDetailView: View {
     @ViewBuilder
     private var markdownContent: some View {
         if isEditing {
-            TextEditor(text: $editBuffer)
-                .font(.system(size: 13 * editorZoom, design: .monospaced))
-                .scrollContentBackground(.hidden)
+            ScrollableTextEditor(
+                text: $editBuffer,
+                font: NSFont.monospacedSystemFont(
+                    ofSize: CGFloat(13 * editorZoom), weight: .regular),
+                scrollRequest: editorScrollRequest,
+                onCaretChange: { caretCharIndex = $0 }
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(PageEditorMetrics.contentInset)
                 .zoomShortcuts($editorZoom)


### PR DESCRIPTION
## Summary

Fixes #268 — outline clicks were a silent no-op while editing a page or source.

### Problem

The outline sidebar (`PageOutlineView`) is shared between reader and editor. Clicking a heading called `store.jumpToAnchorInCurrentSelection(slug)`, which sets `pendingScrollAnchor` — but that's only consumed by `WikiReaderView`'s HTML coordinator. In edit mode (`TextEditor`), nothing consumed it, so clicks did nothing.

### Changes

**1. New `ScrollableTextEditor` (`Sources/WikiFS/ScrollableTextEditor.swift`)**

An `NSViewRepresentable` wrapping `NSTextView` in `NSScrollView` (same backing SwiftUI's `TextEditor` uses), following the existing `ComposerTextView` pattern. Supports:
- `EditorScrollRequest` — scroll + caret to a given char offset (versioned so re-clicks re-fire)
- `onCaretChange` — reports caret index for outline cursor tracking
- Transparent background, monospaced font, auto-substitution disabled

**2. `PageOutlineView` enhancements**

- `HeadingItem` gains `charOffset` (NSString UTF-16 index of the heading line start)
- `onSelect` changed from `(String)` → `(HeadingItem)` so callers get both slug (reader) and charOffset (editor)
- New `caretCharIndex: Int?` param: when non-nil, highlights the heading containing the caret (`.primary` + accent background) and auto-scrolls the outline to keep it visible via `ScrollViewReader`
- `parseHeadings()` now tracks char offsets using `NSString.length` for UTF-16 correctness

**3. Both detail views wired up**

`PageDetailView` and `SourceDetailView` now:
- Use `ScrollableTextEditor` instead of `TextEditor` in edit mode
- Branch outline `onSelect` on `isEditing`: editor scroll (via `EditorScrollRequest`) vs reader anchor (`jumpToAnchorInCurrentSelection`)
- Reset `caretCharIndex` to `nil` when leaving edit mode
- Content areas extracted into computed properties (`contentAndOutline`, `editorContent`, `readerContent`) to keep the Swift type checker within its time budget

### Test plan

- [x] `swift build` passes
- [x] `swift test` — all 1974 tests pass
- [ ] Manual: open a page, expand outline, enter edit mode, click headings → editor scrolls + caret moves
- [ ] Manual: type in editor → outline highlights the heading under the caret
- [ ] Manual: reader mode outline clicks still scroll the HTML preview (unchanged path)
- [ ] Manual: source detail view edit mode outline clicks work
