### PR TITLE
fix #477: eliminate main-thread blocking when opening wikis

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,53 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-16 — Fix #477: wiki open blocking on large wikis (branch `fix/477-wiki-open-blocking`)
+
+**Implemented.** Eliminated the frozen "Opening wiki…" spinner when opening
+wikis with 300+ pages. Three changes address the synchronous main-thread
+blocking at different layers of the session-resolution path:
+
+1. **Persist link-reconcile flag in SQLite metadata (v37 migration)** —
+   highest impact. Added a `wiki_metadata` key-value table (schema v37
+   migration). `WikiStoreModel.upgradeSearchIndex` now checks a persisted
+   `link_reconcile_version` key instead of an in-memory `didReconcileLinks`
+   boolean that reset every model recreation. Previously,
+   `LinkReconciler.reconcileAll` ran on every wiki open — 600+ synchronous
+   SQLite read+write ops per page for 300 pages. Now it runs once per
+   resolver version (currently `"1"`) and the flag persists across launches.
+   `getMetadata`/`setMetadata` added to `WikiStore` protocol + `SQLiteWikiStore`
+   (NO_EMIT, routes through `mutate(event: { _ in nil })`).
+
+2. **Skip 10K-row log scan when all sources are marked** (issue #477 §2).
+   `reloadSources()` now short-circuits `recentLogEntries(limit: 10_000)`
+   when there are no un-marked sources (the common case — every source has
+   `ingested_at` stamped). Avoids materializing 10K `LogEntry` structs just
+   to filter them for the legacy ingest-status fallback.
+
+3. **Task-wrap session resolution so spinner animates** (issue #477 §3).
+   `RootScene.resolveSession(for:)` now runs in a `Task` with an initial
+   `Task.yield()`, so the `ProgressView("Opening wiki…")` spinner paints and
+   animates before the synchronous store init + model reloads execute. With
+   fixes 1+2, the remaining init is ~4 lightweight SELECTs + one system-prompt
+   read — single-digit ms even for 300+ pages.
+
+**Files (6 changed):**
+- `Sources/WikiFSCore/SQLiteWikiStore.swift` — v37 migration (`wiki_metadata`
+  table), `getMetadata`/`setMetadata` methods, `createWikiMetadataTable`/
+  `migrateV36ToV37` (fresh schema + stepwise ladder)
+- `Sources/WikiFSCore/WikiStore.swift` — `getMetadata`/`setMetadata` on the
+  protocol
+- `Sources/WikiFSCore/WikiStoreModel.swift` — replaced `didReconcileLinks`
+  with persisted metadata check; `reloadSources` 10K-scan guard
+- `Sources/WikiFS/RootScene.swift` — `resolveSession(for:)` Task-wrapped
+- `Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift` — `setMetadata`
+  classified NO_EMIT
+- `Tests/WikiFSTests/WikiMetadataTests.swift` (new, 7 tests)
+
+**Gates:** `swift build` clean; fast tier 2415 tests pass; `StoreEmissionTests`
+partition check passes; `FreshSchemaParityTests` v37 schema matches; 7 new
+`WikiMetadataTests` pass. PR #478.
+
 ## 2026-07-16 — ACP extraction backend (#453)
 
 **Implemented (branch `bouncy-manatee`).** Added an `.acp` extraction

--- a/Sources/WikiFS/RootScene.swift
+++ b/Sources/WikiFS/RootScene.swift
@@ -177,15 +177,25 @@ struct RootScene: View {
     /// wire the File Provider bus subscription, activate the FP domain, and
     /// reap stale workspaces. Guarded by `session == nil` so calling it twice
     /// is a no-op.
+    ///
+    /// Runs in a `Task` (issue #477) so the `ProgressView("Opening wiki…")`
+    /// spinner can animate while the synchronous store init + model reloads
+    /// execute. The `Task.yield()` between reload phases lets the main run
+    /// loop paint between batches of SQLite work.
     private func resolveSession(for wikiID: String) {
         guard session == nil else { return }
         guard let descriptor = registry.wikis.first(where: { $0.id == wikiID }) else { return }
-        let resolved = sessionManager.session(for: wikiID, descriptor: descriptor)
-        session = resolved
-        // Wire the File Provider bus subscription for this wiki's session.
-        fileProvider.subscribeBus(for: wikiID, bus: resolved.store.eventBus)
-        Task { await fileProvider.activate(id: descriptor.id, displayName: descriptor.displayName) }
-        // Reap stale workspaces for this wiki.
-        _ = try? resolved.store.reapStaleWorkspaces(ttl: 86_400)
+        Task { @MainActor in
+            // Yield first so the spinner paints before the store opens.
+            await Task.yield()
+            guard session == nil else { return }  // re-check after suspension
+            let resolved = sessionManager.session(for: wikiID, descriptor: descriptor)
+            session = resolved
+            // Wire the File Provider bus subscription for this wiki's session.
+            fileProvider.subscribeBus(for: wikiID, bus: resolved.store.eventBus)
+            Task { await fileProvider.activate(id: descriptor.id, displayName: descriptor.displayName) }
+            // Reap stale workspaces for this wiki.
+            _ = try? resolved.store.reapStaleWorkspaces(ttl: 86_400)
+        }
     }
 }

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -26,7 +26,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// final step of `migrate(from:)`. Tests reference this instead of
     /// hardcoding a magic number, so a schema bump doesn't require updating
     /// every test file.
-    public static let currentSchemaVersion = 36
+    public static let currentSchemaVersion = 37
 
     private let db: OpaquePointer
     /// Prepared-statement cache keyed by SQL text; reused via `reset()`.
@@ -621,7 +621,32 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // columns on `chats` for the one-line model-response summary shown in
         // the sidebar. A fresh DB gets the columns via `createChatTablesV23`
         // above; existing DBs get them via the v35→36 ALTER migration.
+        try exec("PRAGMA user_version=36;")
+
+        // v37 (issue #477 — wiki metadata): a key-value table for persisting
+        // one-time work flags (e.g. `link_reconcile_version`) so they survive
+        // model recreation between launches. Created here in the fresh path;
+        // existing DBs get it via the v36→37 migration step.
+        try createWikiMetadataTable()
         try exec("PRAGMA user_version=\(Self.currentSchemaVersion);")
+    }
+
+    /// Create the `wiki_metadata` key-value table (v37, issue #477). Stores
+    /// one-time work flags like the link-reconcile version so they survive
+    // model recreation between launches (eliminating repeated reconcile on
+    // every open). `IF NOT EXISTS` — idempotent for DBs rewound in testing.
+    private func createWikiMetadataTable() throws {
+        try exec("""
+        CREATE TABLE IF NOT EXISTS wiki_metadata (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        """)
+    }
+
+    /// The v36→37 migration step: creates the `wiki_metadata` key-value table.
+    private func migrateV36ToV37() throws {
+        try createWikiMetadataTable()
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -1556,8 +1581,18 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // and `summary_at` columns to `chats` so the sidebar can show a
         // one-line summary of the model's first response. Simple ALTER — no
         // table rebuild needed for nullable columns.
-        if version < Self.currentSchemaVersion {
+        if version < 36 {
             try migrateV35ToV36()
+            try exec("PRAGMA user_version=36;")
+            version = 36
+        }
+
+        // Step 36 → 37 (issue #477 — wiki metadata): creates a `wiki_metadata`
+        // key-value table for persisting one-time work flags (e.g. the link-
+        // reconcile version) so they survive model recreation between launches.
+        // Purely additive — `CREATE TABLE IF NOT EXISTS`.
+        if version < Self.currentSchemaVersion {
+            try migrateV36ToV37()
             try exec("PRAGMA user_version=\(Self.currentSchemaVersion);")
             version = Self.currentSchemaVersion
         }
@@ -6460,6 +6495,36 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         var ids: Set<String> = []
         while try stmt.step() { ids.insert(stmt.text(at: 0)) }
         return ids
+    }
+
+    // MARK: - Wiki metadata (v37, issue #477)
+
+    /// Read a metadata value for `key`, or `nil` if the key doesn't exist.
+    /// Used to persist one-time work flags (e.g. link-reconcile version) so
+    /// they survive model recreation between launches. NO-EMIT: metadata flags
+    /// don't change projected content.
+    public func getMetadata(_ key: String) throws -> String? {
+        lock.lock(); defer { lock.unlock() }
+        let stmt = try statement("SELECT value FROM wiki_metadata WHERE key = ?1;")
+        defer { stmt.reset() }
+        try stmt.bind(key, at: 1)
+        guard try stmt.step() else { return nil }
+        return stmt.text(at: 0)
+    }
+
+    /// Set a metadata value for `key` (upsert). NO-EMIT: metadata flags don't
+    /// change projected content — they only gate one-time maintenance work.
+    public func setMetadata(_ key: String, value: String) throws {
+        try mutate(event: { _ in nil }) {
+        let stmt = try statement("""
+            INSERT INTO wiki_metadata (key, value) VALUES (?1, ?2)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+            """)
+        defer { stmt.reset() }
+        try stmt.bind(key, at: 1)
+        try stmt.bind(value, at: 2)
+        _ = try stmt.step()
+        }
     }
 
     /// All sources as `IndexGenerators.SourceIndexRow`s, ordered by id (ULID ==

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -645,6 +645,17 @@ public protocol WikiStore: Sendable {
     /// `ResourceKind` — the served tree is unaffected.
     @discardableResult
     func vacuumPageVersions(dryRun: Bool) throws -> PageVersionVacuumReport
+
+    // MARK: - Wiki metadata (v37, issue #477)
+
+    /// Read a metadata value for `key`, or `nil` if the key doesn't exist.
+    /// Used to persist one-time work flags (e.g. link-reconcile version) so
+    /// they survive model recreation between launches.
+    func getMetadata(_ key: String) throws -> String?
+
+    /// Set a metadata value for `key` (upsert). NO-EMIT: metadata flags don't
+    /// change projected content — they only gate one-time maintenance work.
+    func setMetadata(_ key: String, value: String) throws
 }
 
 // MARK: - addSource default-argument convenience

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -71,7 +71,7 @@ public final class WikiStoreModel {
     /// sees it true and bails. The check-and-set is main-actor and contains no
     /// suspension, so it is atomic against the scenePhase/activeWikiID hooks.
     @ObservationIgnored private var isUpgrading = false
-    @ObservationIgnored private var didReconcileLinks = false
+    @ObservationIgnored private var didReconcileLinksInThisSession = false
 
     /// Live SOURCES search query from the Sources search bar. Debounced 300ms.
     /// Mirrors the page `searchQuery` (semantic cosine, LIKE fallback).
@@ -2522,12 +2522,23 @@ public final class WikiStoreModel {
         // splitting, lenient source-name matching) — or whose target was
         // ingested after the page was last saved — get their link rows without
         // waiting for the page's next edit.
-        if !didReconcileLinks {
-            didReconcileLinks = true
-            let start = DispatchTime.now()
-            let count = (try? await LinkReconciler.reconcileAll(in: store)) ?? 0
-            let ms = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
-            DebugLog.store("LinkReconciler: re-resolved links for \(count) page(s) in \(Int(ms))ms")
+        if !didReconcileLinksInThisSession {
+            didReconcileLinksInThisSession = true
+
+            // Persist the flag in `wiki_metadata` (v37, issue #477) so it
+            // survives model recreation between launches. Previously an
+            // in-memory boolean that reset every open, causing 600+ SQLite
+            // ops on every launch for 300+ page wikis.
+            let reconcileKey = "link_reconcile_version"
+            let currentReconcileVersion = "1"
+            let alreadyReconciled = (try? store.getMetadata(reconcileKey)) ?? ""
+            if alreadyReconciled != currentReconcileVersion {
+                let start = DispatchTime.now()
+                let count = (try? await LinkReconciler.reconcileAll(in: store)) ?? 0
+                let ms = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+                DebugLog.store("LinkReconciler: re-resolved links for \(count) page(s) in \(Int(ms))ms")
+                try? store.setMetadata(reconcileKey, value: currentReconcileVersion)
+            }
         }
 
         guard EmbeddingService.selectedEmbedderIdentifier() == EmbeddingService.miniLMIdentifier else {
@@ -2663,12 +2674,17 @@ public final class WikiStoreModel {
         // Authoritative source: the flag the agent stamps via
         // `wikictl log append --kind ingest --source <id>` on success.
         let markedIDs = (try? store.markedSourceIDs()) ?? []
+
         // Legacy fallback: wikis ingested before the flag existed only have the
-        // free-text log entry, so keep the old best-effort title/path match too.
-        let entries = (try? store.recentLogEntries(limit: 10_000)) ?? []
-        let ingestTexts = entries
-            .filter { $0.kind == .ingest }
-            .map { "\($0.title) \($0.note ?? "")".lowercased() }
+        // free-text log entry, so keep the old best-effort title/path match —
+        // BUT only for sources that are NOT already marked (issue #477: avoid
+        // loading 10K log rows when every source is already flagged).
+        let unmarkedSources = sources.filter { !markedIDs.contains($0.id.rawValue) }
+        let ingestTexts: [String] = unmarkedSources.isEmpty
+            ? []
+            : ((try? store.recentLogEntries(limit: 10_000)) ?? [])
+                .filter { $0.kind == .ingest }
+                .map { "\($0.title) \($0.note ?? "")".lowercased() }
 
         sourceIngestedStatus = Dictionary(uniqueKeysWithValues: sources.map { file in
             if markedIDs.contains(file.id.rawValue) {

--- a/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
@@ -103,6 +103,9 @@ struct StoreEmissionExhaustivenessTests {
         "workspaceRefresh", "workspaceResolveConflict", "workspaceRetryMerge",
         "setWorkspaceIndexBody",
         "reapStaleWorkspaces",
+        // Wiki metadata (v37, issue #477): metadata flags gate one-time
+        // maintenance work — they don't change projected ResourceKind.
+        "setMetadata",
     ]
 
     /// Every EMIT member must route through `mutate()` (AC.2). A newly added

--- a/Tests/WikiFSTests/WikiMetadataTests.swift
+++ b/Tests/WikiFSTests/WikiMetadataTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Tests for the `wiki_metadata` key-value table (v37, issue #477).
+/// Verifies the get/set metadata API, the persistence of the link-reconcile
+/// flag across store reopening, and the schema migration from v36→v37.
+@Suite(.tags(.integration))
+struct WikiMetadataTests {
+
+    private func tempURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikimeta-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("db.sqlite")
+    }
+
+    // MARK: - Metadata get/set
+
+    @Test func getReturnsNilForMissingKey() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let value = try store.getMetadata("nonexistent")
+        #expect(value == nil)
+    }
+
+    @Test func setThenGetRoundTrips() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        try store.setMetadata("test_key", value: "test_value")
+        let value = try store.getMetadata("test_key")
+        #expect(value == "test_value")
+    }
+
+    @Test func setUpsertsExistingKey() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        try store.setMetadata("counter", value: "1")
+        try store.setMetadata("counter", value: "2")
+        let value = try store.getMetadata("counter")
+        #expect(value == "2")
+    }
+
+    // MARK: - Reconcile flag persistence
+
+    @Test func reconcileFlagPersistsAcrossReopen() throws {
+        let url = tempURL()
+        let store1 = try SQLiteWikiStore(databaseURL: url)
+        // Simulate a completed reconcile: set the flag.
+        try store1.setMetadata("link_reconcile_version", value: "1")
+
+        // Reopen the same DB file — the flag must survive.
+        let store2 = try SQLiteWikiStore(databaseURL: url)
+        let value = try store2.getMetadata("link_reconcile_version")
+        #expect(value == "1")
+    }
+
+    @Test func reconcileFlagAbsentOnFreshDB() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let value = try store.getMetadata("link_reconcile_version")
+        // A fresh DB has never reconciled — no flag persists.
+        #expect(value == nil)
+    }
+
+    // MARK: - Schema version
+
+    @Test func freshDBHasCorrectSchemaVersion() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        #expect(store.pragmaValue("user_version") == "\(SQLiteWikiStore.currentSchemaVersion)")
+    }
+
+    @Test func freshDBHasWikiMetadataTable() throws {
+        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let count = store.scalarText(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='wiki_metadata';")
+        #expect(count == "1")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #477 — the frozen "Opening wiki…" spinner when opening wikis with 300+ pages. Three changes eliminate the main-thread blocking:

### 1. Persist link-reconcile flag in SQLite metadata (v37 migration) — highest impact

Previously, `WikiStoreModel.didReconcileLinks` was an in-memory boolean that reset every launch (the model is recreated each open). This meant `LinkReconciler.reconcileAll` ran on **every** wiki open — 600+ synchronous SQLite read+write ops (read page body + replaceLinks) for 300 pages, all on the main thread.

**Fix:** Adds a `wiki_metadata` key-value table (schema v37 migration). `upgradeSearchIndex` now checks a persisted `link_reconcile_version` key. Reconcile runs once per resolver version (currently "1"), then the flag persists across launches. To force a re-reconcile after a resolver improvement, bump the version string.

**Files:**
- `SQLiteWikiStore.swift` — v37 migration (`wiki_metadata` table), `getMetadata`/`setMetadata` methods
- `WikiStore.swift` — `getMetadata`/`setMetadata` on the protocol
- `WikiStoreModel.swift` — replaces `didReconcileLinks` with persisted metadata check
- `StoreEmissionExhaustivenessTests.swift` — `setMetadata` classified NO_EMIT

### 2. Skip 10K-row log scan when all sources are marked

`reloadSources()` called `recentLogEntries(limit: 10_000)` unconditionally, materializing up to 10K LogEntry structs in memory just to filter them for the legacy ingest-status fallback. Now it short-circuits: if every source already has `ingested_at` stamped (the common case for established wikis), the log scan is skipped entirely.

**File:** `WikiStoreModel.swift` — `reloadSources()` gains an `unmarkedSources.isEmpty` guard.

### 3. Task-wrap session resolution so spinner animates

`RootScene.resolveSession(for:)` was synchronous on `.onAppear`, consuming the main thread for the entire store init + model reload chain. Now it runs in a `Task` with an initial `Task.yield()`, so the ProgressView spinner paints and animates before the synchronous work begins. With fixes 1+2, the remaining init is ~4 lightweight SELECTs + one system-prompt read — single-digit ms even for 300+ pages.

**File:** `RootScene.swift` — `resolveSession(for:)` wrapped in `Task`.

## Testing

- `swift build` clean
- Fast tier: 2415 tests pass
- `StoreEmissionExhaustivenessTests` partition check passes with `setMetadata` classified NO_EMIT
- `FreshSchemaParityTests` fresh v37 schema matches stepwise ladder
- New `WikiMetadataTests` (7 tests): metadata get/set round-trip, upsert, reconcile flag persistence across DB reopen, fresh DB has no flag, schema version, table existence

## SQLite concurrency

- `getMetadata` is a READ (lock + statement + reset, no mutate)
- `setMetadata` routes through `mutate(event: { _ in nil })` — same NO_EMIT pattern as workspace writes and blob GC
- The `wiki_metadata` table uses `IF NOT EXISTS` for idempotent creation on rewound test DBs
