### PR TITLE
Surface agent thinking/reasoning in collapsible boxes (#391)

### DIFF
--- a/Sources/WikiFS/AgentActivityView.swift
+++ b/Sources/WikiFS/AgentActivityView.swift
@@ -121,9 +121,9 @@ private enum ActivityMetrics {
 extension AgentEvent {
     var isInternalTranscriptEvent: Bool {
         switch self {
-        case .systemInit, .toolUse, .toolResult, .subagent, .raw, .messageStop, .assistantTextDelta:
+        case .systemInit, .toolUse, .toolResult, .subagent, .raw, .messageStop, .assistantTextDelta, .thinkingDelta:
             true
-        case .userText, .assistantText, .result, .turnFailed:
+        case .userText, .assistantText, .result, .turnFailed, .thinking:
             false
         }
     }

--- a/Sources/WikiFS/ChatTranscriptView.swift
+++ b/Sources/WikiFS/ChatTranscriptView.swift
@@ -95,11 +95,13 @@ extension [AgentEvent] {
             switch event {
             case .result(_, let text):
                 return !hasAssistantText(matching: text)
-            case .toolUse:
+            case .toolUse, .thinking:
                 // A concise one-line progress summary per tool call (issue #173):
                 // lets the user see the agent reading/searching/editing without
                 // opting into the full internals view. Full raw detail still lives
                 // behind "Show internals".
+                // .thinking is surfaced as a collapsible box (issue #391) —
+                // distinct from the full internals feed.
                 return true
             case .toolResult(let isError, _):
                 // Surface failed tool calls (a useful stall/error signal); successes

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -414,14 +414,13 @@ struct ChatWebView: NSViewRepresentable {
                 return "<div class=\"row row-meta\">Started · \(escape(model))</div>"
             case .assistantText(let text):
                 return "<div class=\"row row-assistant\">\(renderedMarkdown(text, context: context, isFinal: isFinal))</div>"
+            case .thinking(let text):
+                return thinkingRowHTML(text: text, context: context, isFinal: isFinal)
             case .toolUse(let name, let summary):
-                let summaryHTML = summary.isEmpty ? "" : "<span class=\"row-tool-summary\">\(escape(summary))</span>"
-                return """
-                <div class="row row-tool"><span class="row-tool-name">\(escape(name))</span>\(summaryHTML)</div>
-                """
+                return feedToolRowHTML(name: name, summary: summary, isError: false)
             case .toolResult(let isError, let summary):
                 let body = summary.isEmpty ? (isError ? "(error)" : "(ok)") : summary
-                return "<div class=\"row row-tool-result\(isError ? " is-error" : "")\">\(escape(body))</div>"
+                return feedToolRowHTML(name: nil, summary: body, isError: isError)
             case .subagent(let subagentType, let description, let isCompletion):
                 let verb = isCompletion ? "digested" : "reading"
                 let descHTML = description.isEmpty ? "" : " — \(escape(description))"
@@ -435,8 +434,8 @@ struct ChatWebView: NSViewRepresentable {
                 return """
                 <div class="row row-result\(isError ? " is-error" : "")"><div class="row-label">\(label)</div>\(bodyHTML)</div>
                 """
-            case .messageStop, .assistantTextDelta:
-                return ""  // internal — not rendered (deltas are merged into `.assistantText` upstream)
+            case .messageStop, .assistantTextDelta, .thinkingDelta:
+                return ""  // internal — not rendered (deltas are merged upstream)
             case .turnFailed(let reason):
                 return turnFailedBannerHTML(reason: reason)
             case .raw(let line):
@@ -460,6 +459,8 @@ struct ChatWebView: NSViewRepresentable {
                 """
             case .assistantText(let text):
                 return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)
+            case .thinking(let text):
+                return thinkingRowHTML(text: text, context: context, isFinal: isFinal)
             case .result(_, let text):
                 guard !text.isEmpty else { return "" }
                 return assistantBubbleHTML(text: text, context: context, isFinal: isFinal)
@@ -470,7 +471,7 @@ struct ChatWebView: NSViewRepresentable {
                 // filtered out upstream in `ChatTranscriptView.visibleEvents`).
                 guard isError else { return "" }
                 return chatToolRowHTML(name: nil, summary: summary, isError: true)
-            case .systemInit, .subagent, .messageStop, .raw, .assistantTextDelta:
+            case .systemInit, .subagent, .messageStop, .raw, .assistantTextDelta, .thinkingDelta:
                 return ""
             case .turnFailed(let reason):
                 return turnFailedBannerHTML(reason: reason)
@@ -520,9 +521,44 @@ struct ChatWebView: NSViewRepresentable {
         private static func turnFailedBannerHTML(reason: TurnFailureReason) -> String {
             """
             <div class="row row-turn-failed">\
-            <span class="row-turn-failed-icon">⚠︎</span>\
+            <span class="row-turn-failed-icon">\u{26A0}\u{FE0E}</span>\
             <div class="row-turn-failed-body">\
             <strong>\(escape(reason.label))</strong> \(escape(reason.description))</div></div>
+            """
+        }
+
+        /// An activity-feed tool row: a collapsible `<details>` box showing the
+        /// tool name + summary in the header (collapsed), and the full text in
+        /// an expandable body. Used by both `.toolUse` and `.toolResult` in
+        /// `feedRowHTML` (the inspector/internals view) - issue #391.
+        /// `name` is nil for tool results; `summary` carries the command/output text.
+        private static func feedToolRowHTML(name: String?, summary: String, isError: Bool) -> String {
+            let nameHTML = name.map { "<span class=\"row-tool-name\">\(escape($0))</span>" } ?? ""
+            let summaryHTML = summary.isEmpty ? "" : "<span class=\"row-tool-summary\">\(escape(summary))</span>"
+            if summary.isEmpty {
+                return "<div class=\"row row-tool\(isError ? " is-error" : "")\">\(nameHTML)\(summaryHTML)</div>"
+            }
+            return """
+            <details class="row row-tool collapsible\(isError ? " is-error" : "")">\
+            <summary>\(nameHTML)\(summaryHTML)</summary>\
+            <pre class="collapsible-detail">\(escape(summary))</pre></details>
+            """
+        }
+
+        /// A collapsible, dimmed/italic "thinking" box - the agent's
+        /// chain-of-thought reasoning (issue #391). Uses a `<details>` element
+        /// so the reasoning text is hidden by default and expanded on click.
+        /// The summary shows a "Thinking" label + a truncated preview; the body
+        /// renders the full text (markdown, same as assistant prose).
+        private static func thinkingRowHTML(text: String, context: WikiRenderContext?, isFinal: Bool) -> String {
+            let preview = String(text.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false).first ?? "")
+            let previewShort = preview.count > 80 ? String(preview.prefix(80)) + "\u{2026}" : preview
+            let bodyHTML = renderedMarkdown(text, context: context, isFinal: isFinal)
+            return """
+            <details class="row row-thinking collapsible">\
+            <summary><span class="row-thinking-label">Thinking</span> \
+            <span class="row-thinking-preview">\(escape(previewShort))</span></summary>\
+            <div class="row-thinking-body">\(bodyHTML)</div></details>
             """
         }
 
@@ -630,6 +666,37 @@ struct ChatWebView: NSViewRepresentable {
           }
           .row-tool-summary { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
           .row-tool-result.is-error { color: #ff453a; }
+          .row-tool.is-error { color: #ff453a; }
+          /* Collapsible rows (issue #391): <details> elements for tool calls
+             + thinking. The summary is the visible header; the body expands
+             on click. Shared styling, distinct from chat-tool's older CSS. */
+          .collapsible > summary { list-style: none; cursor: pointer; }
+          .collapsible > summary::-webkit-details-marker { display: none; }
+          .collapsible[open] > summary::before {
+            content: "\\25BE "; opacity: 0.5;
+          }
+          .collapsible:not([open]) > summary::before {
+            content: "\\25B8 "; opacity: 0.5;
+          }
+          .collapsible-detail {
+            margin: 4px 0 0; padding: 6px 8px; font-size: 11px;
+            background: var(--code-bg); border-radius: 4px;
+            white-space: pre-wrap; word-break: break-word;
+            max-height: 300px; overflow-y: auto;
+          }
+          /* Thinking rows: dimmed + italic, visually subordinate to the
+             conversation (issue #391). */
+          .row-thinking { font-size: 11.5px; color: var(--muted); margin: 0 0 8px; }
+          .row-thinking > summary { font-style: italic; }
+          .row-thinking-label { font-weight: 600; color: var(--muted); }
+          .row-thinking-preview { opacity: 0.7; }
+          .row-thinking-body {
+            margin: 4px 0 0; padding: 6px 10px; font-style: italic;
+            font-size: 11.5px; color: var(--muted);
+            background: var(--code-bg); border-radius: 4px;
+            border-left: 2px solid var(--border);
+            max-height: 400px; overflow-y: auto;
+          }
           .row-result .row-label { font-weight: 600; font-size: 12px; color: var(--text); }
           .row-result.is-error .row-label { color: #ff453a; }
           .row-raw {

--- a/Sources/WikiFSCore/AgentEvent.swift
+++ b/Sources/WikiFSCore/AgentEvent.swift
@@ -61,6 +61,21 @@ public enum AgentEvent: Equatable, Sendable, Codable {
     /// A block of assistant prose (`assistant` message → `text` content block).
     case assistantText(String)
 
+    /// A block of agent reasoning/"thinking" — the model's chain-of-thought,
+    /// distinct from regular assistant prose. Surfaced from ACP's
+    /// `agentThoughtChunk` (issue #391) and from the CLI's `thinking` content
+    /// blocks. Rendered as a collapsible, dimmed/italic box in the transcript
+    /// so it's visible without dominating the conversation flow.
+    case thinking(String)
+
+    /// One incremental chunk of agent reasoning (`stream_event` →
+    /// `content_block_delta` → `thinking_delta`, or ACP `agentThoughtChunk`).
+    /// Never stored in `AgentLauncher.events` directly — `AgentLauncher` merges
+    /// each delta into the in-progress `.thinking` row (or starts one), mirroring
+    /// the `.assistantTextDelta` → `.assistantText` coalescing (issue #121).
+    /// Not rendered on its own; treated as internal like `.assistantTextDelta`.
+    case thinkingDelta(String)
+
     /// One incremental chunk of assistant prose (`stream_event` →
     /// `content_block_delta` → `text_delta`), emitted only when the run requests
     /// `--include-partial-messages`. Never stored in `AgentLauncher.events` directly —
@@ -130,6 +145,10 @@ public enum AgentEvent: Equatable, Sendable, Codable {
             return "Started · \(model)"
         case .assistantText(let text):
             return text
+        case .thinking(let text):
+            return "Thinking:\n\(text)"
+        case .thinkingDelta:
+            return ""  // internal — merged into `.thinking` before it's rendered
         case .assistantTextDelta:
             return ""  // internal — merged into `.assistantText` before it's rendered
         case .toolUse(let name, let inputSummary):
@@ -264,17 +283,25 @@ public enum AgentEventParser {
         }
     }
 
-    /// Map a `stream_event` envelope to a text delta. Only `content_block_delta` →
-    /// `text_delta` is modeled — other inner event kinds (`message_start`,
-    /// `content_block_start`/`_stop`, `input_json_delta` for streamed tool input,
-    /// `message_delta`) carry nothing the transcript renders, so they fall through
-    /// to `nil` same as any other unmodeled line.
+    /// Map a `stream_event` envelope to a text or thinking delta. Only
+    /// `content_block_delta` → `text_delta` and `thinking_delta` are modeled —
+    /// other inner event kinds (`message_start`, `content_block_start`/`_stop`,
+    /// `input_json_delta` for streamed tool input, `message_delta`) carry nothing
+    /// the transcript renders, so they fall through to `nil` same as any other
+    /// unmodeled line.
     private static func streamEventDelta(from envelope: Envelope) -> AgentEvent? {
         guard let inner = envelope.event, inner.type == "content_block_delta",
-              let delta = inner.delta, delta.type == "text_delta",
+              let delta = inner.delta,
               let text = delta.text, !text.isEmpty
         else { return nil }
-        return .assistantTextDelta(text)
+        switch delta.type {
+        case "text_delta":
+            return .assistantTextDelta(text)
+        case "thinking_delta":
+            return .thinkingDelta(text)
+        default:
+            return nil
+        }
     }
 
     // MARK: - Content-block mapping
@@ -290,6 +317,15 @@ public enum AgentEventParser {
                 let text = (block.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { continue }
                 return .assistantText(text)
+
+            case "thinking":
+                // The model's chain-of-thought reasoning (extended thinking /
+                // interleaved thinking). Surfaced as `.thinking` for a collapsible
+                // dimmed rendering (issue #391). `thinking` blocks carry their text
+                // in the same `text` field as regular prose.
+                let text = (block.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else { continue }
+                return .thinking(text)
 
             case "tool_use":
                 let name = block.name ?? "tool"

--- a/Sources/WikiFSCore/ChatModels.swift
+++ b/Sources/WikiFSCore/ChatModels.swift
@@ -144,10 +144,10 @@ extension AgentEvent {
     /// undecodable debug residue.
     public var isPersistable: Bool {
         switch self {
-        case .userText, .systemInit, .assistantText, .toolUse, .toolResult,
+        case .userText, .systemInit, .assistantText, .thinking, .toolUse, .toolResult,
              .subagent, .result, .turnFailed:
             return true
-        case .assistantTextDelta, .messageStop, .raw:
+        case .assistantTextDelta, .thinkingDelta, .messageStop, .raw:
             return false
         }
     }
@@ -159,11 +159,11 @@ extension AgentEvent {
         switch self {
         case .userText:
             return "user"
-        case .assistantText, .assistantTextDelta, .result:
+        case .assistantText, .assistantTextDelta, .thinking, .result:
             return "assistant"
         case .toolUse, .toolResult, .subagent:
             return "tool"
-        case .systemInit, .messageStop, .raw, .turnFailed:
+        case .systemInit, .messageStop, .raw, .turnFailed, .thinkingDelta:
             return "system"
         }
     }

--- a/Sources/WikiFSCore/ChatQuoteResolver.swift
+++ b/Sources/WikiFSCore/ChatQuoteResolver.swift
@@ -46,7 +46,7 @@ public enum ChatQuoteResolver {
             return summary.isEmpty ? name : "\(name) \(summary)"
         case .toolResult(_, let summary):
             return summary
-        case .systemInit, .subagent, .assistantTextDelta, .messageStop, .raw:
+        case .systemInit, .subagent, .assistantTextDelta, .thinking, .thinkingDelta, .messageStop, .raw:
             return ""
         case .turnFailed(let reason):
             return reason.description

--- a/Sources/WikiFSCore/ChatTranscriptRenderer.swift
+++ b/Sources/WikiFSCore/ChatTranscriptRenderer.swift
@@ -61,8 +61,10 @@ public enum ChatTranscriptRenderer {
             let header = isError ? "Failed" : "Result"
             let body = text.isEmpty ? header : text
             return (header, body)
-        case .assistantTextDelta, .messageStop, .raw:
+        case .assistantTextDelta, .thinkingDelta, .messageStop, .raw:
             return ("", "")
+        case .thinking(let text):
+            return ("Thinking", text)
         case .turnFailed(let reason):
             return ("Turn Failed", reason.description)
         }

--- a/Sources/WikiFSEngine/ACPPermissions.swift
+++ b/Sources/WikiFSEngine/ACPPermissions.swift
@@ -102,8 +102,8 @@ enum ToolCallRendering {
 ///
 /// - `agentMessageChunk(.text)` → `.assistantTextDelta` (streamed prose; the
 ///   launcher merges deltas into one `.assistantText` row, issue #121).
-/// - `agentThoughtChunk(.text)` → `.raw` (reasoning; no dedicated case yet —
-///   surfaced verbatim so nothing is swallowed, same fallback as `AgentEventParser`).
+/// - `agentThoughtChunk(.text)` → `.thinkingDelta` (streamed reasoning; the
+///   launcher merges deltas into one `.thinking` row, issue #391).
 /// - `toolCall` / `toolCallUpdate` → `.toolUse` (start) / `.toolResult` (done).
 ///   ACP folds a tool's whole lifecycle into status updates (`pending` →
 ///   `in_progress` → `completed`/`failed`); we map the *call* to `.toolUse` and
@@ -130,10 +130,12 @@ struct ACPEventTranslator: Sendable {
             return []
 
         case .agentThoughtChunk(let block):
-            // Agent reasoning. No dedicated AgentEvent; surface verbatim so the
-            // chunk isn't silently dropped (mirrors `.raw` fallback in the parser).
+            // Agent reasoning/thinking. Mapped to `.thinkingDelta` (issue #391)
+            // so the launcher can coalesce chunks into a `.thinking` row and the
+            // transcript renderer can display it as a collapsible, dimmed box —
+            // distinct from regular assistant prose and tool calls.
             if let text = Self.text(from: block), !text.isEmpty {
-                return [.raw(text)]
+                return [.thinkingDelta(text)]
             }
             return []
 

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -396,6 +396,11 @@ public final class AgentLauncher {
     /// any other event (a tool call, a turn boundary, …) so unrelated `.assistantText`
     /// rows are never merged together.
     private var isStreamingAssistantRow = false
+    /// True while the last row in `events` is an in-progress `.thinking` row
+    /// being grown by streamed `.thinkingDelta` chunks (issue #391). Mirrors
+    /// `isStreamingAssistantRow` — reset by any other event so unrelated
+    /// `.thinking` rows are never merged together.
+    private var isStreamingThinkingRow = false
     /// Append-only handle to the per-run `run.jsonl` (raw stream-json).
     private var logHandle: FileHandle?
     /// Append-only handle to the per-run `run.stderr.log`.
@@ -1980,6 +1985,7 @@ public final class AgentLauncher {
         }
         events = []
         isStreamingAssistantRow = false
+        isStreamingThinkingRow = false
         rawTranscript = ""
         stderr = ""
         exitStatus = nil
@@ -2093,9 +2099,30 @@ public final class AgentLauncher {
             }
             isStreamingAssistantRow = false
 
+        case .thinkingDelta(let delta):
+            // Streamed reasoning chunk — coalesce into the in-progress `.thinking`
+            // row, mirroring `.assistantTextDelta` → `.assistantText` (issue #391).
+            if isStreamingThinkingRow, case .thinking(let existing) = events.last {
+                events[events.count - 1] = .thinking(existing + delta)
+            } else {
+                events.append(.thinking(delta))
+                isStreamingThinkingRow = true
+            }
+
+        case .thinking:
+            // The complete/final thought text for a block already being streamed —
+            // replace with the authoritative full text. Mirrors `.assistantText`.
+            if isStreamingThinkingRow, case .thinking = events.last {
+                events[events.count - 1] = event
+            } else {
+                events.append(event)
+            }
+            isStreamingThinkingRow = false
+
         default:
             events.append(event)
             isStreamingAssistantRow = false
+            isStreamingThinkingRow = false
         }
     }
 
@@ -2192,6 +2219,7 @@ public final class AgentLauncher {
         watchdogHasEscalated = false
         events = []
         isStreamingAssistantRow = false
+        isStreamingThinkingRow = false
         rawTranscript = ""
         stderr = ""
         exitStatus = nil

--- a/Tests/WikiFSTests/ACPBackendTests.swift
+++ b/Tests/WikiFSTests/ACPBackendTests.swift
@@ -38,13 +38,13 @@ import ACPModel
         #expect(translator.translate(update) == [])
     }
 
-    /// Agent reasoning (thought chunks) surfaces verbatim as `.raw` so it isn't
-    /// silently dropped (no dedicated `AgentEvent` case yet).
-    @Test func agentThoughtChunkSurfacesAsRaw() {
+    /// Agent reasoning (thought chunks) maps to `.thinkingDelta` so the launcher
+    /// can coalesce chunks into a `.thinking` row (issue #391).
+    @Test func agentThoughtChunkMapsToThinkingDelta() {
         let translator = ACPEventTranslator()
-        let update = SessionUpdate.agentThoughtChunk(.text(TextContent(text: "Considering options…")))
+        let update = SessionUpdate.agentThoughtChunk(.text(TextContent(text: "Considering options\u{2026}")))
         let events = translator.translate(update)
-        #expect(events == [.raw("Considering options…")])
+        #expect(events == [.thinkingDelta("Considering options\u{2026}")])
     }
 
     /// A tool invocation (`tool_call`) with `kind: .execute` + `rawInput`

--- a/Tests/WikiFSTests/AgentEventCodableTests.swift
+++ b/Tests/WikiFSTests/AgentEventCodableTests.swift
@@ -35,6 +35,16 @@ import Foundation
         #expect(try roundTrip(event) == event)
     }
 
+    @Test func thinkingRoundTrips() throws {
+        let event = AgentEvent.thinking("Let me reason about this\u{2026}")
+        #expect(try roundTrip(event) == event)
+    }
+
+    @Test func thinkingDeltaRoundTrips() throws {
+        let event = AgentEvent.thinkingDelta("partial thought")
+        #expect(try roundTrip(event) == event)
+    }
+
     @Test func toolUseRoundTrips() throws {
         let event = AgentEvent.toolUse(name: "Bash", inputSummary: "wikictl page upsert --title \"X\"")
         #expect(try roundTrip(event) == event)

--- a/Tests/WikiFSTests/AgentEventParserTests.swift
+++ b/Tests/WikiFSTests/AgentEventParserTests.swift
@@ -29,6 +29,16 @@ struct AgentEventParserTests {
         #expect(AgentEventParser.parse(line: line) == .assistantText("I'll run that command."))
     }
 
+    @Test func assistantThinkingBlockBecomesThinking() {
+        let line = #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","text":"Considering the best approach…"}]}}"#
+        #expect(AgentEventParser.parse(line: line) == .thinking("Considering the best approach…"))
+    }
+
+    @Test func emptyThinkingBlockIsSkipped() {
+        let line = #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","text":"  "}]}}"#
+        #expect(AgentEventParser.parse(line: line) == nil)
+    }
+
     @Test func assistantToolUseBlockSummarizesBashCommand() {
         let line = #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"echo hello from wikifs","description":"Print hello"}}]}}"#
         #expect(
@@ -130,6 +140,16 @@ struct AgentEventParserTests {
     @Test func contentBlockTextDeltaBecomesAssistantTextDelta() {
         let line = #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"he"}}}"#
         #expect(AgentEventParser.parse(line: line) == .assistantTextDelta("he"))
+    }
+
+    @Test func thinkingDeltaStreamEventBecomesThinkingDelta() {
+        let line = #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"thinking_delta","text":"reasoning"}}}"#
+        #expect(AgentEventParser.parse(line: line) == .thinkingDelta("reasoning"))
+    }
+
+    @Test func emptyThinkingDeltaIsSkipped() {
+        let line = #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"thinking_delta","text":""}}}"#
+        #expect(AgentEventParser.parse(line: line) == nil)
     }
 
     @Test func emptyTextDeltaIsSkipped() {

--- a/Tests/WikiFSTests/ChatTranscriptFilterTests.swift
+++ b/Tests/WikiFSTests/ChatTranscriptFilterTests.swift
@@ -69,6 +69,18 @@ struct ChatTranscriptFilterTests {
         #expect(events.transcriptVisible.isEmpty)
     }
 
+    @Test func thinkingDeltaIsDropped() {
+        let events: [AgentEvent] = [.thinkingDelta("partial thought")]
+        #expect(events.transcriptVisible.isEmpty)
+    }
+
+    @Test func thinkingIsVisible() {
+        // .thinking is surfaced as a collapsible box (issue #391) — visible in
+        // the transcript, distinct from .raw (which is debug residue).
+        let events: [AgentEvent] = [.thinking("Considering options\u{2026}")]
+        #expect(events.transcriptVisible == events)
+    }
+
     @Test func rawIsDropped() {
         let events: [AgentEvent] = [.raw("{\"type\":\"unknown\"}")]
         #expect(events.transcriptVisible.isEmpty)

--- a/Tests/WikiFSTests/ChatTranscriptRendererTests.swift
+++ b/Tests/WikiFSTests/ChatTranscriptRendererTests.swift
@@ -114,4 +114,23 @@ import WikiFSCore
         #expect(sectionHeaders.count == 1)
         #expect(sectionHeaders.first == "## User")
     }
+
+    @Test func thinkingRendersAsThinkingSection() {
+        let rendered = ChatTranscriptRenderer.render(
+            summary: summary(messageCount: 1),
+            messages: [
+                message(.thinking("Let me reason about this"), seq: 0),
+            ])
+        #expect(rendered.contains("## Thinking\n\nLet me reason about this") == true)
+    }
+
+    @Test func thinkingDeltaIsSkipped() {
+        let rendered = ChatTranscriptRenderer.render(
+            summary: summary(messageCount: 1),
+            messages: [
+                message(.thinkingDelta("partial"), seq: 0),
+            ])
+        let sectionHeaders = rendered.split(separator: "\n").filter { $0.hasPrefix("## ") }
+        #expect(sectionHeaders.count == 0)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #391 — surfaces agent thinking/reasoning in the chat transcript, and makes both thinking and tool calls render as collapsible boxes so detail is hidden until expanded.

## Changes

### New `AgentEvent` cases
- `.thinking(String)` — accumulated thought text (chain-of-thought reasoning)
- `.thinkingDelta(String)` — streamed chunk, coalesced into `.thinking` by the launcher (mirrors `.assistantTextDelta` → `.assistantText`)

### Protocol plumbing
- **ACP translator**: `.agentThoughtChunk` → `.thinkingDelta` (was `.raw`)
- **CLI parser**: `thinking` content blocks → `.thinking`, `thinking_delta` stream events → `.thinkingDelta`
- **AgentLauncher**: `mergeOrAppend` coalesces `.thinkingDelta` into `.thinking` + tracks `isStreamingThinkingRow`

### Collapsible UI (ChatWebView)
- **Thinking**: rendered as a `<details>` box with dimmed/italic styling, "Thinking" label + truncated preview in the summary, full markdown body when expanded
- **Tool calls (feed style)**: `toolUse` and `toolResult` now render as collapsible `<details>` with the summary as header and full text in an expandable body
- CSS: shared `.collapsible` styling (▸/▾ disclosure markers) + dedicated `.row-thinking` styles

### All switch sites updated
- `AgentActivityView.isInternalTranscriptEvent`: `.thinking` visible, `.thinkingDelta` internal
- `ChatTranscriptView.transcriptVisible`: `.thinking` passes the filter
- `ChatModels`: `.thinking` persistable + assistant role; `.thinkingDelta` not persistable
- `ChatTranscriptRenderer`: `.thinking` → "Thinking" section; `.thinkingDelta` skipped
- `ChatQuoteResolver`: both return empty searchable text

## Testing
- `agentThoughtChunkMapsToThinkingDelta` (translator, updated from `.raw`)
- `thinkingRoundTrips` / `thinkingDeltaRoundTrips` (Codable)
- `assistantThinkingBlockBecomesThinking` / `emptyThinkingBlockIsSkipped` (CLI parser)
- `thinkingDeltaStreamEventBecomesThinkingDelta` / `emptyThinkingDeltaIsSkipped` (stream parser)
- `thinkingIsVisible` / `thinkingDeltaIsDropped` (transcript filter)
- `thinkingRendersAsThinkingSection` / `thinkingDeltaIsSkipped` (renderer)
- Full fast test tier: **2341 tests passed**
