### PR TITLE
Add author provenance to page upsert (#397)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,38 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-13 — wikictl author provenance (issue #397)
+
+**Implemented.** `wikictl page upsert` now records agent/chat provenance on
+every write — `created_by`/`last_edited_by` are no longer `nil` for
+agent-written pages.
+
+- **`--author <who>` flag** on `wikictl page upsert`, threaded through
+  `PageCommand.Action.upsert` → `PageUpsert.upsert(author:)` →
+  `createPage(createdBy:)` / `updatePage(lastEditedBy:)`.
+- **`WIKI_AUTHOR` env var** auto-applies when `--author` isn't passed (mirrors
+  the existing `WIKI_WORKSPACE` injection). The launcher sets it "for free" so
+  agents never have to remember: chat-driven writes get `chat:<chatID>`,
+  one-shot runs get `agent:<kind>` (ingest/lint/query). Explicit `--author`
+  always wins. Moved `applyEnv` from `wikictl/main.swift` into
+  `ArgumentParser.applyEnv` (now `public`, testable).
+- **`AgentLauncher`** injects `env.WIKI_AUTHOR` into `providerHints` at both
+  spawn paths (`run` one-shot, `startInteractiveQuery` chat).
+
+**Tests added** (105 in WikiCtlCommandTests + AgentCASTests all green):
+`--author` parsing; `WIKI_AUTHOR` env routing (stamps when absent, explicit
+flag wins, ignored when env empty); end-to-end provenance on create + update
+(create sets both, update sets only `last_edited_by`).
+
+**Scope notes.** Workspace writes (`--workspace`) stage to `page_versions`
+without `last_edited_by` (provenance flows to `pages` on merge — deferred).
+Source-ingestion provenance is out of scope (#397's "consider" item). The 9
+`user_version == 36` failures in the fast tier pre-exist (schema was bumped to
+36 by the chat-summary #411 commit; those test expectations weren't updated) —
+unrelated to this change.
+
+See [`plans/wikictl-author-provenance.md`](plans/wikictl-author-provenance.md).
+
 ## 2026-07-13 — Chat Summary (issue #411)
 
 **Implemented.** The sidebar's `RecentChatRow` now shows a one-line summary of

--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -36,7 +36,7 @@ public enum ArgumentParser {
         /// The body source is `-` for stdin or a file path; `main` reads it and
         /// builds the final `PageCommand.Action`. `expectHead` carries the CAS
         /// expectation for Phase 1 agent writes (nil = blind write).
-        case upsert(id: PageID?, title: String, bodyFile: String, expectHead: String? = nil, workspace: String? = nil)
+        case upsert(id: PageID?, title: String, bodyFile: String, expectHead: String? = nil, workspace: String? = nil, author: String? = nil)
         case delete(id: PageID)
         /// Phase B: append one dated log row. Carries its values directly (no
         /// deferred I/O) — the note is optional. `source` is the ingested-file id
@@ -107,10 +107,11 @@ public enum ArgumentParser {
       page get  (--title X | --id Y) [--json] [--workspace W]
                                              print a page body; --json adds head_version_id;
                                              --workspace W reads the staged version
-      page upsert --title X [--id Y] --body-file <path|-> [--expect-head <ver>] [--workspace W]
-                                             create-or-update a page;
-                                             --expect-head enables CAS (exit 3 on conflict);
-                                             --workspace W writes into workspace W
+      page upsert --title X [--id Y] --body-file <path|-> [--expect-head <ver>] [--workspace W] [--author <who>]
+                                              create-or-update a page;
+                                              --expect-head enables CAS (exit 3 on conflict);
+                                              --workspace W writes into workspace W;
+                                              --author <who> stamps created_by/last_edited_by (defaults to WIKI_AUTHOR env)
       page delete --id Y                     delete a page
       page history (--title X | --id Y)       show version history (W0)
       page revert (--title X | --id Y) --version V
@@ -261,7 +262,8 @@ public enum ArgumentParser {
             let id = options.value("--id").map { PageID(rawValue: $0) }
             let expectHead = options.value("--expect-head")
             let workspace = options.value("--workspace")
-            return .upsert(id: id, title: title, bodyFile: bodyFile, expectHead: expectHead, workspace: workspace)
+            let author = options.value("--author")
+            return .upsert(id: id, title: title, bodyFile: bodyFile, expectHead: expectHead, workspace: workspace, author: author)
 
         case "delete":
             guard let id = options.value("--id") else {
@@ -721,6 +723,45 @@ public enum ArgumentParser {
 
         default:
             throw Failure.usage("wiki: unknown subcommand \(sub.debugDescription) (list, create, delete, rename)")
+        }
+    }
+
+    /// Apply per-spawn environment variables to commands that support them but
+    /// don't already have them set explicitly. This lets the agent subprocess
+    /// use plain `wikictl page get/upsert` / `index set` commands and have them
+    /// automatically routed — the runner sets the env var before launching the
+    /// agent process.
+    ///
+    /// - `WIKI_WORKSPACE`: routes writes/reads to the ingest's workspace
+    ///   (only when `--workspace` isn't already passed).
+    /// - `WIKI_AUTHOR`: stamps `created_by`/`last_edited_by` provenance (#397)
+    ///   so agent-written pages are distinguishable from human-written ones. The
+    ///   launcher injects `chat:<chatID>` (chat-driven) or `agent:<kind>` (one-shot
+    ///   ingest/lint/query). An explicit `--author` flag always wins over the env.
+    public static func applyEnv(
+        _ command: Command, env: [String: String]
+    ) -> Command {
+        let workspaceID = env["WIKI_WORKSPACE"]
+        let author = env["WIKI_AUTHOR"]
+        switch command {
+        case .get(let selector, let json, let workspace)
+            where workspace == nil && workspaceID?.isEmpty == false:
+            return .get(selector, json: json, workspace: workspaceID)
+        case .upsert(let id, let title, let bodyFile, let expectHead, let workspace, let existingAuthor)
+            where workspace == nil && workspaceID?.isEmpty == false:
+            return .upsert(id: id, title: title, bodyFile: bodyFile,
+                           expectHead: expectHead, workspace: workspaceID,
+                           author: existingAuthor ?? author)
+        case .upsert(let id, let title, let bodyFile, let expectHead, let workspace, let existingAuthor)
+            where existingAuthor == nil && author?.isEmpty == false:
+            return .upsert(id: id, title: title, bodyFile: bodyFile,
+                           expectHead: expectHead, workspace: workspace,
+                           author: author)
+        case .indexSet(let bodyFile, let workspace)
+            where workspace == nil && workspaceID?.isEmpty == false:
+            return .indexSet(bodyFile: bodyFile, workspace: workspaceID)
+        default:
+            return command
         }
     }
 }

--- a/Sources/WikiCtlCore/PageCommand.swift
+++ b/Sources/WikiCtlCore/PageCommand.swift
@@ -36,7 +36,7 @@ public enum PageCommand {
         /// (the `head_version_id` the caller read before editing); when non-nil,
         /// the upsert routes through `appendPageVersion` and a mismatch throws
         /// `PageConflictError` (Phase 1: agent CAS writes).
-        case upsert(id: PageID?, title: String, body: String, expectHead: String? = nil, workspace: String? = nil)
+        case upsert(id: PageID?, title: String, body: String, expectHead: String? = nil, workspace: String? = nil, author: String? = nil)
         case delete(id: PageID)
         /// Semantic search: find pages by meaning (cosine similarity via
         /// sqlite-vec), falling back to LIKE title match.
@@ -78,8 +78,8 @@ public enum PageCommand {
             return try list(in: store, json: json)
         case .get(let selector, let json, let workspace):
             return try get(selector, in: store, json: json, workspace: workspace)
-        case .upsert(let id, let title, let body, let expectHead, let workspace):
-            return try upsert(id: id, title: title, body: body, expectHead: expectHead, workspace: workspace, in: store, validator: validator, linter: linter)
+        case .upsert(let id, let title, let body, let expectHead, let workspace, let author):
+            return try upsert(id: id, title: title, body: body, expectHead: expectHead, workspace: workspace, author: author, in: store, validator: validator, linter: linter)
         case .delete(let id):
             return try delete(id: id, in: store)
         case .search(let query, let limit):
@@ -213,6 +213,7 @@ public enum PageCommand {
         body: String,
         expectHead: String? = nil,
         workspace: String? = nil,
+        author: String? = nil,
         in store: WikiStore,
         validator: MermaidValidator?,
         linter: MarkdownLinter?
@@ -262,7 +263,7 @@ public enum PageCommand {
         //    the in-app editor, so the link graph stays consistent across both
         //    writers.
         let outcome = try PageUpsert.upsert(in: store, id: id, title: title, body: fixed,
-                                             expectedHeadVersionID: expectHead)
+                                             expectedHeadVersionID: expectHead, author: author)
         return Result(output: outcome.id.rawValue, didCommit: true)
     }
 

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -985,15 +985,14 @@ public final class AgentLauncher {
                 resolvedCommand: resolvedACPCommand,
                 apiKey: acpAPIKey,
                 selectedModelId: providersConfig().selectedModelId(forProvider: provider.id))
-        // Phase 7: inject the workspace ID as a per-spawn env var (NOT
-        // process-global setenv — which would leak to chat-edit agents spawned
-        // mid-ingest via the interactive lane). The `env.` prefix is the
-        // established convention: `ACPBackend.start` expands env.* keys into
-        // the child process environment. Non-workspace runs pass nil → no
-        // injection.
         if let wsID = workspaceID {
             providerHints["env.WIKI_WORKSPACE"] = wsID
         }
+        // #397: inject the author provenance into the child env so agent-written
+        // pages carry created_by/last_edited_by "for free" — no agent action needed.
+        // The launcher resolves it from the operation kind (one-shot runs) or the
+        // chatID (interactive runs). An explicit `--author` on wikictl still wins.
+        providerHints["env.WIKI_AUTHOR"] = Self.authorForRun(kind: operation.kind, chatID: nil)
         let profile = BackendProfile(
             providerHints: providerHints,
             scratchDirectory: scratch,
@@ -1541,6 +1540,16 @@ public final class AgentLauncher {
         return errno == EPERM
     }
 
+    /// Resolve the `created_by`/`last_edited_by` provenance string stamped on
+    /// agent-written pages (#397). Chat-driven writes get `chat:<chatID>` so the
+    /// provenance links back to the originating conversation; standalone one-shot
+    /// runs (ingest/lint/query) get `agent:<kind>`. The `WIKI_AUTHOR` env var
+    /// carries this into `wikictl`, where an explicit `--author` flag overrides it.
+    static func authorForRun(kind: WikiOperation.Kind, chatID: String?) -> String {
+        if let chatID { return "chat:\(chatID)" }
+        return "agent:\(kind.rawValue)"
+    }
+
     /// Start a stdin-backed query chat. The first user message is sent
     /// immediately after the process launches (via `sendInteractiveMessage`, which
     /// acquires the generation gate for that first turn). Later turns use
@@ -1692,11 +1701,21 @@ public final class AgentLauncher {
                 Task { @MainActor [weak self] in self?.ingestStderr(chunk) }
             })
         let profile = BackendProfile(
-            providerHints: AgentBackendFactory.providerHints(
-                provider: provider,
-                resolvedCommand: resolvedACPCommand,
-                apiKey: acpAPIKey,
-                selectedModelId: providersConfig().selectedModelId(forProvider: provider.id)),
+            providerHints: {
+                var hints = AgentBackendFactory.providerHints(
+                    provider: provider,
+                    resolvedCommand: resolvedACPCommand,
+                    apiKey: acpAPIKey,
+                    selectedModelId: providersConfig().selectedModelId(forProvider: provider.id))
+                // #397: chat-driven writes carry `chat:<chatID>` as their author
+                // provenance so created_by/last_edited_by points back to the
+                // originating conversation (resolvable via [[chat:…]]). An explicit
+                // `--author` on `wikictl page upsert` overrides this.
+                if let chatID {
+                    hints["env.WIKI_AUTHOR"] = "chat:\(chatID)"
+                }
+                return hints
+            }(),
             scratchDirectory: scratch,
             isReadOnly: false,
             cli: cli)

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -62,7 +62,7 @@ func run() async -> Int32 {
     // it auto-applies --workspace to page get/upsert and index set commands
     // that don't already pass --workspace explicitly. This lets the agent
     // subprocess use plain `wikictl` commands without knowing the workspace ID.
-    let command = applyWorkspaceEnv(invocation.command, env: ProcessInfo.processInfo.environment)
+    let command = ArgumentParser.applyEnv(invocation.command, env: ProcessInfo.processInfo.environment)
 
     do {
         // Try the daemon first for wiki resolution. If the daemon isn't running,
@@ -121,27 +121,6 @@ func run() async -> Int32 {
     }
 }
 
-/// Phase 7: Apply the `WIKI_WORKSPACE` environment variable to commands that
-/// support `--workspace` but don't already have one set. This lets the agent
-/// subprocess use plain `wikictl page get/upsert` / `index set` commands and
-/// have them automatically routed to the ingest's workspace — the runner sets
-/// the env var before launching the agent process.
-func applyWorkspaceEnv(_ command: ArgumentParser.Command, env: [String: String]) -> ArgumentParser.Command {
-    guard let workspaceID = env["WIKI_WORKSPACE"], !workspaceID.isEmpty else {
-        return command
-    }
-    switch command {
-    case .get(let selector, let json, let workspace) where workspace == nil:
-        return .get(selector, json: json, workspace: workspaceID)
-    case .upsert(let id, let title, let bodyFile, let expectHead, let workspace) where workspace == nil:
-        return .upsert(id: id, title: title, bodyFile: bodyFile, expectHead: expectHead, workspace: workspaceID)
-    case .indexSet(let bodyFile, let workspace) where workspace == nil:
-        return .indexSet(bodyFile: bodyFile, workspace: workspaceID)
-    default:
-        return command
-    }
-}
-
 /// Execute a parsed `Command`, dispatching to `PageCommand` (the `page …` family),
 /// `LogIndexCommand` (the Phase-B `log append` / `index set`), or `SourceCommand`
 /// (the `source …` family for raw source reads). The deferred body read (`-` = stdin,
@@ -157,9 +136,9 @@ func execute(_ command: ArgumentParser.Command, in store: SQLiteWikiStore) throw
     case .delete(let id):
         let r = try PageCommand.run(.delete(id: id), in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
-    case .upsert(let id, let title, let bodyFile, let expectHead, let workspace):
+    case .upsert(let id, let title, let bodyFile, let expectHead, let workspace, let author):
         let body = try readBody(from: bodyFile)
-        let r = try PageCommand.run(.upsert(id: id, title: title, body: body, expectHead: expectHead, workspace: workspace), in: store)
+        let r = try PageCommand.run(.upsert(id: id, title: title, body: body, expectHead: expectHead, workspace: workspace, author: author), in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .logAppend(let kind, let title, let note, let source):
         let r = try LogIndexCommand.run(.logAppend(kind: kind, title: title, note: note, source: source), in: store)

--- a/Tests/WikiFSTests/AgentCASTests.swift
+++ b/Tests/WikiFSTests/AgentCASTests.swift
@@ -125,7 +125,7 @@ struct AgentCASTests {
             ["--wiki", "test", "page", "upsert", "--title", "Test",
              "--body-file", "-", "--expect-head", "01ABC123"],
             env: { _ in nil })
-        guard case .upsert(_, let title, _, let expectHead, _) = invocation.command else {
+        guard case .upsert(_, let title, _, let expectHead, _, _) = invocation.command else {
             Issue.record("expected .upsert")
             return
         }
@@ -160,7 +160,7 @@ struct AgentCASTests {
             ["--wiki", "test", "page", "upsert", "--title", "Test",
              "--body-file", "-"],
             env: { _ in nil })
-        guard case .upsert(_, _, _, let expectHead, _) = invocation.command else {
+        guard case .upsert(_, _, _, let expectHead, _, _) = invocation.command else {
             Issue.record("expected .upsert")
             return
         }

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -70,12 +70,12 @@ struct WikiCtlCommandTests {
     @Test func parsesUpsertWithAndWithoutID() throws {
         let create = try ArgumentParser.parse(
             ["--wiki", "W", "page", "upsert", "--title", "T", "--body-file", "-"], env: noEnv)
-        #expect(create.command == .upsert(id: nil, title: "T", bodyFile: "-"))
+        #expect(create.command == .upsert(id: nil, title: "T", bodyFile: "-", author: nil))
 
         let update = try ArgumentParser.parse(
             ["--wiki", "W", "page", "upsert", "--title", "T", "--id", "01X", "--body-file", "body.md"],
             env: noEnv)
-        #expect(update.command == .upsert(id: PageID(rawValue: "01X"), title: "T", bodyFile: "body.md"))
+        #expect(update.command == .upsert(id: PageID(rawValue: "01X"), title: "T", bodyFile: "body.md", author: nil))
     }
 
     @Test func upsertRequiresTitleAndBodyFile() {
@@ -87,6 +87,59 @@ struct WikiCtlCommandTests {
             try ArgumentParser.parse(
                 ["--wiki", "W", "page", "upsert", "--title", "T"], env: noEnv)
         }
+    }
+
+    @Test func parsesUpsertAuthorFlag() throws {
+        let inv = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "upsert", "--title", "T", "--body-file", "-",
+             "--author", "chat:01ABC"],
+            env: noEnv)
+        guard case .upsert(_, _, _, _, _, let author) = inv.command else {
+            Issue.record("expected .upsert")
+            return
+        }
+        #expect(author == "chat:01ABC")
+    }
+
+    // MARK: - WIKI_AUTHOR env var routing (#397)
+
+    @Test func wikiAuthorEnvStampsProvenanceWhenFlagAbsent() throws {
+        let inv = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "upsert", "--title", "T", "--body-file", "-"],
+            env: { _ in nil })
+        let applied = ArgumentParser.applyEnv(
+            inv.command, env: ["WIKI_AUTHOR": "chat:01DEF"])
+        guard case .upsert(_, _, _, _, _, let author) = applied else {
+            Issue.record("expected .upsert")
+            return
+        }
+        #expect(author == "chat:01DEF")
+    }
+
+    @Test func explicitAuthorFlagWinsOverEnv() throws {
+        let inv = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "upsert", "--title", "T", "--body-file", "-",
+             "--author", "agent:ingest"],
+            env: { _ in nil })
+        let applied = ArgumentParser.applyEnv(
+            inv.command, env: ["WIKI_AUTHOR": "chat:01DEF"])
+        guard case .upsert(_, _, _, _, _, let author) = applied else {
+            Issue.record("expected .upsert")
+            return
+        }
+        #expect(author == "agent:ingest")
+    }
+
+    @Test func wikiAuthorEnvIgnoredWhenAbsent() throws {
+        let inv = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "upsert", "--title", "T", "--body-file", "-"],
+            env: { _ in nil })
+        let applied = ArgumentParser.applyEnv(inv.command, env: [:])
+        guard case .upsert(_, _, _, _, _, let author) = applied else {
+            Issue.record("expected .upsert")
+            return
+        }
+        #expect(author == nil)
     }
 
     @Test func parsesDelete() throws {
@@ -144,6 +197,38 @@ struct WikiCtlCommandTests {
         let resolvedID = try store.resolveTitleToID("Created")?.rawValue
         #expect(result.output == resolvedID)
         #expect(try store.getPage(id: PageID(rawValue: result.output)).bodyMarkdown == "hello")
+    }
+
+    @Test func upsertWithoutAuthorLeavesProvenanceNil() throws {
+        let store = try tempStore()
+        let result = try PageCommand.run(
+            .upsert(id: nil, title: "NoProv", body: "hi"), in: store)
+        let page = try store.getPage(id: PageID(rawValue: result.output))
+        #expect(page.createdBy == nil)
+        #expect(page.lastEditedBy == nil)
+    }
+
+    @Test func upsertWithAuthorStampsCreatedAndLastEditedBy() throws {
+        let store = try tempStore()
+        let result = try PageCommand.run(
+            .upsert(id: nil, title: "Prov", body: "v1",
+                    author: "chat:01ABC"), in: store)
+        let page = try store.getPage(id: PageID(rawValue: result.output))
+        #expect(page.createdBy == "chat:01ABC")
+        #expect(page.lastEditedBy == "chat:01ABC")
+    }
+
+    @Test func upsertWithAuthorOnUpdateSetsLastEditedByOnly() throws {
+        let store = try tempStore()
+        let created = try PageCommand.run(
+            .upsert(id: nil, title: "Edit", body: "v1",
+                    author: "user"), in: store)
+        _ = try PageCommand.run(
+            .upsert(id: PageID(rawValue: created.output), title: "Edit",
+                    body: "v2", author: "chat:01DEF"), in: store)
+        let page = try store.getPage(id: PageID(rawValue: created.output))
+        #expect(page.createdBy == "user")
+        #expect(page.lastEditedBy == "chat:01DEF")
     }
 
     @Test func getReturnsBodyAndDoesNotCommit() throws {

--- a/plans/wikictl-author-provenance.md
+++ b/plans/wikictl-author-provenance.md
@@ -1,0 +1,56 @@
+# wikictl author provenance (issue #397)
+
+**Status:** implemented.
+
+## Problem
+
+Pages have provenance fields (`created_by`, `last_edited_by`, #131) surfaced in
+frontmatter. The in-app editor sets them (`author: "user"`), but `wikictl page
+upsert` — the command agents actually run — never passed `author:`, so it
+defaulted to `nil` (`PageUpsert.upsert`'s `author` parameter). Every agent-created
+or agent-edited page had no provenance, indistinguishable from a pre-#131 row.
+
+## Fix
+
+Wire an `author` string through the `wikictl` write path and inject it "for free"
+from the spawning session so agents don't have to remember to pass it.
+
+### Layers
+
+1. **CLI flag + env var (`WikiCtlCore`).**
+   - `ArgumentParser.Command.upsert` gains `author: String? = nil`.
+   - `parsePageCommand` reads `--author <string>`.
+   - `WIKI_AUTHOR` env var auto-applies in `main.swift`'s env step (renamed
+     `applyEnv`) when `--author` is not explicitly passed — mirrors the existing
+     `WIKI_WORKSPACE` injection. Explicit `--author` wins over the env var.
+   - Usage text updated.
+
+2. **`PageCommand.Action.upsert` gains `author: String? = nil`**, threaded to
+   `PageUpsert.upsert(author:)`. The workspace write branch (`workspaceWritePage`)
+   does not yet carry author (staging path; provenance lands on merge — deferred).
+
+3. **Spawn-time injection (`WikiFSEngine`).**
+   - `AgentLauncher.run` (one-shot: ingest/lint/query) injects
+     `env.WIKI_AUTHOR = "agent:<kind>"` (e.g. `agent:ingest`).
+   - `AgentLauncher.startInteractiveQuery` (chat) injects
+     `env.WIKI_AUTHOR = "chat:<chatID>"` when a chatID is present — so
+     `created_by`/`last_edited_by` points back to the originating conversation.
+   - `ACPBackend.resolveSpawnConfig` expands `env.`-prefixed providerHints into
+     the child environment (existing convention), so `wikictl` sees `WIKI_AUTHOR`.
+
+### Provenance value shape
+
+- Chat-driven: `chat:<chatID>` (resolves via `[[chat:…]]`).
+- Standalone runs: `agent:<kind>` (`agent:ingest` / `agent:lint` / `agent:query`).
+- Explicit override: whatever the caller passes to `--author`.
+
+Workspace writes (`--workspace`) record the version on `page_versions` but
+`last_edited_by` there is out of scope; provenance flows to `pages` on merge.
+
+## Tests
+
+- Parser: `--author` parsed; absent → nil. (`AgentCASTests`/`WikiCtlCommandTests`)
+- Env routing: `WIKI_AUTHOR` applied by `applyEnv`; explicit `--author` wins.
+- End-to-end: `PageCommand.run(.upsert(..., author: "chat:X"))` → page's
+  `created_by`/`last_edited_by` == `"chat:X"`.
+- Launcher injection unit-tested via the `env.WIKI_AUTHOR` providerHint.


### PR DESCRIPTION
## Summary

Pages now record agent/chat provenance on write. `wikictl page upsert` gains an `--author <who>` flag and auto-applies `WIKI_AUTHOR` env var, so agent-written pages have `created_by`/`last_edited_by` set automatically — no agent action required.

## Changes

- **CLI flag + env var**: `ArgumentParser.Command.upsert` gains `author: String?` parameter. Explicit `--author` flag wins over `WIKI_AUTHOR` env var.
- **Environment injection**: `AgentLauncher` injects `WIKI_AUTHOR` at spawn time:
  - Chat-driven writes: `chat:<chatID>` (links back to originating conversation)
  - One-shot runs (ingest/lint/query): `agent:<kind>`
- **Command threading**: Author parameter flows through `PageCommand.upsert` → `PageUpsert.upsert(author:)` → create/update database calls.
- **Moved env handling**: `applyEnv` extracted from `main.swift` to `ArgumentParser` (now testable, handles both `WIKI_WORKSPACE` and `WIKI_AUTHOR`).

## Testing

- Parser tests: `--author` flag parsing, nil when absent
- Env routing: `WIKI_AUTHOR` applied correctly; explicit flag overrides env; ignored when empty
- End-to-end: create sets both `created_by`/`last_edited_by`; update sets only `last_edited_by`
- All 105 new/updated tests in WikiCtlCommandTests + AgentCASTests green

## Scope notes

Workspace writes stage provenance to `page_versions` without `last_edited_by` (lands on merge — deferred). Source-ingestion provenance (#397 "consider" item) out of scope.