### PR TITLE
Add confirm-before-quit dialog with pending save flush

### DIFF
--- a/Sources/WikiFS/GeneralSettingsView.swift
+++ b/Sources/WikiFS/GeneralSettingsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Settings → General tab: app-level toggles that don't fit a domain tab.
+///
+/// Currently hosts the "Confirm before quitting" toggle (key
+/// `confirmBeforeQuitting`, default on). When enabled, a dialog asks the user
+/// to confirm before the app terminates — catching ⌘Q / Apple menu Quit / Dock
+/// Quit / system shutdown.
+struct GeneralSettingsView: View {
+    @AppStorage(QuitConfirmationDelegate.confirmQuitKey)
+    private var confirmBeforeQuitting = true
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Ask before quitting", isOn: $confirmBeforeQuitting)
+                    .help(
+                        "When enabled, Self Driving Wiki asks for confirmation "
+                        + "before quitting — ⌘Q, or closing the last window with ⌘W."
+                    )
+            } header: {
+                Text("Quitting")
+            } footer: {
+                Text(
+                    "You can always quit immediately by choosing "
+                    + "\"Quit\" in the confirmation dialog, or by turning this off."
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+#Preview {
+    GeneralSettingsView()
+        .frame(width: 460, height: 460)
+}

--- a/Sources/WikiFS/QuitConfirmationDelegate.swift
+++ b/Sources/WikiFS/QuitConfirmationDelegate.swift
@@ -18,6 +18,9 @@ import WikiFSEngine
 ///
 /// The confirmation can be toggled in Settings → General (key
 /// `confirmBeforeQuitting`, default **on** so the feature works out of the box).
+/// However, even when the setting is **off**, the app still asks for
+/// confirmation if an extraction, ingestion, or agent operation is in flight —
+/// silent termination during active work could lose data.
 final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Injected dependencies
@@ -26,9 +29,14 @@ final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
     /// Wired in `WikiFSApp.init` after the manager is created.
     var flushPendingSaves: (() -> Void)?
 
-    /// Returns whether any agent (ingest or chat) is actively running. The quit
-    /// dialog message is tailored when operations are in flight.
-    var isAnyAgentRunning: (() -> Bool)?
+    /// Returns a human-readable description of any operation in flight (PDF
+    /// extraction, source ingestion, or an agent run), or `nil` when the app
+    /// is idle. The quit dialog message is tailored based on what's running.
+    ///
+    /// This covers operations that `isRunning` alone misses: `isExtracting`
+    /// (the PDF→Markdown phase before the agent process spawns) and
+    /// non-empty `ingestingSourceIDs` (an agent-phase ingest in progress).
+    var activeOperationDescription: (() -> String?)?
 
     // MARK: - Settings key
 
@@ -50,17 +58,23 @@ final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
         // Flush pending saves regardless — don't lose buffered edits on quit.
         flushPendingSaves?()
 
-        guard Self.confirmBeforeQuitting else {
+        let activeOp = activeOperationDescription?()
+
+        // If nothing is running AND the user has disabled confirm-before-quit,
+        // quit now without a dialog.
+        guard activeOp != nil || Self.confirmBeforeQuitting else {
             return .terminateNow
         }
 
+        // Either the user wants confirmation, or there's active work we
+        // shouldn't interrupt silently — show the dialog in both cases.
         let alert = NSAlert()
         alert.alertStyle = .warning
 
-        if isAnyAgentRunning?() == true {
+        if let description = activeOp {
             alert.messageText = "Quit Self Driving Wiki?"
             alert.informativeText =
-                "An agent operation is still running and will be cancelled. "
+                "\(description) is still running and will be cancelled. "
                 + "Are you sure you want to quit?"
         } else {
             alert.messageText = "Quit Self Driving Wiki?"
@@ -110,9 +124,10 @@ final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
     /// `confirmBeforeQuitting` setting) is deliberate: it only steers the
     /// *last*-window-close case into the termination flow; whether the user is
     /// actually asked, or the app quits immediately, is decided in
-    /// `applicationShouldTerminate` based on the setting. With the setting off,
-    /// the last window close quits the app right away (no dialog); with it on,
-    /// the dialog appears.
+    /// `applicationShouldTerminate` based on the setting (and whether any work
+    /// is in flight). With the setting off and nothing running, the last
+    /// window close quits the app right away (no dialog); with it on, the
+    /// dialog appears. If work is in flight, the dialog appears regardless.
     func applicationShouldTerminateAfterLastWindowClosed(
         _ sender: NSApplication
     ) -> Bool {

--- a/Sources/WikiFS/QuitConfirmationDelegate.swift
+++ b/Sources/WikiFS/QuitConfirmationDelegate.swift
@@ -1,0 +1,121 @@
+import AppKit
+import WikiFSEngine
+
+/// Application delegate that intercepts termination to show a "confirm to quit"
+/// dialog, then flushes pending autosaves before the app actually exits.
+///
+/// Implements `applicationShouldTerminate(_:)` returning `.terminateLater` so the
+/// system pauses termination while we present an `NSAlert`, then we call
+/// `NSApp.reply(toApplicationShouldTerminate:)` with the user's choice. This
+/// catches **all** termination paths: ⌘Q, Apple menu Quit, Dock Quit, and system
+/// shutdown — not just the menu item.
+///
+/// Additionally implements `applicationShouldTerminateAfterLastWindowClosed(_:)`
+/// returning `true`, so closing the final window — e.g. pressing ⌘W repeatedly
+/// until no windows remain — routes through `applicationShouldTerminate`,
+/// triggering the same confirmation dialog. This is the "⌘W too many times"
+/// guardrail: the app won't silently vanish behind a flurry of window closes.
+///
+/// The confirmation can be toggled in Settings → General (key
+/// `confirmBeforeQuitting`, default **on** so the feature works out of the box).
+final class QuitConfirmationDelegate: NSObject, NSApplicationDelegate {
+
+    // MARK: - Injected dependencies
+
+    /// Called before the app terminates so the model can flush buffered edits.
+    /// Wired in `WikiFSApp.init` after the manager is created.
+    var flushPendingSaves: (() -> Void)?
+
+    /// Returns whether any agent (ingest or chat) is actively running. The quit
+    /// dialog message is tailored when operations are in flight.
+    var isAnyAgentRunning: (() -> Bool)?
+
+    // MARK: - Settings key
+
+    static let confirmQuitKey = "confirmBeforeQuitting"
+
+    /// `@AppStorage` doesn't exist in this non-SwiftUI context, but the default
+    /// is "ask" (true) when the key is unset — matching the feature's purpose.
+    static var confirmBeforeQuitting: Bool {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: confirmQuitKey) != nil else { return true }
+        return defaults.bool(forKey: confirmQuitKey)
+    }
+
+    // MARK: - Termination
+
+    func applicationShouldTerminate(
+        _ sender: NSApplication
+    ) -> NSApplication.TerminateReply {
+        // Flush pending saves regardless — don't lose buffered edits on quit.
+        flushPendingSaves?()
+
+        guard Self.confirmBeforeQuitting else {
+            return .terminateNow
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+
+        if isAnyAgentRunning?() == true {
+            alert.messageText = "Quit Self Driving Wiki?"
+            alert.informativeText =
+                "An agent operation is still running and will be cancelled. "
+                + "Are you sure you want to quit?"
+        } else {
+            alert.messageText = "Quit Self Driving Wiki?"
+            alert.informativeText = "Are you sure you want to quit?"
+        }
+
+        let quitButton = alert.addButton(withTitle: "Quit")
+        alert.addButton(withTitle: "Cancel")
+        quitButton.hasDestructiveAction = true
+        quitButton.keyEquivalent = "\r"    // Return → default (Quit)
+        // Make Cancel the escape-equivalent so ⎋ dismisses without quitting.
+        alert.buttons.last?.keyEquivalent = "\u{1b}"
+
+        // Present as a sheet on the current key window when possible; fall back
+        // to a modal dialog when no window is available (e.g. all windows
+        // closed but app still active).
+        if let window = sender.windows.first(
+            where: { $0.isVisible && $0.canBecomeKey }
+        ) {
+            alert.beginSheetModal(for: window) { response in
+                NSApp.reply(
+                    toApplicationShouldTerminate:
+                        response == .alertFirstButtonReturn
+                )
+            }
+        } else {
+            let response = alert.runModal()
+            NSApp.reply(
+                toApplicationShouldTerminate:
+                    response == .alertFirstButtonReturn
+            )
+        }
+
+        // We've deferred the decision to the alert callback.
+        return .terminateLater
+    }
+
+    // MARK: - Last window closed
+
+    /// Asking `true` here makes closing the **last** remaining window (⌘W, the
+    /// close button, or the Window → Close menu item) route through
+    /// `applicationShouldTerminate(_:)`. That's the path that presents the
+    /// confirm-on-quit dialog — so "⌘W too many times" no longer silently
+    /// dismisses the app.
+    ///
+    /// Returning `true` unconditionally (independent of the
+    /// `confirmBeforeQuitting` setting) is deliberate: it only steers the
+    /// *last*-window-close case into the termination flow; whether the user is
+    /// actually asked, or the app quits immediately, is decided in
+    /// `applicationShouldTerminate` based on the setting. With the setting off,
+    /// the last window close quits the app right away (no dialog); with it on,
+    /// the dialog appears.
+    func applicationShouldTerminateAfterLastWindowClosed(
+        _ sender: NSApplication
+    ) -> Bool {
+        return true
+    }
+}

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -139,13 +139,27 @@ struct WikiFSApp: App {
         }
 
         // Wire the quit-confirmation delegate's closures. Flush pending autosaves
-        // (don't lose buffered edits), and report whether any agent is running so
-        // the quit dialog message is tailored when operations are in flight.
+        // (don't lose buffered edits), and report any active operation (extraction,
+        // ingestion, agent run) so the quit dialog message is tailored and the app
+        // won't silently quit mid-work even with the setting off.
         quitDelegate.flushPendingSaves = { [weak manager] in
             manager?.activeStore?.flushPendingSaves()
         }
-        quitDelegate.isAnyAgentRunning = { [weak agentLauncher, weak chatLauncher] in
-            agentLauncher?.isRunning == true || chatLauncher?.isRunning == true
+        quitDelegate.activeOperationDescription = { [weak agentLauncher, weak chatLauncher] in
+            if agentLauncher?.isExtracting == true
+                || chatLauncher?.isExtracting == true {
+                return "A PDF extraction"
+            }
+            if !(agentLauncher?.ingestingSourceIDs.isEmpty ?? true) {
+                return "A source ingestion"
+            }
+            if agentLauncher?.isRunning == true {
+                return "An agent operation"
+            }
+            if chatLauncher?.isRunning == true {
+                return "A chat session"
+            }
+            return nil
         }
     }
 

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -40,6 +40,13 @@ struct WikiFSApp: App {
     @State private var isSceneActive = false
     @Environment(\.scenePhase) private var scenePhase
 
+    /// App delegate that intercepts termination to show a "confirm to quit"
+    /// dialog (toggleable in Settings → General). Catches all quit paths:
+    /// ⌘Q, Apple menu, Dock, and system shutdown.
+    @NSApplicationDelegateAdaptor(
+        QuitConfirmationDelegate.self
+    ) private var quitDelegate
+
     init() {
         // Migrate the renamed chat-zoom @AppStorage key before any ChatView reads
         // it. Idempotent: copies `conversation.zoom` → `chat.zoom` only when the
@@ -129,6 +136,16 @@ struct WikiFSApp: App {
             DebugLog.store("wikid: SMAppService registered, status=\(daemonService.status.rawValue)")
         } catch {
             DebugLog.store("wikid: SMAppService registration failed (expected in dev mode): \(error)")
+        }
+
+        // Wire the quit-confirmation delegate's closures. Flush pending autosaves
+        // (don't lose buffered edits), and report whether any agent is running so
+        // the quit dialog message is tailored when operations are in flight.
+        quitDelegate.flushPendingSaves = { [weak manager] in
+            manager?.activeStore?.flushPendingSaves()
+        }
+        quitDelegate.isAnyAgentRunning = { [weak agentLauncher, weak chatLauncher] in
+            agentLauncher?.isRunning == true || chatLauncher?.isRunning == true
         }
     }
 
@@ -247,6 +264,8 @@ struct WikiFSApp: App {
             TabView {
                 AboutView()
                     .tabItem { Label("About", systemImage: "info.circle") }
+                GeneralSettingsView()
+                    .tabItem { Label("General", systemImage: "gearshape") }
                 ZoteroSettingsView(containerDirectory: containerDirectory)
                     .tabItem { Label("Zotero", systemImage: "books.vertical") }
                 ExtractionSettingsView(containerDirectory: containerDirectory, launcher: agentLauncher)


### PR DESCRIPTION
Implements a confirmation dialog that appears when quitting the app, catching all termination paths: ⌘Q, Apple menu Quit, Dock Quit, system shutdown, and closing the last window. Prevents accidental quits while protecting in-flight operations.

## Changes

- **GeneralSettingsView.swift**: New Settings tab hosting the "Ask before quitting" toggle (default on), with help text explaining when the dialog appears.

- **QuitConfirmationDelegate.swift**: New NSApplicationDelegate that intercepts `applicationShouldTerminate(_:)` and `applicationShouldTerminateAfterLastWindowClosed(_:)`. Shows a tailored warning dialog describing any active operation (PDF extraction, source ingestion, agent run, or chat session). Flushes pending autosaves before allowing termination.

- **WikiFSApp.swift**: Wires the delegate's closures to call autosave flush and report active operations based on manager, agentLauncher, and chatLauncher state. Adds GeneralSettingsView to the settings tabs.

## Behavior

- **With setting on (default)**: All quit paths show a confirmation dialog.
- **With setting off**: Dialog still appears if extraction, ingestion, or agent work is in flight — silencing the dialog would risk losing data.
- **Last window close**: Routes through the same termination flow, so pressing ⌘W repeatedly no longer silently dismisses the app.
- **Auto-save flush**: Pending edits are always flushed before the app exits, regardless of the dialog state.