### PR TITLE
Fix #396: remove Cmd-N New Window command

### DIFF
--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -216,6 +216,10 @@ struct WikiFSApp: App {
         }
         .windowToolbarStyle(.unified)
         .commands {
+            // Suppress the auto-generated File ▸ New Window command (Cmd-N).
+            // This app is single-window per wiki; Cmd-N would open a broken
+            // "No Wikis" empty-state window (issue #396).
+            CommandGroup(replacing: .newItem) { }
             VacuumCommands(sessionManager: sessionManager)
         }
         // Additional wiki windows: value-driven by wiki ID. Opened from the


### PR DESCRIPTION
Closes #396

SwiftUI auto-synthesizes a File ▸ New Window command (Cmd-N) from the bare `WindowGroup`. This app is single-window per wiki, so Cmd-N opened a broken 'No Wikis' empty-state window. Suppress it by replacing the `.newItem` command group with an empty one.