### PR TITLE
Collapsible detail headers for page/source/chat views

### DIFF
--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -39,6 +39,9 @@ struct ChatView: View {
     /// chat tab the outline is closed by default; the user can expand it
     /// within that view's lifetime.
     @State private var chatOutlineExpanded = false
+    /// Per-view collapse state for the header. Starts collapsed; persists
+    /// across same-type tab switches (SwiftUI keeps the view alive).
+    @State private var isHeaderExpanded = false
     /// Persisted toggle to hide tool-call rows from the chat transcript
     /// (issue #381). Independent of "Show internals" which gates the full
     /// raw activity feed.
@@ -458,23 +461,18 @@ struct ChatView: View {
 
     @ViewBuilder
     private func header(for chat: ChatSummary) -> some View {
-        VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
-            Label {
-                EditableTitle(
-                    title: chat.title,
-                    placeholder: "Untitled Chat",
-                    lineLimit: 1,
-                    isDisabled: false,
-                    onCommit: { newTitle in
-                        store.renameChat(id: chat.id, to: newTitle)
-                    }
-                )
-            } icon: {
-                Image(systemName: ResourceKind.chat.systemImageName)
-                    .foregroundStyle(.secondary)
+        CollapsibleDetailHeader(
+            systemImage: ResourceKind.chat.systemImageName,
+            title: chat.title,
+            placeholder: "Untitled Chat",
+            titleLineLimit: 1,
+            isExpanded: $isHeaderExpanded,
+            onTitleCommit: { newTitle in
+                store.renameChat(id: chat.id, to: newTitle)
             }
-
-            Text(chat.updatedAt, style: .date)
+        ) {
+            VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
+                Text(chat.updatedAt, style: .date)
                 .font(.callout)
                 .foregroundStyle(.secondary)
 
@@ -513,6 +511,7 @@ struct ChatView: View {
                     Image(systemName: "sidebar.right")
                 }
                 .help("Toggle Outline")
+            }
             }
         }
         .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)

--- a/Sources/WikiFS/CollapsibleDetailHeader.swift
+++ b/Sources/WikiFS/CollapsibleDetailHeader.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// A detail-view header with a collapsible disclosure area. The title row
+/// (disclosure chevron + resource icon + editable title) is always visible;
+/// the caller-provided metadata and action buttons appear only when expanded.
+///
+/// Each detail view owns its own `@State` expand toggle and passes it as a
+/// binding, so the collapse state persists per-view (survives same-type tab
+/// switches — SwiftUI keeps the view alive) while every fresh detail starts
+/// collapsed.
+///
+/// **Layout:**
+/// ```
+/// collapsed:  ▸  [icon]  Title
+/// expanded:   ▾  [icon]  Title
+///                date · metadata
+///                [Action buttons]
+/// ```
+struct CollapsibleDetailHeader<Expanded: View>: View {
+    let systemImage: String
+    let title: String
+    var placeholder: String = "Untitled"
+    var titleLineLimit: Int? = nil
+    var isTitleDisabled: Bool = false
+    @Binding var isExpanded: Bool
+    let onTitleCommit: (String) -> Void
+    @ViewBuilder let expandedContent: () -> Expanded
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
+            titleRow
+            if isExpanded {
+                expandedContent()
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    // MARK: - Title row (always visible)
+
+    private var titleRow: some View {
+        HStack(alignment: .center, spacing: 6) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 12, height: 12)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.borderless)
+            .help(isExpanded ? "Collapse header" : "Expand header")
+
+            Label {
+                EditableTitle(
+                    title: title,
+                    placeholder: placeholder,
+                    lineLimit: titleLineLimit,
+                    isDisabled: isTitleDisabled,
+                    onCommit: onTitleCommit
+                )
+            } icon: {
+                Image(systemName: systemImage)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -25,6 +25,9 @@ struct PageDetailView: View {
     @AppStorage("editor.zoom") private var editorZoom = Double(ZoomScale.defaultScale)
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
     @AppStorage("isOutlineExpanded") private var isOutlineExpanded = false
+    /// Per-view collapse state for the header. Starts collapsed; persists
+    /// across same-type tab switches (SwiftUI keeps the view alive).
+    @State private var isHeaderExpanded = false
 
     // Find bar state. The model is shared (hoisted to `ContentView` and injected
     // via environment) so the address bar's "Find on Page…" menu item can drive
@@ -34,21 +37,15 @@ struct PageDetailView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header — always visible, same layout in both modes.
-            VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
-                Label {
-                    EditableTitle(
-                        title: store.draftTitle,
-                        placeholder: "Untitled",
-                        isDisabled: false,
-                        onCommit: renameCurrentPage
-                    )
-                } icon: {
-                    Image(systemName: ResourceKind.page.systemImageName)
-                        .foregroundStyle(.secondary)
-                }
-
-                HStack(spacing: 12) {
+            // Header — title always visible; date + action buttons expandable.
+            CollapsibleDetailHeader(
+                systemImage: ResourceKind.page.systemImageName,
+                title: store.draftTitle,
+                isExpanded: $isHeaderExpanded,
+                onTitleCommit: renameCurrentPage
+            ) {
+                VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
+                    HStack(spacing: 12) {
                     if let date = pageUpdatedAt {
                         Text(date, style: .date)
                     }
@@ -126,6 +123,7 @@ struct PageDetailView: View {
                         }
                         .help("Toggle Outline")
                     }
+                    }
                 }
             }
             .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
@@ -163,6 +161,7 @@ struct PageDetailView: View {
             if let id = store.activeTabID {
                 store.setTabEditing(tabID: id, isEditing: newValue)
             }
+            if newValue { isHeaderExpanded = true } // reveal Save/Cancel
             if !newValue { caretCharIndex = nil }
         }
         .background { findShortcutButton }

--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -43,6 +43,9 @@ struct SourceDetailView: View {
     @AppStorage("editor.zoom") private var editorZoom = Double(ZoomScale.defaultScale)
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
     @AppStorage("isOutlineExpanded") private var isOutlineExpanded = false
+    /// Per-view collapse state for the header. Starts collapsed; persists
+    /// across same-type tab switches (SwiftUI keeps the view alive).
+    @State private var isHeaderExpanded = false
     @State private var headVersion: SourceMarkdownVersion?
     @State private var origin: SourceOrigin?
     @State private var isEditing = false
@@ -282,6 +285,7 @@ struct SourceDetailView: View {
             if let id = store.activeTabID {
                 store.setTabEditing(tabID: id, isEditing: newValue)
             }
+            if newValue { isHeaderExpanded = true } // reveal Save/Cancel
             if !newValue { shouldRestoreEditing = false; caretCharIndex = nil }
         }
     }
@@ -289,21 +293,17 @@ struct SourceDetailView: View {
     // MARK: - Header
 
     private var headerSection: some View {
-        VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
-            Label {
-                EditableTitle(
-                    title: displayName,
-                    placeholder: "Untitled",
-                    lineLimit: 2,
-                    isDisabled: isEditLockedExternally,
-                    onCommit: { store.renameSource(id: file.id, to: $0) }
-                )
-            } icon: {
-                Image(systemName: symbol)
-                    .foregroundStyle(.secondary)
-            }
-
-            HStack(spacing: 8) {
+        CollapsibleDetailHeader(
+            systemImage: symbol,
+            title: displayName,
+            placeholder: "Untitled",
+            titleLineLimit: 2,
+            isTitleDisabled: isEditLockedExternally,
+            isExpanded: $isHeaderExpanded,
+            onTitleCommit: { store.renameSource(id: file.id, to: $0) }
+        ) {
+            VStack(alignment: .leading, spacing: PageEditorMetrics.sectionSpacing) {
+                HStack(spacing: 8) {
                 Text(Self.sizeFormatter.string(fromByteCount: Int64(file.byteSize)))
                 metadataSeparator
                 // Compact, single-line dates — "Added Jun 26, 2026 · Updated
@@ -497,6 +497,7 @@ struct SourceDetailView: View {
                     .foregroundStyle(.red)
             }
 
+            }
         }
         .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
         .padding(PageEditorMetrics.contentInset)


### PR DESCRIPTION
## Collapsible detail headers

Adds a collapsible title pane to all three detail views (Page, Source, Chat).
Each header starts **collapsed** — showing just a disclosure chevron + resource
icon + editable title — and expands to reveal the date/metadata and action
buttons.

### What changes

- **New component** `CollapsibleDetailHeader` — a reusable SwiftUI view with a
  `chevron.right`/`chevron.down` disclosure button + resource icon +
  `EditableTitle`, and a `@ViewBuilder` closure for the expanded content.
  Smooth `easeInOut(0.2)` animation on toggle.

- **PageDetailView / SourceDetailView / ChatView** — each header's `Label` +
  `EditableTitle` is replaced by `CollapsibleDetailHeader`, with the date,
  metadata, and action buttons moved into the expanded-content closure.

- **Auto-expand on edit mode** (Page + Source) — entering the editor sets
  `isHeaderExpanded = true` so Save/Cancel are always visible.

- **Per-view persistence** — each detail view owns `@State private var
  isHeaderExpanded = false`. Collapsed by default; persists across same-type
  tab switches (SwiftUI keeps the view alive).

### Files

| File | Change |
|------|--------|
| `Sources/WikiFS/CollapsibleDetailHeader.swift` | **New** — reusable collapsible header component |
| `Sources/WikiFS/PageDetailView.swift` | Header wrapped in `CollapsibleDetailHeader`; auto-expand on edit |
| `Sources/WikiFS/SourceDetailView.swift` | `headerSection` wrapped; auto-expand on edit |
| `Sources/WikiFS/ChatView.swift` | `header(for:)` wrapped |

### Build

`make build` passes cleanly — no errors, no new warnings.
