### PR TITLE
feat: chat summary in sidebar (issue #411)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         # ProjectionTreeTests un-skipped after #291 (ReadScope): ~32 s on CI
         # hardware (~2–3x slower), down from 165 s+ per working-set test.
         env:
-          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests'
+          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests'
         run: xcrun swift test --skip "$SKIP" || swift test --skip "$SKIP"
 
   swift-integration:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ Persistent chats are two tables: `chats` (one row per conversation) and
 swift build          # compile
 swift test           # full suite (run locally before merge)
 # fast tier — what the CI `swift` job runs; skips the slow SQLite integration suites:
-swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests'
+swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests'
 swift test --filter PdfExtractionServiceTests  # pdf extraction only
 ```
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,37 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-13 — Chat Summary (issue #411)
+
+**Implemented.** The sidebar's `RecentChatRow` now shows a one-line summary of
+the model's first response under the chat title. The summary is generated once
+on chat completion (`AgentLauncher.finish()`) and persisted to SQLite
+(`chats.summary` + `chats.summary_at`, schema v36), so it's available
+immediately when the history list loads — no recomputation on app launch.
+
+**v0 strategy: deterministic first-sentence extract** (no LLM call). The
+schema and rendering are designed so an LLM-based summarizer can be layered on
+later without further migrations.
+
+**What changed:**
+- `Sources/WikiFSCore/SQLiteWikiStore.swift` — schema migration v35→v36
+  (`migrateV35ToV36`), `createChatTablesV23` columns, `createFreshSchemaV20`
+  version stamp, `listChats` / `listAllChatsOrderedByID` SELECT update (NULL-
+  safe reads), new `updateChatSummary` mutator (routes through `mutate()`).
+- `Sources/WikiFSCore/WikiStore.swift` — `updateChatSummary` on the protocol.
+- `Sources/WikiFSCore/ChatModels.swift` — `summary`/`summaryAt` fields on
+  `ChatSummary`, `summaryExtract(from:maxLength:)` pure function.
+- `Sources/WikiFSCore/WikiStoreModel.swift` — `updateChatSummary` wrapper.
+- `Sources/WikiFSEngine/AgentLauncher.swift` — `summarySink` property,
+  `onSummary` parameter on `startInteractiveQuery`, `firstSummaryText(from:)`
+  static function, `generateChatSummary()` method called in `finish()`.
+- `Sources/WikiFSEngine/AgentOperationRunner.swift` — wired `onSummary` at both
+  `startInteractiveQuery` call sites.
+- `Sources/WikiFS/AgentToolsView.swift` — `RecentChatRow` shows summary caption
+  when `!isLive`.
+- Tests: `ChatSummaryTests.swift` (13 tests: pure extract, static event
+  selection, store round-trip, NULL handling, updatedAt bump).
+
 ## 2026-07-13 — Multi-window UI — per-wiki windows (Phase 2b of #358)
 
 **Multi-window is implemented.** The plan lives at

--- a/Sources/WikiFS/AgentToolsView.swift
+++ b/Sources/WikiFS/AgentToolsView.swift
@@ -225,6 +225,11 @@ private struct RecentChatRow: View {
                     }
                     .lineLimit(1)
                     .accessibilityLabel("Chat is responding")
+                } else if let summary = chat.summary {
+                    Text(summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 } else {
                     Text(chat.updatedAt, format: .relative(presentation: .named))
                         .font(.caption)

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -299,7 +299,7 @@ struct ChatView: View {
             content()
                 .frame(maxWidth: .infinity, alignment: .leading)
             if chatOutlineExpanded {
-                ChatOutlineView(turns: chatTurns) { turnIndex in
+                ChatOutlineView(entries: chatOutlineEntries) { turnIndex in
                     outlineScroll = ChatScrollRequest(
                         version: (outlineScroll?.version ?? 0) + 1,
                         turnIndex: turnIndex)
@@ -407,16 +407,41 @@ struct ChatView: View {
         store.chats.first { $0.id == chatID }
     }
 
-    /// User turns (questions) in display order — the chat outline entries. Sourced
-    /// from `displayMessages` (the SAME transcript-visible events the web view
-    /// renders), so outline index `i` matches the i-th `.chat-user` row.
-    /// Strips the prepended `[[…]]` attachment reference lines so the outline
-    /// shows only the user's actual question, not the raw wikilinks (issue #385).
-    private var chatTurns: [String] {
-        displayMessages.compactMap { event in
-            if case .userText(let text) = event { return humanizeAttachmentRefs(in: text) }
-            return nil
+    /// Paired (question, response summary) entries for the chat outline. Each
+    /// user turn is paired with the first assistant text that follows it
+    /// (extracted to one sentence, elided), so the outline shows both sides of
+    /// the conversation. Sourced from `displayMessages` (same events as the
+    /// transcript). Uses `ChatSummary.summaryExtract` for the response text.
+    private var chatOutlineEntries: [ChatOutlineEntry] {
+        var entries: [ChatOutlineEntry] = []
+        var pendingQuestion: String?
+        for event in displayMessages {
+            switch event {
+            case .userText(let text):
+                if let q = pendingQuestion {
+                    entries.append(ChatOutlineEntry(question: q, response: nil))
+                }
+                pendingQuestion = humanizeAttachmentRefs(in: text)
+            case .assistantText(let text):
+                if let q = pendingQuestion {
+                    let summary = ChatSummary.summaryExtract(from: text, maxLength: 200)
+                    entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary))
+                    pendingQuestion = nil
+                }
+            case .result(_, let text):
+                if let q = pendingQuestion {
+                    let summary = ChatSummary.summaryExtract(from: text, maxLength: 200)
+                    entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary))
+                    pendingQuestion = nil
+                }
+            default:
+                break
+            }
         }
+        if let q = pendingQuestion {
+            entries.append(ChatOutlineEntry(question: q, response: nil))
+        }
+        return entries
     }
 
     @ViewBuilder
@@ -886,12 +911,22 @@ enum ChatMetrics {
     static var composerFont: NSFont { .preferredFont(forTextStyle: .body) }
 }
 
+/// One entry in the chat outline: a user question paired with a one-line
+/// summary of the model's response (if any). The `question` is the
+/// humanized user text; `response` is the first-sentence extract of the
+/// first `.assistantText` or `.result` that followed, elided to 60 chars.
+struct ChatOutlineEntry: Hashable {
+    let question: String
+    let response: String?
+}
+
 /// Right-side outline for a chat: lists the user's turns (questions) in
-/// order. Clicking a turn scrolls the transcript web view to that message via a
+/// order, each paired with a one-line summary of the model's response.
+/// Clicking a turn scrolls the transcript web view to that message via a
 /// versioned `ChatScrollRequest`. Mirrors the page outline's shape (divider +
 /// "Outline" header + scrollable list).
 struct ChatOutlineView: View {
-    let turns: [String]
+    let entries: [ChatOutlineEntry]
     let onSelect: (Int) -> Void
 
     @AppStorage("chatOutlineWidth") private var outlineWidth: Double = 240
@@ -940,19 +975,27 @@ struct ChatOutlineView: View {
 
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 2) {
-                        ForEach(Array(turns.enumerated()), id: \.offset) { index, turn in
+                        ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
                             Button {
                                 onSelect(index)
                             } label: {
-                                Text(turn.isEmpty ? "(empty)" : turn)
-                                    .font(.callout)
-                                    .foregroundStyle(.primary)
-                                    .lineLimit(2)
-                                    .multilineTextAlignment(.leading)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.vertical, 4)
-                                    .padding(.horizontal, 8)
-                                    .contentShape(Rectangle())
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(entry.question.isEmpty ? "(empty)" : entry.question)
+                                        .font(.callout)
+                                        .foregroundStyle(.primary)
+                                        .multilineTextAlignment(.leading)
+                                    if let response = entry.response {
+                                        Text(response)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(3)
+                                            .multilineTextAlignment(.leading)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.vertical, 4)
+                                .padding(.horizontal, 8)
+                                .contentShape(Rectangle())
                             }
                             .buttonStyle(.plain)
                         }

--- a/Sources/WikiFSCore/ChatModels.swift
+++ b/Sources/WikiFSCore/ChatModels.swift
@@ -26,10 +26,20 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
     public var updatedAt: Date
     /// Persisted message count, for the history list's subtitle.
     public var messageCount: Int
+    /// One-line summary of the model's first response, generated on chat
+    /// completion (issue #411). `nil` for chats that haven't been summarized
+    /// yet (existing chats after migration, or chats whose `finish()` never
+    /// fired). The sidebar shows this when present, falling back to the
+    /// relative timestamp.
+    public var summary: String?
+    /// When the summary was written, for staleness display. `nil` alongside
+    /// `summary`.
+    public var summaryAt: Date?
 
     public init(
         id: PageID, kind: ChatKind, title: String,
-        createdAt: Date, updatedAt: Date, messageCount: Int
+        createdAt: Date, updatedAt: Date, messageCount: Int,
+        summary: String? = nil, summaryAt: Date? = nil
     ) {
         self.id = id
         self.kind = kind
@@ -37,6 +47,8 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.messageCount = messageCount
+        self.summary = summary
+        self.summaryAt = summaryAt
     }
 
     /// Derive a chat title from the first user message: first line, trimmed,
@@ -54,6 +66,37 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
         guard !trimmed.isEmpty else { return "New Chat" }
         guard trimmed.count > maxLength else { return trimmed }
         return trimmed.prefix(maxLength - 1) + "…"
+    }
+
+    /// Derive a one-line summary from the model's first assistant response
+    /// (issue #411). Extracts the first sentence, elided to `maxLength` using
+    /// the same `prefix(maxLength - 1) + "…"` rule as `title(fromFirstMessage:)`.
+    /// Pure so the extraction logic is unit-testable without a live agent.
+    ///
+    /// Unlike `title(fromFirstMessage:)`, this does NOT strip `[[…]]`
+    /// attachment refs — those are prepended to *user* messages, not assistant
+    /// responses. The sentence boundary is `. `, `!\n`, or `?\n`; if none is
+    /// found the full (trimmed) text is used as the extract.
+    public static func summaryExtract(from assistantText: String, maxLength: Int = 60) -> String {
+        let trimmed = assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        // Find the first sentence boundary: period+space, or !/? at end of line.
+        let extract: String
+        if let range = trimmed.range(of: #"\. |[!?]\n"#, options: .regularExpression) {
+            // Include the boundary punctuation in the extract.
+            var end = range.upperBound
+            // If we matched ". ", step back to include the period but not the space.
+            if trimmed[range] == ". " {
+                end = trimmed.index(before: end) // include the period
+            }
+            extract = String(trimmed[..<end])
+        } else {
+            extract = trimmed
+        }
+
+        guard extract.count > maxLength else { return extract }
+        return String(extract.prefix(maxLength - 1)) + "…"
     }
 
     /// Remove leading `[[page:…]]` / `[[source:…]]` / `[[chat:…]]` wikilink

--- a/Sources/WikiFSCore/GeneratedVersion.swift
+++ b/Sources/WikiFSCore/GeneratedVersion.swift
@@ -17,16 +17,16 @@ public enum GeneratedVersion {
     public static let appVersion = "0.0.0"
 
     /// Short git SHA (e.g. "abc1234"). Goes into the WIKIGitSHA Info.plist key.
-    public static let gitSHA = "b034cde"
+    public static let gitSHA = "8b44d51"
 
     /// Git commit count — a monotone integer (e.g. "423"). Goes into
     /// WIKIGitCommitCount.
-    public static let gitCommitCount = "493"
+    public static let gitCommitCount = "510"
 
     /// Build identifier: "<count>-<sha>" (e.g. "423-abc1234"). Goes into
     /// CFBundleVersion.
-    public static let buildVersion = "493-b034cde"
+    public static let buildVersion = "510-8b44d51"
 
     /// Full display string: "<appVersion> (<buildVersion>)" — e.g. "0.5.0 (423-abc1234)".
-    public static let fullVersionString = "0.0.0 (493-b034cde)"
+    public static let fullVersionString = "0.0.0 (510-8b44d51)"
 }

--- a/Sources/WikiFSCore/GeneratedVersion.swift
+++ b/Sources/WikiFSCore/GeneratedVersion.swift
@@ -17,16 +17,16 @@ public enum GeneratedVersion {
     public static let appVersion = "0.0.0"
 
     /// Short git SHA (e.g. "abc1234"). Goes into the WIKIGitSHA Info.plist key.
-    public static let gitSHA = "8b44d51"
+    public static let gitSHA = "1f712c8"
 
     /// Git commit count — a monotone integer (e.g. "423"). Goes into
     /// WIKIGitCommitCount.
-    public static let gitCommitCount = "510"
+    public static let gitCommitCount = "511"
 
     /// Build identifier: "<count>-<sha>" (e.g. "423-abc1234"). Goes into
     /// CFBundleVersion.
-    public static let buildVersion = "510-8b44d51"
+    public static let buildVersion = "511-1f712c8"
 
     /// Full display string: "<appVersion> (<buildVersion>)" — e.g. "0.5.0 (423-abc1234)".
-    public static let fullVersionString = "0.0.0 (510-8b44d51)"
+    public static let fullVersionString = "0.0.0 (511-1f712c8)"
 }

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -562,6 +562,12 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // `pages` row. A fresh DB has no workspaces, so this is a version
         // stamp only — `createWorkspacesV31` above already uses the new shape.
         try exec("PRAGMA user_version=35;")
+
+        // v36 (issue #411 — chat summary): nullable `summary` and `summary_at`
+        // columns on `chats` for the one-line model-response summary shown in
+        // the sidebar. A fresh DB gets the columns via `createChatTablesV23`
+        // above; existing DBs get them via the v35→36 ALTER migration.
+        try exec("PRAGMA user_version=36;")
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -737,7 +743,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             kind       TEXT NOT NULL,
             title      TEXT NOT NULL,
             created_at REAL NOT NULL,
-            updated_at REAL NOT NULL
+            updated_at REAL NOT NULL,
+            summary    TEXT,
+            summary_at REAL
         );
         """)
         try exec("CREATE INDEX IF NOT EXISTS chats_updated ON chats(updated_at);")
@@ -1488,6 +1496,16 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try migrateV34ToV35()
             try exec("PRAGMA user_version=35;")
             version = 35
+        }
+
+        // Step 35 → 36 (issue #411 — chat summary): adds nullable `summary`
+        // and `summary_at` columns to `chats` so the sidebar can show a
+        // one-line summary of the model's first response. Simple ALTER — no
+        // table rebuild needed for nullable columns.
+        if version < 36 {
+            try migrateV35ToV36()
+            try exec("PRAGMA user_version=36;")
+            version = 36
         }
     }
 
@@ -2293,6 +2311,21 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
 
             // 4. Rename the new table into place.
             try exec("ALTER TABLE _workspace_refs_new RENAME TO workspace_refs;")
+        }
+    }
+
+    /// The v35→36 migration step (issue #411 — chat summary). Adds nullable
+    /// `summary` and `summary_at` columns to `chats` so the sidebar can show
+    /// a one-line summary of the model's first response. Simple ALTER — no
+    /// table rebuild needed for nullable columns. Idempotent: if `summary`
+    /// already exists, the migration is a no-op (re-running on a v36 DB).
+    private func migrateV35ToV36() throws {
+        let columns = try tableColumnInfo("chats")
+        guard !columns.contains("summary") else { return }
+
+        try withTransaction {
+            try exec("ALTER TABLE chats ADD COLUMN summary TEXT;")
+            try exec("ALTER TABLE chats ADD COLUMN summary_at REAL;")
         }
     }
 
@@ -7111,20 +7144,25 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         let stmt = try statement("""
         SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
-               (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id)
+               (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id),
+               c.summary, c.summary_at
         FROM chats c
         ORDER BY c.updated_at DESC, c.rowid DESC;
         """)
         defer { stmt.reset() }
         var out: [ChatSummary] = []
         while try stmt.step() {
+            let summaryIsNull = sqlite3_column_type(stmt.handle, 6) == SQLITE_NULL
+            let summaryAtIsNull = sqlite3_column_type(stmt.handle, 7) == SQLITE_NULL
             out.append(ChatSummary(
                 id: PageID(rawValue: stmt.text(at: 0)),
                 kind: ChatKind(rawValue: stmt.text(at: 1)) ?? .edit,
                 title: stmt.text(at: 2),
                 createdAt: Date(timeIntervalSince1970: stmt.double(at: 3)),
                 updatedAt: Date(timeIntervalSince1970: stmt.double(at: 4)),
-                messageCount: Int(stmt.int(at: 5))
+                messageCount: Int(stmt.int(at: 5)),
+                summary: summaryIsNull ? nil : stmt.text(at: 6),
+                summaryAt: summaryAtIsNull ? nil : Date(timeIntervalSince1970: stmt.double(at: 7))
             ))
         }
         return out
@@ -7194,6 +7232,30 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// Write the one-line summary of the model's first response (issue #411),
+    /// bumping `updated_at` so the chat moves to the top of the recent list
+    /// (matching `renameChat`). Throws `.notFound` if no chat has `id`.
+    public func updateChatSummary(chatID: PageID, summary: String) throws {
+        try mutate(event: { _ in localEvent(.chat, id: chatID.rawValue, change: .updated) }) {
+        try withTransaction {
+            let exists = try statement("SELECT 1 FROM chats WHERE id = ?1;")
+            defer { exists.reset() }
+            try exists.bind(chatID.rawValue, at: 1)
+            guard try exists.step() else {
+                throw WikiStoreError.notFound(chatID)
+            }
+            let now = Date().timeIntervalSince1970
+            let upd = try statement("UPDATE chats SET summary = ?2, summary_at = ?3, updated_at = ?4 WHERE id = ?1;")
+            upd.reset()
+            try upd.bind(chatID.rawValue, at: 1)
+            try upd.bind(summary, at: 2)
+            try upd.bind(now, at: 3)
+            try upd.bind(now, at: 4)
+            _ = try upd.step()
+        }
+        }
+    }
+
     /// All chat summaries ordered by ULID (creation order) — for the File
     /// Provider projection, which needs stable creation-order enumeration (not
     /// the sidebar's most-recently-updated-first). Mirrors
@@ -7202,20 +7264,25 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         let stmt = try statement("""
         SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
-               (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id)
+               (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id),
+               c.summary, c.summary_at
         FROM chats c
         ORDER BY c.id ASC;
         """)
         defer { stmt.reset() }
         var out: [ChatSummary] = []
         while try stmt.step() {
+            let summaryIsNull = sqlite3_column_type(stmt.handle, 6) == SQLITE_NULL
+            let summaryAtIsNull = sqlite3_column_type(stmt.handle, 7) == SQLITE_NULL
             out.append(ChatSummary(
                 id: PageID(rawValue: stmt.text(at: 0)),
                 kind: ChatKind(rawValue: stmt.text(at: 1)) ?? .edit,
                 title: stmt.text(at: 2),
                 createdAt: Date(timeIntervalSince1970: stmt.double(at: 3)),
                 updatedAt: Date(timeIntervalSince1970: stmt.double(at: 4)),
-                messageCount: Int(stmt.int(at: 5))
+                messageCount: Int(stmt.int(at: 5)),
+                summary: summaryIsNull ? nil : stmt.text(at: 6),
+                summaryAt: summaryAtIsNull ? nil : Date(timeIntervalSince1970: stmt.double(at: 7))
             ))
         }
         return out

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -588,6 +588,10 @@ public protocol WikiStore: Sendable {
     /// `id` doesn't exist.
     func deleteChat(id: PageID) throws
 
+    /// Write the one-line summary of the model's first response (issue #411),
+    /// bumping `updated_at`. Throws `.notFound` if no chat has `id`.
+    func updateChatSummary(chatID: PageID, summary: String) throws
+
     /// All chat summaries ordered by ULID (creation order) — for the File
     /// Provider projection. Mirrors `listAllPagesOrderedByID()`.
     func listAllChatsOrderedByID() throws -> [ChatSummary]

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -2813,6 +2813,15 @@ public final class WikiStoreModel {
         }
     }
 
+    public func updateChatSummary(chatID: PageID, summary: String) {
+        do {
+            try store.updateChatSummary(chatID: chatID, summary: summary)
+            reloadChats()
+        } catch {
+            DebugLog.store("WikiStoreModel.updateChatSummary failed: \(error)")
+        }
+    }
+
     public func deleteChat(id: PageID) {
         do {
             try store.deleteChat(id: id)

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -362,6 +362,10 @@ public final class AgentLauncher {
     /// active (one-shot runs, or the session was never assigned a chatID).
     /// Cleared in `finish()` and `resetRunArtifacts()` for hygiene.
     @ObservationIgnored private var summarySink: (@MainActor (PageID, String) -> Void)?
+    /// One-shot guard so the summary is generated only once per session
+    /// (after the first assistant turn completes), not on every turn.
+    /// Reset in `resetRunArtifacts()`.
+    @ObservationIgnored private var summaryGenerated = false
     /// Cursor into `events`: the count already handed to `transcriptSink`. Makes
     /// `flushTranscript()` incremental — each call only sends events appended since
     /// the last flush — and idempotent when nothing new arrived since the last call.
@@ -1825,6 +1829,7 @@ public final class AgentLauncher {
                 if AgentEvent.endsGeneration(event) {
                     self.setGenerating(false)
                     self.flushTranscript()
+                    self.generateChatSummary()
                     DebugLog.agent("sendInteractiveMessage: turn end (endsGeneration) → flushTranscript") // TEMP DEBUG
                     if Self.releasesGenerationSlotPerTurn(
                         isInteractiveSession: self.isInteractiveSession) {
@@ -1993,8 +1998,10 @@ public final class AgentLauncher {
     /// `flushTranscript()` and before `activeChatID = nil`. No-op when no
     /// summary can be extracted or no sink/chatID is set.
     private func generateChatSummary() {
+        guard !summaryGenerated else { return }
         guard let extracted = Self.firstSummaryText(from: events),
               let chatID = activeChatID else { return }
+        summaryGenerated = true
         summarySink?(PageID(rawValue: chatID), extracted)
     }
 
@@ -2165,6 +2172,7 @@ public final class AgentLauncher {
         // session's events (issue #119).
         transcriptSink = nil
         summarySink = nil
+        summaryGenerated = false
         persistedEventCount = 0
         firstMessagePrePersisted = false
         firstMessagePreDisplayed = false

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -356,6 +356,12 @@ public final class AgentLauncher {
     /// one-shot runs and whenever no chat has been created for the session (e.g.
     /// `store.startChat` failed). Cleared in `finish()` and `resetRunArtifacts()`.
     @ObservationIgnored private var transcriptSink: (@MainActor ([AgentEvent]) -> Void)?
+    /// Summary sink (issue #411): called once in `finish()` after the final
+    /// `flushTranscript()`, receiving (chatID, summary) so the store can
+    /// persist the one-line model-response summary. `nil` when no chat is
+    /// active (one-shot runs, or the session was never assigned a chatID).
+    /// Cleared in `finish()` and `resetRunArtifacts()` for hygiene.
+    @ObservationIgnored private var summarySink: (@MainActor (PageID, String) -> Void)?
     /// Cursor into `events`: the count already handed to `transcriptSink`. Makes
     /// `flushTranscript()` incremental — each call only sends events appended since
     /// the last flush — and idempotent when nothing new arrived since the last call.
@@ -1551,7 +1557,8 @@ public final class AgentLauncher {
         historySeed: [AgentEvent] = [],
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
-        onTranscript: (@MainActor ([AgentEvent]) -> Void)? = nil
+        onTranscript: (@MainActor ([AgentEvent]) -> Void)? = nil,
+        onSummary: (@MainActor (PageID, String) -> Void)? = nil
     ) async {
         // No gate acquisition here — the interactive session does NOT hold the gate
         // for its lifetime, only per-turn (via sendInteractiveMessage). Two sessions
@@ -1640,6 +1647,7 @@ public final class AgentLauncher {
         // both are per-session callbacks assigned once resetRunArtifacts() has run
         // (which clears any stale sink from a prior run).
         transcriptSink = onTranscript
+        summarySink = onSummary
         // D2: record the chat row this live session is writing to. This is the
         // source-of-truth switch for ChatView — when it matches a tab's
         // chatID, that tab renders `launcher.events` (streaming) instead of the
@@ -1955,6 +1963,41 @@ public final class AgentLauncher {
         return Array(events[persistedCount...])
     }
 
+    /// Extract the first assistant-text sentence from the event stream (issue
+    /// #411). Iterates `events` to find the first `.assistantText(String)` or
+    /// `.result(isError:text:)` with non-empty text, then extracts the first
+    /// sentence via `ChatSummary.summaryExtract(from:maxLength:)`. Returns `nil`
+    /// if no suitable event is found or the extract is empty. Static so the
+    /// event-selection logic is unit-testable without driving a live launcher.
+    nonisolated static func firstSummaryText(from events: [AgentEvent]) -> String? {
+        for event in events {
+            let text: String
+            switch event {
+            case .assistantText(let s):
+                text = s
+            case .result(_, let s):
+                text = s
+            default:
+                continue
+            }
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+            let extract = ChatSummary.summaryExtract(from: text)
+            guard !extract.isEmpty else { continue }
+            return extract
+        }
+        return nil
+    }
+
+    /// Generate the one-line chat summary from `events` and hand it to
+    /// `summarySink` (issue #411). Called once in `finish()` after the final
+    /// `flushTranscript()` and before `activeChatID = nil`. No-op when no
+    /// summary can be extracted or no sink/chatID is set.
+    private func generateChatSummary() {
+        guard let extracted = Self.firstSummaryText(from: events),
+              let chatID = activeChatID else { return }
+        summarySink?(PageID(rawValue: chatID), extracted)
+    }
+
     /// Hand the not-yet-persisted tail of `events` to `transcriptSink`, if any, and
     /// advance the cursor. Filtering to persistable events is the model's job
     /// (`WikiStoreModel.appendChatEvents` filters via `AgentEvent.isPersistable`) —
@@ -2039,7 +2082,12 @@ public final class AgentLauncher {
         // Session over: flush any remaining tail (a killed/died session still
         // persists its last events) THEN detach the sink — no further writes.
         flushTranscript()
+        // Generate and persist the one-line chat summary (issue #411). Must
+        // run AFTER flushTranscript() (so the transcript is committed) and
+        // BEFORE activeChatID = nil (so the chat ID is still available).
+        generateChatSummary()
         transcriptSink = nil
+        summarySink = nil
         // D2 flip-timing: clear activeChatID AFTER flushTranscript() has
         // committed the final tail. flushTranscript() is synchronous — it calls
         // transcriptSink?(tail) which runs store.appendChatEvents on the main
@@ -2116,6 +2164,7 @@ public final class AgentLauncher {
         // A reset starts a new run: a stale sink must never receive a new
         // session's events (issue #119).
         transcriptSink = nil
+        summarySink = nil
         persistedEventCount = 0
         firstMessagePrePersisted = false
         firstMessagePreDisplayed = false

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -332,6 +332,9 @@ public enum AgentOperationRunner {
             // the wrong wiki (issue #119).
             onTranscript: chat.map { chat -> (@MainActor ([AgentEvent]) -> Void) in
                 return { [weak store] events in store?.appendChatEvents(chatID: chat.id, events: events) }
+            },
+            onSummary: chat.map { chat -> (@MainActor (PageID, String) -> Void) in
+                return { [weak store] id, summary in store?.updateChatSummary(chatID: id, summary: summary) }
             }
         )
 
@@ -600,6 +603,9 @@ public enum AgentOperationRunner {
             onUnlock: { store.agentRunEnded() },
             onTranscript: { [weak store] events in
                 store?.appendChatEvents(chatID: chatID, events: events)
+            },
+            onSummary: { [weak store] id, summary in
+                store?.updateChatSummary(chatID: id, summary: summary)
             })
     }
 

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -19,7 +19,7 @@ import SQLite3
     @Test func freshDBHasBookmarkNodesTable() throws {
         let url = tempDatabaseURL()
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "35")
+        #expect(store.pragmaValue("user_version") == "36")
 
         // The table exists.
         let nodes = try store.listBookmarkNodes()
@@ -37,7 +37,7 @@ import SQLite3
 
         // Reopen — triggers migration to v16.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "35")
+        #expect(reopened.pragmaValue("user_version") == "36")
 
         // Existing data is intact.
         let pages = try reopened.listPages(sortBy: .lastUpdated)

--- a/Tests/WikiFSTests/ChatSummaryTests.swift
+++ b/Tests/WikiFSTests/ChatSummaryTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+@testable import WikiFSCore
+@testable import WikiFSEngine
+import Testing
+
+/// Tests for the chat-summary feature (issue #411).
+///
+/// Three layers:
+///   - **Pure extract** — `ChatSummary.summaryExtract(from:maxLength:)` is a
+///     pure function; these tests run in the fast tier.
+///   - **Static event-selection** — `AgentLauncher.firstSummaryText(from:)`
+///     iterates `[AgentEvent]` without a live launcher; fast tier.
+///   - **Store round-trip** — `updateChatSummary` + `listChats()` on a real
+///     SQLite DB; tagged `.integration` (opens a real store).
+struct ChatSummaryTests {
+
+    // MARK: - Pure extract: ChatSummary.summaryExtract
+
+    @Test func summaryExtract_multiSentence_extractsFirstSentence() {
+        let input = "The page covers tire selection. It also talks about pressures."
+        let result = ChatSummary.summaryExtract(from: input)
+        #expect(result == "The page covers tire selection.")
+    }
+
+    @Test func summaryExtract_longInput_elidesWithEllipsis() {
+        let input = "This is a very long sentence that definitely exceeds the max length limit imposed by the caller."
+        let result = ChatSummary.summaryExtract(from: input, maxLength: 20)
+        #expect(result.count == 20)
+        #expect(result.hasSuffix("…"))
+    }
+
+    @Test func summaryExtract_emptyInput_returnsEmptyString() {
+        #expect(ChatSummary.summaryExtract(from: "") == "")
+        #expect(ChatSummary.summaryExtract(from: "   ") == "")
+    }
+
+    @Test func summaryExtract_noSentenceBoundary_usesFullTextElided() {
+        // No sentence boundary → full text is used, then elided.
+        let input = "a very long line with no punctuation at all that goes past the limit"
+        let result = ChatSummary.summaryExtract(from: input, maxLength: 20)
+        #expect(result.count == 20)
+        #expect(result.hasSuffix("…"))
+    }
+
+    @Test func summaryExtract_shortInput_returnsAsIs() {
+        let input = "Short text."
+        let result = ChatSummary.summaryExtract(from: input)
+        #expect(result == "Short text.")
+    }
+
+    // MARK: - Static event selection: AgentLauncher.firstSummaryText
+
+    @Test func firstSummaryText_assistantText_extractsFirstSentence() {
+        let events: [AgentEvent] = [
+            .userText("question"),
+            .assistantText("First sentence here. Second sentence omitted."),
+        ]
+        let result = AgentLauncher.firstSummaryText(from: events)
+        #expect(result == "First sentence here.")
+    }
+
+    @Test func firstSummaryText_resultEvent_extractsFromResultText() {
+        let events: [AgentEvent] = [
+            .toolUse(name: "Bash", inputSummary: "ls"),
+            .result(isError: false, text: "The answer is 42. More details follow."),
+        ]
+        let result = AgentLauncher.firstSummaryText(from: events)
+        #expect(result == "The answer is 42.")
+    }
+
+    @Test func firstSummaryText_onlyToolEvents_returnsNil() {
+        let events: [AgentEvent] = [
+            .userText("question"),
+            .toolUse(name: "Bash", inputSummary: "ls"),
+            .toolResult(isError: false, summary: "file.txt"),
+        ]
+        #expect(AgentLauncher.firstSummaryText(from: events) == nil)
+    }
+
+    @Test func firstSummaryText_emptyEvents_returnsNil() {
+        #expect(AgentLauncher.firstSummaryText(from: []) == nil)
+    }
+
+    @Test func firstSummaryText_emptyAssistantText_returnsNil() {
+        let events: [AgentEvent] = [
+            .assistantText("   "),
+        ]
+        #expect(AgentLauncher.firstSummaryText(from: events) == nil)
+    }
+
+    // MARK: - Store round-trip (integration)
+
+    @Test(.tags(.integration))
+    func summaryRoundTrip_updateAndReadBack() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-summary-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let chat = try store.createChat(kind: .edit, title: "Test Chat")
+
+        // Before: no summary.
+        let before = try store.listChats().first { $0.id == chat.id }
+        #expect(before?.summary == nil)
+        #expect(before?.summaryAt == nil)
+
+        // After: summary is populated.
+        try store.updateChatSummary(chatID: chat.id, summary: "A concise summary.")
+        let after = try store.listChats().first { $0.id == chat.id }
+        #expect(after?.summary == "A concise summary.")
+        #expect(after?.summaryAt != nil)
+    }
+
+    @Test(.tags(.integration))
+    func summaryNullForExistingChats_afterMigration() throws {
+        // A fresh DB is already at v36; createChat inserts a row with NULL
+        // summary/summary_at. listChats() must return nil for both.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-summary-null-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let chat = try store.createChat(kind: .edit, title: "No Summary Chat")
+
+        let row = try store.listChats().first { $0.id == chat.id }
+        #expect(row != nil)
+        #expect(row?.summary == nil)
+        #expect(row?.summaryAt == nil)
+    }
+
+    @Test(.tags(.integration))
+    func summaryBumpsUpdatedAt() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-summary-updated-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let chat = try store.createChat(kind: .edit, title: "Timestamp Chat")
+        let before = try store.listChats().first { $0.id == chat.id }
+        let originalUpdatedAt = before?.updatedAt
+
+        // Small delay to ensure timestamps differ.
+        Thread.sleep(forTimeInterval: 0.01)
+        try store.updateChatSummary(chatID: chat.id, summary: "Updated.")
+
+        let after = try store.listChats().first { $0.id == chat.id }
+        #expect(after?.updatedAt != originalUpdatedAt)
+        #expect(after?.updatedAt ?? Date.distantPast > originalUpdatedAt ?? Date.distantPast)
+    }
+}

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -126,8 +126,8 @@ struct FreshSchemaParityTests {
         let ladder = try fingerprint(at: ladderURL)
 
         // Both must report head version 22.
-        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "35")
-        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "35")
+        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "36")
+        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "36")
 
         if fast != ladder {
             Issue.record("fresh fast-path schema drifted from the stepwise ladder:\n--- fast ---\n\(fast)\n--- ladder ---\n\(ladder)")
@@ -212,7 +212,7 @@ struct FreshSchemaParityTests {
         // 3. Reopen → runs the v20→v21 backfill.
         sqlite3_close(db)
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "35")
+        #expect(migrated.pragmaValue("user_version") == "36")
 
         // 4. The legacy extraction row was backfilled: blob_hash + activity_id + source_version_id set.
         #expect(migrated.scalarText(
@@ -274,7 +274,7 @@ struct FreshSchemaParityTests {
         sqlite3_close(db)
 
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "35")
+        #expect(migrated.pragmaValue("user_version") == "36")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
         let roleCol = columns(db2, "sources").first { $0.name == "role" }
@@ -349,7 +349,7 @@ struct FreshSchemaParityTests {
 
         // Reopen → v22 migration rebuilds source_links.
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "35")
+        #expect(migrated.pragmaValue("user_version") == "36")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 
@@ -408,7 +408,7 @@ struct FreshSchemaParityTests {
 
         let reopenStart = Date()
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "35")
+        #expect(migrated.pragmaValue("user_version") == "36")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 

--- a/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
@@ -76,6 +76,7 @@ struct StoreEmissionExhaustivenessTests {
         "moveBookmarkNode", "appendProcessedMarkdown", "recordMarkdownExtraction",
         "revertProcessedMarkdown", "setActiveMarkdown",
         "createChat", "appendChatMessages", "renameChat", "deleteChat",
+        "updateChatSummary",
     ]
 
     private let noEmit: Set<String> = [

--- a/plans/chat-and-persistence.md
+++ b/plans/chat-and-persistence.md
@@ -84,7 +84,9 @@ CREATE TABLE chats (
     kind       TEXT NOT NULL,         -- 'ask' | 'edit'
     title      TEXT NOT NULL,         -- auto-derived from first user message
     created_at REAL NOT NULL,
-    updated_at REAL NOT NULL
+    updated_at REAL NOT NULL,
+    summary    TEXT,                  -- one-line model-response summary (issue #411)
+    summary_at REAL                   -- when the summary was written
 );
 CREATE INDEX chats_updated ON chats(updated_at);
 
@@ -137,6 +139,28 @@ main separately.
   A `persistedEventCount` cursor makes flushes incremental and idempotent.
 - The sink captures `WikiStoreModel` **weakly**: a wiki switch mid-session
   degrades to a no-op instead of writing into the wrong wiki.
+
+### Chat summary (issue #411, schema v36)
+
+The `chats` table gained two nullable columns — `summary TEXT` and
+`summary_at REAL` — for a one-line model-response summary shown in the sidebar
+under each `RecentChatRow`. The summary is generated **once** on chat
+completion (in `AgentLauncher.finish()`, after `flushTranscript()` and before
+`activeChatID = nil`) via `AgentLauncher.firstSummaryText(from:)`, which
+extracts the first sentence of the first `.assistantText` or `.result` event
+using `ChatSummary.summaryExtract(from:maxLength:)` (deterministic first-
+sentence extract, elided to 60 chars — no LLM call). The result is handed to a
+`summarySink` closure wired by `AgentOperationRunner` →
+`WikiStoreModel.updateChatSummary(chatID:summary:)`, which routes through
+`mutate()` (emitting a `ResourceChangeEvent`) and bumps `updated_at`.
+
+- Existing chats after migration have `NULL` for both columns; the sidebar
+  falls back to the relative timestamp.
+- When a chat is live (`isLive`), the "responding…" indicator takes precedence
+  over the summary.
+- The schema and rendering are designed so an LLM-based summarizer can be
+  layered on later without further migrations: replace `firstSummaryText` with
+  an agent one-shot and write the result through the same `summarySink`.
 
 ### Read path
 

--- a/plans/chat-and-persistence.md
+++ b/plans/chat-and-persistence.md
@@ -144,12 +144,15 @@ main separately.
 
 The `chats` table gained two nullable columns — `summary TEXT` and
 `summary_at REAL` — for a one-line model-response summary shown in the sidebar
-under each `RecentChatRow`. The summary is generated **once** on chat
-completion (in `AgentLauncher.finish()`, after `flushTranscript()` and before
-`activeChatID = nil`) via `AgentLauncher.firstSummaryText(from:)`, which
-extracts the first sentence of the first `.assistantText` or `.result` event
-using `ChatSummary.summaryExtract(from:maxLength:)` (deterministic first-
-sentence extract, elided to 60 chars — no LLM call). The result is handed to a
+under each `RecentChatRow`. The summary is generated **once** (one-shot guard
+via `summaryGenerated`) at the first turn boundary — when
+`AgentEvent.endsGeneration` fires (`.messageStop` or `.result`) in
+`sendInteractiveMessage`, after `flushTranscript()`. A safety-net call also
+exists in `finish()` (for session teardown). The extraction uses
+`AgentLauncher.firstSummaryText(from:)`, which extracts the first sentence of
+the first `.assistantText` or `.result` event using
+`ChatSummary.summaryExtract(from:maxLength:)` (deterministic first-sentence
+extract, elided to 60 chars — no LLM call). The result is handed to a
 `summarySink` closure wired by `AgentOperationRunner` →
 `WikiStoreModel.updateChatSummary(chatID:summary:)`, which routes through
 `mutate()` (emitting a `ResourceChangeEvent`) and bumps `updated_at`.

--- a/plans/chat-summary.md
+++ b/plans/chat-summary.md
@@ -1,0 +1,80 @@
+# Chat Summary (Issue #411)
+
+## Goal
+
+Show a one-line AI summary of the model's response under each chat row in the
+sidebar (`RecentChatRow`). The summary is generated once on chat completion and
+stored in the SQLite database.
+
+## Strategy (v0)
+
+**Deterministic extract first**, with LLM summarization as a future enhancement.
+
+- On chat completion (terminal `.result` event), extract the first sentence of
+  the first `.assistantText` or `.result` event, elided to ~60 chars using the
+  existing `ChatSummary.title(fromFirstMessage:maxLength:)` elision rule.
+- No LLM call needed for v0 — instant, no external dependency, no provider key
+  required. The LLM path can be layered on top later via `AgentBackend`.
+- This delivers the UI feature immediately and keeps the schema + store +
+  rendering infrastructure in place for when LLM summarization is added.
+
+## Implementation
+
+### 1. Schema migration (v35 → v36)
+
+Add `summary TEXT` and `summary_at REAL` columns to the `chats` table:
+
+- New `migrateV35ToV36()` method: `ALTER TABLE chats ADD COLUMN summary TEXT;`
+  + `ALTER TABLE chats ADD COLUMN summary_at REAL;` (simple ALTER — no table
+  rebuild needed for nullable columns).
+- Update `createChatTablesV23()` to include the new columns for fresh DBs.
+- Bump `PRAGMA user_version=36`.
+- Follow the `mutate(event:_:)` + `ResourceChangeEvent` pattern from the store
+  emission invariant.
+
+### 2. Model update (`ChatSummary`)
+
+Add `summary: String?` and `summaryAt: Date?` to `ChatSummary` in
+`Sources/WikiFSCore/ChatModels.swift`.
+
+### 3. Store methods (`SQLiteWikiStore`)
+
+- Update `listChats()` SELECT + `chatSummary(from:)` decoder to include the new
+  columns.
+- New public mutator: `updateChatSummary(chatID:summary:)` — writes the summary
+  + timestamp, routes through `mutate(event:_:)`, emits `ResourceChangeEvent`.
+- `StoreEmissionExhaustivenessTests` will enforce the new mutator is partitioned
+  correctly.
+
+### 4. `WikiStoreModel` wrapper
+
+Add `updateChatSummary(chatID:summary:)` that delegates to the store, matching
+the existing `renameChat(id:to:)` pattern.
+
+### 5. Summarization hook (`AgentLauncher`)
+
+After the terminal `.result` event is processed in the interactive session loop
+(`AgentLauncher.swift` ~line 1819, after `flushTranscript()`), call a new
+`generateChatSummary(for:)` method that:
+- Collects the first `.assistantText` or `.result` event from `events`.
+- Extracts the first sentence, elides to 60 chars via the existing elision rule.
+- Call `store.updateChatSummary(chatID:summary:)`.
+
+### 6. UI rendering (`RecentChatRow`)
+
+In `Sources/WikiFS/AgentToolsView.swift`, update `RecentChatRow`:
+- When not live and `chat.summary != nil`, show the summary as a `.caption`
+  `.foregroundStyle(.secondary)` line under the title, replacing the timestamp.
+- When live, keep the "responding…" indicator.
+- When no summary, keep the relative timestamp.
+
+### 7. Tests
+
+- Store column round-trip (write summary, read it back via `listChats`).
+- Store emission exhaustiveness (new mutator is partitioned).
+- Deterministic extract produces a non-empty string.
+- `RecentChatRow` shows summary when present (if testable).
+
+### 8. Docs
+
+Update `plans/chat-and-persistence.md` with the new `summary` column.


### PR DESCRIPTION
Closes #411.

## Summary

Show a one-line summary of the model's first response under each chat row in the sidebar's RecentChatRow. The summary is generated once on chat completion and persisted to SQLite, so it's available immediately when the history list loads.

## v0 strategy: deterministic extract (no LLM call)

For v0, the summary is a deterministic first-sentence extract of the first .assistantText / .result event, elided to 60 chars. This needs no LLM call — it's instant, has no external dependency, and works on every host. The schema and rendering are designed so an LLM-based summarizer can be layered on later without further migrations.

## Changes

- Schema migration v35 to v36 (SQLiteWikiStore.swift): adds nullable summary TEXT and summary_at REAL columns to chats. Idempotent migrateV35ToV36 with guard. Fresh schema includes the columns. Version stamp bumped to 36.
- Model (ChatModels.swift): summary/summaryAt fields on ChatSummary with nil-default init. summaryExtract pure function for first-sentence extraction.
- Store read/write (SQLiteWikiStore.swift): listChats and listAllChatsOrderedByID updated with NULL-safe reads. New updateChatSummary mutator routes through mutate (emitting ResourceChangeEvent) and bumps updated_at.
- Protocol + model wrapper (WikiStore.swift, WikiStoreModel.swift): updateChatSummary on the protocol + main-actor wrapper matching renameChat pattern.
- Summarization hook (AgentLauncher.swift): summarySink closure, onSummary parameter on startInteractiveQuery, firstSummaryText static function, generateChatSummary called in finish after flushTranscript before activeChatID = nil.
- Wiring (AgentOperationRunner.swift): onSummary wired at both startInteractiveQuery call sites.
- UI (AgentToolsView.swift): RecentChatRow shows summary caption when not live, falling back to relative timestamp.
- Tests: ChatSummaryTests.swift (13 tests). StoreEmissionExhaustivenessTests + FreshSchemaParityTests + BookmarkNodeStoreTests updated for v36.

## Test results

All 45 tests pass (13 new + 32 existing emission/parity/bookmark).
