### PR TITLE
fix: always signal FP + emit bus in WikiChangeBridge.flush (#303)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,32 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-09 — #303: Chat-created pages push to UI via event bus
+
+`WikiChangeBridge.flush` was an either/or: for the active wiki it emitted a
+coarse bus event (model reloaded, but the File Provider was only refreshed
+transitively via the bus subscriber with an extra ~250 ms debounce); for a
+non-active wiki it signaled the File Provider directly and never poked the bus.
+The either/or meant that if `activeWikiID` changed during the coalesce window
+(user switched wikis mid-burst), the model reload was skipped entirely.
+
+**Fix:** `flush` now **always** signals the File Provider directly for the
+changed wiki, **and** emits the coarse bus event when the wiki is the active
+one. Both paths fire unconditionally for their respective targets — no more
+either/or. The redundant FP signal for the active wiki (direct + bus subscriber)
+is harmless: `NSFileProviderManager.signalEnumerator` is idempotent and the FP's
+own coalescer collapses the duplicate.
+
+- `Sources/WikiFS/WikiChangeBridge.swift` — `flush` restructured + doc comment
+  updated.
+- `plans/event-bus.md` — emitter description updated to reflect the new
+  always-signal + conditional-bus-emit behavior.
+- `Tests/WikiFSTests/WikiChangeBridgeBusTests.swift` — two new tests:
+  `crossProcessWriteSurfacedByCoarseEvent` (wikictl write through a separate
+  store with no bus → model picks it up purely from the coarse event) and
+  `burstOfWritesOneCoarseEventSurfacesAll` (a burst of writes collapsed into one
+  coarse event surfaces all pages).
+
 ## 2026-07-09 — #281: Chat quote anchors (`[[chat:Title#"quote"]]`)
 
 `[[chat:Title#"quote"]]` now deep-links to a specific message in a chat

--- a/Sources/WikiFS/WikiChangeBridge.swift
+++ b/Sources/WikiFS/WikiChangeBridge.swift
@@ -117,19 +117,30 @@ final class WikiChangeBridge {
         ChangeCoalescer.Handle(cancel: {})
     }
 
-    /// One coalesced flush for `wikiID`. For the active wiki, emit a coarse
-    /// `.external` event into the active store's bus — the model's `.external`
-    /// subscription rebuilds its projections (replacing the old direct
-    /// `reloadFromStore()`) and the File Provider subscriber signals, both on the
-    /// same bus. For a non-active wiki there is no in-memory store/bus, so signal
-    /// the FP directly (unchanged). The Darwin notification carries no per-
-    /// resource detail, so the reload stays full-model exactly as before.
+    /// One coalesced flush for `wikiID`. Always signals the File Provider for
+    /// the changed wiki — a `wikictl` write can land in any wiki's DB, and that
+    /// wiki's filesystem projection must refresh regardless of which wiki is on
+    /// screen. Additionally, when the changed wiki IS the active one, emits a
+    /// coarse event into the active store's bus so the on-screen model reloads
+    /// its projections (sidebar, sources, chats). For a non-active wiki there is
+    /// no in-memory store/bus, so only the FP is signaled; the model reads fresh
+    /// data when the user later switches to that wiki (`WikiManager.openActive`).
+    ///
+    /// Issue #303: the previous either/or structure (bus-OR-FP) meant the active
+    /// wiki's FP was refreshed only transitively via the bus subscriber (which
+    /// adds a second debounce), and in the edge case where `activeWikiID`
+    /// changed during the coalesce window the model reload was skipped entirely.
+    /// Now both paths fire unconditionally for their respective targets.
     private func flush(wikiID: String) {
+        // Always refresh the File Provider — direct, not via the bus subscriber,
+        // so the mount is consistent for every wiki the bridge observes.
+        Task { await fileProvider.signalChange(forWikiID: wikiID) }
+
+        // If the changed wiki is the one on screen, also poke the bus so the
+        // model rebuilds its projections (sidebar, sources, chats, draft).
         if manager.activeWikiID == wikiID, let bus = manager.activeStore?.eventBus {
             bus.emit(ResourceChangeEvent(
                 wikiID: wikiID, kind: nil, id: "", change: .updated))
-        } else {
-            Task { await fileProvider.signalChange(forWikiID: wikiID) }
         }
     }
 

--- a/Tests/WikiFSTests/WikiChangeBridgeBusTests.swift
+++ b/Tests/WikiFSTests/WikiChangeBridgeBusTests.swift
@@ -82,4 +82,63 @@ struct WikiChangeBridgeBusTests {
 
         #expect(Set(model.summaries.map(\.title)) == ["First", "Second"])
     }
+
+    // MARK: - Issue #303: cross-process (wikictl) writes surfaced by the bridge
+
+    /// Simulates the exact #303 scenario: `wikictl` writes through its own
+    /// `SQLiteWikiStore` (no event bus — `bus?.emit` is a silent no-op in the
+    /// subprocess), and the running app's model only learns about the change via
+    /// the coarse bus event that `WikiChangeBridge.flush` emits after the Darwin
+    /// notification. Verifies the model picks up the page purely from the coarse
+    /// event, with no preceding local write.
+    @MainActor @Test func crossProcessWriteSurfacedByCoarseEvent() async throws {
+        let url = tempDatabaseURL()
+        // Store A = the app's store (has the bus + model).
+        let storeA = try SQLiteWikiStore(databaseURL: url)
+        let bus = WikiEventBus(wikiID: "W")
+        storeA.eventBus = bus
+        let model = WikiStoreModel(store: storeA)
+        #expect(model.summaries.isEmpty)
+
+        // Store B = wikictl's store (same DB file, no bus).
+        let storeB = try SQLiteWikiStore(databaseURL: url)
+        _ = try storeB.createPage(title: "Chat-Created Page")
+
+        // No bus event has fired yet → model is stale.
+        #expect(model.summaries.isEmpty, "no bus event yet → model must be stale")
+
+        // The bridge's coalesced flush emits the coarse event.
+        bus.emit(ResourceChangeEvent(wikiID: "W", kind: nil, id: "", change: .updated))
+        try await awaitTitles(model, expected: ["Chat-Created Page"])
+
+        #expect(Set(model.summaries.map(\.title)).contains("Chat-Created Page"),
+                "coarse event must surface cross-process writes (#303)")
+    }
+
+    /// A burst of `wikictl` writes (multiple pages) collapsed into a SINGLE
+    /// coarse event (the coalesce window) must surface ALL pages, not just the
+    /// last one. This verifies the full-model reload semantics — the Darwin
+    /// notification carries no per-resource detail, so the reload reads
+    /// everything fresh.
+    @MainActor @Test func burstOfWritesOneCoarseEventSurfacesAll() async throws {
+        let url = tempDatabaseURL()
+        let storeA = try SQLiteWikiStore(databaseURL: url)
+        let bus = WikiEventBus(wikiID: "W")
+        storeA.eventBus = bus
+        let model = WikiStoreModel(store: storeA)
+
+        // wikictl creates several pages in quick succession (one subprocess call
+        // per page, but the bridge collapses them into one flush).
+        let storeB = try SQLiteWikiStore(databaseURL: url)
+        for title in ["Alpha", "Beta", "Gamma"] {
+            _ = try storeB.createPage(title: title)
+        }
+
+        // One coarse event after the burst settles.
+        bus.emit(ResourceChangeEvent(wikiID: "W", kind: nil, id: "", change: .updated))
+        try await awaitTitles(model, expected: ["Alpha", "Beta", "Gamma"])
+
+        #expect(Set(model.summaries.map(\.title)) == ["Alpha", "Beta", "Gamma"],
+                "one coarse event must surface the entire burst (#303)")
+    }
 }

--- a/plans/event-bus.md
+++ b/plans/event-bus.md
@@ -86,8 +86,12 @@ lock — the exact deadlock (a) prevents.
 **Emitters:**
 - `SQLiteWikiStore` — one `.local` event per public mutating method (23 methods;
   see the Appendix of the shipped plan / `StoreEmissionExhaustivenessTests`).
-- `WikiChangeBridge.flush` — one coarse `.external` event into the active
-  store's bus (active wiki), or a direct FP signal (non-active wiki).
+- `WikiChangeBridge.flush` — **always** signals the File Provider for the
+  changed wiki (direct, not via the bus subscriber), **and** emits one coarse
+  event into the active store's bus when the changed wiki is the one on screen
+  (issue #303: the old either/or could miss the model reload if `activeWikiID`
+  changed during the coalesce window, and the active wiki's FP was only refreshed
+  transitively via the bus subscriber with an extra debounce).
 - `wikictl` (separate process) is **untouched**: it opens its own store with a
   `nil` bus (emit is a no-op) and keeps posting the Darwin notification.
 


### PR DESCRIPTION
## Summary

Fixes #303.

`WikiChangeBridge.flush` was an either/or: for the active wiki it emitted a coarse bus event (model reloaded, but the File Provider was only refreshed transitively via the bus subscriber with an extra ~250 ms debounce); for a non-active wiki it signaled the File Provider directly and never poked the bus. If `activeWikiID` changed during the coalesce window (user switched wikis mid-burst), the model reload was skipped entirely.

## Fix

`flush` now **always** signals the File Provider directly for the changed wiki, **and** emits the coarse bus event when the wiki is the active one. Both paths fire unconditionally for their respective targets — no more either/or.

The redundant FP signal for the active wiki (direct + bus subscriber) is harmless: `NSFileProviderManager.signalEnumerator` is idempotent and the FP's own coalescer collapses the duplicate.

### Before

```swift
private func flush(wikiID: String) {
    if manager.activeWikiID == wikiID, let bus = manager.activeStore?.eventBus {
        bus.emit(...)               // active wiki: bus only (FP via subscriber w/ extra debounce)
    } else {
        Task { await fileProvider.signalChange(forWikiID: wikiID) }  // non-active: FP only
    }
}
```

### After

```swift
private func flush(wikiID: String) {
    // Always refresh the File Provider — direct, not via the bus subscriber.
    Task { await fileProvider.signalChange(forWikiID: wikiID) }

    // If the changed wiki is the one on screen, also poke the bus.
    if manager.activeWikiID == wikiID, let bus = manager.activeStore?.eventBus {
        bus.emit(...)
    }
}
```

## Test plan

- [x] `swift build` passes
- [x] `WikiChangeBridgeBusTests` — 5/5 pass (2 new: `crossProcessWriteSurfacedByCoarseEvent`, `burstOfWritesOneCoarseEventSurfacesAll`)
- [x] Fast CI tier — 1963 tests pass, 0 failures
- [x] `StoreEmissionTests` — 28/28 pass (unaffected, store emission unchanged)
