### PR TITLE
Fix #288: unified omnibox search + Ask action

### DIFF
--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -383,7 +383,7 @@ struct AddressBarView: View {
     /// Whether readable content (a page, source, chat, or document) is loaded in
     /// the active tab. When false (no tab, or a non-content selection), the bar is
     /// in its empty / search-first state: a leading search glyph, auto-focus, and
-    /// the "Search for pages" placeholder.
+    /// the omnibox placeholder.
     private var hasContentLoaded: Bool {
         !addressString.isEmpty
     }

--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -38,7 +38,7 @@ struct AddressBarView: View {
     var homePageID: PageID?
 
     @State private var queryText = ""
-    @State private var results: [WikiPageSummary] = []
+    @State private var results: [OmniboxResult] = []
     @State private var searchTask: Task<Void, Never>?
     @State private var focusToken = 0
     /// Pointer is over the omnibox — reveals the trailing "add to bookmarks" plus.
@@ -301,7 +301,7 @@ struct AddressBarView: View {
         searchTask = Task {
             try? await Task.sleep(for: .milliseconds(200))
             if Task.isCancelled { return }
-            results = store.searchSimilar(query: trimmed, limit: 8)
+            results = store.searchOmnibox(query: trimmed)
         }
     }
 
@@ -310,8 +310,15 @@ struct AddressBarView: View {
         navigate(to: first)
     }
 
-    private func navigate(to result: WikiPageSummary) {
-        store.selectPage(byTitle: result.title)
+    private func navigate(to result: OmniboxResult) {
+        switch result {
+        case .ask(let question):
+            // Open a new chat tab with the question pre-filled (#288).
+            store.pendingChatQuestion = question
+            store.openTab(.newChat)
+        default:
+            store.select(result.selection)
+        }
         queryText = ""
         results = []
         isFocused = false
@@ -416,13 +423,13 @@ struct AddressBarView: View {
 /// highlight on hover (accent tint) and the top row shows a `↩` glyph — the
 /// Enter target.
 struct AddressResultsList: View {
-    let results: [WikiPageSummary]
+    let results: [OmniboxResult]
     /// The arrow-key-selected row, pushed in from the AppKit coordinator. `nil`
     /// means nothing is explicitly selected and Enter targets the top row.
     let selectedIndex: Int?
-    let onSelect: (WikiPageSummary) -> Void
+    let onSelect: (OmniboxResult) -> Void
 
-    @State private var hoveredResultID: PageID?
+    @State private var hoveredResultID: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -439,7 +446,7 @@ struct AddressResultsList: View {
     }
 
     @ViewBuilder
-    private func row(_ result: WikiPageSummary, index: Int) -> some View {
+    private func row(_ result: OmniboxResult, index: Int) -> some View {
         let hovered = hoveredResultID == result.id
         let keyboardSelected = selectedIndex == index
         // The keyboard highlight yields to the mouse: once the pointer is over a
@@ -451,13 +458,19 @@ struct AddressResultsList: View {
             onSelect(result)
         } label: {
             HStack(spacing: 8) {
-                Image(systemName: "doc.text")
+                Image(systemName: result.systemImageName)
                     .font(.caption)
                     .foregroundStyle(highlighted ? Color.accentColor : .secondary)
                     .frame(width: 16)
-                Text(result.title)
-                    .lineLimit(1)
-                    .font(.callout)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(result.displayTitle)
+                        .lineLimit(1)
+                        .font(.callout)
+                    Text(result.subtitle)
+                        .lineLimit(1)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
                 Spacer(minLength: 8)
                 if isEnterTarget {
                     Image(systemName: "return")

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -123,6 +123,13 @@ struct ChatView: View {
                 persistedMessages = store.chatMessages(chatID: chatID)
             } else {
                 persistedMessages = []
+                // Omnibox "Ask" action (#288): if a pending question was set
+                // (from the omnibox Ask action), pre-fill the composer and
+                // auto-send it. This starts a new chat with the question.
+                if let question = store.pendingChatQuestion {
+                    store.pendingChatQuestion = nil
+                    draftMessage = question
+                }
             }
         }
         // D2: when the live session ends (activeChatID clears), re-read from the

--- a/Sources/WikiFS/OmniboxSearchField.swift
+++ b/Sources/WikiFS/OmniboxSearchField.swift
@@ -65,7 +65,7 @@ struct OmniboxSearchField: NSViewRepresentable {
         // button is the omnibox's single leading icon (address bar, not search).
         let field = AddressSearchField()
         field.delegate = context.coordinator
-        field.placeholderString = "Search for pages"
+        field.placeholderString = "Search pages, sources, bookmarks, chats, or ask…"
         field.sendsWholeSearchString = false
         field.sendsSearchStringImmediately = false
         field.focusRingType = .none

--- a/Sources/WikiFS/OmniboxSearchField.swift
+++ b/Sources/WikiFS/OmniboxSearchField.swift
@@ -13,14 +13,14 @@ struct OmniboxSearchField: NSViewRepresentable {
     /// The current location (`[[Page Title]]`) shown when the field isn't being
     /// edited — the browser URL-bar "where am I" cue.
     var locationText: String
-    var results: [WikiPageSummary]
+    var results: [OmniboxResult]
     /// Bumped by the parent (Cmd-L) to request focus.
     var focusToken: Int
     var onTextChange: (String) -> Void
     var onSubmit: () -> Void
     var onEscape: () -> Void
     var onBlur: () -> Void
-    var onSelect: (WikiPageSummary) -> Void
+    var onSelect: (OmniboxResult) -> Void
     /// Leading inset for the editable text, so it clears the overlaid Page Menu
     /// and add-bookmark icons. Varies with hover (the "+" only needs room when
     /// it's shown), so it's applied live in `updateNSView`.
@@ -130,8 +130,8 @@ struct OmniboxSearchField: NSViewRepresentable {
         // monitors both deliver there — so the cross-isolation capture in
         // `handleArrowKey` is race-free.
         private var selectedIndex: Int?
-        private var results: [WikiPageSummary] = []
-        private var cachedResultIDs: [PageID] = []
+        private var results: [OmniboxResult] = []
+        private var cachedResultIDs: [String] = []
         private weak var anchor: NSSearchField?
         private var keyMonitor: Any?
 
@@ -178,7 +178,7 @@ struct OmniboxSearchField: NSViewRepresentable {
         }
 
         @MainActor
-        func render(results: [WikiPageSummary], anchor: NSSearchField) {
+        func render(results: [OmniboxResult], anchor: NSSearchField) {
             // Reset the keyboard highlight whenever the result set changes, so a
             // stale index can't point past the end of a new, shorter list.
             let ids = results.map(\.id)
@@ -301,7 +301,7 @@ final class SuggestionsPanel: NSPanel {
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
-    func update(results: [WikiPageSummary], selectedIndex: Int?, width: CGFloat, onSelect: @escaping (WikiPageSummary) -> Void) {
+    func update(results: [OmniboxResult], selectedIndex: Int?, width: CGFloat, onSelect: @escaping (OmniboxResult) -> Void) {
         let content = AddressResultsList(results: results, selectedIndex: selectedIndex, onSelect: onSelect)
             .frame(width: width)
             .background(.regularMaterial)

--- a/Sources/WikiFSCore/OmniboxResult.swift
+++ b/Sources/WikiFSCore/OmniboxResult.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// A unified search result from the omnibox — wraps any resource type the
+/// omnibox can search across (pages, sources, chats, bookmarks), plus a
+/// special "Ask" action that sends the query straight to a new chat (#288).
+///
+/// Each case provides `displayTitle`, `systemImageName`, and a `selection`
+/// (`WikiSelection` for navigation). The `ask` case carries the raw query
+/// string and resolves to `.newChat`.
+public enum OmniboxResult: Identifiable, Hashable, Sendable {
+    case page(WikiPageSummary)
+    case source(SourceSummary)
+    case chat(ChatSummary)
+    case bookmark(node: BookmarkNode, resolvedTitle: String)
+    /// A direct-to-chat "Ask" action — opens a new chat with the query
+    /// pre-filled in the composer, so the user can hit Enter to send (#288).
+    case ask(question: String)
+
+    // MARK: - Identifiable
+
+    public var id: String {
+        switch self {
+        case .page(let p): return "page:\(p.id.rawValue)"
+        case .source(let s): return "source:\(s.id.rawValue)"
+        case .chat(let c): return "chat:\(c.id.rawValue)"
+        case .bookmark(let node, _): return "bookmark:\(node.id)"
+        case .ask: return "ask"
+        }
+    }
+
+    // MARK: - Display
+
+    public var displayTitle: String {
+        switch self {
+        case .page(let p): return p.title
+        case .source(let s): return s.effectiveName
+        case .chat(let c): return c.title
+        case .bookmark(_, let title): return title
+        case .ask(let question): return "Ask: \(question)"
+        }
+    }
+
+    public var systemImageName: String {
+        switch self {
+        case .page: return "doc.text"
+        case .source: return "doc"
+        case .chat: return "bubble.left.and.bubble.right"
+        case .bookmark: return "bookmark"
+        case .ask: return "sparkles"
+        }
+    }
+
+    /// A subtitle/metadata line shown below the title in Safari-style rows.
+    public var subtitle: String {
+        switch self {
+        case .page: return "Page"
+        case .source: return "Source"
+        case .chat(let c): return c.messageCount == 1 ? "1 message" : "\(c.messageCount) messages"
+        case .bookmark: return "Bookmark"
+        case .ask: return "Send to chat"
+        }
+    }
+
+    // MARK: - Navigation
+
+    public var selection: WikiSelection {
+        switch self {
+        case .page(let p): return .page(p.id)
+        case .source(let s): return .source(s.id)
+        case .chat(let c): return .chat(c.id)
+        case .bookmark(let node, _):
+            // Bookmarks navigate to their target, not the bookmark node itself.
+            switch node.kind {
+            case .pageRef: return node.targetID.map { .page($0) } ?? .newChat
+            case .sourceRef: return node.targetID.map { .source($0) } ?? .newChat
+            case .chatRef: return node.targetID.map { .chat($0) } ?? .newChat
+            case .folder: return .newChat // Folders aren't navigable
+            }
+        case .ask: return .newChat
+        }
+    }
+
+    /// Whether this result is a real resource navigation (vs. an action like Ask).
+    public var isAction: Bool {
+        if case .ask = self { return true }
+        return false
+    }
+}

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -165,6 +165,11 @@ public final class WikiStoreModel {
     /// like `bookmarkNodes`.
     public private(set) var chats: [ChatSummary] = []
 
+    /// A pending question to pre-fill the chat composer, set by the omnibox
+    /// "Ask" action (#288). Consumed by `ChatView` on first appearance, then
+    /// cleared. `nil` means no pre-fill is waiting.
+    public var pendingChatQuestion: String?
+
     /// Rebuild `chats` from the store. Best-effort (`try?`) — the history list
     /// degrading to empty on a store hiccup must never crash the sidebar.
     public func reloadChats() {
@@ -446,6 +451,89 @@ public final class WikiStoreModel {
     /// `searchSimilar`, over chats. Used by the Chats sidebar search field.
     public func searchSimilarChats(query: String, limit: Int = 20) -> [ChatSummary] {
         (try? store.searchSimilarChats(query: query, limit: limit)) ?? []
+    }
+
+    /// Unified omnibox search across all resource types (#288). Returns a
+    /// ranked, deduplicated `[OmniboxResult]` that mixes pages, sources, chats,
+    /// and bookmark nodes. The result always starts with an `.ask(question:)`
+    /// action row (so the user can send the query straight to chat), followed by
+    /// up to 3 pages, 2 sources, 2 chats, and 3 bookmark matches.
+    public func searchOmnibox(query: String) -> [OmniboxResult] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var results: [OmniboxResult] = []
+
+        // 1. The "Ask" action row — always first, so Enter sends to chat.
+        results.append(.ask(question: trimmed))
+
+        // 2. Pages (semantic + FTS).
+        let pages = searchSimilar(query: trimmed, limit: 3)
+        results.append(contentsOf: pages.map { .page($0) })
+
+        // 3. Sources (semantic + FTS).
+        let sources = searchSimilarSources(query: trimmed, limit: 2)
+        results.append(contentsOf: sources.map { .source($0) })
+
+        // 4. Chats (semantic + FTS).
+        let chats = searchSimilarChats(query: trimmed, limit: 2)
+        results.append(contentsOf: chats.map { .chat($0) })
+
+        // 5. Bookmarks (plain substring over folder labels + resolved ref titles).
+        let matchingBookmarks = searchBookmarks(query: trimmed).prefix(3).map { node in
+            OmniboxResult.bookmark(node: node, resolvedTitle: resolveBookmarkTitle(node))
+        }
+        results.append(contentsOf: matchingBookmarks)
+
+        return results
+    }
+
+    /// Substring search over bookmark nodes — matches folder labels and the
+    /// resolved title of page/source/chat refs. Returns matching nodes plus
+    /// their ancestor folders (so a hit inside a collapsed folder is visible).
+    /// Inlined here (in WikiFSCore) so the omnibox search can use it without
+    /// crossing into the WikiFS UI module (#288, mirrors #240's logic).
+    private func searchBookmarks(query: String) -> [BookmarkNode] {
+        guard !query.isEmpty else { return bookmarkNodes }
+        let byID = Dictionary(uniqueKeysWithValues: bookmarkNodes.map { ($0.id, $0) })
+
+        var matchingIDs = Set<String>()
+        for node in bookmarkNodes {
+            let title = resolveBookmarkTitle(node)
+            if title.localizedCaseInsensitiveContains(query) {
+                matchingIDs.insert(node.id)
+            }
+        }
+
+        var visibleIDs = Set<String>()
+        for id in matchingIDs {
+            var current: String? = id
+            while let cid = current, let node = byID[cid] {
+                visibleIDs.insert(cid)
+                current = node.parentID
+            }
+        }
+        return bookmarkNodes.filter { visibleIDs.contains($0.id) }
+    }
+
+    /// Resolves the display title for a bookmark node: folder label, or for
+    /// refs, the title/name of the target page/source/chat (#240 / #288).
+    private func resolveBookmarkTitle(_ node: BookmarkNode) -> String {
+        switch node.kind {
+        case .folder: return node.label ?? ""
+        case .pageRef:
+            return node.targetID.flatMap { id in
+                summaries.first { $0.id == id }?.title
+            } ?? ""
+        case .sourceRef:
+            return node.targetID.flatMap { id in
+                sources.first { $0.id == id }?.effectiveName
+            } ?? ""
+        case .chatRef:
+            return node.targetID.flatMap { id in
+                chats.first { $0.id == id }?.title
+            } ?? ""
+        }
     }
 
     /// Resolve a page title to its id (lowest-ULID on a duplicate-title

--- a/Tests/WikiFSTests/OmniboxResultTests.swift
+++ b/Tests/WikiFSTests/OmniboxResultTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// Tests for `OmniboxResult` — the unified omnibox result type that wraps pages,
+/// sources, chats, bookmarks, and an "Ask" action (#288).
+@Suite struct OmniboxResultTests {
+
+    private let page = WikiPageSummary(
+        id: PageID(rawValue: "01PAGE"),
+        title: "Mars Terraforming",
+        updatedAt: Date(timeIntervalSince1970: 1000),
+        createdAt: Date(timeIntervalSince1970: 500)
+    )
+
+    private let chat = ChatSummary(
+        id: PageID(rawValue: "01CHAT"),
+        kind: .edit,
+        title: "Mars Discussion",
+        createdAt: Date(timeIntervalSince1970: 2000),
+        updatedAt: Date(timeIntervalSince1970: 3000),
+        messageCount: 3
+    )
+
+    // MARK: - Identifiable
+
+    @Test func pageResultIDHasPagePrefix() {
+        #expect(OmniboxResult.page(page).id == "page:01PAGE")
+    }
+
+    @Test func askResultIDIsStable() {
+        #expect(OmniboxResult.ask(question: "hello").id == "ask")
+    }
+
+    // MARK: - Display
+
+    @Test func pageDisplayTitleIsPageTitle() {
+        #expect(OmniboxResult.page(page).displayTitle == "Mars Terraforming")
+    }
+
+    @Test func askDisplayTitleIncludesQuestion() {
+        #expect(OmniboxResult.ask(question: "How cold is Mars?").displayTitle == "Ask: How cold is Mars?")
+    }
+
+    @Test func pageSystemImageIsDocText() {
+        #expect(OmniboxResult.page(page).systemImageName == "doc.text")
+    }
+
+    @Test func chatSystemImageIsBubbles() {
+        #expect(OmniboxResult.chat(chat).systemImageName == "bubble.left.and.bubble.right")
+    }
+
+    @Test func askSystemImageIsSparkles() {
+        #expect(OmniboxResult.ask(question: "test").systemImageName == "sparkles")
+    }
+
+    // MARK: - Subtitle
+
+    @Test func pageSubtitleIsPage() {
+        #expect(OmniboxResult.page(page).subtitle == "Page")
+    }
+
+    @Test func chatSubtitleIncludesMessageCount() {
+        #expect(OmniboxResult.chat(chat).subtitle == "3 messages")
+    }
+
+    @Test func chatSubtitleSingularMessage() {
+        let single = ChatSummary(
+            id: PageID(rawValue: "01CHAT2"),
+            kind: .edit, title: "Test",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            messageCount: 1
+        )
+        #expect(OmniboxResult.chat(single).subtitle == "1 message")
+    }
+
+    @Test func askSubtitleIsSendToChat() {
+        #expect(OmniboxResult.ask(question: "test").subtitle == "Send to chat")
+    }
+
+    // MARK: - Selection
+
+    @Test func pageSelectionIsPageCase() {
+        #expect(OmniboxResult.page(page).selection == .page(PageID(rawValue: "01PAGE")))
+    }
+
+    @Test func askSelectionIsNewChat() {
+        #expect(OmniboxResult.ask(question: "test").selection == .newChat)
+    }
+
+    // MARK: - isAction
+
+    @Test func askIsAction() {
+        #expect(OmniboxResult.ask(question: "test").isAction == true)
+    }
+
+    @Test func pageIsNotAction() {
+        #expect(OmniboxResult.page(page).isAction == false)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #288 — the omnibox previously searched only pages. This implements unified search across all resource types (pages, sources, chats, bookmarks) with per-type icons and Safari-style two-line result rows, and adds a direct-to-chat "Ask" action that opens a new chat with the query pre-filled in the composer.

## Changes

### 1. New `OmniboxResult` type (`Sources/WikiFSCore/OmniboxResult.swift`)
A unified enum that wraps each resource type plus an `ask` action case:
- `.page(WikiPageSummary)`, `.source(SourceSummary)`, `.chat(ChatSummary)`, `.bookmark(node:resolvedTitle:)`, `.ask(question: String)`
- Provides `displayTitle`, `subtitle`, `systemImageName`, `selection` (→ `WikiSelection`), and `isAction`

### 2. `WikiStoreModel.searchOmnibox(query:)` 
Unified search returning `[OmniboxResult]`:
- **Always starts with `.ask(question:)`** as the first result (Enter sends to chat)
- Up to 3 pages (semantic + FTS), 2 sources, 2 chats, 3 bookmarks (substring)
- Bookmark search inlined from #240's logic (ancestor expansion, label + resolved title matching)

### 3. Omnibox pipeline updated to `OmniboxResult`
Every layer that was hardwired to `WikiPageSummary` now uses `OmniboxResult`:
- `AddressBarView`: `results` state, `runSearch`, `navigate(to:)`
- `OmniboxSearchField`: `results`, `onSelect`, Coordinator types, `cachedResultIDs`
- `SuggestionsPanel.update(...)`
- `AddressResultsList`: **per-type icons** (`doc.text` for pages, `doc` for sources, `bubble.left.and.bubble.right` for chats, `bookmark` for bookmarks, `sparkles` for Ask), **Safari-style two-line rows** with a subtitle/metadata line

### 4. Direct-to-chat "Ask" action
- `WikiStoreModel.pendingChatQuestion: String?` — set by the omnibox Ask action
- `ChatView.task(id: chatID)` consumes it when `chatID == nil` (draft state), pre-filling `draftMessage` with the question
- The user sees their question in the composer and can hit Enter to send, or edit before sending

### 5. Tests — 15 new `OmniboxResultTests`
Covers `id` prefixes, `displayTitle`, `systemImageName`, `subtitle` (including singular/plural message count), `selection`, and `isAction`.

## Design decisions

- **Ask is always first**: The `.ask` row is pinned at position 0 so Enter on an empty selection sends the query straight to chat — the most natural omnibox interaction (type a question, hit Enter, chat starts).
- **Type-capped results**: 3 pages + 2 sources + 2 chats + 3 bookmarks = max 10 resource results + 1 Ask = 11 rows. Keeps the panel concise.
- **Bookmarks use the same ancestor-expansion logic as #240**: hits inside nested folders include their parent folders in the omnibox results.
- **Pre-fill, not auto-send**: The Ask action pre-fills the composer rather than auto-sending, so the user can review/edit before committing.

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter OmniboxResultTests` — 15 tests pass
- [x] `swift test --filter OmniboxSelectionTests|OmniboxLayoutTests|AddressBarLayoutHostedTests` — 39 existing omnibox tests pass
- [x] `swift test` fast tier (2221 tests) — all pass
- [ ] CI green

Closes #288.
