### PR TITLE
Hide read-only tool calls (Bash/Read/Glob/Grep) from chat transcript

### DIFF
--- a/Sources/WikiFS/ChatTranscriptView.swift
+++ b/Sources/WikiFS/ChatTranscriptView.swift
@@ -95,7 +95,14 @@ extension [AgentEvent] {
             switch event {
             case .result(_, let text):
                 return !hasAssistantText(matching: text)
-            case .toolUse, .thinking:
+            case .toolUse(let name, _):
+                // Read-only tool calls (Bash, Read, Glob, Grep) are always
+                // hidden from the transcript — their one-line summaries are
+                // noise. Mutation-relevant calls (Edit, Write, Agent) stay
+                // visible. Full raw detail for every call lives under
+                // "Show internals".
+                return !AgentEvent.readOnlyToolNames.contains(name)
+            case .thinking:
                 // A concise one-line progress summary per tool call (issue #173):
                 // lets the user see the agent reading/searching/editing without
                 // opting into the full internals view. Full raw detail still lives

--- a/Sources/WikiFSCore/AgentEvent.swift
+++ b/Sources/WikiFSCore/AgentEvent.swift
@@ -208,6 +208,14 @@ public enum AgentEvent: Equatable, Sendable, Codable {
         }
     }
 
+    /// Tool-name set for read-only (no wiki mutation) tools. Their one-line
+    /// `.toolUse` summaries are hidden from the transcript by
+    /// `[AgentEvent].transcriptVisible` — only mutation-relevant calls
+    /// (Edit, Write, Agent/Task) remain visible in the feed. Error results
+    /// still surface (they're rare and signal problems); full raw detail
+    /// for every call lives under "Show internals".
+    public static let readOnlyToolNames: Set<String> = ["Bash", "Read", "Glob", "Grep"]
+
     /// Fold a stream of raw events into display rows: consecutive
     /// `.assistantTextDelta` chunks accumulate into ONE `.assistantText` row,
     /// and the final `.assistantText` for a streamed block replaces the

--- a/Tests/WikiFSTests/ChatTranscriptFilterTests.swift
+++ b/Tests/WikiFSTests/ChatTranscriptFilterTests.swift
@@ -20,9 +20,23 @@ struct ChatTranscriptFilterTests {
         #expect(events.transcriptVisible == events)
     }
 
-    @Test func toolUsePasses() {
-        let events: [AgentEvent] = [.toolUse(name: "Bash", inputSummary: "ls")]
+    @Test func editToolUsePasses() {
+        let events: [AgentEvent] = [.toolUse(name: "Edit", inputSummary: "page.md")]
         #expect(events.transcriptVisible == events)
+    }
+
+    @Test func readOnlyToolUseIsDropped() {
+        // Read-only tool calls (Bash, Read, Glob, Grep) are always hidden from
+        // the transcript — their one-line summaries are noise. Only
+        // mutation-relevant calls (Edit, Write, Agent) stay visible.
+        let events: [AgentEvent] = [
+            .toolUse(name: "Bash", inputSummary: "ls"),
+            .toolUse(name: "Read", inputSummary: "page.md"),
+            .toolUse(name: "Glob", inputSummary: "*.swift"),
+            .toolUse(name: "Grep", inputSummary: "pattern"),
+            .toolUse(name: "Edit", inputSummary: "page.md"),
+        ]
+        #expect(events.transcriptVisible == [.toolUse(name: "Edit", inputSummary: "page.md")])
     }
 
     @Test func nonErrorToolResultIsDropped() {
@@ -119,7 +133,6 @@ struct ChatTranscriptFilterTests {
         ]
         #expect(events.transcriptVisible == [
             .userText("What's in the wiki?"),
-            .toolUse(name: "Read", inputSummary: "page.md"),
             .assistantText("Here's what's in the wiki."),
         ])
     }


### PR DESCRIPTION
## Summary

Hides read-only tool call summaries (Bash, Read, Glob, Grep) from the chat transcript. These one-line rows clutter the feed without communicating progress or wiki changes.

## Changes

- **`AgentEvent.swift`**: Added `readOnlyToolNames` static set (`["Bash", "Read", "Glob", "Grep"]`)
- **`ChatTranscriptView.swift`**: Split the `.toolUse` case in `[AgentEvent].transcriptVisible` to drop read-only tools — only mutation-relevant calls (Edit, Write, Agent/Task) remain visible
- **`ChatTranscriptFilterTests.swift`**: Updated existing tests (Read toolUse now correctly dropped) and added `readOnlyToolUseIsDropped` covering all four read-only tools + an Edit that survives

## What still shows

- **Mutation calls** (Edit, Write, Agent/Task) — visible as one-line summaries
- **Error results** — still surface (rare, signal problems)
- **Full raw detail** — every tool call is under **Show internals**
- **Existing "Hide tool calls" toggle** — still works, now only affects Edit/Write/Agent rows

The filter lives in `transcriptVisible`, so it applies consistently to both live streaming and persisted chats.

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter 'ChatTranscriptFilterTests|ChatDisplayMessagesTests'` — all 22 tests pass
- [ ] Manually verify in running app: Bash/Read/Glob/Grep rows absent from transcript, Edit/Write rows present
