### PR TITLE
Fix #348: allow multiple new chat tabs — skip reuse for .newChat

### DIFF
--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -720,7 +720,8 @@ public final class WikiStoreModel {
     /// a copy.
     public func openTab(_ selection: WikiSelection, title: String? = nil) {
         clickStartedAt = DispatchTime.now()
-        if let existing = tabs.first(where: { $0.selection == selection }) {
+        // Don't reuse draft-state tabs (.newChat) — multiple drafts are valid (#348).
+        if selection != .newChat, let existing = tabs.first(where: { $0.selection == selection }) {
             DebugLog.store("[tabs] openTab: focus existing tab for \(selection) (id=\(existing.id))")
             setActiveTab(existing.id)
             return
@@ -744,7 +745,8 @@ public final class WikiStoreModel {
             openTab(selection, title: title)
             return
         }
-        guard !tabs.contains(where: { $0.selection == selection }) else { return }
+        // Don't dedup draft-state tabs (.newChat) — multiple drafts are valid (#348).
+        if selection != .newChat, tabs.contains(where: { $0.selection == selection }) { return }
         let tab = EditorTab(selection: selection, title: title ?? tabTitle(for: selection))
         tabs.append(tab)
         DebugLog.store("[tabs] openTabInBackground: new background tab for \(selection) (id=\(tab.id)), \(tabs.count) tabs total")
@@ -764,7 +766,9 @@ public final class WikiStoreModel {
         // If another tab already displays this selection, reuse it (focus, don't
         // duplicate) — mirrors openTab's dedup. This handles e.g. re-clicking a
         // chat that's already open in another tab.
-        if let existing = tabs.first(where: { $0.selection == selection }), existing.id != id {
+        // Exception: .newChat is a draft state, not a unique resource — don't
+        // reuse an existing draft tab when retargeting to .newChat (#348).
+        if selection != .newChat, let existing = tabs.first(where: { $0.selection == selection }), existing.id != id {
             selectTab(id: existing.id)
             return
         }

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -106,19 +106,19 @@ struct EditorTabTests {
         #expect(model.selection == .page(a.id))
     }
 
-    // MARK: - Singleton chat tab
+    // MARK: - Draft-state (.newChat) tabs
 
-    /// The headline AC: `.newChat` is a singleton key — opening it twice reuses
-    /// the same tab rather than spawning a duplicate. (The old dual `.ask`/
-    /// `.edit` chat-mode coexistence test is gone — there is now one chat
-    @Test func newChatTabIsSingleton() throws {
+    /// `.newChat` is a draft state, not a unique resource — opening it twice
+    /// creates two draft tabs, not a duplicate of a singleton (#348).
+    @Test func newChatAllowsMultipleDraftTabs() throws {
         let (model, _) = try tempModel()
         model.openTab(.newChat)
         #expect(model.tabs.count == 1)
         #expect(model.tabs.contains { $0.selection == .newChat })
-        // Opening again reuses the existing tab (no duplicate).
+        // Opening again creates a second draft tab.
         model.openTab(.newChat)
-        #expect(model.tabs.count == 1)
+        #expect(model.tabs.count == 2)
+        #expect(model.tabs.filter { $0.selection == .newChat }.count == 2)
     }
 
     // MARK: - Singleton reuse
@@ -132,12 +132,10 @@ struct EditorTabTests {
         model.handleSelectionChange(to: .page(a.id))
         model.openTab(.newChat)
         #expect(model.tabs.count == 2)
-        let askTabID = model.tabs[1].id
 
-        // Opening ask again should focus the existing ask tab.
+        // Opening .newChat again creates a second draft tab (#348).
         model.openTab(.newChat)
-        #expect(model.tabs.count == 2)  // No duplicate
-        #expect(model.activeTabID == askTabID)  // Ask tab is active
+        #expect(model.tabs.count == 3)
     }
 
     @Test func singletonSystemPromptReusesExistingTab() throws {
@@ -154,6 +152,31 @@ struct EditorTabTests {
         #expect(model.tabs.count == 1)
         model.openTab(.changeLog)
         #expect(model.tabs.count == 1)
+    }
+
+    // MARK: - retargetTab
+
+    /// Retargeting a tab to `.newChat` should not reuse an existing draft tab
+    /// — each `.newChat` is a separate draft state (#348).
+    @Test func retargetTabToNewChatDoesNotReuseExistingDraft() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+
+        // Open a page tab and a .newChat draft tab.
+        model.openTab(.page(a.id))
+        model.openTab(.newChat)
+        #expect(model.tabs.count == 2)
+
+        let pageTabID = model.tabs[0].id
+        // Retarget the page tab to .newChat — should NOT reuse/focus the existing
+        // draft tab, but instead retarget in place.
+        model.retargetTab(id: pageTabID, to: .newChat)
+        #expect(model.tabs.count == 2) // No tab removed
+        #expect(model.tabs[0].selection == .newChat) // Retargeted in place
+        // The active tab (the .newChat draft, tab 1) is unchanged — retarget
+        // didn't hijack focus to the retargeted tab.
+        #expect(model.tabs[1].selection == .newChat)
     }
 
     // MARK: - selectTab


### PR DESCRIPTION
## Summary

Fixes #348 — when a `.newChat` tab was already open, clicking the "+" button in the Chats sidebar focused the existing draft tab instead of creating a new one. Only one new chat tab could exist at a time.

## Root cause

`WikiStoreModel.openTab(_:)` has tab-reuse logic that deduplicates by selection. This is correct for real resources (pages, sources, chats), but `.newChat` is a draft state, not a unique resource — multiple drafts are valid and each becomes a unique `.chat(id)` on first send via `retargetTab`.

## Changes

- **`openTab`**: Added `selection != .newChat` guard before the dedup check, so multiple `.newChat` draft tabs can coexist.
- **`openTabInBackground`**: Same guard — don't dedup `.newChat` tabs.
- **`retargetTab`**: Same guard — retargeting a tab to `.newChat` should not reuse/focus an existing draft tab (retarget in place instead).
- **Updated tests**: Two tests that asserted singleton reuse of `.newChat` have been updated to reflect the new (correct) behavior — `newChatTabIsSingleton` → `newChatAllowsMultipleDraftTabs`, and `singletonSelectionReusesExistingTab` now expects 3 tabs (page + 2 drafts).
- **New test**: `retargetTabToNewChatDoesNotReuseExistingDraft` — a page tab retargeted to `.newChat` stays in place (doesn't hijack the existing draft tab).

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter EditorTabTests` — 52 tests pass (2 updated, 1 new)
- [x] `swift test` fast tier (2188 tests) — all pass
- [ ] CI green

Closes #348.
