### PR TITLE
fix(ci): move AppKit/WebView tests to integration-only tier (#439)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # merge for fast iteration — see AGENTS.md.
         # To add a slow suite: tag it `.integration` AND append its name here.
         env:
-          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
+          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|QuoteHighlightWebViewTests'
         run: $SWIFT test --skip "$SKIP"
 
   swift-integration:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8110,3 +8110,34 @@ controls. Replaced the menu-bar popover with a unified Activity window.
 **Build/tests:** `swift build` clean; fast tier — 2379 tests pass.
 
 >>>>>>> 3d27d6c (feat: lint queue migration + Activity window)
+
+---
+
+## 2026-07-15 — Fix #439: flaky SIGTRAP (signal 5) in fast-tier CI
+
+**Problem:** The fast-tier `swift` CI job intermittently crashed with
+`Exited with unexpected signal code 5` (SIGTRAP) on `macos-latest`, killing
+the parallel test process. Root cause: two suites instantiate
+`WKWebView`/`NSWindow` off a host app — `SplitDiffSnapshotTests` (renders
+`WKWebView`/`NSHostingController` to PNG snapshots) and
+`QuoteHighlightWebViewTests` (bare `WKWebView` + JS eval). Headless macOS GH
+Actions runners SIGTRAP on AppKit/WebKit under `swift test`'s concurrent
+execution. A secondary `ChatStoreTests.chatMessagesSkipsRowWithCorruptEventJSON`
+WAL-lock failure was a telemetry side-effect of the crash teardown, not a bug.
+
+**Fix:** Moved both suites to the `swift-integration` (full-suite) job only —
+they still gate merges there, but no longer run in the per-commit fast tier.
+- Tagged both suite types with `@Suite(.tags(.integration))` (matches the
+  established pattern in `TestTags.swift`; documents intent + enables IDE/
+  xcodebuild filtering; future-proofs for SwiftPM `--skip` tag support).
+- Appended `SplitDiffSnapshotTests|QuoteHighlightWebViewTests` to the
+  fast-tier `SKIP` env regex in `.github/workflows/ci.yml` (the actual skip
+  mechanism — SwiftPM `--skip` is name-regex, not tag-based).
+
+**Scope note:** Three other suites (`SidebarSelectAllShortcutTests`,
+`ComposerTextViewTests`, `AddressBarLayoutHostedTests`) instantiate `NSWindow`
+only (no `WKWebView`) for layout/shortcut testing — lighter, not observed to
+crash, left in the fast tier per issue #439's stated scope.
+
+**Build:** `make build` clean; the two suites now skip in the fast tier and run
+in `swift-integration`.

--- a/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
@@ -11,6 +11,7 @@ import WebKit
 /// JS that emits the right text but doesn't actually produce a `<mark>`). If
 /// these fail, the highlight JS itself is broken; if they pass, the bug is in
 /// the trigger path (the pending-anchor consume that decides to run it).
+@Suite(.tags(.integration))
 @MainActor
 struct QuoteHighlightWebViewTests {
 

--- a/Tests/WikiFSTests/SplitDiffSnapshotTests.swift
+++ b/Tests/WikiFSTests/SplitDiffSnapshotTests.swift
@@ -10,6 +10,7 @@ import Testing
 /// dark window, lets async work settle, then writes PNGs so the redesigned diff
 /// and chrome can be eyeballed (the "acceptance test is a screenshot" this
 /// layout rework needs). A light structural assertion keeps them honest.
+@Suite(.tags(.integration))
 @MainActor
 struct SplitDiffSnapshotTests {
 


### PR DESCRIPTION
## Summary

The fast-tier `swift` CI job intermittently crashed with `Exited with unexpected signal code 5` (SIGTRAP) on `macos-latest` under parallel `swift test` execution (issue #439). The crash killed the whole process and left logs interleaved, so the failing test could not be isolated — reruns passed.

## Root cause

Two fast-tier suites instantiate `WKWebView`/`NSWindow` off a host app, which headless macOS GitHub Actions runners are known to SIGTRAP on under `swift test`'s concurrent execution:

- **`SplitDiffSnapshotTests`** — creates `NSWindow(contentViewController:)`, renders `WKWebView`/`NSHostingController` to PNG snapshots
- **`QuoteHighlightWebViewTests`** — creates bare `WKWebView` instances and evaluates JS against a live DOM

The secondary `ChatStoreTests.chatMessagesSkipsRowWithCorruptEventJSON` WAL-lock failure was a telemetry side-effect of the crash teardown (a raw `sqlite3_exec` hit `SQLITE_ERROR` while another connection hadn't quiesced its WAL) — it passes in isolation and on `swift-integration`, so it is not a bug.

## Fix

Move both suites to the `swift-integration` (full-suite) job only — they still gate merges there, but no longer run in the per-commit fast tier. This matches the issue's "most robust" option (#1).

- Tagged both suite types with `@Suite(.tags(.integration))` — matches the established pattern in `TestTags.swift`; documents intent, enables IDE/xcodebuild filtering, and future-proofs for when SwiftPM gains `--skip` tag support.
- Appended `SplitDiffSnapshotTests|QuoteHighlightWebViewTests` to the fast-tier `SKIP` env regex in `.github/workflows/ci.yml` — the actual skip mechanism, since SwiftPM's `--skip` is name-regex only, not tag-based.

## Scope note

Three other suites instantiate `NSWindow` only (no `WKWebView`) for layout/shortcut testing:
- `SidebarSelectAllShortcutTests`
- `ComposerTextViewTests`
- `AddressBarLayoutHostedTests`

These are lighter (no WebKit), were not observed to crash, and were left in the fast tier per issue #439's stated scope. They're a possible future consideration if `NSWindow`-only suites ever become flaky.

## Verification

- `make build` clean — the `@Suite(.tags(.integration))` attribute compiles alongside `@MainActor`.
- The two suite names in the `SKIP` regex exactly match the `struct` declarations.
- The fast tier now skips these suites; `swift-integration` still runs them.

Closes #439.
