### PR TITLE
feat: macOS notifications when queue operations complete

### DIFF
--- a/.pr-body-operation-notifier.md
+++ b/.pr-body-operation-notifier.md
@@ -1,0 +1,32 @@
+## Summary
+
+When a lint, extraction, or ingestion operation reaches a terminal state, the app now posts a macOS local notification summarizing the outcome.
+
+## What changed
+
+- **New `OperationNotifier`** (`Sources/WikiFS/OperationNotifier.swift`) — a `@MainActor` class that subscribes to `QueueEngine.events` (the same multicast stream that `QueueActivityTracker` and `MenuBarItemController` already consume). On `.completed` / `.failed` events it posts a `UNNotificationRequest` with a computed title + body. Cancelled items are skipped (user-initiated, not actionable).
+- **Authorization.** Calls `requestAuthorization(options: [.alert, .sound])` at `start()`. When the app is frontmost, notifications land silently in Notification Center; when backgrounded they appear as banners (the useful case for long-running ingest/extraction).
+- **Summary logic** is extracted as `nonisolated static` pure functions: `operationKind(for:)` classifies extraction vs. ingestion vs. lint (with source/page counts, including whole-wiki lint), and `summary(for:outcome:)` produces the title + body. Error messages are truncated to 180 chars. Pluralization handled.
+- **Wiring.** Created in `WikiFSApp.startStatusItem()` alongside `MenuBarItemController`, held strongly on `AppDelegate.operationNotifier` (same retention pattern as the menu-bar controller).
+
+## How it works
+
+The queue engine already emits terminal events (`.completed(item)`, `.failed(item, error:)`) for every extraction, ingestion, and lint. The notifier is a **passive third consumer** of the existing `QueueEventBroadcaster` multicast — no new event sources, no changes to the engine or workers.
+
+| Operation | Completion | Failure |
+|-----------|------------|---------|
+| Extraction (3 files) | "Extraction Complete — 3 files processed" | "Extraction Failed — 3 files: \<error\>" |
+| Ingestion (1 source) | "Ingestion Complete — 1 source ingested" | "Ingestion Failed — 1 source: \<error\>" |
+| Lint (2 pages) | "Lint Complete — 2 pages linted" | "Lint Failed — 2 pages: \<error\>" |
+| Lint (whole wiki) | "Lint Complete — All pages linted" | "Lint Failed — Wiki-wide lint: \<error\>" |
+
+## Tests
+
+`Tests/WikiFSTests/OperationNotifierSummaryTests.swift` — 23 unit tests covering operation-kind classification, completed/failed/cancelled summaries for all three operation types, pluralization edge cases, empty-error fallback, long-error truncation, whole-wiki vs. specific-page lint, and outcome identifiers.
+
+The `OperationNotifier` class itself (UNUserNotificationCenter wiring, event-stream consumption) is AppKit-coupled and not unit-tested — it follows the same pattern as `MenuBarItemController` (event-stream consumer, no unit tests on the subscription).
+
+## Gates
+
+- `make build` — clean
+- 23 new tests + 2385 existing fast-tier tests = 2408 total, all passing

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,44 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-16 — macOS notifications for queue operation completion
+
+**Implemented (branch `wizardly-horse`).** When a lint, extraction, or
+ingestion operation reaches a terminal state, the app now posts a macOS local
+notification (`UNUserNotificationCenter`) summarizing the outcome.
+
+- **New `OperationNotifier`** (`Sources/WikiFS/OperationNotifier.swift`) — a
+  `@MainActor` class that subscribes to `QueueEngine.events` (the same
+  multicast stream that `QueueActivityTracker` and `MenuBarItemController`
+  consume). On `.completed` / `.failed` events it posts a
+  `UNNotificationRequest` with a computed title + body. Cancelled items are
+  skipped (user-initiated, not actionable).
+- **Authorization.** Calls `requestAuthorization(options: [.alert, .sound])`
+  at `start()`. When the app is frontmost, notifications land silently in
+  Notification Center; when backgrounded they appear as banners (the useful
+  case for long-running ingest/extraction).
+- **Summary logic** is extracted as `nonisolated static` pure functions:
+  `operationKind(for:)` classifies extraction vs. ingestion vs. lint (with
+  source/page counts, including whole-wiki lint), and `summary(for:outcome:)`
+  produces the title + body. Error messages are truncated to 180 chars.
+  Pluralization handled ("1 file" vs. "3 files").
+- **Wiring.** Created in `WikiFSApp.startStatusItem()` alongside
+  `MenuBarItemController`, held strongly on `AppDelegate.operationNotifier`
+  (same retention pattern as the menu-bar controller).
+
+**Drives off the queue engine — no new event sources.** The Queue Engine
+already emits `.completed(item)` and `.failed(item, error:)` for every
+extraction, ingestion, and lint item. The notifier is a passive third consumer
+of the existing `QueueEventBroadcaster` multicast.
+
+**Tests** (`Tests/WikiFSTests/OperationNotifierSummaryTests.swift`, 23 tests):
+operation-kind classification, completed/failed/cancelled summaries for all
+three operation types, pluralization edge cases, empty-error fallback,
+long-error truncation, whole-wiki vs. specific-page lint, outcome identifiers.
+
+**Gates:** `make build` clean; 23 new tests + 2385 existing fast-tier tests all
+pass (2408 total).
+
 ## 2026-07-16 — Timestamped untitled pages + rename collision guard
 
 **Implemented (branch `torpid-penguin`).** Two related changes to page-title

--- a/Sources/WikiFS/OperationNotifier.swift
+++ b/Sources/WikiFS/OperationNotifier.swift
@@ -1,0 +1,259 @@
+import Foundation
+import UserNotifications
+import WikiFSCore
+import WikiFSEngine
+
+/// Posts macOS local notifications when queue operations (extraction,
+/// ingestion, lint) reach a terminal state.
+///
+/// Subscribes to ``QueueEngine.events`` alongside ``QueueActivityTracker`` and
+/// ``MenuBarItemController`` — the queue engine's `QueueEventBroadcaster`
+/// multicasts to every subscriber, so adding a third consumer is free.
+///
+/// On `.completed` / `.failed` events the notifier computes a short summary via
+/// ``summary(for:outcome:)`` (a pure function, unit-tested separately) and posts
+/// a `UNNotificationRequest`.  `UNUserNotificationCenter` decides whether to
+/// show a visible banner based on the app's Notification settings and whether
+/// it is frontmost — when the app is active, notifications land silently in
+/// Notification Center; when backgrounded they appear as banners (the useful
+/// case for long-running ingest/extraction).
+///
+/// **Retention.** Like ``MenuBarItemController``, this must be held strongly —
+/// the ``streamTask`` captures `self` weakly, so without a strong external owner
+/// the notifier is deallocated the moment `start()` returns.  `AppDelegate`
+/// owns the reference (see ``AppDelegate.operationNotifier``).
+@MainActor
+final class OperationNotifier {
+
+    // MARK: - Dependencies
+
+    private let queueEngine: QueueEngine
+
+    /// The stream consumer task. Kept so `stop()` can cancel it.
+    private var streamTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(queueEngine: QueueEngine) {
+        self.queueEngine = queueEngine
+    }
+
+    // MARK: - Lifecycle
+
+    /// Request notification authorization (fire-and-forget) and begin consuming
+    /// the engine's event stream. Idempotent — safe to call once.
+    func start() {
+        guard streamTask == nil else { return }
+
+        // Request authorization. Non-blocking: if the user hasn't granted
+        // permission yet, the system prompt appears; if they decline the
+        // notifications are silently dropped (no error). Either way the
+        // stream consumer starts immediately — authorization is independent
+        // of event observation.
+        Task {
+            do {
+                let granted = try await UNUserNotificationCenter.current()
+                    .requestAuthorization(options: [.alert, .sound])
+                DebugLog.config("OperationNotifier: notification authorization granted=\(granted)")
+            } catch {
+                DebugLog.config("OperationNotifier: authorization request failed: \(error)")
+            }
+        }
+
+        // Subscribe to engine events.
+        streamTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await event in self.queueEngine.events {
+                self.handle(event)
+            }
+        }
+    }
+
+    /// Stop consuming events and cancel the stream task.
+    func stop() {
+        streamTask?.cancel()
+        streamTask = nil
+    }
+
+    // MARK: - Event handling
+
+    private func handle(_ event: QueueEvent) {
+        switch event {
+        case .completed(let item):
+            post(item: item, outcome: .completed)
+        case .failed(let item, let error):
+            post(item: item, outcome: .failed(error))
+        // Cancelled is user-initiated — not worth a notification.
+        case .cancelled, .enqueued, .started, .progress, .transcript,
+             .runStateChanged, .reordered:
+            break
+        }
+    }
+
+    // MARK: - Notification posting
+
+    private func post(item: QueueItem, outcome: TerminalOutcome) {
+        guard let summary = Self.summary(for: item, outcome: outcome) else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = summary.title
+        content.body = summary.body
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            // Include the outcome in the identifier so a retried item (failed →
+            // completed) gets two distinct notifications rather than replacing
+            // the first.
+            identifier: "queue-\(item.id)-\(outcome.identifier)",
+            content: content,
+            trigger: nil // Deliver immediately.
+        )
+
+        Task {
+            do {
+                try await UNUserNotificationCenter.current().add(request)
+            } catch {
+                DebugLog.config("OperationNotifier: failed to post notification for item \(item.id): \(error)")
+            }
+        }
+    }
+
+    // MARK: - Summary (pure, unit-tested)
+
+    /// The terminal outcome that drives the notification summary.
+    enum TerminalOutcome: Sendable, Equatable {
+        case completed
+        case failed(String)
+        case cancelled
+
+        /// A short identifier for the notification request identifier.
+        var identifier: String {
+            switch self {
+            case .completed:  return "completed"
+            case .failed:     return "failed"
+            case .cancelled:   return "cancelled"
+            }
+        }
+    }
+
+    /// A computed notification summary — title + body.
+    struct Summary: Sendable, Equatable {
+        let title: String
+        let body: String
+    }
+
+    /// The kind of operation a queue item represents, for notification language.
+    enum OperationKind: Sendable, Equatable {
+        case extraction(sourceCount: Int)
+        case ingestion(sourceCount: Int)
+        /// `pageCount` is `nil` for whole-wiki lint (empty `lintPageIDs` array).
+        case lint(pageCount: Int?)
+    }
+
+    /// Determine the operation kind from a queue item.
+    nonisolated static func operationKind(for item: QueueItem) -> OperationKind {
+        switch item.queue {
+        case .extraction:
+            return .extraction(sourceCount: item.payload.sourceIDs.count)
+        case .ingestion:
+            if let lintPageIDs = item.payload.lintPageIDs {
+                return .lint(pageCount: lintPageIDs.isEmpty ? nil : lintPageIDs.count)
+            }
+            return .ingestion(sourceCount: item.payload.sourceIDs.count)
+        }
+    }
+
+    /// Compute a notification title + body for a terminal queue item.
+    nonisolated static func summary(for item: QueueItem, outcome: TerminalOutcome) -> Summary? {
+        let kind = operationKind(for: item)
+
+        let label: String
+        switch kind {
+        case .extraction: label = "Extraction"
+        case .ingestion:  label = "Ingestion"
+        case .lint:       label = "Lint"
+        }
+
+        let title: String
+        let body: String
+
+        switch outcome {
+        case .completed:
+            title = "\(label) Complete"
+            body = completedBody(for: kind)
+        case .failed(let error):
+            title = "\(label) Failed"
+            body = failedBody(for: kind, error: error)
+        case .cancelled:
+            // Not currently posted (handle() skips .cancelled), but kept for
+            // completeness and future use.
+            title = "\(label) Cancelled"
+            body = cancelledBody(for: kind)
+        }
+
+        return Summary(title: title, body: body)
+    }
+
+    // MARK: - Body text helpers (private, pure)
+
+    private nonisolated static func completedBody(for kind: OperationKind) -> String {
+        switch kind {
+        case .extraction(let count):
+            return "\(count) file\(count == 1 ? "" : "s") processed"
+        case .ingestion(let count):
+            return "\(count) source\(count == 1 ? "" : "s") ingested"
+        case .lint(let pageCount):
+            if let pageCount {
+                return "\(pageCount) page\(pageCount == 1 ? "" : "s") linted"
+            } else {
+                return "All pages linted"
+            }
+        }
+    }
+
+    private nonisolated static func failedBody(for kind: OperationKind, error: String) -> String {
+        // Include a subject (count) so the user knows the scope, then the
+        // error truncated to fit a notification banner.
+        let subject: String
+        switch kind {
+        case .extraction(let count):
+            subject = "\(count) file\(count == 1 ? "" : "s")"
+        case .ingestion(let count):
+            subject = "\(count) source\(count == 1 ? "" : "s")"
+        case .lint(let pageCount):
+            if let pageCount {
+                subject = "\(pageCount) page\(pageCount == 1 ? "" : "s")"
+            } else {
+                subject = "Wiki-wide lint"
+            }
+        }
+
+        let cleanError = error.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayError = cleanError.isEmpty ? "Unknown error" : cleanError
+
+        // Truncate long errors (e.g. stack traces) to fit a notification banner.
+        let maxLen = 180
+        let truncated: String
+        if displayError.count > maxLen {
+            truncated = String(displayError.prefix(maxLen)) + "\u{2026}"
+        } else {
+            truncated = displayError
+        }
+        return "\(subject): \(truncated)"
+    }
+
+    private nonisolated static func cancelledBody(for kind: OperationKind) -> String {
+        switch kind {
+        case .extraction(let count):
+            return "\(count) file\(count == 1 ? "" : "s") \u{2014} cancelled"
+        case .ingestion(let count):
+            return "\(count) source\(count == 1 ? "" : "s") \u{2014} cancelled"
+        case .lint(let pageCount):
+            if let pageCount {
+                return "\(pageCount) page\(pageCount == 1 ? "" : "s") \u{2014} cancelled"
+            } else {
+                return "Wiki-wide lint \u{2014} cancelled"
+            }
+        }
+    }
+}

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -277,6 +277,13 @@ struct WikiFSApp: App {
         statusController.start()
         appDelegate.menuBarItemController = statusController
 
+        // Operation notifier: posts macOS local notifications when extraction,
+        // ingestion, or lint reaches a terminal state. Subscribes to the same
+        // event stream as the tracker and status item (multicast — free).
+        let notifier = OperationNotifier(queueEngine: queueEngine)
+        notifier.start()
+        appDelegate.operationNotifier = notifier
+
         // File Provider setup + change bridge (async).
         Task {
             if let warning = await FileProviderSetupVerifier.verifyAndRepairInstalledProvider() {
@@ -479,6 +486,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `startStatusItem()` returns, which removes the NSStatusItem from the
     /// menu bar before it ever draws.
     @MainActor var menuBarItemController: MenuBarItemController?
+    /// Strong on purpose — the notifier's `streamTask` captures `self` weakly,
+    /// so without a strong owner it deallocates the moment `start()` returns
+    /// (same pattern as `menuBarItemController`).
+    @MainActor var operationNotifier: OperationNotifier?
     @MainActor var bootstrap: (@MainActor () -> Void)?
 
     // MARK: - Quit confirmation (folded in from the former QuitConfirmationDelegate;

--- a/Tests/WikiFSTests/OperationNotifierSummaryTests.swift
+++ b/Tests/WikiFSTests/OperationNotifierSummaryTests.swift
@@ -1,0 +1,205 @@
+import Testing
+import WikiFSCore
+@testable import WikiFS
+
+/// Unit tests for `OperationNotifier.summary(for:outcome:)` — the pure
+/// function that computes the macOS notification title + body from a terminal
+/// `QueueItem`.  The `OperationNotifier` class itself (UNUserNotificationCenter
+/// wiring, event-stream consumption) is AppKit-coupled and not unit-tested here.
+@Suite struct OperationNotifierSummaryTests {
+
+    // MARK: - Helpers
+
+    /// Build a queue item with the given parameters.
+    private func makeItem(
+        queue: QueueKind,
+        sourceIDs: [PageID] = [],
+        lintPageIDs: [PageID]? = nil
+    ) -> QueueItem {
+        QueueItem(
+            id: "TESTITEM001",
+            queue: queue,
+            wikiID: "wiki1",
+            payload: QueueItemPayload(
+                sourceIDs: sourceIDs,
+                lintPageIDs: lintPageIDs),
+            state: .completed,
+            orderingKey: 1000,
+            providerID: "provider-A",
+            attempt: 0,
+            error: nil,
+            createdAt: 1000,
+            startedAt: 2000,
+            finishedAt: 5000
+        )
+    }
+
+    // MARK: - operationKind
+
+    @Test func kindExtraction() {
+        let item = makeItem(queue: .extraction, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2")])
+        let kind = OperationNotifier.operationKind(for: item)
+        #expect(kind == .extraction(sourceCount: 2))
+    }
+
+    @Test func kindIngestion() {
+        let item = makeItem(queue: .ingestion, sourceIDs: [.init(rawValue: "S1")])
+        let kind = OperationNotifier.operationKind(for: item)
+        #expect(kind == .ingestion(sourceCount: 1))
+    }
+
+    @Test func kindLintSpecificPages() {
+        let item = makeItem(
+            queue: .ingestion,
+            lintPageIDs: [.init(rawValue: "P1"), .init(rawValue: "P2"), .init(rawValue: "P3")])
+        let kind = OperationNotifier.operationKind(for: item)
+        #expect(kind == .lint(pageCount: 3))
+    }
+
+    @Test func kindLintWholeWiki() {
+        // Empty lintPageIDs array = whole-wiki lint → pageCount is nil.
+        let item = makeItem(queue: .ingestion, lintPageIDs: [])
+        let kind = OperationNotifier.operationKind(for: item)
+        #expect(kind == .lint(pageCount: nil))
+    }
+
+    // MARK: - Completed summaries
+
+    @Test func completedExtraction() {
+        let item = makeItem(queue: .extraction, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2"), .init(rawValue: "S3")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.title == "Extraction Complete")
+        #expect(s?.body == "3 files processed")
+    }
+
+    @Test func completedExtractionSingle() {
+        let item = makeItem(queue: .extraction, sourceIDs: [.init(rawValue: "S1")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.body == "1 file processed")
+    }
+
+    @Test func completedIngestion() {
+        let item = makeItem(queue: .ingestion, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.title == "Ingestion Complete")
+        #expect(s?.body == "2 sources ingested")
+    }
+
+    @Test func completedIngestionSingle() {
+        let item = makeItem(queue: .ingestion, sourceIDs: [.init(rawValue: "S1")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.body == "1 source ingested")
+    }
+
+    @Test func completedLintSpecificPages() {
+        let item = makeItem(queue: .ingestion, lintPageIDs: [.init(rawValue: "P1"), .init(rawValue: "P2")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.title == "Lint Complete")
+        #expect(s?.body == "2 pages linted")
+    }
+
+    @Test func completedLintSinglePage() {
+        let item = makeItem(queue: .ingestion, lintPageIDs: [.init(rawValue: "P1")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.body == "1 page linted")
+    }
+
+    @Test func completedLintWholeWiki() {
+        let item = makeItem(queue: .ingestion, lintPageIDs: [])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.title == "Lint Complete")
+        #expect(s?.body == "All pages linted")
+    }
+
+    // MARK: - Failed summaries
+
+    @Test func failedExtraction() {
+        let item = makeItem(queue: .extraction, sourceIDs: [.init(rawValue: "S1")])
+        let s = OperationNotifier.summary(for: item, outcome: .failed("Connection refused"))
+        #expect(s?.title == "Extraction Failed")
+        #expect(s?.body == "1 file: Connection refused")
+    }
+
+    @Test func failedIngestion() {
+        let item = makeItem(queue: .ingestion, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2")])
+        let s = OperationNotifier.summary(for: item, outcome: .failed("Timeout"))
+        #expect(s?.title == "Ingestion Failed")
+        #expect(s?.body == "2 sources: Timeout")
+    }
+
+    @Test func failedLintSpecificPages() {
+        let item = makeItem(queue: .ingestion, lintPageIDs: [.init(rawValue: "P1"), .init(rawValue: "P2"), .init(rawValue: "P3")])
+        let s = OperationNotifier.summary(for: item, outcome: .failed("Syntax error"))
+        #expect(s?.title == "Lint Failed")
+        #expect(s?.body == "3 pages: Syntax error")
+    }
+
+    @Test func failedLintWholeWiki() {
+        let item = makeItem(queue: .ingestion, lintPageIDs: [])
+        let s = OperationNotifier.summary(for: item, outcome: .failed("Agent crashed"))
+        #expect(s?.title == "Lint Failed")
+        #expect(s?.body == "Wiki-wide lint: Agent crashed")
+    }
+
+    @Test func failedEmptyErrorFallsBackToUnknown() {
+        let item = makeItem(queue: .extraction, sourceIDs: [.init(rawValue: "S1")])
+        let s = OperationNotifier.summary(for: item, outcome: .failed("   "))
+        #expect(s?.body == "1 file: Unknown error")
+    }
+
+    @Test func failedLongErrorIsTruncated() {
+        let item = makeItem(queue: .ingestion, sourceIDs: [.init(rawValue: "S1")])
+        let longError = String(repeating: "x", count: 300)
+        let s = OperationNotifier.summary(for: item, outcome: .failed(longError))
+        #expect(s != nil)
+        // Body = "1 source: " + 180 chars + "…"  (U+2026 is one character)
+        let expectedPrefix = String(repeating: "x", count: 180)
+        #expect(s?.body == "1 source: \(expectedPrefix)\u{2026}")
+        #expect(s?.body.count ?? 0 < longError.count + 20)
+    }
+
+    // MARK: - Cancelled summaries (not posted today, but tested for completeness)
+
+    @Test func cancelledExtraction() {
+        let item = makeItem(queue: .extraction, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2")])
+        let s = OperationNotifier.summary(for: item, outcome: .cancelled)
+        #expect(s?.title == "Extraction Cancelled")
+        #expect(s?.body == "2 files \u{2014} cancelled")
+    }
+
+    @Test func cancelledIngestionSingle() {
+        let item = makeItem(queue: .ingestion, sourceIDs: [.init(rawValue: "S1")])
+        let s = OperationNotifier.summary(for: item, outcome: .cancelled)
+        #expect(s?.title == "Ingestion Cancelled")
+        #expect(s?.body == "1 source \u{2014} cancelled")
+    }
+
+    @Test func cancelledLintWholeWiki() {
+        let item = makeItem(queue: .ingestion, lintPageIDs: [])
+        let s = OperationNotifier.summary(for: item, outcome: .cancelled)
+        #expect(s?.title == "Lint Cancelled")
+        #expect(s?.body == "Wiki-wide lint \u{2014} cancelled")
+    }
+
+    // MARK: - Outcome identifier
+
+    @Test func outcomeIdentifiers() {
+        #expect(OperationNotifier.TerminalOutcome.completed.identifier == "completed")
+        #expect(OperationNotifier.TerminalOutcome.failed("err").identifier == "failed")
+        #expect(OperationNotifier.TerminalOutcome.cancelled.identifier == "cancelled")
+    }
+
+    // MARK: - Pluralization edge cases
+
+    @Test func zeroSourcesCompleted() {
+        let item = makeItem(queue: .extraction, sourceIDs: [])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.body == "0 files processed")
+    }
+
+    @Test func zeroSourcesFailed() {
+        let item = makeItem(queue: .ingestion, sourceIDs: [])
+        let s = OperationNotifier.summary(for: item, outcome: .failed("oops"))
+        #expect(s?.body == "0 sources: oops")
+    }
+}


### PR DESCRIPTION
## Summary

When a lint, extraction, or ingestion operation reaches a terminal state, the app now posts a macOS local notification summarizing the outcome.

## What changed

- **New `OperationNotifier`** (`Sources/WikiFS/OperationNotifier.swift`) — a `@MainActor` class that subscribes to `QueueEngine.events` (the same multicast stream that `QueueActivityTracker` and `MenuBarItemController` already consume). On `.completed` / `.failed` events it posts a `UNNotificationRequest` with a computed title + body. Cancelled items are skipped (user-initiated, not actionable).
- **Authorization.** Calls `requestAuthorization(options: [.alert, .sound])` at `start()`. When the app is frontmost, notifications land silently in Notification Center; when backgrounded they appear as banners (the useful case for long-running ingest/extraction).
- **Summary logic** is extracted as `nonisolated static` pure functions: `operationKind(for:)` classifies extraction vs. ingestion vs. lint (with source/page counts, including whole-wiki lint), and `summary(for:outcome:)` produces the title + body. Error messages are truncated to 180 chars. Pluralization handled.
- **Wiring.** Created in `WikiFSApp.startStatusItem()` alongside `MenuBarItemController`, held strongly on `AppDelegate.operationNotifier` (same retention pattern as the menu-bar controller).

## How it works

The queue engine already emits terminal events (`.completed(item)`, `.failed(item, error:)`) for every extraction, ingestion, and lint. The notifier is a **passive third consumer** of the existing `QueueEventBroadcaster` multicast — no new event sources, no changes to the engine or workers.

| Operation | Completion | Failure |
|-----------|------------|---------|
| Extraction (3 files) | "Extraction Complete — 3 files processed" | "Extraction Failed — 3 files: \<error\>" |
| Ingestion (1 source) | "Ingestion Complete — 1 source ingested" | "Ingestion Failed — 1 source: \<error\>" |
| Lint (2 pages) | "Lint Complete — 2 pages linted" | "Lint Failed — 2 pages: \<error\>" |
| Lint (whole wiki) | "Lint Complete — All pages linted" | "Lint Failed — Wiki-wide lint: \<error\>" |

## Tests

`Tests/WikiFSTests/OperationNotifierSummaryTests.swift` — 23 unit tests covering operation-kind classification, completed/failed/cancelled summaries for all three operation types, pluralization edge cases, empty-error fallback, long-error truncation, whole-wiki vs. specific-page lint, and outcome identifiers.

The `OperationNotifier` class itself (UNUserNotificationCenter wiring, event-stream consumption) is AppKit-coupled and not unit-tested — it follows the same pattern as `MenuBarItemController` (event-stream consumer, no unit tests on the subscription).

## Gates

- `make build` — clean
- 23 new tests + 2385 existing fast-tier tests = 2408 total, all passing
