### PR TITLE
Plan page versions and workspaces for multi-writer concurrency

### DIFF
--- a/docs/design-plans/2026-07-12-multi-writer-hardening.md
+++ b/docs/design-plans/2026-07-12-multi-writer-hardening.md
@@ -1,0 +1,491 @@
+# Multi-Writer Hardening Design
+
+## Summary
+
+This design hardens the wiki app's storage layer against the failure modes
+that multiple concurrent writers — a human editing pages, an AI agent
+ingesting content, and future parallel background jobs — can trigger. It
+proceeds in two tracks. The **live track** (Phases 1–4) fixes the
+concurrency model already running in production: it extends the
+compare-and-swap discipline that today only protects human saves out to
+agent writes, so an agent can no longer silently clobber an edit made after
+it last read a page. It splits the single global concurrency limiter into
+per-lane queues so a long-running ingest can't starve interactive chat
+turns (or vice versa). It establishes an invariant that every page carries
+an explicit pointer to its current head version, so speculative or
+exploratory writes can never leak into what the app resolves as "the"
+content of a page. And it teaches the autosave path to collapse rapid
+same-actor edits into a single version instead of growing the history
+forever, while fixing an existing bug where the cleanup ("vacuum") job
+could delete page history that was still in use.
+
+The **workspace track** (Phases 5–7) completes an isolation layer — largely
+built but not yet wired up — that lets a large operation such as a
+multi-page ingest stage all of its writes in a private area and merge them
+into the main database atomically, only once the whole operation finishes
+cleanly. This closes the remaining gaps: pages created inside such a
+staging area no longer leave orphaned rows behind if the operation is
+abandoned, and two staging areas that both try to create a page with the
+same title now produce a conflict instead of silently duplicating it.
+Merging a staging area now also regenerates search embeddings and
+reconciles the wiki's structural index instead of leaving them stale.
+Finally, the actual write path is connected end to end so ingestion can opt
+into full isolation behind a feature flag (off by default), while ordinary
+human edits continue to land directly on the main database throughout,
+unaffected by an ingest running in isolation.
+
+## Definition of Done
+
+From the post-merge review of the W0–W4 multi-writer implementation
+(findings L1–L3 live, W1–W4 latent):
+
+1. **Agent writes are CAS-protected end-to-end.** An agent cannot silently
+   overwrite a page edit committed after the agent read that page. (L1)
+2. **Concurrent generations cannot lose updates on shared hot state.** At
+   most one ingest-class run executes at a time until workspace isolation is
+   wired; chat turns still run during an ingest. (L2)
+3. **Main's head resolution is immune to speculative writes.** Every `pages`
+   row has an explicit `page-content` ref; workspace version appends never
+   change what main reads or what CAS compares against. (W1)
+4. **Page history stays bounded and reclaimable.** Rapid autosaves coalesce
+   into the head version; unreachable page versions and their blobs are
+   GC-able via vacuum — and `vacuum-blobs --apply` no longer deletes live
+   page-version blobs. (L3 + the vacuum data-loss bug)
+5. **Workspace-created pages are invisible on main until merge.** Abandoning
+   a workspace leaves no residue on main; two workspaces creating the same
+   title produce a merge conflict, not silent same-title duplicates. (W2)
+6. **A merged page is fully consistent after merge.** Links, FTS, and
+   embeddings reflect the merged body; `wiki_index` merges structurally
+   (line-set three-way), parking only on same-line conflicts. (W3 + D12)
+7. **Ingestion can run isolated in a workspace** behind a capability flag:
+   the agent writes into the workspace, main is untouched until an automatic
+   merge on completion, and stale workspaces are reaped on app launch. (W4)
+
+## Acceptance Criteria
+
+### multi-writer-hardening.AC1: Agent writes are CAS-protected
+- **multi-writer-hardening.AC1.1 Success:** `page upsert --expect-head <current head>` succeeds and appends a version whose parent is that head
+- **multi-writer-hardening.AC1.2 Failure:** `page upsert --expect-head <stale id>` exits with the distinct CAS code, reports the current head, and leaves the page byte-identical
+- **multi-writer-hardening.AC1.3 Success:** `page get` (text and `--json`) includes the page's `head_version_id`
+- **multi-writer-hardening.AC1.4 Edge:** blind `page upsert` (no flag) preserves today's behavior exactly
+- **multi-writer-hardening.AC1.5 Success:** ingest/edit prompt templates contain the read → expect → retry-once discipline (template assertion)
+
+### multi-writer-hardening.AC2: Lane-aware generation gate
+- **multi-writer-hardening.AC2.1 Success:** an interactive turn acquires immediately while an ingest holds the ingest lane
+- **multi-writer-hardening.AC2.2 Success:** a second ingest queues until the first releases; FIFO order within the lane holds
+- **multi-writer-hardening.AC2.3 Failure:** a waiter cancelled while queued never receives or leaks a slot (both lanes)
+- **multi-writer-hardening.AC2.4 Edge:** lane limits are constructor-configurable; `[.ingest: 1, .interactive: 3]` is the app default
+
+### multi-writer-hardening.AC3: Head-ref invariant
+- **multi-writer-hardening.AC3.1 Success:** after v33, every `pages` row has a `page-content` ref whose target equals the previously resolved head
+- **multi-writer-hardening.AC3.2 Success:** `createPage` produces a root version + ref atomically
+- **multi-writer-hardening.AC3.3 Success:** a workspace write to an existing page changes neither `pageHeadVersionID` nor a concurrent human CAS outcome
+- **multi-writer-hardening.AC3.4 Edge:** the `MAX(id)` fallback path logs an assertion when reached (and is unreachable for migrated data)
+- **multi-writer-hardening.AC3.5 Success:** v33 is idempotent (re-running on a migrated DB is a no-op); fresh-path parity holds
+
+### multi-writer-hardening.AC4: Amend + GC
+- **multi-writer-hardening.AC4.1 Success:** two same-actor saves within the coalescing window produce one version row (second amends)
+- **multi-writer-hardening.AC4.2 Failure:** a head referenced by any `workspace_refs` row, or with children, is never amended (save appends)
+- **multi-writer-hardening.AC4.3 Success:** `vacuum-page-versions` deletes only versions unreachable from ref targets and unreferenced by workspaces; dry-run reports without deleting
+- **multi-writer-hardening.AC4.4 Failure:** `vacuum-blobs --apply` retains every blob referenced by `page_versions` (and post-v34 `workspace_refs`)
+- **multi-writer-hardening.AC4.5 Edge:** an amend after the coalescing window expires appends instead
+
+### multi-writer-hardening.AC5: Created-page staging
+- **multi-writer-hardening.AC5.1 Success:** a workspace-created page moves neither the changeToken nor the `pages` count before merge
+- **multi-writer-hardening.AC5.2 Success:** merge mints the `pages` row + root version; the page appears with the staged body and title
+- **multi-writer-hardening.AC5.3 Failure:** merging a created page whose title/slug now exists on main parks the workspace with a conflict (no duplicate page)
+- **multi-writer-hardening.AC5.4 Success:** abandoning a workspace with created pages leaves zero rows on main; vacuum reclaims the staged blobs
+- **multi-writer-hardening.AC5.5 Edge:** the workspace_refs row-shape invariant holds (existing page: `version_id` set; created page: `blob_hash`+`title` set)
+
+### multi-writer-hardening.AC6: Merge completeness
+- **multi-writer-hardening.AC6.1 Success:** after a merge (fast-forward and diff3), each merged page's chunks/embeddings reflect the merged body
+- **multi-writer-hardening.AC6.2 Success:** disjoint `wiki_index` line edits from two workspaces both survive sequential merges
+- **multi-writer-hardening.AC6.3 Failure:** same-line index edits park the second workspace as conflicted
+- **multi-writer-hardening.AC6.4 Success:** a successful merge appends the ingest-completion log entry
+
+### multi-writer-hardening.AC7: Ingest isolation behind flag
+- **multi-writer-hardening.AC7.1 Success:** with `workspacesEnabled`, an ingest leaves main pages and the changeToken untouched until auto-merge
+- **multi-writer-hardening.AC7.2 Success:** a human page edit during an isolated ingest commits immediately to main
+- **multi-writer-hardening.AC7.3 Failure:** an ingest whose merge conflicts parks the workspace and surfaces it via the conflict verbs (main uncorrupted)
+- **multi-writer-hardening.AC7.4 Success:** with the flag off, ingest behavior is byte-identical to today
+- **multi-writer-hardening.AC7.5 Edge:** stale `open` workspaces older than the TTL are reaped at app launch
+
+## Glossary
+
+- **CAS (compare-and-swap)**: An optimistic concurrency technique where a writer states the version it expects to be replacing; the write only succeeds if that expectation still matches the current state, otherwise it fails with a distinct error rather than silently overwriting someone else's change.
+- **Head version / `head_version_id`**: The current, live version of a page — what a fresh read returns and what a CAS write checks its expectation against.
+- **`page-content` ref**: A database row that points a page at the version considered its current head. The design requires every page to have exactly one, so there is never ambiguity about what the "real" content of a page is.
+- **Blob**: The immutable, content-addressed storage of a page's raw text (referenced by hash); versions point at blobs rather than storing page text inline.
+- **Version chain (`parent_id` / `merge_parent_id`)**: The linked history of a page's versions, each pointing back to its predecessor; a version produced by a merge points to two parents instead of one.
+- **Workspace / `workspace_refs`**: A private, isolated staging area where a large operation (e.g., an ingest) can write pages and index changes without those writes being visible on the main database until an explicit merge.
+- **Merge (`workspaceMerge`)**: The operation that folds a workspace's staged changes into the main database, atomically and only when it can do so without conflict.
+- **Fast-forward merge**: A merge where nothing on main changed since the workspace's starting point, so the workspace's changes can be applied directly without reconciling divergent edits.
+- **Three-way merge / diff3**: A merge strategy that compares a common ancestor against two versions that diverged from it, combining non-overlapping changes automatically and flagging a conflict only where both sides changed the same content.
+- **Conflict / "parked"**: The state a workspace enters when a merge can't be resolved automatically; it is set aside for manual resolution rather than being forced through and corrupting main.
+- **Generation gate / lane**: The in-process limiter that caps how many concurrent "runs" (ingests, chat turns, etc.) execute at once; a lane is a named queue (e.g., `ingest`, `interactive`) with its own concurrency limit, so congestion in one kind of work doesn't block the other.
+- **FIFO (first-in-first-out)**: The ordering guarantee that waiters for a queue slot are served in the order they arrived.
+- **`changeToken`**: A single value summarizing the wiki's overall write-generation, used by clients (notably the File Provider) to detect that something changed and a refresh is needed.
+- **Vacuum (`vacuum-blobs` / `vacuum-page-versions`)**: Maintenance commands that delete storage no longer reachable from any live reference (old page versions or blobs) — analogous to garbage collection.
+- **`orphanBlobPredicate`**: The logic vacuum uses to decide whether a blob is still referenced by anything and must therefore be kept.
+- **Schema ladder (v29…v34)**: The app's sequence of numbered, ordered database migration steps, each guarded so it can run safely and idempotently against a database at any prior version.
+- **`wiki_index`**: The wiki's curated navigational index — a singleton table, not a page — staged per-workspace and merged line-set-wise when a workspace lands.
+- **FTS (full-text search)**: The search index over page text, which must stay consistent with a page's current body after edits or merges.
+- **Embeddings / chunks**: Vector representations of pieces ("chunks") of page text used for semantic search, regenerated whenever a page's content changes.
+- **NO-EMIT**: A convention marking store mutations that intentionally do not advance the `changeToken` — used for workspace writes, which must stay invisible until merge.
+- **`@MainActor`**: A Swift concurrency annotation confining a type's methods to the main thread, used here to guarantee the generation gate's internal state is only ever touched one operation at a time.
+- **Capability flag (`workspacesEnabled`)**: A feature flag gating whether a code path — here, workspace-isolated ingestion — is active; defaults off so it can be rolled out gradually.
+- **Coalescing window**: A short time window after an edit during which further edits from the same actor are merged ("amended") into the same version rather than creating a new one, keeping autosave from producing a version per debounce tick.
+- **TTL (time-to-live) / reap**: A staleness threshold after which abandoned workspaces are automatically cleaned up rather than lingering indefinitely.
+- **`wikictl`**: The command-line tool used to drive the wiki store (page reads/writes, workspace admin, vacuum, etc.); also invoked internally by the AI agent.
+- **`AgentOperationRunner` / `OperationRequest`**: The internal components that launch and classify agent-driven runs (ingest, query, chat turn) so the gate/lane and CAS logic know how each should be treated.
+
+## Architecture
+
+Two tracks. The **live track** (Phases 1–4) hardens the concurrency model
+that is actually running today — CAS-only optimistic writes on main with a
+4-slot generation gate. The **workspace track** (Phases 5–7) finishes the
+dormant isolation substrate so ingestion can move inside it.
+
+### Live track
+
+**Agent CAS (Phase 1).** Today only human saves CAS
+(`WikiStoreModel.swift:1143` threads `loadedPageHeadVersionID`); agent
+writes via `wikictl page upsert` pass no expectation
+(`PageCommand.swift:178` → the `nil` default in `PageUpsert.swift:53`).
+The fix extends the existing CAS seam outward: `page get` exposes the head
+version id, `page upsert` gains `--expect-head <versionID>`, and a CAS
+mismatch exits with a distinct code carrying the current head so the agent
+can re-read and reapply. The ingest/edit prompt templates
+(`AgentOperationRunner.swift`) instruct the read → thread → retry-once
+discipline. Blind upsert remains valid for scripts; the app-launched agent
+flows always thread the expectation.
+
+**Gate lanes (Phase 2).** `GenerationGate` (`GenerationGate.swift:25`) is a
+single FIFO with `maxConcurrent: 4` (`WikiFSApp.swift:91`). It becomes
+lane-aware: each acquisition declares a lane derived from
+`OperationRequest` (`OperationRequest.swift:14` — ingest/query/lint are
+one-shot; chat turns are interactive). Lane limits: `ingest: 1`,
+`interactive: 3` (both configurable), preserving the recent win (chat never
+queues behind ingest) while closing the ingest-vs-ingest lost-update window
+until Phase 7 provides real isolation.
+
+Contract (the gate stays `@MainActor`, FIFO-per-lane, cancellation-safe —
+same waiter shape as today):
+
+```swift
+enum GenerationLane: Hashable { case ingest, interactive }
+
+final class GenerationGate {
+    init(laneLimits: [GenerationLane: Int])   // default [.ingest: 1, .interactive: 3]
+    func acquire(_ lane: GenerationLane) async -> Bool   // false = cancelled while waiting
+    func release(_ lane: GenerationLane)
+    var waiterCount: Int { get }               // test seam, unchanged
+}
+```
+
+The gate remains injectable via `AgentLauncher.init(generationGate:)` — the
+future #358 per-window split composes on top (per-window gates, optional
+global parent) without further gate surgery.
+
+**Head-ref invariant (Phase 3).** `migrateV29ToV30`
+(`SQLiteWikiStore.swift:1888`) seeded root versions but no refs, so every
+migrated-never-saved page resolves its head via the `MAX(id)` fallback
+(`pageHeadVersionIDLocked`, `:2631`) — which `workspaceWritePage` (`:2808`)
+poisons by appending speculative rows to the same chain. The fix
+establishes the invariant **every `pages` row has a `page-content` ref**:
+a data-only ladder step (v33) backfills refs for refless pages (pointing at
+the current `MAX(id)` version, i.e. today's resolved head), `createPage`
+seeds a root version + ref, and the `MAX(id)` fallback is demoted to a
+logged assertion path. After this, speculative appends cannot affect main
+reads, human CAS, or merge-base recording.
+
+**Amend + GC (Phase 4).** Autosave (500 ms debounce,
+`WikiStoreModel.swift:1105`) currently appends a version + activity + blob
+per tick. The D14 amend rule lands in `appendPageVersion`
+(`SQLiteWikiStore.swift:2530`): a save *amends* the head version in place
+(replace blob pointer + title, same version id) iff the head was produced
+by the same actor within a coalescing window, has no children, and no
+`workspace_refs.base_version_id`/`version_id` references it; otherwise it
+appends. Reclamation: `vacuumPageVersions(dryRun:)` deletes versions
+unreachable by the `parent_id`/`merge_parent_id` walk from any
+`page-content` ref target and unreferenced by any `workspace_refs` row;
+`orphanBlobPredicate` (`:4897`) gains `page_versions.blob_hash` (and, after
+Phase 5, `workspace_refs.blob_hash`) as reference sources. **The predicate
+fix is urgent**: today `vacuum-blobs --apply` deletes live page-version
+blobs — page history data loss from a shipped admin verb.
+
+### Workspace track
+
+**Created-page staging (Phase 5).** `workspaceWritePage` step 0 (`:2822`)
+creates a placeholder `pages` row for workspace-created pages — moving the
+changeToken, projecting a phantom empty page, leaving a husk on abandon
+(`abandonWorkspace`, `:3291`, deletes only refs), and — because
+`uniqueSlug` (`:5552`) suffixes rather than collides — letting two
+workspaces silently create same-titled duplicate pages. The fix is the
+design's D16: `workspace_refs` gains nullable `blob_hash` + `title`
+columns (v34); for a page with no main row, `version_id` stays NULL and the
+head is the blob. `workspaceMerge` (`:2950`) mints the `pages` row + root
+version at merge, and treats an existing main page with the same
+title/slug as a conflict (unify path), not a duplicate.
+
+Schema delta (v34):
+
+```sql
+ALTER TABLE workspace_refs ADD COLUMN blob_hash TEXT REFERENCES blobs(hash);
+ALTER TABLE workspace_refs ADD COLUMN title     TEXT;
+-- Invariant (enforced by the two write paths, asserted in tests):
+--   existing page:  version_id NOT NULL, blob_hash NULL, title NULL
+--   created page:   version_id NULL,     blob_hash NOT NULL, title NOT NULL
+```
+
+**Merge completeness (Phase 6).** Two gaps in `workspaceMerge`: merged
+pages are never re-embedded (`storePageChunks` callers are only
+`PageUpsert.swift:80` and the bulk indexer), and the `wiki_index` merge
+(design D12) was never implemented — `workspaces.index_body`/
+`index_base_version` exist unused (`:653`). Post-merge, embeddings for
+merged pages regenerate *after* commit (best-effort, mirroring
+`PageUpsert`'s shape — the no-inference-in-transaction rule holds).
+`wiki_index` merges as a line-set three-way (added/removed lines vs the
+base captured in `index_base_version`); a same-line conflict parks the
+workspace like any page conflict. The merge also appends the
+ingest-completion log entry (deferred from the original design's D10).
+
+**Producer wiring (Phase 7).** Workspaces currently have no producer —
+`WorkspaceCommand.swift:19–28` has only admin verbs; there is no
+`--workspace` on `page upsert`. This phase adds the write/read verbs
+(`page upsert --workspace W` → `workspaceWritePage`; `page get --workspace
+W` → overlay read; index update in workspace mode writes
+`workspaces.index_body`), wires `AgentOperationRunner.runMultiIngest` to
+create a workspace, thread the flag to the agent's `wikictl` invocations,
+and auto-merge on completion — all behind a `workspacesEnabled` capability
+flag (default off). `reapStaleWorkspaces` (today `wikictl`-only,
+`WorkspaceCommand.swift:159`) is also invoked on app launch.
+
+`wikictl` CLI contract after Phases 1 + 7:
+
+```
+page get <sel> [--workspace W] [--json]      # output includes head_version_id
+page upsert ... [--expect-head <versionID>]  # CAS; mismatch → exit 3, current head on stderr/JSON
+page upsert ... [--workspace W]              # write into workspace (no main mutation)
+index update ... [--workspace W]             # stage into workspaces.index_body
+workspace create|status|abandon|merge|refresh|conflicts|resolve|retry|reap   # unchanged
+```
+
+## Existing Patterns
+
+This design extends patterns already in the codebase; it introduces no new
+architectural style:
+
+- **CAS protocol**: `appendPageVersion` (`SQLiteWikiStore.swift:2530`) is
+  the template — guard inside `withTransaction`, distinct error type
+  (`PageConflictError`), expectation threaded from the caller. Phase 1
+  extends the same seam through `PageUpsert` to `wikictl`; Phase 4's amend
+  is a branch inside the same method.
+- **Stepwise schema ladder**: v33/v34 follow the guarded, idempotent ladder
+  with fresh-path parity (`FreshSchemaParityTests`), matching the v29→v32
+  steps. v33 is data-only (like the v23 link sweep); v34 is additive
+  `ALTER TABLE` (like v27).
+- **Emission discipline**: every new/changed mutator routes through
+  `mutate()` or is annotated NO-EMIT (`StoreEmissionExhaustivenessTests`).
+  Workspace writes stay token-invisible (NO-EMIT, established by
+  `createWorkspace`/`workspaceWritePage`).
+- **Post-commit inference**: embeddings after the write transaction,
+  best-effort (`renameSource`'s documented shape, `PageUpsert.swift:80`).
+  Phase 6's merge re-embedding follows it.
+- **Lazy vacuum**: `vacuumPageVersions` mirrors `vacuumBlobs`
+  (`:4916`) / `vacuumActivities` (`:4962`) — dry-run default, one
+  transaction, report of reclaimed rows/bytes, surfaced under
+  `wikictl admin`.
+- **Gate mechanics**: Phase 2 preserves `GenerationGate`'s
+  cancellation-safe waiter protocol and `@MainActor` confinement; lanes
+  partition the existing FIFO rather than replacing it.
+
+One deliberate divergence: Phase 3 demotes the sources-inherited
+"default-active = `MAX(id)`" rule for pages. For sources it remains
+correct (nothing appends speculatively to their chains); for pages it is
+retired because workspaces do.
+
+## Implementation Phases
+
+<!-- START_PHASE_1 -->
+### Phase 1: Agent CAS writes
+**Goal:** Agent writes cannot silently clobber newer edits (DoD 1).
+
+**Components:**
+- `Sources/WikiCtlCore/PageCommand.swift` — `--expect-head` on upsert
+  (distinct exit code + current head on mismatch); `head_version_id` in
+  `page get` output (text + `--json`)
+- `Sources/WikiFSCore/PageUpsert.swift` — no signature change (the
+  `expectedHeadVersionID` parameter exists); conflict propagation to the
+  CLI layer
+- `Sources/WikiFS/AgentOperationRunner.swift` — ingest/edit prompt
+  templates gain the read-head → thread-expectation → on-conflict
+  re-read-and-reapply-once discipline
+
+**Dependencies:** None.
+
+**Done when:** Tests verify `multi-writer-hardening.AC1.*` — a stale
+`--expect-head` upsert fails with the distinct code and does not modify the
+page; a fresh one succeeds; blind upsert behavior is unchanged.
+<!-- END_PHASE_1 -->
+
+<!-- START_PHASE_2 -->
+### Phase 2: Lane-aware generation gate
+**Goal:** Ingest-class runs serialize among themselves; chat turns keep
+running during an ingest (DoD 2).
+
+**Components:**
+- `Sources/WikiFS/GenerationGate.swift` — lanes per the Architecture
+  contract (FIFO per lane, cancellation-safe waiters preserved)
+- `Sources/WikiFS/AgentLauncher.swift` — acquisitions declare a lane
+  derived from the run kind (`OperationRequest`: ingest/lint → `.ingest`;
+  chat/query turns → `.interactive`)
+- `Sources/WikiFS/WikiFSApp.swift:91` — construction switches to lane
+  limits (`[.ingest: 1, .interactive: 3]`)
+
+**Dependencies:** None.
+
+**Done when:** Tests verify `multi-writer-hardening.AC2.*` — a second
+ingest queues while the first runs; an interactive turn acquires
+immediately during an ingest; cancellation while queued never leaks a slot.
+<!-- END_PHASE_2 -->
+
+<!-- START_PHASE_3 -->
+### Phase 3: Head-ref invariant (v33 backfill)
+**Goal:** Every page has an explicit `page-content` ref; speculative
+appends cannot affect main (DoD 3).
+
+**Components:**
+- `Sources/WikiFSCore/SQLiteWikiStore.swift` — v33 data-only ladder step
+  backfilling refs for refless pages (target = current resolved head);
+  `createPage` seeds root version + ref; `pageHeadVersionIDLocked`
+  (`:2631`) `MAX(id)` fallback demoted to a logged assertion path;
+  `workspaceWritePage` asserts the main ref exists on first touch of an
+  existing page
+
+**Dependencies:** None (must land before Phase 7 wires producers).
+
+**Done when:** Tests verify `multi-writer-hardening.AC3.*` — post-migration
+every page has a ref; a workspace append leaves `pageHeadVersionID`, human
+CAS, and recorded merge bases unchanged.
+<!-- END_PHASE_3 -->
+
+<!-- START_PHASE_4 -->
+### Phase 4: Autosave amend + version/blob GC
+**Goal:** Bounded history; safe reclamation; fix the vacuum data-loss bug
+(DoD 4).
+
+**Components:**
+- `Sources/WikiFSCore/SQLiteWikiStore.swift` — amend branch in
+  `appendPageVersion` (guards per Architecture); `vacuumPageVersions
+  (dryRun:)` with the reachability rule; `orphanBlobPredicate` (`:4897`)
+  gains `page_versions.blob_hash` (+ `workspace_refs.blob_hash` once v34
+  exists)
+- `Sources/WikiCtlCore/AdminCommand.swift` — `vacuum-page-versions` verb;
+  inclusion in `vacuum-all`
+
+**Dependencies:** Phase 3 (reachability walks ref targets).
+
+**Done when:** Tests verify `multi-writer-hardening.AC4.*` — rapid
+same-actor saves coalesce; a guarded head (workspace base / has children)
+appends instead of amending; vacuum removes only unreachable versions;
+`vacuum-blobs` retains every referenced page blob.
+<!-- END_PHASE_4 -->
+
+<!-- START_PHASE_5 -->
+### Phase 5: Workspace created-page staging (v34)
+**Goal:** Created pages invisible on main until merge; no abandon residue;
+title collisions conflict instead of duplicating (DoD 5).
+
+**Components:**
+- `Sources/WikiFSCore/SQLiteWikiStore.swift` — v34 columns on
+  `workspace_refs` (`blob_hash`, `title`); `workspaceWritePage` (`:2808`)
+  drops the placeholder-`pages`-row creation (blob-headed staging for
+  created pages); `workspaceMerge` (`:2950`) mints the `pages` row + root
+  version at merge and conflicts on an existing same-slug/title main page;
+  `abandonWorkspace` verified residue-free
+- `Sources/WikiCtlCore/WorkspaceCommand.swift` — `status`/`conflicts`
+  output covers staged created pages
+
+**Dependencies:** Phase 3.
+
+**Done when:** Tests verify `multi-writer-hardening.AC5.*` — a created page
+moves neither the changeToken nor the pages count until merge; abandon
+leaves zero main rows; two workspaces creating one title → second merge
+parks with a conflict.
+<!-- END_PHASE_5 -->
+
+<!-- START_PHASE_6 -->
+### Phase 6: Merge completeness — embeddings, wiki_index, log
+**Goal:** Post-merge state fully consistent (DoD 6).
+
+**Components:**
+- `Sources/WikiFSCore/SQLiteWikiStore.swift` — `workspaceMerge` returns the
+  merged page set; `wiki_index` line-set three-way merge against
+  `index_base_version` (same-line conflict parks); ingest-completion log
+  entry appended by the merge
+- `Sources/WikiFSCore/WikiStoreModel.swift` — post-commit re-embedding of
+  merged pages (best-effort, `PageUpsert` shape)
+
+**Dependencies:** Phase 5 (merge path shape).
+
+**Done when:** Tests verify `multi-writer-hardening.AC6.*` — merged page
+chunks reflect the merged body; disjoint index edits from two workspaces
+both land; same-line index edits park.
+<!-- END_PHASE_6 -->
+
+<!-- START_PHASE_7 -->
+### Phase 7: Workspace producer wiring + ingest isolation flag
+**Goal:** Ingestion runs isolated in a workspace behind a flag (DoD 7).
+
+**Components:**
+- `Sources/WikiCtlCore/PageCommand.swift` + `ArgumentParser.swift` —
+  `--workspace` on `page upsert` / `page get` (overlay read); index update
+  staging into `workspaces.index_body`
+- `Sources/WikiFS/AgentOperationRunner.swift` — `runMultiIngest` creates a
+  workspace when `workspacesEnabled`, threads `--workspace` into the
+  agent's `wikictl` calls, auto-merges on completion (parks on conflict,
+  surfaced via the existing conflict verbs)
+- `Sources/WikiFSCore/WikiStoreModel.swift` — `workspacesEnabled`
+  capability flag (default off); `reapStaleWorkspaces` on app launch
+
+**Dependencies:** Phases 3, 5, 6.
+
+**Done when:** Tests verify `multi-writer-hardening.AC7.*` — with the flag
+on, an ingest leaves main and the changeToken untouched until merge; a
+human edit during ingest lands immediately; the run auto-merges (or parks)
+at completion; stale `open` workspaces are reaped at launch.
+<!-- END_PHASE_7 -->
+
+## Additional Considerations
+
+**Hotfix candidate ahead of phase order:** the `orphanBlobPredicate` fix
+(Phase 4) is a one-line change preventing data loss from a shipped admin
+verb (`vacuum-blobs --apply` currently deletes all page-version blobs). It
+can and should be cherry-picked first if any vacuum is run before Phase 4
+lands.
+
+**changeToken:** the v33 backfill writes one ref per refless page, moving
+the `refs.SUM(generation)` fold once at migration — an intended,
+FP-refresh-forcing move (data migrations already do this, e.g. v23). Test
+literals that pin token values update in the same commit. Workspace tables
+remain outside every fold; `page_versions` must never gain a count fold
+(speculative appends would leak into the token).
+
+**Agent retry semantics (Phase 1):** the prompt-level contract is
+retry-once-then-surface — on a second consecutive CAS failure for the same
+page the agent reports the conflict in its output rather than looping.
+This bounds pathological churn against a rapidly-editing human.
+
+**#358 compatibility (multi-window):** lanes (Phase 2) are orthogonal to
+the per-window gate split; the gate stays injectable and `@MainActor`. When
+#358 lands, each window constructs its own lane-configured gate; a global
+resource cap can be added as an optional parent gate without changing this
+design. One window per wiki should be enforced (`WindowGroup(for:)` value
+identity provides it) so two windows never run blind pipelines on one
+database.
+
+**Out of scope:** the merge agent (LLM conflict resolution — design W4
+phase in `plans/page-versions-and-workspaces.md` §9), section-aware diff3,
+partial-land merges, per-wiki agent configuration, and the #358 window
+refactor itself.

--- a/plans/page-versions-and-workspaces-review.md
+++ b/plans/page-versions-and-workspaces-review.md
@@ -1,0 +1,326 @@
+# Adversarial review: `page-versions-and-workspaces.md`
+
+**Reviewed:** `plans/page-versions-and-workspaces.md` (proposed, 2026-07-09)
+**Review date:** 2026-07-09
+**Method:** §2 grounded facts verified against the live v28 tree; substrate
+claims cross-checked against `graph-model-and-versioning.md` and
+`extraction-vs-ingestion-lock.md`; design stress-tested for constraint
+violations, race conditions, and unhandled cases.
+
+## Headline
+
+The thesis is sound and the prior-art framing is genuinely strong, but **three
+blocking schema/concurrency holes contradict enforced constraints the plan
+treats as nonexistent**, and one merge-protocol step violates a documented
+invariant in the plan's own codebase. The "workspace invisible until merge"
+model — the plan's central payoff — is the thing most at risk.
+
+---
+
+## Severity key
+
+- 🔴 **Blocking** — contradicts enforced DB constraints / load-bearing
+  invariants; not buildable as written.
+- 🟠 **High** — design holes that will bite during implementation.
+- 🟡 **Medium** — real work / underspecified, not fatal.
+- ⚪ **Low / accepted-risk** — noted for completeness, not defects.
+
+---
+
+## 🔴 Blocking
+
+### B1. `refs.owner_id` is FK-locked to `sources(id)`. Adding `page-content` to `refs` is not "additive."
+
+The plan (D1, §4.1) adds a `page-content` ref *kind* to the existing `refs`
+table, with `owner_id = pages.id`. But the live schema is:
+
+```sql
+-- SQLiteWikiStore.swift:587
+owner_id TEXT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+```
+
+and `PRAGMA foreign_keys=ON` is set at open (`:177`). With FKs enforced,
+**every `page-content` ref insert fails** — a page id is not in `sources`. The
+plan presents v29 as *additive* and the migration as "seeds one root version per
+existing page and writes no refs." It never mentions that the `refs` table
+itself must be rebuilt to drop the polymorphic FK.
+
+This compounds twice:
+
+- **It's not cheap.** Dropping the `owner_id` FK requires a SQLite table rebuild
+  (create-new / copy / drop / rename), not an `ALTER`.
+- **Dropping the FK loses `ON DELETE CASCADE`.** Today, deleting a source
+  auto-removes its refs. Lose that, and orphaned `source-content` /
+  `source-derived` refs accumulate — which silently drifts the very
+  `COALESCE(SUM(generation),0) FROM refs` fold (`:2038`) the plan swears must
+  stay byte-identical (§5).
+
+**D6 is internally inconsistent.** It claims to "honor graph-model §4.3's
+polymorphism tripwire: the third ref kind arrives *without* widening the
+polymorphic table." But §4.3's tripwire *explicitly* says the third kind is the
+trigger to "evaluate splitting `refs` per-kind into typed tables **or** adding a
+discriminator + CHECK." The CHECK option does **not** fix the FK — and the plan
+picks the shared-table option (the riskier of the two the ancestor named) purely
+to keep the `SUM(generation)` fold unchanged. So there's a genuine tension the
+plan hasn't resolved:
+
+- page-content **in `refs`** → FK problem (this finding);
+- page-content **in a separate `page_refs` table** → the token fold stops moving
+  on page saves and needs a new contributor (which §5 wants to avoid).
+
+Pick one and say so.
+
+### B2. `page_versions.page_id REFERENCES pages(id)`. Workspace-created pages can't exist without a `pages` row.
+
+§4.2 claims "Workspace-created pages hold real `page_versions` rows (append-only
+tables are namespace-free; only *refs* are namespaced)" and the workspace-write
+protocol (§4.3) does "No `pages`-row change, no token movement, no FP
+visibility." But §4.1's own schema is:
+
+```sql
+page_id TEXT NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+```
+
+You cannot insert a `page_versions` row for a page that doesn't exist in `pages`.
+So a workspace that creates a *new* page must create a `pages` row — and that
+row simultaneously:
+
+1. breaks the "no `pages`-row change" invariant,
+2. moves the token (`PagesTokenContributor` counts all `pages` rows),
+3. makes the draft File-Provider-visible,
+4. hits `pages_slug_unique` **at write time, before merge** — which defeats D13,
+   whose entire premise is that slug unification happens *at merge*.
+
+If both workspaces create "Elixir," the second insert throws a UNIQUE constraint
+error during ingestion, not a reviewable merge conflict.
+
+This is the symmetric twin of B1, and it strikes the plan's keystone invariant
+("the token reflects main only; workspace activity is invisible to the FP until
+merged"). The plan needs an explicit answer: either workspaces stage new pages
+in a separate table (then the "namespace-free append-only tables" claim is
+false), or new-page creation lands a `pages` row immediately (then accept the
+token/visibility/slug consequences and rewrite D13).
+
+### B3. The merge protocol regenerates embeddings *inside* the write transaction — a documented invariant violation.
+
+§4.3's merge pseudocode runs "regenerate links/FTS/embeddings for touched pages
+(D10)" inside the single `withTransaction`. The codebase explicitly forbids
+this. The comment at `SQLiteWikiStore.swift:3822`:
+
+> The embedding + FTS side effects run AFTER the commit (best-effort, and **MLX
+> inference must never run under an open write transaction — it would stall
+> `wikictl`**).
+
+`reembedSource` and `reembedChatMessages` both execute post-commit today — this
+is an established, load-bearing pattern (the system prompt repeats it: "Never run
+inference/network inside a transaction"). For a 50-page merge, holding the write
+lock across per-page embedding inference will:
+
+1. violate the rule, and
+2. blow the 5s `busy_timeout` for any concurrent `wikictl` writer or human save,
+   producing `SQLITE_BUSY` mid-merge.
+
+**Fix:** pre-compute embeddings for touched pages *before* the merge transaction,
+persist only the vectors inside it — exactly mirroring `renameSource`'s shape.
+
+---
+
+## 🟠 High
+
+### H1. D14 amend silently rewrites a workspace's merge base.
+
+Autosave amend ("replaces the head version's blob pointer") mutates a
+`page_versions` row in place. But `workspace_refs.base_version_id` references a
+`page_versions.id`. If the app amends a version that an open workspace uses as
+its three-way-merge base, **the merge base content changes underneath the
+in-flight workspace** with no notification.
+
+D14 restricts amend to "parent is current head, same actor, within debounce
+window" — it does *not* add the necessary guard: **amend only if no
+`workspace_refs.base_version_id` points at the target version** (or if the
+version has no children). Otherwise history rewriting corrupts a live merge.
+
+### H2. All-or-nothing merge: one conflicting page parks the whole workspace.
+
+§4.3: any per-page conflict → `abort transaction, park 'conflicted'`. A 50-page
+ingestion with a single conflict on page 7 parks all 50 pages — the 43 clean
+fast-forwards can't land until the conflict resolves. "Rebase-don't-abort" is
+deferred to W4, but the consequence isn't named: **large ingestions have merge
+latency gated by their worst page.**
+
+Consider landing clean pages incrementally (each its own sub-transaction) and
+parking only the conflicting subset — or accept the all-or-nothing semantics
+explicitly and say why (ingestion-internal consistency may demand it).
+
+### H3. D13 slug-unification is underspecified and has an ordering trap.
+
+Two workspaces create same-titled pages → different ULIDs. At merge, "the second
+workspace's body is three-way-merged in and its ULID references rewritten." But
+bodies are content-addressed immutable blobs, so rewriting
+`[[page:<loser-ULID>|…]]` → `[[page:<winner-ULID>|…]]` means minting a *new*
+blob. And the rewrite **must happen before diff3** — otherwise diff3 sees
+phantom conflicts on every link line (loser-ULID ≠ winner-ULID).
+
+The plan treats this as a parenthetical; it's actually a transformation with a
+hard ordering constraint against the merge base.
+
+---
+
+## 🟡 Medium
+
+- **M1. Token byte-identity is fragile, not free.** §5 claims "Phase 0 changes
+  no fold." Precisely: it adds *movement* to the existing `refs` fold (page
+  saves now repoint a `page-content` ref → `generation+1`). The 21 hardcoded
+  byte-for-byte assertions (verified: 5 in `LogIndexTests`, 14 in
+  `SQLiteWikiStoreTests`, 2 in `SystemPromptTests`) will change for any fixture
+  that saves a page post-migration. The migration's refs-table rebuild (B1)
+  itself risks the fold. "Verify byte-identity" is real work, not a checkbox.
+- **M2. Merge-queue executor is unspecified, and `wikictl` is a separate
+  process.** Who drives the serialized merge? For W1–W3 (in-app only) this is
+  fine, but W4 "concurrency unleashed" needs the executor's home nailed down —
+  especially whether a `wikictl`-triggered merge can coordinate with the app's
+  queue.
+- **M3. Abandonment GC is underspecified and interacts with B2.** "Orphaned
+  versions/blobs fall to the existing lazy-GC" assumes a clean orphan shape. If
+  new pages do/don't get `pages` rows (B2), `vacuum-pages` must find pages with
+  no main ref *and* no active workspace — more complex than "join
+  `vacuum-blobs`." The plan should specify the reachable-set query.
+
+---
+
+## ⚪ Low / accepted-risk
+
+- **D3 write-skew** is a defensible judgment call for prose. The one real
+  cross-page invariant is `wiki_index`, and D12's line-set union is
+  well-reasoned — but "same-line conflict → park" still bites on
+  topic-overlapping ingestions (two PDFs about Elixir editing the same index
+  line). Acceptable; just don't claim it eliminates index conflicts.
+- **D7 overlay reads are a moving target.** Mid-ingestion, an agent reads main's
+  latest for untouched pages, so its reasoning can be stale by merge time — a
+  *semantic* conflict diff3 structurally cannot see. The plan consciously
+  rejected snapshot-at-start; the consequence deserves a sentence.
+- **§4.1 vs graph-model §4.6.** The plan routes page bodies through `blobs` and
+  claims "D14's coalescing rule is what makes this honest." graph-model §4.6
+  warned page bodies through blobs "would mint a new SHA-256 on every
+  keystroke-save — the destruction of dedup." D14 *partially* addresses this,
+  but combined with H1 (amend safety), the honesty claim rests on an amend guard
+  that isn't specified. Earn it.
+
+---
+
+## Accuracy notes
+
+### Grounded facts in §2 — verified, essentially all correct
+
+`pages`/`pages_slug_unique` (`:221/:231`), blind `updatePage` (`:2223`),
+`isAgentRunning` lock + single mutation point (`:204/:1281`), reload guards
+(`:997/:1197`), `refs.SUM(generation)` fold (`:2038`), `changeToken`
+contributors (`:1933`), `wiki_index` singleton (`:348`), `wikictl` as a genuine
+second writer (`wikictl/main.swift:79`), the spawn slot (`GenerationGate`
+serializes across all `AgentLauncher`s). Solid grounding.
+
+### Two "mischaracterizations" that aren't
+
+A researcher flagged "v28 head" and "v24 reserved" as contradictions of
+graph-model — they are not. graph-model was *written* when v23 was head and is
+simply stale; the code is at `user_version=28` (`:519/:1282`), so page-versions
+is correctly current. The v24 hole is real (the ladder jumps `23→25` with no
+`24`), so "precedent for holes" is accurate. These are cases where page-versions
+is *more* accurate than its ancestor, not less.
+
+### One framing IS overstated
+
+Confirmed against `extraction-vs-ingestion-lock.md`: "completes the arc that doc
+started" and "the extraction slot is already separate" are overstated. The
+extraction-vs-ingestion plan is a narrow UI-state split
+(`extractingFileIDs`/`ingestingFileIDs`) and a *planned, not implemented*
+extraction lock; it explicitly leaves `isAgentRunning` intact and says nothing
+about versioning or workspaces. This plan builds a new layer on top — it doesn't
+complete that one.
+
+(D15's attribution — *this* plan retires the lock — is correct.)
+
+---
+
+## Verdict & recommendation
+
+The conceptual design — MVCC-as-durable-branches, retire-the-app-lock,
+dumb-fast merge queue that never waits on the LLM — is the right shape and
+well-argued. But **B1, B2, and B3 must be resolved before W0/W1 are buildable as
+written**, because each contradicts an enforced constraint (`foreign_keys=ON`,
+the `page_versions.page_id` FK, the no-inference-in-transaction rule).
+
+Cheapest fixes:
+
+- **B1/B2:** Decide the new-table vs. shared-table question explicitly. Cleanest
+  is probably per-kind typed pointer tables (`page_refs` mirroring
+  `workspace_refs`), accepting a new page-refs token contributor — this is
+  exactly what graph-model §4.3's tripwire recommended and dissolves both FK
+  problems at once. The "byte-identical token" goal isn't worth a
+  polymorphic-FK landmine.
+- **B3:** Pre-compute embeddings pre-transaction; persist vectors inside it
+  (mirror `renameSource`).
+- **H1:** Add the no-base-points-here guard to D14.
+
+---
+
+## Scope judgment — is the full architecture warranted *today*?
+
+The findings above are about whether the plan is **buildable as written**. This
+section is a separate, higher-level judgment: whether the full scope is
+**proportionate to the problem this system actually has now**.
+
+### What's unambiguously worth doing
+
+- **W0 (page versions + CAS + history + revert).** Executes #258, extends a
+  substrate that already exists, and is independently valuable even if nothing
+  else follows. The plan says "W0 stands alone" — treat that as a candidate
+  *stopping point*, not a waypoint.
+- **Retiring the *global* edit lock.** Its one stated reason (last-writer-wins
+  clobber) is removed by per-page CAS. Correct diagnosis.
+
+### Where the proportionality breaks
+
+The actual pain is narrow: *the editor freezes during a minutes-long ingestion.*
+But the conflict rate that justifies the workspaces/merge machinery is low. The
+human edits one page at a time; the agent ingests one file at a time (serialized
+today); they touch overlapping pages only when the human edits a page the agent
+is *also* rewriting (rare — the human usually knows), or when *two concurrent
+ingestions* collide — which is **W4, a stretch goal at the very end**. So the
+entire LLM-conflict-resolution subsystem (W2–W3) is built for a case that's
+uncommon now and only becomes load-bearing in a phase that may never ship.
+
+And it is the *riskiest, least-validated* component — the plan admits "only the
+last part is novel." Trusting an LLM to three-way-merge wiki prose, with no
+fallback if quality disappoints (Bayou op-log is "filed as refinement"), is a
+real bet. Combined with B1–B3 (the design already straining against the
+substrate's constraints), the complexity-to-payoff ratio is uncomfortable for a
+single-user local wiki.
+
+### Pragmatic alternative
+
+1. **Ship W0** — page versioning, CAS, history, revert. Pure win.
+2. **Swap the global edit lock for a per-page lock** — only lock the pages the
+   agent is actively rewriting, not the whole editor. The agent already knows
+   which pages it's touching; `wiki_index` is agent-maintained so locking it is
+   invisible to the human. This captures most of the "editor frozen during
+   ingestion" UX pain at a fraction of the complexity, and W0's per-page CAS
+   handles the genuine race.
+3. **Defer durable workspaces + LLM merge until there's evidence** — build the
+   expensive machinery when concurrent ingestions (W4) are real and the simpler
+   scheme is provably insufficient, not preemptively.
+
+### The one counterweight
+
+Workspaces give **reviewable ingestions** (D5 — "a diff against main inspectable
+before it lands," PR-review for the wiki), and that is valuable *independent* of
+concurrency. But review-before-land is achievable with a staging area, not a
+full MVCC substrate. If reviewable ingestions are the real goal, build that
+directly rather than inheriting it as a side effect of the merge architecture.
+
+### Bottom line
+
+Good diagnosis, right instincts ("never block the queue on the LLM"), excellent
+prior-art grounding — but **more than this system needs yet.** Ship W0 + a
+per-page lock; earn the workspaces/merge superstructure with evidence of real
+overlapping-write conflict rather than building it preemptively.

--- a/plans/page-versions-and-workspaces.md
+++ b/plans/page-versions-and-workspaces.md
@@ -1,12 +1,14 @@
 # Page versions & workspaces — multi-writer without a global lock
 
-**Status:** proposed (2026-07-09). Successor to the multi-writer brainstorm;
-builds directly on `graph-model-and-versioning.md` (the objects/refs
-substrate this plan extends to pages) and completes the arc
-`extraction-vs-ingestion-lock.md` started (that doc unfused extraction from
-the agent lock; this one retires the agent lock itself). Executes
-[#258](https://github.com/tqbf/selfdrivingwiki/issues/258) (page versioning)
-as its Phase 0.
+**Status:** proposed (2026-07-09); **revised 2026-07-09** after adversarial
+review (`page-versions-and-workspaces-review.md` — all three blocking
+findings accepted and resolved, see §8). Builds directly on
+`graph-model-and-versioning.md` (the objects/blobs/PROV substrate this plan
+extends to pages). Related but *not* a continuation:
+`extraction-vs-ingestion-lock.md` is a narrow UI-state split that leaves
+`isAgentRunning` intact; this plan is the layer that retires that lock.
+Executes [#258](https://github.com/tqbf/selfdrivingwiki/issues/258) (page
+versioning) as its Phase W0.
 
 **The organizing idea:** there are two "global locks" in this system and they
 have opposite characters. The SQLite WAL write lock is global but held for
@@ -15,13 +17,23 @@ it happily. The application-level agent edit lock (`isAgentRunning`,
 `WikiStoreModel.swift:203`) is held for the *minutes* an ingestion runs, and
 exists for exactly one reason: an ingestion is a long-running logical
 transaction with no isolation mechanism, so the app protects consistency by
-locking everyone out. This plan gives long-running writers an isolation
-mechanism — durable, named **workspaces** over the append-only version
-substrate the graph-model plan already built — so the only exclusive section
-left is a short merge commit. MVCC and git branches are not two options here;
-on a storage model that is already immutable blobs + append-only versions +
-mutable refs, **a branch is MVCC with the speculative state made durable and
-addressable**. We build that once and get both.
+locking everyone out. This plan removes that lock in two stages:
+
+1. **Now:** per-page CAS (W0) makes the last-writer-wins race — the lock's one
+   stated reason — structurally impossible, and per-page *advisory* locks (W1)
+   shrink the frozen-editor UX from "whole wiki" to "the pages the agent is
+   actually rewriting."
+2. **When concurrency is real:** durable, named **workspaces** over the
+   append-only version substrate give long-running writers true isolation, so
+   the only exclusive section left is a short merge commit. MVCC and git
+   branches are not two options here; on a storage model that is already
+   immutable blobs + append-only versions + mutable pointers, **a branch is
+   MVCC with the speculative state made durable and addressable.**
+
+The workspace/merge phases (W2–W5) are fully designed below — including the
+fixes the adversarial review forced — but **evidence-gated** (§9): they are
+built when concurrent ingestions or reviewable-ingestion review are actually
+wanted, not preemptively.
 
 ---
 
@@ -35,7 +47,7 @@ conflict handler.* Only the last part is novel.
 
 | Design element | Ancestor |
 |---|---|
-| Per-page CAS on a ref | Optimistic concurrency control (Kung & Robinson 1981); git atomic ref update; HTTP ETag/`If-Match` |
+| Per-page CAS on a head pointer | Optimistic concurrency control (Kung & Robinson 1981); git atomic ref update; HTTP ETag/`If-Match` |
 | Read freely, validate write set at short commit; first-committer-wins | Snapshot isolation — Postgres `REPEATABLE READ` |
 | Accepted write-skew anomaly | The canonical SI anomaly; SSI (Ports & Grittner, Postgres `SERIALIZABLE`) is the *rejected* alternative — its read-set tracking cost buys nothing for wiki prose with no cross-page invariants |
 | Durable workspaces for long-lived writers; refresh-before-merge; conflicts materialized as data | 1980s CAD "long transactions" (check-out/check-in); **Oracle Workspace Manager** (`MergeWorkspace`/`RefreshWorkspace`, conflict tables) |
@@ -67,22 +79,31 @@ global lock rebuilt one layer up.
   editor goes read-only with a banner, autosave pauses, Edit/Save disable
   (`PageDetailView.swift:40–89`), and reload paths guard
   (`WikiStoreModel.swift:997`, `:1197`). The spawn slot in
-  `AgentLauncher.swift` serializes all `claude -p` runs; the extraction slot
-  (extraction-vs-ingestion plan) is already separate.
+  `AgentLauncher.swift` serializes all `claude -p` runs; a separate
+  extraction slot is planned (`extraction-vs-ingestion-lock.md`), not yet
+  implemented.
 - The objects substrate from graph-model Phases 1–2 is live: content-addressed
   `blobs`, append-only `source_versions` / `source_markdown_versions`, PROV
-  `agents`/`activities`, and the single mutable `refs` table
-  (`kind, owner_id, version_id, generation, updated_at`,
-  `SQLiteWikiStore.swift:585`) with two kinds (`source-content`,
-  `source-derived`) and the default-active rule (no ref row → `MAX(id)`).
-  Lazy GC exists (`vacuumBlobs`, `vacuum-all`).
+  `agents`/`activities`, and the mutable `refs` table
+  (`SQLiteWikiStore.swift:585`). **Load-bearing constraint the first draft of
+  this plan missed:** `refs.owner_id` carries
+  `REFERENCES sources(id) ON DELETE CASCADE` (`:587`) and
+  `PRAGMA foreign_keys=ON` is set at open (`:177`) — `refs` is structurally
+  *source-owned*; a page id cannot be an owner. Likewise
+  `page_versions.page_id` (§4.1) will FK to `pages(id)`, so no version row
+  can exist for a page with no `pages` row. Both facts shape §4.
+- **The no-inference-in-transaction rule** is documented and load-bearing:
+  "MLX inference must never run under an open write transaction — it would
+  stall `wikictl`" (`SQLiteWikiStore.swift:3822`); `renameSource` runs
+  embedding + FTS side effects *after* commit. Any merge protocol must mirror
+  this shape.
 - The changeToken is assembled from registered `ChangeTokenContributor`s
   (`SQLiteWikiStore.swift:1933`); the current 11-field literal is enforced
-  byte-for-byte by ~20 hardcoded assertions across three test suites. One
-  existing fold is `COALESCE(SUM(generation),0)` over **all** of `refs`
-  (`SQLiteWikiStore.swift:2038`) — load-bearing fact: speculative ref writes
-  must not land in that table or the File Provider token moves on
-  uncommitted work.
+  byte-for-byte by 21 hardcoded assertions (5 `LogIndexTests`,
+  14 `SQLiteWikiStoreTests`, 2 `SystemPromptTests`). One fold is
+  `COALESCE(SUM(generation),0)` over **all** of `refs` (`:2038`) —
+  speculative writes must not land in folded tables or the File Provider
+  token moves on uncommitted work.
 - `wiki_index` is a **singleton table**, not a page (`SQLiteWikiStore.swift:348`)
   — the curated index the agent rewrites on every ingest. It is the guaranteed
   merge hot spot, but being a separate table it can carry its own merge rule
@@ -101,28 +122,31 @@ global lock rebuilt one layer up.
 
 | # | Decision | Rationale |
 |---|----------|-----------|
-| D1 | **Pages join the object model**: append-only `page_versions` + a `page-content` ref kind; a page save = append version + CAS repoint | The prerequisite for everything; executes #258. CAS in one sentence: "repoint P from A to B where B.parent = A; if the ref moved, conflict" |
-| D2 | **`pages.body_markdown` stays, as the materialized main head** (denorm mirror, same flagged discipline as `sources.byte_size` in graph-model §9) | FTS, embeddings, FP projection, UI, and search keep reading the `pages` row unmodified — MVCC lands with **zero read-path migration**. Every main commit updates row + version + ref atomically in one `withTransaction` |
+| D1 | **Pages join the object model**: append-only `page_versions`; a page save = append version + CAS commit. Title lives on the version row, so CAS covers renames too | The prerequisite for everything; executes #258. CAS in one sentence: "commit B whose parent is A, guarded on the head still being A; if it moved, conflict" |
+| D2 | **`pages.body_markdown` stays, as the materialized main head** (denorm mirror, same flagged discipline as `sources.byte_size` in graph-model §9) | FTS, embeddings, FP projection, UI, and search keep reading the `pages` row unmodified — MVCC lands with **zero read-path migration**. Every main commit updates row + version + head pointer atomically in one `withTransaction` |
 | D3 | **Isolation level: snapshot-ish, read-latest + recorded read set, write-set validation at commit, first-committer-wins.** Write skew consciously accepted | Wiki prose has no cross-page invariants, so SI anomalies are harmless by construction; the read set lands in PROV as `used` relations (audit trail, future "cites since-changed content" lint). SSI-style read validation is the named, rejected alternative |
-| D4 | **Humans commit to main; agents get workspaces** | A human save is milliseconds — direct CAS, with CAS failure surfacing as a "page changed underneath you" affordance. Humans never think about branches to fix a typo. Mirrors the extraction-vs-ingestion asymmetry principle |
+| D4 | **Humans commit to main; agents get workspaces** (once W2+ exist) | A human save is milliseconds — direct CAS, with CAS failure surfacing as a "page changed underneath you" affordance. Humans never think about branches to fix a typo. |
 | D5 | **Workspaces are durable rows** (`workspaces` table: ULID, status lifecycle `open → merging → merged \| conflicted \| abandoned`, PROV activity) | Durable speculation = crash recovery, observability (watch the agent work), and **reviewable ingestions** (a workspace is a diff against main inspectable before it lands — PR review for the wiki) |
-| D6 | **`workspace_refs` is a sibling table, not a `workspace` column on `refs`** | Keeps main's `refs` semantics and its `SUM(generation)` changeToken fold byte-identical (no test-literal churn); speculative refs get their own cascade (delete workspace → refs vanish) and never feed the token. Honors graph-model §4.3's polymorphism tripwire: the third ref kind arrives *without* widening the polymorphic table — `refs` instead gains a `CHECK(kind IN (…))` |
-| D7 | **Overlay reads**: in workspace W, resolve W's ref if present, else main. `wikictl --workspace <id>` / `WIKI_WORKSPACE` env selects the namespace; the agent toolchain works unmodified | Union-mount semantics; no snapshot-at-start (that would require a refs journal — rejected, D3 records reads instead) |
+| D6 | **Main's head pointer is `pages.head_version_id`, CAS'd via the existing `pages.version` counter — the `refs` table is untouched** *(revised: review B1)* | `refs.owner_id` is FK-locked to `sources(id)` (§2); adding a page kind means a table rebuild that loses the source-delete cascade. Instead the head pointer rides the same `UPDATE` that maintains the D2 mirror: no new table, no refs rebuild, no new token contributor. **Flagged deviation** from graph-model A2's "all pointers in refs" — justified because `refs` is structurally source-owned, with the §9-deviation precedent. Also kills a latent bug: the inherited "head = `MAX(id)`" default-active rule breaks the moment workspaces append version rows for existing pages; an explicit head pointer makes main's head unambiguous regardless of speculative appends |
+| D7 | **Overlay reads**: in workspace W, resolve W's entry if present, else main. `wikictl --workspace <id>` / `WIKI_WORKSPACE` env selects the namespace; the agent toolchain works unmodified | Union-mount semantics; no snapshot-at-start (that would require a head-pointer journal — rejected, D3 records reads instead). **Named consequence:** main-reads are a moving target — an agent's *reasoning* can be stale by merge time, a semantic conflict diff3 structurally cannot see. Accepted; provenance records what was read |
 | D8 | **Merge ladder**: fast-forward → three-way textual merge (diff3 against recorded base) → **park conflicted** → agent/human resolution as a later ordinary write | The queue stays dumb and fast (Datomic-transactor discipline); LLM resolution happens *outside* the commit path (CouchDB conflict-as-state) |
 | D9 | **Merged versions get two-parent lineage**: `page_versions.merge_parent_id` | A merge is a real PROV activity whose output `wasDerivedFrom` both parents; two parents suffice (no octopus merges) |
-| D10 | **Derived data is regenerated at merge, never merged**: `replaceLinks`, FTS, embeddings re-run for merged pages; the log is append-only (no conflicts); the ingest-completion log entry is written by the *merge*, not the run | Deterministic functions of bodies; merging them would be merging a cache |
+| D10 | **Derived data is regenerated at merge, never merged** — with **inference precomputed *before* the merge transaction** *(revised: review B3)*: embeddings for anticipated merged bodies are computed pre-transaction and only the vectors are persisted inside it; links/FTS regenerate inside (pure SQL); the log is append-only; the ingest-completion log entry is written by the *merge*, not the run | Deterministic functions of bodies; merging them would be merging a cache. The no-inference-in-transaction rule (§2) is documented and load-bearing — the merge mirrors `renameSource`'s post-commit/pre-compute shape |
 | D11 | **Sources stay on main, even during workspace ingestion** | Source chains are append-only + content-addressed — concurrent ingestions cannot conflict on them. A source from an abandoned workspace is just an un-cited source (vacuumable). Keeps the overlay page-only and small |
-| D12 | **`wiki_index` merges structurally, not textually**: it is semantically a link set — merge = three-way *line-set* union (added/removed lines vs base), fallback to parking only on same-line edits | Escrow-transaction reasoning applied to the one guaranteed hot spot. Without this, every merge conflicts, every time |
-| D13 | **Slug collisions are a first-class merge case**: two workspaces creating the same title → merge unifies into one page (first-merged ULID survives; the second workspace's body is three-way-merged in and its ULID references rewritten at merge) | `pages_slug_unique` makes this an error, not a silent dupe — good; the merge must handle it, not crash on it. The silent-divergence alternative (two "Elixir" pages) is worse than a conflict |
-| D14 | **Autosave coalesces into the head version** (git-commit-`--amend` style): a save whose parent is the current head, by the same actor/activity, within a debounce window, *replaces* the head version's blob pointer instead of appending | Without this, the in-app editor's debounced autosave mints a version row every few seconds and the chain is noise. Agents get one version per `wikictl` write (each write is deliberate) |
-| D15 | **The edit lock retires; the spawn slot becomes a throttle** | Once agents write to workspaces, in-app edits *cannot* clobber agent writes — the lock's stated reason (`WikiStoreModel.swift:203`) is gone. The spawn slot stops being a correctness serializer and becomes "at most N concurrent claude processes", the same shape as the extraction slot |
+| D12 | **`wiki_index` merges structurally, not textually**: it is semantically a link set — merge = three-way *line-set* union (added/removed lines vs base), parking only on same-line edits | Escrow-transaction reasoning applied to the one guaranteed hot spot. This *reduces* index conflicts to same-line collisions (e.g. two topic-overlapping ingestions editing one entry); it does not eliminate them |
+| D13 | **Slug collisions are a first-class merge case, resolved entirely at merge** *(revised: reviews B2+H3)*: workspace-created pages never touch `pages` pre-merge (D16), so two workspaces creating the same title cannot collide at write time. At merge, if the slug exists on main: the main page's ULID survives; the workspace body is rewritten `[[page:<loser>|…]]` → `[[page:<winner>|…]]` — **minting a new blob, before diff3 runs** (otherwise every link line is a phantom conflict) — then three-way-merged against the main page (empty base if main's page predates the workspace) | `pages_slug_unique` makes silent duplicates impossible — good; the merge must handle collision as a reviewable case, not crash on it mid-ingestion |
+| D14 | **Autosave coalesces into the head version** (git-commit-`--amend` style): a save whose parent is the current head, by the same actor/activity, within a debounce window, *replaces* the head version's blob pointer instead of appending. **Guard** *(added: review H1)*: never amend a version that any `workspace_refs.base_version_id` or `workspace_refs.version_id` references, or that has children — amend only true, unreferenced heads | Without coalescing, debounced autosave mints a version row every few seconds and the chain is noise (this is what answers graph-model §4.6's "blobs per keystroke" objection). Without the guard, amending rewrites a live workspace's merge base underneath an in-flight merge |
+| D15 | **The edit lock retires; the spawn slot becomes a throttle** | Per-page CAS (W0) removes the lock's stated reason (`WikiStoreModel.swift:203`); per-page advisory locks (W1, D16a) replace its UX role. The spawn slot stops being a correctness serializer and becomes "at most N concurrent claude processes" |
+| D16 | **Workspace-created pages stay entirely in workspace-land until merge** *(added: review B2)*: `workspace_refs` carries nullable `title` + `blob_hash`; for a page with no `pages` row, `version_id` is NULL and the head is the blob. The merge mints the `pages` row and a single root version from the final blob | `page_versions.page_id` FKs to `pages(id)` — a version row cannot precede its page. Creating the `pages` row early would move the token, expose the draft to the FP, and fire `pages_slug_unique` mid-ingestion (defeating D13). Intermediate agent drafts of a *new* page are not history worth keeping (D14's spirit) |
+| D16a | **Per-page advisory locks (W1)**: during an agent run, pages the run has written become read-only in the editor (per-page banner); everything else stays editable. State is in-app only (`WikiStoreModel`, fed by the existing wikictl-write change events), cleared at `endAgentRun` — no DB state, no lease reaping (crash ⇒ run ends ⇒ cleared) | Captures most of the frozen-editor pain at a fraction of the workspace machinery. The lock is *UX*; W0's CAS is the correctness backstop — a human already mid-edit when the agent touches the page simply gets the conflict affordance on save |
+| D17 | **Merge is all-or-nothing per workspace** *(decided: review H2)*: one conflicting page parks the entire workspace; clean pages do not land incrementally | An ingestion is semantically one change-set: landing 43 pages whose bodies link to 7 unmerged ones creates dangling `[[page:ULID]]` references on main — worse than merge latency. **Named consequence:** a large ingestion's merge latency is gated by its worst page. Partial-land is a W4+ refinement *if* evidence shows this hurts |
 
 ## 4. Schema
 
 Additive; follows the stepwise ladder discipline (fresh-path parity enforced
 by `freshFastPathMatchesStepwiseLadder`).
 
-### 4.1 `page_versions` (v29)
+### 4.1 `page_versions` + `pages.head_version_id` (v29 — Phase W0)
 
 ```sql
 CREATE TABLE page_versions (
@@ -136,182 +160,274 @@ CREATE TABLE page_versions (
     saved_at         REAL NOT NULL
 );
 CREATE INDEX page_versions_page ON page_versions(page_id, id);
+
+ALTER TABLE pages ADD COLUMN head_version_id TEXT;  -- D6; NOT NULL after seeding
 ```
 
-Bodies go through `blobs` — at *save* granularity, not keystroke granularity,
-which is what graph-model §4.6 warned about; D14's coalescing rule is what
-makes this honest. Page bodies rarely dedup; the append-only chain, not the
-dedup, is what's being bought.
+- Bodies go through `blobs` at *save* granularity (D14's coalescing + amend
+  guard is what makes this honest against graph-model §4.6's warning).
+  Page bodies rarely dedup; the append-only chain, not dedup, is what's
+  being bought.
+- **Head resolution is `pages.head_version_id`, always** — never `MAX(id)`
+  (D6 records why the sources default-active rule must not be inherited).
+- `refs` is untouched: no rebuild, no lost cascade, no new kind, no token
+  fold movement (§5).
+- Migration (v29, one `withTransaction`): create table; add column; per page
+  `INSERT OR IGNORE` blob of current body → insert root version
+  (`parent_id NULL`, `title` = current, `saved_at = updated_at`) → set
+  `head_version_id`. `pages.version` counters are untouched, so the token is
+  byte-identical across the migration (verified against the 21 literal
+  assertions in the same commit).
 
-The `refs` table gains the `page-content` kind (a `CHECK` constraint listing
-the three kinds, per D6) and the default-active rule carries over verbatim:
-no ref row → head is `MAX(id)`. Migration seeds one root version per existing
-page (blob of current body) and writes **no** refs — main tracks latest by
-default, exactly like sources did in v20.
-
-### 4.2 `workspaces` + `workspace_refs` (v30)
+### 4.2 `workspaces` + `workspace_refs` (v30 — Phase W2, evidence-gated)
 
 ```sql
 CREATE TABLE workspaces (
-    id           TEXT PRIMARY KEY,       -- ULID
-    name         TEXT,                   -- human label ("ingest: foo.pdf")
-    status       TEXT NOT NULL DEFAULT 'open',
-                 -- 'open' | 'merging' | 'merged' | 'conflicted' | 'abandoned'
-    activity_id  TEXT REFERENCES activities(id),  -- the ingestion activity
-    created_at   REAL NOT NULL,
-    updated_at   REAL NOT NULL
+    id                 TEXT PRIMARY KEY,     -- ULID
+    name               TEXT,                 -- human label ("ingest: foo.pdf")
+    status             TEXT NOT NULL DEFAULT 'open',
+                       -- 'open' | 'merging' | 'merged' | 'conflicted' | 'abandoned'
+    activity_id        TEXT REFERENCES activities(id),  -- the ingestion activity
+    index_body         TEXT,                 -- wiki_index draft (singleton, not a versioned owner)
+    index_base_version INTEGER,              -- wiki_index.version observed at first index write
+    created_at         REAL NOT NULL,
+    updated_at         REAL NOT NULL
 );
 
 CREATE TABLE workspace_refs (
-    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-    kind         TEXT NOT NULL CHECK (kind = 'page-content'),
-    owner_id     TEXT NOT NULL,          -- pages.id (may not exist on main yet: page created in-workspace)
-    base_version_id TEXT,                -- main head observed at first write (CAS base; NULL = page created here)
-    version_id   TEXT NOT NULL,          -- the workspace's current head for this page
-    updated_at   REAL NOT NULL,
-    PRIMARY KEY (workspace_id, kind, owner_id)
+    workspace_id    TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    owner_id        TEXT NOT NULL,        -- pages.id, OR a pre-allocated ULID for a page created in-workspace
+    base_version_id TEXT,                 -- main head at first write (merge base + CAS expectation); NULL = created here
+    version_id      TEXT,                 -- workspace head (page_versions.id) — NULL for created pages (D16)
+    blob_hash       TEXT REFERENCES blobs(hash),  -- head body for created pages (D16); NULL otherwise
+    title           TEXT,                 -- title for created pages (D16); NULL otherwise
+    updated_at      REAL NOT NULL,
+    PRIMARY KEY (workspace_id, owner_id)
 );
 ```
 
-- `base_version_id` recorded at the workspace's **first write** to that page
-  is the three-way-merge base and the CAS expectation — the write set and its
-  bases in one table. The *read* set (pages read but not written) is recorded
-  as PROV `used` rows on the ingestion activity (D3) — provenance, not
-  validation input.
-- No FK from `owner_id` to `pages` — a workspace may create a page that
-  doesn't exist on main until merge. The merge transaction creates the
-  `pages` row (or unifies on slug collision, D13).
-- Workspace-created pages hold real `page_versions` rows (append-only tables
-  are namespace-free; only *refs* are namespaced). Abandoning a workspace
-  deletes its refs; orphaned versions/blobs fall to the existing lazy-GC
-  pattern (`vacuum-pages` joins `vacuum-blobs`/`vacuum-all`).
-- `wiki_index` workspace state: one nullable `index_body` snapshot column on
-  `workspaces` (plus `index_base_version`) rather than a ref — it is a
-  singleton, not a versioned owner. Merge applies the D12 line-set rule.
+- **Existing pages**: workspace writes append real `page_versions` rows (the
+  FK is satisfied) and repoint `version_id`; `base_version_id` recorded at
+  first touch is the diff3 base and CAS expectation. These speculative rows
+  never affect main's head (D6 — explicit pointer, not `MAX(id)`).
+- **Created pages** (D16): no `pages` row, no `page_versions` rows —
+  `version_id` NULL, head is `blob_hash`, `title` carried alongside. The
+  merge mints the `pages` row + root version (or unifies on slug collision,
+  D13).
+- The *read* set (pages read but not written) is PROV `used` rows on the
+  ingestion activity (D3) — provenance, not validation input.
+- `wiki_index` staging is two columns on `workspaces` — it is a singleton,
+  not a versioned owner; merge applies the D12 line-set rule against
+  `index_base_version`.
+- Neither table feeds any changeToken fold (§5); `workspace_refs` cascades
+  on workspace delete.
+
+**Abandonment & GC** *(specified: review M3)*: `abandon` deletes the
+workspace row (cascading its refs). Reclamation, lazy, alongside
+`vacuum-blobs` in `vacuum-all`:
+
+- *Orphan speculative versions*: `page_versions` rows that are (a) not an
+  ancestor of any `pages.head_version_id` (walk `parent_id`/`merge_parent_id`
+  from every head), and (b) not referenced by any `workspace_refs.version_id`
+  or `.base_version_id` — delete (`vacuum-page-versions`).
+- *Blobs*: `vacuumBlobs` gains two reference sources —
+  `page_versions.blob_hash` and `workspace_refs.blob_hash`.
+- *Sources added by an abandoned run* (D11): remain as ordinary un-cited
+  sources; the existing orphan-sources query surfaces them for optional
+  cleanup. No automatic delete — they may be legitimately re-cited later.
 
 ### 4.3 The commit protocols
 
-**Human save to main** (Phase 0, replaces blind `updatePage`):
+**Human save to main** (W0, replaces blind `updatePage`):
 
 ```
 withTransaction:
-  head = resolve page-content ref (or MAX(id))
-  guard head == the version the editor loaded   -- CAS; else PageConflictError
-  INSERT blob (OR IGNORE); INSERT page_versions (parent = head)   -- or amend head (D14)
-  UPDATE pages SET body_markdown, title, updated_at, version+1    -- the D2 mirror
-  UPSERT refs('page-content', page, new, generation+1)
-  replaceLinks / FTS / embeddings as today
+  guard pages.version == the version counter the editor loaded   -- CAS; else PageConflictError
+  INSERT blob (OR IGNORE); INSERT page_versions (parent = head_version_id)
+      -- or amend the head version's blob pointer per D14 (guard included)
+  UPDATE pages SET body_markdown, title, updated_at,
+                   version = version + 1, head_version_id = new
+  replaceLinks / FTS as today
+(embeddings: post-commit, best-effort — unchanged from today's shape)
 ```
 
 `PageConflictError` surfaces in the UI as the "page changed underneath you"
 affordance (dirty-editor protection already has the vocabulary). Because the
 guard is SQL inside the transaction, the same protocol is correct from
-`wikictl` cross-process — no in-process lock involved (§2).
+`wikictl` cross-process — no in-process lock involved (§2). `wikictl page
+write` gains an optional `--expect-version N` (agents that read-then-write
+can CAS; bare writes keep today's semantics against the *advisory-locked*
+pages model of W1).
 
-**Workspace write** (agent via `wikictl --workspace W`): append version;
-UPSERT `workspace_refs` (recording `base_version_id` on first touch). No
-`pages`-row change, no token movement, no FP visibility. Milliseconds.
+**Workspace write** (W2+, agent via `wikictl --workspace W`): append version
+(existing page) or update `blob_hash`/`title` (created page); UPSERT
+`workspace_refs`, recording `base_version_id` on first touch. No `pages`-row
+change, no token movement, no FP visibility. Milliseconds.
 
-**Merge** (serialized queue; one short transaction per attempt):
+**Merge** (W2+; serialized queue; one short transaction per attempt):
 
 ```
 mark workspace 'merging'
+PRE-TRANSACTION (no write lock held):
+  compute anticipated merged bodies:
+    slug-collision rewrite first (D13: loser→winner ULIDs, new blobs),
+    then per-page diff3(base, main_head, ws_head)
+  if any page conflicts → park 'conflicted' (no transaction opened)
+  run embedding inference for the anticipated bodies (D10 / B3)
 withTransaction:
-  for each workspace_refs row:
-    main_head = resolve main ref
-    if owner missing on main:  slug-collision check → create page or unify (D13)
-    elif main_head == base:    fast-forward           -- repoint + mirror update
-    else:                      diff3(base, main_head, ws_head)
-                               clean → merge version (merge_parent_id set) + mirror
-                               conflict → abort transaction, park 'conflicted'
-  wiki_index: line-set three-way (D12); same-line conflict → park
-  regenerate links/FTS/embeddings for touched pages (D10)
+  re-validate every base: main head still == base observed pre-transaction
+      -- a human commit raced the pre-compute → abort, re-run pre-compute (cheap loop)
+  for each workspace_refs row: insert merge/root version rows
+      (merge_parent_id set for true merges), update pages mirror + head,
+      create pages rows for D16 pages (slug re-check under the lock)
+  wiki_index: line-set three-way against index_base_version (D12);
+      same-line conflict → abort transaction, park 'conflicted'
+  regenerate links + FTS for touched pages (pure SQL); persist precomputed vectors
   append ingest-completion log entry; merge activity into PROV
 mark 'merged'
 ```
 
-Parking writes the conflict *description* (page, base/ours/theirs version ids)
-onto the workspace and returns — durable, diffable, resumable. Resolution
-(merge agent or human) writes new versions **into the workspace** and
-re-enqueues; the resolver never runs inside the commit path (§1's hard
-constraint). After any merge lands, other open workspaces are unaffected
+All-or-nothing per D17. Parking writes the conflict *description* (page,
+base/ours/theirs version ids) onto the workspace and returns — durable,
+diffable, resumable. Resolution (merge agent or human) writes new versions
+**into the workspace** and re-enqueues; the resolver never runs inside the
+commit path (§1's hard constraint). Other open workspaces are unaffected
 until *their* merge attempt, which revalidates against the new main
-(refresh/rebase — Oracle WM's `RefreshWorkspace` — is the same diff3 run
-voluntarily before merging).
+(refresh/rebase — Oracle WM's `RefreshWorkspace` — is the same pre-compute
+run voluntarily before merging).
+
+**Merge executor** *(specified: review M2)*: the app owns the merge queue (a
+serialized task adjacent to `WikiStoreModel`, same discipline as the spawn
+slot). `wikictl workspace merge` *requests* a merge: if the app is running it
+enqueues (Darwin notification, existing bridge); headless, `wikictl` may
+execute the merge directly — safe because the protocol is pure store calls
+under `withTransaction`, and cross-process exclusion is WAL's job. Revisit at
+W5 if queue-fairness needs richer coordination.
 
 ## 5. changeToken & File Provider
 
 The invariant: **the token reflects main only.** Workspace activity is
 invisible to the File Provider until merged.
 
-- The existing folds already mostly deliver this given D2/D6: the `pages`
-  count+`SUM(version)` fold moves on every main commit (mirror row always
-  updated); `refs.SUM(generation)` moves on repoints; `workspace_refs` is
-  deliberately outside the fold.
-- One new contributor: `page_versions` **is not folded by count** (workspace
-  writes append rows without changing main) — instead nothing new is needed;
-  the mirror + refs folds cover every main-visible mutation (append-without-
-  repoint on main cannot occur for pages: every main commit repoints).
-  Recorded so a future "just add a count fold" doesn't reintroduce
-  speculative-write visibility.
-- Token literals in tests: Phase 0 changes no fold; verify byte-identity in
-  the same commit.
+- W0 adds **no fold and no fold movement**: page commits move the existing
+  `pages` count+`SUM(version)` fold exactly as blind `updatePage` does today
+  (the counter increments on every save either way); `head_version_id` and
+  `page_versions` are outside every fold; `refs` is untouched (D6). The v29
+  migration leaves counters untouched → token byte-identical. The 21
+  hardcoded literal assertions are *verified*, not rewritten, in the W0
+  commit.
+- W2's tables (`workspaces`, `workspace_refs`) are deliberately outside all
+  folds. Merge commits move the `pages` fold (mirror row + counter), which is
+  exactly when the FP must refresh.
+- Recorded so a future "just add a `page_versions` count fold" doesn't
+  reintroduce speculative-write visibility: **`page_versions` must never be
+  folded by count** — workspaces append to it without changing main.
 
 ## 6. What this retires, and what it deliberately doesn't
 
-**Retired:** `isAgentRunning` as an edit lock (D15) — the editor stays
-editable during ingestion; the read-only banner becomes a per-page conflict
-affordance. "Ingestion locks several pages at once" dissolves entirely: nothing
-is locked during ingestion; the multi-page atomic step shrinks to the merge
-transaction, and SQLite's write lock *is* that mutex, already built.
+**Retired:** `isAgentRunning` as a *global* edit lock — W1 replaces it with
+per-page advisory read-only (D16a) + CAS as the correctness backstop; W2+
+replace even that with true isolation. "Ingestion locks several pages at
+once" dissolves entirely at W2: nothing is locked during ingestion; the
+multi-page atomic step shrinks to the merge transaction, and SQLite's write
+lock *is* that mutex, already built.
 
-**Kept:** the spawn slot (as an N-throttle — resource management, not
-correctness); the extraction slot (unchanged); WAL + `busy_timeout`
-cross-process discipline; the method-atomic store + `withTransaction`
-(Phase 0 of graph-model is precisely the substrate this plan stands on); the
-synchronous main-actor write model for human edits.
+**Kept:** the spawn slot (as an N-throttle from W5 — resource management,
+not correctness); WAL + `busy_timeout` cross-process discipline; the
+method-atomic store + `withTransaction` (graph-model Phase 0 is precisely
+the substrate this plan stands on); the synchronous main-actor write model
+for human edits; the post-commit embedding discipline (§2).
 
-**Non-goals, named:** SSI/read-set validation (D3); a refs journal /
+**Non-goals, named:** SSI/read-set validation (D3); a head-pointer journal /
 as-of-snapshot reads (D7); CRDTs/OT (keystroke-scale machinery for an
 agent-scale problem — except the set-union idea, kept for `wiki_index`);
 op-log/replay ingestion (Bayou — filed as refinement if diff3 quality
 disappoints); actual git as substrate (FTS, vec, FP live in SQLite; Fossil
-proves the semantics port); multi-level/nested workspaces; chat tables
-(v25/v28) — single-writer surfaces, out of scope.
+proves the semantics port); multi-level/nested workspaces; partial-land
+merges (D17 — revisit with evidence); chat tables (v25/v28) — single-writer
+surfaces, out of scope.
 
-## 7. Phases
+## 7. Per-page advisory locks (W1, the cheap UX win)
 
-Each gate is demoable; each phase ships alone and is independently valuable.
+The narrow, real pain today: *the whole editor freezes for the minutes an
+ingestion runs.* W1 fixes that without any workspace machinery:
+
+- `WikiStoreModel` gains `agentTouchedPageIDs: Set<PageID>`, populated from
+  the existing wikictl-write change events during a run (the agent "locks"
+  a page by writing it), cleared in `endAgentRun` (crash ⇒ cleared — no
+  leases, no reaping, no DB state).
+- `PageDetailView`'s read-only gating switches from `store.isAgentRunning`
+  to `agentTouchedPageIDs.contains(page.id)`; the banner becomes per-page
+  ("The agent is updating this page…"). Autosave pauses only for touched
+  pages.
+- The race this cannot prevent — human already mid-edit when the agent first
+  touches the page — is exactly what W0's CAS catches: the human's save gets
+  the conflict affordance instead of silently clobbering (or being
+  clobbered). Advisory lock = UX; CAS = correctness. `wiki_index` needs no
+  lock (agent-maintained, not a page, humans never edit it).
+- One agent run at a time is *kept* in W1 (today's spawn-slot serialization)
+  — agent-vs-agent contention does not exist yet, which is what makes
+  advisory locks sufficient. They are throwaway-cheap when W2 arrives.
+
+## 8. Review reconciliation (2026-07-09)
+
+Disposition of `page-versions-and-workspaces-review.md`, recorded so it
+isn't relitigated:
+
+| Finding | Disposition |
+|---|---|
+| **B1** `refs.owner_id` FK-locked to sources | **Accepted; fixed differently than proposed.** Not typed `page_refs` tables — the head pointer moves onto the `pages` row (D6), which also fixes the latent `MAX(id)`-head bug and keeps the token story trivial. `refs` untouched |
+| **B2** workspace-created pages can't exist without a `pages` row | **Accepted.** D16: created pages live as `blob_hash`+`title` on `workspace_refs` until merge; §4.2 schema revised; D13 rewritten to match |
+| **B3** inference inside the merge transaction | **Accepted.** D10 + §4.3: pre-compute embeddings pre-transaction, re-validate bases under the lock, persist vectors inside — mirroring `renameSource` |
+| **H1** amend rewrites a live merge base | **Accepted.** D14 gains the no-references guard |
+| **H2** all-or-nothing parking | **Accepted as a decision, not a defect.** D17: all-or-nothing kept (dangling-link argument), consequence named, partial-land evidence-gated |
+| **H3** slug-unification ordering | **Accepted.** D13: ULID rewrite mints new blobs *before* diff3 |
+| **M1** token fragility | **Dissolved by the B1 fix** (no refs movement, no migration rebuild); literal verification stays a named W0 task |
+| **M2** merge executor unspecified | **Specified** (§4.3: app-owned queue, wikictl request-or-headless-execute) |
+| **M3** GC underspecified | **Specified** (§4.2: reachable-set rules for versions, blobs, orphan sources) |
+| **⚪ overlay staleness / D12 residual conflicts / §4.6 honesty** | Sentences added at D7, D12, D14 |
+| **Accuracy: extraction-doc lineage overstated** | Fixed in the status block and §2 |
+| **Scope judgment** | **Partially accepted.** The reviewer's sequencing is adopted (W1 advisory locks pulled forward; workspaces evidence-gated). The requirement itself — concurrent ingestions — stands as the destination: it was the originating goal, and the reviewer's per-page-lock alternative only suffices *because* it presumes single-agent serialization (locks between concurrent agents = unknown write sets + deadlock + lease reaping, the same reasons the brainstorm rejected pessimistic locking). Workspaces remain the design for that future; they are no longer the next step |
+
+## 9. Phases
+
+W0 and W1 are the committed near-term work. **W2–W5 are evidence-gated**:
+build them when (a) concurrent ingestions are actually wanted, or
+(b) reviewable-before-land ingestion is actually wanted, or (c) CAS-conflict
+telemetry from W0/W1 shows real contention. Until a gate condition is true,
+this section is a finished design on the shelf, not a queue.
 
 | Phase | Contents | Gate |
 |-------|----------|------|
-| **W0 — Page versions & CAS** (v29; executes #258) | `page_versions` + blob-backed bodies, `page-content` ref kind + `CHECK` on `refs.kind`, root-version seeding migration, CAS save protocol + `PageConflictError` + editor conflict affordance, autosave amend rule (D14), `wikictl page history` / `revert` (pointer copy), `vacuum-pages` | Two writers race one page: loser gets a conflict, no silent clobber; page history browsable; revert = one-row repoint; token literals byte-identical |
-| **W1 — Workspaces, overlay, fast-forward merge** (v30) | `workspaces` + `workspace_refs`, overlay resolution in the store, `wikictl --workspace` (create/status/abandon verbs), ingestion runs in a workspace behind a capability flag, merge = fast-forward-only (any divergence → workspace parks `conflicted`, retryable), edit lock retired behind the same flag | **Edit a page while an ingestion runs** — both land; a deliberately-conflicting ingestion parks without corrupting main; abandoned workspace GCs clean |
-| **W2 — Real merge** | diff3 against `base_version_id`, `merge_parent_id` lineage + merge PROV activity, derived-data regeneration at merge, slug-collision unification (D13), `wiki_index` line-set merge (D12), refresh/rebase verb | Two overlapping ingestions (shared touched page + both touching the index) both merge cleanly; merged page shows two-parent history |
-| **W3 — Conflict resolution & review** | Parked-conflict data model surfaced: pending-ingestions panel (workspace diff vs main, per-page base/ours/theirs), merge-agent resolution path (writes into the workspace, re-enqueues), human resolve/abandon UI, conflict-state `wikictl` verbs | A conflicted workspace is reviewable as a diff; the merge agent resolves a real conflict and the merge completes; a second workspace merges *while* the first sits parked (no head-of-line block) |
-| **W4 — Concurrency unleashed** | Spawn slot → configurable N-throttle; multiple simultaneous ingestions end-to-end; merge-queue fairness (rebase-don't-abort); workspace TTL/reaper for crashed runs; read-set PROV recording + "cites since-changed content" lint (stretch) | Two ingestions run concurrently from the UI, queries and edits proceed throughout, both land (one via merge), and the whole run is auditable in PROV |
+| **W0 — Page versions & CAS** (v29; executes #258) | `page_versions` + blob-backed bodies, `pages.head_version_id` (D6), root-version seeding migration, CAS save protocol + `PageConflictError` + editor conflict affordance, autosave amend rule + guard (D14), `wikictl page history` / `revert` (head repoint + mirror), `--expect-version` on `wikictl page write`, token-literal verification | Two writers race one page: loser gets a conflict, no silent clobber; page history browsable; revert = one-row repoint + mirror; token byte-identical across migration |
+| **W1 — Per-page advisory locks; global lock retired** (no schema) | `agentTouchedPageIDs` on the model (fed by existing change events), per-page read-only banner + per-page autosave pause, `isAgentRunning` demoted to run-status display (kept for query-debug UI), reload guards re-scoped | **Edit page B while an ingestion rewrites page A** — B saves normally; A shows a per-page banner; a human already editing A gets the CAS affordance on save, not a clobber |
+| **W2 — Workspaces & fast-forward merge** (v30) *(gated)* | `workspaces` + `workspace_refs` (incl. D16 created-page staging), overlay resolution in the store, `wikictl --workspace` (create/status/abandon/merge verbs), ingestion behind a capability flag, merge = fast-forward-only (any divergence parks `conflicted`, retryable), GC (`vacuum-page-versions`, blob sources) | An ingestion runs in a workspace invisibly to the FP (token unchanged until merge); FF merge lands it atomically; a deliberately-conflicting ingestion parks without corrupting main; abandoned workspace GCs clean |
+| **W3 — Real merge** *(gated)* | Pre-transaction diff3 + embedding precompute + base re-validation (§4.3), `merge_parent_id` lineage + merge PROV activity, slug-collision unification with pre-diff3 ULID rewrite (D13), `wiki_index` line-set merge (D12), refresh/rebase verb | Two overlapping ingestions (shared touched page + both touching the index) both merge cleanly; merged page shows two-parent history |
+| **W4 — Conflict resolution & review** *(gated)* | Parked-conflict data model surfaced: pending-ingestions panel (workspace diff vs main, per-page base/ours/theirs), merge-agent resolution path (writes into the workspace, re-enqueues), human resolve/abandon UI, conflict-state `wikictl` verbs; partial-land revisited iff D17 latency bites | A conflicted workspace is reviewable as a diff; the merge agent resolves a real conflict and the merge completes; a second workspace merges *while* the first sits parked (no head-of-line block) |
+| **W5 — Concurrency unleashed** *(gated)* | Spawn slot → configurable N-throttle; multiple simultaneous ingestions end-to-end; merge-queue fairness (rebase-don't-abort); workspace TTL/reaper for crashed runs; read-set PROV recording + "cites since-changed content" lint (stretch) | Two ingestions run concurrently from the UI, queries and edits proceed throughout, both land (one via merge), and the whole run is auditable in PROV |
 
-Dependency notes: W0 stands alone (page history + conflict detection is
-worth shipping even if workspaces never follow). W1 needs W0. W2–W4 are
-strictly ordered. The extraction-slot work (extraction-vs-ingestion plan) is
-orthogonal and can land any time.
+Dependency notes: W0 stands alone and is a legitimate stopping point. W1
+needs W0 (CAS is the backstop that makes advisory-only locks safe). W2 needs
+W0; W3–W5 are strictly ordered after W2. The extraction-slot work
+(`extraction-vs-ingestion-lock.md`) is orthogonal and can land any time.
 
-## 8. Open questions
+## 10. Open questions
 
-1. **Merge-agent identity & prompt surface** — a PROV `agents` row, clearly;
-   but does it run as a `claude -p` spawn through the same throttle, and what
-   does its context packet contain (base/ours/theirs + both activities'
-   plans)? Decide in W3.
-2. **Title-only edits vs body edits in CAS** — does a rename race a body edit
-   (title lives on `page_versions` per §4.1)? Proposal: title is part of the
-   version, so yes, CAS covers it; renames are cheap to re-apply. Confirm in W0.
-3. **Merge-hint metadata** (Bayou-style): should an ingestion's activity
+1. **Merge-agent identity & prompt surface** (W4) — a PROV `agents` row,
+   clearly; but does it run as a `claude -p` spawn through the same throttle,
+   and what does its context packet contain (base/ours/theirs + both
+   activities' plans)?
+2. **Merge-hint metadata** (Bayou-style, W4): should an ingestion's activity
    carry a hint ("my index edits are additive; my page edits are
    section-appends") the merge agent reads before general diff3? Cheap to add
-   to `activities.plan`; decide when W3 shows real conflict shapes.
-4. **Event bus / Darwin notifications for workspace state** — the FP token
-   ignores workspaces by design (§5), but the *app UI* wants live workspace
-   status; probably the existing event bus, decide in W1.
-5. **Section-aware diff3** — line-based diff3 first (W2); markdown
+   to `activities.plan`; decide when W4 shows real conflict shapes.
+3. **Workspace state on the event bus** (W2) — the FP token ignores
+   workspaces by design (§5), but the app UI wants live workspace status;
+   probably the existing event bus.
+4. **Section-aware diff3** (W3) — line-based diff3 first; markdown
    section-aware merge (heading-scoped) only if real conflicts show it pays.
    Dolt's lesson says it will; earn it with evidence.
+5. **Agent CAS policy** (W1) — when a `wikictl page write --expect-version`
+   fails mid-run because a human won the race, does the agent re-read and
+   retry (likely), or surface to the run log and continue? Decide during W1
+   implementation; today's blind-write behavior is the fallback.

--- a/plans/page-versions-and-workspaces.md
+++ b/plans/page-versions-and-workspaces.md
@@ -1,0 +1,317 @@
+# Page versions & workspaces — multi-writer without a global lock
+
+**Status:** proposed (2026-07-09). Successor to the multi-writer brainstorm;
+builds directly on `graph-model-and-versioning.md` (the objects/refs
+substrate this plan extends to pages) and completes the arc
+`extraction-vs-ingestion-lock.md` started (that doc unfused extraction from
+the agent lock; this one retires the agent lock itself). Executes
+[#258](https://github.com/tqbf/selfdrivingwiki/issues/258) (page versioning)
+as its Phase 0.
+
+**The organizing idea:** there are two "global locks" in this system and they
+have opposite characters. The SQLite WAL write lock is global but held for
+*milliseconds* — it is not the problem and every design below funnels through
+it happily. The application-level agent edit lock (`isAgentRunning`,
+`WikiStoreModel.swift:203`) is held for the *minutes* an ingestion runs, and
+exists for exactly one reason: an ingestion is a long-running logical
+transaction with no isolation mechanism, so the app protects consistency by
+locking everyone out. This plan gives long-running writers an isolation
+mechanism — durable, named **workspaces** over the append-only version
+substrate the graph-model plan already built — so the only exclusive section
+left is a short merge commit. MVCC and git branches are not two options here;
+on a storage model that is already immutable blobs + append-only versions +
+mutable refs, **a branch is MVCC with the speculative state made durable and
+addressable**. We build that once and get both.
+
+---
+
+## 1. Prior art (why this shape, recorded so it isn't relitigated)
+
+Every element below has a named ancestor with documented failure modes.
+What we are building is precisely: *Postgres snapshot-isolation semantics with
+git's merge instead of Postgres's abort-and-retry, an Oracle-Workspace-Manager
+workspace lifecycle, CouchDB's conflict-as-durable-state, and an LLM as the
+conflict handler.* Only the last part is novel.
+
+| Design element | Ancestor |
+|---|---|
+| Per-page CAS on a ref | Optimistic concurrency control (Kung & Robinson 1981); git atomic ref update; HTTP ETag/`If-Match` |
+| Read freely, validate write set at short commit; first-committer-wins | Snapshot isolation — Postgres `REPEATABLE READ` |
+| Accepted write-skew anomaly | The canonical SI anomaly; SSI (Ports & Grittner, Postgres `SERIALIZABLE`) is the *rejected* alternative — its read-set tracking cost buys nothing for wiki prose with no cross-page invariants |
+| Durable workspaces for long-lived writers; refresh-before-merge; conflicts materialized as data | 1980s CAD "long transactions" (check-out/check-in); **Oracle Workspace Manager** (`MergeWorkspace`/`RefreshWorkspace`, conflict tables) |
+| Branch + type-aware three-way merge over structured data | **Dolt** (cell-wise merge), git diff3; **Fossil** is the existence proof that git semantics on SQLite is not a research project |
+| Serialized, dumb, fast commit point | Datomic transactor; FoundationDB resolver; merge queues (bors) |
+| Conflict as first-class persistent state, resolution is an ordinary later write | **CouchDB** revision trees |
+| Hot-page escape hatch (commutative ops, set-union merge) | Escrow transactions (O'Neil 1986) |
+| Op-log/replay alternative (not taken) | Bayou (1995) merge procedures — filed as a future refinement if textual merge quality disappoints |
+
+**The one hard constraint prior art adds:** the merge queue must never wait on
+the merge *agent*. Fast-forward and clean textual merges happen inline in the
+commit transaction; anything needing an LLM is **parked** as a conflicted
+workspace and re-enters the queue when resolved. Otherwise one gnarly conflict
+head-of-line-blocks every ingestion behind a minutes-long LLM call — the
+global lock rebuilt one layer up.
+
+## 2. Current state (grounded, v28 tree)
+
+- `pages` is `(id, title, slug, body_markdown, created_at, updated_at,
+  version)` with `pages_slug_unique` (`SQLiteWikiStore.swift:221`). The body
+  is **mutated in place** by `updatePage(id:title:body:)`
+  (`SQLiteWikiStore.swift:2223`); the `version` counter increments but is
+  never checked — there is no CAS, no history, no conflict detection. The
+  doc-comment on the edit lock names the consequence: it exists so "in-app
+  edits can't clobber the agent's `wikictl` writes (last-writer-wins race)"
+  (`WikiStoreModel.swift:203`).
+- The edit lock is `isAgentRunning`, set via `beginAgentRun`/`endAgentRun`
+  (single mutation point, `WikiStoreModel.swift:1269`). While true: the
+  editor goes read-only with a banner, autosave pauses, Edit/Save disable
+  (`PageDetailView.swift:40–89`), and reload paths guard
+  (`WikiStoreModel.swift:997`, `:1197`). The spawn slot in
+  `AgentLauncher.swift` serializes all `claude -p` runs; the extraction slot
+  (extraction-vs-ingestion plan) is already separate.
+- The objects substrate from graph-model Phases 1–2 is live: content-addressed
+  `blobs`, append-only `source_versions` / `source_markdown_versions`, PROV
+  `agents`/`activities`, and the single mutable `refs` table
+  (`kind, owner_id, version_id, generation, updated_at`,
+  `SQLiteWikiStore.swift:585`) with two kinds (`source-content`,
+  `source-derived`) and the default-active rule (no ref row → `MAX(id)`).
+  Lazy GC exists (`vacuumBlobs`, `vacuum-all`).
+- The changeToken is assembled from registered `ChangeTokenContributor`s
+  (`SQLiteWikiStore.swift:1933`); the current 11-field literal is enforced
+  byte-for-byte by ~20 hardcoded assertions across three test suites. One
+  existing fold is `COALESCE(SUM(generation),0)` over **all** of `refs`
+  (`SQLiteWikiStore.swift:2038`) — load-bearing fact: speculative ref writes
+  must not land in that table or the File Provider token moves on
+  uncommitted work.
+- `wiki_index` is a **singleton table**, not a page (`SQLiteWikiStore.swift:348`)
+  — the curated index the agent rewrites on every ingest. It is the guaranteed
+  merge hot spot, but being a separate table it can carry its own merge rule
+  without touching the page machinery.
+- Links are ULID-canonical at rest (Phase 5, shipped); `page_links` /
+  `source_links` / FTS / embeddings are all deterministic functions of page
+  bodies — re-derivable, never merged.
+- Schema ladder head is **v28** (`SQLiteWikiStore.swift:519`); v24 is a
+  reserved, never-stamped slot (precedent for holes). Next step: **v29**.
+- Cross-process: `wikictl` (PageCommand etc. in `WikiCtlCore`) is a genuine
+  second writer over WAL + `busy_timeout`; the File Provider extension is a
+  reader. Any CAS discipline must therefore live in SQL
+  (`UPDATE … WHERE`-guarded), not in an in-process lock.
+
+## 3. Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Pages join the object model**: append-only `page_versions` + a `page-content` ref kind; a page save = append version + CAS repoint | The prerequisite for everything; executes #258. CAS in one sentence: "repoint P from A to B where B.parent = A; if the ref moved, conflict" |
+| D2 | **`pages.body_markdown` stays, as the materialized main head** (denorm mirror, same flagged discipline as `sources.byte_size` in graph-model §9) | FTS, embeddings, FP projection, UI, and search keep reading the `pages` row unmodified — MVCC lands with **zero read-path migration**. Every main commit updates row + version + ref atomically in one `withTransaction` |
+| D3 | **Isolation level: snapshot-ish, read-latest + recorded read set, write-set validation at commit, first-committer-wins.** Write skew consciously accepted | Wiki prose has no cross-page invariants, so SI anomalies are harmless by construction; the read set lands in PROV as `used` relations (audit trail, future "cites since-changed content" lint). SSI-style read validation is the named, rejected alternative |
+| D4 | **Humans commit to main; agents get workspaces** | A human save is milliseconds — direct CAS, with CAS failure surfacing as a "page changed underneath you" affordance. Humans never think about branches to fix a typo. Mirrors the extraction-vs-ingestion asymmetry principle |
+| D5 | **Workspaces are durable rows** (`workspaces` table: ULID, status lifecycle `open → merging → merged \| conflicted \| abandoned`, PROV activity) | Durable speculation = crash recovery, observability (watch the agent work), and **reviewable ingestions** (a workspace is a diff against main inspectable before it lands — PR review for the wiki) |
+| D6 | **`workspace_refs` is a sibling table, not a `workspace` column on `refs`** | Keeps main's `refs` semantics and its `SUM(generation)` changeToken fold byte-identical (no test-literal churn); speculative refs get their own cascade (delete workspace → refs vanish) and never feed the token. Honors graph-model §4.3's polymorphism tripwire: the third ref kind arrives *without* widening the polymorphic table — `refs` instead gains a `CHECK(kind IN (…))` |
+| D7 | **Overlay reads**: in workspace W, resolve W's ref if present, else main. `wikictl --workspace <id>` / `WIKI_WORKSPACE` env selects the namespace; the agent toolchain works unmodified | Union-mount semantics; no snapshot-at-start (that would require a refs journal — rejected, D3 records reads instead) |
+| D8 | **Merge ladder**: fast-forward → three-way textual merge (diff3 against recorded base) → **park conflicted** → agent/human resolution as a later ordinary write | The queue stays dumb and fast (Datomic-transactor discipline); LLM resolution happens *outside* the commit path (CouchDB conflict-as-state) |
+| D9 | **Merged versions get two-parent lineage**: `page_versions.merge_parent_id` | A merge is a real PROV activity whose output `wasDerivedFrom` both parents; two parents suffice (no octopus merges) |
+| D10 | **Derived data is regenerated at merge, never merged**: `replaceLinks`, FTS, embeddings re-run for merged pages; the log is append-only (no conflicts); the ingest-completion log entry is written by the *merge*, not the run | Deterministic functions of bodies; merging them would be merging a cache |
+| D11 | **Sources stay on main, even during workspace ingestion** | Source chains are append-only + content-addressed — concurrent ingestions cannot conflict on them. A source from an abandoned workspace is just an un-cited source (vacuumable). Keeps the overlay page-only and small |
+| D12 | **`wiki_index` merges structurally, not textually**: it is semantically a link set — merge = three-way *line-set* union (added/removed lines vs base), fallback to parking only on same-line edits | Escrow-transaction reasoning applied to the one guaranteed hot spot. Without this, every merge conflicts, every time |
+| D13 | **Slug collisions are a first-class merge case**: two workspaces creating the same title → merge unifies into one page (first-merged ULID survives; the second workspace's body is three-way-merged in and its ULID references rewritten at merge) | `pages_slug_unique` makes this an error, not a silent dupe — good; the merge must handle it, not crash on it. The silent-divergence alternative (two "Elixir" pages) is worse than a conflict |
+| D14 | **Autosave coalesces into the head version** (git-commit-`--amend` style): a save whose parent is the current head, by the same actor/activity, within a debounce window, *replaces* the head version's blob pointer instead of appending | Without this, the in-app editor's debounced autosave mints a version row every few seconds and the chain is noise. Agents get one version per `wikictl` write (each write is deliberate) |
+| D15 | **The edit lock retires; the spawn slot becomes a throttle** | Once agents write to workspaces, in-app edits *cannot* clobber agent writes — the lock's stated reason (`WikiStoreModel.swift:203`) is gone. The spawn slot stops being a correctness serializer and becomes "at most N concurrent claude processes", the same shape as the extraction slot |
+
+## 4. Schema
+
+Additive; follows the stepwise ladder discipline (fresh-path parity enforced
+by `freshFastPathMatchesStepwiseLadder`).
+
+### 4.1 `page_versions` (v29)
+
+```sql
+CREATE TABLE page_versions (
+    id               TEXT PRIMARY KEY,   -- ULID; chain order = ULID order
+    page_id          TEXT NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    parent_id        TEXT,               -- wasDerivedFrom; NULL = root
+    merge_parent_id  TEXT,               -- second parent; non-NULL = merge commit (D9)
+    blob_hash        TEXT NOT NULL REFERENCES blobs(hash),
+    title            TEXT NOT NULL,      -- title at this version (rename history)
+    activity_id      TEXT REFERENCES activities(id),  -- wasGeneratedBy
+    saved_at         REAL NOT NULL
+);
+CREATE INDEX page_versions_page ON page_versions(page_id, id);
+```
+
+Bodies go through `blobs` — at *save* granularity, not keystroke granularity,
+which is what graph-model §4.6 warned about; D14's coalescing rule is what
+makes this honest. Page bodies rarely dedup; the append-only chain, not the
+dedup, is what's being bought.
+
+The `refs` table gains the `page-content` kind (a `CHECK` constraint listing
+the three kinds, per D6) and the default-active rule carries over verbatim:
+no ref row → head is `MAX(id)`. Migration seeds one root version per existing
+page (blob of current body) and writes **no** refs — main tracks latest by
+default, exactly like sources did in v20.
+
+### 4.2 `workspaces` + `workspace_refs` (v30)
+
+```sql
+CREATE TABLE workspaces (
+    id           TEXT PRIMARY KEY,       -- ULID
+    name         TEXT,                   -- human label ("ingest: foo.pdf")
+    status       TEXT NOT NULL DEFAULT 'open',
+                 -- 'open' | 'merging' | 'merged' | 'conflicted' | 'abandoned'
+    activity_id  TEXT REFERENCES activities(id),  -- the ingestion activity
+    created_at   REAL NOT NULL,
+    updated_at   REAL NOT NULL
+);
+
+CREATE TABLE workspace_refs (
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    kind         TEXT NOT NULL CHECK (kind = 'page-content'),
+    owner_id     TEXT NOT NULL,          -- pages.id (may not exist on main yet: page created in-workspace)
+    base_version_id TEXT,                -- main head observed at first write (CAS base; NULL = page created here)
+    version_id   TEXT NOT NULL,          -- the workspace's current head for this page
+    updated_at   REAL NOT NULL,
+    PRIMARY KEY (workspace_id, kind, owner_id)
+);
+```
+
+- `base_version_id` recorded at the workspace's **first write** to that page
+  is the three-way-merge base and the CAS expectation — the write set and its
+  bases in one table. The *read* set (pages read but not written) is recorded
+  as PROV `used` rows on the ingestion activity (D3) — provenance, not
+  validation input.
+- No FK from `owner_id` to `pages` — a workspace may create a page that
+  doesn't exist on main until merge. The merge transaction creates the
+  `pages` row (or unifies on slug collision, D13).
+- Workspace-created pages hold real `page_versions` rows (append-only tables
+  are namespace-free; only *refs* are namespaced). Abandoning a workspace
+  deletes its refs; orphaned versions/blobs fall to the existing lazy-GC
+  pattern (`vacuum-pages` joins `vacuum-blobs`/`vacuum-all`).
+- `wiki_index` workspace state: one nullable `index_body` snapshot column on
+  `workspaces` (plus `index_base_version`) rather than a ref — it is a
+  singleton, not a versioned owner. Merge applies the D12 line-set rule.
+
+### 4.3 The commit protocols
+
+**Human save to main** (Phase 0, replaces blind `updatePage`):
+
+```
+withTransaction:
+  head = resolve page-content ref (or MAX(id))
+  guard head == the version the editor loaded   -- CAS; else PageConflictError
+  INSERT blob (OR IGNORE); INSERT page_versions (parent = head)   -- or amend head (D14)
+  UPDATE pages SET body_markdown, title, updated_at, version+1    -- the D2 mirror
+  UPSERT refs('page-content', page, new, generation+1)
+  replaceLinks / FTS / embeddings as today
+```
+
+`PageConflictError` surfaces in the UI as the "page changed underneath you"
+affordance (dirty-editor protection already has the vocabulary). Because the
+guard is SQL inside the transaction, the same protocol is correct from
+`wikictl` cross-process — no in-process lock involved (§2).
+
+**Workspace write** (agent via `wikictl --workspace W`): append version;
+UPSERT `workspace_refs` (recording `base_version_id` on first touch). No
+`pages`-row change, no token movement, no FP visibility. Milliseconds.
+
+**Merge** (serialized queue; one short transaction per attempt):
+
+```
+mark workspace 'merging'
+withTransaction:
+  for each workspace_refs row:
+    main_head = resolve main ref
+    if owner missing on main:  slug-collision check → create page or unify (D13)
+    elif main_head == base:    fast-forward           -- repoint + mirror update
+    else:                      diff3(base, main_head, ws_head)
+                               clean → merge version (merge_parent_id set) + mirror
+                               conflict → abort transaction, park 'conflicted'
+  wiki_index: line-set three-way (D12); same-line conflict → park
+  regenerate links/FTS/embeddings for touched pages (D10)
+  append ingest-completion log entry; merge activity into PROV
+mark 'merged'
+```
+
+Parking writes the conflict *description* (page, base/ours/theirs version ids)
+onto the workspace and returns — durable, diffable, resumable. Resolution
+(merge agent or human) writes new versions **into the workspace** and
+re-enqueues; the resolver never runs inside the commit path (§1's hard
+constraint). After any merge lands, other open workspaces are unaffected
+until *their* merge attempt, which revalidates against the new main
+(refresh/rebase — Oracle WM's `RefreshWorkspace` — is the same diff3 run
+voluntarily before merging).
+
+## 5. changeToken & File Provider
+
+The invariant: **the token reflects main only.** Workspace activity is
+invisible to the File Provider until merged.
+
+- The existing folds already mostly deliver this given D2/D6: the `pages`
+  count+`SUM(version)` fold moves on every main commit (mirror row always
+  updated); `refs.SUM(generation)` moves on repoints; `workspace_refs` is
+  deliberately outside the fold.
+- One new contributor: `page_versions` **is not folded by count** (workspace
+  writes append rows without changing main) — instead nothing new is needed;
+  the mirror + refs folds cover every main-visible mutation (append-without-
+  repoint on main cannot occur for pages: every main commit repoints).
+  Recorded so a future "just add a count fold" doesn't reintroduce
+  speculative-write visibility.
+- Token literals in tests: Phase 0 changes no fold; verify byte-identity in
+  the same commit.
+
+## 6. What this retires, and what it deliberately doesn't
+
+**Retired:** `isAgentRunning` as an edit lock (D15) — the editor stays
+editable during ingestion; the read-only banner becomes a per-page conflict
+affordance. "Ingestion locks several pages at once" dissolves entirely: nothing
+is locked during ingestion; the multi-page atomic step shrinks to the merge
+transaction, and SQLite's write lock *is* that mutex, already built.
+
+**Kept:** the spawn slot (as an N-throttle — resource management, not
+correctness); the extraction slot (unchanged); WAL + `busy_timeout`
+cross-process discipline; the method-atomic store + `withTransaction`
+(Phase 0 of graph-model is precisely the substrate this plan stands on); the
+synchronous main-actor write model for human edits.
+
+**Non-goals, named:** SSI/read-set validation (D3); a refs journal /
+as-of-snapshot reads (D7); CRDTs/OT (keystroke-scale machinery for an
+agent-scale problem — except the set-union idea, kept for `wiki_index`);
+op-log/replay ingestion (Bayou — filed as refinement if diff3 quality
+disappoints); actual git as substrate (FTS, vec, FP live in SQLite; Fossil
+proves the semantics port); multi-level/nested workspaces; chat tables
+(v25/v28) — single-writer surfaces, out of scope.
+
+## 7. Phases
+
+Each gate is demoable; each phase ships alone and is independently valuable.
+
+| Phase | Contents | Gate |
+|-------|----------|------|
+| **W0 — Page versions & CAS** (v29; executes #258) | `page_versions` + blob-backed bodies, `page-content` ref kind + `CHECK` on `refs.kind`, root-version seeding migration, CAS save protocol + `PageConflictError` + editor conflict affordance, autosave amend rule (D14), `wikictl page history` / `revert` (pointer copy), `vacuum-pages` | Two writers race one page: loser gets a conflict, no silent clobber; page history browsable; revert = one-row repoint; token literals byte-identical |
+| **W1 — Workspaces, overlay, fast-forward merge** (v30) | `workspaces` + `workspace_refs`, overlay resolution in the store, `wikictl --workspace` (create/status/abandon verbs), ingestion runs in a workspace behind a capability flag, merge = fast-forward-only (any divergence → workspace parks `conflicted`, retryable), edit lock retired behind the same flag | **Edit a page while an ingestion runs** — both land; a deliberately-conflicting ingestion parks without corrupting main; abandoned workspace GCs clean |
+| **W2 — Real merge** | diff3 against `base_version_id`, `merge_parent_id` lineage + merge PROV activity, derived-data regeneration at merge, slug-collision unification (D13), `wiki_index` line-set merge (D12), refresh/rebase verb | Two overlapping ingestions (shared touched page + both touching the index) both merge cleanly; merged page shows two-parent history |
+| **W3 — Conflict resolution & review** | Parked-conflict data model surfaced: pending-ingestions panel (workspace diff vs main, per-page base/ours/theirs), merge-agent resolution path (writes into the workspace, re-enqueues), human resolve/abandon UI, conflict-state `wikictl` verbs | A conflicted workspace is reviewable as a diff; the merge agent resolves a real conflict and the merge completes; a second workspace merges *while* the first sits parked (no head-of-line block) |
+| **W4 — Concurrency unleashed** | Spawn slot → configurable N-throttle; multiple simultaneous ingestions end-to-end; merge-queue fairness (rebase-don't-abort); workspace TTL/reaper for crashed runs; read-set PROV recording + "cites since-changed content" lint (stretch) | Two ingestions run concurrently from the UI, queries and edits proceed throughout, both land (one via merge), and the whole run is auditable in PROV |
+
+Dependency notes: W0 stands alone (page history + conflict detection is
+worth shipping even if workspaces never follow). W1 needs W0. W2–W4 are
+strictly ordered. The extraction-slot work (extraction-vs-ingestion plan) is
+orthogonal and can land any time.
+
+## 8. Open questions
+
+1. **Merge-agent identity & prompt surface** — a PROV `agents` row, clearly;
+   but does it run as a `claude -p` spawn through the same throttle, and what
+   does its context packet contain (base/ours/theirs + both activities'
+   plans)? Decide in W3.
+2. **Title-only edits vs body edits in CAS** — does a rename race a body edit
+   (title lives on `page_versions` per §4.1)? Proposal: title is part of the
+   version, so yes, CAS covers it; renames are cheap to re-apply. Confirm in W0.
+3. **Merge-hint metadata** (Bayou-style): should an ingestion's activity
+   carry a hint ("my index edits are additive; my page edits are
+   section-appends") the merge agent reads before general diff3? Cheap to add
+   to `activities.plan`; decide when W3 shows real conflict shapes.
+4. **Event bus / Darwin notifications for workspace state** — the FP token
+   ignores workspaces by design (§5), but the *app UI* wants live workspace
+   status; probably the existing event bus, decide in W1.
+5. **Section-aware diff3** — line-based diff3 first (W2); markdown
+   section-aware merge (heading-scoped) only if real conflicts show it pays.
+   Dolt's lesson says it will; earn it with evidence.


### PR DESCRIPTION
## Summary

Add comprehensive design plan for eliminating the global agent edit lock by implementing snapshot-isolation semantics over a durable workspace substrate. This plan directly addresses #258 (page versioning) and completes the multi-writer concurrency arc started in extraction-vs-ingestion-lock.md.

## What changed

Added `plans/page-versions-and-workspaces.md`, a detailed 5-phase implementation plan that:

- Introduces `page_versions` (append-only, content-addressed) + page-content refs for CAS-based optimistic concurrency
- Adds durable `workspaces` table for long-lived ingestion writers, with per-workspace `refs` overlay
- Implements merge ladder: fast-forward → diff3 merge → park-on-conflict with LLM/human resolution outside the commit path
- Retires `isAgentRunning` lock; keeps spawn throttle (resource management, not correctness)
- Records design rationale, prior art (Postgres SI, Oracle Workspace Manager, CouchDB conflict-as-state), and 15 key decisions
- Phases the rollout: W0 (versions + CAS), W1 (workspaces + overlay), W2 (real merge), W3 (conflict UI), W4 (concurrency at scale)

## Why

The agent edit lock exists because long-running ingestions lack isolation — they're logical transactions over WAL with no MVCC. This plan gives them one: named, durable workspaces with three-way merge (like git, but on SQLite). The only exclusive section becomes a short merge commit, not multi-minute ingestion. Humans edit main directly (milliseconds); agents get speculative branches. No silent clobber, no head-of-line blocking on LLM resolution.

## Next steps

Phase 0 (W0) is immediately implementable and ships standalone: page history + conflict detection. Gate: two writers racing a page—loser gets a conflict, no silent overwrite.
