### PR TITLE
Add Share and Reveal in Finder buttons to chat detail view

### DIFF
--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -310,6 +310,28 @@ struct ConversationView: View {
                     }
                     .help("Reveal this conversation in the sidebar")
                 }
+                if fileProvider.path != nil, let chatID {
+                    Button("Share", systemImage: "square.and.arrow.up") {
+                        Task {
+                            guard let url = await fileProvider.resolveChatByNameURL(id: chatID) else { return }
+                            let picker = NSSharingServicePicker(items: [url])
+                            let mouseScreen = NSEvent.mouseLocation
+                            guard let window = NSApplication.shared.keyWindow,
+                                  let contentView = window.contentView else { return }
+                            let windowPoint = window.convertPoint(fromScreen: mouseScreen)
+                            let viewPoint = contentView.convert(windowPoint, from: nil)
+                            picker.show(
+                                relativeTo: NSRect(origin: viewPoint,
+                                                   size: NSSize(width: 1, height: 1)),
+                                of: contentView, preferredEdge: .minY)
+                        }
+                    }
+                    .help("Share this conversation")
+                    Button("Reveal in Finder", systemImage: "folder") {
+                        Task { await fileProvider.revealChatInFinder(id: chatID) }
+                    }
+                    .help("Reveal this conversation file in Finder")
+                }
                 Button {
                     chatOutlineExpanded.toggle()
                 } label: {

--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -323,6 +323,14 @@ final class FileProviderSpike {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
+    /// Reveal a chat transcript file in Finder via its `chat-by-name` leaf
+    /// identifier. Mirrors `revealPageInFinder`. Best-effort: silently no-ops if
+    /// the domain isn't active or the daemon can't resolve the item.
+    func revealChatInFinder(id: PageID) async {
+        guard let url = await resolveChatByNameURL(id: id) else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
     /// Open a page in its default app (e.g. a Markdown editor), in the ACTIVE
     /// wiki’s domain. Resolves the page’s user-visible URL via its
     /// `page-by-title` identifier (the same resolution `share`/`reveal` use) and
@@ -407,6 +415,29 @@ final class FileProviderSpike {
                 timeout: .seconds(5))
         } catch {
             DebugLog.fileprovider("resolvePageByTitleURL: failed — \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Resolve the user-visible URL for sharing a chat via its `chat-by-name`
+    /// leaf identifier. Mirrors `resolvePageByTitleURL`/`resolveSourceByNameURL`
+    /// — the daemon returns the canonical URL directly, so no path construction
+    /// and no cold-cache race. Returns `nil` if the domain isn't active or the
+    /// daemon can't resolve the item.
+    func resolveChatByNameURL(id: PageID) async -> URL? {
+        guard let wikiID = activeWikiID else { return nil }
+        let domain = domain(id: wikiID, displayName: wikiID)
+        guard let manager = NSFileProviderManager(for: domain) else { return nil }
+        let identifier = NSFileProviderItemIdentifier(WikiFSContainerID.chatByName(id.rawValue))
+        do {
+            let url = try await userVisibleURL(
+                manager: manager,
+                itemIdentifier: identifier,
+                timeout: .seconds(5))
+            DebugLog.fileprovider("resolveChatByNameURL: resolved \(url.lastPathComponent)")
+            return url
+        } catch {
+            DebugLog.fileprovider("resolveChatByNameURL: failed — \(error.localizedDescription)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary

Adds **Share** and **Reveal in Finder** buttons to the chat detail view header, matching the existing buttons in `PageDetailView`.

## Changes

- **`FileProviderSpike.swift`** — two chat counterparts to the existing page methods:
  - `resolveChatByNameURL(id:)` — resolves a chat transcript's user-visible mount URL via its `chat-by-name:<ulid>` File Provider leaf identifier (mirrors `resolvePageByTitleURL`).
  - `revealChatInFinder(id:)` — resolves that URL and selects it in Finder (mirrors `revealPageInFinder`).
- **`ConversationView.swift`** — adds **Share** and **Reveal in Finder** buttons to `header(for:)`, between "Show in List" and the outline toggle. Both are gated on `fileProvider.path != nil` and a non-nil `chatID`, the same conditions `PageDetailView` uses.

## Notes

- Share reuses the exact `NSSharingServicePicker` anchor-at-cursor pattern from `PageDetailView`.
- Buttons only appear for persisted chats (non-nil `chatID`); draft `.ask`/`.edit` states correctly show neither.

Build clean; full test suite passes.
