### PR TITLE
Fix stale changeToken: delete source/page refs on delete

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,34 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-12 — Fix orphaned `refs` on source/page delete (changeToken stale)
+
+**Symptom.** `changeTokenAdvancesOnIngestAndDelete` (and
+`deleteSourceCascadesVersionsAndRefsKeepsBlobs`) failed after the W0
+workspace commit (#312), not — as initially suspected — the #131 provenance
+commit (which only touched `user_version` literals in this test file).
+
+**Root cause.** W0 (`5fb2650`, PR #312) rebuilt the `refs` table to drop the
+`owner_id REFERENCES sources(id) ON DELETE CASCADE` FK, because `owner_id` is
+now polymorphic: a source id for `source-content`/`source-derived` refs, a page
+id for `page-content` refs (a single FK onto `sources` no longer fits). The
+`source_versions` / `source_markdown_versions` rows still cascade via their own
+FKs, but the `refs` row itself has no cascade — so `deleteSource` orphaned it.
+The orphan left `refsGenerationSum` (a `changeToken` fold) stale, so the token
+didn't advance on delete and the File Provider's `files/` tree wouldn't refresh.
+
+**Fix.** `deleteSource` now explicitly `DELETE FROM refs WHERE owner_id = ?1
+AND kind IN ('source-content','source-derived')` inside the same
+`withTransaction` as the source row delete. Mirrored in `deletePage` for
+`page-content` refs (same latent leak — a page with a CAS `page-content` ref
+would orphan it on delete).
+
+**Tests.** The two regressing tests pass; full `changeToken`/delete/emission/
+schema/workspace sweep (90 tests) green; fast tier (2304 tests) green. The two
+pre-existing migration-test failures (`migrateV19ToV20…`,
+`migrateV28ToV29RewritesAskChatsToEdit`) fail identically on clean `ebd31e4`
+and are unrelated to this change.
+
 ## 2026-07-11 — W4: Concurrency at scale (PR #312)
 
 **What shipped.** Phase W4 (final) of the multi-writer concurrency plan:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,34 +2,6 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-## 2026-07-12 — Fix orphaned `refs` on source/page delete (changeToken stale)
-
-**Symptom.** `changeTokenAdvancesOnIngestAndDelete` (and
-`deleteSourceCascadesVersionsAndRefsKeepsBlobs`) failed after the W0
-workspace commit (#312), not — as initially suspected — the #131 provenance
-commit (which only touched `user_version` literals in this test file).
-
-**Root cause.** W0 (`5fb2650`, PR #312) rebuilt the `refs` table to drop the
-`owner_id REFERENCES sources(id) ON DELETE CASCADE` FK, because `owner_id` is
-now polymorphic: a source id for `source-content`/`source-derived` refs, a page
-id for `page-content` refs (a single FK onto `sources` no longer fits). The
-`source_versions` / `source_markdown_versions` rows still cascade via their own
-FKs, but the `refs` row itself has no cascade — so `deleteSource` orphaned it.
-The orphan left `refsGenerationSum` (a `changeToken` fold) stale, so the token
-didn't advance on delete and the File Provider's `files/` tree wouldn't refresh.
-
-**Fix.** `deleteSource` now explicitly `DELETE FROM refs WHERE owner_id = ?1
-AND kind IN ('source-content','source-derived')` inside the same
-`withTransaction` as the source row delete. Mirrored in `deletePage` for
-`page-content` refs (same latent leak — a page with a CAS `page-content` ref
-would orphan it on delete).
-
-**Tests.** The two regressing tests pass; full `changeToken`/delete/emission/
-schema/workspace sweep (90 tests) green; fast tier (2304 tests) green. The two
-pre-existing migration-test failures (`migrateV19ToV20…`,
-`migrateV28ToV29RewritesAskChatsToEdit`) fail identically on clean `ebd31e4`
-and are unrelated to this change.
-
 ## 2026-07-11 — W4: Concurrency at scale (PR #312)
 
 **What shipped.** Phase W4 (final) of the multi-writer concurrency plan:

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -3734,6 +3734,17 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try deleteAttachments.bind(id.rawValue, at: 1)
             _ = try deleteAttachments.step()
 
+            // `page-content` refs use the page id as `owner_id`. Like sources,
+            // the `refs` table has no FK cascade onto `pages` (W0/#312 made
+            // `owner_id` polymorphic), so a page with a CAS `page-content` ref
+            // would leak the ref row on delete — orphaning `version_id` and
+            // staling the changeToken. Delete it in the same transaction.
+            let deleteRefs = try statement(
+                "DELETE FROM refs WHERE owner_id = ?1 AND kind = 'page-content';")
+            deleteRefs.reset()
+            try deleteRefs.bind(id.rawValue, at: 1)
+            _ = try deleteRefs.step()
+
             let stmt = try statement("DELETE FROM pages WHERE id = ?1;")
             stmt.reset()
             try stmt.bind(id.rawValue, at: 1)
@@ -4938,10 +4949,32 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
     public func deleteSource(id: PageID) throws {
         try mutate(event: { _ in localEvent(.source, id: id.rawValue, change: .deleted) }) {
-        let stmt = try statement("DELETE FROM sources WHERE id = ?1;")
-        defer { stmt.reset() }
-        try stmt.bind(id.rawValue, at: 1)
-        _ = try stmt.step()
+        // The `refs` table has NO `owner_id REFERENCES sources(id) ON DELETE
+        // CASCADE` FK — W0 (#312) dropped it because `owner_id` is polymorphic:
+        // a source id for `source-content`/`source-derived` refs, a page id for
+        // `page-content` refs. So deleting a source would otherwise orphan its
+        // ref rows (the `version_id` they point at cascades away via
+        // `source_versions`/`source_markdown_versions` FKs, but the ref row
+        // itself survives), leaving `refsGenerationSum` — a changeToken fold —
+        // stale and the File Provider's `files/` tree unrefreshed. Delete the
+        // source's refs explicitly, in the same transaction as the source row.
+        // Regression: `changeTokenAdvancesOnIngestAndDelete`,
+        // `deleteSourceCascadesVersionsAndRefsKeepsBlobs`.
+        try withTransaction {
+            let deleteRefs = try statement(
+                """
+                DELETE FROM refs
+                WHERE owner_id = ?1 AND kind IN ('source-content','source-derived');
+                """)
+            defer { deleteRefs.reset() }
+            try deleteRefs.bind(id.rawValue, at: 1)
+            _ = try deleteRefs.step()
+
+            let stmt = try statement("DELETE FROM sources WHERE id = ?1;")
+            defer { stmt.reset() }
+            try stmt.bind(id.rawValue, at: 1)
+            _ = try stmt.step()
+        }
         }
     }
 


### PR DESCRIPTION
## Summary

`changeTokenAdvancesOnIngestAndDelete` (and `deleteSourceCascadesVersionsAndRefsKeepsBlobs`) regressed, leaving the change token stale so the File Provider `files/` tree would not refresh after a delete.

## Root cause

Not the #131 provenance commit (it only touched `user_version` literals in the test file). The real culprit is the **W0 workspace commit (`5fb2650`, PR #312)**, which rebuilt the `refs` table to drop the `owner_id REFERENCES sources(id) ON DELETE CASCADE` foreign key.

`refs.owner_id` is now polymorphic — a source id for `source-content`/`source-derived` refs, and a page id for `page-content` refs — so a single FK onto `sources` no longer fits. The `source_versions`/`source_markdown_versions` rows still cascade on delete via their own FKs, but the `refs` row itself lost its cascade, and `deleteSource`/`deletePage` were never updated to compensate. The orphaned ref left `refsGenerationSum` (a `changeToken` fold) stale.

Expected after delete: `0:0:1:1:1:0:1:0:1:1:2:0:0:0` (refsGenSum 2→1)
Actual:               `0:0:1:1:1:0:1:0:1:2:2:0:0:0` (orphan, stays 2)

## Fix

`Sources/WikiFSCore/SQLiteWikiStore.swift`:
- `deleteSource` now explicitly `DELETE FROM refs WHERE owner_id = ?1 AND kind IN ('source-content','source-derived')` inside the same `withTransaction` as the source-row delete.
- `deletePage` mirrored the same cleanup for `page-content` refs (same latent leak for pages with a CAS `page-content` ref).

## Verification

- Both regressing tests pass: `changeTokenAdvancesOnIngestAndDelete`, `deleteSourceCascadesVersionsAndRefsKeepsBlobs`.
- Full `changeToken` / delete / emission / schema / workspace sweep (90 tests) green.
- Fast tier: 2304 tests pass.
- The two pre-existing migration-test failures (`migrateV19ToV20…`, `migrateV28ToV29RewritesAskChatsToEdit`) fail identically on clean `ebd31e4` and are unrelated to this change.
