### PR TITLE
Fix #277: self-heal File Provider deletion diff after extension restart

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,36 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-09 — #277: File Provider deletion signaling — self-heal on extension restart
+
+**Problem:** #111/#276 fixed deleted sources/pages lingering in the File
+Provider by diffing the last-reported item set (`knownItems`) against the
+current one in `WikiFSEnumerator.enumerateChanges` and calling
+`didDeleteItems`. But `knownItems` is process-static (in-memory only), while
+the sync anchor is persisted by the File Provider framework across extension
+process restarts. On a routine extension relaunch the framework can call
+`enumerateChanges(from: validAnchor)` with no prior `enumerateItems` in the new
+process → `knownItems` is nil → the deletion diff is skipped → deletions that
+landed while the process was dead are silently dropped (the original #111
+symptom reintroduced). The docstring also wrongly claimed the anchor "expires"
+on restart (it doesn't — only unparseable/legacy anchors expire).
+
+**Fix:** in `enumerateChanges`, when the baseline is absent, return
+`syncAnchorExpired` instead of diffing against an empty set. The framework then
+discards its cache and does a clean full `enumerateItems`, which re-seeds the
+baseline. Cost is one full re-enumeration per container after a restart; the
+restart path now emits only the expiry (no wasteful `didUpdate`). Corrected the
+misleading `KnownItemSet` docstring. Findings #2 (kinds) / #3 (nested) / #4
+(concurrency) from the issue review were closed by tests, not code: the diff is
+generic over `projection.children(of:)`, the `NSLock` guards only the dict
+get/set (DB read + diff run unlocked), and the `wikiID/container` cache key
+can't collide.
+
+**Tests:** 4 new cases in `EnumeratorDeletionTests` — bookmark-ref deletion,
+chat deletion, nested folder deletion, and the restart baseline-loss case
+(asserts anchor expiry, not a silent drop). Full suite 7/7 pass
+(`swift test --filter EnumeratorDeletionTests`).
+
 ## 2026-07-09 — #235: Prevent silent hang when starting Edit/Ask during ingest extraction
 
 **Problem:** Starting an Edit (or Ask) session immediately after kicking off an

--- a/Sources/WikiFSFileProvider/WikiFSEnumerator.swift
+++ b/Sources/WikiFSFileProvider/WikiFSEnumerator.swift
@@ -42,8 +42,11 @@ final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
     /// knows about, so a row removed from SQLite has no way to leave the
     /// projection (issue #111). The set is seeded by `enumerateItems` and
     /// refreshed on every `enumerateChanges`. It survives enumerator recreation
-    /// within one extension process; a process restart falls back to a full
-    /// re-enumeration (the anchor expires), which re-seeds the set.
+    /// within one extension process, but NOT an extension process restart (it is
+    /// in-memory only). On restart the File Provider may call `enumerateChanges`
+    /// directly with its persisted anchor; `enumerateChanges` detects the missing
+    /// baseline and expires the anchor so the framework re-enumerates and re-seeds
+    /// the set (#277).
     private final class KnownItemSet: @unchecked Sendable {
         private let lock = NSLock()
         private var sets: [String: Set<NSFileProviderItemIdentifier>] = [:]
@@ -111,6 +114,23 @@ final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
         // higher itemVersions (contentVersion derives from the bumped per-page
         // version), so the File Provider invalidates materialized copies and re-fetches.
         let items = currentItems()
+        let currentIDs = Set(items.map(\.itemIdentifier))
+
+        // Baseline-missing guard (#277): the known-item set is process-static —
+        // it does NOT survive an extension process restart. The sync anchor, by
+        // contrast, is persisted by the File Provider framework across restarts,
+        // so on relaunch the framework can call `enumerateChanges(from: validAnchor)`
+        // WITHOUT a prior `enumerateItems`. Diffing against an empty set would
+        // silently drop every deletion that landed while the process was down —
+        // reintroducing #111 after any routine extension relaunch. Instead, when
+        // the baseline is absent we expire the anchor: the framework discards its
+        // cache and does a clean full `enumerateItems`, which re-seeds the
+        // baseline. The cost is one full re-enumeration per container after a restart.
+        guard let known = Self.knownItems.get(cacheKey) else {
+            observer.finishEnumeratingWithError(Self.expiredError)
+            return
+        }
+
         observer.didUpdate(items)
 
         // Report deletions: identifiers the File Provider knew about that are no longer
@@ -118,12 +138,9 @@ final class WikiFSEnumerator: NSObject, NSFileProviderEnumerator {
         // the File Provider has no signal to evict removed rows, so they linger forever
         // (#111). We diff the last-reported set (seeded by `enumerateItems` /
         // the prior `enumerateChanges`) against the current one.
-        let currentIDs = Set(items.map(\.itemIdentifier))
-        if let known = Self.knownItems.get(cacheKey) {
-            let deleted = known.subtracting(currentIDs)
-            if !deleted.isEmpty {
-                observer.didDeleteItems(withIdentifiers: Array(deleted))
-            }
+        let deleted = known.subtracting(currentIDs)
+        if !deleted.isEmpty {
+            observer.didDeleteItems(withIdentifiers: Array(deleted))
         }
         Self.knownItems.set(cacheKey, currentIDs)
 

--- a/Tests/WikiFSTests/EnumeratorDeletionTests.swift
+++ b/Tests/WikiFSTests/EnumeratorDeletionTests.swift
@@ -139,4 +139,109 @@ struct EnumeratorDeletionTests {
         #expect(changeObs.updated.isEmpty)
         #expect(changeObs.finishedWithError == nil)
     }
+
+    // MARK: - Resource-kind coverage (#277 review point 2)
+
+    @Test func deletingBookmarkRefReportsDidDeleteItems() throws {
+        let s = try seed()
+        // A page to point the bookmark ref at; the ref is a root-level leaf under
+        // the top-level bookmarks container.
+        let page = try s.store.createPage(title: "Target Page")
+        let ref = try s.store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .pageRef, label: nil, targetID: page.id)
+        let enumerator = WikiFSEnumerator(container: Projection.Identity.bookmarks,
+                                          projection: s.projection)
+
+        let enumObs = MockEnumerationObserver()
+        enumerator.enumerateItems(for: enumObs, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        #expect(enumObs.enumerated.count == 1)
+
+        let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
+        let deletedID = Projection.Identity.bookmarkPageRef(ref.id)
+        try s.store.deleteBookmarkNode(id: ref.id)
+
+        let changeObs = MockChangeObserver()
+        enumerator.enumerateChanges(for: changeObs, from: anchor)
+
+        #expect(changeObs.deleted == [deletedID])
+        #expect(changeObs.updated.isEmpty)
+        #expect(changeObs.finishedWithError == nil)
+    }
+
+    @Test func deletingChatReportsDidDeleteItems() throws {
+        let s = try seed()
+        let chat = try s.store.createChat(kind: .ask, title: "A Chat")
+        let enumerator = WikiFSEnumerator(container: Projection.Identity.chatsByID,
+                                          projection: s.projection)
+
+        let enumObs = MockEnumerationObserver()
+        enumerator.enumerateItems(for: enumObs, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        #expect(enumObs.enumerated.count == 1)
+
+        let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
+        let deletedID = Projection.Identity.chatByID(chat.id.rawValue)
+        try s.store.deleteChat(id: chat.id)
+
+        let changeObs = MockChangeObserver()
+        enumerator.enumerateChanges(for: changeObs, from: anchor)
+
+        #expect(changeObs.deleted == [deletedID])
+        #expect(changeObs.updated.isEmpty)
+        #expect(changeObs.finishedWithError == nil)
+    }
+
+    // MARK: - Nested container deletion (#277 review point 3)
+
+    @Test func deletingNestedFolderReportsDidDeleteItems() throws {
+        let s = try seed()
+        let page = try s.store.createPage(title: "Child Target")
+        // A root folder containing one page-ref child.
+        let folder = try s.store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder, label: "Folder", targetID: nil)
+        _ = try s.store.createBookmarkNode(
+            parentID: folder.id, position: 0, kind: .pageRef, label: nil, targetID: page.id)
+        let enumerator = WikiFSEnumerator(container: Projection.Identity.bookmarks,
+                                          projection: s.projection)
+
+        // The root bookmarks container exposes only root nodes → just the folder.
+        let enumObs = MockEnumerationObserver()
+        enumerator.enumerateItems(for: enumObs, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        #expect(enumObs.enumerated.count == 1)
+
+        let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
+        let deletedID = Projection.Identity.bookmarkFolder(folder.id)
+        try s.store.deleteBookmarkNode(id: folder.id)
+
+        let changeObs = MockChangeObserver()
+        enumerator.enumerateChanges(for: changeObs, from: anchor)
+
+        #expect(changeObs.deleted == [deletedID])
+        #expect(changeObs.finishedWithError == nil)
+    }
+
+    // MARK: - Restart baseline loss (#277 review point 1)
+
+    @Test func missingBaselineAfterRestartExpiresAnchor() throws {
+        // Simulates the post-restart state: the File Provider holds a still-valid
+        // sync anchor and calls `enumerateChanges` WITHOUT a prior `enumerateItems`
+        // in this process, so the in-memory known-item baseline is absent (#277).
+        // Each test's projection uses a unique wikiID, so the baseline is nil here
+        // exactly as it would be in a freshly-relaunched extension process.
+        let s = try seed()
+        let enumerator = WikiFSEnumerator(container: Projection.Identity.sourcesByID,
+                                          projection: s.projection)
+
+        // No `enumerateItems` — the baseline is never seeded (mirrors a restart).
+        let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
+        try s.store.deleteSource(id: s.sources[0].id)
+
+        let changeObs = MockChangeObserver()
+        enumerator.enumerateChanges(for: changeObs, from: anchor)
+
+        // With no baseline to diff against, the enumerator must NOT silently drop
+        // the deletion; it expires the anchor so the framework re-enumerates.
+        #expect(changeObs.deleted.isEmpty)
+        let err = try #require(changeObs.finishedWithError)
+        #expect((err as NSError).code == NSFileProviderError.syncAnchorExpired.rawValue)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #277.

#111/#276 fixed deleted sources/pages lingering in the File Provider by diffing the last-reported item set (`knownItems`) against the current one in `WikiFSEnumerator.enumerateChanges` and calling `didDeleteItems`. This PR addresses the review gaps raised in #277.

## The real bug: extension restart silently drops deletions (#1)

`knownItems` is **process-static** (in-memory only), while the **sync anchor is persisted by the File Provider framework** across extension process restarts. On a routine extension relaunch the framework can call `enumerateChanges(from: validAnchor)` with no prior `enumerateItems` in the new process → `knownItems` is `nil` → the deletion diff was skipped → deletions that landed while the process was dead were **silently dropped**. This reintroduced the original #111 symptom after any routine extension relaunch (not just a crash).

The `KnownItemSet` docstring also wrongly claimed the anchor "expires" on restart — it doesn't; only unparseable/legacy anchors expire.

**Fix:** in `enumerateChanges`, when the baseline is absent, return `syncAnchorExpired` instead of diffing against an empty set. The framework then discards its cache and does a clean full `enumerateItems`, which re-seeds the baseline. Cost is one full re-enumeration per container after a restart; the restart path now emits only the expiry (no wasteful `didUpdate`). Docstring corrected.

## Review points closed by tests (no code change needed)

- **2 (resource kinds):** the diff is generic over `projection.children(of:)`, so bookmark and chat deletion work — now locked in by tests.
- **3 (nested container deletion):** deleting a bookmark folder is correctly reported via `didDeleteItems` from the parent container's enumeration — now tested.
- **4 (multi-wiki concurrency):** non-issue. The `NSLock` guards only the dict `get`/`set` (microseconds); DB reads and the set-diff run **unlocked**, so unrelated wikis aren't serialized. The `wikiID/container` cache key can't collide (wikiID is a ULID).

## Tests

4 new cases in `EnumeratorDeletionTests`:

- `deletingBookmarkRefReportsDidDeleteItems` — bookmark kind
- `deletingChatReportsDidDeleteItems` — chat kind
- `deletingNestedFolderReportsDidDeleteItems` — nested folder deletion
- `missingBaselineAfterRestartExpiresAnchor` — asserts anchor expiry, not a silent drop

Full suite **7/7 pass** (`swift test --filter EnumeratorDeletionTests`), including the 3 original tests — no regression from the `if let` → `guard let` refactor.
