### PR TITLE
Reorganize welcome "Get Started" into Add Page / Add Source / Add Chat (#278)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,39 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-09 — #278: Reorganize welcome "Get Started" into Add Page / Add Source / Add Chat
+
+The welcome screen's "Get Started" row (`WikiDetailView.swift`, `case .none`)
+was a flat `FlowLayout` of up to four ingestion-shaped buttons (Add from URL,
+Add File, Add Folder, Add from Zotero-when-configured) — conflating several
+actions under one heading and offering no path to the two other primary object
+types the intro cards above it advertise (Pages, Chats). Reorganized it into
+**three primary buttons** that map 1:1 to the Pages / Sources / Chats intro
+rows:
+
+- **Add Page** — `store.newPageInNewTab()` (untitled → editor in a new tab),
+  mirroring the Pages sidebar `+` and the window toolbar's New Page.
+- **Add Source** — a native SwiftUI `Menu` (`.menuStyle(.button)` +
+  `.bordered`/`.large`, matching the codebase's `WikiSwitcher` convention) that
+  consolidates the four existing ingestion handlers: URL (`addURLHandler?("")`),
+  File (`WikiFilePanels.chooseFile` + `store.addFiles`), Folder
+  (`showingImportMarkdown = true`), and Zotero (`showingAddFromZotero = true`,
+  item appears only when `isZoteroConfigured`).
+- **Add Chat** — `store.openTab(.edit)`, mirroring the Chats sidebar `+` New
+  Chat (there is only Edit mode now; Ask was removed).
+
+Resolved the issue's open questions: Add Source → native pull-down Menu (vs
+popover/sheet); Add Page → untitled straight into edit mode (no title prompt,
+matching the rest of the app); Add Chat → Edit (only mode). Per swiftui-pro,
+button actions were extracted into `addPage`/`addChat`/`addFile` methods and the
+`Button(_:systemImage:action:)` initializer form is used where possible (text +
+icon labels for VoiceOver). Gave File vs Folder distinct menu icons
+(`doc` / `folder`) — the originals both used `doc.badge.plus`.
+
+**Files:** `Sources/WikiFS/WikiDetailView.swift` (view only — no store/schema
+change). **Gate:** `swift build` clean; fast-tier `swift test` — **1963 tests in
+162 suites** pass.
+
 ## 2026-07-09 — #303: Chat-created pages push to UI via event bus
 
 `WikiChangeBridge.flush` was an either/or: for the active wiki it emitted a

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -79,44 +79,37 @@ struct WikiDetailView: View {
                             .font(.headline)
                             .foregroundStyle(.secondary)
 
+                        // Three primary entry points, 1:1 with the intro rows
+                        // above (Pages / Sources / Chats). The four ingestion
+                        // actions collapse under a single "Add Source" menu.
                         FlowLayout(spacing: 12) {
-                            Button {
-                                addURLHandler?("")
-                            } label: {
-                                Label("Add from URL", systemImage: "link.badge.plus")
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.large)
+                            Button("Add Page", systemImage: "doc.badge.plus", action: addPage)
+                                .buttonStyle(.bordered)
+                                .controlSize(.large)
 
-                            Button {
-                                if let url = WikiFilePanels.chooseFile(title: "Add File", prompt: "Add File") {
-                                    Task {
-                                        await store.addFiles([url])
+                            Menu {
+                                Button("Add from URL", systemImage: "link.badge.plus") {
+                                    addURLHandler?("")
+                                }
+                                Button("Add File", systemImage: "doc", action: addFile)
+                                Button("Add Folder", systemImage: "folder") {
+                                    showingImportMarkdown = true
+                                }
+                                if isZoteroConfigured {
+                                    Button("Add from Zotero", systemImage: "books.vertical") {
+                                        showingAddFromZotero = true
                                     }
                                 }
                             } label: {
-                                Label("Add File", systemImage: "doc.badge.plus")
+                                Label("Add Source", systemImage: "tray.and.arrow.down")
                             }
+                            .menuStyle(.button)
                             .buttonStyle(.bordered)
                             .controlSize(.large)
 
-                            Button {
-                                showingImportMarkdown = true
-                            } label: {
-                                Label("Add Folder", systemImage: "doc.badge.plus")
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.large)
-
-                            if isZoteroConfigured {
-                                Button {
-                                    showingAddFromZotero = true
-                                } label: {
-                                    Label("Add from Zotero", systemImage: "books.vertical")
-                                }
+                            Button("Add Chat", systemImage: "plus.bubble", action: addChat)
                                 .buttonStyle(.bordered)
                                 .controlSize(.large)
-                            }
                         }
                     }
                     .padding(.top, 20)
@@ -234,6 +227,28 @@ struct WikiDetailView: View {
                 Text(description)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Get Started actions
+
+    /// Create an untitled page and open it in a new tab (mirrors the Pages
+    /// sidebar `+` and the window toolbar's New Page).
+    private func addPage() {
+        store.newPageInNewTab()
+    }
+
+    /// Start a new chat in the Edit draft state (mirrors the Chats sidebar `+`).
+    private func addChat() {
+        store.openTab(.edit)
+    }
+
+    /// Pick a single file via the open panel and ingest it.
+    private func addFile() {
+        if let url = WikiFilePanels.chooseFile(title: "Add File", prompt: "Add File") {
+            Task {
+                await store.addFiles([url])
             }
         }
     }


### PR DESCRIPTION
## Summary

Reorganizes the welcome screen's "Get Started" row into three primary entry points that map 1:1 to the Pages / Sources / Chats intro cards above them. Resolves #278.

Previously the row was a flat `FlowLayout` of up to four ingestion-shaped buttons (Add from URL, Add File, Add Folder, Add from Zotero-when-configured) — conflating several actions under one heading and offering no path to the two other primary object types the app advertises.

## Changes

`Sources/WikiFS/WikiDetailView.swift` (view only — no store/schema change):

- **Add Page** — `store.newPageInNewTab()`, creating an untitled page straight into the editor in a new tab. Mirrors the Pages sidebar `+` and the window toolbar's New Page.
- **Add Source** — a native SwiftUI `Menu` (`.menuStyle(.button)` + `.bordered`/`.large`, matching the codebase's `WikiSwitcher` convention) consolidating the four existing ingestion handlers:
  - URL → `addURLHandler?("")`
  - File → `WikiFilePanels.chooseFile` + `store.addFiles`
  - Folder → `showingImportMarkdown = true`
  - Zotero → `showingAddFromZotero = true` (item appears only when `isZoteroConfigured`)
- **Add Chat** — `store.openTab(.edit)`, mirroring the Chats sidebar `+` New Chat.

## Open questions (resolved)

- **Add Source presentation** → native pull-down `Menu` (standard macOS idiom, least code, visual parity with the other two buttons).
- **Add Page** → untitled, straight into edit mode (no title prompt — matches the rest of the app, which has no title-prompt flow).
- **Add Chat mode** → Edit (only mode now; Ask was removed).

## Notes

- Per the swiftui-pro skill, button actions were extracted into `addPage` / `addChat` / `addFile` methods, and the `Button(_:systemImage:action:)` initializer form is used where possible so labels carry both icon + text for VoiceOver.
- Gave File vs Folder distinct menu icons (`doc` / `folder`) — the originals both used `doc.badge.plus`.

## Verification

- `swift build` — clean.
- Fast-tier `swift test` — **1963 tests in 162 suites** pass.
