### PR TITLE
Align conversation view and update Chats UI labels

### DIFF
--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -343,7 +343,6 @@ struct ConversationView: View {
                 } label: {
                     Image(systemName: "sidebar.right")
                 }
-                .buttonStyle(.borderless)
                 .help("Toggle Outline")
             }
         }

--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -193,7 +193,7 @@ struct ConversationView: View {
 
     @ViewBuilder
     private var liveConversation: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
             if let chat = chatSummary {
                 header(for: chat)
                 Divider().opacity(PageEditorMetrics.dividerOpacity)

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -70,7 +70,7 @@ struct WikiDetailView: View {
                         introRow(title: "Pages", description: "Create and edit markdown notes with deep wiki-linking.", systemImage: "doc.text")
                         introRow(title: "Sources", description: "Manage and ingest raw material from URLs, folders, or Zotero.", systemImage: "tray.full")
                         introRow(title: "Bookmarks", description: "Organize pages and sources into a custom folder tree for quick access.", systemImage: "bookmark")
-                        introRow(title: "Agent", description: "Query the agent, check wiki health, and view system logs.", systemImage: "sparkles")
+                        introRow(title: "Chats", description: "Ask questions and edit your wiki through conversation.", systemImage: "bubble.left.and.bubble.right")
                     }
                     .frame(maxWidth: 400)
 


### PR DESCRIPTION
## Summary

- Add `.leading` alignment to `liveConversation` VStack to align content flush left
- Remove `.borderless` button style from outline toggle to use default button styling
- Rename "Agent" to "Chats" in intro row with updated icon and description to better reflect the feature's purpose

## Why

Improves visual consistency in the conversation view and clarifies the chat feature's purpose with more intuitive naming and icons.