### PR TITLE
Fix chat transcript right margin to match left

### DIFF
--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -668,7 +668,9 @@ struct ChatWebView: NSViewRepresentable {
           body {
             font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
             font-size: 13px; line-height: 1.5; color: var(--text);
-            padding: 10px 0; -webkit-font-smoothing: antialiased;
+            /* Right-side padding keeps content clear of the WebView's scrollbar
+               so the right margin matches the left (which has no scrollbar). */
+            padding: 10px 12px 10px 0; -webkit-font-smoothing: antialiased;
             /* Never let content exceed the web view's width — long tokens/URLs
                in list items and paragraphs wrap instead of clipping off the
                right edge or pushing list markers off the left. */


### PR DESCRIPTION
## Summary

The chat transcript's right margin appeared narrower than the left because the WKWebView's scrollbar eats into the right edge of the content area. The SwiftUI container padding (`.padding(.horizontal, ...)`) was already symmetric — the asymmetry was entirely inside the web view.

## Changes

- `Sources/WikiFS/ChatWebView.swift`: Changed the transcript HTML `body` CSS from `padding: 10px 0` to `padding: 10px 12px 10px 0`, adding a 12px right inset so content clears the scrollbar and the right margin matches the left.
