### PR TITLE
Add per-wiki home page (#280)

### DIFF
--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -33,6 +33,9 @@ struct AddressBarView: View {
     /// the field (`OmniboxLayout.leadingChrome`): with the sidebar hidden the detail
     /// region spans the whole window and includes the traffic-light + toggle zone.
     var sidebarVisible: Bool
+    /// The active wiki's configured home page (issue #280). `nil` hides the home
+    /// button — there's nowhere to navigate to yet.
+    var homePageID: PageID?
 
     @State private var queryText = ""
     @State private var results: [WikiPageSummary] = []
@@ -70,6 +73,12 @@ struct AddressBarView: View {
                 store.navigateForward()
             }
             .keyboardShortcut("]", modifiers: .command)
+
+            if let homePageID {
+                navButton("house", help: "Go to home page", enabled: true) {
+                    _ = store.selectPage(byID: homePageID)
+                }
+            }
 
             omniboxField
         }

--- a/Sources/WikiFS/ContentView.swift
+++ b/Sources/WikiFS/ContentView.swift
@@ -239,6 +239,14 @@ struct ContentView: View {
         return wiki.displayName
     }
 
+    /// The active wiki's configured home page, if any (issue #280). `nil` hides
+    /// the omnibox home button.
+    private var activeHomePageID: PageID? {
+        guard let id = manager.activeWikiID,
+              let wiki = manager.wikis.first(where: { $0.id == id }) else { return nil }
+        return wiki.homePageID
+    }
+
     /// The selected-document/source detail pane, extracted so the `HStack`'s
     /// view builder stays under the type-checker's complexity budget.
     // MARK: - Detail column (extracted so `body` stays type-checkable; the
@@ -301,6 +309,7 @@ struct ContentView: View {
                                wikiName: activeWikiName,
                                detailWidth: detailWidth,
                                sidebarVisible: columnVisibility != .detailOnly,
+                               homePageID: activeHomePageID,
                                onAddToBookmarks: { omniboxBookmarkContext = $0 })
             }
 

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -365,6 +365,15 @@ extension PagesListViewController {
             menu.addItem(menuItem(
                 title: "Rename",
                 systemImage: "pencil", action: #selector(renameAction(_:)), payload: payload))
+            if isCurrentHomePage(clicked.id) {
+                menu.addItem(menuItem(
+                    title: "Clear Home Page",
+                    systemImage: "house.slash", action: #selector(clearHomePageAction(_:)), payload: payload))
+            } else {
+                menu.addItem(menuItem(
+                    title: "Set as Home Page",
+                    systemImage: "house", action: #selector(setHomePageAction(_:)), payload: payload))
+            }
         }
 
         menu.addItem(menuItem(
@@ -372,6 +381,14 @@ extension PagesListViewController {
             systemImage: "trash", action: #selector(deleteAction(_:)), payload: payload))
 
         return menu
+    }
+
+    /// Whether `pageID` is the active wiki's configured home page (issue #280) —
+    /// decides "Set as Home Page" vs. "Clear Home Page" in the context menu.
+    private func isCurrentHomePage(_ pageID: PageID) -> Bool {
+        guard let manager, let wikiID = manager.activeWikiID,
+              let wiki = manager.wikis.first(where: { $0.id == wikiID }) else { return false }
+        return wiki.homePageID == pageID
     }
 
     private func menuItem(title: String, systemImage: String,
@@ -413,6 +430,15 @@ extension PagesListViewController {
     }
     @objc private func renameAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onRename(p.clicked) }
+    }
+    @objc private func setHomePageAction(_ sender: NSMenuItem) {
+        guard let p = sender.representedObject as? PagesMenuPayload,
+              let manager, let wikiID = manager.activeWikiID else { return }
+        manager.setHomePage(id: wikiID, pageID: p.clicked.id)
+    }
+    @objc private func clearHomePageAction(_ sender: NSMenuItem) {
+        guard let manager, let wikiID = manager.activeWikiID else { return }
+        manager.setHomePage(id: wikiID, pageID: nil)
     }
     @objc private func deleteAction(_ sender: NSMenuItem) {
         if let p = sender.representedObject as? PagesMenuPayload { callbacks?.onDelete(p.effectiveIDs) }

--- a/Sources/WikiFSCore/WikiDescriptor.swift
+++ b/Sources/WikiFSCore/WikiDescriptor.swift
@@ -27,11 +27,17 @@ public struct WikiDescriptor: Codable, Identifiable, Equatable, Sendable {
     /// the switcher and which wiki the app opens on launch.
     public var lastUsedAt: Date
 
-    public init(id: String, displayName: String, createdAt: Date, lastUsedAt: Date) {
+    /// The page this wiki's home button navigates to. `nil` means no home page
+    /// has been set (the button is hidden). References a page's stable ID, not
+    /// its title, so a page rename doesn't orphan the setting.
+    public var homePageID: PageID?
+
+    public init(id: String, displayName: String, createdAt: Date, lastUsedAt: Date, homePageID: PageID? = nil) {
         self.id = id
         self.displayName = displayName
         self.createdAt = createdAt
         self.lastUsedAt = lastUsedAt
+        self.homePageID = homePageID
     }
 
     /// Mint a fresh descriptor with a new ULID. `createdAt`/`lastUsedAt` are the

--- a/Sources/WikiFSCore/WikiManager.swift
+++ b/Sources/WikiFSCore/WikiManager.swift
@@ -223,6 +223,16 @@ public final class WikiManager {
         await renameDomain?(id, trimmed)
     }
 
+    /// Set (or clear, with `nil`) a wiki's home page — the page its home button
+    /// navigates to.
+    public func setHomePage(id: String, pageID: PageID?) {
+        guard descriptorExists(id) else { return }
+        var registry = WikiRegistry.load(from: containerDirectory)
+        registry.setHomePage(id: id, pageID: pageID)
+        try? registry.save(to: containerDirectory)
+        wikis = registry.wikis
+    }
+
     /// Export one wiki as a single SQLite file. A WAL checkpoint runs first so
     /// the copied `.sqlite` contains the latest committed pages, files, prompt,
     /// index, and log without requiring `-wal` / `-shm` sidecars.

--- a/Sources/WikiFSCore/WikiRegistry.swift
+++ b/Sources/WikiFSCore/WikiRegistry.swift
@@ -48,6 +48,12 @@ public struct WikiRegistry: Codable, Equatable, Sendable {
         wikis[index].displayName = displayName
     }
 
+    /// Set (or clear, with `nil`) a wiki's home page. No-op if the id is unknown.
+    public mutating func setHomePage(id: String, pageID: PageID?) {
+        guard let index = wikis.firstIndex(where: { $0.id == id }) else { return }
+        wikis[index].homePageID = pageID
+    }
+
     /// Mark a wiki as just-used: bump `lastUsedAt` and move it to the front so MRU
     /// ordering (and the launch pick) stays correct.
     public mutating func touch(id: String, now: Date = Date()) {

--- a/Tests/WikiFSTests/WikiRegistryTests.swift
+++ b/Tests/WikiFSTests/WikiRegistryTests.swift
@@ -92,4 +92,48 @@ struct WikiRegistryTests {
         #expect(registry.isEmpty)
         #expect(registry.descriptor(id: wiki.id) == nil)
     }
+
+    // MARK: - Home page (issue #280)
+
+    @Test func setHomePageStoresAndClears() {
+        var registry = WikiRegistry()
+        let wiki = WikiDescriptor.make(displayName: "Home Test")
+        registry.add(wiki)
+        #expect(registry.descriptor(id: wiki.id)?.homePageID == nil)
+
+        let pageID = PageID(rawValue: "page-1")
+        registry.setHomePage(id: wiki.id, pageID: pageID)
+        #expect(registry.descriptor(id: wiki.id)?.homePageID == pageID)
+
+        registry.setHomePage(id: wiki.id, pageID: nil)
+        #expect(registry.descriptor(id: wiki.id)?.homePageID == nil)
+    }
+
+    @Test func setHomePageNoOpForUnknownID() {
+        var registry = WikiRegistry()
+        registry.setHomePage(id: "unknown", pageID: PageID(rawValue: "page-1"))
+        #expect(registry.isEmpty)
+    }
+
+    @Test func decodesLegacyRegistryMissingHomePageIDAsNil() throws {
+        let dir = tempDirectory()
+        let legacyJSON = """
+        {"wikis":[{"id":"01ABC","displayName":"Legacy","createdAt":"2024-01-01T00:00:00Z","lastUsedAt":"2024-01-01T00:00:00Z"}]}
+        """
+        try Data(legacyJSON.utf8).write(to: dir.appendingPathComponent(WikiRegistry.fileName))
+        let loaded = WikiRegistry.load(from: dir)
+        #expect(loaded.descriptor(id: "01ABC")?.homePageID == nil)
+    }
+
+    @Test func homePageSurvivesRoundTrip() throws {
+        let dir = tempDirectory()
+        var registry = WikiRegistry()
+        let wiki = WikiDescriptor.make(displayName: "Persisted")
+        registry.add(wiki)
+        registry.setHomePage(id: wiki.id, pageID: PageID(rawValue: "page-1"))
+        try registry.save(to: dir)
+
+        let loaded = WikiRegistry.load(from: dir)
+        #expect(loaded.descriptor(id: wiki.id)?.homePageID == PageID(rawValue: "page-1"))
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a toolbar house-icon button (next to back/forward) that navigates to a configurable per-wiki home page; hidden when no home page is set.
- Adds `homePageID: PageID?` to `WikiDescriptor`, persisted via `WikiRegistry`/`WikiManager` (`setHomePage(id:pageID:)`), backward-compatible with existing `wikis.json` (missing field decodes to `nil`).
- Adds "Set as Home Page" / "Clear Home Page" to the page list's right-click context menu, toggling based on whether the clicked page is the current home page.

Closes #280.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter WikiRegistryTests` passes (11 tests, including legacy-JSON backward-compat decode)
- [ ] Manual: set a home page via right-click, confirm toolbar house button appears and navigates; clear it and confirm button disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)