### PR TITLE
Fix Settings dialog clipping the Agents tab

### DIFF
--- a/Sources/WikiFS/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/ExtractionSettingsView.swift
@@ -98,7 +98,7 @@ struct ExtractionSettingsView: View {
             backendConfigSection
         }
         .formStyle(.grouped)
-        .frame(width: Metrics.width, height: Metrics.height)
+        .frame(minWidth: Metrics.width, minHeight: Metrics.height)
         .disabled(extractionInProgress)
         .alert("Couldn't Connect to Claude", isPresented: anthropicErrorBinding,
                presenting: anthropicErrorMessage) { _ in

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -254,8 +254,9 @@ struct WikiFSApp: App {
                 AgentsSettingsView(containerDirectory: containerDirectory)
                     .tabItem { Label("Agents", systemImage: "cpu") }
             }
-            .frame(width: 460, height: 460)
+            .frame(minWidth: 560, minHeight: 520)
         }
+        .windowResizability(.contentMinSize)
     }
 }
 

--- a/Sources/WikiFS/ZoteroSettingsView.swift
+++ b/Sources/WikiFS/ZoteroSettingsView.swift
@@ -72,7 +72,7 @@ struct ZoteroSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: Metrics.width)
+        .frame(minWidth: Metrics.width)
         .onAppear { load() }
         .alert(
             "Couldn't Connect to Zotero",

--- a/Tests/WikiFSTests/BookmarkTargetPickerSelectionTests.swift
+++ b/Tests/WikiFSTests/BookmarkTargetPickerSelectionTests.swift
@@ -5,6 +5,7 @@ import Testing
 /// Tests for `BookmarkTargetPickerSheet.parentID(forSelection:)` — the
 /// sentinel-to-nil conversion that lets the picker offer a "Bookmarks" root
 /// destination (parentID == nil) alongside real folders (#243).
+@MainActor
 @Suite struct BookmarkTargetPickerSelectionTests {
 
     @Test func rootSentinelMapsToNilParentID() {


### PR DESCRIPTION
## Summary

The Settings dialog was too small to show the Agents tab properly. PR #375 replaced the old Agent + Providers tabs with the larger unified AgentsSettingsView (minWidth: 560, minHeight: 520), but the parent TabView still had a fixed .frame(width: 460, height: 460) that clamped it and made the window non-resizable.

## Changes

- WikiFSApp.swift (Settings TabView): fixed frame -> minWidth/minHeight 560x520 + .windowResizability(.contentMinSize)
- ZoteroSettingsView.swift: fixed width -> minWidth (fills window instead of leaving dead space)
- ExtractionSettingsView.swift: fixed width/height -> minWidth/minHeight

Switching from fixed to minimum dimensions makes the Settings window large enough for the Agents tab, resizable so the user can grow it further, and consistent across tabs.

## Testing

- swift build — clean
- Fast tier: 2292 tests in 191 suites pass