### PR TITLE
Split slow SQLite integration tests out of CI (#292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,15 @@ jobs:
         run: make check-prompts
       - name: Build
         run: swift build || xcrun swift build
-      - name: Test
-        run: swift test || xcrun swift test
+      - name: Test (fast tier — slow SQLite suites skipped, issue #292)
+        # CI runs only the fast tier. The slow SQLite integration suites
+        # (tagged .integration in Tests/WikiFSTests/TestTags.swift) are skipped
+        # by name: `swift test` does not yet filter by tag (SwiftPM's --skip is
+        # name-regex only; tag filtering is xcodebuild-only). The full suite
+        # (including these) must be run locally before merge — see AGENTS.md.
+        env:
+          SKIP: 'ProjectionTreeTests|EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests'
+        run: swift test --skip "$SKIP" || xcrun swift test --skip "$SKIP"
 
   python:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,9 +194,20 @@ Persistent chats are two tables: `chats` (one row per conversation) and
 **Swift** (from repo root):
 ```
 swift build          # compile
-swift test           # full suite
+swift test           # full suite (run locally before merge)
+# fast tier — what CI runs; skips the slow SQLite integration suites:
+swift test --skip 'ProjectionTreeTests|EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests'
 swift test --filter PdfExtractionServiceTests  # pdf extraction only
 ```
+
+CI runs the **fast tier** only (issue #292): it skips the slow SQLite
+integration suites, which open real databases and dominate runtime (notably
+`ProjectionTreeTests` working-set tests at 165s+ each, #291). They are tagged
+`.integration` (`Tests/WikiFSTests/TestTags.swift`); note `swift test` does not
+yet filter by tag, so CI skips them by name. **Run the full `swift test` locally
+before merging** so those suites aren't skipped. To mark a new slow suite, add
+`.tags(.integration)` AND append its name to the CI skip regex in
+`.github/workflows/ci.yml`.
 
 **Python / pdf2md** (from `tools/pdf2md`):
 ```

--- a/Tests/WikiFSTests/EnumeratorDeletionTests.swift
+++ b/Tests/WikiFSTests/EnumeratorDeletionTests.swift
@@ -7,6 +7,7 @@ import WikiFSCore
 /// Tests that `WikiFSEnumerator.enumerateChanges` reports deletions via
 /// `didDeleteItems(_:)` (issue #111). Without that call, rows removed from
 /// SQLite linger in the File Provider projection forever.
+@Suite(.tags(.integration))
 struct EnumeratorDeletionTests {
 
     // MARK: - Mock observers

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -8,7 +8,8 @@ import SQLite3
 /// any drift (a forgotten table/column/index/FK/trigger) would silently make
 /// fresh dbs differ from upgraded ones. This forces a fresh db through the FULL
 /// ladder and compares the two schema-identical.
-@Suite struct FreshSchemaParityTests {
+@Suite(.tags(.integration))
+struct FreshSchemaParityTests {
 
     private func tempURL() -> URL {
         let dir = FileManager.default.temporaryDirectory

--- a/Tests/WikiFSTests/ProjectionTreeTests.swift
+++ b/Tests/WikiFSTests/ProjectionTreeTests.swift
@@ -14,6 +14,7 @@ import WikiFSCore
 /// They rely on the `databaseURL` injection seam (Phase B.0) so the projection
 /// is exercisable without the App Group sandbox (`ProjectionTests` could only
 /// test pure functions before it).
+@Suite(.tags(.integration))
 struct ProjectionTreeTests {
 
     /// A seeded projection: two pages, a text source (no `.md` sibling), and a

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -6,6 +6,7 @@ import CryptoKit
 
 /// Store-level tests: persistence across reopen, pragmas + schema, slug
 /// collision handling, and ULID ordering.
+@Suite(.tags(.integration))
 struct SQLiteWikiStoreTests {
 
     /// Make a fresh on-disk DB URL in a unique temp directory.

--- a/Tests/WikiFSTests/StoreEmissionTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionTests.swift
@@ -8,7 +8,8 @@ import Foundation
 /// `Task`), so a lock-guarded collector is polled until the event lands; because
 /// events arrive a runloop tick after `emit`, prerequisite mutations are awaited
 /// (then the collector cleared) before the mutation under test runs.
-@Suite struct StoreEmissionTests {
+@Suite(.tags(.integration))
+struct StoreEmissionTests {
 
     /// Lock-guarded, synchronous collector — the `@MainActor` handler appends
     /// without awaiting.

--- a/Tests/WikiFSTests/TestTags.swift
+++ b/Tests/WikiFSTests/TestTags.swift
@@ -1,0 +1,20 @@
+import Testing
+
+/// Marks a test suite as a slow SQLite **integration** test (issue #292), so it
+/// can be excluded from per-commit CI.
+///
+/// **Important:** `swift test` (SwiftPM) does NOT yet filter by tag — its
+/// `--skip`/`--filter` match test names by regex only (tag filtering is
+/// xcodebuild-only, 16.3+). So CI excludes these suites *by name* via a regex
+/// that mirrors this tag — see `.github/workflows/ci.yml` and `AGENTS.md`. The
+/// tag still earns its keep: it documents intent, enables IDE/xcodebuild local
+/// filtering (`xcodebuild -skip-testing-tags integration`), and future-proofs CI
+/// for when SwiftPM gains `--skip .integration`.
+///
+/// Apply `.tags(.integration)` to suites that open a real SQLite store and are
+/// too slow for per-commit CI — notably the N+1 working-set paths (issue #291).
+/// When you do, ALSO append the suite name to the CI skip regex so it is
+/// actually excluded. Pure-logic tests stay untagged so they always run in CI.
+extension Tag {
+    @Tag static var integration: Tag
+}


### PR DESCRIPTION
## Summary

Closes #292 — split the test suite into a fast tier (CI-default) and a slow SQLite integration tier (local/nightly), cutting the ~11 min CI runtime dominated by `ProjectionTreeTests` working-set tests (165s+ each, #291).

## What changed

- **`Tests/WikiFSTests/TestTags.swift`** (new) — defines an `.integration` tag via the Swift Testing `@Tag` macro, with the tier convention documented.
- **Five slow suites** tagged `.integration`: `ProjectionTreeTests`, `EnumeratorDeletionTests`, `SQLiteWikiStoreTests`, `StoreEmissionTests`, `FreshSchemaParityTests`.
- **`.github/workflows/ci.yml`** — the Test step now runs `swift test --skip '<five suite names>'` (the fast tier).
- **`AGENTS.md`** — documents the fast tier, the local full-run requirement, and the rule for new slow suites (tag it **and** add the name to the CI regex).

## ⚠️ Important finding: `swift test` can't filter by tag yet

I started with the tag-driven approach (`swift test --skip .integration`), but **it didn't work** — `swift test`'s `--skip`/`--filter` match test names by regex only. Tag-based filtering is **xcodebuild-only** (16.3+); SwiftPM doesn't have it yet (still a [pitch](https://forums.swift.org/t/pitch-tag-based-test-execution-filtering/86001)). So `--skip .integration` matched nothing and the slow suite ran.

**Adaptation:** CI excludes the suites **by name** via a regex that mirrors the `.integration` tag. The tags are kept because they still add value: they document intent, enable IDE/`xcodebuild -skip-testing-tags integration` for local runs, and future-proof CI for when SwiftPM gains `--skip .integration` (then the name regex can be dropped). This dual mechanism is documented in `TestTags.swift`, `AGENTS.md`, and the CI step.

## Verification

- `swift test --skip '<regex>' --filter ProjectionTreeTests` → **0 tests in 8.6s** (build only), proving the tagged suite is excluded.
- `swift test --skip '<regex>' --filter FindModelTests` → **13 tests pass**, proving the regex doesn't over-match (non-slow suites still run).
- `swift build --build-tests` clean; the `@Tag` macro and `.tags(.integration)` compile under Swift 6.3.

The PR's CI run itself is the end-to-end confirmation (it should finish well under the previous ~11 min).

## To mark a future slow suite
Add `.tags(.integration)` to the suite **and** append its name to the `SKIP` regex in `.github/workflows/ci.yml`. (Documented in all three files.)
