### PR TITLE
Fix hardening feedback: 3 failing tests + 2 Phase-7 latent defects

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,40 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-12 — Hardening Feedback Fixes (Fable Review)
+
+Addressed 3 failing tests + 2 latent Phase-7 defects from the Fable review of
+the multi-writer hardening commit (`de539d7`).
+
+**3 failing tests (all CI-skipped `SQLiteWikiStoreTests`):**
+1. `changeTokenAdvancesOnEveryMutation` — test expected `refsGenSum` unchanged
+   after `deletePage`, but the hardening commit correctly cascades the page's
+   `page-content` ref on delete. Fixed the test literal + comment.
+2. `migrateV28ToV29RewritesAskChatsToEdit` — v29→v30 refs rebuild queried a
+   `refs` table absent from the chats-only fixture. Added table-existence guard
+   (create fresh if missing), matching the v30 `hasPages` convention.
+3. `migrateV19ToV20_hashesContentIntoBlobsAndDropsContentColumn` — v32→v33's
+   `tableColumnInfo("pages")` and v33→v34's backfill against a sources-only
+   fixture. Added `sqlite_master` existence guards on both steps.
+
+**Latent defect 1 (Phase 7): `workspaceWritePage` status guard.** Writes to a
+`merged`/`conflicted`/`abandoned` workspace succeeded silently. Added a
+`status == 'open'` guard (one query) at the top of the transaction. Two tests
+added to `WorkspaceStagingTests`.
+
+**Latent defect 2 (Phase 7): `WIKI_WORKSPACE` global `setenv`.** The env var
+was process-global, leaking to chat-edit agents spawned mid-ingest via the
+interactive lane. Replaced `setenv`/`unsetenv` in `AgentOperationRunner` with
+per-spawn environment injection: `workspaceID` threaded through
+`AgentLauncher.run()` → `providerHints["env.WIKI_WORKSPACE"]` →
+`ACPBackend.start` (already handled `env.*` prefix) +
+`ClaudeCLIBackend.start` (added `env.*` expansion). `OperationCommand.environment`
+changed `let` → `var` to enable post-construction injection. This also fixes
+the cancelled-while-queued stale-env-var case (no global state to leave stale).
+
+All 55 `SQLiteWikiStoreTests` + `WorkspaceStagingTests` pass. Full fast-tier
+CI (2349 tests) passes.
+
 ## 2026-07-12 — Multi-Writer Hardening: All 7 Phases Complete
 
 **All 7 phases of the multi-writer hardening plan are implemented.** The

--- a/Sources/WikiFS/AgentLauncher.swift
+++ b/Sources/WikiFS/AgentLauncher.swift
@@ -833,6 +833,7 @@ final class AgentLauncher {
         systemPrompt: String,
         wikictlDirectory: String,
         ingestingSourceIDs: Set<PageID> = [],
+        workspaceID: String? = nil,
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void
     ) async {
@@ -1019,12 +1020,22 @@ final class AgentLauncher {
             onStderrChunk: { [weak self] chunk in
                 Task { @MainActor [weak self] in self?.ingestStderr(chunk) }
             })
-        let profile = BackendProfile(
-            providerHints: AgentBackendFactory.providerHints(
+        var providerHints = AgentBackendFactory.providerHints(
                 provider: provider,
                 resolvedCommand: resolvedACPCommand,
                 apiKey: acpAPIKey,
-                selectedModelId: providersConfig().selectedModelId(forProvider: provider.id)),
+                selectedModelId: providersConfig().selectedModelId(forProvider: provider.id))
+        // Phase 7: inject the workspace ID as a per-spawn env var (NOT
+        // process-global setenv — which would leak to chat-edit agents spawned
+        // mid-ingest via the interactive lane). The `env.` prefix is the
+        // established convention: ACPBackend.start already expands env.* keys
+        // into the child process environment, and ClaudeCLIBackend.start does
+        // the same (see below). Non-workspace runs pass nil → no injection.
+        if let wsID = workspaceID {
+            providerHints["env.WIKI_WORKSPACE"] = wsID
+        }
+        let profile = BackendProfile(
+            providerHints: providerHints,
             scratchDirectory: scratch,
             isReadOnly: false,
             cli: cli)

--- a/Sources/WikiFS/AgentOperationRunner.swift
+++ b/Sources/WikiFS/AgentOperationRunner.swift
@@ -170,17 +170,16 @@ enum AgentOperationRunner {
         DebugLog.ingest("runMultiIngest: handing off \(sources.count) source(s), totalBytes=\(sources.reduce(0) { $0 + $1.bytes.count })")
 
         // Phase 7: workspace-isolated ingestion. When the capability flag is on,
-        // create a workspace, set WIKI_WORKSPACE so the agent's `wikictl` calls
-        // route into it, and auto-merge on completion. When the flag is off,
-        // behavior is identical to today (writes directly to main).
+        // create a workspace, pass the workspace ID to the launcher so it injects
+        // `WIKI_WORKSPACE` into the child process's per-spawn environment (NOT
+        // process-global setenv — which would leak to chat-edit agents spawned
+        // mid-ingest via the interactive lane), and auto-merge on completion.
+        // When the flag is off, behavior is identical to today (writes to main).
         if store.workspacesEnabled {
             do {
                 let wsID = try store.createWorkspace(
                     name: "ingest-\(sourceIDs.count)", activityID: nil)
                 DebugLog.ingest("runMultiIngest: workspace isolated, wsID=\(wsID)")
-                // Set the env var so the agent's wikictl subprocess calls auto-route
-                // to the workspace. The subprocess inherits the parent's environment.
-                setenv("WIKI_WORKSPACE", wsID, 1)
                 await run(
                     request: .ingest(sources: sources, stateMarkdown: stateMarkdown),
                     launcher: launcher,
@@ -188,6 +187,7 @@ enum AgentOperationRunner {
                     manager: manager,
                     fileProvider: fileProvider,
                     ingestingSourceIDs: Set(sourceIDs),
+                    workspaceID: wsID,
                     onWorkspaceMerge: { [weak store] in
                         // Auto-merge after the agent finishes. The merge is
                         // best-effort: if it conflicts, the workspace is parked
@@ -199,7 +199,6 @@ enum AgentOperationRunner {
                         } catch {
                             DebugLog.ingest("runMultiIngest: workspace merge FAILED wsID=\(wsID) — \(error.localizedDescription)")
                         }
-                        unsetenv("WIKI_WORKSPACE")
                     })
             } catch {
                 DebugLog.ingest("runMultiIngest: workspace creation FAILED — falling back to main, \(error.localizedDescription)")
@@ -653,6 +652,7 @@ enum AgentOperationRunner {
         manager: WikiManager,
         fileProvider: FileProviderSpike,
         ingestingSourceIDs: Set<PageID> = [],
+        workspaceID: String? = nil,
         onWorkspaceMerge: (@MainActor () -> Void)? = nil
     ) async {
         guard let wikiID = manager.activeWikiID else { return }
@@ -676,6 +676,7 @@ enum AgentOperationRunner {
             systemPrompt: store.currentSystemPromptBody(),
             wikictlDirectory: HelpersLocation.wikictlDirectory,
             ingestingSourceIDs: ingestingSourceIDs,
+            workspaceID: workspaceID,
             onLock: { store.agentRunStarted() },
             onUnlock: {
                 store.agentRunEnded()

--- a/Sources/WikiFS/ClaudeCLIBackend.swift
+++ b/Sources/WikiFS/ClaudeCLIBackend.swift
@@ -156,7 +156,7 @@ actor ClaudeCLIBackend: AgentBackend {
         // (Settings modelOverride → per-op alias). Default = unchanged.
         let cliSelectedModel = profile.providerHints["cliSelectedModel"]
         let isInteractive: Bool
-        let command: OperationCommand
+        var command: OperationCommand
         if case .queryChat = cli.operation {
             isInteractive = true
             command = OperationCommand.buildInteractiveQuery(
@@ -186,6 +186,15 @@ actor ClaudeCLIBackend: AgentBackend {
                 selectedModel: cliSelectedModel
             )
         }
+
+        // Phase 7: expand `env.*` provider hints into the child process
+        // environment (matches ACPBackend.start's convention). Used for
+        // per-spawn WIKI_WORKSPACE injection — NOT process-global setenv.
+        var commandEnv = command.environment
+        for (key, value) in profile.providerHints where key.hasPrefix("env.") {
+            commandEnv[String(key.dropFirst(4))] = value
+        }
+        command.environment = commandEnv
 
         DebugLog.agent("ClaudeCLIBackend.start: command \(command.debugSummary)") // TEMP DEBUG (existed; re-tagged)
         DebugLog.agent("ClaudeCLIBackend.start: isInteractive=\(isInteractive) exe=\(command.executable) argCount=\(command.arguments.count) authSet=\(!(command.environment["ANTHROPIC_API_KEY"]?.isEmpty ?? true)) cwd=\(profile.scratchDirectory?.lastPathComponent ?? "(none)")") // TEMP DEBUG

--- a/Sources/WikiFSCore/OperationCommand.swift
+++ b/Sources/WikiFSCore/OperationCommand.swift
@@ -18,7 +18,9 @@ public struct OperationCommand: Equatable, Sendable {
     /// The full argument vector after `executable`.
     public let arguments: [String]
     /// The child process environment (a copy of the parent's, plus our additions).
-    public let environment: [String: String]
+    /// `var` so backends can inject per-spawn env (e.g. `WIKI_WORKSPACE` from
+    /// `providerHints`) after `OperationCommand.build` constructs the base.
+    public var environment: [String: String]
     /// The working directory: a per-run WRITABLE scratch dir (Claude Code needs a
     /// writable cwd for session/todo scratch — decision #4). NEVER the read-only
     /// mount.

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -1967,11 +1967,35 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             //    Guard: if refs already has the CHECK (a DB rewound to v29 for
             //    testing after already being at v30), the rebuild is a no-op
             //    (copy → drop → rename is identity).
-            let refsHasCheck = try queryScalarText(
-                "SELECT sql FROM sqlite_master WHERE type='table' AND name='refs';").contains("CHECK")
-            if !refsHasCheck {
+            //
+            //    Guard: hand-built migration fixtures (e.g. a v28 chats-only DB)
+            //    may not have a `refs` table at all — the v19→v20 step that
+            //    creates it was skipped. If refs doesn't exist, create it fresh
+            //    (the CHECK-constrained shape) rather than copying from nothing.
+            let refsExists = try queryScalarText(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='refs';") != "0"
+            if refsExists {
+                let refsHasCheck = try queryScalarText(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='refs';").contains("CHECK")
+                if !refsHasCheck {
+                    try exec("""
+                    CREATE TABLE _refs_new (
+                        kind       TEXT NOT NULL CHECK (kind IN ('source-content','source-derived','page-content')),
+                        owner_id   TEXT NOT NULL,
+                        version_id TEXT NOT NULL,
+                        generation INTEGER NOT NULL DEFAULT 1,
+                        updated_at REAL NOT NULL,
+                        PRIMARY KEY (kind, owner_id)
+                    );
+                    """)
+                    try exec("INSERT INTO _refs_new (kind, owner_id, version_id, generation, updated_at) SELECT kind, owner_id, version_id, generation, updated_at FROM refs;")
+                    try exec("DROP TABLE refs;")
+                    try exec("ALTER TABLE _refs_new RENAME TO refs;")
+                }
+            } else {
+                // No `refs` table → create the CHECK-constrained shape fresh.
                 try exec("""
-                CREATE TABLE _refs_new (
+                CREATE TABLE IF NOT EXISTS refs (
                     kind       TEXT NOT NULL CHECK (kind IN ('source-content','source-derived','page-content')),
                     owner_id   TEXT NOT NULL,
                     version_id TEXT NOT NULL,
@@ -1980,9 +2004,6 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                     PRIMARY KEY (kind, owner_id)
                 );
                 """)
-                try exec("INSERT INTO _refs_new (kind, owner_id, version_id, generation, updated_at) SELECT kind, owner_id, version_id, generation, updated_at FROM refs;")
-                try exec("DROP TABLE refs;")
-                try exec("ALTER TABLE _refs_new RENAME TO refs;")
             }
 
             // 3. Seed root versions for existing pages. Idempotent: if
@@ -2072,16 +2093,30 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         try withTransaction {
             // Guard: check each column exists before adding (the fresh schema
             // createFreshSchemaV20 may already include them on a rewound DB).
-            let pagesCols = try tableColumnInfo("pages")
-            if !pagesCols.contains("created_by") {
-                try exec("ALTER TABLE pages ADD COLUMN created_by TEXT;")
+            // Also guard table existence: hand-built migration fixtures (e.g.
+            // a v28 chats-only DB) may not have `pages` or
+            // `source_markdown_versions` — the steps that create them (0→1,
+            // 7→8) were skipped because the fixture stamps a high user_version.
+            // Migrating such a fixture all the way to v35 must not throw on a
+            // table that was never created.
+            let hasPages = try queryScalarText(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='pages';") != "0"
+            if hasPages {
+                let pagesCols = try tableColumnInfo("pages")
+                if !pagesCols.contains("created_by") {
+                    try exec("ALTER TABLE pages ADD COLUMN created_by TEXT;")
+                }
+                if !pagesCols.contains("last_edited_by") {
+                    try exec("ALTER TABLE pages ADD COLUMN last_edited_by TEXT;")
+                }
             }
-            if !pagesCols.contains("last_edited_by") {
-                try exec("ALTER TABLE pages ADD COLUMN last_edited_by TEXT;")
-            }
-            let smvCols = try tableColumnInfo("source_markdown_versions")
-            if !smvCols.contains("technique") {
-                try exec("ALTER TABLE source_markdown_versions ADD COLUMN technique TEXT;")
+            let hasSMV = try queryScalarText(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='source_markdown_versions';") != "0"
+            if hasSMV {
+                let smvCols = try tableColumnInfo("source_markdown_versions")
+                if !smvCols.contains("technique") {
+                    try exec("ALTER TABLE source_markdown_versions ADD COLUMN technique TEXT;")
+                }
             }
         }
     }
@@ -2095,6 +2130,19 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// re-running on a v34 DB is a no-op (all pages already have refs).
     private func migrateV33ToV34() throws {
         try withTransaction {
+            // Guard: hand-built migration fixtures (e.g. a v19 sources-only or
+            // v28 chats-only DB) may not have `pages` or `refs` — the steps
+            // that create them (0→1 for pages, 19→20 for refs) were skipped
+            // because the fixture stamps a high user_version. If the tables
+            // don't exist, there is nothing to backfill → no-op. Matches the
+            // resilience convention from migrateV29ToV30 (hasPages guard).
+            let hasPages = try queryScalarText(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='pages';") != "0"
+            guard hasPages else { return }
+            let hasRefs = try queryScalarText(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='refs';") != "0"
+            guard hasRefs else { return }
+
             // Reuse the legacy-import agent (same as v20/v30 seeding).
             let legacyAgentID = try legacyImportAgentID()
             let now = Date().timeIntervalSince1970
@@ -3322,6 +3370,19 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let nowTS = now.timeIntervalSince1970
 
         return try withTransaction {
+            // Guard: the workspace must be 'open'. Writes to a
+            // merged/conflicted/abandoned workspace would succeed silently but
+            // be invisible — the workspace will never merge again, so agent
+            // edits (e.g. via a stale WIKI_WORKSPACE env var) would vanish.
+            let statusStmt = try statement(
+                "SELECT status FROM workspaces WHERE id = ?1;")
+            statusStmt.reset()
+            try statusStmt.bind(workspaceID, at: 1)
+            guard try statusStmt.step(), statusStmt.text(at: 0) == "open" else {
+                throw WikiStoreError.unexpected("workspace \(workspaceID) is not open")
+            }
+            statusStmt.reset()
+
             // 0. Determine whether the page exists on main.
             let pageExists = try statement("SELECT 1 FROM pages WHERE id = ?1;")
             try pageExists.bind(pageID.rawValue, at: 1)

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -219,10 +219,11 @@ public final class WikiStoreModel {
     public private(set) var isIngestInProgress = false
 
     /// Phase 7: capability flag for workspace-isolated ingestion. When true,
-    /// `AgentOperationRunner.runMultiIngest` creates a workspace, sets
-    /// `WIKI_WORKSPACE` so the agent's `wikictl` calls route into it, and
-    /// auto-merges on completion. Defaults to `false` — existing behavior is
-    /// unchanged when the flag is off.
+    /// `AgentOperationRunner.runMultiIngest` creates a workspace, passes the
+    /// workspace ID to the launcher (which injects `WIKI_WORKSPACE` into the
+    /// child process's per-spawn environment — NOT process-global `setenv`),
+    /// and auto-merges on completion. Defaults to `false` — existing behavior
+    /// is unchanged when the flag is off.
     public var workspacesEnabled: Bool = false
 
     // MARK: - Workspace facades (Phase 7)

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -178,10 +178,12 @@ struct SQLiteWikiStoreTests {
         try store.updatePage(id: b.id, title: "Beta", body: "beta edit")
         #expect(try store.changeToken() == "2:4:0:0:1:0:1:0:0:2:2:0:0:0")
 
-        // Delete changes page COUNT and SUM. deletePage does NOT cascade refs/
-        // activities, so refsGenSum + actCount are unchanged.
+        // Delete changes page COUNT and SUM. deletePage also cascades the page's
+        // `page-content` ref (W0/#312 made refs.owner_id polymorphic with no FK
+        // cascade), so refsGenSum drops from 2 → 1. Activities are provenance and
+        // are NOT cascaded, so actCount stays at 2.
         try store.deletePage(id: b.id)
-        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0:0:2:2:0:0:0")
+        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0:0:1:2:0:0:0")
     }
 
     /// The token MUST advance on ingest AND on delete (else the `files/` tree

--- a/Tests/WikiFSTests/WorkspaceStagingTests.swift
+++ b/Tests/WikiFSTests/WorkspaceStagingTests.swift
@@ -175,6 +175,42 @@ struct WorkspaceStagingTests {
         let mainPage = try store.getPage(id: newPageID)
         #expect(mainPage.bodyMarkdown == "other body")
     }
+
+    // MARK: - AC7 (latent defect fix): workspaceWritePage rejects non-open workspaces
+
+    @Test func writePageRejectsMergedWorkspace() throws {
+        let store = try tempStore()
+        let existingPage = try store.createPage(title: "Pre-existing")
+
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        // Stage and merge → status is 'merged'.
+        _ = try store.workspaceWritePage(
+            workspaceID: wsID, pageID: existingPage.id, title: "Pre-existing", body: "ws edit")
+        try store.workspaceMerge(workspaceID: wsID)
+
+        // A subsequent write to the merged workspace must throw, not silently
+        // succeed (which would vanish the edit — the workspace will never merge
+        // again).
+        #expect(throws: WikiStoreError.self) {
+            _ = try store.workspaceWritePage(
+                workspaceID: wsID, pageID: existingPage.id, title: "Pre-existing", body: "lost edit")
+        }
+    }
+
+    @Test func writePageRejectsAbandonedWorkspace() throws {
+        let store = try tempStore()
+        let existingPage = try store.createPage(title: "Pre-existing")
+
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        _ = try store.workspaceWritePage(
+            workspaceID: wsID, pageID: existingPage.id, title: "Pre-existing", body: "ws edit")
+        try store.abandonWorkspace(id: wsID)
+
+        #expect(throws: WikiStoreError.self) {
+            _ = try store.workspaceWritePage(
+                workspaceID: wsID, pageID: existingPage.id, title: "Pre-existing", body: "lost edit")
+        }
+    }
 }
 
 // MARK: - Test helper extension


### PR DESCRIPTION
## Summary

Fixes the 5 issues identified in the Fable review of the multi-writer hardening commit (`de539d7`).

## Changes

### 3 failing tests (all in `SQLiteWikiStoreTests`, all CI-skipped)

1. **`changeTokenAdvancesOnEveryMutation`** — the *test* was wrong, not the store. Its final assertion expected `refsGenSum` unchanged after `deletePage`, but the hardening commit correctly deletes the page's `page-content` ref on delete (no FK cascade on `refs.owner_id`). Fixed the test literal (`refsGenSum: 2 → 1`) and the comment.

2. **`migrateV28ToV29RewritesAskChatsToEdit`** — the v29→v30 refs table rebuild queried `FROM refs` unconditionally, but the chats-only test fixture has no `refs` table (the v19→v20 step that creates it was skipped). Added a `sqlite_master` table-existence guard: if `refs` doesn't exist, create the CHECK-constrained shape fresh. Matches the established `hasPages` convention from the same migration.

3. **`migrateV19ToV20_hashesContentIntoBlobsAndDropsContentColumn`** — v32→v33's `tableColumnInfo("pages")` and v33→v34's backfill queried tables absent from a sources-only fixture. Added `sqlite_master` existence guards on both steps (matching the v30 convention).

### Latent defect 1: `workspaceWritePage` status guard

Writes to a `merged`/`conflicted`/`abandoned` workspace succeeded silently — combined with a stale env var, agent edits would vanish into a workspace that will never merge again. Added a one-query `status == 'open'` guard at the top of the transaction. Two tests added to `WorkspaceStagingTests`.

### Latent defect 2: `WIKI_WORKSPACE` global `setenv` → per-spawn environment injection

The env var was process-global (`setenv` in `AgentOperationRunner`), so child processes inherited it transitively — and Phase 2's whole point is that interactive turns run *during* an ingest. A chat-edit agent spawned mid-ingest would inherit the var, and `wikictl` would route its page writes into the ingest's workspace. Worse, `unsetenv` rode `onUnlock`/`onWorkspaceMerge`, so a run cancelled while queued never fired it, leaving the var stale for the app's lifetime.

**Fix:** Replaced the global `setenv`/`unsetenv` with per-spawn environment injection:
- `workspaceID` threaded through `AgentLauncher.run()` → `providerHints["env.WIKI_WORKSPACE"]`
- `ACPBackend.start` already handled the `env.*` prefix convention
- `ClaudeCLIBackend.start` gained the same `env.*` expansion (mirroring ACP)
- `OperationCommand.environment` changed `let` → `var` to enable post-construction injection
- Also fixes the cancelled-while-queued stale-env-var case (no global state to leave stale)

## Test results

- All 55 `SQLiteWikiStoreTests` + `WorkspaceStagingTests` pass
- All hardening AC suites pass (`BlobVacuumTests`, `AgentCASTests`, `GenerationGateLaneTests`, `PageVersionTests`, `WorkspaceMergeCompletenessTests`, `IngestIsolationTests`, `WorkspaceTests`)
- Full fast-tier CI (2349 tests) passes

## Follow-up recommended (not in this PR)

- Pre-merge hook or second CI job that runs the skipped SQLite integration suites, so the AC suites actually gate merges.
