### PR TITLE
Fix #407: make chat rows draggable from the sidebar

### DIFF
--- a/Sources/WikiFS/AgentToolsView.swift
+++ b/Sources/WikiFS/AgentToolsView.swift
@@ -37,6 +37,9 @@ struct AgentToolsView: View {
                             isLive: isLive(chat)
                         )
                             .tag(WikiSelection.chat(chat.id))
+                            .draggable(SidebarDragPayloadList([
+                                SidebarDragPayload(kind: .chat, id: chat.id.rawValue)
+                            ]))
                             .contextMenu {
                                 Button("Rename Chat…") {
                                     renameDraft = chat.title


### PR DESCRIPTION
Closes #407

Chat rows in `AgentToolsView` used a SwiftUI `List` without `.draggable`, so they couldn't be dragged at all. Pages and sources use `NSTableView` with `pasteboardWriterForRow`, and the address bar uses `.draggable` — chats had neither.

Add `.draggable` with a `SidebarDragPayloadList` containing a `.chat` payload, matching the address bar's pattern. Chat rows can now be dragged to bookmarks, the welcome screen, and the chat composer as attachments.