### PR TITLE
Simplify chat detail metadata to show date only

### DIFF
--- a/Sources/WikiFS/ConversationView.swift
+++ b/Sources/WikiFS/ConversationView.swift
@@ -297,17 +297,12 @@ struct ConversationView: View {
                     .textSelection(.enabled)
             } icon: {
                 Image(systemName: chat.kind == .ask ? "bubble.left.and.bubble.right" : "square.and.pencil")
-                    .font(.largeTitle)
                     .foregroundStyle(.secondary)
             }
 
-            HStack(spacing: 6) {
-                Text("\(chat.messageCount) message\(chat.messageCount == 1 ? "" : "s")")
-                Text("·")
-                Text(chat.updatedAt, format: .dateTime)
-            }
-            .font(.callout)
-            .foregroundStyle(.secondary)
+            Text(chat.updatedAt, style: .date)
+                .font(.callout)
+                .foregroundStyle(.secondary)
 
             HStack(spacing: 10) {
                 if let chatID {


### PR DESCRIPTION
Remove message count from the chat metadata display and update the date format from full dateTime to date-only. This streamlines the chat detail view by focusing on the essential information (when the conversation was last updated) while reducing visual clutter. Also removes the `.largeTitle` font styling from the chat icon.