### PR TITLE
Phase 1E: wikid daemon tests + Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,9 +350,10 @@ install-daemon:
 	@swift build --target wikid
 	@echo "→ Installing launchd plist…"
 	@mkdir -p $(dir $(WIKID_PLIST_DST))
-	@# Copy the plist, substituting the binary path so launchd knows where wikid lives.
-	@plutil -remove ProgramArguments -o /dev/null $(WIKID_PLIST) 2>/dev/null || true
-	@plutil -insert ProgramArguments.0 -string "$(WIKID_BIN)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST)
+	@# Copy the plist template, then inject the binary path into a ProgramArguments array.
+	@cp $(WIKID_PLIST) $(WIKID_PLIST_DST)
+	@plutil -insert ProgramArguments -array -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null || true
+	@plutil -insert ProgramArguments.0 -string "$(WIKID_BIN)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST)
 	@launchctl unload $(WIKID_PLIST_DST) 2>/dev/null || true
 	@launchctl load $(WIKID_PLIST_DST)
 	@echo "✓ wikid installed. It will auto-start when a client connects via XPC."

--- a/Package.swift
+++ b/Package.swift
@@ -187,7 +187,7 @@ let package = Package(
         ),
         .testTarget(
             name: "WikiFSTests",
-            dependencies: ["WikiFSCore", "WikiCtlCore", "WikiFS", "WikiFSMLX", "WikiFSEngine", "WikiFSFileProvider",
+            dependencies: ["WikiFSCore", "WikiCtlCore", "WikiFS", "WikiFSMLX", "WikiFSEngine", "WikiFSFileProvider", "wikid",
                            // ACP model types for ACPBackendTests (no live subprocess — pure translator tests).
                            .product(name: "ACPModel", package: "swift-acp")],
             path: "Tests/WikiFSTests",

--- a/Tests/WikiFSTests/WikiDaemonTests.swift
+++ b/Tests/WikiFSTests/WikiDaemonTests.swift
@@ -1,0 +1,306 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import wikid
+
+/// Tests for the `WikiDaemon` — the daemon's in-process registry + store
+/// lifecycle logic. These test the daemon directly (not over XPC), using a
+/// temp container directory for hermetic isolation. See
+/// `plans/multi-wiki-daemon.md` §4.2 + §9 (Phase 1E).
+struct WikiDaemonTests {
+
+    private func tempDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikid-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func makeDaemon(dir: URL) -> WikiDaemon {
+        WikiDaemon(containerDirectory: dir)
+    }
+
+    // MARK: - Registry: listWikis
+
+    @Test func listWikisEmptyOnFreshDirectory() {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = daemon.listWikis()
+        let wikis = try! JSONDecoder().decode([WikiDescriptor].self, from: data)
+        #expect(wikis.isEmpty)
+    }
+
+    @Test func listWikisReturnsCreatedWikis() {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        _ = daemon.createWiki(name: "Alpha")
+        _ = daemon.createWiki(name: "Beta")
+        let data = daemon.listWikis()
+        let wikis = try! JSONDecoder().decode([WikiDescriptor].self, from: data)
+        #expect(wikis.count == 2)
+        // MRU: most recently created/used first. Beta was created last.
+        #expect(wikis[0].displayName == "Beta")
+        #expect(wikis[1].displayName == "Alpha")
+    }
+
+    // MARK: - Registry: createWiki
+
+    @Test func createWikiReturnsDescriptor() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "My Wiki"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+        #expect(descriptor.displayName == "My Wiki")
+        #expect(!descriptor.id.isEmpty)
+        #expect(descriptor.homePageID != nil)  // Home page is seeded
+    }
+
+    @Test func createWikiTrimsWhitespace() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "  Spaced  "))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+        #expect(descriptor.displayName == "Spaced")
+    }
+
+    @Test func createWikiUsesDefaultNameForEmpty() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "   "))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+        #expect(descriptor.displayName == "Untitled Wiki")
+    }
+
+    @Test func createWikiCreatesDBFile() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Test"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+        let dbURL = dir.appendingPathComponent("\(descriptor.id).sqlite")
+        #expect(FileManager.default.fileExists(atPath: dbURL.path))
+    }
+
+    @Test func createWikiSeedsHomePage() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Test"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+        #expect(descriptor.homePageID != nil)
+
+        // Verify the Home page actually exists in the DB
+        let dbURL = dir.appendingPathComponent("\(descriptor.id).sqlite")
+        let store = try SQLiteWikiStore(databaseURL: dbURL)
+        let pages = try store.listPages(sortBy: .newestFirst)
+        #expect(pages.count == 1)
+        #expect(pages[0].title == "Home")
+    }
+
+    @Test func createWikiPersistsToRegistry() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        _ = daemon.createWiki(name: "Persisted")
+        // Re-load the registry from disk — it should survive
+        let registry = WikiRegistry.load(from: dir)
+        #expect(registry.wikis.count == 1)
+        #expect(registry.wikis[0].displayName == "Persisted")
+    }
+
+    // MARK: - Registry: resolveWiki
+
+    @Test func resolveWikiByULID() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let createData = try #require(daemon.createWiki(name: "Find Me"))
+        let created = try JSONDecoder().decode(WikiDescriptor.self, from: createData)
+
+        let resolveData = try #require(daemon.resolveWiki(selector: created.id))
+        let resolved = try JSONDecoder().decode(WikiDescriptor.self, from: resolveData)
+        #expect(resolved.id == created.id)
+        #expect(resolved.displayName == "Find Me")
+    }
+
+    @Test func resolveWikiByDisplayName() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        _ = daemon.createWiki(name: "By Name")
+
+        let resolveData = try #require(daemon.resolveWiki(selector: "By Name"))
+        let resolved = try JSONDecoder().decode(WikiDescriptor.self, from: resolveData)
+        #expect(resolved.displayName == "By Name")
+    }
+
+    @Test func resolveWikiReturnsNilForUnknown() {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        #expect(daemon.resolveWiki(selector: "nonexistent") == nil)
+    }
+
+    @Test func resolveWikiULIDTakesPrecedenceOverDisplayName() throws {
+        // If a wiki's displayName happens to match another wiki's ULID,
+        // the ULID lookup should win (mirrors WikiResolver behavior).
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let createData = try #require(daemon.createWiki(name: "Alpha"))
+        let alpha = try JSONDecoder().decode(WikiDescriptor.self, from: createData)
+        _ = daemon.createWiki(name: "Beta")
+        // Resolve by Alpha's ULID — should get Alpha, not Beta
+        let resolveData = try #require(daemon.resolveWiki(selector: alpha.id))
+        let resolved = try JSONDecoder().decode(WikiDescriptor.self, from: resolveData)
+        #expect(resolved.id == alpha.id)
+    }
+
+    // MARK: - Registry: deleteWiki
+
+    @Test func deleteWikiRemovesFromRegistry() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Delete Me"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        let success = daemon.deleteWiki(id: descriptor.id)
+        #expect(success)
+
+        let registry = WikiRegistry.load(from: dir)
+        #expect(registry.wikis.isEmpty)
+    }
+
+    @Test func deleteWikiRemovesDBFiles() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Delete Me"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+        let dbURL = dir.appendingPathComponent("\(descriptor.id).sqlite")
+        #expect(FileManager.default.fileExists(atPath: dbURL.path))
+
+        _ = daemon.deleteWiki(id: descriptor.id)
+        #expect(!FileManager.default.fileExists(atPath: dbURL.path))
+        #expect(!FileManager.default.fileExists(atPath: dbURL.path + "-wal"))
+        #expect(!FileManager.default.fileExists(atPath: dbURL.path + "-shm"))
+    }
+
+    // MARK: - Registry: renameWiki
+
+    @Test func renameWikiChangesDisplayNameOnly() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Old Name"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        let success = daemon.renameWiki(id: descriptor.id, name: "New Name")
+        #expect(success)
+
+        let resolveData = try #require(daemon.resolveWiki(selector: descriptor.id))
+        let resolved = try JSONDecoder().decode(WikiDescriptor.self, from: resolveData)
+        #expect(resolved.displayName == "New Name")
+        #expect(resolved.id == descriptor.id)  // Identity unchanged
+    }
+
+    @Test func renameWikiRejectsEmptyName() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Test"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        let success = daemon.renameWiki(id: descriptor.id, name: "   ")
+        #expect(!success)
+    }
+
+    @Test func renameWikiReturnsFalseForUnknownID() {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let success = daemon.renameWiki(id: "nonexistent", name: "Whatever")
+        #expect(!success)
+    }
+
+    // MARK: - Store lifecycle: openStore
+
+    @Test func openStoreReturnsTrueForExistingWiki() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Open Me"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        let success = daemon.openStore(wikiID: descriptor.id)
+        #expect(success)
+    }
+
+    @Test func openStoreReturnsFalseForUnknownWiki() {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let success = daemon.openStore(wikiID: "nonexistent")
+        #expect(!success)
+    }
+
+    @Test func openStoreIsIdempotent() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Test"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        #expect(daemon.openStore(wikiID: descriptor.id))
+        #expect(daemon.openStore(wikiID: descriptor.id))  // Second open is a no-op
+    }
+
+    // MARK: - Store lifecycle: closeStore
+
+    @Test func closeStoreDoesNotCrash() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Close Me"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        daemon.openStore(wikiID: descriptor.id)
+        daemon.closeStore(wikiID: descriptor.id)  // Should not crash
+
+        // Reopening should work after close
+        #expect(daemon.openStore(wikiID: descriptor.id))
+    }
+
+    // MARK: - Store lifecycle: changeToken
+
+    @Test func changeTokenReturnsNonEmptyForOpenStore() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Token Test"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        daemon.openStore(wikiID: descriptor.id)
+        let token = daemon.changeToken(wikiID: descriptor.id)
+        #expect(!token.isEmpty)
+    }
+
+    @Test func changeTokenReturnsEmptyForUnknownWiki() {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let token = daemon.changeToken(wikiID: "nonexistent")
+        #expect(token.isEmpty)
+    }
+
+    // MARK: - Multiple wikis
+
+    @Test func multipleWikisAreIndependent() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let aData = try #require(daemon.createWiki(name: "Wiki A"))
+        let bData = try #require(daemon.createWiki(name: "Wiki B"))
+        let a = try JSONDecoder().decode(WikiDescriptor.self, from: aData)
+        let b = try JSONDecoder().decode(WikiDescriptor.self, from: bData)
+
+        #expect(a.id != b.id)
+
+        // Both stores can be open simultaneously
+        #expect(daemon.openStore(wikiID: a.id))
+        #expect(daemon.openStore(wikiID: b.id))
+
+        // Change tokens are independent
+        let tokenA = daemon.changeToken(wikiID: a.id)
+        let tokenB = daemon.changeToken(wikiID: b.id)
+        // They could technically be equal on fresh wikis, but both should be non-empty
+        #expect(!tokenA.isEmpty)
+        #expect(!tokenB.isEmpty)
+
+        // Deleting A doesn't affect B
+        _ = daemon.deleteWiki(id: a.id)
+        #expect(daemon.openStore(wikiID: b.id))
+    }
+}


### PR DESCRIPTION
## Phase 1E: daemon tests + end-to-end verification

### WikiDaemonTests (24 new tests, all pass)

Tests the daemon's in-process logic directly (not over XPC), using temp container dirs for hermetic isolation:

- **Registry**: listWikis (empty, returns created, MRU order), createWiki (descriptor, whitespace trim, default name, DB file creation, Home page seeding, registry persistence), resolveWiki (by ULID, by displayName, nil for unknown, ULID precedence), deleteWiki (registry removal, DB+WAL file removal), renameWiki (display name only, rejects empty, false for unknown)
- **Store lifecycle**: openStore (true for existing, false for unknown, idempotent), closeStore (no crash, reopens), changeToken (non-empty for open, empty for unknown)
- **Independence**: multiple wikis with independent stores + tokens; deleting one doesn't affect the other

### Makefile fix

The `install-daemon` target was failing because `plutil -insert ProgramArguments.0` can't insert into a non-existent key path. Fixed: copy the template, create the array, then insert.

### End-to-end smoke test (manual)

| AC | Status |
|----|--------|
| `make install-daemon` → daemon starts via launchd | ✅ |
| `wikictl wiki list` → returns wikis via XPC | ✅ (3 existing wikis) |
| `wikictl wiki create --name 'Test'` → creates via XPC | ✅ |
| `wikictl wiki rename --id ... --name 'New'` | ✅ |
| `wikictl wiki delete --id ...` → removes wiki + DB | ✅ |
| Crash recovery (SIGKILL → launchd restarts) | ⚠️ Known issue |

**Known issue:** after SIGKILL, the mach service registration gets stale and `NSXPCConnection` hangs. An `unload + load` cycle restores service. This is an `NSXPCListener(machServiceName:)` registration refinement for production hardening — the graceful degradation path (wikictl falls back to direct file access when the daemon is unavailable) prevents user-visible breakage.

### Test totals

Fast tier: **2378 tests in 194 suites pass** (24 new daemon tests + 2354 existing).