### PR TITLE
Timestamp untitled pages + rename collision guard

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,52 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-<<<<<<< HEAD
+## 2026-07-16 — Timestamped untitled pages + rename collision guard
+
+**Implemented (branch `torpid-penguin`).** Two related changes to page-title
+behavior:
+
+1. **Timestamped default title.** Creating a new page with no explicit title
+   (`model.newPage()` / `model.newPageInNewTab()`) now produces
+   `"Untitled 2026-07-16 14:30:45"` instead of bare `"Untitled"`. This makes
+   multiple new pages instantly distinguishable in the sidebar and avoids
+   title collisions (which would otherwise silently duplicate-title, with
+   wiki-links resolving to whichever page has the lowest ULID).
+   - `WikiStoreModel.defaultUntitledTitle()` — a `public static` that formats
+     `Date()` via a private `DateFormatter` (`"yyyy-MM-dd HH:mm:ss"`).
+   - Default parameters on `newPage` and `newPageInNewTab` use it (can't use
+     `Self.` — Swift forbids covariant `Self` in default args; explicit
+     `WikiStoreModel.defaultUntitledTitle()` works).
+   - Callers that pass explicit titles (Home page seeding, `wikictl`, tests)
+     are unaffected.
+
+2. **Rename collision guard.** `WikiStoreModel.rename(_:to:)` now checks
+   whether another page already has the target title (case-insensitive,
+   matching `resolveTitleToID` / wiki-link resolution) BEFORE writing. If a
+   collision exists, the rename is blocked — the title stays unchanged, and
+   `renameConflictingTitle` is set so views can show an alert.
+   - `renameConflictingTitle: String?` — observable on the model; UI shows
+     "Title Already Exists" alert in `PageDetailView` and `PagesContainerView`.
+   - `clearRenameConflict()` — dismisses the alert state.
+   - The check skips the page being renamed itself (`existingID != id`), so
+     re-saving the same title is a no-op (not a false collision).
+   - `WikiNameRules.sanitized` is applied before the collision check and before
+     the write, so e.g. `A|B` is stored as `A-B` and compared consistently.
+
+**Tests** (`Tests/WikiFSTests/PageTitleCollisionTests.swift`, 9 tests):
+- `defaultUntitledTitleIncludesTimestamp` / `ChangesOverTime` — the formatter
+  produces a parseable timestamp that differs across seconds.
+- `newPageWithoutExplicitTitleGetsTimestamp` / `InNewTab` — end-to-end store
+  round-trip gets a timestamped title.
+- `renameToExistingTitleIsBlocked` / `CaseInsensitiveIsBlocked` — the rename
+  doesn't change the title and surfaces the conflict.
+- `renameToOwnTitleIsAllowed` — no false positive when renaming to the same
+  title.
+- `renameToUniqueTitleSucceeds` — normal renames still work.
+- `clearRenameConflictResets` — the alert state is dismissible.
+
+**Gates:** `swift build` clean; 9 new tests + 69 existing
+(Navigation/EditableTitle/WikiNameRules/EditorTab) all pass.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/Sources/WikiFS/PageDetailView.swift
+++ b/Sources/WikiFS/PageDetailView.swift
@@ -182,6 +182,19 @@ struct PageDetailView: View {
             guard findModel.currentMatchIndex > 0 else { return }
             findVersion &+= 1
         }
+        .alert(
+            "Title Already Exists",
+            isPresented: Binding(
+                get: { store.renameConflictingTitle != nil },
+                set: { if !$0 { store.clearRenameConflict() } }
+            )
+        ) {
+            Button("OK", role: .cancel) { store.clearRenameConflict() }
+        } message: {
+            if let title = store.renameConflictingTitle {
+                Text("A page with the title “\(title)” already exists. Please choose a different name.")
+            }
+        }
     }
 
     // MARK: - Content + Outline

--- a/Sources/WikiFS/PagesContainerView.swift
+++ b/Sources/WikiFS/PagesContainerView.swift
@@ -45,6 +45,19 @@ struct PagesContainerView: View {
             Button("Cancel", role: .cancel) { renameTarget = nil }
             Button("Rename") { commitRename() }
         }
+        .alert(
+            "Title Already Exists",
+            isPresented: Binding(
+                get: { store.renameConflictingTitle != nil },
+                set: { if !$0 { store.clearRenameConflict() } }
+            )
+        ) {
+            Button("OK", role: .cancel) { store.clearRenameConflict() }
+        } message: {
+            if let title = store.renameConflictingTitle {
+                Text("A page with the title “\(title)” already exists. Please choose a different name.")
+            }
+        }
         .sheet(item: $addToBookmarksContext) { ctx in
             BookmarkTargetPickerSheet(
                 store: store,

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1078,8 +1078,22 @@ public final class WikiStoreModel {
         }
     }
 
+    /// Date formatter for default untitled page titles, so rapid page
+    /// creation doesn't collide or look identical in the sidebar.
+    private static let untitledDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+
+    /// The default title for a new page: "Untitled" + a timestamp so multiple
+    /// new pages are distinguishable and unlikely to collide.
+    public static func defaultUntitledTitle() -> String {
+        "Untitled \(untitledDateFormatter.string(from: Date()))"
+    }
+
     /// Create a new page and open it in a new tab.
-    public func newPageInNewTab(title: String = "Untitled") {
+    public func newPageInNewTab(title: String = WikiStoreModel.defaultUntitledTitle()) {
         flushPendingSaves()
         do {
             let page = try store.createPage(title: title, createdBy: "user")
@@ -1541,7 +1555,7 @@ public final class WikiStoreModel {
     // MARK: - Mutations
 
     @discardableResult
-    public func newPage(title: String = "Untitled") -> PageID? {
+    public func newPage(title: String = WikiStoreModel.defaultUntitledTitle()) -> PageID? {
         flushPendingSaves()
         do {
             let page = try store.createPage(title: title, createdBy: "user")
@@ -1560,18 +1574,38 @@ public final class WikiStoreModel {
         }
     }
 
+    /// When non-nil, the last rename was blocked because another page already
+    /// has that title. Views observe this to show an alert, then call
+    /// `clearRenameConflict()` to dismiss.
+    public private(set) var renameConflictingTitle: String?
+
+    public func clearRenameConflict() {
+        renameConflictingTitle = nil
+    }
+
     public func rename(_ id: PageID, to newTitle: String) {
         // Persist any pending edits to whatever's open first, then rename.
         flushPendingSave()
+        renameConflictingTitle = nil
+        let sanitizedTitle = WikiNameRules.sanitized(newTitle)
         do {
+            // Block rename if another page already has this title (case-
+            // insensitive, matching wiki-link resolution). The user gets an
+            // alert via `renameConflictingTitle` instead of a silent revert.
+            if let existingID = try store.resolveTitleToID(sanitizedTitle),
+               existingID != id {
+                renameConflictingTitle = sanitizedTitle
+                DebugLog.store("WikiStoreModel.rename blocked: '\(sanitizedTitle)' already exists (page \(existingID.rawValue))")
+                return
+            }
             let page = try store.getPage(id: id)
             let cleanBody = PageMarkdownFormat.stripped(body: page.bodyMarkdown, title: page.title)
-            try store.updatePage(id: id, title: newTitle, body: cleanBody, lastEditedBy: nil)
+            try store.updatePage(id: id, title: sanitizedTitle, body: cleanBody, lastEditedBy: nil)
             reloadSummaries()
-            if selection == .page(id) { draftTitle = newTitle }
+            if selection == .page(id) { draftTitle = sanitizedTitle }
             // Update any tab showing this renamed page.
             for i in tabs.indices where tabs[i].selection == .page(id) {
-                tabs[i].title = newTitle
+                tabs[i].title = sanitizedTitle
             }
         } catch {
             DebugLog.store("WikiStoreModel.rename failed: \(error)")

--- a/Tests/WikiFSTests/PageTitleCollisionTests.swift
+++ b/Tests/WikiFSTests/PageTitleCollisionTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Tests for:
+/// 1. Default untitled page titles include a timestamp so they don't collide.
+/// 2. Renaming a page to a title already used by another page is blocked.
+@MainActor
+struct PageTitleCollisionTests {
+
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-title-collision-\(UUID().uuidString).sqlite")
+    }
+
+    // MARK: - Timestamped default title
+
+    @Test func defaultUntitledTitleIncludesTimestamp() {
+        let title = WikiStoreModel.defaultUntitledTitle()
+        // Should start with "Untitled " and have a date-like suffix.
+        #expect(title.hasPrefix("Untitled "))
+        // The suffix should be parseable as "yyyy-MM-dd HH:mm:ss".
+        let suffix = title.dropFirst("Untitled ".count)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        #expect(formatter.date(from: String(suffix)) != nil)
+    }
+
+    @Test func defaultUntitledTitleChangesOverTime() async throws {
+        let title1 = WikiStoreModel.defaultUntitledTitle()
+        // Wait just over a second so the timestamp is different at second
+        // granularity (DateFormatter rounds to whole seconds).
+        try await Task.sleep(for: .seconds(2))
+        let title2 = WikiStoreModel.defaultUntitledTitle()
+        #expect(title1 != title2)
+    }
+
+    @Test func newPageWithoutExplicitTitleGetsTimestamp() throws {
+        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        model.newPage()
+        let summary = try #require(model.summaries.first)
+        #expect(summary.title.hasPrefix("Untitled "))
+        #expect(summary.title != "Untitled")
+    }
+
+    @Test func newPageInNewTabWithoutExplicitTitleGetsTimestamp() throws {
+        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        model.newPageInNewTab()
+        let summary = try #require(model.summaries.first)
+        #expect(summary.title.hasPrefix("Untitled "))
+        #expect(summary.title != "Untitled")
+    }
+
+    // MARK: - Rename collision
+
+    @Test func renameToExistingTitleIsBlocked() throws {
+        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        model.newPage(title: "First Page")
+        model.newPage(title: "Second Page")
+        guard case let .page(secondID)? = model.selection else {
+            Issue.record("expected a page selection"); return
+        }
+
+        // Try to rename Second Page → "First Page" (already exists).
+        model.rename(secondID, to: "First Page")
+
+        // The rename should be blocked: title unchanged, conflict surfaced.
+        #expect(model.summaries.first { $0.id == secondID }?.title == "Second Page")
+        #expect(model.renameConflictingTitle == "First Page")
+    }
+
+    @Test func renameToOwnTitleIsAllowed() throws {
+        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        model.newPage(title: "Same Title")
+        guard case let .page(id)? = model.selection else {
+            Issue.record("expected a page selection"); return
+        }
+
+        // Renaming to the same title should not trigger a conflict.
+        model.rename(id, to: "Same Title")
+        #expect(model.renameConflictingTitle == nil)
+        #expect(model.summaries.first { $0.id == id }?.title == "Same Title")
+    }
+
+    @Test func renameToExistingTitleCaseInsensitiveIsBlocked() throws {
+        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        model.newPage(title: "My Page")
+        model.newPage(title: "Other Page")
+        guard case let .page(otherID)? = model.selection else {
+            Issue.record("expected a page selection"); return
+        }
+
+        // "MY PAGE" should collide with "My Page" (case-insensitive).
+        model.rename(otherID, to: "MY PAGE")
+        #expect(model.summaries.first { $0.id == otherID }?.title == "Other Page")
+        #expect(model.renameConflictingTitle == "MY PAGE")
+    }
+
+    @Test func renameToUniqueTitleSucceeds() throws {
+        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        model.newPage(title: "Alpha")
+        model.newPage(title: "Beta")
+        guard case let .page(betaID)? = model.selection else {
+            Issue.record("expected a page selection"); return
+        }
+
+        model.rename(betaID, to: "Gamma")
+        #expect(model.renameConflictingTitle == nil)
+        #expect(model.summaries.first { $0.id == betaID }?.title == "Gamma")
+    }
+
+    @Test func clearRenameConflictResets() throws {
+        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        model.newPage(title: "A")
+        model.newPage(title: "B")
+        guard case let .page(bID)? = model.selection else {
+            Issue.record("expected a page selection"); return
+        }
+
+        model.rename(bID, to: "A")
+        #expect(model.renameConflictingTitle != nil)
+
+        model.clearRenameConflict()
+        #expect(model.renameConflictingTitle == nil)
+    }
+}


### PR DESCRIPTION
## What

Two related changes to page-title behavior:

1. **Timestamped default untitled page titles.** Creating a new page without an explicit title now produces e.g. `Untitled 2026-07-16 14:30:45` instead of bare `Untitled`. This makes multiple new pages instantly distinguishable in the sidebar and avoids silent title collisions (which would otherwise cause wiki-links to resolve to whichever page has the lowest ULID).

2. **Rename collision guard.** `WikiStoreModel.rename(_:to:)` now checks whether another page already has the target title (case-insensitive, matching `resolveTitleToID` / wiki-link resolution) before writing. If a collision exists, the rename is blocked — the title stays unchanged, and `renameConflictingTitle` is set so views can show a "Title Already Exists" alert in both `PageDetailView` and `PagesContainerView`.

## Details

### Timestamped default
- `WikiStoreModel.defaultUntitledTitle()` — public static that formats `Date()` via a private `DateFormatter` (`yyyy-MM-dd HH:mm:ss`).
- Default parameters on `newPage` and `newPageInNewTab` use it.
- Callers that pass explicit titles (Home page seeding, `wikictl`, tests) are unaffected.

### Rename collision
- `renameConflictingTitle: String?` — observable property on the model; UI shows "Title Already Exists" alert.
- `clearRenameConflict()` — dismisses the alert state.
- The check skips the page being renamed itself (`existingID != id`), so re-saving the same title is a no-op.
- `WikiNameRules.sanitized` is applied before the collision check and write, so sanitized names compare consistently.

## Tests

9 new tests in `Tests/WikiFSTests/PageTitleCollisionTests.swift`:
- Timestamp format + changes over time
- End-to-end store round-trip for both `newPage` / `newPageInNewTab`
- Rename blocked on exact match
- Rename blocked on case-insensitive match
- Rename to own title allowed (no false positive)
- Rename to unique title succeeds
- Conflict state dismissible

69 existing tests across NavigationSaveTests, EditableTitleTests, WikiNameRulesTests, EditorTabTests all pass. `swift build` clean.
