### PR TITLE
Deduplicate queue ingestion and allow multiple Ingest taps

### DIFF
--- a/Sources/WikiFS/QueueIngestionHelper.swift
+++ b/Sources/WikiFS/QueueIngestionHelper.swift
@@ -8,6 +8,11 @@ import WikiFSEngine
 /// markdown, enqueues extraction first, waits for it, then enqueues the
 /// ingestion item. For non-PDFs or PDFs with existing markdown, enqueues
 /// ingestion directly.
+///
+/// **Deduplication:** before enqueuing, checks the engine's active items
+/// (`.queued` or `.running`) for this wiki. Sources already active in either
+/// the extraction or ingestion queue are skipped — a user tapping Ingest
+/// multiple times on the same source won't create duplicate queue entries.
 @MainActor
 func enqueueIngestion(
     sourceIDs: [PageID],
@@ -17,9 +22,28 @@ func enqueueIngestion(
 ) async {
     guard !sourceIDs.isEmpty else { return }
 
+    // Deduplicate: collect sourceIDs already active (queued or running)
+    // for this wiki in either queue, and skip them.
+    let snapshot = await queueEngine.snapshot()
+    let activeSourceIDs = Set(
+        snapshot.activeItems
+            .filter { $0.wikiID == wikiID }
+            .flatMap { $0.payload.sourceIDs }
+    )
+    let newSourceIDs = sourceIDs.filter { !activeSourceIDs.contains($0) }
+
+    let skipped = sourceIDs.count - newSourceIDs.count
+    if skipped > 0 {
+        DebugLog.ingest("enqueueIngestion: skipped \(skipped) source(s) already in queue")
+    }
+    guard !newSourceIDs.isEmpty else {
+        DebugLog.ingest("enqueueIngestion: all source(s) already in queue — nothing to do")
+        return
+    }
+
     var ingestionSourceIDs: [PageID] = []
 
-    for sourceID in sourceIDs {
+    for sourceID in newSourceIDs {
         // Check if this source needs extraction first.
         if let source = store.sources.first(where: { $0.id == sourceID }),
            source.mimeType == "application/pdf",

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -987,8 +987,13 @@ struct SourceDetailView: View {
             }
         }
         .keyboardShortcut(.return, modifiers: .command)
-        .disabled(isRunning || isIngesting || isAnySourceIngesting
-                  || isThisFileExtracting || isEditLockedExternally)
+        // Don't disable during an active ingestion or extraction — the queue
+        // engine serializes both (ingestion maxConcurrent=1 per provider;
+        // extraction limit 1 for local pdf2md). A second tap just appends to
+        // the queue. `isRunning` still blocks when a *chat* agent is running
+        // (no ingest active) to avoid a launcher preflight refusal.
+        .disabled((isRunning && !isAnySourceIngesting)
+                  || isEditLockedExternally)
         .confirmationDialog(
             "Ingest Again?",
             isPresented: $showReingestConfirmation,


### PR DESCRIPTION
## Summary

Added deduplication logic to the ingestion queue to prevent duplicate entries when users tap Ingest multiple times on the same source. Updated the UI to permit repeated taps since the queue engine now filters duplicates.

### Changes

**QueueIngestionHelper.swift:**
- Before enqueuing, snapshot the queue engine's active items (queued or running) and filter out sources already in either the extraction or ingestion queue
- Log skipped sources for observability
- Early return if all sources are already active

**SourceDetailView.swift:**
- Relaxed the Ingest button's disable logic: now only blocks when a chat agent is running (not during active ingestion/extraction)
- The queue engine serializes both operations (ingestion maxConcurrent=1 per provider; extraction limit 1 for local pdf2md), so multiple taps safely append to the queue rather than creating duplicates
- Clarified intent in code comment

### Why

Users tapping Ingest multiple times on the same source would previously create duplicate queue entries. Now the button remains enabled and duplicate taps are silently deduplicated, improving user experience without risking redundant work.