### PR TITLE
fix(#430): persist chat composer draft across tab switches

### DIFF
--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -27,7 +27,6 @@ struct ChatView: View {
     var session: WikiSession
     let fileProvider: FileProviderSpike
 
-    @State private var draftMessage = ""
     @State private var showsInternals = false
     @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ChatMetrics.composerFont)
     @State private var persistedMessages: [ChatMessage] = []
@@ -35,7 +34,11 @@ struct ChatView: View {
     /// context for the next message (issue #385).
     @State private var attachments: [ChatAttachment] = []
     @AppStorage("chat.zoom") private var chatZoom = Double(ZoomScale.defaultScale)
-    @AppStorage("isChatOutlineExpanded") private var chatOutlineExpanded = false
+    /// Outline starts collapsed on every new chat view instance — not a
+    /// persisted global toggle (was @AppStorage). Each time you switch to a
+    /// chat tab the outline is closed by default; the user can expand it
+    /// within that view's lifetime.
+    @State private var chatOutlineExpanded = false
     /// Persisted toggle to hide tool-call rows from the chat transcript
     /// (issue #381). Independent of "Show internals" which gates the full
     /// raw activity feed.
@@ -134,7 +137,7 @@ struct ChatView: View {
                 // auto-send it. This starts a new chat with the question.
                 if let question = store.pendingChatQuestion {
                     store.pendingChatQuestion = nil
-                    draftMessage = question
+                    store.draftChatMessage = question
                 }
             }
         }
@@ -553,7 +556,7 @@ struct ChatView: View {
                 attachmentChips
             }
             ComposerTextView(
-                text: $draftMessage,
+                text: $store.draftChatMessage,
                 isEditable: enabled,
                 font: composerFont,
                 onSubmit: sendMessage,
@@ -563,7 +566,7 @@ struct ChatView: View {
                 .frame(height: composerHeight)
                 .frame(maxWidth: .infinity)
                 .overlay(alignment: .topLeading) {
-                    if draftMessage.isEmpty {
+                    if store.draftChatMessage.isEmpty {
                         Text("Ask a question, or ask to update the wiki…")
                             .font(.body)
                             .foregroundStyle(.secondary)
@@ -684,7 +687,7 @@ struct ChatView: View {
     /// True once the composer holds non-whitespace text — drives the send
     /// button's visibility (paseo shows no glyph until you type).
     private var hasDraftText: Bool {
-        !draftMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     /// Green when the message can be sent, a muted grey while it can't (e.g. a
@@ -702,9 +705,9 @@ struct ChatView: View {
         // being silently dropped (issue #380). The draft is preserved so the
         // user can send it once the agent finishes.
         guard canSend else { return }
-        let message = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        let message = store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
-        draftMessage = ""
+        store.clearActiveChatDraft()
         // Build the wire message: prepend attachment references so the agent
         // has context about the dragged-in pages/sources (issue #385).
         let wireMessage: String
@@ -811,7 +814,7 @@ struct ChatView: View {
             && canType
             && !launcher.isGenerating
             && !launcher.isAwaitingGenerationSlot
-            && !draftMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var sendButtonTitle: String {

--- a/Sources/WikiFSCore/EditorTab.swift
+++ b/Sources/WikiFSCore/EditorTab.swift
@@ -17,6 +17,10 @@ public struct EditorTab: Hashable, Sendable, Identifiable {
     /// Non-nil only while `isEditing` and the user has unsaved changes.
     public var pendingDraftTitle: String? = nil
     public var pendingDraftBody: String? = nil
+    /// In-progress chat composer draft stashed when the user switches away from
+    /// a chat tab without sending (issue #430). Non-nil while the composer has
+    /// unsent text; restored on tab switch-back so the draft survives.
+    public var pendingChatDraft: String? = nil
 
     public init(selection: WikiSelection, title: String) {
         self.id = UUID()

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -202,6 +202,13 @@ public final class WikiStoreModel {
         didSet { if draftSystemPrompt != oldValue { isSystemPromptDirty = true } }
     }
 
+    /// Live chat composer buffer — the single source of in-flight chat text.
+    /// Stashed per-tab via `EditorTab.pendingChatDraft` (like draftTitle/draftBody
+    /// for pages) so switching tabs and back preserves unsent composer text
+    /// (issue #430). ChatView binds ComposerTextView to `$store.draftChatMessage`
+    /// instead of local @State, which would be lost on view recreation.
+    public var draftChatMessage: String = ""
+
     /// Number of concurrent agent runs (interactive sessions or one-shot
     /// `claude -p` operations) currently writing to THIS wiki. When the LAST
     /// run ends, the model reloads from the store so the sidebar reflects the
@@ -657,6 +664,17 @@ public final class WikiStoreModel {
 
     // MARK: - Chat link resolution
 
+    /// Clears the active chat tab's composer draft — both the live
+    /// `draftChatMessage` buffer and the stashed `pendingChatDraft`. Called by
+    /// `ChatView.sendMessage` after a message is sent so the text doesn't
+    /// reappear on tab switch-back (issue #430).
+    public func clearActiveChatDraft() {
+        draftChatMessage = ""
+        if let tabID = activeTabID, let i = tabs.firstIndex(where: { $0.id == tabID }) {
+            tabs[i].pendingChatDraft = nil
+        }
+    }
+
     /// Navigate to the chat with `id` from a clicked canonical
     /// `wiki://chat?id=<ULID>` link. A direct selection — no title resolution,
     /// so it is stable across renames. Returns `false` when the id names no
@@ -790,6 +808,18 @@ public final class WikiStoreModel {
            tabs[i].isEditing {
             tabs[i].pendingDraftTitle = draftTitle
             tabs[i].pendingDraftBody = draftBody
+        }
+        // Stash the outgoing chat tab's composer draft so it survives the
+        // switch-back (issue #430). Unconditional — the composer is always
+        // "drafting"; there's no edit-mode gate like the page editor.
+        if let outgoingID = activeTabID,
+           let i = tabs.firstIndex(where: { $0.id == outgoingID }) {
+            switch tabs[i].selection {
+            case .newChat, .chat:
+                tabs[i].pendingChatDraft = draftChatMessage
+            default:
+                break
+            }
         }
         isApplyingTabSelection = true
         activeTabID = id
@@ -965,6 +995,7 @@ public final class WikiStoreModel {
         // Discard any stashed draft (user chose to close without saving).
         tabs[index].pendingDraftTitle = nil
         tabs[index].pendingDraftBody = nil
+        tabs[index].pendingChatDraft = nil
         pendingCloseTabID = nil
         applyCloseTab(id: id, at: index)
     }
@@ -980,6 +1011,7 @@ public final class WikiStoreModel {
         guard let i = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         tabs[i].pendingDraftTitle = nil
         tabs[i].pendingDraftBody = nil
+        tabs[i].pendingChatDraft = nil
         loadDrafts(for: selection)
     }
 
@@ -1107,6 +1139,16 @@ public final class WikiStoreModel {
             draftBody = ""
             loadedPage = nil
             loadedPageHeadVersionID = nil
+        }
+        // Restore the incoming tab's stashed chat composer draft (issue #430).
+        // For chat tabs (.newChat/.chat) this restores unsent text; for all
+        // other tab types pendingChatDraft is nil, so the composer is cleared.
+        if let tabID = activeTabID,
+           let i = tabs.firstIndex(where: { $0.id == tabID }),
+           let pending = tabs[i].pendingChatDraft {
+            draftChatMessage = pending
+        } else {
+            draftChatMessage = ""
         }
         isDraftDirty = restoredFromPendingDraft
         isSystemPromptDirty = false

--- a/pr-430-body.md
+++ b/pr-430-body.md
@@ -1,0 +1,35 @@
+## Summary
+
+Fixes #430 — chat composer text was lost when switching tabs and back. Also closes the chat outline view on new chats by default (it should not be visible).
+
+## Changes
+
+### Composer draft persistence across tab switches (#430)
+
+The composer text lived in `@State private var draftMessage` on `ChatView`, which is recreated when the tab view is torn down on switch-back — so unsent text was lost. The fix mirrors the existing page-draft stash/restore pattern (`EditorTab.pendingDraftTitle/Body` + `WikiStoreModel.draftTitle/draftBody`):
+
+**`Sources/WikiFSCore/EditorTab.swift`**
+- New `pendingChatDraft: String?` — stashes unsent composer text per-tab (like `pendingDraftTitle`/`pendingDraftBody` for pages).
+
+**`Sources/WikiFSCore/WikiStoreModel.swift`**
+- New `draftChatMessage: String` — the live chat composer buffer (single source of in-flight text, like `draftTitle`/`draftBody`/`draftSystemPrompt`).
+- `setActiveTab(_:)` — stashes the outgoing chat tab's `draftChatMessage` into `pendingChatDraft` before switching.
+- `loadDrafts(for:)` — restores the incoming tab's stashed `pendingChatDraft` (or clears it for non-chat tabs).
+- New `clearActiveChatDraft()` — clears both the live buffer and the stash after a send (so sent text doesn't reappear on switch-back).
+- `confirmCloseTab()` / `discardPendingDraft(tabID:)` — also clear `pendingChatDraft` (mirroring the page-draft clear).
+
+**`Sources/WikiFS/ChatView.swift`**
+- Replaced `@State private var draftMessage` with `$store.draftChatMessage` binding.
+- `sendMessage()` — reads from `store.draftChatMessage`, calls `store.clearActiveChatDraft()` after extracting the message (instead of `draftMessage = ""`).
+- `hasDraftText` / `canSend` — now read `store.draftChatMessage`.
+- Omnibox pre-fill — writes to `store.draftChatMessage` instead of the local `@State`.
+
+### Close outline view on new chats by default
+
+- `@AppStorage("isChatOutlineExpanded")` → `@State private var chatOutlineExpanded = false`. The outline toggle was a persisted global — expanding it in one chat made it appear in every chat thereafter. Now each new chat view starts with the outline collapsed; the user can expand it within that view's lifetime.
+
+## Test results
+
+- `make check` — clean
+- `swift test --filter 'EditorTabTests|ChatViewD2Tests'` — 68/68 pass
+- Fast tier: 2331 tests in 195 suites, all pass


### PR DESCRIPTION
## Summary

Fixes #430 — chat composer text was lost when switching tabs and back. Also closes the chat outline view on new chats by default (it should not be visible).

## Changes

### Composer draft persistence across tab switches (#430)

The composer text lived in `@State private var draftMessage` on `ChatView`, which is recreated when the tab view is torn down on switch-back — so unsent text was lost. The fix mirrors the existing page-draft stash/restore pattern (`EditorTab.pendingDraftTitle/Body` + `WikiStoreModel.draftTitle/draftBody`):

**`Sources/WikiFSCore/EditorTab.swift`**
- New `pendingChatDraft: String?` — stashes unsent composer text per-tab (like `pendingDraftTitle`/`pendingDraftBody` for pages).

**`Sources/WikiFSCore/WikiStoreModel.swift`**
- New `draftChatMessage: String` — the live chat composer buffer (single source of in-flight text, like `draftTitle`/`draftBody`/`draftSystemPrompt`).
- `setActiveTab(_:)` — stashes the outgoing chat tab's `draftChatMessage` into `pendingChatDraft` before switching.
- `loadDrafts(for:)` — restores the incoming tab's stashed `pendingChatDraft` (or clears it for non-chat tabs).
- New `clearActiveChatDraft()` — clears both the live buffer and the stash after a send (so sent text doesn't reappear on switch-back).
- `confirmCloseTab()` / `discardPendingDraft(tabID:)` — also clear `pendingChatDraft` (mirroring the page-draft clear).

**`Sources/WikiFS/ChatView.swift`**
- Replaced `@State private var draftMessage` with `$store.draftChatMessage` binding.
- `sendMessage()` — reads from `store.draftChatMessage`, calls `store.clearActiveChatDraft()` after extracting the message (instead of `draftMessage = ""`).
- `hasDraftText` / `canSend` — now read `store.draftChatMessage`.
- Omnibox pre-fill — writes to `store.draftChatMessage` instead of the local `@State`.

### Close outline view on new chats by default

- `@AppStorage("isChatOutlineExpanded")` → `@State private var chatOutlineExpanded = false`. The outline toggle was a persisted global — expanding it in one chat made it appear in every chat thereafter. Now each new chat view starts with the outline collapsed; the user can expand it within that view's lifetime.

## Test results

- `make check` — clean
- `swift test --filter 'EditorTabTests|ChatViewD2Tests'` — 68/68 pass
- Fast tier: 2331 tests in 195 suites, all pass
