### PR TITLE
Fix #238: Surface bookmark mutation errors as alerts

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,25 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-10 — #238: Surface a busy alert instead of a silent no-op for bookmark writes
+
+**Problem:** Bookmark mutations (`createFolder`/`addPageRef`/`addSourceRef`/
+`addChatRef`/`renameBookmarkNode`/`deleteBookmarkNode`/`moveBookmarkNode` in
+`WikiStoreModel`) caught store errors and only logged them via `DebugLog` —
+there was no `isAgentRunning`-style guard on bookmarks (they're a separate
+`bookmark_nodes` table, not wiki content, so gating them like page/source edits
+would be wrong). An ingest is a separate `wikictl` process; its long write
+transactions can outlast the store's 5s `busy_timeout` and make a concurrent
+bookmark write in the app process fail with "database is locked" — which
+previously looked exactly like a silent no-op in the UI.
+
+**Fix:** All six bookmark mutation catch blocks now route through
+`WikiStoreModel.reportBookmarkFailure`, which sets the existing
+`storeError` alert (already rendered in `ContentView` via `StoreErrorSheet`,
+the same mechanism used for delete/rename failures). SQLite busy/locked errors
+get a friendly "The wiki is busy… try again in a moment" message instead of
+the raw SQLite error text.
+
 ## 2026-07-09 — #279: Signal the bookmarks container on store events
 
 **Problem:** `FileProviderSpike.signalChange(forWikiID:)` had a hardcoded list

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SQLite3
 import UniformTypeIdentifiers
 
 /// Progress of the blocking search-index upgrade (see
@@ -2460,6 +2461,27 @@ public final class WikiStoreModel {
 
     // MARK: - Bookmark node mutations
 
+    /// Surface a bookmark-mutation failure via the shared `storeError` alert
+    /// (issue #238) instead of a silent no-op — the store's `NSRecursiveLock`
+    /// plus its 5s `busy_timeout` means a concurrent ingest holding a long
+    /// write transaction can make a bookmark write fail with "database is
+    /// locked" rather than merely queue behind it, and that failure was
+    /// previously only logged via `DebugLog`, with no UI feedback at all.
+    private func reportBookmarkFailure(_ action: String, _ error: Error) {
+        DebugLog.store("WikiStoreModel.\(action) failed: \(error)")
+        let isBusy: Bool
+        if case .sqlite(let code, _)? = error as? WikiStoreError, code == SQLITE_BUSY || code == SQLITE_LOCKED {
+            isBusy = true
+        } else {
+            isBusy = false
+        }
+        storeError = StoreError(
+            title: "Couldn't Update Bookmarks",
+            message: isBusy
+                ? "The wiki is busy — an ingest or agent run may be writing to it. Try again in a moment."
+                : "Could not update bookmarks: \(error.localizedDescription)")
+    }
+
     /// Create a folder at root or inside another folder. Returns the new node id,
     /// or `nil` on failure.
     @discardableResult
@@ -2473,7 +2495,7 @@ public final class WikiStoreModel {
             reloadBookmarkNodes()
             return node.id
         } catch {
-            DebugLog.store("WikiStoreModel.createFolder failed: \(error)")
+            reportBookmarkFailure("createFolder", error)
             return nil
         }
     }
@@ -2491,7 +2513,7 @@ public final class WikiStoreModel {
             let ms = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
             DebugLog.tabs("addPageRef: done in \(String(format: "%.1f", ms)) ms")
         } catch {
-            DebugLog.store("WikiStoreModel.addPageRef failed: \(error)")
+            reportBookmarkFailure("addPageRef", error)
         }
     }
 
@@ -2505,7 +2527,7 @@ public final class WikiStoreModel {
                 label: nil, targetID: sourceID)
             reloadBookmarkNodes()
         } catch {
-            DebugLog.store("WikiStoreModel.addSourceRef failed: \(error)")
+            reportBookmarkFailure("addSourceRef", error)
         }
     }
 
@@ -2519,7 +2541,7 @@ public final class WikiStoreModel {
                 label: nil, targetID: chatID)
             reloadBookmarkNodes()
         } catch {
-            DebugLog.store("WikiStoreModel.addChatRef failed: \(error)")
+            reportBookmarkFailure("addChatRef", error)
         }
     }
 
@@ -2529,7 +2551,7 @@ public final class WikiStoreModel {
             try store.updateBookmarkNode(id: id, label: label)
             reloadBookmarkNodes()
         } catch {
-            DebugLog.store("WikiStoreModel.renameBookmarkNode failed: \(error)")
+            reportBookmarkFailure("renameBookmarkNode", error)
         }
     }
 
@@ -2539,7 +2561,7 @@ public final class WikiStoreModel {
             try store.deleteBookmarkNode(id: id)
             reloadBookmarkNodes()
         } catch {
-            DebugLog.store("WikiStoreModel.deleteBookmarkNode failed: \(error)")
+            reportBookmarkFailure("deleteBookmarkNode", error)
         }
     }
 
@@ -2552,7 +2574,7 @@ public final class WikiStoreModel {
             reloadBookmarkNodes()
             return true
         } catch {
-            DebugLog.store("WikiStoreModel.moveBookmarkNode failed: \(error)")
+            reportBookmarkFailure("moveBookmarkNode", error)
             return false
         }
     }

--- a/Tests/WikiFSTests/BookmarkMutationErrorSurfaceTests.swift
+++ b/Tests/WikiFSTests/BookmarkMutationErrorSurfaceTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// Regression coverage for issue #238: bookmark mutation failures (e.g. a
+/// concurrent ingest process holding the DB long enough to trip the store's
+/// busy_timeout) must surface via `WikiStoreModel.storeError`, not vanish into
+/// `DebugLog` as a silent no-op.
+@MainActor
+struct BookmarkMutationErrorSurfaceTests {
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bookmark-error-surface-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    @Test func moveBookmarkNodeFailureSetsStoreError() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+
+        #expect(model.storeError == nil)
+
+        // Moving a node that doesn't exist throws WikiStoreError.unexpected —
+        // previously only logged, now must surface as a user-facing alert.
+        let ok = model.moveBookmarkNode(id: "missing-node", toParentID: nil, position: 0)
+
+        #expect(ok == false)
+        #expect(model.storeError != nil)
+        #expect(model.storeError?.title == "Couldn't Update Bookmarks")
+    }
+
+    @Test func successfulMutationLeavesStoreErrorUntouched() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let page = try store.createPage(title: "One")
+        let model = WikiStoreModel(store: store)
+
+        model.addPageRef(parentID: nil, pageID: page.id)
+
+        #expect(model.storeError == nil)
+        #expect(model.bookmarkNodes.count == 1)
+    }
+}


### PR DESCRIPTION
## Problem

Bookmark mutations (createFolder, addPageRef, addSourceRef, addChatRef, renameBookmarkNode, deleteBookmarkNode, moveBookmarkNode) caught store errors and only logged them via DebugLog. Since bookmark writes aren't gated by an `isAgentRunning` guard (they're a separate `bookmark_nodes` table, not wiki content), a concurrent ingest process holding the database long enough to trip the store's 5s busy_timeout could cause a bookmark write to fail with "database is locked" — which appeared as a silent no-op in the UI.

## Solution

All six bookmark mutation catch blocks now route through a new `reportBookmarkFailure` helper that sets the existing `storeError` alert (already rendered via `StoreErrorSheet`, the same mechanism used for delete/rename failures on wiki content). SQLite busy/locked errors get a friendly "The wiki is busy — an ingest or agent run may be writing to it. Try again in a moment." message instead of raw SQLite error text.

## Changes

- Added `reportBookmarkFailure` private method to centralize error surfacing with smart detection of SQLite busy/locked conditions
- Updated all 6 bookmark mutation methods to use the new error handler
- Added regression tests for bookmark mutation error surfacing