### PR TITLE
Fix #381: add expand/collapse for tool calls + hide toggle

### DIFF
--- a/Sources/WikiFS/ChatTranscriptView.swift
+++ b/Sources/WikiFS/ChatTranscriptView.swift
@@ -37,15 +37,18 @@ struct ChatTranscriptView: View {
     /// Versioned quote-anchor highlight request (`[[chat:Title#"quote"]]`,
     /// issue #281), forwarded to the transcript web view.
     var quoteAnchor: ChatHighlightRequest? = nil
+    /// When true, tool-call rows are filtered from the transcript (issue #381).
+    var hideToolCalls: Bool = false
 
     var body: some View {
-        Group {
-            if events.isEmpty {
+        let visibleEvents = hideToolCalls ? events.filter { !$0.isToolCall } : events
+        return Group {
+            if visibleEvents.isEmpty {
                 placeholder
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             } else {
                 ChatWebView(
-                    events: events,
+                    events: visibleEvents,
                     style: .chat,
                     onWikiLink: onWikiLink,
                     renderContext: renderContext,

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -33,6 +33,10 @@ struct ChatView: View {
     @State private var persistedMessages: [ChatMessage] = []
     @AppStorage("chat.zoom") private var chatZoom = Double(ZoomScale.defaultScale)
     @AppStorage("isChatOutlineExpanded") private var chatOutlineExpanded = false
+    /// Persisted toggle to hide tool-call rows from the chat transcript
+    /// (issue #381). Independent of "Show internals" which gates the full
+    /// raw activity feed.
+    @AppStorage("chat.hideToolCalls") private var hideToolCalls = false
     @State private var outlineScroll: ChatScrollRequest? = nil
     @State private var quoteAnchor: ChatHighlightRequest? = nil
     /// The chat's always-ask/yolo mode (shared with the launcher, read at spawn).
@@ -183,6 +187,7 @@ struct ChatView: View {
                 }
                 Menu {
                     Toggle("Show internals", isOn: $showsInternals)
+                    Toggle("Hide tool calls", isOn: $hideToolCalls)
                     if let status = launcher.exitStatus {
                         Label(status == 0 ? "Ended" : "Exited \(status)", systemImage: status == 0 ? "checkmark.circle" : "xmark.circle")
                     }
@@ -284,7 +289,8 @@ struct ChatView: View {
                         blobStore: store,
                         zoom: chatZoom,
                         scrollRequest: outlineScroll,
-                        quoteAnchor: quoteAnchor
+                        quoteAnchor: quoteAnchor,
+                        hideToolCalls: hideToolCalls
                     )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .padding(.horizontal, PageEditorMetrics.contentInset)

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -490,9 +490,19 @@ struct ChatWebView: NSViewRepresentable {
             let nameHTML = name.map { "<span class=\"chat-tool-name\">\(escape($0))</span>" } ?? ""
             let body = summary.isEmpty ? (isError ? "(error)" : "") : summary
             let summaryHTML = body.isEmpty ? "" : "<span class=\"chat-tool-summary\">\(escape(body))</span>"
+            // Expandable tool row (issue #381): a <details> element so the user
+            // can click to reveal the full summary. Only adds the disclosure if
+            // there's content to expand into; otherwise renders as before.
+            if body.isEmpty {
+                return """
+                <div class="row chat-row chat-tool\(isError ? " is-error" : "")">\
+                \(nameHTML)\(summaryHTML)</div>
+                """
+            }
             return """
-            <div class="row chat-row chat-tool\(isError ? " is-error" : "")">\
-            \(nameHTML)\(summaryHTML)</div>
+            <details class="row chat-row chat-tool\(isError ? " is-error" : "")">\
+            <summary>\(nameHTML)\(summaryHTML)</summary>\
+            <pre class="chat-tool-detail\">\(escape(body))</pre></details>
             """
         }
 
@@ -641,6 +651,20 @@ struct ChatWebView: NSViewRepresentable {
           }
           .chat-tool.is-error { color: #ff453a; }
           .chat-tool.is-error .chat-tool-name { color: #ff453a; }
+          .chat-tool > summary { list-style: none; cursor: pointer; }
+          .chat-tool > summary::-webkit-details-marker { display: none; }
+          .chat-tool[open] > summary .chat-tool-summary::before {
+            content: "▾ "; opacity: 0.5;
+          }
+          .chat-tool:not([open]) > summary .chat-tool-summary::before {
+            content: "▸ "; opacity: 0.5;
+          }
+          .chat-tool-detail {
+            margin: 4px 0 0; padding: 6px 8px; font-size: 11px;
+            background: var(--code-bg); border-radius: 4px;
+            white-space: pre-wrap; word-break: break-word;
+            max-height: 200px; overflow-y: auto;
+          }
           p { margin: 0 0 0.6em; }
           p:last-child { margin-bottom: 0; }
           h1, h2, h3, h4, h5, h6 { line-height: 1.25; font-weight: 600; margin: 0.7em 0 0.3em; }

--- a/Sources/WikiFSCore/AgentEvent.swift
+++ b/Sources/WikiFSCore/AgentEvent.swift
@@ -130,6 +130,15 @@ public enum AgentEvent: Equatable, Sendable, Codable {
         if case .messageStop = event { return true }
         return false
     }
+
+    /// True for tool-use and tool-result events (issue #381). Used to filter
+    /// tool calls from the transcript when `hideToolCalls` is enabled.
+    public var isToolCall: Bool {
+        switch self {
+        case .toolUse, .toolResult: return true
+        default: return false
+        }
+    }
 }
 
 /// Tolerant line-at-a-time parser for `claude -p --output-format stream-json`


### PR DESCRIPTION
Closes #381

Two changes for tool-call display in the chat transcript:

1. **Expandable tool rows**: tool-call rows now render as `<details>` elements so clicking expands to reveal the full tool summary (previously only a fixed one-line summary was shown, with no way to see more). CSS adds a disclosure triangle indicator.

2. **Persisted 'Hide tool calls' toggle**: `@AppStorage('chat.hideToolCalls')` in the Activity menu filters all toolUse/toolResult events from the transcript, independent of the 'Show internals' toggle which gates the full raw activity feed.