### PR TITLE
Fix compiler warnings from #334 stall recovery

### DIFF
--- a/Sources/WikiFS/ACPBackend.swift
+++ b/Sources/WikiFS/ACPBackend.swift
@@ -513,14 +513,14 @@ actor ACPBackend: AgentBackend {
     /// was resolved, false if no such pending id exists.
     func resolvePermission(sessionHandle: SessionHandle, optionId: String) async -> Bool {
         guard let session = sessions[sessionHandle.id] else { return false }
-        return await session.permissionDelegate.resolve(optionId: optionId)
+        return session.permissionDelegate.resolve(optionId: optionId)
     }
 
     /// The currently-pending permission requests for a session (always-ask
     /// mode). The future UI surfaces these as Approve/Reject affordances.
     func pendingPermissions(sessionHandle: SessionHandle) async -> [PendingPermission] {
         guard let session = sessions[sessionHandle.id] else { return [] }
-        return await session.permissionDelegate.pendingSnapshot()
+        return session.permissionDelegate.pendingSnapshot()
     }
 
     /// Drain all pending always-ask requests for a session (resume each as

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1490,7 +1490,7 @@ final class AgentLauncher {
     /// (`kill(-pid, ...)`) so agent-spawned children are also killed.
     private func startKillEscalation(pid: Int32) {
         guard pid > 0 else { return }
-        Task { @MainActor [weak self] in
+        Task { @MainActor in
             // Phase 1: wait for cancel to take effect.
             try? await Task.sleep(for: .seconds(10))
             if Self.isProcessAlive(pid) {


### PR DESCRIPTION
Removes 3 compiler warnings introduced/fixed during the #334 stall recovery work:

- `ACPBackend.resolvePermission`/`pendingPermissions`: remove unnecessary `await` on synchronous `ACPPermissionDelegate` calls
- `AgentLauncher.startKillEscalation`: remove unused `[weak self]` capture (closure only calls statics + `kill()`)