### PR TITLE
Add debug logging for SQLite transactions and database connections

### DIFF
--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -2647,6 +2647,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             displayName = nil
         }
 
+        DebugLog.store("addSource ENTER filename=\(filename) bytes=\(data.count) thread=\(Thread.current)")
         return try mutate(event: { source in localEvent(.source, id: source.id.rawValue, change: .created) }) {
         guard data.count <= Self.ingestByteCap else {
             throw WikiStoreError.unexpected(
@@ -4817,7 +4818,14 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let depth = transactionDepth
         let savepoint = "wiki_txn_\(depth)"
         if depth == 0 {
-            try exec("BEGIN IMMEDIATE;")
+            let start = DispatchTime.now()
+            do {
+                try exec("BEGIN IMMEDIATE;")
+            } catch {
+                let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+                DebugLog.store("withTransaction BEGIN IMMEDIATE failed after \(elapsedMs)ms — \(error)")
+                throw error
+            }
         } else {
             try exec("SAVEPOINT \(savepoint);")
         }
@@ -4918,6 +4926,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         defer { sqlite3_free(errmsg) }
         guard rc == SQLITE_OK else {
             let msg = errmsg.map { String(cString: $0) } ?? SQLiteStatement.message(db)
+            if rc == SQLITE_BUSY || rc == SQLITE_LOCKED {
+                DebugLog.store("exec BUSY/LOCKED rc=\(rc) sql=\(sql) thread=\(Thread.current) msg=\(msg)")
+            }
             throw WikiStoreError.sqlite(code: rc, message: msg)
         }
     }

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -350,6 +350,7 @@ struct Projection {
             if cachedStore == nil {
                 let url = databaseURL ?? DatabaseLocation.extensionContainerURL(forWikiID: wikiID)
                 if let url, FileManager.default.fileExists(atPath: url.path) {
+                    DebugLog.fileprovider("ReadScope opening cached read-only connection wikiID=\(wikiID) thread=\(Thread.current)")
                     cachedStore = try? SQLiteWikiStore(readOnlyURL: url)
                 }
             }
@@ -378,6 +379,7 @@ struct Projection {
         if let scope = readStoreHolder { return scope.store }
         let url = databaseURL ?? DatabaseLocation.extensionContainerURL(forWikiID: wikiID)
         guard let url, FileManager.default.fileExists(atPath: url.path) else { return nil }
+        DebugLog.fileprovider("openReadStore opening short-lived read-only connection wikiID=\(wikiID) thread=\(Thread.current)")
         return try? SQLiteWikiStore(readOnlyURL: url)
     }
 


### PR DESCRIPTION
Adds comprehensive debug logging to track SQLite transaction and connection behavior, particularly for diagnosing concurrency issues and lock contention.

## Changes

- **Transaction initialization**: Log elapsed time and detailed error info when `BEGIN IMMEDIATE` fails
- **Source ingestion**: Log entry point with filename, data size, and thread ID
- **Lock contention**: Log `SQLITE_BUSY` and `SQLITE_LOCKED` errors with SQL statement and thread info
- **Read-only connections**: Log lifecycle events in file provider (cached and short-lived connection opens)

These logs will help identify transaction deadlocks, lock timeouts, and cross-thread database access patterns during investigation of concurrency issues.