### PR TITLE
Fix compiler warnings: unused bindings and dead nil-coalescing

### DIFF
--- a/Sources/WikiFSCore/QueueStore.swift
+++ b/Sources/WikiFSCore/QueueStore.swift
@@ -567,7 +567,7 @@ public final class QueueStore: @unchecked Sendable {
 
         return try rewrap {
             let sql: String
-            if let queue {
+            if queue != nil {
                 sql = """
                 SELECT \(Self.selectColumns)
                 FROM queue_items

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -2081,7 +2081,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             // 3. Seed root versions for existing pages. Idempotent: if
             //    page_versions already has rows (a rewound DB), skip.
             let pageCount = try queryScalarText(
-                "SELECT COUNT(*) FROM page_versions;") ?? "0"
+                "SELECT COUNT(*) FROM page_versions;")
             guard pageCount == "0" else { return }
 
             let hasPages = try queryScalarText(
@@ -2106,7 +2106,6 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
                 _ = try seedAgent.step()
             }
 
-            let now = Date().timeIntervalSince1970
             let select = try statement("""
             SELECT id, title, body_markdown, created_at FROM pages;
             """)
@@ -3345,7 +3344,6 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             guard try target.step() else {
                 throw WikiStoreError.unexpected("version \(versionID) not found for page \(pageID.rawValue)")
             }
-            let blobHash = target.text(at: 0)
             let title = target.text(at: 1)
             let bodyData = target.blob(at: 2)
             let body = String(data: bodyData, encoding: .utf8) ?? ""

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -282,7 +282,7 @@ struct PageVersionTests {
 
         // v3 — save by agent-A (amend fails: different actor → append)
         // This makes v2 have a child (v3).
-        let v3 = try store.appendPageVersion(
+        try store.appendPageVersion(
             pageID: page.id, title: "Guarded Page", body: "v3 body",
             expectedHeadVersionID: v2, lastEditedBy: "agent-A")
 

--- a/Tests/WikiFSTests/Phase6PinningStoreTests.swift
+++ b/Tests/WikiFSTests/Phase6PinningStoreTests.swift
@@ -69,7 +69,7 @@ struct Phase6PinningStoreTests {
         let source = try store.addSource(filename: "doc.pdf", data: Data("pdf".utf8))
 
         let v1 = try store.appendProcessedMarkdown(sourceID: source.id, content: "v1", origin: "t", note: nil)
-        let v2 = try store.appendProcessedMarkdown(sourceID: source.id, content: "v2", origin: "t", note: nil)
+        try store.appendProcessedMarkdown(sourceID: source.id, content: "v2", origin: "t", note: nil)
 
         // A cite @v1, a cite @v2, and an embed @v1 — three distinct edges under
         // source_links_edge (from, to, role, COALESCE(pin, '')).


### PR DESCRIPTION
## Summary

Removes all compiler warnings from the test target and the main framework target. Builds and tests are now warning-free.

## Changes

### Test files
- **`PageVersionTests.swift:285`** — `let v3 = try store.appendPageVersion(...)` → `try store.appendPageVersion(...)`. The return value was never referenced; the call (side effect: making v2 have a child) is kept.
- **`Phase6PinningStoreTests.swift:72`** — `let v2 = try store.appendProcessedMarkdown(...)` → `try store.appendProcessedMarkdown(...)`. The return value was never referenced; the append (creating version "2" for the cite-v2 link) is kept.

### Source files
- **`SQLiteWikiStore.swift:2084`** — Removed dead `?? "0"` nil-coalescing. `queryScalarText` returns non-optional `String`, so the right side was unreachable.
- **`SQLiteWikiStore.swift:2109`** — Removed unused `let now = Date().timeIntervalSince1970`. The migration loop uses `createdAt` from the cursor, not this value.
- **`SQLiteWikiStore.swift:3348`** — Removed unused `let blobHash = target.text(at: 0)`. The column was read but never used in the version-apply path.
- **`QueueStore.swift:570`** — Changed `if let queue {` → `if queue != nil {`. The bound value was unused in that branch; only the SQL selection needed the truthiness check.

## Verification

- `swift build --build-tests` — zero warnings
- `swift test` — all 2,561 tests pass
