### PR TITLE
Replace chats list with native table view supporting multi-select

### DIFF
--- a/Sources/WikiFS/AgentToolsView.swift
+++ b/Sources/WikiFS/AgentToolsView.swift
@@ -3,21 +3,21 @@ import WikiFSEngine
 import WikiFSCore
 import WikiFSEngine
 
-/// The Chats section — a small SwiftUI `List` of the wiki's chat history.
-/// Mirrors the Pages/Sources/Bookmarks tabs: single-purpose, focused on one
-/// content type. Maintenance/diagnostic surfaces (Lint, Instructions,
-/// Activity) moved to the app's maintenance menu (issue #282). These are
-/// navigation items, so single-click selects AND opens (the binding's `set`
-/// calls `store.openTab`). No per-row gesture, so no latency.
+/// The Chats section — a native `NSTableView` (`ChatsListView`) of the wiki's
+/// chat history. Mirrors the Pages/Sources/Bookmarks tabs structurally:
+/// native multi-selection (Shift / Cmd / right-click), double-click to open,
+/// drag-out, and batch context menus — so all four sidebar sections share the
+/// same selection semantics. Maintenance/diagnostic surfaces (Lint,
+/// Instructions, Activity) moved to the app's maintenance menu (issue #282).
 struct AgentToolsView: View {
     @Bindable var store: WikiStoreModel
-    /// The chat launcher — backs the live indicator on recent-chat rows (D4).
+    /// The chat launcher — backs the live "responding…" indicator on rows.
     /// Chats are always write-capable (the read-only Ask mode was removed).
     @Bindable var chatLauncher: AgentLauncher
 
     /// The chat being renamed, if any. Non-nil presents the rename alert. The
     /// draft text is tracked separately so the rename can be committed on
-    /// confirm. (D4)
+    /// confirm.
     @State private var renamingChat: ChatSummary?
     @State private var renameDraft: String = ""
 
@@ -26,56 +26,19 @@ struct AgentToolsView: View {
             chatsHeader
             chatSearchBar
             Divider()
-            ScrollViewReader { proxy in
-                List(selection: Binding(
-                    get: { store.activeTab?.selection },
-                    set: { sel in if let sel { store.openTab(sel) } }
-                )) {
-                    ForEach(visibleChats) { chat in
-                        RecentChatRow(
-                            chat: chat,
-                            isLive: isLive(chat)
-                        )
-                            .tag(WikiSelection.chat(chat.id))
-                            .draggable(SidebarDragPayloadList([
-                                SidebarDragPayload(kind: .chat, id: chat.id.rawValue)
-                            ]))
-                            .contextMenu {
-                                Button("Rename Chat…") {
-                                    renameDraft = chat.title
-                                    renamingChat = chat
-                                }
-                                Button("Delete Chat", role: .destructive) {
-                                    store.deleteChat(id: chat.id)
-                                }
-                            }
-                    }
-                }
-                .overlay {
-                    if visibleChats.isEmpty && !store.chatSearchQuery.isEmpty {
-                        Text("No matching chats")
-                            .foregroundStyle(.secondary).font(.callout)
-                    }
-                }
-                .listStyle(.inset)
-                .scrollContentBackground(.hidden)
-                .padding(.top, 4)
-                // "Show In List" reveal: a detail-view button requested that a
-                // chat be surfaced. The active tab already selects this chat
-                // (we're viewing it), so the row is highlighted — we only need
-                // to scroll it into view. `.onAppear` covers the freshly-mounted
-                // case (SidebarView just switched to the Chats section);
-                // `.onChange` covers the already-visible case.
-                .onAppear { revealPendingChat(proxy: proxy) }
-                .onChange(of: store.pendingSidebarRevealVersion) { _, _ in
-                    revealPendingChat(proxy: proxy)
+            ZStack(alignment: .topLeading) {
+                ChatsListView(store: store, chatLauncher: chatLauncher,
+                              callbacks: callbacks)
+                if visibleChats.isEmpty && !store.chatSearchQuery.isEmpty {
+                    Text("No matching chats")
+                        .foregroundStyle(.secondary).font(.callout)
+                        .padding(.vertical, 8).padding(.horizontal, 4)
                 }
             }
         }
-        // Rename alert: a single `.alert` driven by `renamingChat`, with a text
-        // field. Commit on the primary action, dismiss otherwise. The store
-        // method (`store.renameChat`) is the first UI caller of the tested
-        // `WikiStore.renameChat` path. (D4)
+        // Rename alert: driven by `renamingChat`. The `ChatsListViewController`
+        // calls `onRename` with the clicked `ChatSummary`; the container owns
+        // the alert text field so the rename can be edited before committing.
         .alert("Rename Chat", isPresented: Binding(
             get: { renamingChat != nil },
             set: { if !$0 { renamingChat = nil } }
@@ -153,99 +116,38 @@ struct AgentToolsView: View {
         .padding(.vertical, 6)
     }
 
-    // MARK: - Live indicator
+    // MARK: - Callbacks
 
-    /// The single chat launcher. Chats are always write-capable now (the
-    /// read-only Ask mode was removed), so there is one launcher. (D4)
-    private func launcher(for kind: ChatKind) -> AgentLauncher {
-        chatLauncher
+    private var callbacks: ChatsListCallbacks {
+        ChatsListCallbacks(
+            onOpen: { ids in
+                for id in ids { store.openTab(.chat(id)) }
+            },
+            onOpenBackground: { ids in
+                for id in ids { store.openTabInBackground(.chat(id)) }
+            },
+            onRename: { chat in beginRename(chat) },
+            onDelete: { ids in
+                for id in ids { store.deleteChat(id: id) }
+            })
     }
 
-    /// A row is live when it is the active session of the chat launcher
-    /// AND that launcher is mid-generation. Delegates to the pure static
-    /// predicate so the rule is unit-testable without driving launcher state.
-    /// (D4)
-    private func isLive(_ chat: ChatSummary) -> Bool {
-        let match = launcher(for: chat.kind)
-        return Self.isLiveRow(
-            activeChatID: match.activeChatID,
-            isGenerating: match.isGenerating,
-            chatID: chat.id
-        )
+    private func beginRename(_ chat: ChatSummary) {
+        renameDraft = chat.title
+        renamingChat = chat
     }
 
-    /// Scroll to the chat row requested by the "Show In List" button, then
-    /// consume the pending reveal so it fires exactly once. The scroll is
-    /// deferred to the next runloop pass so the List has laid out its rows
-    /// when this view was just mounted by the section switch in `SidebarView`.
-    private func revealPendingChat(proxy: ScrollViewProxy) {
-        guard let pending = store.pendingSidebarReveal,
-              case .chat(let id) = pending else { return }
-        store.consumePendingSidebarReveal()
-        DispatchQueue.main.async {
-            withAnimation {
-                proxy.scrollTo(WikiSelection.chat(id), anchor: .center)
-            }
-        }
-    }
+    // MARK: - Live indicator (pure predicate, unit-tested)
 
     /// Pure predicate for the row live indicator: a row shows a "responding…"
     /// badge when its chat is the launcher's active live session AND that
     /// launcher is actively generating. Extracted as a pure static function so
     /// it is unit-testable without driving launcher state (mirrors
-    /// `AgentLauncher.showsQueryDebugControls`). (D4)
+    /// `AgentLauncher.showsQueryDebugControls`). The native
+    /// `ChatsListViewController.isLive` delegates to this.
     static func isLiveRow(
         activeChatID: String?, isGenerating: Bool, chatID: PageID
     ) -> Bool {
         isGenerating && activeChatID == chatID.rawValue
-    }
-}
-
-/// One row in the "Recent Chats" section. When `isLive` is true a
-/// small tinted `circle.fill` + "responding…" caption is shown so the
-/// one-per-kind live-session constraint is *visible* instead of surprising.
-/// (D4)
-private struct RecentChatRow: View {
-    let chat: ChatSummary
-    let isLive: Bool
-
-    var body: some View {
-        Label {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(chat.title)
-                    .font(.body)
-                    .fontWeight(.medium)
-                    .lineLimit(1)
-                if isLive {
-                    HStack(spacing: 3) {
-                        Image(systemName: "circle.fill")
-                            .font(.system(size: 6))
-                            .symbolRenderingMode(.palette)
-                            .foregroundStyle(.tint)
-                        Text("responding…")
-                            .font(.caption)
-                            .foregroundStyle(.tint)
-                    }
-                    .lineLimit(1)
-                    .accessibilityLabel("Chat is responding")
-                } else if let summary = chat.summary {
-                    Text(summary)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                } else {
-                    Text(chat.updatedAt, format: .relative(presentation: .named))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-        } icon: {
-            Image(systemName: ResourceKind.chat.systemImageName)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .frame(width: 18)
-        }
-        .padding(.vertical, 3)
     }
 }

--- a/Sources/WikiFS/ChatsListView.swift
+++ b/Sources/WikiFS/ChatsListView.swift
@@ -1,0 +1,427 @@
+import AppKit
+import WikiFSEngine
+import SwiftUI
+import WikiFSCore
+
+// MARK: - SwiftUI bridge
+
+/// Native `NSTableView` for the chats sidebar. Replaces the SwiftUI
+/// `List(selection:)` (single-select only) with a table that supports native
+/// multi-selection (Shift / Cmd / right-click), drag-out, and batch context
+/// menus — matching `PagesListView` / `SourcesListView` structurally.
+///
+/// Single-click selects; double-click opens. The active tab's chat is
+/// reconciled into the highlight on every SwiftUI update (mirrors Pages).
+struct ChatsListView: NSViewControllerRepresentable {
+    let store: WikiStoreModel
+    /// The chat launcher — drives the live "responding…" indicator on rows.
+    let chatLauncher: AgentLauncher
+    let callbacks: ChatsListCallbacks
+
+    func makeNSViewController(context: Context) -> ChatsListViewController {
+        let vc = ChatsListViewController()
+        vc.store = store
+        vc.chatLauncher = chatLauncher
+        vc.callbacks = callbacks
+        return vc
+    }
+
+    func updateNSViewController(_ vc: ChatsListViewController, context: Context) {
+        vc.store = store
+        vc.chatLauncher = chatLauncher
+        vc.callbacks = callbacks
+        let visible = store.chatSearchQuery.isEmpty ? store.chats : store.chatSearchResults
+        let needs = vc.needsReload(visible)
+        DebugLog.tabs("ChatsListView.updateNSVC: count=\(visible.count) needsReload=\(needs)")
+        if needs { vc.reloadData(from: visible) }
+        vc.reconcileHighlight(activeSelection: store.activeTab?.selection)
+        if let pending = store.pendingSidebarReveal, case .chat(let id) = pending {
+            _ = vc.revealAndSelect(id: id)
+            store.consumePendingSidebarReveal()
+        }
+    }
+}
+
+// MARK: - Callbacks
+
+struct ChatsListCallbacks {
+    /// Open (foreground tab). Context-menu "Open N" passes the effective
+    /// selection.
+    var onOpen: ([PageID]) -> Void
+    /// Open in a background tab. Single or batch.
+    var onOpenBackground: ([PageID]) -> Void
+    var onRename: (ChatSummary) -> Void
+    var onDelete: ([PageID]) -> Void
+}
+
+/// Carries the right-clicked row + the effective selection (selected ∪ clicked)
+/// to the `@objc` menu handlers.
+private struct ChatsMenuPayload {
+    let clicked: ChatSummary
+    let effectiveIDs: [PageID]
+}
+
+// MARK: - View controller
+
+final class ChatsListViewController: NSViewController {
+    var scrollView: NSScrollView!
+    var tableView: ChatsNSTableView!
+    var store: WikiStoreModel?
+    var chatLauncher: AgentLauncher?
+    var callbacks: ChatsListCallbacks?
+
+    private var items: [ChatSummary] = []
+    private var lastCount = -1
+    private var lastSignature = ""
+    /// Re-entrancy guard: selecting a row programmatically must not loop back.
+    private var isReconcilingHighlight = false
+
+    override func loadView() {
+        scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.drawsBackground = false
+
+        tableView = ChatsNSTableView()
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.headerView = nil
+        tableView.rowHeight = 36
+        tableView.allowsEmptySelection = true
+        tableView.allowsMultipleSelection = true
+        tableView.backgroundColor = .clear
+        tableView.doubleAction = #selector(onDoubleClick)
+        tableView.target = self
+        tableView.setDraggingSourceOperationMask(.copy, forLocal: true)
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("chat"))
+        tableView.addTableColumn(column)
+
+        scrollView.documentView = tableView
+        scrollView.contentView.automaticallyAdjustsContentInsets = false
+        view = scrollView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        reloadData()
+    }
+
+    // MARK: - Reload
+
+    func needsReload(_ rows: [ChatSummary]) -> Bool {
+        guard rows.count == lastCount else { return true }
+        return signature(rows) != lastSignature
+    }
+
+    func reloadData(from rows: [ChatSummary]? = nil) {
+        let rows = rows ?? items
+        items = rows
+        lastCount = rows.count
+        lastSignature = signature(rows)
+        tableView.reloadData()
+    }
+
+    private func signature(_ rows: [ChatSummary]) -> String {
+        rows.map {
+            "\($0.id.rawValue)|\($0.title)|\($0.updatedAt.timeIntervalSince1970)|\($0.summary ?? "")"
+        }.joined(separator: "\n")
+    }
+
+    // MARK: - Highlight sync
+
+    /// Reflect the active tab's selection into the table highlight. Called every
+    /// `updateNSViewController`. Only acts when the table is in single-selection
+    /// state so user multi-selects (Cmd/Shift) aren't clobbered.
+    func reconcileHighlight(activeSelection: WikiSelection?) {
+        guard !isReconcilingHighlight, tableView.selectedRowIndexes.count <= 1 else { return }
+        switch activeSelection {
+        case .chat(let id):
+            guard let row = items.firstIndex(where: { $0.id == id }) else { return }
+            if tableView.selectedRow != row {
+                isReconcilingHighlight = true
+                tableView.selectRowIndexes(IndexSet([row]), byExtendingSelection: false)
+                isReconcilingHighlight = false
+            }
+        default:
+            if tableView.selectedRow >= 0 {
+                isReconcilingHighlight = true
+                tableView.deselectAll(self)
+                isReconcilingHighlight = false
+            }
+        }
+    }
+
+    // MARK: - Reveal ("Show In List")
+
+    /// Explicit "Show In List" reveal: select the target row and scroll it into
+    /// view. Unlike ``reconcileHighlight``, this bypasses the multi-select guard
+    /// (an explicit user action should win over a Cmd/Shift selection) and always
+    /// scrolls.
+    @discardableResult
+    func revealAndSelect(id: PageID) -> Bool {
+        guard let row = items.firstIndex(where: { $0.id == id }) else { return false }
+        isReconcilingHighlight = true
+        tableView.selectRowIndexes(IndexSet([row]), byExtendingSelection: false)
+        isReconcilingHighlight = false
+        tableView.scrollRowToVisible(row)
+        return true
+    }
+
+    // MARK: - Double-click
+
+    @objc private func onDoubleClick() {
+        let row = tableView.clickedRow
+        guard row >= 0, row < items.count else { return }
+        callbacks?.onOpen([items[row].id])
+    }
+
+    // MARK: - Live indicator
+
+    /// A row is live when it is the active session of the chat launcher AND that
+    /// launcher is mid-generation. Delegates to the pure static predicate
+    /// (`AgentToolsView.isLiveRow`) so the rule has one unit-tested source.
+    private func isLive(_ chat: ChatSummary) -> Bool {
+        guard let launcher = chatLauncher else { return false }
+        return AgentToolsView.isLiveRow(
+            activeChatID: launcher.activeChatID,
+            isGenerating: launcher.isGenerating,
+            chatID: chat.id
+        )
+    }
+}
+
+// MARK: - Data source
+
+extension ChatsListViewController: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int { items.count }
+
+    func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
+        guard row >= 0, row < items.count else { return nil }
+        return SidebarDragPayload(kind: .chat, id: items[row].id.rawValue).makePasteboardWriter()
+    }
+}
+
+// MARK: - Delegate
+
+extension ChatsListViewController: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row >= 0, row < items.count else { return nil }
+        let chat = items[row]
+        let cellID = NSUserInterfaceItemIdentifier("chat-cell")
+
+        let cell: ChatsCellView
+        if let reused = tableView.makeView(withIdentifier: cellID, owner: nil) as? ChatsCellView {
+            cell = reused
+        } else {
+            cell = ChatsCellView()
+            cell.identifier = cellID
+        }
+        cell.configure(chat: chat, isLive: isLive(chat))
+        return cell
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat { 36 }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool { true }
+
+    // Swipe-to-delete (macOS 11+; app targets macOS 15).
+    func tableView(_ tableView: NSTableView,
+                   rowActionsForRow row: Int,
+                   edge: NSTableView.RowActionEdge) -> [NSTableViewRowAction] {
+        guard edge == .trailing, row >= 0, row < items.count else { return [] }
+        let delete = NSTableViewRowAction(style: .destructive, title: "Delete") { [weak self] _, r in
+            guard let self, r < self.items.count else { return }
+            self.callbacks?.onDelete([self.items[r].id])
+        }
+        delete.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
+        return [delete]
+    }
+}
+
+// MARK: - Context menu
+
+extension ChatsListViewController {
+    /// Built lazily on right-click. Effective selection = selected ∪ clicked
+    /// (right-clicked row joins the batch even if not already selected —
+    /// standard macOS semantics, mirroring `PagesListViewController`).
+    func menuForRow(_ row: Int) -> NSMenu? {
+        guard row >= 0, row < items.count else { return nil }
+        let clicked = items[row]
+        let selected = tableView.selectedRowIndexes
+        let inSelection = selected.contains(row)
+        let effectiveIDs = (inSelection ? Array(selected) : [row])
+            .sorted().map { items[$0].id }
+        let isBatch = effectiveIDs.count > 1
+        let count = effectiveIDs.count
+        let payload = ChatsMenuPayload(clicked: clicked, effectiveIDs: effectiveIDs)
+
+        let menu = NSMenu()
+
+        menu.addItem(menuItem(
+            title: isBatch ? "Open \(count) Chats" : "Open",
+            systemImage: "arrow.up.forward.app", action: #selector(openAction(_:)), payload: payload))
+
+        menu.addItem(menuItem(
+            title: isBatch ? "Open \(count) in Background" : "Open in Background",
+            systemImage: "dock.arrow.down.rectangle", action: #selector(openBackgroundAction(_:)),
+            payload: payload))
+
+        menu.addItem(.separator())
+
+        if !isBatch {
+            menu.addItem(menuItem(
+                title: "Rename Chat…",
+                systemImage: "pencil", action: #selector(renameAction(_:)), payload: payload))
+        }
+
+        menu.addItem(menuItem(
+            title: isBatch ? "Delete \(count) Chats" : "Delete",
+            systemImage: "trash", action: #selector(deleteAction(_:)), payload: payload))
+
+        return menu
+    }
+
+    private func menuItem(title: String, systemImage: String,
+                          action: Selector, payload: ChatsMenuPayload) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.image = NSImage(systemSymbolName: systemImage, accessibilityDescription: nil)
+        item.target = self
+        item.representedObject = payload
+        return item
+    }
+
+    @objc private func openAction(_ sender: NSMenuItem) {
+        if let p = sender.representedObject as? ChatsMenuPayload { callbacks?.onOpen(p.effectiveIDs) }
+    }
+    @objc private func openBackgroundAction(_ sender: NSMenuItem) {
+        if let p = sender.representedObject as? ChatsMenuPayload { callbacks?.onOpenBackground(p.effectiveIDs) }
+    }
+    @objc private func renameAction(_ sender: NSMenuItem) {
+        if let p = sender.representedObject as? ChatsMenuPayload { callbacks?.onRename(p.clicked) }
+    }
+    @objc private func deleteAction(_ sender: NSMenuItem) {
+        if let p = sender.representedObject as? ChatsMenuPayload { callbacks?.onDelete(p.effectiveIDs) }
+    }
+}
+
+// MARK: - Cell
+
+/// A chat row cell: leading icon, title (body, medium weight, truncated), and a
+/// subtitle that adapts between "responding…" (live, tinted), the chat summary,
+/// and the relative timestamp. Built once, configured on reuse.
+final class ChatsCellView: NSTableCellView {
+    private let iconView = NSImageView()
+    private let titleField = NSTextField(labelWithString: "")
+    private let subtitleField = NSTextField(labelWithString: "")
+    private let liveDot = NSImageView()
+    private let liveLabel = NSTextField(labelWithString: "responding…")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    private func setup() {
+        for v in [iconView, titleField, subtitleField, liveDot, liveLabel] {
+            v.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(v)
+        }
+
+        iconView.contentTintColor = .secondaryLabelColor
+
+        titleField.font = .systemFont(ofSize: 13, weight: .medium)
+        titleField.lineBreakMode = .byTruncatingTail
+        titleField.cell?.truncatesLastVisibleLine = true
+        titleField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        subtitleField.font = .systemFont(ofSize: 11)
+        subtitleField.textColor = .secondaryLabelColor
+        subtitleField.lineBreakMode = .byTruncatingTail
+        subtitleField.cell?.truncatesLastVisibleLine = true
+        subtitleField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        liveDot.image = NSImage(systemSymbolName: "circle.fill",
+                                accessibilityDescription: nil)
+        liveDot.contentTintColor = .controlAccentColor
+        liveLabel.font = .systemFont(ofSize: 11)
+        liveLabel.textColor = .controlAccentColor
+        liveLabel.isHidden = true
+        liveDot.isHidden = true
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            iconView.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            iconView.widthAnchor.constraint(equalToConstant: 18),
+            iconView.heightAnchor.constraint(equalToConstant: 18),
+
+            titleField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 6),
+            titleField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            titleField.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+
+            subtitleField.leadingAnchor.constraint(equalTo: titleField.leadingAnchor),
+            subtitleField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            subtitleField.topAnchor.constraint(equalTo: titleField.bottomAnchor, constant: 1),
+
+            liveDot.leadingAnchor.constraint(equalTo: titleField.leadingAnchor),
+            liveDot.centerYAnchor.constraint(equalTo: subtitleField.centerYAnchor),
+            liveDot.widthAnchor.constraint(equalToConstant: 6),
+            liveDot.heightAnchor.constraint(equalToConstant: 6),
+
+            liveLabel.leadingAnchor.constraint(equalTo: liveDot.trailingAnchor, constant: 3),
+            liveLabel.centerYAnchor.constraint(equalTo: subtitleField.centerYAnchor),
+            liveLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+
+    func configure(chat: ChatSummary, isLive: Bool) {
+        iconView.image = NSImage(systemSymbolName: ResourceKind.chat.systemImageName,
+                                  accessibilityDescription: nil)
+        let title = chat.title.isEmpty ? "New Chat" : chat.title
+        titleField.stringValue = title
+        toolTip = title
+
+        if isLive {
+            subtitleField.isHidden = true
+            liveDot.isHidden = false
+            liveLabel.isHidden = false
+        } else {
+            liveDot.isHidden = true
+            liveLabel.isHidden = true
+            subtitleField.isHidden = false
+            if let summary = chat.summary {
+                subtitleField.stringValue = summary
+            } else {
+                subtitleField.stringValue = chat.updatedAt.formatted(.relative(presentation: .named))
+            }
+        }
+    }
+}
+
+// MARK: - NSTableView subclass
+
+final class ChatsNSTableView: NSTableView {
+    /// Right-click → per-row context menu.
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let point = convert(event.locationInWindow, from: nil)
+        let row = self.row(at: point)
+        guard row >= 0 else { return nil }
+        return (self.delegate as? ChatsListViewController)?.menuForRow(row)
+    }
+
+    /// Cmd+A → select all rows, scoped to this table (mirrors `PagesNSTableView`).
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard event.modifierFlags.contains(.command),
+              event.charactersIgnoringModifiers == "a" else {
+            return super.performKeyEquivalent(with: event)
+        }
+        guard isSelfOrDescendantFirstResponder() else {
+            return super.performKeyEquivalent(with: event)
+        }
+        self.selectAll(self)
+        return true
+    }
+}

--- a/Sources/WikiFS/EditBookmarkSheet.swift
+++ b/Sources/WikiFS/EditBookmarkSheet.swift
@@ -46,7 +46,7 @@ struct EditBookmarkSheet: View {
                 }
 
                 // Timestamps (read-only) — issue #242. Relative date mirrors
-                // RecentChatRow's treatment of chat.updatedAt; the absolute date
+                // ChatsCellView's treatment of chat.updatedAt; the absolute date
                 // is the tooltip for precision. "Updated" only appears when the
                 // node has actually changed since creation.
                 if let node {


### PR DESCRIPTION
## Summary

Migrate the Chats sidebar section from a SwiftUI `List(selection:)` (single-select only) to a native `NSTableView` (`ChatsListView`) with full multi-selection support (Shift / Cmd / right-click), drag-out, and batch context menus — matching the structural semantics of Pages/Sources/Bookmarks tabs.

## Changes

- **AgentToolsView.swift**: Replaced the SwiftUI List implementation with a bridge to `ChatsListView`. Updated documentation to reflect native table architecture. Removed `RecentChatRow` (now `ChatsCellView` in the native view). Preserved the pure `isLiveRow` predicate as a unit-testable static method.

- **ChatsListView.swift** (new): Complete native implementation with:
  - `ChatsListView`: NSViewControllerRepresentable bridge
  - `ChatsListViewController`: Manages the table, selection reconciliation, reveal-and-scroll ("Show In List"), and row state
  - `ChatsCellView`: Native cell view with icon, title, and adaptive subtitle (live indicator / summary / timestamp)
  - `ChatsNSTableView`: Subclass with right-click context menu and Cmd+A selection
  - Callbacks pattern for open/open-background/rename/delete interactions

- **EditBookmarkSheet.swift**: Updated comment reference from `RecentChatRow` to `ChatsCellView`.

## Why

The SwiftUI `List(selection:)` binding only supports single selection. Native multi-select is essential for batch operations (open N chats, delete N chats) and matches the UX of the other sidebar sections.