### PR TITLE
feat: keep menubar active after window close, add Open Wiki menu

### DIFF
--- a/Sources/WikiFS/MenuBarItemController.swift
+++ b/Sources/WikiFS/MenuBarItemController.swift
@@ -28,6 +28,14 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     private let queueEngine: QueueEngine
     private let activityTracker: QueueActivityTracker
     private weak var sessionManager: SessionManager?
+    /// The wiki registry — drives the "Open Wiki" menu items. Read fresh each
+    /// time the menu opens (`menuNeedsUpdate`), so newly-created wikis appear
+    /// without a manual refresh.
+    private let registry: WikiRegistryClient
+    /// Bridges to SwiftUI's `openWindow(value:)` so selecting a wiki from the
+    /// status bar menu opens (or focuses) that wiki's window — even in
+    /// accessory mode when no windows are visible.
+    private let openWindowBridge: OpenWindowBridge
 
     // MARK: - AppKit
 
@@ -48,11 +56,15 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     init(
         queueEngine: QueueEngine,
         activityTracker: QueueActivityTracker,
-        sessionManager: SessionManager
+        sessionManager: SessionManager,
+        registry: WikiRegistryClient,
+        openWindowBridge: OpenWindowBridge
     ) {
         self.queueEngine = queueEngine
         self.activityTracker = activityTracker
         self.sessionManager = sessionManager
+        self.registry = registry
+        self.openWindowBridge = openWindowBridge
     }
 
     // MARK: - Lifecycle
@@ -118,6 +130,34 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     }
 
     private func buildMenu(_ menu: NSMenu, snapshot: QueueSnapshot) {
+        // Open Wiki section: lists every wiki so the user can get back to a
+        // window even when all windows are closed (accessory mode). Each item
+        // calls `openWindowBridge.openWiki(wiki.id)` which opens or focuses
+        // that wiki's window via SwiftUI's `WindowGroup(for: String.self)`.
+        if !registry.wikis.isEmpty {
+            for wiki in registry.wikis {
+                let item = NSMenuItem(
+                    title: wiki.displayName,
+                    action: #selector(openWikiWindow(_:)),
+                    keyEquivalent: "")
+                item.target = self
+                item.representedObject = wiki.id
+                // Show a checkmark next to the most-recently-used wiki.
+                item.state = (registry.activeWikiID == wiki.id) ? .on : .off
+                menu.addItem(item)
+            }
+            menu.addItem(.separator())
+        } else {
+            // No wikis exist: offer the main window so the user can create one.
+            let item = NSMenuItem(
+                title: "New Wiki…",
+                action: #selector(openMainWindow(_:)),
+                keyEquivalent: "")
+            item.target = self
+            menu.addItem(item)
+            menu.addItem(.separator())
+        }
+
         // Per-queue windows.
         let ingestionItem = NSMenuItem(
             title: "Agent Queue…",
@@ -173,6 +213,17 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
             action: #selector(NSApplication.terminate(_:)),
             keyEquivalent: "q")
         menu.addItem(quitItem)
+    }
+
+    @objc private func openWikiWindow(_ sender: NSMenuItem?) {
+        guard let wikiID = sender?.representedObject as? String else { return }
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        openWindowBridge.openWiki?(wikiID)
+    }
+
+    @objc private func openMainWindow(_ sender: NSMenuItem?) {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        openWindowBridge.openMain?()
     }
 
     @objc private func openIngestionWindow(_ sender: NSMenuItem?) {

--- a/Sources/WikiFS/OpenWindowBridge.swift
+++ b/Sources/WikiFS/OpenWindowBridge.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SwiftUI
+
+/// Bridges SwiftUI's `@Environment(\.openWindow)` action to AppKit code that
+/// can't access the SwiftUI environment (notably `MenuBarItemController` and
+/// `AppDelegate.applicationShouldHandleReopen`).
+///
+/// The app is single-window-per-wiki: `WindowGroup(for: String.self)`
+/// deduplicates by `==`, so `openWiki(id)` either opens a new wiki window or
+/// focuses the existing one for that wiki — the Safari/Xcode "open in new
+/// window" pattern used by `WikiSwitcher`.
+///
+/// A hidden helper view (`WindowBridgeProbe`) installed in the main
+/// `WindowGroup` captures `@Environment(\.openWindow)` and sets
+/// `openWiki` via `wire(openWindow:)`. Everything is `@MainActor` (the
+/// environment value, the bridge, and all call sites), so no `Sendable`
+/// concerns.
+///
+/// Before the bridge is wired (briefly, during launch), `openWiki` is nil —
+/// calling it is a no-op. The menu items read `registry.wikis` directly so
+/// the list is always current; the bridge is only the action transport.
+@MainActor
+final class OpenWindowBridge {
+    /// Opens (or focuses) the wiki window for the given wiki ID. Set by
+    /// `WindowBridgeProbe` from a SwiftUI view that has access to
+    /// `@Environment(\.openWindow)`.
+    var openWiki: ((String) -> Void)?
+
+    /// Opens the main (launch) window — used when there are no wikis yet, or
+    /// as a fallback from `applicationShouldHandleReopen`. Set by
+    /// `WindowBridgeProbe` via `openWindow(id: "main")`.
+    var openMain: (() -> Void)?
+}
+
+/// Invisible helper view that captures `@Environment(\.openWindow)` (only
+/// available inside a `WindowGroup`'s view hierarchy) and wires it into the
+/// ``OpenWindowBridge`` so AppKit code can trigger window opening.
+///
+/// `Color.clear` with zero size renders nothing visible. `.onAppear` fires
+/// once when the hosting window first renders; the closures capture the
+/// `OpenWindowAction` struct by value, so they remain callable even after the
+/// window hosting this probe is closed — the system action outlives the view.
+struct WindowBridgeProbe: View {
+    let bridge: OpenWindowBridge
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Color.clear
+            .frame(maxWidth: 0, maxHeight: 0)
+            .onAppear { wire() }
+    }
+
+    private func wire() {
+        // `openWindow(value: wikiID)` targets `WindowGroup(for: String.self)`,
+        // deduplicating by ==: if a window for that wiki is already open, it's
+        // focused instead of spawning a duplicate.
+        bridge.openWiki = { wikiID in
+            openWindow(value: wikiID)
+        }
+        // `openWindow(id: "main")` targets the main `WindowGroup(id: "main")`.
+        bridge.openMain = {
+            openWindow(id: "main")
+        }
+    }
+}

--- a/Sources/WikiFS/WikiFSApp.swift
+++ b/Sources/WikiFS/WikiFSApp.swift
@@ -62,6 +62,11 @@ struct WikiFSApp: App {
     /// Built lazily after `bootstrap` (it needs the registered wikis) — see the
     /// `.task` below. The change bridge observes `wikictl`'s Darwin notifications.
     @State private var changeBridge: WikiChangeBridge?
+    /// Bridges SwiftUI's `@Environment(\.openWindow)` to AppKit (menu bar,
+    /// app delegate) so wiki windows can be reopened from the status item
+    /// when no windows are visible (accessory mode). Wired by
+    /// `WindowBridgeProbe`, a hidden view inside the main `WindowGroup`.
+    @State private var openWindowBridge = OpenWindowBridge()
 
     // NOTE: There must be exactly ONE @NSApplicationDelegateAdaptor. Registering
     // two adaptors with different types (e.g. a separate QuitConfirmationDelegate)
@@ -273,7 +278,9 @@ struct WikiFSApp: App {
         let statusController = MenuBarItemController(
             queueEngine: queueEngine,
             activityTracker: activityTracker,
-            sessionManager: sessionManager)
+            sessionManager: sessionManager,
+            registry: registry,
+            openWindowBridge: openWindowBridge)
         statusController.start()
         appDelegate.menuBarItemController = statusController
 
@@ -323,6 +330,13 @@ struct WikiFSApp: App {
             }
             return nil
         }
+        appDelegate.reopenMostRecentWiki = { [registry, openWindowBridge] in
+            if let wikiID = registry.activeWikiID ?? registry.wikis.first?.id {
+                openWindowBridge.openWiki?(wikiID)
+            } else {
+                openWindowBridge.openMain?()
+            }
+        }
     }
 
     var body: some Scene {
@@ -330,13 +344,18 @@ struct WikiFSApp: App {
         // wiki via the `registry.activeWikiID` → `wikiID` adoption flow in
         // `RootScene`. This avoids the "empty window flash" that
         // `WindowGroup(for:)` would show before `.task` runs.
-        WindowGroup {
+        //
+        // `id: "main"` lets `openWindow(id: "main")` reopen this window from
+        // the status bar menu / Dock click when all windows are closed
+        // (accessory mode) and there are no wikis to open via `openWindow(value:)`.
+        WindowGroup(id: "main") {
             RootScene(
                 wikiID: nil,
                 registry: registry,
                 sessionManager: sessionManager,
                 fileProvider: fileProvider
             )
+            .background(WindowBridgeProbe(bridge: openWindowBridge))
             .appEnvironment(tracker: activityTracker)
             .alert(
                 "Install Self Driving Wiki in Applications",
@@ -398,6 +417,7 @@ struct WikiFSApp: App {
                 sessionManager: sessionManager,
                 fileProvider: fileProvider
             )
+            .background(WindowBridgeProbe(bridge: openWindowBridge))
             .appEnvironment(tracker: activityTracker)
             .onAppear {
                 DebugLog.tabs("RootScene wiki-window onAppear: wikiID=\(wikiID ?? "nil")")
@@ -493,6 +513,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The quit dialog message is tailored based on what's running.
     var activeOperationDescription: (() -> String?)?
 
+    /// Called from `applicationShouldHandleReopen` (Dock click) to restore a
+    /// wiki window when the user reopens the app with no visible windows.
+    /// Opens the MRU wiki's window, or the main window (empty-state) if no
+    /// wikis exist. Wired in `startStatusItem()` where both `registry` and
+    /// `openWindowBridge` are in scope.
+    var reopenMostRecentWiki: (() -> Void)?
+
     /// `@AppStorage` key for the "ask before quitting" toggle (Settings →
     /// General). Default is "ask" (true) when unset — matching the feature's
     /// purpose. Referenced by `GeneralSettingsView`.
@@ -580,10 +607,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// When the user reopens the app (Dock click, status item), restore
-    /// normal dock presence (AC1.3).
+    /// normal dock presence (AC1.3) and open a wiki window if none are
+    /// visible — so the user isn't stranded in accessory mode with no way
+    /// back to their content.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if !flag {
-            NSApp.setActivationPolicy(.regular)
+        MainActor.assumeIsolated {
+            if !flag {
+                NSApp.setActivationPolicy(.regular)
+                reopenMostRecentWiki?()
+            }
         }
         return true
     }


### PR DESCRIPTION
## Problem

When all wiki windows are closed, the app drops to `.accessory` mode (Dock hidden, menu bar hidden). The status item persisted in the menu bar (that already worked), but its dropdown had **no way to reopen a wiki window** — the user was stranded in menu-bar-only mode with no path back to their content.

## Solution

Add an "Open Wiki" section to the status bar dropdown menu, and fix `applicationShouldHandleReopen` so Dock-click actually restores a window.

### OpenWindowBridge

SwiftUI's `@Environment(\.openWindow)` is only available inside a `WindowGroup`'s view hierarchy. `MenuBarItemController` (AppKit) and `AppDelegate` can't access it directly. A small bridge solves this:

- **`OpenWindowBridge`** (`@MainActor` class) — holds two closure properties: `openWiki((String) -> Void)?` and `openMain(() -> Void)?`
- **`WindowBridgeProbe`** — a zero-size invisible view (`.background`) placed inside each `WindowGroup`. On `.onAppear`, it captures `@Environment(\.openWindow)` and wires the bridge closures. The closures capture the `OpenWindowAction` struct by value, so they remain callable even after the hosting window is closed.

### Status bar menu — wiki list

The top of the status bar dropdown now lists every wiki from the registry (with a checkmark on the active/MRU wiki). Selecting one calls `openWindowBridge.openWiki?(wikiID)`, which triggers SwiftUI's `openWindow(value: wikiID)` — targeting `WindowGroup(for: String.self)`, which deduplicates by `==` (opens a new window or focuses the existing one for that wiki).

When no wikis exist, the menu shows "New Wiki…" instead, which opens the main window's empty-state where the user can create one.

The menu is rebuilt on every open via `menuNeedsUpdate`, so newly-created wikis appear without a manual refresh.

### Dock-click reopen

`applicationShouldHandleReopen` previously only called `NSApp.setActivationPolicy(.regular)` — restoring Dock presence but opening no window. Now it also calls a `reopenMostRecentWiki` closure (wired in `startStatusItem()`) that opens the MRU wiki's window, or falls back to the main window if no wikis exist.

### Main WindowGroup id

The main `WindowGroup` now has `id: "main"` so `openWindow(id: "main")` can reopen it — used as the fallback when no wikis exist.

## Files changed

| File | Change |
|------|--------|
| `Sources/WikiFS/OpenWindowBridge.swift` | **New.** Bridge class + probe view |
| `Sources/WikiFS/WikiFSApp.swift` | Bridge `@State`, `id: "main"`, probe injection, reopen closure, `applicationShouldHandleReopen` fix |
| `Sources/WikiFS/MenuBarItemController.swift` | Registry + bridge params, wiki menu items, `@objc` handlers |

## Testing

- `swift build` — compiles clean
- `swift test` (fast tier, 2385 tests) — all pass
