### PR TITLE
Fix #240: add bookmarks substring search with ancestor expansion

### DIFF
--- a/Sources/WikiFS/BookmarksContainerView.swift
+++ b/Sources/WikiFS/BookmarksContainerView.swift
@@ -12,18 +12,28 @@ struct BookmarksContainerView: View {
     var onEdit: (String) -> Void
     var onNewFolder: () -> Void
 
+    @State private var searchText: String = ""
+
     var body: some View {
         VStack(spacing: 0) {
             // Section header: title on the left, compact action buttons on the
             // right — the native macOS pattern (Finder, Notes, Mail).
             bookmarksHeader
 
+            // Search field: substring filter over bookmark labels and resolved
+            // page/source/chat titles (issue #240).
+            if !store.bookmarkNodes.isEmpty {
+                bookmarksSearchBar
+                Divider()
+            }
+
             Divider()
 
             // NSOutlineView — instant selection, native macOS performance
             BookmarksOutlineView(
                 store: store,
-                nodes: store.bookmarkNodes,
+                nodes: filteredNodes,
+                forceExpandAll: !searchText.isEmpty,
                 fileProvider: fileProvider,
                 onOpen: { selections in
                     for sel in selections { store.openTab(sel) }
@@ -85,6 +95,105 @@ struct BookmarksContainerView: View {
         }
         .buttonStyle(.plain)
         .help(help)
+    }
+
+    // MARK: - Search
+
+    private var bookmarksSearchBar: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+            TextField("Search bookmarks…", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.callout)
+                .disableAutocorrection(true)
+            if !searchText.isEmpty {
+                Button { searchText = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .padding(8)
+        .padding(.horizontal, 4)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+
+    /// When search is active, returns only matching nodes plus their ancestor
+    /// folders (so hits inside nested folders are visible). When search is
+    /// empty, returns all nodes unchanged.
+    private var filteredNodes: [BookmarkNode] {
+        let allNodes = store.bookmarkNodes
+        guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return allNodes
+        }
+        return Self.filterNodes(
+            allNodes,
+            query: searchText,
+            resolveTitle: { Self.resolveTitle(for: $0, in: store) }
+        )
+    }
+
+    /// Resolves the display title for a bookmark node: folder label, or for
+    /// refs, the title/name of the target page/source/chat.
+    static func resolveTitle(for node: BookmarkNode, in store: WikiStoreModel) -> String {
+        switch node.kind {
+        case .folder:
+            return node.label ?? ""
+        case .pageRef:
+            return node.targetID.flatMap { id in
+                store.summaries.first { $0.id == id }?.title
+            } ?? ""
+        case .sourceRef:
+            return node.targetID.flatMap { id in
+                store.sources.first { $0.id == id }?.effectiveName
+            } ?? ""
+        case .chatRef:
+            return node.targetID.flatMap { id in
+                store.chats.first { $0.id == id }?.title
+            } ?? ""
+        }
+    }
+
+    /// Pure filtering logic: returns nodes whose resolved title matches `query`
+    /// (case-insensitive substring), plus all ancestor folders so nested hits
+    /// are visible. Extracted so the rule is unit-testable without a live store.
+    nonisolated static func filterNodes(
+        _ nodes: [BookmarkNode],
+        query: String,
+        resolveTitle: (BookmarkNode) -> String
+    ) -> [BookmarkNode] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else { return nodes }
+
+        let byID = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0) })
+
+        // Collect ids of nodes that match the query.
+        var matchingIDs = Set<String>()
+        for node in nodes {
+            let title = resolveTitle(node)
+            if title.localizedCaseInsensitiveContains(q) {
+                matchingIDs.insert(node.id)
+            }
+        }
+
+        // Expand to include all ancestors of matching nodes (so a hit inside a
+        // nested folder is visible when the folder would otherwise be collapsed).
+        var visibleIDs = Set<String>()
+        for id in matchingIDs {
+            var current: String? = id
+            while let cid = current, let node = byID[cid] {
+                visibleIDs.insert(cid)
+                current = node.parentID
+            }
+        }
+
+        return nodes.filter { visibleIDs.contains($0.id) }
     }
 }
 

--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -18,6 +18,9 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
     /// the omnibox "+", context menus, etc. update the database but the outline
     /// never refreshes (no SwiftUI state change to force `updateNSViewController`).
     let nodes: [BookmarkNode]
+    /// When true, all folders are force-expanded (used during search so hits
+    /// inside collapsed folders are immediately visible).
+    var forceExpandAll: Bool = false
     let fileProvider: FileProviderSpike
     var onOpen: ([WikiSelection]) -> Void
     var onOpenBackground: ([WikiSelection]) -> Void
@@ -52,7 +55,8 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
             onAddPage: onAddPage, onAddSource: onAddSource,
             onNewFolder: onNewFolder, onNewSubfolder: onNewSubfolder
         )
-        let needs = vc.needsReload(nodes: nodes)
+        let needs = vc.needsReload(nodes: nodes) || vc.forceExpandAll != forceExpandAll
+        vc.forceExpandAll = forceExpandAll
         DebugLog.tabs("BookmarksOutlineView.updateNSVC: nodes=\(nodes.count) needsReload=\(needs)")
         if needs {
             vc.reloadData(from: nodes)
@@ -115,6 +119,9 @@ final class BookmarksOutlineViewController: NSViewController {
     /// Tracks whether the initial expand-all has run. After that, reloads
     /// preserve the user's expand/collapse choices instead of force-expanding.
     private var hasPerformedInitialLoad = false
+
+    /// When true, all folders are force-expanded on reload (search mode).
+    var forceExpandAll = false
 
     override func loadView() {
         scrollView = NSScrollView()
@@ -194,6 +201,13 @@ final class BookmarksOutlineViewController: NSViewController {
                 outlineView.expandItem(node)
             }
             hasPerformedInitialLoad = true
+        } else if forceExpandAll {
+            // Search mode: force-expand all folders so hits inside collapsed
+            // folders are immediately visible.
+            outlineView.reloadData()
+            for node in nodes where node.kind == .folder {
+                outlineView.expandItem(node)
+            }
         } else {
             // Subsequent reloads: snapshot expanded state, reload, restore.
             let expandedIDs = Set(

--- a/Tests/WikiFSTests/BookmarksSearchTests.swift
+++ b/Tests/WikiFSTests/BookmarksSearchTests.swift
@@ -1,0 +1,130 @@
+import Testing
+@testable import WikiFS
+import WikiFSCore
+
+/// Tests for `BookmarksContainerView.filterNodes` — the pure substring search
+/// over bookmark nodes (folder labels + resolved ref titles), with ancestor
+/// expansion so hits inside nested folders are visible (#240).
+@Suite struct BookmarksSearchTests {
+
+    // MARK: - Helpers
+
+    private func folder(_ id: String, parent: String? = nil, label: String) -> BookmarkNode {
+        BookmarkNode(id: id, parentID: parent, position: 0, kind: .folder,
+                     label: label, targetID: nil)
+    }
+
+    private func pageRef(_ id: String, parent: String?, target: String) -> BookmarkNode {
+        BookmarkNode(id: id, parentID: parent, position: 0, kind: .pageRef,
+                     label: nil, targetID: PageID(rawValue: target))
+    }
+
+    private func sourceRef(_ id: String, parent: String?, target: String) -> BookmarkNode {
+        BookmarkNode(id: id, parentID: parent, position: 0, kind: .sourceRef,
+                     label: nil, targetID: PageID(rawValue: target))
+    }
+
+    /// A trivial title resolver: maps node.targetID?.rawValue to the title,
+    /// or node.label for folders.
+    private static func resolver(_ node: BookmarkNode) -> String {
+        switch node.kind {
+        case .folder: return node.label ?? ""
+        default: return node.targetID?.rawValue ?? ""
+        }
+    }
+
+    // MARK: - Empty / no-match
+
+    @Test func emptyQueryReturnsAllNodes() {
+        let nodes = [
+            folder("a", label: "Alpha"),
+            folder("b", label: "Beta"),
+        ]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "", resolveTitle: Self.resolver)
+        #expect(result.count == 2)
+    }
+
+    @Test func whitespaceQueryReturnsAllNodes() {
+        let nodes = [folder("a", label: "Alpha")]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "   ", resolveTitle: Self.resolver)
+        #expect(result.count == 1)
+    }
+
+    @Test func noMatchReturnsEmpty() {
+        let nodes = [folder("a", label: "Alpha")]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "xyz", resolveTitle: Self.resolver)
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Folder label matching
+
+    @Test func matchesFolderLabelCaseInsensitive() {
+        let nodes = [folder("a", label: "Reading List")]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "reading", resolveTitle: Self.resolver)
+        #expect(result.count == 1)
+        #expect(result[0].id == "a")
+    }
+
+    // MARK: - Ref title matching
+
+    @Test func matchesPageRefTitle() {
+        let nodes = [
+            folder("f", label: "Folder"),
+            pageRef("p", parent: "f", target: "Mars Terraforming Guide"),
+        ]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "mars", resolveTitle: Self.resolver)
+        // Match + ancestor folder
+        #expect(result.count == 2)
+        #expect(result.contains { $0.id == "p" })
+        #expect(result.contains { $0.id == "f" })
+    }
+
+    @Test func matchesSourceRefTitle() {
+        let nodes = [
+            sourceRef("s", parent: nil, target: "NASA Report.pdf"),
+        ]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "nasa", resolveTitle: Self.resolver)
+        #expect(result.count == 1)
+        #expect(result[0].id == "s")
+    }
+
+    // MARK: - Ancestor expansion
+
+    @Test func deeplyNestedMatchIncludesEntireAncestorChain() {
+        let nodes = [
+            folder("root", label: "Root"),
+            folder("mid", parent: "root", label: "Mid"),
+            folder("leaf", parent: "mid", label: "Leaf"),
+            pageRef("p", parent: "leaf", target: "Hidden Gem"),
+        ]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "hidden", resolveTitle: Self.resolver)
+        // Matching node + 3 ancestor folders
+        #expect(result.count == 4)
+        #expect(Set(result.map(\.id)) == Set(["p", "leaf", "mid", "root"]))
+    }
+
+    @Test func nonMatchingSiblingIsExcluded() {
+        let nodes = [
+            folder("f", label: "Folder"),
+            pageRef("p1", parent: "f", target: "Mars Guide"),
+            pageRef("p2", parent: "f", target: "Venus Guide"),
+        ]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "mars", resolveTitle: Self.resolver)
+        // Folder + matching page, but NOT the non-matching sibling
+        #expect(result.count == 2)
+        #expect(Set(result.map(\.id)) == Set(["f", "p1"]))
+    }
+
+    // MARK: - Multiple matches
+
+    @Test func multipleMatchesAllIncluded() {
+        let nodes = [
+            folder("f1", label: "Mars Research"),
+            folder("f2", label: "Venus Research"),
+            folder("f3", label: "Mercury Notes"),
+        ]
+        let result = BookmarksContainerView.filterNodes(nodes, query: "research", resolveTitle: Self.resolver)
+        #expect(result.count == 2)
+        #expect(Set(result.map(\.id)) == Set(["f1", "f2"]))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #240 — bookmarks had no search or filter UI. This adds a substring search field to the Bookmarks panel header that filters by folder label and resolved page/source/chat ref titles, with ancestor folder expansion so hits inside nested folders are visible.

## Changes

- **Search field in `BookmarksContainerView`**: a magnifying-glass text field below the header action buttons, shown only when bookmarks exist. Typing filters the tree in real time; a clear button appears when text is present.
- **`filterNodes` logic**: case-insensitive substring match over folder labels and resolved ref titles (page title via `store.summaries`, source name via `store.sources.effectiveName`, chat title via `store.chats`). Matching nodes include all ancestor folders so nested hits are visible. Non-matching siblings are excluded.
- **`forceExpandAll` on `BookmarksOutlineView`**: when search is active, all folders are force-expanded so matched children inside collapsed folders are immediately visible. A new `forceExpandAll` parameter flows through to `reloadData`, which bypasses the normal expand-state preservation.
- **`nonisolated static func filterNodes`**: the filtering logic is extracted as a pure function taking a title-resolving closure, so it's unit-testable without a live `WikiStoreModel`.

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter BookmarksSearchTests` — 9 new tests pass
- [x] `swift test` fast tier (2196 tests) — all pass
- [ ] CI green

### Tests cover:
- Empty / whitespace query returns all nodes
- No match returns empty
- Folder label match (case-insensitive)
- Page ref title match + ancestor folder included
- Source ref title match
- Deeply nested match includes entire ancestor chain (3 levels)
- Non-matching sibling is excluded
- Multiple matches all included

Closes #240.
