### PR TITLE
Fix: continue chat shows full history during live session

### DIFF
--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -1542,6 +1542,7 @@ final class AgentLauncher {
         wikictlDirectory: String,
         chatID: String? = nil,
         firstMessagePrePersisted: Bool = false,
+        historySeed: [AgentEvent] = [],
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
         onTurnBoundary: @escaping @MainActor (Bool) -> Void,
@@ -1553,7 +1554,15 @@ final class AgentLauncher {
 
         // Preflight (no gate held — early returns here don't need gate release).
         resetRunArtifacts()
-        DebugLog.agent("startInteractiveQuery: enter firstMsg=\"\(firstMessage.prefix(80))\" chatID=\(chatID ?? "nil") wikiID=\(wikiID)") // TEMP DEBUG
+        // Seed `events` with the persisted chat history so a continued chat
+        // shows its full transcript during the live session (the view sources
+        // from `launcher.events` when `isLiveChat`). `persistedEventCount` is
+        // set so `flushTranscript` never re-persisted the already-stored rows.
+        if !historySeed.isEmpty {
+            events = historySeed
+            persistedEventCount = historySeed.count
+        }
+        DebugLog.agent("startInteractiveQuery: enter firstMsg=\"\(firstMessage.prefix(80))\" chatID=\(chatID ?? "nil") wikiID=\(wikiID) historySeed=\(historySeed.count)") // TEMP DEBUG
         // Consumed by the first `sendInteractiveMessage` to skip re-persisting
         // the user message the model already seeded at chat creation.
         self.firstMessagePrePersisted = firstMessagePrePersisted

--- a/Sources/WikiFS/AgentOperationRunner.swift
+++ b/Sources/WikiFS/AgentOperationRunner.swift
@@ -559,6 +559,7 @@ enum AgentOperationRunner {
             systemPrompt: store.currentSystemPromptBody(),
             wikictlDirectory: HelpersLocation.wikictlDirectory,
             chatID: chatID.rawValue,
+            historySeed: history.map(\.event),
             onLock: { store.beginAgentRun() },
             onUnlock: { store.endAgentRun() },
             onTurnBoundary: { store.setAgentRunning($0) },

--- a/Tests/WikiFSTests/ChatPersistenceTests.swift
+++ b/Tests/WikiFSTests/ChatPersistenceTests.swift
@@ -52,6 +52,42 @@ struct ChatPersistenceTests {
         #expect(tail == Array(sampleEvents[2...]))
     }
 
+    // MARK: - History seeding (continue chat shows full transcript)
+
+    // When `startInteractiveQuery` receives a `historySeed`, it pre-populates
+    // `events` and sets `persistedEventCount` so the seeded (already-stored)
+    // rows are never re-persisted by `flushTranscript`. The pure invariant is:
+    // `unflushedTail(events: persistedCount:)` must return ONLY the new tail.
+
+    @Test func historySeedSetup_makesUnflushedTailEmptyBeforeNewEvents() {
+        // A continued chat seeds 3 prior events; persistedEventCount is set to 3.
+        // Before any new events arrive, flushTranscript would produce nothing.
+        let seeded: [AgentEvent] = [
+            .userText("old question"),
+            .assistantText("old answer"),
+            .toolUse(name: "Bash", inputSummary: "ls"),
+        ]
+        let tail = AgentLauncher.unflushedTail(events: seeded, persistedCount: seeded.count)
+        #expect(tail.isEmpty)
+    }
+
+    @Test func historySeedSetup_flushOnlyPersistsNewTail() {
+        // Seed 3 prior events, then append 2 new events (the continue turn).
+        // flushTranscript must produce only the 2 new events, not the 3 seeded.
+        let seeded: [AgentEvent] = [
+            .userText("old question"),
+            .assistantText("old answer"),
+            .systemInit(model: "claude"),
+        ]
+        var events = seeded
+        events.append(.userText("continue question"))
+        events.append(.assistantText("continue answer"))
+        let tail = AgentLauncher.unflushedTail(events: events, persistedCount: seeded.count)
+        #expect(tail.count == 2)
+        #expect(tail[0] == .userText("continue question"))
+        #expect(tail[1] == .assistantText("continue answer"))
+    }
+
     // MARK: - End-to-end sink installation via startInteractiveQuery
 
     // No existing seam lets tests feed stdout lines into `AgentLauncher` without


### PR DESCRIPTION
## Bug

When continuing a persisted chat, `startInteractiveQuery` called `resetRunArtifacts()` which set `events = []`. Then `activeChatID = chatID` was set, flipping `ChatView` to live mode. Since `isLiveChat` was true, the view sourced from `launcher.events` — now empty — making all prior history invisible during the continue session.

The data was always in the DB (persisted via the transcript sink), but invisible in the UI because the live path didn't seed the prior history into `events[]`.

## Root cause context

PR #340 fixed the watchdog false positive (`lastActivityAt` not updated in consumer loops) that reaped sessions mid-response. But the symptom — a continued chat losing its visible history — was not addressed. This PR fixes the symptom: even if a session is reaped and the user continues, the full transcript remains visible.

## Fix

Added `historySeed: [AgentEvent]` parameter to `startInteractiveQuery`. After `resetRunArtifacts()`, the launcher seeds `events` with the persisted chat history and sets `persistedEventCount` so `flushTranscript` only persists the new tail (no duplicate rows).

`continueChat` passes `history.map(\.event)` as the seed.

### Changes

- `AgentLauncher.startInteractiveQuery`: new `historySeed` parameter (default `[]`). After `resetRunArtifacts()`, if non-empty, sets `events = historySeed` and `persistedEventCount = historySeed.count`.
- `AgentOperationRunner.continueChat`: passes `historySeed: history.map(\.event)`.
- `ChatPersistenceTests`: 2 new tests verifying the `persistedEventCount` invariant via `unflushedTail`.

## Test results

Fast tier: 2149 tests pass (including 2 new tests).
