### PR TITLE
Fix #386: show tool name and file path in permission approval dialog

### DIFF
--- a/Sources/WikiFS/PermissionApprovalView.swift
+++ b/Sources/WikiFS/PermissionApprovalView.swift
@@ -39,9 +39,18 @@ struct PermissionApprovalView: View {
                 Text(titleText)
                     .font(.subheadline)
                     .fontWeight(.semibold)
-                Text("The agent is waiting for your approval to proceed.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if let summary = detailText {
+                    Text(summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                }
+                if !showsDetail {
+                    Text("The agent is waiting for your approval to proceed.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer(minLength: 8)
             HStack(spacing: 8) {
@@ -71,9 +80,20 @@ struct PermissionApprovalView: View {
         .accessibilityLabel("Permission request awaiting approval")
     }
 
-    /// The request's title: the tool-call's title if offered (e.g. "Edit file"),
-    /// otherwise a generic "Approve write?" prompt.
+    /// The request's title: the tool name if available (e.g. "Edit file"),
+    /// otherwise a generic "Approve this change?" prompt.
     private var titleText: String {
-        permission.title ?? "Approve this change?"
+        permission.toolName ?? permission.title ?? "Approve this change?"
+    }
+
+    /// The file path or other input detail for the pending change, if any.
+    private var detailText: String? {
+        permission.inputSummary
+    }
+
+    /// Whether we have a real tool name or path to show instead of the generic
+    /// caption.
+    private var showsDetail: Bool {
+        detailText != nil
     }
 }

--- a/Sources/WikiFSEngine/ACPPermissions.swift
+++ b/Sources/WikiFSEngine/ACPPermissions.swift
@@ -191,11 +191,22 @@ public enum PermissionPolicy: String, Sendable, CaseIterable {
 public struct PendingPermission: Sendable, Equatable {
     public let toolCallId: String
     public let title: String?
+    /// A human-readable tool name (e.g. "Edit file", "Create directory").
+    /// Derived from the permission request's `ToolCallUpdate.title`/`.kind`.
+    public let toolName: String?
+    /// A one-liner summary of what the tool will do (e.g. the file path being
+    /// edited). Derived from `ToolCallUpdate.locations`.
+    public let inputSummary: String?
     public let options: [PermissionOption]
 
-    public init(toolCallId: String, title: String?, options: [PermissionOption]) {
+    public init(
+        toolCallId: String, title: String?, toolName: String?,
+        inputSummary: String?, options: [PermissionOption]
+    ) {
         self.toolCallId = toolCallId
         self.title = title
+        self.toolName = toolName
+        self.inputSummary = inputSummary
         self.options = options
     }
 
@@ -220,6 +231,8 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     /// A pending request's resolution channel.
     private struct Pending {
         let options: [PermissionOption]
+        let toolName: String?
+        let inputSummary: String?
         let continuation: CheckedContinuation<RequestPermissionResponse, Never>
     }
 
@@ -279,10 +292,15 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
         request: RequestPermissionRequest,
         lock: OSAllocatedUnfairLock<LockedState>
     ) async -> RequestPermissionResponse {
-        await withCheckedContinuation { (continuation: CheckedContinuation<RequestPermissionResponse, Never>) in
+        let toolCall = request.toolCall
+        let toolName = Self.toolName(for: toolCall)
+        let inputSummary = Self.toolSummary(for: toolCall)
+        return await withCheckedContinuation { (continuation: CheckedContinuation<RequestPermissionResponse, Never>) in
             lock.withLock { state in
                 state.pending[request.toolCall.toolCallId] = Pending(
                     options: request.options,
+                    toolName: toolName,
+                    inputSummary: inputSummary,
                     continuation: continuation
                 )
             }
@@ -362,7 +380,13 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     func pendingSnapshot() -> [PendingPermission] {
         lock.withLock { state in
             state.pending.map { (toolCallId, pending) in
-                PendingPermission(toolCallId: toolCallId, title: nil, options: pending.options)
+                PendingPermission(
+                    toolCallId: toolCallId,
+                    title: pending.toolName,
+                    toolName: pending.toolName,
+                    inputSummary: pending.inputSummary,
+                    options: pending.options
+                )
             }
         }
     }
@@ -410,6 +434,24 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     }
 
     // MARK: - Helpers
+
+    /// A renderable tool name for a permission request. Prefers the ACP
+    /// `title`; falls back to the `kind` (capitalized), then a generic "tool".
+    /// Same logic as `ACPEventTranslator.toolName(for:)`.
+    private static func toolName(for call: ToolCallUpdate) -> String? {
+        if let title = call.title, !title.isEmpty { return title }
+        if let kind = call.kind { return kind.rawValue.capitalized }
+        return nil
+    }
+
+    /// A one-liner summary for a permission request — the file path being
+    /// changed. Same logic as `ACPEventTranslator.toolSummary(for:)`.
+    private static func toolSummary(for call: ToolCallUpdate) -> String? {
+        if let path = call.locations?.first?.path, !path.isEmpty {
+            return path
+        }
+        return nil
+    }
 
     /// Pick the "allow" option from a permission request's options. An allow
     /// option's `kind` is `allow_once`/`allow_always`; fall back to any option


### PR DESCRIPTION
Closes #386

The permission approval dialog previously showed only a generic 'Approve this change?' prompt with no indication of what tool was being approved or what file was being changed.

Changes:
- Capture the full ToolCallUpdate (tool name + file path) in the Pending struct at deferPermission time, instead of only storing options
- Propagate toolName and inputSummary through PendingPermission
- Update PermissionApprovalView to display the tool name as the title and the affected file path as the caption
- Falls back to the generic prompt when no tool details are available