### PR TITLE
Fix #239: give the agent CRUD access to bookmarks

### DIFF
--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -69,6 +69,8 @@ public enum ArgumentParser {
         case admin(AdminCommand.Action)
         /// Chat commands: list, read chat transcripts from SQLite.
         case chat(ChatCommand.Action)
+        /// Bookmark commands: list, create, rename, delete, move (#239).
+        case bookmark(BookmarkCommand.Action)
         /// Workspace commands (W1, PR #312): create, status, abandon, merge.
         case workspace(WorkspaceCommand.Action)
     }
@@ -128,6 +130,16 @@ public enum ArgumentParser {
       chat search --query X [--limit N]      semantic + keyword search of chats
       chat rename (--id X | --title T) --to <new-title>
                                                rename a chat
+      bookmark list [--json]                   list bookmark nodes (TSV, or JSON)
+      bookmark create-folder [--parent ID] --name <name>
+                                               create a bookmark folder
+      bookmark add-ref [--parent ID] --kind <page|source|chat> --target <id>
+                                               add a page/source/chat ref to bookmarks
+      bookmark rename --id <node-id> --to <new-name>
+                                               rename a bookmark folder
+      bookmark delete --id <node-id>           delete a bookmark node (cascades)
+      bookmark move --id <node-id> [--parent ID] [--position N]
+                                               move a bookmark node
       workspace create [--name N]              create a workspace (prints ID)
       workspace status --id W                  show workspace status + pages
       workspace abandon --id W                abandon a workspace (GC refs)
@@ -178,6 +190,8 @@ public enum ArgumentParser {
             command = try parseAdminCommand(Array(args.dropFirst()))
         case "chat":
             command = try parseChatCommand(Array(args.dropFirst()))
+        case "bookmark":
+            command = try parseBookmarkCommand(Array(args.dropFirst()))
         case "workspace":
             command = try parseWorkspaceCommand(Array(args.dropFirst()))
         default:
@@ -417,6 +431,78 @@ public enum ArgumentParser {
             throw Failure.usage("index set: --body-file is required (path or -)")
         }
         return .indexSet(bodyFile: bodyFile)
+    }
+
+    // MARK: - bookmark
+
+    private static func parseBookmarkCommand(_ args: [String]) throws -> Command {
+        guard let sub = args.first else { throw Failure.usage("bookmark: missing subcommand") }
+        let rest = Array(args.dropFirst())
+        let options = try Options(rest)
+
+        switch sub {
+        case "list":
+            return .bookmark(.list(json: options.flag("--json")))
+
+        case "create-folder":
+            guard let name = options.value("--name"), !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw Failure.usage("bookmark create-folder: --name <folder-name> is required")
+            }
+            let parentID = options.value("--parent")  // nil = root
+            return .bookmark(.createFolder(parentID: parentID, name: name))
+
+        case "add-ref":
+            guard let kindStr = options.value("--kind") else {
+                throw Failure.usage("bookmark add-ref: --kind <page|source|chat> is required")
+            }
+            let kind: BookmarkNodeKind
+            switch kindStr {
+            case "page": kind = .pageRef
+            case "source": kind = .sourceRef
+            case "chat": kind = .chatRef
+            default:
+                throw Failure.usage("bookmark add-ref: --kind must be page, source, or chat")
+            }
+            guard let targetID = options.value("--target"), !targetID.isEmpty else {
+                throw Failure.usage("bookmark add-ref: --target <id> is required")
+            }
+            let parentID = options.value("--parent")
+            return .bookmark(.addRef(parentID: parentID, kind: kind, targetID: PageID(rawValue: targetID)))
+
+        case "rename":
+            guard let id = options.value("--id"), !id.isEmpty else {
+                throw Failure.usage("bookmark rename: --id <node-id> is required")
+            }
+            guard let newName = options.value("--to"), !newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw Failure.usage("bookmark rename: --to <new-name> is required")
+            }
+            return .bookmark(.rename(id: id, to: newName))
+
+        case "delete":
+            guard let id = options.value("--id"), !id.isEmpty else {
+                throw Failure.usage("bookmark delete: --id <node-id> is required")
+            }
+            return .bookmark(.delete(id: id))
+
+        case "move":
+            guard let id = options.value("--id"), !id.isEmpty else {
+                throw Failure.usage("bookmark move: --id <node-id> is required")
+            }
+            let toParent = options.value("--parent")  // nil = root
+            let position: Int
+            if let raw = options.value("--position") {
+                guard let n = Int(raw) else {
+                    throw Failure.usage("bookmark move: --position must be an integer")
+                }
+                position = n
+            } else {
+                position = -1  // Append to end
+            }
+            return .bookmark(.move(id: id, toParentID: toParent, position: position))
+
+        default:
+            throw Failure.usage("bookmark: unknown subcommand \(sub.debugDescription)")
+        }
     }
 
     private static func parseWorkspaceCommand(_ args: [String]) throws -> Command {

--- a/Sources/WikiCtlCore/BookmarkCommand.swift
+++ b/Sources/WikiCtlCore/BookmarkCommand.swift
@@ -1,0 +1,147 @@
+import Foundation
+import WikiFSCore
+
+/// The `wikictl bookmark …` subcommands, executed against an already-opened
+/// `WikiStore`. Mirrors `ChatCommand` / `SourceCommand` — split from process
+/// concerns (arg parsing, stdin, the Darwin post, opening the DB) so the whole
+/// surface is unit-testable against a temp DB.
+///
+/// Read and write: `list` prints all bookmark nodes (TSV), `create-folder`,
+/// `add-ref`, `rename`, `delete`, and `move` mutate the bookmark tree and
+/// commit (the caller posts the Darwin notification on `didCommit`).
+public enum BookmarkCommand {
+
+    /// What a command produced: text to print and whether it COMMITTED a write.
+    public struct Result: Equatable {
+        public var output: String
+        public var didCommit: Bool
+
+        public init(output: String, didCommit: Bool) {
+            self.output = output
+            self.didCommit = didCommit
+        }
+    }
+
+    public enum Action: Equatable {
+        case list(json: Bool)
+        case createFolder(parentID: String?, name: String)
+        case addRef(parentID: String?, kind: BookmarkNodeKind, targetID: PageID)
+        case rename(id: String, to: String)
+        case delete(id: String)
+        case move(id: String, toParentID: String?, position: Int)
+    }
+
+    public enum Failure: Error, CustomStringConvertible {
+        case message(String)
+
+        public var description: String {
+            switch self {
+            case .message(let text): text
+            }
+        }
+    }
+
+    /// Run one action against `store`. Reads never commit; mutations do.
+    public static func run(_ action: Action, in store: WikiStore) throws -> Result {
+        switch action {
+        case .list(let json):
+            return try list(in: store, json: json)
+        case .createFolder(let parentID, let name):
+            return try createFolder(parentID: parentID, name: name, in: store)
+        case .addRef(let parentID, let kind, let targetID):
+            return try addRef(parentID: parentID, kind: kind, targetID: targetID, in: store)
+        case .rename(let id, let newName):
+            return try rename(id: id, to: newName, in: store)
+        case .delete(let id):
+            return try delete(id: id, in: store)
+        case .move(let id, let toParentID, let position):
+            return try move(id: id, toParentID: toParentID, position: position, in: store)
+        }
+    }
+
+    // MARK: - list
+
+    private static func list(in store: WikiStore, json: Bool) throws -> Result {
+        let nodes = try store.listBookmarkNodes()
+        if json {
+            // Manual JSONL — BookmarkNode isn't Codable.
+            let lines = nodes.map { node in
+                let parent = node.parentID ?? ""
+                let label = node.label ?? ""
+                let target = node.targetID?.rawValue ?? ""
+                return "{\"id\":\"\(escape(node.id))\",\"parentID\":\"\(escape(parent))\",\"position\":\(node.position),\"kind\":\"\(node.kind.rawValue)\",\"label\":\"\(escape(label))\",\"targetID\":\"\(escape(target))\"}"
+            }
+            return Result(
+                output: lines.joined(separator: "\n"),
+                didCommit: false
+            )
+        }
+        // TSV: id <tab> parentID <tab> position <tab> kind <tab> label <tab> targetID
+        let lines = nodes.map { node in
+            "\(node.id)\t\(node.parentID ?? "")\t\(node.position)\t\(node.kind.rawValue)\t\(node.label ?? "")\t\(node.targetID?.rawValue ?? "")"
+        }
+        return Result(
+            output: lines.joined(separator: "\n"),
+            didCommit: false
+        )
+    }
+
+    /// Minimal JSON string escaping for manual JSONL output.
+    private static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\t", with: "\\t")
+    }
+
+    // MARK: - create-folder
+
+    private static func createFolder(parentID: String?, name: String, in store: WikiStore) throws -> Result {
+        let node = try store.createBookmarkNode(
+            parentID: parentID, position: -1, kind: .folder, label: name, targetID: nil
+        )
+        return Result(output: "Created folder \"\(name)\" (id: \(node.id)).", didCommit: true)
+    }
+
+    // MARK: - add-ref
+
+    private static func addRef(
+        parentID: String?, kind: BookmarkNodeKind, targetID: PageID, in store: WikiStore
+    ) throws -> Result {
+        let node = try store.createBookmarkNode(
+            parentID: parentID, position: -1, kind: kind, label: nil, targetID: targetID
+        )
+        let kindLabel: String
+        switch kind {
+        case .pageRef: kindLabel = "page"
+        case .sourceRef: kindLabel = "source"
+        case .chatRef: kindLabel = "chat"
+        case .folder: kindLabel = "folder"
+        }
+        return Result(
+            output: "Added \(kindLabel) ref (\(targetID.rawValue)) to bookmarks (id: \(node.id)).",
+            didCommit: true
+        )
+    }
+
+    // MARK: - rename
+
+    private static func rename(id: String, to newName: String, in store: WikiStore) throws -> Result {
+        try store.updateBookmarkNode(id: id, label: newName)
+        return Result(output: "Renamed bookmark node \(id) to \"\(newName)\".", didCommit: true)
+    }
+
+    // MARK: - delete
+
+    private static func delete(id: String, in store: WikiStore) throws -> Result {
+        try store.deleteBookmarkNode(id: id)
+        return Result(output: "Deleted bookmark node \(id) (and descendants).", didCommit: true)
+    }
+
+    // MARK: - move
+
+    private static func move(id: String, toParentID: String?, position: Int, in store: WikiStore) throws -> Result {
+        try store.moveBookmarkNode(id: id, toParentID: toParentID, position: position)
+        return Result(output: "Moved bookmark node \(id).", didCommit: true)
+    }
+}

--- a/Sources/WikiFSCore/WikiStateSnapshot.swift
+++ b/Sources/WikiFSCore/WikiStateSnapshot.swift
@@ -37,6 +37,10 @@ public struct WikiStateSnapshot: Equatable, Sendable {
   /// already rendered as its grep-able `## [date] kind | title` line (plus note),
   /// matching exactly what `log.md`'s `tail` would show.
   public let recentLog: [String]
+  /// The bookmark tree (folders + page/source/chat refs), flat but ordered
+  /// parents-before-children, siblings by position. Included so the agent can
+  /// see how the user has organized bookmarks and mirror that structure (#239).
+  public let bookmarkNodes: [BookmarkNode]
 
   /// Cap on listed titles for large wikis: list the most-recently-updated ~150
   /// and note the remainder, so a 10k-page wiki doesn't blow up the prompt.
@@ -49,12 +53,14 @@ public struct WikiStateSnapshot: Equatable, Sendable {
     pageTitles: [String],
     truncatedPageCount: Int,
     indexBody: String,
-    recentLog: [String]
+    recentLog: [String],
+    bookmarkNodes: [BookmarkNode] = []
   ) {
     self.pageTitles = pageTitles
     self.truncatedPageCount = truncatedPageCount
     self.indexBody = indexBody
     self.recentLog = recentLog
+    self.bookmarkNodes = bookmarkNodes
   }
 
   /// Build a snapshot from raw state, applying the large-wiki cap. `allTitles`
@@ -66,7 +72,8 @@ public struct WikiStateSnapshot: Equatable, Sendable {
   public static func make(
     allTitles: [String],
     indexBody: String,
-    logLines: [String]
+    logLines: [String],
+    bookmarkNodes: [BookmarkNode] = []
   ) -> WikiStateSnapshot {
     let listed = Array(allTitles.prefix(maxListedTitles))
     let dropped = max(0, allTitles.count - listed.count)
@@ -74,7 +81,8 @@ public struct WikiStateSnapshot: Equatable, Sendable {
       pageTitles: listed,
       truncatedPageCount: dropped,
       indexBody: indexBody,
-      recentLog: logLines
+      recentLog: logLines,
+      bookmarkNodes: bookmarkNodes
     )
   }
 
@@ -126,6 +134,63 @@ public struct WikiStateSnapshot: Equatable, Sendable {
       lines.append(recentLog.joined(separator: "\n"))
     }
 
+    // Bookmark tree (#239: let the agent see the user's bookmark organization).
+    lines.append("")
+    lines.append("## Bookmarks")
+    if bookmarkNodes.isEmpty {
+      lines.append("No bookmarks yet.")
+    } else {
+      lines.append(
+        "The user's bookmark organization. Use `wikictl bookmark` subcommands to manage these.")
+      lines.append("")
+      lines.append(Self.renderBookmarkTree(bookmarkNodes))
+    }
+
     return lines.joined(separator: "\n") + "\n"
+  }
+
+  /// Renders a flat `[BookmarkNode]` list (parents-before-children, siblings by
+  /// position) as an indented markdown tree. Folders show their label; refs
+  /// show their target id. The indentation level reflects nesting depth.
+  static func renderBookmarkTree(_ nodes: [BookmarkNode]) -> String {
+    // Build parent→children map for tree traversal.
+    var childrenMap: [String?: [BookmarkNode]] = [:]
+    for node in nodes {
+      childrenMap[node.parentID, default: []].append(node)
+    }
+    // Sort each group by position.
+    for key in childrenMap.keys {
+      childrenMap[key]?.sort { $0.position < $1.position }
+    }
+
+    var lines: [String] = []
+    func renderChildren(of parentID: String?, depth: Int) {
+      let children = childrenMap[parentID] ?? []
+      for child in children {
+        let indent = String(repeating: "  ", count: depth)
+        let icon: String
+        let label: String
+        switch child.kind {
+        case .folder:
+          icon = "📁"
+          label = child.label ?? "(unnamed folder)"
+        case .pageRef:
+          icon = "📄"
+          label = "page:\(child.targetID?.rawValue ?? "?")"
+        case .sourceRef:
+          icon = "📎"
+          label = "source:\(child.targetID?.rawValue ?? "?")"
+        case .chatRef:
+          icon = "💬"
+          label = "chat:\(child.targetID?.rawValue ?? "?")"
+        }
+        lines.append("\(indent)- \(icon) \(label)")
+        if child.kind == .folder {
+          renderChildren(of: child.id, depth: depth + 1)
+        }
+      }
+    }
+    renderChildren(of: nil, depth: 0)
+    return lines.joined(separator: "\n")
   }
 }

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -2092,7 +2092,12 @@ public final class WikiStoreModel {
         // uses, so the snapshot lines are byte-identical to what `tail log.md`
         // shows (no second, drifting log format).
         let logLines = logEntries.map { LogRenderer.line(for: $0) }
-        return WikiStateSnapshot.make(allTitles: titles, indexBody: indexBody, logLines: logLines)
+        // Include the bookmark tree so the agent can see the user's organization (#239).
+        let bookmarks = (try? store.listBookmarkNodes()) ?? []
+        return WikiStateSnapshot.make(
+            allTitles: titles, indexBody: indexBody, logLines: logLines,
+            bookmarkNodes: bookmarks
+        )
     }
 
     /// Render the operation log exactly as the File Provider's `log.md` does, so

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -143,6 +143,9 @@ func execute(_ command: ArgumentParser.Command, in store: SQLiteWikiStore) throw
     case .chat(let action):
         let r = try ChatCommand.run(action, in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
+    case .bookmark(let action):
+        let r = try BookmarkCommand.run(action, in: store)
+        return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .workspace(let action):
         let r = try WorkspaceCommand.run(action, in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)

--- a/Tests/WikiFSTests/BookmarkCommandTests.swift
+++ b/Tests/WikiFSTests/BookmarkCommandTests.swift
@@ -1,0 +1,242 @@
+import Testing
+import Foundation
+@testable import WikiCtlCore
+@testable import WikiFSCore
+
+/// Tests for `wikictl bookmark` subcommands (#239) — list, create-folder,
+/// add-ref, rename, delete, move — against a temp SQLite store.
+@Suite struct BookmarkCommandTests {
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bookmark-cmd-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    private func tempStore() throws -> SQLiteWikiStore {
+        try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+    }
+
+    private let noEnv: (String) -> String? = { _ in nil }
+
+    // MARK: - list
+
+    @Test func listEmptyBookmarks() throws {
+        let store = try tempStore()
+        let result = try BookmarkCommand.run(.list(json: false), in: store)
+        #expect(result.didCommit == false)
+        #expect(result.output.isEmpty)
+    }
+
+    @Test func listOutputsTSV() throws {
+        let store = try tempStore()
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, kind: .folder,
+                                          label: "Research", targetID: nil)
+        let result = try BookmarkCommand.run(.list(json: false), in: store)
+        #expect(result.didCommit == false)
+        #expect(result.output.contains("Research"))
+        #expect(result.output.contains("folder"))
+    }
+
+    @Test func listOutputsJSON() throws {
+        let store = try tempStore()
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, kind: .folder,
+                                          label: "Research", targetID: nil)
+        let result = try BookmarkCommand.run(.list(json: true), in: store)
+        #expect(result.didCommit == false)
+        #expect(result.output.contains("\"label\":\"Research\""))
+        #expect(result.output.contains("\"kind\":\"folder\""))
+    }
+
+    // MARK: - create-folder
+
+    @Test func createFolderCommitsAndOutputsConfirmation() throws {
+        let store = try tempStore()
+        let result = try BookmarkCommand.run(
+            .createFolder(parentID: nil, name: "Research"), in: store
+        )
+        #expect(result.didCommit == true)
+        #expect(result.output.contains("Research"))
+        // Verify it was actually created.
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.count == 1)
+        #expect(nodes[0].label == "Research")
+    }
+
+    @Test func createNestedFolder() throws {
+        let store = try tempStore()
+        let parent = try store.createBookmarkNode(parentID: nil, position: 0,
+                                                    kind: .folder, label: "Parent", targetID: nil)
+        let result = try BookmarkCommand.run(
+            .createFolder(parentID: parent.id, name: "Child"), in: store
+        )
+        #expect(result.didCommit == true)
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.count == 2)
+        let child = nodes.first { $0.parentID == parent.id }
+        #expect(child?.label == "Child")
+    }
+
+    // MARK: - add-ref
+
+    @Test func addPageRefCommits() throws {
+        let store = try tempStore()
+        let result = try BookmarkCommand.run(
+            .addRef(parentID: nil, kind: .pageRef, targetID: PageID(rawValue: "01PAGE")),
+            in: store
+        )
+        #expect(result.didCommit == true)
+        #expect(result.output.contains("page"))
+        #expect(result.output.contains("01PAGE"))
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.count == 1)
+        #expect(nodes[0].kind == .pageRef)
+        #expect(nodes[0].targetID?.rawValue == "01PAGE")
+    }
+
+    @Test func addSourceRefCommits() throws {
+        let store = try tempStore()
+        let result = try BookmarkCommand.run(
+            .addRef(parentID: nil, kind: .sourceRef, targetID: PageID(rawValue: "01SRC")),
+            in: store
+        )
+        #expect(result.didCommit == true)
+        #expect(result.output.contains("source"))
+    }
+
+    @Test func addChatRefCommits() throws {
+        let store = try tempStore()
+        let result = try BookmarkCommand.run(
+            .addRef(parentID: nil, kind: .chatRef, targetID: PageID(rawValue: "01CHAT")),
+            in: store
+        )
+        #expect(result.didCommit == true)
+        #expect(result.output.contains("chat"))
+    }
+
+    // MARK: - rename
+
+    @Test func renameCommitsAndUpdateLabel() throws {
+        let store = try tempStore()
+        let node = try store.createBookmarkNode(parentID: nil, position: 0,
+                                                 kind: .folder, label: "Old", targetID: nil)
+        let result = try BookmarkCommand.run(
+            .rename(id: node.id, to: "New"), in: store
+        )
+        #expect(result.didCommit == true)
+        #expect(result.output.contains("New"))
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.first?.label == "New")
+    }
+
+    // MARK: - delete
+
+    @Test func deleteCommits() throws {
+        let store = try tempStore()
+        let node = try store.createBookmarkNode(parentID: nil, position: 0,
+                                                 kind: .folder, label: "ToDelete", targetID: nil)
+        let result = try BookmarkCommand.run(.delete(id: node.id), in: store)
+        #expect(result.didCommit == true)
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.isEmpty)
+    }
+
+    // MARK: - move
+
+    @Test func moveCommits() throws {
+        let store = try tempStore()
+        let node = try store.createBookmarkNode(parentID: nil, position: 0,
+                                                 kind: .folder, label: "Movable", targetID: nil)
+        let result = try BookmarkCommand.run(
+            .move(id: node.id, toParentID: nil, position: 5), in: store
+        )
+        #expect(result.didCommit == true)
+    }
+
+    // MARK: - argument parsing
+
+    @Test func parseListReturnsBookmarkList() throws {
+        let inv = try ArgumentParser.parse(["--wiki", "W", "bookmark", "list"], env: noEnv)
+        guard case .bookmark(let action) = inv.command,
+              case .list(let json) = action else {
+            Issue.record("expected .bookmark(.list)"); return
+        }
+        #expect(json == false)
+    }
+
+    @Test func parseCreateFolder() throws {
+        let inv = try ArgumentParser.parse([
+            "--wiki", "W", "bookmark", "create-folder", "--name", "Research"
+        ], env: noEnv)
+        guard case .bookmark(let action) = inv.command,
+              case .createFolder(let parent, let name) = action else {
+            Issue.record("expected .bookmark(.createFolder)"); return
+        }
+        #expect(parent == nil)
+        #expect(name == "Research")
+    }
+
+    @Test func parseAddRef() throws {
+        let inv = try ArgumentParser.parse([
+            "--wiki", "W", "bookmark", "add-ref", "--kind", "page", "--target", "01PAGE"
+        ], env: noEnv)
+        guard case .bookmark(let action) = inv.command,
+              case .addRef(let parent, let kind, let target) = action else {
+            Issue.record("expected .bookmark(.addRef)"); return
+        }
+        #expect(parent == nil)
+        #expect(kind == .pageRef)
+        #expect(target.rawValue == "01PAGE")
+    }
+
+    @Test func parseRename() throws {
+        let inv = try ArgumentParser.parse([
+            "--wiki", "W", "bookmark", "rename", "--id", "abc", "--to", "NewName"
+        ], env: noEnv)
+        guard case .bookmark(let action) = inv.command,
+              case .rename(let id, let to) = action else {
+            Issue.record("expected .bookmark(.rename)"); return
+        }
+        #expect(id == "abc")
+        #expect(to == "NewName")
+    }
+
+    @Test func parseDelete() throws {
+        let inv = try ArgumentParser.parse([
+            "--wiki", "W", "bookmark", "delete", "--id", "abc"
+        ], env: noEnv)
+        guard case .bookmark(let action) = inv.command,
+              case .delete(let id) = action else {
+            Issue.record("expected .bookmark(.delete)"); return
+        }
+        #expect(id == "abc")
+    }
+
+    @Test func parseMove() throws {
+        let inv = try ArgumentParser.parse([
+            "--wiki", "W", "bookmark", "move", "--id", "abc", "--position", "3"
+        ], env: noEnv)
+        guard case .bookmark(let action) = inv.command,
+              case .move(let id, let parent, let pos) = action else {
+            Issue.record("expected .bookmark(.move)"); return
+        }
+        #expect(id == "abc")
+        #expect(parent == nil)
+        #expect(pos == 3)
+    }
+
+    @Test func parseCreateFolderRequiresName() throws {
+        #expect(throws: ArgumentParser.Failure.self) {
+            _ = try ArgumentParser.parse(["--wiki", "W", "bookmark", "create-folder"], env: noEnv)
+        }
+    }
+
+    @Test func parseAddRefRequiresKind() throws {
+        #expect(throws: ArgumentParser.Failure.self) {
+            _ = try ArgumentParser.parse([
+                "--wiki", "W", "bookmark", "add-ref", "--target", "01PAGE"
+            ], env: noEnv)
+        }
+    }
+}

--- a/Tests/WikiFSTests/BookmarkStateSnapshotTests.swift
+++ b/Tests/WikiFSTests/BookmarkStateSnapshotTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// Tests for the bookmark tree section in `WikiStateSnapshot.renderStateFile()`
+/// and the `renderBookmarkTree` helper (#239).
+@Suite struct BookmarkStateSnapshotTests {
+
+    // MARK: - renderBookmarkTree
+
+    @Test func emptyBookmarksShowsNoBookmarksYet() {
+        let snapshot = WikiStateSnapshot.make(
+            allTitles: ["Page A"], indexBody: "", logLines: [], bookmarkNodes: []
+        )
+        let md = snapshot.renderStateFile()
+        #expect(md.contains("## Bookmarks"))
+        #expect(md.contains("No bookmarks yet."))
+    }
+
+    @Test func rootFolderRendersWithLabel() {
+        let nodes = [
+            BookmarkNode(id: "f1", parentID: nil, position: 0, kind: .folder,
+                         label: "Research", targetID: nil),
+        ]
+        let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
+        #expect(tree.contains("📁 Research"))
+    }
+
+    @Test func nestedFoldersRenderIndented() {
+        let nodes = [
+            BookmarkNode(id: "root", parentID: nil, position: 0, kind: .folder,
+                         label: "Root", targetID: nil),
+            BookmarkNode(id: "child", parentID: "root", position: 0, kind: .folder,
+                         label: "Child", targetID: nil),
+        ]
+        let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
+        let lines = tree.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines.count == 2)
+        #expect(lines[0].contains("Root"))
+        #expect(!lines[0].hasPrefix("  "))  // Root at depth 0
+        #expect(lines[1].hasPrefix("  "))    // Child at depth 1
+        #expect(lines[1].contains("Child"))
+    }
+
+    @Test func pageRefRendersWithTargetID() {
+        let nodes = [
+            BookmarkNode(id: "p1", parentID: nil, position: 0, kind: .pageRef,
+                         label: nil, targetID: PageID(rawValue: "01PAGE")),
+        ]
+        let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
+        #expect(tree.contains("📄"))
+        #expect(tree.contains("page:01PAGE"))
+    }
+
+    @Test func sourceRefRendersWithTargetID() {
+        let nodes = [
+            BookmarkNode(id: "s1", parentID: nil, position: 0, kind: .sourceRef,
+                         label: nil, targetID: PageID(rawValue: "01SRC")),
+        ]
+        let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
+        #expect(tree.contains("source:01SRC"))
+    }
+
+    @Test func chatRefRendersWithTargetID() {
+        let nodes = [
+            BookmarkNode(id: "c1", parentID: nil, position: 0, kind: .chatRef,
+                         label: nil, targetID: PageID(rawValue: "01CHAT")),
+        ]
+        let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
+        #expect(tree.contains("chat:01CHAT"))
+    }
+
+    @Test func mixedTreeRendersInOrder() {
+        let nodes = [
+            BookmarkNode(id: "f1", parentID: nil, position: 0, kind: .folder,
+                         label: "Research", targetID: nil),
+            BookmarkNode(id: "p1", parentID: "f1", position: 1, kind: .pageRef,
+                         label: nil, targetID: PageID(rawValue: "01PAGE")),
+            BookmarkNode(id: "p2", parentID: "f1", position: 0, kind: .pageRef,
+                         label: nil, targetID: PageID(rawValue: "02PAGE")),
+            BookmarkNode(id: "f2", parentID: nil, position: 1, kind: .folder,
+                         label: "Notes", targetID: nil),
+        ]
+        let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
+        let lines = tree.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        // Root has 2 folders, f1 first (position 0), f2 second (position 1)
+        #expect(lines[0].contains("Research"))
+        #expect(lines[1].hasPrefix("  "))  // child of Research
+        #expect(lines[2].hasPrefix("  "))  // child of Research
+        // p2 should come before p1 (position 0 < position 1)
+        #expect(lines[1].contains("02PAGE"))
+        #expect(lines[2].contains("01PAGE"))
+        #expect(lines[3].contains("Notes"))
+    }
+
+    @Test func bookmarkSectionIncludedInStateFile() {
+        let nodes = [
+            BookmarkNode(id: "f1", parentID: nil, position: 0, kind: .folder,
+                         label: "Research", targetID: nil),
+        ]
+        let snapshot = WikiStateSnapshot.make(
+            allTitles: ["Page A"], indexBody: "", logLines: [],
+            bookmarkNodes: nodes
+        )
+        let md = snapshot.renderStateFile()
+        #expect(md.contains("## Bookmarks"))
+        #expect(md.contains("Research"))
+        #expect(md.contains("wikictl bookmark"))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #239 — the agent (Ask/Edit) had zero visibility into the user's bookmark organization. This adds the bookmark tree to the agent state snapshot and `wikictl bookmark` CRUD subcommands.

## Changes

### 1. Bookmark tree in `WikiStateSnapshot` (read visibility)
- Added `bookmarkNodes: [BookmarkNode]` field to `WikiStateSnapshot` (with default `[]` for backward compatibility)
- `WikiStoreModel.currentStateSnapshot()` now calls `store.listBookmarkNodes()` and includes the tree
- `renderStateFile()` renders a `## Bookmarks` section with an indented tree:
  - 📁 folders (label), 📄 page refs (target id), 📎 source refs, 💬 chat refs
  - Sorted by position within each parent group
  - The section tells the agent to use `wikictl bookmark` subcommands for management

### 2. `wikictl bookmark` CRUD subcommands (write access)
New `BookmarkCommand.swift` with 6 actions:

| Command | Flags | Description |
|---|---|---|
| `bookmark list [--json]` | | List all bookmark nodes (TSV or JSONL) |
| `bookmark create-folder` | `--name`, `[--parent ID]` | Create a folder (root or nested) |
| `bookmark add-ref` | `--kind <page\|source\|chat>`, `--target ID`, `[--parent ID]` | Add a page/source/chat ref |
| `bookmark rename` | `--id`, `--to` | Rename a folder |
| `bookmark delete` | `--id` | Delete a node (cascades to descendants) |
| `bookmark move` | `--id`, `[--parent ID]`, `[--position N]` | Move/reparent a node |

- All write commands set `didCommit = true` (triggers Darwin notification for File Provider refresh)
- Follows the `ChatCommand` pattern: `Action` enum, `run(_:in:)`, `Result` struct
- Added parsing in `ArgumentParser.parseBookmarkCommand`, dispatch in `main.swift`, usage text

### 3. Tests — 27 new tests
- **BookmarkStateSnapshotTests** (8): empty bookmarks, root folder, nested folders, page/source/chat ref rendering, mixed tree ordering (position sort), state file inclusion
- **BookmarkCommandTests** (19): list (empty/TSV/JSON), create-folder (root/nested), add-ref (all 3 kinds), rename, delete, move, and 7 argument parsing tests including validation failures

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter 'BookmarkStateSnapshotTests|BookmarkCommandTests'` — 27 tests pass
- [x] `swift test` fast tier (2293 tests) — all pass
- [ ] CI green

Closes #239.
