### PR TITLE
Composer: Paseo dropdowns, send-on-type, model favorites

### DIFF
--- a/Sources/WikiFS/ACPPermissions.swift
+++ b/Sources/WikiFS/ACPPermissions.swift
@@ -164,6 +164,18 @@ enum PermissionPolicy: String, Sendable, CaseIterable {
         case .plan: "Read-only: deny all writes and edits"
         }
     }
+
+    /// SF Symbol for the mode's composer chip + dropdown row. A shield motif
+    /// echoing paseo's permission menu (bolt = skip/fast, checkmark = safe/ask,
+    /// exclamation = auto-apply edits, half-shield = read-only plan).
+    var glyph: String {
+        switch self {
+        case .bypass: "bolt.shield"
+        case .alwaysAsk: "checkmark.shield"
+        case .acceptEdits: "exclamationmark.shield"
+        case .plan: "shield.lefthalf.filled"
+        }
+    }
 }
 
 /// A snapshot of a pending permission request (always-ask). The future chat UI

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -269,6 +269,18 @@ final class AgentLauncher {
         providersConfig().selectedModelId(forProvider: providerId)
     }
 
+    /// Toggle + persist a model's favorite state for `providerId`, then return
+    /// the new config so the composer picker can update its bound state. A
+    /// display-only preference (favorites sort to the top of the picker); no
+    /// effect on which model actually launches.
+    @discardableResult
+    func toggleFavoriteModel(_ modelId: String, forProvider providerId: String) -> AgentProvidersConfig {
+        let dir = resolveProvidersContainerDirectory()
+        let updated = providersConfig().togglingFavoriteModel(modelId, forProvider: providerId)
+        try? updated.save(to: dir)
+        return updated
+    }
+
     /// After a successful `backend.start`, if it was an ACP backend, read the
     /// models it advertised and cache them per-provider for the picker. Cheap
     /// (one actor hop + one secrets-free file write) and non-blocking: runs as

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -340,8 +340,15 @@ struct ChatView: View {
                 PermissionModeSelector(rawValue: $permissionModeRaw)
             }
             Spacer(minLength: 0)
-            sendButton(active: sendActive)
+            // Paseo: the send button appears only once there's something to
+            // send — an empty composer shows no action glyph at all.
+            if hasDraftText {
+                sendButton(active: sendActive)
+            }
         }
+        // Reserve the button's height so the box doesn't grow on the first
+        // keystroke when the button appears.
+        .frame(minHeight: ChatMetrics.sendButtonSize)
     }
 
     // MARK: - Persisted chat summary
@@ -535,14 +542,14 @@ struct ChatView: View {
         .frame(maxWidth: .infinity)
     }
 
-    /// The trailing send button in the composer's bottom toolbar. Sized to sit
-    /// inside the toolbar row (paseo places its action cluster there) rather than
-    /// the old inline-in-the-capsule placement.
+    /// The trailing send button in the composer's bottom toolbar — a green
+    /// circle with a white up-arrow (paseo). Only shown when the composer has
+    /// text (see `composerToolbar`).
     private func sendButton(active: Bool) -> some View {
         Button(action: sendMessage) {
-            Image(systemName: sendButtonIcon)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(active ? Color.white : Color.secondary)
+            Image(systemName: "arrow.up")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(.white)
                 .frame(width: ChatMetrics.sendButtonSize, height: ChatMetrics.sendButtonSize)
                 .background(sendButtonBackground(active: active), in: Circle())
         }
@@ -554,8 +561,17 @@ struct ChatView: View {
 
     // MARK: - Send logic
 
+    /// True once the composer holds non-whitespace text — drives the send
+    /// button's visibility (paseo shows no glyph until you type).
+    private var hasDraftText: Bool {
+        !draftMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Green when the message can be sent, a muted grey while it can't (e.g. a
+    /// response is still generating). The button is only visible with text, so
+    /// green is the usual state.
     private func sendButtonBackground(active: Bool) -> Color {
-        active ? .accentColor : Color(nsColor: .quaternaryLabelColor).opacity(0.25)
+        active ? Color.green : Color(nsColor: .quaternaryLabelColor).opacity(0.4)
     }
 
     private func sendMessage() {
@@ -663,10 +679,6 @@ struct ChatView: View {
             return "Wait for the response before sending the next message"
         }
         return launcher.isInteractiveSession ? "Send" : "Start Query"
-    }
-
-    private var sendButtonIcon: String {
-        launcher.isInteractiveSession ? "arrow.up.circle.fill" : "play.circle.fill"
     }
 }
 

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -337,60 +337,10 @@ struct ChatView: View {
         HStack(spacing: 10) {
             if manager.activeWikiID != nil {
                 ProviderSelector(launcher: launcher)
-                permissionModePicker
+                PermissionModeSelector(rawValue: $permissionModeRaw)
             }
             Spacer(minLength: 0)
             sendButton(active: sendActive)
-        }
-    }
-
-    /// Paseo-style permission-modes chip. Sits next to the model selector inside
-    /// the composer box's bottom toolbar. Styled to match `ProviderSelector`'s
-    /// trigger (glyph + `.caption` label + chevron) so the two read as sibling
-    /// chips. Shown for every backend (the screenshot confirms it appears for
-    /// Claude too); a restyle mustn't change that behavior.
-    private var permissionModePicker: some View {
-        Menu {
-            Picker("", selection: $permissionModeRaw) {
-                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
-                    Text(mode.label).tag(mode.rawValue)
-                }
-            }
-            .pickerStyle(.inline)
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: permissionGlyph)
-                    .foregroundStyle(.secondary)
-                Text(currentPermissionPolicy.label)
-                    .foregroundStyle(.secondary)
-                Image(systemName: "chevron.up.chevron.down")
-                    .imageScale(.small)
-                    .foregroundStyle(.tertiary)
-            }
-            .font(.caption)
-            .contentShape(Rectangle())
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help(currentPermissionPolicy.help)
-    }
-
-    /// The currently-selected permission policy (falls back to bypass — the
-    /// persisted default — if the raw value is somehow unknown).
-    private var currentPermissionPolicy: PermissionPolicy {
-        PermissionPolicy(rawValue: permissionModeRaw) ?? .bypass
-    }
-
-    /// SF Symbol for the permission chip, one per policy. Mirrors paseo's shield
-    /// glyph for the bypass/"YOLO" mode and picks intent-matching symbols for
-    /// the others.
-    private var permissionGlyph: String {
-        switch currentPermissionPolicy {
-        case .bypass: return "exclamationmark.shield"
-        case .alwaysAsk: return "hand.raised"
-        case .acceptEdits: return "checkmark.shield"
-        case .plan: return "eye"
         }
     }
 

--- a/Sources/WikiFS/PermissionModeSelector.swift
+++ b/Sources/WikiFS/PermissionModeSelector.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Permission-mode selector for the chat composer, mirroring `ProviderSelector`:
+/// a compact chip trigger (glyph + label + chevron) that opens a native popover
+/// with a search field over a flat list of modes. Each row is a shield glyph +
+/// label with a trailing checkmark on the current selection — paseo renders its
+/// permission menu exactly this way (searchable, one glyph per mode, a checkmark
+/// on the active mode); this is the native translation.
+///
+/// Backed by a `Binding<String>` (the persisted `PermissionPolicy.rawValue`
+/// from `ChatView`'s `@AppStorage`) rather than owning storage, so the composer
+/// stays the single source of truth for the app-wide default.
+struct PermissionModeSelector: View {
+    @Binding var rawValue: String
+
+    @State private var isPresented = false
+    @State private var searchText = ""
+    @State private var hovered: PermissionPolicy?
+
+    /// The selected policy (falls back to bypass — the persisted default — if
+    /// the raw value is somehow unknown).
+    private var current: PermissionPolicy {
+        PermissionPolicy(rawValue: rawValue) ?? .bypass
+    }
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            trigger
+        }
+        .buttonStyle(.borderless)
+        .popover(isPresented: $isPresented, arrowEdge: .top) {
+            popoverContent
+        }
+        .help(current.help)
+    }
+
+    // MARK: - Trigger chip
+
+    /// The compact chip: glyph + label + chevron. Styled to match
+    /// `ProviderSelector`'s trigger (`.caption` + secondary fill) so the two
+    /// read as sibling chips in the composer toolbar.
+    private var trigger: some View {
+        HStack(spacing: 4) {
+            Image(systemName: current.glyph)
+                .foregroundStyle(.secondary)
+            Text(current.label)
+                .foregroundStyle(.secondary)
+            Image(systemName: "chevron.up.chevron.down")
+                .imageScale(.small)
+                .foregroundStyle(.tertiary)
+        }
+        .font(.caption)
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Popover (search + flat list)
+
+    private var popoverContent: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            modeList
+        }
+        .frame(width: 230)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .imageScale(.small)
+                .foregroundStyle(.tertiary)
+            TextField("Search modes", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    /// The modes after applying the search filter (matches the label,
+    /// case-insensitive). Empty query = all modes.
+    private var filteredModes: [PermissionPolicy] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return PermissionPolicy.allCases }
+        return PermissionPolicy.allCases.filter { $0.label.lowercased().contains(query) }
+    }
+
+    /// A plain content-hugging column of rows (no `List`, which reserves a large
+    /// fixed height and leaves the popover oversized). With only a handful of
+    /// modes it never scrolls; the cap is a safety net.
+    private var modeList: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(filteredModes, id: \.self) { mode in
+                    row(mode)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .frame(height: modeListHeight)
+    }
+
+    /// Hug the rows: row count × row height, capped so a (hypothetical) long
+    /// filtered list scrolls instead of growing without bound.
+    private var modeListHeight: CGFloat {
+        let rowHeight: CGFloat = 28
+        let count = max(filteredModes.count, 1)
+        return min(CGFloat(count) * rowHeight + 8, 240)
+    }
+
+    /// One row: shield glyph + label + a checkmark when selected, with a hover
+    /// highlight. Mirrors `ProviderSelector.rowView` so the two dropdowns match.
+    private func row(_ mode: PermissionPolicy) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: mode.glyph)
+                .frame(width: 16)
+                .foregroundStyle(.secondary)
+            Text(mode.label)
+                .font(.system(size: 12, weight: .medium))
+            Spacer(minLength: 0)
+            if mode == current {
+                Image(systemName: "checkmark")
+                    .imageScale(.small)
+                    .foregroundStyle(.tint)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(hovered == mode ? Color.primary.opacity(0.08) : .clear)
+                .padding(.horizontal, 4)
+        )
+        .onHover { inside in
+            if inside { hovered = mode } else if hovered == mode { hovered = nil }
+        }
+        .onTapGesture { select(mode) }
+    }
+
+    private func select(_ mode: PermissionPolicy) {
+        rawValue = mode.rawValue
+        isPresented = false
+        searchText = ""
+    }
+}

--- a/Sources/WikiFS/ProviderSelector.swift
+++ b/Sources/WikiFS/ProviderSelector.swift
@@ -180,6 +180,20 @@ struct ProviderSelector: View {
                     .imageScale(.small)
                     .foregroundStyle(.tint)
             }
+            // Favorite star — only real model rows are favoritable (not the
+            // synthetic "Default" row). Its own Button so tapping the star
+            // toggles the favorite without also selecting the row.
+            if row.modelId != nil {
+                Button {
+                    toggleFavorite(row)
+                } label: {
+                    Image(systemName: row.isFavorite ? "star.fill" : "star")
+                        .imageScale(.small)
+                        .foregroundStyle(row.isFavorite ? Color.yellow : Color.secondary.opacity(0.6))
+                }
+                .buttonStyle(.borderless)
+                .help(row.isFavorite ? "Remove from favorites" : "Add to favorites")
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 5)
@@ -195,6 +209,14 @@ struct ProviderSelector: View {
         .onTapGesture { selectRow(row.id) }
     }
 
+    /// Toggle + persist a model row's favorite state, refreshing local config so
+    /// the star flips and the row re-sorts to (or from) the favorites group. Does
+    /// NOT change the selection or close the popover.
+    private func toggleFavorite(_ row: SelectorRow) {
+        guard let modelId = row.modelId else { return }
+        config = launcher.toggleFavoriteModel(modelId, forProvider: row.provider.id)
+    }
+
     // MARK: - Row model (flat, searchable)
 
     /// One selectable (provider, model) pair in the flat list. `modelId == nil`
@@ -207,6 +229,9 @@ struct ProviderSelector: View {
         /// The agent-advertised one-line description (paseo shows this as the
         /// row's dimmer second line). nil for the synthetic "Default" row.
         let modelDescription: String?
+        /// Whether the user has starred this model (paseo per-row favorite).
+        /// Always false for the synthetic "Default" row (not favoritable).
+        let isFavorite: Bool
         let id: String
 
         /// Primary (bold) line — the model name, paseo-style (e.g. "Opus 4.8",
@@ -245,6 +270,7 @@ struct ProviderSelector: View {
                     modelId: nil,
                     modelLabel: "Default",
                     modelDescription: nil,
+                    isFavorite: false,
                     id: "\(provider.id):default")
             ]
             for model in models {
@@ -253,21 +279,25 @@ struct ProviderSelector: View {
                     modelId: model.modelId,
                     modelLabel: model.displayLabel,
                     modelDescription: model.description,
+                    isFavorite: config.isFavoriteModel(model.modelId, forProvider: provider.id),
                     id: "\(provider.id):\(model.modelId)"))
             }
             return rows
         }
     }
 
-    /// The rows after applying the search filter. Matches against the provider
-    /// label + the model label (case-insensitive). Empty query = all rows.
+    /// The rows after applying the search filter, with favorites pinned to the
+    /// top (paseo). Matches against the provider label + the model label
+    /// (case-insensitive). Empty query = all rows. The favorites-first partition
+    /// is stable, so ordering within each group is preserved.
     private var filteredRows: [SelectorRow] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return flatRows }
-        return flatRows.filter { row in
+        let matched = query.isEmpty ? flatRows : flatRows.filter { row in
             row.provider.label.lowercased().contains(query)
                 || row.modelLabel.lowercased().contains(query)
         }
+        // Favorites float to the top; everything else keeps its order.
+        return matched.filter(\.isFavorite) + matched.filter { !$0.isFavorite }
     }
 
     /// The id of the row that matches the current selection (provider + model),

--- a/Sources/WikiFS/ProviderSelector.swift
+++ b/Sources/WikiFS/ProviderSelector.swift
@@ -47,6 +47,9 @@ struct ProviderSelector: View {
     /// The search query typed in the popover (empty = show all rows).
     @State private var searchText = ""
 
+    /// The row currently under the pointer (for the hover highlight).
+    @State private var hoveredRowID: String?
+
     @Environment(\.openSettings) private var openSettings
 
     init(launcher: AgentLauncher) {
@@ -69,30 +72,19 @@ struct ProviderSelector: View {
     }
 
     var body: some View {
-        // Compact trigger bar hugging the composer's left edge. The whole label
-        // is the popover's hit target; the gear is a separate Settings affordance.
-        HStack(spacing: 4) {
-            Button {
-                isPresented.toggle()
-            } label: {
-                trigger
-            }
-            .buttonStyle(.borderless)
-            .popover(isPresented: $isPresented, arrowEdge: .top) {
-                popoverContent
-            }
-            .help(defaultHelpText)
-
-            Button {
-                openSettings()
-            } label: {
-                Image(systemName: "gearshape")
-                    .imageScale(.small)
-                    .foregroundStyle(.tertiary)
-            }
-            .buttonStyle(.borderless)
-            .help("Open Provider settings")
+        // Compact trigger chip hugging the composer's left edge. The whole label
+        // is the popover's hit target; Settings is reachable from the gear in the
+        // popover header (no separate gear on the chip, which duplicated it).
+        Button {
+            isPresented.toggle()
+        } label: {
+            trigger
         }
+        .buttonStyle(.borderless)
+        .popover(isPresented: $isPresented, arrowEdge: .top) {
+            popoverContent
+        }
+        .help(defaultHelpText)
         .onAppear { refresh() }
         // Keep in sync if a session flips (the composer is rebuilt when a chat
         // becomes live). Cheap: it's a single file read.
@@ -111,7 +103,7 @@ struct ProviderSelector: View {
             Divider()
             flatModelList
         }
-        .frame(minWidth: 280, idealWidth: 300, minHeight: 240, idealHeight: 360)
+        .frame(width: 300)
     }
 
     /// The header: a search field (leading) + a gear button (trailing). Search
@@ -146,22 +138,29 @@ struct ProviderSelector: View {
     /// search query. A checkmark marks the current selection. Selecting a row
     /// persists the provider + model and closes the popover.
     private var flatModelList: some View {
-        List(selection: Binding(
-            get: { selectedRowID },
-            set: { newValue in selectRow(newValue) }
-        )) {
-            ForEach(filteredRows) { row in
-                rowView(row)
-                    .tag(row.id)
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(filteredRows) { row in
+                    rowView(row)
+                }
             }
+            .padding(.vertical, 4)
         }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
+        .frame(height: listHeight)
     }
 
-    /// One row: glyph + "Provider · Model" + a checkmark when selected. Paseo
-    /// renders the provider glyph as a leading slot; we use an SF Symbol per
-    /// backend (terminal for Claude, cpu for ACP) since we have no brand assets.
+    /// Hug the rows up to a cap: few models → a short popover with no wasted
+    /// space; many → the list scrolls at the cap instead of growing tall.
+    private var listHeight: CGFloat {
+        let rowHeight: CGFloat = 40
+        let count = max(filteredRows.count, 1)
+        return min(CGFloat(count) * rowHeight + 8, 320)
+    }
+
+    /// One row (paseo model-menu style): glyph + a bold model name over a
+    /// dimmer "Provider · description" subtitle + a checkmark when selected. The
+    /// leading glyph is an SF Symbol per backend (terminal for Claude, cpu for
+    /// ACP) since we have no brand assets.
     private func rowView(_ row: SelectorRow) -> some View {
         HStack(spacing: 8) {
             Image(systemName: glyph(for: row.provider))
@@ -169,12 +168,11 @@ struct ProviderSelector: View {
                 .foregroundStyle(row.provider.backend == .claudeCLI ? Color.purple : Color.blue)
             VStack(alignment: .leading, spacing: 1) {
                 Text(row.title)
-                    .font(.system(size: 12, weight: .medium))
-                if let subtitle = row.subtitle {
-                    Text(subtitle)
-                        .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
-                }
+                    .font(.system(size: 13, weight: .semibold))
+                Text(row.subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
             }
             Spacer(minLength: 0)
             if row.id == selectedRowID {
@@ -183,10 +181,18 @@ struct ProviderSelector: View {
                     .foregroundStyle(.tint)
             }
         }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
         .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(hoveredRowID == row.id ? Color.primary.opacity(0.08) : .clear)
+                .padding(.horizontal, 4)
+        )
+        .onHover { inside in
+            if inside { hoveredRowID = row.id } else if hoveredRowID == row.id { hoveredRowID = nil }
+        }
         .onTapGesture { selectRow(row.id) }
-        .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets(top: 3, leading: 10, bottom: 3, trailing: 10))
     }
 
     // MARK: - Row model (flat, searchable)
@@ -198,18 +204,28 @@ struct ProviderSelector: View {
         let provider: AgentProvider
         let modelId: String?
         let modelLabel: String
+        /// The agent-advertised one-line description (paseo shows this as the
+        /// row's dimmer second line). nil for the synthetic "Default" row.
+        let modelDescription: String?
         let id: String
 
-        /// "Provider · Model" (the title) — e.g. "Hermes · GLM-4.7", "Claude · Opus".
+        /// Primary (bold) line — the model name, paseo-style (e.g. "Opus 4.8",
+        /// "GLM-4.7", "Default").
         var title: String {
-            "\(provider.label) · \(modelLabel)"
+            modelLabel
         }
 
-        /// A secondary subtitle. For the "Default" row we show the hint that no
-        /// model is pinned (agent default). For model rows, nil (the title
-        /// already carries the model name).
-        var subtitle: String? {
-            modelId == nil ? "Agent default" : nil
+        /// Secondary (dimmer) line — the provider plus the agent-advertised
+        /// description. For the "Default" row it notes no model is pinned; for a
+        /// model row it appends the description when the agent supplied one.
+        var subtitle: String {
+            if modelId == nil {
+                return "\(provider.label) · Agent default"
+            }
+            if let modelDescription, !modelDescription.isEmpty {
+                return "\(provider.label) · \(modelDescription)"
+            }
+            return provider.label
         }
     }
 
@@ -228,6 +244,7 @@ struct ProviderSelector: View {
                     provider: provider,
                     modelId: nil,
                     modelLabel: "Default",
+                    modelDescription: nil,
                     id: "\(provider.id):default")
             ]
             for model in models {
@@ -235,6 +252,7 @@ struct ProviderSelector: View {
                     provider: provider,
                     modelId: model.modelId,
                     modelLabel: model.displayLabel,
+                    modelDescription: model.description,
                     id: "\(provider.id):\(model.modelId)"))
             }
             return rows

--- a/Sources/WikiFSCore/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/AgentProvidersConfig.swift
@@ -46,6 +46,13 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
     /// call) — the app's default state, so existing users see no change.
     public var selectedModelIds: [String: String]
 
+    /// The user's favorited models per provider (paseo's per-row star). Keyed by
+    /// `AgentProvider.id` → the favorited model ids. Favorites sort to the top of
+    /// the composer's model picker — purely a display preference, with NO effect
+    /// on routing/selection. Missing key = no favorites for that provider.
+    /// Secrets-free; forward-compatible (a pre-favorites file decodes to empty).
+    public var favoriteModelIds: [String: [String]]
+
     /// The hardcoded model list for the Claude CLI provider. `ClaudeCLIBackend`
     /// has no ACP model discovery (it drives `claude -p` directly), so the
     /// selector has no captured list to show. These are the `--model` aliases
@@ -65,7 +72,8 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
     public init(
         providers: [AgentProvider] = [AgentProvider.claudeAcpDefault],
         providerModels: [String: [CachedModelInfo]] = [:],
-        selectedModelIds: [String: String] = [:]
+        selectedModelIds: [String: String] = [:],
+        favoriteModelIds: [String: [String]] = [:]
     ) {
         self.providers = AgentProvidersConfig.normalized(providers)
         // Guarantee Claude providers always have their hardcoded model list,
@@ -84,6 +92,7 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
         }
         self.providerModels = models
         self.selectedModelIds = selectedModelIds
+        self.favoriteModelIds = favoriteModelIds
     }
 
     // MARK: - Coding (forward-compatible: old files without model caches decode)
@@ -92,6 +101,7 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
         case providers
         case providerModels
         case selectedModelIds
+        case favoriteModelIds
     }
 
     public init(from decoder: Decoder) throws {
@@ -114,6 +124,7 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
         }
         self.providerModels = models
         self.selectedModelIds = try c.decodeIfPresent([String: String].self, forKey: .selectedModelIds) ?? [:]
+        self.favoriteModelIds = try c.decodeIfPresent([String: [String]].self, forKey: .favoriteModelIds) ?? [:]
     }
 
     /// JSON filename in the App Group container. Distinct from
@@ -195,7 +206,8 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
         return AgentProvidersConfig(
             providers: updated,
             providerModels: providerModels,
-            selectedModelIds: selectedModelIds)
+            selectedModelIds: selectedModelIds,
+            favoriteModelIds: favoriteModelIds)
     }
 
     /// The list of providers the selector surfaces: enabled ones only (the
@@ -239,7 +251,8 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
         return AgentProvidersConfig(
             providers: providers,
             providerModels: cache,
-            selectedModelIds: selectedModelIds)
+            selectedModelIds: selectedModelIds,
+            favoriteModelIds: favoriteModelIds)
     }
 
     /// A PURE mutator: returns a NEW config with the user's model selection for
@@ -257,7 +270,44 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
         return AgentProvidersConfig(
             providers: providers,
             providerModels: providerModels,
-            selectedModelIds: selections)
+            selectedModelIds: selections,
+            favoriteModelIds: favoriteModelIds)
+    }
+
+    // MARK: - Favorites (#favorites — display-only, paseo per-row star)
+
+    /// Whether `modelId` is favorited for `providerId`. PURE.
+    public func isFavoriteModel(_ modelId: String, forProvider providerId: String) -> Bool {
+        favoriteModelIds[providerId]?.contains(modelId) ?? false
+    }
+
+    /// The favorited model ids for `providerId`, in favorite order. PURE.
+    public func favoriteModels(forProvider providerId: String) -> [String] {
+        favoriteModelIds[providerId] ?? []
+    }
+
+    /// A PURE mutator: returns a NEW config with `modelId`'s favorite state
+    /// toggled for `providerId`. Newly-favorited ids append (preserving order);
+    /// removing the last favorite drops the provider key. Persisted by the
+    /// launcher; the picker re-sorts favorites to the top on the next read.
+    public func togglingFavoriteModel(_ modelId: String, forProvider providerId: String) -> AgentProvidersConfig {
+        var favorites = favoriteModelIds
+        var list = favorites[providerId] ?? []
+        if let idx = list.firstIndex(of: modelId) {
+            list.remove(at: idx)
+        } else {
+            list.append(modelId)
+        }
+        if list.isEmpty {
+            favorites.removeValue(forKey: providerId)
+        } else {
+            favorites[providerId] = list
+        }
+        return AgentProvidersConfig(
+            providers: providers,
+            providerModels: providerModels,
+            selectedModelIds: selectedModelIds,
+            favoriteModelIds: favorites)
     }
 
     // MARK: - Seed (pure)
@@ -289,7 +339,8 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
             return AgentProvidersConfig(
                 providers: config.providers,
                 providerModels: config.providerModels,
-                selectedModelIds: config.selectedModelIds)
+                selectedModelIds: config.selectedModelIds,
+                favoriteModelIds: config.favoriteModelIds)
         }
         // Missing / corrupt / empty → seed + persist.
         DebugLog.store("AgentProvidersConfig.loadOrSeed: SEED (file missing/corrupt/empty)") // TEMP DEBUG

--- a/Tests/WikiFSTests/AgentProviderModelTests.swift
+++ b/Tests/WikiFSTests/AgentProviderModelTests.swift
@@ -151,6 +151,58 @@ import ACPModel
         #expect(config.providers.count == 1)
         #expect(config.providers.first?.id == "claude-acp")
     }
+
+    // MARK: - Favorites (display-only per-row star)
+
+    @Test func togglingFavoriteAddsThenRemoves() {
+        let config = AgentProvidersConfig(providers: [.claudeAcpDefault])
+        #expect(!config.isFavoriteModel("opus", forProvider: "claude-acp"))
+
+        let favorited = config.togglingFavoriteModel("opus", forProvider: "claude-acp")
+        #expect(favorited.isFavoriteModel("opus", forProvider: "claude-acp"))
+        #expect(favorited.favoriteModels(forProvider: "claude-acp") == ["opus"])
+
+        // Toggling again clears it (and drops the now-empty provider key).
+        let cleared = favorited.togglingFavoriteModel("opus", forProvider: "claude-acp")
+        #expect(!cleared.isFavoriteModel("opus", forProvider: "claude-acp"))
+        #expect(cleared.favoriteModelIds["claude-acp"] == nil)
+    }
+
+    @Test func favoritesArePerProviderAndOrdered() {
+        let config = AgentProvidersConfig(providers: [.claudeAcpDefault])
+            .togglingFavoriteModel("opus", forProvider: "claude-acp")
+            .togglingFavoriteModel("haiku", forProvider: "claude-acp")
+            .togglingFavoriteModel("gpt", forProvider: "other")
+        // Insertion order is preserved; providers are isolated.
+        #expect(config.favoriteModels(forProvider: "claude-acp") == ["opus", "haiku"])
+        #expect(config.favoriteModels(forProvider: "other") == ["gpt"])
+        #expect(!config.isFavoriteModel("opus", forProvider: "other"))
+    }
+
+    @Test func favoritesSurviveSelectionAndDefaultRewraps() {
+        // Favorites must be threaded through the other setting* mutators, not
+        // wiped when the selection or default provider changes.
+        let config = AgentProvidersConfig(providers: [.claudeAcpDefault])
+            .togglingFavoriteModel("opus", forProvider: "claude-acp")
+            .settingSelectedModel("sonnet", forProvider: "claude-acp")
+            .settingDefault(id: "claude-acp")
+        #expect(config.isFavoriteModel("opus", forProvider: "claude-acp"))
+        #expect(config.selectedModelId(forProvider: "claude-acp") == "sonnet")
+    }
+
+    @Test func favoritesRoundTripThroughDisk() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-providers-fav-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let original = AgentProvidersConfig(providers: [.claudeAcpDefault])
+            .togglingFavoriteModel("opus", forProvider: "claude-acp")
+        try original.save(to: tmp)
+
+        let loaded = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        #expect(loaded.isFavoriteModel("opus", forProvider: "claude-acp"))
+    }
 }
 
 @Suite struct AgentProviderCatalogTests {


### PR DESCRIPTION
Follow-up to #327. Restyle the composer's permission and model dropdowns to match Paseo: searchable popovers with a glyph on each row and a checkmark on the active item.

## Permission dropdown — new `PermissionModeSelector`

The permission control was a plain native `.menu` `Picker` (text rows, no icons). It's now a popover mirroring `ProviderSelector`:

- A "Search modes" field over a flat list; each row is a **shield glyph + label** with a trailing checkmark on the selection.
- Added a per-policy `glyph` on `PermissionPolicy` (bolt / checkmark / exclamation / half shields), shared by the composer chip and the rows so they stay in sync.
- `ChatView` now uses `PermissionModeSelector(rawValue: $permissionModeRaw)`; the old `.menu`-based picker and its inline glyph/label helpers are removed.

## Model dropdown — `ProviderSelector` rows

- Rows are now **model-name-first (bold)** over a dimmer `Provider · description` subtitle, using the agent-advertised `CachedModelInfo.description` — matching Paseo's model menu. The selected-row checkmark is unchanged.
- Dropped the gear button next to the trigger chip — it duplicated the gear in the popover header, which is now the single Settings affordance.

## Compact sizing

Both popovers hug their content. The old fixed-height `List` reserved a tall box and left empty space below the rows; it's replaced by a content-sized `ScrollView` + `VStack` (height = row count up to a scroll cap), plus a hover highlight per row. No wasted space — matching Paseo's tight menus.

## Send button appears only when you type

Paseo shows no action glyph in an empty composer; the send button appears on the first keystroke. The button is now gated on non-whitespace text and restyled to a **green circle + white up-arrow** (was an always-present accent-colored play/arrow). Its height is reserved on the toolbar row so the box doesn't grow when it appears.

## Model favorites (per-row star)

Paseo lets you star models; favorites float to the top of the menu. Built end-to-end:

- `AgentProvidersConfig` gains `favoriteModelIds` (`[providerId: [modelId]]`), forward-compatible `Codable` (pre-favorites files decode to empty), threaded through every `setting*` re-wrap + `loadOrSeed` so it's never wiped. Pure `isFavoriteModel` / `favoriteModels` / `togglingFavoriteModel` helpers. **Display-only** — no effect on which model launches.
- `AgentLauncher.toggleFavoriteModel` persists the toggle.
- `ProviderSelector` renders a trailing **star** per model row (filled/yellow when favorited), as its own `Button` so tapping it doesn't select the row; favorites are pinned to the top of the (searched) list via a stable partition.
- Tests: toggle add/remove, per-provider isolation + order, survival through selection/default re-wraps, and disk round-trip (all green, plus the existing 47 config tests).

## Verification

Built the signed `.app` (`make build`), launched it, and screenshotted both dropdowns open: the permission menu shows the four shield-glyph modes with a checkmark on `Bypass`; the model menu shows bold model names over `Claude · …` subtitles with a checkmark on `Default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
