### PR TITLE
Move Settings from app menu to menu-bar icon

### DIFF
--- a/Sources/WikiFS/MenuBarItemController.swift
+++ b/Sources/WikiFS/MenuBarItemController.swift
@@ -12,7 +12,11 @@ import WikiFSEngine
 /// bar icon that changes shape reads as a different app).
 ///
 /// The menu-bar dropdown groups queue windows, a Maintenance submenu
-/// (Vacuum All, Agent Instructions), and Quit.
+/// (Vacuum All, Agent Instructions), Settings, and Quit. Settings lives
+/// here rather than in the "Self Driving Wiki" app menu because the status
+/// item is the always-available surface — in accessory mode there's no menu
+/// bar at all. The app-menu items are removed in
+/// `AppDelegate.removeRedundantAppMenuItems`.
 ///
 /// Lives in `WikiFS` because it uses AppKit (`NSStatusItem`, `NSWindow`)
 /// and SwiftUI for the window content. The engine itself stays headless.
@@ -146,6 +150,17 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
 
+        // Settings — moved here from the "Self Driving Wiki" app menu (the
+        // status item is reachable even in accessory mode; the app menu
+        // isn't). Opens the Settings scene via the same selector the gear
+        // buttons use (`showSettingsWindow:`).
+        let settingsItem = NSMenuItem(
+            title: "Settings…",
+            action: #selector(openSettings(_:)),
+            keyEquivalent: "")
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
         // About + Quit.
         let aboutItem = NSMenuItem(
             title: "About Self Driving Wiki",
@@ -184,6 +199,14 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     @objc private func openAgentInstructions(_ sender: NSMenuItem?) {
         targetSession?.store.openTab(.systemPrompt)
         activateWikiWindow()
+    }
+
+    /// Open the Settings window. Sends the Settings scene's action
+    /// (`showSettingsWindow:`) — the same selector the activity-window gear
+    /// buttons use — so a single code path opens Settings everywhere.
+    @objc private func openSettings(_ sender: NSMenuItem?) {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        NSApplication.shared.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
     }
 
     /// Bring a wiki window to the front. `openTab` switches the tab inside

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -509,6 +509,57 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DebugLog.tabs("AppDelegate: applicationDidFinishLaunching")
         MainActor.assumeIsolated {
             bootstrap?()
+            removeRedundantAppMenuItems()
+        }
+    }
+
+    /// Remove the auto-generated "About" and "Settings…" items from the
+    /// "Self Driving Wiki" app menu. Both are surfaced under the menu-bar
+    /// icon instead (`MenuBarItemController.buildMenu`) — the status item is
+    /// reachable even in accessory mode, when the app has no menu bar. The
+    /// Settings scene itself is untouched, so `showSettingsWindow:` (gear
+    /// buttons, "Open Settings…") and the window keep working; the About
+    /// panel opens from the icon via `orderFrontStandardAboutPanel:`.
+    @MainActor
+    private func removeRedundantAppMenuItems() {
+        let settingsAction = Selector(("showSettingsWindow:"))
+        let aboutAction = #selector(NSApplication.orderFrontStandardAboutPanel(_:))
+        guard let mainMenu = NSApp.mainMenu else { return }
+        for topLevel in mainMenu.items {
+            guard let submenu = topLevel.submenu else { continue }
+            // Iterate a snapshot (`submenu.items` is a fresh array), so
+            // removing while iterating is safe. `action` is optional, so
+            // compare against the selectors directly (optional == non-optional
+            // lifts via Equatable) rather than via a Set<Selector>.
+            submenu.items
+                .filter {
+                    $0.action == settingsAction
+                        || $0.action == aboutAction
+                        || $0.title.hasPrefix("Settings")
+                        || $0.title.hasPrefix("About")
+                }
+                .forEach { submenu.removeItem($0) }
+            tidySeparators(in: submenu)
+        }
+    }
+
+    /// Collapse leading separators and consecutive duplicate separators that
+    /// removing items leaves behind — NSMenu doesn't auto-merge them, so an
+    /// un-tidied menu could start with a blank divider.
+    @MainActor
+    private func tidySeparators(in menu: NSMenu) {
+        while menu.items.first?.isSeparatorItem == true {
+            menu.removeItem(at: 0)
+        }
+        var index = 0
+        while index < menu.items.count {
+            let nextIsSeparator = index + 1 < menu.items.count
+                && menu.items[index + 1].isSeparatorItem
+            if menu.items[index].isSeparatorItem && nextIsSeparator {
+                menu.removeItem(at: index)
+            } else {
+                index += 1
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Moves the Settings menu item from the "Self Driving Wiki" app menu to the menu-bar dropdown, ensuring Settings is always accessible even in accessory mode where the app menu bar is unavailable.

## Changes

**MenuBarItemController.swift**
- Added Settings menu item to the menu-bar dropdown
- Implemented `openSettings(_:)` action that sends the same `showSettingsWindow:` selector the gear buttons use, unifying the code path for opening Settings
- Updated documentation to reflect Settings' new location

**WikiFSApp.swift** (AppDelegate)
- Added `removeRedundantAppMenuItems()` call during app launch to strip the auto-generated About and Settings items from the app menu
- Implemented `removeRedundantAppMenuItems()` to remove duplicate menu items by action selector and title prefix
- Implemented `tidySeparators(in:)` helper to collapse leading and consecutive separators left behind after item removal

## Why

The status-bar icon is the always-reachable surface for this app, available even in accessory mode where there's no app menu bar. By surfacing Settings (and About) through the icon's dropdown, we ensure these features remain accessible in all modes and simplify the overall menu structure.