### PR TITLE
Add copy button to agent chat responses (#285)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ Resources/mlx.metallib
 
 .vscode/
 
-.xcodebuildmcp/tmp/
+.xcodebuildmcp/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-09 — #285: Copy button on agent chat responses
+
+Each assistant/response bubble in the chat transcript (Ask/Edit + Query) now has
+a hover-revealed **Copy** button that writes the raw markdown text (not the
+rendered HTML) to the system pasteboard — no more drag-selecting to copy an
+answer.
+
+The transcript is a single `WKWebView` (`ChatWebView`), so the button is an
+HTML/CSS `:hover` affordance inside the rendered bubble markup, not a SwiftUI
+modifier. Each `.chat-assistant` bubble emits a `<button class="copy-btn"
+data-copy="<escaped raw text>">`. A delegated `document`-level click listener
+posts the `data-copy` payload to a new `copyText` `WKScriptMessageHandler` on the
+`WKUserContentController`; the coordinator writes it via the standard
+`NSPasteboard.general` idiom. The button shows brief "Copied" feedback.
+
+Scoped to `.chat` style only (the user-facing transcript). The internals/activity
+feed (`feedRowHTML`) is unchanged (non-goal per the issue). 6 new tests in
+`ChatWebViewLinkifyTests` cover: assistant + result rows carry `data-copy`,
+user/tool rows don't, HTML-special-char escaping, and the empty-result guard.
+
 ## 2026-07-09 — #245: Semantic + FTS search over chats
 
 Past Ask/Edit conversations are now searchable by meaning + keywords, mirroring

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -79,12 +79,26 @@ struct ChatWebView: NSViewRepresentable {
     /// never scrolls; consumed in `updateNSView`.
     var scrollRequest: ChatScrollRequest? = nil
 
+    /// Name of the `WKScriptMessage` channel the per-bubble "Copy" button posts
+    /// to (issue #285). The JS click listener calls
+    /// `window.webkit.messageHandlers.copyText.postMessage(text)`; the coordinator
+    /// writes `text` to `NSPasteboard`.
+    static let copyMessageName = "copyText"
+
     func makeNSView(context: Context) -> WKWebView {
         // Register the blob scheme handler BEFORE the first load (same wiring
         // as `WikiReaderView`, reader lines ~326–348) so `wiki-blob://source/<id>`
         // images and media resolve inside chat transcripts. The handler weakly
         // references the store; refreshed each update like `onWikiLink`.
         let config = WKWebViewConfiguration()
+        // Message handler for the per-bubble "Copy" button (issue #285): the JS
+        // click listener posts the raw markdown text; the coordinator writes it
+        // to NSPasteboard. Retained by the content controller; the coordinator
+        // holds the webView weakly so there's no cycle (same pattern as
+        // WikiReaderView's LinkHoverMessageHandler).
+        let cc = WKUserContentController()
+        cc.add(context.coordinator, name: Self.copyMessageName)
+        config.userContentController = cc
         let blobHandler = BlobSchemeHandler(store: blobStore)
         config.setURLSchemeHandler(blobHandler, forURLScheme: BlobSchemeHandler.scheme)
         let webView = WKWebView(frame: .zero, configuration: config)
@@ -122,7 +136,7 @@ struct ChatWebView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
         weak var webView: WKWebView?
         var style: VisualStyle = .activityFeed
         /// Routes a clicked `wiki://` link out to the view's `onWikiLink`
@@ -278,6 +292,22 @@ struct ChatWebView: NSViewRepresentable {
             webView?.evaluateJavaScript("replaceLastRow(\(jsonString))", completionHandler: nil)
         }
 
+        // MARK: - Copy button (issue #285)
+
+        /// Receives the raw markdown text from the JS click listener and writes it
+        /// to the system pasteboard. Called on the main thread by WebKit.
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard message.name == ChatWebView.copyMessageName,
+                  let text = message.body as? String
+            else { return }
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(text, forType: .string)
+        }
+
         // MARK: - Row rendering
 
         private static func rowHTML(for event: AgentEvent, style: VisualStyle, context: WikiRenderContext?, isFinal: Bool) -> String {
@@ -370,14 +400,10 @@ struct ChatWebView: NSViewRepresentable {
                 <div class="row chat-row chat-user"><div class="bubble">\(escapePreservingBreaks(text))</div></div>
                 """
             case .assistantText(let text):
-                return """
-                <div class="row chat-row chat-assistant"><div class="bubble">\(renderedMarkdown(text, context: context, isFinal: isFinal))</div></div>
-                """
+                return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)
             case .result(_, let text):
                 guard !text.isEmpty else { return "" }
-                return """
-                <div class="row chat-row chat-assistant"><div class="bubble">\(renderedMarkdown(text, context: context, isFinal: isFinal))</div></div>
-                """
+                return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)
             case .toolUse(let name, let summary):
                 return chatToolRowHTML(name: name, summary: summary, isError: false)
             case .toolResult(let isError, let summary):
@@ -388,6 +414,19 @@ struct ChatWebView: NSViewRepresentable {
             case .systemInit, .subagent, .messageStop, .raw, .assistantTextDelta:
                 return ""
             }
+        }
+
+        /// A chat-style assistant bubble (markdown prose + a hover-revealed "Copy"
+        /// button). Shared by `.assistantText` and `.result` rows (issue #285).
+        /// The button's `data-copy` attribute carries the **raw markdown** (HTML-
+        /// attribute-escaped) — not the rendered HTML — so the clipboard gets the
+        /// plain text the user would have drag-selected.
+        private static func assistantBubbleHTML(text: String, context: WikiRenderContext?, isFinal: Bool) -> String {
+            """
+            <div class="row chat-row chat-assistant"><div class="bubble">\
+            <button class="copy-btn" type="button" data-copy="\(htmlAttributeEscape(text))">Copy</button>\
+            \(renderedMarkdown(text, context: context, isFinal: isFinal))</div></div>
+            """
         }
 
         /// A single muted, left-aligned progress line for a tool call — the
@@ -411,6 +450,13 @@ struct ChatWebView: NSViewRepresentable {
 
         private static func escapePreservingBreaks(_ s: String) -> String {
             escape(s).replacingOccurrences(of: "\n", with: "<br>")
+        }
+
+        /// Escapes a string for safe embedding in a double-quoted HTML attribute
+        /// value. The DOM decodes entities when reading `.dataset`, so JS receives
+        /// the original text verbatim — no JSON round-trip needed.
+        private static func htmlAttributeEscape(_ s: String) -> String {
+            escape(s).replacingOccurrences(of: "\"", with: "&quot;")
         }
 
         /// Minimal document the whole feed lives in — internal scrolling
@@ -469,6 +515,18 @@ struct ChatWebView: NSViewRepresentable {
             background: var(--code-bg); border-radius: 14px;
             padding: 11px 16px; white-space: pre-wrap; font-size: 13.5px;
           }
+          .chat-assistant .bubble { position: relative; }
+          .copy-btn {
+            position: absolute; top: 0; right: 0;
+            opacity: 0; transition: opacity 0.15s ease;
+            -webkit-appearance: none; appearance: none;
+            background: var(--code-bg); border: none; border-radius: 5px;
+            padding: 2px 7px; font: inherit; font-size: 11px;
+            color: var(--muted); cursor: pointer; line-height: 1.4;
+          }
+          .chat-assistant:hover .copy-btn { opacity: 0.75; }
+          .copy-btn:hover { opacity: 1; color: var(--text); }
+          .copy-btn.copied { opacity: 1; color: #34c759; }
           .chat-tool {
             justify-content: flex-start; align-items: baseline;
             gap: 6px; font-size: 11.5px; color: var(--muted);
@@ -521,6 +579,26 @@ struct ChatWebView: NSViewRepresentable {
             }
             window.scrollTo(0, document.body.scrollHeight);
           }
+          // Delegated click handler for the per-bubble "Copy" button (issue #285).
+          // Works on dynamically-appended rows since it's on `document`. Posts the
+          // raw markdown text (from `data-copy`) to the Swift message handler, then
+          // briefly shows "Copied" feedback.
+          document.addEventListener('click', function(e) {
+            var btn = e.target.closest && e.target.closest('.copy-btn');
+            if (!btn) return;
+            e.preventDefault();
+            var text = btn.dataset.copy || '';
+            try {
+              window.webkit.messageHandlers.copyText.postMessage(text);
+            } catch (err) { /* handler not registered — no-op */ }
+            var orig = btn.textContent;
+            btn.textContent = 'Copied';
+            btn.classList.add('copied');
+            setTimeout(function() {
+              btn.textContent = orig;
+              btn.classList.remove('copied');
+            }, 1200);
+          });
         </script>
         </body></html>
         """

--- a/Tests/WikiFSTests/ChatWebViewLinkifyTests.swift
+++ b/Tests/WikiFSTests/ChatWebViewLinkifyTests.swift
@@ -90,6 +90,47 @@ struct ChatWebViewLinkifyTests {
         #expect(html.isEmpty)
     }
 
+    // MARK: - Copy button (issue #285)
+
+    @Test func chatAssistantRowHasCopyButtonWithRawText() {
+        let html = Transcript.chatRowHTML(for: .assistantText("Hello **world**."))
+        #expect(html.contains("copy-btn"))
+        // The raw markdown (not rendered HTML) is in data-copy.
+        #expect(html.contains(#"data-copy="Hello **world**.""#))
+    }
+
+    @Test func chatResultRowHasCopyButtonWithRawText() {
+        let html = Transcript.chatRowHTML(for: .result(isError: false, text: "Done."))
+        #expect(html.contains("copy-btn"))
+        #expect(html.contains(#"data-copy="Done.""#))
+    }
+
+    @Test func chatUserRowHasNoCopyButton() {
+        let html = Transcript.chatRowHTML(for: .userText("Hello"))
+        #expect(!html.contains("copy-btn"))
+    }
+
+    @Test func chatToolRowsHaveNoCopyButton() {
+        let toolUse = Transcript.chatRowHTML(for: .toolUse(name: "Read", inputSummary: "x"))
+        let toolResult = Transcript.chatRowHTML(for: .toolResult(isError: true, summary: "fail"))
+        #expect(!toolUse.contains("copy-btn"))
+        #expect(!toolResult.contains("copy-btn"))
+    }
+
+    @Test func copyDataAttributeEscapesHtmlSpecialChars() {
+        let html = Transcript.chatRowHTML(for: .assistantText(#"Say "hi" <b> & bye"#))
+        #expect(html.contains("data-copy="))
+        // Double quotes → &quot;, < → &lt;, > → &gt;, & → &amp;.
+        #expect(html.contains("&quot;hi&quot;"))
+        #expect(html.contains("&lt;b&gt;"))
+        #expect(html.contains("&amp; bye"))
+    }
+
+    @Test func emptyResultRowHasNoCopyButton() {
+        let html = Transcript.chatRowHTML(for: .result(isError: false, text: ""))
+        #expect(html.isEmpty)
+    }
+
     // MARK: - Phase A.2: nil-context path is behavior-preserving
     //
     // The historical callers that pass NO context (e.g. AgentActivityView's
@@ -211,9 +252,13 @@ struct AgentTranscriptRenderContextTests {
         let row = Transcript.chatRowHTML(
             for: .assistantText("See [[source:\(paperID.rawValue)|stale]]."),
             context: ctx, isFinal: true)
-        // The healed name appears inside the chat bubble; the stale alias does not.
+        // The healed name appears inside the chat bubble's link; the stale alias
+        // does not. Note: the raw text survives in the copy button's `data-copy`
+        // attribute (issue #285), so we check the *rendered link* text, not the
+        // whole row.
         #expect(row.contains("My Paper"))
-        #expect(!row.contains("stale"))
+        #expect(row.contains(">My Paper</a>"))
+        #expect(!row.contains(">stale</a>"))
     }
 
     // MARK: - Two-tier streaming render (isFinal)


### PR DESCRIPTION
Closes #285.

## Summary

Each assistant/response bubble in the chat transcript now has a hover-revealed **Copy** button that writes the raw markdown text (not the rendered HTML) to the system pasteboard — no more drag-selecting to copy an answer.

## Approach

The transcript is a single `WKWebView` (`ChatWebView`), so the copy button is an HTML/CSS `:hover` affordance inside the rendered bubble markup — not a SwiftUI modifier. No per-turn view tree exists to attach `.onHover` to.

- **`chatRowHTML`**: `.assistantText` and `.result` bubbles now emit `<button class="copy-btn" data-copy="<escaped raw text>">Copy</button>` via a shared `assistantBubbleHTML` helper. The `data-copy` attribute carries the raw markdown source (HTML-attribute-escaped via the new `htmlAttributeEscape` helper) — the DOM decodes entities on read, so JS gets the original text verbatim.
- **CSS**: `.copy-btn` is absolutely positioned at the top-right of the bubble, `opacity: 0` by default, fading to `0.75` on `.chat-assistant:hover` and `1` on `.copy-btn:hover`.
- **JS**: A delegated `document`-level click listener (works on dynamically-appended rows) posts the `data-copy` payload to the `copyText` message handler, then briefly shows "Copied" feedback.
- **Swift bridge**: A new `WKUserContentController` on `ChatWebView`'s config registers the `Coordinator` as a `WKScriptMessageHandler` for `copyText`. The coordinator writes the text to `NSPasteboard.general` using the standard `clearContents()` + `setString` idiom (same as `VerificationPopover`). No retain cycle — the coordinator holds the webView weakly.

## Scope

Scoped to `.chat` style (the user-facing Ask/Edit + Query transcript). The internals/activity feed (`feedRowHTML`) is unchanged — copying tool-call/internal rows is a non-goal per the issue.

## Testing

- 6 new tests in `ChatWebViewLinkifyTests`: assistant + result rows carry `data-copy` with raw text, user/tool rows don't, HTML-special-char escaping (`"` → `&quot;`, `<` → `&lt;`, `&` → `&amp;`), empty-result guard.
- 1 existing test updated (`chatRowHTMLThreadsContextIntoAssistantBubble`): now checks the rendered `<a>` link text rather than the whole row, since the raw text legitimately survives in `data-copy`.
- Full fast-tier suite: 1927 tests pass.
