### PR TITLE
Confirm before quitting (#377)

### DIFF
--- a/Sources/WikiFS/GeneralSettingsView.swift
+++ b/Sources/WikiFS/GeneralSettingsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Settings → General tab: app-level toggles that don't fit a domain tab.
+///
+/// Currently hosts the "Confirm before quitting" toggle (key
+/// `confirmBeforeQuitting`, default on). When enabled, a dialog asks the user
+/// to confirm before the app terminates — catching ⌘Q / Apple menu Quit / Dock
+/// Quit / system shutdown.
+struct GeneralSettingsView: View {
+    @AppStorage(QuitConfirmationDelegate.confirmQuitKey)
+    private var confirmBeforeQuitting = true
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Ask before quitting", isOn: $confirmBeforeQuitting)
+                    .help(
+                        "When enabled, Self Driving Wiki asks for confirmation "
+                        + "before quitting — ⌘Q, or closing the last window with ⌘W."
+                    )
+            } header: {
+                Text("Quitting")
+            } footer: {
+                Text(
+                    "You can always quit immediately by choosing "
+                    + "\"Quit\" in the confirmation dialog, or by turning this off."
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+#Preview {
+    GeneralSettingsView()
+        .frame(width: 460, height: 460)
+}

--- a/Sources/WikiFS/QuitConfirmationDelegate.swift
+++ b/Sources/WikiFS/QuitConfirmationDelegate.swift
@@ -18,6 +18,9 @@ import WikiFSEngine
 ///
 /// The confirmation can be toggled in Settings → General (key
 /// `confirmBeforeQuitting`, default **on** so the feature works out of the box).
+/// However, even when the setting is **off**, the app still asks for
+/// confirmation if an extraction, ingestion, or agent operation is in flight —
+/// silent termination during active work could lose data.
 final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Injected dependencies
@@ -26,9 +29,14 @@ final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
     /// Wired in `WikiFSApp.init` after the manager is created.
     var flushPendingSaves: (() -> Void)?
 
-    /// Returns whether any agent (ingest or chat) is actively running. The quit
-    /// dialog message is tailored when operations are in flight.
-    var isAnyAgentRunning: (() -> Bool)?
+    /// Returns a human-readable description of any operation in flight (PDF
+    /// extraction, source ingestion, or an agent run), or `nil` when the app
+    /// is idle. The quit dialog message is tailored based on what's running.
+    ///
+    /// This covers operations that `isRunning` alone misses: `isExtracting`
+    /// (the PDF→Markdown phase before the agent process spawns) and
+    /// non-empty `ingestingSourceIDs` (an agent-phase ingest in progress).
+    var activeOperationDescription: (() -> String?)?
 
     // MARK: - Settings key
 
@@ -50,17 +58,23 @@ final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
         // Flush pending saves regardless — don't lose buffered edits on quit.
         flushPendingSaves?()
 
-        guard Self.confirmBeforeQuitting else {
+        let activeOp = activeOperationDescription?()
+
+        // If nothing is running AND the user has disabled confirm-before-quit,
+        // quit now without a dialog.
+        guard activeOp != nil || Self.confirmBeforeQuitting else {
             return .terminateNow
         }
 
+        // Either the user wants confirmation, or there's active work we
+        // shouldn't interrupt silently — show the dialog in both cases.
         let alert = NSAlert()
         alert.alertStyle = .warning
 
-        if isAnyAgentRunning?() == true {
+        if let description = activeOp {
             alert.messageText = "Quit Self Driving Wiki?"
             alert.informativeText =
-                "An agent operation is still running and will be cancelled. "
+                "\(description) is still running and will be cancelled. "
                 + "Are you sure you want to quit?"
         } else {
             alert.messageText = "Quit Self Driving Wiki?"
@@ -110,9 +124,10 @@ final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
     /// `confirmBeforeQuitting` setting) is deliberate: it only steers the
     /// *last*-window-close case into the termination flow; whether the user is
     /// actually asked, or the app quits immediately, is decided in
-    /// `applicationShouldTerminate` based on the setting. With the setting off,
-    /// the last window close quits the app right away (no dialog); with it on,
-    /// the dialog appears.
+    /// `applicationShouldTerminate` based on the setting (and whether any work
+    /// is in flight). With the setting off and nothing running, the last
+    /// window close quits the app right away (no dialog); with it on, the
+    /// dialog appears. If work is in flight, the dialog appears regardless.
     func applicationShouldTerminateAfterLastWindowClosed(
         _ sender: NSApplication
     ) -> Bool {

--- a/Sources/WikiFS/QuitConfirmationDelegate.swift
+++ b/Sources/WikiFS/QuitConfirmationDelegate.swift
@@ -1,0 +1,121 @@
+import AppKit
+import WikiFSEngine
+
+/// Application delegate that intercepts termination to show a "confirm to quit"
+/// dialog, then flushes pending autosaves before the app actually exits.
+///
+/// Implements `applicationShouldTerminate(_:)` returning `.terminateLater` so the
+/// system pauses termination while we present an `NSAlert`, then we call
+/// `NSApp.reply(toApplicationShouldTerminate:)` with the user's choice. This
+/// catches **all** termination paths: ⌘Q, Apple menu Quit, Dock Quit, and system
+/// shutdown — not just the menu item.
+///
+/// Additionally implements `applicationShouldTerminateAfterLastWindowClosed(_:)`
+/// returning `true`, so closing the final window — e.g. pressing ⌘W repeatedly
+/// until no windows remain — routes through `applicationShouldTerminate`,
+/// triggering the same confirmation dialog. This is the "⌘W too many times"
+/// guardrail: the app won't silently vanish behind a flurry of window closes.
+///
+/// The confirmation can be toggled in Settings → General (key
+/// `confirmBeforeQuitting`, default **on** so the feature works out of the box).
+final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
+
+    // MARK: - Injected dependencies
+
+    /// Called before the app terminates so the model can flush buffered edits.
+    /// Wired in `WikiFSApp.init` after the manager is created.
+    var flushPendingSaves: (() -> Void)?
+
+    /// Returns whether any agent (ingest or chat) is actively running. The quit
+    /// dialog message is tailored when operations are in flight.
+    var isAnyAgentRunning: (() -> Bool)?
+
+    // MARK: - Settings key
+
+    static let confirmQuitKey = "confirmBeforeQuitting"
+
+    /// `@AppStorage` doesn't exist in this non-SwiftUI context, but the default
+    /// is "ask" (true) when the key is unset — matching the feature's purpose.
+    static var confirmBeforeQuitting: Bool {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: confirmQuitKey) != nil else { return true }
+        return defaults.bool(forKey: confirmQuitKey)
+    }
+
+    // MARK: - Termination
+
+    func applicationShouldTerminate(
+        _ sender: NSApplication
+    ) -> NSApplication.TerminateReply {
+        // Flush pending saves regardless — don't lose buffered edits on quit.
+        flushPendingSaves?()
+
+        guard Self.confirmBeforeQuitting else {
+            return .terminateNow
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+
+        if isAnyAgentRunning?() == true {
+            alert.messageText = "Quit Self Driving Wiki?"
+            alert.informativeText =
+                "An agent operation is still running and will be cancelled. "
+                + "Are you sure you want to quit?"
+        } else {
+            alert.messageText = "Quit Self Driving Wiki?"
+            alert.informativeText = "Are you sure you want to quit?"
+        }
+
+        let quitButton = alert.addButton(withTitle: "Quit")
+        alert.addButton(withTitle: "Cancel")
+        quitButton.hasDestructiveAction = true
+        quitButton.keyEquivalent = "\r"    // Return → default (Quit)
+        // Make Cancel the escape-equivalent so ⎋ dismisses without quitting.
+        alert.buttons.last?.keyEquivalent = "\u{1b}"
+
+        // Present as a sheet on the current key window when possible; fall back
+        // to a modal dialog when no window is available (e.g. all windows
+        // closed but app still active).
+        if let window = sender.windows.first(
+            where: { $0.isVisible && $0.canBecomeKey }
+        ) {
+            alert.beginSheetModal(for: window) { response in
+                NSApp.reply(
+                    toApplicationShouldTerminate:
+                        response == .alertFirstButtonReturn
+                )
+            }
+        } else {
+            let response = alert.runModal()
+            NSApp.reply(
+                toApplicationShouldTerminate:
+                    response == .alertFirstButtonReturn
+            )
+        }
+
+        // We've deferred the decision to the alert callback.
+        return .terminateLater
+    }
+
+    // MARK: - Last window closed
+
+    /// Asking `true` here makes closing the **last** remaining window (⌘W, the
+    /// close button, or the Window → Close menu item) route through
+    /// `applicationShouldTerminate(_:)`. That's the path that presents the
+    /// confirm-on-quit dialog — so "⌘W too many times" no longer silently
+    /// dismisses the app.
+    ///
+    /// Returning `true` unconditionally (independent of the
+    /// `confirmBeforeQuitting` setting) is deliberate: it only steers the
+    /// *last*-window-close case into the termination flow; whether the user is
+    /// actually asked, or the app quits immediately, is decided in
+    /// `applicationShouldTerminate` based on the setting. With the setting off,
+    /// the last window close quits the app right away (no dialog); with it on,
+    /// the dialog appears.
+    func applicationShouldTerminateAfterLastWindowClosed(
+        _ sender: NSApplication
+    ) -> Bool {
+        return true
+    }
+}

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -63,6 +63,13 @@ struct WikiFSApp: App {
     /// `.task` below. The change bridge observes `wikictl`'s Darwin notifications.
     @State private var changeBridge: WikiChangeBridge?
 
+    /// App delegate that intercepts termination to show a "confirm to quit"
+    /// dialog (toggleable in Settings → General). Catches all quit paths:
+    /// ⌘Q, Apple menu, Dock, and system shutdown.
+    @NSApplicationDelegateAdaptor(
+        QuitConfirmationDelegate.self
+    ) private var quitDelegate
+
     init() {
         // Migrate the renamed chat-zoom @AppStorage key before any ChatView reads
         // it. Idempotent: copies `conversation.zoom` → `chat.zoom` only when the
@@ -289,6 +296,33 @@ struct WikiFSApp: App {
             changeBridge = bridge
             appDelegate.sessionManager = sessionManager
         }
+
+        // Wire the quit-confirmation delegate's closures. Flush pending autosaves
+        // (don't lose buffered edits), and report any active operation (extraction,
+        // ingestion, agent run) so the quit dialog message is tailored and the app
+        // won't silently quit mid-work even with the setting off.
+        quitDelegate.flushPendingSaves = { [weak sessionManager] in
+            sessionManager?.flushAllSessions()
+        }
+        quitDelegate.activeOperationDescription = { [weak activityTracker, weak sessionManager] in
+            if activityTracker?.isExtracting == true {
+                return "A PDF extraction"
+            }
+            if activityTracker?.isIngesting == true {
+                return "A source ingestion"
+            }
+            if let sm = sessionManager {
+                for session in sm.allSessions {
+                    if session.agentLauncher.isRunning {
+                        return "An agent operation"
+                    }
+                    if session.chatLauncher.isRunning {
+                        return "A chat session"
+                    }
+                }
+            }
+            return nil
+        }
     }
 
     var body: some Scene {
@@ -395,6 +429,8 @@ struct WikiFSApp: App {
                 AboutView()
                     .tag(SettingsTab.about)
                     .tabItem { Label("About", systemImage: "info.circle") }
+                GeneralSettingsView()
+                    .tabItem { Label("General", systemImage: "gearshape") }
                 ZoteroSettingsView(containerDirectory: containerDirectory)
                     .tag(SettingsTab.zotero)
                     .tabItem { Label("Zotero", systemImage: "books.vertical") }


### PR DESCRIPTION
## Confirm before quitting (#377)

Adds a quit-confirmation dialog that intercepts all termination paths
(⌘Q, Apple menu Quit, Dock Quit, system shutdown, and last-window-close
via ⌘W). Toggleable in Settings → General (default on).

### Behavior

- When **confirm-before-quitting is on**: a warning dialog asks for
  confirmation before the app terminates. The dialog message is tailored
  based on what's running:
  - *"A PDF extraction is still running and will be cancelled."*
  - *"A source ingestion is still running and will be cancelled."*
  - *"An agent operation is still running and will be cancelled."*
  - *"A chat session is still running and will be cancelled."*
  - Generic "Are you sure you want to quit?" when idle.

- When **confirm-before-quitting is off** but work is in flight
  (extraction, ingestion, agent run, or chat): the dialog **still
  appears** — silent termination during active work could lose data.

- When **off and idle**: quits immediately, no dialog.

- **⌘W guardrail**: `applicationShouldTerminateAfterLastWindowClosed`
  returns `true`, so closing the last window routes through the same
  termination flow (and the same dialog logic above).

### Implementation

| File | Change |
|------|--------|
| `QuitConfirmationDelegate.swift` | New `NSApplicationDelegate` implementing `applicationShouldTerminate` (returns `.terminateLater`, presents `NSAlert`, then replies) and `applicationShouldTerminateAfterLastWindowClosed` (returns `true`). Uses `activeOperationDescription: (() -> String?)?` closure to detect in-flight work. |
| `WikiFSApp.swift` | Wires `@NSApplicationDelegateAdaptor(QuitConfirmationDelegate.self)`. Flushes all sessions on quit via `sessionManager.flushAllSessions()`. Checks `activityTracker.isExtracting` / `isIngesting` and iterates `sessionManager.allSessions` for `agentLauncher.isRunning` / `chatLauncher.isRunning`. |
| `GeneralSettingsView.swift` | New Settings → General tab with the "Ask before quitting" toggle (`@AppStorage("confirmBeforeQuitting")`, default on). |

### How active operations are detected

The `activeOperationDescription` closure returns a human-readable string
(or `nil` when idle), checked in priority order:

1. `activityTracker.isExtracting` — queue-driven extraction (pdf2md / Claude / Docling)
2. `activityTracker.isIngesting` — queue-driven ingestion or lint
3. Any session's `agentLauncher.isRunning` — agent process alive (ingest/query/lint)
4. Any session's `chatLauncher.isRunning` — chat agent process alive

This covers the extraction and ingestion phases that `isRunning` alone
misses (extraction runs before the agent process spawns; ingestion is
tracked separately from the generation gate).
