### PR TITLE
ACP multi-phase ingestion (planner → executors → finalizer) + bundled bun fix

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,72 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-10 — Multi-phase ACP ingestion (planner → executors → finalizer)
+
+**Problem:** Large-source ACP ingestion relied on Claude's in-process sub-agents
+(the Sonnet `source-reader` digester spawned via `--agents`). Sub-agents don't
+work over ACP — the protocol has no custom agent types and background agents
+can't complete within a single turn. So a large ingest over ACP silently stalled.
+
+**Fix:** Replaced the one-shot spawn with a multi-process architecture for ACP
+large ingests (> 4 KB):
+
+1. **Planner** (Opus, 1 session): reads staged sources, decides the page set,
+   writes a `plan.json` to the scratch directory. Does NOT write wiki pages.
+2. **Executors** (Sonnet, N sessions — one per source file): each reads its
+   assigned pages from `plan.json` + the source section, writes pages via
+   `$WIKICTL page upsert`. Sequential (parallel is a future optimization).
+3. **Finalizer** (Opus, 1 session): reads `$WIKICTL page list`, writes
+   `index.md` via `$WIKICTL index set`, records log entries via
+   `$WIKICTL log append --kind ingest --source <id>`.
+
+Each phase is a clean, independent single-turn ACP session — no sub-agents, no
+background dispatch, no sleep. Tiny sources (< 4 KB) and all CLI runs use the
+existing single-session path unchanged.
+
+**Lifecycle design:** `runACPIngestPlannerExecutors()` is a structural
+replacement for `run()`'s spawn-commit block. It is dispatched AFTER `run()` has
+acquired the generation gate, fired `onLock`, opened log files, and set
+`isRunning`/`ingestingSourceIDs`. It owns per-phase: `BackendProfile` (model
+override), `sessionHandle`, `currentRunToken`. The per-phase `onExit` closure
+does NOT call `finish()` (phase-tracking only); `finish()` is called exactly once
+at the end. If the user hits Stop, `stopAgent()` cancels the live phase's session,
+remaining phases are skipped, and `finish()` runs once via the cancellation path.
+
+**Fallback:** If the planner fails or produces no valid `plan.json`, the
+orchestration falls back to single-session ACP ingest (the original one-shot
+prompt with the "no sub-agents" instruction).
+
+**Model override for executors:** The alias "sonnet" doesn't match
+`ACPModelSelectionResolver` (exact-id matching). Instead, after the planner
+session starts, the advertised models are read via `ACPBackend.availableModels`
+and the first model whose id/name contains "sonnet" is selected. Falls back to
+the provider's default if no match.
+
+**Files changed:**
+- `Sources/WikiFSCore/ACPIngestPlan.swift` (**new**): `Codable` plan schema
+  (`ACPIngestPageAssignment`, `ACPIngestPlan`), tolerant JSON extraction
+  (`extract(from:)` — strips fences, substrings `{`→`}`), pure prompt builders
+  (`ACPIngestPrompts.plannerPrompt`/`executorPrompt`/`finalizerPrompt`).
+- `Sources/WikiFS/AgentLauncher.swift`: `runACPIngestPlannerExecutors()` method
+  + `runPhase()` helper + `runACPIngestFallback()` + `findSonnetModelId()`.
+  Dispatch point inserted after `onLock` in `run()` for `useACP && .opusCurator`.
+- `prompts/ingest-planner.md`, `prompts/ingest-executor.md`,
+  `prompts/ingest-finalizer.md` (**new**): codegen'd into `GeneratedPrompts.swift`.
+- `Tests/WikiFSTests/FakeAgentBackend.swift` (**new**): test double conforming to
+  `AgentBackend`.
+- `Tests/WikiFSTests/ACPIngestPlanTests.swift` (**new**): 23 tests — plan
+  encode/decode round-trip, `assignments(forSource:)`, `distinctSourceFiles`,
+  tolerant JSON extraction (clean/fenced/prose-wrapped/invalid), prompt builders,
+  `findSonnetModelId` (match/name/no-match/empty/case-insensitive),
+  FakeAgentBackend recording (start/send/cancel sequence, failure, model hints).
+- `Sources/WikiFSCore/WikiOperation.swift`: `sourceID(fromPath:)` → `public`.
+- `tools/promptgen/main.swift`: registered 3 new prompt entries.
+
+**Not verified:** The full orchestration needs a live ACP agent for end-to-end
+verification (integration-level). The FakeAgentBackend infrastructure is provided
+for future integration tests that drive the launcher end-to-end.
+
 ## 2026-07-11 — Provider selector under the chat composer (#325)
 
 **Change:** added a compact **provider selector** under the chat composer

--- a/Sources/WikiFS/ACPBackend.swift
+++ b/Sources/WikiFS/ACPBackend.swift
@@ -144,10 +144,26 @@ actor ACPBackend: AgentBackend {
         await client.setDelegate(permissionDelegate)
 
         DebugLog.agent("ACPBackend.start: launching \(spawn.executablePath) \(spawn.arguments.joined(separator: " "))") // TEMP DEBUG (existed; re-tagged)
+        // Build the environment so the agent can find wikictl + the wiki DB.
+        // Mirrors what OperationCommand.resolveWikictl does for the CLI backend.
+        var env = ProcessInfo.processInfo.environment
+        if let cli = profile.cli {
+            env["WIKI_DB"] = cli.wikiID
+            env["WIKI_ROOT"] = cli.wikiRoot
+            env["WIKICTL"] = cli.wikictlDirectory + "/wikictl"
+            let existingPath = env["PATH"] ?? "/usr/bin:/bin"
+            env["PATH"] = cli.wikictlDirectory + ":" + existingPath
+        }
+        // Also add any extra env from the provider config.
+        for (key, value) in profile.providerHints where key.hasPrefix("env.") {
+            env[String(key.dropFirst(4))] = value
+        }
+
         try await client.launch(
             agentPath: spawn.executablePath,
             arguments: spawn.arguments,
-            workingDirectory: spawn.workingDirectory
+            workingDirectory: spawn.workingDirectory,
+            environment: env
         )
 
         DebugLog.agent("ACPBackend.start: process launched, sending initialize") // TEMP DEBUG (existed; re-tagged)

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1018,10 +1018,14 @@ final class AgentLauncher {
             let backend = self.backend
             let generationGateReleasesPerTurn = Self.releasesGenerationSlotPerTurn(
                 isInteractiveSession: isInteractiveSession)
+            // For ACP, the prompt is sent via `send()` (not baked into the CLI
+            // argv like the CLI backend). For CLI, the prompt is already in the
+            // `-p` flag so an empty string is correct (just drains stdout).
+            let promptText = useACP ? operation.prompt(wikiRoot: wikiRoot) : ""
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 let stream = await backend.send(
-                    TurnInput(userText: ""), into: session)
+                    TurnInput(userText: promptText), into: session)
                 for await event in stream {
                     self.mergeOrAppend(event)
                     if AgentEvent.endsGeneration(event) {

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -878,14 +878,21 @@ final class AgentLauncher {
         var resolvedACPCommand: [String] = []
         var acpAPIKey: String?
         if useACP, let command = provider.command, let exe = command.first {
-            switch PathPreflight.resolveOnLoginShell(executable: AgentCommandConfig.expandTilde(exe)) {
-            case .found(let path):
-                resolvedACPCommand = [path] + Array(command.dropFirst())
-            case .missing(let reason):
-                preflightError = reason
-                isRunning = false
-                releaseGenerationSlot()
-                return
+            // For "bun", prefer the binary bundled in Contents/Helpers so the app
+            // works without a system-wide bun install. Fall back to PATH resolution.
+            if exe == "bun",
+               let bundled = Bundle.main.url(forAuxiliaryExecutable: "bun")?.path {
+                resolvedACPCommand = [bundled] + Array(command.dropFirst())
+            } else {
+                switch PathPreflight.resolveOnLoginShell(executable: AgentCommandConfig.expandTilde(exe)) {
+                case .found(let path):
+                    resolvedACPCommand = [path] + Array(command.dropFirst())
+                case .missing(let reason):
+                    preflightError = reason
+                    isRunning = false
+                    releaseGenerationSlot()
+                    return
+                }
             }
             acpAPIKey = acpCredentialStore.apiKey(forProvider: provider.id)
         }

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1021,7 +1021,14 @@ final class AgentLauncher {
             // For ACP, the prompt is sent via `send()` (not baked into the CLI
             // argv like the CLI backend). For CLI, the prompt is already in the
             // `-p` flag so an empty string is correct (just drains stdout).
-            let promptText = useACP ? operation.prompt(wikiRoot: wikiRoot) : ""
+            // For ACP, the sub-agent plan (source-reader digester agents) doesn't
+            // work — ACP has no custom agent types and background agents can't
+            // complete within a single turn. Append an instruction to do
+            // everything directly.
+            var promptText = useACP ? operation.prompt(wikiRoot: wikiRoot) : ""
+            if useACP {
+                promptText += "\n\nIMPORTANT: Do NOT dispatch sub-agents, background tasks, or async agents. Do NOT use sleep or ScheduleWakeup. Read all sources, process them, and write all wiki pages directly in THIS session — everything must complete before you stop."
+            }
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 let stream = await backend.send(

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import WikiFSCore
+import ACPModel
 
 /// Runs the three `claude -p` operations — Ingest / Query / Lint — against the
 /// currently-selected wiki, streaming a live activity feed back into the app
@@ -880,8 +881,10 @@ final class AgentLauncher {
         if useACP, let command = provider.command, let exe = command.first {
             // For "bun", prefer the binary bundled in Contents/Helpers so the app
             // works without a system-wide bun install. Fall back to PATH resolution.
+            // NOTE: Bundle.url(forAuxiliaryExecutable:) does NOT search
+            // Contents/Helpers (only MacOS + Resources), so we check manually.
             if exe == "bun",
-               let bundled = Bundle.main.url(forAuxiliaryExecutable: "bun")?.path {
+               let bundled = Self.bundledHelperPath("bun") {
                 resolvedACPCommand = [bundled] + Array(command.dropFirst())
             } else {
                 switch PathPreflight.resolveOnLoginShell(executable: AgentCommandConfig.expandTilde(exe)) {
@@ -962,6 +965,30 @@ final class AgentLauncher {
         self.ingestingSourceIDs = ingestingSourceIDs
         onLock()
         onUnlockHandler = onUnlock
+
+        // Multi-phase ACP ingest: for large sources over ACP, sub-agents (the
+        // Sonnet `source-reader` digester) don't work — ACP has no custom agent
+        // types and background agents can't complete within a single turn. Replace
+        // the one-shot spawn with sequential single-turn sessions: planner →
+        // executors → finalizer. Tiny sources (< 4 KB) and all CLI runs use the
+        // existing single-session path below.
+        if useACP, case .ingest(_, _, _, let plan) = operation, plan.isLargeSource {
+            await runACPIngestPlannerExecutors(
+                provider: provider,
+                scratch: scratch,
+                operation: operation,
+                wikiRoot: wikiRoot,
+                wikiID: wikiID,
+                systemPrompt: systemPrompt,
+                wikictlDirectory: wikictlDirectory,
+                resolvedACPCommand: resolvedACPCommand,
+                acpAPIKey: acpAPIKey,
+                resolvedPath: resolvedPath,
+                agentConfig: agentConfig,
+                sandbox: sandbox
+            )
+            return
+        }
 
         // Build the backend profile. The launcher resolves app-level concerns
         // (scratch dir, sandbox, config, executable path); the backend owns
@@ -1064,6 +1091,317 @@ final class AgentLauncher {
         }
     }
 
+    // MARK: - Multi-phase ACP ingestion (planner → executors → finalizer)
+
+    /// Replace the broken single-session ACP ingestion (which relies on Claude's
+    /// in-process sub-agents that don't work over ACP) with a multi-process
+    /// architecture: a **Planner** session reads sources and produces a page plan
+    /// (`plan.json`), then **Executor** sessions each write their assigned pages
+    /// directly via `wikictl`, and a **Finalizer** session writes `index.md` + log
+    /// entries. Each phase is a clean, independent single-turn ACP session — no
+    /// sub-agents, no background dispatch, no sleep.
+    ///
+    /// **Lifecycle ownership:** This method is a structural replacement for
+    /// `run()`'s spawn-commit block for ACP large ingest. It is called AFTER
+    /// `run()` has acquired the generation gate, fired `onLock`, opened log files,
+    /// and set `isRunning`/`setGenerating(true)`/`ingestingSourceIDs`. It MUST:
+    /// - Pass a phase-tracking `onExit` to each phase (does NOT call `finish()`).
+    /// - Update `sessionHandle`/`currentRunToken` per phase so `stopAgent()` and
+    ///   the watchdog track the live phase.
+    /// - Call `finish()` exactly once at the end (success or unrecoverable failure).
+    private func runACPIngestPlannerExecutors(
+        provider: AgentProvider,
+        scratch: URL,
+        operation: WikiOperation,
+        wikiRoot: String,
+        wikiID: String,
+        systemPrompt: String,
+        wikictlDirectory: String,
+        resolvedACPCommand: [String],
+        acpAPIKey: String?,
+        resolvedPath: String,
+        agentConfig: AgentCommandConfig,
+        sandbox: SandboxProfile.SandboxInvocation?
+    ) async {
+        // Safety net: if any code path exits without calling finish() (e.g. an
+        // unexpected throw from a future adding await between phases), ensure the
+        // generation gate + edit lock are released. finish() is idempotent (guards
+        // isRunning), so this is a no-op when finish() was already called.
+        defer {
+            if isRunning { finish(status: -1) }
+        }
+
+        startCompletionWatchdog()
+
+        guard case .ingest(let sourcePaths, let stagedSourcePaths, let stateFilePath, _) = operation else {
+            DebugLog.agent("runACPIngest: not an ingest operation — aborting")
+            finish(status: -1)
+            return
+        }
+        let sourceIDs = sourcePaths.map { WikiOperation.sourceID(fromPath: $0) }
+        let sourceFileNames = stagedSourcePaths.map { ($0 as NSString).lastPathComponent }
+
+        // Build a shared CLI profile closure (sets env vars the ACP backend reads:
+        // WIKI_DB, WIKI_ROOT, WIKICTL, PATH). The ACP backend ignores
+        // resolvedExecutable/command/sandbox (those are CLI-backend-only), but
+        // the env vars are critical.
+        let selectedModelId = providersConfig().selectedModelId(forProvider: provider.id)
+        let makeCLIProfile = { (op: WikiOperation) in
+            CLIProfile(
+                operation: op,
+                wikiRoot: wikiRoot,
+                wikiID: wikiID,
+                wikictlDirectory: wikictlDirectory,
+                resolvedExecutable: resolvedPath,
+                command: agentConfig,
+                sandbox: sandbox)
+        }
+        let makeProviderHints = { (modelId: String?) in
+            AgentBackendFactory.providerHints(
+                provider: provider,
+                resolvedCommand: resolvedACPCommand,
+                apiKey: acpAPIKey,
+                selectedModelId: modelId)
+        }
+
+        // --- Phase 1: Planner (Opus / default model) ---
+        DebugLog.agent("runACPIngest: Phase 1 — Planner")
+        let plannerProfile = BackendProfile(
+            providerHints: makeProviderHints(selectedModelId),
+            scratchDirectory: scratch,
+            isReadOnly: false,
+            cli: makeCLIProfile(operation))
+        let plannerPrompt = ACPIngestPrompts.plannerPrompt(
+            stateFilePath: stateFilePath,
+            stagedSourcePaths: stagedSourcePaths,
+            sourceIDs: sourceIDs)
+
+        guard let plannerSession = await runPhase(
+            profile: plannerProfile,
+            systemPrompt: systemPrompt,
+            prompt: plannerPrompt,
+            phaseName: "planner"
+        ) else {
+            // Planner failed — fall back to single-session ACP ingest.
+            DebugLog.agent("runACPIngest: planner failed — falling back to single-session")
+            await runACPIngestFallback(
+                operation: operation,
+                wikiRoot: wikiRoot,
+                scratch: scratch,
+                systemPrompt: systemPrompt,
+                makeCLIProfile: makeCLIProfile,
+                makeProviderHints: makeProviderHints,
+                selectedModelId: selectedModelId,
+                provider: provider)
+            return
+        }
+
+        // Capture models (provider-level, not phase-level) + pick Sonnet for executors.
+        var executorModelId: String? = nil
+        if let acp = backend as? ACPBackend {
+            let models = await acp.availableModels(for: plannerSession)
+            captureAndCacheModels(provider: provider, session: plannerSession)
+            executorModelId = Self.findSonnetModelId(in: models)
+            if executorModelId == nil {
+                DebugLog.agent("runACPIngest: no Sonnet model in advertised list (\(models.map { $0.modelId })); executors use default model")
+            }
+        }
+        await backend.cancel(plannerSession)
+
+        // Check for cancellation (user hit Stop during planner).
+        guard isRunning else {
+            DebugLog.agent("runACPIngest: cancelled after planner phase")
+            return  // finish() already called by stopAgent()
+        }
+
+        // Read the plan the planner wrote.
+        guard let plan = ACPIngestPlan.load(from: scratch) else {
+            // No valid plan.json — fall back to single-session.
+            DebugLog.agent("runACPIngest: no valid plan.json — falling back to single-session")
+            await runACPIngestFallback(
+                operation: operation,
+                wikiRoot: wikiRoot,
+                scratch: scratch,
+                systemPrompt: systemPrompt,
+                makeCLIProfile: makeCLIProfile,
+                makeProviderHints: makeProviderHints,
+                selectedModelId: selectedModelId,
+                provider: provider)
+            return
+        }
+        DebugLog.agent("runACPIngest: plan loaded — \(plan.pages.count) pages across \(plan.distinctSourceFiles.count) source file(s)")
+
+        // --- Phase 2: Executors (one per source file, Sonnet) ---
+        for sourceFile in plan.distinctSourceFiles {
+            guard isRunning else { break }  // cancelled
+            let assignments = plan.assignments(forSource: sourceFile)
+            guard !assignments.isEmpty else { continue }
+            let executorProfile = BackendProfile(
+                providerHints: makeProviderHints(executorModelId),
+                scratchDirectory: scratch,
+                isReadOnly: false,
+                cli: makeCLIProfile(operation))
+            let executorPrompt = ACPIngestPrompts.executorPrompt(
+                stateFilePath: stateFilePath,
+                assignments: assignments,
+                allPageTitles: plan.allPageTitles,
+                sourceIDs: sourceIDs)
+            DebugLog.agent("runACPIngest: Phase 2 — Executor[\(sourceFile)] (\(assignments.count) page(s))")
+            // Partial failure: log and continue to next executor.
+            if let session = await runPhase(
+                profile: executorProfile,
+                systemPrompt: systemPrompt,
+                prompt: executorPrompt,
+                phaseName: "executor[\(sourceFile)]"
+            ) {
+                await backend.cancel(session)
+            } else {
+                DebugLog.agent("runACPIngest: executor[\(sourceFile)] FAILED — skipping (partial failure)")
+            }
+        }
+
+        // Check for cancellation before finalizer.
+        guard isRunning else {
+            DebugLog.agent("runACPIngest: cancelled after executor phases")
+            return
+        }
+
+        // --- Phase 3: Finalizer (Opus / default model) ---
+        let finalizerProfile = BackendProfile(
+            providerHints: makeProviderHints(selectedModelId),
+            scratchDirectory: scratch,
+            isReadOnly: false,
+            cli: makeCLIProfile(operation))
+        let finalizerPrompt = ACPIngestPrompts.finalizerPrompt(
+            stateFilePath: stateFilePath,
+            sourceFileNames: sourceFileNames,
+            sourceIDs: sourceIDs)
+        DebugLog.agent("runACPIngest: Phase 3 — Finalizer")
+        if let session = await runPhase(
+            profile: finalizerProfile,
+            systemPrompt: systemPrompt,
+            prompt: finalizerPrompt,
+            phaseName: "finalizer"
+        ) {
+            await backend.cancel(session)
+        }
+
+        finish(status: 0)
+    }
+
+    /// Run one ACP phase: start a session, send the prompt, drain to
+    /// `.messageStop`/`.result`, then return the session (caller cancels).
+    /// The `onExit` closure is phase-tracking only — it logs but does NOT call
+    /// `finish()`. That is the critical lifecycle invariant: `finish()` is called
+    /// exactly once by `runACPIngestPlannerExecutors()` at the very end.
+    ///
+    /// Updates `sessionHandle` + `currentRunToken` so `stopAgent()` and the
+    /// watchdog target the live phase. Returns `nil` if `backend.start` throws.
+    private func runPhase(
+        profile: BackendProfile,
+        systemPrompt: String,
+        prompt: String,
+        phaseName: String
+    ) async -> SessionHandle? {
+        let runToken = UUID()
+        do {
+            DebugLog.agent("runACPIngest[\(phaseName)]: starting")
+            let session = try await backend.start(
+                profile: profile,
+                systemPrompt: systemPrompt,
+                onExit: { status in
+                    // Phase tracker: does NOT call finish(). The orchestrator
+                    // owns finish(); a per-phase exit is just telemetry.
+                    DebugLog.agent("runACPIngest[\(phaseName)]: onExit status=\(status) (phase-tracked)")
+                })
+            sessionHandle = session
+            currentRunToken = runToken
+
+            setGenerating(true)
+            let backend = self.backend
+            let stream = await backend.send(TurnInput(userText: prompt), into: session)
+            for await event in stream {
+                mergeOrAppend(event)
+                if AgentEvent.endsGeneration(event) {
+                    setGenerating(false)
+                    flushTranscript()
+                    // One-shot runs do NOT release the generation gate per turn —
+                    // the gate is held across all phases and released by finish().
+                }
+            }
+            DebugLog.agent("runACPIngest[\(phaseName)]: stream drained")
+            return session
+        } catch {
+            DebugLog.agent("runACPIngest[\(phaseName)]: FAILED: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Fallback: single-session ACP ingest when the planner fails or produces no
+    /// valid `plan.json`. Sends the original one-shot ingest prompt (with the
+    /// "no sub-agents" instruction) in one session, then calls `finish()`.
+    private func runACPIngestFallback(
+        operation: WikiOperation,
+        wikiRoot: String,
+        scratch: URL,
+        systemPrompt: String,
+        makeCLIProfile: (WikiOperation) -> CLIProfile,
+        makeProviderHints: (String?) -> [String: String],
+        selectedModelId: String?,
+        provider: AgentProvider
+    ) async {
+        let profile = BackendProfile(
+            providerHints: makeProviderHints(selectedModelId),
+            scratchDirectory: scratch,
+            isReadOnly: false,
+            cli: makeCLIProfile(operation))
+        var promptText = operation.prompt(wikiRoot: wikiRoot)
+        promptText += "\n\nIMPORTANT: Do NOT dispatch sub-agents, background tasks, or async agents. Do NOT use sleep or ScheduleWakeup. Read all sources, process them, and write all wiki pages directly in THIS session — everything must complete before you stop."
+
+        if let session = await runPhase(
+            profile: profile,
+            systemPrompt: systemPrompt,
+            prompt: promptText,
+            phaseName: "fallback-single"
+        ) {
+            captureAndCacheModels(provider: provider, session: session)
+            await backend.cancel(session)
+            finish(status: 0)
+        } else {
+            finish(status: -1)
+        }
+    }
+
+    /// Resolve the path to a binary bundled in `Contents/Helpers/`, or nil if
+    /// not present or not executable.
+    ///
+    /// `Bundle.url(forAuxiliaryExecutable:)` does NOT search `Contents/Helpers/`
+    /// (it only looks in `Contents/MacOS/` and `Contents/Resources/`), so we
+    /// construct the path manually. This is the fix for "bun not found on your
+    /// path" — bun was correctly bundled in Helpers but the old API call never
+    /// found it.
+    static nonisolated func bundledHelperPath(_ name: String) -> String? {
+        let path = Bundle.main.bundleURL
+            .appendingPathComponent("Contents")
+            .appendingPathComponent("Helpers")
+            .appendingPathComponent(name)
+            .path
+        return FileManager.default.isExecutableFile(atPath: path) ? path : nil
+    }
+
+    /// Find the advertised Sonnet model id for executor profiles. The alias
+    /// "sonnet" will NOT match `ACPModelSelectionResolver` (it does exact-id
+    /// matching against advertised models), so we search for a model whose id or
+    /// name contains "sonnet" (case-insensitive). Returns nil if no match — the
+    /// caller falls back to the provider's default model.
+    static nonisolated func findSonnetModelId(in models: [ModelInfo]) -> String? {
+        models.first { model in
+            let id = model.modelId.lowercased()
+            let name = model.name.lowercased()
+            return id.contains("sonnet") || name.contains("sonnet")
+        }?.modelId
+    }
+
     /// Heartbeat logger + stale-idle detector. Replaces the old liveness-poller
     /// (which polled `process?.isRunning` — impossible now that `Process` lives
     /// behind the `AgentBackend` port). The backend's `onExit` callback is the
@@ -1151,8 +1489,10 @@ final class AgentLauncher {
         if useACP, let command = provider.command, let exe = command.first {
             // For "bun", prefer the binary bundled in Contents/Helpers so the app
             // works without a system-wide bun install. Fall back to PATH resolution.
+            // NOTE: Bundle.url(forAuxiliaryExecutable:) does NOT search
+            // Contents/Helpers (only MacOS + Resources), so we check manually.
             if exe == "bun",
-               let bundled = Bundle.main.url(forAuxiliaryExecutable: "bun")?.path {
+               let bundled = Self.bundledHelperPath("bun") {
                 DebugLog.agent("startInteractiveQuery: using bundled bun at \(bundled)") // TEMP DEBUG
                 resolvedACPCommand = [bundled] + Array(command.dropFirst())
             } else {

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -91,6 +91,13 @@ struct WikiFSApp: App {
         let generationGate = GenerationGate()
         _agentLauncher = State(initialValue: AgentLauncher(generationGate: generationGate, extractionCoordinator: coordinator))
         _chatLauncher   = State(initialValue: AgentLauncher(generationGate: generationGate, extractionCoordinator: coordinator))
+
+        // Assert bun is bundled — ACP providers (claude-acp via bunx) are broken
+        // without it. If this fires, run `./build.sh` (which now hard-fails when
+        // bun is absent) and reinstall to /Applications.
+        if AgentLauncher.bundledHelperPath("bun") == nil {
+            DebugLog.agent("⚠️ LAUNCH CHECK: bun NOT found in Contents/Helpers — ACP ingestion will fail. Run ./build.sh and reinstall.")
+        }
     }
 
     var body: some Scene {

--- a/Sources/WikiFSCore/ACPIngestPlan.swift
+++ b/Sources/WikiFSCore/ACPIngestPlan.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+/// The `Codable` contract between the **planner** and **executor** phases of
+/// multi-phase ACP ingestion (`runACPIngestPlannerExecutors`).
+///
+/// The planner (Opus) reads staged sources, decides the page set, and writes a
+/// `plan.json` in the scratch directory. Executors (Sonnet) each read the plan +
+/// their assigned source section and write wiki pages via `wikictl`.
+///
+/// This is the pure, unit-tested schema + extraction + prompt builders — no I/O,
+/// no ACP session management. The orchestration lives in `AgentLauncher`.
+///
+/// See `plans/acp-multi-phase-ingestion.md` for the architecture.
+
+// MARK: - Plan schema
+
+/// One page assignment: the planner's decision that this page should exist,
+/// backed by a specific section of a staged source file.
+public struct ACPIngestPageAssignment: Codable, Equatable, Sendable {
+    /// The wiki page title to create or update (upserting an existing title
+    /// updates it — the planner checks `$WIKICTL page list` for dedup).
+    public let title: String
+    /// The staged source filename in the scratch directory (e.g. `"source-1.md"`).
+    public let sourceFile: String
+    /// Human-readable description of where in the source file the content for
+    /// this page is (e.g. `"lines 1-80"`, `"section 'Intro'"`, `"entire file"`).
+    public let sourceRanges: String
+    /// A 1-3 sentence description of what the page covers. Helps the executor
+    /// know what to write without re-reading the entire source.
+    public let outline: String
+
+    public init(title: String, sourceFile: String, sourceRanges: String, outline: String) {
+        self.title = title
+        self.sourceFile = sourceFile
+        self.sourceRanges = sourceRanges
+        self.outline = outline
+    }
+}
+
+/// The full plan: all page assignments + the source IDs (for `wikictl log append
+/// --source`).
+public struct ACPIngestPlan: Codable, Equatable, Sendable {
+    /// All page assignments. Executors are grouped by `sourceFile` and each
+    /// executor receives its subset.
+    public let pages: [ACPIngestPageAssignment]
+    /// The source IDs (ULIDs) for `wikictl log append --kind ingest --source <id>`.
+    /// Echoed from the planner prompt; copied verbatim to `plan.json`.
+    public let sourceIDs: [String]
+
+    public init(pages: [ACPIngestPageAssignment], sourceIDs: [String]) {
+        self.pages = pages
+        self.sourceIDs = sourceIDs
+    }
+
+    /// Group pages by source file — each executor gets one source file's pages.
+    /// Returns assignments for the given source filename only.
+    public func assignments(forSource file: String) -> [ACPIngestPageAssignment] {
+        pages.filter { $0.sourceFile == file }
+    }
+
+    /// The distinct source files referenced by the plan, in first-occurrence
+    /// order. Used to assign executors (one executor per source file).
+    public var distinctSourceFiles: [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for page in pages where !seen.contains(page.sourceFile) {
+            seen.insert(page.sourceFile)
+            result.append(page.sourceFile)
+        }
+        return result
+    }
+
+    /// All page titles (for cross-linking in the executor prompt).
+    public var allPageTitles: [String] {
+        pages.map(\.title)
+    }
+
+    // MARK: - Tolerant JSON extraction
+
+    /// Extract an `ACPIngestPlan` from raw bytes that may be wrapped in prose or
+    /// ```json fences. Claude routinely wraps JSON in markdown or surrounding
+    /// text. The extraction:
+    /// 1. Strips leading/trailing whitespace.
+    /// 2. Strips ```json or ``` fences if present.
+    /// 3. Substrings from the first `{` to the last `}`.
+    /// 4. Decodes via `JSONDecoder`.
+    ///
+    /// Returns `nil` if the bytes contain no valid plan JSON.
+    public static func extract(from data: Data) -> ACPIngestPlan? {
+        guard let raw = String(data: data, encoding: .utf8) else { return nil }
+        return extract(from: raw)
+    }
+
+    /// String-based extraction (testable without `Data` round-trip).
+    public static func extract(from raw: String) -> ACPIngestPlan? {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Strip ```json … ``` fences if present.
+        if s.hasPrefix("```") {
+            // Remove opening fence (```json or ```).
+            if let firstNewline = s.firstIndex(of: "\n") {
+                s = String(s[s.index(after: firstNewline)...])
+            }
+            // Remove closing fence.
+            if let closingRange = s.range(of: "```", options: .backwards) {
+                s = String(s[..<closingRange.lowerBound])
+            }
+            s = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // Substring from first `{` to last `}`.
+        guard let firstBrace = s.firstIndex(of: "{"),
+              let lastBrace = s.lastIndex(of: "}"),
+              firstBrace <= lastBrace else {
+            return nil
+        }
+        let jsonSubstring = String(s[firstBrace...lastBrace])
+
+        guard let jsonData = jsonSubstring.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ACPIngestPlan.self, from: jsonData)
+    }
+
+    /// Read `plan.json` from the given directory and extract the plan.
+    /// Returns `nil` if the file is missing or invalid.
+    public static func load(from directory: URL) -> ACPIngestPlan? {
+        let planURL = directory.appendingPathComponent("plan.json")
+        guard let data = try? Data(contentsOf: planURL) else { return nil }
+        return extract(from: data)
+    }
+}
+
+// MARK: - Pure prompt builders
+
+/// Pure (no I/O) prompt builders for the three phases of multi-phase ACP
+/// ingestion. Each fills a `GeneratedPrompts` template via `PromptTemplate.fill`.
+/// Unit-tested directly — no ACP session required.
+public enum ACPIngestPrompts {
+
+    /// The planner task prompt. Instructs Opus to read staged sources, decide
+    /// the page set, and write `plan.json` — without writing any wiki pages.
+    public static func plannerPrompt(
+        stateFilePath: String,
+        stagedSourcePaths: [String],
+        sourceIDs: [String]
+    ) -> String {
+        let sourceFiles = stagedSourcePaths
+            .map { path -> String in
+                // Show the filename (the agent's cwd is the scratch dir) + the
+                // absolute path so the agent knows where it is.
+                let name = (path as NSString).lastPathComponent
+                return "- \(name)  (absolute: \(path))"
+            }
+            .joined(separator: "\n")
+
+        return PromptTemplate.fill(GeneratedPrompts.ingestPlanner, [
+            "STATE_FILE_PATH": stateFilePath,
+            "SOURCE_FILES": sourceFiles,
+            "SOURCE_IDS": sourceIDs.joined(separator: ", "),
+        ])
+    }
+
+    /// The executor task prompt. Instructs Sonnet to read its assigned source
+    /// section and write each page via `$WIKICTL page upsert`. Cross-references
+    /// all page titles for linking.
+    public static func executorPrompt(
+        stateFilePath: String,
+        assignments: [ACPIngestPageAssignment],
+        allPageTitles: [String],
+        sourceIDs: [String]
+    ) -> String {
+        let assignedPages = assignments.map { a -> String in
+            """
+            ### \(a.title)
+            - Source: \(a.sourceFile), \(a.sourceRanges)
+            - Outline: \(a.outline)
+            """
+        }.joined(separator: "\n\n")
+
+        let primarySourceFile = assignments.first?.sourceFile ?? "source-1.md"
+
+        return PromptTemplate.fill(GeneratedPrompts.ingestExecutor, [
+            "STATE_FILE_PATH": stateFilePath,
+            "ASSIGNED_PAGES": assignedPages,
+            "ALL_PAGE_TITLES": allPageTitles.map { "- \($0)" }.joined(separator: "\n"),
+            "SOURCE_IDS": sourceIDs.joined(separator: ", "),
+            "PRIMARY_SOURCE_FILE": primarySourceFile,
+        ])
+    }
+
+    /// The finalizer task prompt. Instructs Opus to write `index.md` and record
+    /// log entries for each source.
+    public static func finalizerPrompt(
+        stateFilePath: String,
+        sourceFileNames: [String],
+        sourceIDs: [String]
+    ) -> String {
+        // Pair source file names with IDs for the log entries.
+        let pairs = zip(sourceFileNames, sourceIDs).map { name, id -> String in
+            "- \(name) → \(id)"
+        }.joined(separator: "\n")
+
+        return PromptTemplate.fill(GeneratedPrompts.ingestFinalizer, [
+            "STATE_FILE_PATH": stateFilePath,
+            "SOURCE_FILES_AND_IDS": pairs,
+        ])
+    }
+}

--- a/Sources/WikiFSCore/GeneratedPrompts.swift
+++ b/Sources/WikiFSCore/GeneratedPrompts.swift
@@ -470,4 +470,146 @@ Steps:
 
 """#
 
+    static let ingestPlanner = #"""
+PLANNER PHASE — Multi-page ingest. You are the PLANNER. Read the staged source files, decide what pages this wiki should have, and write a plan. Do NOT write any wiki pages in this phase.
+
+## Wiki state snapshot
+
+A snapshot of the current wiki state is at: {{STATE_FILE_PATH}}
+Read it FIRST to see what pages already exist. This avoids creating duplicates on re-ingest.
+
+## Source files (in your working directory)
+
+{{SOURCE_FILES}}
+
+## Source IDs (required for wikictl log --source)
+
+{{SOURCE_IDS}}
+
+## Instructions
+
+1. Read the wiki state snapshot at the path above to see existing pages and the current index.
+
+2. Check existing pages: `$WIKICTL page list` — update-in-place rather than creating duplicates on re-ingest.
+
+3. For each source file, inspect its size and structure. Use `wc -l`, `head`, `sed -n 'START,ENDp'`, or `grep` to sample the content without reading the entire file if it is large.
+
+4. DECIDE the page set: what summary/entity/concept pages does this wiki need? Each page is backed by content from ONE source file (the `sourceFile` field). Cross-reference across sources to find connections and avoid duplicate pages. If two sources discuss the same topic, assign the page to the source with the most content on that topic and cross-link from the other executor's pages using [[wiki links]].
+
+5. Write your plan to `plan.json` in your current working directory using this EXACT JSON schema:
+
+```json
+{
+  "pages": [
+    {
+      "title": "Page Title",
+      "sourceFile": "source-1.md",
+      "sourceRanges": "lines 1-80",
+      "outline": "1-3 sentence description of what this page covers"
+    }
+  ],
+  "sourceIDs": ["<id1>", "<id2>"]
+}
+```
+
+### Field rules
+
+- `title`: the wiki page title (clear, specific, stable). Upserting an existing title updates it.
+- `sourceFile`: the actual filename in your working directory (e.g. "source-1.md").
+- `sourceRanges`: a human-readable description of where in the source file the content for this page is (e.g. "lines 1-80" or "section 'Introduction'" or "entire file").
+- `outline`: a 1-3 sentence description of what the page will cover.
+- `sourceIDs`: the list of source IDs given above. Copy them verbatim.
+
+IMPORTANT:
+- Do NOT write any wiki pages in this phase. No `$WIKICTL page upsert`.
+- Do NOT dispatch sub-agents, background tasks, or async agents.
+- Do NOT use sleep or ScheduleWakeup.
+- Write ONLY `plan.json` and stop.
+
+"""#
+
+    static let ingestExecutor = #"""
+EXECUTOR PHASE — Multi-page ingest. You are an EXECUTOR. You have been assigned specific pages to write. Read your source section and write each page via `$WIKICTL page upsert`.
+
+## Wiki state snapshot
+
+A snapshot of the current wiki state is at: {{STATE_FILE_PATH}}
+
+## Your assigned pages
+
+{{ASSIGNED_PAGES}}
+
+## All pages in this ingest (for cross-linking)
+
+{{ALL_PAGE_TITLES}}
+
+## Source IDs
+
+{{SOURCE_IDS}}
+
+## Instructions
+
+For EACH assigned page:
+
+1. Read the source file section at the given range. The source file is in your working directory. Use `sed -n 'START,ENDp' {{PRIMARY_SOURCE_FILE}}` or `cat {{PRIMARY_SOURCE_FILE}}` to read the relevant section.
+
+2. Write the page body to `./body.md`:
+   - Summarize the source content into a clear, well-structured wiki page.
+   - Cross-link related pages with [[Page Title]] wiki-links. Use the page titles listed above.
+   - Cite sources by their `sources/…` path.
+
+3. Create or update the page: `$WIKICTL page upsert --title 'PAGE TITLE' --body-file ./body.md`
+
+4. Verify: `$WIKICTL page get --title 'PAGE TITLE'`
+
+### Write rules
+
+- The ONLY way to create or update content is `$WIKICTL`. The wiki mount is READ-ONLY.
+- Always use `--body-file ./body.md`, never shell pipes or heredocs.
+- After a write, read it back with `$WIKICTL page get` (the mount lags the database by ~5s).
+
+IMPORTANT:
+- Do NOT dispatch sub-agents, background tasks, or async agents.
+- Do NOT use sleep or ScheduleWakeup.
+- Write ALL your assigned pages before stopping.
+
+"""#
+
+    static let ingestFinalizer = #"""
+FINALIZER PHASE — Multi-page ingest. The executors have written all wiki pages. Your job is to finalize the ingestion: write index.md and record log entries.
+
+## Wiki state snapshot
+
+A snapshot of the current wiki state is at: {{STATE_FILE_PATH}}
+
+## Source files and IDs
+
+For each source, record the ingest in the log. The source files and their IDs are:
+
+{{SOURCE_FILES_AND_IDS}}
+
+## Instructions
+
+1. Read the current page list: `$WIKICTL page list`
+
+2. Write `index.md` — the curated catalog of ALL pages in the wiki (not just new ones). Write it to `./index.md`, then: `$WIKICTL index set --body-file ./index.md`
+
+3. For EACH source listed above, record the ingest in the log:
+   ```
+   $WIKICTL log append --kind ingest --title "<source file name>" --source <id>
+   ```
+   The `--source` id is REQUIRED — it marks that file as Ingested in the app.
+
+### Write rules
+
+- The ONLY way to create or update content is `$WIKICTL`. The wiki mount is READ-ONLY.
+- Always use `--body-file ./index.md`, never shell pipes or heredocs.
+
+IMPORTANT:
+- Do NOT dispatch sub-agents, background tasks, or async agents.
+- Do NOT use sleep or ScheduleWakeup.
+- Write the index.md and ALL log entries before stopping.
+
+"""#
+
 }

--- a/Sources/WikiFSCore/IngestPlan.swift
+++ b/Sources/WikiFSCore/IngestPlan.swift
@@ -52,6 +52,17 @@ public enum IngestPlan: Equatable, Sendable {
     sourceByteSize < tinySourceByteThreshold ? .singleOpus : .opusCurator
   }
 
+  /// Whether this plan is for a large source that needs multi-phase processing
+  /// (planner → executors → finalizer for ACP, or curator + digesters for CLI).
+  /// Model-agnostic: any powerful model can be the planner/curator — this is a
+  /// source-size predicate, NOT a model-tier gate.
+  public var isLargeSource: Bool {
+    switch self {
+    case .singleOpus: false
+    case .opusCurator: true
+    }
+  }
+
   /// The top-level `--model` alias. ALWAYS `opus` — Opus is the curator/writer in
   /// both modes; the single pass and the curator both run on Opus.
   public var topLevelModelAlias: String {

--- a/Sources/WikiFSCore/WikiOperation.swift
+++ b/Sources/WikiFSCore/WikiOperation.swift
@@ -155,7 +155,7 @@ extension WikiOperation {
   /// Recover the source id from its `sources/by-id/<id>[.ext]` path —
   /// the leaf stem IS the id (`FilenameEscaping.byIDSourceFilename`). The agent
   /// echoes it back via `wikictl log append --kind ingest --source <id>`.
-  static func sourceID(fromPath path: String) -> String {
+  public static func sourceID(fromPath path: String) -> String {
     let leaf = (path as NSString).lastPathComponent
     return (leaf as NSString).deletingPathExtension
   }

--- a/Tests/WikiFSTests/ACPIngestPlanTests.swift
+++ b/Tests/WikiFSTests/ACPIngestPlanTests.swift
@@ -1,0 +1,357 @@
+import Foundation
+import Testing
+import ACPModel
+@testable import WikiFSCore
+@testable import WikiFS
+
+/// Unit tests for the multi-phase ACP ingestion plan schema, tolerant JSON
+/// extraction, prompt builders, and the `findSonnetModelId` helper.
+///
+/// The multi-session orchestration itself (`runACPIngestPlannerExecutors`) is
+/// integration-level — it requires a live ACP agent or a fully-wired
+/// `AgentLauncher` with generation gate + edit lock. The `FakeAgentBackend`
+/// infrastructure is provided for future integration tests that drive the
+/// launcher end-to-end.
+@Suite struct ACPIngestPlanTests {
+
+    // MARK: - Plan schema (AC.2)
+
+    @Test func testPlanDecodeRoundTrip() {
+        let plan = ACPIngestPlan(
+            pages: [
+                ACPIngestPageAssignment(
+                    title: "Photosynthesis",
+                    sourceFile: "source-1.md",
+                    sourceRanges: "lines 1-80",
+                    outline: "Overview of photosynthesis."),
+                ACPIngestPageAssignment(
+                    title: "Calvin Cycle",
+                    sourceFile: "source-1.md",
+                    sourceRanges: "lines 81-120",
+                    outline: "Carbon fixation pathway."),
+            ],
+            sourceIDs: ["01J5ABC", "01J5DEF"])
+
+        let encoder = JSONEncoder()
+        let data = try! encoder.encode(plan)
+
+        let decoder = JSONDecoder()
+        let decoded = try! decoder.decode(ACPIngestPlan.self, from: data)
+
+        #expect(decoded == plan)
+        #expect(decoded.pages.count == 2)
+        #expect(decoded.sourceIDs == ["01J5ABC", "01J5DEF"])
+    }
+
+    @Test func testAssignmentsForSource() {
+        let plan = ACPIngestPlan(
+            pages: [
+                ACPIngestPageAssignment(title: "A", sourceFile: "source-1.md", sourceRanges: "1-10", outline: "a"),
+                ACPIngestPageAssignment(title: "B", sourceFile: "source-2.md", sourceRanges: "1-10", outline: "b"),
+                ACPIngestPageAssignment(title: "C", sourceFile: "source-1.md", sourceRanges: "11-20", outline: "c"),
+            ],
+            sourceIDs: ["id1", "id2"])
+
+        let source1 = plan.assignments(forSource: "source-1.md")
+        #expect(source1.count == 2)
+        #expect(source1.map(\.title) == ["A", "C"])
+
+        let source2 = plan.assignments(forSource: "source-2.md")
+        #expect(source2.count == 1)
+        #expect(source2.first?.title == "B")
+
+        #expect(plan.assignments(forSource: "source-3.md").isEmpty)
+    }
+
+    @Test func testDistinctSourceFiles() {
+        let plan = ACPIngestPlan(
+            pages: [
+                ACPIngestPageAssignment(title: "A", sourceFile: "source-1.md", sourceRanges: "", outline: ""),
+                ACPIngestPageAssignment(title: "B", sourceFile: "source-2.md", sourceRanges: "", outline: ""),
+                ACPIngestPageAssignment(title: "C", sourceFile: "source-1.md", sourceRanges: "", outline: ""),
+            ],
+            sourceIDs: [])
+
+        // First-occurrence order, no duplicates.
+        #expect(plan.distinctSourceFiles == ["source-1.md", "source-2.md"])
+    }
+
+    @Test func testAllPageTitles() {
+        let plan = ACPIngestPlan(
+            pages: [
+                ACPIngestPageAssignment(title: "Alpha", sourceFile: "s1.md", sourceRanges: "", outline: ""),
+                ACPIngestPageAssignment(title: "Beta", sourceFile: "s1.md", sourceRanges: "", outline: ""),
+            ],
+            sourceIDs: [])
+
+        #expect(plan.allPageTitles == ["Alpha", "Beta"])
+    }
+
+    // MARK: - Tolerant JSON extraction (AC.2)
+
+    @Test func testTolerantJSONExtractionClean() {
+        let raw = """
+        {"pages":[{"title":"Test","sourceFile":"s.md","sourceRanges":"1-10","outline":"desc"}],"sourceIDs":["id1"]}
+        """
+        let plan = ACPIngestPlan.extract(from: raw)
+        #expect(plan != nil)
+        #expect(plan?.pages.count == 1)
+        #expect(plan?.pages.first?.title == "Test")
+        #expect(plan?.sourceIDs == ["id1"])
+    }
+
+    @Test func testTolerantJSONExtractionFenced() {
+        let raw = """
+        Here is my plan:
+
+        ```json
+        {"pages":[{"title":"Fenced","sourceFile":"s.md","sourceRanges":"1-5","outline":"x"}],"sourceIDs":["a"]}
+        ```
+
+        That's it.
+        """
+        let plan = ACPIngestPlan.extract(from: raw)
+        #expect(plan != nil)
+        #expect(plan?.pages.first?.title == "Fenced")
+    }
+
+    @Test func testTolerantJSONExtractionProseWrapped() {
+        let raw = """
+        I analyzed the sources and here is the plan:
+
+        {"pages":[{"title":"Prose","sourceFile":"s.md","sourceRanges":"entire","outline":"y"}],"sourceIDs":["b"]}
+
+        The above plan covers all content.
+        """
+        let plan = ACPIngestPlan.extract(from: raw)
+        #expect(plan != nil)
+        #expect(plan?.pages.first?.title == "Prose")
+    }
+
+    @Test func testTolerantJSONExtractionInvalid() {
+        #expect(ACPIngestPlan.extract(from: "") == nil)
+        #expect(ACPIngestPlan.extract(from: "no json here at all") == nil)
+        #expect(ACPIngestPlan.extract(from: "```json\nnot valid json\n```") == nil)
+        #expect(ACPIngestPlan.extract(from: "{ broken json }") == nil)
+    }
+
+    @Test func testTolerantJSONExtractionFromData() {
+        let raw = #"{"pages":[],"sourceIDs":[]}"#
+        let data = raw.data(using: .utf8)!
+        let plan = ACPIngestPlan.extract(from: data)
+        #expect(plan != nil)
+        #expect(plan?.pages.isEmpty == true)
+    }
+
+    @Test func testLoadFromDirectory() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let plan = ACPIngestPlan(
+            pages: [ACPIngestPageAssignment(title: "X", sourceFile: "s.md", sourceRanges: "1", outline: "x")],
+            sourceIDs: ["id1"])
+        let data = try JSONEncoder().encode(plan)
+        try data.write(to: tmpDir.appendingPathComponent("plan.json"))
+
+        let loaded = ACPIngestPlan.load(from: tmpDir)
+        #expect(loaded != nil)
+        #expect(loaded?.pages.first?.title == "X")
+    }
+
+    @Test func testLoadFromDirectoryMissing() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        #expect(ACPIngestPlan.load(from: tmpDir) == nil)
+    }
+
+    // MARK: - Prompt builders
+
+    @Test func testPlannerPromptFillsPlaceholders() {
+        let prompt = ACPIngestPrompts.plannerPrompt(
+            stateFilePath: "/tmp/WIKI_STATE.md",
+            stagedSourcePaths: ["/tmp/scratch/source-1.md", "/tmp/scratch/source-2.md"],
+            sourceIDs: ["01ABC", "01DEF"])
+
+        #expect(prompt.contains("/tmp/WIKI_STATE.md"))
+        #expect(prompt.contains("source-1.md"))
+        #expect(prompt.contains("source-2.md"))
+        #expect(prompt.contains("01ABC"))
+        #expect(prompt.contains("01DEF"))
+        #expect(prompt.contains("plan.json"))
+    }
+
+    @Test func testExecutorPromptFillsPlaceholders() {
+        let assignments = [
+            ACPIngestPageAssignment(title: "Alpha", sourceFile: "source-1.md", sourceRanges: "lines 1-50", outline: "Overview of alpha."),
+            ACPIngestPageAssignment(title: "Beta", sourceFile: "source-1.md", sourceRanges: "lines 51-100", outline: "Details of beta."),
+        ]
+        let prompt = ACPIngestPrompts.executorPrompt(
+            stateFilePath: "/tmp/state.md",
+            assignments: assignments,
+            allPageTitles: ["Alpha", "Beta", "Gamma"],
+            sourceIDs: ["id1"])
+
+        #expect(prompt.contains("Alpha"))
+        #expect(prompt.contains("Beta"))
+        #expect(prompt.contains("lines 1-50"))
+        #expect(prompt.contains("lines 51-100"))
+        #expect(prompt.contains("Gamma"))  // cross-link reference
+        #expect(prompt.contains("source-1.md"))
+    }
+
+    @Test func testFinalizerPromptFillsPlaceholders() {
+        let prompt = ACPIngestPrompts.finalizerPrompt(
+            stateFilePath: "/tmp/state.md",
+            sourceFileNames: ["source-1.md", "source-2.md"],
+            sourceIDs: ["id1", "id2"])
+
+        #expect(prompt.contains("source-1.md"))
+        #expect(prompt.contains("source-2.md"))
+        #expect(prompt.contains("id1"))
+        #expect(prompt.contains("id2"))
+        #expect(prompt.contains("index set"))
+        #expect(prompt.contains("log append"))
+    }
+
+    // MARK: - findSonnetModelId
+
+    @Test func testFindSonnetModelIdMatch() {
+        let models = [
+            ModelInfo(modelId: "claude-opus-4-20250514", name: "Claude Opus 4"),
+            ModelInfo(modelId: "claude-sonnet-4-5-20250929", name: "Claude Sonnet 4.5"),
+            ModelInfo(modelId: "claude-haiku-3-5", name: "Claude Haiku 3.5"),
+        ]
+        let result = AgentLauncher.findSonnetModelId(in: models)
+        #expect(result == "claude-sonnet-4-5-20250929")
+    }
+
+    @Test func testFindSonnetModelIdByName() {
+        let models = [
+            ModelInfo(modelId: "model-abc", name: "Sonnet Pro"),
+        ]
+        let result = AgentLauncher.findSonnetModelId(in: models)
+        #expect(result == "model-abc")
+    }
+
+    @Test func testFindSonnetModelIdNoMatch() {
+        let models = [
+            ModelInfo(modelId: "claude-opus-4", name: "Opus"),
+            ModelInfo(modelId: "gpt-4o", name: "GPT-4o"),
+        ]
+        let result = AgentLauncher.findSonnetModelId(in: models)
+        #expect(result == nil)
+    }
+
+    @Test func testFindSonnetModelIdEmpty() {
+        #expect(AgentLauncher.findSonnetModelId(in: []) == nil)
+    }
+
+    @Test func testFindSonnetModelIdCaseInsensitive() {
+        let models = [
+            ModelInfo(modelId: "CLAUDE-SONNET-4", name: "Sonnet"),
+        ]
+        let result = AgentLauncher.findSonnetModelId(in: models)
+        #expect(result == "CLAUDE-SONNET-4")
+    }
+
+    // MARK: - FakeAgentBackend recording
+
+    @Test func testFakeBackendRecordsCalls() async throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let planData = try JSONEncoder().encode(ACPIngestPlan(
+            pages: [ACPIngestPageAssignment(title: "Test", sourceFile: "source-1.md", sourceRanges: "1-10", outline: "x")],
+            sourceIDs: ["id1"]))
+
+        let fake = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [.assistantText("Planning..."), .messageStop], planJSON: planData),
+            FakeSessionBehavior(events: [.toolUse(name: "Bash", inputSummary: "wikictl page upsert"), .messageStop]),
+            FakeSessionBehavior(events: [.toolUse(name: "Bash", inputSummary: "wikictl index set"), .messageStop]),
+        ])
+
+        let profile = BackendProfile(scratchDirectory: scratch)
+
+        // Simulate 3 phases: planner → executor → finalizer.
+        let session1 = try await fake.start(profile: profile, systemPrompt: "sys") { _ in }
+        _ = await fake.send(TurnInput(userText: "planner prompt"), into: session1)
+        await fake.cancel(session1)
+
+        let session2 = try await fake.start(profile: profile, systemPrompt: "sys") { _ in }
+        _ = await fake.send(TurnInput(userText: "executor prompt"), into: session2)
+        await fake.cancel(session2)
+
+        let session3 = try await fake.start(profile: profile, systemPrompt: "sys") { _ in }
+        _ = await fake.send(TurnInput(userText: "finalizer prompt"), into: session3)
+        await fake.cancel(session3)
+
+        // Assert the recording matches the expected sequence.
+        let startCount = await fake.startCount
+        let sendCount = await fake.sendCount
+        let cancelCount = await fake.cancelCount
+        #expect(startCount == 3)
+        #expect(sendCount == 3)
+        #expect(cancelCount == 3)
+
+        let texts = await fake.sentTexts
+        #expect(texts == ["planner prompt", "executor prompt", "finalizer prompt"])
+
+        // plan.json was written by session 1.
+        let plan = ACPIngestPlan.load(from: scratch)
+        #expect(plan != nil)
+        #expect(plan?.pages.first?.title == "Test")
+
+        // Events were recorded.
+        let events = await fake.allYieldedEvents
+        #expect(events.count == 6) // 2 per session
+    }
+
+    @Test func testFakeBackendFailureOnStart() async {
+        let fake = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(shouldFailOnStart: true),
+        ])
+
+        let profile = BackendProfile()
+        do {
+            _ = try await fake.start(profile: profile, systemPrompt: "") { _ in }
+            #expect(Bool(false), "Should have thrown")
+        } catch {
+            // Expected
+        }
+
+        let startCount = await fake.startCount
+        #expect(startCount == 1) // start was attempted (recorded before throw)
+    }
+
+    @Test func testFakeBackendDefaultBehaviorWhenEmpty() async throws {
+        let fake = FakeAgentBackend(behaviors: [])
+
+        let session = try await fake.start(profile: BackendProfile(), systemPrompt: "") { _ in }
+        let stream = await fake.send(TurnInput(userText: "test"), into: session)
+        var events: [AgentEvent] = []
+        for await event in stream {
+            events.append(event)
+        }
+        #expect(events == [.messageStop])
+    }
+
+    @Test func testFakeBackendRecordsModelHints() async throws {
+        let fake = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(),
+            FakeSessionBehavior(),
+        ])
+
+        let hints1 = BackendProfile(providerHints: ["acpSelectedModelId": "opus-4"])
+        _ = try await fake.start(profile: hints1, systemPrompt: "") { _ in }
+
+        let hints2 = BackendProfile(providerHints: ["acpSelectedModelId": "sonnet-4"])
+        _ = try await fake.start(profile: hints2, systemPrompt: "") { _ in }
+
+        let recorded = await fake.startModelHints
+        #expect(recorded == ["opus-4", "sonnet-4"])
+    }
+}

--- a/Tests/WikiFSTests/FakeAgentBackend.swift
+++ b/Tests/WikiFSTests/FakeAgentBackend.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+
+/// Per-session scripted behavior for `FakeAgentBackend`. Each `start()` call
+/// pops the next behavior in sequence.
+struct FakeSessionBehavior: Sendable {
+    /// Events to yield in `send()` (ended implicitly by finishing the stream).
+    /// Defaults to just `.messageStop` (the turn-boundary marker).
+    var events: [AgentEvent] = [.messageStop]
+    /// If true, `start()` throws `FakeBackendError.startFailed`.
+    var shouldFailOnStart: Bool = false
+    /// If set, write this JSON to `plan.json` in the scratch directory on
+    /// `start()`, simulating the planner phase's output.
+    var planJSON: Data? = nil
+
+    init(
+        events: [AgentEvent] = [.messageStop],
+        shouldFailOnStart: Bool = false,
+        planJSON: Data? = nil
+    ) {
+        self.events = events
+        self.shouldFailOnStart = shouldFailOnStart
+        self.planJSON = planJSON
+    }
+}
+
+enum FakeBackendError: Error {
+    case startFailed
+}
+
+/// Test double conforming to `AgentBackend`. Records all `start`/`send`/`cancel`
+/// calls, yields scripted `AgentEvent` sequences per session, and can write a
+/// canned `plan.json` to simulate the planner phase.
+///
+/// Usage: construct with a list of `FakeSessionBehavior` (one per expected
+/// `start()` call), inject into `AgentLauncher.backend`, drive the launcher,
+/// then assert on the recorded calls.
+actor FakeAgentBackend: AgentBackend {
+
+    // MARK: - Records (for assertion)
+
+    private(set) var startCount = 0
+    private(set) var sendCount = 0
+    private(set) var cancelCount = 0
+    /// Session IDs in start order.
+    private(set) var startedSessionIDs: [String] = []
+    /// Sent prompt texts in send order.
+    private(set) var sentTexts: [String] = []
+    /// Cancelled session IDs in cancel order.
+    private(set) var cancelledSessionIDs: [String] = []
+    /// All events yielded across all sessions (flattened, in order).
+    private(set) var allYieldedEvents: [AgentEvent] = []
+    /// Model hints seen in start profiles (the `acpSelectedModelId` provider hint).
+    private(set) var startModelHints: [String?] = []
+
+    // MARK: - Scripted behavior
+
+    private var behaviors: [FakeSessionBehavior]
+    private var behaviorIndex = 0
+    private var sessionCounter = 0
+    private var sessionBehaviors: [String: FakeSessionBehavior] = [:]
+
+    init(behaviors: [FakeSessionBehavior] = []) {
+        self.behaviors = behaviors
+    }
+
+    // MARK: - AgentBackend conformance
+
+    func start(
+        profile: BackendProfile,
+        systemPrompt: String,
+        onExit: @escaping @Sendable (Int) -> Void
+    ) async throws -> SessionHandle {
+        startCount += 1
+
+        let behavior = behaviorIndex < behaviors.count
+            ? behaviors[behaviorIndex]
+            : FakeSessionBehavior()
+        behaviorIndex += 1
+
+        startModelHints.append(profile.providerHints["acpSelectedModelId"])
+
+        if behavior.shouldFailOnStart {
+            throw FakeBackendError.startFailed
+        }
+
+        sessionCounter += 1
+        let sessionId = "fake-\(sessionCounter)"
+        startedSessionIDs.append(sessionId)
+        sessionBehaviors[sessionId] = behavior
+
+        // Write plan.json if configured (simulates the planner writing the plan).
+        if let planData = behavior.planJSON, let scratch = profile.scratchDirectory {
+            let planURL = scratch.appendingPathComponent("plan.json")
+            try? planData.write(to: planURL)
+        }
+
+        return SessionHandle(id: sessionId)
+    }
+
+    func send(_ turn: TurnInput, into session: SessionHandle) async -> AsyncStream<AgentEvent> {
+        sendCount += 1
+        sentTexts.append(turn.userText)
+
+        let events = sessionBehaviors[session.id]?.events ?? [.messageStop]
+        allYieldedEvents.append(contentsOf: events)
+
+        return AsyncStream { continuation in
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+        }
+    }
+
+    func resume(sessionID: String, profile: BackendProfile) async throws -> SessionHandle? {
+        return nil
+    }
+
+    func cancel(_ session: SessionHandle) async {
+        cancelCount += 1
+        cancelledSessionIDs.append(session.id)
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -106,14 +106,17 @@ else
   echo "  (${PODCAST_HELPER_NAME} not found at ${PODCAST_HELPER_BIN} — Apple Podcasts transcript ingest will be unavailable)"
 fi
 # Bun runtime — bundled so ACP providers (claude-acp via bunx) work without a
-# system-wide install. Resolved from BUN_INSTALL or PATH; skipped (not fatal)
-# if absent (the provider falls back to PATH resolution at spawn time).
+# system-wide install. Resolved from BUN_INSTALL or ~/.bun. REQUIRED: if absent
+# the build fails rather than shipping a broken app that errors at spawn time.
 BUN_SRC="${BUN_INSTALL:-$HOME/.bun}/bin/bun"
 if [ -x "${BUN_SRC}" ]; then
   cp "${BUN_SRC}" "${HELPERS_DIR}/bun"
   echo "  ✓ bundled bun ($(file -b "${BUN_SRC}" | cut -d, -f1))"
 else
-  echo "  (bun not found at ${BUN_SRC} — ACP providers will need bun on PATH)"
+  echo "  ✗ FATAL: bun not found at ${BUN_SRC}" >&2
+  echo "    Install it:  curl -fsSL https://bun.sh/install | bash" >&2
+  echo "    Or set BUN_INSTALL to point at your bun binary's directory." >&2
+  exit 1
 fi
 # wikictl is a plain CLI with no Info.plist, so it can't read the App Group id
 # the way the .app/.appex do. Drop a sidecar that WikiIdentifiers reads. It must

--- a/plans/acp-backend-and-permissions.md
+++ b/plans/acp-backend-and-permissions.md
@@ -94,3 +94,75 @@ agent-dependent, and yolo is the safe default.
   reference) — more work, but no external dependency risk.
 - Live end-to-end testing needs a working ACP agent + credentials; the spike can
   only fully validate behavior where one is installed.
+
+## Multi-phase ingestion (planner → executors → finalizer)
+
+Large-source ACP ingestion cannot use Claude's in-process sub-agents (the Sonnet
+`source-reader` digester) — ACP has no custom agent types and background agents
+can't complete within a single turn. Instead, the ingestion is split into
+sequential single-turn ACP sessions:
+
+### Architecture
+
+```
+run() [gate acquired, onLock fired]
+  └─ if useACP && .opusCurator:
+       runACPIngestPlannerExecutors()
+         ├─ Phase 1: Planner (Opus)
+         │    read sources → write plan.json
+         ├─ Phase 2: Executors (Sonnet, N×)
+         │    each: read plan.json + source section → wikictl page upsert
+         ├─ Phase 3: Finalizer (Opus)
+         │    wikictl page list → wikictl index set → wikictl log append
+         └─ finish(0)
+  └─ else:
+       existing single-session path (singleOpus prompt / CLI)
+```
+
+### Lifecycle invariants
+
+- **Generation gate:** acquired once by `run()`, held across ALL phases, released
+  by `finish()` at the end. NOT released per-turn (one-shot runs hold the gate
+  through `finish()`).
+- **`onLock`:** fired once by `run()` before dispatch. NOT re-fired per phase.
+- **`finish()`:** called exactly once by the orchestrator (success: `finish(0)`;
+  failure: `finish(-1)`). The per-phase `onExit` closures do NOT call `finish()`.
+- **`sessionHandle`/`currentRunToken`:** updated per phase so `stopAgent()` and
+  the watchdog track the live phase.
+- **Stop during a phase:** `stopAgent()` cancels the live session + calls
+  `finish(-1)`. Remaining phases skip (checked via `isRunning` guard). Partial
+  pages already written stay (intentional — partial progress > rollback).
+- **Partial executor failure:** if an executor's `backend.start` throws or the
+  stream errors, the orchestrator logs and continues to the next executor. The
+  finalizer runs best-effort.
+- **Planner failure / invalid plan.json:** falls back to single-session ACP
+  ingest (the original one-shot prompt with the "no sub-agents" instruction).
+
+### Plan schema (`ACPIngestPlan`)
+
+```json
+{
+  "pages": [
+    {
+      "title": "Page Title",
+      "sourceFile": "source-1.md",
+      "sourceRanges": "lines 1-80",
+      "outline": "1-3 sentence description"
+    }
+  ],
+  "sourceIDs": ["01J5ABC", "01J5DEF"]
+}
+```
+
+The planner writes this to `plan.json` in the scratch directory. Executors are
+grouped by `sourceFile` (one executor per source file). Tolerant extraction
+(`ACPIngestPlan.extract(from:)`) strips ```` ```json ```` fences and substrings
+from first `{` to last `}` to handle Claude wrapping JSON in prose.
+
+### Model selection
+
+Executors should use Sonnet (cheaper). The alias "sonnet" does NOT match
+`ACPModelSelectionResolver` (exact-id matching). Instead, after the planner
+session starts, `ACPBackend.availableModels(for:)` is read and the first model
+whose id/name contains "sonnet" is selected via `findSonnetModelId()`. Falls
+back to the provider's default model if no match.

--- a/prompts/ingest-executor.md
+++ b/prompts/ingest-executor.md
@@ -1,0 +1,43 @@
+EXECUTOR PHASE — Multi-page ingest. You are an EXECUTOR. You have been assigned specific pages to write. Read your source section and write each page via `$WIKICTL page upsert`.
+
+## Wiki state snapshot
+
+A snapshot of the current wiki state is at: {{STATE_FILE_PATH}}
+
+## Your assigned pages
+
+{{ASSIGNED_PAGES}}
+
+## All pages in this ingest (for cross-linking)
+
+{{ALL_PAGE_TITLES}}
+
+## Source IDs
+
+{{SOURCE_IDS}}
+
+## Instructions
+
+For EACH assigned page:
+
+1. Read the source file section at the given range. The source file is in your working directory. Use `sed -n 'START,ENDp' {{PRIMARY_SOURCE_FILE}}` or `cat {{PRIMARY_SOURCE_FILE}}` to read the relevant section.
+
+2. Write the page body to `./body.md`:
+   - Summarize the source content into a clear, well-structured wiki page.
+   - Cross-link related pages with [[Page Title]] wiki-links. Use the page titles listed above.
+   - Cite sources by their `sources/…` path.
+
+3. Create or update the page: `$WIKICTL page upsert --title 'PAGE TITLE' --body-file ./body.md`
+
+4. Verify: `$WIKICTL page get --title 'PAGE TITLE'`
+
+### Write rules
+
+- The ONLY way to create or update content is `$WIKICTL`. The wiki mount is READ-ONLY.
+- Always use `--body-file ./body.md`, never shell pipes or heredocs.
+- After a write, read it back with `$WIKICTL page get` (the mount lags the database by ~5s).
+
+IMPORTANT:
+- Do NOT dispatch sub-agents, background tasks, or async agents.
+- Do NOT use sleep or ScheduleWakeup.
+- Write ALL your assigned pages before stopping.

--- a/prompts/ingest-finalizer.md
+++ b/prompts/ingest-finalizer.md
@@ -1,0 +1,33 @@
+FINALIZER PHASE — Multi-page ingest. The executors have written all wiki pages. Your job is to finalize the ingestion: write index.md and record log entries.
+
+## Wiki state snapshot
+
+A snapshot of the current wiki state is at: {{STATE_FILE_PATH}}
+
+## Source files and IDs
+
+For each source, record the ingest in the log. The source files and their IDs are:
+
+{{SOURCE_FILES_AND_IDS}}
+
+## Instructions
+
+1. Read the current page list: `$WIKICTL page list`
+
+2. Write `index.md` — the curated catalog of ALL pages in the wiki (not just new ones). Write it to `./index.md`, then: `$WIKICTL index set --body-file ./index.md`
+
+3. For EACH source listed above, record the ingest in the log:
+   ```
+   $WIKICTL log append --kind ingest --title "<source file name>" --source <id>
+   ```
+   The `--source` id is REQUIRED — it marks that file as Ingested in the app.
+
+### Write rules
+
+- The ONLY way to create or update content is `$WIKICTL`. The wiki mount is READ-ONLY.
+- Always use `--body-file ./index.md`, never shell pipes or heredocs.
+
+IMPORTANT:
+- Do NOT dispatch sub-agents, background tasks, or async agents.
+- Do NOT use sleep or ScheduleWakeup.
+- Write the index.md and ALL log entries before stopping.

--- a/prompts/ingest-planner.md
+++ b/prompts/ingest-planner.md
@@ -1,0 +1,54 @@
+PLANNER PHASE — Multi-page ingest. You are the PLANNER. Read the staged source files, decide what pages this wiki should have, and write a plan. Do NOT write any wiki pages in this phase.
+
+## Wiki state snapshot
+
+A snapshot of the current wiki state is at: {{STATE_FILE_PATH}}
+Read it FIRST to see what pages already exist. This avoids creating duplicates on re-ingest.
+
+## Source files (in your working directory)
+
+{{SOURCE_FILES}}
+
+## Source IDs (required for wikictl log --source)
+
+{{SOURCE_IDS}}
+
+## Instructions
+
+1. Read the wiki state snapshot at the path above to see existing pages and the current index.
+
+2. Check existing pages: `$WIKICTL page list` — update-in-place rather than creating duplicates on re-ingest.
+
+3. For each source file, inspect its size and structure. Use `wc -l`, `head`, `sed -n 'START,ENDp'`, or `grep` to sample the content without reading the entire file if it is large.
+
+4. DECIDE the page set: what summary/entity/concept pages does this wiki need? Each page is backed by content from ONE source file (the `sourceFile` field). Cross-reference across sources to find connections and avoid duplicate pages. If two sources discuss the same topic, assign the page to the source with the most content on that topic and cross-link from the other executor's pages using [[wiki links]].
+
+5. Write your plan to `plan.json` in your current working directory using this EXACT JSON schema:
+
+```json
+{
+  "pages": [
+    {
+      "title": "Page Title",
+      "sourceFile": "source-1.md",
+      "sourceRanges": "lines 1-80",
+      "outline": "1-3 sentence description of what this page covers"
+    }
+  ],
+  "sourceIDs": ["<id1>", "<id2>"]
+}
+```
+
+### Field rules
+
+- `title`: the wiki page title (clear, specific, stable). Upserting an existing title updates it.
+- `sourceFile`: the actual filename in your working directory (e.g. "source-1.md").
+- `sourceRanges`: a human-readable description of where in the source file the content for this page is (e.g. "lines 1-80" or "section 'Introduction'" or "entire file").
+- `outline`: a 1-3 sentence description of what the page will cover.
+- `sourceIDs`: the list of source IDs given above. Copy them verbatim.
+
+IMPORTANT:
+- Do NOT write any wiki pages in this phase. No `$WIKICTL page upsert`.
+- Do NOT dispatch sub-agents, background tasks, or async agents.
+- Do NOT use sleep or ScheduleWakeup.
+- Write ONLY `plan.json` and stop.

--- a/tools/promptgen/main.swift
+++ b/tools/promptgen/main.swift
@@ -36,6 +36,9 @@ let entries: [(file: String, constant: String)] = [
     ("chat.md",                       "chat"),
     ("lint-task.md",                 "lintTask"),
     ("lint-page-task.md",            "lintPageTask"),
+    ("ingest-planner.md",            "ingestPlanner"),
+    ("ingest-executor.md",           "ingestExecutor"),
+    ("ingest-finalizer.md",          "ingestFinalizer"),
 ]
 
 // Resolve the repo root from this script's location (tools/promptgen/ → up 2).


### PR DESCRIPTION
## Summary

Large-source ACP ingestion was broken: it relied on Claude's in-process sub-agents (the Sonnet `source-reader` digester via `--agents`), which don't work over ACP — the protocol has no custom agent types and background agents can't complete within a single turn.

This PR replaces the one-shot spawn with a **multi-process architecture**: sequential single-turn ACP sessions that each do one job.

### Multi-phase ingestion

| Phase | Model | Sessions | Job |
|---|---|---|---|
| **Planner** | default (Opus) | 1 | Reads sources, decides page set, writes `plan.json` |
| **Executors** | Sonnet | N (one per source file) | Each reads its assigned pages + source section, writes via `$WIKICTL page upsert` |
| **Finalizer** | default (Opus) | 1 | Writes `index.md` via `$WIKICTL index set`, logs via `$WIKICTL log append` |

Triggered only for `useACP && plan.isLargeSource` (sources ≥ 4 KB over ACP). Tiny sources and all CLI runs use the existing single-session path unchanged.

**Fallback:** if the planner fails or produces no valid `plan.json`, the orchestration falls back to single-session ACP ingest (the original one-shot prompt).

### Bundled bun fix

`Bundle.url(forAuxiliaryExecutable:)` only searches `Contents/MacOS/` and `Contents/Resources/` — **not** `Contents/Helpers/` where bun is bundled. This caused "bun not found on your path" even though bun was correctly bundled. Fixed with a manual `bundledHelperPath()` check. Also:
- `build.sh` now **hard-fails** if bun is missing (was silently skipped)
- App **asserts** bun presence on launch (logs a warning to Console.app)

### Changes

**New files:**
- `Sources/WikiFSCore/ACPIngestPlan.swift` — `Codable` plan schema, tolerant JSON extraction (strips ```json fences, substrings `{`→`}`), pure prompt builders
- `Tests/WikiFSTests/FakeAgentBackend.swift` — test double conforming to `AgentBackend`
- `Tests/WikiFSTests/ACPIngestPlanTests.swift` — 23 tests
- `prompts/ingest-{planner,executor,finalizer}.md` — phase prompt templates

**Modified:**
- `Sources/WikiFS/AgentLauncher.swift` — `runACPIngestPlannerExecutors()`, `runPhase()`, `runACPIngestFallback()`, `findSonnetModelId()`, `bundledHelperPath()`, dispatch in `run()`
- `Sources/WikiFS/WikiFSApp.swift` — launch-time bun assertion
- `Sources/WikiFSCore/IngestPlan.swift` — `isLargeSource` (model-agnostic predicate)
- `Sources/WikiFSCore/WikiOperation.swift` — `sourceID(fromPath:)` → `public`
- `build.sh` — hard-fail on missing bun
- `tools/promptgen/main.swift` — 3 new prompt entries
- `Sources/WikiFSCore/GeneratedPrompts.swift` — regenerated

### Test plan

- [x] `swift build` — clean (no warnings from new code)
- [x] `swift test --filter ACPIngestPlanTests` — 23 tests pass
- [x] Fast-tier suite (2112 tests) — all pass
- [x] `make check-prompts` — parity check passes
- [x] Manual: ingest a large source (> 4 KB) over ACP, verify pages appear
- [ ] Manual: tiny source (< 4 KB) uses single-session path
