### PR TITLE
Fix ingestion: use bundled bun in run() path

### DIFF
--- a/Sources/WikiFS/ACPBackend.swift
+++ b/Sources/WikiFS/ACPBackend.swift
@@ -144,10 +144,26 @@ actor ACPBackend: AgentBackend {
         await client.setDelegate(permissionDelegate)
 
         DebugLog.agent("ACPBackend.start: launching \(spawn.executablePath) \(spawn.arguments.joined(separator: " "))") // TEMP DEBUG (existed; re-tagged)
+        // Build the environment so the agent can find wikictl + the wiki DB.
+        // Mirrors what OperationCommand.resolveWikictl does for the CLI backend.
+        var env = ProcessInfo.processInfo.environment
+        if let cli = profile.cli {
+            env["WIKI_DB"] = cli.wikiID
+            env["WIKI_ROOT"] = cli.wikiRoot
+            env["WIKICTL"] = cli.wikictlDirectory + "/wikictl"
+            let existingPath = env["PATH"] ?? "/usr/bin:/bin"
+            env["PATH"] = cli.wikictlDirectory + ":" + existingPath
+        }
+        // Also add any extra env from the provider config.
+        for (key, value) in profile.providerHints where key.hasPrefix("env.") {
+            env[String(key.dropFirst(4))] = value
+        }
+
         try await client.launch(
             agentPath: spawn.executablePath,
             arguments: spawn.arguments,
-            workingDirectory: spawn.workingDirectory
+            workingDirectory: spawn.workingDirectory,
+            environment: env
         )
 
         DebugLog.agent("ACPBackend.start: process launched, sending initialize") // TEMP DEBUG (existed; re-tagged)

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1018,10 +1018,14 @@ final class AgentLauncher {
             let backend = self.backend
             let generationGateReleasesPerTurn = Self.releasesGenerationSlotPerTurn(
                 isInteractiveSession: isInteractiveSession)
+            // For ACP, the prompt is sent via `send()` (not baked into the CLI
+            // argv like the CLI backend). For CLI, the prompt is already in the
+            // `-p` flag so an empty string is correct (just drains stdout).
+            let promptText = useACP ? operation.prompt(wikiRoot: wikiRoot) : ""
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 let stream = await backend.send(
-                    TurnInput(userText: ""), into: session)
+                    TurnInput(userText: promptText), into: session)
                 for await event in stream {
                     self.mergeOrAppend(event)
                     if AgentEvent.endsGeneration(event) {

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -878,14 +878,21 @@ final class AgentLauncher {
         var resolvedACPCommand: [String] = []
         var acpAPIKey: String?
         if useACP, let command = provider.command, let exe = command.first {
-            switch PathPreflight.resolveOnLoginShell(executable: AgentCommandConfig.expandTilde(exe)) {
-            case .found(let path):
-                resolvedACPCommand = [path] + Array(command.dropFirst())
-            case .missing(let reason):
-                preflightError = reason
-                isRunning = false
-                releaseGenerationSlot()
-                return
+            // For "bun", prefer the binary bundled in Contents/Helpers so the app
+            // works without a system-wide bun install. Fall back to PATH resolution.
+            if exe == "bun",
+               let bundled = Bundle.main.url(forAuxiliaryExecutable: "bun")?.path {
+                resolvedACPCommand = [bundled] + Array(command.dropFirst())
+            } else {
+                switch PathPreflight.resolveOnLoginShell(executable: AgentCommandConfig.expandTilde(exe)) {
+                case .found(let path):
+                    resolvedACPCommand = [path] + Array(command.dropFirst())
+                case .missing(let reason):
+                    preflightError = reason
+                    isRunning = false
+                    releaseGenerationSlot()
+                    return
+                }
             }
             acpAPIKey = acpCredentialStore.apiKey(forProvider: provider.id)
         }

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1021,7 +1021,14 @@ final class AgentLauncher {
             // For ACP, the prompt is sent via `send()` (not baked into the CLI
             // argv like the CLI backend). For CLI, the prompt is already in the
             // `-p` flag so an empty string is correct (just drains stdout).
-            let promptText = useACP ? operation.prompt(wikiRoot: wikiRoot) : ""
+            // For ACP, the sub-agent plan (source-reader digester agents) doesn't
+            // work — ACP has no custom agent types and background agents can't
+            // complete within a single turn. Append an instruction to do
+            // everything directly.
+            var promptText = useACP ? operation.prompt(wikiRoot: wikiRoot) : ""
+            if useACP {
+                promptText += "\n\nIMPORTANT: Do NOT dispatch sub-agents, background tasks, or async agents. Do NOT use sleep or ScheduleWakeup. Read all sources, process them, and write all wiki pages directly in THIS session — everything must complete before you stop."
+            }
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 let stream = await backend.send(


### PR DESCRIPTION
The run() method (used for ingestion/lint) resolved the ACP provider's command via PATH lookup, missing the bundled-bun check that startInteractiveQuery had. Since claude-acp is now the default provider, ingestion tried to find bun on the system PATH and failed.

Apply the same Bundle.main.url(forAuxiliaryExecutable:)` bundled-bun resolution to run().