### PR TITLE
Add page icon to PageDetailView header

### DIFF
--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -237,9 +237,9 @@ struct AddressBarView: View {
     /// non-content selections (system prompt, change log, etc.).
     private var contentSymbol: String {
         switch store.activeTab?.selection {
-        case .page: "doc.text"
-        case .source: "tray.full"
-        case .chat, .newChat: "bubble.left.and.bubble.right"
+        case .page: ResourceKind.page.systemImageName
+        case .source: ResourceKind.source.systemImageName
+        case .chat, .newChat: ResourceKind.chat.systemImageName
         default: "text.page.badge.magnifyingglass"
         }
     }

--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -200,13 +200,25 @@ struct AddressBarView: View {
 
     // MARK: - Reader menu (Safari-style page controls)
 
-    /// The leading page-menu button (Safari's "Page Menu" glyph); opens a
-    /// dropdown with Zoom and Find on Page.
+    /// The leading icon: reflects the active tab's content type (matching the
+    /// sidebar and detail-view icons) and opens a dropdown with Zoom and Find
+    /// on Page. Draggable — dragging it carries a `SidebarDragPayloadList` for
+    /// the current page/source/chat, so it can be dropped on the welcome screen
+    /// or bookmarks just like a sidebar row.
+    @ViewBuilder
     private var readerMenuButton: some View {
+        if let payload = dragPayload {
+            readerMenuButtonCore.draggable(payload)
+        } else {
+            readerMenuButtonCore
+        }
+    }
+
+    private var readerMenuButtonCore: some View {
         Button {
             showReaderMenu.toggle()
         } label: {
-            Image(systemName: "text.page.badge.magnifyingglass")
+            Image(systemName: contentSymbol)
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
                 .frame(width: 18, height: 22)
@@ -216,6 +228,36 @@ struct AddressBarView: View {
         .help("Page controls")
         .popover(isPresented: $showReaderMenu, arrowEdge: .bottom) {
             ReaderControlsMenu(zoom: $readerZoom, onFind: findOnPage)
+        }
+    }
+
+    /// The SF Symbol matching the active tab's content type, so the omnibox's
+    /// leading icon agrees with the sidebar section icon and the detail-view
+    /// header icon. Falls back to the generic page-controls glyph for
+    /// non-content selections (system prompt, change log, etc.).
+    private var contentSymbol: String {
+        switch store.activeTab?.selection {
+        case .page: "doc.text"
+        case .source: "tray.full"
+        case .chat, .newChat: "bubble.left.and.bubble.right"
+        default: "text.page.badge.magnifyingglass"
+        }
+    }
+
+    /// A `SidebarDragPayloadList` for the currently-loaded resource, so the
+    /// omnibox icon can be dragged to the welcome screen or bookmarks like a
+    /// sidebar row. `nil` when the selection isn't a draggable page/source/chat.
+    private var dragPayload: SidebarDragPayloadList? {
+        guard let selection = store.activeTab?.selection else { return nil }
+        switch selection {
+        case .page(let id):
+            return SidebarDragPayloadList([SidebarDragPayload(kind: .page, id: id.rawValue)])
+        case .source(let id):
+            return SidebarDragPayloadList([SidebarDragPayload(kind: .source, id: id.rawValue)])
+        case .chat(let id):
+            return SidebarDragPayloadList([SidebarDragPayload(kind: .chat, id: id.rawValue)])
+        default:
+            return nil
         }
     }
 

--- a/Sources/WikiFS/AgentToolsView.swift
+++ b/Sources/WikiFS/AgentToolsView.swift
@@ -230,7 +230,7 @@ private struct RecentChatRow: View {
                 }
             }
         } icon: {
-            Image(systemName: "bubble.left.and.bubble.right")
+            Image(systemName: ResourceKind.chat.systemImageName)
                 .font(.body)
                 .foregroundStyle(.secondary)
                 .frame(width: 18)

--- a/Sources/WikiFS/BookmarksContainerView.swift
+++ b/Sources/WikiFS/BookmarksContainerView.swift
@@ -70,10 +70,10 @@ struct BookmarksContainerView: View {
             headerButton(systemImage: "folder.badge.plus", help: "New Folder") {
                 onNewFolder()
             }
-            headerButton(systemImage: "doc.text", help: "Add Page…") {
+            headerButton(systemImage: ResourceKind.page.systemImageName, help: "Add Page…") {
                 onShowPicker(PickerContext(id: UUID(), parentID: nil, kind: .pages))
             }
-            headerButton(systemImage: "doc", help: "Add Source…") {
+            headerButton(systemImage: ResourceKind.source.systemImageName, help: "Add Source…") {
                 onShowPicker(PickerContext(id: UUID(), parentID: nil, kind: .sources))
             }
         }

--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -136,8 +136,11 @@ final class BookmarksOutlineViewController: NSViewController {
         // Required for the outline view to act as a drop target at all — without
         // this, validateDrop/acceptDrop are never called and no highlight shows.
         // `.string` powers intra-tree reorder (a node id); `.url` lets a
-        // `wiki://` link dragged out of a page/source body land here (issue #169).
-        outlineView.registerForDraggedTypes([.string, .init("public.url")])
+        // `wiki://` link dragged out of a page/source body land here (issue #169);
+        // the sidebar-item type lets the omnibox icon (and sidebar rows via
+        // SwiftUI .draggable) drop a page/source/chat here to create a bookmark.
+        let sidebarItemType = NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
+        outlineView.registerForDraggedTypes([.string, .init("public.url"), sidebarItemType])
         // NSTableView/NSOutlineView is its own NSDraggingSource; there is no
         // delegate callback for this — the mask is configured imperatively.
         // Without it, the default local-drag mask is a multi-bit value that
@@ -252,13 +255,13 @@ final class BookmarksOutlineViewController: NSViewController {
         case .folder: return "folder"
         case .pageRef:
             let isStale = node.targetID.flatMap { id in store?.summaries.first { $0.id == id } } == nil
-            return isStale ? "exclamationmark.triangle" : "doc.text"
+            return isStale ? "exclamationmark.triangle" : ResourceKind.page.systemImageName
         case .sourceRef:
             let isStale = node.targetID.flatMap { id in store?.sources.first { $0.id == id } } == nil
-            return isStale ? "exclamationmark.triangle" : "doc"
+            return isStale ? "exclamationmark.triangle" : ResourceKind.source.systemImageName
         case .chatRef:
             let isStale = node.targetID.flatMap { id in store?.chats.first { $0.id == id } } == nil
-            return isStale ? "exclamationmark.triangle" : "bubble.left.and.bubble.right"
+            return isStale ? "exclamationmark.triangle" : ResourceKind.chat.systemImageName
         }
     }
 
@@ -375,6 +378,55 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
         return nil
     }
 
+    /// Read the first `SidebarDragPayloadList` from a drag pasteboard. The
+    /// omnibox icon (and sidebar rows via SwiftUI `.draggable`) write payload
+    /// JSON under the `wikiSidebarItem` UTType. Returns nil for non-sidebar
+    /// drags (wiki-link drops, intra-tree reorders).
+    private static func firstSidebarPayload(from pb: NSPasteboard) -> SidebarDragPayloadList? {
+        let sidebarType = NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
+        guard let data = pb.data(forType: sidebarType),
+              let list = try? JSONDecoder().decode(SidebarDragPayloadList.self, from: data) else {
+            return nil
+        }
+        return list
+    }
+
+    /// Resolve a dropped sidebar-item payload and insert a bookmark node for
+    /// each target (page/source/chat) at the drop position. Mirrors the
+    /// wiki-link drop's parent/position resolution.
+    @discardableResult
+    private func acceptSidebarPayloadDrop(_ list: SidebarDragPayloadList,
+                                          onto item: Any?, atIndex index: Int,
+                                          store: WikiStoreModel) -> Bool {
+        let parentID: String?
+        let basePosition: Int
+        if let folder = item as? BookmarkNode, folder.kind == .folder {
+            parentID = folder.id
+            basePosition = index >= 0 ? index : children(of: folder.id).count
+        } else if let leaf = item as? BookmarkNode {
+            parentID = leaf.parentID
+            basePosition = index >= 0 ? index : leaf.position
+        } else {
+            parentID = nil
+            basePosition = index >= 0 ? index : children(of: nil).count
+        }
+        var position = basePosition
+        for payload in list.items {
+            let pageID = PageID(rawValue: payload.id)
+            switch payload.kind {
+            case .page:
+                store.addPageRef(parentID: parentID, pageID: pageID, position: position)
+            case .source:
+                store.addSourceRef(parentID: parentID, sourceID: pageID, position: position)
+            case .chat:
+                store.addChatRef(parentID: parentID, chatID: pageID, position: position)
+            }
+            DebugLog.tabs("[drop] sidebar-item bookmark created: kind=\(payload.kind) id=\(payload.id) parentID=\(parentID ?? "root") position=\(position)")
+            position += 1
+        }
+        return true
+    }
+
     /// Resolve a dropped `wiki://` link to a page/source and insert a bookmark
     /// node for it at the drop position. Mirrors `WikiReaderView.linkRoute(for:)`'s
     /// resolution: title from `WikiLinkMarkdown.target`, kind from `resolvedKind`,
@@ -456,6 +508,15 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             if item is BookmarkNode { return .copy }              // leaf → sibling
             return []
         }
+        // Sidebar-item drop: a page/source/chat dragged from the omnibox icon
+        // or a sidebar row via SwiftUI .draggable. Accept as `.copy` so
+        // `acceptDrop` creates a bookmark node for the payload's target.
+        if Self.firstSidebarPayload(from: info.draggingPasteboard) != nil {
+            if item == nil { return .copy }                       // root
+            if (item as? BookmarkNode)?.kind == .folder { return .copy }
+            if item is BookmarkNode { return .copy }              // leaf → sibling
+            return []
+        }
         guard info.draggingSourceOperationMask.contains(.move) else { return [] }
         // Allow drop onto folders or between rows.
         if let folder = item as? BookmarkNode, folder.kind == .folder {
@@ -483,6 +544,12 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
         // `.string` as a bookmark *node id* and would no-op on a `wiki://` URL.
         if let url = Self.firstWikiLinkURL(from: info.draggingPasteboard) {
             return acceptWikiLinkDrop(url: url, onto: item, atIndex: index, store: store)
+        }
+
+        // Sidebar-item drop → create a bookmark for each page/source/chat in
+        // the payload (omnibox icon drag, or a SwiftUI .draggable sidebar row).
+        if let payloadList = Self.firstSidebarPayload(from: info.draggingPasteboard) {
+            return acceptSidebarPayloadDrop(payloadList, onto: item, atIndex: index, store: store)
         }
 
         // Multi-selection is allowed, so a reorder drag can carry more than one
@@ -639,9 +706,9 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
         // Add Page / Add Source — folder, single item only.
         if !isBatch && clicked.kind == .folder {
             menu.addItem(.separator())
-            menu.addItem(menuItem("Add Page…", systemImage: "doc.text",
+            menu.addItem(menuItem("Add Page…", systemImage: ResourceKind.page.systemImageName,
                                   action: #selector(addPageAction(_:)), payload: payload))
-            menu.addItem(menuItem("Add Source…", systemImage: "doc",
+            menu.addItem(menuItem("Add Source…", systemImage: ResourceKind.source.systemImageName,
                                   action: #selector(addSourceAction(_:)), payload: payload))
         }
 

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -235,7 +235,7 @@ struct ChatView: View {
         } else if chatID != nil && !isLiveChat && chatSummary == nil {
             // Persisted chat that no longer exists in the store.
             ContentUnavailableView {
-                Label("Chat Missing", systemImage: "bubble.left.and.bubble.right")
+                Label("Chat Missing", systemImage: ResourceKind.chat.systemImageName)
             } description: {
                 Text("This chat is no longer available.")
             }
@@ -383,7 +383,7 @@ struct ChatView: View {
                     }
                 )
             } icon: {
-                Image(systemName: "bubble.left.and.bubble.right")
+                Image(systemName: ResourceKind.chat.systemImageName)
                     .foregroundStyle(.secondary)
             }
 

--- a/Sources/WikiFS/ItemPickerSheet.swift
+++ b/Sources/WikiFS/ItemPickerSheet.swift
@@ -125,7 +125,7 @@ struct ItemPickerSheet: View {
             Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                 .foregroundStyle(isSelected ? Color.accentColor : .secondary)
                 .font(.callout)
-            Image(systemName: item.isPage ? "doc.text" : "doc")
+            Image(systemName: item.isPage ? ResourceKind.page.systemImageName : ResourceKind.source.systemImageName)
                 .foregroundStyle(.secondary)
                 .font(.callout)
             Text(item.title)

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -42,7 +42,7 @@ struct PageDetailView: View {
                         onCommit: renameCurrentPage
                     )
                 } icon: {
-                    Image(systemName: "doc.text")
+                    Image(systemName: ResourceKind.page.systemImageName)
                         .foregroundStyle(.secondary)
                 }
 

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -34,12 +34,17 @@ struct PageDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header — always visible, same layout in both modes.
             VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
-                EditableTitle(
-                    title: store.draftTitle,
-                    placeholder: "Untitled",
-                    isDisabled: false,
-                    onCommit: renameCurrentPage
-                )
+                Label {
+                    EditableTitle(
+                        title: store.draftTitle,
+                        placeholder: "Untitled",
+                        isDisabled: false,
+                        onCommit: renameCurrentPage
+                    )
+                } icon: {
+                    Image(systemName: "doc.text")
+                        .foregroundStyle(.secondary)
+                }
 
                 HStack(spacing: 12) {
                     if let date = pageUpdatedAt {

--- a/Sources/WikiFS/PagesListView.swift
+++ b/Sources/WikiFS/PagesListView.swift
@@ -260,7 +260,7 @@ extension PagesListViewController: NSTableViewDelegate {
             ])
         }
 
-        cell.imageView?.image = NSImage(systemSymbolName: "doc.text", accessibilityDescription: nil)
+        cell.imageView?.image = NSImage(systemSymbolName: ResourceKind.page.systemImageName, accessibilityDescription: nil)
         cell.textField?.stringValue = summary.title.isEmpty ? "Untitled" : summary.title
         cell.toolTip = summary.title.isEmpty ? "Untitled" : summary.title
         return cell
@@ -334,7 +334,7 @@ extension PagesListViewController {
 
         menu.addItem(menuItem(
             title: isBatch ? "Add \(count) Pages to Bookmarks…" : "Add to Bookmarks…",
-            systemImage: "bookmark", action: #selector(addToBookmarksAction(_:)), payload: payload))
+            systemImage: ResourceKind.bookmark.systemImageName, action: #selector(addToBookmarksAction(_:)), payload: payload))
 
         if isBatch {
             menu.addItem(menuItem(

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -59,10 +59,10 @@ struct SidebarView: View {
 
         var systemImage: String {
             switch self {
-            case .pages: "doc.text"
-            case .sources: "tray.full"
-            case .bookmarks: "bookmark"
-            case .chats: "bubble.left.and.bubble.right"
+            case .pages: ResourceKind.page.systemImageName
+            case .sources: ResourceKind.source.systemImageName
+            case .bookmarks: ResourceKind.bookmark.systemImageName
+            case .chats: ResourceKind.chat.systemImageName
             }
         }
     }

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -1049,9 +1049,9 @@ struct SourceDetailView: View {
         }
     }
 
-    /// Matches the sidebar's Sources section icon (`tray.full`) so the same
-    /// source is represented by one icon everywhere in the app.
-    private var symbol: String { "tray.full" }
+    /// Matches the sidebar's Sources section icon so each source has one
+    /// consistent icon everywhere in the app.
+    private var symbol: String { ResourceKind.source.systemImageName }
 
     // MARK: - Find bar
 

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -1049,11 +1049,9 @@ struct SourceDetailView: View {
         }
     }
 
-    private var symbol: String {
-        if file.mimeType == "application/pdf" { return "doc.richtext" }
-        if let mime = file.mimeType, mime.hasPrefix("text/") { return "doc.plaintext" }
-        return "doc"
-    }
+    /// Matches the sidebar's Sources section icon (`tray.full`) so the same
+    /// source is represented by one icon everywhere in the app.
+    private var symbol: String { "tray.full" }
 
     // MARK: - Find bar
 

--- a/Sources/WikiFS/SourcesListView.swift
+++ b/Sources/WikiFS/SourcesListView.swift
@@ -204,10 +204,10 @@ final class SourceListCellView: NSTableCellView {
         }
     }
 
+    /// Matches the sidebar's Sources section icon and the SourceDetailView
+    /// header icon — one icon per source everywhere.
     private static func symbol(for source: SourceSummary) -> String {
-        if source.mimeType == "application/pdf" { return "doc.richtext" }
-        if let mime = source.mimeType, mime.hasPrefix("text/") { return "doc.plaintext" }
-        return "doc"
+        ResourceKind.source.systemImageName
     }
 
     private static let sizeFormatter: ByteCountFormatter = {
@@ -430,7 +430,7 @@ extension SourcesListViewController {
 
         menu.addItem(item(
             title: isMulti ? "Add \(count) Sources to Bookmarks…" : "Add to Bookmarks…",
-            systemImage: "bookmark", action: #selector(addToBookmarksAction(_:)), payload: payload))
+            systemImage: ResourceKind.bookmark.systemImageName, action: #selector(addToBookmarksAction(_:)), payload: payload))
 
         if isMulti {
             menu.addItem(item(title: "Share \(count) Sources", systemImage: "square.and.arrow.up",

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -66,10 +66,10 @@ struct WikiDetailView: View {
                     .padding(.top, 60)
 
                     VStack(alignment: .leading, spacing: 20) {
-                        introRow(title: "Pages", description: "Create and edit markdown notes with deep wiki-linking.", systemImage: "doc.text")
-                        introRow(title: "Sources", description: "Manage and ingest raw material from URLs, folders, or Zotero.", systemImage: "tray.full")
-                        introRow(title: "Bookmarks", description: "Organize pages and sources into a custom folder tree for quick access.", systemImage: "bookmark")
-                        introRow(title: "Chats", description: "Ask questions and edit your wiki through chat.", systemImage: "bubble.left.and.bubble.right")
+                        introRow(title: "Pages", description: "Create and edit markdown notes with deep wiki-linking.", systemImage: ResourceKind.page.systemImageName)
+                        introRow(title: "Sources", description: "Manage and ingest raw material from URLs, folders, or Zotero.", systemImage: ResourceKind.source.systemImageName)
+                        introRow(title: "Bookmarks", description: "Organize pages and sources into a custom folder tree for quick access.", systemImage: ResourceKind.bookmark.systemImageName)
+                        introRow(title: "Chats", description: "Ask questions and edit your wiki through chat.", systemImage: ResourceKind.chat.systemImageName)
                     }
                     .frame(maxWidth: 400)
 
@@ -178,7 +178,7 @@ struct WikiDetailView: View {
             }
         case .bookmark:
             ContentUnavailableView {
-                Label("Bookmarks", systemImage: "bookmark")
+                Label("Bookmarks", systemImage: ResourceKind.bookmark.systemImageName)
             } description: {
                 Text("Bookmark folders are managed in the sidebar.")
             }

--- a/Sources/WikiFSCore/OmniboxResult.swift
+++ b/Sources/WikiFSCore/OmniboxResult.swift
@@ -42,10 +42,10 @@ public enum OmniboxResult: Identifiable, Hashable, Sendable {
 
     public var systemImageName: String {
         switch self {
-        case .page: return "doc.text"
-        case .source: return "doc"
-        case .chat: return "bubble.left.and.bubble.right"
-        case .bookmark: return "bookmark"
+        case .page: return ResourceKind.page.systemImageName
+        case .source: return ResourceKind.source.systemImageName
+        case .chat: return ResourceKind.chat.systemImageName
+        case .bookmark: return ResourceKind.bookmark.systemImageName
         case .ask: return "sparkles"
         }
     }

--- a/Sources/WikiFSCore/Resource.swift
+++ b/Sources/WikiFSCore/Resource.swift
@@ -34,6 +34,22 @@ public protocol Resource: Sendable {
 /// *consumer* of kinds, not their home).
 public enum ResourceKind: String, Sendable, CaseIterable {
     case page, source, systemPrompt, wikiIndex, log, bookmark, chat
+
+    /// The SF Symbol name used for this resource kind across every UI surface:
+    /// sidebar sections, detail-view headers, the omnibox icon, bookmark row
+    /// icons, source list rows, and the picker sheet. Centralized here so a
+    /// kind's icon can't drift between surfaces.
+    public var systemImageName: String {
+        switch self {
+        case .page:        "doc.text"
+        case .source:      "tray.full"
+        case .bookmark:    "bookmark"
+        case .chat:        "bubble.left.and.bubble.right"
+        case .systemPrompt: "doc.text"
+        case .wikiIndex:   "book.closed"
+        case .log:         "clock.arrow.circlepath"
+        }
+    }
 }
 
 /// Declares one resource kind's contribution to the whole-wiki


### PR DESCRIPTION
## Summary

Centralize all resource-type SF Symbol icon names in one place (`ResourceKind.systemImageName`) and use them consistently across every UI surface. Also add a content-type icon to the omnibox and make it draggable to bookmarks.

## Changes

### Centralized icons (`ResourceKind.systemImageName`)

Added a single `systemImageName` property on `ResourceKind` in `Sources/WikiFSCore/Resource.swift`:

| Kind | Symbol |
|------|--------|
| page | `doc.text` |
| source | `tray.full` |
| chat | `bubble.left.and.bubble.right` |
| bookmark | `bookmark` |
| systemPrompt | `doc.text` |
| wikiIndex | `book.closed` |
| log | `clock.arrow.circlepath` |

Replaced every scattered string literal across 14 files with a reference to it:

- `SidebarView` — section selector icons
- `PageDetailView` / `SourceDetailView` — header icons
- `AddressBarView` — omnibox content-type icon
- `OmniboxResult` — search result icons
- `BookmarksOutlineView` — row icons + context menu items
- `PagesListView` / `SourcesListView` — row icons + context menus
- `WikiDetailView` — intro rows + empty states
- `ItemPickerSheet`, `BookmarksContainerView`, `ChatView`, `AgentToolsView`

### Page icon in PageDetailView

Wraps `EditableTitle` in a `Label` with a `doc.text` icon, matching the pattern already used in `SourceDetailView`.

### Single source icon everywhere

`SourceDetailView` and `SourcesListView` now use `tray.full` for all sources, replacing the old file-type-dependent icons (`doc.richtext` for PDF, `doc.plaintext` for text, `doc` for others).

### Omnibox icon + drag-and-drop to bookmarks

The omnibox's leading icon now reflects the active tab's content type (matching sidebar/detail-view icons) instead of a generic page-controls glyph. The icon is draggable — dragging it carries a `SidebarDragPayloadList` for the current page/source/chat.

To make the drop work, the bookmarks `NSOutlineView` now:
- Registers for the `wikiSidebarItem` UTType (in addition to `.string` and `public.url`)
- Accepts sidebar-item drags as `.copy` in `validateDrop`
- Decodes the payload and creates page/source/chat bookmark refs at the drop position in `acceptDrop`

## Testing

- `swift build` — ✅ compiles cleanly
