### PR TITLE
Fix #131: richer page/source provenance as generated frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Resources/mlx.metallib
 
 .xcodebuildmcp/
 tmp/
+:memory:*

--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -200,7 +200,7 @@ public enum SourceCommand {
         guard try store.hasProcessedMarkdown(sourceID: id) else {
             throw Failure.message("no processed markdown for this source")
         }
-        try store.appendProcessedMarkdown(sourceID: id, content: content, origin: "user", note: nil)
+        try store.appendProcessedMarkdown(sourceID: id, content: content, origin: "user", note: nil, technique: nil)
         return Result(payload: .text(""), didCommit: true)
     }
 
@@ -320,7 +320,7 @@ public enum SourceCommand {
                 sourceID: id, data: data, mimeType: nil, provenance: prov)
         case .derivedMarkdown(let content):
             try store.appendProcessedMarkdown(
-                sourceID: id, content: content, origin: "transcript", note: nil)
+                sourceID: id, content: content, origin: "transcript", note: nil, technique: nil)
         }
         return Result(
             payload: .text("Refreshed \(origin.displayLabel) source."),

--- a/Sources/WikiFSCore/PageMarkdownFormat.swift
+++ b/Sources/WikiFSCore/PageMarkdownFormat.swift
@@ -43,13 +43,26 @@ public enum PageMarkdownFormat {
     /// YAML frontmatter + blank line + H1 + blank line + body.
     /// `body_markdown` in SQLite must already be clean (no frontmatter, no H1)
     /// before calling this; pass through `stripped(body:title:)` if unsure.
+    ///
+    /// Provenance fields (created_by, last_edited_by) are included when present
+    /// (#131). When absent (pre-#131 rows), they are omitted — the agent and
+    /// readers can treat them as "unknown".
     public static func fileContent(for page: WikiPage) -> String {
         let dateStr = localDateString(from: page.updatedAt)
         let escapedTitle = page.title.replacingOccurrences(of: "\\", with: "\\\\")
                                      .replacingOccurrences(of: "\"", with: "\\\"")
         let cleanBody = stripped(body: page.bodyMarkdown, title: page.title)
 
-        var result = "---\ntitle: \"\(escapedTitle)\"\ndate: \(dateStr)\n---\n\n# \(page.title)"
+        // Build frontmatter, conditionally adding provenance fields.
+        var fm = "title: \"\(escapedTitle)\"\ndate: \(dateStr)"
+        if let createdBy = page.createdBy {
+            fm += "\ncreated_by: \(createdBy)"
+        }
+        if let lastEditedBy = page.lastEditedBy, lastEditedBy != page.createdBy {
+            fm += "\nlast_edited_by: \(lastEditedBy)"
+        }
+
+        var result = "---\n\(fm)\n---\n\n# \(page.title)"
         if !cleanBody.isEmpty {
             result += "\n\n\(cleanBody)"
         }
@@ -58,8 +71,31 @@ public enum PageMarkdownFormat {
 
     // MARK: - Private
 
-    private static func localDateString(from date: Date) -> String {
+    static func localDateString(from date: Date) -> String {
         let c = Calendar.current.dateComponents([.year, .month, .day], from: date)
         return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+}
+
+/// Shared logic for the source-markdown frontmatter contract: the processed
+/// markdown body is stored without frontmatter; the file provider adds it on
+/// the fly when serving the `.md` sibling so readers can see provenance
+/// (origin, processing date, extraction technique) without a side channel.
+public enum SourceMarkdownFormat {
+
+    /// Wrap a source markdown version's body with YAML frontmatter carrying
+    /// provenance metadata (#131). Frontmatter is omitted for empty bodies.
+    public static func fileContent(for version: SourceMarkdownVersion) -> String {
+        var fm: [String] = []
+        fm.append("origin: \(version.origin)")
+        fm.append("date: \(PageMarkdownFormat.localDateString(from: version.createdAt))")
+        if let technique = version.technique {
+            fm.append("technique: \(technique)")
+        }
+        if let note = version.note, !note.isEmpty {
+            let escaped = note.replacingOccurrences(of: "\"", with: "\\\"")
+            fm.append("note: \"\(escaped)\"")
+        }
+        return "---\n\(fm.joined(separator: "\n"))\n---\n\n\(version.content)"
     }
 }

--- a/Sources/WikiFSCore/PageUpsert.swift
+++ b/Sources/WikiFSCore/PageUpsert.swift
@@ -50,7 +50,8 @@ public enum PageUpsert {
         id: PageID?,
         title: String,
         body: String,
-        expectedHeadVersionID: String? = nil
+        expectedHeadVersionID: String? = nil,
+        author: String? = nil
     ) throws -> Outcome {
         // Sanitize BEFORE the title→id resolve, not just in the store's
         // create/update (which sanitizes again as a backstop): resolving the
@@ -68,7 +69,7 @@ public enum PageUpsert {
             resolveSource: store.resolveSourceByName,
             resolveChat: store.resolveChatByTitle)) ?? body
         let outcome = try writePage(in: store, id: id, title: title, body: canonicalBody,
-                                     expectedHeadVersionID: expectedHeadVersionID)
+                                     expectedHeadVersionID: expectedHeadVersionID, author: author)
         // Parse the CANONICAL body so link rows match the stored bytes exactly.
         try store.replaceLinks(from: outcome.id, parsedLinks: WikiLinkParser.parse(canonicalBody))
         // Compute + store chunk embeddings for the page body. Non-fatal: a
@@ -90,7 +91,8 @@ public enum PageUpsert {
         id: PageID?,
         title: String,
         body: String,
-        expectedHeadVersionID: String?
+        expectedHeadVersionID: String?,
+        author: String? = nil
     ) throws -> Outcome {
         if let id {
             // When CAS is active, route through appendPageVersion (versioned
@@ -99,9 +101,9 @@ public enum PageUpsert {
             if let expected = expectedHeadVersionID {
                 _ = try store.appendPageVersion(
                     pageID: id, title: title, body: body,
-                    expectedHeadVersionID: expected)
+                    expectedHeadVersionID: expected, lastEditedBy: author)
             } else {
-                try store.updatePage(id: id, title: title, body: body)
+                try store.updatePage(id: id, title: title, body: body, lastEditedBy: author)
             }
             return Outcome(id: id, didCreate: false)
         }
@@ -109,14 +111,14 @@ public enum PageUpsert {
             if let expected = expectedHeadVersionID {
                 _ = try store.appendPageVersion(
                     pageID: existing, title: title, body: body,
-                    expectedHeadVersionID: expected)
+                    expectedHeadVersionID: expected, lastEditedBy: author)
             } else {
-                try store.updatePage(id: existing, title: title, body: body)
+                try store.updatePage(id: existing, title: title, body: body, lastEditedBy: author)
             }
             return Outcome(id: existing, didCreate: false)
         }
-        let page = try store.createPage(title: title)
-        try store.updatePage(id: page.id, title: title, body: body)
+        let page = try store.createPage(title: title, createdBy: author)
+        try store.updatePage(id: page.id, title: title, body: body, lastEditedBy: author)
         return Outcome(id: page.id, didCreate: true)
     }
 }

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -225,7 +225,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             body_markdown TEXT NOT NULL DEFAULT '',
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL,
-            version INTEGER NOT NULL DEFAULT 1
+            version INTEGER NOT NULL DEFAULT 1,
+            created_by TEXT,
+            last_edited_by TEXT
         );
         """)
         try exec("CREATE UNIQUE INDEX pages_slug_unique ON pages(slug);")
@@ -295,7 +297,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             activity_id       TEXT REFERENCES activities(id),
             source_version_id TEXT,
             blob_hash         TEXT REFERENCES blobs(hash),
-            mime_type         TEXT NOT NULL DEFAULT 'text/markdown'
+            mime_type         TEXT NOT NULL DEFAULT 'text/markdown',
+            technique         TEXT
         );
         """)
         try exec("""
@@ -539,6 +542,12 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // parked as `conflicted`. Purely additive.
         try createWorkspaceConflictsV32()
         try exec("PRAGMA user_version=32;")
+
+        // v33 (#131 — provenance frontmatter): adds `created_by`,
+        // `last_edited_by` to `pages` and `technique` to
+        // `source_markdown_versions`. The columns are already in the fresh
+        // schema's CREATE TABLE above, so this just advances the version stamp.
+        try exec("PRAGMA user_version=33;")
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -1420,6 +1429,18 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try exec("PRAGMA user_version=32;")
             version = 32
         }
+
+        // Step 32 → 33 (#131 — provenance frontmatter): adds `created_by` and
+        // `last_edited_by` nullable text columns to `pages` (agent/model
+        // attribution), and a `technique` nullable text column to
+        // `source_markdown_versions` (which extraction backend produced it).
+        // All additive — existing rows get NULL, which the frontmatter layer
+        // treats as "unknown" and omits.
+        if version < 33 {
+            try migrateV32ToV33()
+            try exec("PRAGMA user_version=33;")
+            version = 33
+        }
     }
 
     /// The v19→20 migration step. Creates the objects tables, then — for every
@@ -1996,6 +2017,38 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// v32 → v33 (#131): adds provenance columns to `pages`
+    /// (`created_by`, `last_edited_by`) and `source_markdown_versions`
+    /// (`technique`). All nullable, additive — existing rows get NULL.
+    private func migrateV32ToV33() throws {
+        try withTransaction {
+            // Guard: check each column exists before adding (the fresh schema
+            // createFreshSchemaV20 may already include them on a rewound DB).
+            let pagesCols = try tableColumnInfo("pages")
+            if !pagesCols.contains("created_by") {
+                try exec("ALTER TABLE pages ADD COLUMN created_by TEXT;")
+            }
+            if !pagesCols.contains("last_edited_by") {
+                try exec("ALTER TABLE pages ADD COLUMN last_edited_by TEXT;")
+            }
+            let smvCols = try tableColumnInfo("source_markdown_versions")
+            if !smvCols.contains("technique") {
+                try exec("ALTER TABLE source_markdown_versions ADD COLUMN technique TEXT;")
+            }
+        }
+    }
+
+    /// Returns column names for `table` via pragma_table_info.
+    private func tableColumnInfo(_ table: String) throws -> Set<String> {
+        let stmt = try statement("SELECT name FROM pragma_table_info('\(table)');")
+        defer { stmt.reset() }
+        var cols: Set<String> = []
+        while try stmt.step() {
+            cols.insert(stmt.text(at: 0))
+        }
+        return cols
+    }
+
     /// One-time backfill for the v18→19 step: hash every existing source's
     /// `content` (SHA-256, hex) into the new `content_hash` column. Content is a
     /// pure function of the stored bytes, so this is safe to compute once and
@@ -2455,7 +2508,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     public func getPage(id: PageID) throws -> WikiPage {
         lock.lock(); defer { lock.unlock() }
         let stmt = try statement("""
-        SELECT id, title, slug, body_markdown, created_at, updated_at, version
+        SELECT id, title, slug, body_markdown, created_at, updated_at, version, created_by, last_edited_by
         FROM pages WHERE id = ?1;
         """)
         defer { stmt.reset() }
@@ -2468,11 +2521,13 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             bodyMarkdown: stmt.text(at: 3),
             createdAt: Date(timeIntervalSince1970: stmt.double(at: 4)),
             updatedAt: Date(timeIntervalSince1970: stmt.double(at: 5)),
-            version: Int(stmt.int(at: 6))
+            version: Int(stmt.int(at: 6)),
+            createdBy: sqlite3_column_type(stmt.handle, 7) == SQLITE_NULL ? nil : stmt.text(at: 7),
+            lastEditedBy: sqlite3_column_type(stmt.handle, 8) == SQLITE_NULL ? nil : stmt.text(at: 8)
         )
     }
 
-    public func createPage(title: String) throws -> WikiPage {
+    public func createPage(title: String, createdBy: String? = nil) throws -> WikiPage {
         try mutate(event: { page in localEvent(.page, id: page.id.rawValue, change: .created) }) {
         // Titles must stay linkable (`[[title]]`) — see WikiNameRules.
         let title = WikiNameRules.sanitized(title)
@@ -2480,23 +2535,25 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let slug = try uniqueSlug(from: title, id: id)
         let now = Date()
         let stmt = try statement("""
-        INSERT INTO pages (id, title, slug, body_markdown, created_at, updated_at, version)
-        VALUES (?1, ?2, ?3, '', ?4, ?4, 1);
+        INSERT INTO pages (id, title, slug, body_markdown, created_at, updated_at, version, created_by, last_edited_by)
+        VALUES (?1, ?2, ?3, '', ?4, ?4, 1, ?5, ?5);
         """)
         defer { stmt.reset() }
         try stmt.bind(id.rawValue, at: 1)
         try stmt.bind(title, at: 2)
         try stmt.bind(slug, at: 3)
         try stmt.bind(now.timeIntervalSince1970, at: 4)
+        if let createdBy { try stmt.bind(createdBy, at: 5) } else { try stmt.bind(nil, at: 5) }
         _ = try stmt.step()
         return WikiPage(
             id: id, title: title, slug: slug, bodyMarkdown: "",
-            createdAt: now, updatedAt: now, version: 1
+            createdAt: now, updatedAt: now, version: 1,
+            createdBy: createdBy, lastEditedBy: createdBy
         )
         }
     }
 
-    public func updatePage(id: PageID, title: String, body: String) throws {
+    public func updatePage(id: PageID, title: String, body: String, lastEditedBy: String? = nil) throws {
         try mutate(event: { _ in localEvent(.page, id: id.rawValue, change: .updated) }) {
         // Recompute slug from the (possibly renamed) title, then bump version
         // and updated_at. version bumps support Phase 3 change signaling.
@@ -2506,7 +2563,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let stmt = try statement("""
         UPDATE pages
         SET title = ?2, slug = ?3, body_markdown = ?4,
-            updated_at = ?5, version = version + 1
+            updated_at = ?5, version = version + 1, last_edited_by = ?6
         WHERE id = ?1;
         """)
         defer { stmt.reset() }
@@ -2515,6 +2572,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         try stmt.bind(slug, at: 3)
         try stmt.bind(body, at: 4)
         try stmt.bind(Date().timeIntervalSince1970, at: 5)
+        if let lastEditedBy { try stmt.bind(lastEditedBy, at: 6) } else { try stmt.bind(nil, at: 6) }
         _ = try stmt.step()
         guard sqlite3_changes(db) > 0 else { throw WikiStoreError.notFound(id) }
         }
@@ -2529,7 +2587,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// and reads stay unchanged.
     public func appendPageVersion(
         pageID: PageID, title: String, body: String,
-        expectedHeadVersionID: String?
+        expectedHeadVersionID: String?,
+        lastEditedBy: String? = nil
     ) throws -> String {
         try mutate(event: { _ in localEvent(.page, id: pageID.rawValue, change: .updated) }) {
         let title = WikiNameRules.sanitized(title)
@@ -2591,7 +2650,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             let upPage = try statement("""
             UPDATE pages
             SET title = ?2, slug = ?3, body_markdown = ?4,
-                updated_at = ?5, version = version + 1
+                updated_at = ?5, version = version + 1, last_edited_by = ?6
             WHERE id = ?1;
             """)
             upPage.reset()
@@ -2600,6 +2659,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try upPage.bind(slug, at: 3)
             try upPage.bind(body, at: 4)
             try upPage.bind(nowTS, at: 5)
+            if let lastEditedBy { try upPage.bind(lastEditedBy, at: 6) } else { try upPage.bind(nil, at: 6) }
             _ = try upPage.step()
             guard sqlite3_changes(db) > 0 else { throw WikiStoreError.notFound(pageID) }
 
@@ -7097,7 +7157,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             activityID: textOrNull(7),
             sourceVersionID: textOrNull(8),
             blobHash: textOrNull(9),
-            mimeType: textOrNull(10) ?? "text/markdown"
+            mimeType: textOrNull(10) ?? "text/markdown",
+            technique: textOrNull(11)
         )
     }
 
@@ -7108,7 +7169,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     smv.id, smv.file_id, smv.parent_id,
     COALESCE(CAST(b.content AS TEXT), ''),
     smv.origin, smv.note, smv.created_at,
-    smv.activity_id, smv.source_version_id, smv.blob_hash, smv.mime_type
+    smv.activity_id, smv.source_version_id, smv.blob_hash, smv.mime_type,
+    smv.technique
     """
     private static let smvBlobJoin = "LEFT JOIN blobs b ON b.hash = smv.blob_hash"
 
@@ -7343,12 +7405,12 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         var out: [ExtractionAlternative] = []
         while try stmt.step() {
             let version = sourceMarkdownVersion(from: stmt)
-            // Columns 0–10 are the smv row (see `smvSelectColumns`); 11/12 are
+            // Columns 0–11 are the smv row (see `smvSelectColumns`); 12/13 are
             // the agent name/version from the join.
-            let agentName = (sqlite3_column_type(stmt.handle, 11) == SQLITE_NULL)
-                ? "unknown" : stmt.text(at: 11)
-            let modelVersion: String? = (sqlite3_column_type(stmt.handle, 12) == SQLITE_NULL)
-                ? nil : stmt.text(at: 12)
+            let agentName = (sqlite3_column_type(stmt.handle, 12) == SQLITE_NULL)
+                ? "unknown" : stmt.text(at: 12)
+            let modelVersion: String? = (sqlite3_column_type(stmt.handle, 13) == SQLITE_NULL)
+                ? nil : stmt.text(at: 13)
             out.append(ExtractionAlternative(
                 version: version,
                 backendDisplayName: ExtractionAlternative.backendDisplayName(agentName: agentName),
@@ -7391,7 +7453,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
     @discardableResult
     public func appendProcessedMarkdown(sourceID: PageID, content: String,
-                                        origin: String, note: String?) throws -> SourceMarkdownVersion {
+                                        origin: String, note: String?,
+                                        technique: String? = nil) throws -> SourceMarkdownVersion {
         try mutate(event: { _ in localEvent(.source, id: sourceID.rawValue, change: .updated) }) {
         let id = PageID(rawValue: ULID.generate())
         let parentID = try processedMarkdownHead(sourceID: sourceID)?.id
@@ -7403,8 +7466,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let stmt = try statement("""
         INSERT INTO source_markdown_versions
           (id, file_id, parent_id, origin, note, created_at,
-           blob_hash, mime_type)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'text/markdown');
+           blob_hash, mime_type, technique)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'text/markdown', ?8);
         """)
         defer { stmt.reset() }
         try stmt.bind(id.rawValue, at: 1)
@@ -7414,6 +7477,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         if let note { try stmt.bind(note, at: 5) }
         try stmt.bind(now.timeIntervalSince1970, at: 6)
         try stmt.bind(blobHash, at: 7)
+        if let technique { try stmt.bind(technique, at: 8) } else { try stmt.bind(nil, at: 8) }
         _ = try stmt.step()
 
         // Re-embed the source from the just-written content + its name so content
@@ -7427,7 +7491,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         return SourceMarkdownVersion(
             id: id, sourceID: sourceID, parentID: parentID,
             content: content, origin: origin, note: note, createdAt: now,
-            blobHash: blobHash, mimeType: "text/markdown"
+            blobHash: blobHash, mimeType: "text/markdown", technique: technique
         )
         }
     }
@@ -7484,8 +7548,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             let ins = try statement("""
             INSERT INTO source_markdown_versions
               (id, file_id, parent_id, origin, note, created_at,
-               activity_id, source_version_id, blob_hash, mime_type)
-            VALUES (?1, ?2, ?3, 'extraction', ?4, ?5, ?6, ?7, ?8, 'text/markdown');
+               activity_id, source_version_id, blob_hash, mime_type, technique)
+            VALUES (?1, ?2, ?3, 'extraction', ?4, ?5, ?6, ?7, ?8, 'text/markdown', ?9);
             """)
             ins.reset()
             try ins.bind(id.rawValue, at: 1)
@@ -7496,6 +7560,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try ins.bind(activityID, at: 6)
             if let resolvedSourceVersionID { try ins.bind(resolvedSourceVersionID, at: 7) }
             try ins.bind(blobHash, at: 8)
+            try ins.bind(backend.rawValue, at: 9)
             _ = try ins.step()
             ins.reset()
         }
@@ -7513,7 +7578,8 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             id: id, sourceID: sourceID, parentID: parentID,
             content: content, origin: "extraction", note: note, createdAt: now,
             activityID: storedActivityID, sourceVersionID: resolvedSourceVersionID,
-            blobHash: storedBlobHash, mimeType: "text/markdown"
+            blobHash: storedBlobHash, mimeType: "text/markdown",
+            technique: backend.rawValue
         )
         }
     }

--- a/Sources/WikiFSCore/SourceMarkdownVersion.swift
+++ b/Sources/WikiFSCore/SourceMarkdownVersion.swift
@@ -38,6 +38,10 @@ public struct SourceMarkdownVersion: Identifiable, Hashable, Sendable {
     public let blobHash: String?
     /// MIME type of the body (`text/markdown`).
     public let mimeType: String
+    /// Which extraction backend/technique produced this version (e.g.
+    /// "pdf2md", "anthropic", "gemini", "docling"). `nil` for pre-#131 rows
+    /// and for user edits/reverts (#131).
+    public let technique: String?
 
     public init(
         id: PageID,
@@ -50,7 +54,8 @@ public struct SourceMarkdownVersion: Identifiable, Hashable, Sendable {
         activityID: String? = nil,
         sourceVersionID: String? = nil,
         blobHash: String? = nil,
-        mimeType: String = "text/markdown"
+        mimeType: String = "text/markdown",
+        technique: String? = nil
     ) {
         self.id = id
         self.sourceID = sourceID
@@ -63,5 +68,6 @@ public struct SourceMarkdownVersion: Identifiable, Hashable, Sendable {
         self.sourceVersionID = sourceVersionID
         self.blobHash = blobHash
         self.mimeType = mimeType
+        self.technique = technique
     }
 }

--- a/Sources/WikiFSCore/WikiPage.swift
+++ b/Sources/WikiFSCore/WikiPage.swift
@@ -9,6 +9,12 @@ public struct WikiPage: Identifiable, Hashable, Sendable {
     public let createdAt: Date
     public var updatedAt: Date
     public var version: Int
+    /// Which agent/model created this page (e.g. "claude-sonnet-4-5-20250929",
+    /// "user"). `nil` for pages created before provenance tracking (#131).
+    public var createdBy: String?
+    /// Which agent/model last edited this page. `nil` if unknown or unchanged
+    /// since creation (#131).
+    public var lastEditedBy: String?
 
     public init(
         id: PageID,
@@ -17,7 +23,9 @@ public struct WikiPage: Identifiable, Hashable, Sendable {
         bodyMarkdown: String,
         createdAt: Date,
         updatedAt: Date,
-        version: Int
+        version: Int,
+        createdBy: String? = nil,
+        lastEditedBy: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -26,5 +34,7 @@ public struct WikiPage: Identifiable, Hashable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.version = version
+        self.createdBy = createdBy
+        self.lastEditedBy = lastEditedBy
     }
 }

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -108,8 +108,8 @@ public protocol WikiStore: Sendable {
     /// Page summaries ordered by the given sort criterion.
     func listPages(sortBy: PageSortOrder) throws -> [WikiPageSummary]
     func getPage(id: PageID) throws -> WikiPage
-    func createPage(title: String) throws -> WikiPage
-    func updatePage(id: PageID, title: String, body: String) throws
+    func createPage(title: String, createdBy: String?) throws -> WikiPage
+    func updatePage(id: PageID, title: String, body: String, lastEditedBy: String?) throws
     func deletePage(id: PageID) throws
 
     /// Resolve a page *title* to its id, or nil if no page has that title.
@@ -309,7 +309,8 @@ public protocol WikiStore: Sendable {
     /// head to set `parentID`. Returns the new version.
     @discardableResult
     func appendProcessedMarkdown(sourceID: PageID, content: String,
-                                 origin: String, note: String?) throws -> SourceMarkdownVersion
+                                 origin: String, note: String?,
+                                 technique: String?) throws -> SourceMarkdownVersion
 
     /// Revert to an older version by appending a NEW version whose content
     /// copies the target. History is preserved; HEAD = the new revert version.
@@ -342,7 +343,8 @@ public protocol WikiStore: Sendable {
     /// the new version's id.
     func appendPageVersion(
         pageID: PageID, title: String, body: String,
-        expectedHeadVersionID: String?
+        expectedHeadVersionID: String?,
+        lastEditedBy: String?
     ) throws -> String
 
     /// Resolve the active page-content version id (ref → version_id, or

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -999,7 +999,7 @@ public final class WikiStoreModel {
     public func newPageInNewTab(title: String = "Untitled") {
         flushPendingSaves()
         do {
-            let page = try store.createPage(title: title)
+            let page = try store.createPage(title: title, createdBy: "user")
             try store.replaceLinks(from: page.id, parsedLinks: WikiLinkParser.parse(page.bodyMarkdown))
             reloadSummaries()
             openTab(.page(page.id), title: title)
@@ -1140,7 +1140,8 @@ public final class WikiStoreModel {
             // the editor loaded, this throws `PageConflictError` instead of
             // silently clobbering.
             try PageUpsert.upsert(in: store, id: id, title: draftTitle, body: draftBody,
-                                  expectedHeadVersionID: loadedPageHeadVersionID)
+                                  expectedHeadVersionID: loadedPageHeadVersionID,
+                                  author: "user")
             isDraftDirty = false
             // After a successful versioned save, refresh the head version id so
             // the next save CAS-expects the version we just wrote.
@@ -1442,7 +1443,7 @@ public final class WikiStoreModel {
     public func newPage(title: String = "Untitled") -> PageID? {
         flushPendingSaves()
         do {
-            let page = try store.createPage(title: title)
+            let page = try store.createPage(title: title, createdBy: "user")
             // A fresh page has an empty body, so this resolves to no links — but
             // run it for uniformity with the save() path (and so a future
             // create-with-body wouldn't silently skip link indexing).
@@ -1464,7 +1465,7 @@ public final class WikiStoreModel {
         do {
             let page = try store.getPage(id: id)
             let cleanBody = PageMarkdownFormat.stripped(body: page.bodyMarkdown, title: page.title)
-            try store.updatePage(id: id, title: newTitle, body: cleanBody)
+            try store.updatePage(id: id, title: newTitle, body: cleanBody, lastEditedBy: nil)
             reloadSummaries()
             if selection == .page(id) { draftTitle = newTitle }
             // Update any tab showing this renamed page.
@@ -1753,7 +1754,7 @@ public final class WikiStoreModel {
                 provenance: prov, role: .primary)
             let markdown = String(data: transcript.data, encoding: .utf8) ?? ""
             try store.appendProcessedMarkdown(
-                sourceID: summary.id, content: markdown, origin: "transcript", note: nil)
+                sourceID: summary.id, content: markdown, origin: "transcript", note: nil, technique: nil)
             reloadSources()
             openTab(.source(summary.id))
             return URLFetchService.FetchOutcome(
@@ -1939,7 +1940,7 @@ public final class WikiStoreModel {
                 sourceID: id, data: data, mimeType: nil, provenance: prov)
         case .derivedMarkdown(let content):
             try store.appendProcessedMarkdown(
-                sourceID: id, content: content, origin: "transcript", note: nil)
+                sourceID: id, content: content, origin: "transcript", note: nil, technique: nil)
         }
         reloadSources()
         return "Refreshed \(origin.displayLabel) source."
@@ -2170,7 +2171,7 @@ public final class WikiStoreModel {
         guard let bytes = try? store.sourceContent(id: file.id),
               let text = String(data: bytes, encoding: .utf8) else { return nil }
         return try? store.appendProcessedMarkdown(
-            sourceID: file.id, content: text, origin: "source", note: nil)
+            sourceID: file.id, content: text, origin: "source", note: nil, technique: nil)
     }
 
     /// True when at least one processed-markdown version exists for this source.
@@ -2242,7 +2243,7 @@ public final class WikiStoreModel {
     @discardableResult
     public func saveProcessedMarkdown(for sourceID: PageID, content: String) -> SourceMarkdownVersion? {
         try? store.appendProcessedMarkdown(
-            sourceID: sourceID, content: content, origin: "user", note: nil)
+            sourceID: sourceID, content: content, origin: "user", note: nil, technique: nil)
     }
 
     /// Seed the first processed-markdown version for a PDF from extraction

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -620,12 +620,14 @@ struct Projection {
                       let head = try? store.processedMarkdownHead(sourceID: PageID(rawValue: ulid)) else {
                     return nil
                 }
+                // Wrap with provenance frontmatter (#131).
+                let wrapped = SourceMarkdownFormat.fileContent(for: head)
                 // By-name markdown siblings: rewrite [[wikilinks]] to relative links.
                 if id.rawValue.hasPrefix(Identity.sourceMarkdownByNamePrefix) {
-                    return projection.rewriteLinks(head.content, maps: projection.makeLinkMaps(),
+                    return projection.rewriteLinks(wrapped, maps: projection.makeLinkMaps(),
                                                    baseDir: Self.sourcesByNameDir)
                 }
-                return Data(head.content.utf8)
+                return Data(wrapped.utf8)
             }
             if let ulid = Identity.fileULID(from: id) {
                 guard let store = projection.openReadStore(),

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -1161,7 +1161,7 @@ struct Projection {
                 filename: humanName, ext: "md", sourceID: source.id.rawValue)
             : FilenameEscaping.byIDSourceFilename(sourceID: source.id.rawValue, ext: "md")
         let parent = isByName ? Identity.sourcesByName : Identity.sourcesByID
-        let size = contentData?.count ?? head.content.utf8.count
+        let size = contentData?.count ?? SourceMarkdownFormat.fileContent(for: head).utf8.count
         return .file(
             id: id, parent: parent, name: name, size: size,
             version: Data(head.id.rawValue.utf8),

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -19,7 +19,7 @@ import SQLite3
     @Test func freshDBHasBookmarkNodesTable() throws {
         let url = tempDatabaseURL()
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "32")
+        #expect(store.pragmaValue("user_version") == "33")
 
         // The table exists.
         let nodes = try store.listBookmarkNodes()
@@ -37,7 +37,7 @@ import SQLite3
 
         // Reopen — triggers migration to v16.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "32")
+        #expect(reopened.pragmaValue("user_version") == "33")
 
         // Existing data is intact.
         let pages = try reopened.listPages(sortBy: .lastUpdated)

--- a/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
+++ b/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
@@ -20,7 +20,7 @@ struct EmbeddingMetaCutoverTests {
     @Test func freshDBSeedsNLEmbedderIdentifier() throws {
         let store = try tempStore()
         let stored = store.pragmaValue("user_version")
-        #expect(stored == "32")
+        #expect(stored == "33")
         // ensureEmbedderConsistency with the default identifier (nlembedding-512)
         // is a no-op: the seed matches, so nothing is wiped.
         store.ensureEmbedderConsistency(activeIdentifierOverride: NLEmbedder.identifier)

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -126,8 +126,8 @@ struct FreshSchemaParityTests {
         let ladder = try fingerprint(at: ladderURL)
 
         // Both must report head version 22.
-        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "32")
-        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "32")
+        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "33")
+        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "33")
 
         if fast != ladder {
             Issue.record("fresh fast-path schema drifted from the stepwise ladder:\n--- fast ---\n\(fast)\n--- ladder ---\n\(ladder)")
@@ -212,7 +212,7 @@ struct FreshSchemaParityTests {
         // 3. Reopen → runs the v20→v21 backfill.
         sqlite3_close(db)
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "32")
+        #expect(migrated.pragmaValue("user_version") == "33")
 
         // 4. The legacy extraction row was backfilled: blob_hash + activity_id + source_version_id set.
         #expect(migrated.scalarText(
@@ -274,7 +274,7 @@ struct FreshSchemaParityTests {
         sqlite3_close(db)
 
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "32")
+        #expect(migrated.pragmaValue("user_version") == "33")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
         let roleCol = columns(db2, "sources").first { $0.name == "role" }
@@ -349,7 +349,7 @@ struct FreshSchemaParityTests {
 
         // Reopen → v22 migration rebuilds source_links.
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "32")
+        #expect(migrated.pragmaValue("user_version") == "33")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 
@@ -408,7 +408,7 @@ struct FreshSchemaParityTests {
 
         let reopenStart = Date()
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "32")
+        #expect(migrated.pragmaValue("user_version") == "33")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -238,7 +238,7 @@ struct LogIndexTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 32)
+        #expect(sqlite3_column_int(stmt, 0) == 33)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
+++ b/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
@@ -191,7 +191,7 @@ struct Phase5StoreCanonicalizationTests {
 
         // Reopen → v23 sweep runs.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "32")
+        #expect(reopened.pragmaValue("user_version") == "33")
 
         let migrated = try reopened.getPage(id: linkerID)
         // Resolvable link canonicalized; forward link left verbatim.

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -112,7 +112,7 @@ struct ProcessedMarkdownTests {
 
     @Test func freshDBHasV8Schema() throws {
         let store = try tempStore()
-        #expect(store.pragmaValue("user_version") == "32")
+        #expect(store.pragmaValue("user_version") == "33")
     }
 
     @Test func v7DBUpgradesToV8PreservingData() throws {
@@ -128,7 +128,7 @@ struct ProcessedMarkdownTests {
 
         // Opening runs v7→v8→…→v15 migration.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "32")
+        #expect(store.pragmaValue("user_version") == "33")
         // Pre-existing file is intact.
         let content = try store.sourceContent(
             id: PageID(rawValue: "01J00000000000000000000000"))

--- a/Tests/WikiFSTests/ProjectionTests.swift
+++ b/Tests/WikiFSTests/ProjectionTests.swift
@@ -99,8 +99,8 @@ struct ProjectionTests {
         #expect(node.ingestedExt == "md")
         // mimeType is "text/markdown"
         #expect(node.mimeType == "text/markdown")
-        // size is head.content.utf8.count
-        #expect(node.size == head.content.utf8.count)
+        // size is the frontmatter-wrapped content
+        #expect(node.size == SourceMarkdownFormat.fileContent(for: head).utf8.count)
         // created and modified are head.createdAt
         #expect(node.created == createdAt)
         #expect(node.modified == createdAt)
@@ -153,8 +153,8 @@ struct ProjectionTests {
         #expect(node.ingestedExt == "md")
         // mimeType is "text/markdown"
         #expect(node.mimeType == "text/markdown")
-        // size is head.content.utf8.count
-        #expect(node.size == head.content.utf8.count)
+        // size is the frontmatter-wrapped content
+        #expect(node.size == SourceMarkdownFormat.fileContent(for: head).utf8.count)
         // created and modified are head.createdAt
         #expect(node.created == createdAt)
         #expect(node.modified == createdAt)

--- a/Tests/WikiFSTests/ProjectionTreeTests.swift
+++ b/Tests/WikiFSTests/ProjectionTreeTests.swift
@@ -150,7 +150,7 @@ struct ProjectionTreeTests {
         guard let head = try s.store.processedMarkdownHead(sourceID: s.pdfSource.id) else {
             Issue.record("markdown head not found"); return
         }
-        #expect(s.projection.contents(for: id) == Data(head.content.utf8))
+        #expect(s.projection.contents(for: id) == Data(SourceMarkdownFormat.fileContent(for: head).utf8))
     }
 
     @Test func markdownSiblingAppearsForNonTextSource() throws {

--- a/Tests/WikiFSTests/ProvenanceFrontmatterTests.swift
+++ b/Tests/WikiFSTests/ProvenanceFrontmatterTests.swift
@@ -1,0 +1,129 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// Tests for provenance frontmatter generation (#131):
+/// - `PageMarkdownFormat.fileContent` includes `created_by` / `last_edited_by`
+///   when present, omits them when nil.
+/// - `SourceMarkdownFormat.fileContent` includes `origin`, `date`, `technique`.
+@Suite struct ProvenanceFrontmatterTests {
+
+    // MARK: - Page frontmatter
+
+    private func samplePage(
+        createdBy: String? = nil,
+        lastEditedBy: String? = nil
+    ) -> WikiPage {
+        WikiPage(
+            id: PageID(rawValue: "01PAGE"),
+            title: "Mars Terraforming",
+            slug: "mars-terraforming",
+            bodyMarkdown: "## Phase 1\n\nAtmospheric processing.",
+            createdAt: Date(timeIntervalSince1970: 1000000000),
+            updatedAt: Date(timeIntervalSince1970: 2000000000),
+            version: 3,
+            createdBy: createdBy,
+            lastEditedBy: lastEditedBy
+        )
+    }
+
+    @Test func pageFrontmatterWithoutProvenance() {
+        let page = samplePage()
+        let md = PageMarkdownFormat.fileContent(for: page)
+        #expect(md.contains("---"))
+        #expect(md.contains("title:"))
+        #expect(md.contains("date:"))
+        #expect(!md.contains("created_by:"))
+        #expect(!md.contains("last_edited_by:"))
+    }
+
+    @Test func pageFrontmatterWithCreatedBy() {
+        let page = samplePage(createdBy: "user", lastEditedBy: "user")
+        let md = PageMarkdownFormat.fileContent(for: page)
+        #expect(md.contains("created_by: user"))
+        // last_edited_by is omitted when it equals created_by
+        #expect(!md.contains("last_edited_by:"))
+    }
+
+    @Test func pageFrontmatterWithDifferentEditor() {
+        let page = samplePage(createdBy: "user", lastEditedBy: "claude-sonnet-4-5-20250929")
+        let md = PageMarkdownFormat.fileContent(for: page)
+        #expect(md.contains("created_by: user"))
+        #expect(md.contains("last_edited_by: claude-sonnet-4-5-20250929"))
+    }
+
+    @Test func pageFrontmatterWithOnlyLastEditedBy() {
+        let page = samplePage(createdBy: nil, lastEditedBy: "agent")
+        let md = PageMarkdownFormat.fileContent(for: page)
+        #expect(!md.contains("created_by:"))
+        #expect(md.contains("last_edited_by: agent"))
+    }
+
+    @Test func pageFrontmatterBodyPreserved() {
+        let page = samplePage()
+        let md = PageMarkdownFormat.fileContent(for: page)
+        #expect(md.contains("# Mars Terraforming"))
+        #expect(md.contains("## Phase 1"))
+        #expect(md.contains("Atmospheric processing."))
+    }
+
+    // MARK: - Source markdown frontmatter
+
+    private func sampleVersion(
+        origin: String = "extraction",
+        technique: String? = "anthropic",
+        note: String? = nil
+    ) -> SourceMarkdownVersion {
+        SourceMarkdownVersion(
+            id: PageID(rawValue: "01SMV"),
+            sourceID: PageID(rawValue: "01SRC"),
+            parentID: nil,
+            content: "# Extracted Content\n\nSome text.",
+            origin: origin,
+            note: note,
+            createdAt: Date(timeIntervalSince1970: 1500000000),
+            technique: technique
+        )
+    }
+
+    @Test func sourceFrontmatterIncludesOriginAndDate() {
+        let ver = sampleVersion()
+        let md = SourceMarkdownFormat.fileContent(for: ver)
+        #expect(md.contains("---"))
+        #expect(md.contains("origin: extraction"))
+        #expect(md.contains("date:"))
+    }
+
+    @Test func sourceFrontmatterIncludesTechnique() {
+        let ver = sampleVersion(technique: "gemini")
+        let md = SourceMarkdownFormat.fileContent(for: ver)
+        #expect(md.contains("technique: gemini"))
+    }
+
+    @Test func sourceFrontmatterOmitsTechniqueWhenNil() {
+        let ver = sampleVersion(technique: nil)
+        let md = SourceMarkdownFormat.fileContent(for: ver)
+        #expect(!md.contains("technique:"))
+    }
+
+    @Test func sourceFrontmatterIncludesNote() {
+        let ver = sampleVersion(note: "Re-extracted with better model")
+        let md = SourceMarkdownFormat.fileContent(for: ver)
+        #expect(md.contains("note:"))
+        #expect(md.contains("Re-extracted with better model"))
+    }
+
+    @Test func sourceFrontmatterBodyPreserved() {
+        let ver = sampleVersion()
+        let md = SourceMarkdownFormat.fileContent(for: ver)
+        #expect(md.contains("# Extracted Content"))
+        #expect(md.contains("Some text."))
+    }
+
+    @Test func sourceFrontmatterUserEdit() {
+        let ver = sampleVersion(origin: "user", technique: nil)
+        let md = SourceMarkdownFormat.fileContent(for: ver)
+        #expect(md.contains("origin: user"))
+        #expect(!md.contains("technique:"))
+    }
+}

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -67,7 +67,7 @@ struct SQLiteWikiStoreTests {
         // user_version guard: a fresh DB runs all migration steps → version 16.
         // Reopening must not re-run DDL (no-op bootstrap).
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "32")
+        #expect(userVersion == "33")
         let reopened = try SQLiteWikiStore(databaseURL: url)
         // If bootstrap weren't guarded, the CREATE TABLE would throw here.
         #expect((try? reopened.listPages(sortBy: .lastUpdated)) != nil)
@@ -325,7 +325,7 @@ struct SQLiteWikiStoreTests {
         defer { sqlite3_close(db) }
 
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "32")
+        #expect(userVersion == "33")
 
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"))
@@ -369,7 +369,7 @@ struct SQLiteWikiStoreTests {
 
     @Test func freshDBReachesUserVersion18() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(store.pragmaValue("user_version") == "32")
+        #expect(store.pragmaValue("user_version") == "33")
     }
 
     @Test func v11SourceLinksHasDeleteCascade() throws {
@@ -625,7 +625,7 @@ struct SQLiteWikiStoreTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarText(db, "PRAGMA user_version;") == "32")
+        #expect(scalarText(db, "PRAGMA user_version;") == "33")
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"))
         for expected in ["blobs", "agents", "activities", "source_versions", "refs"] {
@@ -686,7 +686,7 @@ struct SQLiteWikiStoreTests {
 
         // Reopen → migrates 19→20.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "32")
+        #expect(store.pragmaValue("user_version") == "33")
 
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
@@ -744,7 +744,7 @@ struct SQLiteWikiStoreTests {
 
         // Reopen → migrates 28→29.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "32")
+        #expect(store.pragmaValue("user_version") == "33")
 
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)

--- a/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
+++ b/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
@@ -49,7 +49,7 @@ struct SourceEmbeddingSearchTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarInt(db, "PRAGMA user_version;") == 32)
+        #expect(scalarInt(db, "PRAGMA user_version;") == 33)
         #expect(tableExists(db, "source_chunks"))
         // page chunk table mirrors the source one.
         #expect(tableExists(db, "page_chunks"))

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -279,7 +279,7 @@ struct SourcesTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 32)
+        #expect(sqlite3_column_int(stmt, 0) == 33)
         _ = store
     }
 

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -234,7 +234,7 @@ struct SystemPromptTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 32)
+        #expect(sqlite3_column_int(stmt, 0) == 33)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
+++ b/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
@@ -104,7 +104,7 @@ struct WikiNameSanitizationStoreTests {
 
         // Reopen → the 17→18 step sweeps the dirty names.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "32")
+        #expect(reopened.pragmaValue("user_version") == "33")
         let page = try reopened.getPage(id: pageID!)
         #expect(page.title == "(Draft) Bad - #Title") // inner # is fine, kept
         #expect(try reopened.getSource(id: sourceID!).displayName == "Foo - Bar)")


### PR DESCRIPTION
## Summary

Fixes #131 — pages had zero attribution (no `created_by`, no `last_edited_by`), and source markdown was served raw with no frontmatter despite the store already tracking `origin` and `createdAt`. This adds provenance columns to the schema, surfaces them as generated frontmatter, and threads attribution through the write paths.

## Changes

### 1. Schema migration (v32 → v33)
- Added `created_by TEXT` and `last_edited_by TEXT` (nullable) to `pages` table
- Added `technique TEXT` (nullable) to `source_markdown_versions`
- Migration is idempotent — guards via `pragma_table_info` before `ALTER TABLE ADD COLUMN`
- Fresh schema (`createFreshSchemaV20`) updated to include the new columns + `user_version=33`
- Updated 20+ existing test assertions from `user_version == 32` to `== 33`

### 2. Model updates
- **`WikiPage`**: added `createdBy: String?` and `lastEditedBy: String?` fields (with defaults for backward compatibility)
- **`SourceMarkdownVersion`**: added `technique: String?` field
- **`WikiStore` protocol**: `createPage`, `updatePage`, `appendPageVersion`, `appendProcessedMarkdown` all accept new provenance parameters

### 3. Provenance threading
- **`PageUpsert.upsert`**: accepts `author: String?` param, threads through to `createPage(createdBy:)`, `updatePage(lastEditedBy:)`, and `appendPageVersion(lastEditedBy:)`
- **`WikiStoreModel`**: user-initiated saves pass `author: "user"`; user-initiated page creation passes `createdBy: "user"`
- **`recordMarkdownExtraction`**: writes `technique = backend.rawValue` (e.g. `"anthropic"`, `"gemini"`, `"localPdf2md"`, `"doclingServe"`) into the smv row
- **`appendProcessedMarkdown`**: accepts `technique: String?` param

### 4. Generated frontmatter
- **`PageMarkdownFormat.fileContent`**: includes `created_by` and `last_edited_by` in YAML frontmatter when present; omits when nil; suppresses `last_edited_by` when it equals `created_by` (no redundant "edited by same author")
- **New `SourceMarkdownFormat.fileContent`**: wraps source markdown body with YAML frontmatter (`origin`, `date`, `technique`, optional `note`)
- **File Provider `Projection`**: source `.md` siblings now served with frontmatter instead of raw content

### 5. `processedMarkdownAlternatives` column shift fix
- `smvSelectColumns` now includes `smv.technique` as column 11; updated the `processedMarkdownAlternatives` query to read agent name/version from columns 12/13 instead of 11/12

### 6. Tests — 11 new `ProvenanceFrontmatterTests`
- Page frontmatter: without provenance, with `created_by`, with different editor, with only `last_edited_by`, body preservation
- Source frontmatter: `origin`+`date`, `technique` (present/nil), `note`, body preservation, user edit path

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter ProvenanceFrontmatterTests` — 11 tests pass
- [x] `swift test` fast tier (2304 tests) — all pass
- [ ] CI green

Closes #131.
