### PR TITLE
fix: render YouTube embeds under a real origin to prevent error 153

### DIFF
--- a/Sources/WikiFS/WikiReaderView.swift
+++ b/Sources/WikiFS/WikiReaderView.swift
@@ -912,7 +912,14 @@ internal struct WikiReaderRep: NSViewRepresentable {
                     ReaderTiming.point("webview.main-hop", ms: Self.elapsedMs(since: convertDone))
                     ReaderTiming.point("webview.convert", ms: convertMs)
                     self.htmlLoadStart = DispatchTime.now()
-                    webView.loadHTMLString(html, baseURL: URL(string: "about:blank"))
+                    // Load under a real https origin (not about:blank) so embedded
+                    // players that validate the parent origin work — notably the
+                    // YouTube iframe, which 153-errors under an opaque `null` origin
+                    // (issue #206). All in-document links/images use absolute schemes
+                    // (wiki://, wiki-blob://, http[s]://), so base-relative resolution
+                    // is unaffected. Must stay in lock-step with the `?origin=` param
+                    // stamped onto the YouTube embed URL in ExternalEmbed.
+                    webView.loadHTMLString(html, baseURL: WikiReaderOrigin.url)
                 }
             }
         }

--- a/Sources/WikiFSCore/ExternalEmbed.swift
+++ b/Sources/WikiFSCore/ExternalEmbed.swift
@@ -48,6 +48,26 @@ public struct SourceEmbedDescriptor: Sendable, Equatable {
     }
 }
 
+// MARK: - WikiReaderOrigin
+
+/// The synthetic https origin the page reader's WKWebView document is loaded
+/// under (`loadHTMLString(baseURL:)`). YouTube's embedded player rejects an
+/// embed whose parent document has no real origin (opaque `null` under an
+/// `about:blank` base) with **error 153** — so the reader document needs a real
+/// origin AND the YouTube embed URL must carry a matching `?origin=` param.
+///
+/// Defined here — in the same file as the embed-URL builder that stamps
+/// `?origin=` — so the URL the iframe points at and the `baseURL` the reader
+/// loads the wrapping document under can never drift out of lock-step. The host
+/// is a private synthetic name (not a real site); it only has to be a
+/// syntactically valid https origin that the reader and the embed agree on.
+public enum WikiReaderOrigin {
+    /// The origin string, e.g. stamped into `?origin=` on the YouTube embed URL.
+    public static let string = "https://reader.wikifs.local"
+    /// The same origin as a `URL`, for `loadHTMLString(baseURL:)`.
+    public static var url: URL? { URL(string: string) }
+}
+
 // MARK: - EmbedTarget
 
 /// The render decision `ExternalEmbed` makes for one descriptor: *what kind* of
@@ -104,7 +124,20 @@ public enum ExternalEmbed {
         switch mime {
         case "video/youtube":
             guard let id = d.externalIdentity, !id.isEmpty else { return nil }
-            return EmbedTarget(kind: .iframe, url: "https://www.youtube-nocookie.com/embed/\(id)")
+            // Privacy-enhanced host (no tracking cookies) — but the player 153-errors
+            // unless the embed carries the reader's origin. `enablejsapi=1` lets the
+            // player postMessage back to the parent; `origin`/`widget_referrer` name
+            // the reader origin the parent document is actually loaded under
+            // (`WikiReaderOrigin` → the WKWebView baseURL). Percent-encode the `://`
+            // in the origin value so it survives as a single query value (mirrors the
+            // SoundCloud track-URL encoding below).
+            var allowed = CharacterSet.urlQueryAllowed
+            allowed.remove(charactersIn: ":/")
+            let origin = WikiReaderOrigin.string.addingPercentEncoding(withAllowedCharacters: allowed)
+                ?? WikiReaderOrigin.string
+            let url = "https://www.youtube-nocookie.com/embed/\(id)"
+                + "?enablejsapi=1&origin=\(origin)&widget_referrer=\(origin)"
+            return EmbedTarget(kind: .iframe, url: url)
         case "video/vimeo":
             guard let id = d.externalIdentity, !id.isEmpty else { return nil }
             return EmbedTarget(kind: .iframe, url: "https://player.vimeo.com/video/\(id)")

--- a/Sources/WikiFSCore/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSCore/WikiLinkMarkdown.swift
@@ -393,6 +393,15 @@ public enum WikiLinkMarkdown {
             switch target.kind {
             case .iframe:
                 let sizeClass = iframeSizeClass(for: target.url)
+                // YouTube-specific: the player initializes a JS runtime that
+                // 153-errors under `loading="lazy"` (WebKit suspends the frame,
+                // the player inits against a detached/zero-size iframe) and needs
+                // the reader's referrer to be forwarded. Eager-load it and set an
+                // explicit referrer policy. Other providers (Vimeo/Spotify/…) keep
+                // lazy loading unchanged — they render fine as-is (issue #206 non-goal).
+                if target.url.contains("youtube-nocookie.com") || target.url.contains("youtube.com") {
+                    return "<iframe src=\"\(embedEscape(target.url))\" class=\"wiki-embed \(sizeClass)\" allow=\"encrypted-media; picture-in-picture; fullscreen\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+                }
                 return "<iframe src=\"\(embedEscape(target.url))\" class=\"wiki-embed \(sizeClass)\" allow=\"encrypted-media; picture-in-picture; fullscreen\" loading=\"lazy\"></iframe>"
             case .audio:
                 return "<audio src=\"\(embedEscape(target.url))\" controls class=\"wiki-embed\"></audio>"

--- a/Tests/WikiFSTests/BytelessEmbedIntegrationTests.swift
+++ b/Tests/WikiFSTests/BytelessEmbedIntegrationTests.swift
@@ -108,7 +108,9 @@ struct BytelessEmbedIntegrationTests {
         // The descriptor yields a YouTube iframe target.
         let target = try #require(ExternalEmbed.target(for: d))
         #expect(target.kind == .iframe)
-        #expect(target.url == "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+        // Embed URL carries the reader origin (issue #206: no origin ⇒ error 153).
+        #expect(target.url.hasPrefix("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?"))
+        #expect(target.url.contains("origin="))
     }
 
     // MARK: - AC.1: provider URL routing (no network)

--- a/Tests/WikiFSTests/ExternalEmbedTests.swift
+++ b/Tests/WikiFSTests/ExternalEmbedTests.swift
@@ -24,7 +24,15 @@ struct ExternalEmbedTests {
         let t = try #require(ExternalEmbed.target(for: descriptor(
             mimeType: "video/youtube", externalIdentity: "dQw4w9WgXcQ")))
         #expect(t.kind == .iframe)
-        #expect(t.url == "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+        // Privacy-enhanced host + the reader origin threaded through so the player
+        // accepts the embed (no origin ⇒ error 153, issue #206). Origin `://` is
+        // percent-encoded as a query value.
+        let origin = WikiReaderOrigin.string.addingPercentEncoding(
+            withAllowedCharacters: {
+                var a = CharacterSet.urlQueryAllowed; a.remove(charactersIn: ":/"); return a
+            }())!
+        #expect(t.url == "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
+            + "?enablejsapi=1&origin=\(origin)&widget_referrer=\(origin)")
     }
 
     @Test func vimeoTarget() throws {

--- a/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
+++ b/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
@@ -498,9 +498,27 @@ struct WikiLinkMarkdownTests {
         #expect(out.contains("<iframe"))
         #expect(out.contains("youtube-nocookie.com/embed/dQw4w9WgXcQ"))
         #expect(out.contains("wiki-embed"))
-        #expect(out.contains("loading=\"lazy\""))
+        // YouTube iframes are eager-loaded (NOT lazy) and carry a referrer policy —
+        // lazy-loading + null referrer is what produced error 153 (issue #206).
+        #expect(!out.contains("loading=\"lazy\""))
+        #expect(out.contains("referrerpolicy=\"strict-origin-when-cross-origin\""))
         #expect(!out.contains("wiki-blob://"))  // external, not blob
         #expect(!out.contains("wiki://"))  // not a fallback cite link
+    }
+
+    @Test func embedNonYouTubeIframeKeepsLazyLoading() {
+        // Non-goal guard (issue #206): Vimeo/Spotify/etc. iframes render unchanged —
+        // still lazy-loaded, no YouTube-specific attributes.
+        let id = PageID(rawValue: "01HTESTVIMEO00000000000000")
+        let target = EmbedTarget(kind: .iframe, url: "https://player.vimeo.com/video/76979871")
+        let out = WikiLinkMarkdown.linkified(
+            "![[source:video]]",
+            isResolved: { _, _ in true },
+            embedInfo: { _ in WikiLinkMarkdown.SourceEmbedInfo(id: id, mimeType: "video/vimeo", target: target) }
+        )
+        #expect(out.contains("<iframe"))
+        #expect(out.contains("player.vimeo.com/video/76979871"))
+        #expect(out.contains("loading=\"lazy\""))
     }
 
     @Test func embedDirectRemoteAudioTargetRendersNativeAudio() {

--- a/Tests/WikiFSTests/WikiRenderContextTests.swift
+++ b/Tests/WikiFSTests/WikiRenderContextTests.swift
@@ -132,7 +132,9 @@ struct WikiRenderContextTests {
         #expect(info.id == ytID)
         let target = try #require(info.target)
         #expect(target.kind == .iframe)
-        #expect(target.url == "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+        // Embed URL carries the reader origin (issue #206: no origin ⇒ error 153).
+        #expect(target.url.hasPrefix("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?"))
+        #expect(target.url.contains("origin="))
     }
 
     // MARK: - displayName

--- a/Tests/WikiFSTests/YouTubeEmbedWebViewTests.swift
+++ b/Tests/WikiFSTests/YouTubeEmbedWebViewTests.swift
@@ -1,0 +1,148 @@
+import AppKit
+import SwiftUI
+import Testing
+import WebKit
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// AC.9 (issue #206): the live WKWebView paint of a YouTube embed. The string
+/// unit tests prove the *iframe HTML* is right; they CANNOT prove the wiring
+/// that actually produced error 153 — the wrapping document's real origin. This
+/// hosts the REAL `WikiReaderView` (through `NSHostingController`, the same seam
+/// the app uses) and inspects the live DOM.
+///
+/// Root cause recap: the document was loaded under `about:blank`, so its origin
+/// was the opaque `null`; the YouTube player rejects an embed with no valid
+/// parent origin (153). The fix loads the document under `WikiReaderOrigin` AND
+/// stamps a matching `?origin=` on the embed URL. This test pins BOTH ends:
+///   1. the live document's `window.origin` is the real reader origin (not null), and
+///   2. the painted iframe's `src` carries that same origin.
+/// A regression to `about:blank` (or a dropped `?origin=`) fails here — which the
+/// 1706 string-output tests could not catch.
+@Suite(.tags(.integration))
+@MainActor
+struct YouTubeEmbedWebViewTests {
+
+    /// A WKWebView in `swift test` has no host app, so JS/view work never fires.
+    /// Creating `NSApplication.shared` gives WebKit the run loop / app context.
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    private func findWebView(_ view: NSView) -> WKWebView? {
+        if let w = view as? WKWebView { return w }
+        for sub in view.subviews { if let f = findWebView(sub) { return f } }
+        return nil
+    }
+
+    @MainActor
+    private func waitForWebView(in window: NSWindow, timeout: TimeInterval = 5) async throws -> WKWebView {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let cv = window.contentView, let w = findWebView(cv) { return w }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        throw NSError(domain: "YouTubeEmbedWebViewTests", code: 1,
+                      userInfo: [NSLocalizedDescriptionKey: "no WKWebView found in hosted window"])
+    }
+
+    /// Evaluate `js` and return its result coerced to a String inside the
+    /// completion (Sendable-safe — only the `String?` crosses the continuation).
+    @MainActor
+    private func evalString(_ webView: WKWebView, _ js: String) async -> String? {
+        await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
+            webView.evaluateJavaScript(js) { result, _ in cont.resume(returning: result as? String) }
+        }
+    }
+
+    /// Poll the live DOM until the reader has painted the embed iframe, returning
+    /// its `src` (the render is async: detached convert → main-hop → loadHTMLString
+    /// → didFinish). "" if it never appears.
+    @MainActor
+    private func waitForIframeSrc(in webView: WKWebView, tries: Int = 60) async -> String {
+        for _ in 0..<tries {
+            let src = await evalString(webView, """
+            (function(){ var f=document.querySelector("iframe.wiki-embed"); return f?f.getAttribute("src"):""; })()
+            """) ?? ""
+            if !src.isEmpty { return src }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return ""
+    }
+
+    @MainActor
+    private func hostedReader(markdown: String, store: WikiStoreModel) throws
+        -> (window: NSWindow, webView: WKWebView) {
+        let view = WikiReaderView(markdown: markdown, currentSelection: store.selection, store: store)
+        let hosting = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: hosting)
+        window.makeKeyAndOrderFront(nil)
+        return (window, findWebView(window.contentView!) ?? WKWebView())
+    }
+
+    /// The gold-standard AC.9 reproduction: seed a byteless YouTube source, render
+    /// the real reader for a page that embeds it, and assert the live DOM. If the
+    /// document were still under `about:blank`, `window.origin` would be `"null"`
+    /// and YouTube would 153 — so this pins the fix at the layer the unit tests
+    /// can't reach.
+    @Test func hostedYouTubeEmbedLoadsUnderRealOriginWithMatchingEmbedURL() async throws {
+        let dbURL = URL.temporaryDirectory.appending(path: "yt-embed-\(UUID().uuidString).sqlite")
+        let sqlite = try SQLiteWikiStore(databaseURL: dbURL)
+        let videoID = "dQw4w9WgXcQ"
+
+        // Seed the byteless YouTube source exactly as the URL recognizer would.
+        _ = try sqlite.addBytelessSource(
+            filename: "youtube-\(videoID)",
+            mimeType: "video/youtube",
+            provenance: SourceProvenance(
+                agentName: "youtube", activityKind: "fetch",
+                plan: "https://youtu.be/\(videoID)",
+                externalRef: "https://youtu.be/\(videoID)",
+                externalIdentity: videoID),
+            role: .primary)
+
+        let store = WikiStoreModel(store: sqlite)
+
+        // A page that embeds the source — the real reader resolves this through
+        // WikiRenderContext.embedInfo → ExternalEmbed.target.
+        let markdown = "# Watch\n\n![[source:youtube-\(videoID)]]"
+
+        let (window, _) = try hostedReader(markdown: markdown, store: store)
+        defer { window.orderOut(nil) }
+        let webView = try await waitForWebView(in: window)
+
+        // 1. The iframe painted with the corrected embed URL (origin threaded in).
+        let src = await waitForIframeSrc(in: webView)
+        #expect(src.contains("youtube-nocookie.com/embed/\(videoID)"),
+                "reader did not paint the YouTube iframe; src=\"\(src)\"")
+        #expect(src.contains("origin="),
+                "embed URL missing the ?origin= param that prevents error 153; src=\"\(src)\"")
+
+        // 2. THE wiring fix: the live document is loaded under the real reader
+        //    origin, NOT the opaque `null` of about:blank (the direct cause of 153).
+        let origin = await evalString(webView, "String(window.origin)") ?? ""
+        #expect(origin == WikiReaderOrigin.string,
+                "document origin is \"\(origin)\" (expected \(WikiReaderOrigin.string)); a null/about:blank origin is what triggers YouTube error 153")
+
+        // 3. And the embed's origin param matches that document origin — the two
+        //    MUST agree for the player to accept the embed.
+        let encodedOrigin = WikiReaderOrigin.string.addingPercentEncoding(
+            withAllowedCharacters: {
+                var a = CharacterSet.urlQueryAllowed; a.remove(charactersIn: ":/"); return a
+            }()) ?? WikiReaderOrigin.string
+        #expect(src.contains("origin=\(encodedOrigin)"),
+                "embed origin param does not match the document origin; src=\"\(src)\"")
+
+        // 4. The YouTube iframe is eager-loaded (no lazy suspension racing the
+        //    player init) and carries a referrer policy.
+        let attrs = await evalString(webView, """
+        (function(){ var f=document.querySelector("iframe.wiki-embed");
+          return f ? (f.getAttribute("loading")||"none")+"|"+(f.getAttribute("referrerpolicy")||"none") : "no-iframe"; })()
+        """) ?? ""
+        #expect(attrs == "none|strict-origin-when-cross-origin",
+                "YouTube iframe should be eager-loaded with a referrer policy; got \"\(attrs)\"")
+    }
+}


### PR DESCRIPTION
YouTube's privacy-enhanced player rejected embeds with error 153
(video player configuration error) because the reader loaded its
document under `about:blank` (opaque `null` origin) and the embed URL
carried no `origin` param. The player's postMessage handshake needs a
valid parent origin matching the embed's `?origin=`.

- ExternalEmbed: add shared `WikiReaderOrigin`; stamp
  `?enablejsapi=1&origin=…&widget_referrer=…` on the YouTube embed URL.
- WikiReaderView: load the document under `WikiReaderOrigin.url` instead
  of `about:blank` (all in-doc URLs are absolute, so base-relative
  resolution is unaffected).
- WikiLinkMarkdown: eager-load the YouTube iframe (drop `loading="lazy"`,
  which races the player init) and set a referrer policy. Other providers
  unchanged.
- Add YouTubeEmbedWebViewTests: hosted NSHostingController + live WKWebView
  paint (AC.9) asserting the document's real `window.origin` and a matching
  embed `origin=` — the wiring the string-output tests can't reach.

Fixes #206

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
