### PR TITLE
fix: show "Lint queued" instead of "Ingest queued" for lint operations

### DIFF
--- a/Sources/WikiFS/MenuBarItemController.swift
+++ b/Sources/WikiFS/MenuBarItemController.swift
@@ -350,13 +350,19 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
             // Show a transient popover anchored to the status item so the
             // user gets immediate feedback that their ingest / extraction
             // was queued — before the icon even updates.
+            let isLint = item.queue == .ingestion
+                && item.payload.lintPageIDs != nil
             showTransientHint(
-                message: item.queue == .ingestion
-                    ? "Ingest queued"
-                    : "Extraction queued",
-                symbol: item.queue == .ingestion
-                    ? "books.vertical.fill"
-                    : "doc.text.magnifyingglass"
+                message: isLint
+                    ? "Lint queued"
+                    : (item.queue == .ingestion
+                        ? "Ingest queued"
+                        : "Extraction queued"),
+                symbol: isLint
+                    ? "checkmark.seal"
+                    : (item.queue == .ingestion
+                        ? "books.vertical.fill"
+                        : "doc.text.magnifyingglass")
             )
             // Refresh snapshot + update icon so the menu bar immediately
             // reflects queued items (not just running ones). Without this,


### PR DESCRIPTION
## Summary

When clicking the Lint button, the menubar transient popover showed "Ingest queued" instead of "Lint queued".

Lint operations are enqueued on the `.ingestion` queue with `lintPageIDs` set in the payload (per the existing `QueueItemPayload` contract). The transient popup in `MenuBarItemController` only checked `item.queue == .ingestion`, so lint items fell through to the generic "Ingest queued" message.

## Changes

- Added a `lintPageIDs != nil` check in the `.enqueued` case of `MenuBarItemController`
- Lint items now show **"Lint queued"** with a `checkmark.seal` symbol
- Ingestion and extraction messages/symbols are unchanged

## Test plan

- [ ] Click the Lint button → popover should say "Lint queued"
- [ ] Trigger an ingest → popover should say "Ingest queued" (unchanged)
- [ ] Trigger an extraction → popover should say "Extraction queued" (unchanged)
