### PR TITLE
ACP stall recovery: watchdog kill escalation (#334 Phase 3)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,47 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-11 — ACP stall recovery: watchdog kill escalation (#334 Phase 3)
+
+**Problem:** Phases 1 + 2 fixed the stall detection, recovery, and root causes.
+But if the ACPBackend watchdog's `cancelSession` fails to unblock `sendPrompt`,
+and the SDK's `terminate()` also fails (the process is truly wedged), the agent
+process stays alive with no way to kill it. The launcher watchdog was log-only.
+
+**Phase 3 fix:**
+
+- **Stall escalation in `startCompletionWatchdog`:** when `isRunning` and idle
+  exceeds `watchdogStallThreshold` (180s — more generous than ACPBackend's
+  per-turn 120s, this is the backstop), the watchdog calls `stopAgent()` (cancel
+  + finish) and spawns a separate kill-escalation task. A `watchdogHasEscalated`
+  flag prevents double-escalation. Reset in `resetRunArtifacts()` + `finish()`.
+- **Kill escalation (`startKillEscalation`):** runs as a separate Task because
+  `stopAgent()` sets `isRunning = false` (which exits the heartbeat loop). Checks
+  `kill(pid, 0)` directly — not `isRunning` — to detect whether the process is
+  actually dead. Escalation sequence: wait 10s for cancel → `kill(-pid, SIGTERM)`
+  (process group) → wait 5s → `kill(-pid, SIGKILL)`. The `terminationHandler`
+  fires after the kill → `onExit` → `finish()`.
+- **Pure decision helper:** `shouldEscalateWatchdog(isRunning:idleSeconds:
+  stallThreshold:alreadyEscalated:)` — extracted as a `nonisolated static` so
+  it's unit-testable without driving launcher state. `watchdogStallThreshold`
+  is also `nonisolated static`.
+- **Debug cleanup:** stripped the two noisy TEMP DEBUG lines that dumped raw
+  `session/update` JSON (800-char prefix) and per-event descriptions — too
+  verbose for production. Kept the lifecycle markers (start/send/cancel/
+  heartbeat) which were essential for diagnosing the original incident.
+
+**Tests (7 new):** `WatchdogEscalationTests` — escalate at/above threshold,
+don't escalate when not running / below threshold / already escalated / no
+activity record.
+
+**Gate:** `swift build` clean; fast tier **2147 tests in 181 suites pass**.
+
+**Files changed:**
+- `Sources/WikiFS/AgentLauncher.swift` — stall escalation + kill sequence +
+  `watchdogHasEscalated` flag + pure decision helper.
+- `Sources/WikiFS/ACPBackend.swift` — stripped 2 noisy TEMP DEBUG lines.
+- `Tests/WikiFSTests/WatchdogEscalationTests.swift` (new) — 7 tests.
+
 ## 2026-07-11 — ACP stall recovery: SDK fork + root-cause fixes (#334 Phase 2)
 
 **Problem:** Phase 1 (#335) fixed the *symptom* (permanent stall → failed turn

--- a/Sources/WikiFS/ACPBackend.swift
+++ b/Sources/WikiFS/ACPBackend.swift
@@ -583,19 +583,10 @@ actor ACPBackend: AgentBackend {
     ) -> [AgentEvent] {
         do {
             let data = try JSONEncoder().encode(params)
-            // TEMP DEBUG: log raw session/update JSON so we can see exactly what
-            // the agent sent (text? tool call? empty?). Strip with grep TEMP DEBUG.
-            if let raw = String(data: data, encoding: .utf8) {
-                DebugLog.agent("ACPBackend: raw session/update json (prefix 800): \(raw.prefix(800))")
-            }
             let envelope = try JSONDecoder().decode(SessionUpdateNotification.self, from: data)
             // Scope to our session (the shared notification stream is global).
             guard envelope.sessionId.value == sessionId.value else { return [] }
             let events = translator.translate(envelope.update)
-            // TEMP DEBUG: log the translated event types + snippet.
-            for event in events {
-                DebugLog.agent("ACPBackend: translated event: \(String(describing: event).prefix(300))")
-            }
             return events
         } catch {
             return [.raw("ACP session/update decode error: \(error.localizedDescription)")]

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -398,6 +398,9 @@ final class AgentLauncher {
     /// Backstop poller that reconciles the UI if the process `terminationHandler`
     /// is ever missed (see `startCompletionWatchdog`). Cancelled on teardown.
     private var watchdogTask: Task<Void, Never>?
+    /// True once the launcher watchdog has escalated (stopAgent + kill sequence).
+    /// Prevents double-escalation. Reset in `resetRunArtifacts()`.
+    private var watchdogHasEscalated = false
     /// True while the last row in `events` is an in-progress `.assistantText` row
     /// being grown by streamed `.assistantTextDelta` chunks (issue #121). Reset by
     /// any other event (a tool call, a turn boundary, …) so unrelated `.assistantText`
@@ -1421,15 +1424,36 @@ final class AgentLauncher {
         }?.modelId
     }
 
-    /// Heartbeat logger + stale-idle detector. Replaces the old liveness-poller
+    /// Stall threshold for the launcher-level watchdog. More generous than the
+    /// ACPBackend's per-turn 120s `TurnLivenessPolicy` — this is the backstop
+    /// that fires when the backend watchdog's recovery fails (cancelSession
+    /// didn't unblock sendPrompt) and the process is truly wedged.
+    nonisolated static let watchdogStallThreshold: TimeInterval = 180
+
+    /// Pure stall-detection decision for the launcher watchdog. Extracted so
+    /// the threshold logic is unit-testable without driving launcher state.
+    /// - Returns: true if the watchdog should escalate (stopAgent + kill).
+    nonisolated static func shouldEscalateWatchdog(
+        isRunning: Bool,
+        idleSeconds: TimeInterval,
+        stallThreshold: TimeInterval,
+        alreadyEscalated: Bool
+    ) -> Bool {
+        isRunning && !alreadyEscalated && idleSeconds >= stallThreshold
+    }
+
+    /// Heartbeat logger + stall escalation. Replaces the old liveness-poller
     /// (which polled `process?.isRunning` — impossible now that `Process` lives
     /// behind the `AgentBackend` port). The backend's `onExit` callback is the
     /// sole completion signal: it fires exactly once from `terminationHandler`
-    /// and drives `finish()`. This watchdog logs a heartbeat for post-hoc
-    /// analysis and warns if the session has been idle for a long time, but it
-    /// no longer reconciles a missed `terminationHandler` (the `onExit` gate is
-    /// one-shot and reliable — `Process.terminationHandler` always fires on
-    /// process exit, including crash/kill).
+    /// and drives `finish()`.
+    ///
+    /// **Phase 3 escalation (plans/acp-stall-recovery.md §3):** if the session
+    /// has been idle for `watchdogStallThreshold` (180s) and hasn't already
+    /// escalated, this watchdog calls `stopAgent()` (cancel + finish) and
+    /// spawns a separate kill-escalation task: wait 10s → `SIGTERM` the process
+    /// group → wait 5s → `SIGKILL`. The `terminationHandler` fires after the
+    /// kill → `onExit` → `finish()`.
     private func startCompletionWatchdog() {
         watchdogTask?.cancel()
         watchdogTask = Task { @MainActor [weak self] in
@@ -1441,8 +1465,56 @@ final class AgentLauncher {
                 DebugLog.agent(
                     "heartbeat pid=\(pid) isRunning=\(self.isRunning) "
                     + "events=\(self.events.count) idleSec=\(String(format: "%.1f", idle))")
+
+                // Stall escalation: if idle exceeds threshold, stop + kill.
+                if Self.shouldEscalateWatchdog(
+                    isRunning: self.isRunning,
+                    idleSeconds: idle,
+                    stallThreshold: Self.watchdogStallThreshold,
+                    alreadyEscalated: self.watchdogHasEscalated
+                ) {
+                    self.watchdogHasEscalated = true
+                    DebugLog.agent("watchdog: STALL detected (idle \(Int(idle))s pid=\(pid)) — escalating: stopAgent() + kill sequence")
+                    self.stopAgent()
+                    self.startKillEscalation(pid: pid)
+                }
             }
         }
+    }
+
+    /// After `stopAgent()`, if the process doesn't die within the escalation
+    /// timeouts, escalate to `SIGTERM` → `SIGKILL`. Runs as a separate Task
+    /// because `stopAgent()` sets `isRunning = false` (which exits the heartbeat
+    /// loop above). Checks `kill(pid, 0)` directly — not `isRunning` — to detect
+    /// whether the process is actually dead. Sends to the process GROUP
+    /// (`kill(-pid, ...)`) so agent-spawned children are also killed.
+    private func startKillEscalation(pid: Int32) {
+        guard pid > 0 else { return }
+        Task { @MainActor [weak self] in
+            // Phase 1: wait for cancel to take effect.
+            try? await Task.sleep(for: .seconds(10))
+            if Self.isProcessAlive(pid) {
+                DebugLog.agent("watchdog: cancel didn't kill pid=\(pid), sending SIGTERM to process group")
+                kill(-pid, SIGTERM)
+
+                // Phase 2: wait for SIGTERM.
+                try? await Task.sleep(for: .seconds(5))
+                if Self.isProcessAlive(pid) {
+                    DebugLog.agent("watchdog: SIGTERM didn't kill pid=\(pid), sending SIGKILL to process group")
+                    kill(-pid, SIGKILL)
+                }
+            }
+            // After SIGKILL (or if already dead), the terminationHandler fires
+            // → onExit → finish(). No manual finish() needed here.
+            DebugLog.agent("watchdog: kill escalation complete for pid=\(pid)")
+        }
+    }
+
+    /// Check if a process is alive via `kill(pid, 0)`. Returns true if the
+    /// process exists (including if we don't have permission to signal it).
+    private static func isProcessAlive(_ pid: Int32) -> Bool {
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
     }
 
     /// Start a stdin-backed query chat. The first user message is sent
@@ -1991,6 +2063,7 @@ final class AgentLauncher {
         DebugLog.agent("finish: status=\(status) events=\(events.count) activeChatID=\(activeChatID ?? "nil")") // TEMP DEBUG (existed; re-tagged + chatID)
         watchdogTask?.cancel()
         watchdogTask = nil
+        watchdogHasEscalated = false
         // Session over: flush any remaining tail (a killed/died session still
         // persists its last events) THEN detach the sink — no further writes.
         flushTranscript()
@@ -2056,6 +2129,7 @@ final class AgentLauncher {
         DebugLog.agent("resetRunArtifacts: clearing per-run artifacts (prior activeChatID=\(activeChatID ?? "nil"))") // TEMP DEBUG
         watchdogTask?.cancel()
         watchdogTask = nil
+        watchdogHasEscalated = false
         events = []
         isStreamingAssistantRow = false
         rawTranscript = ""

--- a/Tests/WikiFSTests/WatchdogEscalationTests.swift
+++ b/Tests/WikiFSTests/WatchdogEscalationTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import WikiFS
+
+/// Unit tests for the launcher watchdog's stall-escalation decision
+/// (`plans/acp-stall-recovery.md` Phase 3 §3).
+///
+/// The decision is extracted as a PURE static so it's unit-testable without
+/// driving launcher state or spawning processes.
+@Suite struct WatchdogEscalationTests {
+
+    // MARK: - Escalate
+
+    @Test func escalatesWhenIdleExceedsThreshold() {
+        #expect(AgentLauncher.shouldEscalateWatchdog(
+            isRunning: true,
+            idleSeconds: 181,
+            stallThreshold: 180,
+            alreadyEscalated: false
+        ) == true)
+    }
+
+    @Test func escalatesAtExactlyThreshold() {
+        #expect(AgentLauncher.shouldEscalateWatchdog(
+            isRunning: true,
+            idleSeconds: 180,
+            stallThreshold: 180,
+            alreadyEscalated: false
+        ) == true)
+    }
+
+    // MARK: - Don't escalate
+
+    @Test func noEscalateWhenNotRunning() {
+        #expect(AgentLauncher.shouldEscalateWatchdog(
+            isRunning: false,
+            idleSeconds: 9999,
+            stallThreshold: 180,
+            alreadyEscalated: false
+        ) == false)
+    }
+
+    @Test func noEscalateWhenIdleBelowThreshold() {
+        #expect(AgentLauncher.shouldEscalateWatchdog(
+            isRunning: true,
+            idleSeconds: 179,
+            stallThreshold: 180,
+            alreadyEscalated: false
+        ) == false)
+    }
+
+    @Test func noEscalateWhenAlreadyEscalated() {
+        #expect(AgentLauncher.shouldEscalateWatchdog(
+            isRunning: true,
+            idleSeconds: 9999,
+            stallThreshold: 180,
+            alreadyEscalated: true
+        ) == false)
+    }
+
+    @Test func noEscalateWhenNoActivityRecorded() {
+        // idleSeconds = -1 (no lastActivityAt) — should not escalate.
+        #expect(AgentLauncher.shouldEscalateWatchdog(
+            isRunning: true,
+            idleSeconds: -1,
+            stallThreshold: 180,
+            alreadyEscalated: false
+        ) == false)
+    }
+
+    // MARK: - Threshold constant
+
+    @Test func defaultStallThresholdIs180() {
+        #expect(AgentLauncher.watchdogStallThreshold == 180)
+    }
+}


### PR DESCRIPTION
## ACP stall recovery — Phase 3 (watchdog kill escalation)

Closes #334 (Phase 3 — final phase). Builds on Phase 1 (#335) + Phase 2 (#336).

### What changed

The launcher's heartbeat watchdog was log-only. Now it **escalates** when a
session is truly wedged:

1. **Detect:** idle exceeds `watchdogStallThreshold` (180s — backstop behind
   ACPBackend's per-turn 120s `TurnLivenessPolicy`)
2. **Cancel:** `stopAgent()` (backend cancel + finish)
3. **SIGTERM:** after 10s, if `kill(pid, 0)` shows the process is still alive,
   `kill(-pid, SIGTERM)` (process group — kills agent-spawned children too)
4. **SIGKILL:** after 5s more, if still alive, `kill(-pid, SIGKILL)`

The kill escalation runs as a **separate Task** because `stopAgent()` sets
`isRunning = false` (which exits the heartbeat loop). It checks `kill(pid, 0)`
directly — not `isRunning` — to detect whether the process is actually dead.

### Also

- Stripped 2 noisy TEMP DEBUG lines (raw `session/update` JSON dump + per-event
  log). Kept the lifecycle markers that were essential for diagnosing the
  original incident.
- Pure decision helper `shouldEscalateWatchdog(...)` extracted as
  `nonisolated static` for testability.

### Tests

7 new `WatchdogEscalationTests`. Fast tier: **2147 tests in 181 suites pass**.

### Full #334 summary (all 3 phases)

| Phase | PR | What |
|-------|-----|------|
| 1 | #335 | Inactivity watchdog (`TurnLivenessPolicy`) + session-lifetime drain (`NotificationFanout`) + stall error synthesis |
| 2 | #336 | SDK fork (ordered reads, non-blocking requests, stderr, PID) + app-side wiring |
| 3 | this | Launcher kill escalation (cancel → SIGTERM → SIGKILL) + debug cleanup |

The app now degrades from a permanent hang to a failed turn with retry, in at
most ~3 layers of defense: per-turn inactivity watchdog (120s) → session kill
escalation (180s + 15s) → `SIGKILL`.
