### PR TITLE
Fix: SQLite statement reset leak pinning stale WAL snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         # ProjectionTreeTests un-skipped after #291 (ReadScope): ~32 s on CI
         # hardware (~2–3x slower), down from 165 s+ per working-set test.
         env:
-          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests'
+          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests'
         run: swift test --skip "$SKIP" || xcrun swift test --skip "$SKIP"
 
   python:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Resources/mlx.metallib
 .vscode/
 
 .xcodebuildmcp/
+tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,12 @@ agents, NOT Polytoken):
   still flow through the `@MainActor` model; off-main reads go through
   `WikiReadPool`.** Multi-step writes compose via `withTransaction` (savepoint
   nesting — never raw `BEGIN`), and no statement handle or column pointer may
-  cross a method boundary. Never run inference/network inside a transaction,
-  and never pool `init(databaseURL:)` connections (that init writes; read-only
-  pools use `init(readOnlyURL:)`). Follow
+  cross a method boundary. Every stepped `SQLiteStatement` must be covered by
+  `defer { stmt.reset() }` — a statement left at `SQLITE_ROW` pins the
+  connection's WAL read snapshot, causing stale reads and `BEGIN IMMEDIATE`
+  failures after external writes (#332). Never run inference/network inside a
+  transaction, and never pool `init(databaseURL:)` connections (that init
+  writes; read-only pools use `init(readOnlyURL:)`). Follow
   [`docs/skills/sqlite-concurrency/SKILL.md`](docs/skills/sqlite-concurrency/SKILL.md)
   and `plans/graph-model-and-versioning.md` §8; regression suite:
   `swift test --filter StoreConcurrencyTests`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,49 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-11 — Fix: SQLite statement reset leak pinning stale WAL snapshots (#332)
+
+**Problem:** Cached SELECT statements across 18 functions (26 leaking statements)
+in `SQLiteWikiStore.swift` used a "reset-before-use" idiom (`stmt.reset()` before
+`bind`/`step`) that cleared the *previous* call's leftover but left the
+*current* call's statement stepped-to-`SQLITE_ROW` (busy) when the function
+returned. A busy statement holds an implicit read transaction open, pinning the
+connection's WAL read snapshot. After an external writer (`wikictl`, another
+store instance) commits, the pinned snapshot is stale — subsequent reads return
+old data and `BEGIN IMMEDIATE` fails with `SQLITE_BUSY_SNAPSHOT`.
+
+**Fix (Phase 1):** At every affected site, replaced the leading `stmt.reset()`
+with `defer { stmt.reset() }` immediately after `try statement(...)`. This bounds
+the statement's read transaction to the call, covering success, early-return, and
+throw paths uniformly. Also converted the migration-loop statements
+(`resolveVersion`/`resolveVersionMax`) and fixed `revertProcessedMarkdown`, which
+stepped a `target` statement to ROW before entering `withTransaction` — added an
+explicit `target.reset()` after extracting values so the read snapshot is released
+before `BEGIN IMMEDIATE`.
+
+**Guard (Phase 2):** Added `SQLiteStatement.isBusy` (wraps `sqlite3_stmt_busy`),
+an internal `assertNoBusyStatements()` method (iterates the statement cache,
+throws if any is busy), and a `_testProbeBusyStatement()` test seam. The guard
+fires at the top of `withTransaction` at depth 0 (`#if DEBUG` only) — before
+`BEGIN IMMEDIATE`.
+
+**Tests (Phase 3):** New `SQLiteStatementLifecycleTests` suite (not
+`.integration`-tagged → runs in CI): `noBusyStatementsAfterReads` (Test 1,
+deterministic — exercises every fixed site via public callers, asserts no busy
+statement), `detectsBusyStatement` (AC.2 — verifies the guard throws). Integration
+suite `SQLiteStatementLifecycleIntegrationTests` (`.integration`-tagged):
+multi-connection WAL write-lock and read-only stale-snapshot tests.
+
+**Documentation (Phase 4):** Updated `docs/skills/sqlite-concurrency/SKILL.md`
+(new §7 on statement lifetime discipline), `AGENTS.md` (rule addition to the
+SQLite concurrency bullet), CI skip regex in `.github/workflows/ci.yml`.
+
+**Files changed:**
+- `Sources/WikiFSCore/SQLiteStatement.swift` — added `isBusy`
+- `Sources/WikiFSCore/SQLiteWikiStore.swift` — 18 functions + migration + `revertProcessedMarkdown` fixed; `assertNoBusyStatements()` + `_testProbeBusyStatement()` added; guard in `withTransaction`
+- `Tests/WikiFSTests/SQLiteStatementLifecycleTests.swift` — new test file
+- `docs/skills/sqlite-concurrency/SKILL.md`, `AGENTS.md`, `.github/workflows/ci.yml` — documentation + CI
+
 ## 2026-07-10 — Multi-phase ACP ingestion (planner → executors → finalizer)
 
 **Problem:** Large-source ACP ingestion relied on Claude's in-process sub-agents

--- a/Sources/WikiFSCore/SQLiteStatement.swift
+++ b/Sources/WikiFSCore/SQLiteStatement.swift
@@ -32,6 +32,14 @@ final class SQLiteStatement {
         sqlite3_clear_bindings(handle)
     }
 
+    /// True when the statement is stepped-to-ROW but not yet reset — i.e. it
+    /// holds an implicit read transaction open, pinning the connection's WAL
+    /// snapshot. Every stepped statement must be covered by `defer { reset() }`.
+    var isBusy: Bool {
+        guard let handle else { return false }
+        return sqlite3_stmt_busy(handle) != 0
+    }
+
     // MARK: - Binding (1-based indexes, per the SQLite C API)
 
     func bind(_ value: String, at index: Int32) throws {

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -1535,10 +1535,12 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             JOIN source_versions sv ON sv.id = r.version_id
             WHERE r.kind = 'source-content' AND r.owner_id = ?1;
             """)
+            defer { resolveVersion.reset() }
             let resolveVersionMax = try statement("""
             SELECT id FROM source_versions
             WHERE source_id = ?1 ORDER BY id DESC LIMIT 1;
             """)
+            defer { resolveVersionMax.reset() }
 
             for row in rows {
                 // SHA-256 of the UTF-8 markdown bytes.
@@ -1591,8 +1593,6 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             insBlob.reset()
             insActivity.reset()
             upd.reset()
-            resolveVersion.reset()
-            resolveVersionMax.reset()
         }
     }
 
@@ -2402,7 +2402,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             // Direct existence check — no `getChat` entity fetch needed; the
             // canonical resolver only needs to know whether the id is live.
             let stmt = try statement("SELECT 1 FROM chats WHERE id = ?1;")
-            stmt.reset()
+            defer { stmt.reset() }
             try stmt.bind(id.rawValue, at: 1)
             return (try stmt.step()) ? id : nil
         }
@@ -2959,7 +2959,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         SELECT COUNT(*) FROM source_versions
         WHERE activity_id = ?1 AND original_path IS NOT NULL;
         """)
-        stmt.reset()
+        defer { stmt.reset() }
         try stmt.bind(activityID, at: 1)
         guard try stmt.step() else { return false }
         return stmt.int(at: 0) > 0
@@ -3237,7 +3237,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         JOIN source_versions sv ON sv.id = r.version_id
         WHERE r.kind = 'source-content' AND r.owner_id = ?1;
         """)
-        refStmt.reset()
+        defer { refStmt.reset() }
         try refStmt.bind(id.rawValue, at: 1)
         var blobHash: String?
         if try refStmt.step() {
@@ -3253,7 +3253,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             SELECT blob_hash FROM source_versions
             WHERE source_id = ?1 ORDER BY id DESC LIMIT 1;
             """)
-            maxStmt.reset()
+            defer { maxStmt.reset() }
             try maxStmt.bind(id.rawValue, at: 1)
             if try maxStmt.step() {
                 if sqlite3_column_type(maxStmt.handle, 0) != SQLITE_NULL {
@@ -3272,7 +3272,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
         // 3. Read the blob bytes.
         let blobStmt = try statement("SELECT content FROM blobs WHERE hash = ?1;")
-        blobStmt.reset()
+        defer { blobStmt.reset() }
         try blobStmt.bind(blobHash, at: 1)
         guard try blobStmt.step() else {
             // A version points at a blob that is missing — an integrity break
@@ -3298,7 +3298,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         JOIN source_versions sv ON sv.id = r.version_id
         WHERE r.kind = 'source-content' AND r.owner_id = ?1;
         """)
-        refStmt.reset()
+        defer { refStmt.reset() }
         try refStmt.bind(sourceID.rawValue, at: 1)
         if try refStmt.step() {
             return sourceVersion(from: refStmt)
@@ -3309,7 +3309,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         FROM source_versions
         WHERE source_id = ?1 ORDER BY id DESC LIMIT 1;
         """)
-        maxStmt.reset()
+        defer { maxStmt.reset() }
         try maxStmt.bind(sourceID.rawValue, at: 1)
         guard try maxStmt.step() else { return nil }
         return sourceVersion(from: maxStmt)
@@ -3373,7 +3373,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         LEFT JOIN agents a ON a.id = act.agent_id
         WHERE r.kind = 'source-content' AND r.owner_id = ?1;
         """)
-        refStmt.reset()
+        defer { refStmt.reset() }
         try refStmt.bind(sourceID.rawValue, at: 1)
         if try refStmt.step() {
             return originFrom(stmt: refStmt)
@@ -3386,7 +3386,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         LEFT JOIN agents a ON a.id = act.agent_id
         WHERE sv.source_id = ?1 ORDER BY sv.id DESC LIMIT 1;
         """)
-        maxStmt.reset()
+        defer { maxStmt.reset() }
         try maxStmt.bind(sourceID.rawValue, at: 1)
         guard try maxStmt.step() else { return nil }
         return originFrom(stmt: maxStmt)
@@ -3466,12 +3466,12 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     private func legacyImportAgentID() throws -> String {
         let find = try statement(
             "SELECT id FROM agents WHERE name = 'legacy-import' LIMIT 1;")
-        find.reset()
+        defer { find.reset() }
         if try find.step() { return find.text(at: 0) }
         let id = ULID.generate()
         let ins = try statement(
             "INSERT INTO agents (id, kind, name) VALUES (?1, 'software', 'legacy-import');")
-        ins.reset()
+        defer { ins.reset() }
         try ins.bind(id, at: 1)
         _ = try ins.step()
         return id
@@ -3485,7 +3485,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                              version: String? = nil, externalRef: String? = nil) throws -> String {
         let find = try statement(
             "SELECT id FROM agents WHERE name = ?1 AND kind = ?2 LIMIT 1;")
-        find.reset()
+        defer { find.reset() }
         try find.bind(name, at: 1)
         try find.bind(kind, at: 2)
         if try find.step() { return find.text(at: 0) }
@@ -3494,7 +3494,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         INSERT INTO agents (id, kind, name, version, external_ref)
         VALUES (?1, ?2, ?3, ?4, ?5);
         """)
-        ins.reset()
+        defer { ins.reset() }
         try ins.bind(id, at: 1)
         try ins.bind(kind, at: 2)
         try ins.bind(name, at: 3)
@@ -3760,7 +3760,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             SELECT blob_hash, mime_type FROM source_versions
             WHERE id = ?1 AND source_id = ?2;
             """)
-            target.reset()
+            defer { target.reset() }
             try target.bind(versionID.rawValue, at: 1)
             try target.bind(sourceID.rawValue, at: 2)
             guard try target.step() else {
@@ -3775,7 +3775,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             var byteSize: Int64 = 0
             if let blobHash {
                 let bs = try statement("SELECT byte_size FROM blobs WHERE hash = ?1;")
-                bs.reset()
+                defer { bs.reset() }
                 try bs.bind(blobHash, at: 1)
                 if try bs.step() { byteSize = bs.int(at: 0) }
             }
@@ -3830,7 +3830,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         SELECT generation FROM refs
         WHERE kind = 'source-content' AND owner_id = ?1;
         """)
-        stmt.reset()
+        defer { stmt.reset() }
         try stmt.bind(sourceID.rawValue, at: 1)
         if try stmt.step() { return Int(stmt.int(at: 0)) }
         return nil
@@ -4334,7 +4334,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             // Capture the parent for sibling renumbering after the delete.
             let info = try statement(
                 "SELECT parent_id FROM bookmark_nodes WHERE id = ?1;")
-            info.reset()
+            defer { info.reset() }
             try info.bind(id, at: 1)
             var oldParent: String? = nil
             if try info.step() {
@@ -4362,7 +4362,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             // Read the node's current parent + position.
             let info = try statement(
                 "SELECT parent_id, position FROM bookmark_nodes WHERE id = ?1;")
-            info.reset()
+            defer { info.reset() }
             try info.bind(id, at: 1)
             guard try info.step() else {
                 throw WikiStoreError.unexpected("moveBookmarkNode: node \(id) not found")
@@ -4376,6 +4376,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                 var ancestor: String? = toParentID
                 let ancestorStmt = try statement(
                     "SELECT parent_id FROM bookmark_nodes WHERE id = ?1;")
+                defer { ancestorStmt.reset() }
                 while let current = ancestor {
                     if current == id {
                         throw WikiStoreError.unexpected(
@@ -4535,7 +4536,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         return try mutate(event: { _ in localEvent(.chat, id: chatID.rawValue, change: .updated) }) {
         let inserted = try withTransaction {
             let exists = try statement("SELECT 1 FROM chats WHERE id = ?1;")
-            exists.reset()
+            defer { exists.reset() }
             try exists.bind(chatID.rawValue, at: 1)
             guard try exists.step() else {
                 throw WikiStoreError.notFound(chatID)
@@ -4545,7 +4546,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             // so the first row lands at 0).
             let maxSeq = try statement(
                 "SELECT COALESCE(MAX(seq), -1) FROM chat_messages WHERE chat_id = ?1;")
-            maxSeq.reset()
+            defer { maxSeq.reset() }
             try maxSeq.bind(chatID.rawValue, at: 1)
             _ = try maxSeq.step()
             var nextSeq = Int(maxSeq.int(at: 0)) + 1
@@ -4729,7 +4730,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         try mutate(event: { _ in localEvent(.chat, id: id.rawValue, change: .updated) }) {
         try withTransaction {
             let exists = try statement("SELECT 1 FROM chats WHERE id = ?1;")
-            exists.reset()
+            defer { exists.reset() }
             try exists.bind(id.rawValue, at: 1)
             guard try exists.step() else {
                 throw WikiStoreError.notFound(id)
@@ -4818,6 +4819,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let depth = transactionDepth
         let savepoint = "wiki_txn_\(depth)"
         if depth == 0 {
+            #if DEBUG
+            try assertNoBusyStatements()
+            #endif
             let start = DispatchTime.now()
             do {
                 try exec("BEGIN IMMEDIATE;")
@@ -4917,6 +4921,31 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         statements[sql] = stmt
         return stmt
     }
+
+    #if DEBUG
+    /// Assert no cached statement is left busy. A busy statement pins the
+    /// connection's WAL read snapshot, causing stale reads and write-lock
+    /// failures after external commits (#332). Acquires the recursive lock
+    /// internally — safe from within `withTransaction` (re-entrant) and
+    /// from bare test calls.
+    internal func assertNoBusyStatements() throws {
+        lock.lock(); defer { lock.unlock() }
+        for (sql, stmt) in statements {
+            if stmt.isBusy {
+                throw WikiStoreError.unexpected(
+                    "Busy cached statement detected: \(sql.prefix(80))")
+            }
+        }
+    }
+
+    /// Test-only seam: prepare-and-step a SQL string without resetting,
+    /// so `testAssertNoBusyStatementsDetectsLeak` can trigger a busy state.
+    internal func _testProbeBusyStatement(_ sql: String) throws {
+        lock.lock(); defer { lock.unlock() }
+        let stmt = try statement(sql)
+        _ = try stmt.step()   // intentionally NOT reset — simulates the bug
+    }
+    #endif
 
     /// Execute a statement that returns no rows (DDL / PRAGMA assignment).
     /// Not cached — these run once at open time.
@@ -5762,12 +5791,11 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         \(Self.smvBlobJoin)
         WHERE r.kind = 'source-derived' AND r.owner_id = ?1;
         """) {
-            refStmt.reset()
+            defer { refStmt.reset() }
             try refStmt.bind(sourceID.rawValue, at: 1)
             if try refStmt.step() {
                 return sourceMarkdownVersion(from: refStmt)
             }
-            refStmt.reset()
         }
         guard let stmt = try? statement("""
         SELECT \(Self.smvSelectColumns)
@@ -5886,16 +5914,15 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         SELECT version_id FROM refs
         WHERE kind = 'source-derived' AND owner_id = ?1;
         """) {
-            refStmt.reset()
+            defer { refStmt.reset() }
             try refStmt.bind(sourceID.rawValue, at: 1)
             if try refStmt.step() { return refStmt.text(at: 0) }
-            refStmt.reset()
         }
         let maxStmt = try statement("""
         SELECT id FROM source_markdown_versions
         WHERE file_id = ?1 ORDER BY id DESC LIMIT 1;
         """)
-        maxStmt.reset()
+        defer { maxStmt.reset() }
         try maxStmt.bind(sourceID.rawValue, at: 1)
         if try maxStmt.step() { return maxStmt.text(at: 0) }
         return nil
@@ -6126,7 +6153,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         SELECT version_id FROM refs
         WHERE kind = 'source-derived' AND owner_id = ?1;
         """)
-        stmt.reset()
+        defer { stmt.reset() }
         try stmt.bind(sourceID.rawValue, at: 1)
         if try stmt.step() { return stmt.text(at: 0) }
         return nil
@@ -6162,6 +6189,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                 sourceID: sourceID, content: targetVersion.content,
                 origin: "revert", note: "revert to \(versionID.rawValue)")
         }
+        // All values extracted — release the read snapshot before the write
+        // transaction so `target` is not left busy through BEGIN IMMEDIATE (#332).
+        target.reset()
 
         // Append a new row reusing the target's blob_hash (INSERT OR IGNORE on the
         // existing hash is a no-op — zero new blob bytes), then repoint the ref.
@@ -6235,7 +6265,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         SELECT generation FROM refs
         WHERE kind = 'source-derived' AND owner_id = ?1;
         """)
-        stmt.reset()
+        defer { stmt.reset() }
         try stmt.bind(sourceID.rawValue, at: 1)
         if try stmt.step() { return Int(stmt.int(at: 0)) }
         return nil
@@ -6252,7 +6282,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             SELECT 1 FROM source_markdown_versions
             WHERE id = ?1 AND file_id = ?2;
             """)
-            check.reset()
+            defer { check.reset() }
             try check.bind(versionID.rawValue, at: 1)
             try check.bind(sourceID.rawValue, at: 2)
             guard try check.step() else {

--- a/Tests/WikiFSTests/SQLiteStatementLifecycleTests.swift
+++ b/Tests/WikiFSTests/SQLiteStatementLifecycleTests.swift
@@ -1,0 +1,211 @@
+import Testing
+import Foundation
+import SQLite3
+@testable import WikiFSCore
+
+/// Statement-lifecycle regression tests for issue #332: cached SELECT
+/// statements must never be left stepped-to-ROW (busy) when a method returns.
+/// A busy statement pins the connection's WAL read snapshot, causing stale
+/// reads and `BEGIN IMMEDIATE` failures after external writes.
+///
+/// **`noBusyStatementsAfterReads`** is the authoritative guard: deterministic
+/// (`sqlite3_stmt_busy`), SQLite-version-independent, CI-fast. It exercises
+/// every fixed statement site via public callers and asserts
+/// `assertNoBusyStatements()` after each.
+///
+/// **`detectsBusyStatement`** verifies the guard itself throws when a
+/// statement IS left busy (AC.2).
+///
+/// These tests use a single connection with deterministic checks — no
+/// multi-connection WAL behavior, no slow working-set — so they are NOT
+/// `.integration`-tagged and run in CI.
+@Suite struct SQLiteStatementLifecycleTests {
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stmt-lifecycle-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    // MARK: - AC.2: assertNoBusyStatements() throws when a statement is busy
+
+    @Test func detectsBusyStatement() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        // Step without resetting — simulates the #332 bug.
+        try store._testProbeBusyStatement("SELECT 1;")
+        #expect(throws: WikiStoreError.self) {
+            try store.assertNoBusyStatements()
+        }
+    }
+
+    // MARK: - Test 1: no busy statements after any read or write-adjacent method
+
+    @Test func noBusyStatementsAfterReads() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+
+        // --- Setup: create data that exercises all fixed statement sites ---
+
+        let page = try store.createPage(title: "Test Page")
+
+        // addSource WITHOUT provenance → exercises legacyImportAgentID.
+        let source = try store.addSource(
+            filename: "doc.txt", data: Data("original content".utf8))
+
+        // addSource WITH provenance → exercises ensureAgent.
+        _ = try store.addSource(
+            filename: "fetched.html", data: Data("<html>fetched</html>".utf8),
+            provenance: SourceProvenance(
+                agentName: "website", activityKind: "fetch",
+                plan: "https://example.com", externalRef: "https://example.com/page",
+                externalIdentity: "https://example.com/page"))
+
+        // appendContentVersion → exercises refGeneration.
+        let v2 = try store.appendContentVersion(
+            sourceID: source.id, data: Data("version two".utf8))
+
+        // Record two extractions → populates smv tables.
+        let smv1 = try store.recordMarkdownExtraction(
+            sourceID: source.id, content: "# Extracted",
+            backend: .anthropic, modelVersion: "claude-test")
+        let smv2 = try store.recordMarkdownExtraction(
+            sourceID: source.id, content: "# Re-extracted",
+            backend: .gemini)
+
+        // Bookmark tree for delete + move tests.
+        let folder = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder,
+            label: "Folder", targetID: nil)
+        let bookmark = try store.createBookmarkNode(
+            parentID: nil, position: 1, kind: .pageRef,
+            label: nil, targetID: page.id)
+
+        // Chat for append/rename tests.
+        let chat = try store.createChat(kind: .edit, title: "Test Chat")
+
+        // --- Write-adjacent methods: call each, then assert no busy statements ---
+
+        // setActiveMarkdown → check + upsertMarkdownDerivedRef → markdownDerivedGeneration.
+        try store.setActiveMarkdown(sourceID: source.id, to: smv1.id)
+        try store.assertNoBusyStatements()
+
+        // revertProcessedMarkdown → upsertMarkdownDerivedRef → markdownDerivedGeneration.
+        _ = try store.revertProcessedMarkdown(sourceID: source.id, to: smv2.id)
+        try store.assertNoBusyStatements()
+
+        // rollbackSourceContent → refGeneration + target + bs.
+        try store.rollbackSourceContent(
+            sourceID: source.id, to: PageID(rawValue: v2.id))
+        try store.assertNoBusyStatements()
+
+        // recordMarkdownExtraction (after ref is set) → markdownDerivedRef ROW path.
+        _ = try store.recordMarkdownExtraction(
+            sourceID: source.id, content: "# Third extraction",
+            backend: .localPdf2md)
+        try store.assertNoBusyStatements()
+
+        // deleteBookmarkNode → info.
+        try store.deleteBookmarkNode(id: bookmark.id)
+        try store.assertNoBusyStatements()
+
+        // moveBookmarkNode into a parent → info + ancestorStmt (root-hit path).
+        let leaf = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .pageRef,
+            label: nil, targetID: page.id)
+        try store.moveBookmarkNode(id: leaf.id, toParentID: folder.id, position: 0)
+        try store.assertNoBusyStatements()
+
+        // appendChatMessages → exists + maxSeq.
+        _ = try store.appendChatMessages(
+            chatID: chat.id, events: [.userText("hello")])
+        try store.assertNoBusyStatements()
+
+        // renameChat → exists.
+        try store.renameChat(id: chat.id, to: "Renamed Chat")
+        try store.assertNoBusyStatements()
+
+        // --- Read methods: call each, then assert no busy statements ---
+
+        _ = try store.sourceContent(id: source.id)
+        try store.assertNoBusyStatements()
+
+        _ = try store.activeContentVersion(sourceID: source.id)
+        try store.assertNoBusyStatements()
+
+        _ = try store.sourceOrigin(sourceID: source.id)
+        try store.assertNoBusyStatements()
+
+        _ = try store.hasImageSiblings(sourceID: source.id)
+        try store.assertNoBusyStatements()
+
+        // canonicalLinkID(.chat) → exercise via replaceLinks with a chat link.
+        try store.replaceLinks(from: page.id, parsedLinks: [
+            WikiLinkParser.ParsedLink(
+                linkType: .chat, target: chat.id.rawValue,
+                linkText: "Chat"),
+        ])
+        try store.assertNoBusyStatements()
+
+        _ = try store.processedMarkdownHead(sourceID: source.id)
+        try store.assertNoBusyStatements()
+
+        _ = try store.processedMarkdownHeadID(sourceID: source.id)
+        try store.assertNoBusyStatements()
+    }
+}
+
+/// Multi-connection integration tests for issue #332: a leaked busy statement
+/// on one connection should not block writes or serve stale reads after an
+/// external commit advances the WAL.
+///
+/// These require real WAL cross-connection behavior and may be SQLite-version-
+/// dependent. `noBusyStatementsAfterReads` (above) is the authoritative,
+/// version-independent regression guard.
+@Suite(.tags(.integration)) struct SQLiteStatementLifecycleIntegrationTests {
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stmt-lifecycle-int-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    // MARK: - Test 2: leaked statement does not block write after external commit
+
+    @Test func leakedStatementDoesNotBlockWriteAfterExternalCommit() throws {
+        let url = tempDatabaseURL()
+
+        // Store A: add a source, then read its content (pre-fix: leaves blobStmt busy).
+        let storeA = try SQLiteWikiStore(databaseURL: url)
+        let source = try storeA.addSource(
+            filename: "f.txt", data: Data("original".utf8))
+        _ = try storeA.sourceContent(id: source.id)
+
+        // Store B: a separate writer commits (advances the WAL).
+        let storeB = try SQLiteWikiStore(databaseURL: url)
+        _ = try storeB.addSource(
+            filename: "g.txt", data: Data("other".utf8))
+
+        // Store A: write through withTransaction → BEGIN IMMEDIATE.
+        // Pre-fix: SQLITE_BUSY_SNAPSHOT. Post-fix: succeeds.
+        try storeA.deleteSource(id: source.id)
+    }
+
+    // MARK: - Test 3: read-only store has no busy statements after sourceContent
+
+    @Test func readOnlyStoreHasNoBusyStatementsAfterRead() throws {
+        let url = tempDatabaseURL()
+
+        let writer = try SQLiteWikiStore(databaseURL: url)
+        let source = try writer.addSource(
+            filename: "f.txt", data: Data("original".utf8))
+
+        // Open a read-only store (simulates the File Provider / WikiReadPool path).
+        let reader = try SQLiteWikiStore(readOnlyURL: url)
+        _ = try reader.sourceContent(id: source.id)
+
+        // The deterministic check: no statement should be left busy.
+        // Pre-fix: blobStmt is busy → throws. Post-fix: passes.
+        try reader.assertNoBusyStatements()
+    }
+}

--- a/docs/skills/sqlite-concurrency/SKILL.md
+++ b/docs/skills/sqlite-concurrency/SKILL.md
@@ -129,6 +129,51 @@ rather than a crash-safety requirement — but do not convert it to a background
 job without designing model coordination (who reloads observable state, when)
 — plan §13.4.
 
+### 7. Statement lifetime: always `defer { stmt.reset() }`
+
+A prepared statement left stepped-to-`SQLITE_ROW` (busy) holds an **implicit
+read transaction** open on the connection, pinning the WAL read snapshot. In
+WAL mode this has two consequences:
+
+1. **Stale reads** — subsequent reads on the same connection see data as of the
+   pinned snapshot, even after an external writer commits.
+2. **Write-lock failure** — `BEGIN IMMEDIATE` fails with `SQLITE_BUSY_SNAPSHOT`
+   when the snapshot is stale relative to the WAL head.
+
+This was the root cause of issue #332: 18 functions used a "reset-before-use"
+idiom (`stmt.reset()` *before* `bind`/`step`) that cleared the *previous* call's
+leftover but left the *current* call's statement busy on return.
+
+**The rule:** every stepped statement gets `defer { stmt.reset() }` immediately
+after `try statement(...)`. This covers all exit paths — success, early return,
+and throw — uniformly.
+
+```swift
+// ✅ Correct — defer bounds the statement's read transaction to the call.
+let stmt = try statement("SELECT … WHERE id = ?1;")
+defer { stmt.reset() }
+try stmt.bind(id, at: 1)
+if try stmt.step() { return stmt.text(at: 0) }
+
+// ❌ Wrong — reset-before-use clears the PREVIOUS call's leftover but leaves
+// the CURRENT call's statement busy at ROW when the function returns.
+let stmt = try statement("SELECT … WHERE id = ?1;")
+stmt.reset()
+try stmt.bind(id, at: 1)
+if try stmt.step() { return stmt.text(at: 0) }
+```
+
+When a read precedes a `withTransaction` in the same method (e.g.
+`revertProcessedMarkdown` reads a target row, then writes), add an explicit
+`target.reset()` after extracting the values — the `defer` fires at scope exit,
+but `withTransaction` runs first and its debug guard would fire.
+
+**Debug guard:** `assertNoBusyStatements()` (DEBUG-only) is called at the top of
+`withTransaction` at depth 0 — it throws if any cached statement is busy before
+`BEGIN IMMEDIATE`. The `SQLiteStatement.isBusy` property wraps
+`sqlite3_stmt_busy`. The regression test `noBusyStatementsAfterReads` exercises
+every fixed site and asserts no busy statement remains.
+
 ## Anti-patterns (updated)
 
 - **Pooling `init(databaseURL:)` connections** — that init writes (migrations,
@@ -140,6 +185,9 @@ job without designing model coordination (who reloads observable state, when)
 - **Letting a statement or column pointer outlive its method** — the lock can't
   protect it.
 - **`String(cString:)` on a DB column** — byte-length lossy decode only.
+- **Reset-before-use instead of `defer { stmt.reset() }`** — leaves the
+  statement busy at `SQLITE_ROW` when the function returns, pinning the WAL
+  snapshot (#332). Always `defer` immediately after `try statement(...)`.
 - **Treating `SQLITE_OPEN_FULLMUTEX` as app-level safety** — it serializes C
   calls, not bind/step/read sequences; the recursive lock does that.
 
@@ -153,4 +201,6 @@ grep -c "lock.lock(); defer { lock.unlock() }" Sources/WikiFSCore/SQLiteWikiStor
 grep -n "BEGIN IMMEDIATE\|ROLLBACK" Sources/WikiFSCore/SQLiteWikiStore.swift   # only inside withTransaction
 # The regression suite:
 swift test --filter StoreConcurrencyTests
+# Statement lifecycle (issue #332):
+swift test --filter SQLiteStatementLifecycleTests
 ```


### PR DESCRIPTION
## Fix: SQLite statement reset leak pinning stale WAL snapshots (#332)

### Root cause

Cached SELECT statements across 18 functions (26 leaking statements) in `SQLiteWikiStore.swift` used a "reset-before-use" idiom — `stmt.reset()` called *before* `bind`/`step`, intended to clear the *previous* call's leftover. But this left the *current* call's statement stepped-to-`SQLITE_ROW` (busy) when the function returned. A busy statement holds an implicit read transaction open, **pinning the connection's WAL read snapshot**. After an external writer (`wikictl`, another store instance) commits:

- **Stale reads** — subsequent reads on the same connection return old data
- **Write-lock failure** — `BEGIN IMMEDIATE` fails with `SQLITE_BUSY_SNAPSHOT`

This was misdiagnosed as architectural "stale WAL read state" — the daemon/IPC rearchitecture (#187/#124) is not justified by this bug.

### Fix

At every affected site, replaced the leading `stmt.reset()` with `defer { stmt.reset() }` immediately after `try statement(...)`. This bounds the statement's read transaction to the call, covering success, early-return, and throw paths uniformly.

Also fixed `revertProcessedMarkdown`, which stepped a `target` SELECT to ROW and then entered `withTransaction` — added an explicit `target.reset()` after extracting values so the read snapshot is released before `BEGIN IMMEDIATE`.

### Guards

- **`SQLiteStatement.isBusy`** — wraps `sqlite3_stmt_busy`
- **`assertNoBusyStatements()`** — DEBUG-only guard, iterates the statement cache and throws if any is busy
- Called at the top of `withTransaction` at depth 0, before `BEGIN IMMEDIATE`

### Tests

- `noBusyStatementsAfterReads` — deterministic, CI-fast: exercises all 26 fixed sites via public callers, asserts no busy statement remains
- `detectsBusyStatement` — verifies the guard throws when a statement IS busy
- `leakedStatementDoesNotBlockWriteAfterExternalCommit` / `readOnlyStoreHasNoBusyStatementsAfterRead` — integration (multi-connection WAL)

All 2243 tests pass with no regressions.

Fixes #332.
