### PR TITLE
Conversation view: zoom, title/date header, margin, and turn outline

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,48 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-08 — #275: Conversation view layout parity with PageDetailView
+
+PR #275 (`conversation-zoom-header-fix`) brings the conversation surface's
+header, outline, and content layout in line with `PageDetailView` so the two
+detail surfaces read as siblings.
+
+**What shipped (7 commits on top of the branch):**
+- **Zoom fix** — `ConversationView`'s zoom consumer wiring was dropped in an
+  earlier change; re-added `@AppStorage("conversation.zoom")` +
+  `.zoomShortcuts`/`.zoomScroll`, `zoom:` flows to both transcript web views,
+  and the composer font scales too.
+- **Title + date header for live chats** — live conversations had no header
+  (only persisted chats did). Added the shared `header(for:)` + divider to the
+  live view. Title restyled to `.largeTitle` to match page/source detail.
+- **Left margin** — left-aligned transcript + composer at
+  `PageEditorMetrics.contentInset` (12pt) instead of a centered 900pt column.
+  Removed dead `conversationHorizontalInset`.
+- **Header restructured to VStack** — the outline toggle was floating at the
+  top-right corner (`HStack(.top)` + `Spacer`). Restructured to a `VStack`
+  matching `PageDetailView`: title → metadata row → button row.
+- **Show in List button** — added `sidebar.left` button calling
+  `store.requestSidebarReveal(.chat(chatID))`; shown only for persisted/live
+  chats (hidden in the draft `.ask`/`.edit` state).
+- **Draggable outline** — `ChatOutlineView` now mirrors `PageOutlineView`:
+  draggable divider with resize cursor, dynamic width via
+  `@AppStorage("chatOutlineWidth")`, `.windowBackgroundColor`.
+  `withChatOutline` stretches content to `.infinity` so the outline sits flush
+  against the right window edge.
+- **Full-width content** — removed the 900pt `chatColumnWidth` cap (live +
+  persisted transcript, composer, editing banner). All now fill available
+  width like `PageDetailView`.
+- **Transcript CSS cleanup** — `body { padding: 10px }` → `padding: 10px 0`
+  (vertical only) to stop double-stacking horizontal padding with the SwiftUI
+  `.padding(.horizontal, 12pt)`.
+- **Full-width agent bubbles** — changed `.chat-row .bubble` max-width
+  selector to `.chat-user .bubble` so only user messages are capped at
+  `min(760px, 86%)`. Agent responses fill the width, eliminating the
+  perceived right-margin gap when reading agent text.
+
+**Files touched:** `Sources/WikiFS/ConversationView.swift`,
+`Sources/WikiFS/AgentTranscriptWebView.swift`.
+
 ## 2026-07-08 — #242: Bookmark created/updated timestamps
 
 Bookmarks now carry `createdAt`/`updatedAt` so the UI can show "date added"/"date

--- a/Sources/WikiFS/AgentTranscriptWebView.swift
+++ b/Sources/WikiFS/AgentTranscriptWebView.swift
@@ -21,6 +21,15 @@ import WikiFSCore
 /// full reload — so an in-progress text selection survives a streaming run. A
 /// count *decrease* (a reset) or a `showsInternals` change (which changes which
 /// underlying events are visible) forces a full rebuild.
+/// A versioned request to scroll the chat transcript to a user turn. Mirrors the
+/// reader's anchor-version pattern: `version` bumps to signal a new request;
+/// `turnIndex` is the 0-based index among the `.chat-user` rows the transcript
+/// renders. Consumed in `AgentTranscriptWebView.updateNSView`.
+struct ChatScrollRequest: Equatable {
+    let version: Int
+    let turnIndex: Int
+}
+
 struct AgentTranscriptWebView: NSViewRepresentable {
     /// `.activityFeed` is the inspector look (labeled rows, tool calls,
     /// diagnostics). `.chat` is the Query page look (right-aligned capsule
@@ -66,6 +75,9 @@ struct AgentTranscriptWebView: NSViewRepresentable {
     /// `readerZoom`). Defaults to 1× so callers that don't pass a value render
     /// at native size.
     var zoom: Double = Double(ZoomScale.defaultScale)
+    /// Versioned request to scroll to a user turn (outline click). `nil` (default)
+    /// never scrolls; consumed in `updateNSView`.
+    var scrollRequest: ChatScrollRequest? = nil
 
     func makeNSView(context: Context) -> WKWebView {
         // Register the blob scheme handler BEFORE the first load (same wiring
@@ -99,6 +111,13 @@ struct AgentTranscriptWebView: NSViewRepresentable {
             handler.store = blobStore
         }
         context.coordinator.apply(events: events, showsInternals: showsInternals)
+        // Outline click → scroll the i-th user bubble into view. Only fires when
+        // the version advances, so unrelated re-renders (streaming) don't re-scroll.
+        if let req = scrollRequest, req.version != context.coordinator.appliedScrollVersion {
+            context.coordinator.appliedScrollVersion = req.version
+            let js = "(function(){var u=document.querySelectorAll('.chat-user');var el=u[\(req.turnIndex)];if(el){el.scrollIntoView({block:'start'});}})()"
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -114,6 +133,9 @@ struct AgentTranscriptWebView: NSViewRepresentable {
         /// `currentContext`); the value is `Sendable` so it can flow into the
         /// pure static render functions.
         var renderContext: (() -> WikiRenderContext?)?
+        /// Last chat-outline scroll request applied, so an unchanged request
+        /// doesn't re-scroll on every re-render.
+        var appliedScrollVersion: Int = -1
         private var renderedCount = 0
         private var renderedShowsInternals: Bool?
         private var isLoaded = false

--- a/Sources/WikiFS/AgentTranscriptWebView.swift
+++ b/Sources/WikiFS/AgentTranscriptWebView.swift
@@ -464,7 +464,7 @@ struct AgentTranscriptWebView: NSViewRepresentable {
           .chat-row { display: flex; margin: 0 0 14px; }
           .chat-user { justify-content: flex-end; }
           .chat-assistant { justify-content: flex-start; }
-          .chat-row .bubble { max-width: min(760px, 86%); }
+          .chat-user .bubble { max-width: min(760px, 86%); }
           .chat-user .bubble {
             background: var(--code-bg); border-radius: 14px;
             padding: 11px 16px; white-space: pre-wrap; font-size: 13.5px;

--- a/Sources/WikiFS/AgentTranscriptWebView.swift
+++ b/Sources/WikiFS/AgentTranscriptWebView.swift
@@ -440,7 +440,7 @@ struct AgentTranscriptWebView: NSViewRepresentable {
           body {
             font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
             font-size: 13px; line-height: 1.5; color: var(--text);
-            padding: 10px; -webkit-font-smoothing: antialiased;
+            padding: 10px 0; -webkit-font-smoothing: antialiased;
           }
           .row { margin: 0 0 8px; }
           .row-label { font-size: 11px; font-weight: 600; color: var(--muted); margin-bottom: 2px; }

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -287,30 +287,38 @@ struct ConversationView: View {
 
     @ViewBuilder
     private func header(for chat: ChatSummary) -> some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(chat.title)
-                    .font(.largeTitle)
-                    .bold()
-                    .lineLimit(1)
-                    .textSelection(.enabled)
-                HStack(spacing: 6) {
-                    Text("\(chat.messageCount) message\(chat.messageCount == 1 ? "" : "s")")
-                    Text("·")
-                    Text(chat.updatedAt, format: .dateTime)
+        VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
+            Text(chat.title)
+                .font(.largeTitle)
+                .bold()
+                .lineLimit(1)
+                .textSelection(.enabled)
+
+            HStack(spacing: 6) {
+                Text("\(chat.messageCount) message\(chat.messageCount == 1 ? "" : "s")")
+                Text("·")
+                Text(chat.updatedAt, format: .dateTime)
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+
+            HStack(spacing: 10) {
+                if let chatID {
+                    Button("Show in List", systemImage: "sidebar.left") {
+                        store.requestSidebarReveal(.chat(chatID))
+                    }
+                    .help("Reveal this conversation in the sidebar")
                 }
-                .font(.callout)
-                .foregroundStyle(.secondary)
+                Button {
+                    chatOutlineExpanded.toggle()
+                } label: {
+                    Image(systemName: "sidebar.right")
+                }
+                .buttonStyle(.borderless)
+                .help("Toggle Outline")
             }
-            Spacer(minLength: 0)
-            Button {
-                chatOutlineExpanded.toggle()
-            } label: {
-                Image(systemName: "sidebar.right")
-            }
-            .buttonStyle(.borderless)
-            .help("Toggle Outline")
         }
+        .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
         .padding(.horizontal, PageEditorMetrics.contentInset)
         .padding(.top, PageEditorMetrics.contentInset)
         .padding(.bottom, ConversationMetrics.sectionSpacing)

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -52,21 +52,12 @@ struct ConversationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                ZStack(alignment: .topTrailing) {
-                    content
-                    if showsDebugControls {
-                        controls
-                            .padding(.top, ConversationMetrics.debugTopInset)
-                            .padding(.trailing, ConversationMetrics.contentInset)
-                    }
-                }
-                if chatOutlineExpanded {
-                    ChatOutlineView(turns: chatTurns) { turnIndex in
-                        outlineScroll = ChatScrollRequest(
-                            version: (outlineScroll?.version ?? 0) + 1,
-                            turnIndex: turnIndex)
-                    }
+            ZStack(alignment: .topTrailing) {
+                content
+                if showsDebugControls {
+                    controls
+                        .padding(.top, ConversationMetrics.debugTopInset)
+                        .padding(.trailing, ConversationMetrics.contentInset)
                 }
             }
             .frame(minWidth: PageEditorMetrics.detailMinWidth)
@@ -178,6 +169,25 @@ struct ConversationView: View {
         }
     }
 
+    // MARK: - Content + outline
+
+    /// Wraps `content` with the optional right-side chat outline. Placed BELOW
+    /// the header so the title pane spans full width and the outline sits beside
+    /// the transcript (matching the page detail's content+outline layout).
+    @ViewBuilder
+    private func withChatOutline<C: View>(@ViewBuilder _ content: () -> C) -> some View {
+        HStack(spacing: 0) {
+            content()
+            if chatOutlineExpanded {
+                ChatOutlineView(turns: chatTurns) { turnIndex in
+                    outlineScroll = ChatScrollRequest(
+                        version: (outlineScroll?.version ?? 0) + 1,
+                        turnIndex: turnIndex)
+                }
+            }
+        }
+    }
+
     // MARK: - Live conversation (streaming)
 
     @ViewBuilder
@@ -187,26 +197,30 @@ struct ConversationView: View {
                 header(for: chat)
                 Divider().opacity(PageEditorMetrics.dividerOpacity)
             }
-            if showsEditingEnabledBanner {
-                editingEnabledBanner
-                    .padding(.top, bannerTopReservation)
-                    .padding(.bottom, ConversationMetrics.sectionSpacing)
+            withChatOutline {
+                VStack(spacing: 0) {
+                    if showsEditingEnabledBanner {
+                        editingEnabledBanner
+                            .padding(.top, bannerTopReservation)
+                            .padding(.bottom, ConversationMetrics.sectionSpacing)
+                    }
+                    QueryTranscriptView(
+                        launcher: launcher,
+                        onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
+                        renderContext: { [weak store] in store?.renderContext() },
+                        blobStore: store,
+                        zoom: conversationZoom,
+                        scrollRequest: outlineScroll
+                    )
+                        .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
+                        .padding(.horizontal, PageEditorMetrics.contentInset)
+                        .padding(.top, showsEditingEnabledBanner || chatSummary != nil ? 0 : ConversationMetrics.conversationTopInset)
+                    liveComposer
+                        .padding(.horizontal, PageEditorMetrics.contentInset)
+                        .padding(.top, ConversationMetrics.sectionSpacing)
+                        .padding(.bottom, ConversationMetrics.contentInset)
+                }
             }
-            QueryTranscriptView(
-                launcher: launcher,
-                onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
-                renderContext: { [weak store] in store?.renderContext() },
-                blobStore: store,
-                zoom: conversationZoom,
-                scrollRequest: outlineScroll
-            )
-                .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
-                .padding(.horizontal, PageEditorMetrics.contentInset)
-                .padding(.top, showsEditingEnabledBanner || chatSummary != nil ? 0 : ConversationMetrics.conversationTopInset)
-            liveComposer
-                .padding(.horizontal, PageEditorMetrics.contentInset)
-                .padding(.top, ConversationMetrics.sectionSpacing)
-                .padding(.bottom, ConversationMetrics.contentInset)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
     }
@@ -241,7 +255,9 @@ struct ConversationView: View {
             VStack(alignment: .leading, spacing: 0) {
                 header(for: chat)
                 Divider().opacity(PageEditorMetrics.dividerOpacity)
-                persistedTranscript
+                withChatOutline {
+                    persistedTranscript
+                }
             }
         } else {
             ContentUnavailableView {

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -39,6 +39,8 @@ struct ConversationView: View {
     @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ConversationMetrics.composerFont)
     @State private var persistedMessages: [ChatMessage] = []
     @AppStorage("conversation.zoom") private var conversationZoom = Double(ZoomScale.defaultScale)
+    @AppStorage("isChatOutlineExpanded") private var chatOutlineExpanded = false
+    @State private var outlineScroll: ChatScrollRequest? = nil
 
     /// True when this surface is rendering the active live session (D2
     /// source-of-truth rule). The view sources from `launcher.events`; when
@@ -50,12 +52,21 @@ struct ConversationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ZStack(alignment: .topTrailing) {
-                content
-                if showsDebugControls {
-                    controls
-                        .padding(.top, ConversationMetrics.debugTopInset)
-                        .padding(.trailing, ConversationMetrics.contentInset)
+            HStack(spacing: 0) {
+                ZStack(alignment: .topTrailing) {
+                    content
+                    if showsDebugControls {
+                        controls
+                            .padding(.top, ConversationMetrics.debugTopInset)
+                            .padding(.trailing, ConversationMetrics.contentInset)
+                    }
+                }
+                if chatOutlineExpanded {
+                    ChatOutlineView(turns: chatTurns) { turnIndex in
+                        outlineScroll = ChatScrollRequest(
+                            version: (outlineScroll?.version ?? 0) + 1,
+                            turnIndex: turnIndex)
+                    }
                 }
             }
             .frame(minWidth: PageEditorMetrics.detailMinWidth)
@@ -186,7 +197,8 @@ struct ConversationView: View {
                 onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
                 renderContext: { [weak store] in store?.renderContext() },
                 blobStore: store,
-                zoom: conversationZoom
+                zoom: conversationZoom,
+                scrollRequest: outlineScroll
             )
                 .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
                 .padding(.horizontal, PageEditorMetrics.contentInset)
@@ -244,21 +256,44 @@ struct ConversationView: View {
         store.chats.first { $0.id == chatID }
     }
 
+    /// User turns (questions) in display order — the chat outline entries. Sourced
+    /// from the SAME transcript-visible events the web view renders, so outline
+    /// index `i` matches the i-th `.chat-user` row.
+    private var chatTurns: [String] {
+        let events = isLiveChat
+            ? launcher.events.transcriptVisible
+            : persistedMessages.map(\.event).transcriptVisible
+        return events.compactMap { event in
+            if case .userText(let text) = event { return text }
+            return nil
+        }
+    }
+
     @ViewBuilder
     private func header(for chat: ChatSummary) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(chat.title)
-                .font(.largeTitle)
-                .bold()
-                .lineLimit(1)
-                .textSelection(.enabled)
-            HStack(spacing: 6) {
-                Text("\(chat.messageCount) message\(chat.messageCount == 1 ? "" : "s")")
-                Text("·")
-                Text(chat.updatedAt, format: .dateTime)
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(chat.title)
+                    .font(.largeTitle)
+                    .bold()
+                    .lineLimit(1)
+                    .textSelection(.enabled)
+                HStack(spacing: 6) {
+                    Text("\(chat.messageCount) message\(chat.messageCount == 1 ? "" : "s")")
+                    Text("·")
+                    Text(chat.updatedAt, format: .dateTime)
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
             }
-            .font(.callout)
-            .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            Button {
+                chatOutlineExpanded.toggle()
+            } label: {
+                Image(systemName: "sidebar.right")
+            }
+            .buttonStyle(.borderless)
+            .help("Toggle Outline")
         }
         .padding(.horizontal, PageEditorMetrics.contentInset)
         .padding(.top, PageEditorMetrics.contentInset)
@@ -282,7 +317,8 @@ struct ConversationView: View {
                 onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
                 renderContext: { [weak store] in store?.renderContext() },
                 blobStore: store,
-                zoom: conversationZoom
+                zoom: conversationZoom,
+                scrollRequest: outlineScroll
             )
             .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -586,5 +622,53 @@ enum ConversationMetrics {
     static var sendButtonBottomInset: CGFloat {
         (ComposerTextView.oneLineHeight(for: composerFont)
             + composerVerticalPadding * 2 - sendButtonSize) / 2
+    }
+}
+
+/// Right-side outline for a conversation: lists the user's turns (questions) in
+/// order. Clicking a turn scrolls the transcript web view to that message via a
+/// versioned `ChatScrollRequest`. Mirrors the page outline's shape (divider +
+/// "Outline" header + scrollable list).
+struct ChatOutlineView: View {
+    let turns: [String]
+    let onSelect: (Int) -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor))
+                .frame(width: 1)
+                .frame(maxHeight: .infinity)
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Outline")
+                    .font(.headline)
+                    .padding([.horizontal, .top])
+                    .padding(.bottom, 8)
+                Divider()
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(Array(turns.enumerated()), id: \.offset) { index, turn in
+                            Button {
+                                onSelect(index)
+                            } label: {
+                                Text(turn.isEmpty ? "(empty)" : turn)
+                                    .font(.callout)
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(2)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.vertical, 4)
+                                    .padding(.horizontal, 8)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
+            .frame(width: 240)
+            .background(Color(nsColor: .textBackgroundColor))
+        }
     }
 }

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -213,7 +213,7 @@ struct ConversationView: View {
                         zoom: conversationZoom,
                         scrollRequest: outlineScroll
                     )
-                        .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .padding(.horizontal, PageEditorMetrics.contentInset)
                         .padding(.top, showsEditingEnabledBanner || chatSummary != nil ? 0 : ConversationMetrics.conversationTopInset)
                     liveComposer
@@ -345,8 +345,7 @@ struct ConversationView: View {
                 zoom: conversationZoom,
                 scrollRequest: outlineScroll
             )
-            .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             .padding(.horizontal, PageEditorMetrics.contentInset)
             // D3: the persisted chat's composer continues the conversation
             // (seeded-fallback). Enabled when the kind's launcher is idle; disabled
@@ -385,7 +384,7 @@ struct ConversationView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
-        .frame(maxWidth: ConversationMetrics.chatColumnWidth)
+        .frame(maxWidth: .infinity)
         .background(.orange.opacity(0.15))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay {
@@ -465,7 +464,7 @@ struct ConversationView: View {
                 .strokeBorder(Color(nsColor: .separatorColor).opacity(0.55), lineWidth: 1)
         }
         .shadow(color: Color.black.opacity(0.06), radius: 18, x: 0, y: 8)
-        .frame(maxWidth: ConversationMetrics.chatColumnWidth)
+        .frame(maxWidth: .infinity)
     }
 
     // MARK: - Send logic
@@ -629,7 +628,6 @@ enum ConversationMetrics {
     static let debugTopInset: CGFloat = 18
     static let controlsBandHeight: CGFloat = 28
     static let conversationTopInset: CGFloat = 56
-    static let chatColumnWidth: CGFloat = 900
     static let emptyStateHorizontalInset: CGFloat = 72
     static let emptyStateSpacing: CGFloat = 28
     static let emptyStateBottomBias: CGFloat = 96

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -178,6 +178,7 @@ struct ConversationView: View {
     private func withChatOutline<C: View>(@ViewBuilder _ content: () -> C) -> some View {
         HStack(spacing: 0) {
             content()
+                .frame(maxWidth: .infinity, alignment: .leading)
             if chatOutlineExpanded {
                 ChatOutlineView(turns: chatTurns) { turnIndex in
                     outlineScroll = ChatScrollRequest(
@@ -657,18 +658,50 @@ struct ChatOutlineView: View {
     let turns: [String]
     let onSelect: (Int) -> Void
 
+    @AppStorage("chatOutlineWidth") private var outlineWidth: Double = 240
+    @State private var dragStartWidth: Double? = nil
+
     var body: some View {
         HStack(spacing: 0) {
+            // Draggable divider on the outline's leading edge. A 1pt separator
+            // line with a wider invisible hit area so it's easy to grab.
             Rectangle()
                 .fill(Color(nsColor: .separatorColor))
                 .frame(width: 1)
                 .frame(maxHeight: .infinity)
+                .padding(.horizontal, 4)
+                .contentShape(Rectangle())
+                .onHover { isHovering in
+                    if isHovering {
+                        NSCursor.resizeLeftRight.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+                .gesture(
+                    DragGesture()
+                        .onChanged { value in
+                            if dragStartWidth == nil {
+                                dragStartWidth = outlineWidth
+                            }
+                            if let start = dragStartWidth {
+                                let newWidth = start - Double(value.translation.width)
+                                outlineWidth = max(60, min(600, newWidth))
+                            }
+                        }
+                        .onEnded { _ in
+                            dragStartWidth = nil
+                        }
+                )
+                .zIndex(1)
+
             VStack(alignment: .leading, spacing: 0) {
                 Text("Outline")
                     .font(.headline)
-                    .padding([.horizontal, .top])
-                    .padding(.bottom, 8)
+                    .padding()
+
                 Divider()
+
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(turns.enumerated()), id: \.offset) { index, turn in
@@ -691,8 +724,8 @@ struct ChatOutlineView: View {
                     .padding(.vertical, 6)
                 }
             }
-            .frame(width: 240)
-            .background(Color(nsColor: .textBackgroundColor))
+            .frame(width: outlineWidth)
+            .background(Color(nsColor: .windowBackgroundColor))
         }
     }
 }

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -38,6 +38,7 @@ struct ConversationView: View {
     @State private var showsInternals = false
     @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ConversationMetrics.composerFont)
     @State private var persistedMessages: [ChatMessage] = []
+    @AppStorage("conversation.zoom") private var conversationZoom = Double(ZoomScale.defaultScale)
 
     /// True when this surface is rendering the active live session (D2
     /// source-of-truth rule). The view sources from `launcher.events`; when
@@ -59,6 +60,11 @@ struct ConversationView: View {
             }
             .frame(minWidth: PageEditorMetrics.detailMinWidth)
             .background(Color(nsColor: .textBackgroundColor))
+        }
+        .zoomShortcuts($conversationZoom)
+        .zoomScroll($conversationZoom)
+        .onChange(of: conversationZoom) { _, _ in
+            composerHeight = ComposerTextView.oneLineHeight(for: composerFont)
         }
         .onChange(of: launcher.isRunning) { _, isRunning in
             // Belt-and-suspenders: clear the internals toggle when a run ends so a
@@ -166,6 +172,10 @@ struct ConversationView: View {
     @ViewBuilder
     private var liveConversation: some View {
         VStack(spacing: 0) {
+            if let chat = chatSummary {
+                header(for: chat)
+                Divider().opacity(PageEditorMetrics.dividerOpacity)
+            }
             if showsEditingEnabledBanner {
                 editingEnabledBanner
                     .padding(.top, bannerTopReservation)
@@ -175,10 +185,11 @@ struct ConversationView: View {
                 launcher: launcher,
                 onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
                 renderContext: { [weak store] in store?.renderContext() },
-                blobStore: store
+                blobStore: store,
+                zoom: conversationZoom
             )
                 .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
-                .padding(.top, showsEditingEnabledBanner ? 0 : ConversationMetrics.conversationTopInset)
+                .padding(.top, showsEditingEnabledBanner || chatSummary != nil ? 0 : ConversationMetrics.conversationTopInset)
             liveComposer
                 .padding(.horizontal, ConversationMetrics.conversationHorizontalInset)
                 .padding(.top, ConversationMetrics.sectionSpacing)
@@ -241,8 +252,6 @@ struct ConversationView: View {
                 .lineLimit(1)
                 .textSelection(.enabled)
             HStack(spacing: 6) {
-                Text(chat.kind == .ask ? "Ask" : "Edit")
-                Text("·")
                 Text("\(chat.messageCount) message\(chat.messageCount == 1 ? "" : "s")")
                 Text("·")
                 Text(chat.updatedAt, format: .dateTime)
@@ -271,7 +280,8 @@ struct ConversationView: View {
                 style: .chat,
                 onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
                 renderContext: { [weak store] in store?.renderContext() },
-                blobStore: store
+                blobStore: store,
+                zoom: conversationZoom
             )
             .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
             .frame(maxWidth: .infinity, alignment: .center)
@@ -340,13 +350,21 @@ struct ConversationView: View {
 
     // MARK: - Composer
 
+    /// The composer's AppKit font, scaled by the persisted conversation zoom so
+    /// ⌘+/⌘− resize the input alongside the transcript (parity with the page
+    /// editor's `editor.zoom`).
+    private var composerFont: NSFont {
+        let base = ConversationMetrics.composerFont
+        return base.withSize(base.pointSize * CGFloat(conversationZoom))
+    }
+
     private func composer(enabled: Bool) -> some View {
         let sendActive = canSend && enabled
         return HStack(alignment: .bottom, spacing: 10) {
             ComposerTextView(
                 text: $draftMessage,
                 isEditable: enabled,
-                font: ConversationMetrics.composerFont,
+                font: composerFont,
                 onSubmit: sendMessage,
                 measuredHeight: $composerHeight
             )

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -189,13 +189,14 @@ struct ConversationView: View {
                 zoom: conversationZoom
             )
                 .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
+                .padding(.horizontal, PageEditorMetrics.contentInset)
                 .padding(.top, showsEditingEnabledBanner || chatSummary != nil ? 0 : ConversationMetrics.conversationTopInset)
             liveComposer
-                .padding(.horizontal, ConversationMetrics.conversationHorizontalInset)
+                .padding(.horizontal, PageEditorMetrics.contentInset)
                 .padding(.top, ConversationMetrics.sectionSpacing)
                 .padding(.bottom, ConversationMetrics.contentInset)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
     }
 
     private var emptyState: some View {
@@ -284,7 +285,8 @@ struct ConversationView: View {
                 zoom: conversationZoom
             )
             .frame(maxWidth: ConversationMetrics.chatColumnWidth, maxHeight: .infinity)
-            .frame(maxWidth: .infinity, alignment: .center)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, PageEditorMetrics.contentInset)
             // D3: the persisted chat's composer continues the conversation
             // (seeded-fallback). Enabled when the kind's launcher is idle; disabled
             // with a slot-style caption when a different conversation is responding.
@@ -303,7 +305,7 @@ struct ConversationView: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        .padding(.horizontal, ConversationMetrics.conversationHorizontalInset)
+        .padding(.horizontal, PageEditorMetrics.contentInset)
         .padding(.bottom, ConversationMetrics.contentInset)
         .frame(maxWidth: .infinity)
     }
@@ -565,7 +567,6 @@ enum ConversationMetrics {
     static let sectionSpacing: CGFloat = 16
     static let debugTopInset: CGFloat = 18
     static let controlsBandHeight: CGFloat = 28
-    static let conversationHorizontalInset: CGFloat = 48
     static let conversationTopInset: CGFloat = 56
     static let chatColumnWidth: CGFloat = 900
     static let emptyStateHorizontalInset: CGFloat = 72

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -247,7 +247,7 @@ struct ConversationView: View {
     private func header(for chat: ChatSummary) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(chat.title)
-                .font(.title2)
+                .font(.largeTitle)
                 .bold()
                 .lineLimit(1)
                 .textSelection(.enabled)

--- a/Sources/WikiFS/QueryTranscriptView.swift
+++ b/Sources/WikiFS/QueryTranscriptView.swift
@@ -20,6 +20,8 @@ struct QueryTranscriptView: View {
     /// Page-zoom multiplier forwarded to the transcript web view. Bound to the
     /// `conversation.zoom` AppStorage by the conversation surface.
     var zoom: Double = Double(ZoomScale.defaultScale)
+    /// Versioned scroll-to-turn request, forwarded to the transcript web view.
+    var scrollRequest: ChatScrollRequest? = nil
 
     var body: some View {
         Group {
@@ -33,7 +35,8 @@ struct QueryTranscriptView: View {
                     onWikiLink: onWikiLink,
                     renderContext: renderContext,
                     blobStore: blobStore,
-                    zoom: zoom
+                    zoom: zoom,
+                    scrollRequest: scrollRequest
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }

--- a/plans/query-conversation.md
+++ b/plans/query-conversation.md
@@ -30,6 +30,30 @@ asks to save, update, add, rewrite, log, or otherwise persist something.
 - The sidebar separates app-level destinations into Tools (Query) and System
   (Activity, Instructions), with Pages and Files left as content lists.
 
+### Layout parity with PageDetailView (#275)
+
+The conversation surface (`ConversationView`) mirrors `PageDetailView`'s
+header + content + outline layout so the two detail surfaces read as siblings:
+
+- **Header** — `VStack`: title (`.largeTitle`) → metadata row (message count ·
+  date) → button row. The button row holds a "Show in List" button
+  (`sidebar.left` → `requestSidebarReveal(.chat(id))`, hidden in draft state)
+  and the outline toggle (`sidebar.right`). Both live and persisted chats use
+  the same `header(for:)` + divider.
+- **Content width** — transcript, composer, and editing banner fill the full
+  available width (`maxWidth: .infinity`) with `contentInset` (12pt) padding.
+  No `chatColumnWidth` cap (the old 900pt limit was removed).
+- **Outline** — `ChatOutlineView` mirrors `PageOutlineView`: draggable divider
+  with resize cursor, dynamic width via `@AppStorage("chatOutlineWidth")`
+  (default 240, range 60–600), `.windowBackgroundColor`. The outline sits flush
+  against the right window edge (`withChatOutline` stretches content to
+  `.infinity`). Lists user turns in order; clicking scrolls the transcript via
+  a versioned `ChatScrollRequest`.
+- **Chat bubble CSS** — agent responses fill the available width (no
+  `max-width` cap); only user messages are capped at `min(760px, 86%)` and
+  right-aligned. Transcript `body` padding is vertical-only (`10px 0`); the
+  SwiftUI layer handles horizontal insets.
+
 ## Agent Session
 
 Interactive Query uses Claude Code's print-mode streaming input:


### PR DESCRIPTION
## Summary

Conversation-view improvements: restore broken text zoom, add a title + date header to live chats, align the left margin with the page detail, match the page title font, add a right-side turn outline, and bring the header's outline toggle + Show-in-List button in line with the page detail layout.

## Changes

### Fix: conversation zoom did nothing
An earlier change dropped `ConversationView`'s zoom *consumer* wiring while the infra survived, so the transcript always rendered at `pageZoom = 1.0`. Re-added: `@AppStorage("conversation.zoom")` + `.zoomShortcuts`/`.zoomScroll`, `zoom:` flows to both transcript web views, and the composer font scales too. Conversations now zoom like pages/sources.

### Title + date header (like pages/sources)
- **Live conversations had no header** — only persisted chats did. Added the shared `header(for:)` (+ divider) to the live view, so a conversation shows title + date whether live or persisted.
- Restyled to title + message-count + date, dropping the vestigial Ask/Edit kind label.
- Title font bumped to `.largeTitle` to match the page/source detail title (`EditableTitle`).

### Left margin matches the page detail
Left-aligned the transcript + composer at `PageEditorMetrics.contentInset` (12pt) instead of a centered chat column / 48pt inset, so the conversation's left edge aligns with the page detail. Removed the dead `conversationHorizontalInset`.

### Right-side turn outline
- New `ChatOutlineView` lists the user's turns (questions) in order on the right, with a `sidebar.right` toggle in the conversation header (mirrors the page outline: divider + "Outline" header + scrollable list).
- Clicking a turn scrolls the transcript to it via a versioned `ChatScrollRequest` (the reader's anchor-version pattern): the web view runs `querySelectorAll('.chat-user')[i].scrollIntoView()`. No changes to the streaming render.
- Wired through `QueryTranscriptView` (live) and the persisted `AgentTranscriptWebView`.

### Header layout parity with PageDetailView
- The outline toggle was floating at the top-right corner of the header (`HStack(.top)` + `Spacer`). Restructured to a `VStack` matching `PageDetailView`: title → metadata row → button row. The toggle now sits on a button row below the metadata.
- Added a **Show in List** button (`sidebar.left`) to the button row, calling `store.requestSidebarReveal(.chat(chatID))` to reveal the conversation in the sidebar. Only shown for persisted/live chats (hidden in the draft `.ask`/`.edit` state).

**No Reveal-in-Finder** on conversations — chats live only in the SQLite DB; the File Provider projects `pages/` and `sources/` but no `chats/` tree, so there's no per-conversation file to reveal. (Per operator decision.)

## Test plan
- [x] `swift build`
- [x] `swift test --filter ConversationViewD2Tests|AgentTranscriptLinkifyTests` — passes
