### PR TITLE
Fix #389: chat search box clips first row in list

### DIFF
--- a/Sources/WikiFS/AgentToolsView.swift
+++ b/Sources/WikiFS/AgentToolsView.swift
@@ -56,6 +56,7 @@ struct AgentToolsView: View {
                 }
                 .listStyle(.inset)
                 .scrollContentBackground(.hidden)
+                .padding(.top, 4)
                 // "Show In List" reveal: a detail-view button requested that a
                 // chat be surfaced. The active tab already selects this chat
                 // (we're viewing it), so the row is highlighted — we only need


### PR DESCRIPTION
Closes #389

Add 4pt top padding to the chat List in AgentToolsView. The .inset list style's built-in top inset, combined with .scrollContentBackground(.hidden) and zero VStack spacing, caused the first row to render partially behind the divider/search bar.