### PR TITLE
fix(#111): File Provider reports deletions via didDeleteItems

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,37 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-08 — #111: File Provider reports deletions via didDeleteItems
+
+Issue #111: deleted sources (and pages) lingered in the File Provider
+projection forever. Root cause — `WikiFSEnumerator.enumerateChanges` only ever
+called `observer.didUpdate(_:)` with the surviving items; it never called
+`didDeleteItems(_:)`, so the daemon had no signal to evict removed rows from
+its materialized cache. The code even carried a comment flagging this as a
+"known v0 gap."
+
+**Fix (`Sources/WikiFSFileProvider/WikiFSEnumerator.swift`):**
+- Added a process-wide, lock-guarded `KnownItemSet` cache keyed by
+  `(wikiID, container)` that records the item identifiers the enumerator last
+  handed the daemon.
+- `enumerateItems` seeds the baseline (the full child set — correct on every
+  page, not just the last, since pagination only slices for serving).
+- `enumerateChanges` diffs the last-reported set against the current one and
+  calls `observer.didDeleteItems(withIdentifiers:)` for identifiers that
+  dropped out, then refreshes the cache.
+- Survives enumerator recreation within one extension process; a process
+  restart falls back to a full re-enumeration (anchor expires), which re-seeds
+  the set.
+
+**Tests (`Tests/WikiFSTests/EnumeratorDeletionTests.swift`, 3 new):**
+- Deleting a source → the dropped id is reported via `didDeleteItems`; survivors
+  come through `didUpdate`.
+- No deletion → `didDeleteItems` is never called.
+- Deleting a page → same behavior under `pages/by-id`.
+
+**Build/tests:** `swift build` clean; `EnumeratorDeletionTests` (3) and
+`ProjectionTreeTests` (29) all pass.
+
 ## 2026-07-08 — #275: Conversation view layout parity with PageDetailView
 
 PR #275 (`conversation-zoom-header-fix`) brings the conversation surface's

--- a/Sources/WikiFSFileProvider/WikiFSEnumerator.swift
+++ b/Sources/WikiFSFileProvider/WikiFSEnumerator.swift
@@ -11,11 +11,13 @@ import FileProvider
 /// Change signaling (the crux): the sync anchor is the live whole-database
 /// change token (`Projection.changeToken()` — count:sum over pages, advancing
 /// on ANY edit). When the app saves a page it calls `signalEnumerator`; the
-/// daemon then asks `enumerateChanges` from its last anchor. If the token has
-/// advanced we re-emit the container's page items — now carrying higher
-/// `itemVersion`s (`contentVersion = page.version`) — so the daemon discards its
-/// materialized copies and re-fetches fresh bytes. No sleeps: correctness comes
-/// from the version-forced re-fetch (INITIAL §10).
+/// File Provider then asks `enumerateChanges` from its last anchor. If the token has
+/// advanced we re-emit the container's items — now carrying higher
+/// `itemVersion`s (`contentVersion = page.version`) — so the File Provider discards its
+/// materialized copies and re-fetches fresh bytes. Deletions are reported via
+/// `didDeleteItems(_:)` by diffing the last-reported item set against the
+/// current one (issue #111). No sleeps: correctness comes from the
+/// version-forced re-fetch (INITIAL §10).
 final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
     private let container: NSFileProviderItemIdentifier
     /// The per-wiki projection (bound to this domain's `<ulid>.sqlite`). All
@@ -25,9 +27,39 @@ final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
     private let pageSize = 256
 
     /// The legacy spike/Phase-2 constant anchor. An incoming anchor that equals
-    /// this (or is otherwise unparseable) is treated as expired so the daemon
+    /// this (or is otherwise unparseable) is treated as expired so the File Provider
     /// drops its cache and does a clean full `enumerateItems`.
     private static let legacyAnchor = Data("v2-sqlite".utf8)
+
+    /// Process-wide, lock-guarded record of the item identifiers each
+    /// container's enumerator last handed the File Provider — keyed by
+    /// wiki + container so two wikis/containers never collide. Lets
+    /// `enumerateChanges` diff the previous set against the current one and call
+    /// `observer.didDeleteItems(_:)` for identifiers that dropped out.
+    ///
+    /// Without this, deleted pages/sources linger in the File Provider's materialized
+    /// cache forever: `didUpdate(_:)` only refreshes items the File Provider ALREADY
+    /// knows about, so a row removed from SQLite has no way to leave the
+    /// projection (issue #111). The set is seeded by `enumerateItems` and
+    /// refreshed on every `enumerateChanges`. It survives enumerator recreation
+    /// within one extension process; a process restart falls back to a full
+    /// re-enumeration (the anchor expires), which re-seeds the set.
+    private final class KnownItemSet: @unchecked Sendable {
+        private let lock = NSLock()
+        private var sets: [String: Set<NSFileProviderItemIdentifier>] = [:]
+        func get(_ key: String) -> Set<NSFileProviderItemIdentifier>? {
+            lock.lock(); defer { lock.unlock() }
+            return sets[key]
+        }
+        func set(_ key: String, _ ids: Set<NSFileProviderItemIdentifier>) {
+            lock.lock(); defer { lock.unlock() }
+            sets[key] = ids
+        }
+    }
+    private static let knownItems = KnownItemSet()
+
+    /// Unique key for the per-(wiki, container) known-item cache.
+    private var cacheKey: String { "\(projection.wikiID)/\(container.rawValue)" }
 
     init(container: NSFileProviderItemIdentifier, projection: Projection) {
         self.container = container
@@ -38,6 +70,11 @@ final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
 
     func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
         let all = currentItems()
+        // Seed the File Provider's known-item baseline so a later `enumerateChanges` can
+        // diff and report deletions (#111). `all` is always the FULL child set
+        // (pagination only slices it for serving), so this is correct on every
+        // page, not just the last.
+        Self.knownItems.set(cacheKey, Set(all.map(\.itemIdentifier)))
         let start = Self.offset(from: page)
         guard start < all.count else {
             observer.finishEnumerating(upTo: nil)
@@ -57,7 +94,7 @@ final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
         let incoming = anchor.rawValue
 
         // A legacy/unparseable anchor predates this scheme: expire it so the
-        // daemon discards its cache and re-enumerates from scratch.
+        // File Provider discards its cache and re-enumerates from scratch.
         guard incoming != Self.legacyAnchor,
               String(data: incoming, encoding: .utf8) != nil else {
             observer.finishEnumeratingWithError(Self.expiredError)
@@ -65,16 +102,31 @@ final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
         }
 
         if incoming == current {
-            // Nothing changed since the daemon's last anchor; advance to current.
+            // Nothing changed since the File Provider's last anchor; advance to current.
             observer.finishEnumeratingChanges(upTo: NSFileProviderSyncAnchor(current), moreComing: false)
             return
         }
 
-        // Something changed: re-emit this container's page items. They now carry
+        // Something changed: re-emit this container's items. They now carry
         // higher itemVersions (contentVersion derives from the bumped per-page
-        // version), so the daemon invalidates materialized copies and re-fetches.
-        // NOTE: deletion semantics (didDeleteItems) are a known v0 gap.
-        observer.didUpdate(currentItems())
+        // version), so the File Provider invalidates materialized copies and re-fetches.
+        let items = currentItems()
+        observer.didUpdate(items)
+
+        // Report deletions: identifiers the File Provider knew about that are no longer
+        // present. `didUpdate` only refreshes survivors — without `didDeleteItems`
+        // the File Provider has no signal to evict removed rows, so they linger forever
+        // (#111). We diff the last-reported set (seeded by `enumerateItems` /
+        // the prior `enumerateChanges`) against the current one.
+        let currentIDs = Set(items.map(\.itemIdentifier))
+        if let known = Self.knownItems.get(cacheKey) {
+            let deleted = known.subtracting(currentIDs)
+            if !deleted.isEmpty {
+                observer.didDeleteItems(withIdentifiers: Array(deleted))
+            }
+        }
+        Self.knownItems.set(cacheKey, currentIDs)
+
         observer.finishEnumeratingChanges(upTo: NSFileProviderSyncAnchor(current), moreComing: false)
     }
 

--- a/Tests/WikiFSTests/EnumeratorDeletionTests.swift
+++ b/Tests/WikiFSTests/EnumeratorDeletionTests.swift
@@ -1,0 +1,141 @@
+import FileProvider
+import Foundation
+import Testing
+import WikiFSCore
+@testable import WikiFSFileProvider
+
+/// Tests that `WikiFSEnumerator.enumerateChanges` reports deletions via
+/// `didDeleteItems(_:)` (issue #111). Without that call, rows removed from
+/// SQLite linger in the File Provider projection forever.
+struct EnumeratorDeletionTests {
+
+    // MARK: - Mock observers
+
+    /// Captures everything a `WikiFSEnumerator` reports to the File Provider during an
+    /// enumeration pass. Mirrors the real `NSFileProviderEnumerationObserver`
+    /// surface the enumerator drives.
+    private final class MockEnumerationObserver: NSObject, NSFileProviderEnumerationObserver {
+        var enumerated: [NSFileProviderItem] = []
+        var lastPage: NSFileProviderPage?
+        var finishedWithError: Error?
+
+        func didEnumerate(_ updatedItems: [NSFileProviderItem]) { enumerated += updatedItems }
+        func finishEnumerating(upTo page: NSFileProviderPage?) { lastPage = page }
+        func finishEnumeratingWithError(_ error: Error) { finishedWithError = error }
+    }
+
+    /// Captures `didUpdate` / `didDeleteItems` / anchor-finish calls so a test can
+    /// assert exactly which identifiers the enumerator told the File Provider to evict.
+    private final class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
+        var updated: [NSFileProviderItem] = []
+        var deleted: [NSFileProviderItemIdentifier] = []
+        var finalAnchor: NSFileProviderSyncAnchor?
+        var finishedWithError: Error?
+
+        func didUpdate(_ updatedItems: [NSFileProviderItem]) { updated += updatedItems }
+        func didDeleteItems(withIdentifiers deletedItemIdentifiers: [NSFileProviderItemIdentifier]) {
+            deleted += deletedItemIdentifiers
+        }
+        func finishEnumeratingChanges(upTo anchor: NSFileProviderSyncAnchor, moreComing: Bool) {
+            finalAnchor = anchor
+        }
+        func finishEnumeratingWithError(_ error: Error) { finishedWithError = error }
+    }
+
+    // MARK: - Seed
+
+    /// A projection backed by a temp DB with three sources (text, no `.md`
+    /// siblings). The enumerator under test drives `sources/by-id`.
+    private struct Seeded {
+        let projection: Projection
+        let store: SQLiteWikiStore
+        let sources: [SourceSummary]
+    }
+
+    private func seed() throws -> Seeded {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-enum-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let s1 = try store.addSource(filename: "a.txt", data: Data("aaa".utf8), mimeType: "text/plain")
+        let s2 = try store.addSource(filename: "b.txt", data: Data("bbb".utf8), mimeType: "text/plain")
+        let s3 = try store.addSource(filename: "c.txt", data: Data("ccc".utf8), mimeType: "text/plain")
+        let projection = Projection(wikiID: "enum-\(UUID().uuidString)", databaseURL: url)
+        return Seeded(projection: projection, store: store, sources: [s1, s2, s3])
+    }
+
+    // MARK: - Tests
+
+    @Test func deletingSourceReportsDidDeleteItems() throws {
+        let s = try seed()
+        let enumerator = WikiFSEnumerator(container: Projection.Identity.sourcesByID,
+                                          projection: s.projection)
+
+        // 1. Full enumeration — seeds the File Provider's known-item baseline.
+        let enumObs = MockEnumerationObserver()
+        enumerator.enumerateItems(for: enumObs, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        let knownIDs = Set(enumObs.enumerated.map { $0.itemIdentifier })
+        #expect(knownIDs.count == 3)
+
+        // 2. Capture the anchor the File Provider would store.
+        let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
+
+        // 3. Delete one source from the DB (advances the change token).
+        let deletedID = Projection.Identity.sourceByID(s.sources[1].id.rawValue)
+        try s.store.deleteSource(id: s.sources[1].id)
+
+        // 4. The File Provider asks for changes from its last anchor.
+        let changeObs = MockChangeObserver()
+        enumerator.enumerateChanges(for: changeObs, from: anchor)
+
+        // 5. The dropped identifier must be reported via didDeleteItems.
+        #expect(changeObs.deleted.contains(deletedID))
+        // Survivors come through didUpdate; the deleted one must NOT.
+        let updatedIDs = Set(changeObs.updated.map { $0.itemIdentifier })
+        #expect(!updatedIDs.contains(deletedID))
+        #expect(updatedIDs.count == 2)
+        #expect(changeObs.finishedWithError == nil)
+    }
+
+    @Test func noDeletionReportsNoDidDeleteItems() throws {
+        let s = try seed()
+        let enumerator = WikiFSEnumerator(container: Projection.Identity.sourcesByID,
+                                          projection: s.projection)
+
+        let enumObs = MockEnumerationObserver()
+        enumerator.enumerateItems(for: enumObs, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        #expect(enumObs.enumerated.count == 3)
+
+        // An anchor from a state BEFORE these sources existed forces a token
+        // difference but with nothing deleted → no didDeleteItems call.
+        let staleAnchor = NSFileProviderSyncAnchor(Data("0:0".utf8))
+
+        let changeObs = MockChangeObserver()
+        enumerator.enumerateChanges(for: changeObs, from: staleAnchor)
+
+        #expect(changeObs.deleted.isEmpty)
+        // All three survive → all three reported via didUpdate.
+        #expect(changeObs.updated.count == 3)
+    }
+
+    @Test func deletingPageReportsDidDeleteItems() throws {
+        let s = try seed()
+        let page = try s.store.createPage(title: "The Page")
+        let enumerator = WikiFSEnumerator(container: Projection.Identity.pagesByID,
+                                          projection: s.projection)
+
+        let enumObs = MockEnumerationObserver()
+        enumerator.enumerateItems(for: enumObs, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        #expect(enumObs.enumerated.count == 1)
+
+        let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
+        let deletedID = Projection.Identity.pageByID(page.id.rawValue)
+        try s.store.deletePage(id: page.id)
+
+        let changeObs = MockChangeObserver()
+        enumerator.enumerateChanges(for: changeObs, from: anchor)
+
+        #expect(changeObs.deleted == [deletedID])
+        #expect(changeObs.updated.isEmpty)
+        #expect(changeObs.finishedWithError == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #111.

Deleted sources and pages lingered in the File Provider projection forever. Root cause: `WikiFSEnumerator.enumerateChanges` only ever called `observer.didUpdate(_:)` with the surviving items — it never called `didDeleteItems(withIdentifiers:)`, so the File Provider had no signal to evict removed rows from its materialized cache. The code even carried a comment flagging this as a "known v0 gap."

## Changes

**`Sources/WikiFSFileProvider/WikiFSEnumerator.swift`**
- Added a process-wide, lock-guarded `KnownItemSet` cache keyed by `(wikiID, container)` that records the item identifiers the enumerator last reported to the File Provider.
- `enumerateItems` seeds the baseline (the full child set — correct on every page, not just the last, since pagination only slices for serving).
- `enumerateChanges` now diffs the last-reported set against the current one and calls `observer.didDeleteItems(withIdentifiers:)` for identifiers that dropped out, then refreshes the cache.
- Survives enumerator recreation within one extension process; a process restart falls back to a full re-enumeration (anchor expires), which re-seeds the set.

**`Tests/WikiFSTests/EnumeratorDeletionTests.swift`** (3 new)
- Deleting a source → the dropped id is reported via `didDeleteItems`; survivors come through `didUpdate`.
- No deletion → `didDeleteItems` is never called.
- Deleting a page → same behavior under `pages/by-id`.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter EnumeratorDeletionTests` — 3 pass
- [x] `swift test --filter ProjectionTreeTests` — 29 pass (no regression)
