### PR TITLE
feat: chat composer — add-context picker, layout polish, flush diagnostics

### DIFF
--- a/Sources/WikiFS/AddContextPicker.swift
+++ b/Sources/WikiFS/AddContextPicker.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+import WikiFSCore
+
+/// The composer's "+" add-context button: a compact chip that opens a native
+/// popover with a search field over a flat list of the wiki's pages, sources,
+/// and chats. Selecting a row attaches it as context for the next message —
+/// the click-to-add counterpart to the sidebar drag-and-drop path (issue #385).
+///
+/// Modeled on `ProviderSelector` / `PermissionModeSelector` so it reads as a
+/// sibling chip in the composer toolbar: a glyph trigger, a searchable popover,
+/// hover-highlighted rows. It emits a `SidebarDragPayload` (the app's existing
+/// attach currency) via `onAdd`, so `ChatView` builds the `ChatAttachment` with
+/// the same code that a sidebar drop uses.
+struct AddContextPicker: View {
+    @Bindable var store: WikiStoreModel
+    /// Called with the selected item's payload. The composer turns it into a
+    /// `ChatAttachment` and appends it (de-duplicating).
+    let onAdd: (SidebarDragPayload) -> Void
+
+    @State private var isPresented = false
+    @State private var searchText = ""
+    @State private var hoveredID: String?
+
+    /// Cap the unfiltered list so a large wiki doesn't render thousands of rows
+    /// before the user has typed anything to narrow it.
+    private static let unfilteredLimit = 50
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            Image(systemName: "plus")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .popover(isPresented: $isPresented, arrowEdge: .top) {
+            popoverContent
+        }
+        .help("Add a page, source, or chat as context")
+    }
+
+    // MARK: - Row model
+
+    private struct Item: Identifiable {
+        let kind: SidebarDragPayload.Kind
+        let itemID: String
+        let name: String
+
+        var id: String { "\(kind.rawValue):\(itemID)" }
+
+        var glyph: String {
+            switch kind {
+            case .page:   return "doc.text"
+            case .source: return "doc"
+            case .chat:   return "bubble.left.and.bubble.right"
+            }
+        }
+
+        var kindLabel: String {
+            switch kind {
+            case .page:   return "Page"
+            case .source: return "Source"
+            case .chat:   return "Chat"
+            }
+        }
+
+        var payload: SidebarDragPayload {
+            SidebarDragPayload(kind: kind, id: itemID)
+        }
+    }
+
+    /// Every attachable item in the wiki (pages + sources + chats), unfiltered.
+    private var allItems: [Item] {
+        let pages = store.summaries.map {
+            Item(kind: .page, itemID: $0.id.rawValue, name: $0.title)
+        }
+        let sources = store.sources
+            .filter(\.isPrimary)
+            .map { Item(kind: .source, itemID: $0.id.rawValue, name: $0.effectiveName) }
+        let chats = store.chats.map {
+            Item(kind: .chat, itemID: $0.id.rawValue, name: $0.title)
+        }
+        return pages + sources + chats
+    }
+
+    /// Items after the search filter. Empty query shows a capped prefix so the
+    /// popover stays snappy; a query matches on the display name.
+    private var filteredItems: [Item] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return Array(allItems.prefix(Self.unfilteredLimit)) }
+        return allItems.filter { $0.name.lowercased().contains(query) }
+    }
+
+    // MARK: - Popover
+
+    private var popoverContent: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            itemList
+        }
+        .frame(width: 320)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .imageScale(.small)
+                .foregroundStyle(.tertiary)
+            TextField("Search pages, sources, and chats", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    private var itemList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                if filteredItems.isEmpty {
+                    Text("No matches")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 12)
+                } else {
+                    ForEach(filteredItems) { item in
+                        row(item)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .frame(height: listHeight)
+    }
+
+    /// Hug the rows up to a cap so a short list makes a short popover.
+    private var listHeight: CGFloat {
+        let rowHeight: CGFloat = 34
+        let count = max(filteredItems.count, 1)
+        return min(CGFloat(count) * rowHeight + 8, 360)
+    }
+
+    private func row(_ item: Item) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: item.glyph)
+                .frame(width: 16)
+                .foregroundStyle(Color.blue)
+            Text(item.name)
+                .font(.system(size: 13))
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            Text(item.kindLabel)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(hoveredID == item.id ? Color.primary.opacity(0.08) : .clear)
+                .padding(.horizontal, 4)
+        )
+        .onHover { inside in
+            if inside { hoveredID = item.id } else if hoveredID == item.id { hoveredID = nil }
+        }
+        .onTapGesture { select(item) }
+    }
+
+    private func select(_ item: Item) {
+        onAdd(item.payload)
+        isPresented = false
+        searchText = ""
+    }
+}

--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -340,22 +340,22 @@ struct ChatView: View {
                         hideToolCalls: hideToolCalls
                     )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .padding(.horizontal, PageEditorMetrics.contentInset)
+                        .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                         .padding(.top, chatSummary != nil ? 0 : ChatMetrics.chatTopInset)
                     if transcriptIsRunning && launcher.isGenerating {
                         thinkingIndicator
-                            .padding(.horizontal, PageEditorMetrics.contentInset)
+                            .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                             .padding(.bottom, ChatMetrics.sectionSpacing / 2)
                     }
                     if let pending = livePendingPermission {
                         PermissionApprovalView(permission: pending) { optionId in
                             Task { await launcher.resolvePendingPermission(optionId: optionId) }
                         }
-                        .padding(.horizontal, PageEditorMetrics.contentInset)
+                        .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                         .padding(.bottom, ChatMetrics.sectionSpacing / 2)
                     }
                     chatComposer
-                        .padding(.horizontal, PageEditorMetrics.contentInset)
+                        .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                         .padding(.top, ChatMetrics.sectionSpacing)
                         .padding(.bottom, ChatMetrics.contentInset)
                 }
@@ -386,6 +386,15 @@ struct ChatView: View {
     @ViewBuilder
     private func composerToolbar(sendActive: Bool) -> some View {
         HStack(spacing: 10) {
+            // Click-to-add context: a "+" that opens a searchable picker of the
+            // wiki's pages/sources/chats. Selecting one attaches it as context
+            // (same currency as the sidebar drag-and-drop path, issue #385).
+            AddContextPicker(store: store) { payload in
+                let attachment = ChatAttachment(payload: payload, store: store)
+                if !attachments.contains(attachment) {
+                    attachments.append(attachment)
+                }
+            }
             // Inside ContentView the session is always non-nil (a wiki is
             // open), so the provider/model chips are always shown.
             ProviderSelector(launcher: launcher)
@@ -584,13 +593,13 @@ struct ChatView: View {
         .padding(.top, ChatMetrics.composerTopPadding)
         .padding(.bottom, ChatMetrics.composerBottomPadding)
         .background(
-            Color(nsColor: .controlBackgroundColor),
+            Color(nsColor: .textBackgroundColor),
             in: RoundedRectangle(cornerRadius: ChatMetrics.composerCornerRadius, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: ChatMetrics.composerCornerRadius, style: .continuous)
-                .strokeBorder(Color(nsColor: .separatorColor).opacity(0.55), lineWidth: 1)
+                .strokeBorder(Color(nsColor: .separatorColor).opacity(0.9), lineWidth: 1.5)
         }
-        .shadow(color: Color.black.opacity(0.06), radius: 18, x: 0, y: 8)
+        .shadow(color: Color.black.opacity(0.10), radius: 20, x: 0, y: 8)
         .frame(maxWidth: .infinity)
         // Accept sidebar drags anywhere in the composer box. This is the
         // innermost drop target for SidebarDragPayloadList — it intercepts the
@@ -623,7 +632,7 @@ struct ChatView: View {
     private var stopButton: some View {
         Button(action: { launcher.stopAgent() }) {
             Image(systemName: "stop.circle.fill")
-                .font(.system(size: 15, weight: .bold))
+                .font(.system(size: 17, weight: .bold))
                 .foregroundStyle(.white)
                 .frame(width: ChatMetrics.sendButtonSize, height: ChatMetrics.sendButtonSize)
                 .background(Color.red.opacity(0.85), in: Circle())
@@ -638,7 +647,7 @@ struct ChatView: View {
     private func sendButton(active: Bool) -> some View {
         Button(action: sendMessage) {
             Image(systemName: "arrow.up")
-                .font(.system(size: 15, weight: .bold))
+                .font(.system(size: 17, weight: .bold))
                 .foregroundStyle(.white)
                 .frame(width: ChatMetrics.sendButtonSize, height: ChatMetrics.sendButtonSize)
                 .background(sendButtonBackground(active: active), in: Circle())
@@ -914,20 +923,24 @@ enum ChatMetrics {
     static let debugTopInset: CGFloat = 18
     static let controlsBandHeight: CGFloat = 28
     static let chatTopInset: CGFloat = 56
+    /// Extra horizontal breathing room added to the transcript + composer on
+    /// top of `PageEditorMetrics.contentInset`, so the chat content (numbered
+    /// lists especially) sits well clear of the window edges.
+    static let extraHorizontalMargin: CGFloat = 18
     /// Horizontal inset of the composer box's contents (paseo-style). Also the
     /// effective left margin for the text, since `ComposerTextView` uses zero
     /// line-fragment padding.
-    static let composerHorizontalPadding: CGFloat = 16
+    static let composerHorizontalPadding: CGFloat = 18
     /// Top inset above the text inside the composer box.
-    static let composerTopPadding: CGFloat = 12
+    static let composerTopPadding: CGFloat = 14
     /// Bottom inset below the toolbar row inside the composer box.
-    static let composerBottomPadding: CGFloat = 10
+    static let composerBottomPadding: CGFloat = 12
     /// Vertical gap between the text and the toolbar row inside the box.
-    static let composerRowSpacing: CGFloat = 8
+    static let composerRowSpacing: CGFloat = 10
     /// Corner radius of the unified composer box (paseo uses a soft rounded
     /// rectangle, not a full pill).
-    static let composerCornerRadius: CGFloat = 16
-    static let sendButtonSize: CGFloat = 30
+    static let composerCornerRadius: CGFloat = 18
+    static let sendButtonSize: CGFloat = 34
     /// Font for `ComposerTextView` — matches the previous `TextField`'s
     /// `.font(.body)`, expressed as an `NSFont` since the composer is
     /// AppKit-backed.

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -617,6 +617,10 @@ struct ChatWebView: NSViewRepresentable {
             font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
             font-size: 13px; line-height: 1.5; color: var(--text);
             padding: 10px 0; -webkit-font-smoothing: antialiased;
+            /* Never let content exceed the web view's width — long tokens/URLs
+               in list items and paragraphs wrap instead of clipping off the
+               right edge or pushing list markers off the left. */
+            overflow-wrap: break-word; word-wrap: break-word;
           }
           .row { margin: 0 0 8px; }
           .row-label { font-size: 11px; font-weight: 600; color: var(--muted); margin-bottom: 2px; }
@@ -712,8 +716,10 @@ struct ChatWebView: NSViewRepresentable {
             background: var(--code-bg); border-radius: 6px; overflow: auto;
           }
           pre code { background: none; padding: 0; font-size: 0.9em; }
-          ul, ol { padding-left: 1.4em; margin: 0 0 0.6em; }
-          li { margin: 0.1em 0; }
+          /* Slightly larger left padding so multi-digit markers ("10.") sit
+             fully inside the content box and never clip off the left edge. */
+          ul, ol { padding-left: 1.8em; margin: 0 0 0.6em; }
+          li { margin: 0.1em 0; overflow-wrap: break-word; word-wrap: break-word; }
           blockquote {
             margin: 0 0 0.6em; padding: 0 0 0 0.8em;
             border-left: 3px solid var(--border); color: var(--muted);

--- a/Sources/WikiFS/PermissionModeSelector.swift
+++ b/Sources/WikiFS/PermissionModeSelector.swift
@@ -52,7 +52,7 @@ struct PermissionModeSelector: View {
                 .imageScale(.small)
                 .foregroundStyle(.tertiary)
         }
-        .font(.caption)
+        .font(.callout)
         .contentShape(Rectangle())
     }
 

--- a/Sources/WikiFS/ProviderSelector.swift
+++ b/Sources/WikiFS/ProviderSelector.swift
@@ -325,7 +325,7 @@ struct ProviderSelector: View {
                 .imageScale(.small)
                 .foregroundStyle(.tertiary)
         }
-        .font(.caption)
+        .font(.callout)
         .contentShape(Rectangle())
     }
 

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -2050,6 +2050,30 @@ public final class AgentLauncher {
         guard persistedEventCount < events.count else { return }
         let tail = Self.unflushedTail(events: events, persistedCount: persistedEventCount)
         persistedEventCount = events.count
+        // Diagnostic (issue: "page attached → no response"): summarize what the
+        // turn actually produced so a repro tells us empty/tool-only vs. a live
+        // render bug. Logs the tail's event-kind histogram + total assistant
+        // text length.
+        var kinds: [String: Int] = [:]
+        var assistantChars = 0
+        for e in tail {
+            let k: String
+            switch e {
+            case .userText: k = "userText"
+            case .assistantText(let t): k = "assistantText"; assistantChars += t.count
+            case .assistantTextDelta: k = "assistantTextDelta"
+            case .toolUse: k = "toolUse"
+            case .toolResult: k = "toolResult"
+            case .subagent: k = "subagent"
+            case .result(_, let t): k = "result"; assistantChars += t.count
+            case .systemInit: k = "systemInit"
+            case .messageStop: k = "messageStop"
+            case .turnFailed: k = "turnFailed"
+            case .raw: k = "raw"
+            }
+            kinds[k, default: 0] += 1
+        }
+        DebugLog.agent("flushTranscript: tail=\(tail.count) assistantChars=\(assistantChars) kinds=\(kinds)")
         transcriptSink?(tail)
     }
 


### PR DESCRIPTION
## Summary

Chat composer UX improvements: more readable transcript margins, a more prominent composer with larger controls, and a new **"+" add-context picker** for attaching pages/sources/chats by search. Also adds a small transcript-flush diagnostic to aid future "no response" triage.

## Changes

### Composer & transcript layout
- **Numbered lists no longer clip off the sides.** Added `overflow-wrap`/`word-wrap` to the transcript body and list items, and widened `ol`/`ul` left padding so multi-digit markers ("10.") sit fully inside the content box.
- **More margin around the chat window** via a new `ChatMetrics.extraHorizontalMargin`, applied to the transcript, thinking indicator, permission view, and composer.
- **More visible composer + bigger buttons** (paseo parity): brighter box fill, stronger border/shadow, larger corner radius and internal padding, bigger send/stop glyphs, and larger provider/permission chip fonts.

### "+" add-context picker (new)
- New `AddContextPicker.swift`: a "+" chip in the composer toolbar that opens a native popover with a search field over a flat, filterable list of the wiki's **pages, sources, and chats** (glyph + name + kind badge, hover highlight).
- Selecting a row attaches it as context via the existing `SidebarDragPayload` → `ChatAttachment` path — the click-to-add counterpart to sidebar drag-and-drop (issue #385). Empty query shows a capped prefix; typing filters by name.

### Diagnostics
- `AgentLauncher.flushTranscript` now logs the per-turn assistant-text length + event-kind histogram (`assistantChars=… kinds=[…]`). Useful for triaging "spinner, no response" reports — a page-attached turn logging `assistantChars=0` with only `toolResult` errors is the mount-read-failure signature (see #441).

## Verification

Built and driven live (computer-use) on the installed app: the "+" picker, search filtering, attachment chip, wikilink-rendered user message, and full agent response all work end-to-end. Rebased onto `main`; contains exactly two commits (composer/picker, diagnostics).

## Notes
- Scoped narrowly to the composer/transcript. The mount → `wikictl` read-path refactor is tracked separately in #441.
