### PR TITLE
Wire chat search into the ingest workflow (#246)

### DIFF
--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -55,7 +55,10 @@ struct ChatView: View {
     /// `launcher.events`; everything else renders the persisted rows. Both are
     /// `transcriptVisible`-filtered. Extracted as a static func so the selection
     /// logic is unit-testable without a SwiftUI view tree.
-    static func displayMessages(
+    ///
+    /// `nonisolated`: this is a pure array selector (no view/actor state), so it
+    /// can be called from nonisolated test contexts without crossing the main actor.
+    nonisolated static func displayMessages(
         isLiveChat: Bool,
         launcherEvents: [AgentEvent],
         persistedEvents: [AgentEvent]

--- a/Sources/WikiFSCore/GeneratedPrompts.swift
+++ b/Sources/WikiFSCore/GeneratedPrompts.swift
@@ -126,10 +126,15 @@ The wiki is projected read-only at `$WIKI_ROOT`. Browse it with
   to find one by meaning); read a transcript with `wikictl chat get --id <id>` or
   `--title "Title"`. Chats project as `chats/by-id/<ULID>.md` on the mount. The
   canonical form `[[chat:01J…|Title]]` is stable across renames. Chat links
-  cannot be embeds (`![[chat:…]]` is invalid). To cite a specific message, append
-  a quote anchor — `[[chat:Title#"distinctive passage"]]` (the `#"…"` wraps a
-  substring that appears in the transcript); it opens the chat, scrolls to that
-  message, and highlights the passage.
+  cannot be embeds (`![[chat:…]]` is invalid). **Use this syntax whenever you
+  reference a past chat** — in a page you write (`[[chat:Title]]` alongside the
+  page's other wikilinks) or in your reply within the current conversation
+  (e.g. "we discussed this in [[chat:Title]]") — rather than describing the
+  chat in prose. This is how a reader (or the app) navigates straight to it.
+  To cite a specific message, append a quote anchor —
+  `[[chat:Title#"distinctive passage"]]` (the `#"…"` wraps a substring that
+  appears in the transcript); it opens the chat, scrolls to that message, and
+  highlights the passage.
 - **External sources** (papers, books, URLs NOT ingested into this wiki) get
   standard academic footnote citations: `[^id]: Author (Year), "Title", Journal/
   Publisher. DOI or URL`. If only a URL is available, that's fine. External
@@ -247,15 +252,20 @@ snapshot-aware refresh is implemented (the guard reports this clearly).
 
 **Ingest** — bring one raw source into the wiki:
 1. Read the source (`Read` for PDFs/images, `cat` for text).
-2. Write at least one summary page capturing its key content via
+2. Check for relevant prior discussion: `$WIKICTL chat search --query "…"` for
+   the source's topic, and `$WIKICTL chat get --id I` on any promising hit —
+   incorporate what the user already cared about into the pages you write, and
+   cite the chat itself with `[[chat:Title]]` (see Link to chats above). This
+   is a quick, targeted lookup, not a mount exploration.
+3. Write at least one summary page capturing its key content via
    `$WIKICTL page upsert`. FOOTNOTE EVERY CLAIM drawn from the source with
    `[^id]` + `[^id]: [[source:DisplayName#"distinctive quote"]]` — see the
    Footnotes convention above for exact syntax.
-3. Create or update the entity/concept pages it mentions, cross-linking with
+4. Create or update the entity/concept pages it mentions, cross-linking with
    `[[wiki links]]`.
-4. Rewrite `index.md` via `$WIKICTL index set` so the catalog lists the pages
+5. Rewrite `index.md` via `$WIKICTL index set` so the catalog lists the pages
    you just wrote (read the current set with `$WIKICTL page list` first).
-5. Record it: `$WIKICTL log append --kind ingest --source <file-id> --title "<source>" --note "…"`.
+6. Record it: `$WIKICTL log append --kind ingest --source <file-id> --title "<source>" --note "…"`.
    The `--source <file-id>` (given in the ingest task as SOURCE_ID) marks the
    file Ingested in the app — always pass it on a successful ingest.
 

--- a/prompts/system-prompt-default.md
+++ b/prompts/system-prompt-default.md
@@ -116,10 +116,15 @@ The wiki is projected read-only at `$WIKI_ROOT`. Browse it with
   to find one by meaning); read a transcript with `wikictl chat get --id <id>` or
   `--title "Title"`. Chats project as `chats/by-id/<ULID>.md` on the mount. The
   canonical form `[[chat:01J…|Title]]` is stable across renames. Chat links
-  cannot be embeds (`![[chat:…]]` is invalid). To cite a specific message, append
-  a quote anchor — `[[chat:Title#"distinctive passage"]]` (the `#"…"` wraps a
-  substring that appears in the transcript); it opens the chat, scrolls to that
-  message, and highlights the passage.
+  cannot be embeds (`![[chat:…]]` is invalid). **Use this syntax whenever you
+  reference a past chat** — in a page you write (`[[chat:Title]]` alongside the
+  page's other wikilinks) or in your reply within the current conversation
+  (e.g. "we discussed this in [[chat:Title]]") — rather than describing the
+  chat in prose. This is how a reader (or the app) navigates straight to it.
+  To cite a specific message, append a quote anchor —
+  `[[chat:Title#"distinctive passage"]]` (the `#"…"` wraps a substring that
+  appears in the transcript); it opens the chat, scrolls to that message, and
+  highlights the passage.
 - **External sources** (papers, books, URLs NOT ingested into this wiki) get
   standard academic footnote citations: `[^id]: Author (Year), "Title", Journal/
   Publisher. DOI or URL`. If only a URL is available, that's fine. External
@@ -237,15 +242,20 @@ snapshot-aware refresh is implemented (the guard reports this clearly).
 
 **Ingest** — bring one raw source into the wiki:
 1. Read the source (`Read` for PDFs/images, `cat` for text).
-2. Write at least one summary page capturing its key content via
+2. Check for relevant prior discussion: `$WIKICTL chat search --query "…"` for
+   the source's topic, and `$WIKICTL chat get --id I` on any promising hit —
+   incorporate what the user already cared about into the pages you write, and
+   cite the chat itself with `[[chat:Title]]` (see Link to chats above). This
+   is a quick, targeted lookup, not a mount exploration.
+3. Write at least one summary page capturing its key content via
    `$WIKICTL page upsert`. FOOTNOTE EVERY CLAIM drawn from the source with
    `[^id]` + `[^id]: [[source:DisplayName#"distinctive quote"]]` — see the
    Footnotes convention above for exact syntax.
-3. Create or update the entity/concept pages it mentions, cross-linking with
+4. Create or update the entity/concept pages it mentions, cross-linking with
    `[[wiki links]]`.
-4. Rewrite `index.md` via `$WIKICTL index set` so the catalog lists the pages
+5. Rewrite `index.md` via `$WIKICTL index set` so the catalog lists the pages
    you just wrote (read the current set with `$WIKICTL page list` first).
-5. Record it: `$WIKICTL log append --kind ingest --source <file-id> --title "<source>" --note "…"`.
+6. Record it: `$WIKICTL log append --kind ingest --source <file-id> --title "<source>" --note "…"`.
    The `--source <file-id>` (given in the ingest task as SOURCE_ID) marks the
    file Ingested in the app — always pass it on a successful ingest.
 


### PR DESCRIPTION
## Summary
- Closes #246: the `wikictl chat list/get/search` tooling already existed and was already read-only/lock-free, but nothing in the ingest workflow told the agent to use it, and the ingest task prompt's "act immediately, don't explore the mount first" line actively discouraged looking around before writing.
- Adds an explicit ingest step: before writing pages, search past chats for relevant prior discussion (`wikictl chat search`) and pull any promising hit (`wikictl chat get`) — framed as a targeted lookup, not a mount exploration, so it doesn't conflict with the existing "don't explore" guidance.
- Makes the `[[chat:Title]]` link convention explicit that the agent should cite chats it references this way — both in pages it writes and in conversation replies — rather than describing them in prose.

## Test plan
- [x] `make prompts` regenerated `Sources/WikiFSCore/GeneratedPrompts.swift` from the edited `prompts/system-prompt-default.md`
- [x] `swift test --filter GeneratedPromptsParityTests` passes (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)