### PR TITLE
Fix #448: queue engine dispatch bug + test fixture round-robin

### DIFF
--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -108,6 +108,14 @@ public actor QueueEngine {
             DebugLog.store("QueueEngine.start: reset \(resetCount) running items to queued")
         }
 
+        // Re-sync in-memory state after the reset. If items were dispatched
+        // during `enqueue` before `start()` was called, `resetRunningToQueued`
+        // may have reset those items from `.running` to `.queued` in the DB
+        // without clearing the in-memory provider counts / wiki set. Without
+        // this rebuild, `dispatchScan` would skip those items because the
+        // stale counts make the provider look at-capacity.
+        await rebuildInMemoryState()
+
         // Load run states.
         for queue in [QueueKind.extraction, QueueKind.ingestion] {
             runStates[queue] = (try? store.queueRunState(for: queue)) ?? .running

--- a/Tests/WikiFSTests/QueueEngineTests.swift
+++ b/Tests/WikiFSTests/QueueEngineTests.swift
@@ -463,7 +463,16 @@ struct QueueEngineTests {
 
         let recorder = FakeWorkerRecorder()
         let factory = FakeWorkerFactory(
-            providerID: { _ in "p1" },
+            providerID: { item in
+                // Round-robin: w1→p1, w2→p2, w3→p1, ...
+                // Two providers with limit 1 each means two wikis run
+                // concurrently; the third waits for a slot to free.
+                switch item.wikiID {
+                case "w1", "w3": return "p1"
+                case "w2": return "p2"
+                default: return "p1"
+                }
+            },
             worker: { item in recorder.record(item.id) }
         )
         // Two providers, limit 1 each, so two wikis can run concurrently.


### PR DESCRIPTION
Fixes #448

## Summary

Two issues caused `QueueEngineTests/testItemsFromMultipleWikisInOneQueue` to fail on CI.

### 1. Test fixture bug

The `FakeWorkerFactory` assigned **all** items to provider `"p1"` despite the config having limits for both `"p1"` and `"p2"`. With all items on one provider with limit 1, they ran sequentially instead of concurrently — and the 3rd item didn't complete within the 5s timeout.

Fixed by round-robining providers in the test fixture: `w1→p1`, `w2→p2`, `w3→p1`. Two wikis run concurrently (as the test comment intended); the third waits for a slot to free.

### 2. Dispatch bug

`QueueEngine.start()` calls `store.resetRunningToQueued()` for crash recovery. But if items were already dispatched during `enqueue()` (before `start()` was called), the DB reset leaves those items as `.queued` while the in-memory `providerActiveCounts` still reflects them as running. `dispatchScan` then skips them because the stale count makes the provider look at-capacity — the item is stuck in `.queued` with no trigger to re-dispatch it.

Fixed by calling `rebuildInMemoryState()` after `resetRunningToQueued()` to sync in-memory state with the DB, clearing stale provider counts.

## Test plan

- [x] All 19 `QueueEngineTests` pass
- [x] `testItemsFromMultipleWikisInOneQueue` passes
- [x] `testItemsDispatchInOrderingKeyOrder` (same symptom) passes
