### PR TITLE
ACP stall recovery: SDK fork + root-cause fixes (#334 Phase 2)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,64 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-11 — ACP stall recovery: SDK fork + root-cause fixes (#334 Phase 2)
+
+**Problem:** Phase 1 (#335) fixed the *symptom* (permanent stall → failed turn
+with retry). Phase 2 fixes the four *root causes* inside the swift-acp SDK.
+
+**SDK fork:** Forked `wiedymi/swift-acp` v0.1.0 → `wsargent/swift-acp` v0.2.0.
+Upstream confirmed dead since v0.1.0 (no fixes available). `Package.swift`
+swapped to the fork pinned to `v0.2.0`. Upstream PRs offered when the upstream
+resumes.
+
+**Four root-cause fixes (all in the fork):**
+
+1. **Ordered transport reads** (the likely loss in the observed incident).
+   `ACPProcessManager.startReading()` and `StdioTransport.startReading()` spawned
+   an unstructured `Task { processIncomingData }` per pipe chunk — tasks raced
+   across actor hops and could swap chunk order, corrupting JSON-RPC framing and
+   silently dropping messages. Replaced with an ordered `AsyncStream<Data>` pipe:
+   the readabilityHandler yields into the stream; ONE long-lived consumer calls
+   `processIncomingData` in arrival order. Same fix in both transports.
+
+2. **Non-blocking incoming requests.** `Client.handleMessage` dispatched
+   `.request` handling inline — `handleIncomingRequest` awaited
+   `requestRouter.routeRequest` on the actor. Under `.alwaysAsk`, a
+   `session/request_permission` that suspends on a user decision froze the whole
+   actor (no responses, no notifications). Now wrapped in `Task { }` — responses
+   and notification yields stay inline (they're fast).
+
+3. **Stderr forwarding.** `startReadingStderr` discarded stderr entirely.
+   Now yields lines to a new `stderrLines()` stream on `Client`. Default consumer
+   is none (preserving behavior). The app wires it to `DebugLog.agent`.
+
+4. **PID exposure.** `ProcessRegistry` recorded pid/pgid but had no read API.
+   `Client` gains `processIdentifier()` and `processGroupIdentifier()` methods.
+   The app threads the PID to `AgentLauncher.currentProcessID` via
+   `ACPBackend.processIdentifier(for:)` → `captureProcessID(session:)`.
+
+**App-side wiring:**
+- `ACPBackend.start`: starts a stderr drain task → `DebugLog.agent`.
+- `ACPBackend.processIdentifier(for:)`: delegates to `session.client.processIdentifier()`.
+- `AgentLauncher.captureProcessID(session:)`: called alongside
+  `captureAndCacheModels` at all 4 spawn sites → assigns `currentProcessID`.
+
+**Gate:** `swift build` clean (fork + app); fast tier **2140 tests in 180 suites
+pass**. No new tests (SDK changes are in the fork; the app-side wiring is thin
+delegation). Phase 2 ship gate: live-agent smoke (multi-turn session incl.
+always-ask permission mid-turn) — needs manual verification with credentials.
+
+**Files changed (selfdrivingwiki):**
+- `Package.swift` — swapped to `wsargent/swift-acp` from `0.2.0`.
+- `Package.resolved` — resolved fork.
+- `Sources/WikiFS/ACPBackend.swift` — `processIdentifier(for:)` + stderr drain.
+- `Sources/WikiFS/AgentLauncher.swift` — `captureProcessID(session:)` + 4 call sites.
+
+**Files changed (fork: wsargent/swift-acp):**
+- `Sources/ACP/Internal/ProcessManager.swift` — ordered reads + stderr + PID.
+- `Sources/ACP/Transport/StdioTransport.swift` — ordered reads.
+- `Sources/ACP/Client.swift` — non-blocking requests + PID/stderr accessors.
+
 ## 2026-07-11 — ACP stall recovery: app-side hang prevention (#334 Phase 1)
 
 **Problem:** An ACP turn could stall permanently — `client.sendPrompt()` never

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9283dc652690a16d2cd00f77490e1cf00bab192f77a5f38572bac3f06be3e673",
+  "originHash" : "de8b297184834dd084ca37beae354f63bb72e410c49181abcb7bb5f076eb5120",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
-        "version" : "0.31.4"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
@@ -31,10 +31,19 @@
     {
       "identity" : "swift-acp",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/wiedymi/swift-acp",
+      "location" : "https://github.com/wsargent/swift-acp",
       "state" : {
-        "revision" : "e606d69b06f1af09675fa3a96393b1934f68038c",
-        "version" : "0.1.0"
+        "revision" : "3f99b2ccaf9f35966dec4817ebc4fdf72b9049be",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -132,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,10 +31,13 @@ let package = Package(
         // ACPBackend (plans/acp-backend-and-permissions.md): the app is the ACP
         // *client*; it launches any ACP agent subprocess over JSON-RPC/stdio and
         // mediates writes via session/request_permission (the always-ask/yolo lever).
-        // NOTE: the README says `from: "1.0.0"` but the only published tag is
-        // v0.1.0 (24 commits, community/early). Pin 0.1.0 and validate under Swift
-        // 6.0 / macOS 15 — see plans/acp-spike-findings.md.
-        .package(url: "https://github.com/wiedymi/swift-acp", from: "0.1.0"),
+        //
+        // Forked from wiedymi/swift-acp v0.1.0 (plans/acp-stall-recovery.md Phase 2):
+        // the upstream is dead since v0.1.0 and has four root-cause bugs (unordered
+        // transport reads, actor head-of-line blocking on request_permission,
+        // discarded stderr, unexposed PID). The fork fixes all four. Upstream PRs
+        // offered when the upstream resumes.
+        .package(url: "https://github.com/wsargent/swift-acp", from: "0.2.0"),
     ],
     targets: [
         // Statically-linked sqlite-vec (semantic vector search). The amalgamation

--- a/Sources/WikiFS/ACPBackend.swift
+++ b/Sources/WikiFS/ACPBackend.swift
@@ -281,6 +281,16 @@ actor ACPBackend: AgentBackend {
         }
         DebugLog.agent("ACPBackend.start: session-lifetime notification drain started") // TEMP DEBUG (existed; re-tagged)
 
+        // Forward agent stderr to DebugLog.agent (SDK fork Fix 3). Best-effort:
+        // the stream finishes on terminate, so this task exits naturally.
+        Task { [client] in
+            guard let stderrStream = await client.stderrLines() else { return }
+            for await line in stderrStream {
+                if Task.isCancelled { break }
+                DebugLog.agent("ACP stderr: \(line)")
+            }
+        }
+
         let sessionID = UUID().uuidString
         sessions[sessionID] = ACPSession(
             client: client,
@@ -476,6 +486,15 @@ actor ACPBackend: AgentBackend {
     func availableModels(for sessionHandle: SessionHandle) async -> [ModelInfo] {
         guard let session = sessions[sessionHandle.id] else { return [] }
         return session.modelsInfo?.availableModels ?? []
+    }
+
+    /// The agent process identifier for a session (SDK fork Fix 4). nil when
+    /// the session is gone or the process hasn't launched. The launcher reads
+    /// this to populate `currentProcessID` so the watchdog can eventually
+    /// `kill(pgid)` a stuck agent.
+    func processIdentifier(for sessionHandle: SessionHandle) async -> Int32? {
+        guard let session = sessions[sessionHandle.id] else { return nil }
+        return await session.client.processIdentifier()
     }
 
     /// The agent's current model id for a session (`ModelsInfo.currentModelId`),

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -307,6 +307,22 @@ final class AgentLauncher {
         }
     }
 
+    /// After a successful `backend.start`, if it was an ACP backend, read the
+    /// process identifier and assign `currentProcessID` (SDK fork Fix 4). Lets
+    /// the watchdog `kill(pgid)` a stuck agent after cancel fails. Non-blocking:
+    /// runs as a detached `@MainActor` Task.
+    func captureProcessID(session: SessionHandle) {
+        guard let acp = backend as? ACPBackend else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let pid = await acp.processIdentifier(for: session)
+            if let pid {
+                self.currentProcessID = pid
+                DebugLog.agent("captureProcessID: pid=\(pid)") // TEMP DEBUG
+            }
+        }
+    }
+
     /// The currently-pending write-permission requests surfaced from the backend
     /// (always-ask mode). When non-empty AND this surface is the live chat, the
     /// UI renders an inline Approve/Reject affordance (slice 2). Mirrors how
@@ -1037,6 +1053,7 @@ final class AgentLauncher {
             // #329: cache the agent's advertised models per-provider for the
             // picker (ACP only; the CLI backend has no model discovery).
             captureAndCacheModels(provider: provider, session: session)
+            captureProcessID(session: session)
             startCompletionWatchdog()
 
             // Consume the per-turn stream in a background Task (fire-and-forget:
@@ -1201,6 +1218,7 @@ final class AgentLauncher {
         if let acp = backend as? ACPBackend {
             let models = await acp.availableModels(for: plannerSession)
             captureAndCacheModels(provider: provider, session: plannerSession)
+            captureProcessID(session: plannerSession)
             executorModelId = Self.findSonnetModelId(in: models)
             if executorModelId == nil {
                 DebugLog.agent("runACPIngest: no Sonnet model in advertised list (\(models.map { $0.modelId })); executors use default model")
@@ -1365,6 +1383,7 @@ final class AgentLauncher {
             phaseName: "fallback-single"
         ) {
             captureAndCacheModels(provider: provider, session: session)
+            captureProcessID(session: session)
             await backend.cancel(session)
             finish(status: 0)
         } else {
@@ -1650,6 +1669,7 @@ final class AgentLauncher {
             // here (after spawn commit) so the session record is populated; it
             // runs as a detached task and never blocks the first turn.
             captureAndCacheModels(provider: provider, session: session)
+            captureProcessID(session: session)
             DebugLog.agent("startInteractiveQuery: spawned") // TEMP DEBUG (existed; re-tagged)
             // Start the first turn — this acquires the generation gate for turn 1.
             sendInteractiveMessage(firstMessage, displayText: firstMessageDisplay)


### PR DESCRIPTION
## ACP stall recovery — Phase 2 (SDK fork + root-cause fixes)

Closes #334 (Phase 2). Builds on Phase 1 (#335).

### What changed

Forked `wiedymi/swift-acp` v0.1.0 → **`wsargent/swift-acp` v0.2.0**. Upstream
confirmed dead since v0.1.0 (no fixes available). `Package.swift` swapped to
the fork.

### Four root-cause fixes (in the fork)

| Fix | What | Where |
|-----|------|-------|
| **1. Ordered transport reads** | Replace `Task { processIncomingData }` per chunk with an ordered `AsyncStream<Data>` pipe — readabilityHandler yields, ONE consumer processes in arrival order | `ACPProcessManager` + `StdioTransport` |
| **2. Non-blocking requests** | Wrap `.request` handling in `Task {}` in `Client.handleMessage` so `request_permission` can't freeze the actor | `Client.swift` |
| **3. Stderr forwarding** | `startReadingStderr` now yields to a `stderrLines()` stream instead of discarding | `ACPProcessManager` |
| **4. PID exposure** | `Client.processIdentifier()` + `processGroupIdentifier()` — was unreachable inside `ProcessRegistry` | `ACPProcessManager` + `Client` |

### App-side wiring (this repo)

- `ACPBackend.start`: stderr drain → `DebugLog.agent`
- `ACPBackend.processIdentifier(for:)`: delegates to `Client.processIdentifier()`
- `AgentLauncher.captureProcessID(session:)`: assigns `currentProcessID` at all 4 spawn sites

### Gate

- `swift build` clean (fork + app)
- Fast tier: **2140 tests in 180 suites pass**
- Phase 2 ship gate: live-agent smoke (multi-turn + always-ask mid-turn) — needs manual verification with credentials

### Fork

- Repo: https://github.com/wsargent/swift-acp
- Tag: `v0.2.0`
- Upstream PRs will be offered if/when the upstream resumes
