### PR TITLE
Wire seeded Home page ID into wiki descriptor (#315)

### DIFF
--- a/Sources/WikiFSCore/WikiManager.swift
+++ b/Sources/WikiFSCore/WikiManager.swift
@@ -184,11 +184,13 @@ public final class WikiManager {
     @discardableResult
     public func createWiki(displayName: String) async -> WikiDescriptor {
         let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let descriptor = WikiDescriptor.make(displayName: trimmed.isEmpty ? "Untitled Wiki" : trimmed)
+        var descriptor = WikiDescriptor.make(displayName: trimmed.isEmpty ? "Untitled Wiki" : trimmed)
         // Opening a fresh SQLiteWikiStore runs the full bootstrap ladder (pages +
         // system_prompt seed). A new wiki should have a Home page so its mount is
-        // non-empty, mirroring the app's launch behavior.
-        createDatabaseIfNeeded(for: descriptor, seedHome: true)
+        // non-empty, mirroring the app's launch behavior. The seeded page becomes
+        // the wiki's home page so the home button works without a manual "Set as
+        // Home Page" step (#315).
+        descriptor.homePageID = createDatabaseIfNeeded(for: descriptor, seedHome: true)
 
         var registry = WikiRegistry.load(from: containerDirectory)
         registry.add(descriptor)
@@ -329,7 +331,14 @@ public final class WikiManager {
             // bus from the app layer. See `plans/event-bus.md`.
             store.eventBus = WikiEventBus(wikiID: id)
             model = WikiStoreModel(store: store)
-            if model.summaries.isEmpty { model.newPage(title: "Home") }
+            if model.summaries.isEmpty {
+                let homeID = model.newPage(title: "Home")
+                // Mirror `createWiki`'s linkage (#315): a freshly-seeded Home page
+                // becomes the wiki's home page when none is set yet.
+                if let homeID, descriptorExists(id), wikis.first(where: { $0.id == id })?.homePageID == nil {
+                    setHomePage(id: id, pageID: homeID)
+                }
+            }
             // Off-main snapshot reads (debounced search) go through a read-only
             // pool over the same file. Only for real file-backed DBs — a second
             // connection to `:memory:` would see a different, empty database.
@@ -368,16 +377,20 @@ public final class WikiManager {
 
     /// Create the wiki's DB file if absent by opening it once (which runs the
     /// bootstrap ladder), optionally seeding a Home page.
-    private func createDatabaseIfNeeded(for descriptor: WikiDescriptor, seedHome: Bool = false) {
+    /// Returns the seeded Home page's ID (when `seedHome` seeds one), so the
+    /// caller can wire it into `WikiDescriptor.homePageID`.
+    @discardableResult
+    private func createDatabaseIfNeeded(for descriptor: WikiDescriptor, seedHome: Bool = false) -> PageID? {
         let url = databaseURL(forWikiID: descriptor.id)
         do {
             let store = try makeStore(url)
             if seedHome, let model = makeModelIfEmpty(store) {
-                model.newPage(title: "Home")
+                return model.newPage(title: "Home")
             }
         } catch {
             DebugLog.store("WikiManager: createDatabase failed for \(descriptor.id): \(error)")
         }
+        return nil
     }
 
     /// Wrap a freshly-opened store in a model only when it has no pages, so the

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1338,7 +1338,8 @@ public final class WikiStoreModel {
 
     // MARK: - Mutations
 
-    public func newPage(title: String = "Untitled") {
+    @discardableResult
+    public func newPage(title: String = "Untitled") -> PageID? {
         flushPendingSaves()
         do {
             let page = try store.createPage(title: title)
@@ -1350,8 +1351,10 @@ public final class WikiStoreModel {
             let newSelection = WikiSelection.page(page.id)
             recordHistoryTransition(from: loadedSelection, to: newSelection)
             openTab(newSelection, title: title)
+            return page.id
         } catch {
             DebugLog.store("WikiStoreModel.newPage failed: \(error)")
+            return nil
         }
     }
 


### PR DESCRIPTION
## What
Capture the ID of the automatically-seeded Home page when creating or opening a wiki, and wire it into the descriptor so the home button works without a manual "Set as Home Page" step.

## Why
When a new wiki is created, a Home page is automatically seeded as part of the database bootstrap process. Similarly, when opening an existing wiki with an empty database, a Home page is created. However, the descriptor's `homePageID` was not set, requiring users to manually designate the page as "Home" before the home navigation button would work.

This change makes automatic seeding complete by capturing the created page's ID and wiring it directly into the descriptor.

## Changes
- `WikiStoreModel.newPage()` now returns the created page's `PageID` (or `nil` on error) and is marked `@discardableResult` to support existing callers that don't need the ID
- `WikiManager.createDatabaseIfNeeded()` captures and returns the seeded page's ID
- In `createWiki()`, the returned ID is assigned to `descriptor.homePageID` before persisting
- When opening an existing wiki with an empty database, `setHomePage()` is called with the newly created page ID to achieve the same linkage