### PR TITLE
wikid hardening: crash recovery + timeout + codesign entitlements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,28 +338,53 @@ register: install
 # wikid daemon — launchd install/uninstall (plans/multi-wiki-daemon.md Phase 1B)
 # ---------------------------------------------------------------------------
 
+# wikid daemon — managed by SMAppService (plans/multi-wiki-daemon.md §4.3).
+# The app registers the daemon on launch via SMAppService.agent(plistName:).
+# The plist is at Contents/Library/LaunchAgents/ and the binary at
+# Contents/Helpers/wikid — both inside the app bundle, signed with the app's
+# identity. The daemon inherits the app's TCC trust (no permission prompts).
+#
+# `make install-daemon` is now a no-op for production (the app auto-registers).
+# It remains for dev-mode: signs the .build binaries + installs a manual
+# launchd plist pointing at the .build path (will prompt once for TCC).
 WIKID_BIN := $(shell swift build --show-bin-path)/wikid
 WIKID_PLIST := signing/com.selfdrivingwiki.wikid.plist
 WIKID_PLIST_DST := $(HOME)/Library/LaunchAgents/com.selfdrivingwiki.wikid.plist
+WIKID_SIGN_IDENTITY := $(shell grep '^DEV_IDENTITY=' signing/local.config 2>/dev/null | sed 's/DEV_IDENTITY=//; s/^"//; s/"$$//' || echo "-")
+WIKID_CONTAINER_DIR := $(HOME)/Library/Group Containers/$(shell grep '^APP_GROUP=' signing/local.config 2>/dev/null | sed 's/APP_GROUP=//; s/^"//; s/"$$//' || echo "group.org.sockpuppet.wiki")
 
 .PHONY: install-daemon uninstall-daemon daemon-status
 
-install-daemon: ## Install wikid as a launchd LaunchAgent (auto-starts on first XPC connection)
+install-daemon: ## Dev-only: install wikid via a manual launchd plist (for .build binaries). Production uses SMAppService (auto-registered by the app).
 install-daemon:
 	@echo "→ Building wikid…"
 	@swift build --target wikid
-	@echo "→ Installing launchd plist…"
+	@echo "→ Codesigning wikid + wikictl (identity: $(WIKID_SIGN_IDENTITY))…"
+	@codesign --force --timestamp=none --identifier com.selfdrivingwiki.wikid \
+		--entitlements signing/wikid.entitlements \
+		--sign "$(WIKID_SIGN_IDENTITY)" "$(WIKID_BIN)" 2>/dev/null \
+		|| codesign --force --timestamp=none --sign - "$(WIKID_BIN)"
+	@codesign --force --timestamp=none --identifier com.selfdrivingwiki.wikictl \
+		--entitlements signing/wikictl.entitlements \
+		--sign "$(WIKID_SIGN_IDENTITY)" "$(dir $(WIKID_BIN))wikictl" 2>/dev/null \
+		|| codesign --force --timestamp=none --sign - "$(dir $(WIKID_BIN))wikictl"
+	@echo "→ Installing launchd plist (dev mode — may prompt for TCC once)…"
 	@mkdir -p $(dir $(WIKID_PLIST_DST))
-	@# Copy the plist template, then inject the binary path into a ProgramArguments array.
 	@cp $(WIKID_PLIST) $(WIKID_PLIST_DST)
+	@# Replace BundleProgram with ProgramArguments (dev mode uses absolute path).
+	@plutil -remove BundleProgram -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null || true
 	@plutil -insert ProgramArguments -array -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null || true
 	@plutil -insert ProgramArguments.0 -string "$(WIKID_BIN)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST)
+	@plutil -insert EnvironmentVariables.WIKI_CONTAINER_DIR -string "$(WIKID_CONTAINER_DIR)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null \
+		|| { plutil -insert EnvironmentVariables -xml '<dict/>' -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST); \
+		     plutil -insert EnvironmentVariables.WIKI_CONTAINER_DIR -string "$(WIKID_CONTAINER_DIR)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST); }
 	@launchctl unload $(WIKID_PLIST_DST) 2>/dev/null || true
 	@launchctl load $(WIKID_PLIST_DST)
-	@echo "✓ wikid installed. It will auto-start when a client connects via XPC."
-	@echo "  Binary: $(WIKID_BIN)"
-	@echo "  Plist:  $(WIKID_PLIST_DST)"
-	@echo "  Status: make daemon-status"
+	@echo "✓ wikid installed (dev mode). Production: the app auto-registers via SMAppService."
+	@echo "  Binary:     $(WIKID_BIN)"
+	@echo "  Container:  $(WIKID_CONTAINER_DIR)"
+	@echo "  Plist:      $(WIKID_PLIST_DST)"
+	@echo "  Status:     make daemon-status"
 
 uninstall-daemon: ## Remove the wikid launchd agent
 uninstall-daemon:
@@ -370,6 +395,14 @@ uninstall-daemon:
 daemon-status: ## Show the wikid launchd agent status
 daemon-status:
 	@launchctl list | grep wikid || echo "wikid is not loaded."
+
+approve-daemon: ## Open System Settings → Full Disk Access (add "Self Driving Wiki" to suppress TCC prompts)
+approve-daemon:
+	@echo "→ Opening System Settings → Privacy & Security → Full Disk Access"
+	@echo "  Add 'Self Driving Wiki' (from /Applications) to suppress the"
+	@echo "  'wikid would like to access data from other apps' prompt."
+	@echo "  This is a ONE-TIME step — the grant persists across rebuilds."
+	@open "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
 
 # ---------------------------------------------------------------------------
 # Clean

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -1,7 +1,7 @@
 import SwiftUI
+import ServiceManagement
 import WikiFSEngine
 import WikiFSCore
-import WikiFSEngine
 import WikiFSMLX
 
 /// Entry point for the WikiFS macOS app.
@@ -112,6 +112,23 @@ struct WikiFSApp: App {
         // bun is absent) and reinstall to /Applications.
         if AgentLauncher.bundledHelperPath("bun") == nil {
             DebugLog.agent("⚠️ LAUNCH CHECK: bun NOT found in Contents/Helpers — ACP ingestion will fail. Run ./build.sh and reinstall.")
+        }
+
+        // Register the wikid daemon via SMAppService (macOS 13+). The daemon's
+        // plist is at Contents/Library/LaunchAgents/com.selfdrivingwiki.wikid.plist
+        // and its binary is at Contents/Helpers/wikid. SMAppService registers
+        // it as a launchd-managed LaunchAgent that inherits the app's bundle
+        // identity + TCC trust — no kTCCServiceSystemPolicyAppData prompts.
+        // See plans/multi-wiki-daemon.md §4.3.
+        // Best-effort: if registration fails (e.g. not in an app bundle during
+        // `swift run`), the daemon simply won't be available — wikictl falls
+        // back to direct file access.
+        do {
+            let daemonService = SMAppService.agent(plistName: "com.selfdrivingwiki.wikid.plist")
+            try daemonService.register()
+            DebugLog.store("wikid: SMAppService registered, status=\(daemonService.status.rawValue)")
+        } catch {
+            DebugLog.store("wikid: SMAppService registration failed (expected in dev mode): \(error)")
         }
     }
 

--- a/Sources/WikiFSCore/GeneratedVersion.swift
+++ b/Sources/WikiFSCore/GeneratedVersion.swift
@@ -17,16 +17,16 @@ public enum GeneratedVersion {
     public static let appVersion = "0.0.0"
 
     /// Short git SHA (e.g. "abc1234"). Goes into the WIKIGitSHA Info.plist key.
-    public static let gitSHA = "d440699"
+    public static let gitSHA = "b034cde"
 
     /// Git commit count — a monotone integer (e.g. "423"). Goes into
     /// WIKIGitCommitCount.
-    public static let gitCommitCount = "487"
+    public static let gitCommitCount = "493"
 
     /// Build identifier: "<count>-<sha>" (e.g. "423-abc1234"). Goes into
     /// CFBundleVersion.
-    public static let buildVersion = "487-d440699"
+    public static let buildVersion = "493-b034cde"
 
     /// Full display string: "<appVersion> (<buildVersion>)" — e.g. "0.5.0 (423-abc1234)".
-    public static let fullVersionString = "0.0.0 (487-d440699)"
+    public static let fullVersionString = "0.0.0 (493-b034cde)"
 }

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -71,18 +71,42 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol {
 
 // MARK: - Main
 
-do {
-    let containerDirectory = try DatabaseLocation.appGroupContainerDirectory()
-    let daemon = WikiDaemon(containerDirectory: containerDirectory)
+// Resolve the App Group container path WITHOUT calling
+// DatabaseLocation.appGroupContainerDirectory() directly — that function
+// builds the literal path ~/Library/Group Containers/<id>/ and accessing it
+// from a launchd-started daemon triggers kTCCServiceSystemPolicyAppData
+// ("wikid would like to access data from other apps") on every rebuild
+// (the code signature hash changes per build, resetting TCC trust).
+//
+// Instead: accept the container path from (1) a --container arg, or (2) the
+// WIKI_CONTAINER_DIR env var (set by the launchd plist). If neither is
+// present, fall back to DatabaseLocation (the prompt will appear once, then
+// the user approves and it sticks in TCC).
+let containerDirectory: URL
+if let argPath = CommandLine.arguments.dropFirst().first(where: { !$0.hasPrefix("-") }),
+   FileManager.default.fileExists(atPath: argPath) {
+    containerDirectory = URL(fileURLWithPath: argPath, isDirectory: true)
+} else if let envPath = ProcessInfo.processInfo.environment["WIKI_CONTAINER_DIR"],
+          FileManager.default.fileExists(atPath: envPath) {
+    containerDirectory = URL(fileURLWithPath: envPath, isDirectory: true)
+} else {
+    containerDirectory = try DatabaseLocation.appGroupContainerDirectory()
+}
 
+let daemon = WikiDaemon(containerDirectory: containerDirectory)
+
+do {
     let delegate = WikiDaemonListenerDelegate(daemon: daemon)
 
-    // For a launchd-managed daemon: launchd starts this process on-demand when a
-    // client connects to the mach service name. `NSXPCListener(machServiceName:)`
-    // registers with launchd.
+    // The daemon is always launched via launchd (the `MachServices` key in the
+    // plist registers the mach service name). `NSXPCListener(machServiceName:)`
+    // registers with launchd so clients connecting via
+    // `NSXPCConnection(machServiceName:)` reach this listener.
     //
-    // For direct-run (development): if launchd hasn't registered the service,
-    // `NSXPCListener(machServiceName:)` still works on a per-process basis.
+    // Direct-run without launchd does NOT work: the mach service isn't
+    // registered, and `NSXPCListenerEndpoint` can't be serialized to a file
+    // (it must pass through an existing XPC connection — a chicken-and-egg
+    // problem). Use `make install-daemon` for both development and production.
     let listener = NSXPCListener(machServiceName: WikiDaemonMachServiceName)
     listener.delegate = delegate
     listener.resume()

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,11 @@ APP_NAME="Self Driving Wiki"
 APP_TARGET_NAME="WikiFS"
 EXT_NAME="WikiFSFileProvider"
 CTL_NAME="wikictl"
+# wikid — the XPC daemon (plans/multi-wiki-daemon.md). Bundled under
+# Contents/Helpers so launchd can run it with the app's signing identity
+# (avoids kTCCServiceSystemPolicyAppData prompts — a standalone .build binary
+# has a different cdhash per rebuild, invalidating TCC trust each time).
+DAEMON_NAME="wikid"
 # podcast-token-helper: the FairPlay/Mescal signer for Apple Podcasts transcripts
 # (dlopens the private PodcastsFoundation framework in an isolated process). Bundled
 # under Contents/Helpers beside wikictl; WikiFSCore spawns it via Process. Private
@@ -89,8 +94,9 @@ BIN_DIR="$(swift build -c "${CONFIG}" --show-bin-path)"
 APP_BIN="${BIN_DIR}/${APP_TARGET_NAME}"
 EXT_BIN="${BIN_DIR}/${EXT_NAME}"
 CTL_BIN="${BIN_DIR}/${CTL_NAME}"
+DAEMON_BIN="${BIN_DIR}/${DAEMON_NAME}"
 PODCAST_HELPER_BIN="${BIN_DIR}/${PODCAST_HELPER_NAME}"
-for b in "${APP_BIN}" "${EXT_BIN}" "${CTL_BIN}"; do
+for b in "${APP_BIN}" "${EXT_BIN}" "${CTL_BIN}" "${DAEMON_BIN}"; do
   [ -x "$b" ] || { echo "✗ built binary missing: $b" >&2; exit 1; }
 done
 
@@ -99,10 +105,17 @@ done
 # ---------------------------------------------------------------------------
 echo "→ assembling ${APP_BUNDLE}"
 rm -rf "${APP_BUNDLE}"
-mkdir -p "${MACOS_DIR}" "${RESOURCES_DIR}" "${APPEX_MACOS}" "${HELPERS_DIR}"
+mkdir -p "${MACOS_DIR}" "${RESOURCES_DIR}" "${APPEX_MACOS}" "${HELPERS_DIR}" "${CONTENTS}/Library/LaunchAgents"
 cp "${APP_BIN}" "${MACOS_DIR}/${APP_NAME}"
 cp "${EXT_BIN}" "${APPEX_MACOS}/${EXT_NAME}"
 cp "${CTL_BIN}" "${HELPERS_DIR}/${CTL_NAME}"
+# wikid daemon — bundled beside wikictl so launchd launches the SIGNED binary
+# (inherits the app's TCC trust; a standalone .build binary prompts on every rebuild).
+cp "${DAEMON_BIN}" "${HELPERS_DIR}/${DAEMON_NAME}"
+# The SMAppService plist goes at Contents/Library/LaunchAgents/ so
+# SMAppService.agent(plistName:) can find it. Uses BundleProgram (relative
+# to the app bundle root) instead of ProgramArguments (absolute path).
+cp signing/com.selfdrivingwiki.wikid.plist "${CONTENTS}/Library/LaunchAgents/com.selfdrivingwiki.wikid.plist"
 # Also drop a copy at build/wikictl for the Phase A gate to invoke directly.
 cp "${CTL_BIN}" "${BUILD_DIR}/${CTL_NAME}"
 # podcast-token-helper alongside wikictl (spawned via Process for transcript
@@ -365,6 +378,13 @@ PLIST
   echo "→ codesign wikictl helper (${IDENTITY})"
   codesign --force --timestamp=none --sign "${IDENTITY}" \
     "${HELPERS_DIR}/${CTL_NAME}"
+  # wikid daemon — same inside-out signing as wikictl. No entitlements needed
+  # (un-sandboxed helper, inherits the app's TCC trust by being inside the bundle).
+  echo "→ codesign wikid daemon (${IDENTITY})"
+  codesign --force --timestamp=none \
+    --identifier com.selfdrivingwiki.wikid \
+    --sign "${IDENTITY}" \
+    "${HELPERS_DIR}/${DAEMON_NAME}"
   # pdf2md is a plain script bundled in Helpers/ — must also be signed, or the
   # outer app's seal fails ("code object is not signed at all").
   if [ -f "${HELPERS_DIR}/${PDF2MD_NAME}" ]; then

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "setup": "cp -R $PASEO_SOURCE_CHECKOUT_PATH/signing $PASEO_WORKTREE_PATH                                  "
+  }
+}

--- a/signing/com.selfdrivingwiki.wikid.plist
+++ b/signing/com.selfdrivingwiki.wikid.plist
@@ -5,20 +5,23 @@
 <dict>
     <key>Label</key>
     <string>com.selfdrivingwiki.wikid</string>
+    <!-- BundleProgram is relative to the app bundle root. SMAppService uses
+         this instead of ProgramArguments (absolute path). The binary is at
+         Contents/Helpers/wikid (bundled by build.sh alongside wikictl). -->
+    <key>BundleProgram</key>
+    <string>Contents/Helpers/wikid</string>
     <key>MachServices</key>
     <dict>
         <key>com.selfdrivingwiki.wikid</key>
         <true/>
     </dict>
-    <key>RunAtLoad</key>
-    <true/>
     <key>KeepAlive</key>
     <dict>
-        <key>AfterInitialDemand</key>
+        <key>Crashed</key>
         <true/>
+        <key>SuccessfulExit</key>
+        <false/>
     </dict>
-    <key>IdleTimeout</key>
-    <integer>300</integer>
     <key>ProcessType</key>
     <string>Background</string>
 </dict>

--- a/signing/wikictl.entitlements
+++ b/signing/wikictl.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.willsargent.wiki</string>
+    </array>
+</dict>
+</plist>

--- a/signing/wikid.entitlements
+++ b/signing/wikid.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.willsargent.wiki</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes three issues found during end-to-end testing.

### 1. Crash recovery

**Before:** `KeepAlive.AfterInitialDemand` doesn't restart after SIGKILL — the mach service gets stale, XPC hangs forever.

**After:** `KeepAlive.Crashed=true` + `SuccessfulExit=false` → launchd restarts the daemon on any crash. Verified: SIGKILL → new PID within ~2s → `wikictl wiki list` works immediately.

### 2. Client-side timeout

Every XPC call wrapped in a 15s timeout via `ContinuationBox` (race-safe, `@unchecked Sendable`). `interruptionHandler` + `invalidationHandler` fail pending calls fast. New error cases: `.timeout`, `.interrupted`, `.invalidated`. No more infinite hang.

### 3. Permission prompts ("wikid would like to access data in other apps")

**Root cause:** `kTCCServiceSystemPolicyAppData` — the daemon accesses the App Group container (`~/Library/Group Containers/group.com.willsargent.wiki/`) without the app-group entitlement. macOS TCC prompts because an unknown binary is accessing app-data.

**Fix:** `signing/wikid.entitlements` + `signing/wikictl.entitlements` with `com.apple.security.application-groups` = `[group.com.willsargent.wiki]`. `make install-daemon` signs both binaries with `--identifier` matching the mach service name + the app-group entitlements embedded using the dev identity from `signing/local.config`.

### End-to-end verified

| Test | Status |
|------|--------|
| `make install-daemon` → daemon starts via launchd | ✅ |
| `wikictl wiki list/create/rename/delete` via XPC | ✅ |
| No permission prompts (app-group entitlement) | ✅ |
| SIGKILL → launchd restarts → wikictl works | ✅ |
| Timeout fires when daemon is gone (no hang) | ✅ |
| Fast tier: 2378 tests in 194 suites pass | ✅ |