### PR TITLE
Fix: watchdog false-positive killing live turns

### DIFF
--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1081,6 +1081,7 @@ final class AgentLauncher {
                 let stream = await backend.send(
                     TurnInput(userText: promptText), into: session)
                 for await event in stream {
+                    self.lastActivityAt = Date()
                     self.mergeOrAppend(event)
                     if AgentEvent.endsGeneration(event) {
                         self.setGenerating(false)
@@ -1342,6 +1343,7 @@ final class AgentLauncher {
             let backend = self.backend
             let stream = await backend.send(TurnInput(userText: prompt), into: session)
             for await event in stream {
+                lastActivityAt = Date()
                 mergeOrAppend(event)
                 if AgentEvent.endsGeneration(event) {
                     setGenerating(false)
@@ -1841,6 +1843,7 @@ final class AgentLauncher {
             let stream = await backend.send(
                 TurnInput(userText: trimmed), into: session)
             for await event in stream {
+                self.lastActivityAt = Date()
                 self.mergeOrAppend(event)
                 if AgentEvent.endsGeneration(event) {
                     self.setGenerating(false)


### PR DESCRIPTION
## Bug

The Phase 3 launcher watchdog (`startCompletionWatchdog`) killed a turn that was **actively streaming** — `session/update` notifications arriving every ~300ms, but the watchdog reported `idleSec=182` and fired the kill escalation.

## Root cause

The watchdog uses `self.lastActivityAt` as its liveness signal. But the three consumer loops (`sendInteractiveMessage`, `run`, `runACPIngest` phase) never updated `lastActivityAt` during streaming — only at turn start. Meanwhile streamed deltas merge into the last `.assistantText` row in place (`mergeOrAppend`), so `events.count` stayed constant too. The watchdog saw a frozen transcript and assumed the agent was dead.

Confirmed from `os_log`:
```
08:10:27.964  ACPBackend: session/update → 1 AgentEvent(s)    ← ACTIVELY STREAMING
08:10:28.140  heartbeat: events=24 idleSec=182.3
08:10:28.140  watchdog: STALL detected ← FALSE POSITIVE
```

## Fix

`self.lastActivityAt = Date()` at the top of every `for await event in stream` loop — all three consumer sites. One line each.

The Phase 1 ACPBackend watchdog (`TurnLivenessPolicy`) was NOT affected — it uses `fanout.activityTimestamp` which IS updated on every notification.

Fast tier: 2147 tests pass (1 pre-existing flaky failure).