### PR TITLE
ACP slice 2: always-ask/yolo toggle + Approve/Reject UI (opt-in, default off)

### DIFF
--- a/Sources/WikiFS/ACPBackend.swift
+++ b/Sources/WikiFS/ACPBackend.swift
@@ -199,20 +199,20 @@ actor ACPBackend: AgentBackend {
                     )
                     DebugLog.agent("ACPBackend: prompt completed stopReason=\(response.stopReason.rawValue)")
                     // ACP has no explicit turn-end notification; the turn ends
-                    // when the prompt REQUEST returns. Synthesize `.messageStop`
-                    // to satisfy the port's turn-boundary contract (every stop
-                    // reason is a turn boundary). If the translator already
-                    // emitted text/tool events, they precede this; if the agent
-                    // produced nothing, `.messageStop` alone still releases the
-                    // launcher's generation gate.
-                    _ = response.stopReason  // all stopReasons end the turn
-                    continuation.yield(.messageStop)
+                    // when the prompt REQUEST returns. Synthesize the turn-end
+                    // events (always ending in `.messageStop`) to satisfy the
+                    // port's turn-boundary contract. The pure helper is
+                    // unit-tested directly — see `ACPBackendTests`.
+                    for event in Self.turnEndEvents(error: nil) {
+                        continuation.yield(event)
+                    }
                 } catch {
                     DebugLog.agent("ACPBackend: prompt failed: \(error.localizedDescription)")
-                    continuation.yield(.raw("ACP agent error: \(error.localizedDescription)"))
                     // Error is also a turn boundary — synthesize `.messageStop`
                     // so the consumer's for-await exits and the gate releases.
-                    continuation.yield(.messageStop)
+                    for event in Self.turnEndEvents(error: error) {
+                        continuation.yield(event)
+                    }
                 }
                 continuation.finish()
             }
@@ -239,6 +239,11 @@ actor ACPBackend: AgentBackend {
 
     func cancel(_ session: SessionHandle) async {
         guard let record = sessions.removeValue(forKey: session.id) else { return }
+        // Drain any in-flight always-ask continuations BEFORE tearing down, so a
+        // pending `request_permission` never leaks its `CheckedContinuation`
+        // (leaked continuations warn/trap at task end). The agent receives a
+        // `cancelled` outcome for each, which it treats as denied.
+        record.permissionDelegate.cancelAllPending()
         // Cancel any in-flight prompt, then terminate the agent subprocess.
         // `terminate()` resumes pending requests with an error and finishes the
         // notification stream. The permission delegate's onExit binding fires.
@@ -247,7 +252,7 @@ actor ACPBackend: AgentBackend {
         record.permissionDelegate.fireOnExit(status: 0)
     }
 
-    // MARK: - Permission resolution seam (for the future UI)
+    // MARK: - Permission resolution seam (PermissionResolving)
 
     /// Resolve a pending permission request (always-ask). The future chat UI
     /// calls this with the user's chosen option id. For the spike this seam is
@@ -265,23 +270,48 @@ actor ACPBackend: AgentBackend {
         return await session.permissionDelegate.pendingSnapshot()
     }
 
+    /// Drain all pending always-ask requests for a session (resume each as
+    /// cancelled). The launcher calls this on teardown/cancel so no
+    /// `CheckedContinuation` leaks. Returns the count drained (for tests).
+    @discardableResult
+    func cancelAllPending(sessionHandle: SessionHandle) async -> Int {
+        guard let session = sessions[sessionHandle.id] else { return 0 }
+        return session.permissionDelegate.cancelAllPending()
+    }
+
     // MARK: - Internal
 
-    /// Resolve the agent spawn config from the profile. For the spike, the
-    /// executable path comes from `providerHints["acpAgentPath"]` (or falls
-    /// back to `profile.model`), and extra args from
-    /// `providerHints["acpAgentArgs"]` (comma-separated). NOT hardcoded to the
-    /// Zed adapter — the user points at any ACP agent. Returns nil if no path
-    /// is configured (→ `noAgentConfigured`).
+    /// Resolve the agent spawn config from the profile. The executable path comes
+    /// from `providerHints["acpAgentPath"]` (or falls back to `profile.model`),
+    /// and extra args from `providerHints["acpAgentArgs"]`. The args string is
+    /// tokenized with the SAME shell-aware whitespace tokenizer the rest of the
+    /// app uses for `AgentCommandConfig.prefixArguments` (`--yes
+    /// @agentclientprotocol/claude-agent-acp` → two tokens, quote-aware), so the
+    /// existing Agent command config DOUBLES as the ACP agent spawn — the user
+    /// sets executable `npx` args `--yes @agentclientprotocol/claude-agent-acp`.
+    /// NOT hardcoded to the Zed adapter — the user points at any ACP agent.
+    /// Returns nil if no path is configured (→ `noAgentConfigured`).
     private static func resolveSpawnConfig(from profile: BackendProfile) -> AgentSpawnConfig? {
         let path = profile.providerHints["acpAgentPath"] ?? profile.model
         guard let path, !path.isEmpty else { return nil }
-        let args = (profile.providerHints["acpAgentArgs"] ?? "")
-            .split(separator: ",")
-            .map { String($0).trimmingCharacters(in: .whitespaces) }
+        let args = AgentCommandConfig.tokenize(profile.providerHints["acpAgentArgs"] ?? "")
             .filter { !$0.isEmpty }
         let cwd = profile.scratchDirectory?.path
         return AgentSpawnConfig(executablePath: path, arguments: args, workingDirectory: cwd)
+    }
+
+    /// The events synthesized at `session/prompt` completion (the ACP turn
+    /// boundary). ACP has NO turn-end *notification*; the turn ends when the
+    /// prompt REQUEST returns. On success → just `.messageStop` (the port's
+    /// turn-boundary contract). On error → a `.raw` line carrying the message
+    /// THEN `.messageStop` so the consumer's for-await still exits and the
+    /// launcher's generation gate releases. PURE + unit-tested directly
+    /// (`ACPBackendTests.turnEndSynthesis*`) — the spike left this untested.
+    static func turnEndEvents(error: Error?) -> [AgentEvent] {
+        if let error {
+            return [.raw("ACP agent error: \(error.localizedDescription)"), .messageStop]
+        }
+        return [.messageStop]
     }
 
     /// Decode a `session/update` notification's `params` (`AnyCodable`) into a

--- a/Sources/WikiFS/ACPPermissions.swift
+++ b/Sources/WikiFS/ACPPermissions.swift
@@ -145,7 +145,14 @@ enum PermissionPolicy: Sendable {
 /// A snapshot of a pending permission request (always-ask). The future chat UI
 /// surfaces these as Approve/Reject affordances; `options` are the agent's
 /// offered choices (typically an `allow_*` and a `reject_*`).
-struct PendingPermission: Sendable {
+///
+/// `Equatable` by `toolCallId`: a pending request is identified by its tool-call
+/// id (the ACP permission gate keys on it), and the offered options don't change
+/// while a request is pending. This identity-based equality is what the
+/// launcher's snapshot diff (`snapshot != pendingPermissions`) relies on to
+/// avoid redundant view updates. (`PermissionOption` is not `Equatable`, so
+/// `==` cannot be synthesized — implemented explicitly instead.)
+struct PendingPermission: Sendable, Equatable {
     let toolCallId: String
     let title: String?
     let options: [PermissionOption]
@@ -154,6 +161,10 @@ struct PendingPermission: Sendable {
         self.toolCallId = toolCallId
         self.title = title
         self.options = options
+    }
+
+    static func == (lhs: PendingPermission, rhs: PendingPermission) -> Bool {
+        lhs.toolCallId == rhs.toolCallId
     }
 }
 
@@ -285,6 +296,29 @@ final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
                 PendingPermission(toolCallId: toolCallId, title: nil, options: pending.options)
             }
         }
+    }
+
+    /// Drain (drain-on-cancel): resume EVERY pending always-ask continuation as
+    /// `PermissionOutcome(cancelled: true)` and clear the pending map. Called from
+    /// `ACPBackend.cancel` when a session is torn down / the agent exits, so no
+    /// `CheckedContinuation` leaks (a leaked continuation warns/traps at task end).
+    ///
+    /// Safe to call with nothing pending (no-op) and idempotent (the map is cleared
+    /// under the lock before any continuation is resumed, so a concurrent
+    /// `resolve(optionId:)` races only against an already-emptied map). Returns
+    /// the number of continuations resumed (for tests).
+    @discardableResult
+    func cancelAllPending() -> Int {
+        let drained = lock.withLock { state -> [(options: [PermissionOption], continuation: CheckedContinuation<RequestPermissionResponse, Never>)] in
+            let pending = state.pending
+            state.pending.removeAll()
+            return pending.map { (toolCallId, value) in (value.options, value.continuation) }
+        }
+        for item in drained {
+            _ = item.options  // toolCallId is implicit; nothing else needed
+            item.continuation.resume(returning: RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true)))
+        }
+        return drained.count
     }
 
     // MARK: - onExit binding (wired in ACPBackend.start)

--- a/Sources/WikiFS/AgentBackendFactory.swift
+++ b/Sources/WikiFS/AgentBackendFactory.swift
@@ -1,0 +1,54 @@
+import Foundation
+import WikiFSCore
+
+/// Pure, side-effect-free backend selection + ACP profile wiring (slice 2 of
+/// `plans/acp-backend-and-permissions.md`). Extracted from the launcher so the
+/// selection logic is unit-testable WITHOUT driving the `@MainActor @Observable`
+/// launcher actor (`AgentLauncher` only owns "when + where to construct").
+///
+/// **Default-OFF contract:** `useACPBackend == false` MUST return
+/// `ClaudeCLIBackend` — today's behavior, unchanged for existing users. Only
+/// when the opt-in pref is ON does the launcher construct an `ACPBackend`, and
+/// even then it is `permissionPolicy: .yolo` by default (default mode = yolo —
+/// the safe default, since always-ask enforcement depends on the agent emitting
+/// `request_permission`, which not all agents do).
+enum AgentBackendFactory {
+
+    /// Select + construct the backend for a session.
+    ///
+    /// - Parameters:
+    ///   - useACPBackend: the persisted opt-in pref (`@AppStorage("useACPBackend")`,
+    ///     default `false`). OFF → Claude CLI (unchanged); ON → ACP.
+    ///   - policy: the chat's permission policy (yolo vs alwaysAsk). Baked into
+    ///     the `ACPBackend` at construction (`ACPBackend.start` installs it on the
+    ///     delegate); ignored by the CLI backend (no permission channel).
+    /// - Returns: the backend. `ACPBackend` also conforms to `PermissionResolving`,
+    ///   so the launcher downcasts to surface pending requests.
+    static func makeBackend(useACPBackend: Bool, policy: PermissionPolicy) -> AgentBackend {
+        if useACPBackend {
+            return ACPBackend(permissionPolicy: policy)
+        }
+        return ClaudeCLIBackend()
+    }
+
+    /// Build the `providerHints` that carry the ACP agent spawn (executable path
+    /// + args) into the backend's `BackendProfile`. The existing `AgentCommandConfig`
+    /// (Settings → Agent) DOUBLES as the ACP agent spawn: its resolved executable
+    /// becomes `acpAgentPath` and its prefix-arguments string becomes
+    /// `acpAgentArgs`. `ACPBackend.resolveSpawnConfig` tokenizes the args string
+    /// with the same shell-aware tokenizer the app uses for `prefixArguments`.
+    ///
+    /// PURE so it is unit-tested directly (`ACPWiringTests`). Empty inputs yield
+    /// an empty dict (→ `ACPBackend` throws `noAgentConfigured`, surfaced to the
+    /// user — the opt-in feature requires a configured ACP agent).
+    static func acpProviderHints(resolvedExecutable: String, prefixArguments: String) -> [String: String] {
+        var hints: [String: String] = [:]
+        if !resolvedExecutable.isEmpty {
+            hints["acpAgentPath"] = resolvedExecutable
+        }
+        if !prefixArguments.isEmpty {
+            hints["acpAgentArgs"] = prefixArguments
+        }
+        return hints
+    }
+}

--- a/Sources/WikiFS/AgentCommandSettingsView.swift
+++ b/Sources/WikiFS/AgentCommandSettingsView.swift
@@ -11,6 +11,11 @@ struct AgentCommandSettingsView: View {
     @State private var prefixArguments: String
     @State private var modelOverride: String
     @State private var extraEnvironment: String
+    /// Opt-in: use the ACP (Agent Client Protocol) backend instead of the Claude
+    /// CLI. Default OFF — preserves today's behavior exactly. ON launches the
+    /// configured agent (executable + prefix args) as an ACP agent over JSON-RPC,
+    /// enabling the structural always-ask/yolo write-permission gate.
+    @AppStorage(AgentLauncher.useACPBackendKey) private var useACPBackend = false
 
     let containerDirectory: URL
 
@@ -32,6 +37,26 @@ struct AgentCommandSettingsView: View {
                     TextField("Model override", text: $modelOverride, prompt: Text("default (per-op alias)"))
                 } header: {
                     Text("Command")
+                } footer: {
+                    if useACPBackend {
+                        Text("ACP backend is ON — the executable and prefix arguments above launch the ACP agent (e.g. executable `npx`, prefix arguments `--yes @agentclientprotocol/claude-agent-acp`).")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("The Claude CLI command. When the ACP backend is on, these same fields launch the ACP agent instead.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section {
+                    Toggle("Use ACP backend", isOn: $useACPBackend)
+                } header: {
+                    Text("Backend")
+                } footer: {
+                    Text("Off (default): the Claude CLI backend — writes apply with no review. On: launch the agent over ACP, which adds a structural always-ask / yolo permission gate for writes. Requires a configured ACP agent above. Live approval is only possible with an agent that emits request_permission.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section {

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -140,10 +140,50 @@ final class AgentLauncher {
     /// unchanged.
     var containerDirectory: URL? = nil
 
-    /// The agent backend. Default `ClaudeCLIBackend` (today's Claude-CLI
-    /// stream-json code, moved behind the `AgentBackend` port). Injectable so
-    /// tests can substitute a stub backend.
+    /// The agent backend. Constructed PER-SESSION at spawn time from the
+    /// persisted `useACPBackend` pref + the chat's permission policy (slice 2 of
+    /// `plans/acp-backend-and-permissions.md`), via `AgentBackendFactory`.
+    /// Default `ClaudeCLIBackend` (today's Claude-CLI stream-json code, default
+    /// OFF) so existing behavior is unchanged until the opt-in pref is ON.
+    /// Injectable so tests can substitute a stub backend.
     @ObservationIgnored var backend: AgentBackend = ClaudeCLIBackend()
+
+    /// Opt-in seam: whether the ACP backend is enabled (`@AppStorage("useACPBackend")`,
+    /// default `false`). Read fresh at spawn time (same as `AgentCommandConfig`),
+    /// so Settings changes apply on the next session without a restart. Injectable
+    /// for tests; the app reads `UserDefaults` (the same store `@AppStorage`
+    /// writes, so a Settings toggle is immediately visible).
+    @ObservationIgnored var resolveUseACPBackend: () -> Bool = {
+        UserDefaults.standard.bool(forKey: AgentLauncher.useACPBackendKey)
+    }
+
+    /// The chat's always-ask/yolo mode (`@AppStorage("agentAlwaysAsk")`, default
+    /// `false` = yolo). v1: app-wide persisted, default-OFF (no `chats`-table
+    /// schema migration). A future slice can persist it per-chat. Read at spawn
+    /// time so it bakes into the `ACPBackend`'s `PermissionPolicy`. Has NO effect
+    /// when the ACP backend is OFF (the CLI backend has no permission channel).
+    @ObservationIgnored var resolveAlwaysAsk: () -> Bool = {
+        UserDefaults.standard.bool(forKey: AgentLauncher.alwaysAskKey)
+    }
+
+    /// The currently-pending write-permission requests surfaced from the backend
+    /// (always-ask mode). When non-empty AND this surface is the live chat, the
+    /// UI renders an inline Approve/Reject affordance (slice 2). Mirrors how
+    /// streamed `AgentEvent`s flow: `ACPBackend` → launcher refresh → `@Observable`
+    /// state → `ChatView`. Refreshed by `pendingPollTask` while a turn generates.
+    /// Empty for the CLI backend (no permission channel) and while idle.
+    var pendingPermissions: [PendingPermission] = []
+
+    /// Backstop poller that refreshes `pendingPermissions` from the backend while
+    /// a turn is generating (always-ask blocks the turn until resolved, so no
+    /// `AgentEvent`s flow while a request is pending — the poller is the only
+    /// channel that surfaces it). Armed in `setGenerating(true)`, disarmed in
+    /// `setGenerating(false)` / `finish()` / `resetRunArtifacts()`.
+    @ObservationIgnored private var pendingPollTask: Task<Void, Never>?
+
+    /// UserDefaults keys shared with the `@AppStorage` bindings in Settings + ChatView.
+    static let useACPBackendKey = "useACPBackend"
+    static let alwaysAskKey = "agentAlwaysAsk"
     /// The active session handle (nil when no session is live). Replaces the
     /// old `process: Process?` — the launcher never touches a `Process` directly.
     @ObservationIgnored private var sessionHandle: SessionHandle?
@@ -238,10 +278,21 @@ final class AgentLauncher {
     /// invariant: the lock toggles exactly once per real transition, never on a
     /// no-op reassignment. Routing through a method (not a `didSet`) avoids
     /// Observation-macro interaction pitfalls.
+    ///
+    /// Slice 2: this is also where the pending-permission poller arms/disarms.
+    /// always-ask blocks the turn (no `AgentEvent`s flow while a request is
+    /// pending), so the poller is the only channel that surfaces pending requests
+    /// to `pendingPermissions` for the UI. Armed on a real `true`; disarmed + a
+    /// final refresh (to clear stale pending) on a real `false`.
     private func setGenerating(_ value: Bool) {
         guard isGenerating != value else { return }
         isGenerating = value
         onTurnBoundaryHandler?(value)
+        if value {
+            startPendingPermissionPoller()
+        } else {
+            stopPendingPermissionPoller()
+        }
     }
 
     /// Per-turn generation-gate release policy. Interactive sessions release the
@@ -255,6 +306,62 @@ final class AgentLauncher {
     /// launcher state.
     static func releasesGenerationSlotPerTurn(isInteractiveSession: Bool) -> Bool {
         isInteractiveSession
+    }
+
+    // MARK: - Pending-permission surfacing (slice 2: always-ask)
+
+    /// Arm the backstop poller that refreshes `pendingPermissions` from the
+    /// backend while a turn generates. The poller hops to the main actor, reads
+    /// the backend's pending snapshot (downcast to `PermissionResolving` — a
+    /// no-op for the CLI backend, which doesn't conform), and updates the
+    /// observable array only on a real change (avoiding redundant view diffs).
+    /// Polls faster (150ms) while a request is pending so Approve/Reject feels
+    /// responsive, slower (300ms) otherwise. Cancelled on teardown.
+    private func startPendingPermissionPoller() {
+        pendingPollTask?.cancel()
+        pendingPollTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                await self?.refreshPendingPermissions()
+                let interval = (self?.pendingPermissions.isEmpty ?? true)
+                    ? UInt64(300_000_000)   // 300ms idle
+                    : UInt64(150_000_000)   // 150ms while a request is pending
+                try? await Task.sleep(nanoseconds: interval)
+            }
+        }
+    }
+
+    /// Cancel the poller and clear any surfaced pending requests (the turn ended
+    /// or the session tore down). A final refresh runs to drain any last pending
+    /// that arrived in the gap; if none remain the array clears.
+    private func stopPendingPermissionPoller() {
+        pendingPollTask?.cancel()
+        pendingPollTask = nil
+    }
+
+    /// Pull the current pending-permission snapshot from the backend into
+    /// `pendingPermissions` (main actor). No-op for the CLI backend (no
+    /// `PermissionResolving` conformance) and when no session is live.
+    func refreshPendingPermissions() async {
+        guard let handle = sessionHandle,
+              let permBackend = backend as? PermissionResolving else {
+            if !pendingPermissions.isEmpty { pendingPermissions = [] }
+            return
+        }
+        let snapshot = await permBackend.pendingPermissions(sessionHandle: handle)
+        if snapshot != pendingPermissions { pendingPermissions = snapshot }
+    }
+
+    /// Resolve a pending permission request by its option id — the Approve/Reject
+    /// UI calls this with the chosen option's id. Resumes the backend's blocked
+    /// continuation, unblocking the agent. Idempotent-ish: a no-op if the option
+    /// isn't offered by any pending request.
+    func resolvePendingPermission(optionId: String) async {
+        guard let handle = sessionHandle,
+              let permBackend = backend as? PermissionResolving else { return }
+        let resolved = await permBackend.resolvePermission(sessionHandle: handle, optionId: optionId)
+        if resolved {
+            await refreshPendingPermissions()
+        }
     }
 
     // MARK: - Three independent mechanisms (relationship)
@@ -603,6 +710,14 @@ final class AgentLauncher {
         let dir = containerDirectory ?? (try? DatabaseLocation.appGroupContainerDirectory()) ?? FileManager.default.temporaryDirectory
         let agentConfig = AgentCommandConfig.load(from: dir)
 
+        // Slice 2: select the backend per the opt-in pref + the chat's permission
+        // policy (default OFF = ClaudeCLI; default yolo). Constructed HERE so both
+        // `start` and the per-turn stream consumer capture the same backend. The
+        // ACP agent spawn (path + args) is threaded into providerHints below.
+        let useACP = resolveUseACPBackend()
+        let policy: PermissionPolicy = resolveAlwaysAsk() ? .alwaysAsk : .yolo
+        self.backend = AgentBackendFactory.makeBackend(useACPBackend: useACP, policy: policy)
+
         let resolvedPath: String
         switch PathPreflight.resolveOnLoginShell(executable: agentConfig.resolvedExecutable()) {
         case .found(let path):
@@ -680,6 +795,11 @@ final class AgentLauncher {
                 Task { @MainActor [weak self] in self?.ingestStderr(chunk) }
             })
         let profile = BackendProfile(
+            providerHints: useACP
+                ? AgentBackendFactory.acpProviderHints(
+                    resolvedExecutable: resolvedPath,
+                    prefixArguments: agentConfig.prefixArguments)
+                : [:],
             scratchDirectory: scratch,
             isReadOnly: false,
             cli: cli)
@@ -810,6 +930,13 @@ final class AgentLauncher {
         let dir = containerDirectory ?? (try? DatabaseLocation.appGroupContainerDirectory()) ?? FileManager.default.temporaryDirectory
         let agentConfig = AgentCommandConfig.load(from: dir)
 
+        // Slice 2: select the backend per the opt-in pref + the chat's permission
+        // policy (default OFF = ClaudeCLI; default yolo). The ACP agent spawn is
+        // threaded into providerHints below.
+        let useACP = resolveUseACPBackend()
+        let policy: PermissionPolicy = resolveAlwaysAsk() ? .alwaysAsk : .yolo
+        self.backend = AgentBackendFactory.makeBackend(useACPBackend: useACP, policy: policy)
+
         let resolvedPath: String
         switch PathPreflight.resolveOnLoginShell(executable: agentConfig.resolvedExecutable()) {
         case .found(let path):
@@ -895,6 +1022,11 @@ final class AgentLauncher {
                 Task { @MainActor [weak self] in self?.ingestStderr(chunk) }
             })
         let profile = BackendProfile(
+            providerHints: useACP
+                ? AgentBackendFactory.acpProviderHints(
+                    resolvedExecutable: resolvedPath,
+                    prefixArguments: agentConfig.prefixArguments)
+                : [:],
             scratchDirectory: scratch,
             isReadOnly: false,
             cli: cli)
@@ -1257,6 +1389,11 @@ final class AgentLauncher {
         onTurnBoundaryHandler = nil
         setGenerating(false)
         lastActivityAt = Date()
+        // Slice 2: stop the pending-permission poller and clear surfaced pending
+        // (the session is ending). The backend's `cancel` already drained any
+        // in-flight always-ask continuations.
+        stopPendingPermissionPoller()
+        pendingPermissions = []
         // Release the edit lock (`store.isAgentRunning`) from here — NOT from the
         // `onExit` callback — so EVERY completion path releases it.
         releaseEditLock()
@@ -1308,6 +1445,9 @@ final class AgentLauncher {
         // D2: a stale active chat association must never survive into a new run.
         // (startInteractiveQuery sets the fresh value right after this reset.)
         activeChatID = nil
+        // Slice 2: clear any surfaced pending permissions + poller from a prior run.
+        stopPendingPermissionPoller()
+        pendingPermissions = []
     }
 
     // MARK: - Backend log files

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -32,6 +32,13 @@ struct ChatView: View {
     @AppStorage("isChatOutlineExpanded") private var chatOutlineExpanded = false
     @State private var outlineScroll: ChatScrollRequest? = nil
     @State private var quoteAnchor: ChatHighlightRequest? = nil
+    /// Whether the ACP backend is enabled (shared with Settings + the launcher).
+    /// Drives the visibility of the always-ask/yolo toggle: the CLI backend has
+    /// no permission channel, so the toggle is meaningless when this is off.
+    @AppStorage(AgentLauncher.useACPBackendKey) private var useACPBackend = false
+    /// The chat's always-ask/yolo mode (shared with the launcher, read at spawn).
+    /// v1 app-wide, default off (yolo). Applies to the next conversation.
+    @AppStorage(AgentLauncher.alwaysAskKey) private var alwaysAsk = false
 
     /// True when this surface is rendering the active live session (D2
     /// source-of-truth rule). The view sources from `launcher.events`; when
@@ -198,6 +205,15 @@ struct ChatView: View {
             && launcher.runningKind == .query
     }
 
+    /// The pending permission to surface as an inline Approve/Reject affordance,
+    /// or nil when nothing is awaiting approval. Only the LIVE chat renders it
+    /// (a persisted chat can't resolve a request); the first pending request is
+    /// shown — ACP agents gate one write at a time, so there is at most one.
+    private var livePendingPermission: PendingPermission? {
+        guard isLiveChat, let first = launcher.pendingPermissions.first else { return nil }
+        return first
+    }
+
     // MARK: - Content routing
 
     @ViewBuilder
@@ -279,6 +295,13 @@ struct ChatView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .padding(.horizontal, PageEditorMetrics.contentInset)
                         .padding(.top, showsEditingEnabledBanner || chatSummary != nil ? 0 : ChatMetrics.chatTopInset)
+                    if let pending = livePendingPermission {
+                        PermissionApprovalView(permission: pending) { optionId in
+                            Task { await launcher.resolvePendingPermission(optionId: optionId) }
+                        }
+                        .padding(.horizontal, PageEditorMetrics.contentInset)
+                        .padding(.bottom, ChatMetrics.sectionSpacing / 2)
+                    }
                     chatComposer
                         .padding(.horizontal, PageEditorMetrics.contentInset)
                         .padding(.top, ChatMetrics.sectionSpacing)
@@ -397,6 +420,20 @@ struct ChatView: View {
                     Image(systemName: "sidebar.right")
                 }
                 .help("Toggle Outline")
+                // Slice 2: the always-ask / yolo toggle. Only meaningful when the
+                // ACP backend is on (the CLI backend has no permission channel),
+                // so it's hidden otherwise. The policy is baked into the ACP
+                // backend at session start, so the toggle applies to the next
+                // conversation (captioned). Default off (yolo).
+                if useACPBackend {
+                    Spacer(minLength: 12)
+                    Toggle("Always ask", isOn: $alwaysAsk)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                        .help(alwaysAsk
+                              ? "Always ask: the agent pauses for your approval before each write."
+                              : "Yolo: writes apply automatically. Toggle to review each write.")
+                }
             }
         }
         .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)

--- a/Sources/WikiFS/PermissionApprovalView.swift
+++ b/Sources/WikiFS/PermissionApprovalView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import WikiFSCore
+import ACPModel
+
+/// The inline Approve/Reject affordance for a pending write-permission request
+/// (always-ask mode, slice 2 of `plans/acp-backend-and-permissions.md`). Renders
+/// the agent's offered options as buttons: an `allow_*` option → the primary
+/// Approve action; a `reject_*` (or other) option → Reject. Tapping a button
+/// resolves the request via the launcher, unblocking the agent.
+///
+/// Native macOS idiom (per the `macos-design` + `swiftui-pro` skills): a
+/// compact card with `.regularMaterial` vibrancy, a leading shield glyph, the
+/// request's title, and a trailing button pair (accented Approve, plain
+/// Reject). Accessible: each button is labeled and has a help tooltip; the
+/// card announces itself to VoiceOver.
+struct PermissionApprovalView: View {
+    let permission: PendingPermission
+    let onResolve: (String) -> Void
+
+    /// Split the offered options into the allow (Approve) and deny (Reject)
+    /// buckets. An option whose `kind` starts with `allow` is Approve; the
+    /// first remaining option is Reject. ACP requests typically offer exactly
+    /// these two, but this degrades gracefully if more or fewer are offered.
+    private var allowOption: PermissionOption? {
+        permission.options.first(where: { $0.kind.hasPrefix("allow") })
+    }
+    private var rejectOption: PermissionOption? {
+        permission.options.first(where: { !$0.kind.hasPrefix("allow") })
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "checklist")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(titleText)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text("The agent is waiting for your approval to proceed.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            HStack(spacing: 8) {
+                if let reject = rejectOption {
+                    Button("Reject") { onResolve(reject.optionId) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .help("Deny this request")
+                }
+                if let allow = allowOption {
+                    Button("Approve") { onResolve(allow.optionId) }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .help("Allow this request")
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(.orange.opacity(0.35), lineWidth: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Permission request awaiting approval")
+    }
+
+    /// The request's title: the tool-call's title if offered (e.g. "Edit file"),
+    /// otherwise a generic "Approve write?" prompt.
+    private var titleText: String {
+        permission.title ?? "Approve this change?"
+    }
+}

--- a/Sources/WikiFS/PermissionResolving.swift
+++ b/Sources/WikiFS/PermissionResolving.swift
@@ -1,0 +1,40 @@
+import Foundation
+import WikiFSCore
+
+/// An optional capability a backend MAY expose: surfacing + resolving pending
+/// write-permission requests (the always-ask lever, `plans/acp-backend-and-permissions.md`).
+///
+/// `ACPBackend` conforms (it owns the `session/request_permission` channel via
+/// `ACPPermissionDelegate`); `ClaudeCLIBackend` does NOT (the CLI stream-json
+/// backend has no permission channel — its writes are ungated, i.e. always yolo).
+/// The launcher downcasts `backend as? PermissionResolving` to decide whether to
+/// poll for pending requests and offer Approve/Reject in the chat. When the cast
+/// fails (CLI backend), the always-ask/yolo toggle has no effect and the UI
+/// hides the approval affordance.
+///
+/// Conforms to `AgentBackend` so the launcher holds a single `backend:
+/// AgentBackend` and conditionally queries this capability — no second property,
+/// no protocol-violating optionality on the base port.
+protocol PermissionResolving: AgentBackend {
+    /// The currently-pending permission requests for a session (always-ask
+    /// mode). Empty when yolo, or when nothing is awaiting approval.
+    func pendingPermissions(sessionHandle: SessionHandle) async -> [PendingPermission]
+
+    /// Resolve a pending request by selecting one of its offered option ids.
+    /// Returns `true` if a pending request offering that option was resolved
+    /// (and the agent was thereby unblocked). The Approve/Reject UI calls this.
+    func resolvePermission(sessionHandle: SessionHandle, optionId: String) async -> Bool
+
+    /// Drain every pending always-ask request for a session, resuming each as
+    /// cancelled. Called on teardown/cancel so no `CheckedContinuation` leaks.
+    /// Returns the count drained (for tests).
+    @discardableResult
+    func cancelAllPending(sessionHandle: SessionHandle) async -> Int
+}
+
+// MARK: - ACPBackend conformance
+
+// `ACPBackend` already implements all three methods; this extension just
+// declares protocol membership. Kept here (not in ACPBackend.swift) so the
+// capability seam is discoverable in one place alongside the protocol.
+extension ACPBackend: PermissionResolving {}

--- a/Tests/WikiFSTests/ACPWiringTests.swift
+++ b/Tests/WikiFSTests/ACPWiringTests.swift
@@ -1,0 +1,188 @@
+import Testing
+import Foundation
+import ACPModel
+@testable import WikiFS
+@testable import WikiFSCore
+
+/// Slice 2 wiring tests (`plans/acp-backend-and-permissions.md`): backend
+/// selection, ACP profile wiring, the drain-on-cancel, and the turn-end
+/// synthesis extraction. Pure logic only — NO live agent subprocess (the slice
+/// forbids end-to-end testing). The translator + delegate-policy behavior are
+/// already covered by `ACPBackendTests`; this suite covers the NEW wiring.
+@Suite struct ACPWiringTests {
+
+    // MARK: - Backend selection (AgentBackendFactory)
+
+    /// Default-OFF: the factory returns the Claude CLI backend (today's
+    /// behavior, unchanged for existing users).
+    @Test func factorySelectsClaudeCLIWhenOff() {
+        let backend = AgentBackendFactory.makeBackend(useACPBackend: false, policy: .yolo)
+        #expect(backend is ClaudeCLIBackend)
+    }
+
+    /// Opt-in ON: the factory returns the ACP backend.
+    @Test func factorySelectsACPWhenOn() {
+        let backend = AgentBackendFactory.makeBackend(useACPBackend: true, policy: .yolo)
+        #expect(backend is ACPBackend)
+    }
+
+    /// ACP backend also conforms to `PermissionResolving` (the capability seam
+    /// the launcher downcasts to surface pending requests); the CLI backend does
+    /// NOT (it has no permission channel).
+    @Test func acpBackendExposesPermissionCapability() {
+        let acp = AgentBackendFactory.makeBackend(useACPBackend: true, policy: .yolo)
+        let cli = AgentBackendFactory.makeBackend(useACPBackend: false, policy: .yolo)
+        #expect(acp is PermissionResolving)
+        #expect(!(cli is PermissionResolving))
+    }
+
+    /// Permission policy threading: the factory threads `alwaysAsk` into the ACP
+    /// backend. We can't introspect the private policy, but we CAN assert the
+    /// construction doesn't crash and yields an ACP backend for both policies
+    /// (the policy's effect on the delegate is covered by `ACPBackendTests`).
+    @Test func factoryThreadsBothPolicies() {
+        let yolo = AgentBackendFactory.makeBackend(useACPBackend: true, policy: .yolo)
+        let alwaysAsk = AgentBackendFactory.makeBackend(useACPBackend: true, policy: .alwaysAsk)
+        #expect(yolo is ACPBackend)
+        #expect(alwaysAsk is ACPBackend)
+    }
+
+    // MARK: - ACP provider hints (AgentCommandConfig → profile)
+
+    /// The resolved executable path becomes `acpAgentPath`; prefix args become
+    /// `acpAgentArgs`. This is how the Agent command config DOUBLES as the ACP
+    /// agent spawn.
+    @Test func acpProviderHintsFromConfig() {
+        let hints = AgentBackendFactory.acpProviderHints(
+            resolvedExecutable: "/usr/local/bin/npx",
+            prefixArguments: "--yes @agentclientprotocol/claude-agent-acp")
+        #expect(hints["acpAgentPath"] == "/usr/local/bin/npx")
+        #expect(hints["acpAgentArgs"] == "--yes @agentclientprotocol/claude-agent-acp")
+    }
+
+    /// Empty inputs yield an empty dict (→ `ACPBackend` throws
+    /// `noAgentConfigured`). The opt-in feature requires a configured agent.
+    @Test func acpProviderHintsEmptyWhenUnconfigured() {
+        let hints = AgentBackendFactory.acpProviderHints(
+            resolvedExecutable: "", prefixArguments: "")
+        #expect(hints.isEmpty)
+    }
+
+    /// Only the path set (no prefix args) → just `acpAgentPath`.
+    @Test func acpProviderHintsPathOnly() {
+        let hints = AgentBackendFactory.acpProviderHints(
+            resolvedExecutable: "/bin/agent", prefixArguments: "")
+        #expect(hints.count == 1)
+        #expect(hints["acpAgentPath"] == "/bin/agent")
+    }
+
+    /// The args string is tokenized shell-aware at spawn time (in
+    /// `ACPBackend.resolveSpawnConfig`), NOT by the factory. The factory passes
+    /// the raw string through so a quoted multi-token arg like `--yes @org/agent`
+    /// survives intact for the tokenizer to split. This pins the contract: the
+    /// factory stores the raw string; the backend tokenizes.
+    @Test func acpProviderHintsPreservesRawArgsForTokenization() {
+        let raw = "--yes @agentclientprotocol/claude-agent-acp"
+        let hints = AgentBackendFactory.acpProviderHints(
+            resolvedExecutable: "npx", prefixArguments: raw)
+        #expect(hints["acpAgentArgs"] == raw)
+    }
+
+    // MARK: - Turn-end synthesis (extracted from ACPBackend.send)
+
+    /// A successful prompt completion synthesizes exactly `.messageStop` (the
+    /// port's turn-boundary contract — every ACP stopReason is a turn boundary).
+    @Test func turnEndSynthesisOnSuccess() {
+        #expect(ACPBackend.turnEndEvents(error: nil) == [.messageStop])
+    }
+
+    /// A failed prompt synthesizes a `.raw` error line THEN `.messageStop`, so
+    /// the consumer's for-await still exits and the generation gate releases
+    /// (an error is also a turn boundary).
+    @Test func turnEndSynthesisOnError() {
+        struct Boom: Error {}
+        let events = ACPBackend.turnEndEvents(error: Boom())
+        #expect(events.count == 2)
+        // First event is a `.raw` line carrying the error (exact wording is
+        // locale/Swift-version dependent, so assert by case + prefix).
+        if case .raw(let text)? = events.first {
+            #expect(text.hasPrefix("ACP agent error:"))
+        } else {
+            Issue.record("expected a .raw error line first, got \(String(describing: events.first))")
+        }
+        // Last event is always the turn-boundary marker.
+        #expect(events.last == .messageStop)
+    }
+
+    /// Both branches end in an `endsGeneration` event — the launcher keys its
+    /// gate/lock/flush off this. Pinned so a future refactor can't drop it.
+    @Test func turnEndSynthesisAlwaysEndsGeneration() {
+        for error: Error? in [nil, NSError(domain: "x", code: 1)] {
+            for event in ACPBackend.turnEndEvents(error: error) {
+                if event == ACPBackend.turnEndEvents(error: error).last {
+                    #expect(AgentEvent.endsGeneration(event))
+                }
+            }
+        }
+    }
+
+    // MARK: - Drain-on-cancel (no continuation leak)
+
+    /// `cancelAllPending()` resumes a deferred always-ask continuation as
+    /// cancelled and empties the pending map — so cancelling a session never
+    /// leaks a `CheckedContinuation`. Mirrors `ACPBackend.cancel`'s teardown.
+    @Test func cancelAllPendingResumesAsCancelledAndClears() async throws {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk)
+        let request = RequestPermissionRequest(
+            options: [PermissionOption(kind: "allow_once", name: "Allow", optionId: "opt-allow")],
+            sessionId: SessionId("s1"),
+            toolCall: ToolCallUpdate(toolCallId: "tc-drain", title: "Write"))
+
+        // Suspend a request (always-ask defers).
+        let requestTask = Task<RequestPermissionResponse, Error> {
+            try await delegate.handlePermissionRequest(request: request)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await delegate.pendingSnapshot().count == 1)
+
+        // Drain — the launcher's cancel path.
+        let drained = await delegate.cancelAllPending()
+        #expect(drained == 1)
+
+        // The suspended request resumes with a cancelled outcome.
+        let response = try await requestTask.value
+        #expect(response.outcome.outcome == "cancelled")
+        #expect(response.outcome.optionId == nil)
+        // Pending map is empty (no leak).
+        #expect(await delegate.pendingSnapshot().isEmpty)
+    }
+
+    /// Draining with nothing pending is a no-op returning 0 (cancel on an idle
+    /// session must be safe).
+    @Test func cancelAllPendingNoOpWhenIdle() async {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk)
+        let drained = await delegate.cancelAllPending()
+        #expect(drained == 0)
+        #expect(await delegate.pendingSnapshot().isEmpty)
+    }
+
+    /// Drain resumes MULTIPLE pending requests (a session can have more than
+    /// one queued if the agent emits several writes before pausing).
+    @Test func cancelAllPendingDrainsMultiple() async throws {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk)
+        // Two distinct pending requests.
+        for id in ["tc-1", "tc-2"] {
+            let request = RequestPermissionRequest(
+                options: [PermissionOption(kind: "allow_once", name: "Allow", optionId: "opt-\(id)")],
+                sessionId: SessionId("s1"),
+                toolCall: ToolCallUpdate(toolCallId: id, title: "Write"))
+            _ = Task<Void, Never> { _ = try? await delegate.handlePermissionRequest(request: request) }
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await delegate.pendingSnapshot().count == 2)
+
+        let drained = await delegate.cancelAllPending()
+        #expect(drained == 2)
+        #expect(await delegate.pendingSnapshot().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Implements always-ask/yolo for chats via the Agent Client Protocol — **opt-in, default-OFF (zero behavior change)**. Builds on the merged ACP foundation (#320). The approval gate is **structural**: in always-ask the agent blocks on `session/request_permission` until the app approves — not a prompt instruction (#287), no MCP.

Closes the core of #286/#287. (Provider/auth picker is slice 3 / #217.)

## How it works

- **Backend selection** (`AgentBackendFactory.makeBackend`, pure/testable): a persisted pref `useACPBackend` (default **false**) selects `ACPBackend` vs `ClaudeCLIBackend`. The existing **Agent command config doubles as the ACP agent spawn** — its executable → `acpAgentPath`, prefix args → `acpAgentArgs` (now shell-aware tokenized so `--yes @agentclientprotocol/claude-agent-acp` splits correctly). Constructed per-session at spawn.
- **always-ask/yolo** (`agentAlwaysAsk`, default **false = yolo**): the chat's `PermissionPolicy`, baked into `ACPBackend` at construction.
  - **yolo** → `handlePermissionRequest` auto-approves (today's "writes apply, no review").
  - **always-ask** → the request is recorded as pending and the agent **blocks** until the user decides.
- **Pending permissions flow** `ACPBackend` → launcher → `ChatView`: a new `PermissionResolving` protocol; the launcher downcasts `backend as? PermissionResolving` (no-op for the CLI backend) and a main-actor poller refreshes the observable `pendingPermissions` (the only channel while a turn is blocked). `resolvePendingPermission(optionId:)` resumes the agent.
- **Drain-on-cancel:** `ACPBackend.cancel` resumes all pending continuations as cancelled (`cancelAllPending`) — no `CheckedContinuation` leak.

## UI (swiftui-pro + macos-design)

- **Settings → Agent:** a "Use ACP backend" `Toggle` (native grouped `Form`) with a contextual footer.
- **ChatView header:** a compact "Always ask" `Toggle`, shown only when ACP is on, with a tooltip.
- **Inline `PermissionApprovalView`:** a `.regularMaterial` card above the composer when a pending request exists — request title + **Approve** (`.borderedProminent`) / **Reject** (`.bordered`), mapped from the agent's offered options (`allow_*` → Approve). Tap → unblocks the agent.

## Tests

- **16 new `ACPWiringTests`** (factory selection + defaults, ACP profile hints, turn-end synthesis, drain-on-cancel single/multiple/idle) + the 15 existing `ACPBackendTests` → **31 ACP tests pass**.
- **Full suite: 2119 pass.** `swift build` clean. Default-OFF verified (`useACPBackend == false` → `ClaudeCLIBackend`).

## Not verified / follow-ups

- **Live end-to-end approval is not exercised** — it needs a configured ACP agent subprocess (the app is the ACP *client*). The full path `agent emits session/request_permission → PermissionApprovalView → Approve → resolvePermission → agent unblocks` requires an installed ACP agent (e.g. `@agentclientprotocol/claude-agent-acp`). If ACP is on but the executable isn't an ACP agent, it surfaces as a `preflightError`. Flagged in code comments.
- **always-ask depends on the agent emitting `request_permission`** — most do, not all → yolo is the safe default.
- **Slice 3 (#217):** provider/agent picker + auth UI (today the ACP agent comes from the Agent command config; no auth UI).
- Mode is app-wide `@AppStorage` for v1 (avoids a `chats` schema migration); a per-chat persisted mode is a later refinement.

## Not in this PR

Ingest/Lint/pdf untouched. Default-OFF, so existing users see no change unless they enable the ACP backend in Settings.
