### PR TITLE
Move chat footer below responses + add timestamps to chat outline

### DIFF
--- a/Sources/WikiFS/ChatView.swift
+++ b/Sources/WikiFS/ChatView.swift
@@ -452,33 +452,44 @@ struct ChatView: View {
     /// the conversation. Sourced from `displayMessages` (same events as the
     /// transcript). Uses `ChatSummary.summaryExtract` for the response text.
     private var chatOutlineEntries: [ChatOutlineEntry] {
+        let msgs = displayMessages
+        let timestamps = displayTimestamps
         var entries: [ChatOutlineEntry] = []
         var pendingQuestion: String?
-        for event in displayMessages {
+        var pendingQuestionTS: Date?
+        for (i, event) in msgs.enumerated() {
+            let ts = i < timestamps.count ? timestamps[i] : nil
             switch event {
             case .userText(let text):
                 if let q = pendingQuestion {
-                    entries.append(ChatOutlineEntry(question: q, response: nil))
+                    entries.append(ChatOutlineEntry(question: q, response: nil,
+                                                    questionTimestamp: pendingQuestionTS, responseTimestamp: nil))
                 }
                 pendingQuestion = humanizeAttachmentRefs(in: text)
+                pendingQuestionTS = ts
             case .assistantText(let text):
                 if let q = pendingQuestion {
                     let summary = ChatSummary.summaryExtract(from: text, maxLength: 200)
-                    entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary))
+                    entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
+                                                    questionTimestamp: pendingQuestionTS, responseTimestamp: ts))
                     pendingQuestion = nil
+                    pendingQuestionTS = nil
                 }
             case .result(_, let text):
                 if let q = pendingQuestion {
                     let summary = ChatSummary.summaryExtract(from: text, maxLength: 200)
-                    entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary))
+                    entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
+                                                    questionTimestamp: pendingQuestionTS, responseTimestamp: ts))
                     pendingQuestion = nil
+                    pendingQuestionTS = nil
                 }
             default:
                 break
             }
         }
         if let q = pendingQuestion {
-            entries.append(ChatOutlineEntry(question: q, response: nil))
+            entries.append(ChatOutlineEntry(question: q, response: nil,
+                                            questionTimestamp: pendingQuestionTS, responseTimestamp: nil))
         }
         return entries
     }
@@ -977,6 +988,8 @@ enum ChatMetrics {
 struct ChatOutlineEntry: Hashable {
     let question: String
     let response: String?
+    let questionTimestamp: Date?
+    let responseTimestamp: Date?
 }
 
 /// Right-side outline for a chat: lists the user's turns (questions) in
@@ -1038,17 +1051,36 @@ struct ChatOutlineView: View {
                             Button {
                                 onSelect(index)
                             } label: {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(entry.question.isEmpty ? "(empty)" : entry.question)
-                                        .font(.callout)
-                                        .foregroundStyle(.primary)
-                                        .multilineTextAlignment(.leading)
-                                    if let response = entry.response {
-                                        Text(response)
+                                VStack(alignment: .leading, spacing: 0) {
+                                    // Timestamp header for the turn
+                                    if let ts = entry.questionTimestamp {
+                                        Text(ts, format: .dateTime.hour().minute())
+                                            .font(.caption2)
+                                            .foregroundStyle(.tertiary)
+                                            .padding(.bottom, 2)
+                                    }
+                                    // User question line item
+                                    HStack(alignment: .top, spacing: 4) {
+                                        Text("•")
                                             .font(.caption)
                                             .foregroundStyle(.secondary)
-                                            .lineLimit(3)
+                                        Text(entry.question.isEmpty ? "(empty)" : entry.question)
+                                            .font(.callout)
+                                            .foregroundStyle(.primary)
                                             .multilineTextAlignment(.leading)
+                                    }
+                                    // Agent response line item
+                                    if let response = entry.response {
+                                        HStack(alignment: .top, spacing: 4) {
+                                            Text("•")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                            Text(response)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                                .lineLimit(3)
+                                                .multilineTextAlignment(.leading)
+                                        }
                                     }
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -569,21 +569,26 @@ struct ChatWebView: NSViewRepresentable {
         private static func assistantBubbleHTML(text: String, context: WikiRenderContext?, isFinal: Bool, timestamp: Date? = nil, allEvents: [AgentEvent] = [], allTimestamps: [Date?] = [], index: Int = -1) -> String {
             var html = """
             <div class="row chat-row chat-assistant"><div class="bubble">\
-            <button class="copy-btn" type="button" data-copy="\(htmlAttributeEscape(text))" aria-label="Copy">\(Self.copyIconSVG)</button>\
             \(renderedMarkdown(text, context: context, isFinal: isFinal))</div>
             """
 
+            // Footer action bar: sits on its own line directly beneath the bubble
+            // so it reads as attached to the response. Holds the copy button and,
+            // when a timestamp is available, the "Worked for Xs" label (which
+            // hover-swaps to the completion timestamp).
+            var metaHTML = ""
             if let ts = timestamp {
                 let duration = Self.workDuration(at: index, timestamps: allTimestamps)
                 let durationLabel = duration.map { "Worked for \(Self.formatDuration($0))" } ?? ""
                 let timestampLabel = Self.formatTimestamp(ts)
-                // The footer: a sizer (hidden, reserves width) + the visible
+                // The meta: a sizer (hidden, reserves width) + the visible
                 // duration label + the timestamp (hidden by default). On hover,
                 // the duration fades out and the timestamp fades in — pure CSS,
                 // width stays stable (sizer reserves the wider of the two).
                 let durationHTML = durationLabel.isEmpty ? "" : #"<span class="turn-duration">\#(escape(durationLabel))</span>"#
-                html += #"<div class="turn-footer"><span class="turn-sizer">\#(escape(timestampLabel))</span>\#(durationHTML)<span class="turn-timestamp">\#(escape(timestampLabel))</span></div>"#
+                metaHTML = #"<span class="turn-meta"><span class="turn-sizer">\#(escape(timestampLabel))</span>\#(durationHTML)<span class="turn-timestamp">\#(escape(timestampLabel))</span></span>"#
             }
+            html += #"<div class="turn-footer"><button class="copy-btn" type="button" data-copy="\#(htmlAttributeEscape(text))" aria-label="Copy">\#(Self.copyIconSVG)</button>\#(metaHTML)</div>"#
 
             html += "</div>"
             return html
@@ -840,8 +845,14 @@ struct ChatWebView: NSViewRepresentable {
             padding: 11px 16px; white-space: pre-wrap; font-size: 13.5px;
           }
           .chat-assistant .bubble { position: relative; }
+          /* Footer action bar beneath the response: copy button + "Worked for Xs"
+             label share one line, left-aligned under the bubble so they read as
+             attached to it. */
+          .turn-footer {
+            display: flex; align-items: center; gap: 4px;
+            margin-top: 4px; min-height: 20px;
+          }
           .copy-btn {
-            position: absolute; top: 2px; right: 2px;
             display: flex; align-items: center; justify-content: center;
             opacity: 0; transition: opacity 0.15s ease, color 0.15s ease;
             -webkit-appearance: none; appearance: none;
@@ -853,11 +864,11 @@ struct ChatWebView: NSViewRepresentable {
           .copy-btn:hover { opacity: 1; color: var(--text); background: var(--code-bg); }
           .copy-btn.copied { opacity: 1; color: #34c759; }
           .copy-btn svg { display: block; }
-          /* Turn footer: "Worked for Xs" with hover-swap to timestamp.
-             Mirrors Paseo's AssistantTurnFooter — a sizer reserves width so
-             the label doesn't shift when swapping. */
-          .turn-footer {
-            position: relative; margin-top: 6px;
+          /* "Worked for Xs" with hover-swap to timestamp. Mirrors Paseo's
+             AssistantTurnFooter — a sizer reserves width so the label doesn't
+             shift when swapping. */
+          .turn-meta {
+            position: relative; display: inline-block;
             min-height: 16px;
           }
           .turn-sizer {

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -838,7 +838,7 @@ struct ChatWebView: NSViewRepresentable {
           .row-turn-failed-body strong { font-weight: 600; color: #ff9f0a; }
           .chat-row { display: flex; margin: 0 0 14px; }
           .chat-user { justify-content: flex-end; }
-          .chat-assistant { justify-content: flex-start; }
+          .chat-assistant { justify-content: flex-start; flex-direction: column; }
           .chat-user .bubble { max-width: min(760px, 86%); }
           .chat-user .bubble {
             background: var(--code-bg); border-radius: 14px;
@@ -850,7 +850,7 @@ struct ChatWebView: NSViewRepresentable {
              attached to it. */
           .turn-footer {
             display: flex; align-items: center; gap: 4px;
-            margin-top: 4px; min-height: 20px;
+            margin-top: 4px; margin-left: 6px; min-height: 20px;
           }
           .copy-btn {
             display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
## Summary

Two improvements to the chat view layout:

### 1. Move copy icon + "Worked for" footer below assistant responses

Previously, the `.turn-footer` (copy button + "Worked for Xs" duration) appeared **to the right** of the agent's response bubble because `.chat-row` uses `display: flex` (horizontal). This made it look disconnected from the response.

**Fix:** Added `flex-direction: column` to `.chat-assistant` so the footer stacks vertically beneath the bubble. Added a small `margin-left: 6px` indent so the footer reads as attached to the response.

### 2. Add timestamps to chat outline

The chat outline (right sidebar) now shows a timestamp header for each turn, with the user question and agent response as two separate bullet-points beneath it:

```
2:45 PM
• What's the capital of France?
• The capital of France is Paris...
```

**Changes:**
- `ChatOutlineEntry` gained `questionTimestamp` and `responseTimestamp` fields
- `chatOutlineEntries` now enumerates `displayMessages` with indices to pull parallel `displayTimestamps`
- `ChatOutlineView` redesigned: timestamp header (`.caption2` / `.tertiary`) at top, user question as primary bullet (`.callout`), agent response as secondary bullet (`.caption`)

## Files changed

- `Sources/WikiFS/ChatWebView.swift` — CSS: `flex-direction: column` on `.chat-assistant`, `margin-left` on `.turn-footer`
- `Sources/WikiFS/ChatView.swift` — `ChatOutlineEntry` struct, `chatOutlineEntries` timestamp tracking, `ChatOutlineView` layout
