### PR TITLE
Fix #405: reset thinking timer on each interactive turn

### DIFF
--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -431,8 +431,14 @@ public final class AgentLauncher {
         guard isGenerating != value else { return }
         isGenerating = value
         if value {
+            // Anchor the thinking timer at the start of each generation phase
+            // (each interactive turn, one-shot run, etc.) so the timer resets
+            // to 0s per turn rather than accumulating across the session
+            // (issue #405).
+            runStartedAt = Date()
             startPendingPermissionPoller()
         } else {
+            runStartedAt = nil
             stopPendingPermissionPoller()
         }
     }
@@ -915,9 +921,9 @@ public final class AgentLauncher {
         if sandbox != nil { createSandboxTmpDir(in: scratch) }
 
         // RESERVE per-run metadata. isRunning is already `true` (set above).
+        // Note: runStartedAt is set inside setGenerating(true) below.
         let now = Date()
         runningKind = operation.kind
-        runStartedAt = now
         lastActivityAt = now
         openLogFiles(in: scratch)
         // A one-shot run is "generating" for its whole duration. The edit lock
@@ -1625,10 +1631,10 @@ public final class AgentLauncher {
         if sandbox != nil { createSandboxTmpDir(in: scratch) }
 
         // RESERVE per-run metadata. isRunning will be set at spawn commit below
-        // (after backend.start succeeds).
+        // (after backend.start succeeds). runStartedAt is set inside
+        // setGenerating(true) at spawn commit.
         let now = Date()
         runningKind = operation.kind
-        runStartedAt = now
         lastActivityAt = now
         openLogFiles(in: scratch)
         // SPAWN COMMIT: a query chat never ingests, so the agent-phase flag


### PR DESCRIPTION
Closes #405

The inline `Thinking… Ns` timer in ChatView was driven by `launcher.runStartedAt`, which was only set once when the interactive session was spawned — not on subsequent turns. Each new turn's timer accumulated all prior turn time.

Fix: manage `runStartedAt` inside `setGenerating()` — set to `Date()` when generation starts, `nil` when it stops. Every turn transition goes through `setGenerating(true/false)`, so the timer now resets to 0s on each turn.