### PR TITLE
Fix schema-version test failures: add currentSchemaVersion constant

### DIFF
--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -21,6 +21,13 @@ import CryptoKit
 /// See `plans/graph-model-and-versioning.md` §8 and
 /// `.claude/skills/sqlite-concurrency/SKILL.md`.
 public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
+
+    /// The latest schema version stamped by `createFreshSchemaV20()` and the
+    /// final step of `migrate(from:)`. Tests reference this instead of
+    /// hardcoding a magic number, so a schema bump doesn't require updating
+    /// every test file.
+    public static let currentSchemaVersion = 36
+
     private let db: OpaquePointer
     /// Prepared-statement cache keyed by SQL text; reused via `reset()`.
     private var statements: [String: SQLiteStatement] = [:]
@@ -567,7 +574,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // columns on `chats` for the one-line model-response summary shown in
         // the sidebar. A fresh DB gets the columns via `createChatTablesV23`
         // above; existing DBs get them via the v35→36 ALTER migration.
-        try exec("PRAGMA user_version=36;")
+        try exec("PRAGMA user_version=\(Self.currentSchemaVersion);")
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -1502,10 +1509,10 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // and `summary_at` columns to `chats` so the sidebar can show a
         // one-line summary of the model's first response. Simple ALTER — no
         // table rebuild needed for nullable columns.
-        if version < 36 {
+        if version < Self.currentSchemaVersion {
             try migrateV35ToV36()
-            try exec("PRAGMA user_version=36;")
-            version = 36
+            try exec("PRAGMA user_version=\(Self.currentSchemaVersion);")
+            version = Self.currentSchemaVersion
         }
     }
 

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -19,7 +19,7 @@ import SQLite3
     @Test func freshDBHasBookmarkNodesTable() throws {
         let url = tempDatabaseURL()
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "36")
+        #expect(store.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         // The table exists.
         let nodes = try store.listBookmarkNodes()
@@ -37,7 +37,7 @@ import SQLite3
 
         // Reopen — triggers migration to v16.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "36")
+        #expect(reopened.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         // Existing data is intact.
         let pages = try reopened.listPages(sortBy: .lastUpdated)

--- a/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
+++ b/Tests/WikiFSTests/EmbeddingMetaCutoverTests.swift
@@ -20,7 +20,7 @@ struct EmbeddingMetaCutoverTests {
     @Test func freshDBSeedsNLEmbedderIdentifier() throws {
         let store = try tempStore()
         let stored = store.pragmaValue("user_version")
-        #expect(stored == "35")
+        #expect(stored == "\(SQLiteWikiStore.currentSchemaVersion)")
         // ensureEmbedderConsistency with the default identifier (nlembedding-512)
         // is a no-op: the seed matches, so nothing is wiped.
         store.ensureEmbedderConsistency(activeIdentifierOverride: NLEmbedder.identifier)

--- a/Tests/WikiFSTests/FreshSchemaParityTests.swift
+++ b/Tests/WikiFSTests/FreshSchemaParityTests.swift
@@ -126,8 +126,8 @@ struct FreshSchemaParityTests {
         let ladder = try fingerprint(at: ladderURL)
 
         // Both must report head version 22.
-        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "36")
-        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "36")
+        #expect(try SQLiteWikiStore(databaseURL: fastURL).pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
+        #expect(try SQLiteWikiStore(databaseURL: ladderURL).pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         if fast != ladder {
             Issue.record("fresh fast-path schema drifted from the stepwise ladder:\n--- fast ---\n\(fast)\n--- ladder ---\n\(ladder)")
@@ -212,7 +212,7 @@ struct FreshSchemaParityTests {
         // 3. Reopen → runs the v20→v21 backfill.
         sqlite3_close(db)
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "36")
+        #expect(migrated.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         // 4. The legacy extraction row was backfilled: blob_hash + activity_id + source_version_id set.
         #expect(migrated.scalarText(
@@ -274,7 +274,7 @@ struct FreshSchemaParityTests {
         sqlite3_close(db)
 
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "36")
+        #expect(migrated.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
         let roleCol = columns(db2, "sources").first { $0.name == "role" }
@@ -349,7 +349,7 @@ struct FreshSchemaParityTests {
 
         // Reopen → v22 migration rebuilds source_links.
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "36")
+        #expect(migrated.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 
@@ -408,7 +408,7 @@ struct FreshSchemaParityTests {
 
         let reopenStart = Date()
         let migrated = try SQLiteWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "36")
+        #expect(migrated.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
         let db2 = try open(url)
         defer { sqlite3_close(db2) }
 

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -238,7 +238,7 @@ struct LogIndexTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 35)
+        #expect(sqlite3_column_int(stmt, 0) == SQLiteWikiStore.currentSchemaVersion)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
+++ b/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
@@ -191,7 +191,7 @@ struct Phase5StoreCanonicalizationTests {
 
         // Reopen → v23 sweep runs.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "35")
+        #expect(reopened.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         let migrated = try reopened.getPage(id: linkerID)
         // Resolvable link canonicalized; forward link left verbatim.

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -115,7 +115,7 @@ struct ProcessedMarkdownTests {
 
     @Test func freshDBHasV8Schema() throws {
         let store = try tempStore()
-        #expect(store.pragmaValue("user_version") == "35")
+        #expect(store.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
     }
 
     @Test func v7DBUpgradesToV8PreservingData() throws {
@@ -131,7 +131,7 @@ struct ProcessedMarkdownTests {
 
         // Opening runs v7→v8→…→v15 migration.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "35")
+        #expect(store.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
         // Pre-existing file is intact.
         let content = try store.sourceContent(
             id: PageID(rawValue: "01J00000000000000000000000"))

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -67,7 +67,7 @@ struct SQLiteWikiStoreTests {
         // user_version guard: a fresh DB runs all migration steps → version 16.
         // Reopening must not re-run DDL (no-op bootstrap).
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "35")
+        #expect(userVersion == "\(SQLiteWikiStore.currentSchemaVersion)")
         let reopened = try SQLiteWikiStore(databaseURL: url)
         // If bootstrap weren't guarded, the CREATE TABLE would throw here.
         #expect((try? reopened.listPages(sortBy: .lastUpdated)) != nil)
@@ -341,7 +341,7 @@ struct SQLiteWikiStoreTests {
         defer { sqlite3_close(db) }
 
         let userVersion = scalarText(db, "PRAGMA user_version;")
-        #expect(userVersion == "35")
+        #expect(userVersion == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"))
@@ -385,7 +385,7 @@ struct SQLiteWikiStoreTests {
 
     @Test func freshDBReachesUserVersion18() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(store.pragmaValue("user_version") == "35")
+        #expect(store.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
     }
 
     @Test func v11SourceLinksHasDeleteCascade() throws {
@@ -641,7 +641,7 @@ struct SQLiteWikiStoreTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarText(db, "PRAGMA user_version;") == "35")
+        #expect(scalarText(db, "PRAGMA user_version;") == "\(SQLiteWikiStore.currentSchemaVersion)")
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"))
         for expected in ["blobs", "agents", "activities", "source_versions", "refs"] {
@@ -702,7 +702,7 @@ struct SQLiteWikiStoreTests {
 
         // Reopen → migrates 19→20.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "35")
+        #expect(store.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
@@ -760,7 +760,7 @@ struct SQLiteWikiStoreTests {
 
         // Reopen → migrates 28→29.
         let store = try SQLiteWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "35")
+        #expect(store.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
 
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)

--- a/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
+++ b/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
@@ -49,7 +49,7 @@ struct SourceEmbeddingSearchTests {
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
         defer { sqlite3_close(db) }
 
-        #expect(scalarInt(db, "PRAGMA user_version;") == 35)
+        #expect(scalarInt(db, "PRAGMA user_version;") == SQLiteWikiStore.currentSchemaVersion)
         #expect(tableExists(db, "source_chunks"))
         // page chunk table mirrors the source one.
         #expect(tableExists(db, "page_chunks"))

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -279,7 +279,7 @@ struct SourcesTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 35)
+        #expect(sqlite3_column_int(stmt, 0) == SQLiteWikiStore.currentSchemaVersion)
         _ = store
     }
 

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -234,7 +234,7 @@ struct SystemPromptTests {
         #expect(sqlite3_prepare_v2(check, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK)
         defer { sqlite3_finalize(stmt) }
         #expect(sqlite3_step(stmt) == SQLITE_ROW)
-        #expect(sqlite3_column_int(stmt, 0) == 35)
+        #expect(sqlite3_column_int(stmt, 0) == SQLiteWikiStore.currentSchemaVersion)
         _ = store
     }
 }

--- a/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
+++ b/Tests/WikiFSTests/WikiNameSanitizationStoreTests.swift
@@ -104,7 +104,7 @@ struct WikiNameSanitizationStoreTests {
 
         // Reopen → the 17→18 step sweeps the dirty names.
         let reopened = try SQLiteWikiStore(databaseURL: url)
-        #expect(reopened.pragmaValue("user_version") == "35")
+        #expect(reopened.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
         let page = try reopened.getPage(id: pageID!)
         #expect(page.title == "(Draft) Bad - #Title") // inner # is fine, kept
         #expect(try reopened.getSource(id: sourceID!).displayName == "Foo - Bar)")


### PR DESCRIPTION
## What

Fixes 9 failing tests caused by stale hardcoded schema-version literals.

## Root cause

Issue #411 (chat summary) bumped the SQLite schema from v35 → v36, but 9 test files still asserted `user_version == 35`. These were never updated when the schema advanced.

## Fix

1. **Added `SQLiteWikiStore.currentSchemaVersion`** (`public static let = 36`) — a single source of truth for the expected schema version. The fresh-schema stamp and the final migration-ladder step now reference `Self.currentSchemaVersion` instead of a magic number.

2. **Replaced all 21 hardcoded version literals** across 11 test files with `SQLiteWikiStore.currentSchemaVersion` (string-interpolated for `pragmaValue` comparisons, bare for `sqlite3_column_int` / `scalarInt`). This covers the 9 failing fast-tier tests plus 3 `SQLiteWikiStoreTests` references that would have failed in the integration CI job.

## Why

The next schema bump (v36 → v37) now requires changing one constant — no test-file updates needed. The magic-number pattern was a latent footgun: the v36 bump silently broke 9 tests because there was no single source of truth for the expected version.

## Tests

`swift build` clean. Fast tier: **2310 tests in 195 suites pass**.
