### PR TITLE
Fix CI: update tests for PR #404 changes

### DIFF
--- a/Tests/WikiFSTests/ChatWebViewLinkifyTests.swift
+++ b/Tests/WikiFSTests/ChatWebViewLinkifyTests.swift
@@ -6,8 +6,9 @@ import Testing
 
 /// Tests for the agent transcript's wiki-link linkify pre-pass. Assistant/result
 /// rows run their markdown through `ReaderMarkdown.prepared` so `[[wiki-links]]`
-/// render as clickable `wiki://` anchors; user text is left literal (a user
-/// typing `[[Foo]]` is not a link). Covers AC.3 at the row-render seam.
+/// render as clickable `wiki://` anchors. User text is also rendered through
+/// the markdown renderer so attachment references from drag-to-chat (#385)
+/// render as clickable links.
 ///
 /// Phase A.2 adds a `WikiRenderContext`-aware variant (`renderedMarkdown(_:context:)`,
 /// `feedRowHTML(for:context:isFinal:)`, `chatRowHTML(for:context:isFinal:)`) so
@@ -32,12 +33,13 @@ struct ChatWebViewLinkifyTests {
         #expect(html.contains("<a "))
     }
 
-    @Test func feedUserRowStaysLiteral() {
+    @Test func feedUserRowLinkifiesWikiLinks() {
+        // User text is now rendered through the markdown renderer so that
+        // attachment references ([[source:Name]]) render as clickable links
+        // (issue #385).
         let html = Transcript.feedRowHTML(for: .userText("See [[Page]] here."))
-        // No anchor tag — the raw brackets survive as literal text.
-        #expect(!html.contains("<a "))
-        #expect(!html.contains("wiki://"))
-        #expect(html.contains("[[Page]]"))
+        #expect(html.contains("<a "))
+        #expect(html.contains("wiki://"))
     }
 
     @Test func feedResultRowLinkifies() {
@@ -51,10 +53,13 @@ struct ChatWebViewLinkifyTests {
         #expect(html.contains("<a "))
     }
 
-    @Test func chatUserRowStaysLiteral() {
+    @Test func chatUserRowLinkifiesWikiLinks() {
+        // User text is now rendered through the markdown renderer so that
+        // attachment references ([[source:Name]]) render as clickable links
+        // (issue #385).
         let html = Transcript.chatRowHTML(for: .userText("See [[Page]] here."))
-        #expect(!html.contains("<a "))
-        #expect(!html.contains("wiki://"))
+        #expect(html.contains("<a "))
+        #expect(html.contains("wiki://"))
     }
 
     @Test func chatResultRowLinkifies() {

--- a/Tests/WikiFSTests/ComposerTextViewTests.swift
+++ b/Tests/WikiFSTests/ComposerTextViewTests.swift
@@ -15,10 +15,10 @@ import Testing
     // linear in `lineHeight`, so this exercises the formula without coupling
     // the test to a real font's metrics.
     private let lineHeight: CGFloat = 20
-    private var minHeight: CGFloat { lineHeight * 1 + ComposerTextView.Metrics.verticalInset }
+    private var minHeight: CGFloat { lineHeight * 3 + ComposerTextView.Metrics.verticalInset }
     private var maxHeight: CGFloat { lineHeight * 6 + ComposerTextView.Metrics.verticalInset }
 
-    @Test func clampedHeightBelowOneLineClampsToMinimum() {
+    @Test func clampedHeightBelowMinimumClampsToMinimum() {
         #expect(ComposerTextView.clampedHeight(contentHeight: 0, lineHeight: lineHeight) == minHeight)
         #expect(ComposerTextView.clampedHeight(contentHeight: 10, lineHeight: lineHeight) == minHeight)
     }

--- a/Tests/WikiFSTests/SidebarDragPasteboardBridgeTests.swift
+++ b/Tests/WikiFSTests/SidebarDragPasteboardBridgeTests.swift
@@ -9,8 +9,8 @@ import UniformTypeIdentifiers
 /// Verifies the AppKit→SwiftUI drag bridge at the pasteboard level: an
 /// `NSPasteboardWriting` produced by the sidebar lists must put valid JSON under
 /// the sidebar-item type identifier (so SwiftUI's `.dropDestination(for:)` can
-/// decode it), and the bookmark writer must keep the `.string` node id for
-/// intra-tree reorder alongside the payload.
+/// decode it), and the bookmark writer must keep the bookmark-node-id (a private
+/// pasteboard type, not `.string`) for intra-tree reorder alongside the payload.
 @MainActor
 struct SidebarDragPasteboardBridgeTests {
 
@@ -52,7 +52,10 @@ struct SidebarDragPasteboardBridgeTests {
         let pb = write(SidebarDragPasteboardItem(payloads: [payload], bookmarkNodeID: "node-42"))
 
         // Intra-tree reorder reads this (BookmarksOutlineView.acceptDrop).
-        #expect(pb.string(forType: .string) == "node-42")
+        // Uses a private pasteboard type (not .string) so WKWebView doesn't
+        // intercept bookmark drags (issue #385).
+        let bookmarkType = NSPasteboard.PasteboardType("com.selfdrivingwiki.bookmark-node-id")
+        #expect(pb.string(forType: bookmarkType) == "node-42")
         // The welcome-screen drop reads this.
         let decoded = try JSONDecoder().decode(
             SidebarDragPayloadList.self,
@@ -65,7 +68,8 @@ struct SidebarDragPasteboardBridgeTests {
         // An empty folder has nothing to open, so it carries only the reorder id.
         let pb = write(SidebarDragPasteboardItem(payloads: [], bookmarkNodeID: "folder-1"))
 
-        #expect(pb.string(forType: .string) == "folder-1")
+        let bookmarkType = NSPasteboard.PasteboardType("com.selfdrivingwiki.bookmark-node-id")
+        #expect(pb.string(forType: bookmarkType) == "folder-1")
         #expect(pb.data(forType: sidebarType) == nil)
     }
 


### PR DESCRIPTION
PR #404 changed three behaviors but didn't update the corresponding tests:

1. **SidebarDragPasteboardBridgeTests** — bookmark node ID now uses a private pasteboard type (`com.selfdrivingwiki.bookmark-node-id`) instead of `.string` (so WKWebView doesn't intercept bookmark drags). Updated tests to read from the new type.

2. **ComposerTextViewTests** — `minLines` changed from 1 to 3 (bigger composer for easier drop targeting). Updated test constants from `lineHeight * 1` to `lineHeight * 3` and renamed `clampedHeightBelowOneLineClampsToMinimum` → `clampedHeightBelowMinimumClampsToMinimum`.

3. **ChatWebViewLinkifyTests** — user text is now rendered through `renderedMarkdown` so attachment wikilinks (`[[source:Name]]`) render as clickable links. Updated tests from `*StaysLiteral` to `*LinkifiesWikiLinks`.

All 46 tests in the affected suites pass locally.