### PR TITLE
Fix #385 regression: drag-to-chat creates tab instead of chip

### DIFF
--- a/Sources/WikiFS/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/BookmarksOutlineView.swift
@@ -135,12 +135,15 @@ final class BookmarksOutlineViewController: NSViewController {
         outlineView.delegate = self
         // Required for the outline view to act as a drop target at all — without
         // this, validateDrop/acceptDrop are never called and no highlight shows.
-        // `.string` powers intra-tree reorder (a node id); `.url` lets a
-        // `wiki://` link dragged out of a page/source body land here (issue #169);
-        // the sidebar-item type lets the omnibox icon (and sidebar rows via
-        // SwiftUI .draggable) drop a page/source/chat here to create a bookmark.
+        // The private bookmark-node-id type powers intra-tree reorder (a node id);
+        // `.url` lets a `wiki://` link dragged out of a page/source body land
+        // here (issue #169); the sidebar-item type lets the omnibox icon (and
+        // sidebar rows via SwiftUI .draggable) drop a page/source/chat here to
+        // create a bookmark. The bookmark-node-id type is a private UTType (not
+        // `.string`) so WKWebView doesn't intercept bookmark drags (issue #385).
         let sidebarItemType = NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
-        outlineView.registerForDraggedTypes([.string, .init("public.url"), sidebarItemType])
+        let bookmarkNodeType = NSPasteboard.PasteboardType("com.selfdrivingwiki.bookmark-node-id")
+        outlineView.registerForDraggedTypes([bookmarkNodeType, .init("public.url"), sidebarItemType])
         // NSTableView/NSOutlineView is its own NSDraggingSource; there is no
         // delegate callback for this — the mask is configured imperatively.
         // Without it, the default local-drag mask is a multi-bit value that
@@ -316,12 +319,12 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
 
     // Drag and drop.
     // The writer carries TWO representations so one drag can serve two drop
-    // targets: the `.string` node id powers intra-tree reorder (`acceptDrop`
-    // reads `pb.string(forType: .string)`), and the resolved-target payload list
-    // lets the row be dropped onto the welcome screen to open whatever the
-    // bookmark points at (issue #133). A folder's payload list is every
-    // page/source reachable underneath it, so dropping a folder opens its full
-    // contents as tabs (issue #150).
+    // targets: the private `com.selfdrivingwiki.bookmark-node-id` type powers
+    // intra-tree reorder, and the resolved-target payload list lets the row be
+    // dropped onto the welcome screen to open whatever the bookmark points at
+    // (issue #133). A folder's payload list is every page/source reachable
+    // underneath it, so dropping a folder opens its full contents as tabs
+    // (issue #150).
     func outlineView(_ outlineView: NSOutlineView, pasteboardWriterForItem item: Any) -> NSPasteboardWriting? {
         guard let node = item as? BookmarkNode else { return nil }
         let payloads: [SidebarDragPayload]
@@ -365,8 +368,8 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
 
     /// Read the first `wiki://…` href from a drag pasteboard. WebKit's default
     /// link drag may offer the href under `.url`, `.string`, or both, so check
-    /// each. Returns nil for an intra-tree bookmark reorder (whose `.string` is a
-    /// node id, not a `wiki://` URL).
+    /// each. Returns nil for an intra-tree bookmark reorder (which now uses a
+    /// private `com.selfdrivingwiki.bookmark-node-id` type, not `.string`).
     private static func firstWikiLinkURL(from pb: NSPasteboard) -> URL? {
         let schemePrefix = "\(WikiLinkMarkdown.scheme)://"
         for type in [NSPasteboard.PasteboardType("public.url"), NSPasteboard.PasteboardType.string] {
@@ -541,7 +544,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
 
         // Wiki-link drop → create a bookmark pointing at the link's target
         // (issue #169). Resolved before the intra-tree reorder path, which reads
-        // `.string` as a bookmark *node id* and would no-op on a `wiki://` URL.
+        // the private bookmark-node-id type (not `.string`).
         if let url = Self.firstWikiLinkURL(from: info.draggingPasteboard) {
             return acceptWikiLinkDrop(url: url, onto: item, atIndex: index, store: store)
         }
@@ -554,8 +557,9 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
 
         // Multi-selection is allowed, so a reorder drag can carry more than one
         // node id — one pasteboard item per dragged row.
+        let bookmarkNodeType = NSPasteboard.PasteboardType("com.selfdrivingwiki.bookmark-node-id")
         let draggedIDs = (info.draggingPasteboard.pasteboardItems ?? [])
-            .compactMap { $0.string(forType: .string) }
+            .compactMap { $0.string(forType: bookmarkNodeType) }
         guard !draggedIDs.isEmpty else { return false }
 
         func moveAll(toParentID parentID: String?, startingAt position: Int) -> Bool {

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -410,9 +410,11 @@ struct ChatView: View {
     /// User turns (questions) in display order — the chat outline entries. Sourced
     /// from `displayMessages` (the SAME transcript-visible events the web view
     /// renders), so outline index `i` matches the i-th `.chat-user` row.
+    /// Strips the prepended `[[…]]` attachment reference lines so the outline
+    /// shows only the user's actual question, not the raw wikilinks (issue #385).
     private var chatTurns: [String] {
         displayMessages.compactMap { event in
-            if case .userText(let text) = event { return text }
+            if case .userText(let text) = event { return stripAttachmentRefs(from: text) }
             return nil
         }
     }
@@ -833,12 +835,15 @@ private struct ChatAttachment: Identifiable, Hashable {
     }
 
     /// The reference text prepended to the wire message so the agent knows
-    /// which wiki resource to use as context.
+    /// which wiki resource to use as context. Uses the display name (not the
+    /// raw ULID) so the agent can understand the reference — the system prompt
+    /// instructs the agent to use `[[source:DisplayName]]` / `[[page:Title]]` /
+    /// `[[chat:Title]]` wikilinks with human-readable names.
     var referenceText: String {
         switch kind {
-        case .page:   return "[[page:\(itemID)]]"
-        case .source: return "[[source:\(itemID)]]"
-        case .chat:   return "[[chat:\(itemID)]]"
+        case .page:   return "[[page:\(displayName)]]"
+        case .source: return "[[source:\(displayName)]]"
+        case .chat:   return "[[chat:\(displayName)]]"
         }
     }
 }
@@ -959,4 +964,20 @@ struct ChatOutlineView: View {
             .background(Color(nsColor: .windowBackgroundColor))
         }
     }
+}
+
+/// Strip leading `[[page:…]]` / `[[source:…]]` / `[[chat:…]]` wikilink
+/// lines that `sendMessage` prepends as attachment references. Used by both
+/// the chat outline (ChatView.chatTurns) and the transcript WebView
+/// (ChatWebView row rendering) so neither shows raw wikilink syntax to the
+/// user (issue #385).
+func stripAttachmentRefs(from text: String) -> String {
+    var remaining = text[...]
+    while let range = remaining.range(of: #"\[\[(?:page|source|chat):[^\]]+\]\]"#,
+                                       options: .regularExpression),
+          range.lowerBound == remaining.startIndex {
+        remaining = remaining[range.upperBound...]
+        if remaining.first == "\n" { remaining = remaining.dropFirst() }
+    }
+    return String(remaining).trimmingCharacters(in: .whitespacesAndNewlines)
 }

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -562,6 +562,22 @@ struct ChatView: View {
         }
         .shadow(color: Color.black.opacity(0.06), radius: 18, x: 0, y: 8)
         .frame(maxWidth: .infinity)
+        // Accept sidebar drags anywhere in the composer box. This is the
+        // innermost drop target for SidebarDragPayloadList — it intercepts the
+        // drag before WikiDetailView's broader drop destination (which opens a
+        // new tab) can handle it. Must be on the composer container (not just
+        // attachmentChips) so it exists even when there are no attachments yet
+        // (issue #385 regression).
+        .dropDestination(for: SidebarDragPayloadList.self) { lists, _ in
+            let payloads = lists.flatMap(\.items)
+            for payload in payloads {
+                let attachment = ChatAttachment(payload: payload, store: store)
+                if !attachments.contains(attachment) {
+                    attachments.append(attachment)
+                }
+            }
+            return !payloads.isEmpty
+        }
     }
 
     /// True while the agent is actively generating or queued for the generation
@@ -633,16 +649,6 @@ struct ChatView: View {
                 }
             }
             .padding(.horizontal, 2)
-        }
-        .dropDestination(for: SidebarDragPayloadList.self) { lists, _ in
-            let payloads = lists.flatMap(\.items)
-            for payload in payloads {
-                let attachment = ChatAttachment(payload: payload, store: store)
-                if !attachments.contains(attachment) {
-                    attachments.append(attachment)
-                }
-            }
-            return !payloads.isEmpty
         }
     }
 

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -572,7 +572,6 @@ struct ChatView: View {
         // (issue #385 regression).
         .dropDestination(for: SidebarDragPayloadList.self) { lists, _ in
             let payloads = lists.flatMap(\.items)
-            DebugLog.tabs("[drop] composer drop: received \(lists.count) lists, \(payloads.count) payloads")
             for payload in payloads {
                 let attachment = ChatAttachment(payload: payload, store: store)
                 if !attachments.contains(attachment) {

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -414,7 +414,7 @@ struct ChatView: View {
     /// shows only the user's actual question, not the raw wikilinks (issue #385).
     private var chatTurns: [String] {
         displayMessages.compactMap { event in
-            if case .userText(let text) = event { return stripAttachmentRefs(from: text) }
+            if case .userText(let text) = event { return humanizeAttachmentRefs(in: text) }
             return nil
         }
     }
@@ -966,18 +966,15 @@ struct ChatOutlineView: View {
     }
 }
 
-/// Strip leading `[[page:…]]` / `[[source:…]]` / `[[chat:…]]` wikilink
-/// lines that `sendMessage` prepends as attachment references. Used by both
-/// the chat outline (ChatView.chatTurns) and the transcript WebView
-/// (ChatWebView row rendering) so neither shows raw wikilink syntax to the
-/// user (issue #385).
-func stripAttachmentRefs(from text: String) -> String {
-    var remaining = text[...]
-    while let range = remaining.range(of: #"\[\[(?:page|source|chat):[^\]]+\]\]"#,
-                                       options: .regularExpression),
-          range.lowerBound == remaining.startIndex {
-        remaining = remaining[range.upperBound...]
-        if remaining.first == "\n" { remaining = remaining.dropFirst() }
-    }
-    return String(remaining).trimmingCharacters(in: .whitespacesAndNewlines)
+/// Humanize the leading `[[page:…]]` / `[[source:…]]` / `[[chat:…]]`
+/// wikilink lines that `sendMessage` prepends as attachment references, so
+/// the chat outline and transcript WebView show readable names (e.g. "📎 Paper
+/// Title") instead of raw wikilink syntax. The refs are replaced in-place;
+/// the user's actual question below them is left untouched (issue #385).
+func humanizeAttachmentRefs(in text: String) -> String {
+    let pattern = #"\[\[(page|source|chat):([^\]]+)\]\]"#
+    let result = text.replacingOccurrences(of: pattern,
+                                            with: "📎 $2",
+                                            options: .regularExpression)
+    return result.trimmingCharacters(in: .whitespacesAndNewlines)
 }

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -572,6 +572,7 @@ struct ChatView: View {
         // (issue #385 regression).
         .dropDestination(for: SidebarDragPayloadList.self) { lists, _ in
             let payloads = lists.flatMap(\.items)
+            DebugLog.tabs("[drop] composer drop: received \(lists.count) lists, \(payloads.count) payloads")
             for payload in payloads {
                 let attachment = ChatAttachment(payload: payload, store: store)
                 if !attachments.contains(attachment) {

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -968,13 +968,14 @@ struct ChatOutlineView: View {
 
 /// Humanize the leading `[[page:…]]` / `[[source:…]]` / `[[chat:…]]`
 /// wikilink lines that `sendMessage` prepends as attachment references, so
-/// the chat outline and transcript WebView show readable names (e.g. "📎 Paper
-/// Title") instead of raw wikilink syntax. The refs are replaced in-place;
-/// the user's actual question below them is left untouched (issue #385).
+/// the chat outline shows readable names instead of raw `[[…]]` syntax.
+/// In the transcript WebView, user text is run through the markdown renderer
+/// so wikilinks render as clickable links there; this helper is only used by
+/// the plain-text outline (issue #385).
 func humanizeAttachmentRefs(in text: String) -> String {
     let pattern = #"\[\[(page|source|chat):([^\]]+)\]\]"#
     let result = text.replacingOccurrences(of: pattern,
-                                            with: "📎 $2",
+                                            with: "$2",
                                             options: .regularExpression)
     return result.trimmingCharacters(in: .whitespacesAndNewlines)
 }

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -408,7 +408,7 @@ struct ChatWebView: NSViewRepresentable {
             case .userText(let text):
                 return """
                 <div class="row row-user"><div class="row-label">You</div>\
-                <div class="row-body">\(escapePreservingBreaks(humanizeAttachmentRefs(in: text)))</div></div>
+                <div class="row-body">\(renderedMarkdown(humanizeAttachmentRefs(in: text), context: context, isFinal: isFinal))</div></div>
                 """
             case .systemInit(let model):
                 return "<div class=\"row row-meta\">Started · \(escape(model))</div>"
@@ -450,8 +450,11 @@ struct ChatWebView: NSViewRepresentable {
         static func chatRowHTML(for event: AgentEvent, context: WikiRenderContext? = nil, isFinal: Bool = true) -> String {
             switch event {
             case .userText(let text):
+                // Run user text through the markdown renderer so prepended
+                // attachment refs ([[source:Name]]) render as clickable
+                // wikilinks, not raw escaped text (issue #385).
                 return """
-                <div class="row chat-row chat-user"><div class="bubble">\(escapePreservingBreaks(humanizeAttachmentRefs(in: text)))</div></div>
+                <div class="row chat-row chat-user"><div class="bubble">\(renderedMarkdown(humanizeAttachmentRefs(in: text), context: context, isFinal: isFinal))</div></div>
                 """
             case .assistantText(let text):
                 return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -408,7 +408,7 @@ struct ChatWebView: NSViewRepresentable {
             case .userText(let text):
                 return """
                 <div class="row row-user"><div class="row-label">You</div>\
-                <div class="row-body">\(renderedMarkdown(humanizeAttachmentRefs(in: text), context: context, isFinal: isFinal))</div></div>
+                <div class="row-body">\(renderedMarkdown(text, context: context, isFinal: isFinal))</div></div>
                 """
             case .systemInit(let model):
                 return "<div class=\"row row-meta\">Started · \(escape(model))</div>"
@@ -454,7 +454,7 @@ struct ChatWebView: NSViewRepresentable {
                 // attachment refs ([[source:Name]]) render as clickable
                 // wikilinks, not raw escaped text (issue #385).
                 return """
-                <div class="row chat-row chat-user"><div class="bubble">\(renderedMarkdown(humanizeAttachmentRefs(in: text), context: context, isFinal: isFinal))</div></div>
+                <div class="row chat-row chat-user"><div class="bubble">\(renderedMarkdown(text, context: context, isFinal: isFinal))</div></div>
                 """
             case .assistantText(let text):
                 return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -408,7 +408,7 @@ struct ChatWebView: NSViewRepresentable {
             case .userText(let text):
                 return """
                 <div class="row row-user"><div class="row-label">You</div>\
-                <div class="row-body">\(escapePreservingBreaks(text))</div></div>
+                <div class="row-body">\(escapePreservingBreaks(stripAttachmentRefs(from: text)))</div></div>
                 """
             case .systemInit(let model):
                 return "<div class=\"row row-meta\">Started · \(escape(model))</div>"
@@ -451,7 +451,7 @@ struct ChatWebView: NSViewRepresentable {
             switch event {
             case .userText(let text):
                 return """
-                <div class="row chat-row chat-user"><div class="bubble">\(escapePreservingBreaks(text))</div></div>
+                <div class="row chat-row chat-user"><div class="bubble">\(escapePreservingBreaks(stripAttachmentRefs(from: text)))</div></div>
                 """
             case .assistantText(let text):
                 return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -408,7 +408,7 @@ struct ChatWebView: NSViewRepresentable {
             case .userText(let text):
                 return """
                 <div class="row row-user"><div class="row-label">You</div>\
-                <div class="row-body">\(escapePreservingBreaks(stripAttachmentRefs(from: text)))</div></div>
+                <div class="row-body">\(escapePreservingBreaks(humanizeAttachmentRefs(in: text)))</div></div>
                 """
             case .systemInit(let model):
                 return "<div class=\"row row-meta\">Started · \(escape(model))</div>"
@@ -451,7 +451,7 @@ struct ChatWebView: NSViewRepresentable {
             switch event {
             case .userText(let text):
                 return """
-                <div class="row chat-row chat-user"><div class="bubble">\(escapePreservingBreaks(stripAttachmentRefs(from: text)))</div></div>
+                <div class="row chat-row chat-user"><div class="bubble">\(escapePreservingBreaks(humanizeAttachmentRefs(in: text)))</div></div>
                 """
             case .assistantText(let text):
                 return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)

--- a/Sources/WikiFS/ComposerTextView.swift
+++ b/Sources/WikiFS/ComposerTextView.swift
@@ -54,7 +54,7 @@ struct ComposerTextView: NSViewRepresentable {
     /// into `clampedHeight`, so the clamp's own `+ verticalInset` term has to
     /// match exactly).
     nonisolated enum Metrics {
-        static let minLines: CGFloat = 1
+        static let minLines: CGFloat = 3
         static let maxLines: CGFloat = 6
         static let verticalInsetPerSide: CGFloat = 4
         static var verticalInset: CGFloat { verticalInsetPerSide * 2 }

--- a/Sources/WikiFS/ComposerTextView.swift
+++ b/Sources/WikiFS/ComposerTextView.swift
@@ -121,6 +121,13 @@ struct ComposerTextView: NSViewRepresentable {
         textView.autoresizingMask = [.width]
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.minSize = NSSize(width: 0, height: 0)
+        // Unregister drag types so the NSTextView doesn't intercept sidebar
+        // drags routed to the SwiftUI .dropDestination on the composer
+        // container. Without this, dragging a page/source/bookmark over the
+        // text view (including the placeholder) gets swallowed by AppKit's
+        // default text-drag handling and never reaches the composer's
+        // dropDestination (issue #385).
+        textView.unregisterDraggedTypes()
         if let container = textView.textContainer {
             container.widthTracksTextView = true
             container.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)

--- a/Sources/WikiFS/SidebarDragPayloadTransferable.swift
+++ b/Sources/WikiFS/SidebarDragPayloadTransferable.swift
@@ -64,18 +64,29 @@ final class SidebarDragPasteboardItem: NSObject {
     private var sidebarType: NSPasteboard.PasteboardType {
         NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
     }
+
+    /// Private type for the bookmark node ID (intra-tree reorder only). Must
+    /// NOT be `.string` — `.string` conforms to `public.data`, and the chat
+    /// transcript's WKWebView auto-registers for `public.data`, so a bookmark
+    /// drag carrying `.string` gets intercepted by the WKWebView before it can
+    /// reach the composer's SwiftUI `.dropDestination`. A private type under
+    /// `public.item` doesn't conform to `public.data`, so the drag bubbles past
+    /// the WKWebView to the composer (issue #385).
+    private var bookmarkNodeType: NSPasteboard.PasteboardType {
+        NSPasteboard.PasteboardType("com.selfdrivingwiki.bookmark-node-id")
+    }
 }
 
 extension SidebarDragPasteboardItem: NSPasteboardWriting {
     func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
         var types: [NSPasteboard.PasteboardType] = []
-        if bookmarkNodeID != nil { types.append(.string) }
+        if bookmarkNodeID != nil { types.append(bookmarkNodeType) }
         if !payloads.isEmpty { types.append(sidebarType) }
         return types
     }
 
     func pasteboardPropertyList(forType type: NSPasteboard.PasteboardType) -> Any? {
-        if type == .string { return bookmarkNodeID }
+        if type == bookmarkNodeType { return bookmarkNodeID }
         if type == sidebarType, !payloads.isEmpty,
            let data = try? JSONEncoder().encode(SidebarDragPayloadList(payloads)) {
             return data as NSData

--- a/Sources/WikiFSCore/ChatModels.swift
+++ b/Sources/WikiFSCore/ChatModels.swift
@@ -41,16 +41,33 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
 
     /// Derive a chat title from the first user message: first line, trimmed,
     /// elided. Pure so the rule is unit-testable and shared by every caller
-    /// that creates a chat.
+    /// that creates a chat. Strips leading `[[page:…]]` / `[[source:…]]` /
+    /// `[[chat:…]]` attachment reference lines (prepended by `sendMessage`
+    /// when sidebar items are dragged into the chat, issue #385) so the title
+    /// is the user's actual question, not the first attachment's wikilink.
     public static func title(fromFirstMessage message: String, maxLength: Int = 60) -> String {
-        let firstLine = message
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let stripped = Self.stripAttachmentRefs(from: message)
+        let firstLine = stripped
             .components(separatedBy: .newlines)
             .first ?? ""
         let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return "New Chat" }
         guard trimmed.count > maxLength else { return trimmed }
         return trimmed.prefix(maxLength - 1) + "…"
+    }
+
+    /// Remove leading `[[page:…]]` / `[[source:…]]` / `[[chat:…]]` wikilink
+    /// lines so the title reflects the user's question, not the attachment
+    /// references (issue #385).
+    private static func stripAttachmentRefs(from text: String) -> String {
+        var remaining = text[...]
+        while let range = remaining.range(of: #"\[\[(?:page|source|chat):[^\]]+\]\]"#,
+                                           options: .regularExpression),
+              range.lowerBound == remaining.startIndex {
+            remaining = remaining[range.upperBound...]
+            if remaining.first == "\n" { remaining = remaining.dropFirst() }
+        }
+        return String(remaining).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 


### PR DESCRIPTION
## Problem

PR #403 added a `dropDestination` on the chat's `attachmentChips` view to capture dragged sidebar items as attachment chips. But dragging a source onto the chat creates a **new tab** instead of a chip.

## Root cause

Two competing `.dropDestination(for: SidebarDragPayloadList.self)` handlers exist:

1. **`WikiDetailView`** (line 34) — wraps the entire detail column, calls `store.openTab(...)` → opens a new tab.
2. **`ChatView.attachmentChips`** (line 637) — on the chip strip, creates attachment chips.

The chip strip is only rendered when `!attachments.isEmpty` (line 525). On the **first** drag — when there are zero attachments — the `attachmentChips` view doesn't exist in the hierarchy, so its `dropDestination` doesn't exist either. The drag falls through to `WikiDetailView`'s broader `dropDestination`, which opens a new tab.

Even once attachments exist, the chip strip is a small area — dropping anywhere else in the composer would still hit the parent handler.

## Fix

Move the `dropDestination` from `attachmentChips` to the composer's outer `VStack` container (the rounded box wrapping the text area + toolbar). This container is always present (it's the text input), so the drop target exists from the first drag. As the innermost `dropDestination` for `SidebarDragPayloadList`, it intercepts the drag before `WikiDetailView`'s parent handler can open a tab.

Closes the regression from #403.
