### PR TITLE
Fix #349: rename chats from detail view and wikictl

### DIFF
--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -126,6 +126,8 @@ public enum ArgumentParser {
       chat list [--json]                     list chats (TSV, or JSON lines)
       chat get  (--id X | --title T)         print a chat transcript as markdown
       chat search --query X [--limit N]      semantic + keyword search of chats
+      chat rename (--id X | --title T) --to <new-title>
+                                               rename a chat
       workspace create [--name N]              create a workspace (prints ID)
       workspace status --id W                  show workspace status + pages
       workspace abandon --id W                abandon a workspace (GC refs)
@@ -392,6 +394,13 @@ public enum ArgumentParser {
                 limit = 10
             }
             return .chat(.search(query: query, limit: limit))
+
+        case "rename":
+            let selector = try options.requireChatSelector()
+            guard let newName = options.value("--to"), !newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw Failure.usage("chat rename: --to <new-title> is required")
+            }
+            return .chat(.rename(selector, to: newName))
 
         default:
             throw Failure.usage("chat: unknown subcommand \(sub.debugDescription)")

--- a/Sources/WikiCtlCore/ChatCommand.swift
+++ b/Sources/WikiCtlCore/ChatCommand.swift
@@ -7,12 +7,13 @@ import WikiFSCore
 /// unit-testable against a temp DB.
 ///
 /// Read-only: `list` prints all chats (TSV or JSON), `get` prints one chat's
-/// transcript as rendered markdown (via `ChatTranscriptRenderer`). No write
-/// subcommands — chats are created/appended by the app's chat layer.
+/// transcript as rendered markdown (via `ChatTranscriptRenderer`). `rename`
+/// updates a chat's title. No other write subcommands — chats are
+/// created/appended by the app's chat layer.
 public enum ChatCommand {
 
     /// What a command produced: text to print and whether it COMMITTED a write.
-    /// Chat commands are always reads, so `didCommit` is always false.
+    /// Read commands have `didCommit = false`; `rename` commits.
     public struct Result: Equatable {
         public var output: String
         public var didCommit: Bool
@@ -33,6 +34,7 @@ public enum ChatCommand {
         case list(json: Bool)
         case get(Selector)
         case search(query: String, limit: Int)
+        case rename(Selector, to: String)
     }
 
     public enum Failure: Error, CustomStringConvertible {
@@ -45,7 +47,7 @@ public enum ChatCommand {
         }
     }
 
-    /// Run one action against `store`. All actions are pure reads.
+    /// Run one action against `store`. Reads never commit; `rename` does.
     public static func run(_ action: Action, in store: WikiStore) throws -> Result {
         switch action {
         case .list(let json):
@@ -54,6 +56,8 @@ public enum ChatCommand {
             return try get(selector, in: store)
         case .search(let query, let limit):
             return try search(query: query, limit: limit, in: store)
+        case .rename(let selector, let newTitle):
+            return try rename(selector, to: newTitle, in: store)
         }
     }
 
@@ -109,6 +113,17 @@ public enum ChatCommand {
             return "\(chat.id.rawValue)\t\(title)\t\(chat.kind.rawValue)\t\(chat.messageCount)"
         }.joined(separator: "\n")
         return Result(output: output, didCommit: false)
+    }
+
+    // MARK: - rename
+
+    /// Rename a chat's title and rebuild the `chat_search` FTS sidecar.
+    /// Commits — the caller posts the Darwin notification on `didCommit`.
+    /// Mirrors `SourceCommand.rename`.
+    private static func rename(_ selector: Selector, to newTitle: String, in store: WikiStore) throws -> Result {
+        let id = try resolve(selector, in: store)
+        try store.renameChat(id: id, to: newTitle)
+        return Result(output: "Renamed chat to \"\(newTitle)\".", didCommit: true)
     }
 
     // MARK: - Selector resolution

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -366,11 +366,15 @@ struct ChatView: View {
     private func header(for chat: ChatSummary) -> some View {
         VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
             Label {
-                Text(chat.title)
-                    .font(.largeTitle)
-                    .bold()
-                    .lineLimit(1)
-                    .textSelection(.enabled)
+                EditableTitle(
+                    title: chat.title,
+                    placeholder: "Untitled Chat",
+                    lineLimit: 1,
+                    isDisabled: false,
+                    onCommit: { newTitle in
+                        store.renameChat(id: chat.id, to: newTitle)
+                    }
+                )
             } icon: {
                 Image(systemName: "bubble.left.and.bubble.right")
                     .foregroundStyle(.secondary)

--- a/Tests/WikiFSTests/ChatSearchTests.swift
+++ b/Tests/WikiFSTests/ChatSearchTests.swift
@@ -192,4 +192,68 @@ import SQLite3
         #expect(query == "hello")
         #expect(limit == 3)
     }
+
+    // MARK: - wikictl `chat rename`
+
+    @Test func chatRenameByIdCommitsAndUpdatesTitle() throws {
+        let store = try tempStore()
+        let chat = try store.createChat(kind: .edit, title: "Old Title")
+        let result = try ChatCommand.run(
+            .rename(.id(chat.id), to: "New Title"), in: store
+        )
+        #expect(result.didCommit == true)
+        #expect(result.output.contains("New Title"))
+        // Store-level verify: the title actually changed.
+        let chats = try store.listAllChatsOrderedByID()
+        #expect(chats.first(where: { $0.id == chat.id })?.title == "New Title")
+    }
+
+    @Test func chatRenameByTitleResolvesAndRenames() throws {
+        let store = try tempStore()
+        _ = try store.createChat(kind: .edit, title: "Original Title")
+        let result = try ChatCommand.run(
+            .rename(.title("Original Title"), to: "Renamed"), in: store
+        )
+        #expect(result.didCommit == true)
+        let chats = try store.listAllChatsOrderedByID()
+        #expect(chats.first?.title == "Renamed")
+    }
+
+    @Test func parseChatRenameRequiresTo() throws {
+        #expect(throws: ArgumentParser.Failure.self) {
+            _ = try ArgumentParser.parse([
+                "--wiki", "W", "chat", "rename", "--id", "abc",
+            ], env: noEnv)
+        }
+    }
+
+    @Test func parseChatRenameByIdProducesCorrectAction() throws {
+        let inv = try ArgumentParser.parse([
+            "--wiki", "W", "chat", "rename", "--id", "abc123", "--to", "New Name",
+        ], env: noEnv)
+        guard case .chat(let action) = inv.command,
+              case .rename(let selector, let newTitle) = action else {
+            Issue.record("expected .chat(.rename)"); return
+        }
+        guard case .id(let id) = selector else {
+            Issue.record("expected .id selector"); return
+        }
+        #expect(id.rawValue == "abc123")
+        #expect(newTitle == "New Name")
+    }
+
+    @Test func parseChatRenameByTitleProducesCorrectAction() throws {
+        let inv = try ArgumentParser.parse([
+            "--wiki", "W", "chat", "rename", "--title", "Old", "--to", "New",
+        ], env: noEnv)
+        guard case .chat(let action) = inv.command,
+              case .rename(let selector, let newTitle) = action else {
+            Issue.record("expected .chat(.rename)"); return
+        }
+        guard case .title(let title) = selector else {
+            Issue.record("expected .title selector"); return
+        }
+        #expect(title == "Old")
+        #expect(newTitle == "New")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #349 — chat titles were only editable via the sidebar context menu in `AgentToolsView`. This adds inline rename to the `ChatView` header and a `wikictl chat rename` subcommand.

## Changes

### 1. ChatView header — editable title
- Replaced the static `Text(chat.title)` with `EditableTitle` (the same reusable component used by `PageDetailView` and `SourceDetailView`).
- Double-click or right-click → Rename toggles an inline `TextField`. Return commits, Escape cancels, click-away commits.
- On commit, calls `store.renameChat(id: chat.id, to:)` — the store already emits `ResourceChangeEvent` (so the UI refreshes through normal change-signaling) and rebuilds the `chat_search` FTS sidecar.

### 2. Sidebar / outline surfaces — audit
- `AgentToolsView` (the ONLY chat-listing surface in the sidebar, used by `SidebarView` for the `.chats` section) already has a "Rename Chat…" context menu with an alert-driven `TextField`. No changes needed.

### 3. wikictl `chat rename`
- Added `case rename(Selector, to: String)` to `ChatCommand.Action`.
- Added `rename(_:to:in:)` private method that resolves the selector, calls `store.renameChat(id:to:)`, and returns a committed result (`didCommit: true`).
- Added `"rename"` case to the argument parser: `chat rename (--id X | --title T) --to <new-title>`, mirroring the existing `source rename` pattern.
- Updated usage text.

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter ChatSearchTests` — 18 tests pass (5 new: rename by id, rename by title, parse missing --to, parse by id, parse by title)
- [x] `swift test` fast tier (2192 tests) — all pass
- [ ] CI green

## Acceptance criteria checklist

- [x] Double-click on the chat title in `ChatView` header lets the user rename it inline
- [x] All outline/sidebar surfaces that list chats expose a "Rename Chat…" action (already done in `AgentToolsView`)
- [x] `wikictl chat rename (--id X | --title T) --to <new-title>` renames a chat and prints confirmation
- [x] Rename refreshes the UI via the existing `ResourceChangeEvent` path (no manual reload)
- [x] FTS index (`chat_search`) is updated (already handled by `renameChat`, verified by existing `searchReflectsRename` test)

Closes #349.
