### PR TITLE
Rename Agent tab to Chats; move Lint/Instructions/Activity to maintenance menu

### DIFF
--- a/Sources/WikiFS/AgentToolsView.swift
+++ b/Sources/WikiFS/AgentToolsView.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 import WikiFSCore
 
-/// The Agent section — a small SwiftUI `List` of the agent mode entries (Ask /
-/// Edit / Lint / Activity / Instructions). These are navigation items, so
-/// single-click selects AND opens (the binding's `set` calls `store.openTab`),
-/// restoring the behavior the shared-`List` had before the double-click
-/// experiment. No per-row gesture, so no latency.
+/// The Chats section — a small SwiftUI `List` of the conversation entry plus the
+/// "Recent Conversations" history. Mirrors the Pages/Sources/Bookmarks tabs:
+/// single-purpose, focused on one content type. Maintenance/diagnostic surfaces
+/// (Lint, Instructions, Activity) moved to the app's maintenance menu (issue
+/// #282). These are navigation items, so single-click selects AND opens (the
+/// binding's `set` calls `store.openTab`). No per-row gesture, so no latency.
 struct AgentToolsView: View {
     @Bindable var store: WikiStoreModel
     /// The Ask (read-only) conversation launcher — backs the live indicator on
@@ -24,7 +25,7 @@ struct AgentToolsView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text("Agent").font(.headline).foregroundStyle(.primary)
+                Text("Chats").font(.headline).foregroundStyle(.primary)
                 Spacer()
             }
             .padding(.horizontal, 12)
@@ -38,21 +39,6 @@ struct AgentToolsView: View {
                     systemImage: "bubble.left.and.text.bubble.right")
                     .tag(WikiSelection.edit)
                     .help("Chat with the agent — ask questions, or ask it to update the wiki. It proposes changes and waits for your approval before writing.")
-
-                SidebarModeRow(title: "Lint", subtitle: "Health-check the wiki",
-                    systemImage: "checkmark.shield")
-                    .tag(WikiSelection.lint)
-                    .help("Check the wiki for stale content, broken links, and inconsistencies")
-
-                SidebarModeRow(title: "Activity", subtitle: "Operation log",
-                    systemImage: "clock.arrow.circlepath")
-                    .tag(WikiSelection.changeLog)
-                    .help("Operation history, projected read-only as log.md")
-
-                SidebarModeRow(title: "Instructions", subtitle: "Agent prompt",
-                    systemImage: "sparkles")
-                    .tag(WikiSelection.systemPrompt)
-                    .help("Agent instructions, projected read-only as CLAUDE.md and AGENTS.md")
 
                 if !store.chats.isEmpty {
                     Section {

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 import WikiFSCore
 
-/// Sidebar host: a section-selector bar (Pages / Sources / Bookmarks / Agent)
+/// Sidebar host: a section-selector bar (Pages / Sources / Bookmarks / Chats)
 /// above the active section's view. Each section is now an independent view:
 /// Pages, Sources, and Bookmarks are native AppKit `NSTableView`/`NSOutlineView`
-/// (instant selection, native double-click); Agent is a small SwiftUI `List`.
+/// (instant selection, native double-click); Chats is a small SwiftUI `List`.
 /// The shared SwiftUI `List(selection:)` and cross-section multi-select
 /// machinery are gone — each view owns its selection.
 struct SidebarView: View {
@@ -47,7 +47,7 @@ struct SidebarView: View {
     /// The sidebar's sections. Each gets an icon in the selector bar and, when
     /// selected, fills the list below.
     enum SidebarSection: String, CaseIterable, Identifiable {
-        case pages, sources, bookmarks, agent
+        case pages, sources, bookmarks, chats
 
         var id: String { rawValue }
 
@@ -56,7 +56,7 @@ struct SidebarView: View {
             case .pages: "Pages"
             case .sources: "Sources"
             case .bookmarks: "Bookmarks"
-            case .agent: "Agent"
+            case .chats: "Chats"
             }
         }
 
@@ -65,7 +65,7 @@ struct SidebarView: View {
             case .pages: "doc.text"
             case .sources: "tray.full"
             case .bookmarks: "bookmark"
-            case .agent: "sparkles"
+            case .chats: "bubble.left.and.bubble.right"
             }
         }
     }
@@ -182,7 +182,7 @@ struct SidebarView: View {
                     showingNewBookmarkFolder = true
                     newBookmarkFolderName = ""
                 })
-        case .agent:
+        case .chats:
             AgentToolsView(store: store, askLauncher: askLauncher, editLauncher: editLauncher)
         }
     }

--- a/Sources/WikiFS/VacuumCommands.swift
+++ b/Sources/WikiFS/VacuumCommands.swift
@@ -1,12 +1,17 @@
 import SwiftUI
 import WikiFSCore
 
-/// Help-menu command for reclaiming orphaned storage (#253 + #257). Opens a
-/// confirm alert (a read-only dry-run preview → Vacuum / Cancel) that sweeps
-/// both orphaned blobs and orphaned activities in one pass. The wiring lives
-/// in `WikiManager.previewVacuumAll` / `applyVacuumAll` and the alert is hosted
-/// on the app's root scene. Menu items that open a dialog end with "…" (macOS
-/// convention).
+/// Help-menu commands for wiki maintenance and diagnostics (#253 + #257 + #282).
+///
+/// Two kinds of items live here:
+///   * **Actions** that open a confirm dialog (end with "…", macOS convention) —
+///     "Vacuum All…" reclaims orphaned blobs and activities in one pass
+///     (`WikiManager.previewVacuumAll` / `applyVacuumAll`, hosted on the root scene).
+///   * **Navigation** items that open a maintenance/detail tab in the main
+///     window — Lint, Agent Instructions, and Activity Log. These were moved out
+///     of the Chats sidebar tab (issue #282) so that tab is a pure chat list.
+///     They reuse the existing `WikiSelection` destinations already rendered by
+///     `WikiDetailView`.
 struct VacuumCommands: Commands {
     let manager: WikiManager
 
@@ -14,6 +19,18 @@ struct VacuumCommands: Commands {
         CommandGroup(after: .help) {
             Button("Vacuum All…") {
                 manager.previewVacuumAll()
+            }
+
+            Divider()
+
+            Button("Lint Wiki") {
+                manager.activeStore?.openTab(.lint)
+            }
+            Button("Agent Instructions") {
+                manager.activeStore?.openTab(.systemPrompt)
+            }
+            Button("Activity Log") {
+                manager.activeStore?.openTab(.changeLog)
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #282 — rename the **Agent** sidebar tab to **Chats** and move Lint / Instructions / Activity out of it into the app's maintenance menu, so the tab is a single-purpose chat list consistent with Pages / Sources / Bookmarks.

## Changes

### `AgentToolsView.swift`
- Removed the **Lint**, **Activity**, and **Instructions** `SidebarModeRow` entries.
- The list now contains only **Conversation** + **Recent Conversations** — a pure chat surface.
- Renamed the section header from "Agent" → "Chats".

### `SidebarView.swift`
- Renamed the `SidebarSection` enum case `.agent` → `.chats` (private nested enum; no external references).
- Title "Agent" → "Chats"; icon `sparkles` → `bubble.left.and.bubble.right`.
- Updated `bookmarksOrList` switch case + doc comments.

### `VacuumCommands.swift`
- Added three navigation items to the existing `CommandGroup(after: .help)` maintenance menu:
  - **Lint Wiki** → opens `.lint`
  - **Agent Instructions** → opens `.systemPrompt`
  - **Activity Log** → opens `.changeLog`
- These reuse the existing `WikiSelection` destinations already rendered by `WikiDetailView`, so no new views were needed. Separated from "Vacuum All…" by a divider.

## Notes
- The Settings-window `Label("Agent", systemImage: "terminal")` tab (CLI command config) was intentionally left as-is — it's genuinely about the agent CLI, not chats.
- Build clean; all 2030 tests pass.
