### PR TITLE
Fix omnibox toolbar: keep trailing controls flush right (#114)

### DIFF
--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -58,12 +58,39 @@ struct AddressBarView: View {
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
 
     var body: some View {
-        // Back / Forward + the omnibox are one `.navigation` group, flush-left in
-        // the detail region. The nav buttons are fixed-width; the field is given an
-        // explicit width (`fieldWidth`) so it stretches from just after them to the
-        // trailing wiki switcher, shrinking as the window narrows / the wiki name
-        // grows and expanding once the switcher overflows (see `OmniboxLayout`).
-        HStack(spacing: 6) {
+        // Back / Forward (+ Home) + the omnibox are one `.navigation` group,
+        // flush-left in the detail region. The nav cluster sits tightly grouped on
+        // its own (Safari-style), separated from the omnibox pill by a wider gap so
+        // it doesn't read as fused to it. The nav buttons are fixed-width; the field
+        // is given an explicit width (`fieldWidth`) so it stretches from just after
+        // the gap to the trailing wiki switcher, shrinking as the window narrows /
+        // the wiki name grows and expanding once the switcher overflows (see
+        // `OmniboxLayout`). The gap's width is baked into `OmniboxLayout.Metrics`
+        // (`openLeadingChrome`/`closedLeadingChrome`) — changing the spacing here
+        // without updating those constants would reopen the flush-right bug fixed
+        // in issue #114, just at a different threshold.
+        HStack(spacing: AddressBarMetrics.navToOmniboxGap) {
+            navButtonGroup
+            omniboxGroup
+        }
+        // Cmd-L flips `isFocused`; turn that into a focus request for the field.
+        .onChange(of: isFocused) { _, focused in
+            if focused { focusToken &+= 1 }
+        }
+        // Empty state (no content loaded): focus the field so the user can type
+        // a search immediately — at launch and whenever the last tab closes.
+        .onAppear { focusIfEmpty() }
+        .onChange(of: hasContentLoaded) { _, loaded in
+            if !loaded { focusIfEmpty() }
+        }
+    }
+
+    /// Back / Forward (+ Home when the active wiki has one configured), grouped
+    /// tightly on their own so the cluster reads as a single control distinct from
+    /// the omnibox pill — the wider gap to `omniboxGroup` (`AddressBarMetrics.
+    /// navToOmniboxGap`, set on the parent `HStack`) does the actual separating.
+    private var navButtonGroup: some View {
+        HStack(spacing: AddressBarMetrics.navButtonSpacing) {
             navButton("chevron.left", help: "Go back", enabled: store.canNavigateBack) {
                 store.navigateBack()
             }
@@ -79,18 +106,28 @@ struct AddressBarView: View {
                     _ = store.selectPage(byID: homePageID)
                 }
             }
+        }
+    }
 
+    /// The omnibox field plus, once the field has hit its readability cap
+    /// (`OmniboxLayout.Metrics.maxWidth`), an invisible trailing spacer that
+    /// absorbs the rest of the space the field would otherwise have grown into.
+    /// Without this, the field stalls at `maxWidth` on wide windows while the
+    /// trailing wiki switcher and transcript toggle — separate, later toolbar
+    /// items — stay put, opening a gap between them and the true trailing edge
+    /// (issue #114). The spacer is zero-width below the cap, matching the old
+    /// behavior exactly.
+    private var omniboxGroup: some View {
+        HStack(spacing: 0) {
             omniboxField
-        }
-        // Cmd-L flips `isFocused`; turn that into a focus request for the field.
-        .onChange(of: isFocused) { _, focused in
-            if focused { focusToken &+= 1 }
-        }
-        // Empty state (no content loaded): focus the field so the user can type
-        // a search immediately — at launch and whenever the last tab closes.
-        .onAppear { focusIfEmpty() }
-        .onChange(of: hasContentLoaded) { _, loaded in
-            if !loaded { focusIfEmpty() }
+            if overflowSpacerWidth > 0 {
+                // `Color.clear` is still hit-testable by default — without this it
+                // would swallow clicks/drags over what reads as empty toolbar space
+                // (including the window-drag region past the cap), even though
+                // nothing is drawn there.
+                Color.clear.frame(width: overflowSpacerWidth)
+                    .allowsHitTesting(false)
+            }
         }
     }
 
@@ -152,7 +189,7 @@ struct AddressBarView: View {
         Button(action: action) {
             Image(systemName: symbol)
                 .font(.system(size: 15, weight: .medium))
-                .frame(width: 22, height: 28)
+                .frame(width: AddressBarMetrics.navButtonWidth, height: 28)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.borderless)
@@ -220,6 +257,20 @@ struct AddressBarView: View {
         return OmniboxLayout.fieldWidth(
             detailWidth: detailWidth,
             sidebarVisible: sidebarVisible,
+            homeButtonShown: homePageID != nil,
+            switcherExtra: switcherExtra)
+    }
+
+    /// Extra width appended after the field in `omniboxGroup` once `fieldWidth`
+    /// has hit its cap — keeps the trailing switcher/toggle flush against the
+    /// window edge instead of stalling short of it. Zero everywhere below the cap.
+    private var overflowSpacerWidth: CGFloat {
+        let switcherExtra = headlineTextWidth(wikiName)
+            - headlineTextWidth(AddressBarMetrics.baselineSwitcherName)
+        return OmniboxLayout.overflowSpacerWidth(
+            detailWidth: detailWidth,
+            sidebarVisible: sidebarVisible,
+            homeButtonShown: homePageID != nil,
             switcherExtra: switcherExtra)
     }
 
@@ -438,6 +489,20 @@ struct AddressResultsList: View {
 // MARK: - Metrics
 
 enum AddressBarMetrics {
+    /// Fixed width of each Back/Forward/Home nav button. Shared with
+    /// `OmniboxLayout.Metrics.homeButtonExtra`'s derivation — when the Home
+    /// button shows, the field's leading edge shifts right by exactly this plus
+    /// one `navButtonSpacing`.
+    static let navButtonWidth: CGFloat = 22
+    /// Spacing between Back/Forward/Home within `navButtonGroup` — tight, so the
+    /// cluster reads as one control.
+    static let navButtonSpacing: CGFloat = 4
+    /// Gap between `navButtonGroup` and the omnibox pill — wider than
+    /// `navButtonSpacing` so the nav cluster reads as visually distinct from the
+    /// omnibox rather than fused to it. This width is baked into
+    /// `OmniboxLayout.Metrics.openLeadingChrome`/`closedLeadingChrome`; changing it
+    /// here requires updating those constants by the same delta.
+    static let navToOmniboxGap: CGFloat = 14
     /// The wiki-switcher name the trailing reservation is tuned against. A name
     /// wider than this reserves the extra width (the omnibox yields it); a narrower
     /// one lets the omnibox reclaim it. Only the width *difference* is used, so the

--- a/Sources/WikiFS/OmniboxLayout.swift
+++ b/Sources/WikiFS/OmniboxLayout.swift
@@ -25,31 +25,54 @@ enum OmniboxLayout {
         /// The field never grows beyond this, so it isn't an unreadable line on a
         /// very wide monitor.
         var maxWidth: CGFloat
-        /// Fixed chrome to the field's left (Back/Forward/magnifier + gaps) when the
-        /// sidebar is *shown*. The traffic-light + sidebar-toggle zone then sits over
-        /// the sidebar, outside the measured detail region, so only the nav buttons
-        /// remain between the detail region's edge and the field.
+        /// Fixed chrome to the field's left (Back/Forward, the tight gap between
+        /// them, and the wider gap to the omnibox pill — `AddressBarMetrics.
+        /// navButtonSpacing`/`navToOmniboxGap`) when the sidebar is *shown*. The
+        /// traffic-light + sidebar-toggle zone then sits over the sidebar, outside
+        /// the measured detail region, so only the nav cluster + gap remain between
+        /// the detail region's edge and the field.
         var openLeadingChrome: CGFloat
         /// Fixed chrome to the field's left when the sidebar is *hidden*. The detail
         /// region now spans the whole window, so it includes the traffic lights +
-        /// sidebar toggle ahead of the nav buttons — a larger offset.
+        /// sidebar toggle ahead of the nav cluster — a larger offset.
         var closedLeadingChrome: CGFloat
+        /// Extra leading chrome added when the omnibox's Home button is shown (a
+        /// wiki with a configured home page, issue #280, adds a fourth nav
+        /// button). Equal to the button's own width (`AddressBarMetrics.
+        /// navButtonWidth`, 22) plus the one extra internal nav-cluster gap it
+        /// introduces (`AddressBarMetrics.navButtonSpacing`, 4). Previously
+        /// omitted entirely: the field's leading edge (and therefore its
+        /// trailing edge too, since width is computed from it) silently sat 26pt
+        /// further right than this math assumed for any wiki with a home page
+        /// configured — a WINDOW-WIDTH-INDEPENDENT encroachment into the
+        /// trailing switcher/toggle's reserved space, since it's a fixed offset
+        /// baked into every window size alike. That wiki's Toggle Transcript
+        /// button would sit in the `»` overflow permanently, not just past some
+        /// width threshold.
+        var homeButtonExtra: CGFloat
 
         static let `default` = Metrics(
             trailingWithSwitcher: 180,
             trailingOverflow: 60,
             minWidth: 120,
             maxWidth: 1200,
-            openLeadingChrome: 64,
-            closedLeadingChrome: 208)
+            openLeadingChrome: 70,
+            closedLeadingChrome: 214,
+            homeButtonExtra: 26)
     }
 
     /// Fixed chrome to the field's left, measured from the detail region's leading
     /// edge. It differs by sidebar state only because the traffic-light + toggle
     /// zone sits over the detail region when the sidebar is hidden and over the
-    /// sidebar when it's shown (see the `Metrics` fields).
-    static func leadingChrome(sidebarVisible: Bool, metrics: Metrics = .default) -> CGFloat {
-        sidebarVisible ? metrics.openLeadingChrome : metrics.closedLeadingChrome
+    /// sidebar when it's shown (see the `Metrics` fields). `homeButtonShown` adds
+    /// `homeButtonExtra` for the wiki's optional fourth nav button (issue #280) —
+    /// omitting this when the button is shown was the root cause of the Toggle
+    /// Transcript button permanently sitting in the toolbar's `»` overflow for
+    /// any wiki with a configured home page, at any window width.
+    static func leadingChrome(sidebarVisible: Bool, homeButtonShown: Bool = false,
+                             metrics: Metrics = .default) -> CGFloat {
+        let base = sidebarVisible ? metrics.openLeadingChrome : metrics.closedLeadingChrome
+        return homeButtonShown ? base + metrics.homeButtonExtra : base
     }
 
     /// The omnibox field's width, driven by the reliably-measurable detail-region
@@ -59,10 +82,11 @@ enum OmniboxLayout {
     /// core only ever uses their difference (the span right of the field's start).
     /// This keeps the stretch/shrink/overflow-expand behavior identical while
     /// sourcing it from a measurement the toolbar can't strand.
-    static func fieldWidth(detailWidth: CGFloat, sidebarVisible: Bool,
+    static func fieldWidth(detailWidth: CGFloat, sidebarVisible: Bool, homeButtonShown: Bool = false,
                            switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
         fieldWidth(windowWidth: detailWidth,
-                   fieldLeadingX: leadingChrome(sidebarVisible: sidebarVisible, metrics: metrics),
+                   fieldLeadingX: leadingChrome(sidebarVisible: sidebarVisible,
+                                               homeButtonShown: homeButtonShown, metrics: metrics),
                    switcherExtra: switcherExtra, metrics: metrics)
     }
 
@@ -83,6 +107,20 @@ enum OmniboxLayout {
                              switcherExtra: switcherExtra, metrics: metrics) >= metrics.minWidth
     }
 
+    /// The field width before the `maxWidth` clamp — what the field would need to
+    /// be to stay exactly flush against the trailing switcher/overflow button.
+    /// Shared by `fieldWidth` (which clamps it for readability) and
+    /// `overflowSpacerWidth` (which reports how much of it got clamped away), so
+    /// the two always agree on where the true trailing edge is.
+    private static func rawFieldWidth(windowWidth: CGFloat, fieldLeadingX: CGFloat,
+                                      switcherExtra: CGFloat, metrics: Metrics) -> CGFloat {
+        let kept = widthKeepingSwitcher(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
+                                        switcherExtra: switcherExtra, metrics: metrics)
+        return kept >= metrics.minWidth
+            ? kept
+            : windowWidth - metrics.trailingOverflow - fieldLeadingX
+    }
+
     /// The omnibox field's width. It stretches from its measured leading edge to
     /// just short of the trailing items, shrinks as the window narrows or the wiki
     /// name lengthens, and — once the switcher can no longer fit and drops into the
@@ -98,11 +136,34 @@ enum OmniboxLayout {
     static func fieldWidth(windowWidth: CGFloat, fieldLeadingX: CGFloat,
                            switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
         guard windowWidth > 0 else { return metrics.minWidth }
-        let kept = widthKeepingSwitcher(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
-                                        switcherExtra: switcherExtra, metrics: metrics)
-        let raw = kept >= metrics.minWidth
-            ? kept
-            : windowWidth - metrics.trailingOverflow - fieldLeadingX
+        let raw = rawFieldWidth(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
+                                switcherExtra: switcherExtra, metrics: metrics)
         return min(max(raw, metrics.minWidth), metrics.maxWidth)
+    }
+
+    /// Extra invisible width to place immediately after the (possibly capped)
+    /// field, inside the same toolbar item, so the trailing wiki switcher and
+    /// transcript toggle stay pinned to the window's true trailing edge even once
+    /// `fieldWidth` has hit `maxWidth` and stopped growing (issue #114). Below the
+    /// cap this is always zero — `fieldWidth` alone already sums exactly to the
+    /// trailing edge, same as before this existed.
+    static func overflowSpacerWidth(windowWidth: CGFloat, fieldLeadingX: CGFloat,
+                                    switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
+        guard windowWidth > 0 else { return 0 }
+        let raw = rawFieldWidth(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
+                                switcherExtra: switcherExtra, metrics: metrics)
+        return max(0, raw - metrics.maxWidth)
+    }
+
+    /// `overflowSpacerWidth`, sourced from the same measurable `(detailWidth,
+    /// sidebarVisible)` pair `fieldWidth(detailWidth:sidebarVisible:switcherExtra:)`
+    /// uses, for the same reason: the field's own leading edge gets stranded when
+    /// the toolbar pushes it into overflow.
+    static func overflowSpacerWidth(detailWidth: CGFloat, sidebarVisible: Bool, homeButtonShown: Bool = false,
+                                    switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
+        overflowSpacerWidth(windowWidth: detailWidth,
+                            fieldLeadingX: leadingChrome(sidebarVisible: sidebarVisible,
+                                                        homeButtonShown: homeButtonShown, metrics: metrics),
+                            switcherExtra: switcherExtra, metrics: metrics)
     }
 }

--- a/Tests/WikiFSTests/AddressBarLayoutHostedTests.swift
+++ b/Tests/WikiFSTests/AddressBarLayoutHostedTests.swift
@@ -1,0 +1,124 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+
+/// Hosted-view checks that the SwiftUI wiring behind the omnibox toolbar item
+/// actually renders the width `OmniboxLayout` computes. `OmniboxLayoutTests`
+/// only proves the pure math is right; it can't catch a `Color.clear` spacer
+/// wired into the wrong `HStack`, an extra implicit spacing eating into it, or
+/// the field itself silently growing past its cap — all invisible to the pure
+/// function but exactly the class of bug issue #114 was about (a real widget
+/// stalling short of the true trailing edge). Render the actual view and read
+/// its layout back.
+///
+/// A `NSHostingController.view.fittingSize` is used rather than a real
+/// `NSToolbar` (which needs a window on screen with a toolbar attached and adds
+/// its own empirically-observed padding — see `OmniboxLayout.Metrics`'s
+/// `openLeadingChrome`/`closedLeadingChrome` doc comments). Absolute widths
+/// aren't comparable to those constants outside a real toolbar, so these tests
+/// assert *deltas*: how much the rendered width moves when `detailWidth` moves.
+/// That's exactly what the fix is about — the group's total rendered width must
+/// track `detailWidth` 1:1 everywhere, including past the field's cap — and it's
+/// invariant to whatever padding a real `NSToolbar` adds on top.
+@MainActor
+struct AddressBarLayoutHostedTests {
+    /// An `NSHostingController` in a `swift test` CLI has no host app, so give
+    /// AppKit one to lay out into (same pattern as `QuoteHighlightWebViewTests`).
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("address-bar-layout-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    /// Hosts the real `AddressBarView` at a fixed `detailWidth` and returns its
+    /// natural (unconstrained) width — the same sizing an `NSToolbar` reads to
+    /// place the trailing items after it. `homePageID` mirrors the real trigger
+    /// for the Home nav button (issue #280): non-`nil` renders a fourth nav
+    /// button, exactly like a wiki with a configured home page.
+    private func renderedWidth(detailWidth: CGFloat, sidebarVisible: Bool,
+                               homePageID: PageID? = nil) async throws -> CGFloat {
+        _ = Self.app
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+        let view = AddressBarView(
+            store: model,
+            isFocused: .constant(false),
+            wikiName: "My Wiki",
+            detailWidth: detailWidth,
+            sidebarVisible: sidebarVisible,
+            homePageID: homePageID,
+            onAddToBookmarks: { _ in })
+            .environment(FindModel())
+        let hosting = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: hosting)
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil) }
+        // Give SwiftUI a layout pass before reading geometry.
+        try await Task.sleep(nanoseconds: 150_000_000)
+        return hosting.view.fittingSize.width
+    }
+
+    /// Below the cap: the field alone absorbs window growth, 1-for-1, same as
+    /// before the spacer existed — this proves the fix didn't disturb the
+    /// unclamped case.
+    @Test func renderedWidthTracksDetailWidthOneForOneBelowTheCap() async throws {
+        let narrow = try await renderedWidth(detailWidth: 700, sidebarVisible: true)
+        let wider = try await renderedWidth(detailWidth: 800, sidebarVisible: true)
+        #expect(abs((wider - narrow) - 100) < 1)
+    }
+
+    /// The regression this issue is about: past the field's `maxWidth` cap, a
+    /// widening window used to produce NO change in the group's rendered width
+    /// (the field was stuck at the cap and nothing else absorbed the rest) — that
+    /// frozen total is exactly the growing trailing-edge gap the user reported.
+    /// With the spacer wired in, the rendered width must keep tracking
+    /// `detailWidth` 1-for-1 even past the cap.
+    @Test func renderedWidthKeepsTrackingDetailWidthPastTheCap() async throws {
+        let m = OmniboxLayout.Metrics.default
+        let field2000 = OmniboxLayout.fieldWidth(detailWidth: 2000, sidebarVisible: true, switcherExtra: 0)
+        let field2200 = OmniboxLayout.fieldWidth(detailWidth: 2200, sidebarVisible: true, switcherExtra: 0)
+        // Sanity: both points really are past the cap (field itself is frozen).
+        #expect(field2000 == m.maxWidth)
+        #expect(field2200 == m.maxWidth)
+
+        let atCap = try await renderedWidth(detailWidth: 2000, sidebarVisible: true)
+        let pastCap = try await renderedWidth(detailWidth: 2200, sidebarVisible: true)
+        #expect(abs((pastCap - atCap) - 200) < 1)
+    }
+
+    /// Same check with the sidebar hidden (the other `leadingChrome` branch),
+    /// since the fix touches both.
+    @Test func renderedWidthKeepsTrackingDetailWidthPastTheCapWithSidebarHidden() async throws {
+        let atCap = try await renderedWidth(detailWidth: 2200, sidebarVisible: false)
+        let pastCap = try await renderedWidth(detailWidth: 2400, sidebarVisible: false)
+        #expect(abs((pastCap - atCap) - 200) < 1)
+    }
+
+    /// The home-button regression: a wiki with a configured home page (issue
+    /// #280) renders a fourth nav button. If `OmniboxLayout` doesn't know about
+    /// it (`homeButtonShown`), the field doesn't shrink to compensate, so the
+    /// WHOLE group (nav cluster + gap + field) renders WIDER than with no home
+    /// button — encroaching into the trailing switcher/toggle's reserved space
+    /// by exactly the button's footprint. That's what permanently pushed the
+    /// Toggle Transcript button into the toolbar's `»` overflow for any such
+    /// wiki, at any window width (a fixed offset, not a threshold — widening the
+    /// window never fixed it). With the fix, the field shrinks by exactly the
+    /// button's own footprint, so the total rendered width is UNCHANGED whether
+    /// or not the home button shows — the trailing items land in the same place
+    /// either way.
+    @Test func homeButtonDoesNotChangeTotalRenderedWidthBecauseTheFieldCompensates() async throws {
+        let withoutHome = try await renderedWidth(detailWidth: 900, sidebarVisible: true, homePageID: nil)
+        let withHome = try await renderedWidth(detailWidth: 900, sidebarVisible: true,
+                                               homePageID: PageID(rawValue: "test-home-page"))
+        #expect(abs(withoutHome - withHome) < 1)
+    }
+}

--- a/Tests/WikiFSTests/OmniboxLayoutTests.swift
+++ b/Tests/WikiFSTests/OmniboxLayoutTests.swift
@@ -88,6 +88,53 @@ import Testing
         #expect(w == m.maxWidth)
     }
 
+    // MARK: Overflow spacer (issue #114)
+    //
+    // Once `fieldWidth` hits `maxWidth` it stops absorbing extra window width, so
+    // `fieldLeadingX + fieldWidth + trailingWithSwitcher` no longer sums to
+    // `windowWidth` — the invariant that otherwise keeps the trailing switcher +
+    // transcript toggle flush against the true edge. `overflowSpacerWidth` reports
+    // exactly the shortfall so the toolbar item can absorb it itself.
+
+    @Test func overflowSpacerIsZeroBelowTheCap() {
+        // 1200 window: field (820) is well under maxWidth, nothing to absorb.
+        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
+        #expect(s == 0)
+    }
+
+    @Test func overflowSpacerIsZeroExactlyAtTheCap() {
+        // kept == maxWidth exactly: 200 + 1200 + 180 = 1580.
+        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1580, fieldLeadingX: 200, switcherExtra: 0)
+        #expect(s == 0)
+    }
+
+    @Test func overflowSpacerAbsorbsExactlyWhatTheCapClampedAway() {
+        // 2000 window: field clamps to maxWidth (1200); the spacer must make up
+        // the rest so fieldLeadingX + fieldWidth + spacer + trailing == windowWidth.
+        let w = OmniboxLayout.fieldWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
+        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
+        #expect(200 + w + s + m.trailingWithSwitcher == 2000)
+        #expect(s == 420)
+    }
+
+    @Test func overflowSpacerGrowsOneForOneWithWindowWidthPastTheCap() {
+        let base = OmniboxLayout.overflowSpacerWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
+        let wider = OmniboxLayout.overflowSpacerWidth(windowWidth: 2100, fieldLeadingX: 200, switcherExtra: 0)
+        #expect(wider == base + 100)
+    }
+
+    @Test func overflowSpacerMatchesTheIssueThreshold() {
+        // Sidebar open: issue #114's gap starts once detailWidth exceeds
+        // maxWidth + trailingWithSwitcher + openLeadingChrome (derived from default
+        // metrics rather than hardcoded, so this doesn't fight future retuning).
+        // Below/at it the spacer is zero; just past it the gap starts opening.
+        let threshold = m.maxWidth + m.trailingWithSwitcher + m.openLeadingChrome
+        let atThreshold = OmniboxLayout.overflowSpacerWidth(detailWidth: threshold, sidebarVisible: true, switcherExtra: 0)
+        let pastThreshold = OmniboxLayout.overflowSpacerWidth(detailWidth: threshold + 1, sidebarVisible: true, switcherExtra: 0)
+        #expect(atThreshold == 0)
+        #expect(pastThreshold == 1)
+    }
+
     @Test func returnsFloorBeforeGeometryIsKnown() {
         // windowWidth 0 → not yet measured → floor, never a negative width.
         #expect(OmniboxLayout.fieldWidth(windowWidth: 0, fieldLeadingX: 0, switcherExtra: 0) == m.minWidth)
@@ -108,6 +155,48 @@ import Testing
         #expect(OmniboxLayout.leadingChrome(sidebarVisible: true) == m.openLeadingChrome)
         #expect(OmniboxLayout.leadingChrome(sidebarVisible: false) == m.closedLeadingChrome)
         #expect(m.openLeadingChrome < m.closedLeadingChrome)
+    }
+
+    // MARK: Home button leading chrome
+    //
+    // A wiki with a configured home page (issue #280) adds a fourth nav button,
+    // shifting the field's real leading edge right by `homeButtonExtra`. Omitting
+    // this previously under-reserved the field's own width by that fixed amount —
+    // independent of window width — permanently encroaching into the trailing
+    // switcher/toggle's space for any such wiki (that wiki's Toggle Transcript
+    // button sat in the `»` overflow no matter how wide the window was resized).
+
+    @Test func homeButtonAddsExtraLeadingChromeInBothSidebarStates() {
+        #expect(OmniboxLayout.leadingChrome(sidebarVisible: true, homeButtonShown: true)
+                == m.openLeadingChrome + m.homeButtonExtra)
+        #expect(OmniboxLayout.leadingChrome(sidebarVisible: false, homeButtonShown: true)
+                == m.closedLeadingChrome + m.homeButtonExtra)
+    }
+
+    @Test func homeButtonShrinksTheFieldByExactlyItsOwnWidth() {
+        // Isolates the home-button effect: same detailWidth/sidebar state, only
+        // `homeButtonShown` differs, so the field must shrink by exactly
+        // `homeButtonExtra` — the button's own width plus its one nav-cluster gap.
+        let withoutHome = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true, switcherExtra: 0)
+        let withHome = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true,
+                                                homeButtonShown: true, switcherExtra: 0)
+        #expect(withoutHome - withHome == m.homeButtonExtra)
+    }
+
+    @Test func homeButtonEncroachmentIsIndependentOfWindowWidth() {
+        // The reported bug: unlike an overflow threshold (which clears once the
+        // window is wide enough), a missing home-button reservation is a FIXED
+        // offset — it never resolves no matter how wide the window gets. Confirm
+        // the fixed invariant holds (trailing edge stays correctly reserved) at
+        // both a narrow-ish and a very wide detailWidth, with the home button shown.
+        for detailWidth: CGFloat in [700, 2200] {
+            let field = OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: true,
+                                                 homeButtonShown: true, switcherExtra: 73.5)
+            let spacer = OmniboxLayout.overflowSpacerWidth(detailWidth: detailWidth, sidebarVisible: true,
+                                                           homeButtonShown: true, switcherExtra: 73.5)
+            let leading = OmniboxLayout.leadingChrome(sidebarVisible: true, homeButtonShown: true)
+            #expect(leading + field + spacer + m.trailingWithSwitcher + 73.5 == detailWidth)
+        }
     }
 
     @Test func detailWidthDriverDelegatesToTheCore() {
@@ -133,9 +222,9 @@ import Testing
         // its floor to reclaim the freed trailing space (same behavior as the core,
         // reached via the detail-width overload).
         let w = OmniboxLayout.fieldWidth(detailWidth: 360, sidebarVisible: true, switcherExtra: 0)
-        // 360 - 64 chrome - 180 keepsSwitcher = 116 < 120 floor → overflow path:
-        // 360 - 64 - 60 overflow = 236.
-        #expect(w == 236)
+        // 360 - 70 chrome - 180 keepsSwitcher = 110 < 120 floor → overflow path:
+        // 360 - 70 - 60 overflow = 230.
+        #expect(w == 230)
         #expect(w > m.minWidth)
     }
 


### PR DESCRIPTION
## Summary

Fixes #114 (the "Toggle Transcript" button drifting from flush-right once the address bar hits its width cap), plus a related bug in the same code found while verifying the fix: the toggle button was permanently non-flush (at any window width) for any wiki with a configured home page.

- **Cap overflow (#114):** `OmniboxLayout.fieldWidth` clamps the field to `maxWidth` for readability. Below the cap, the field's width happened to sum exactly to the toolbar's full width, which is what kept the trailing wiki switcher + toggle button flush. Once a window was wide enough that the *uncapped* field would exceed the cap, nothing absorbed the freed space, opening a growing gap. Added `OmniboxLayout.overflowSpacerWidth`, an invisible (non-hit-testable) spacer placed right after the field, inside the same toolbar item, that absorbs exactly what the cap clamped away.
- **Home button leading-chrome (issue #280 interaction):** a wiki with a configured home page renders a fourth nav button that shifts the field's real leading edge right by ~26pt, but the leading-chrome math never accounted for it — permanently under-reserving trailing space for any such wiki, independent of window width (confirmed via a real screenshot, and by ruling out a font-measurement/threshold explanation first). Added `Metrics.homeButtonExtra` and threaded a `homeButtonShown` flag through the leading-chrome calculation.
- Also separated the Back/Forward/Home nav cluster from the omnibox pill visually (tighter internal spacing, wider gap to the pill), which required a small compensating bump to the leading-chrome constants.

## Verification

- 25 pure-math unit tests in `OmniboxLayoutTests.swift`.
- New hosted-rendering tests in `AddressBarLayoutHostedTests.swift` that render the actual `AddressBarView` in an `NSHostingController` and measure real SwiftUI layout (not just the pure math) — each was sanity-checked by temporarily reverting its corresponding fix and confirming the test fails with the exact expected discrepancy (e.g. a 26.0pt delta matching the home-button footprint precisely).
- Full suite: 2216/2216 passing.

Note: NSToolbar's real overflow decisions can't be driven headlessly in this environment, so this is verified via math + real-view geometry, not an actual on-screen toolbar — worth a quick visual check when convenient.

## Test plan

- [ ] Build and run the app; resize the window past ~1450–1600pt with the sidebar open/closed and confirm the Toggle Transcript button stays flush right.
- [ ] Configure a home page for a wiki (issue #280 feature) and confirm the toggle button is still flush right, at both narrow and wide window widths.
- [ ] Confirm the Back/Forward/Home nav cluster reads as visually separated from the search field pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)