### PR TITLE
Fix #279: signal the bookmarks container on store events

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-09 — #279: Signal the bookmarks container on store events
+
+**Problem:** `FileProviderSpike.signalChange(forWikiID:)` had a hardcoded list
+of containers to proactively refresh on every store event. The top-level
+`bookmarks/` folder was missing — only pages/root/indexes/sources/chats views
+plus `.workingSet` were signaled. So a Finder/Terminal user browsing
+`bookmarks/` directly wouldn't see bookmark create/move/delete changes until a
+working-set sweep re-enumerated. (The working set still caught deletions
+authoritatively; the per-container signal is an optimization for proactive
+refresh.)
+
+**Fix:** added `NSFileProviderItemIdentifier(WikiFSContainerID.bookmarks)` to
+the `containers` array in `signalChange(forWikiID:)`. Bookmarks use
+`NestedResourceProjection` (arbitrary-depth folders), so only the top-level
+container needs signaling — nested folder enumerators refresh via the parent's
+`didUpdate` re-enumeration.
+
+**Tests:** no new tests — the signal path is best-effort against
+`NSFileProviderManager` and not unit-testable. `swift build` clean.
+
 ## 2026-07-09 — #277: File Provider deletion signaling — self-heal on extension restart
 
 **Problem:** #111/#276 fixed deleted sources/pages lingering in the File

--- a/Sources/WikiFS/FileProviderSpike.swift
+++ b/Sources/WikiFS/FileProviderSpike.swift
@@ -484,6 +484,10 @@ final class FileProviderSpike {
             NSFileProviderItemIdentifier(WikiFSContainerID.chats),
             NSFileProviderItemIdentifier(WikiFSContainerID.chatsByID),
             NSFileProviderItemIdentifier(WikiFSContainerID.chatsByName),
+            // Bookmarks are a NestedResourceProjection (arbitrary-depth folders),
+            // so only the top-level `bookmarks/` container needs signaling —
+            // nested folder enumerators refresh via the parent's re-enumeration (#279).
+            NSFileProviderItemIdentifier(WikiFSContainerID.bookmarks),
             .workingSet,
         ]
         for container in containers {


### PR DESCRIPTION
## Summary

Closes #279.

`FileProviderSpike.signalChange(forWikiID:)` had a hardcoded list of containers to proactively refresh on every store event, but the top-level `bookmarks/` folder was missing — only pages/root/indexes/sources/chats views plus `.workingSet` were signaled. So a Finder/Terminal user browsing `bookmarks/` directly wouldn't see bookmark create/move/delete changes until a working-set sweep re-enumerated.

(The working set still caught deletions authoritatively — the #111 `KnownItemSet` diff is the real deletion path and works for any container as long as `enumerateChanges` is called. The per-container signal here is an optimization for proactive refresh.)

## Fix

Added one entry to the `containers` array in `signalChange(forWikiID:)`:

```swift
NSFileProviderItemIdentifier(WikiFSContainerID.bookmarks),
```

Bookmarks use `NestedResourceProjection` (arbitrary-depth folders), so only the top-level `bookmarks/` container needs signaling — nested folder enumerators refresh via the parent's `didUpdate` re-enumeration. This mirrors how the chat containers were added when the chat projection hooked into the #111 system.

## Tests

No new tests — the signal path is best-effort against `NSFileProviderManager` and isn't unit-testable. `swift build` is clean.
