### PR TITLE
Fix #383: chat search results opening wrong chat body

### DIFF
--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -2549,14 +2549,12 @@ public final class WikiStoreModel {
             try? await Task.sleep(for: .milliseconds(300))
             guard !Task.isCancelled, let self else { return }
             let query = self.chatSearchQuery
-            let results: [ChatSummary]
-            if let pool = self.readPool {
-                results = (try? await pool.asyncRead { reader in
-                    try reader.searchSimilarChats(query: query, limit: 20)
-                }) ?? []
-            } else {
-                results = (try? self.store.searchSimilarChats(query: query, limit: 20)) ?? []
-            }
+            // Use the main store (same connection as chatMessages load) so the
+            // search results and the body load see the same WAL snapshot —
+            // eliminates cross-connection staleness where the read pool could
+            // return a chat_id that's been renamed/reordered since the last
+            // checkpoint (issue #383).
+            let results = (try? self.store.searchSimilarChats(query: query, limit: 20)) ?? []
             guard !Task.isCancelled else { return }
             self.chatSearchResults = results
         }


### PR DESCRIPTION
Closes #383

The sidebar chat search used WikiReadPool (a separate read-only SQLite connection) while the chat body load used the main store connection. In WAL mode, the read pool connection could serve a stale snapshot relative to the main writer — returning a chat_id whose content had since changed, so the title (from the search result) didn't match the body (loaded from the main store).

Switch scheduleChatSearch to use the main store directly (same as the omnibox search path already does), so search results and body load see the same WAL snapshot.