### PR TITLE
Fix #243: add top-level Bookmarks destination row to BookmarkTargetPickerSheet

### DIFF
--- a/Sources/WikiFS/BookmarkTargetPickerSheet.swift
+++ b/Sources/WikiFS/BookmarkTargetPickerSheet.swift
@@ -38,8 +38,23 @@ struct BookmarkTargetPickerSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var searchText: String = ""
-    @State private var selectedFolderID: String? = nil
+    /// Pre-selected to the bookmarks root so "Add" is enabled immediately,
+    /// even in a wiki with no folders yet (#243).
+    @State private var selectedFolderID: String? = BookmarkTargetPickerSheet.rootFolderID
     @State private var newFolderName: String = ""
+
+    /// Sentinel id representing the bookmarks root (`parentID == nil`).
+    /// The picker treats this as a selectable destination alongside real
+    /// folders, so the user can bookmark to the top level without first
+    /// creating a folder (#243).
+    private static let rootFolderID = "__bookmarks_root__"
+
+    /// Converts the internal selection id to the `parentID` value expected
+    /// by `onConfirm` — the root sentinel maps to `nil`, everything else
+    /// passes through unchanged. Exposed for testing (#243).
+    static func parentID(forSelection selection: String?) -> String? {
+        selection == rootFolderID ? nil : selection
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -56,6 +71,11 @@ struct BookmarkTargetPickerSheet: View {
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
+                    rootRow
+                    if !filteredFolders.isEmpty {
+                        Divider()
+                            .padding(.vertical, 2)
+                    }
                     ForEach(filteredFolders) { folder in
                         row(for: folder)
                     }
@@ -88,8 +108,9 @@ struct BookmarkTargetPickerSheet: View {
                 }
                 .keyboardShortcut(.cancelAction)
                 Button("Add") {
-                    DebugLog.tabs("BookmarkTargetPickerSheet: Add — parentID=\(selectedFolderID ?? "nil"), \(ids.count) items")
-                    onConfirm(selectedFolderID)
+                    let parentID = Self.parentID(forSelection: selectedFolderID)
+                    DebugLog.tabs("BookmarkTargetPickerSheet: Add — parentID=\(parentID ?? "nil"), \(ids.count) items")
+                    onConfirm(parentID)
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
@@ -161,6 +182,34 @@ struct BookmarkTargetPickerSheet: View {
         .padding(8)
         .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    // MARK: - Root row (top-level destination)
+
+    /// A pinned row representing the bookmarks root (`parentID == nil`),
+    /// so the user can bookmark to the top level without first creating a
+    /// folder. Selectable like any folder row (#243).
+    @ViewBuilder
+    private var rootRow: some View {
+        let isSelected = selectedFolderID == Self.rootFolderID
+        HStack(spacing: 8) {
+            Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                .font(.callout)
+            Image(systemName: "bookmarks")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+            Text("Bookmarks")
+                .font(.callout)
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selectedFolderID = (isSelected ? nil : Self.rootFolderID)
+        }
     }
 
     // MARK: - Folder row (single-select)

--- a/Tests/WikiFSTests/BookmarkTargetPickerSelectionTests.swift
+++ b/Tests/WikiFSTests/BookmarkTargetPickerSelectionTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import WikiFS
+
+/// Tests for `BookmarkTargetPickerSheet.parentID(forSelection:)` — the
+/// sentinel-to-nil conversion that lets the picker offer a "Bookmarks" root
+/// destination (parentID == nil) alongside real folders (#243).
+@Suite struct BookmarkTargetPickerSelectionTests {
+
+    @Test func rootSentinelMapsToNilParentID() {
+        #expect(BookmarkTargetPickerSheet.parentID(forSelection: "__bookmarks_root__") == nil)
+    }
+
+    @Test func realFolderIDPassesThrough() {
+        #expect(BookmarkTargetPickerSheet.parentID(forSelection: "01HZXAMPLE000FOLDER") == "01HZXAMPLE000FOLDER")
+    }
+
+    @Test func nilSelectionPassesThroughAsNil() {
+        // When the user taps to deselect everything, nil stays nil.
+        #expect(BookmarkTargetPickerSheet.parentID(forSelection: nil) == nil)
+    }
+
+    @Test func emptyStringPassesThrough() {
+        // Edge case: an empty (but non-nil) selection is not the sentinel.
+        #expect(BookmarkTargetPickerSheet.parentID(forSelection: "") == "")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #243 — the bookmark target picker (`BookmarkTargetPickerSheet`) had no row representing the bookmarks root (`parentID == nil`), so in a wiki with zero folders the user was forced to create a folder before they could confirm "Add", even though the data model already supports root-level bookmarks.

## Changes

- **Added a pinned "Bookmarks" root row** at the top of the folder list in `BookmarkTargetPickerSheet`, selectable like any folder row. Selecting it means "bookmark to the top level" (`parentID = nil`).
- **Pre-selected root on appear** so the "Add" button is enabled immediately in an empty wiki — no forced folder creation.
- **Sentinel-based selection**: used a constant `__bookmarks_root__` to distinguish "root selected" from "nothing selected" (both were `nil` before), converted back to `nil` in `onConfirm` via a testable static method `parentID(forSelection:)`.
- **Added `BookmarkTargetPickerSelectionTests`** covering the sentinel-to-nil conversion (root sentinel → nil, real folder ID → passthrough, nil → nil, empty string → passthrough).

## Before / After

| Scenario | Before | After |
|---|---|---|
| Empty wiki, open picker | "No folders yet — create one below." Add disabled | "Bookmarks" root row pre-selected, Add enabled |
| Wiki with folders | Root not offered as destination | Root row pinned above folder list |
| Selecting root then confirming | N/A (impossible) | `onConfirm(nil)` → bookmark created at top level |

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter BookmarkTargetPickerSelectionTests` — 4 new tests pass
- [x] `swift test` (fast tier, 2191 tests) — all pass
- [ ] CI green

Closes #243.
