### PR TITLE
Fix #380: don't drop chat messages typed during generation

### DIFF
--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -561,6 +561,13 @@ struct ChatView: View {
     }
 
     private func sendMessage() {
+        // Guard: don't clear the draft or attempt to send when the agent is
+        // generating or waiting for a slot. The Send button is already gated
+        // by `canSend`, but the Return key in ComposerTextView calls this
+        // unconditionally — so the same guard here prevents the message from
+        // being silently dropped (issue #380). The draft is preserved so the
+        // user can send it once the agent finishes.
+        guard canSend else { return }
         let message = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
         draftMessage = ""


### PR DESCRIPTION
Closes #380

The Return key in ComposerTextView called sendMessage() unconditionally, which cleared the draft and attempted to send even while the agent was generating. The send would silently fail (AgentLauncher.shouldSendMessage gates on !isGenerating), and the draft was already cleared — so the message was lost with no UI feedback.

Add a canSend guard at the top of sendMessage() so the draft is preserved when the agent is generating or waiting for a slot, matching the Send button's existing gating.