### PR TITLE
Export FileProvider as Open Knowledge Format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ NOTARY_PROFILE ?= wikifs-notary
 PROVISION_PROFILE ?=
 NOTES_FILE       ?=
 
-.PHONY: all deps build check test release run clean install uninstall register help prune-provider-registrations \
+.PHONY: all deps build check test release run reload clean install uninstall register help prune-provider-registrations \
         check-version notary-setup sign zip-notary notarize staple zip-release \
         checksum verify-release dist github-release print-version icon prompts check-prompts
 
@@ -91,6 +91,11 @@ help:
 	@echo "  check-prompts     CI gate — fail if GeneratedPrompts.swift is stale vs prompts/*.md"
 	@echo "  release           Build release into ./$(APP)"
 	@echo "  run               Install to /Applications and launch $(APP_NAME)"
+	@echo "  reload            Like run, but forces the File Provider domain to reset —"
+	@echo "                    use after changing FileProvider rendering (Projection.swift,"
+	@echo "                    PageMarkdownFormat, RelativeLinkRewriter, …); the daemon"
+	@echo "                    caches materialized files by data version, so a rendering-only"
+	@echo "                    change is otherwise invisible until content is next edited"
 	@echo "  clean             Remove ./build/ ./.build/ ./dist/"
 	@echo "  deps              Verify build prerequisites (auto-run before build)"
 	@echo ""
@@ -210,6 +215,47 @@ print-version:
 
 run: install
 	open "$(INSTALLED_APP)"
+
+# `reload` — like `run`, but forces every registered File Provider domain to be
+# removed and re-added before it mounts again.
+#
+# Why this exists: fileproviderd caches each materialized file's bytes keyed
+# by the DATA version the extension reports (page.version / chat.updatedAt /
+# the whole-DB changeToken — see Projection.swift's `pageFileNode` etc.), NOT
+# by the extension's own build/code version. So a rebuild that changes how a
+# file is RENDERED (e.g. #216's [[wikilink]] → relative-Markdown-link rewrite)
+# is invisible to already-materialized files on disk: the daemon sees the same
+# reported version it already cached and never calls back into the extension
+# for fresh bytes. A plain `make install`/`run` — even a from-scratch rebuild —
+# does not fix this; the stale copies live in fileproviderd's cache, not the
+# app bundle. There is no `fileproviderctl` evict/reimport subcommand on this
+# OS to force it from the shell, and a raw `rm` on a mounted file round-trips
+# through the (read-only) extension's `deleteItem` and is rejected.
+#
+# The one CLI-drivable fix is the app's own `WIKIFS_REENUMERATE=1` hatch
+# (FileProviderSpike.swift `registerDomain`): read once at launch, it calls
+# `NSFileProviderManager.remove(domain)` for each wiki before re-adding it —
+# tearing down and rebuilding the whole projection, which forces a full
+# re-fetch. `open --env` (macOS 14+) sets that var for the freshly-launched
+# process; a plain `open` does not propagate shell environment into the
+# relaunch, so this can't just be `WIKIFS_REENUMERATE=1 open ...`. Both the
+# app and extension processes are killed first so `-n` (new instance) doesn't
+# leave a stale, non-reset instance running alongside the fresh one.
+#
+# This is a one-shot manual hatch for local dev; it is deliberately NOT the
+# default `run`/`install` behavior because a full domain reset re-downloads
+# everything and would slow down routine iteration unrelated to rendering
+# changes. The permanent, no-flag-needed fix for a SHIPPED rendering-contract
+# change is bumping `FileProviderSpike.currentSchemaVersion`, which resets
+# every user's domain automatically on next launch (see its doc comment) —
+# use `reload` here to verify, then decide separately whether the change
+# warrants that bump.
+reload: install
+	@pkill -f "$(INSTALLED_APP)/Contents/MacOS/$(APP_NAME)" 2>/dev/null && echo "✓ killed running $(APP_NAME)" || true
+	@pkill -f "$(EXT_NAME).appex" 2>/dev/null && echo "✓ killed stale $(EXT_NAME) process" || true
+	@sleep 1
+	open --env WIKIFS_REENUMERATE=1 -n "$(INSTALLED_APP)"
+	@echo "✓ relaunched $(APP_NAME) with WIKIFS_REENUMERATE=1 — File Provider domain(s) will reset on this launch"
 
 install: build prune-provider-registrations
 	@if [ ! -d "$(APP)" ]; then echo "✗ $(APP) missing — build failed?"; exit 1; fi

--- a/Sources/WikiFSCore/RelativeLinkRewriter.swift
+++ b/Sources/WikiFSCore/RelativeLinkRewriter.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Rewrites Obsidian-style `[[wiki-links]]` in a page body to standard
+/// relative Markdown links `[display](filename.md)` for the `pages/by-title`
+/// filesystem projection. Allows external tools like Obsidian and VS Code
+/// to follow links when they point at the `pages/by-title/` folder as a vault.
+///
+/// Rules:
+/// - Only plain page links (`[[Title]]`, `[[Title|alias]]`, `[[Title#anchor]]`)
+///   are rewritten — `[[source:…]]`, `[[chat:…]]`, and embeds (`![[…]]`) are
+///   left verbatim (no corresponding file exists in `by-title/`).
+/// - Unresolvable links (broken, links to deleted pages) are left as
+///   `[[wikilink]]` so Obsidian treats them as "new page" stubs.
+/// - Links inside code spans and fenced code blocks are left verbatim.
+/// - Fragment anchors (`[[Title#Heading]]`) are preserved in the rewritten link.
+/// - `#`-in-title disambiguation uses `WikiLinkResolver` (same rule as in-app).
+/// - The filename in the output URL is percent-encoded for Markdown compatibility.
+///
+/// This is a **filesystem projection** concern only — the on-disk by-title body
+/// has rewritten links; the SQLite store retains `[[…]]` verbatim. Nothing
+/// here writes back to the store.
+public enum RelativeLinkRewriter {
+
+    private static let regex = WikiLinkSpan.regex
+
+    /// Rewrite all resolvable page `[[wiki-links]]` in `body` to relative
+    /// Markdown links `[display](filename.md)`.
+    ///
+    /// - Parameters:
+    ///   - body: Full page content as produced by `PageMarkdownFormat.fileContent`
+    ///           (YAML frontmatter + H1 + body). Frontmatter is passed through
+    ///           unchanged since no `[[…]]` occurs in well-formed frontmatter.
+    ///   - resolver: Maps a canonical (whitespace-collapsed) page title to its
+    ///               by-title filename (e.g. `"Home"` → `"Home--01ABC.md"`).
+    ///               Returns `nil` when the title has no matching page.
+    /// - Returns: The rewritten body, or `body` unchanged if no resolvable page
+    ///            links were found.
+    public static func rewrite(_ body: String, resolver: (String) -> String?) -> String {
+        let ns = body as NSString
+        let codeRanges = WikiLinkSpan.protectedCodeRanges(in: body)
+        let matches = regex.matches(in: body, range: NSRange(location: 0, length: ns.length))
+
+        var out = ""
+        var cursor = 0
+
+        for match in matches {
+            let full = match.range
+
+            // Leave links inside code spans and fenced blocks verbatim.
+            if WikiLinkSpan.isProtected(full, by: codeRanges) { continue }
+
+            // Copy the gap before this match. If a `!` embed prefix immediately
+            // precedes the match, consume it so we can emit `![[…]]` verbatim
+            // (the `!` is already excluded from the match range).
+            let isEmbedPrefix = WikiLinkSpan.isEmbedPrefix(ns, full)
+            let copyEnd = isEmbedPrefix ? full.location - 1 : full.location
+            if copyEnd > cursor {
+                out += ns.substring(with: NSRange(location: cursor, length: copyEnd - cursor))
+            }
+            cursor = full.location + full.length
+
+            // Embeds (`![[source:…]]` etc.) — no relative file exists; leave verbatim.
+            if isEmbedPrefix {
+                out += "!" + ns.substring(with: full)
+                continue
+            }
+
+            let rawTarget = ns.substring(with: match.range(at: 1))
+            let aliasRange = match.range(at: 2)
+            let rawAlias = aliasRange.location != NSNotFound
+                ? ns.substring(with: aliasRange) : nil
+
+            let fixed = WikiLinkFixer.fix(target: rawTarget, alias: rawAlias)
+            let collapsed = WikiText.normalized(fixed.target)
+            guard !collapsed.isEmpty else {
+                out += ns.substring(with: full)
+                continue
+            }
+
+            // Split on "#" and strip version pin — same pipeline as WikiLinkMarkdown.
+            let (base, _) = WikiLinkParser.splitFragment(collapsed)
+            guard !base.isEmpty else {
+                // Same-page anchor (`[[#Heading]]`): no file target; leave as-is.
+                out += ns.substring(with: full)
+                continue
+            }
+
+            let (bareBase, _) = WikiLinkParser.splitVersionPin(base)
+            let (kind, bareTarget) = WikiLinkParser.classify(bareBase)
+
+            guard !bareTarget.isEmpty,
+                  !WikiLinkParser.isEmptyPrefix(bareBase),
+                  kind == .page else {
+                // source:, chat:, or empty prefix — no by-title file; leave as-is.
+                out += ns.substring(with: full)
+                continue
+            }
+
+            // Resolve, handling `#`-in-title disambiguation.
+            let split = WikiLinkResolver.resolvedSplit(of: collapsed) { resolver($0) != nil }
+            let linkTitle = split?.base ?? bareTarget
+            let linkFragment = split?.fragment
+
+            guard let filename = resolver(linkTitle) else {
+                // Unresolvable (ghost link): leave as [[wikilink]].
+                out += ns.substring(with: full)
+                continue
+            }
+
+            // Display text: alias > link title.
+            let rawDisplay: String
+            if let alias = fixed.alias {
+                let a = WikiText.normalized(alias)
+                rawDisplay = a.isEmpty ? linkTitle : a
+            } else {
+                rawDisplay = linkTitle
+            }
+            let safeDisplay = rawDisplay
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "[", with: "\\[")
+                .replacingOccurrences(of: "]", with: "\\]")
+
+            // Percent-encode the filename for the Markdown URL (spaces → %20 etc.).
+            // Remove `()` from allowed set so an unbalanced `)` never ends the link.
+            let encodedFilename = filename
+                .addingPercentEncoding(withAllowedCharacters: markdownPathAllowed)
+                ?? filename
+
+            if let frag = linkFragment, !frag.isEmpty {
+                let encodedFrag = frag
+                    .addingPercentEncoding(withAllowedCharacters: markdownFragmentAllowed)
+                    ?? frag
+                out += "[\(safeDisplay)](\(encodedFilename)#\(encodedFrag))"
+            } else {
+                out += "[\(safeDisplay)](\(encodedFilename))"
+            }
+        }
+
+        // Tail text after the last match.
+        if cursor < ns.length {
+            out += ns.substring(with: NSRange(location: cursor, length: ns.length - cursor))
+        }
+        return out
+    }
+
+    // MARK: - Private
+
+    /// URL path characters allowed in the Markdown link destination. Starts from
+    /// `urlPathAllowed` and removes `()` (an unbalanced `)` would end the link
+    /// destination early in CommonMark parsers).
+    private static let markdownPathAllowed: CharacterSet = {
+        var set = CharacterSet.urlPathAllowed
+        set.remove(charactersIn: "()")
+        return set
+    }()
+
+    /// Fragment characters allowed after `#`. Removes `#`, `"`, `%`, and `()`
+    /// to match `WikiLinkMarkdown`'s fragment encoding rules.
+    private static let markdownFragmentAllowed: CharacterSet = {
+        var set = CharacterSet.urlFragmentAllowed
+        set.remove(charactersIn: "#\"%()")
+        return set
+    }()
+}

--- a/Sources/WikiFSCore/RelativeLinkRewriter.swift
+++ b/Sources/WikiFSCore/RelativeLinkRewriter.swift
@@ -1,41 +1,87 @@
 import Foundation
 
-/// Rewrites Obsidian-style `[[wiki-links]]` in a page body to standard
-/// relative Markdown links `[display](filename.md)` for the `pages/by-title`
-/// filesystem projection. Allows external tools like Obsidian and VS Code
-/// to follow links when they point at the `pages/by-title/` folder as a vault.
+/// Rewrites Obsidian-style `[[wiki-links]]` in a projected document to standard
+/// relative Markdown links `[display](relative/path.md)` so external tools like
+/// Obsidian (vault rooted at the mount) and VS Code can follow them.
+///
+/// Handles all three linkable namespaces, each resolving to a file elsewhere in
+/// the projection tree:
+///   * `[[Title]]` / `[[page:<ULID>|alias]]`   → `pages/by-title/<file>.md`
+///   * `[[source:Name]]` / `[[source:<ULID>]]` → `sources/by-name/<file>`
+///   * `[[chat:Title]]` / `[[chat:<ULID>]]`    → `chats/by-name/<file>.md`
+///
+/// The link destination is computed **relative to the directory of the document
+/// being rewritten** (`Resolver.baseDir`), so a page→page link stays a sibling
+/// (`Other--01AB.md`) while a page→source link climbs out (`../../sources/…`).
 ///
 /// Rules:
-/// - Only plain page links (`[[Title]]`, `[[Title|alias]]`, `[[Title#anchor]]`)
-///   are rewritten — `[[source:…]]`, `[[chat:…]]`, and embeds (`![[…]]`) are
-///   left verbatim (no corresponding file exists in `by-title/`).
-/// - Unresolvable links (broken, links to deleted pages) are left as
-///   `[[wikilink]]` so Obsidian treats them as "new page" stubs.
-/// - Links inside code spans and fenced code blocks are left verbatim.
-/// - Fragment anchors (`[[Title#Heading]]`) are preserved in the rewritten link.
-/// - `#`-in-title disambiguation uses `WikiLinkResolver` (same rule as in-app).
-/// - The filename in the output URL is percent-encoded for Markdown compatibility.
+/// - Unresolvable targets (deleted / unknown) are left `[[…]]` verbatim so
+///   Obsidian treats them as "new page" stubs.
+/// - Embeds (`![[source:…]]`) are left verbatim — they're media, not links.
+/// - Links inside code spans / fenced blocks are left verbatim.
+/// - Heading fragments (`#Section`) are preserved; quote fragments (`#"quote"`,
+///   used by source cites) are dropped — they aren't resolvable anchors.
+/// - Canonical ULID targets resolve by id and self-heal the display text to the
+///   target's CURRENT title (unless an explicit alias is present).
+/// - `#`-in-name disambiguation reuses `WikiLinkResolver` (same rule as in-app).
 ///
-/// This is a **filesystem projection** concern only — the on-disk by-title body
-/// has rewritten links; the SQLite store retains `[[…]]` verbatim. Nothing
-/// here writes back to the store.
+/// This is a **filesystem projection** concern only — the SQLite store retains
+/// `[[…]]` verbatim; nothing here writes back.
 public enum RelativeLinkRewriter {
+
+    /// A resolved link target: its root-relative path components (last component
+    /// is the filename) and the CURRENT display title (for the alias fallback).
+    public struct Target: Equatable, Sendable {
+        public let path: [String]
+        public let title: String
+        public init(path: [String], title: String) {
+            self.path = path
+            self.title = title
+        }
+    }
+
+    /// Namespace resolution injected by the caller. Each closure takes the
+    /// prefix-stripped target and whether it is a canonical ULID, returning the
+    /// resolved `Target` or `nil` (unknown → link left verbatim).
+    public struct Resolver {
+        /// Root-relative path components of the directory holding the document
+        /// being rewritten — e.g. `["pages", "by-title"]`.
+        public let baseDir: [String]
+        public let page:   (_ target: String, _ isCanonicalID: Bool) -> Target?
+        public let source: (_ target: String, _ isCanonicalID: Bool) -> Target?
+        public let chat:   (_ target: String, _ isCanonicalID: Bool) -> Target?
+
+        public init(
+            baseDir: [String],
+            page: @escaping (String, Bool) -> Target?,
+            source: @escaping (String, Bool) -> Target?,
+            chat: @escaping (String, Bool) -> Target?
+        ) {
+            self.baseDir = baseDir
+            self.page = page
+            self.source = source
+            self.chat = chat
+        }
+
+        func namespace(for kind: WikiLinkParser.ParsedLink.LinkType) -> (String, Bool) -> Target? {
+            switch kind {
+            case .page:   return page
+            case .source: return source
+            case .chat:   return chat
+            }
+        }
+    }
 
     private static let regex = WikiLinkSpan.regex
 
-    /// Rewrite all resolvable page `[[wiki-links]]` in `body` to relative
-    /// Markdown links `[display](filename.md)`.
+    /// Rewrite all resolvable `[[wiki-links]]` in `body` to relative Markdown links.
     ///
     /// - Parameters:
-    ///   - body: Full page content as produced by `PageMarkdownFormat.fileContent`
-    ///           (YAML frontmatter + H1 + body). Frontmatter is passed through
-    ///           unchanged since no `[[…]]` occurs in well-formed frontmatter.
-    ///   - resolver: Maps a canonical (whitespace-collapsed) page title to its
-    ///               by-title filename (e.g. `"Home"` → `"Home--01ABC.md"`).
-    ///               Returns `nil` when the title has no matching page.
-    /// - Returns: The rewritten body, or `body` unchanged if no resolvable page
-    ///            links were found.
-    public static func rewrite(_ body: String, resolver: (String) -> String?) -> String {
+    ///   - body: Full projected document (frontmatter + content). Frontmatter is
+    ///           passed through since no `[[…]]` occurs in well-formed frontmatter.
+    ///   - resolver: Namespace resolution + the document's `baseDir`.
+    /// - Returns: The rewritten body, or `body` unchanged if nothing resolved.
+    public static func rewrite(_ body: String, resolver: Resolver) -> String {
         let ns = body as NSString
         let codeRanges = WikiLinkSpan.protectedCodeRanges(in: body)
         let matches = regex.matches(in: body, range: NSRange(location: 0, length: ns.length))
@@ -50,8 +96,7 @@ public enum RelativeLinkRewriter {
             if WikiLinkSpan.isProtected(full, by: codeRanges) { continue }
 
             // Copy the gap before this match. If a `!` embed prefix immediately
-            // precedes the match, consume it so we can emit `![[…]]` verbatim
-            // (the `!` is already excluded from the match range).
+            // precedes the match, consume it so we can emit `![[…]]` verbatim.
             let isEmbedPrefix = WikiLinkSpan.isEmbedPrefix(ns, full)
             let copyEnd = isEmbedPrefix ? full.location - 1 : full.location
             if copyEnd > cursor {
@@ -59,7 +104,7 @@ public enum RelativeLinkRewriter {
             }
             cursor = full.location + full.length
 
-            // Embeds (`![[source:…]]` etc.) — no relative file exists; leave verbatim.
+            // Embeds (`![[source:…]]` etc.) — media, not links; leave verbatim.
             if isEmbedPrefix {
                 out += "!" + ns.substring(with: full)
                 continue
@@ -76,9 +121,11 @@ public enum RelativeLinkRewriter {
                 out += ns.substring(with: full)
                 continue
             }
+            let alias = fixed.alias.map { WikiText.normalized($0) }.flatMap { $0.isEmpty ? nil : $0 }
 
-            // Split on "#" and strip version pin — same pipeline as WikiLinkMarkdown.
-            let (base, _) = WikiLinkParser.splitFragment(collapsed)
+            // Split on "#"/"#\"" and strip version pin — same pipeline as the
+            // in-app renderer, so on-disk and in-app resolve the same set.
+            let (base, baseFragment) = WikiLinkParser.splitFragment(collapsed)
             guard !base.isEmpty else {
                 // Same-page anchor (`[[#Heading]]`): no file target; leave as-is.
                 out += ns.substring(with: full)
@@ -88,52 +135,52 @@ public enum RelativeLinkRewriter {
             let (bareBase, _) = WikiLinkParser.splitVersionPin(base)
             let (kind, bareTarget) = WikiLinkParser.classify(bareBase)
 
-            guard !bareTarget.isEmpty,
-                  !WikiLinkParser.isEmptyPrefix(bareBase),
-                  kind == .page else {
-                // source:, chat:, or empty prefix — no by-title file; leave as-is.
+            guard !bareTarget.isEmpty, !WikiLinkParser.isEmptyPrefix(bareBase) else {
                 out += ns.substring(with: full)
                 continue
             }
 
-            // Resolve, handling `#`-in-title disambiguation.
-            let split = WikiLinkResolver.resolvedSplit(of: collapsed) { resolver($0) != nil }
-            let linkTitle = split?.base ?? bareTarget
-            let linkFragment = split?.fragment
+            let resolve = resolver.namespace(for: kind)
 
-            guard let filename = resolver(linkTitle) else {
-                // Unresolvable (ghost link): leave as [[wikilink]].
-                out += ns.substring(with: full)
+            // Canonical ULID target: resolve by id, self-heal display to current title.
+            if WikiLinkParser.isCanonicalULID(bareTarget) {
+                guard let target = resolve(bareTarget, true) else {
+                    out += ns.substring(with: full)   // deleted → ghost
+                    continue
+                }
+                out += markdownLink(display: alias ?? target.title,
+                                    path: relativePath(from: resolver.baseDir, to: target.path),
+                                    fragment: baseFragment)
                 continue
             }
 
-            // Display text: alias > link title.
-            let rawDisplay: String
-            if let alias = fixed.alias {
-                let a = WikiText.normalized(alias)
-                rawDisplay = a.isEmpty ? linkTitle : a
-            } else {
-                rawDisplay = linkTitle
+            // Name-based target: strip the `kind:` prefix (if present) BEFORE
+            // `#`-in-name disambiguation, else the split keys carry the prefix and
+            // never resolve. Page links usually have no prefix; source/chat do.
+            let nameSearch = stripPrefix(kind, from: collapsed)
+            let split = WikiLinkResolver.resolvedSplit(of: nameSearch) {
+                resolve($0, false) != nil
             }
-            let safeDisplay = rawDisplay
-                .replacingOccurrences(of: "\\", with: "\\\\")
-                .replacingOccurrences(of: "[", with: "\\[")
-                .replacingOccurrences(of: "]", with: "\\]")
-
-            // Percent-encode the filename for the Markdown URL (spaces → %20 etc.).
-            // Remove `()` from allowed set so an unbalanced `)` never ends the link.
-            let encodedFilename = filename
-                .addingPercentEncoding(withAllowedCharacters: markdownPathAllowed)
-                ?? filename
-
-            if let frag = linkFragment, !frag.isEmpty {
-                let encodedFrag = frag
-                    .addingPercentEncoding(withAllowedCharacters: markdownFragmentAllowed)
-                    ?? frag
-                out += "[\(safeDisplay)](\(encodedFilename)#\(encodedFrag))"
+            // When a split resolved, take ITS (base, fragment) — even a nil
+            // fragment (the whole name matched). Only fall back to the heuristic
+            // `splitFragment` result when nothing resolved (ghost link).
+            let linkName: String
+            let linkFragment: String?
+            if let split {
+                linkName = split.base
+                linkFragment = split.fragment
             } else {
-                out += "[\(safeDisplay)](\(encodedFilename))"
+                linkName = bareTarget
+                linkFragment = baseFragment
             }
+
+            guard let target = resolve(linkName, false) else {
+                out += ns.substring(with: full)   // ghost link
+                continue
+            }
+            out += markdownLink(display: alias ?? target.title,
+                                path: relativePath(from: resolver.baseDir, to: target.path),
+                                fragment: linkFragment)
         }
 
         // Tail text after the last match.
@@ -143,19 +190,68 @@ public enum RelativeLinkRewriter {
         return out
     }
 
+    // MARK: - Relative path
+
+    /// Root-relative path from `baseDir` (a directory) to `target` (whose last
+    /// component is a filename), percent-encoded per component. Same directory →
+    /// bare filename; different subtree → `../…/…`.
+    static func relativePath(from baseDir: [String], to target: [String]) -> String {
+        let targetDir = target.dropLast()
+        var common = 0
+        while common < baseDir.count && common < targetDir.count
+                && baseDir[common] == targetDir[common] {
+            common += 1
+        }
+        let ups = baseDir.count - common
+        var comps = Array(repeating: "..", count: ups)
+        comps += target[common...]
+        return comps
+            .map { $0.addingPercentEncoding(withAllowedCharacters: markdownPathAllowed) ?? $0 }
+            .joined(separator: "/")
+    }
+
     // MARK: - Private
 
-    /// URL path characters allowed in the Markdown link destination. Starts from
-    /// `urlPathAllowed` and removes `()` (an unbalanced `)` would end the link
-    /// destination early in CommonMark parsers).
+    /// Strip a leading `page:` / `source:` / `chat:` prefix matching `kind` from
+    /// `collapsed`, preserving any inner `#` (so `#`-in-name disambiguation works).
+    private static func stripPrefix(_ kind: WikiLinkParser.ParsedLink.LinkType,
+                                    from collapsed: String) -> String {
+        let token = "\(kind.rawValue):"
+        return collapsed.hasPrefix(token) ? String(collapsed.dropFirst(token.count)) : collapsed
+    }
+
+    /// Build one `[display](path#fragment)` Markdown link. Escapes `[`/`]`/`\` in
+    /// the display text; drops quote-style fragments (`"…"`) that aren't
+    /// resolvable anchors; percent-encodes a kept heading fragment. `path` is
+    /// already percent-encoded by `relativePath`.
+    private static func markdownLink(display: String, path: String,
+                                     fragment: String?) -> String {
+        let safeDisplay = display
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "[", with: "\\[")
+            .replacingOccurrences(of: "]", with: "\\]")
+        // A quote fragment (source cite, `#"…"`) is not a heading anchor — drop it.
+        if let frag = fragment, !frag.isEmpty, !frag.hasPrefix("\"") {
+            let encodedFrag = frag
+                .addingPercentEncoding(withAllowedCharacters: markdownFragmentAllowed)
+                ?? frag
+            return "[\(safeDisplay)](\(path)#\(encodedFrag))"
+        }
+        return "[\(safeDisplay)](\(path))"
+    }
+
+    /// URL path characters allowed in a Markdown link destination component.
+    /// Removes `()` (an unbalanced `)` ends the destination early in CommonMark)
+    /// and `/` (we join components ourselves, so a `/` inside a component would
+    /// forge a false path separator).
     private static let markdownPathAllowed: CharacterSet = {
         var set = CharacterSet.urlPathAllowed
-        set.remove(charactersIn: "()")
+        set.remove(charactersIn: "()/")
         return set
     }()
 
-    /// Fragment characters allowed after `#`. Removes `#`, `"`, `%`, and `()`
-    /// to match `WikiLinkMarkdown`'s fragment encoding rules.
+    /// Fragment characters allowed after `#`. Removes `#`, `"`, `%`, and `()` to
+    /// match `WikiLinkMarkdown`'s fragment encoding rules.
     private static let markdownFragmentAllowed: CharacterSet = {
         var set = CharacterSet.urlFragmentAllowed
         set.remove(charactersIn: "#\"%()")

--- a/Sources/WikiFSCore/SourceImageRewriter.swift
+++ b/Sources/WikiFSCore/SourceImageRewriter.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Rewrites plain CommonMark image srcs (`![alt](src)`) in source-markdown
+/// content that were downloaded during website-snapshot ingestion
+/// (`WebsiteSnapshotExtractor`) and stored as flat sibling `sources` rows
+/// (`SQLiteWikiStore.addSnapshotImage`). The extractor rewrites `<img src>` to
+/// a relative path like `potluck/diagram.png` as if a nested folder existed
+/// next to the markdown, but the FileProvider projection places every source
+/// flat under `sources/by-name/` — so that relative path never resolves on
+/// disk (or in the in-app WKWebView reader, without this same lookup).
+///
+/// Mirrors `MarkdownHTMLRenderer.resolvedImageSrc` (`Sources/WikiFS/MarkdownHTMLRenderer.swift`),
+/// the in-app renderer's EXACT-STRING resolution of the same `original_path`
+/// data (`SQLiteWikiStore.siblingImageResolvers()`) — but implemented as a
+/// regex pass here (no `swift-markdown`/`import Markdown`, which is an
+/// app-target-only dependency not linked into `WikiFSCore`/`WikiFSFileProvider` —
+/// see `Package.swift`). Filtering rule is IDENTICAL: absolute (`http`/`https`),
+/// `data:`, `wiki-blob:`, `wiki:` srcs pass through untouched; any other src is
+/// looked up EXACTLY (no fuzzy/basename matching) in the resolver; an
+/// unresolved relative src is left verbatim — same "don't guess" discipline
+/// the in-app renderer uses.
+///
+/// This is a filesystem-projection concern only — SQLite retains the raw
+/// extracted markdown verbatim; nothing here writes back.
+public enum SourceImageRewriter {
+
+    /// Namespace resolution for one document being rewritten.
+    public struct Resolver {
+        /// Root-relative directory of the document being rewritten — e.g.
+        /// `["sources", "by-name"]`.
+        public let baseDir: [String]
+        /// EXACT `original_path` (as it appears in the markdown `![](src)`) →
+        /// the resolved target, or `nil` if unresolved.
+        public let resolve: (String) -> RelativeLinkRewriter.Target?
+
+        public init(baseDir: [String], resolve: @escaping (String) -> RelativeLinkRewriter.Target?) {
+            self.baseDir = baseDir
+            self.resolve = resolve
+        }
+    }
+
+    /// `![alt](src)` — alt has no unescaped `]`; src runs to the first
+    /// unescaped `)` or whitespace (an optional `"title"` after whitespace is
+    /// tolerated but not captured/preserved — none of today's snapshot images
+    /// carry one, and dropping it if present is an acceptable, documented
+    /// simplification). Capture groups: 1 = alt, 2 = src.
+    private static let regex = try! NSRegularExpression(
+        pattern: #"!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)"#)
+
+    public static func rewrite(_ body: String, resolver: Resolver) -> String {
+        let ns = body as NSString
+        let codeRanges = WikiLinkSpan.protectedCodeRanges(in: body)
+        let matches = regex.matches(in: body, range: NSRange(location: 0, length: ns.length))
+
+        var out = ""
+        var cursor = 0
+        for match in matches {
+            let full = match.range
+            if WikiLinkSpan.isProtected(full, by: codeRanges) { continue }
+
+            let src = ns.substring(with: match.range(at: 2))
+            guard let target = resolvedTarget(for: src, resolver: resolver) else { continue }
+
+            if full.location > cursor {
+                out += ns.substring(with: NSRange(location: cursor, length: full.location - cursor))
+            }
+            let alt = ns.substring(with: match.range(at: 1))
+            let path = RelativeLinkRewriter.relativePath(from: resolver.baseDir, to: target.path)
+            out += "![\(alt)](\(path))"
+            cursor = full.location + full.length
+        }
+        if cursor < ns.length {
+            out += ns.substring(with: NSRange(location: cursor, length: ns.length - cursor))
+        }
+        return out
+    }
+
+    /// `nil` for absolute/data/wiki-scheme srcs (leave verbatim, pass copies
+    /// through untouched by the caller's cursor logic) OR an unresolved
+    /// relative src (also leave verbatim). Mirrors
+    /// `MarkdownHTMLRenderer.resolvedImageSrc`'s filter list exactly.
+    private static func resolvedTarget(for src: String, resolver: Resolver) -> RelativeLinkRewriter.Target? {
+        guard !src.isEmpty else { return nil }
+        let lower = src.lowercased()
+        if lower.hasPrefix("http") || lower.hasPrefix("data:")
+            || lower.hasPrefix("wiki-blob:") || lower.hasPrefix("wiki:") {
+            return nil
+        }
+        return resolver.resolve(src)
+    }
+}

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -558,10 +558,8 @@ struct Projection {
                   let page = try? store.getPage(id: PageID(rawValue: ulid)) else { return nil }
             // For by-title pages, size must match the rewritten bytes that
             // contents(for:) will serve — a mismatch truncates cat (#216).
-            if id.rawValue.hasPrefix(Identity.byTitlePrefix),
-               let pages = try? store.listAllPagesOrderedByID() {
-                let map = projection.titleToFilenameMap(pages: pages)
-                let data = projection.byTitleContent(for: page, map: map)
+            if id.rawValue.hasPrefix(Identity.byTitlePrefix) {
+                let data = projection.byTitleContent(for: page, maps: projection.makeLinkMaps())
                 return Self.pageFileNode(for: id, page: page, contentData: data)
             }
             return Self.pageFileNode(for: id, page: page)
@@ -571,10 +569,8 @@ struct Projection {
                   let store = projection.openReadStore(),
                   let page = try? store.getPage(id: PageID(rawValue: ulid)) else { return nil }
             // By-title view: rewrite [[wikilinks]] to relative Markdown links.
-            if id.rawValue.hasPrefix(Identity.byTitlePrefix),
-               let pages = try? store.listAllPagesOrderedByID() {
-                let map = projection.titleToFilenameMap(pages: pages)
-                return projection.byTitleContent(for: page, map: map)
+            if id.rawValue.hasPrefix(Identity.byTitlePrefix) {
+                return projection.byTitleContent(for: page, maps: projection.makeLinkMaps())
             }
             return Data(PageMarkdownFormat.fileContent(for: page).utf8)
         }
@@ -598,10 +594,9 @@ struct Projection {
                     return nil
                 }
                 // For by-name markdown siblings, size must match rewritten bytes.
-                if id.rawValue.hasPrefix(Identity.sourceMarkdownByNamePrefix),
-                   let pages = try? store.listAllPagesOrderedByID() {
-                    let map = projection.titleToFilenameMap(pages: pages)
-                    let data = projection.rewriteMarkdown(head.content, map: map)
+                if id.rawValue.hasPrefix(Identity.sourceMarkdownByNamePrefix) {
+                    let data = projection.rewriteLinks(head.content, maps: projection.makeLinkMaps(),
+                                                       baseDir: Self.sourcesByNameDir)
                     return Self.sourceMarkdownNode(for: id, source: file, head: head, contentData: data)
                 }
                 return Self.sourceMarkdownNode(for: id, source: file, head: head)
@@ -620,10 +615,9 @@ struct Projection {
                     return nil
                 }
                 // By-name markdown siblings: rewrite [[wikilinks]] to relative links.
-                if id.rawValue.hasPrefix(Identity.sourceMarkdownByNamePrefix),
-                   let pages = try? store.listAllPagesOrderedByID() {
-                    let map = projection.titleToFilenameMap(pages: pages)
-                    return projection.rewriteMarkdown(head.content, map: map)
+                if id.rawValue.hasPrefix(Identity.sourceMarkdownByNamePrefix) {
+                    return projection.rewriteLinks(head.content, maps: projection.makeLinkMaps(),
+                                                   baseDir: Self.sourcesByNameDir)
                 }
                 return Data(head.content.utf8)
             }
@@ -648,12 +642,11 @@ struct Projection {
                   let chats = try? store.listAllChatsOrderedByID(),
                   let chat = chats.first(where: { $0.id.rawValue == ulid }) else { return nil }
             // For by-name chats, size must match rewritten bytes.
-            if id.rawValue.hasPrefix(Identity.chatByNamePrefix),
-               let pages = try? store.listAllPagesOrderedByID() {
-                let map = projection.titleToFilenameMap(pages: pages)
+            if id.rawValue.hasPrefix(Identity.chatByNamePrefix) {
                 let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
                 let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
-                let data = projection.rewriteMarkdown(raw, map: map)
+                let data = projection.rewriteLinks(raw, maps: projection.makeLinkMaps(),
+                                                   baseDir: Self.chatsByNameDir)
                 return Self.chatFileNode(for: id, chat: chat, in: store, contentData: data)
             }
             return Self.chatFileNode(for: id, chat: chat, in: store)
@@ -666,10 +659,9 @@ struct Projection {
                   let messages = try? store.chatMessages(chatID: chat.id) else { return nil }
             let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
             // By-name chats: rewrite [[wikilinks]] to relative links.
-            if id.rawValue.hasPrefix(Identity.chatByNamePrefix),
-               let pages = try? store.listAllPagesOrderedByID() {
-                let map = projection.titleToFilenameMap(pages: pages)
-                return projection.rewriteMarkdown(raw, map: map)
+            if id.rawValue.hasPrefix(Identity.chatByNamePrefix) {
+                return projection.rewriteLinks(raw, maps: projection.makeLinkMaps(),
+                                               baseDir: Self.chatsByNameDir)
             }
             return Data(raw.utf8)
         }
@@ -906,12 +898,37 @@ struct Projection {
         name.replacingOccurrences(of: "/", with: "-")
     }
 
+    /// The projection-relative directory components CONTAINING `node` —
+    /// `["bookmarks"]` for a root-level ref, plus one sanitized label per
+    /// ancestor folder (root → immediate parent). Used as the rewriter's
+    /// `baseDir` so a nested ref's links climb the right number of `../`.
+    /// The parent walk is capped (matches `BookmarkNode.displayPath`) so a
+    /// corrupted parent cycle can't loop forever.
+    private func bookmarkBaseDir(for node: BookmarkNode,
+                                 in nodes: [BookmarkNode]) -> [String] {
+        var byID: [String: BookmarkNode] = [:]
+        byID.reserveCapacity(nodes.count)
+        for n in nodes { byID[n.id] = n }
+
+        var labels: [String] = []
+        var current = node.parentID.flatMap { byID[$0] }
+        var depth = 0
+        let maxDepth = 64
+        while let folder = current, depth < maxDepth {
+            depth += 1
+            labels.insert(Self.sanitizeFilename(folder.label ?? "Untitled"), at: 0)
+            current = folder.parentID.flatMap { byID[$0] }
+        }
+        return ["bookmarks"] + labels
+    }
+
     /// Build a `ProjectedNode` for one bookmark node, resolving the target for
     /// refs. Stale refs (target deleted) render as a small placeholder file so
     /// the tree shape is preserved. All bookmark nodes are versioned by the
     /// change token so any mutation re-fetches them.
     private func bookmarkNodeItem(
-        for node: BookmarkNode, in store: SQLiteWikiStore
+        for node: BookmarkNode, in store: SQLiteWikiStore,
+        maps: LinkMaps, allNodes: [BookmarkNode]
     ) -> ProjectedNode {
         let id = Self.bookmarkID(for: node)
         let parent = Self.bookmarkParent(for: node)
@@ -922,7 +939,9 @@ struct Projection {
         case .pageRef:
             if let targetID = node.targetID,
                let page = try? store.getPage(id: targetID) {
-                let body = Data(PageMarkdownFormat.fileContent(for: page).utf8)
+                let baseDir = bookmarkBaseDir(for: node, in: allNodes)
+                let body = rewriteLinks(PageMarkdownFormat.fileContent(for: page),
+                                        maps: maps, baseDir: baseDir)
                 let name = Self.sanitizeFilename(page.title) + ".md"
                 return .file(id: id, parent: parent, name: name, size: body.count,
                              version: version, metadataVersion: version,
@@ -951,7 +970,9 @@ struct Projection {
             if let targetID = node.targetID,
                let chat = (try? store.listAllChatsOrderedByID())?.first(where: { $0.id == targetID }) {
                 let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
-                let body = Data(ChatTranscriptRenderer.render(summary: chat, messages: messages).utf8)
+                let baseDir = bookmarkBaseDir(for: node, in: allNodes)
+                let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
+                let body = rewriteLinks(raw, maps: maps, baseDir: baseDir)
                 let name = Self.sanitizeFilename(chat.title) + ".md"
                 return .file(id: id, parent: parent, name: name, size: body.count,
                              version: version, metadataVersion: version,
@@ -970,7 +991,7 @@ struct Projection {
               let store = openReadStore(),
               let nodes = try? store.listBookmarkNodes(),
               let node = nodes.first(where: { $0.id == ulid }) else { return nil }
-        return bookmarkNodeItem(for: node, in: store)
+        return bookmarkNodeItem(for: node, in: store, maps: makeLinkMaps(), allNodes: nodes)
     }
 
     /// Enumerate the children of a bookmark container (the topLevel folder or a
@@ -987,10 +1008,11 @@ struct Projection {
         }
         guard let store = openReadStore(),
               let nodes = try? store.listBookmarkNodes() else { return [] }
+        let maps = makeLinkMaps()
         return nodes
             .filter { $0.parentID == parentID }
             .sorted { $0.position < $1.position }
-            .compactMap { bookmarkNodeItem(for: $0, in: store) }
+            .compactMap { bookmarkNodeItem(for: $0, in: store, maps: maps, allNodes: nodes) }
     }
 
     /// Serve content for a bookmark ref leaf, resolving the target. Folders
@@ -1008,7 +1030,9 @@ struct Projection {
                   let page = try? store.getPage(id: targetID) else {
                 return Data("# Stale reference\n\nThis bookmark points to a deleted page.".utf8)
             }
-            return Data(PageMarkdownFormat.fileContent(for: page).utf8)
+            return rewriteLinks(PageMarkdownFormat.fileContent(for: page),
+                                maps: makeLinkMaps(),
+                                baseDir: bookmarkBaseDir(for: node, in: nodes))
         case .sourceRef:
             guard let targetID = node.targetID else {
                 return Data("# Stale reference\n\nThis bookmark points to a deleted source.".utf8)
@@ -1021,7 +1045,9 @@ struct Projection {
                 return Data("# Stale reference\n\nThis bookmark points to a deleted chat.".utf8)
             }
             let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
-            return Data(ChatTranscriptRenderer.render(summary: chat, messages: messages).utf8)
+            let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
+            return rewriteLinks(raw, maps: makeLinkMaps(),
+                                baseDir: bookmarkBaseDir(for: node, in: nodes))
         }
     }
 
@@ -1029,7 +1055,8 @@ struct Projection {
     private func allBookmarkNodes() -> [ProjectedNode] {
         guard let store = openReadStore(),
               let nodes = try? store.listBookmarkNodes() else { return [] }
-        return nodes.compactMap { bookmarkNodeItem(for: $0, in: store) }
+        let maps = makeLinkMaps()
+        return nodes.compactMap { bookmarkNodeItem(for: $0, in: store, maps: maps, allNodes: nodes) }
     }
 
     // MARK: - Metadata resolution
@@ -1181,31 +1208,94 @@ struct Projection {
         )
     }
 
-    /// Build a title → by-title-filename map for all pages. Used by the by-title
-    /// link rewriter so `[[wikilinks]]` resolve to sibling filenames.
-    private func titleToFilenameMap(pages: [WikiPage]) -> [String: String] {
-        var map: [String: String] = [:]
-        for page in pages {
-            map[page.title] = FilenameEscaping.byTitleFilename(
-                title: page.title, pageID: page.id.rawValue)
+    // MARK: - Link rewriting (by-title / by-name views)
+
+    /// Root-relative directory of each projected view, matching the FileProvider
+    /// tree. These are the `baseDir` / target-path prefixes the rewriter uses to
+    /// compute relative link destinations across namespaces.
+    static let pagesByTitleDir  = ["pages", "by-title"]
+    static let sourcesByNameDir = ["sources", "by-name"]
+    static let chatsByNameDir   = ["chats", "by-name"]
+
+    /// The six title/id → target maps the rewriter resolves against, built once
+    /// from the store. Keys: page/chat by title, source by human name, and each
+    /// by uppercased ULID (canonical `[[page:<ULID>]]` form). A `resolver` for a
+    /// given document `baseDir` closes over these to relativize each target path.
+    struct LinkMaps {
+        let pageByTitle:  [String: RelativeLinkRewriter.Target]
+        let pageByID:     [String: RelativeLinkRewriter.Target]
+        let sourceByName: [String: RelativeLinkRewriter.Target]
+        let sourceByID:   [String: RelativeLinkRewriter.Target]
+        let chatByTitle:  [String: RelativeLinkRewriter.Target]
+        let chatByID:     [String: RelativeLinkRewriter.Target]
+
+        func resolver(baseDir: [String]) -> RelativeLinkRewriter.Resolver {
+            RelativeLinkRewriter.Resolver(
+                baseDir: baseDir,
+                page:   { t, isID in isID ? pageByID[t.uppercased()]   : pageByTitle[t] },
+                source: { t, isID in isID ? sourceByID[t.uppercased()] : sourceByName[t] },
+                chat:   { t, isID in isID ? chatByID[t.uppercased()]   : chatByTitle[t] }
+            )
         }
-        return map
     }
 
-    /// Produce the rewritten by-title content for `page`: replaces `[[wikilinks]]`
-    /// with relative Markdown links pointing to sibling by-title files. The
-    /// returned `Data` is the single source of truth for both `documentSize`
-    /// (reported in `pageFileNode`) and the bytes served by `contents(for:)`.
-    private func byTitleContent(for page: WikiPage, map: [String: String]) -> Data {
-        rewriteMarkdown(PageMarkdownFormat.fileContent(for: page), map: map)
+    /// Build the link-resolution maps from the shared read store. Resilient to
+    /// pre-migration tables (missing → empty map → links left `[[…]]` verbatim).
+    /// Source links target the readable `.md` sibling when one exists, else the
+    /// verbatim file — matching the file that `sourceNodes` actually projects.
+    private func makeLinkMaps() -> LinkMaps {
+        let store = openReadStore()
+
+        var pageByTitle: [String: RelativeLinkRewriter.Target] = [:]
+        var pageByID: [String: RelativeLinkRewriter.Target] = [:]
+        for page in (try? store?.listAllPagesOrderedByID()) ?? [] {
+            let file = FilenameEscaping.byTitleFilename(title: page.title, pageID: page.id.rawValue)
+            let target = RelativeLinkRewriter.Target(path: Self.pagesByTitleDir + [file], title: page.title)
+            pageByTitle[page.title] = target
+            pageByID[page.id.rawValue.uppercased()] = target
+        }
+
+        var sourceByName: [String: RelativeLinkRewriter.Target] = [:]
+        var sourceByID: [String: RelativeLinkRewriter.Target] = [:]
+        let heads = (try? store?.processedMarkdownHeadsBySource()) ?? [:]
+        for row in (try? store?.listAllSourcesOrderedByID()) ?? [] {
+            let humanName = row.displayName ?? row.filename
+            // Sibling eligibility mirrors `sourceNodes`: a processed head AND a
+            // non-`text/*` mime yields the `.md` sibling; otherwise the verbatim file.
+            let hasSibling = heads[row.id] != nil && (row.mime.map { !$0.hasPrefix("text/") } ?? false)
+            let file = hasSibling
+                ? FilenameEscaping.byNameSourceFilename(filename: humanName, ext: "md", sourceID: row.id)
+                : FilenameEscaping.byNameSourceFilename(filename: humanName, ext: row.ext, sourceID: row.id)
+            let target = RelativeLinkRewriter.Target(path: Self.sourcesByNameDir + [file], title: humanName)
+            sourceByName[humanName] = target
+            sourceByID[row.id.uppercased()] = target
+        }
+
+        var chatByTitle: [String: RelativeLinkRewriter.Target] = [:]
+        var chatByID: [String: RelativeLinkRewriter.Target] = [:]
+        for chat in (try? store?.listAllChatsOrderedByID()) ?? [] {
+            let file = FilenameEscaping.byTitleFilename(title: chat.title, pageID: chat.id.rawValue)
+            let target = RelativeLinkRewriter.Target(path: Self.chatsByNameDir + [file], title: chat.title)
+            chatByTitle[chat.title] = target
+            chatByID[chat.id.rawValue.uppercased()] = target
+        }
+
+        return LinkMaps(pageByTitle: pageByTitle, pageByID: pageByID,
+                        sourceByName: sourceByName, sourceByID: sourceByID,
+                        chatByTitle: chatByTitle, chatByID: chatByID)
     }
 
-    /// Rewrite `[[wikilinks]]` in `raw` to relative Markdown links using
-    /// `map` (page title → by-title filename). Single source of truth shared by
-    /// pages, source-markdown siblings, and chat transcripts.
-    private func rewriteMarkdown(_ raw: String, map: [String: String]) -> Data {
-        let rewritten = RelativeLinkRewriter.rewrite(raw) { map[$0] }
-        return Data(rewritten.utf8)
+    /// Rewrite `[[wikilinks]]` in `raw` to relative Markdown links, computing
+    /// destinations relative to `baseDir` (the document's own directory). Single
+    /// source of truth for both `documentSize` and served bytes — a mismatch
+    /// truncates `cat`, so every size/content pair must share this.
+    private func rewriteLinks(_ raw: String, maps: LinkMaps, baseDir: [String]) -> Data {
+        Data(RelativeLinkRewriter.rewrite(raw, resolver: maps.resolver(baseDir: baseDir)).utf8)
+    }
+
+    /// The rewritten by-title page content (page bodies live in `pages/by-title`).
+    private func byTitleContent(for page: WikiPage, maps: LinkMaps) -> Data {
+        rewriteLinks(PageMarkdownFormat.fileContent(for: page), maps: maps, baseDir: Self.pagesByTitleDir)
     }
 
     // MARK: - Enumeration
@@ -1313,11 +1403,11 @@ struct Projection {
     private func pageNodes(byTitle: Bool) -> [ProjectedNode] {
         guard let store = openReadStore(),
               let pages = try? store.listAllPagesOrderedByID() else { return [] }
-        let titleMap = byTitle ? titleToFilenameMap(pages: pages) : nil
+        let maps = byTitle ? makeLinkMaps() : nil
         return pages.map { page in
             let id = byTitle ? Identity.pageByTitle(page.id.rawValue)
                              : Identity.pageByID(page.id.rawValue)
-            let contentData = titleMap.map { byTitleContent(for: page, map: $0) }
+            let contentData = maps.map { byTitleContent(for: page, maps: $0) }
             return Self.pageFileNode(for: id, page: page, contentData: contentData)
         }
     }
@@ -1333,10 +1423,8 @@ struct Projection {
         guard let store = openReadStore(),
               let files = try? store.listAllSourcesOrderedByID() else { return [] }
         let heads = (try? store.processedMarkdownHeadsBySource()) ?? [:]
-        // Build title map once for by-name markdown sibling rewriting.
-        let titleMap: [String: String]? = byName
-            ? (try? store.listAllPagesOrderedByID()).map { titleToFilenameMap(pages: $0) }
-            : nil
+        // Build link maps once for by-name markdown sibling rewriting.
+        let maps = byName ? makeLinkMaps() : nil
         return files.flatMap { row in
             let id = byName ? Identity.sourceByName(row.id) : Identity.sourceByID(row.id)
             let summary = SourceSummary(
@@ -1352,7 +1440,9 @@ struct Projection {
             let markdownID = byName
                 ? Identity.sourceMarkdownByName(row.id)
                 : Identity.sourceMarkdownByID(row.id)
-            let contentData = titleMap.map { rewriteMarkdown(head.content, map: $0) }
+            let contentData = maps.map {
+                rewriteLinks(head.content, maps: $0, baseDir: Self.sourcesByNameDir)
+            }
             return [verbatimNode, Self.sourceMarkdownNode(for: markdownID, source: summary,
                                                           head: head, contentData: contentData)]
         }
@@ -1365,19 +1455,17 @@ struct Projection {
     private func chatNodes(byName: Bool) -> [ProjectedNode] {
         guard let store = openReadStore(),
               let chats = try? store.listAllChatsOrderedByID() else { return [] }
-        // Build title map once for by-name chat rewriting.
-        let titleMap: [String: String]? = byName
-            ? (try? store.listAllPagesOrderedByID()).map { titleToFilenameMap(pages: $0) }
-            : nil
+        // Build link maps once for by-name chat rewriting.
+        let maps = byName ? makeLinkMaps() : nil
         return chats.map { chat in
             let id = byName ? Identity.chatByName(chat.id.rawValue)
                             : Identity.chatByID(chat.id.rawValue)
-            guard let map = titleMap else {
+            guard let maps else {
                 return Self.chatFileNode(for: id, chat: chat, in: store)
             }
             let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
             let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
-            let data = rewriteMarkdown(raw, map: map)
+            let data = rewriteLinks(raw, maps: maps, baseDir: Self.chatsByNameDir)
             return Self.chatFileNode(for: id, chat: chat, in: store, contentData: data)
         }
     }

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -597,6 +597,13 @@ struct Projection {
                       let head = try? store.processedMarkdownHead(sourceID: PageID(rawValue: ulid)) else {
                     return nil
                 }
+                // For by-name markdown siblings, size must match rewritten bytes.
+                if id.rawValue.hasPrefix(Identity.sourceMarkdownByNamePrefix),
+                   let pages = try? store.listAllPagesOrderedByID() {
+                    let map = projection.titleToFilenameMap(pages: pages)
+                    let data = projection.rewriteMarkdown(head.content, map: map)
+                    return Self.sourceMarkdownNode(for: id, source: file, head: head, contentData: data)
+                }
                 return Self.sourceMarkdownNode(for: id, source: file, head: head)
             }
             if let ulid = Identity.fileULID(from: id) {
@@ -611,6 +618,12 @@ struct Projection {
                 guard let store = projection.openReadStore(),
                       let head = try? store.processedMarkdownHead(sourceID: PageID(rawValue: ulid)) else {
                     return nil
+                }
+                // By-name markdown siblings: rewrite [[wikilinks]] to relative links.
+                if id.rawValue.hasPrefix(Identity.sourceMarkdownByNamePrefix),
+                   let pages = try? store.listAllPagesOrderedByID() {
+                    let map = projection.titleToFilenameMap(pages: pages)
+                    return projection.rewriteMarkdown(head.content, map: map)
                 }
                 return Data(head.content.utf8)
             }
@@ -634,6 +647,15 @@ struct Projection {
                   let store = projection.openReadStore(),
                   let chats = try? store.listAllChatsOrderedByID(),
                   let chat = chats.first(where: { $0.id.rawValue == ulid }) else { return nil }
+            // For by-name chats, size must match rewritten bytes.
+            if id.rawValue.hasPrefix(Identity.chatByNamePrefix),
+               let pages = try? store.listAllPagesOrderedByID() {
+                let map = projection.titleToFilenameMap(pages: pages)
+                let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
+                let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
+                let data = projection.rewriteMarkdown(raw, map: map)
+                return Self.chatFileNode(for: id, chat: chat, in: store, contentData: data)
+            }
             return Self.chatFileNode(for: id, chat: chat, in: store)
         },
         contentForLeaf: { projection, id in
@@ -642,7 +664,14 @@ struct Projection {
                   let chats = try? store.listAllChatsOrderedByID(),
                   let chat = chats.first(where: { $0.id.rawValue == ulid }),
                   let messages = try? store.chatMessages(chatID: chat.id) else { return nil }
-            return Data(ChatTranscriptRenderer.render(summary: chat, messages: messages).utf8)
+            let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
+            // By-name chats: rewrite [[wikilinks]] to relative links.
+            if id.rawValue.hasPrefix(Identity.chatByNamePrefix),
+               let pages = try? store.listAllPagesOrderedByID() {
+                let map = projection.titleToFilenameMap(pages: pages)
+                return projection.rewriteMarkdown(raw, map: map)
+            }
+            return Data(raw.utf8)
         }
     )
 
@@ -1079,7 +1108,8 @@ struct Projection {
     static func sourceMarkdownNode(
         for id: NSFileProviderItemIdentifier,
         source: SourceSummary,
-        head: SourceMarkdownVersion
+        head: SourceMarkdownVersion,
+        contentData: Data? = nil
     ) -> ProjectedNode {
         let raw = id.rawValue
         let isByName = raw.hasPrefix(Identity.sourceMarkdownByNamePrefix)
@@ -1089,8 +1119,9 @@ struct Projection {
                 filename: humanName, ext: "md", sourceID: source.id.rawValue)
             : FilenameEscaping.byIDSourceFilename(sourceID: source.id.rawValue, ext: "md")
         let parent = isByName ? Identity.sourcesByName : Identity.sourcesByID
+        let size = contentData?.count ?? head.content.utf8.count
         return .file(
-            id: id, parent: parent, name: name, size: head.content.utf8.count,
+            id: id, parent: parent, name: name, size: size,
             version: Data(head.id.rawValue.utf8),
             metadataVersion: Data(head.id.rawValue.utf8),
             created: head.createdAt, modified: head.createdAt,
@@ -1166,7 +1197,13 @@ struct Projection {
     /// returned `Data` is the single source of truth for both `documentSize`
     /// (reported in `pageFileNode`) and the bytes served by `contents(for:)`.
     private func byTitleContent(for page: WikiPage, map: [String: String]) -> Data {
-        let raw = PageMarkdownFormat.fileContent(for: page)
+        rewriteMarkdown(PageMarkdownFormat.fileContent(for: page), map: map)
+    }
+
+    /// Rewrite `[[wikilinks]]` in `raw` to relative Markdown links using
+    /// `map` (page title → by-title filename). Single source of truth shared by
+    /// pages, source-markdown siblings, and chat transcripts.
+    private func rewriteMarkdown(_ raw: String, map: [String: String]) -> Data {
         let rewritten = RelativeLinkRewriter.rewrite(raw) { map[$0] }
         return Data(rewritten.utf8)
     }
@@ -1296,6 +1333,10 @@ struct Projection {
         guard let store = openReadStore(),
               let files = try? store.listAllSourcesOrderedByID() else { return [] }
         let heads = (try? store.processedMarkdownHeadsBySource()) ?? [:]
+        // Build title map once for by-name markdown sibling rewriting.
+        let titleMap: [String: String]? = byName
+            ? (try? store.listAllPagesOrderedByID()).map { titleToFilenameMap(pages: $0) }
+            : nil
         return files.flatMap { row in
             let id = byName ? Identity.sourceByName(row.id) : Identity.sourceByID(row.id)
             let summary = SourceSummary(
@@ -1311,7 +1352,9 @@ struct Projection {
             let markdownID = byName
                 ? Identity.sourceMarkdownByName(row.id)
                 : Identity.sourceMarkdownByID(row.id)
-            return [verbatimNode, Self.sourceMarkdownNode(for: markdownID, source: summary, head: head)]
+            let contentData = titleMap.map { rewriteMarkdown(head.content, map: $0) }
+            return [verbatimNode, Self.sourceMarkdownNode(for: markdownID, source: summary,
+                                                          head: head, contentData: contentData)]
         }
     }
 
@@ -1322,10 +1365,20 @@ struct Projection {
     private func chatNodes(byName: Bool) -> [ProjectedNode] {
         guard let store = openReadStore(),
               let chats = try? store.listAllChatsOrderedByID() else { return [] }
+        // Build title map once for by-name chat rewriting.
+        let titleMap: [String: String]? = byName
+            ? (try? store.listAllPagesOrderedByID()).map { titleToFilenameMap(pages: $0) }
+            : nil
         return chats.map { chat in
             let id = byName ? Identity.chatByName(chat.id.rawValue)
                             : Identity.chatByID(chat.id.rawValue)
-            return Self.chatFileNode(for: id, chat: chat, in: store)
+            guard let map = titleMap else {
+                return Self.chatFileNode(for: id, chat: chat, in: store)
+            }
+            let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
+            let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
+            let data = rewriteMarkdown(raw, map: map)
+            return Self.chatFileNode(for: id, chat: chat, in: store, contentData: data)
         }
     }
 
@@ -1336,7 +1389,8 @@ struct Projection {
     /// the node. Like `pageFileNode(for:page:)`.
     static func chatFileNode(for id: NSFileProviderItemIdentifier,
                              chat: ChatSummary,
-                             in store: SQLiteWikiStore) -> ProjectedNode {
+                             in store: SQLiteWikiStore,
+                             contentData: Data? = nil) -> ProjectedNode {
         let raw = id.rawValue
         let isByName = raw.hasPrefix(Identity.chatByNamePrefix)
         let name = isByName
@@ -1345,12 +1399,18 @@ struct Projection {
         let parent = isByName ? Identity.chatsByName : Identity.chatsByID
         // Render once for size; `contents(for:)` renders again independently (the
         // read store is cheap + WAL — same pattern as pages). The renderer is
-        // deterministic, so the two renders agree byte-for-byte.
-        let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
-        let rendered = Data(ChatTranscriptRenderer.render(summary: chat, messages: messages).utf8)
+        // deterministic, so the two renders agree byte-for-byte. For by-name,
+        // the caller may supply pre-rewritten bytes so size == rewritten content.
+        let size: Int
+        if let data = contentData {
+            size = data.count
+        } else {
+            let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
+            size = ChatTranscriptRenderer.render(summary: chat, messages: messages).utf8.count
+        }
         let version = Data(String(chat.updatedAt.timeIntervalSince1970).utf8)
         return .file(
-            id: id, parent: parent, name: name, size: rendered.count,
+            id: id, parent: parent, name: name, size: size,
             version: version, metadataVersion: version,
             created: chat.createdAt, modified: chat.updatedAt
         )

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -556,12 +556,26 @@ struct Projection {
             guard let ulid = Identity.pageULID(from: id),
                   let store = projection.openReadStore(),
                   let page = try? store.getPage(id: PageID(rawValue: ulid)) else { return nil }
+            // For by-title pages, size must match the rewritten bytes that
+            // contents(for:) will serve — a mismatch truncates cat (#216).
+            if id.rawValue.hasPrefix(Identity.byTitlePrefix),
+               let pages = try? store.listAllPagesOrderedByID() {
+                let map = projection.titleToFilenameMap(pages: pages)
+                let data = projection.byTitleContent(for: page, map: map)
+                return Self.pageFileNode(for: id, page: page, contentData: data)
+            }
             return Self.pageFileNode(for: id, page: page)
         },
         contentForLeaf: { projection, id in
             guard let ulid = Identity.pageULID(from: id),
                   let store = projection.openReadStore(),
                   let page = try? store.getPage(id: PageID(rawValue: ulid)) else { return nil }
+            // By-title view: rewrite [[wikilinks]] to relative Markdown links.
+            if id.rawValue.hasPrefix(Identity.byTitlePrefix),
+               let pages = try? store.listAllPagesOrderedByID() {
+                let map = projection.titleToFilenameMap(pages: pages)
+                return projection.byTitleContent(for: page, map: map)
+            }
             return Data(PageMarkdownFormat.fileContent(for: page).utf8)
         }
     )
@@ -1114,15 +1128,19 @@ struct Projection {
     }
 
     /// Build a file node for a page row, under whichever view `id` belongs to.
+    /// Pass `contentData` when the caller has already computed the rewritten
+    /// bytes (by-title view) so the reported `documentSize` matches what
+    /// `contents(for:)` will serve — a mismatch truncates `cat`.
     static func pageFileNode(for id: NSFileProviderItemIdentifier,
-                             page: WikiPage) -> ProjectedNode {
+                             page: WikiPage,
+                             contentData: Data? = nil) -> ProjectedNode {
         let raw = id.rawValue
         let isByTitle = raw.hasPrefix(Identity.byTitlePrefix)
         let name = isByTitle
             ? FilenameEscaping.byTitleFilename(title: page.title, pageID: page.id.rawValue)
             : FilenameEscaping.byIDFilename(pageID: page.id.rawValue)
         let parent = isByTitle ? Identity.pagesByTitle : Identity.pagesByID
-        let fileData = Data(PageMarkdownFormat.fileContent(for: page).utf8)
+        let fileData = contentData ?? Data(PageMarkdownFormat.fileContent(for: page).utf8)
         return .file(
             id: id, parent: parent, name: name, size: fileData.count,
             version: Data(String(page.version).utf8),
@@ -1130,6 +1148,27 @@ struct Projection {
                 "\(page.title)|\(page.updatedAt.timeIntervalSince1970)|\(page.version)".utf8),
             created: page.createdAt, modified: page.updatedAt
         )
+    }
+
+    /// Build a title → by-title-filename map for all pages. Used by the by-title
+    /// link rewriter so `[[wikilinks]]` resolve to sibling filenames.
+    private func titleToFilenameMap(pages: [WikiPage]) -> [String: String] {
+        var map: [String: String] = [:]
+        for page in pages {
+            map[page.title] = FilenameEscaping.byTitleFilename(
+                title: page.title, pageID: page.id.rawValue)
+        }
+        return map
+    }
+
+    /// Produce the rewritten by-title content for `page`: replaces `[[wikilinks]]`
+    /// with relative Markdown links pointing to sibling by-title files. The
+    /// returned `Data` is the single source of truth for both `documentSize`
+    /// (reported in `pageFileNode`) and the bytes served by `contents(for:)`.
+    private func byTitleContent(for page: WikiPage, map: [String: String]) -> Data {
+        let raw = PageMarkdownFormat.fileContent(for: page)
+        let rewritten = RelativeLinkRewriter.rewrite(raw) { map[$0] }
+        return Data(rewritten.utf8)
     }
 
     // MARK: - Enumeration
@@ -1231,14 +1270,18 @@ struct Projection {
     }
 
     /// All page rows projected as file nodes under the given view, ordered by id
-    /// (ULID == creation order).
+    /// (ULID == creation order). For the by-title view, builds a title map once
+    /// and computes rewritten content per page so `documentSize` matches the
+    /// rewritten bytes that `contents(for:)` will serve.
     private func pageNodes(byTitle: Bool) -> [ProjectedNode] {
         guard let store = openReadStore(),
               let pages = try? store.listAllPagesOrderedByID() else { return [] }
+        let titleMap = byTitle ? titleToFilenameMap(pages: pages) : nil
         return pages.map { page in
             let id = byTitle ? Identity.pageByTitle(page.id.rawValue)
                              : Identity.pageByID(page.id.rawValue)
-            return Self.pageFileNode(for: id, page: page)
+            let contentData = titleMap.map { byTitleContent(for: page, map: $0) }
+            return Self.pageFileNode(for: id, page: page, contentData: contentData)
         }
     }
 

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -604,6 +604,12 @@ struct Projection {
             if let ulid = Identity.fileULID(from: id) {
                 guard let store = projection.openReadStore(),
                       let file = try? store.getSource(id: PageID(rawValue: ulid)) else { return nil }
+                if id.rawValue.hasPrefix(Identity.sourceByNamePrefix) {
+                    let contentData = projection.rewrittenVerbatimSourceContent(
+                        id: PageID(rawValue: ulid), mimeType: file.mimeType,
+                        maps: projection.makeLinkMaps())
+                    return Self.sourceNode(for: id, file: file, contentData: contentData)
+                }
                 return Self.sourceNode(for: id, file: file)
             }
             return nil
@@ -623,7 +629,14 @@ struct Projection {
             }
             if let ulid = Identity.fileULID(from: id) {
                 guard let store = projection.openReadStore(),
+                      let file = try? store.getSource(id: PageID(rawValue: ulid)),
                       let data = try? store.sourceContent(id: PageID(rawValue: ulid)) else { return nil }
+                if id.rawValue.hasPrefix(Identity.sourceByNamePrefix),
+                   let rewritten = projection.rewrittenVerbatimSourceContent(
+                       id: PageID(rawValue: ulid), mimeType: file.mimeType,
+                       maps: projection.makeLinkMaps()) {
+                    return rewritten
+                }
                 return data
             }
             return nil
@@ -1163,7 +1176,8 @@ struct Projection {
     /// display name (or filename fallback) + updated_at so a rename re-fetches
     /// the by-name node. By-id stays filename-keyed (stable identity).
     static func sourceNode(for id: NSFileProviderItemIdentifier,
-                                 file: SourceSummary) -> ProjectedNode {
+                                 file: SourceSummary,
+                                 contentData: Data? = nil) -> ProjectedNode {
         let raw = id.rawValue
         let isByName = raw.hasPrefix(Identity.sourceByNamePrefix)
         let humanName = file.displayName ?? file.filename
@@ -1176,7 +1190,7 @@ struct Projection {
             ? "\(humanName)|\(file.updatedAt.timeIntervalSince1970)|\(file.version)"
             : "\(file.filename)|\(file.updatedAt.timeIntervalSince1970)|\(file.version)"
         return .file(
-            id: id, parent: parent, name: name, size: file.byteSize,
+            id: id, parent: parent, name: name, size: contentData?.count ?? file.byteSize,
             version: Data(String(file.version).utf8),
             metadataVersion: Data(metaKey.utf8),
             created: file.createdAt, modified: file.updatedAt,
@@ -1228,6 +1242,7 @@ struct Projection {
         let sourceByID:   [String: RelativeLinkRewriter.Target]
         let chatByTitle:  [String: RelativeLinkRewriter.Target]
         let chatByID:     [String: RelativeLinkRewriter.Target]
+        let siblingImages: [PageID: [String: PageID]]   // sourceID -> [originalPath -> sibling sourceID]
 
         func resolver(baseDir: [String]) -> RelativeLinkRewriter.Resolver {
             RelativeLinkRewriter.Resolver(
@@ -1236,6 +1251,17 @@ struct Projection {
                 source: { t, isID in isID ? sourceByID[t.uppercased()] : sourceByName[t] },
                 chat:   { t, isID in isID ? chatByID[t.uppercased()]   : chatByTitle[t] }
             )
+        }
+
+        /// The image-src resolver for ONE source's own markdown, or an
+        /// always-nil resolver if it has no image siblings (the common case —
+        /// most sources never call this at all, gated by the caller).
+        func imageResolver(forSource sourceID: PageID, baseDir: [String]) -> SourceImageRewriter.Resolver {
+            let siblingMap = siblingImages[sourceID] ?? [:]
+            return SourceImageRewriter.Resolver(baseDir: baseDir, resolve: { originalPath in
+                guard let siblingID = siblingMap[originalPath] else { return nil }
+                return sourceByID[siblingID.rawValue.uppercased()]
+            })
         }
     }
 
@@ -1280,9 +1306,12 @@ struct Projection {
             chatByID[chat.id.rawValue.uppercased()] = target
         }
 
+        let siblingImages = (try? store?.siblingImageResolvers()) ?? [:]
+
         return LinkMaps(pageByTitle: pageByTitle, pageByID: pageByID,
                         sourceByName: sourceByName, sourceByID: sourceByID,
-                        chatByTitle: chatByTitle, chatByID: chatByID)
+                        chatByTitle: chatByTitle, chatByID: chatByID,
+                        siblingImages: siblingImages)
     }
 
     /// Rewrite `[[wikilinks]]` in `raw` to relative Markdown links, computing
@@ -1296,6 +1325,27 @@ struct Projection {
     /// The rewritten by-title page content (page bodies live in `pages/by-title`).
     private func byTitleContent(for page: WikiPage, maps: LinkMaps) -> Data {
         rewriteLinks(PageMarkdownFormat.fileContent(for: page), maps: maps, baseDir: Self.pagesByTitleDir)
+    }
+
+    /// Rewrite relative image srcs in a markdown-native verbatim source's own
+    /// content, IF it has image siblings (`makeLinkMaps().siblingImages`).
+    /// Returns `nil` when there's nothing to rewrite (binary sources, sources
+    /// with no image siblings, or non-`by-name` requests) — the caller then
+    /// falls back to raw stored bytes with NO computation, matching today's
+    /// behavior exactly for every unaffected source (the overwhelming
+    /// majority). Byte-identity: both the size path and content path MUST
+    /// call this with the same inputs and use the SAME returned Data.
+    private func rewrittenVerbatimSourceContent(
+        id: PageID, mimeType: String?, maps: LinkMaps
+    ) -> Data? {
+        guard let mime = mimeType, mime.hasPrefix("text/"),
+              let siblingMap = maps.siblingImages[id], !siblingMap.isEmpty,
+              let store = openReadStore(),
+              let raw = try? store.sourceContent(id: id),
+              let text = String(data: raw, encoding: .utf8) else { return nil }
+        let resolver = maps.imageResolver(forSource: id, baseDir: Self.sourcesByNameDir)
+        let rewritten = SourceImageRewriter.rewrite(text, resolver: resolver)
+        return Data(rewritten.utf8)
     }
 
     // MARK: - Enumeration
@@ -1432,7 +1482,12 @@ struct Projection {
                 mimeType: row.mime, byteSize: row.byteSize,
                 createdAt: row.createdAt, updatedAt: row.updatedAt, version: row.version,
                 displayName: row.displayName)
-            let verbatimNode = Self.sourceNode(for: id, file: summary)
+            let verbatimContentData = byName
+                ? maps.map { rewrittenVerbatimSourceContent(
+                    id: PageID(rawValue: row.id), mimeType: row.mime, maps: $0) }
+                  .flatMap { $0 }
+                : nil
+            let verbatimNode = Self.sourceNode(for: id, file: summary, contentData: verbatimContentData)
             // Sibling eligibility: has a chain AND is NOT markdown-native.
             // Markdown-native sources don't get a sibling — the verbatim .md is the content.
             guard let head = heads[row.id],

--- a/Tests/WikiFSTests/ProjectionTreeTests.swift
+++ b/Tests/WikiFSTests/ProjectionTreeTests.swift
@@ -87,6 +87,44 @@ struct ProjectionTreeTests {
         #expect(s.projection.contents(for: id) == expected)
     }
 
+    @Test func byTitlePageRewritesLinksAndSizeMatchesBytes() throws {
+        // A page body linking to another page (canonical ULID) and a source
+        // (canonical ULID). The by-title view must rewrite both AND report a
+        // size equal to the rewritten bytes — a mismatch truncates `cat` (#216).
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-proj-links-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let target = try store.createPage(title: "Target Page")
+        let pdf = try store.addSource(
+            filename: "paper.pdf", data: Data("%PDF fake".utf8), mimeType: "application/pdf")
+        _ = try store.appendProcessedMarkdown(
+            sourceID: pdf.id, content: "# Paper", origin: "test", note: nil)
+        let src = try store.createPage(title: "Home")
+        try store.updatePage(
+            id: src.id, title: "Home",
+            body: "See [[page:\(target.id.rawValue)|the target]] and "
+                + "[[source:\(pdf.id.rawValue)|the paper]].")
+        let projection = Projection(wikiID: "links-\(UUID().uuidString)", databaseURL: url)
+
+        let id = Projection.Identity.pageByTitle(src.id.rawValue)
+        guard let node = projection.node(for: id),
+              let bytes = projection.contents(for: id) else {
+            Issue.record("by-title node/content not found"); return
+        }
+        // Invariant: reported size == served bytes.
+        #expect(node.size == bytes.count)
+
+        let text = String(decoding: bytes, as: UTF8.self)
+        // Page link → sibling; source link → climbs to sources/by-name.
+        let targetFile = FilenameEscaping.byTitleFilename(
+            title: "Target Page", pageID: target.id.rawValue)
+        #expect(text.contains("[the target](\(targetFile.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!))"))
+        #expect(text.contains("[the paper](../../sources/by-name/"))
+        // No raw wikilinks remain.
+        #expect(!text.contains("[[page:"))
+        #expect(!text.contains("[[source:"))
+    }
+
     @Test func sourceNodeResolvesWithVerbatimContent() throws {
         let s = try seed()
         let id = Projection.Identity.sourceByID(s.pdfSource.id.rawValue)
@@ -382,6 +420,124 @@ struct ProjectionTreeTests {
         #expect(names.contains("bookmarks"))
         // The folder is now empty.
         #expect(b.projection.children(of: Projection.Identity.bookmarks).isEmpty)
+    }
+
+    @Test func bookmarkPageRefRewritesLinksAndSizeMatchesBytes() throws {
+        // A page body linking to another page (canonical ULID). The bookmark
+        // pageRef must rewrite [[page:...]] → relative links and report a size
+        // equal to the rewritten bytes — a mismatch truncates `cat` (#216).
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-bm-links-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let target = try store.createPage(title: "Target Page")
+        let home = try store.createPage(title: "Home")
+        try store.updatePage(
+            id: home.id, title: "Home",
+            body: "See [[page:\(target.id.rawValue)|t]].")
+        let pageRefNode = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .pageRef, label: nil, targetID: home.id)
+        let projection = Projection(wikiID: "bm-links-\(UUID().uuidString)", databaseURL: url)
+
+        let id = Projection.Identity.bookmarkPageRef(pageRefNode.id)
+        guard let node = projection.node(for: id),
+              let bytes = projection.contents(for: id) else {
+            Issue.record("bookmark page ref node/content not found"); return
+        }
+        // Invariant: reported size == served bytes.
+        #expect(node.size == bytes.count)
+
+        let text = String(decoding: bytes, as: UTF8.self)
+        // Page link → sibling (one ../ to climb from bookmarks/ to root).
+        let targetFile = FilenameEscaping.byTitleFilename(
+            title: "Target Page", pageID: target.id.rawValue)
+        let encoded = targetFile.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
+        #expect(text.contains("[t](../pages/by-title/\(encoded))"))
+        // No raw wikilinks remain.
+        #expect(!text.contains("[[page:"))
+    }
+
+    @Test func nestedBookmarkPageRefClimbsCorrectDepth() throws {
+        // A page ref nested one level deep (inside a folder) must climb with
+        // two `../` to reach the root.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-bm-nested-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let target = try store.createPage(title: "Target")
+        let home = try store.createPage(title: "Home")
+        try store.updatePage(
+            id: home.id, title: "Home",
+            body: "Link: [[page:\(target.id.rawValue)]].")
+        let folder = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .folder, label: "Research", targetID: nil)
+        let pageRefNode = try store.createBookmarkNode(
+            parentID: folder.id, position: 0, kind: .pageRef, label: nil, targetID: home.id)
+        let projection = Projection(wikiID: "bm-nested-\(UUID().uuidString)", databaseURL: url)
+
+        let id = Projection.Identity.bookmarkPageRef(pageRefNode.id)
+        guard let node = projection.node(for: id),
+              let bytes = projection.contents(for: id) else {
+            Issue.record("nested bookmark content not found"); return
+        }
+        // Byte-identity must hold at nested depth too (size path builds baseDir
+        // from the same ancestor walk as the content path).
+        #expect(node.size == bytes.count)
+        let text = String(decoding: bytes, as: UTF8.self)
+        // Two levels: bookmarks/Research/ → root → pages/by-title/ = ../../pages/by-title/
+        #expect(text.contains("../../pages/by-title/"))
+    }
+
+    @Test func bookmarkChatRefRewritesLinksAndSizeMatchesBytes() throws {
+        // A chat transcript containing a [[page:...]] link, bookmarked as a
+        // chatRef, must rewrite the link AND keep size == served bytes (#216).
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-bm-chat-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let target = try store.createPage(title: "Referenced Page")
+        let chat = try store.createChat(kind: .edit, title: "Chat With Link")
+        _ = try store.appendChatMessages(
+            chatID: chat.id,
+            events: [.userText("See [[page:\(target.id.rawValue)|that page]]."),
+                     .assistantText("Sure.")])
+        let chatRefNode = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .chatRef, label: nil, targetID: chat.id)
+        let projection = Projection(wikiID: "bm-chat-\(UUID().uuidString)", databaseURL: url)
+
+        let id = Projection.Identity.bookmarkChatRef(chatRefNode.id)
+        guard let node = projection.node(for: id),
+              let bytes = projection.contents(for: id) else {
+            Issue.record("bookmark chat ref node/content not found"); return
+        }
+        // Invariant: reported size == served bytes.
+        #expect(node.size == bytes.count)
+        let text = String(decoding: bytes, as: UTF8.self)
+        // Root-level chatRef: one ../ to reach the pages view.
+        #expect(text.contains("[that page](../pages/by-title/"))
+        #expect(!text.contains("[[page:"))
+    }
+
+    @Test func bookmarkSourceRefIsLeftVerbatimWithSizeMatch() throws {
+        // A bookmark sourceRef must serve verbatim sourceContent bytes unchanged,
+        // and node.size must equal the byte count (#216).
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-bm-source-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+        let pdfBytes = Data("%PDF-1.4 test content".utf8)
+        let pdf = try store.addSource(
+            filename: "doc.pdf", data: pdfBytes, mimeType: "application/pdf")
+        let sourceRefNode = try store.createBookmarkNode(
+            parentID: nil, position: 0, kind: .sourceRef, label: nil, targetID: pdf.id)
+        let projection = Projection(wikiID: "bm-source-\(UUID().uuidString)", databaseURL: url)
+
+        let id = Projection.Identity.bookmarkSourceRef(sourceRefNode.id)
+        guard let node = projection.node(for: id),
+              let bytes = projection.contents(for: id) else {
+            Issue.record("bookmark source ref node/content not found"); return
+        }
+        // Invariant: reported size == served bytes.
+        #expect(node.size == bytes.count)
+        // Verbatim bytes from sourceContent.
+        let expected = try store.sourceContent(id: pdf.id)
+        #expect(bytes == expected)
     }
 
     // MARK: - Chats projection (#119)

--- a/Tests/WikiFSTests/ProjectionTreeTests.swift
+++ b/Tests/WikiFSTests/ProjectionTreeTests.swift
@@ -169,6 +169,78 @@ struct ProjectionTreeTests {
         #expect(!ids.contains(Projection.Identity.sourceMarkdownByID(s.textSource.id.rawValue)))
     }
 
+    // MARK: - Source image rewriting (snapshot siblings)
+
+    @Test func snapshotImageSiblingResolvesAndRewritesPath() throws {
+        // Create a markdown-native source with an image that has a sibling.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-image-snapshot-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+
+        // Create a fetch activity for the snapshot.
+        let provenance = SourceProvenance(agentName: "test", activityKind: "website-snapshot")
+        let activityID = try store.ensureFetchActivity(provenance: provenance)
+
+        // Create the main markdown source WITH the activity (same pattern as storeSnapshot).
+        let mdSource = try store.addSource(
+            filename: "article.md", data: Data("![alt](assets/pic.png)".utf8),
+            mimeType: "text/markdown", provenance: provenance, role: .primary,
+            originalPath: nil, activityID: activityID)
+
+        // Add the snapshot image as a sibling (same activity).
+        _ = try store.addSnapshotImage(
+            filename: "pic.png", data: Data("png-data".utf8), mimeType: "image/png",
+            originalPath: "assets/pic.png", sourceURL: URL(string: "https://example.com/pic.png")!,
+            activityID: activityID, role: .media)
+
+        let projection = Projection(wikiID: "snapshot-\(UUID().uuidString)", databaseURL: url)
+
+        // Verify by-name view: node size must match served content.
+        let id = Projection.Identity.sourceByName(mdSource.id.rawValue)
+        guard let node = projection.node(for: id) else {
+            Issue.record("source node not found"); return
+        }
+        guard let bytes = projection.contents(for: id) else {
+            Issue.record("source content not found"); return
+        }
+
+        // Invariant: reported size == served bytes.
+        #expect(node.size == bytes.count)
+
+        // The served content should have rewritten the image path.
+        let text = String(decoding: bytes, as: UTF8.self)
+        #expect(!text.contains("assets/pic.png"))
+        // Should contain the by-name filename of the sibling (without "assets/" prefix).
+        #expect(text.contains("![alt](pic"))
+    }
+
+    @Test func sourceWithoutImageSiblingsIsUnaffected() throws {
+        // A text source with NO image siblings should serve unmodified bytes,
+        // and size should match byteSize, same as today (regression guard).
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-no-image-\(UUID().uuidString).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: url)
+
+        let originalData = Data("This markdown has ![alt](missing.png) but no siblings.".utf8)
+        let textSource = try store.addSource(
+            filename: "lonely.md", data: originalData, mimeType: "text/markdown")
+
+        let projection = Projection(wikiID: "no-image-\(UUID().uuidString)", databaseURL: url)
+
+        // By-name view.
+        let id = Projection.Identity.sourceByName(textSource.id.rawValue)
+        guard let node = projection.node(for: id) else {
+            Issue.record("source node not found"); return
+        }
+        guard let bytes = projection.contents(for: id) else {
+            Issue.record("source content not found"); return
+        }
+
+        // Both size and content must be unchanged.
+        #expect(node.size == originalData.count)
+        #expect(bytes == originalData)
+    }
+
     @Test func workingSetIncludesFlatLeaves() throws {
         let s = try seed()
         let ids = Set(s.projection.children(of: .workingSet).map(\.id))

--- a/Tests/WikiFSTests/RelativeLinkRewriterTests.swift
+++ b/Tests/WikiFSTests/RelativeLinkRewriterTests.swift
@@ -3,123 +3,219 @@ import Testing
 @testable import WikiFSCore
 
 /// Unit tests for the `[[wiki-link]]` → relative-Markdown-link rewriter used by
-/// the `pages/by-title` FileProvider projection. No store, no view: the resolver
-/// is injected as a closure, exactly as `Projection` supplies it.
+/// the `by-title` / `by-name` FileProvider projections. No store, no view: the
+/// namespace resolution + baseDir are injected, exactly as `Projection` supplies.
 struct RelativeLinkRewriterTests {
 
-    private func resolve(_ title: String) -> String? {
-        switch title {
-        case "Home":     return "Home--01AAAAAAAA.md"
-        case "Alpha":    return "Alpha--01BBBBBBBB.md"
-        case "C# Guide": return "C# Guide--01CCCCCCCC.md"
-        default:         return nil
-        }
+    // Canonical ULIDs for the fixture rows (26-char Crockford base32, uppercase).
+    private static let homeID   = "01AAAAAAAAAAAAAAAAAAAAAAAA"
+    private static let alphaID  = "01BBBBBBBBBBBBBBBBBBBBBBBB"
+    private static let srcID     = "01CCCCCCCCCCCCCCCCCCCCCCCC"
+    private static let chatID    = "01DDDDDDDDDDDDDDDDDDDDDDDD"
+
+    private typealias Target = RelativeLinkRewriter.Target
+
+    private static let pages: [String: Target] = [
+        "Home":  Target(path: ["pages", "by-title", "Home--01AAAAAA.md"], title: "Home"),
+        "Alpha": Target(path: ["pages", "by-title", "Alpha--01BBBBBB.md"], title: "Alpha"),
+        "C# Guide": Target(path: ["pages", "by-title", "C# Guide--01AAAAAA.md"], title: "C# Guide"),
+    ]
+    private static let pagesByID: [String: Target] = [
+        homeID.uppercased():  pages["Home"]!,
+        alphaID.uppercased(): pages["Alpha"]!,
+    ]
+    private static let sources: [String: Target] = [
+        "Teleportation.pdf": Target(path: ["sources", "by-name", "Teleportation--01CCCCCC.md"],
+                                    title: "Teleportation.pdf"),
+    ]
+    private static let sourcesByID: [String: Target] = [
+        srcID.uppercased(): sources["Teleportation.pdf"]!,
+    ]
+    private static let chats: [String: Target] = [
+        "My Chat": Target(path: ["chats", "by-name", "My Chat--01DDDDDD.md"], title: "My Chat"),
+    ]
+    private static let chatsByID: [String: Target] = [
+        chatID.uppercased(): chats["My Chat"]!,
+    ]
+
+    /// A resolver rooted at `baseDir` (default: the page by-title view).
+    private func resolver(baseDir: [String] = ["pages", "by-title"]) -> RelativeLinkRewriter.Resolver {
+        RelativeLinkRewriter.Resolver(
+            baseDir: baseDir,
+            page:   { t, isID in isID ? Self.pagesByID[t.uppercased()]   : Self.pages[t] },
+            source: { t, isID in isID ? Self.sourcesByID[t.uppercased()] : Self.sources[t] },
+            chat:   { t, isID in isID ? Self.chatsByID[t.uppercased()]   : Self.chats[t] }
+        )
     }
 
-    // MARK: - Basic rewrites
+    /// Convenience: rewrite from the page view.
+    private func rewrite(_ body: String, baseDir: [String] = ["pages", "by-title"]) -> String {
+        RelativeLinkRewriter.rewrite(body, resolver: resolver(baseDir: baseDir))
+    }
 
-    @Test func simplePageLinkBecomesRelativeMarkdownLink() {
-        let out = RelativeLinkRewriter.rewrite("See [[Home]] here.", resolver: resolve)
-        #expect(out == "See [Home](Home--01AAAAAAAA.md) here.")
+    // MARK: - Page links (name-based)
+
+    @Test func simplePageLinkBecomesSiblingLink() {
+        #expect(rewrite("See [[Home]] here.") == "See [Home](Home--01AAAAAA.md) here.")
     }
 
     @Test func aliasedLinkUsesAliasTextAndTargetFilename() {
-        let out = RelativeLinkRewriter.rewrite("Go to [[Home|start page]].", resolver: resolve)
-        #expect(out == "Go to [start page](Home--01AAAAAAAA.md).")
+        #expect(rewrite("Go to [[Home|start page]].") == "Go to [start page](Home--01AAAAAA.md).")
     }
 
     @Test func multipleLinksAreEachRewritten() {
-        let out = RelativeLinkRewriter.rewrite("[[Home]] and [[Alpha]].", resolver: resolve)
-        #expect(out == "[Home](Home--01AAAAAAAA.md) and [Alpha](Alpha--01BBBBBBBB.md).")
+        #expect(rewrite("[[Home]] and [[Alpha]].")
+            == "[Home](Home--01AAAAAA.md) and [Alpha](Alpha--01BBBBBB.md).")
     }
 
-    // MARK: - Anchors
+    // MARK: - Canonical ULID page links (Phase 5 form)
 
-    @Test func anchorIsPreservedAfterFilename() {
-        let out = RelativeLinkRewriter.rewrite("See [[Home#Introduction]].", resolver: resolve)
-        #expect(out == "See [Home](Home--01AAAAAAAA.md#Introduction).")
+    @Test func canonicalULIDPageLinkResolvesByIDAndUsesAlias() {
+        #expect(rewrite("A [[page:\(Self.homeID)|Geoffrey Litt]] essay.")
+            == "A [Geoffrey Litt](Home--01AAAAAA.md) essay.")
     }
 
-    @Test func aliasedAnchorLinkUsesAliasAndPreservesFragment() {
-        let out = RelativeLinkRewriter.rewrite("[[Home#Intro|intro]]", resolver: resolve)
-        #expect(out == "[intro](Home--01AAAAAAAA.md#Intro)")
+    @Test func canonicalULIDPageLinkWithoutAliasUsesCurrentTitle() {
+        #expect(rewrite("See [[page:\(Self.alphaID)]].") == "See [Alpha](Alpha--01BBBBBB.md).")
+    }
+
+    @Test func canonicalULIDPageLinkPreservesHeadingFragment() {
+        #expect(rewrite("[[page:\(Self.homeID)#Intro|home intro]]")
+            == "[home intro](Home--01AAAAAA.md#Intro)")
+    }
+
+    @Test func canonicalULIDForDeletedPageStaysVerbatim() {
+        let missing = "01ZZZZZZZZZZZZZZZZZZZZZZZZ"
+        #expect(rewrite("[[page:\(missing)|Gone]]") == "[[page:\(missing)|Gone]]")
+    }
+
+    @Test func lowercaseULIDIsTreatedAsNameAndStaysVerbatim() {
+        // ULID.allowedCharacters is uppercase-only by design: a lowercase ULID
+        // is NOT canonical, resolves by name → no match → left verbatim.
+        let lower = Self.homeID.lowercased()
+        #expect(rewrite("[[page:\(lower)|Home]]") == "[[page:\(lower)|Home]]")
+    }
+
+    // MARK: - Source links → sources/by-name (cross-namespace)
+
+    @Test func canonicalSourceLinkResolvesToRelativePath() {
+        // From pages/by-title, a source cite climbs out to sources/by-name.
+        let out = rewrite("Cite [[source:\(Self.srcID)|the essay]].")
+        #expect(out == "Cite [the essay](../../sources/by-name/Teleportation--01CCCCCC.md).")
+    }
+
+    @Test func sourceQuoteFragmentIsDropped() {
+        // A `#"quote"` cite fragment isn't a resolvable anchor — drop it.
+        let out = rewrite("[[source:\(Self.srcID)#\"What if we invented teleportation?\"|cite]]")
+        #expect(out == "[cite](../../sources/by-name/Teleportation--01CCCCCC.md)")
+    }
+
+    @Test func nameBasedSourceLinkResolves() {
+        let out = rewrite("[[source:Teleportation.pdf]]")
+        #expect(out == "[Teleportation.pdf](../../sources/by-name/Teleportation--01CCCCCC.md)")
+    }
+
+    @Test func unknownSourceLinkStaysVerbatim() {
+        #expect(rewrite("[[source:missing.pdf]]") == "[[source:missing.pdf]]")
+    }
+
+    // MARK: - Chat links → chats/by-name (cross-namespace)
+
+    @Test func canonicalChatLinkResolvesToRelativePath() {
+        // The space in "My Chat" is percent-encoded in the PATH; the display
+        // text keeps the literal space.
+        let out = rewrite("See [[chat:\(Self.chatID)|our chat]].")
+        #expect(out == "See [our chat](../../chats/by-name/My%20Chat--01DDDDDD.md).")
+    }
+
+    @Test func nameBasedChatLinkResolves() {
+        let out = rewrite("[[chat:My Chat]]")
+        #expect(out == "[My Chat](../../chats/by-name/My%20Chat--01DDDDDD.md)")
+    }
+
+    @Test func unknownChatLinkStaysVerbatim() {
+        #expect(rewrite("[[chat:Nope]]") == "[[chat:Nope]]")
+    }
+
+    // MARK: - baseDir sensitivity (same doc kind → sibling; cross-kind → climb)
+
+    @Test func sourceViewLinkingToAnotherSourceIsSibling() {
+        // A source markdown sibling links to another source in the same dir.
+        let out = rewrite("[[source:\(Self.srcID)|self]]", baseDir: ["sources", "by-name"])
+        #expect(out == "[self](Teleportation--01CCCCCC.md)")
+    }
+
+    @Test func sourceViewLinkingToPageClimbsOut() {
+        let out = rewrite("[[Home]]", baseDir: ["sources", "by-name"])
+        #expect(out == "[Home](../../pages/by-title/Home--01AAAAAA.md)")
+    }
+
+    @Test func chatViewLinkingToPageClimbsOut() {
+        let out = rewrite("[[page:\(Self.homeID)|Home]]", baseDir: ["chats", "by-name"])
+        #expect(out == "[Home](../../pages/by-title/Home--01AAAAAA.md)")
     }
 
     // MARK: - Hash-in-title disambiguation
 
     @Test func hashInTitleIsDisambiguatedCorrectly() {
-        // "C# Guide" is a real page; "C" is not. Should resolve to C# Guide.
-        let out = RelativeLinkRewriter.rewrite("See [[C# Guide]].", resolver: resolve)
-        #expect(out == "See [C# Guide](C%23%20Guide--01CCCCCCCC.md).")
+        // "C# Guide" is a real page; "C" is not.
+        #expect(rewrite("See [[C# Guide]].") == "See [C# Guide](C%23%20Guide--01AAAAAA.md).")
     }
 
-    // MARK: - Unresolvable links stay verbatim
+    // MARK: - Anchors (page headings)
+
+    @Test func anchorIsPreservedAfterFilename() {
+        #expect(rewrite("See [[Home#Introduction]].")
+            == "See [Home](Home--01AAAAAA.md#Introduction).")
+    }
+
+    @Test func aliasedAnchorLinkUsesAliasAndPreservesFragment() {
+        #expect(rewrite("[[Home#Intro|intro]]") == "[intro](Home--01AAAAAA.md#Intro)")
+    }
+
+    // MARK: - Unresolvable / non-link forms stay verbatim
 
     @Test func unknownPageLinkStaysVerbatim() {
-        let out = RelativeLinkRewriter.rewrite("[[Deleted Page]]", resolver: resolve)
-        #expect(out == "[[Deleted Page]]")
-    }
-
-    // MARK: - Non-page links stay verbatim
-
-    @Test func sourceLinkStaysVerbatim() {
-        let out = RelativeLinkRewriter.rewrite("[[source:report.pdf]]", resolver: resolve)
-        #expect(out == "[[source:report.pdf]]")
-    }
-
-    @Test func chatLinkStaysVerbatim() {
-        let out = RelativeLinkRewriter.rewrite("[[chat:My Chat]]", resolver: resolve)
-        #expect(out == "[[chat:My Chat]]")
+        #expect(rewrite("[[Deleted Page]]") == "[[Deleted Page]]")
     }
 
     @Test func embedStaysVerbatim() {
-        let out = RelativeLinkRewriter.rewrite("![[source:image.png]]", resolver: resolve)
-        #expect(out == "![[source:image.png]]")
+        #expect(rewrite("![[source:image.png]]") == "![[source:image.png]]")
     }
 
-    // MARK: - Code span protection
+    @Test func canonicalSourceEmbedStaysVerbatim() {
+        let body = "![[source:\(Self.srcID)]]"
+        #expect(rewrite(body) == body)
+    }
 
     @Test func linkInsideCodeSpanIsLeftVerbatim() {
-        let out = RelativeLinkRewriter.rewrite("Use `[[Home]]` in code.", resolver: resolve)
-        #expect(out == "Use `[[Home]]` in code.")
+        #expect(rewrite("Use `[[Home]]` in code.") == "Use `[[Home]]` in code.")
     }
 
     @Test func linkInsideFencedBlockIsLeftVerbatim() {
         let body = "```\n[[Home]]\n```"
-        let out = RelativeLinkRewriter.rewrite(body, resolver: resolve)
-        #expect(out == body)
+        #expect(rewrite(body) == body)
     }
-
-    // MARK: - Same-page anchors stay verbatim
 
     @Test func samePageAnchorStaysVerbatim() {
-        let out = RelativeLinkRewriter.rewrite("Jump to [[#Introduction]].", resolver: resolve)
-        #expect(out == "Jump to [[#Introduction]].")
+        #expect(rewrite("Jump to [[#Introduction]].") == "Jump to [[#Introduction]].")
     }
 
-    // MARK: - Filename percent-encoding
+    // MARK: - Percent-encoding
 
-    @Test func filenameWithSpecialCharsIsPercentEncoded() {
-        // A filename with spaces must be percent-encoded so Markdown parsers
-        // don't break the link at the first space.
-        var called = false
-        let out = RelativeLinkRewriter.rewrite("[[Home]]", resolver: { title in
-            called = true
-            return "My Home Page--01AA.md"   // has spaces
-        })
-        #expect(called)
-        #expect(out == "[Home](My%20Home%20Page--01AA.md)")
+    @Test func filenameWithSpacesIsPercentEncodedPerComponent() {
+        // Spaces in the filename → %20; the `/` path separators are NOT encoded.
+        let out = rewrite("[[chat:My Chat]]")
+        #expect(out == "[My Chat](../../chats/by-name/My%20Chat--01DDDDDD.md)")
+        #expect(!out.contains("%2F"))   // separators intact
     }
 
-    // MARK: - Passthrough when no links
+    // MARK: - Passthrough
 
     @Test func bodyWithNoLinksIsReturnedUnchanged() {
         let body = "Just plain text, no wikilinks."
-        let out = RelativeLinkRewriter.rewrite(body, resolver: resolve)
-        #expect(out == body)
+        #expect(rewrite(body) == body)
     }
-
-    // MARK: - Frontmatter passthrough
 
     @Test func yamlFrontmatterIsNotModified() {
         let body = """
@@ -132,8 +228,22 @@ struct RelativeLinkRewriterTests {
 
         See [[Alpha]].
         """
-        let out = RelativeLinkRewriter.rewrite(body, resolver: resolve)
+        let out = rewrite(body)
         #expect(out.hasPrefix("---\ntitle: \"Home\"\ndate: 2026-07-11\n---"))
-        #expect(out.contains("[Alpha](Alpha--01BBBBBBBB.md)"))
+        #expect(out.contains("[Alpha](Alpha--01BBBBBB.md)"))
+    }
+
+    // MARK: - relativePath unit
+
+    @Test func relativePathSameDirIsBareFilename() {
+        let p = RelativeLinkRewriter.relativePath(
+            from: ["pages", "by-title"], to: ["pages", "by-title", "Home--01AA.md"])
+        #expect(p == "Home--01AA.md")
+    }
+
+    @Test func relativePathCrossSubtreeClimbs() {
+        let p = RelativeLinkRewriter.relativePath(
+            from: ["pages", "by-title"], to: ["sources", "by-name", "x.md"])
+        #expect(p == "../../sources/by-name/x.md")
     }
 }

--- a/Tests/WikiFSTests/RelativeLinkRewriterTests.swift
+++ b/Tests/WikiFSTests/RelativeLinkRewriterTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Unit tests for the `[[wiki-link]]` → relative-Markdown-link rewriter used by
+/// the `pages/by-title` FileProvider projection. No store, no view: the resolver
+/// is injected as a closure, exactly as `Projection` supplies it.
+struct RelativeLinkRewriterTests {
+
+    private func resolve(_ title: String) -> String? {
+        switch title {
+        case "Home":     return "Home--01AAAAAAAA.md"
+        case "Alpha":    return "Alpha--01BBBBBBBB.md"
+        case "C# Guide": return "C# Guide--01CCCCCCCC.md"
+        default:         return nil
+        }
+    }
+
+    // MARK: - Basic rewrites
+
+    @Test func simplePageLinkBecomesRelativeMarkdownLink() {
+        let out = RelativeLinkRewriter.rewrite("See [[Home]] here.", resolver: resolve)
+        #expect(out == "See [Home](Home--01AAAAAAAA.md) here.")
+    }
+
+    @Test func aliasedLinkUsesAliasTextAndTargetFilename() {
+        let out = RelativeLinkRewriter.rewrite("Go to [[Home|start page]].", resolver: resolve)
+        #expect(out == "Go to [start page](Home--01AAAAAAAA.md).")
+    }
+
+    @Test func multipleLinksAreEachRewritten() {
+        let out = RelativeLinkRewriter.rewrite("[[Home]] and [[Alpha]].", resolver: resolve)
+        #expect(out == "[Home](Home--01AAAAAAAA.md) and [Alpha](Alpha--01BBBBBBBB.md).")
+    }
+
+    // MARK: - Anchors
+
+    @Test func anchorIsPreservedAfterFilename() {
+        let out = RelativeLinkRewriter.rewrite("See [[Home#Introduction]].", resolver: resolve)
+        #expect(out == "See [Home](Home--01AAAAAAAA.md#Introduction).")
+    }
+
+    @Test func aliasedAnchorLinkUsesAliasAndPreservesFragment() {
+        let out = RelativeLinkRewriter.rewrite("[[Home#Intro|intro]]", resolver: resolve)
+        #expect(out == "[intro](Home--01AAAAAAAA.md#Intro)")
+    }
+
+    // MARK: - Hash-in-title disambiguation
+
+    @Test func hashInTitleIsDisambiguatedCorrectly() {
+        // "C# Guide" is a real page; "C" is not. Should resolve to C# Guide.
+        let out = RelativeLinkRewriter.rewrite("See [[C# Guide]].", resolver: resolve)
+        #expect(out == "See [C# Guide](C%23%20Guide--01CCCCCCCC.md).")
+    }
+
+    // MARK: - Unresolvable links stay verbatim
+
+    @Test func unknownPageLinkStaysVerbatim() {
+        let out = RelativeLinkRewriter.rewrite("[[Deleted Page]]", resolver: resolve)
+        #expect(out == "[[Deleted Page]]")
+    }
+
+    // MARK: - Non-page links stay verbatim
+
+    @Test func sourceLinkStaysVerbatim() {
+        let out = RelativeLinkRewriter.rewrite("[[source:report.pdf]]", resolver: resolve)
+        #expect(out == "[[source:report.pdf]]")
+    }
+
+    @Test func chatLinkStaysVerbatim() {
+        let out = RelativeLinkRewriter.rewrite("[[chat:My Chat]]", resolver: resolve)
+        #expect(out == "[[chat:My Chat]]")
+    }
+
+    @Test func embedStaysVerbatim() {
+        let out = RelativeLinkRewriter.rewrite("![[source:image.png]]", resolver: resolve)
+        #expect(out == "![[source:image.png]]")
+    }
+
+    // MARK: - Code span protection
+
+    @Test func linkInsideCodeSpanIsLeftVerbatim() {
+        let out = RelativeLinkRewriter.rewrite("Use `[[Home]]` in code.", resolver: resolve)
+        #expect(out == "Use `[[Home]]` in code.")
+    }
+
+    @Test func linkInsideFencedBlockIsLeftVerbatim() {
+        let body = "```\n[[Home]]\n```"
+        let out = RelativeLinkRewriter.rewrite(body, resolver: resolve)
+        #expect(out == body)
+    }
+
+    // MARK: - Same-page anchors stay verbatim
+
+    @Test func samePageAnchorStaysVerbatim() {
+        let out = RelativeLinkRewriter.rewrite("Jump to [[#Introduction]].", resolver: resolve)
+        #expect(out == "Jump to [[#Introduction]].")
+    }
+
+    // MARK: - Filename percent-encoding
+
+    @Test func filenameWithSpecialCharsIsPercentEncoded() {
+        // A filename with spaces must be percent-encoded so Markdown parsers
+        // don't break the link at the first space.
+        var called = false
+        let out = RelativeLinkRewriter.rewrite("[[Home]]", resolver: { title in
+            called = true
+            return "My Home Page--01AA.md"   // has spaces
+        })
+        #expect(called)
+        #expect(out == "[Home](My%20Home%20Page--01AA.md)")
+    }
+
+    // MARK: - Passthrough when no links
+
+    @Test func bodyWithNoLinksIsReturnedUnchanged() {
+        let body = "Just plain text, no wikilinks."
+        let out = RelativeLinkRewriter.rewrite(body, resolver: resolve)
+        #expect(out == body)
+    }
+
+    // MARK: - Frontmatter passthrough
+
+    @Test func yamlFrontmatterIsNotModified() {
+        let body = """
+        ---
+        title: "Home"
+        date: 2026-07-11
+        ---
+
+        # Home
+
+        See [[Alpha]].
+        """
+        let out = RelativeLinkRewriter.rewrite(body, resolver: resolve)
+        #expect(out.hasPrefix("---\ntitle: \"Home\"\ndate: 2026-07-11\n---"))
+        #expect(out.contains("[Alpha](Alpha--01BBBBBBBB.md)"))
+    }
+}

--- a/Tests/WikiFSTests/SourceImageRewriterTests.swift
+++ b/Tests/WikiFSTests/SourceImageRewriterTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Unit tests for the image-src rewriter used by the `by-name` FileProvider
+/// projection to resolve relative image paths in markdown-native snapshot
+/// sources. No store, no view: namespace resolution is injected, exactly as
+/// `Projection` supplies.
+struct SourceImageRewriterTests {
+
+    // Canonical ULIDs for fixture sibling images.
+    private static let pic1ID = "01AAAAAAAAAAAAAAAAAAAAAAAA"
+    private static let pic2ID = "01BBBBBBBBBBBBBBBBBBBBBBBB"
+
+    private typealias Target = RelativeLinkRewriter.Target
+
+    /// Resolver that maps two snapshot images.
+    private func resolver(baseDir: [String] = ["sources", "by-name"]) -> SourceImageRewriter.Resolver {
+        let siblingImages: [String: Target] = [
+            "assets/pic.png": Target(path: ["sources", "by-name", "pic--\(Self.pic1ID.dropFirst(22)).png"],
+                                     title: "pic.png"),
+            "images/diagram.svg": Target(path: ["sources", "by-name", "diagram--\(Self.pic2ID.dropFirst(22)).svg"],
+                                         title: "diagram.svg"),
+        ]
+        return SourceImageRewriter.Resolver(baseDir: baseDir, resolve: { path in
+            siblingImages[path]
+        })
+    }
+
+    /// Convenience: rewrite from the sources/by-name view.
+    private func rewrite(_ body: String, baseDir: [String] = ["sources", "by-name"]) -> String {
+        SourceImageRewriter.rewrite(body, resolver: resolver(baseDir: baseDir))
+    }
+
+    // MARK: - Basic image rewriting
+
+    @Test func relativeImageSrcIsRewrittenToResolved() {
+        let input = "![diagram](assets/pic.png)"
+        let output = rewrite(input)
+        #expect(output.contains("![diagram](pic"))
+        #expect(output.contains(".png)"))
+        #expect(!output.contains("assets/"))
+    }
+
+    @Test func multipleImagesResolveIndependently() {
+        let input = "![pic1](assets/pic.png) and ![pic2](images/diagram.svg)"
+        let output = rewrite(input)
+        #expect(output.contains("![pic1](pic"))
+        #expect(output.contains("![pic2](diagram"))
+        #expect(!output.contains("assets/") && !output.contains("images/"))
+    }
+
+    @Test func altTextIsPreservedVerbatim() {
+        let input = "![my special diagram [note]](assets/pic.png)"
+        let output = rewrite(input)
+        #expect(output.contains("![my special diagram [note]]"))
+    }
+
+    // MARK: - Unresolved relative paths
+
+    @Test func unresolvedRelativeSrcLeftVerbatim() {
+        let input = "![missing](unknown/file.png)"
+        #expect(rewrite(input) == input)
+    }
+
+    @Test func absoluteHttpUrlLeftVerbatim() {
+        let input = "![external](https://example.com/pic.png)"
+        #expect(rewrite(input) == input)
+    }
+
+    @Test func absoluteHttpsUrlLeftVerbatim() {
+        let input = "![secure](https://cdn.example.com/image.png)"
+        #expect(rewrite(input) == input)
+    }
+
+    @Test func dataUrlLeftVerbatim() {
+        let input = "![inline](data:image/png;base64,iVBORw0KG)"
+        #expect(rewrite(input) == input)
+    }
+
+    @Test func wikiBlobUrlLeftVerbatim() {
+        let input = "![blob](wiki-blob:abc123)"
+        #expect(rewrite(input) == input)
+    }
+
+    @Test func wikiSchemeUrlLeftVerbatim() {
+        let input = "![ref](wiki:source:01ABC)"
+        #expect(rewrite(input) == input)
+    }
+
+    // MARK: - Code protection
+
+    @Test func imageInInlineCodeLeftVerbatim() {
+        let input = "Use `![alt](assets/pic.png)` syntax."
+        #expect(rewrite(input) == input)
+    }
+
+    @Test func imageInFencedBlockLeftVerbatim() {
+        let input = """
+        ```markdown
+        ![alt](assets/pic.png)
+        ```
+        """
+        #expect(rewrite(input) == input)
+    }
+
+    @Test func imageOutsideCodeWithImageInCodeKeepsExternal() {
+        let input = """
+        ![real](assets/pic.png)
+
+        `![not real](assets/pic.png)`
+        """
+        let output = rewrite(input)
+        // First line rewritten
+        #expect(output.contains("![real](pic"))
+        // Second line stays verbatim
+        #expect(output.contains("`![not real](assets/pic.png)`"))
+    }
+
+    // MARK: - Sibling-directory resolution
+
+    @Test func siblingInSameDirectoryNeedsNoDots() {
+        // When both the markdown and the sibling are in sources/by-name,
+        // the relative path is just the filename.
+        let input = "![pic](assets/pic.png)"
+        let output = rewrite(input, baseDir: ["sources", "by-name"])
+        #expect(output.contains("![pic](pic--") && output.contains(".png)"))
+        #expect(!output.contains(".."))
+    }
+}

--- a/plans/bookmark-relative-links.md
+++ b/plans/bookmark-relative-links.md
@@ -1,0 +1,233 @@
+# Bookmark relative-link rewriting (issue #216 follow-on)
+
+**Status:** Ready to execute.
+
+**Context.** The FileProvider projection rewrites `[[wikilinks]]` → relative
+Markdown links in the `pages/by-title`, `sources/by-name` (markdown siblings),
+and `chats/by-name` views (see `Sources/WikiFSCore/RelativeLinkRewriter.swift`
+and `Sources/WikiFSFileProvider/Projection.swift`). The `bookmarks/` tree does
+NOT — its `pageRef` / `chatRef` leaves still serve raw `[[…]]`. This plan closes
+that gap.
+
+**Confirmed decisions (from the parent conversation):**
+- Vault root is the **mount root**, so cross-namespace `../…` links resolve.
+- `sourceRef` bookmarks serve **verbatim binary bytes** (`store.sourceContent`)
+  and must NOT be rewritten — only `pageRef` and `chatRef` render markdown.
+- The size path (`bookmarkNodeItem`) and the content path (`bookmarkContent`)
+  must produce **byte-identical** output — a mismatch truncates `cat` (#216).
+
+**The one hard part — `baseDir` varies by depth.** A bookmark ref at
+`bookmarks/Research/Papers/Note.md` needs `../../../pages/by-title/…`. The ref's
+directory is `["bookmarks"] + <sanitized folder labels root→parent>`. Every
+other view has a fixed depth-2 `baseDir`; bookmarks are arbitrary-depth.
+
+All changes are in **`Sources/WikiFSFileProvider/Projection.swift`** plus tests
+in **`Tests/WikiFSTests/ProjectionTreeTests.swift`**. No changes to
+`RelativeLinkRewriter` (its `Resolver`/`baseDir` API already supports this).
+
+---
+
+## Task 1 — `baseDir` from a bookmark node's ancestor chain
+
+Add a helper that returns the projection-relative directory components for the
+folder CONTAINING a bookmark node, by walking `parentID` up through folders.
+
+Add near the other bookmark helpers (after `sanitizeFilename`, ~line 899):
+
+```swift
+    /// The projection-relative directory components CONTAINING `node` —
+    /// `["bookmarks"]` for a root-level ref, plus one sanitized label per
+    /// ancestor folder (root → immediate parent). Used as the rewriter's
+    /// `baseDir` so a nested ref's links climb the right number of `../`.
+    /// The parent walk is capped (matches `BookmarkNode.displayPath`) so a
+    /// corrupted parent cycle can't loop forever.
+    private func bookmarkBaseDir(for node: BookmarkNode,
+                                 in nodes: [BookmarkNode]) -> [String] {
+        var byID: [String: BookmarkNode] = [:]
+        byID.reserveCapacity(nodes.count)
+        for n in nodes { byID[n.id] = n }
+
+        var labels: [String] = []
+        var current = node.parentID.flatMap { byID[$0] }
+        var depth = 0
+        let maxDepth = 64
+        while let folder = current, depth < maxDepth {
+            depth += 1
+            labels.insert(Self.sanitizeFilename(folder.label ?? "Untitled"), at: 0)
+            current = folder.parentID.flatMap { byID[$0] }
+        }
+        return ["bookmarks"] + labels
+    }
+```
+
+**Notes:**
+- `node` itself is the ref (or folder); we start from its `parentID`, so the
+  returned dir is the ref's *containing* directory (excludes the ref filename).
+- Folder labels use `sanitizeFilename` (same as the folder node names emitted by
+  `bookmarkNodeItem`'s `.folder` case) so the path segments match on disk.
+- Untitled folders fall back to `"Untitled"` — matching the `.folder` name.
+
+**Verify:** compiles (`swift build`). Behavior is exercised by Task 4 tests.
+
+---
+
+## Task 2 — thread `LinkMaps` + rewrite into `bookmarkNodeItem` (size path)
+
+`bookmarkNodeItem` currently renders `pageRef`/`chatRef` markdown raw. Rewrite
+it, and size from the rewritten bytes. `sourceRef` and stale placeholders are
+left untouched.
+
+Change the signature to accept the maps and the full node list (needed for
+`baseDir`):
+
+```swift
+    private func bookmarkNodeItem(
+        for node: BookmarkNode, in store: SQLiteWikiStore,
+        maps: LinkMaps, allNodes: [BookmarkNode]
+    ) -> ProjectedNode {
+```
+
+Inside, in the `.pageRef` resolved branch, replace:
+
+```swift
+                let body = Data(PageMarkdownFormat.fileContent(for: page).utf8)
+```
+with:
+```swift
+                let baseDir = bookmarkBaseDir(for: node, in: allNodes)
+                let body = rewriteLinks(PageMarkdownFormat.fileContent(for: page),
+                                        maps: maps, baseDir: baseDir)
+```
+
+In the `.chatRef` resolved branch, replace:
+
+```swift
+                let body = Data(ChatTranscriptRenderer.render(summary: chat, messages: messages).utf8)
+```
+with:
+```swift
+                let baseDir = bookmarkBaseDir(for: node, in: allNodes)
+                let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
+                let body = rewriteLinks(raw, maps: maps, baseDir: baseDir)
+```
+
+Leave `.sourceRef` (verbatim binary) and all `Stale reference` placeholders
+exactly as they are.
+
+**Verify:** compiles after Task 3 updates the callers.
+
+---
+
+## Task 3 — build maps + pass through at the three callers
+
+`bookmarkNodeItem` is called from three sites, each of which already has the
+node list from `listBookmarkNodes()`. Build `makeLinkMaps()` once per call and
+thread both through.
+
+### 3a. `bookmarkNode(for:)`
+```swift
+    private func bookmarkNode(for id: NSFileProviderItemIdentifier) -> ProjectedNode? {
+        guard let ulid = Identity.bookmarkULID(from: id),
+              let store = openReadStore(),
+              let nodes = try? store.listBookmarkNodes(),
+              let node = nodes.first(where: { $0.id == ulid }) else { return nil }
+        return bookmarkNodeItem(for: node, in: store, maps: makeLinkMaps(), allNodes: nodes)
+    }
+```
+
+### 3b. `bookmarkChildren(of:)` — the final `compactMap`
+```swift
+        let maps = makeLinkMaps()
+        return nodes
+            .filter { $0.parentID == parentID }
+            .sorted { $0.position < $1.position }
+            .compactMap { bookmarkNodeItem(for: $0, in: store, maps: maps, allNodes: nodes) }
+```
+
+### 3c. `allBookmarkNodes()`
+```swift
+    private func allBookmarkNodes() -> [ProjectedNode] {
+        guard let store = openReadStore(),
+              let nodes = try? store.listBookmarkNodes() else { return [] }
+        let maps = makeLinkMaps()
+        return nodes.compactMap { bookmarkNodeItem(for: $0, in: store, maps: maps, allNodes: nodes) }
+    }
+```
+
+**Verify:** `swift build` clean (ignore the pre-existing `FileProviderSpike`
+`no-usage` warning).
+
+---
+
+## Task 4 — rewrite `bookmarkContent` (content path — MUST match Task 2)
+
+`bookmarkContent` serves the bytes. Apply the SAME rewrite for `pageRef` and
+`chatRef` so `size == bytes`. It already has `store`, `nodes`, and `node`.
+
+In `.pageRef`, replace:
+```swift
+            return Data(PageMarkdownFormat.fileContent(for: page).utf8)
+```
+with:
+```swift
+            return rewriteLinks(PageMarkdownFormat.fileContent(for: page),
+                                maps: makeLinkMaps(),
+                                baseDir: bookmarkBaseDir(for: node, in: nodes))
+```
+
+In `.chatRef`, replace:
+```swift
+            let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
+            return Data(ChatTranscriptRenderer.render(summary: chat, messages: messages).utf8)
+```
+with:
+```swift
+            let messages = (try? store.chatMessages(chatID: chat.id)) ?? []
+            let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)
+            return rewriteLinks(raw, maps: makeLinkMaps(),
+                                baseDir: bookmarkBaseDir(for: node, in: nodes))
+```
+
+Leave `.folder` (nil), `.sourceRef` (verbatim), and stale placeholders as-is.
+
+**Verify:** `swift build` clean.
+
+---
+
+## Task 5 — tests
+
+Add to `Tests/WikiFSTests/ProjectionTreeTests.swift`. Check the store API for
+creating bookmark nodes first (search `SQLiteWikiStore` for
+`createBookmark`/`addBookmark`/`insertBookmarkNode`); use whatever the existing
+bookmark tests use. Use `Projection.Identity.bookmarkPageRef(node.id)` for the
+leaf id.
+
+1. **Root-level pageRef rewrites with single `../` and size matches bytes.**
+   Seed a page `Target`, a page `Home` whose body links `[[page:<TargetID>|t]]`,
+   a root bookmark pageRef → `Home`. Assert:
+   - `node.size == contents(for: id)!.count`
+   - content contains `[t](../pages/by-title/Target Page--<short>.md)` (one `../`)
+   - no `[[page:` remains.
+
+2. **Nested pageRef climbs the right depth.** Put the pageRef inside a folder
+   `Research` (one level). Assert content contains `../../pages/by-title/`.
+
+3. **sourceRef is left verbatim.** A bookmark sourceRef → the pdf source still
+   serves `store.sourceContent(id:)` bytes unchanged, `size == bytes`.
+
+4. **`bookmarkBaseDir` unit** (if practical without a store): a root ref →
+   `["bookmarks"]`; a ref under folder "A" → `["bookmarks", "A"]`; under "A/B"
+   → `["bookmarks", "A", "B"]`. Sanitizes a label containing `/`.
+
+**Verify:** `swift test --filter "ProjectionTreeTests"` green; then the broader
+`swift test --filter "RelativeLinkRewriter|Projection"` still green.
+
+---
+
+## Out of scope / notes
+- The 4 pre-existing `SQLiteWikiStoreTests` failures (`refs` table / change
+  token / v29 migration) are unrelated — do not try to fix them here.
+- No `RelativeLinkRewriter` changes: its `Resolver.baseDir` already accepts an
+  arbitrary-depth directory.
+- The live mount stays stale until the extension is rebuilt/reinstalled — a
+  deployment step, not part of this plan.

--- a/plans/source-image-relative-links.md
+++ b/plans/source-image-relative-links.md
@@ -1,0 +1,466 @@
+# Resolve relative image srcs in source-markdown files (follow-on to #216)
+
+**Status:** Ready to execute.
+
+**Bug report:** In the live mount, `sources/by-name/Potluck- Dynamic documents as
+personal software--01KX139J.md` has broken images: the markdown contains plain
+CommonMark `![](potluck/micro-syntax-1.png)`, but no `potluck/` folder exists
+anywhere in the projection. The actual file lives flat at
+`sources/by-name/micro-syntax-1--01KX139J.png`.
+
+**Root cause.** `WebsiteSnapshotExtractor` downloads a page's images during
+website-snapshot ingestion and rewrites `<img src>` to a relative path like
+`potluck/micro-syntax-1.png`, as if a `potluck/` subfolder existed next to the
+markdown. But `SQLiteWikiStore.addSnapshotImage` stores each image as its own
+independent, flat `sources` row (`WikiStoreModel.storeSnapshot`), and the
+FileProvider projection places **all** sources flat under `sources/by-name/` —
+there is no nested folder. The relative path in the markdown never resolves.
+
+**This is unrelated to `[[wikilinks]]`** — `RelativeLinkRewriter` only matches
+`[[...]]`/`![[...]]` syntax and never touches plain `![alt](src)` images. This
+bug predates PR #352 / issue #216 entirely.
+
+**The in-app renderer already solves this correctly** — study it before
+touching FileProvider code:
+- `SQLiteWikiStore.siblingImageResolvers()` (`Sources/WikiFSCore/SQLiteWikiStore.swift:3365`)
+  returns `[PageID: [String: PageID]]`: for each source, its active version's
+  `[original_path → sibling image sourceID]` map, built by joining
+  `source_versions` on the shared `activity_id` (the page and its images are
+  committed together — see `WikiStoreModel.storeSnapshot`).
+- `WikiRenderContext` captures this once as `siblingMaps` (`WikiRenderContext.swift:85`).
+- `WikiReaderView.swift:842-894` resolves each rendered source's OWN sibling
+  map (`context.siblingMaps[sourceID]`), and `MarkdownHTMLRenderer.swift:147-155`
+  (`resolvedImageSrc`) does the exact-string match: absolute (`http`/`https`),
+  `data:`, `wiki-blob:`, `wiki:` srcs pass through untouched; any other src is
+  looked up **exactly** in the map; unmatched relative srcs are left verbatim
+  (no guessing).
+
+**Do not reuse `MarkdownHTMLRenderer`** — it depends on `swift-markdown`
+(`import Markdown`), which is linked ONLY to the `WikiFS` app target, not
+`WikiFSCore`/`WikiFSFileProvider` (check `Package.swift` — the `Markdown`
+product dependency is scoped to the app executable). Write a small,
+regex-based rewriter in `WikiFSCore` instead, mirroring how
+`RelativeLinkRewriter` handles `[[wikilinks]]` without a full Markdown parser.
+
+**Scope: verbatim `sources/by-name` text files ONLY, not the `.md` sibling.**
+This matters and is easy to get wrong — verify before coding:
+
+```sh
+cat "/Users/wsargent/Library/CloudStorage/SelfDrivingWiki-MalleableSoftware/sources/by-name/"*Potluck*
+```
+There is only ONE file for this source (no separate `.md` sibling). Per
+`Projection.sourceNodes(byName:)`'s existing sibling-eligibility rule
+(`!mime.hasPrefix("text/")`), a markdown-native source (its own `mimeType`
+already `text/markdown` or similar, as produced by `WebsiteSnapshotExtractor`'s
+`.htmlConverted` output) does NOT get a `.md` sibling — **the verbatim
+`sources/by-name`/`sources/by-id` file IS the rendered content**. That file is
+served by `sourceNode`/`sourceContent` (the `fileULID` branches in
+`sourcesProjection`), a COMPLETELY DIFFERENT code path from
+`sourceMarkdownNode`/`processedMarkdownHead` (the `.md` sibling, which PR #352
+already rewrites for `[[wikilinks]]`). `siblingImageResolvers()` is non-empty
+ONLY for sources ingested via `WikiStoreModel.storeSnapshot` (grep confirms
+`addSnapshotImage` has exactly one call site), which are always this
+markdown-native verbatim case — so this plan touches ONLY the verbatim
+`by-name` path. Do not touch the `.md`-sibling path; it's out of scope
+(currently unpopulated, would be speculative).
+
+**The size/content byte-identity invariant applies here too, and is currently
+NOT held for `sourceNode`** — this is new ground, read carefully.
+`sourceNode` (`Projection.swift:1165`) reports `size: file.byteSize`, the
+**stored** DB column, not a computed content length — unlike `pageFileNode`/
+`sourceMarkdownNode`/`chatFileNode`, which all already accept an optional
+`contentData: Data?` to keep size in sync with rewritten bytes. This plan adds
+that same optional parameter to `sourceNode`, used ONLY when we rewrite
+image srcs (which changes byte length); binary/non-text/no-sibling sources are
+completely unaffected and keep using `file.byteSize` as today.
+
+All source changes are in **`Sources/WikiFSCore/`** (new file
+`SourceImageRewriter.swift`) and **`Sources/WikiFSFileProvider/Projection.swift`**.
+Tests in **`Tests/WikiFSTests/`**.
+
+---
+
+## Task 1 — `SourceImageRewriter` (new file, `Sources/WikiFSCore/SourceImageRewriter.swift`)
+
+Pure, regex-based, no swift-markdown dependency. Mirrors `RelativeLinkRewriter`'s
+style: a `Resolver`/`baseDir` pair, code-span protection via the SAME shared
+`WikiLinkSpan.protectedCodeRanges`/`isProtected` helpers (already in
+`WikiFSCore`, general-purpose — not wikilink-specific), and the SAME
+`Target`/`relativePath` reuse from `RelativeLinkRewriter` (same module, so
+`RelativeLinkRewriter.relativePath` and `RelativeLinkRewriter.Target` are both
+directly callable — `relativePath` is `internal`, fine within `WikiFSCore`;
+`Target` is already `public`).
+
+```swift
+import Foundation
+
+/// Rewrites plain CommonMark image srcs (`![alt](src)`) in source-markdown
+/// content that were downloaded during website-snapshot ingestion
+/// (`WebsiteSnapshotExtractor`) and stored as flat sibling `sources` rows
+/// (`SQLiteWikiStore.addSnapshotImage`). The extractor rewrites `<img src>` to
+/// a relative path like `potluck/diagram.png` as if a nested folder existed
+/// next to the markdown, but the FileProvider projection places every source
+/// flat under `sources/by-name/` — so that relative path never resolves on
+/// disk (or in the in-app WKWebView reader, without this same lookup).
+///
+/// Mirrors `MarkdownHTMLRenderer.resolvedImageSrc` (`Sources/WikiFS/MarkdownHTMLRenderer.swift`),
+/// the in-app renderer's EXACT-STRING resolution of the same `original_path`
+/// data (`SQLiteWikiStore.siblingImageResolvers()`) — but implemented as a
+/// regex pass here (no `swift-markdown`/`import Markdown`, which is an
+/// app-target-only dependency not linked into `WikiFSCore`/`WikiFSFileProvider` —
+/// see `Package.swift`). Filtering rule is IDENTICAL: absolute (`http`/`https`),
+/// `data:`, `wiki-blob:`, `wiki:` srcs pass through untouched; any other src is
+/// looked up EXACTLY (no fuzzy/basename matching) in the resolver; an
+/// unresolved relative src is left verbatim — same "don't guess" discipline
+/// the in-app renderer uses.
+///
+/// This is a filesystem-projection concern only — SQLite retains the raw
+/// extracted markdown verbatim; nothing here writes back.
+public enum SourceImageRewriter {
+
+    /// Namespace resolution for one document being rewritten.
+    public struct Resolver {
+        /// Root-relative directory of the document being rewritten — e.g.
+        /// `["sources", "by-name"]`.
+        public let baseDir: [String]
+        /// EXACT `original_path` (as it appears in the markdown `![](src)`) →
+        /// the resolved target, or `nil` if unresolved.
+        public let resolve: (String) -> RelativeLinkRewriter.Target?
+
+        public init(baseDir: [String], resolve: @escaping (String) -> RelativeLinkRewriter.Target?) {
+            self.baseDir = baseDir
+            self.resolve = resolve
+        }
+    }
+
+    /// `![alt](src)` — alt has no unescaped `]`; src runs to the first
+    /// unescaped `)` or whitespace (an optional `"title"` after whitespace is
+    /// tolerated but not captured/preserved — none of today's snapshot images
+    /// carry one, and dropping it if present is a acceptable, documented
+    /// simplification). Capture groups: 1 = alt, 2 = src.
+    private static let regex = try! NSRegularExpression(
+        pattern: #"!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)"#)
+
+    public static func rewrite(_ body: String, resolver: Resolver) -> String {
+        let ns = body as NSString
+        let codeRanges = WikiLinkSpan.protectedCodeRanges(in: body)
+        let matches = regex.matches(in: body, range: NSRange(location: 0, length: ns.length))
+
+        var out = ""
+        var cursor = 0
+        for match in matches {
+            let full = match.range
+            if WikiLinkSpan.isProtected(full, by: codeRanges) { continue }
+
+            let src = ns.substring(with: match.range(at: 2))
+            guard let target = resolvedTarget(for: src, resolver: resolver) else { continue }
+
+            if full.location > cursor {
+                out += ns.substring(with: NSRange(location: cursor, length: full.location - cursor))
+            }
+            let alt = ns.substring(with: match.range(at: 1))
+            let path = RelativeLinkRewriter.relativePath(from: resolver.baseDir, to: target.path)
+            out += "![\(alt)](\(path))"
+            cursor = full.location + full.length
+        }
+        if cursor < ns.length {
+            out += ns.substring(with: NSRange(location: cursor, length: ns.length - cursor))
+        }
+        return out
+    }
+
+    /// `nil` for absolute/data/wiki-scheme srcs (leave verbatim, pass copies
+    /// through untouched by the caller's cursor logic) OR an unresolved
+    /// relative src (also leave verbatim). Mirrors
+    /// `MarkdownHTMLRenderer.resolvedImageSrc`'s filter list exactly.
+    private static func resolvedTarget(for src: String, resolver: Resolver) -> RelativeLinkRewriter.Target? {
+        guard !src.isEmpty else { return nil }
+        let lower = src.lowercased()
+        if lower.hasPrefix("http") || lower.hasPrefix("data:")
+            || lower.hasPrefix("wiki-blob:") || lower.hasPrefix("wiki:") {
+            return nil
+        }
+        return resolver.resolve(src)
+    }
+}
+```
+
+**Verify:** `swift build` (this file alone compiles; `RelativeLinkRewriter.Target`
+is `public`, `relativePath` is `internal`-but-same-module — confirm no access
+error).
+
+---
+
+## Task 2 — thread a per-source image resolver into `Projection`
+
+### 2a. Extend `LinkMaps` construction to also capture sibling-image data
+
+In `makeLinkMaps()` (`Projection.swift`), after building the existing six
+maps, also fetch and store the sibling-image resolver dict:
+
+```swift
+struct LinkMaps {
+    // ... existing six fields unchanged ...
+    let siblingImages: [PageID: [String: PageID]]   // sourceID -> [originalPath -> sibling sourceID]
+
+    // existing resolver(baseDir:) unchanged
+
+    /// The image-src resolver for ONE source's own markdown, or an
+    /// always-nil resolver if it has no image siblings (the common case —
+    /// most sources never call this at all, gated by the caller).
+    func imageResolver(forSource sourceID: PageID, baseDir: [String]) -> SourceImageRewriter.Resolver {
+        let siblingMap = siblingImages[sourceID] ?? [:]
+        return SourceImageRewriter.Resolver(baseDir: baseDir, resolve: { originalPath in
+            guard let siblingID = siblingMap[originalPath] else { return nil }
+            return sourceByID[siblingID.rawValue.uppercased()]
+        })
+    }
+}
+```
+
+In `makeLinkMaps()`'s body, add:
+```swift
+let siblingImages = (try? store?.siblingImageResolvers()) ?? [:]
+```
+and pass it into the `LinkMaps(...)` construction. (`SQLiteWikiStore.siblingImageResolvers()`
+is `public func ... throws -> [PageID: [String: PageID]]` — already exists,
+`Sources/WikiFSCore/SQLiteWikiStore.swift:3365`. `store` here is the same
+`openReadStore()` result already used to build the other five maps — reuse it,
+do not open a second connection.)
+
+**Why `sourceByID` (not a new map) resolves the sibling's target correctly:**
+sibling images have no processed-markdown head (nothing calls
+`appendProcessedMarkdown` for them), so `makeLinkMaps()`'s existing
+`hasSibling` check for that row is false, and `sourceByID[siblingID]` already
+resolves to the sibling's OWN verbatim by-name `Target` (e.g.
+`micro-syntax-1--01KX139J.png`) — exactly the file that exists on disk. No new
+lookup table needed.
+
+**Verify:** compiles (used starting Task 3).
+
+---
+
+## Task 3 — apply the rewrite to verbatim `sources/by-name` text files, with the size/content invariant
+
+This touches THREE call sites, all in the `.fileULID` / verbatim-node family —
+NOT the `sourceMarkdownByNamePrefix` family (that's the `.md` sibling, out of
+scope per the header notes).
+
+### 3a. `Self.sourceNode` — accept optional `contentData`
+
+```swift
+    static func sourceNode(for id: NSFileProviderItemIdentifier,
+                                 file: SourceSummary,
+                                 contentData: Data? = nil) -> ProjectedNode {
+        let raw = id.rawValue
+        let isByName = raw.hasPrefix(Identity.sourceByNamePrefix)
+        let humanName = file.displayName ?? file.filename
+        let name = isByName
+            ? FilenameEscaping.byNameSourceFilename(
+                filename: humanName, ext: file.ext, sourceID: file.id.rawValue)
+            : FilenameEscaping.byIDSourceFilename(sourceID: file.id.rawValue, ext: file.ext)
+        let parent = isByName ? Identity.sourcesByName : Identity.sourcesByID
+        let metaKey = isByName
+            ? "\(humanName)|\(file.updatedAt.timeIntervalSince1970)|\(file.version)"
+            : "\(file.filename)|\(file.updatedAt.timeIntervalSince1970)|\(file.version)"
+        return .file(
+            id: id, parent: parent, name: name, size: contentData?.count ?? file.byteSize,
+            version: Data(String(file.version).utf8),
+            metadataVersion: Data(metaKey.utf8),
+            created: file.createdAt, modified: file.updatedAt,
+            ingestedExt: file.ext,
+            mimeType: file.mimeType
+        )
+    }
+```
+
+### 3b. A shared helper: compute rewritten verbatim content (or nil if unaffected)
+
+Add near `rewriteLinks`/`byTitleContent` in `Projection`:
+
+```swift
+    /// Rewrite relative image srcs in a markdown-native verbatim source's own
+    /// content, IF it has image siblings (`makeLinkMaps().siblingImages`).
+    /// Returns `nil` when there's nothing to rewrite (binary sources, sources
+    /// with no image siblings, or non-`by-name` requests) — the caller then
+    /// falls back to raw stored bytes with NO computation, matching today's
+    /// behavior exactly for every unaffected source (the overwhelming
+    /// majority). Byte-identity: both the size path and content path MUST
+    /// call this with the same inputs and use the SAME returned Data.
+    private func rewrittenVerbatimSourceContent(
+        id: PageID, mimeType: String?, maps: LinkMaps
+    ) -> Data? {
+        guard let mime = mimeType, mime.hasPrefix("text/"),
+              let siblingMap = maps.siblingImages[id], !siblingMap.isEmpty,
+              let store = openReadStore(),
+              let raw = try? store.sourceContent(id: id),
+              let text = String(data: raw, encoding: .utf8) else { return nil }
+        let resolver = maps.imageResolver(forSource: id, baseDir: Self.sourcesByNameDir)
+        let rewritten = SourceImageRewriter.rewrite(text, resolver: resolver)
+        return Data(rewritten.utf8)
+    }
+```
+
+### 3c. `sourcesProjection.nodeForLeaf` — the `fileULID` branch
+
+Current:
+```swift
+            if let ulid = Identity.fileULID(from: id) {
+                guard let store = projection.openReadStore(),
+                      let file = try? store.getSource(id: PageID(rawValue: ulid)) else { return nil }
+                return Self.sourceNode(for: id, file: file)
+            }
+```
+Change to:
+```swift
+            if let ulid = Identity.fileULID(from: id) {
+                guard let store = projection.openReadStore(),
+                      let file = try? store.getSource(id: PageID(rawValue: ulid)) else { return nil }
+                if id.rawValue.hasPrefix(Identity.sourceByNamePrefix) {
+                    let contentData = projection.rewrittenVerbatimSourceContent(
+                        id: PageID(rawValue: ulid), mimeType: file.mimeType,
+                        maps: projection.makeLinkMaps())
+                    return Self.sourceNode(for: id, file: file, contentData: contentData)
+                }
+                return Self.sourceNode(for: id, file: file)
+            }
+```
+
+### 3d. `sourcesProjection.contentForLeaf` — the `fileULID` branch
+
+Current:
+```swift
+            if let ulid = Identity.fileULID(from: id) {
+                guard let store = projection.openReadStore(),
+                      let data = try? store.sourceContent(id: PageID(rawValue: ulid)) else { return nil }
+                return data
+            }
+```
+Change to:
+```swift
+            if let ulid = Identity.fileULID(from: id) {
+                guard let store = projection.openReadStore(),
+                      let file = try? store.getSource(id: PageID(rawValue: ulid)),
+                      let data = try? store.sourceContent(id: PageID(rawValue: ulid)) else { return nil }
+                if id.rawValue.hasPrefix(Identity.sourceByNamePrefix),
+                   let rewritten = projection.rewrittenVerbatimSourceContent(
+                       id: PageID(rawValue: ulid), mimeType: file.mimeType,
+                       maps: projection.makeLinkMaps()) {
+                    return rewritten
+                }
+                return data
+            }
+```
+(Note the extra `store.getSource` fetch for the mime type — matches the
+existing pattern elsewhere in this file of fetching row metadata + content
+separately; not a regression in connection count since `openReadStore()`
+returns the same cached `ReadScope` connection within one call.)
+
+### 3e. `sourceNodes(byName:)` — the enumeration path's `verbatimNode`
+
+Current (inside the `byName` branch, before the sibling-eligibility guard):
+```swift
+            let verbatimNode = Self.sourceNode(for: id, file: summary)
+```
+Change to (only build `maps`/attempt rewrite for `byName`, mirroring the
+existing `titleMap`/`maps` pattern already used for the `.md`-sibling
+`contentData` a few lines below in this same function):
+```swift
+            let verbatimContentData = byName
+                ? projection.rewrittenVerbatimSourceContent(
+                    id: PageID(rawValue: row.id), mimeType: row.mime, maps: maps)
+                : nil
+            let verbatimNode = Self.sourceNode(for: id, file: summary, contentData: verbatimContentData)
+```
+`maps` is already built once per call earlier in this function (the existing
+`let maps = byName ? makeLinkMaps() : nil` line) — reuse it, do not call
+`makeLinkMaps()` again per row. Note: `maps` is `LinkMaps?` there; adjust
+`rewrittenVerbatimSourceContent`'s call to unwrap it, or restructure so the
+`byName ? ... : nil` ternary short-circuits before touching `maps!`.
+
+**Verify:** `swift build` clean.
+
+---
+
+## Task 4 — do NOT serve rewritten content bytes without a matching size, and vice versa
+
+Read back Tasks 3c/3d/3e once written and confirm by inspection: every place
+that builds a `ProjectedNode` with `size: contentData?.count ?? file.byteSize`
+for a `sourceByNamePrefix` id has a `contentForLeaf`/enumeration counterpart
+that serves EXACTLY that same `contentData` (not a fresh, potentially
+different, rewrite). This is the same invariant class as PR #352 — the
+`rewrittenVerbatimSourceContent` helper is deliberately the single
+computation point (called from both node and content paths) to guarantee this
+by construction, same as `rewriteLinks`/`byTitleContent` do for pages.
+
+---
+
+## Task 5 — tests
+
+Add to `Tests/WikiFSTests/` — a new file `SourceImageRewriterTests.swift` for
+the pure unit tests, plus cases in `ProjectionTreeTests.swift` for the
+end-to-end integration.
+
+### 5a. `SourceImageRewriterTests.swift` (pure, no store)
+
+- Relative src matching the resolver → rewritten to the resolved relative path.
+- `http(s)://`, `data:`, `wiki:`, `wiki-blob:` srcs left verbatim (resolver
+  never consulted — assert via a resolver that would fatal/flag if called, or
+  simply assert the output is byte-identical to input for these cases).
+- Unresolved relative src (not in the resolver's map) left verbatim.
+- Image inside a code span / fenced block left verbatim.
+- Multiple images in one document each resolve independently.
+- `alt` text is preserved verbatim in the output.
+- A resolver whose target lives in the SAME baseDir yields a bare sibling
+  filename (no `../`) — reuses `RelativeLinkRewriter.relativePath`, so a
+  single sanity-check test here is enough (that function already has its own
+  unit tests).
+
+### 5b. `ProjectionTreeTests.swift` integration case
+
+Seed a source via `store.addSource(filename:..., data:..., mimeType: "text/markdown")`
+whose body is `Data("![alt](assets/pic.png)".utf8)`, seed a SECOND source via
+`store.addSnapshotImage(filename: "pic.png", data: <bytes>, mimeType: "image/png",
+originalPath: "assets/pic.png", sourceURL: URL(string: "https://example.com/pic.png")!,
+activityID: <the SAME activityID>, role: .media)`. Getting a real, valid
+`activityID` requires `store.ensureFetchActivity(provenance:)` — check its
+signature and `SourceProvenance`'s fields first (search
+`Sources/WikiFSCore/SQLiteWikiStore.swift` for `ensureFetchActivity` and
+`Sources/WikiFSCore/*.swift` for `struct SourceProvenance`) and construct a
+minimal fake provenance; mirror any existing test in
+`Tests/WikiFSTests/SQLiteWikiStoreTests.swift` that already calls
+`addSnapshotImage` or `ensureFetchActivity` for the exact call shape, if one
+exists (grep first — don't guess the argument list).
+
+Then assert, via `Projection.Identity.sourceByName(sourceID)`:
+- `node.size == contents(for: id)!.count` (byte-identity).
+- The served content contains `![alt](pic--<shortID>.png)` or whatever the
+  actual resolved by-name filename is — assert with the real
+  `FilenameEscaping.byNameSourceFilename(...)` computed value, not a literal
+  guess.
+- A control case: a text source with NO image siblings serves byte-identical,
+  unmodified content and `size == file.byteSize` (regression guard — the vast
+  majority of sources must be completely unaffected by this change).
+
+**Verify:** `swift test --filter "SourceImageRewriterTests|ProjectionTreeTests"`
+all green.
+
+---
+
+## Out of scope / notes
+- The `.md`-processed-sibling path (`sourceMarkdownByNamePrefix`) is
+  deliberately untouched — `siblingImageResolvers()` has no entries for that
+  case today (only `WikiStoreModel.storeSnapshot`'s verbatim markdown-native
+  page calls `addSnapshotImage`). If a future extraction pipeline starts
+  producing sibling images for a processed `.md` head, wiring
+  `rewrittenVerbatimSourceContent`'s pattern into `sourceMarkdownNode`/
+  `processedMarkdownHead` would be a natural, small follow-up — do not do it
+  speculatively here.
+- `sources/by-id` is untouched (matches the by-title/by-name-only precedent
+  from #216).
+- Pages and chats are untouched — `siblingImageResolvers()` is keyed by
+  SOURCE id only; nothing in the pages/chats schema produces this kind of
+  `original_path` sibling relationship.
+- After landing, verify live with `make reload` (added in the prior commit),
+  the same deployment step used to verify #216 — a code-only rendering change
+  is invisible to already-materialized files until the domain resets.


### PR DESCRIPTION
## Summary

Closes #216. Rewrites `[[wikilinks]]` in the FileProvider filesystem projection to standard relative Markdown links (`[Title](relative/path.md)`) so external tools like Obsidian and VS Code can follow them when pointed at the mount.

Covers all four linkable views:
- **`pages/by-title/`** — page↔page links stay siblings
- **`sources/by-name/`** — the readable `.md` sibling (LLM-extracted markdown) rewrites; the verbatim source file (PDF, audio, etc.) does not
- **`chats/by-name/`** — chat transcripts rewrite
- **`bookmarks/`** — `pageRef`/`chatRef` leaves rewrite with a per-node relative path derived from folder nesting depth; `sourceRef` stays verbatim binary

Both name-based (`[[Title]]`) and canonical ULID-form (`[[page:<ULID>|alias]]`, the Phase 5 storage format) links resolve. Unresolvable/deleted-target links are left as `[[wikilink]]` (Obsidian's native "new page" stub behavior). Non-page-file link kinds inside a rewritten document (e.g. a source's `#"quote"` cite fragment) are handled without emitting dead anchors.

## Design notes

- **`by-id/` views are unchanged** — only `by-title`/`by-name` (human-readable) views rewrite, since only those have stable sibling filenames worth linking between.
- **Size/content byte-identity invariant preserved.** The FileProvider reports `documentSize` from one code path and serves bytes from another; every rewritten view computes the SAME `Data` for both, or `cat` truncates the file. This is enforced by construction (`rewriteLinks(...)` is the single source of truth per view) and covered by integration tests asserting `node.size == bytes.count`.
- **Cross-namespace relative paths assume Obsidian's vault root is the mount root** (not `pages/by-title/`) — a page→source or page→chat link needs to climb out via `../..`.

## Deployment note: `make reload`

`fileproviderd` caches a materialized file's bytes keyed by the **data** version the extension reports (`page.version` / `chat.updatedAt` / the whole-DB change token), not by the extension's own code version. Since this PR only changes *rendering*, not underlying page/source/chat data, a plain rebuild — even a from-scratch `rm -rf` + reinstall — does not refresh already-materialized files on disk; the daemon sees an unchanged reported version and never calls back into the extension.

Added `make reload`: kills the running app + extension, then relaunches with the existing `WIKIFS_REENUMERATE=1` one-shot hatch (`FileProviderSpike.swift`) via `open --env`, which tears down and re-adds every wiki's File Provider domain, forcing a full re-fetch. Verified end-to-end against a real vault — a previously-stale by-title page now serves rewritten relative links after `make reload`.

This is a one-shot manual dev hatch, not the default `run`/`install` behavior (a full domain reset re-downloads everything, so it shouldn't run on every routine launch). Whether this rendering-contract change also warrants bumping `FileProviderSpike.currentSchemaVersion` — which resets every *user's* domain automatically on next launch — is a separate call; `reload` doc-comments that tradeoff for whoever makes it.

## Test plan

- [x] Unit tests for `RelativeLinkRewriter` — name/ULID resolution, `#`-in-title disambiguation, fragment/anchor handling, non-page-kind passthrough, code-span protection, percent-encoding
- [x] Integration tests exercising a live `SQLiteWikiStore` + `Projection`, asserting rewritten output and size==bytes for by-title pages and root/nested bookmark refs
- [x] `swift build` clean; 316+ tests green across the link/projection test suites
- [x] Manual verification against a real mounted vault (`make reload` → previously-stale page now shows rewritten `[Geoffrey Litt](Geoffrey%20Litt--01KX149Q.md)` and cross-namespace `[AI as teleportation](../../sources/by-name/AI%20as%20teleportation--01KX13AQ.md)` links, both resolving to real files on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-on: relative image srcs in source-markdown files

While verifying #216 live, found that source-markdown files (from website-snapshot ingestion) reference images with relative paths like `potluck/diagram.png` — these never resolve, because the FileProvider projection places all sources flat under `sources/by-name/` (no nested folders). **This is unrelated to `[[wikilinks]]`** — `RelativeLinkRewriter` only touches `[[...]]`/`![[...]]` syntax, never plain `![alt](src)` CommonMark images — so this bug predates this PR entirely.

The in-app WKWebView reader already solves this correctly (`SQLiteWikiStore.siblingImageResolvers()` + `MarkdownHTMLRenderer`'s exact-string src resolution). Added `SourceImageRewriter` mirroring that same filtering/resolution logic as a regex pass (swift-markdown is an app-target-only dependency, not linked into `WikiFSCore`/`WikiFSFileProvider`), so the FileProvider projection now serves the same resolved images the app already renders correctly in-app.

Scoped strictly to verbatim `sources/by-name` text files (markdown-native snapshot pages) — the `.md`-processed-sibling path has no populated sibling-image data today and is untouched. Extends the size/content byte-identity invariant to `sourceNode`, which previously reported the stored `byteSize` column unconditionally; sources with no image siblings (the vast majority) are completely unaffected by construction.

Verified live: `sources/by-name/Potluck- Dynamic documents as personal software--01KX139J.md` had 22 broken `![](potluck/...)` image refs; after this fix, all 22 rewrite to their real sibling filenames (e.g. `![](micro-syntax-1--01KX139J.png)`), zero `potluck/` references remain, and every resolved target file genuinely exists on disk.
