### PR TITLE
Fix #475: run() awaits the turn stream before returning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,13 @@ agents, NOT Polytoken):
   no matter how the app launched. The only exception is real CLI stdout (e.g.
   `wikictl`'s command output).
 
+* Never use bare `try?` to swallow errors silently — it hides failures and has
+  already caused lost transcripts (`QueueStore.swift:156-160`) and misattributed
+  queue items (#475). Use `do { try … } catch { DebugLog.store(…) }` (or the
+  appropriate `DebugLog` channel) so the failure is at least visible in
+  Console.app. If ignoring the error is genuinely correct, add a comment saying
+  why.
+
 * Never commit or push directly to `main`. Always work on a feature branch, push
   the branch, and open a PR. You may push PR branches but MUST NOT merge them to
   main yourself.

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -139,6 +139,15 @@ public final class AgentLauncher {
     /// substitute a stub backend.
     @ObservationIgnored var backend: AgentBackend = ACPBackend()
 
+    /// Factory closure that constructs the backend for a session. Called at
+    /// spawn time in `run()` / `startInteractiveQuery()` so a fresh backend is
+    /// built per session with the current permission policy. Injectable so tests
+    /// can substitute a stub backend that survives the `self.backend = ...`
+    /// assignment in `run()` (setting `backend` directly is overwritten).
+    @ObservationIgnored var resolveBackend: (PermissionPolicy) -> AgentBackend = {
+        AgentBackendFactory.makeBackend(policy: $0)
+    }
+
     /// The chat's permission mode (`@AppStorage("agentPermissionMode")`, default
     /// `.bypass`). v1: app-wide persisted. Read at spawn time so it bakes into
     /// the `ACPBackend`'s `PermissionPolicy`.
@@ -719,7 +728,7 @@ public final class AgentLauncher {
         // (or selected) provider, and resolves its PATH command + Keychain key
         // into providerHints. The app is ACP-only.
         let provider = resolveSelectedProvider()
-        self.backend = AgentBackendFactory.makeBackend(policy: policy)
+        self.backend = resolveBackend(policy)
 
         // Resolve the provider's spawn command (PATH-resolved because the
         // swift-acp SDK's launch() does NOT do PATH lookup) + the Keychain-backed
@@ -852,10 +861,12 @@ public final class AgentLauncher {
             captureProcessID(session: session)
             startCompletionWatchdog()
 
-            // Consume the per-turn stream in a background Task (fire-and-forget:
-            // run() returns after spawn commit; the stream is drained async).
-            // This replaces the old readabilityHandler → ingestStdout path.
-            let backend = self.backend
+            // Consume the per-turn stream INLINE so run() does not return until
+            // the turn completes. The queue worker awaits run() to decide when
+            // the item is done — a fire-and-forget Task here marks it completed
+            // while the agent is still streaming (#475). Mirrors the pattern in
+            // sendInteractiveMessage. The @MainActor await suspends per event;
+            // it does not block the main actor.
             let generationGateReleasesPerTurn = Self.releasesGenerationSlotPerTurn(
                 isInteractiveSession: isInteractiveSession)
             // The prompt is sent via `send()`. The sub-agent plan (source-reader
@@ -864,21 +875,26 @@ public final class AgentLauncher {
             // an instruction to do everything directly.
             var promptText = operation.prompt(wikiRoot: wikiRoot)
             promptText += "\n\nIMPORTANT: Do NOT dispatch sub-agents, background tasks, or async agents. Do NOT use sleep or ScheduleWakeup. Read all sources, process them, and write all wiki pages directly in THIS session — everything must complete before you stop."
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                let stream = await backend.send(
-                    TurnInput(userText: promptText), into: session)
-                for await event in stream {
-                    self.lastActivityAt = Date()
-                    self.mergeOrAppend(event)
-                    if AgentEvent.endsGeneration(event) {
-                        self.setGenerating(false)
-                        self.flushTranscript()
-                        if generationGateReleasesPerTurn {
-                            self.releaseGenerationSlot()
-                        }
+            let stream = await self.backend.send(
+                TurnInput(userText: promptText), into: session)
+            for await event in stream {
+                self.lastActivityAt = Date()
+                self.mergeOrAppend(event)
+                if AgentEvent.endsGeneration(event) {
+                    self.setGenerating(false)
+                    self.flushTranscript()
+                    if generationGateReleasesPerTurn {
+                        self.releaseGenerationSlot()
                     }
                 }
+            }
+            // Stream ended (turn done or process died). If onExit hasn't fired
+            // yet (finish() not called), ensure teardown happens before run()
+            // returns so callers see post-finish state: gate released, run
+            // lifecycle decremented, onAgentEvent cleared. finish() is idempotent
+            // (isRunning guard), so a later onExit-triggered finish() is a no-op.
+            if isRunning {
+                finish(status: exitStatus ?? 0)
             }
         } catch {
             DebugLog.agent("run: spawn FAILED: \(error.localizedDescription)")
@@ -947,7 +963,7 @@ public final class AgentLauncher {
         if let cached = cache[cacheKey] {
             backend = cached
         } else {
-            backend = AgentBackendFactory.makeBackend(policy: policy)
+            backend = resolveBackend(policy)
             cache[cacheKey] = backend
         }
         let providerHints = AgentBackendFactory.providerHints(
@@ -1441,7 +1457,7 @@ public final class AgentLauncher {
         let provider = resolveSelectedProvider()
         let resolvedSelectedModel = providersConfig().selectedModelId(forProvider: provider.id)
         DebugLog.agent("startInteractiveQuery: provider=\(provider.id) selectedModel=\(resolvedSelectedModel ?? "nil")") // TEMP DEBUG
-        self.backend = AgentBackendFactory.makeBackend(policy: policy)
+        self.backend = resolveBackend(policy)
 
         // Resolve the provider's spawn command (PATH-resolved) + the
         // Keychain-backed API key (keyed by provider id).

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -358,8 +358,12 @@ public actor QueueEngine {
             // display plumbing; the final `.assistantText` carries the full
             // text, so persisting every delta bloats rows AND rehydrates as
             // one row per word-fragment.
-            guard event.isPersistable else { return }
-            try? store.appendItemEvent(itemID: id, event: event)
+                guard event.isPersistable else { return }
+                do {
+                    try store.appendItemEvent(itemID: id, event: event)
+                } catch {
+                    DebugLog.store("QueueEngine: appendItemEvent failed for item=\(id): \(error)")
+                }
         }
     }
 

--- a/Tests/WikiFSTests/RunAwaitsTurnTests.swift
+++ b/Tests/WikiFSTests/RunAwaitsTurnTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import WikiFSEngine
+import Testing
+import ACPModel
+import WikiFSEngine
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// Regression tests for issue #475: `AgentLauncher.run()` must not return
+/// until the agent's turn stream completes. Previously, the stream loop was
+/// spawned as a fire-and-forget `Task`, so `run()` returned immediately after
+/// spawn — the queue marked the item `completed` while the agent was still
+/// working, and a concurrent ingest's transcript landed on the wrong item.
+///
+/// These tests drive `run()` end-to-end with a `FakeAgentBackend` (injected
+/// via `resolveBackend`), verifying:
+/// 1. All events are consumed and forwarded to `onAgentEvent` before `run()` returns.
+/// 2. `finish()` is called (gate released, `isRunning == false`) before `run()` returns.
+/// 3. A second `run()` can proceed immediately after the first (no gate leak).
+@MainActor
+struct RunAwaitsTurnTests {
+
+    // MARK: - Helpers
+
+    private func makeLauncher(backend: any AgentBackend) -> AgentLauncher {
+        let launcher = AgentLauncher()
+        launcher.resolveBackend = { _ in backend }
+        launcher.resolveClaude = { .found(path: "/usr/bin/true") }
+        launcher.acpCredentialStore = InMemoryACPCredentialStore()
+        launcher.resolveSelectedProvider = {
+            AgentProvider(
+                id: "fake",
+                label: "Fake",
+                command: ["/usr/bin/true"],
+                enabled: true,
+                isDefault: true
+            )
+        }
+        // Avoid touching the TCC-protected App Group container — use a
+        // temp directory so provider config load/seed/save doesn't block.
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        launcher.resolveProvidersContainerDirectory = { tempDir }
+        launcher.containerDirectory = tempDir
+        return launcher
+    }
+
+    private func makeRequest() -> OperationRequest {
+        .ingest(
+            sources: [OperationRequest.StagedSource(
+                bytes: Data("# Test\n".utf8),
+                ext: "md",
+                displayPath: "sources/by-id/test.md"
+            )],
+            stateMarkdown: "# State"
+        )
+    }
+
+    private func runOneShot(
+        launcher: AgentLauncher,
+        onEvent: (@Sendable (AgentEvent) -> Void)? = nil
+    ) async {
+        await launcher.run(
+            request: makeRequest(),
+            wikiID: "test-wiki",
+            wikiRoot: "/tmp",
+            systemPrompt: "sys",
+            wikictlDirectory: "/tmp",
+            ingestingSourceIDs: [],
+            onEvent: onEvent,
+            onLock: {},
+            onUnlock: {}
+        )
+    }
+
+    // MARK: - Tests
+
+    /// All events from the stream must be consumed and forwarded to the
+    /// `onAgentEvent` callback before `run()` returns. Before the fix, `run()`
+    /// returned immediately after spawn (fire-and-forget Task), so events
+    /// arrived after the caller had already moved on — the caller would see
+    /// zero events at the point `run()` returned.
+    @Test func runForwardsAllEventsBeforeReturning() async throws {
+        let testEvents: [AgentEvent] = [
+            .assistantText("Step 1"),
+            .assistantText("Step 2"),
+            .assistantText("Step 3"),
+            .messageStop,
+        ]
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: testEvents)
+        ])
+        let launcher = makeLauncher(backend: backend)
+        let collected = CollectedEvents()
+
+        await runOneShot(launcher: launcher, onEvent: { event in
+            collected.append(event)
+        })
+
+        // After run() returns, all 4 events should have been forwarded.
+        // Before the fix, this was 0 because the stream Task hadn't run yet.
+        let events = collected.snapshot
+        #expect(events.count == 4)
+        #expect(events.contains(.messageStop))
+
+        // The launcher's own events array also has all 4.
+        #expect(launcher.events.count == 4)
+        #expect(launcher.isRunning == false)
+    }
+
+    /// After `run()` returns, `finish()` has been called: the gate is released
+    /// and `isRunning` is false. Before the fix, `run()` returned while the
+    /// agent was still streaming — `isRunning` was still true and the gate
+    /// was still held.
+    @Test func runCallsFinishBeforeReturning() async throws {
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [.messageStop])
+        ])
+        let launcher = makeLauncher(backend: backend)
+
+        await runOneShot(launcher: launcher)
+
+        #expect(launcher.isRunning == false)
+        #expect(launcher.generationSlotWaiterCount == 0)
+
+        let sendCount = await backend.sendCount
+        #expect(sendCount == 1)
+    }
+
+    /// After `run()` returns, a second `run()` can proceed immediately (no
+    /// gate leak / deadlock). Before the fix, the gate was released only when
+    /// `finish()` eventually fired from `onExit` — which could take minutes.
+    @Test func secondRunProceedsWithoutDeadlock() async throws {
+        let backend1 = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [.messageStop])
+        ])
+        let launcher = makeLauncher(backend: backend1)
+
+        await runOneShot(launcher: launcher)
+        #expect(launcher.isRunning == false)
+
+        // A second run with a fresh backend can acquire the gate immediately.
+        let backend2 = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [.messageStop])
+        ])
+        launcher.resolveBackend = { _ in backend2 }
+
+        await runOneShot(launcher: launcher)
+        #expect(launcher.isRunning == false)
+
+        let sendCount = await backend2.sendCount
+        #expect(sendCount == 1)
+    }
+}
+
+// MARK: - CollectedEvents helper
+
+/// A lock-protected array for collecting events from a `@Sendable` callback.
+private final class CollectedEvents: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [AgentEvent] = []
+
+    func append(_ event: AgentEvent) {
+        lock.lock(); events.append(event); lock.unlock()
+    }
+
+    var snapshot: [AgentEvent] {
+        lock.lock(); defer { lock.unlock() }
+        return events
+    }
+}

--- a/details
+++ b/details
@@ -1,0 +1,1109 @@
+Analysis of sampling swiftpm-testing-helper (pid 54258) every 1 millisecond
+Process:         swiftpm-testing-helper [54258]
+Path:            /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/libexec/swift/pm/swiftpm-testing-helper
+Load Address:    0x1025fc000
+Identifier:      swiftpm-testing-helper
+Version:         24907
+Build Info:      IDEApplication-24959000000000000~2 (17F113)
+Code Type:       ARM64
+Platform:        macOS
+Parent Process:  swift-package [52746]
+Target Type:     live task
+
+Date/Time:       2026-07-16 14:37:37.624 -0700
+Launch Time:     2026-07-16 14:37:24.310 -0700
+OS Version:      macOS 26.5.2 (25F84)
+Report Version:  7
+Analysis Tool:   /usr/bin/sample
+
+Physical footprint:         22.6M
+Physical footprint (peak):  22.9M
+Idle exit:                  untracked
+----
+
+Call graph:
+    787 Thread_32836853   DispatchQueue_1: com.apple.main-thread  (serial)
+    + 787 completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*)  (in libswift_Concurrency.dylib) + 1  [0x28c994ec5]
+    +   787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +     787 specialized closure #1 in closure #1 in static Runner._forEach<A, B>(in:namingTasksWith:_:)  (in Testing) + 1  [0x107b1e08d]
+    +       787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +         787 <deduplicated_symbol>  (in Testing) + 1  [0x107a79811]
+    +           787 <deduplicated_symbol>  (in Testing) + 1  [0x107a5cfc5]
+    +             787 closure #4 in static Runner._runTestCases<A>(_:within:context:)  (in Testing) + 1  [0x107b0ec2d]
+    +               787 specialized static Runner._runTestCase(_:within:context:)  (in Testing) + 1  [0x107b20ae9]
+    +                 787 specialized static Test.Case.withCurrent<A>(_:perform:)  (in Testing) + 1  [0x107b11f39]
+    +                   787 TaskLocal.withValue<A>(_:operation:isolation:file:line:)  (in libswift_Concurrency.dylib) + 1  [0x28c9e68ad]
+    +                     787 TaskLocal.withValueImpl<A>(_:operation:isolation:file:line:)  (in libswift_Concurrency.dylib) + 1  [0x28c9e6c85]
+    +                       787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +                         787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6e8a1]
+    +                           787 specialized TestCancellable.withCancellationHandling<A>(_:)  (in Testing) + 1  [0x107b44c31]
+    +                             787 TaskLocal.withValue<A>(_:operation:isolation:file:line:)  (in libswift_Concurrency.dylib) + 1  [0x28c9e68ad]
+    +                               787 TaskLocal.withValueImpl<A>(_:operation:isolation:file:line:)  (in libswift_Concurrency.dylib) + 1  [0x28c9e6c85]
+    +                                 787 <deduplicated_symbol>  (in Testing) + 1  [0x107a5cfc5]
+    +                                   787 specialized closure #1 in TestCancellable.withCancellationHandling<A>(_:)  (in Testing) + 1  [0x107b91745]
+    +                                     787 withTaskCancellationHandler<A>(operation:onCancel:isolation:)  (in libswift_Concurrency.dylib) + 1  [0x28c9b7a3d]
+    +                                       787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +                                         787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6e8a1]
+    +                                           787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +                                             787 closure #1 in static Runner._runTestCase(_:within:context:)  (in Testing) + 1  [0x107b0f9d9]
+    +                                               787 specialized static Issue.withErrorRecording(at:configuration:isolation:_:)  (in Testing) + 1  [0x107adaa2d]
+    +                                                 787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +                                                   787 closure #1 in closure #1 in static Runner._runTestCase(_:within:context:)  (in Testing) + 1  [0x107b10aa5]
+    +                                                     787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +                                                       787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f8fd]
+    +                                                         787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+    +                                                           787 <deduplicated_symbol>  (in Testing) + 1  [0x107a6f8fd]
+    +                                                             787 partial apply for implicit closure #1 in static RunAwaitsTurnTests.$s11WikiFSTests18RunAwaitsTurnTestsV29runCallsFinishBeforeReturning4TestfMp_25generator3a8ed4392fb91fe4fMu_@Sendable ()  (in WikiFSPackageTests) + 1  [0x112abc48d]  /<compiler-generated>:0
+    +                                                               787 implicit closure #1 in static RunAwaitsTurnTests.$s11WikiFSTests18RunAwaitsTurnTestsV29runCallsFinishBeforeReturning4TestfMp_25generator3a8ed4392fb91fe4fMu_@Sendable ()  (in WikiFSPackageTests) + 1  [0x112ab9dfd]  @__swiftmacro_11WikiFSTests18RunAwaitsTurnTestsV29runCallsFinishBeforeReturning4TestfMp_.swift:0
+    +                                                                 787 static RunAwaitsTurnTests.$s11WikiFSTests18RunAwaitsTurnTestsV29runCallsFinishBeforeReturning4TestfMp_17Z3a8ed4392fb91fe4fMu_@Sendable ()  (in WikiFSPackageTests) + 1  [0x112ab8b39]  @__swiftmacro_11WikiFSTests18RunAwaitsTurnTestsV29runCallsFinishBeforeReturning4TestfMp_.swift:4
+    +                                                                   787 RunAwaitsTurnTests.runCallsFinishBeforeReturning()  (in WikiFSPackageTests) + 1  [0x112ab90c5]  RunAwaitsTurnTests.swift:116
+    +                                                                     787 RunAwaitsTurnTests.runOneShot(launcher:onEvent:)  (in WikiFSPackageTests) + 1  [0x112ab643d]  RunAwaitsTurnTests.swift:58
+    +                                                                       787 AgentLauncher.run(request:wikiID:wikiRoot:systemPrompt:wikictlDirectory:ingestingSourceIDs:workspaceID:onEvent:onLock:onUnlock:)  (in WikiFSPackageTests) + 5864  [0x111f5f754]  AgentLauncher.swift:826
+    +                                                                         787 AgentLauncher.providersConfig()  (in WikiFSPackageTests) + 248  [0x111f51bac]  AgentLauncher.swift:198
+    +                                                                           787 static AgentProvidersConfig.loadOrSeed(from:discover:)  (in WikiFSPackageTests) + 1492  [0x111cc8648]  AgentProvidersConfig.swift:368
+    +                                                                             787 AgentProvidersConfig.save(to:)  (in WikiFSPackageTests) + 760  [0x111cc8d08]  AgentProvidersConfig.swift:381
+    +                                                                               787 Data.write(to:options:)  (in Foundation) + 2524  [0x189beed0c]
+    +                                                                                 787 closure #1 in writeToFileAux(path:buffer:options:attributes:reportProgress:)  (in Foundation) + 968  [0x189c130e8]
+    +                                                                                   787 createProtectedTemporaryFile(at:inPath:options:variant:)  (in Foundation) + 2044  [0x189c0a750]
+    +                                                                                     787 _NSOpenFileDescriptor_Protected  (in Foundation) + 260  [0x18986e2d0]
+    +                                                                                       787 open  (in libsystem_kernel.dylib) + 64  [0x187f498f0]
+    +                                                                                         787 __open  (in libsystem_kernel.dylib) + 8  [0x187f3e694]
+    787 Thread_32836862
+      787 start_wqthread  (in libsystem_pthread.dylib) + 8  [0x187f7cc10]
+        787 _pthread_wqthread  (in libsystem_pthread.dylib) + 368  [0x187f7df0c]
+          787 __workq_kernreturn  (in libsystem_kernel.dylib) + 8  [0x187f3f9f0]
+
+Total number in stack (recursive counted multiple, when >=5):
+        8       <deduplicated_symbol>  (in Testing) + 1  [0x107a6f901]
+
+Sort by top of stack, same collapsed (when >= 5):
+        __open  (in libsystem_kernel.dylib)        787
+        __workq_kernreturn  (in libsystem_kernel.dylib)        787
+
+Binary Images:
+       0x1025fc000 -        0x1025fcb97 +swiftpm-testing-helper (24907) <4EB4A7D1-5653-3DFC-A72C-B419749A7345> /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/libexec/swift/pm/swiftpm-testing-helper
+       0x102654000 -        0x102654c97 +lib_TestingInterop.dylib (1902) <AFEF7129-D17D-3925-ADF5-14AE12759CBB> /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/lib_TestingInterop.dylib
+       0x107a40000 -        0x107bd194f  com.apple.dt.swift-testing (1.0 - 1902) <85E3CCFF-C7D0-3FF9-8085-8348315D76B3> /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Versions/A/Testing
+       0x10fea8000 -        0x11386b81f +WikiFSPackageTests (0) <9CA2AB80-D088-3F40-A3AD-298BD707EFB8> /Users/*/WikiFSPackageTests
+       0x187b1c000 -        0x187b6eb4b  libobjc.A.dylib (951.7) <FF1D8AE4-ABEF-35F1-A30A-1183B9CB414F> /usr/lib/libobjc.A.dylib
+       0x187b6f000 -        0x187ba3d07  libdyld.dylib (1378) <B147D877-D0C2-388F-B38D-D3132E39905F> /usr/lib/system/libdyld.dylib
+       0x187ba4000 -        0x187c4a217  dyld (1.0.0 - 1378) <F924BDD3-4365-3466-9580-8B1B3FA8F857> /usr/lib/dyld
+       0x187c4b000 -        0x187c4e228  libsystem_blocks.dylib (96) <CC947089-488D-316B-A9C7-46DEC0F73145> /usr/lib/system/libsystem_blocks.dylib
+       0x187c4f000 -        0x187ca355f  libxpc.dylib (3102.120.13) <C40FCAE8-7A17-3D82-87CB-3DA4802ADEF1> /usr/lib/system/libxpc.dylib
+       0x187ca4000 -        0x187cc49ff  libsystem_trace.dylib (1861.120.4) <D0FABAB3-5AE7-3F10-8C62-60CBF5D70850> /usr/lib/system/libsystem_trace.dylib
+       0x187cc5000 -        0x187d735f7  libcorecrypto.dylib (1922.121.1) <A01A158D-6FE7-3B1C-A2C4-6BCB90D7314A> /usr/lib/system/libcorecrypto.dylib
+       0x187d74000 -        0x187dc41d7  libsystem_malloc.dylib (812.100.31) <5FAE4807-4D2B-3A95-A63A-DD96D3DA11B4> /usr/lib/system/libsystem_malloc.dylib
+       0x187dc5000 -        0x187e0c23f  libdispatch.dylib (1542.100.32) <F071EFE4-299F-3089-ACC4-0025B8FFB52A> /usr/lib/system/libdispatch.dylib
+       0x187e0d000 -        0x187e0fffb  libsystem_featureflags.dylib (103) <71FCFFBD-85F8-3365-AFE0-BECEA4369122> /usr/lib/system/libsystem_featureflags.dylib
+       0x187e10000 -        0x187e90d9f  libsystem_c.dylib (1752.120.2) <694B7881-1BF3-3D0F-8F19-B50AE4E8EF8A> /usr/lib/system/libsystem_c.dylib
+       0x187e91000 -        0x187f21ae7  libc++.1.dylib (2100.43) <5013C0F8-84A9-3B56-9FEB-C353816A750F> /usr/lib/libc++.1.dylib
+       0x187f22000 -        0x187f3c75f  libc++abi.dylib (2100.43) <E482D257-E5A0-3816-BD97-7B39342958DA> /usr/lib/libc++abi.dylib
+       0x187f3d000 -        0x187f7a2af  libsystem_kernel.dylib (12377.121.10) <FCA53B98-3D6A-38B2-A0EC-DF0F7E05F171> /usr/lib/system/libsystem_kernel.dylib
+       0x187f7b000 -        0x187f87b3b  libsystem_pthread.dylib (539.100.4) <4F33683C-18C8-39A1-800B-2E3BD43BCC13> /usr/lib/system/libsystem_pthread.dylib
+       0x187f88000 -        0x187f90963  libsystem_platform.dylib (375.120.2) <160FD864-8D15-36FC-9E97-9725388CFAFE> /usr/lib/system/libsystem_platform.dylib
+       0x187f91000 -        0x187fc06eb  libsystem_info.dylib (600) <3D62F2D9-F516-31BF-83C7-E203D872300B> /usr/lib/system/libsystem_info.dylib
+       0x187fc1000 -        0x18851f31f  com.apple.CoreFoundation (6.9 - 5026.5.4.1.402) <4BBD0DA8-C600-3F3A-A38B-6664652FA04A> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+       0x188520000 -        0x18883abff  com.apple.LaunchServices (1141.1 - 1141.1) <F32798D4-CA63-3935-B694-F45DAFFE5655> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+       0x18883b000 -        0x188a239bf  com.apple.gpusw.MetalTools (1.0 - 1) <2C2180C9-E027-3712-BED5-73645D651BFD> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
+       0x188a24000 -        0x18921e4bf  libBLAS.dylib (1551.100.26) <F078C775-D8DC-3C4D-879F-A9BB228DBE06> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+       0x18921f000 -        0x18932e35f  com.apple.Lexicon-framework (1.0 - 195.12) <16E3C45A-3C24-33D7-AD1C-1F6A215E57E7> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
+       0x18932f000 -        0x18949c417  libSparse.dylib (184.80.2) <C479DB8D-CF22-336C-B455-0CF900D96647> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
+       0x18949d000 -        0x1895300ff  com.apple.SystemConfiguration (1.21 - 1.21) <3E3C91CD-C9CE-3186-B49F-FBF3E6F1696B> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+       0x189531000 -        0x18956557b  libCRFSuite.dylib (55) <5220F98F-4B63-31DF-B1BA-F507F9441C35> /usr/lib/libCRFSuite.dylib
+       0x189566000 -        0x18982da1f  libmecabra.dylib (1121.5.1) <FF02DD93-271F-37F9-BA73-6C177B205849> /usr/lib/libmecabra.dylib
+       0x18982e000 -        0x18a81041f  com.apple.Foundation (6.9 - 5026.5.4.1.402) <0C8C2A94-A688-3529-B2BB-4640DF195105> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+       0x18a811000 -        0x18a9bfedf  com.apple.LanguageModeling (1.0 - 433.5) <176F6DE9-FC2F-3BB6-AE93-43746F86F99E> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+       0x18a9c0000 -        0x18aae0cbf  com.apple.CoreDisplay (291.4 - 291.4) <C5ACFCC5-A8E3-3DA5-BEB8-F3F3B932BD63> /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
+       0x18aae1000 -        0x18aea3c1f  com.apple.audio.AudioToolboxCore (1.0 - 1556.604) <868DF717-7563-39D0-95EB-19AB37629A5A> /System/Library/PrivateFrameworks/AudioToolboxCore.framework/Versions/A/AudioToolboxCore
+       0x18aea4000 -        0x18b0ccf3f  com.apple.CoreText (877.5.0.1 - 877.5.0.1) <9F6BA277-F8CA-38F6-80D3-897B304A0D4F> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+       0x18b0cd000 -        0x18b862e7f  com.apple.audio.CoreAudio (5.0 - 5.0) <242B3E7E-7A94-33DA-9D5B-C6739557CEB9> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+       0x18b863000 -        0x18bc81aff  com.apple.security (7.0 - 61901.120.67) <8FDCF5BF-61B9-3D69-BF9E-D134D220B8D9> /System/Library/Frameworks/Security.framework/Versions/A/Security
+       0x18bc82000 -        0x18bf57d53  libicucore.A.dylib (76142.5.1.200) <EB0C6EA9-E934-3776-9FD1-AF5E473552AA> /usr/lib/libicucore.A.dylib
+       0x18bf58000 -        0x18bf61e5f  libsystem_darwin.dylib (1752.120.2) <8858F025-745A-388E-9544-080781CC9A69> /usr/lib/system/libsystem_darwin.dylib
+       0x18bf62000 -        0x18c259cbf  com.apple.CoreServices.CarbonCore (1333 - 1333) <D5517285-3BB1-37C7-9ECA-B9E6D99DF7CF> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+       0x18c25a000 -        0x18c299c1b  com.apple.CoreServicesInternal (505 - 505) <0FBC8F4C-B825-381C-8728-762844E11392> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+       0x18c29a000 -        0x18c2d91bf  com.apple.CSStore (1141.1 - 1141.1) <1E543EF0-6C96-389F-9B2A-9614B625D198> /System/Library/PrivateFrameworks/CoreServicesStore.framework/Versions/A/CoreServicesStore
+       0x18c2da000 -        0x18c3c225f  com.apple.framework.IOKit (2.0.2 - 100231.120.3) <13C5D661-B23A-3AD8-88BB-2DE56023B840> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+       0x18c3c3000 -        0x18c3d51b6  libsystem_notify.dylib (348.120.4) <64D76451-1E0C-369B-A631-54DA3140E083> /usr/lib/system/libsystem_notify.dylib
+       0x18c3d6000 -        0x18c43268f  libsandbox.1.dylib (2680.120.12) <314286A0-7DB1-3E53-A763-6BF2F6795CA7> /usr/lib/libsandbox.1.dylib
+       0x18c433000 -        0x18db55f9f  com.apple.AppKit (6.9 - 2685.60.104) <C92CC156-D767-322B-B79B-433F56E72561> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+       0x18db56000 -        0x18dd0e83f  com.apple.UIFoundation (1.0 - 1019) <800C2811-E036-3D5A-BE89-C1D1EBD7B746> /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+       0x18dd0f000 -        0x18dd253ff  com.apple.UniformTypeIdentifiers (709 - 709) <D24AEC54-C332-3707-A7CC-BB0710F6D193> /System/Library/Frameworks/UniformTypeIdentifiers.framework/Versions/A/UniformTypeIdentifiers
+       0x18dd26000 -        0x18df79bdf  com.apple.desktopservices (26.0 - 1827.5.2) <DDE1A537-370A-314A-BA9A-43FCB5D4B867> /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
+       0x18dfd0000 -        0x18e20045f  com.apple.CoreDuet (1.0 - 1) <E8B64A4F-69E1-3E8D-8AE1-DF623A6F9145> /System/Library/PrivateFrameworks/CoreDuet.framework/Versions/A/CoreDuet
+       0x18e201000 -        0x18e2d995f  libboringssl.dylib (532.120.8) <611779E1-4B3F-310E-B070-1062D4707AA4> /usr/lib/libboringssl.dylib
+       0x18e2da000 -        0x18e68f1df  com.apple.CFNetwork (1.0 - 3860.600.21) <96293549-E281-3713-8ABF-886F0F966951> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+       0x18e690000 -        0x18e6aaf7b  libsystem_networkextension.dylib (2226.121.1) <0331EE20-A1FB-3C0D-990A-F65939CFF505> /usr/lib/system/libsystem_networkextension.dylib
+       0x18e6ab000 -        0x18e6ac067  libenergytrace.dylib (23) <E59503ED-FB38-3FBC-8999-83124D31645B> /usr/lib/libenergytrace.dylib
+       0x18e6ad000 -        0x18e72cf3f  libMobileGestalt.dylib (1484.120.3) <FA923504-DDCB-3138-ACC5-FB1D38183C78> /usr/lib/libMobileGestalt.dylib
+       0x18e72d000 -        0x18e744fdf  libsystem_asl.dylib (406) <F40838DF-2F15-3F62-970F-DEE25706BF1B> /usr/lib/system/libsystem_asl.dylib
+       0x18e745000 -        0x18e768797  com.apple.TCC (1.0 - 1) <46AC4453-DB23-3C07-A0EB-A68277A24098> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+       0x18e769000 -        0x18ed1fbbf  com.apple.SkyLight (1.600.0 - 922.7) <6F1978A2-1B8A-3A44-903D-532EED7106EB> /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
+       0x18ed20000 -        0x18f47503f  com.apple.CoreGraphics (2.0 - 1965.5.1) <3B96EADF-571C-3690-B5CE-7672B45CE859> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+       0x18f476000 -        0x18f61db8b  com.apple.ColorSync (4.13.0 - 3813.5.1) <24C07C0F-03C6-302B-9E54-5ED3A01B730E> /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
+       0x18f61e000 -        0x18f68935f  com.apple.HIServices (1.22 - 817) <34C40608-353D-3A06-BBF1-6B927CB8B39D> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+       0x18f787000 -        0x18f97b45f  com.apple.Montreal (1.0 - 178) <62CA7BC0-B6F0-31EE-AA0A-0A5CF5660D0D> /System/Library/PrivateFrameworks/Montreal.framework/Versions/A/Montreal
+       0x18f97c000 -        0x18fa713df  com.apple.NLP (1.0 - 233) <EE00B294-6CD3-3BBF-B826-A1CAE8FE495F> /System/Library/PrivateFrameworks/NLP.framework/Versions/A/NLP
+       0x18fa72000 -        0x18fe5ff5f  com.apple.CoreData (120 - 1526) <0A6EBD87-B6D8-3CFB-88A9-A091CE155610> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+       0x18fe60000 -        0x18fe7bd5f  com.apple.ProtocolBuffer (1 - 310.25.2.9.2) <52A2B4A4-4DB3-3FC3-B3F1-21E64D2F2003> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+       0x18fe7c000 -        0x190064a2f  libsqlite3.dylib (382) <2197AD4A-E0F8-38FF-924C-D9A97343680F> /usr/lib/libsqlite3.dylib
+       0x190065000 -        0x1900ef29f  com.apple.Accounts (113 - 113) <4FD07F3E-B251-3CF7-9EB4-95A7057585A7> /System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
+       0x1900f0000 -        0x190106e7f  com.apple.commonutilities (8.0 - 900) <769B76BE-AFA0-30FF-B348-6C04CD74DA59> /System/Library/PrivateFrameworks/CommonUtilities.framework/Versions/A/CommonUtilities
+       0x190107000 -        0x1901f849f  com.apple.BaseBoard (732.1.1 - 732.1.1) <03F3FD64-6BF3-326A-8004-C4EE9563571A> /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
+       0x1901f9000 -        0x19026493f  com.apple.RunningBoardServices (1.0 - 1015.100.16) <38F6DAD8-C5D2-37D8-9915-1CE94A572062> /System/Library/PrivateFrameworks/RunningBoardServices.framework/Versions/A/RunningBoardServices
+       0x190265000 -        0x1902d8c37  com.apple.AE (944 - 944) <0B347618-0BCF-3104-84B4-C0C0909E9C80> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+       0x1902d9000 -        0x1902ead87  libdns_services.dylib (2881.120.11) <E8717AA2-B706-36BB-A8FF-7EB3E64E58D5> /usr/lib/libdns_services.dylib
+       0x1902eb000 -        0x1902f3387  libsystem_symptoms.dylib (2169.120.7) <F5029F5C-1BF3-31C7-892E-BC8606AC829E> /usr/lib/system/libsystem_symptoms.dylib
+       0x1902f4000 -        0x191b1175f  com.apple.Network (1.0 - 5812.121.1) <C901F589-30E9-3847-B8FD-0DA14F3E8A09> /System/Library/Frameworks/Network.framework/Versions/A/Network
+       0x191b12000 -        0x191b41ddf  com.apple.analyticsd (1.0 - 1) <5F3582B5-C44E-3B5A-8C3D-E4DA63B8C6D8> /System/Library/PrivateFrameworks/CoreAnalytics.framework/Versions/A/CoreAnalytics
+       0x191b42000 -        0x191b438bb  libDiagnosticMessagesClient.dylib (113) <0770F750-6155-3991-9FDE-968CB42647DF> /usr/lib/libDiagnosticMessagesClient.dylib
+       0x191b44000 -        0x191bb033f  com.apple.spotlight.metadata.utilities (1.0 - 2418.5.9.101) <B4AB943C-5D50-3ADF-8175-4B56301C6DC3> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
+       0x191bb1000 -        0x191c3cb5f  com.apple.Metadata (26.5 - 2418.5.9.101) <E968E783-21CF-32A8-9C69-6C6870C36CDC> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+       0x191c3d000 -        0x191c461eb  com.apple.DiskArbitration (2.7 - 2.7) <18127B89-B783-3D13-882D-4F601449EA8A> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+       0x191c47000 -        0x19206b063  com.apple.vImage (8.1 - 632.120.2) <F2338A5A-848F-3745-9C95-92835FED69BC> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+       0x19206c000 -        0x192481cdf  com.apple.QuartzCore (1195.14.4 - 1195.14.4) <4D34EB4E-2BBB-3751-A362-8E2EB74656E8> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+       0x192482000 -        0x1924d34ff  libFontRegistry.dylib (408.4.0.1) <3480BBE1-4AE8-3066-BCB7-EAA15F37C64E> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+       0x1924d4000 -        0x19265a83f  com.apple.coreui (2.1 - 975) <16B8FC27-89EC-397F-870E-5717E2A04092> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+       0x19265b000 -        0x19278f6df  com.apple.ViewBridge (832 - 832) <83587E84-006F-3CD7-AB52-08763AB8A9FE> /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
+       0x192790000 -        0x192799e7f  com.apple.PerformanceAnalysis (1.427 - 427) <79B6355E-BD40-3D29-A27D-B8BAFEFC4CE4> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+       0x19279a000 -        0x1927a7aff  com.apple.OpenDirectory (26.5 - 666.100.1) <96F04359-D02E-3990-B798-4FE4448067BE> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+       0x1927a8000 -        0x1927d127f  com.apple.CFOpenDirectory (26.5 - 666.100.1) <270997B5-219E-3253-AFDD-619027EFDC6B> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+       0x1927d2000 -        0x1927de91b  com.apple.CoreServices.FSEvents (1413.100.6 - 1413.100.6) <7AA0D80A-3240-37B5-94D2-0C9B14103993> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+       0x1927df000 -        0x1928080df  com.apple.coreservices.SharedFileList (225 - 225) <997A2621-7998-38C3-B92C-7BD5A2A2B066> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
+       0x192809000 -        0x19280c08f  libapp_launch_measurement.dylib (17) <7760B2FE-B4E6-3244-B941-0A5277879853> /usr/lib/libapp_launch_measurement.dylib
+       0x19280d000 -        0x1928559bf  com.apple.CoreAutoLayout (1.0 - 34) <A53A5066-0626-325A-BADA-9F438AE63BB2> /System/Library/PrivateFrameworks/CoreAutoLayout.framework/Versions/A/CoreAutoLayout
+       0x192856000 -        0x19293c1db  libxml2.2.dylib (39.10.2) <572562FB-CEAA-3174-955C-D8B748EAD534> /usr/lib/libxml2.2.dylib
+       0x19293d000 -        0x1929bd85f  com.apple.CoreVideo (1.8 - 734.4) <8A36CB95-D65E-3838-8837-22FD9A7E3D9C> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+       0x1929be000 -        0x1929c0f5f  com.apple.loginsupport (3.0 - 264.4.1) <867D855C-0CD1-32D3-9345-83E99EC84CB6> /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+       0x1929c1000 -        0x1929fe41f  com.apple.aps.framework (4.0 - 4.0) <5157F14C-3E37-3E26-895A-5D69B1A25D30> /System/Library/PrivateFrameworks/ApplePushService.framework/Versions/A/ApplePushService
+       0x1929ff000 -        0x192a2b65f  com.apple.UserManagement (1.0 - 1) <20A5542F-F968-33E9-ABEE-DF2829C727ED> /System/Library/PrivateFrameworks/UserManagement.framework/Versions/A/UserManagement
+       0x192a2c000 -        0x192e53eff  com.apple.cloudkit.CloudKit (2360.120.2 - 2360.120.2) <E36022B1-863C-3E36-81A9-4EDD183F95AE> /System/Library/Frameworks/CloudKit.framework/Versions/A/CloudKit
+       0x192e54000 -        0x192f2867f  com.apple.CloudDocs (1.0 - 4479.121.1) <3030B709-68A8-36CE-AA8E-B63AEAA250E9> /System/Library/PrivateFrameworks/CloudDocs.framework/Versions/A/CloudDocs
+       0x192f29000 -        0x19376279f  com.apple.CoreML (1.0 - 3520.5.1) <00F01374-D6EA-3445-9598-42F360C651B4> /System/Library/Frameworks/CoreML.framework/Versions/A/CoreML
+       0x193763000 -        0x19430d5ff  libwebrtc.dylib (624.2.5.11.8) <E1A8890E-2D8B-3F9A-8521-1F962FC512B8> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/Frameworks/libwebrtc.dylib
+       0x19430e000 -        0x19458eaff  com.apple.corelocation (3075.0.8 - 3075.0.8) <0B130666-4338-377E-B4F4-C12280DE050C> /System/Library/Frameworks/CoreLocation.framework/Versions/A/CoreLocation
+       0x19458f000 -        0x1945c7257  libsystem_containermanager.dylib (725.120.2) <518BE44D-AA31-31E6-B44B-A37AD5E47040> /usr/lib/system/libsystem_containermanager.dylib
+       0x1945c8000 -        0x1945e425f  com.apple.IOSurface (393.5.7 - 393.5.7) <B572C01C-59C9-3A03-9EA2-899DE87F3702> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+       0x1945e5000 -        0x1945ef05f  com.apple.IOAccelerator (487.4.3 - 487.4.3) <1A671DA5-99DE-3CFC-83BF-2563BFA4E32F> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+       0x1945f0000 -        0x1948c9d5f  com.apple.Metal (373.2 - 373.2) <A5124C88-37B2-3F0D-94AC-B9A984420F0C> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
+       0x1948ca000 -        0x1948f305f  com.apple.audio.caulk (1.0 - 214.600.10) <47E71130-9608-3D99-ACEB-DF5638BC08DF> /System/Library/PrivateFrameworks/caulk.framework/Versions/A/caulk
+       0x1948f4000 -        0x194a9529f  com.apple.CoreMedia (1.0 - 3320.8.5.2) <AA302266-89A8-33AB-80EC-D93AD5E35220> /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
+       0x194a96000 -        0x194d6523f  libFontParser.dylib (435.5.0.1) <BEE48214-EE69-3830-BDED-ED0C88434BC1> /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
+       0x194d66000 -        0x19506111f  com.apple.HIToolbox (2.1.1 - 1250.1) <8716490E-ACC2-3688-8C2F-5CA42B4C9DA9> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+       0x195062000 -        0x1950765ff  com.apple.framework.DFRFoundation (1.0 - 293.1.1) <801CC18F-7E1A-3D24-9F67-AA8EAE0C1465> /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
+       0x195077000 -        0x19507c35f  com.apple.dt.XCTTargetBootstrap (26.5 - 24901) <E6AD8738-584A-3C0E-994D-A3C7608079AA> /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
+       0x19507d000 -        0x1950ba19f  com.apple.CoreSVG (1.0 - 341) <DE184D2F-7A17-3567-A3DD-014FA1D13141> /System/Library/PrivateFrameworks/CoreSVG.framework/Versions/A/CoreSVG
+       0x1950bb000 -        0x1953fac3f  com.apple.ImageIO (3.3.0 - 2784.5.5) <EEB840D5-3559-386F-BBD3-D24AA749D2EC> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+       0x1953fb000 -        0x1958e5f9f  com.apple.CoreImage (19.0.0 - 1592.120.2) <09D074A8-A66A-33F1-A5D9-89DE8A7D5287> /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
+       0x1958e6000 -        0x19599fddf  com.apple.MetalPerformanceShaders.MPSCore (1.0 - 1) <5ECFEA4E-D0ED-3809-AE36-F6A226913EC1> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSCore.framework/Versions/A/MPSCore
+       0x1959a0000 -        0x1959a45d7  libsystem_configuration.dylib (1405.120.5) <0F7BBC1C-3D50-3E59-A31F-E4672A80BCEB> /usr/lib/system/libsystem_configuration.dylib
+       0x1959a5000 -        0x1959ab8cf  libsystem_sandbox.dylib (2680.120.12) <EC3A75EA-44C0-3A0B-9BF7-71C117B0A9C6> /usr/lib/system/libsystem_sandbox.dylib
+       0x1959ac000 -        0x1959ad17f  com.apple.AggregateDictionary (1.0 - 1) <9526ACB3-9F77-3C63-94E3-1F7FF9FFD848> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
+       0x1959ae000 -        0x1959b24d3  com.apple.AppleSystemInfo (3.1.5 - 3.1.5) <1AF0471A-7CA4-363A-A88C-878F918559C3> /System/Library/PrivateFrameworks/AppleSystemInfo.framework/Versions/A/AppleSystemInfo
+       0x1959b3000 -        0x1959b446b  liblangid.dylib (140) <150F6708-1CA6-341A-A2A0-46CB1BA1A23C> /usr/lib/liblangid.dylib
+       0x1959b5000 -        0x195ad445f  com.apple.CoreNLP (1.0 - 313) <50C546E9-E6E0-3E9F-9E7A-9473578D7433> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
+       0x195ad5000 -        0x195adb91f  com.apple.LinguisticData (1.0 - 483.10) <88A7B02D-D5D3-3120-9D38-BCD3B8A1BC08> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
+       0x195adc000 -        0x196b63bcf  libBNNS.dylib (1961.120.8) <27D26BDE-14F4-3EBC-9A1F-195C0F69EFB7> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
+       0x196b64000 -        0x196ca146f  libvDSP.dylib (1126.100.7) <81359684-F2CB-3A26-A032-265A85B354EB> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+       0x196ca2000 -        0x196cd563f  com.apple.CoreEmoji (1.0 - 261.4.6) <E96057B3-D377-3475-9A61-2D83325AA54C> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
+       0x196cd6000 -        0x196d0f267  com.apple.IOMobileFramebuffer (343.0.0 - 343.0.0) <AD6AF1CD-4106-32CB-9512-A51BD8DAC459> /System/Library/PrivateFrameworks/IOMobileFramebuffer.framework/Versions/A/IOMobileFramebuffer
+       0x196d10000 -        0x196d9219f  com.apple.framework.CoreWLAN (16.0 - 1657) <AAB6F51A-504F-3BD4-9E92-827A0236CC2E> /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
+       0x196d93000 -        0x196f07e5f  com.apple.CoreUtils (8.3 - 830.22) <DCF4FA98-C827-3C83-9EE4-8CFB4CC6AC6C> /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
+       0x196f08000 -        0x196f1f6df  com.apple.MobileKeyBag (2.0 - 1.0) <DD679B3D-7C31-3A73-AA3F-E38AE71F6082> /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
+       0x196f20000 -        0x196f2e0ff  com.apple.AssertionServices (1.0 - 1015.100.16) <2AFED4E5-1BEF-3620-A118-13C2487C5E8A> /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
+       0x196f2f000 -        0x196fc1a9f  com.apple.securityfoundation (6.0 - 55293) <B186B3B6-62A5-3680-8FB4-1CC6DFB3D551> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+       0x196fc2000 -        0x196ff32ff  com.apple.coreservices.BackgroundTaskManagement (1.0 - 104) <C8C301D5-8180-31EF-ACC6-F754D14E23AC> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
+       0x196ff4000 -        0x196ffe6ff  com.apple.xpc.ServiceManagement (1.0 - 1) <B4D80E9A-21A4-3005-9457-F03598B6704B> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
+       0x196fff000 -        0x1970021fb  libquarantine.dylib (196.120.2) <5849009B-ACA3-3796-94C4-BBDF8D300EBA> /usr/lib/system/libquarantine.dylib
+       0x197003000 -        0x19700e2bf  libCheckFix.dylib (33) <60BF3A9B-F3E5-3AF0-ADE5-F86DEBD5CC5C> /usr/lib/libCheckFix.dylib
+       0x19700f000 -        0x1970267ab  libcoretls.dylib (187.100.3) <888DACFD-0135-3166-83EE-4E14D9A4A98B> /usr/lib/libcoretls.dylib
+       0x197027000 -        0x197038273  libbsm.0.dylib (90) <D82537E0-FE06-3158-BC46-D1073D1D4384> /usr/lib/libbsm.0.dylib
+       0x197039000 -        0x197097c6b  libmecab.dylib (1121.5.1) <B8A7C8DB-0176-3E90-929C-238A56EF45B8> /usr/lib/libmecab.dylib
+       0x197098000 -        0x19709a41b  libgermantok.dylib (31) <55193FF8-D101-3B4B-B6FB-01EA87FC3D37> /usr/lib/libgermantok.dylib
+       0x19709b000 -        0x1970aee3f  libLinearAlgebra.dylib (1551.100.26) <3849C130-9327-3672-88E1-B0E548F4EB82> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+       0x1970af000 -        0x19730517f  com.apple.MetalPerformanceShaders.MPSNeuralNetwork (1.0 - 1) <A8E8C36C-8F11-3ED5-B9B3-2810EDDD4D77> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
+       0x197306000 -        0x19735a19f  com.apple.MetalPerformanceShaders.MPSRayIntersector (1.0 - 1) <FCB4E780-9954-345D-B82F-9D319958448E> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
+       0x19735b000 -        0x1974ededf  com.apple.MLCompute (1.0 - 1) <E2533BA9-11AF-3045-B98E-F52D3C4F1878> /System/Library/Frameworks/MLCompute.framework/Versions/A/MLCompute
+       0x1974ee000 -        0x19751f57f  com.apple.MetalPerformanceShaders.MPSMatrix (1.0 - 1) <21591139-CD3C-36AB-8191-28193ACD17A7> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
+       0x197520000 -        0x1976efcdf  com.apple.MetalPerformanceShaders.MPSNDArray (1.0 - 1) <1CBC037E-8038-32F6-880A-6F3825544713> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNDArray.framework/Versions/A/MPSNDArray
+       0x1976f0000 -        0x1977841df  com.apple.MetalPerformanceShaders.MPSImage (1.0 - 1) <35130CF5-F99D-3CED-9993-48AEE13ECA36> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSImage.framework/Versions/A/MPSImage
+       0x197785000 -        0x1977904b3  com.apple.AppleFSCompression (174.100.2 - 1.0) <1B79BCD7-4B46-302B-8008-86CBD62FEB0A> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
+       0x197791000 -        0x19779d0a3  libbz2.1.0.dylib (49) <928515D6-6108-3757-97F4-256F9F9CFBC8> /usr/lib/libbz2.1.0.dylib
+       0x19779e000 -        0x1977a4d03  libsystem_coreservices.dylib (191.4.5) <9576143B-C303-35A3-BA63-1FD06EDA2BB1> /usr/lib/system/libsystem_coreservices.dylib
+       0x1977a5000 -        0x1977d6adf  com.apple.CoreServices.OSServices (1141.1 - 1141.1) <F42F7727-9C73-3148-B41C-186607715B54> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+       0x1977d7000 -        0x197b5d8ff  com.apple.AuthKit (1.0 - 1) <12E2B998-E463-3B84-8606-C0FB645D5BB0> /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
+       0x197b5e000 -        0x197bae6ff  com.apple.UserNotifications (1.0 - 640.5.32) <D7EE8BEC-0ADB-3272-9DB5-B02A2F77F84A> /System/Library/Frameworks/UserNotifications.framework/Versions/A/UserNotifications
+       0x197baf000 -        0x197d1969f  com.apple.CoreSpotlight (1.0 - 2418.5.9.101) <D6EE486B-2645-352D-A385-EE7D1CB125C3> /System/Library/Frameworks/CoreSpotlight.framework/Versions/A/CoreSpotlight
+       0x197d1a000 -        0x197d28d97  libz.1.dylib (100.120.1) <863BB312-F115-32B0-889F-D3B42857A7A6> /usr/lib/libz.1.dylib
+       0x197d29000 -        0x197d66a77  libsystem_m.dylib (3312.100.1) <A7E0863C-101A-31A0-922B-ED9B02626151> /usr/lib/system/libsystem_m.dylib
+       0x197d67000 -        0x197d67c9b  libcharset.1.dylib (115.120.2) <338A5252-594A-3AC5-B274-5AB3CE5820C6> /usr/lib/libcharset.1.dylib
+       0x197d68000 -        0x197d6b527  libmacho.dylib (1378) <755441B4-C034-3E3A-8E3C-F424FBB28261> /usr/lib/system/libmacho.dylib
+       0x197d6c000 -        0x197d84dc3  libkxld.dylib (12377.121.10) <907233E7-3366-3FB9-B000-F20DB619DA61> /usr/lib/system/libkxld.dylib
+       0x197d85000 -        0x197d923a7  libcommonCrypto.dylib (600035) <CE357BB1-2D49-37CC-9FFE-D093936B1475> /usr/lib/system/libcommonCrypto.dylib
+       0x197d93000 -        0x197d9cca3  libunwind.dylib (2100.2) <FC8F0C4E-6FB0-3E27-ABEF-B0FA720CD5E4> /usr/lib/system/libunwind.dylib
+       0x197d9d000 -        0x197da4349  liboah.dylib (367.9) <8651ED4F-6506-3788-B56B-32EE414A85CA> /usr/lib/liboah.dylib
+       0x197da5000 -        0x197daf7ff  libcopyfile.dylib (240) <8ACFAC7A-88E9-3EF4-853F-A9140FF110E5> /usr/lib/system/libcopyfile.dylib
+       0x197db0000 -        0x197db3987  libcompiler_rt.dylib (103.3) <AA79151F-C19D-3C7C-92F8-B10F04D82C1C> /usr/lib/system/libcompiler_rt.dylib
+       0x197db4000 -        0x197db878b  libsystem_collections.dylib (1752.120.2) <72DB5BE7-EF78-37D0-8AAD-53E37CFE4287> /usr/lib/system/libsystem_collections.dylib
+       0x197db9000 -        0x197dbc4cf  libsystem_secinit.dylib (168.100.7) <E525C566-CDA4-3D99-B12B-1615FD54A1F3> /usr/lib/system/libsystem_secinit.dylib
+       0x197dbd000 -        0x197dbfbf7  libremovefile.dylib (85.100.6) <635E661D-80A7-340D-A165-3F7D318FDFC9> /usr/lib/system/libremovefile.dylib
+       0x197dc0000 -        0x197dc0f27  libkeymgr.dylib (31) <8C08891A-DF1C-3DCC-AB64-4742FD6BE9BA> /usr/lib/system/libkeymgr.dylib
+       0x197dc1000 -        0x197dc9e37  libsystem_dnssd.dylib (2881.120.11) <6F45DF3F-233B-3BC3-BA8C-B43E7DA884BF> /usr/lib/system/libsystem_dnssd.dylib
+       0x197dca000 -        0x197dcf09b  libcache.dylib (95) <189B576E-6176-3F82-8FA4-5914B0BEAEE7> /usr/lib/system/libcache.dylib
+       0x197dd0000 -        0x197dd1ce3  libSystem.B.dylib (1356) <BA6A669A-3BB9-3BC7-85E8-8F0C1E68351E> /usr/lib/libSystem.B.dylib
+       0x197dd2000 -        0x197dd3fcf  libfakelink.dylib (5) <C7FBDAB2-BA25-3B1B-924B-6CD5EB501D3D> /usr/lib/libfakelink.dylib
+       0x197dd4000 -        0x197dd4a33  com.apple.SoftLinking (1.0 - 71) <B47F8999-CDB3-308F-9129-E690590605D8> /System/Library/PrivateFrameworks/SoftLinking.framework/Versions/A/SoftLinking
+       0x197e0a000 -        0x197e112bb  libiconv.2.dylib (115.120.2) <7C02D8F4-1921-323C-9D3D-A5D9B0ACDD78> /usr/lib/libiconv.2.dylib
+       0x197e12000 -        0x197e24457  libcmph.dylib (9) <A30B8DE9-5419-3A74-B197-24C60EB4FD88> /usr/lib/libcmph.dylib
+       0x197e25000 -        0x197f1cedf  libarchive.2.dylib (167.120.3) <98ED60D0-2C5C-31A2-81BA-17C9C2312B7E> /usr/lib/libarchive.2.dylib
+       0x197f1d000 -        0x197f8285b  com.apple.SearchKit (1.4.2 - 1.4.2) <B73B7F8E-666B-33EA-AC89-9DE4F7C25835> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+       0x197f83000 -        0x197f8b18f  libThaiTokenizer.dylib (28) <43BAB012-1CCE-3DDC-9832-3A93EF0BAD9C> /usr/lib/libThaiTokenizer.dylib
+       0x197f8c000 -        0x197faff37  com.apple.applesauce (1.0 - 17.7) <9F8F8959-64E3-3B88-BC05-20ACA5436052> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
+       0x197fb0000 -        0x197fc84ab  libapple_nghttp2.dylib (37.120.3) <7C8B8B14-EC40-3F5B-8265-8975D4D4E83B> /usr/lib/libapple_nghttp2.dylib
+       0x197fc9000 -        0x197fefac3  libSparseBLAS.dylib (1551.100.26) <EF675037-43BA-3616-8BEF-662BA272F3D7> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
+       0x197ff0000 -        0x197ff163f  com.apple.MetalPerformanceShaders.MetalPerformanceShaders (1.0 - 1) <1FC17E05-127E-3222-B3A2-72912C49821C> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
+       0x197ff2000 -        0x197ff7ff7  libpam.2.dylib (35) <24C42EB6-FC23-3D66-A260-CAD78EF8637B> /usr/lib/libpam.2.dylib
+       0x197ff8000 -        0x1980ccd97  libcompression.dylib (193.120.2) <F9FEA7C5-8DE1-3EE6-BFD3-E8B5698D73A6> /usr/lib/libcompression.dylib
+       0x1980cd000 -        0x1980d1267  libQuadrature.dylib (8) <A285FC62-DE15-317B-8451-619953D3660A> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
+       0x1980d2000 -        0x1992a294f  libLAPACK.dylib (1551.100.26) <7275296D-74F2-3020-B2C5-E2EA0E7A6F7A> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+       0x1992a3000 -        0x1992f943f  com.apple.DictionaryServices (1.2 - 382) <1C33980B-2B1B-3374-8DFF-C0589BDA8D37> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+       0x1992fa000 -        0x1993184f7  liblzma.5.dylib (21) <9F5AA0F6-7C29-3699-8AA3-C7B56284D3F4> /usr/lib/liblzma.5.dylib
+       0x199319000 -        0x19931a85f  libcoretls_cfhelpers.dylib (187.100.3) <236BD946-7627-367C-8150-FCC9297471E1> /usr/lib/libcoretls_cfhelpers.dylib
+       0x19931b000 -        0x19938e5bf  com.apple.APFS (2811.121.1 - 2811.121.1) <D26A2CE1-9650-3242-B82B-040554465DFA> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
+       0x19938f000 -        0x19939d693  libxar.1.dylib (503) <689E5ED9-2D46-3B4C-8942-B5A6D7495445> /usr/lib/libxar.1.dylib
+       0x19939e000 -        0x1993a179b  libutil.dylib (73) <93D2F3FE-6001-3A87-BF89-3ECABFF334CE> /usr/lib/libutil.dylib
+       0x1993a2000 -        0x1993cccbf  libxslt.1.dylib (21.13.2) <C7FCA882-8EB6-3AB6-B137-DD9816B7BC0A> /usr/lib/libxslt.1.dylib
+       0x1993cd000 -        0x1993d4127  libChineseTokenizer.dylib (44) <606A5EA1-AA94-3D7D-BC23-6D97C5A3A6F7> /usr/lib/libChineseTokenizer.dylib
+       0x1993d5000 -        0x19944e587  libvMisc.dylib (1126.100.7) <73154851-2341-34B7-8214-625C9219A676> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+       0x19944f000 -        0x1994de45f  libate.dylib (3.0.9) <30643AB8-BA08-3222-9AD2-64248E503B89> /usr/lib/libate.dylib
+       0x1994df000 -        0x1994e7923  libIOReport.dylib (107) <511E156A-71B5-3936-933A-D41A0B23ED9A> /usr/lib/libIOReport.dylib
+       0x1994e8000 -        0x1994fb1bf  com.apple.CrashReporterSupport (10.13 - 15140) <482F92F1-D855-36EC-8E3D-C084CFA61B27> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+       0x1994fc000 -        0x19951cb5f  com.apple.AppSSOCore (1.0 - 483.120.4) <18B5AD6A-ADD8-3AC3-A4C5-47099F6DB9C0> /System/Library/PrivateFrameworks/AppSSOCore.framework/Versions/A/AppSSOCore
+       0x19951d000 -        0x19961a83f  com.apple.CVNLP (1.0 - 119) <F47FC0F7-A128-3B7C-B059-9F0836040CCF> /System/Library/PrivateFrameworks/CVNLP.framework/Versions/A/CVNLP
+       0x19961b000 -        0x19963ee3f  com.apple.SharedWebCredentials (1001 - 1036.2) <CBF4DB42-28FB-37B8-A82C-23CC61910540> /System/Library/PrivateFrameworks/SharedWebCredentials.framework/Versions/A/SharedWebCredentials
+       0x19963f000 -        0x19967ff9f  com.apple.pluginkit.framework (1.0 - 1) <6A017CC8-84D1-36E5-ADE4-2A2EDC08D67F> /System/Library/PrivateFrameworks/PlugInKit.framework/Versions/A/PlugInKit
+       0x199680000 -        0x199687403  libMatch.1.dylib (49) <96C8879C-B224-388A-AC38-F7D0B21D395D> /usr/lib/libMatch.1.dylib
+       0x199688000 -        0x1996f599f  libCoreStorage.dylib (568) <C41B6247-F32B-35C2-A3C1-77E2B499BDF5> /usr/lib/libCoreStorage.dylib
+       0x1996f6000 -        0x19973e9ff  com.apple.AppleVAFramework (6.2.10 - 6.2.10) <6CFBB631-D1EF-3D92-AE69-6758E7BDE4C5> /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
+       0x19973f000 -        0x199759ccf  libexpat.1.dylib (47) <B7EE1C84-0D24-3B3F-8A1F-94ADDCFE777C> /usr/lib/libexpat.1.dylib
+       0x19975a000 -        0x199763bd3  libheimdal-asn1.dylib (710.100.4) <AF872616-7404-3D91-BA6B-A723D4269665> /usr/lib/libheimdal-asn1.dylib
+       0x199764000 -        0x1997c461f  com.apple.IconFoundation (494 - 494) <731868E5-7869-3A78-90C6-09CAF5A9F3D5> /System/Library/PrivateFrameworks/IconFoundation.framework/Versions/A/IconFoundation
+       0x1997c5000 -        0x199882f1f  com.apple.IconServices (494 - 494) <617475BA-7A95-3F7B-B47E-DAD358C41E23> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+       0x199883000 -        0x199944edf  com.apple.MediaExperience (1.0 - 1) <507B3FE7-C5C1-30DB-935C-C478FF7B4096> /System/Library/PrivateFrameworks/MediaExperience.framework/Versions/A/MediaExperience
+       0x199945000 -        0x1999710bf  com.apple.persistentconnection (1.0 - 1.0) <BD6B69EF-B070-3469-B569-75D40AA5E0EE> /System/Library/PrivateFrameworks/PersistentConnection.framework/Versions/A/PersistentConnection
+       0x199972000 -        0x1999817ff  com.apple.GraphVisualizer (1.0 - 307) <6F1E4885-F5B7-3B50-9C33-044B6925A07F> /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
+       0x199982000 -        0x1999c151f  com.apple.OTSVG (1.0 - 877.5.0.1) <42167641-18E8-3F36-AF17-A7D4244D6059> /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
+       0x1999c2000 -        0x1999cec7f  com.apple.xpc.AppServerSupport (1.0 - 3102.120.13) <AB36D838-16DB-3974-ABEC-220B5026013E> /System/Library/PrivateFrameworks/AppServerSupport.framework/Versions/A/AppServerSupport
+       0x1999cf000 -        0x1999d5abf  libspindump.dylib (419.10) <5EAE94A8-4A96-3DBD-8FC6-DA684427813F> /usr/lib/libspindump.dylib
+       0x1999d6000 -        0x199a96dff  com.apple.Heimdal (4.0 - 2.0) <29B023E7-2213-362C-80BD-8A463A229936> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+       0x199a97000 -        0x199aba79f  com.apple.login (3.0 - 3.0) <133855CE-1DFF-3C95-92F0-424A112740CC> /System/Library/PrivateFrameworks/login.framework/Versions/A/login
+       0x199abb000 -        0x199c3bcbf  com.apple.corebrightness (1.0 - 1) <A78FFE19-75C5-32DD-9FD5-FA7168ADE5B5> /System/Library/PrivateFrameworks/CoreBrightness.framework/Versions/A/CoreBrightness
+       0x199ce8000 -        0x199ce9207  libodfde.dylib (26) <2BDD9534-0CBC-3C83-AF05-89CBE6C38E88> /usr/lib/libodfde.dylib
+       0x199cea000 -        0x199d64643  com.apple.bom (14.0 - 277) <901BB89C-28BA-3CDF-B088-6484E180B2E5> /System/Library/PrivateFrameworks/Bom.framework/Versions/A/Bom
+       0x199d65000 -        0x199da96ef  com.apple.AppleJPEG (1.0 - 1) <63F815E9-899E-3F5E-8837-43C168F606C6> /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+       0x199daa000 -        0x199f6a92f  libJP2.dylib (2784.5.5) <8D5B9707-E8DE-393F-9677-9084581261CD> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+       0x199f6b000 -        0x199f6ce1f  com.apple.WatchdogClient.framework (1.0 - 333) <05DDF467-0A3F-3F3F-821F-3063D15BDDF6> /System/Library/PrivateFrameworks/WatchdogClient.framework/Versions/A/WatchdogClient
+       0x199f6d000 -        0x199fb2c1f  com.apple.MultitouchSupport.framework (9450.2 - 9450.2) <20C49E65-4FDC-3FA2-ADD2-8BD540F8849B> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+       0x199fb3000 -        0x19a50929f  com.apple.VideoToolbox (1.0 - 3320.8.5.2) <E0E56BFC-6557-37D7-B729-E48E65E9C18D> /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
+       0x19a50a000 -        0x19a52f20f  libAudioToolboxUtility.dylib (1556.604) <8679E444-23B4-3B9F-8D0A-18ACEED541C5> /usr/lib/libAudioToolboxUtility.dylib
+       0x19a530000 -        0x19a55a01f  libPng.dylib (2784.5.5) <00E32167-5D99-3AC7-A74F-6954A84D09A9> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+       0x19a55b000 -        0x19a5bba77  libTIFF.dylib (2784.5.5) <56756A7F-9BBE-38B8-85C4-719610A6C089> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+       0x19a5bc000 -        0x19a5db257  com.apple.IOPresentment (67 - 67) <C9C0A630-F275-3ABE-BFE2-86ECE91F83CA> /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
+       0x19a5dc000 -        0x19a5e07d3  com.apple.GPUWrangler (8.1.12 - 8.1.12) <1644240B-3D71-35E7-AC5B-2A69E6B29535> /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
+       0x19a5e1000 -        0x19a5e3913  libRadiance.dylib (2784.5.5) <3A6C1170-7833-3098-BA1A-4B0E39186F0E> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+       0x19a5e4000 -        0x19a5e92f3  com.apple.DSExternalDisplay (3.1 - 380) <DDF7A5A5-72F8-3580-9FF6-2A02E4ADE864> /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
+       0x19a5ea000 -        0x19a614baf  libJPEG.dylib (2784.5.5) <92BE8449-C2AA-3EAD-B038-777516E4C9E0> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+       0x19a615000 -        0x19a64257f  com.apple.ATSUI (1.0 - 1) <862A05C7-A3CD-32A4-A781-79EEFACA3A40> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATSUI.framework/Versions/A/ATSUI
+       0x19a643000 -        0x19a6489fb  libGIF.dylib (2784.5.5) <B001874B-CE97-3379-952E-0E0FCC4270A6> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+       0x19a649000 -        0x19a65919f  com.apple.CMCaptureCore (1.0 - 665.120.8) <95190CD1-3456-355B-9369-5604AA49C1F3> /System/Library/PrivateFrameworks/CMCaptureCore.framework/Versions/A/CMCaptureCore
+       0x19a65a000 -        0x19a6cc71f  com.apple.print.framework.PrintCore (19 - 601.2) <CFCCA576-9B0F-333F-90CC-50202E57874D> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+       0x19a6cd000 -        0x19a76391f  com.apple.TextureIO (3.10.12 - 3.10.12) <86370757-B646-3574-ACF3-0FA71A201C89> /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
+       0x19a764000 -        0x19aa6df9f  com.apple.InternationalSupport (1.0 - 74) <E9D66213-9909-311D-8AB4-798EF0C8C82B> /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
+       0x19aa6e000 -        0x19aabfd1f  com.apple.datadetectorscore (8.0 - 821.7) <12E5A60A-43E6-37D7-96E9-C81C2E731534> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+       0x19aac0000 -        0x19ab308df  com.apple.UserActivity (551 - 551) <E1E83216-0E8D-32D5-B2F8-8E7AED8236A9> /System/Library/PrivateFrameworks/UserActivity.framework/Versions/A/UserActivity
+       0x19ab31000 -        0x19b5d08df  com.apple.MediaToolbox (1.0 - 3320.8.5.2) <75A5FE86-3A47-38A2-8367-AB9EE90CEA1F> /System/Library/Frameworks/MediaToolbox.framework/Versions/A/MediaToolbox
+       0x19b5d1000 -        0x19b63f86f  libusrtcp.dylib (5812.121.1) <54F1B848-D6B1-3DB0-B640-FA6A86262C1D> /usr/lib/libusrtcp.dylib
+       0x19b640000 -        0x19bbe17bf  libswiftCore.dylib (6.3.2 - 6.3.2.1.3) <7669D858-D332-36C7-9C6C-4564FFBEA8D2> /usr/lib/swift/libswiftCore.dylib
+       0x19bbe2000 -        0x19bc5ac9f  com.apple.imfoundation (10.0 - 1000) <6A585A92-1A65-3B22-9312-38B740042418> /System/Library/PrivateFrameworks/IMFoundation.framework/Versions/A/IMFoundation
+       0x19bc5b000 -        0x19bc9401f  com.apple.locationsupport (3075.0.8 - 3075.0.8) <5ABE90A9-571C-320C-B9E2-F15346757A42> /System/Library/PrivateFrameworks/LocationSupport.framework/Versions/A/LocationSupport
+       0x19bc95000 -        0x19bcea17f  libSessionUtility.dylib (398.601) <3D82E6A1-1D29-3274-84DD-BDF36B6F7962> /System/Library/PrivateFrameworks/AudioSession.framework/libSessionUtility.dylib
+       0x19bceb000 -        0x19bebfc3f  com.apple.audio.toolbox.AudioToolbox (1.14 - 1.14) <B0ED86EE-4A99-3D39-AFC1-BC3361F630D8> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+       0x19bec0000 -        0x19bf40b7f  com.apple.audio.AudioSession (1.0 - 398.601) <23137B46-437B-382A-BF06-17C82F58149B> /System/Library/PrivateFrameworks/AudioSession.framework/Versions/A/AudioSession
+       0x19bf41000 -        0x19bf5a39f  libAudioStatistics.dylib (262.601) <9AD96BE7-444B-3641-9B75-8F4EE1A686BF> /usr/lib/libAudioStatistics.dylib
+       0x19bf5b000 -        0x19bf8893f  com.apple.speech.synthesis.framework (9.2.22 - 9.2.22) <BE00EBFA-9214-3004-90AC-0BD224B51E69> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+       0x19bf89000 -        0x19bfd04bf  com.apple.ApplicationServices.ATS (377 - 593) <FB4E0EBB-6886-3EDB-AED1-F9A63496889A> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+       0x19bfd1000 -        0x19bfed19b  libresolv.9.dylib (96) <90D545B0-52B4-335D-A075-4A7B83C01FC8> /usr/lib/libresolv.9.dylib
+       0x19bfee000 -        0x19c0007e7  libsasl2.2.dylib (215) <28BFB13B-08D2-3705-A634-B4E888613489> /usr/lib/libsasl2.2.dylib
+       0x19c001000 -        0x19c00d87f  com.apple.multiverse (1.0 - 117) <30196297-DB9B-3B87-9178-5A02C0320D4D> /System/Library/PrivateFrameworks/MultiverseSupport.framework/Versions/A/MultiverseSupport
+       0x19c00e000 -        0x19c075767  libParallelCompression.dylib (450.100.4) <0C9ADA86-5273-3425-AB67-50EF66E3540E> /usr/lib/libParallelCompression.dylib
+       0x19c076000 -        0x19c0af75f  com.apple.securityinterface (10.0 - 55210.100.6) <D54CF7FB-18F3-38B1-844C-68A9DF9740D8> /System/Library/Frameworks/SecurityInterface.framework/Versions/A/SecurityInterface
+       0x19c0b0000 -        0x19c0e59df  com.apple.CoreFollowUp-OSX (1.0 - 281.5.2) <715F286A-D4CF-3EA5-ACCA-C0E98EAD3C2D> /System/Library/PrivateFrameworks/CoreFollowUp.framework/Versions/A/CoreFollowUp
+       0x19c0e6000 -        0x19c1e887f  com.apple.CoreMediaIO (1000.0 - 5617.100.5) <2691DDA0-F0E1-37B6-A74C-D28AF97DF8F3> /System/Library/Frameworks/CoreMediaIO.framework/Versions/A/CoreMediaIO
+       0x19c1e9000 -        0x19c2c9337  libSMC.dylib (38) <CD66132B-7D67-36D2-82BC-FFFACBAAF05A> /usr/lib/libSMC.dylib
+       0x19c2ca000 -        0x19c328b9f  libcups.2.dylib (522.4) <CC1FB779-0931-313B-93CC-C842BCEA8485> /usr/lib/libcups.2.dylib
+       0x19c329000 -        0x19c335c17  com.apple.NetAuth (6.2 - 6.2) <F039515C-B344-37B5-B705-E58B48AD3C5D> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+       0x19c336000 -        0x19c33adcb  com.apple.ColorSyncLegacy (4.13.0 - 1) <BAF488A8-B84C-3A76-80AD-33AFDDCF1E20> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
+       0x19c33b000 -        0x19c343def  com.apple.QD (4.0 - 451) <A3E51F97-7B2E-3BFA-8F10-918531B7F52D> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+       0x19c344000 -        0x19c351b1f  com.apple.perfdata (1.0 - 130) <63F6F6B4-A2A8-3647-BDEB-50508AE91B8F> /System/Library/PrivateFrameworks/perfdata.framework/Versions/A/perfdata
+       0x19c352000 -        0x19c35fc9f  libperfcheck.dylib (46) <F900A796-0FF7-3195-85CF-80D62DF5C477> /usr/lib/libperfcheck.dylib
+       0x19c360000 -        0x19c371187  com.apple.Kerberos (3.0 - 1) <D81F4821-8D01-394B-812B-657C3114A356> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+       0x19c372000 -        0x19c3c3aaf  com.apple.GSS (4.0 - 2.0) <9149B4E1-8502-3A93-9944-61323F4725E1> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
+       0x19c3c4000 -        0x19c3d4d6f  com.apple.CommonAuth (4.0 - 2.0) <B703DB83-34E2-3728-89DF-41421EC67747> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+       0x19c3d5000 -        0x19c4b901f  com.apple.MobileAssets (1.0 - 1837.121.1) <95D9C5B8-40A8-3F25-B1FC-C4468D133923> /System/Library/PrivateFrameworks/MobileAsset.framework/Versions/A/MobileAsset
+       0x19c4ba000 -        0x19c508b1f  com.apple.CacheDelete (1.0 - 1) <3040663D-7715-37D2-A1D7-52874AEB2F02> /System/Library/PrivateFrameworks/CacheDelete.framework/Versions/A/CacheDelete
+       0x19c509000 -        0x19c54be5f  com.apple.security.KeychainCircle.KeychainCircle (1.0 - 1) <EEC8FA48-0F41-30D3-83D2-6E3A16B16D14> /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
+       0x19c54c000 -        0x19c55b160  com.apple.CorePhoneNumbers (1.0 - 1) <CF1CBC2C-A525-3C79-B709-D5C23B2CB33A> /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
+       0x19c55c000 -        0x19c5e545f  libTelephonyUtilDynamic.dylib (6392) <D40349E1-7A6C-38D6-BA00-1F17C5B60414> /usr/lib/libTelephonyUtilDynamic.dylib
+       0x19cf0f000 -        0x19d1d8aff  com.apple.NetworkExtension (1.0 - 1) <8618B266-AF27-3652-8E9A-7CCC336C9DA5> /System/Library/Frameworks/NetworkExtension.framework/Versions/A/NetworkExtension
+       0x19d1d9000 -        0x19d3fe23f  com.apple.ids (10.0 - 1000) <19DAB4A1-E58C-36E3-9EA2-294474E3DA98> /System/Library/PrivateFrameworks/IDS.framework/Versions/A/IDS
+       0x19d3ff000 -        0x19da79edf  com.apple.idsfoundation (10.0 - 1000) <8BBB5442-C708-3B08-B6C3-6483B918D0F8> /System/Library/PrivateFrameworks/IDSFoundation.framework/Versions/A/IDSFoundation
+       0x19da7a000 -        0x19de82abf  com.apple.Sharing (2094.60.51 - 2094.60.51) <28F48BEF-DAD2-38A7-81D1-A467BA05589D> /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
+       0x19de83000 -        0x19df3afff  com.apple.Bluetooth (1.0 - 1) <ECC3B4EE-BCE4-3974-8703-3C9FF2E50BB9> /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+       0x19df59000 -        0x19dff139f  com.apple.ProtectedCloudStorage (1.0 - 1) <66379965-7301-341F-8C75-E3D090ECEE7C> /System/Library/PrivateFrameworks/ProtectedCloudStorage.framework/Versions/A/ProtectedCloudStorage
+       0x19dff2000 -        0x19e0582bf  com.apple.QuickLookFramework (5.0 - 1018.5.5) <FBDB7CE7-4A17-3010-81B8-D30B00BADC96> /System/Library/Frameworks/QuickLook.framework/Versions/A/QuickLook
+       0x19e059000 -        0x19e0774bf  com.apple.MetalKit (173.7 - 173.7) <3363CCA6-8191-39C6-B60E-F92BEDBE0497> /System/Library/Frameworks/MetalKit.framework/Versions/A/MetalKit
+       0x19e078000 -        0x19e07c98f  libxcselect.dylib (2416) <2856942D-B495-38EC-AD47-DBC2EE7380AB> /usr/lib/libxcselect.dylib
+       0x19e130000 -        0x19e13637f  libdscsym.dylib (427) <0DB62A71-808C-3FFC-9D1C-6418BE34775D> /usr/lib/libdscsym.dylib
+       0x19e137000 -        0x19e22aa36  com.apple.combine (1.0 - 3023) <D757C287-429D-3F70-B903-C942A00F2DAA> /System/Library/Frameworks/Combine.framework/Versions/A/Combine
+       0x19e22b000 -        0x1a00622ff  com.apple.GeoServices (1.0 - 2031.25.2.9.19) <F108CE7C-95A5-37B2-A895-F754A3D45B79> /System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
+       0x1a0063000 -        0x1a006e647  com.apple.DirectoryService.Framework (26.5 - 666.100.1) <53422671-002F-30C5-BC86-A96FD98762BC> /System/Library/Frameworks/DirectoryService.framework/Versions/A/DirectoryService
+       0x1a008b000 -        0x1a008e967  com.apple.speech.recognition.framework (6.0.5 - 6.0.5) <508F1E1B-781A-365C-922D-4FB01AB8D92D> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+       0x1a008f000 -        0x1a00a0375  com.apple.AppleLDAP (26.5 - 63) <6105749E-3F3B-3DB4-8052-CFC0563C8C79> /System/Library/PrivateFrameworks/AppleLDAP.framework/Versions/A/AppleLDAP
+       0x1a00a1000 -        0x1a035581f  com.apple.MapKit (1.0 - 2511.25.2.9.7) <29042770-279E-3C50-AF03-64466117E9FB> /System/Library/Frameworks/MapKit.framework/Versions/A/MapKit
+       0x1a0363000 -        0x1a03691d7  com.apple.IOPlatformPluginFamily (1.0 - 1) <577403EC-FBA3-3FFB-BF06-D4A2359F6EC5> /System/Library/PrivateFrameworks/IOPlatformPluginFamily.framework/Versions/A/IOPlatformPluginFamily
+       0x1a039d000 -        0x1a03c53bf  com.apple.GLKit (129 - 129) <0549C92D-A261-30A4-84EA-2CC4DD32C76F> /System/Library/Frameworks/GLKit.framework/Versions/A/GLKit
+       0x1a03d7000 -        0x1a041a19f  libnetworkextension.dylib (2226.121.1) <E69A1A8C-FF57-3EF1-AA54-18641187E2E7> /usr/lib/libnetworkextension.dylib
+       0x1a041b000 -        0x1a043dd9f  com.apple.Accessibility (1.0 - 1) <3191BC82-AC85-3201-9F16-99498A36ACC4> /System/Library/Frameworks/Accessibility.framework/Versions/A/Accessibility
+       0x1a0476000 -        0x1a0477a33  libCTGreenTeaLogger.dylib (13187) <29AC12E8-C01E-3E7A-8820-7D3D73691498> /usr/lib/libCTGreenTeaLogger.dylib
+       0x1a0478000 -        0x1a047886f  com.apple.Accelerate.vecLib (3.11 - vecLib 3.11) <46556F2E-DD6B-3A4A-B2A3-4F844ED123EC> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+       0x1a049d000 -        0x1a049d98f  com.apple.CoreServices (1226 - 1226) <FF182FDE-8926-3DFB-8D12-C1258443F67F> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+       0x1a049e000 -        0x1a04ff79f  com.apple.CoreAppleCVA (4.4.0 - 4.4.0) <D3ADB2E1-FF63-3802-B698-F3AF1951D508> /System/Library/PrivateFrameworks/CoreAppleCVA.framework/Versions/A/CoreAppleCVA
+       0x1a071c000 -        0x1a071c417  com.apple.Accelerate (1.11 - Accelerate 1.11) <1DF31AEA-3D8E-382D-9493-D74635AA1CD4> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+       0x1a074b000 -        0x1a076afff  com.apple.AssetCacheServices (140.120.2 - 140.120.2) <3EB5DED0-C315-35EC-84DD-A0E9583AF252> /System/Library/PrivateFrameworks/AssetCacheServices.framework/Versions/A/AssetCacheServices
+       0x1a076b000 -        0x1a077d53f  com.apple.MediaAccessibility (1.0 - 153) <1B3ED36B-833B-37CD-8E66-CF2B0377A886> /System/Library/Frameworks/MediaAccessibility.framework/Versions/A/MediaAccessibility
+       0x1a077e000 -        0x1a0783553  com.apple.AppleSRP (5.0 - 1) <70522B86-7AF5-32A8-89AD-F4A3E0156134> /System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
+       0x1a0784000 -        0x1a07c40bf  com.apple.framework.SystemAdministration (1.0 - 1.0) <A679AA64-8B36-3F7E-8C03-4F45FC8EA679> /System/Library/PrivateFrameworks/SystemAdministration.framework/Versions/A/SystemAdministration
+       0x1a07c5000 -        0x1a0e5eebf  com.apple.VN (9.5.4 - 9.5.4) <A4C14C63-1C00-388A-9067-E859844B98B0> /System/Library/Frameworks/Vision.framework/Versions/A/Vision
+       0x1a0e5f000 -        0x1a0e5f3ef  libswiftFoundation.dylib (2000) <9694F7D1-82E7-3E83-96FA-23EBFDF40117> /usr/lib/swift/libswiftFoundation.dylib
+       0x1a0e60000 -        0x1a0f3a47f  com.apple.AddressBook.ContactsFoundation (8.0 - 1397.600.2) <47998525-142D-3473-928E-4A2F9736660A> /System/Library/PrivateFrameworks/ContactsFoundation.framework/Versions/A/ContactsFoundation
+       0x1a0f3b000 -        0x1a0fb9d5f  com.apple.contacts.ContactsPersistence (1.0 - 3804.600.21) <AAF71D57-A9CB-3009-838C-F45AE7E772AB> /System/Library/PrivateFrameworks/ContactsPersistence.framework/Versions/A/ContactsPersistence
+       0x1a0fba000 -        0x1a112345f  com.apple.AddressBook.core (1.0 - 2732.600.11) <07BA5321-D287-3EBE-9B05-73A1CD202FA8> /System/Library/PrivateFrameworks/AddressBookCore.framework/Versions/A/AddressBookCore
+       0x1a1124000 -        0x1a13cac7f  com.apple.contacts (1.0 - 3804.600.21) <22A21A06-22D5-3358-96AE-C1117A20D723> /System/Library/Frameworks/Contacts.framework/Versions/A/Contacts
+       0x1a13cb000 -        0x1a13db61f  com.apple.PersonaKit (1.0 - 1) <76D09132-A0C8-320E-90D3-CD63CBA7F465> /System/Library/PrivateFrameworks/PersonaKit.framework/Versions/A/PersonaKit
+       0x1a13dc000 -        0x1a13e2fdf  com.apple.communicationsfilter (10.0 - 1000) <EBDBD642-F989-3FEB-B1EB-D48EACB6C6B2> /System/Library/PrivateFrameworks/CommunicationsFilter.framework/Versions/A/CommunicationsFilter
+       0x1a13e3000 -        0x1a150c31f  com.apple.FamilyCircle (1.0 - 2) <C530AE8F-51AC-35CC-949C-BE8442EEBEF2> /System/Library/PrivateFrameworks/FamilyCircle.framework/Versions/A/FamilyCircle
+       0x1a150d000 -        0x1a161709f  com.apple.CoreBluetooth (195.7) <90E0951B-62AB-3BE0-B026-A178A556E3EA> /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+       0x1a1618000 -        0x1a16275df  com.apple.SymptomDiagnosticReporter (1.0 - 411.120.4) <FF9F1A47-EE31-3182-9AA1-4D325D6DA8A0> /System/Library/PrivateFrameworks/SymptomDiagnosticReporter.framework/Versions/A/SymptomDiagnosticReporter
+       0x1a1628000 -        0x1a165625f  com.apple.PowerLog (1.0 - 1) <BE05FF5C-4DE3-3B2C-B20F-BC5D46938816> /System/Library/PrivateFrameworks/PowerLog.framework/Versions/A/PowerLog
+       0x1a1657000 -        0x1a1663eff  com.apple.AppleIDAuthSupport (1.0 - 1) <A55A0E18-291E-3C31-9DA8-D7FEC261BA69> /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
+       0x1a1664000 -        0x1a17156df  com.apple.DiscRecording (9.0.3 - 9030.4.5) <BCE71519-708B-3376-B013-2B691BD174AC> /System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
+       0x1a1716000 -        0x1a1747137  com.apple.MediaKit (16 - 938) <A01852D0-D4E4-30EC-A47C-3B0AB6711F2F> /System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
+       0x1a1748000 -        0x1a182ab9f  com.apple.DiskManagement (15.0 - 1037.120.10) <A15BDA62-3EED-3FBD-8342-1F488BCD9A77> /System/Library/PrivateFrameworks/DiskManagement.framework/Versions/A/DiskManagement
+       0x1a182b000 -        0x1a183723f  com.apple.CoreAUC (620.1 - 620.1) <200EA03B-1BC8-3444-8A31-0F7CCC3E54F4> /System/Library/PrivateFrameworks/CoreAUC.framework/Versions/A/CoreAUC
+       0x1a1838000 -        0x1a183b77b  com.apple.Mangrove (1.0 - 25) <B7125474-75F9-30F7-BE1C-59DCD294B6AA> /System/Library/PrivateFrameworks/Mangrove.framework/Versions/A/Mangrove
+       0x1a183c000 -        0x1a1869f87  com.apple.CoreAVCHD (6.0.0 - 6244.1) <6D6D8FE1-B996-3AEF-84F8-5693EC5F19F6> /System/Library/PrivateFrameworks/CoreAVCHD.framework/Versions/A/CoreAVCHD
+       0x1a186a000 -        0x1a1a4035f  com.apple.FileProvider (4018.120.24 - 4018.120.24) <97C2F59F-171B-3AAF-A0F5-9B123705CA7B> /System/Library/Frameworks/FileProvider.framework/Versions/A/FileProvider
+       0x1a1a41000 -        0x1a1a673ff  com.apple.GenerationalStorage (2.0 - 397.120.2) <C3ECF0E6-8383-3ACD-942C-DDC90BC8EC50> /System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
+       0x1a1a68000 -        0x1a1a996ff  com.apple.security.octagontrust (1.0 - 1) <B1C44902-09BF-37BC-8720-8718949F85E8> /System/Library/PrivateFrameworks/OctagonTrust.framework/Versions/A/OctagonTrust
+       0x1a1a9a000 -        0x1a1abc61f  com.apple.CPAnalytics (1.0 - 851.0.103) <71551474-60E4-3C60-9514-F674BA67DBC7> /System/Library/PrivateFrameworks/CPAnalytics.framework/Versions/A/CPAnalytics
+       0x1a2005000 -        0x1a21ecabf  com.apple.CoreTelephony (113 - 13187) <77B17C80-3275-3BDC-BE00-C4E69C44EEDD> /System/Library/Frameworks/CoreTelephony.framework/Versions/A/CoreTelephony
+       0x1a2209000 -        0x1a221f950  libswiftDispatch.dylib (1542.100.32) <460CFC58-0973-3A20-B504-A0A294C1E16D> /usr/lib/swift/libswiftDispatch.dylib
+       0x1a2220000 -        0x1a248f11f  com.apple.AVFCore (1.0 - 2420.7.1) <DE1329C3-A78D-3555-B296-BB5EFDB5BFCB> /System/Library/PrivateFrameworks/AVFCore.framework/Versions/A/AVFCore
+       0x1a2490000 -        0x1a25693bf  com.apple.FrontBoardServices (1000.4.11 - 1000.4.11) <8CC7D6B4-44E2-3C89-9FE1-41F07E500995> /System/Library/PrivateFrameworks/FrontBoardServices.framework/Versions/A/FrontBoardServices
+       0x1a256a000 -        0x1a25f6c3f  com.apple.BoardServices (1.0 - 732.1.1) <B4561AEC-EE52-3447-960B-4D2F2F3EF720> /System/Library/PrivateFrameworks/BoardServices.framework/Versions/A/BoardServices
+       0x1a25f7000 -        0x1a26361bf  com.apple.contacts.vCard (1.0 - 3804.600.21) <1037AB64-D33F-3E10-A725-DAE05FA19293> /System/Library/PrivateFrameworks/vCard.framework/Versions/A/vCard
+       0x1a2637000 -        0x1a264453f  com.apple.GraphicsServices (1.0 - 1.0) <4236E533-C3F8-340F-A462-F15D599395A8> /System/Library/PrivateFrameworks/GraphicsServices.framework/Versions/A/GraphicsServices
+       0x1a2649000 -        0x1a26caadf  com.apple.CryptoTokenKit (1.0 - 1) <F69F574F-27D3-39ED-ABD8-1564E510EBBC> /System/Library/Frameworks/CryptoTokenKit.framework/Versions/A/CryptoTokenKit
+       0x1a26cb000 -        0x1a273761f  com.apple.LocalAuthentication (1.0 - 2005.121.1) <F1A019BA-F431-3CBA-B6D4-170AE2C6A4AD> /System/Library/Frameworks/LocalAuthentication.framework/Versions/A/LocalAuthentication
+       0x1a2738000 -        0x1a274567f  com.apple.CoreAuthentication.SharedUtils (1.0 - 2005.121.1) <FC94DE9D-C44B-33B1-94B7-84C6650E71F1> /System/Library/Frameworks/LocalAuthentication.framework/Support/SharedUtils.framework/Versions/A/SharedUtils
+       0x1a2746000 -        0x1a27cd57f  com.apple.avfoundationcf (2.0 - 770.7.1) <A0698FEF-77F2-3877-ADA2-93E1D65105D4> /System/Library/PrivateFrameworks/AVFoundationCF.framework/Versions/A/AVFoundationCF
+       0x1a2889000 -        0x1a295fb9f  com.apple.SAObjects (1.0 - 1) <AA18CFD1-B5CE-3B41-936E-0AA049D2ED72> /System/Library/PrivateFrameworks/SAObjects.framework/Versions/A/SAObjects
+       0x1a2960000 -        0x1a2981e9f  com.apple.DebugSymbols (216 - 217) <13499229-A245-3C95-AC94-1DB8B274CF09> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+       0x1a2982000 -        0x1a2adeddf  com.apple.CoreSymbolication (16.0 - 64575.53.2) <C2CC83D4-7E1C-3E78-AEC8-1ABDE74F9FAD> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+       0x1a2adf000 -        0x1a2ae909f  com.apple.CoreTime (334.0.16.3 - 334.0.16.3) <FD342B51-EA5D-388C-9BAB-29F7670FE3FB> /System/Library/PrivateFrameworks/CoreTime.framework/Versions/A/CoreTime
+       0x1a2aea000 -        0x1a2bddaff  com.apple.Rapport (7.1 - 715.2) <5391C234-E4D0-32FB-BFFF-70CFEBBF5525> /System/Library/PrivateFrameworks/Rapport.framework/Versions/A/Rapport
+       0x1a2bde000 -        0x1a38a35df  com.apple.private.EmbeddedAcousticRecognition (1.0 - 1) <17C20A23-27AC-306F-8985-303EE9FE2188> /System/Library/PrivateFrameworks/EmbeddedAcousticRecognition.framework/Versions/A/EmbeddedAcousticRecognition
+       0x1a38a4000 -        0x1a38fa87f  com.apple.coreduetcontext (1.0 - 1) <169C3E11-9BAB-3BF3-91E4-2B10391534F5> /System/Library/PrivateFrameworks/CoreDuetContext.framework/Versions/A/CoreDuetContext
+       0x1a38fb000 -        0x1a3f733ff  com.apple.Intents (1.0 - 1) <4809E70A-7A2F-372C-BA73-90ED2A92A18A> /System/Library/Frameworks/Intents.framework/Versions/A/Intents
+       0x1a3f74000 -        0x1a3f74f3f  com.apple.framework.Apple80211 (1.0 - 19150.2) <68E43D2F-5464-36F0-A16E-24A4A23C0742> /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
+       0x1a3f75000 -        0x1a443683f  com.apple.CoreWiFi (1.0 - 1006.2) <29E96A67-76A9-351D-BAA7-FC6DCF3A0D58> /System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+       0x1a4437000 -        0x1a44a959f  com.apple.BackBoardServices (1.0 - 1.0) <DDC32AF8-8864-3DE0-A855-5283510925B9> /System/Library/PrivateFrameworks/BackBoardServices.framework/Versions/A/BackBoardServices
+       0x1a44aa000 -        0x1a44e54ef  com.apple.LDAPFramework (2.4.28 - 194.5) <53F32E19-D2E6-3256-9206-75B92E519199> /System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
+       0x1a44e6000 -        0x1a44e77b7  com.apple.TrustEvaluationAgent (2.0 - 38) <B2593AAA-A99A-30C1-A0FC-3315ACC16951> /System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
+       0x1a4615000 -        0x1a46ce57f  com.apple.DiskImagesFramework (683.100.3 - 683.100.3) <C8288C8D-4483-3393-B249-E952FFAF1EBE> /System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
+       0x1a46cf000 -        0x1a470ed7f  com.apple.SystemConfiguration.EAP8021X (14.0.0 - 14.0) <14D7D0FC-F026-3B1A-A0A6-F652E740978D> /System/Library/PrivateFrameworks/EAP8021X.framework/Versions/A/EAP8021X
+       0x1a470f000 -        0x1a47255bf  com.apple.RemoteServiceDiscovery (1.0 - 219.120.2) <CA4D9399-0E89-3014-92DD-B722678ED9F6> /System/Library/PrivateFrameworks/RemoteServiceDiscovery.framework/Versions/A/RemoteServiceDiscovery
+       0x1a4726000 -        0x1a473bc3f  com.apple.xpc.RemoteXPC (1.0 - 3102.120.13) <8CA8360A-FE67-33A5-AEE4-097AEE5B945C> /System/Library/PrivateFrameworks/RemoteXPC.framework/Versions/A/RemoteXPC
+       0x1a47bb000 -        0x1a47be653  com.apple.help (1.3.8 - 81) <3F228BBE-FDCF-3688-A809-0B697D320575> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+       0x1a47bf000 -        0x1a47c339f  com.apple.EFILogin (2.0 - 2) <BC3474B4-C240-3A8E-A764-F303D9E7133B> /System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
+       0x1a47c4000 -        0x1a47cfa07  libcsfde.dylib (568) <0E256194-6294-39D5-BA0E-59C828F0591F> /usr/lib/libcsfde.dylib
+       0x1a47d0000 -        0x1a4850f43  libcurl.4.dylib (166.0.0.0.1) <2F97CC24-F631-37B1-83CA-54632BF597FE> /usr/lib/libcurl.4.dylib
+       0x1a4851000 -        0x1a485659f  com.apple.LoginUICore (4.0 - 4.0) <EFC68C8F-FA52-37FC-B34A-5765E33BBFA7> /System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/Frameworks/LoginUICore.framework/Versions/A/LoginUICore
+       0x1a4857000 -        0x1a489a25f  com.apple.AppSupport (1.0.0 - 29) <7410CCEF-077F-37FF-B0B0-5D65B0D2F66C> /System/Library/PrivateFrameworks/AppSupport.framework/Versions/A/AppSupport
+       0x1a489b000 -        0x1a48e3cdf  com.apple.AppSSO (1.0 - 483.120.4) <F485B56B-FC7C-3844-B1A2-585D26C04166> /System/Library/PrivateFrameworks/AppSSO.framework/Versions/A/AppSSO
+       0x1a4b6a000 -        0x1a4b6a927  com.apple.ApplicationServices (48 - 66) <F8C449A5-01C3-3728-AD27-D615CD76AE28> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+       0x1a4b6b000 -        0x1a4b6df3f  com.apple.InternationalTextSearch (1.0 - 1) <F227A966-D677-379F-BAEF-89DC18A81AB7> /System/Library/PrivateFrameworks/InternationalTextSearch.framework/Versions/A/InternationalTextSearch
+       0x1a4b6e000 -        0x1a4c353ff  com.apple.ClassKit (1.2 - 151.5) <DC894999-F5C3-3EB8-8901-91BCAFC7AEEF> /System/Library/Frameworks/ClassKit.framework/Versions/A/ClassKit
+       0x1a4c36000 -        0x1a4ebb8bf  com.apple.AppleAccount (1.0 - 1.0) <415BF5A1-C825-38CC-9063-A63F6BCC3A6A> /System/Library/PrivateFrameworks/AppleAccount.framework/Versions/A/AppleAccount
+       0x1a4ebc000 -        0x1a4f0c53f  com.apple.AppleIDSSOAuthentication (1.0 - 1) <C8B04C74-4545-3FE9-B302-F769ED0E15CA> /System/Library/PrivateFrameworks/AppleIDSSOAuthentication.framework/Versions/A/AppleIDSSOAuthentication
+       0x1a4f0d000 -        0x1a4f62d7f  com.apple.CorePrediction (1.0 - 1) <F965A23B-BC2C-3E7E-A603-AE2C506F807F> /System/Library/PrivateFrameworks/CorePrediction.framework/Versions/A/CorePrediction
+       0x1a4f63000 -        0x1a50b6a9f  com.apple.AuthKitUI (1.0 - 1) <9F778A4B-47EE-3A51-8BC8-BD292274C3B7> /System/Library/PrivateFrameworks/AuthKitUI.framework/Versions/A/AuthKitUI
+       0x1a513a000 -        0x1a513dd3f  com.apple.security.CryptoKit-C-Bridging (1.0 - 1) <CB10F56E-9B75-3D0E-9EF8-C053F4A519BB> /System/Library/PrivateFrameworks/CryptoKitCBridging.framework/Versions/A/CryptoKitCBridging
+       0x1a513e000 -        0x1a513e3f7  libHeimdalProxy.dylib (88) <A963CA1C-050B-3E90-B2FF-D7989435DB5D> /System/Library/Frameworks/Kerberos.framework/Versions/A/Libraries/libHeimdalProxy.dylib
+       0x1a513f000 -        0x1a513f512  com.apple.audio.units.AudioUnit (1.14 - 1.14) <3F940A44-680F-3BA8-9E3A-69F2D510D27E> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+       0x1a514e000 -        0x1a5153c73  com.apple.NetFSServer (2.0 - 1) <A6B0AC17-A4AB-3666-A90E-22699EC42A68> /System/Library/PrivateFrameworks/NetFSServer.framework/Versions/A/NetFSServer
+       0x1a5169000 -        0x1a5187b9f  com.apple.StreamingZip (1.0 - 1) <F297C9A4-AEDF-3553-B20E-CD7DFC54CC0B> /System/Library/PrivateFrameworks/StreamingZip.framework/Versions/A/StreamingZip
+       0x1a5188000 -        0x1a51e0adf  com.apple.DuetActivityScheduler (1.0 - 1) <EBC77AB0-599A-39E1-97E4-F0158AB3CBB3> /System/Library/PrivateFrameworks/DuetActivityScheduler.framework/Versions/A/DuetActivityScheduler
+       0x1a51e1000 -        0x1a51e46bf  libswiftObjectiveC.dylib (951.7) <32C98979-0F18-3513-AFAB-2F5D2B9ED0B9> /usr/lib/swift/libswiftObjectiveC.dylib
+       0x1a51e5000 -        0x1a52026ff  libswiftos.dylib (1082) <49255E53-3F00-3F06-A64A-76A63C798956> /usr/lib/swift/libswiftos.dylib
+       0x1a5203000 -        0x1a521395f  com.apple.IntentsFoundation (1.0 - 1) <8945BFBF-1B91-3891-BD26-A8843D0C3EAB> /System/Library/PrivateFrameworks/IntentsFoundation.framework/Versions/A/IntentsFoundation
+       0x1a5214000 -        0x1a521d4bf  com.apple.PushKit (1.0 - 1) <E81811CD-4882-3C36-87EB-5D4B410E72CD> /System/Library/Frameworks/PushKit.framework/Versions/A/PushKit
+       0x1a521e000 -        0x1a527a81f  com.apple.cloudkit.C2 (1.3 - 2300.120) <B27A8B8E-040F-3120-A104-2A23DC9AE14C> /System/Library/PrivateFrameworks/C2.framework/Versions/A/C2
+       0x1a527b000 -        0x1a52c801f  com.apple.QuickLookThumbnailing (1.0 - 208.6.1) <16775C1A-3860-3A98-9C55-ED7C26BC1DE5> /System/Library/Frameworks/QuickLookThumbnailing.framework/Versions/A/QuickLookThumbnailing
+       0x1a52c9000 -        0x1a611a73f  com.apple.vision.EspressoFramework (1.0 - 3525.1.1) <194D781A-C519-3A70-8418-205BF9C76929> /System/Library/PrivateFrameworks/Espresso.framework/Versions/A/Espresso
+       0x1a611b000 -        0x1a614b99f  com.apple.ANEServices (9.511 - 9.511) <AFB2E1E5-465C-37EA-A8C8-4CC2DB06DE29> /System/Library/PrivateFrameworks/ANEServices.framework/Versions/A/ANEServices
+       0x1a614c000 -        0x1a61da85f  com.apple.proactive.support.ProactiveSupport (1.0 - 418.1) <29BBA828-5852-3A0C-94D9-C03990CB86CA> /System/Library/PrivateFrameworks/ProactiveSupport.framework/Versions/A/ProactiveSupport
+       0x1a61db000 -        0x1a61f1e5f  com.apple.corerecents (1.0 - 1) <CA3CA427-E79E-35A8-8453-E3AD4356E6A4> /System/Library/PrivateFrameworks/CoreRecents.framework/Versions/A/CoreRecents
+       0x1a61f2000 -        0x1a62363df  com.apple.iCalendar (7.0 - 1169.4.3) <0BACD324-FCF2-304B-A5EF-9DDECB535343> /System/Library/PrivateFrameworks/iCalendar.framework/Versions/A/iCalendar
+       0x1a6237000 -        0x1a62d5e5f  com.apple.CalendarFoundation (8.0 - 1603.4.5) <F0FBEBEF-B6CD-3112-AD14-D2E4F5978209> /System/Library/PrivateFrameworks/CalendarFoundation.framework/Versions/A/CalendarFoundation
+       0x1a62d6000 -        0x1a62d6527  com.apple.CoreDuetDaemonProtocol (1.0 - 1) <472CCADB-45C1-30D5-B4B1-BA9B1CA77074> /System/Library/PrivateFrameworks/CoreDuetDaemonProtocol.framework/Versions/A/CoreDuetDaemonProtocol
+       0x1a62d7000 -        0x1a62fb29f  com.apple.ASEProcessing (1.55.0 - 1.55.0) <9271A817-7C78-3210-8B0C-91A552667200> /System/Library/PrivateFrameworks/ASEProcessing.framework/Versions/A/ASEProcessing
+       0x1a62fc000 -        0x1a639bdff  com.apple.framework.ConfigurationProfiles (18.0 - 1800) <72DF65CA-9F2F-3F60-8215-7B954173268F> /System/Library/PrivateFrameworks/ConfigurationProfiles.framework/Versions/A/ConfigurationProfiles
+       0x1a6621000 -        0x1a667ea5f  com.apple.AOSAccounts (1.3.1 - 210.575.2) <69816BEE-EF10-35AC-943A-618AA41CEF9D> /System/Library/PrivateFrameworks/AOSAccounts.framework/Versions/A/AOSAccounts
+       0x1a6c01000 -        0x1a6c5db17  com.apple.ChunkingLibrary (2300.104 - 2300.104) <65EC14B9-2451-38FB-89FB-59E22A99570B> /System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
+       0x1a6da6000 -        0x1a6db93df  com.apple.MediaLibrary (1.12.0 - 812) <E32F7F22-E2BA-368B-BB3C-3317490D975D> /System/Library/Frameworks/MediaLibrary.framework/Versions/A/MediaLibrary
+       0x1a6dba000 -        0x1a6e1c83f  com.apple.CalDAV (8.0 - 1155.4.3) <A27BA289-02B7-326C-8A00-3BBE83104278> /System/Library/PrivateFrameworks/CalDAV.framework/Versions/A/CalDAV
+       0x1a6e1d000 -        0x1a6eef8ff  com.apple.CoreSuggestions (1.0 - 1311.7) <604860EF-BF26-3339-B019-D2441B50D5F4> /System/Library/PrivateFrameworks/CoreSuggestions.framework/Versions/A/CoreSuggestions
+       0x1a6ef0000 -        0x1a70f393f  com.apple.eventkit (3.0 - 1934.4.9) <54498E05-DBC3-3F53-9F25-749FA15A8320> /System/Library/Frameworks/EventKit.framework/Versions/A/EventKit
+       0x1a70f4000 -        0x1a712433f  com.apple.RTCReporting (13.1.47 - 166.2) <A0B55574-B78C-3762-9F1B-3A1420F4071E> /System/Library/PrivateFrameworks/RTCReporting.framework/Versions/A/RTCReporting
+       0x1a7125000 -        0x1a734ec7f  com.apple.WebKitLegacy (21624 - 21624.2.5.11.8) <62A22F21-9C14-3F2D-AB41-768CCAD7E1CC> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebKitLegacy.framework/Versions/A/WebKitLegacy
+       0x1a739e000 -        0x1a740c11f  com.apple.CoreML.AppleNeuralEngine (1.0 - 1) <7FB3D6E4-0FB7-3516-B62F-4ACD1DF155B2> /System/Library/PrivateFrameworks/AppleNeuralEngine.framework/Versions/A/AppleNeuralEngine
+       0x1a755a000 -        0x1a7628c1f  com.apple.audio.midi.CoreMIDI (2.0 - 88) <F649A68B-864A-3F02-959A-69FD9980B29C> /System/Library/Frameworks/CoreMIDI.framework/Versions/A/CoreMIDI
+       0x1a774d000 -        0x1a774d467  com.apple.Cocoa (6.11 - 24) <10E639EE-4336-3D8E-87D7-A3FFB8570DEB> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+       0x1a778e000 -        0x1a77a211f  com.apple.AskPermission (129.5.3 - 129.5.3) <2965FC84-5097-3709-8942-33E901FE97AC> /System/Library/PrivateFrameworks/AskPermission.framework/Versions/A/AskPermission
+       0x1a77a3000 -        0x1a82675ff  com.apple.AppleMediaServices (1.0 - 1) <C012BDFD-0921-33DF-AC5A-AB59C226E5CF> /System/Library/PrivateFrameworks/AppleMediaServices.framework/Versions/A/AppleMediaServices
+       0x1a8268000 -        0x1a826c75f  com.apple.IOSurfaceAccelerator (1.0.0 - 1.0.0) <70103161-0443-3F67-85D7-BD25455F271F> /System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/Versions/A/IOSurfaceAccelerator
+       0x1a826d000 -        0x1a827233f  libUAPreferences.dylib (736.20) <E82E43B5-E35D-364E-9ED5-B8334CA583C6> /System/Library/PrivateFrameworks/UniversalAccess.framework/Versions/A/Libraries/libUAPreferences.dylib
+       0x1a8273000 -        0x1a8294f3f  com.apple.framework.familycontrols (4.1 - 410) <7A3D3AF4-E192-31D0-A9C9-76C69AB23CC4> /System/Library/PrivateFrameworks/FamilyControls.framework/Versions/A/FamilyControls
+       0x1a8295000 -        0x1a82a133f  com.apple.CommerceCore (1.0 - 716.4.2) <A5B0F387-04E0-3056-A8B2-7C02FF603048> /System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Frameworks/CommerceCore.framework/Versions/A/CommerceCore
+       0x1a82a2000 -        0x1a86ba33f  com.apple.MediaRemote (1.0 - 1) <2DBEEDFA-7B88-3E72-948A-9D349156333F> /System/Library/PrivateFrameworks/MediaRemote.framework/Versions/A/MediaRemote
+       0x1a86bb000 -        0x1a89800df  com.apple.AssistantServices (1.0 - 1) <513988B9-97B7-3D57-88E6-2657DFE5ACF7> /System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/AssistantServices
+       0x1a8981000 -        0x1a899445f  com.apple.PhotoFoundation (1.0 - 851.0.103) <987F359E-0BC4-3A97-97DF-0BC8F840016D> /System/Library/PrivateFrameworks/PhotoFoundation.framework/Versions/A/PhotoFoundation
+       0x1a8995000 -        0x1a8dc0e3f  com.apple.imsharedutilities (10.0 - 1000) <D9FCC857-FC7C-3AE4-B0FC-51CDCE82C36C> /System/Library/PrivateFrameworks/IMSharedUtilities.framework/Versions/A/IMSharedUtilities
+       0x1a8dca000 -        0x1a8dceb3f  com.apple.DisplayServicesFW (3.1 - 380) <5AAC4E99-0468-3BD4-99A4-4DD9DE7D937D> /System/Library/PrivateFrameworks/DisplayServices.framework/Versions/A/DisplayServices
+       0x1a8dcf000 -        0x1a8ebc83f  com.apple.LoginUIKit (4.0 - 4.0) <9AA20A91-10DB-33A4-B19F-3352B2CCAB31> /System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/LoginUIKit
+       0x1a8ebd000 -        0x1a8edd23f  com.apple.icloud.FMCoreLite (1.0 - 1) <82C6E06E-A6E3-3627-90EA-D68841C3E733> /System/Library/PrivateFrameworks/FMCoreLite.framework/Versions/A/FMCoreLite
+       0x1a8ede000 -        0x1a996689f  com.apple.PassKitCore (1.0 - 1) <F97CE5DE-0CA1-35D1-BE84-26B6CBD07387> /System/Library/PrivateFrameworks/PassKitCore.framework/Versions/A/PassKitCore
+       0x1a9db3000 -        0x1a9de6327  libtidy.A.dylib (20.1) <93F4FC3C-A4E9-3658-9D50-BD1406C717A0> /usr/lib/libtidy.A.dylib
+       0x1a9de7000 -        0x1a9e14fbf  com.apple.MarkupUI (1.0 - 560.4.2) <02B63210-9E39-3188-AD9D-B36478AE653C> /System/Library/PrivateFrameworks/MarkupUI.framework/Versions/A/MarkupUI
+       0x1a9e15000 -        0x1a9e2cedf  com.apple.Engram (1.0 - 1) <50208CA5-45CB-350F-AEF5-5DA9331AD165> /System/Library/PrivateFrameworks/Engram.framework/Versions/A/Engram
+       0x1a9e2d000 -        0x1a9e49b9f  com.apple.openscripting (1.7 - 200) <67CE0B19-146A-3E47-A1C8-40AA120E459D> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+       0x1a9e4a000 -        0x1a9e4cd27  com.apple.securityhi (9.0 - 55010) <7ADCFC9C-78DC-3D01-802F-EB04542677B3> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+       0x1a9e4d000 -        0x1a9e4d863  com.apple.ink.framework (10.15 - 227) <B30EC417-785A-356A-AF2C-E88F643326AB> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+       0x1a9e4e000 -        0x1a9e51ba7  com.apple.CommonPanels (1.2.6 - 106.1) <C88DC508-569F-3EC5-BBEA-6F12E5223CD1> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+       0x1a9e52000 -        0x1a9e541fb  com.apple.ImageCapture (2020.2.2 - 2020.2.2) <21A5F3D8-D253-34F5-8AF9-D626F57FFF08> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+       0x1a9e55000 -        0x1ab94b4ff  com.apple.JavaScriptCore (21624 - 21624.2.5.11.8) <1914F733-4AF2-3AD7-9061-CA21FFC33841> /System/Library/Frameworks/JavaScriptCore.framework/Versions/A/JavaScriptCore
+       0x1ab94c000 -        0x1ab94d65f  com.apple.PowerlogControl (1.0 - 1) <A3ABAEE7-577C-31FF-B2E0-877DDF4550F6> /System/Library/PrivateFrameworks/PowerlogControl.framework/Versions/A/PowerlogControl
+       0x1ab94e000 -        0x1ab954ddf  libUniversalAccess.dylib (736.20) <743F4A4B-E512-30E5-B493-4D0A868367E3> /usr/lib/libUniversalAccess.dylib
+       0x1ab9b3000 -        0x1aba3225f  com.apple.CoreCDP-OSX (1.0 - 1) <E25B9B99-7A55-3449-AFD0-183A0795B25B> /System/Library/PrivateFrameworks/CoreCDP.framework/Versions/A/CoreCDP
+       0x1aba33000 -        0x1aba443bf  com.apple.SetupAssistantFramework (1.0 - 1) <33F18E58-B207-34DC-9715-46DFA35090A1> /System/Library/PrivateFrameworks/SetupAssistantFramework.framework/Versions/A/SetupAssistantFramework
+       0x1aba45000 -        0x1abc868ff  com.apple.AVFCapture (1.0 - 665.120.8) <2C84B3B4-9CD6-3D6F-818E-A1B076D503E8> /System/Library/PrivateFrameworks/AVFCapture.framework/Versions/A/AVFCapture
+       0x1abc87000 -        0x1abdb7d1f  com.apple.Quagga (186 - 186) <E7C2B00B-88D9-3855-B8A5-78B00332F77F> /System/Library/PrivateFrameworks/Quagga.framework/Versions/A/Quagga
+       0x1abdb8000 -        0x1ac3f369f  com.apple.CMCapture (1.0 - 665.120.8) <8F0F4BF4-A7E7-36F6-9FB7-0E691EDCF8B1> /System/Library/PrivateFrameworks/CMCapture.framework/Versions/A/CMCapture
+       0x1ac3f4000 -        0x1ac57791f  com.apple.RenderBox (7.4.25 - 7.4.25) <36149B4B-E579-37BC-9504-8A1DC4677C6E> /System/Library/PrivateFrameworks/RenderBox.framework/Versions/A/RenderBox
+       0x1aca12000 -        0x1acacc93f  com.apple.accounts.AccountsDaemon (113 - 113) <D13B7D03-3ABA-3662-A0A7-4F1D64CA78F8> /System/Library/PrivateFrameworks/AccountsDaemon.framework/Versions/A/AccountsDaemon
+       0x1acacd000 -        0x1acad003f  com.apple.OAuth (25 - 25) <827170BF-EFD2-3ADB-97EA-60DC351E0A58> /System/Library/PrivateFrameworks/OAuth.framework/Versions/A/OAuth
+       0x1ad0dc000 -        0x1ad12643f  com.apple.CloudServices (1.0 - 694.120.16) <9BF79FE7-B363-30F5-B09F-6B2054584F30> /System/Library/PrivateFrameworks/CloudServices.framework/Versions/A/CloudServices
+       0x1ad127000 -        0x1ad13a9ff  com.apple.HID (1.0 - 1) <E5C2582B-2B2A-3B7E-A473-DF40A707C4C8> /System/Library/PrivateFrameworks/HID.framework/Versions/A/HID
+       0x1ad1ad000 -        0x1ad23147f  com.apple.coredav (1.0.1 - 1236.4.5) <CDCA62FD-F0E1-3C62-B926-96E12BAF48F9> /System/Library/PrivateFrameworks/CoreDAV.framework/Versions/A/CoreDAV
+       0x1ad2a1000 -        0x1ad32b0ff  com.apple.MediaServices (1.0 - 4025.600.3) <865ACF96-BF9D-3F57-A7A1-C477D23A8598> /System/Library/PrivateFrameworks/MediaServices.framework/Versions/A/MediaServices
+       0x1ad32c000 -        0x1ad3520bf  com.apple.IASUtilities (1.0 - 661.100.2) <44DA9FC4-3C13-3528-92A4-5CDDAF3DCE77> /System/Library/PrivateFrameworks/IASUtilities.framework/Versions/A/IASUtilities
+       0x1ad3f5000 -        0x1ad43707f  com.apple.VirtualGarage (1.0 - 1) <B0383898-91AF-3F44-8CE8-46CA01DBDA10> /System/Library/PrivateFrameworks/VirtualGarage.framework/Versions/A/VirtualGarage
+       0x1ad447000 -        0x1ad447847  com.apple.marco (10.0 - 1000) <D84F54CD-C59F-3897-8764-2C3DFFF8011C> /System/Library/PrivateFrameworks/Marco.framework/Versions/A/Marco
+       0x1ad448000 -        0x1ad49008b  com.apple.private.yara (1.0 - 1) <0336EF5C-F5FE-36A3-8831-2C79999FF779> /System/Library/PrivateFrameworks/yara.framework/Versions/A/yara
+       0x1ad491000 -        0x1ad5170bf  com.apple.CoreRecognition (1.3 - 157) <59B768D9-D5FB-3017-9614-04FD3ACBC9F8> /System/Library/PrivateFrameworks/CoreRecognition.framework/Versions/A/CoreRecognition
+       0x1ad518000 -        0x1ad52a31f  com.apple.PersonaUI (1.0 - 1) <A4242B63-7804-3DDB-9EBF-EC79B4EFA55F> /System/Library/PrivateFrameworks/PersonaUI.framework/Versions/A/PersonaUI
+       0x1ad52b000 -        0x1ad7ab3ff  com.apple.Contacts.ContactsUICore (1.0 - 3683.600.21) <DF4DEC99-1841-36A5-90A9-245FA5E0BA94> /System/Library/PrivateFrameworks/ContactsUICore.framework/Versions/A/ContactsUICore
+       0x1ad7ac000 -        0x1ad91383f  com.apple.ContactsUI (14.0 - 2732.600.11) <A28A5842-B3B7-3310-9ED1-4D58FB01A44C> /System/Library/Frameworks/ContactsUI.framework/Versions/A/ContactsUI
+       0x1ad914000 -        0x1ad99793f  com.apple.contacts.ContactsAutocomplete (1.0 - 1356.500.41) <F118F195-3CAB-3F61-863A-108744166A3A> /System/Library/PrivateFrameworks/ContactsAutocomplete.framework/Versions/A/ContactsAutocomplete
+       0x1ad9eb000 -        0x1ada2569f  com.apple.proactive.support.ProactiveEventTracker (1.0 - 418.1) <FD9C8468-9594-3DE9-99A6-7E935B22C641> /System/Library/PrivateFrameworks/ProactiveEventTracker.framework/Versions/A/ProactiveEventTracker
+       0x1adb26000 -        0x1add6213f  com.apple.framework.calculate (1.4 - 17) <10356426-B248-366A-A0C8-059D9E4F07F7> /System/Library/PrivateFrameworks/Calculate.framework/Versions/A/Calculate
+       0x1ae02b000 -        0x1ae02c17f  com.apple.PhoneNumbers (1.0 - 1) <5DF851D6-7A0C-3527-ACD3-FF67854CBAA9> /System/Library/PrivateFrameworks/PhoneNumbers.framework/Versions/A/PhoneNumbers
+       0x1ae02d000 -        0x1ae0366bf  com.apple.URLFormatting (296 - 296.11) <8027C557-9D0A-341B-99D8-28BBA2CEAE7E> /System/Library/PrivateFrameworks/URLFormatting.framework/Versions/A/URLFormatting
+       0x1ae037000 -        0x1ae142a3f  com.apple.accessibility.AXCoreUtilities (1.0 - 1) <F889CA9F-E013-3B23-80DD-E9D55CF9B97F> /System/Library/PrivateFrameworks/AXCoreUtilities.framework/Versions/A/AXCoreUtilities
+       0x1ae143000 -        0x1ae17975f  libAccessibility.dylib (3191.34.1) <2DBECAC3-5DE1-32F4-845E-C4078D35DEB9> /usr/lib/libAccessibility.dylib
+       0x1ae17a000 -        0x1b1b380bf  com.apple.WebCore (21624 - 21624.2.5.11.8) <C03A2292-12FD-3BA8-99AF-845C2000FE47> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/WebCore
+       0x1b1b39000 -        0x1b1c0581f  com.apple.PackageKit (3.0 - 1491.120.2) <696A5737-A7FE-3989-9861-C3553BCBB764> /System/Library/PrivateFrameworks/PackageKit.framework/Versions/A/PackageKit
+       0x1b1c06000 -        0x1b1c151ff  com.apple.NetFS (6.0 - 4.0) <EC590F25-F5DD-35D6-A594-4BE577637264> /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+       0x1b1d65000 -        0x1b1d94fbf  com.apple.quicklook.QuickLookSupport (1.0 - 208.6.1) <EA09D5BE-FBBF-399E-B51A-65352BB3E161> /System/Library/PrivateFrameworks/QuickLookSupport.framework/Versions/A/QuickLookSupport
+       0x1b1d95000 -        0x1b1eadb9f  com.apple.siri.parsec.CoreParsec (1.0 - 3525.4.2) <CE9875DD-4C3F-360B-8542-4FFBD3B67940> /System/Library/PrivateFrameworks/CoreParsec.framework/Versions/A/CoreParsec
+       0x1b1eae000 -        0x1b20feb1f  com.apple.TelephonyUtilities (1.0 - 1.0) <C3515C95-4578-3BD7-A9E4-0BAF515E5D38> /System/Library/PrivateFrameworks/TelephonyUtilities.framework/Versions/A/TelephonyUtilities
+       0x1b20ff000 -        0x1b215f4df  com.apple.DeviceManagement (1.0 - 249.100.1) <682978CC-6B80-3A76-8A4C-E9E3CE591EE3> /System/Library/PrivateFrameworks/DeviceManagement.framework/Versions/A/DeviceManagement
+       0x1b2160000 -        0x1b2160357  libswiftCoreGraphics.dylib (17) <1C6E4B94-1F7F-369A-93C5-D81CD65BDC5A> /usr/lib/swift/libswiftCoreGraphics.dylib
+       0x1b2161000 -        0x1b2163707  libswiftDarwin.dylib (377.120.8) <F2EED553-64EC-398C-98BA-32EFDFAE0FC3> /usr/lib/swift/libswiftDarwin.dylib
+       0x1b2259000 -        0x1b3841d3f  com.apple.WebKit (21624 - 21624.2.5.11.8) <49B21D99-8716-31B8-8686-71B287325F1D> /System/Library/Frameworks/WebKit.framework/Versions/A/WebKit
+       0x1b3c8b000 -        0x1b3c8b517  com.apple.CorePDF (4.0 - 555) <8BD7369B-A6E9-3BD3-811D-3BB072F207FB> /System/Library/PrivateFrameworks/CorePDF.framework/Versions/A/CorePDF
+       0x1b3c8c000 -        0x1b3c8c817  com.apple.Carbon (160 - 170) <EC627671-51E2-338B-A466-7C5BBBACBD67> /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+       0x1b3c8d000 -        0x1b402729f  com.apple.coremotion (3075.0.8 - 3075.0.8) <1CD38C4A-17E1-32A4-AF49-10BE025F8C28> /System/Library/Frameworks/CoreMotion.framework/Versions/A/CoreMotion
+       0x1b408f000 -        0x1b408f5a7  com.apple.avfoundation (2.0 - 2420.7.1) <52AAB771-EA83-316A-9923-14E3F691D801> /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+       0x1b41c3000 -        0x1b42ac4bf  libquic.dylib (5812.121.1) <18372066-7FBC-34AD-AD6B-A7D31A879F8D> /usr/lib/libquic.dylib
+       0x1b42b1000 -        0x1b42b74af  com.apple.EmbeddedOSSupportHost (1.0 - 1) <04D24651-5D99-3893-B04E-C1A9FAEE5C26> /System/Library/PrivateFrameworks/EmbeddedOSSupportHost.framework/Versions/A/EmbeddedOSSupportHost
+       0x1b42b8000 -        0x1b42e0eff  com.apple.private.SystemPolicy (1.0 - 1) <3B04FCE5-C2EF-3F95-94B5-C2E838F8F8F1> /System/Library/PrivateFrameworks/SystemPolicy.framework/Versions/A/SystemPolicy
+       0x1b42e1000 -        0x1b430887f  com.apple.icloud.FindMyDevice (1.0 - 1) <E7F389DE-0136-3548-A024-9F7A9399373C> /System/Library/PrivateFrameworks/FindMyDevice.framework/Versions/A/FindMyDevice
+       0x1b46bf000 -        0x1b46e759f  com.apple.sidecar-core (1.0 - 380.1) <D4E79962-7056-3C1B-A239-C9468D7CB8E2> /System/Library/PrivateFrameworks/SidecarCore.framework/Versions/A/SidecarCore
+       0x1b46e8000 -        0x1b46ededf  com.apple.QuickLookNonBaseSystem (1.0 - 1) <3155347C-13AF-3AB0-83CA-391167120B4C> /System/Library/PrivateFrameworks/QuickLookNonBaseSystem.framework/Versions/A/QuickLookNonBaseSystem
+       0x1b46ee000 -        0x1b472b43f  com.apple.datadetectors (5.0 - 469.1) <E42CB09E-AAE6-3292-B871-E612E207F7DD> /System/Library/PrivateFrameworks/DataDetectors.framework/Versions/A/DataDetectors
+       0x1b491d000 -        0x1b49b2fbf  com.apple.CoreRoutine (1.0 - 1075.0.2) <834B5E6C-3C1D-385B-8A20-F8C898140882> /System/Library/PrivateFrameworks/CoreRoutine.framework/Versions/A/CoreRoutine
+       0x1b49b3000 -        0x1b49d697f  com.apple.mediastream (1.0 - 851.0.103) <9E327A93-813F-34E9-8DDA-63302E3134F6> /System/Library/PrivateFrameworks/MediaStream.framework/Versions/A/MediaStream
+       0x1b4d0e000 -        0x1b4d12de3  com.apple.CoreOptimization (1.0 - 1) <AC7CB217-140A-3AA1-84B8-1FFD836103BA> /System/Library/PrivateFrameworks/CoreOptimization.framework/Versions/A/CoreOptimization
+       0x1b4d13000 -        0x1b4d26e1f  com.apple.FeatureFlagsSupport (1.0 - 103) <A669B9D9-5063-3A74-85B9-D1E41BCBCE39> /System/Library/PrivateFrameworks/FeatureFlagsSupport.framework/Versions/A/FeatureFlagsSupport
+       0x1b4d27000 -        0x1b4d2c9ff  com.apple.incomingcallfilter (10.0 - 1000) <4367255A-D233-3946-9E6B-31BE2E62D6A4> /System/Library/PrivateFrameworks/IncomingCallFilter.framework/Versions/A/IncomingCallFilter
+       0x1b4d2d000 -        0x1b4d85e1f  com.apple.facetimeservices (10.0 - 1000) <7D32291B-1981-39DE-9282-6009A56ED5FE> /System/Library/PrivateFrameworks/FTServices.framework/Versions/A/FTServices
+       0x1b4d86000 -        0x1b4d9b53f  com.apple.CoreSDB (10.0 - 1000) <EBC18FE3-4EAA-330E-B9E2-1E872274175B> /System/Library/PrivateFrameworks/CoreSDB.framework/Versions/A/CoreSDB
+       0x1b4e32000 -        0x1b4e4eb1f  com.apple.contacts.donation (1.0 - 1123.500.31) <FAA03532-7F81-34AF-B198-F866981D9A44> /System/Library/PrivateFrameworks/ContactsDonation.framework/Versions/A/ContactsDonation
+       0x1b4e4f000 -        0x1b4ec885f  com.apple.NaturalLanguage (1.0 - 114) <9FD6F8F7-507E-32EC-9230-B3DCF61908AF> /System/Library/Frameworks/NaturalLanguage.framework/Versions/A/NaturalLanguage
+       0x1b4ec9000 -        0x1b4ef1e7f  com.apple.SafariServices.framework (21624 - 21624.2.5.11.8) <80173D0D-63D4-3F6F-8FA1-AD00743A247D> /System/Library/Frameworks/SafariServices.framework/Versions/A/SafariServices
+       0x1b4f09000 -        0x1b4f97b3f  com.apple.Catalyst (1.0 - 18.100.1) <91300FB5-09F3-31C4-B8A6-D330E08E067F> /System/Library/PrivateFrameworks/Catalyst.framework/Versions/A/Catalyst
+       0x1b4fbe000 -        0x1b5005d7f  com.apple.LocalAuthentication.DaemonUtils (1.0 - 2005.121.1) <AA10869C-A29E-333E-BD0D-13E37C3F35A9> /System/Library/Frameworks/LocalAuthentication.framework/Support/DaemonUtils.framework/Versions/A/DaemonUtils
+       0x1b5006000 -        0x1b504c6ff  com.apple.BiometricKit (1.0 - 545.100.10) <983FFD9A-7714-3050-A6DE-85D9DD6D2E0D> /System/Library/PrivateFrameworks/BiometricKit.framework/Versions/A/BiometricKit
+       0x1b518d000 -        0x1b521bbff  com.apple.LoggingSupport (1.0 - 1861.120.4) <2619A5F3-D97D-3946-B49A-5FA3164FB197> /System/Library/PrivateFrameworks/LoggingSupport.framework/Versions/A/LoggingSupport
+       0x1b521c000 -        0x1b5228acb  com.apple.MallocStackLogging (1.0 - 65000) <782A39D3-C9FD-3E0B-B8FB-26E5D749BE57> /System/Library/PrivateFrameworks/MallocStackLogging.framework/Versions/A/MallocStackLogging
+       0x1b522c000 -        0x1b524daff  com.apple.StorageManagement (1.0 - 1) <2277EB93-863B-3127-9A6B-50FE6D35B306> /System/Library/PrivateFrameworks/StorageManagement.framework/Versions/A/StorageManagement
+       0x1b524e000 -        0x1b52a6b3f  libmis.dylib (463.100.17) <B0F26447-E3DF-33C0-AF33-1109BD0701EA> /usr/lib/libmis.dylib
+       0x1b52a7000 -        0x1b52aac5f  com.apple.gpusw.GPURawCounter (34 - 34) <A0191D2E-4C57-30F7-A206-78FB4188D01E> /System/Library/PrivateFrameworks/GPURawCounter.framework/Versions/A/GPURawCounter
+       0x1b52ab000 -        0x1b52ca87f  libswiftCoreAudio.dylib (411.601) <23AF0BE1-B688-3E32-90BB-920D0C00036A> /usr/lib/swift/libswiftCoreAudio.dylib
+       0x1b52cb000 -        0x1b52d1327  libswiftCoreFoundation.dylib (2411) <4C233FFB-F11A-34AA-9515-74C21E8EE968> /usr/lib/swift/libswiftCoreFoundation.dylib
+       0x1b52d2000 -        0x1b52dd4bf  libswiftIntents.dylib (12) <8A28E574-898C-3D3F-BB71-2D3CFBF9D30A> /usr/lib/swift/libswiftIntents.dylib
+       0x1b52de000 -        0x1b532a843  libswiftXPC.dylib (128.120.2) <0AA69D52-271B-38E0-A156-8BD7F73A4C9C> /usr/lib/swift/libswiftXPC.dylib
+       0x1b532b000 -        0x1b532b7ff  libswiftCoreImage.dylib (2.2) <E49A26D5-9332-3FCF-9C98-1D07890514F1> /usr/lib/swift/libswiftCoreImage.dylib
+       0x1b532c000 -        0x1b532c8a3  libswiftIOKit.dylib (1) <D47B9CC1-B622-31ED-8957-FA79ED1718CE> /usr/lib/swift/libswiftIOKit.dylib
+       0x1b532d000 -        0x1b578eaff  com.apple.CoreHandwriting (161 - 1.2) <4EADF900-3ED6-32FE-9B9F-DF12EBE147C0> /System/Library/PrivateFrameworks/CoreHandwriting.framework/Versions/A/CoreHandwriting
+       0x1b578f000 -        0x1b59c16bf  com.apple.imageKit (3.0 - 1233) <D08DA270-9425-3CE2-A7CA-027473C4725B> /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/ImageKit
+       0x1b59c2000 -        0x1b5b8599f  com.apple.PencilKit (1.0 - 1) <2A0F4C82-598F-32AA-8419-E56D450DD7E0> /System/Library/Frameworks/PencilKit.framework/Versions/A/PencilKit
+       0x1b5b86000 -        0x1b5b9aa7f  com.apple.sidecar-ui (1.0 - 380.1) <A7B9A077-CCB0-3F61-9DF0-C503F79197E2> /System/Library/PrivateFrameworks/SidecarUI.framework/Versions/A/SidecarUI
+       0x1b5b9b000 -        0x1b5ba929f  com.apple.performance.SignpostCollection (1.174.8 - 174.8) <5A70C8E8-16BC-3E17-9E39-5358644B36DE> /System/Library/PrivateFrameworks/SignpostCollection.framework/Versions/A/SignpostCollection
+       0x1b5baa000 -        0x1b5baa2c7  com.apple.WebInspectorUI (21624 - 21624.2.5.11.8) <9053BE38-C7DC-3A23-914B-B033DF6262BA> /System/Library/PrivateFrameworks/WebInspectorUI.framework/Versions/A/WebInspectorUI
+       0x1b5bab000 -        0x1b5bec1ff  com.apple.OnBoardingKit (1.0 - 1) <D027A284-20EC-3748-9C28-63F132D22DAD> /System/Library/PrivateFrameworks/OnBoardingKit.framework/Versions/A/OnBoardingKit
+       0x1b5c8b000 -        0x1b5c9a17f  com.apple.CoreKDL (1.0 - 1) <74B6B820-3187-337B-9719-4FE78237EBC3> /System/Library/PrivateFrameworks/CoreKDL.framework/Versions/A/CoreKDL
+       0x1b5c9b000 -        0x1b5d199ff  com.apple.TrialProto (1.0 - 474.2.18.2) <9530E088-9C67-34D2-ADCB-A38D9DEF5466> /System/Library/PrivateFrameworks/TrialProto.framework/Versions/A/TrialProto
+       0x1b5d1a000 -        0x1b5dc36ff  com.apple.trial (1.0 - 474.2.18.2) <33D5F7C5-A40C-3EA1-B937-19BB9FD22986> /System/Library/PrivateFrameworks/Trial.framework/Versions/A/Trial
+       0x1b5dc4000 -        0x1b629cd3f  com.apple.SearchFoundation (1.0 - 3525.4.2) <0866B7E9-7220-3EF1-9A79-A5DC5F17ADFA> /System/Library/PrivateFrameworks/SearchFoundation.framework/Versions/A/SearchFoundation
+       0x1b629d000 -        0x1b668b43f  com.apple.Photos (1.0 - 851.0.103) <86D78F0C-DA0A-3CB2-86E7-30552FE45872> /System/Library/Frameworks/Photos.framework/Versions/A/Photos
+       0x1b668c000 -        0x1b6707dbf  com.apple.ImageCaptureCore (2020.2.2 - 2020.2.2) <6CAEA28B-823D-3681-9BD3-EBD3BEC60413> /System/Library/Frameworks/ImageCaptureCore.framework/Versions/A/ImageCaptureCore
+       0x1b6708000 -        0x1b67309bf  com.apple.quartzfilters (1.10.0 - 103) <290156B1-78AA-37D7-AD39-2313E846D07C> /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/QuartzFilters.framework/Versions/A/QuartzFilters
+       0x1b6731000 -        0x1b6777d1f  com.apple.IntlPreferences (2.0 - 475.4.1) <EE6AFF75-5982-35FE-9818-C6346E570899> /System/Library/PrivateFrameworks/IntlPreferences.framework/Versions/A/IntlPreferences
+       0x1b6778000 -        0x1b67b329f  com.apple.ToneLibrary (1.0 - 1) <A07833F5-47CE-3322-9AFE-2B4B3E12A63F> /System/Library/PrivateFrameworks/ToneLibrary.framework/Versions/A/ToneLibrary
+       0x1b67b4000 -        0x1b67bceff  com.apple.CoreFollowUpUI (1.0 - 281.5.2) <A7F85D7F-14E2-32B4-A71A-CB3BBE378F03> /System/Library/PrivateFrameworks/CoreFollowUpUI.framework/Versions/A/CoreFollowUpUI
+       0x1b6884000 -        0x1b692be7f  com.apple.CallKit (1.0 - 1) <AA9C1600-0B68-3B76-8791-329604A8DB6B> /System/Library/Frameworks/CallKit.framework/Versions/A/CallKit
+       0x1b692c000 -        0x1b6a5077f  com.apple.ScreenTimeCore (3.0 - 605.5.10) <692092BA-6006-3F5C-98FD-CE152C213575> /System/Library/PrivateFrameworks/ScreenTimeCore.framework/Versions/A/ScreenTimeCore
+       0x1b6a5b000 -        0x1b6a74c7f  com.apple.contextkit.ContextKit (1.0 - 1) <46CD6A0D-21DE-392E-8278-6B539AB0F1E2> /System/Library/PrivateFrameworks/ContextKit.framework/Versions/A/ContextKit
+       0x1b6a75000 -        0x1b6c6439f  com.apple.Safari.Core (21624 - 21624.2.5.11.8) <05822DDA-F85E-3107-8095-3A58A91BB410> /System/Library/PrivateFrameworks/SafariCore.framework/Versions/A/SafariCore
+       0x1b6f64000 -        0x1b73540bf  com.apple.iTunesCloud (1.0 - 4025.600.5) <D2DCF87A-0413-3091-947D-7EB8E466C40D> /System/Library/PrivateFrameworks/iTunesCloud.framework/Versions/A/iTunesCloud
+       0x1b735b000 -        0x1b73942c7  libbootpolicy.dylib (289.100.5) <53AF23CF-CBCF-35E7-A3D6-1C4742A617AD> /usr/lib/libbootpolicy.dylib
+       0x1b7395000 -        0x1b74e0f1f  com.apple.AnnotationKit (1.0 - 560.4.2) <C4A87B7C-BAF6-3F07-BF1B-C08F916E130E> /System/Library/PrivateFrameworks/AnnotationKit.framework/Versions/A/AnnotationKit
+       0x1b74e1000 -        0x1b79c17bf  com.apple.QuartzComposer (5.1 - 387) <29ECE1AA-EF8E-36A5-8D41-F7F41DF7E9C9> /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/QuartzComposer.framework/Versions/A/QuartzComposer
+       0x1b79c2000 -        0x1b7aea61f  com.apple.PDFKit (1.0 - 1451.5.3) <4D3B489A-B511-3D37-A5DB-7E337B7B5350> /System/Library/Frameworks/PDFKit.framework/Versions/A/PDFKit
+       0x1b7aeb000 -        0x1b811b55f  com.apple.SceneKit (1.0 - 608.500) <A29E03FD-F84A-3305-B09D-C6F06B427201> /System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit
+       0x1b8436000 -        0x1b8440b1f  com.apple.BridgeXPC (1.0 - 39) <C737EB94-52A7-3EA2-94FB-8C5829DB6D41> /System/Library/PrivateFrameworks/BridgeXPC.framework/Versions/A/BridgeXPC
+       0x1b8441000 -        0x1b846f9bf  com.apple.skp.FeedbackLogger (1.0 - 1) <B2E6D6F4-9995-32F3-BBC8-AB0537E32B00> /System/Library/PrivateFrameworks/FeedbackLogger.framework/Versions/A/FeedbackLogger
+       0x1b8470000 -        0x1b86cb49f  com.apple.AppleMediaServicesUI (1.0 - 1) <C5128121-32DD-3DBD-AA8C-530406FBD18C> /System/Library/PrivateFrameworks/AppleMediaServicesUI.framework/Versions/A/AppleMediaServicesUI
+       0x1b86cc000 -        0x1b86ee1ff  com.apple.DistributionKit (700 - 1000) <625FB2E8-70BA-3EA5-AE5A-462CA4FDFEC6> /System/Library/PrivateFrameworks/Install.framework/Frameworks/DistributionKit.framework/Versions/A/DistributionKit
+       0x1b86ef000 -        0x1b874479f  com.apple.OSPersonalization (1.0 - 149) <AA7886FB-84CF-3ECE-9976-6B319A70CD80> /System/Library/PrivateFrameworks/OSPersonalization.framework/Versions/A/OSPersonalization
+       0x1b8c57000 -        0x1b8cb5c5f  com.apple.CommerceKit (1.2.0 - 716.4.2) <2EE52BE3-F39F-35E8-A505-5193FF087C54> /System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/CommerceKit
+       0x1b8cb6000 -        0x1b8cbb95f  com.apple.ServerInformation (2.0 - 1) <0DC0681E-39B5-30B0-9FE5-845222313582> /System/Library/PrivateFrameworks/ServerInformation.framework/Versions/A/ServerInformation
+       0x1b8cbc000 -        0x1b8ce125f  com.apple.icloud.FMCore (1.0 - 1) <3037D463-415A-3937-8405-AA9F8BEC8836> /System/Library/PrivateFrameworks/FMCore.framework/Versions/A/FMCore
+       0x1b8e1f000 -        0x1b8e3688b  libswiftsimd.dylib (23) <C949C0B7-988E-3352-9778-3568FC2BC4EA> /usr/lib/swift/libswiftsimd.dylib
+       0x1b8e37000 -        0x1b907393f  com.apple.CallHistory (1.0 - 106.600.51.1.1) <2251758F-F508-388A-ADB6-F018386F15D8> /System/Library/PrivateFrameworks/CallHistory.framework/Versions/A/CallHistory
+       0x1b9074000 -        0x1b909ec9f  com.apple.MobileInstallation (2.0 - 1.0) <80BFAA6E-0D21-34F1-9454-9C192DE147C3> /System/Library/PrivateFrameworks/MobileInstallation.framework/Versions/A/MobileInstallation
+       0x1b90ad000 -        0x1b92840ff  com.apple.TextInput (1.0 - 1.0) <E57DF0CD-431B-3BA0-B20E-368AA9D11084> /System/Library/PrivateFrameworks/TextInput.framework/Versions/A/TextInput
+       0x1b9475000 -        0x1b9e7f77f  com.apple.PhotoLibraryServices (1.0 - 851.0.103) <19CE3E8B-8CDC-3FF1-983D-79FC0B0032EB> /System/Library/PrivateFrameworks/PhotoLibraryServices.framework/Versions/A/PhotoLibraryServices
+       0x1b9eb5000 -        0x1ba0232df  com.apple.PeopleSuggester (1.0 - 1) <0DF3DA30-718F-3825-BD13-E6EBC9D59C13> /System/Library/PrivateFrameworks/PeopleSuggester.framework/Versions/A/PeopleSuggester
+       0x1ba064000 -        0x1ba07175f  com.apple.CaptiveNetworkSupport (13.0 - 1) <B5B27283-D789-361D-868B-1F6369204254> /System/Library/PrivateFrameworks/CaptiveNetwork.framework/Versions/A/CaptiveNetwork
+       0x1ba1e3000 -        0x1ba24935f  com.apple.StoreFoundation (1.0 - 716.4.2) <D976F291-1D50-3DD1-8801-CED99470551E> /System/Library/PrivateFrameworks/StoreFoundation.framework/Versions/A/StoreFoundation
+       0x1ba4ec000 -        0x1ba50637f  com.apple.LookupFramework (1.2 - 321.3) <D7F4894E-908F-3A23-B7F6-47D5EA5908F8> /System/Library/PrivateFrameworks/Lookup.framework/Versions/A/Lookup
+       0x1ba507000 -        0x1ba5432af  libncurses.5.4.dylib (79) <E7B888EE-3DCC-302F-9B18-9B78ACE85D28> /usr/lib/libncurses.5.4.dylib
+       0x1ba544000 -        0x1ba54d37f  com.apple.IOAccelMemoryInfo (1.0 - 1) <3DFF5F1E-C080-3C9D-A8C5-3C56854BD24D> /System/Library/PrivateFrameworks/IOAccelMemoryInfo.framework/Versions/A/IOAccelMemoryInfo
+       0x1ba5d5000 -        0x1ba5d5677  com.apple.quartzframework (1.5 - 26) <3461A189-8554-319D-87DB-4906A301716E> /System/Library/Frameworks/Quartz.framework/Versions/A/Quartz
+       0x1ba661000 -        0x1ba68055f  com.apple.IntentsCore (1.0 - 1) <248A2E6C-5C37-35FD-9D67-D16E71D6BE55> /System/Library/PrivateFrameworks/IntentsCore.framework/Versions/A/IntentsCore
+       0x1ba681000 -        0x1ba736f5f  com.apple.NearField (365.3.1 - 365.3.1) <67A84671-3AF5-335F-9F04-915B84EAFB0C> /System/Library/PrivateFrameworks/NearField.framework/Versions/A/NearField
+       0x1ba737000 -        0x1ba7486b7  com.apple.GPUInfo (1.3.15 - 1.3.15) <12EA2EC6-BE85-38ED-A1D8-9968C0F96E59> /System/Library/PrivateFrameworks/GPUInfo.framework/Versions/A/GPUInfo
+       0x1ba749000 -        0x1ba751cbf  com.apple.BridgeOSSoftwareUpdate (1.0 - 1) <A8E04F16-901D-3197-91B2-5EFF465765F2> /System/Library/PrivateFrameworks/BridgeOSSoftwareUpdate.framework/Versions/A/BridgeOSSoftwareUpdate
+       0x1ba752000 -        0x1ba761d3f  com.apple.InstallerDiagnostics (1.0 - 1) <DAE251FE-6DC5-322D-9C9F-AAB80D1C550B> /System/Library/PrivateFrameworks/InstallerDiagnostics.framework/Versions/A/InstallerDiagnostics
+       0x1ba795000 -        0x1ba98575f  com.apple.AOSKit (1.07 - 282) <194F7207-6AA5-318A-9C19-735CD3D9B8BB> /System/Library/PrivateFrameworks/AOSKit.framework/Versions/A/AOSKit
+       0x1bacd9000 -        0x1bbbc9adf  com.apple.siri.SiriInstrumentation (1.0 - 1) <380C7259-846C-3F13-8FAD-22180E86B85F> /System/Library/PrivateFrameworks/SiriInstrumentation.framework/Versions/A/SiriInstrumentation
+       0x1bbbe5000 -        0x1bbc060ff  libswiftCoreLocation.dylib (53) <02AAFEE7-1870-34C0-8AAC-4AC1447D7256> /usr/lib/swift/libswiftCoreLocation.dylib
+       0x1bbc07000 -        0x1bbc100be  libswiftCoreMIDI.dylib (6) <68160211-1089-3958-A8A1-3E8B3C389499> /usr/lib/swift/libswiftCoreMIDI.dylib
+       0x1bbc4c000 -        0x1bbfa88df  com.apple.IMDPersistence (10.0 - 1000) <A9429EF8-59F1-36D3-8BF8-A2DC36A66B22> /System/Library/PrivateFrameworks/IMDPersistence.framework/Versions/A/IMDPersistence
+       0x1bbfa9000 -        0x1bbfaf3bf  com.apple.idskvstore (10.0 - 1000) <D354BFCB-6FF6-301B-9F83-42EF1B3ACED4> /System/Library/PrivateFrameworks/IDSKVStore.framework/Versions/A/IDSKVStore
+       0x1bbfb0000 -        0x1bbfdeadf  com.apple.LocalAuthenticationUI (1.0 - 2005.121.1) <6D21316A-C06F-3F59-8570-DB1A3A53CFCC> /System/Library/PrivateFrameworks/LocalAuthenticationUI.framework/Versions/A/LocalAuthenticationUI
+       0x1bc09e000 -        0x1bc23a27f  com.apple.AddressBook.framework (14.0 - 2732.600.11) <83A4EF45-1037-384D-B68F-F4C63EC0CDE5> /System/Library/Frameworks/AddressBook.framework/Versions/A/AddressBook
+       0x1bc23b000 -        0x1bc25c3df  com.apple.ToneKit (1.0 - 1) <6C55881B-E689-382A-8EA1-34D45BFE8D32> /System/Library/PrivateFrameworks/ToneKit.framework/Versions/A/ToneKit
+       0x1bc25d000 -        0x1bc2fc03f  com.apple.AppStoreDaemon (1.0 - 1) <FFFB7072-3989-39B4-8979-349D801DACC3> /System/Library/PrivateFrameworks/AppStoreDaemon.framework/Versions/A/AppStoreDaemon
+       0x1bc3f3000 -        0x1bc3f9bbf  com.apple.MSUDataAccessor (1.0 - 1) <B73070EE-3FE8-354E-A3BB-84894636D3BA> /System/Library/PrivateFrameworks/MSUDataAccessor.framework/Versions/A/MSUDataAccessor
+       0x1bc4b8000 -        0x1bc4e5bdf  libnfshared.dylib (365.3.1) <E259E732-468E-39B2-80DD-5327BD9F931E> /usr/lib/libnfshared.dylib
+       0x1bc4e6000 -        0x1bc6e2c9f  com.apple.Navigation (1.0 - 1) <A58E32ED-63D7-378E-88BE-8244F6A9F8C0> /System/Library/PrivateFrameworks/Navigation.framework/Versions/A/Navigation
+       0x1bc6e3000 -        0x1bc6fd0df  com.apple.ExternalAccessory (1.0.0 - 1.0) <830A6FCA-B0CF-3294-AD90-9D4D9B1E2652> /System/Library/Frameworks/ExternalAccessory.framework/ExternalAccessory
+       0x1bc6fe000 -        0x1bc71841f  com.apple.IAP (1.0 - 1.0.0) <A56E33F0-5EDD-32C0-9006-E013970E67D9> /System/Library/PrivateFrameworks/IAP.framework/Versions/A/IAP
+       0x1bc81b000 -        0x1bc87da5f  com.apple.SoftwareUpdateCoreSupport (1.0 - 1) <34E714DF-AC10-3E52-862E-7FD8AE96EFA7> /System/Library/PrivateFrameworks/SoftwareUpdateCoreSupport.framework/Versions/A/SoftwareUpdateCoreSupport
+       0x1bc898000 -        0x1bc89b65f  com.apple.ftclientservices (10.0 - 1000) <822F0D14-543C-321F-B354-D98689A7939F> /System/Library/PrivateFrameworks/FTClientServices.framework/Versions/A/FTClientServices
+       0x1bc94c000 -        0x1bcaa65bf  com.apple.chronoservices (1) <9405677F-EB3A-3A63-A129-2A1975196A82> /System/Library/PrivateFrameworks/ChronoServices.framework/Versions/A/ChronoServices
+       0x1bcaa8000 -        0x1bcc550ff  com.apple.AOSUI (1.2 - 898.475.6) <B4C5B599-81F6-35A8-BEC4-165241CF7507> /System/Library/PrivateFrameworks/AOSUI.framework/Versions/A/AOSUI
+       0x1bcc56000 -        0x1bcc63b1f  com.apple.icloud.FindMyDeviceUI (1.0 - 18) <C84BF6BA-C47A-33CC-B02D-2D4A7C56C1EE> /System/Library/PrivateFrameworks/FindMyDeviceUI.framework/Versions/A/FindMyDeviceUI
+       0x1bcca9000 -        0x1bccddc7f  libtailspin.dylib (250.2) <6E5B5951-141C-3B86-B36A-21A334F6AE44> /usr/lib/libtailspin.dylib
+       0x1bccde000 -        0x1be42777f  com.apple.SwiftUI (7.5.3 - 7.5.3) <90F7FA24-A280-3E8A-A62D-148B11BFC28D> /System/Library/Frameworks/SwiftUI.framework/Versions/A/SwiftUI
+       0x1be428000 -        0x1be46d0ff  com.apple.AttributeGraph (7.0.80 - 7.0.80) <99647A0F-5B58-3E14-B260-9A6F14AD5FC0> /System/Library/PrivateFrameworks/AttributeGraph.framework/Versions/A/AttributeGraph
+       0x1be46e000 -        0x1be4f261f  com.apple.EmojiFoundation (1.0 - 1) <FFA1E302-8BB6-357F-A174-D978CE8B7CB2> /System/Library/PrivateFrameworks/EmojiFoundation.framework/Versions/A/EmojiFoundation
+       0x1be4f3000 -        0x1be5dccbf  com.apple.CoreCDPInternal (1.0 - 1) <B5326ABB-730B-3C2E-9A8B-10255FC29D7E> /System/Library/PrivateFrameworks/CoreCDPInternal.framework/Versions/A/CoreCDPInternal
+       0x1be5dd000 -        0x1bee8369f  libfaceCore.dylib (9.5.4) <534C5D06-891B-3115-8691-27A0CE8BA743> /System/Library/Frameworks/Vision.framework/libfaceCore.dylib
+       0x1bee84000 -        0x1bf0f659f  com.apple.TextRecognition (1.0 - 157) <95B7C7C6-75F9-3FC4-B384-BF2FFB30FE05> /System/Library/PrivateFrameworks/TextRecognition.framework/Versions/A/TextRecognition
+       0x1bf0f7000 -        0x1bf10e25f  com.apple.Futhark (1.0 - 1) <A8140F7D-3768-3975-89B6-FFD1728D00EB> /System/Library/PrivateFrameworks/Futhark.framework/Versions/A/Futhark
+       0x1bf10f000 -        0x1bf19f31f  com.apple.DifferentialPrivacy (1.0 - 1) <3C142B6E-254B-3146-88C6-C89DEB2626F3> /System/Library/PrivateFrameworks/DifferentialPrivacy.framework/Versions/A/DifferentialPrivacy
+       0x1bf1a0000 -        0x1bf1e617f  com.apple.SafariFoundation (21624 - 21624.2.5.11.8) <650EAD9F-1E73-313F-989A-A49664905BA9> /System/Library/PrivateFrameworks/SafariFoundation.framework/Versions/A/SafariFoundation
+       0x1bf64f000 -        0x1bf688ba7  com.apple.MobileBluetooth (1.0 - 1.0) <8377CD6D-C3D0-3FA1-8BAE-861C09F032BC> /System/Library/PrivateFrameworks/MobileBluetooth.framework/Versions/A/MobileBluetooth
+       0x1bf68f000 -        0x1bf80a1bf  com.apple.AuthenticationServices (12.0 - 21624.2.5.11.8) <60059F4D-7F9A-3C5D-8117-DDB456CE0868> /System/Library/Frameworks/AuthenticationServices.framework/Versions/A/AuthenticationServices
+       0x1c0340000 -        0x1c039723f  com.apple.biome.BiomeFoundation (1.0 - 209.18) <6F0943D8-345B-328C-8A5E-8D10B3BC3CC3> /System/Library/PrivateFrameworks/BiomeFoundation.framework/Versions/A/BiomeFoundation
+       0x1c0398000 -        0x1c039ccff  com.apple.DAAPKit (1.0 - 4025.500.37) <D4EDD0BA-F5C6-3D9D-89F1-5E0F8604D10C> /System/Library/PrivateFrameworks/DAAPKit.framework/Versions/A/DAAPKit
+       0x1c0423000 -        0x1c04e75ff  com.apple.icloud.SPOwner (1.0 - 423.25.2.23.4) <941049ED-6CED-3598-A6A8-A59A4ADBD3A9> /System/Library/PrivateFrameworks/SPOwner.framework/Versions/A/SPOwner
+       0x1c2f8b000 -        0x1c303697f  com.apple.cloudkit.MMCS (1.3 - 2300.120) <36DCED9E-99F1-341E-A6AB-2CB0D2026D82> /System/Library/PrivateFrameworks/MMCS.framework/Versions/A/MMCS
+       0x1c3037000 -        0x1c30ae3df  com.apple.acg.InertiaCam (1.0 - 1) <A47D26A2-5721-3C0F-8CFA-5E4DAD11861F> /System/Library/PrivateFrameworks/InertiaCam.framework/Versions/A/InertiaCam
+       0x1c311d000 -        0x1c3239a9f  com.apple.ConfigurationEngineModel (1.0 - 249.100.1) <E98DD61F-3D8B-39D6-AFB7-DA7AF7CEA6F3> /System/Library/PrivateFrameworks/ConfigurationEngineModel.framework/Versions/A/ConfigurationEngineModel
+       0x1c3270000 -        0x1c327da1f  libswiftMetal.dylib (373.2) <16B01E1B-6BDD-3C6B-9A8B-495C3B661B9B> /usr/lib/swift/libswiftMetal.dylib
+       0x1c327e000 -        0x1c3284e05  libswiftCompression.dylib (11) <5EA10BB9-2198-33D7-811A-BE5EAE0A2EED> /usr/lib/swift/libswiftCompression.dylib
+       0x1c3620000 -        0x1c36320df  com.apple.SpotlightReceiver (1.0 - 2418.5.9.101) <0EBBF775-E80D-37C2-ACC1-16411A09743A> /System/Library/PrivateFrameworks/SpotlightReceiver.framework/Versions/A/SpotlightReceiver
+       0x1c38a4000 -        0x1c3cc483f  com.apple.imcore (10.0 - 1000) <E62F6467-6FEF-3AF9-89E4-CB17C2048ACE> /System/Library/PrivateFrameworks/IMCore.framework/Versions/A/IMCore
+       0x1c3cc5000 -        0x1c3ce18bf  com.apple.ftawd (8.0 - 900) <5C27AEA3-F2F5-324A-83E4-04F3AADCA4EA> /System/Library/PrivateFrameworks/FTAWD.framework/Versions/A/FTAWD
+       0x1c419e000 -        0x1c41a209f  com.apple.iChat.InstantMessage (8.0 - 5501) <D717022C-9592-3AA3-8BAA-8D72AC673754> /System/Library/Frameworks/InstantMessage.framework/Versions/A/InstantMessage
+       0x1c41af000 -        0x1c4259d5f  libFDR.dylib (1499.100.48) <62340EBF-17DB-3393-9653-003A30263E5D> /usr/lib/libFDR.dylib
+       0x1c425a000 -        0x1c42da8ff  com.apple.TimeSync (1.0 - 1450.2) <26B42ED2-04F5-3F97-A88E-77AA2425D79D> /System/Library/PrivateFrameworks/TimeSync.framework/Versions/A/TimeSync
+       0x1c42db000 -        0x1c48a5e9f  com.apple.biome.BiomeStreams (1.0 - 209.18) <B05E6A84-BC87-3977-B790-2391073FF393> /System/Library/PrivateFrameworks/BiomeStreams.framework/Versions/A/BiomeStreams
+       0x1c48a6000 -        0x1c48b84df  com.apple.framework.ctcategories (1.0 - 49.4.1) <A0934962-C81C-3734-82B2-320E13C2D9FD> /System/Library/PrivateFrameworks/Categories.framework/Versions/A/Categories
+       0x1c4d79000 -        0x1c4d8d8ff  com.apple.SoftwareUpdateCoreConnect (1.0 - 1) <8B5F0FE6-EFC0-32B3-8414-6E67E97CCD87> /System/Library/PrivateFrameworks/SoftwareUpdateCoreConnect.framework/Versions/A/SoftwareUpdateCoreConnect
+       0x1c4da6000 -        0x1c4e1f45f  com.apple.StorageKit (1.0 - 1037.120.10) <B4F4B8DC-D751-3889-9839-941A5BEEC53D> /System/Library/PrivateFrameworks/StorageKit.framework/Versions/A/StorageKit
+       0x1c4e20000 -        0x1c4e6165f  com.apple.framework.corewlankit (16.0 - 1657) <E72A3231-8819-3155-AB86-918FCF56BA86> /System/Library/PrivateFrameworks/CoreWLANKit.framework/Versions/A/CoreWLANKit
+       0x1c5f18000 -        0x1c5f21b5f  com.apple.audio.IOKitten (300.1 - 300.1) <10C7A07C-23EE-36DA-824B-DA5077536AEB> /System/Library/PrivateFrameworks/IOKitten.framework/Versions/A/IOKitten
+       0x1c6315000 -        0x1c634513f  com.apple.coreduet.KnowledgeMonitor (1.0 - 1) <0FE5D721-224E-3E38-96BF-39A0E97F35EF> /System/Library/PrivateFrameworks/KnowledgeMonitor.framework/Versions/A/KnowledgeMonitor
+       0x1c6346000 -        0x1c638bf5f  com.apple.UsageTracking (3.0 - 392.5.1) <CFD1ED4E-B49D-38D6-860F-86B97243E258> /System/Library/PrivateFrameworks/UsageTracking.framework/Versions/A/UsageTracking
+       0x1c638c000 -        0x1c71ca19f  com.apple.VectorKit (1.0 - 2001.25.2.9.8) <7A253DAD-FEA5-31FE-89F9-5599D2C560EF> /System/Library/PrivateFrameworks/VectorKit.framework/Versions/A/VectorKit
+       0x1c71cb000 -        0x1c7235c1f  com.apple.osanalytics.OSAnalytics (1.0 - 1) <D3398082-B264-37E9-B546-1BB0DE974E81> /System/Library/PrivateFrameworks/OSAnalytics.framework/Versions/A/OSAnalytics
+       0x1c7236000 -        0x1c726175f  libMemoryResourceException.dylib (314.120.5) <FB0BC6F6-2C3E-3EF4-B946-96FF272A824F> /usr/lib/libMemoryResourceException.dylib
+       0x1c7262000 -        0x1c72de87f  com.apple.NetworkServiceProxyFramework (1.0 - 1) <C405B306-415A-30CB-BF59-25BB31EF0447> /System/Library/PrivateFrameworks/NetworkServiceProxy.framework/Versions/A/NetworkServiceProxy
+       0x1c730b000 -        0x1c731665f  com.apple.CloudPhotoServicesConfiguration (11.0 - 851.0.103) <DD42D8C7-D96A-3BE8-B3D9-3A908F1A8F98> /System/Library/PrivateFrameworks/CloudPhotoServicesConfiguration.framework/Versions/A/CloudPhotoServicesConfiguration
+       0x1c7337000 -        0x1c758927f  com.apple.CloudPhotoLibrary (1.0 - 851.0.103) <18B0E0D1-87AF-33C4-A5D5-07F2EEF252E6> /System/Library/PrivateFrameworks/CloudPhotoLibrary.framework/Versions/A/CloudPhotoLibrary
+       0x1c75b1000 -        0x1c7927fa7  com.apple.SDAPI (1.0 - 1) <898FF323-D416-34B1-B5FF-1AF688F3E343> /System/Library/PrivateFrameworks/SDAPI.framework/Versions/A/SDAPI
+       0x1c85ed000 -        0x1c865edff  com.apple.Transparency (1.0 - 1547.120.20) <8A731CEE-3088-3344-A7D5-85EDDA11888C> /System/Library/PrivateFrameworks/Transparency.framework/Versions/A/Transparency
+       0x1c8665000 -        0x1c8666f9f  libswiftQuartzCore.dylib (5) <481AAE69-579E-3DF4-B1F0-113E54B8EAA9> /usr/lib/swift/libswiftQuartzCore.dylib
+       0x1c8a58000 -        0x1c8a5d8e7  com.apple.kperf (1.0 - 1) <23264FF1-B323-3B46-893D-42378F45FE8A> /System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf
+       0x1c8a5e000 -        0x1c8b4f65f  com.apple.libktrace (1.0 - 683.100.8) <83E28A1E-2318-3F7E-BE64-102530737DAE> /System/Library/PrivateFrameworks/ktrace.framework/Versions/A/ktrace
+       0x1c8b50000 -        0x1c8b5705f  com.apple.BezelServicesFW (374 - 374) <DC5C4CC1-A980-37B6-8D93-AD3AD2E4785A> /System/Library/PrivateFrameworks/BezelServices.framework/Versions/A/BezelServices
+       0x1c8b6f000 -        0x1c8b7463f  com.apple.MobileSystemServices (1.0 - 1) <05D57959-6BE2-3FFE-A842-09A3FA930624> /System/Library/PrivateFrameworks/MobileSystemServices.framework/Versions/A/MobileSystemServices
+       0x1c8bd7000 -        0x1c8c0639f  com.apple.frameworks.preferencepanes (16.0 - 16.0) <676FB6E1-83EF-3AE9-B8BD-4E7005065411> /System/Library/Frameworks/PreferencePanes.framework/Versions/A/PreferencePanes
+       0x1c8c07000 -        0x1c8c0fb5f  com.apple.InAppMessagesCore (1.0 - 1) <73EF2C4D-A89E-3F9F-A237-29BC7BDEBA3E> /System/Library/PrivateFrameworks/InAppMessagesCore.framework/Versions/A/InAppMessagesCore
+       0x1c8c10000 -        0x1c8c343ff  com.apple.InAppMessages (1.0 - 1) <4870373E-E935-387B-99B5-EFCF365327E0> /System/Library/PrivateFrameworks/InAppMessages.framework/Versions/A/InAppMessages
+       0x1c8c35000 -        0x1c8cc175f  com.apple.EmailCore (11.0 - 3864.600.51.1.1) <BEB5AFF9-F3EA-3249-A126-F9420D4CCA5C> /System/Library/PrivateFrameworks/EmailCore.framework/Versions/A/EmailCore
+       0x1c8d07000 -        0x1c8d0cb3f  com.apple.FindMyMac (3.1 - 75.25.2.23.2) <4B13A0F4-B05C-3DEE-88F3-37941574700C> /System/Library/PrivateFrameworks/FindMyMac.framework/Versions/A/FindMyMac
+       0x1c8d0d000 -        0x1c8d1c77f  com.apple.MobileActivation (1.0 - 1076.120.12) <67E0E64E-B34C-3BFD-A5CC-0234F0E7438B> /System/Library/PrivateFrameworks/MobileActivationMacOS.framework/Versions/A/MobileActivationMacOS
+       0x1c9363000 -        0x1c9396b5f  com.apple.photo.MediaConversionService (11.0 - 851.0.103) <3EFD3D3E-1081-361C-A4C2-DB92EF4A7D7A> /System/Library/PrivateFrameworks/MediaConversionService.framework/Versions/A/MediaConversionService
+       0x1c939e000 -        0x1c942b45f  com.apple.signpost.SignpostSupport (1.174.8 - 174.8) <71BB8292-225F-346B-89AF-4F99D22851EB> /System/Library/PrivateFrameworks/SignpostSupport.framework/Versions/A/SignpostSupport
+       0x1c942c000 -        0x1c9594cdf  com.apple.ModelIO (268.2.2 - 268.2.2) <E58D9341-A878-3AB7-B385-8458E2B43F0F> /System/Library/Frameworks/ModelIO.framework/Versions/A/ModelIO
+       0x1c9595000 -        0x1c95cc87f  com.apple.UIKitServices (1.0 - 9126.5.5.2.401) <BAB77727-1ADD-3FB3-9196-6B89AC72B3AC> /System/Library/PrivateFrameworks/UIKitServices.framework/Versions/A/UIKitServices
+       0x1c95cd000 -        0x1c9777aff  com.apple.SampleAnalysis (1.0 - 427) <FAF891F5-F079-3AEC-BCB0-34FBDF780D6D> /System/Library/PrivateFrameworks/SampleAnalysis.framework/Versions/A/SampleAnalysis
+       0x1c9851000 -        0x1c9b4ceff  com.apple.photo.NeutrinoCore (1.0 - 851.0.103) <A9E0507D-A962-3833-8808-78F478F878A0> /System/Library/PrivateFrameworks/NeutrinoCore.framework/Versions/A/NeutrinoCore
+       0x1c9d2a000 -        0x1c9dd371f  com.apple.EmailFoundation (11.0 - 3864.600.51.1.1) <FB579A44-01C8-34F5-BA42-2F1DA65FF5A3> /System/Library/PrivateFrameworks/EmailFoundation.framework/Versions/A/EmailFoundation
+       0x1ca083000 -        0x1ca160a9f  libauthinstall.dylib (1104.120.3.0.1) <D3EDFC89-792E-395B-9FCC-09CE9009AC39> /usr/lib/libauthinstall.dylib
+       0x1ca161000 -        0x1ca18329f  libamsupport.dylib (434.120.4) <C01C56CE-81B4-308E-A1BE-07C445941133> /usr/lib/libamsupport.dylib
+       0x1ca203000 -        0x1ca47ac7f  com.apple.Speech (1.0 - 1) <DDC3CB1B-DE48-30FA-932D-17E21FF448D5> /System/Library/Frameworks/Speech.framework/Versions/A/Speech
+       0x1ca558000 -        0x1ca55aadf  com.apple.ScreenTimeServiceUI (3.0 - 605.5.10) <6067A611-511C-3636-8111-240583264570> /System/Library/PrivateFrameworks/ScreenTimeServiceUI.framework/Versions/A/ScreenTimeServiceUI
+       0x1ca55f000 -        0x1ca5bf0bf  com.apple.biome.BiomePubSub (1.0 - 209.18) <5BA2374F-9154-3DC4-A761-D3C6E167F148> /System/Library/PrivateFrameworks/BiomePubSub.framework/Versions/A/BiomePubSub
+       0x1ca5c0000 -        0x1ca602fff  com.apple.biome.BiomeStorage (1.0 - 209.18) <A69679B4-A9DF-39B0-B361-F116246BB7D7> /System/Library/PrivateFrameworks/BiomeStorage.framework/Versions/A/BiomeStorage
+       0x1ca73f000 -        0x1ca83aff7  libcrypto.42.dylib (109.100.2) <36A5C02F-E637-3B29-98B6-C20211C2B423> /usr/lib/libcrypto.42.dylib
+       0x1ca8ec000 -        0x1ca8ff1ff  com.apple.private.XprotectFrameWork.XprotectFramework (1.0 - 1) <BB3AE58B-96C7-37F6-A834-271A7AC3CB5B> /System/Library/PrivateFrameworks/XprotectFramework.framework/Versions/A/XprotectFramework
+       0x1cacfb000 -        0x1cae75cff  com.apple.LinkPresentation (296 - 296.11) <02648F5E-D900-3EB5-9843-3C9E7B4D860F> /System/Library/Frameworks/LinkPresentation.framework/Versions/A/LinkPresentation
+       0x1cb0fb000 -        0x1cb23a13f  com.apple.PhotosFormats (1.0 - 851.0.103) <E2201A2F-F0DD-3882-82CC-9F8FEABD91FF> /System/Library/PrivateFrameworks/PhotosFormats.framework/Versions/A/PhotosFormats
+       0x1cbcf9000 -        0x1cbd2e31f  com.apple.DeviceIdentity (1.0 - 1) <82A3389D-6D75-3AF2-8A0E-38C9DC42D272> /System/Library/PrivateFrameworks/DeviceIdentity.framework/Versions/A/DeviceIdentity
+       0x1cce56000 -        0x1cce61c1f  com.apple.EmailAddressing (11.0 - 3864.600.51.1.1) <E638BD27-64B0-35FF-89B0-77F808A8A053> /System/Library/PrivateFrameworks/EmailAddressing.framework/Versions/A/EmailAddressing
+       0x1cce62000 -        0x1ccfd751f  com.apple.Email (11.0 - 3864.600.51.1.1) <CA1A8D4B-A849-3C1D-8452-2DB11B4917BC> /System/Library/PrivateFrameworks/Email.framework/Versions/A/Email
+       0x1ccfd9000 -        0x1cd0f8e9f  com.apple.CoreMediaStream (1.0 - 851.0.103) <493D5164-E3A7-3A86-9D36-D61E0C98C175> /System/Library/PrivateFrameworks/CoreMediaStream.framework/Versions/A/CoreMediaStream
+       0x1cd0f9000 -        0x1cd10813f  libswiftUniformTypeIdentifiers.dylib (877.5.1) <BD304D00-8CE3-3528-914A-DBAD4831A95E> /usr/lib/swift/libswiftUniformTypeIdentifiers.dylib
+       0x1cd109000 -        0x1cd1cea9b  libswiftAccelerate.dylib (77.100.2) <4A2ADA9C-22FB-307F-AA1E-1D85F1579BCF> /usr/lib/swift/libswiftAccelerate.dylib
+       0x1cd323000 -        0x1cd33411f  libpartition2_dynamic.dylib (3476.120.8.0.2) <B57303C4-A549-35C8-9857-DEAC6891A79D> /usr/lib/libpartition2_dynamic.dylib
+       0x1cd890000 -        0x1cd89afdf  com.apple.AFKUser (1.0 - 1) <51F853F3-E890-3D4D-A00D-12C7869B9B22> /System/Library/PrivateFrameworks/AFKUser.framework/Versions/A/AFKUser
+       0x1cddde000 -        0x1cddf1aff  com.apple.dynamicdesktop (1.0 - 2427.4.7) <670453C7-9ABE-3E5E-A047-73898F03D36E> /System/Library/PrivateFrameworks/DynamicDesktop.framework/Versions/A/DynamicDesktop
+       0x1cf8ea000 -        0x1cfb635df  com.apple.photo.PhotoImaging (1.0 - 851.0.103) <5C2898E5-BFFC-31A4-A022-471248C213FA> /System/Library/PrivateFrameworks/PhotoImaging.framework/Versions/A/PhotoImaging
+       0x1cfd3a000 -        0x1cfd44b3f  com.apple.CPMS (1.0 - 1) <1BF2C90B-B778-338E-8C84-6EA6CCE0041B> /System/Library/PrivateFrameworks/CPMS.framework/Versions/A/CPMS
+       0x1d0b56000 -        0x1d0b94f3f  com.apple.PhotosImagingFoundation (11.0 - 851.0.103) <7327CEE3-5037-3FAD-89CD-E523C862F36D> /System/Library/PrivateFrameworks/PhotosImagingFoundation.framework/Versions/A/PhotosImagingFoundation
+       0x1d0b95000 -        0x1d0ba32df  com.apple.CloudPhotoServices (1.0 - 851.0.103) <93022588-A17C-38AF-A36C-D79CFC4F7D27> /System/Library/PrivateFrameworks/CloudPhotoServices.framework/Versions/A/CloudPhotoServices
+       0x1d0ba4000 -        0x1d0bfda9f  com.apple.acg.AutoLoop (1.0 - 1) <ACB4A492-0912-3379-9C5F-1422904D7006> /System/Library/PrivateFrameworks/AutoLoop.framework/Versions/A/AutoLoop
+       0x1d0cb6000 -        0x1d0fae43f  com.apple.Osprey (1.0 - 1) <FC8D86B3-46BA-3755-99DC-1E00B6C0D184> /System/Library/PrivateFrameworks/Osprey.framework/Versions/A/Osprey
+       0x1d1284000 -        0x1d12e575f  libswiftCoreMedia.dylib (3320.8.5.2) <B6F90BD5-F45A-3775-9479-E7866DF6EE3D> /usr/lib/swift/libswiftCoreMedia.dylib
+       0x1d254d000 -        0x1d255638f  com.apple.kperfdata (1.0 - 1) <9F808B03-77DD-350B-B010-CE77A7154F48> /System/Library/PrivateFrameworks/kperfdata.framework/Versions/A/kperfdata
+       0x1d2573000 -        0x1d257ec9f  com.apple.Reveal (1.0 - 56) <7F7EA779-1A5F-39AA-9D9E-054661EDAA30> /System/Library/PrivateFrameworks/Reveal.framework/Versions/A/Reveal
+       0x1d257f000 -        0x1d2585f5f  com.apple.RevealCore (1.0 - 56) <EB9AE375-E89F-30CC-BF96-369EDEBD61F7> /System/Library/PrivateFrameworks/RevealCore.framework/Versions/A/RevealCore
+       0x1d2a22000 -        0x1d2a36cff  com.apple.BulkSymbolication (1.427 - 427) <2E71F13D-0772-339E-8985-F2685BBA1A85> /System/Library/PrivateFrameworks/BulkSymbolication.framework/Versions/A/BulkSymbolication
+       0x1d2a37000 -        0x1d2a38bbf  libswiftOSLog.dylib (10) <964AB4ED-4361-33BF-949F-C7DE591C5EBE> /usr/lib/swift/libswiftOSLog.dylib
+       0x1d2cd0000 -        0x1d2d185df  libswiftAVFoundation.dylib (2420.7.1) <5BF90953-3D68-3C91-B888-ED6D3B83A690> /usr/lib/swift/libswiftAVFoundation.dylib
+       0x1d6b3d000 -        0x1d6c49d5f  com.apple.Symbolication (16.0 - 64575.70.1) <1BAEF090-27B4-316B-8C9F-E891180781AE> /System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+       0x1d6c4a000 -        0x1d6c8b91f  com.apple.ScreenTimeUI (3.0 - 605.5.10) <9E7647B7-9916-35C0-A38C-E4EC1E332EF7> /System/Library/PrivateFrameworks/ScreenTimeUI.framework/Versions/A/ScreenTimeUI
+       0x1d6cf8000 -        0x1d6d1119f  com.apple.performance.DiagnosticRequest (1.4 - 4) <4CBCEB5B-57C4-316C-A990-F3416BB21C99> /System/Library/PrivateFrameworks/DiagnosticRequest.framework/Versions/A/DiagnosticRequest
+       0x1d7314000 -        0x1d731d4d3  com.apple.framework.netrb (1.0 - 1) <DA1F976F-BF15-3A19-9086-F153C6614D84> /System/Library/PrivateFrameworks/Netrb.framework/Versions/A/Netrb
+       0x1d731e000 -        0x1d7351d3f  com.apple.frameworks.preferencepanessupport (13.0 - 13.0) <EF15E982-9B0C-31B7-83A5-665DEBC6416E> /System/Library/PrivateFrameworks/PreferencePanesSupport.framework/Versions/A/PreferencePanesSupport
+       0x1d7352000 -        0x1d7376c1f  com.apple.CoreMaterial (1.0 - 1) <84638884-B135-3737-B58C-F44FD5AEFB22> /System/Library/PrivateFrameworks/CoreMaterial.framework/Versions/A/CoreMaterial
+       0x1d74cc000 -        0x1d74ce3ff  com.apple.framework.machinesettings (11.0 - 11.0) <BEC0E0E8-B31C-3FF2-B7C9-41D0A23BA62A> /System/Library/PrivateFrameworks/MachineSettings.framework/Versions/A/MachineSettings
+       0x1d74cf000 -        0x1d757b35f  com.apple.CoreCDPUI (1.0 - 1) <8F28B4AD-1952-36C1-9CA4-F267F3CBE92A> /System/Library/PrivateFrameworks/CoreCDPUI.framework/Versions/A/CoreCDPUI
+       0x1d914c000 -        0x1d91db3df  com.apple.AppleCVA (1002.101.0 - 1002.101.0) <5BB3A250-AFA2-3C29-8D8F-E449D36D5D87> /System/Library/PrivateFrameworks/AppleCVA.framework/Versions/A/AppleCVA
+       0x1db18a000 -        0x1db19a3df  com.apple.OSLog (1.0 - 1861.120.4) <68746C62-44B2-377E-BB29-B0B4A6A92B5F> /System/Library/Frameworks/OSLog.framework/Versions/A/OSLog
+       0x1db49c000 -        0x1db5ad75f  com.apple.InternalSwiftProtobuf (1.0 - 1.26.0) <41595ABE-4110-3482-8DA3-839277732E08> /System/Library/PrivateFrameworks/InternalSwiftProtobuf.framework/Versions/A/InternalSwiftProtobuf
+       0x1db5ae000 -        0x1db5ae79f  com.apple.PassKit (1.0 - 1) <C720951E-7DDC-364A-91B9-880248789390> /System/Library/Frameworks/PassKit.framework/Versions/A/PassKit
+       0x1db673000 -        0x1db67e0bf  com.apple.HIDDisplay (1.0 - 1) <E74DCF87-47C7-326B-A77B-1CBB94583B79> /System/Library/PrivateFrameworks/HIDDisplay.framework/Versions/A/HIDDisplay
+       0x1db67f000 -        0x1db6d36ff  com.apple.ReplayKit (1.0 - 1) <0D1FF5DD-9DB2-309B-BD94-9C0513E10AFE> /System/Library/Frameworks/ReplayKit.framework/Versions/A/ReplayKit
+       0x1dd521000 -        0x1ddf906df  com.apple.BlastDoor (1.0 - 1) <9B1BAF36-D607-3CAB-AB12-3560AC9267F3> /System/Library/PrivateFrameworks/BlastDoor.framework/Versions/A/BlastDoor
+       0x1de27c000 -        0x1de32135f  com.apple.security.CryptoKit (1.0 - 1) <73D66B11-1861-3143-A7E5-23F68183B945> /System/Library/Frameworks/CryptoKit.framework/Versions/A/CryptoKit
+       0x1de498000 -        0x1de4af33f  com.apple.BluetoothManager (1.0 - 1) <A3A80AC3-540F-367F-88C1-98866472585E> /System/Library/PrivateFrameworks/BluetoothManager.framework/Versions/A/BluetoothManager
+       0x1de4f2000 -        0x1de52609f  com.apple.PassKitUIFoundation (1.0 - 1642.6.5) <4C5AFA0D-83BC-35F4-AA6E-23FF7E01C649> /System/Library/PrivateFrameworks/PassKitUIFoundation.framework/Versions/A/PassKitUIFoundation
+       0x1df610000 -        0x1df65f23f  com.apple.RemoteConfiguration (3.0 - 401) <9CA8CB5C-1479-345F-B6A8-B22CCFCD8A23> /System/Library/PrivateFrameworks/RemoteConfiguration.framework/Versions/A/RemoteConfiguration
+       0x1e152f000 -        0x1e154cd9f  libedit.3.dylib (65) <62991D93-4364-3F6A-85F2-EA7C3E172BC7> /usr/lib/libedit.3.dylib
+       0x1e1565000 -        0x1e15c43ff  libswiftDemangle.dylib (6.3.2.1.3) <4221FE62-2202-3C4F-B5E6-087D91AFF2FC> /usr/lib/swift/libswiftDemangle.dylib
+       0x1e166e000 -        0x1e1676d5f  com.apple.imtransferservices (10.0 - 1000) <50C7D0FE-47AC-39E9-83B6-934F62A427F4> /System/Library/PrivateFrameworks/IMTransferServices.framework/Versions/A/IMTransferServices
+       0x1e2868000 -        0x1e2bcb39f  com.apple.newstransport (11.5 - 5883) <EEB7C3B4-E940-3258-95ED-9E203A44D94B> /System/Library/PrivateFrameworks/NewsTransport.framework/Versions/A/NewsTransport
+       0x1e2c71000 -        0x1e2c8099f  com.apple.newsfoundation (11.5 - 5883) <B099877E-83BB-33D5-8897-DF3F468770F8> /System/Library/PrivateFrameworks/NewsFoundation.framework/Versions/A/NewsFoundation
+       0x1e2c81000 -        0x1e32af9df  com.apple.newscore (11.5 - 5883) <FD604ADF-4977-353F-9CEE-5C15AAB67C76> /System/Library/PrivateFrameworks/NewsCore.framework/Versions/A/NewsCore
+       0x1e3464000 -        0x1e34656ff  com.apple.preferences.SystemDesktopAppearance (1.0 - 186.4.1) <53F5B6A9-A935-3AC4-AE37-80E2C67BB62E> /System/Library/PrivateFrameworks/SystemDesktopAppearance.framework/Versions/A/SystemDesktopAppearance
+       0x1e3666000 -        0x1e3666af3  com.apple.FeatureFlags (1.0 - 103) <9F17EE22-3F47-3F98-A9B9-1C46372AEE83> /System/Library/PrivateFrameworks/FeatureFlags.framework/Versions/A/FeatureFlags
+       0x1e3672000 -        0x1e3679cbf  libswiftNaturalLanguage.dylib (4.3) <5FF94351-1545-3FE8-8AD2-ADF7D4658B6B> /usr/lib/swift/libswiftNaturalLanguage.dylib
+       0x1e36ea000 -        0x1e373bd3f  com.apple.WiFiPeerToPeer (861.4.0 - 861.4) <EBED941B-3E3D-31CE-9DC0-ED328C38F605> /System/Library/PrivateFrameworks/WiFiPeerToPeer.framework/Versions/A/WiFiPeerToPeer
+       0x1ebb90000 -        0x1ebc76ddf  com.apple.JetUI (1.0 - 1) <1214425D-D156-3E87-AC09-FC9E62D80D02> /System/Library/PrivateFrameworks/JetUI.framework/Versions/A/JetUI
+       0x1ebc77000 -        0x1ec1fef1f  com.apple.JetEngine (1.0 - 1) <2A0A6F81-EEF0-317D-8634-76C96C9037D2> /System/Library/PrivateFrameworks/JetEngine.framework/Versions/A/JetEngine
+       0x1ec71d000 -        0x1ec73f24f  libswiftSwiftOnoneSupport.dylib (6.3.2 - 6.3.2.1.3) <404ED2E8-B497-376D-8342-3D5909B5E006> /usr/lib/swift/libswiftSwiftOnoneSupport.dylib
+       0x1eca11000 -        0x1ecbe3b9f  com.apple.VoiceShortcutClient (1.0 - 4610) <4E0AAD0D-64E6-3C87-971A-DA5E0780648F> /System/Library/PrivateFrameworks/VoiceShortcutClient.framework/Versions/A/VoiceShortcutClient
+       0x1ecd79000 -        0x1ecd7b5bf  com.apple.ConfigProfileHelper (18.0 - 1800) <097D7995-F903-3DA6-91D6-31952FBB2D32> /System/Library/PrivateFrameworks/ConfigProfileHelper.framework/Versions/A/ConfigProfileHelper
+       0x1ecfdd000 -        0x1ed03ec7f  com.apple.ScreenReaderCore (10 - 993) <2F359AAE-E0A3-3873-A4A5-5A8B25F501B2> /System/Library/PrivateFrameworks/ScreenReaderCore.framework/Versions/A/ScreenReaderCore
+       0x1ed0b8000 -        0x1ed1268bf  com.apple.RemoteManagement (1.0 - 2.0) <188F5CF7-9F04-31D3-8B90-BC265D5DD3BE> /System/Library/PrivateFrameworks/RemoteManagement.framework/Versions/A/RemoteManagement
+       0x1ed223000 -        0x1ed226b1f  libswiftCallKit.dylib (4) <92906365-AD9A-301A-9FB6-88F6CD6CC5A7> /usr/lib/swift/libswiftCallKit.dylib
+       0x22a86c000 -        0x22bee5067  com.apple.ANECompiler (9.509.0 - 9.509.0) <C1BFF6AE-BE81-34E5-A731-50AE4FB7BBB2> /System/Library/PrivateFrameworks/ANECompiler.framework/Versions/A/ANECompiler
+       0x22bee6000 -        0x22bef845f  com.apple.DeviceCheck (1.0 - 1) <AB272136-8CFB-3A49-AA60-B3FDAA13F27F> /System/Library/Frameworks/DeviceCheck.framework/Versions/A/DeviceCheck
+       0x22d4e2000 -        0x22d4e92a3  libCoreFSCache.dylib (352.1) <6B2BF8F5-A992-3C28-9BCE-CDC8E4D40E78> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
+       0x22d4ea000 -        0x22d4ef947  libCoreVMClient.dylib (352.1) <5E0DFF0A-81BA-36FB-9AD5-E3494D15B2CA> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+       0x22d4f0000 -        0x22d5002b7  com.apple.opengl (23.1.1 - 23.1.1) <E473AA13-611E-32CB-A676-213173E3AA9E> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+       0x22d501000 -        0x22d5037bf  libCVMSPluginSupport.dylib (23.1.1) <B2CF6AE8-6BAA-3374-BF7E-311343B0104D> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+       0x22d504000 -        0x22d50c4ff  libGFXShared.dylib (23.1.1) <C699C599-0DD8-302A-A96F-3C50B9BD5BC7> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+       0x22d50d000 -        0x22d54054b  libGLImage.dylib (23.1.1) <FC8B70C2-0EAE-303D-AF43-459CA7FB4B15> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+       0x22d541000 -        0x22d57a5bf  libGLU.dylib (23.1.1) <04FFC1B1-DD4D-3355-8EBD-FEA62D339822> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+       0x22d6d1000 -        0x22d6dabc7  libGL.dylib (23.1.1) <110554B2-60B8-39FE-B33B-27CE9F4E5F05> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+       0x22d85d000 -        0x22d8c5d1d  com.apple.opencl (5.5 - 5.5) <1F0A50C0-75CD-3F1B-8506-99506CD17EC3> /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
+       0x22da5c000 -        0x22da5cadf  com.apple.ARKit (1.0 - 746.100.3) <8629C7B5-58C7-34C6-8AA8-02ADDDA09A1A> /System/Library/Frameworks/ARKit.framework/Versions/A/ARKit
+       0x22da5d000 -        0x22db9f9ff  com.apple.audio.AVFAudio (1.0 - 743.508) <34A9C98B-A386-338F-A15D-2C67779545E6> /System/Library/Frameworks/AVFAudio.framework/Versions/A/AVFAudio
+       0x22dba1000 -        0x22dc1bebf  com.apple.AVRouting (1.0 - 1) <576595A2-3A85-353E-9074-2FDB8674966E> /System/Library/Frameworks/AVRouting.framework/Versions/A/AVRouting
+       0x22dd11000 -        0x22e26195f  com.apple.AppIntents (1.0 - 300.5.12.1.401) <E46A9791-C78A-3974-AD58-2CD35A649420> /System/Library/Frameworks/AppIntents.framework/Versions/A/AppIntents
+       0x22e7e2000 -        0x22e7e629f  com.apple.BrowserEngineCore (1.0 - 1) <68EEB6DC-2CFA-391A-8420-F2D60FB8CD4F> /System/Library/Frameworks/BrowserEngineCore.framework/Versions/A/BrowserEngineCore
+       0x22eef0000 -        0x22ef38fdf  com.apple.CoreTransferable (1.0.1 - 1) <E398822C-EF83-3364-91A9-1665F9E09655> /System/Library/Frameworks/CoreTransferable.framework/Versions/A/CoreTransferable
+       0x22f40b000 -        0x22f418bff  com.apple.DataDetection (8.0 - 821.7) <36F9E164-2A30-3480-8651-5B13BBD052C6> /System/Library/Frameworks/DataDetection.framework/Versions/A/DataDetection
+       0x22f422000 -        0x22f43975f  com.apple.dt.DeveloperToolsSupport (23.40.26 - 23.40.26) <5ED60A65-DE46-3C51-874D-608CFCED6A11> /System/Library/Frameworks/DeveloperToolsSupport.framework/Versions/A/DeveloperToolsSupport
+       0x22f43a000 -        0x22f4e2ebf  com.apple.DeviceActivity (3.0 - 392.5.1) <88492991-C2F7-330B-B6C9-220915445662> /System/Library/Frameworks/DeviceActivity.framework/Versions/A/DeviceActivity
+       0x22f56c000 -        0x22f6dff1f  com.apple.ExtensionFoundation (97 - 97) <A3567BE3-4AA2-3554-81AE-FE7EF41E535B> /System/Library/Frameworks/ExtensionFoundation.framework/Versions/A/ExtensionFoundation
+       0x22f6e0000 -        0x22f7227df  com.apple.ExtensionKit (97 - 97) <0C3BD3D1-6B5C-3552-8240-997931560350> /System/Library/Frameworks/ExtensionKit.framework/Versions/A/ExtensionKit
+       0x22f723000 -        0x22f78ed1f  com.apple.FSKit (1.0 - 1) <CCD4CA92-1CC5-3DA4-A107-D5AC3F5A5563> /System/Library/Frameworks/FSKit.framework/Versions/A/FSKit
+       0x22f7ed000 -        0x22fad6ddf  com.apple.FinanceKit (1.0 - 1) <18E37DDB-5CF2-3B60-AF8A-D7196635E01C> /System/Library/Frameworks/FinanceKit.framework/Versions/A/FinanceKit
+       0x22fe5e000 -        0x22fe6633f  com.apple.GeoToolbox (1.0 - 1) <6AD53CFA-669D-35D7-8A21-EB6E62E3D127> /System/Library/Frameworks/GeoToolbox.framework/Versions/A/GeoToolbox
+       0x230950000 -        0x230992a1f  com.apple.LightweightCodeRequirements (1.0 - 1) <DB4F053F-0498-30C7-B2B9-697925B9F03B> /System/Library/Frameworks/LightweightCodeRequirements.framework/Versions/A/LightweightCodeRequirements
+       0x230993000 -        0x2309d69df  com.apple.LiveCommunicationKit (1.0 - 1) <C808C987-4DF8-3A54-9239-64D278A01CB6> /System/Library/Frameworks/LiveCommunicationKit.framework/Versions/A/LiveCommunicationKit
+       0x2309d7000 -        0x2309ee49f  com.apple.LocalAuthenticationEmbeddedUI (1.0 - 2005.121.1) <1E37E05D-A26A-349C-88B2-FAF4703419D8> /System/Library/Frameworks/LocalAuthenticationEmbeddedUI.framework/Versions/A/LocalAuthenticationEmbeddedUI
+       0x230aca000 -        0x230b9731f  com.apple.ManagedSettings (267.120.4 - 267.120.4) <F9AF7374-6D3E-3E11-A2F3-83F9D7F288E9> /System/Library/Frameworks/ManagedSettings.framework/Versions/A/ManagedSettings
+       0x231740000 -        0x2317b41bf  com.apple.MetalFX (31.8 - 31.8) <91D2A0CD-EF16-32C6-95B5-818F6CEF0B72> /System/Library/Frameworks/MetalFX.framework/Versions/A/MetalFX
+       0x2317b6000 -        0x2317d41ff  com.apple.MPSBenchmarkLoop (1.0 - 1) <A8171300-A2FE-39A3-8166-5ED347A9CD56> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSBenchmarkLoop.framework/Versions/A/MPSBenchmarkLoop
+       0x2317d5000 -        0x2317e8e7f  com.apple.MPSFunctions (1.0 - 1) <C50883F0-037D-3888-BC83-5DC5EEE82345> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSFunctions.framework/Versions/A/MPSFunctions
+       0x2317e9000 -        0x2317ee53f  com.apple.MPSHost (1.0 - 1) <7A6AC05D-88B2-31A8-A0A7-F876BF0451B1> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSHost.framework/Versions/A/MPSHost
+       0x2317ef000 -        0x232b2683f  com.apple.MetalPerformanceShadersGraph (6.5.1 - 6.5.1) <2B46E751-D7E4-3728-AA48-1C621E58E7D1> /System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Versions/A/MetalPerformanceShadersGraph
+       0x2331d5000 -        0x23322b81f  com.apple.NearbyInteraction (1.0 - 524.0.7) <4014B446-81BC-3F11-982E-3C4098265F1D> /System/Library/Frameworks/NearbyInteraction.framework/Versions/A/NearbyInteraction
+       0x233af6000 -        0x233c2af3f  com.apple.QuickLookUIFramework (5.0 - 1018.5.5) <B33BF9E7-0B6D-3010-88AD-54E5A13CE94A> /System/Library/Frameworks/QuickLookUI.framework/Versions/A/QuickLookUI
+       0x2342d2000 -        0x2342daaff  com.apple.RelevanceKit (1.0 - 1) <794A8542-B771-3DCD-8FF3-6B19CD87292C> /System/Library/Frameworks/RelevanceKit.framework/Versions/A/RelevanceKit
+       0x234523000 -        0x23458155f  com.apple.ScreenCaptureKit (1) <E2E84DEA-8476-3EA3-93F6-0D10DD080DB0> /System/Library/Frameworks/ScreenCaptureKit.framework/Versions/A/ScreenCaptureKit
+       0x2345aa000 -        0x2346b08bf  com.apple.SensitiveContentAnalysis (1.0 - 1) <2F404DE6-F6C6-3289-BF3C-8CFD6D1055A3> /System/Library/Frameworks/SensitiveContentAnalysis.framework/Versions/A/SensitiveContentAnalysis
+       0x23475c000 -        0x234779c1f  com.apple.SharedWithYouCore (1.0 - 1) <E4A9C3D4-D234-39C3-8142-E20BFA6BC00B> /System/Library/Frameworks/SharedWithYouCore.framework/Versions/A/SharedWithYouCore
+       0x234a96000 -        0x234c024bf  com.apple.SwiftData (1.0 - 135) <69089200-C33B-348E-8E66-8C5954BCF335> /System/Library/Frameworks/SwiftData.framework/Versions/A/SwiftData
+       0x234c03000 -        0x235b5f91f  com.apple.SwiftUICore (7.5.3 - 7.5.3) <A8FC6D2D-DFE9-3557-A734-7F2B231F8C97> /System/Library/Frameworks/SwiftUICore.framework/Versions/A/SwiftUICore
+       0x235b60000 -        0x235b73e3f  com.apple.Symbols (1.0 - 190.4.0.1) <26F39A3A-F460-326C-8B9B-31AB95E32E84> /System/Library/Frameworks/Symbols.framework/Versions/A/Symbols
+       0x235b7a000 -        0x235cb8b5f  com.apple.DataFrame (1.0 - 52) <336816A3-0A7B-30AF-994D-6665D677523D> /System/Library/Frameworks/TabularData.framework/Versions/A/TabularData
+       0x235f17000 -        0x235f97c7f  com.apple.TipKit (26.5 - 120.5.1) <531B7F73-BC62-302C-9053-AA57FD90D002> /System/Library/Frameworks/TipKit.framework/Versions/A/TipKit
+       0x236080000 -        0x23610cc3f  com.apple.Translation (1.0 - 365.11) <BDAFAC25-C899-30A3-AB1F-E55574766C18> /System/Library/Frameworks/Translation.framework/Versions/A/Translation
+       0x23659d000 -        0x2368c59bf  libANGLE-shared.dylib (624.2.5.11.8) <FBE7CA87-07B2-3FDA-A1C6-C092B912678B> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/Frameworks/libANGLE-shared.dylib
+       0x236aa7000 -        0x236ab23bf  com.apple.-GeoToolbox-AppIntents (1.0 - 1) <9FEB8EEE-F2A6-3353-857B-3ACF5FED5668> /System/Library/Frameworks/_GeoToolbox_AppIntents.framework/Versions/A/_GeoToolbox_AppIntents
+       0x236aef000 -        0x236b19b5f  com.apple.CoreLocation.LocationEssentials (1.0 - 1) <7A1955ED-8083-32DC-801A-98997129A200> /System/Library/Frameworks/_LocationEssentials.framework/Versions/A/_LocationEssentials
+       0x23740f000 -        0x23743119f  com.apple.AAAFoundation (1.0 - 1) <9FDC378C-FD43-359A-B94F-B9D9E0CFC57F> /System/Library/PrivateFrameworks/AAAFoundation.framework/Versions/A/AAAFoundation
+       0x237432000 -        0x23749e8df  com.apple.AAAFoundationSwift (1.0 - 1) <8C7DD0A3-6F9E-302E-BF39-C18F63DBA23F> /System/Library/PrivateFrameworks/AAAFoundationSwift.framework/Versions/A/AAAFoundationSwift
+       0x237571000 -        0x23758347f  com.apple.siri.AIMLExperimentationAnalytics (1.0 - 1) <710DE7E4-4C92-3904-80DD-E877DF1F139B> /System/Library/PrivateFrameworks/AIMLExperimentationAnalytics.framework/Versions/A/AIMLExperimentationAnalytics
+       0x238742000 -        0x23879e43f  com.apple.ARKitCore (746.100.3 - 746.100.3) <5DE17ED4-5596-3A36-A199-1086069DFD4C> /System/Library/PrivateFrameworks/ARKitCore.framework/Versions/A/ARKitCore
+       0x2387ce000 -        0x2387d647f  com.apple.ARKitFoundation (746.100.3 - 746.100.3) <771B5AAB-693E-3C66-BAB8-4086FA1E94DD> /System/Library/PrivateFrameworks/ARKitFoundation.framework/Versions/A/ARKitFoundation
+       0x239a17000 -        0x239a9cd87  com.apple.AlgorithmsInternal (1.2 - 5026.5.5) <B427DB64-F570-3F26-8C82-C1D93FD7FC79> /System/Library/PrivateFrameworks/AlgorithmsInternal.framework/Versions/A/AlgorithmsInternal
+       0x239f75000 -        0x23a02637f  com.apple.AppIntentSchemas (1.0 - 3501.5.4) <366697B7-4CAC-3478-85A7-2C91578EEF17> /System/Library/PrivateFrameworks/AppIntentSchemas.framework/Versions/A/AppIntentSchemas
+       0x23a0f7000 -        0x23a39175f  com.apple.AppIntentsServices (1.0 - 40.5.2) <2AD12148-C127-3590-9191-941BA6556B09> /System/Library/PrivateFrameworks/AppIntentsServices.framework/Versions/A/AppIntentsServices
+       0x23a392000 -        0x23a3a3a1f  com.apple.appintents.AppIntentsTypeSupport (1.0 - 300.5.12.1.401) <A49570FF-4B50-35D7-A9F0-5F23D481576E> /System/Library/PrivateFrameworks/AppIntentsTypeSupport.framework/Versions/A/AppIntentsTypeSupport
+       0x23b443000 -        0x23b49825f  com.apple.AppleAccountUI (1.0 - 1) <3A7CCA25-D8CD-3211-B2B0-22867B40DCDC> /System/Library/PrivateFrameworks/AppleAccountUI.framework/Versions/A/AppleAccountUI
+       0x23b4df000 -        0x23b65be9f  com.apple.AppleDepth (158.0 - 158.0) <8ACBFD06-F5D9-31FF-8F05-0F8FC4C30A14> /System/Library/PrivateFrameworks/AppleDepth.framework/Versions/A/AppleDepth
+       0x23b65c000 -        0x23b6e0a7f  com.apple.AppleDepthCore (157.0 - 157.0) <D1025474-07FD-3A33-9145-4CDDA93C8C9C> /System/Library/PrivateFrameworks/AppleDepthCore.framework/Versions/A/AppleDepthCore
+       0x23b6e1000 -        0x23b6f5abf  com.apple.AppleDeviceQuerySupport (1.0 - 408.120.3) <B517FF44-3D3C-333E-BA06-5BF7F91B6D7E> /System/Library/PrivateFrameworks/AppleDeviceQuerySupport.framework/Versions/A/AppleDeviceQuerySupport
+       0x23b748000 -        0x23b76309f  com.apple.siri.flatbuffer.AppleFlatBuffers (1) <8FF1A6D7-BE15-3264-8A29-31BD77165298> /System/Library/PrivateFrameworks/AppleFlatBuffers.framework/Versions/A/AppleFlatBuffers
+       0x23bb1c000 -        0x23bbab5df  com.apple.proactive.AppleIntelligenceReporting (1.0 - 1) <8F94DA86-2C93-3D9B-9E9A-A990075206FF> /System/Library/PrivateFrameworks/AppleIntelligenceReporting.framework/Versions/A/AppleIntelligenceReporting
+       0x23bca2000 -        0x23be70b67  com.apple.cmphoto.AppleJPEGXL (1.0 - 1) <28D39AD4-0E3F-37A6-97E3-EDC13F236542> /System/Library/PrivateFrameworks/AppleJPEGXL.framework/Versions/A/AppleJPEGXL
+       0x23be71000 -        0x23beec1d6  com.apple.AppleKeyStore (1.0 - 1.0) <0DE316FC-3C90-3738-8C19-A74D6E247698> /System/Library/PrivateFrameworks/AppleKeyStore.framework/Versions/A/AppleKeyStore
+       0x23bf1b000 -        0x23c638e9f  com.apple.AppleMediaServicesKitInternal (1.5.3 - 1.5.3) <AE1D9D9F-38D9-303E-9721-2E0E3405007D> /System/Library/PrivateFrameworks/AppleMediaServicesKitInternal.framework/Versions/A/AppleMediaServicesKitInternal
+       0x23c818000 -        0x23c8309df  com.apple.private.AppleMobileFileIntegrity-fmk (1.0 - 1) <9B11DD7D-75DD-3784-945A-411BAED10953> /System/Library/PrivateFrameworks/AppleMobileFileIntegrity.framework/Versions/A/AppleMobileFileIntegrity
+       0x23c9c8000 -        0x23ca43ea7  com.apple.ArgumentParserInternal (1.0 - 1.20.2) <8D84DBA0-B8DB-3E02-99FB-A988759C1A86> /System/Library/PrivateFrameworks/ArgumentParserInternal.framework/Versions/A/ArgumentParserInternal
+       0x23ca5a000 -        0x23caeb97f  com.apple.AskToCore (1.0 - 1) <F4419C41-6332-3C3B-84DB-8E054CE04DA7> /System/Library/PrivateFrameworks/AskToCore.framework/Versions/A/AskToCore
+       0x23cc83000 -        0x23cd29564  com.apple.AsyncAlgorithmsInternal (1.0.0 - 5026.5.5) <AD33265F-750C-351F-81E5-7EC050E4E188> /System/Library/PrivateFrameworks/AsyncAlgorithmsInternal.framework/Versions/A/AsyncAlgorithmsInternal
+       0x23cd2a000 -        0x23cd3c799  com.apple.AtomicsInternal (1.1.0 - 5026.5.5) <5BFF8B6A-704D-3822-804F-ED870A72A295> /System/Library/PrivateFrameworks/AtomicsInternal.framework/Versions/A/AtomicsInternal
+       0x23cdf9000 -        0x23ce1bdff  com.apple.imgaudio.AudioAnalytics (1.0 - 1) <8B4F7F16-1296-3152-A4E2-A360ACAE9622> /System/Library/PrivateFrameworks/AudioAnalytics.framework/Versions/A/AudioAnalytics
+       0x23d185000 -        0x23d2883df  com.apple.AuthenticationServicesCore (1.0 - 21624.2.5.11.8) <1E2C59C7-6D07-3138-AB1E-92ED3257837A> /System/Library/PrivateFrameworks/AuthenticationServicesCore.framework/Versions/A/AuthenticationServicesCore
+       0x23d2d8000 -        0x23d2dafff  com.apple.AvailabilityKit (1.0 - 116.600.22) <FC04D43E-9233-3D46-8653-9D2F2F761467> /System/Library/PrivateFrameworks/AvailabilityKit.framework/Versions/A/AvailabilityKit
+       0x23d2db000 -        0x23d398ebf  com.apple.avatarkit (1.0 - 356.500) <6D4F0DDC-6429-38F3-BC83-A670E8DA51A6> /System/Library/PrivateFrameworks/AvatarKit.framework/Versions/A/AvatarKit
+       0x23d399000 -        0x23d399367  com.apple.AvatarKitContent (1.0 - 356.500) <4C58A473-400D-3DC5-AEA9-6D34F59800CD> /System/Library/PrivateFrameworks/AvatarKitContent.framework/Versions/A/AvatarKitContent
+       0x23d39a000 -        0x23d3e977f  com.apple.AvatarPersistence (1.0 - 395.500.1) <8C90D8E2-8128-32CE-A156-EC34854F55D4> /System/Library/PrivateFrameworks/AvatarPersistence.framework/Versions/A/AvatarPersistence
+       0x23d45d000 -        0x23d4a57df  com.apple.BackBoardHIDEventFoundation (1.0 - 1) <0F0C872C-C531-3898-95BF-3BF1817C87FC> /System/Library/PrivateFrameworks/BackBoardHIDEventFoundation.framework/Versions/A/BackBoardHIDEventFoundation
+       0x23d4a6000 -        0x23d4c85ff  com.apple.BackgroundSystemTasks (1.0 - 1) <F2F9357F-F37E-39A8-938A-6BFD7F8B21FA> /System/Library/PrivateFrameworks/BackgroundSystemTasks.framework/Versions/A/BackgroundSystemTasks
+       0x23d53e000 -        0x23d5578df  com.apple.biome.BiomeDSL (1.0 - 209.18) <F43D5A2A-4470-3827-8CCD-3E7AAA76242E> /System/Library/PrivateFrameworks/BiomeDSL.framework/Versions/A/BiomeDSL
+       0x23d558000 -        0x23de0a19f  com.apple.BiomeLibrary (274.57) <9C4145CD-3C99-35D4-930E-8F0BA4D34596> /System/Library/PrivateFrameworks/BiomeLibrary.framework/Versions/A/BiomeLibrary
+       0x23de0b000 -        0x23de10b5f  com.apple.biome.BiomeSync (1.0 - 209.18) <BD7C9096-8861-331A-BBD3-FC18BE64D611> /System/Library/PrivateFrameworks/BiomeSync.framework/Versions/A/BiomeSync
+       0x23e4d8000 -        0x23e50e69f  com.apple.CBORLibrary (1.0 - 1) <B958625D-8F3B-3087-9C52-23A0F6B579BC> /System/Library/PrivateFrameworks/CBORLibrary.framework/Versions/A/CBORLibrary
+       0x23e863000 -        0x23e86512f  com.apple.CMCaptureDevice (665.120.8) <9A228E12-CA6A-3654-93F1-92813D5EECD2> /System/Library/PrivateFrameworks/CMCaptureDevice.framework/Versions/A/CMCaptureDevice
+       0x23e928000 -        0x23eb3049f  com.apple.CMImaging (1.0 - 665.120.8) <6C681AFA-827C-30FB-9B1E-AD713C7EB29C> /System/Library/PrivateFrameworks/CMImaging.framework/Versions/A/CMImaging
+       0x23eb31000 -        0x23ecfb67f  com.apple.CMPhoto (1.0 - 1) <4A200CAC-2A3B-32B3-850F-B95DEC430F77> /System/Library/PrivateFrameworks/CMPhoto.framework/Versions/A/CMPhoto
+       0x23ed00000 -        0x23ed0dcdf  com.apple.spotlight.CSExattrCrypto (1.0 - 2418.5.9.101) <9D842ECD-3D7E-33D3-9C1D-176758D0205F> /System/Library/PrivateFrameworks/CSExattrCrypto.framework/Versions/A/CSExattrCrypto
+       0x23eeb2000 -        0x23ef707ff  com.apple.CalendarDaemon (1.0 - 1224.4.13) <CFD51E2B-0DD1-3B30-9728-9D15F131019F> /System/Library/PrivateFrameworks/CalendarDaemon.framework/Versions/A/CalendarDaemon
+       0x23ef71000 -        0x23f0a35ff  com.apple.CalendarDatabase (1.0 - 1269.4.7) <CDA91B79-A126-3C86-9BDA-4BAA2C83ACAA> /System/Library/PrivateFrameworks/CalendarDatabase.framework/Versions/A/CalendarDatabase
+       0x23f3aa000 -        0x23f3b7ebf  com.apple.CallsPersistence (1.0 - 1) <1CAE8003-5284-3061-9370-BA07554D879F> /System/Library/PrivateFrameworks/CallsPersistence.framework/Versions/A/CallsPersistence
+       0x23f3b8000 -        0x23f3c39bf  com.apple.CallsUtilities (1.0 - 1) <A3A065B0-10D7-34DD-B15B-760899DF035C> /System/Library/PrivateFrameworks/CallsUtilities.framework/Versions/A/CallsUtilities
+       0x23f3c4000 -        0x23f3e3a61  com.apple.CallsXPC (1.0 - 1) <6ED7211B-5BFB-3626-BCEA-5B5473080DF8> /System/Library/PrivateFrameworks/CallsXPC.framework/Versions/A/CallsXPC
+       0x23f441000 -        0x23f4d98bf  com.apple.biome.CascadeSets (1.0 - 209.18) <137A490E-E366-31C3-A126-FDB5550738F7> /System/Library/PrivateFrameworks/CascadeSets.framework/Versions/A/CascadeSets
+       0x23f4f5000 -        0x23f4facff  com.apple.Centauri (1.0 - 1) <417E41CB-BCBC-373E-A1E3-218FFE48E4BC> /System/Library/PrivateFrameworks/Centauri.framework/Versions/A/Centauri
+       0x23f53a000 -        0x23f556084  com.apple.cryptokit.Chirp (1.0 - 1) <C74EC6F1-FC4A-3B4E-AD0E-255D3895163E> /System/Library/PrivateFrameworks/Chirp.framework/Versions/A/Chirp
+       0x23f9ec000 -        0x23fa2459f  com.apple.CinematicFraming (1.0 - 665.120.8) <EDCAAA7E-E118-36B8-9FAD-32FBD0DDB270> /System/Library/PrivateFrameworks/CinematicFraming.framework/Versions/A/CinematicFraming
+       0x23fc87000 -        0x23fcf751f  com.apple.cloudkit.CloudAsset (2360.120.2) <5A05A302-0A39-354A-94FF-ADAE977F4EE9> /System/Library/PrivateFrameworks/CloudAsset.framework/Versions/A/CloudAsset
+       0x23ff1f000 -        0x23ff92a1f  com.apple.cloudkit.CloudCoreInternal (2360.120.2) <874A1637-CD2D-3687-8BA8-61F73FAA77EA> /System/Library/PrivateFrameworks/CloudCoreInternal.framework/Versions/A/CloudCoreInternal
+       0x2400c4000 -        0x2400d1c9f  com.apple.CloudSettings (1.0 - 1) <F79DE4D1-2093-3067-AE40-86AA9B2297DC> /System/Library/PrivateFrameworks/CloudSettings.framework/Versions/A/CloudSettings
+       0x24018e000 -        0x2402cae3f  com.apple.CloudSubscriptionFeatures (1.0 - 1.9) <233AB763-9428-30AA-828A-A0534F6569DE> /System/Library/PrivateFrameworks/CloudSubscriptionFeatures.framework/Versions/A/CloudSubscriptionFeatures
+       0x2402cb000 -        0x2402e0d3f  com.apple.CloudTelemetry (1.0 - 2350.100.2) <C10CB2CA-2694-3C1C-B7FE-89AC21701176> /System/Library/PrivateFrameworks/CloudTelemetry.framework/Versions/A/CloudTelemetry
+       0x2402e1000 -        0x2402ef9df  CloudTelemetryShared.dylib (2350.100.2) <56DC63F8-57D8-322F-9554-DAF156A80DBD> /System/Library/PrivateFrameworks/CloudTelemetryShared.dylib
+       0x2402f0000 -        0x24037e0ff  com.apple.CloudTelemetryTools (13.1.47 - 2350.100.2) <34AEC476-FE3E-3778-B75E-27DAECF4B27B> /System/Library/PrivateFrameworks/CloudTelemetryTools.framework/Versions/A/CloudTelemetryTools
+       0x24086c000 -        0x2408908ff  com.apple.CollectionViewCore (1.0 - 1) <80629747-CAF1-3B45-9CFE-E514124B2E18> /System/Library/PrivateFrameworks/CollectionViewCore.framework/Versions/A/CollectionViewCore
+       0x240891000 -        0x2409cf4ee  com.apple.CollectionsInternal (1.2.0 - 5026.5.5) <9691DBE8-E342-36B5-8BC3-65954843303A> /System/Library/PrivateFrameworks/CollectionsInternal.framework/Versions/A/CollectionsInternal
+       0x2409e9000 -        0x240ab07bf  com.apple.CommunicationTrust (1) <29052BFE-34DD-33A4-855A-9EC98461643C> /System/Library/PrivateFrameworks/CommunicationTrust.framework/Versions/A/CommunicationTrust
+       0x240b00000 -        0x240b2f63f  com.apple.wakeboard.CompositorNonUI (420.100.10) <1844410C-E747-38FC-A94E-4500A5C06D41> /System/Library/PrivateFrameworks/CompositorNonUI.framework/Versions/A/CompositorNonUI
+       0x240e09000 -        0x240e3cdbf  com.apple.contacts.ContactsAccounts (1.0 - 1) <CB98560D-6927-3766-87A8-B648908428CE> /System/Library/PrivateFrameworks/ContactsAccounts.framework/Versions/A/ContactsAccounts
+       0x240e3d000 -        0x240e40ddf  com.apple.contacts.ContactsMetrics (1 - 21.500.21) <9BC801BF-65A0-3536-85DD-ACF5E65DC8D8> /System/Library/PrivateFrameworks/ContactsMetrics.framework/Versions/A/ContactsMetrics
+       0x240f87000 -        0x240f8c03f  com.apple.contextkit.ContextKitCore (1.0 - 1) <8739E5AA-01EB-3224-B2AA-D6B8C0861A6C> /System/Library/PrivateFrameworks/ContextKitCore.framework/Versions/A/ContextKitCore
+       0x242c8b000 -        0x242d28fff  com.apple.audio.coreaudio.Stravinsky (1.0 - 1) <33EF50E8-AA33-37FE-BC1E-096CCF01327F> /System/Library/PrivateFrameworks/CoreAudioOrchestration.framework/Versions/A/CoreAudioOrchestration
+       0x242dd2000 -        0x242ef4e3f  com.apple.CoreComposite (1.0 - 330.100.6) <728808EE-65BB-3817-B9A5-242EC3163358> /System/Library/PrivateFrameworks/CoreComposite.framework/Versions/A/CoreComposite
+       0x246b35000 -        0x246c3afbf  com.apple.CoreSceneUnderstanding (1.74.0 - 1.74.0) <0114E093-74B6-3A92-BE21-B89C2C4BB502> /System/Library/PrivateFrameworks/CoreSceneUnderstanding.framework/Versions/A/CoreSceneUnderstanding
+       0x246e30000 -        0x246e528b3  com.apple.CoreTransparency (1.0 - 1) <B30A24A6-8307-33F6-806C-DF03990DF212> /System/Library/PrivateFrameworks/CoreTransparency.framework/Versions/A/CoreTransparency
+       0x246e53000 -        0x246e7b0bf  com.apple.CoreUtilsExtras (1.0 - 1) <472AD81F-46BC-3097-B6FB-3280DE9D0568> /System/Library/PrivateFrameworks/CoreUtilsExtras.framework/Versions/A/CoreUtilsExtras
+       0x24739c000 -        0x247458bdf  com.apple.security.CryptoKit-Private (1.0 - 1) <1F1B7999-4A4D-3CE9-B7B8-880227616365> /System/Library/PrivateFrameworks/CryptoKitPrivate.framework/Versions/A/CryptoKitPrivate
+       0x24746d000 -        0x2474777df  com.apple.devicemanagementclient.DEPClientLibrary (1.0 - 1) <958C0BD9-740E-3C44-96BA-3FD9B6B7E387> /System/Library/PrivateFrameworks/DEPClientLibrary.framework/Versions/A/DEPClientLibrary
+       0x24749a000 -        0x2474ded9f  com.apple.devicemanagementclient.DMCEnrollmentLibrary (1.0 - 1) <1E7005D7-0956-3345-9771-B01B3001CA62> /System/Library/PrivateFrameworks/DMCEnrollmentLibrary.framework/Versions/A/DMCEnrollmentLibrary
+       0x24750b000 -        0x2475599df  com.apple.devicemanagementclient.DMCUtilities (1.0 - 1) <33F4B8B1-899B-3952-BEAA-592764FB8B17> /System/Library/PrivateFrameworks/DMCUtilities.framework/Versions/A/DMCUtilities
+       0x2475d6000 -        0x2475dd9bf  com.apple.darwinup-framework (1.0 - 302.100.21) <5C885C5C-04EA-3FC6-9CBC-55F26D6F2237> /System/Library/PrivateFrameworks/Darwinup.framework/Versions/A/Darwinup
+       0x247710000 -        0x247753c9f  com.apple.dataaccess.dataaccessexpress.framework (1.0 - 1.0) <AB885C97-1219-3833-B831-17C627D21490> /System/Library/PrivateFrameworks/DataAccessExpress.framework/Versions/A/DataAccessExpress
+       0x2479ab000 -        0x247a1ae7f  com.apple.aiml.dendrite.Dendrite (1.0 - 1) <D756E55D-B0B1-3858-930D-013952652E35> /System/Library/PrivateFrameworks/Dendrite.framework/Versions/A/Dendrite
+       0x247a1b000 -        0x247b98aff  com.apple.DesignLibrary (7.5.2 - 7.5.2) <4A4E8FA7-6AC3-3D6B-B377-FD39089726BA> /System/Library/PrivateFrameworks/DesignLibrary.framework/Versions/A/DesignLibrary
+       0x247f3a000 -        0x247f4d49f  com.apple.DeviceRecovery (1.0 - 1) <785D04A0-C0D8-3364-BDA5-560381C6553E> /System/Library/PrivateFrameworks/DeviceRecovery.framework/Versions/A/DeviceRecovery
+       0x248118000 -        0x24836537f  com.apple.DiskImages2 (524.120.8 - 524.120.8) <6DCB617F-4A73-3179-A2FE-2D7DD3094100> /System/Library/PrivateFrameworks/DiskImages2.framework/Versions/A/DiskImages2
+       0x248371000 -        0x24838767f  com.apple.DistributedSensing (1.0 - 1) <A854A5CE-F7B0-30A5-8B73-44315872B590> /System/Library/PrivateFrameworks/DistributedSensing.framework/Versions/A/DistributedSensing
+       0x24846d000 -        0x2484dbbbf  com.apple.DoNotDisturb (1.0 - 468.5.5) <163DDE4C-6FAF-355E-A44C-4CD39AD1E96B> /System/Library/PrivateFrameworks/DoNotDisturb.framework/Versions/A/DoNotDisturb
+       0x249280000 -        0x2492813bf  com.apple.private.FaceTimeNameUtility (1.0 - 1) <CC09837F-9F8A-3534-AA75-A238E79EFC63> /System/Library/PrivateFrameworks/FaceTimeNameUtility.framework/Versions/A/FaceTimeNameUtility
+       0x2496f6000 -        0x2497b233f  com.apple.FeedbackService (1.0 - 1) <E49AE121-D25B-332F-960F-CF796B1D7080> /System/Library/PrivateFrameworks/FeedbackService.framework/Versions/A/FeedbackService
+       0x24991e000 -        0x2499e057f  com.apple.findmy.framework.FindMyBase (1.0 - 84.25.2.23.2) <CDC7A01E-3039-3EB8-8707-280E0B4B71ED> /System/Library/PrivateFrameworks/FindMyBase.framework/Versions/A/FindMyBase
+       0x249b4b000 -        0x249b65a5f  com.apple.findmy.framework.FindMyCommon (1.0 - 84.25.2.23.2) <A3F3D65B-041E-371A-ABDF-16CA6292FC67> /System/Library/PrivateFrameworks/FindMyCommon.framework/Versions/A/FindMyCommon
+       0x249c77000 -        0x249dcbb9f  com.apple.findmy.framework.FindMyLocate (1.0 - 1.0) <931359F1-CC37-3CD2-A127-0C6782EE4280> /System/Library/PrivateFrameworks/FindMyLocate.framework/Versions/A/FindMyLocate
+       0x24a00f000 -        0x24a06253f  com.apple.UIKit.FocusEngine (9126.5.5.2.401) <C716E32C-081D-3C43-B660-C96B9A057E4E> /System/Library/PrivateFrameworks/FocusEngine.framework/Versions/A/FocusEngine
+       0x24a1d8000 -        0x24a1db2ff  com.apple.FontServices (1.0 - 1) <A46AB82E-AF94-37A8-A8D8-48B6689934EB> /System/Library/PrivateFrameworks/FontServices.framework/Versions/A/FontServices
+       0x24a1dc000 -        0x24a2cbe2f  libXTFontStaticRegistryData.dylib (335.4.0.6) <9092FEA3-2DFB-32A9-BEFB-01B43E166C48> /System/Library/PrivateFrameworks/FontServices.framework/libXTFontStaticRegistryData.dylib
+       0x24a2cd000 -        0x24a2d9c9f  com.apple.FramePacing (1.0 - 1) <0CEB865C-17EB-3C26-B9C0-CE3689942DB2> /System/Library/PrivateFrameworks/FramePacing.framework/Versions/A/FramePacing
+       0x24a2da000 -        0x24a39b37f  com.apple.FrontBoard (1000.4.11 - 1000.4.11) <77495253-204F-3556-BC19-3F42134AB49C> /System/Library/PrivateFrameworks/FrontBoard.framework/Versions/A/FrontBoard
+       0x24a39c000 -        0x24a3e731f  com.apple.FusionTracker (1.0 - 1) <EE7C5B1B-FA1E-30BA-B176-7C19061EA27F> /System/Library/PrivateFrameworks/FusionTracker.framework/Versions/A/FusionTracker
+       0x24b3fb000 -        0x24b400f07  libGPUCompilerUtils.dylib (32023.884) <C4FEB8D0-1E65-3664-8CBE-0FFAB464AABC> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/libGPUCompilerUtils.dylib
+       0x24f86e000 -        0x24f8ad797  libllvm-flatbuffers.dylib (32023.884) <DA37B086-97F7-3DC1-AA07-442AECCB1666> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/libllvm-flatbuffers.dylib
+       0x24fe0c000 -        0x24ff8ed7f  com.apple.GRDB.GRDBInternal (1.0 - 15.0.0.1) <B254F4DF-0E17-3928-B137-C07A5C5D9201> /System/Library/PrivateFrameworks/GRDBInternal.framework/Versions/A/GRDBInternal
+       0x252f7a000 -        0x252fc77a6  com.apple.GenerativeFunctions.GenerativeFunctions (1.0 - 222.43.2) <F5148B2B-B8E3-319C-B872-8C17ABFF3EEA> /System/Library/PrivateFrameworks/GenerativeFunctions.framework/Versions/A/GenerativeFunctions
+       0x252fc8000 -        0x25305d87f  com.apple.GenerativeFunctions.GenerativeFunctionsFoundation (1.0 - 222.43.2) <295895F9-C36B-38A5-919E-BD3886C398E7> /System/Library/PrivateFrameworks/GenerativeFunctionsFoundation.framework/Versions/A/GenerativeFunctionsFoundation
+       0x25305e000 -        0x2530c397f  com.apple.GenerativeFunctions.GenerativeFunctionsInstrumentation (1.0 - 222.43.2) <34C773F4-A242-341E-9D74-444B3823996A> /System/Library/PrivateFrameworks/GenerativeFunctionsInstrumentation.framework/Versions/A/GenerativeFunctionsInstrumentation
+       0x2530c4000 -        0x2531a5f5f  com.apple.GenerativeFunctions.GenerativeModels (1.0 - 222.43.2) <CDA2383C-99CD-3CDA-A7B2-90D4F49DC4F8> /System/Library/PrivateFrameworks/GenerativeModels.framework/Versions/A/GenerativeModels
+       0x2531a6000 -        0x25321bb9f  com.apple.GenerativeFunctions.GenerativeModelsFoundation (1.0 - 222.43.2) <29B92FD1-0D24-3740-8505-1ED53C637B24> /System/Library/PrivateFrameworks/GenerativeModelsFoundation.framework/Versions/A/GenerativeModelsFoundation
+       0x2532eb000 -        0x2533c027f  com.apple.GeoAnalytics (1.0 - 2031.25.2.9.19) <1063B3F7-483B-3994-A6F2-9C0FB279172C> /System/Library/PrivateFrameworks/GeoAnalytics.framework/Versions/A/GeoAnalytics
+       0x2533c1000 -        0x2533c633f  com.apple.GeoServices (1.0 - 2031.25.2.9.19) <2C893011-4B21-3C52-93D3-A98389345462> /System/Library/PrivateFrameworks/GeoServicesCore.framework/Versions/A/GeoServicesCore
+       0x25356f000 -        0x253632e9f  com.apple.Gestures (9126.1.5 - 9126.1.5) <C2F508D2-F7D8-3669-8D0D-327D9E32EA68> /System/Library/PrivateFrameworks/Gestures.framework/Versions/A/Gestures
+       0x2565cf000 -        0x25661ebbf  com.apple.IASUtilitiesCore (1.0 - 1) <5631E059-40C8-32B8-859F-922A8296B6FB> /System/Library/PrivateFrameworks/IASUtilitiesCore.framework/Versions/A/IASUtilitiesCore
+       0x25669a000 -        0x2566fb31f  com.apple.IO80211 (1.0 - 1) <80913D69-F644-3144-82F6-0F2671912CDC> /System/Library/PrivateFrameworks/IO80211.framework/Versions/A/IO80211
+       0x256705000 -        0x25670f83f  com.apple.IPConfiguration (1.21 - 1.21) <0F52D88C-E4E1-3D6F-AB71-2CB66EC95079> /System/Library/PrivateFrameworks/IPConfiguration.framework/Versions/A/IPConfiguration
+       0x256745000 -        0x2567b607f  com.apple.cocoa.IconRendering (1.0 - 92.2) <F3EAE585-A558-35A0-B4C4-292B4AA69200> /System/Library/PrivateFrameworks/IconRendering.framework/Versions/A/IconRendering
+       0x2567be000 -        0x2567eae5f  com.apple.ImageCaptureDevices (2020.2.2 - 2020.2.2) <363B30F9-BD69-3AC3-88A7-9F75709EAAFB> /System/Library/PrivateFrameworks/ImageCaptureDevices.framework/Versions/A/ImageCaptureDevices
+       0x256f98000 -        0x256fd243f  com.apple.InputAnalytics (1.0 - 111.5.1) <750740F4-D540-3056-B503-E24B6EB69E65> /System/Library/PrivateFrameworks/InputAnalytics.framework/Versions/A/InputAnalytics
+       0x25718c000 -        0x2572952df  com.apple.InstalledContentLibrary (1.0 - 1.0) <AEEEDDBF-FCD1-3251-B0E9-940CE296B1E1> /System/Library/PrivateFrameworks/InstalledContentLibrary.framework/Versions/A/InstalledContentLibrary
+       0x259bb7000 -        0x25a385cbf  com.apple.IntelligencePlatformLibrary (274.57) <A1865439-B63E-3211-A2C4-DAE7F7D25698> /System/Library/PrivateFrameworks/IntelligencePlatformLibrary.framework/Versions/A/IntelligencePlatformLibrary
+       0x25a528000 -        0x25a532fdf  com.apple.IsolatedContextLogging (1.0 - 1) <8C899A23-C8D1-3F21-9B80-B7094E4EEA03> /System/Library/PrivateFrameworks/IsolatedContextLogging.framework/Versions/A/IsolatedContextLogging
+       0x25a533000 -        0x25a56ab5f  com.apple.audio.CoreAudio.IsolatedCoreAudioClient (1.0 - 1) <EA66F16C-573E-31B9-BFDD-630759C13583> /System/Library/PrivateFrameworks/IsolatedCoreAudioClient.framework/Versions/A/IsolatedCoreAudioClient
+       0x25a887000 -        0x25a8a2b3f  com.apple.JetPack-Mac (1.0 - 1) <40FB0179-32CB-3A83-85BC-944CD36FB968> /System/Library/PrivateFrameworks/JetPack.framework/Versions/A/JetPack
+       0x25ae61000 -        0x25afb683f  com.apple.LiftUI (1.2 - 1) <F834F25A-51AC-365D-B363-E5EDE699F4F9> /System/Library/PrivateFrameworks/LiftUI.framework/Versions/A/LiftUI
+       0x25b50c000 -        0x25b68ed5f  com.apple.LinkMetadata (1.0 - 300.5.12.1.401) <CA515246-F6E2-34C1-9745-096A8AF07C26> /System/Library/PrivateFrameworks/LinkMetadata.framework/Versions/A/LinkMetadata
+       0x25b68f000 -        0x25b6bdf44  com.apple.LinkPresentation.StyleSheetParsing (296 - 296.11) <B4D9D566-3F8D-3474-82F5-B3863E5EAAC9> /System/Library/PrivateFrameworks/LinkPresentationStyleSheetParsing.framework/Versions/A/LinkPresentationStyleSheetParsing
+       0x25b6be000 -        0x25b86af9f  com.apple.LinkServices (1.0 - 300.5.12.1.401) <9874D6EB-BB09-3353-ABF3-261DFDD7C834> /System/Library/PrivateFrameworks/LinkServices.framework/Versions/A/LinkServices
+       0x25b8fc000 -        0x25ba8201f  com.apple.LocalAuthenticationCore (2005.121.1) <FA1E84A2-86C9-3C13-91CE-CD61E13841F0> /System/Library/PrivateFrameworks/LocalAuthenticationCore.framework/Versions/A/LocalAuthenticationCore
+       0x25ba83000 -        0x25bac34df  com.apple.LocalAuthenticationCoreUI (2005.121.1) <C001E65F-461D-310A-BC52-35335BAE2D5A> /System/Library/PrivateFrameworks/LocalAuthenticationCoreUI.framework/Versions/A/LocalAuthenticationCoreUI
+       0x25bac4000 -        0x25bae367f  com.apple.LocalAuthenticationCredentialServices (2005.121.1) <64835CFD-5623-3048-8068-0D9682991E06> /System/Library/PrivateFrameworks/LocalAuthenticationCredentialServices.framework/Versions/A/LocalAuthenticationCredentialServices
+       0x25bb21000 -        0x25bb44f7f  com.apple.internal.LocalStatusKit (1.0 - 1) <D0BA2981-5DE3-3A74-BD54-286627BCC2E0> /System/Library/PrivateFrameworks/LocalStatusKit.framework/Versions/A/LocalStatusKit
+       0x25bb49000 -        0x25bb4d5df  com.apple.CoreLocation.LocationLogEncryption (3075.0.8) <636A785A-BBFF-35F1-AA43-3290CB5B1B52> /System/Library/PrivateFrameworks/LocationLogEncryption.framework/Versions/A/LocationLogEncryption
+       0x25bb4e000 -        0x25bb54a9f  com.apple.LockdownMode (1.0 - 1) <CDFAD3CC-ADD5-3ACE-A290-C8E8271EF769> /System/Library/PrivateFrameworks/LockdownMode.framework/Versions/A/LockdownMode
+       0x25bbdd000 -        0x25bc0d83f  com.apple.devicemanagementclient.MDMClientLibrary (1.0 - 1) <3C575A9A-D56A-325D-90ED-C09CAFEA58CC> /System/Library/PrivateFrameworks/MDMClientLibrary.framework/Versions/A/MDMClientLibrary
+       0x25bc67000 -        0x25c2fd923  com.apple.MIL (3520.4 - 3520.4.1) <43AB1D6B-D19B-3115-A2C0-25DF31A5786E> /System/Library/PrivateFrameworks/MIL.framework/Versions/A/MIL
+       0x25c2fe000 -        0x25c37b03f  com.apple.CoreML.MLAssetIO (1.0 - 3520.5.1) <5A718D4F-A715-3E8E-B183-028B85782127> /System/Library/PrivateFrameworks/MLAssetIO.framework/Versions/A/MLAssetIO
+       0x25c37c000 -        0x25c3d5b0f  com.apple.mlcompiler.runtime (3404.3.1 - 3404.3.1) <7C122FB8-637B-3B9E-B6FF-24EED19DB892> /System/Library/PrivateFrameworks/MLCompilerRuntime.framework/Versions/A/MLCompilerRuntime
+       0x25c3d6000 -        0x25c3ef827  com.apple.mlcompiler.services (3404.3.1 - 3404.3.1) <4700B48E-67D3-37D8-8E47-450F26D611B1> /System/Library/PrivateFrameworks/MLCompilerServices.framework/Versions/A/MLCompilerServices
+       0x25f063000 -        0x25f07a31f  com.apple.ggml.ModelAsset (1.0 - 1) <18B57D17-6586-3414-9DAF-7507B843A378> /System/Library/PrivateFrameworks/MLModelAsset.framework/Versions/A/MLModelAsset
+       0x25faf2000 -        0x25faf7d3f  com.apple.ManagedOrganizationContacts (1.2 - 151.5) <D3AC742F-9725-3809-A2CE-581A15A89162> /System/Library/PrivateFrameworks/ManagedOrganizationContacts.framework/Versions/A/ManagedOrganizationContacts
+       0x25faf8000 -        0x25fb3c23f  com.apple.ManagedSettingsObjC (267.120.4 - 267.120.4) <A67AC9B0-8E1A-3CFC-976E-31AE0FE3355A> /System/Library/PrivateFrameworks/ManagedSettingsObjC.framework/Versions/A/ManagedSettingsObjC
+       0x25fb3d000 -        0x25fb4781f  com.apple.ManagedSettingsSupport (267.120.4 - 267.120.4) <8F9BD4FE-0786-3B2D-813D-FF21F129C788> /System/Library/PrivateFrameworks/ManagedSettingsSupport.framework/Versions/A/ManagedSettingsSupport
+       0x2603ed000 -        0x26044eaff  com.apple.MediaAnalysisServices (1.0 - 1) <732B1A8A-E1B0-3F4A-B574-00EB6B64497E> /System/Library/PrivateFrameworks/MediaAnalysisServices.framework/Versions/A/MediaAnalysisServices
+       0x260e73000 -        0x260ed4abf  com.apple.MessageSecurity (1.0 - 195.121.2) <0BAED8A7-51DE-39EE-9686-893CE0916B1B> /System/Library/PrivateFrameworks/MessageSecurity.framework/Versions/A/MessageSecurity
+       0x261e04000 -        0x2620a113f  com.apple.ModelCatalog.ModelCatalog (1.0 - 233.38) <0D097B2C-EE63-3818-B0A8-067D9EC25E6C> /System/Library/PrivateFrameworks/ModelCatalog.framework/Versions/A/ModelCatalog
+       0x26213e000 -        0x2622d63ff  com.apple.ModelManagerServices (1.0 - 1) <74755FB7-F70A-3190-86F9-6ECE22F2204D> /System/Library/PrivateFrameworks/ModelManagerServices.framework/Versions/A/ModelManagerServices
+       0x264e29000 -        0x264eb09bf  com.apple.calls.NeighborhoodActivityConduit (1.0 - 1) <48BF1D29-6915-3EE0-A766-40288A174076> /System/Library/PrivateFrameworks/NeighborhoodActivityConduit.framework/Versions/A/NeighborhoodActivityConduit
+       0x265430000 -        0x26543785f  com.apple.NewsURLBucket (1.0 - 1) <5FB7567D-8DB0-3541-BCF4-917EA6BA1DFF> /System/Library/PrivateFrameworks/NewsURLBucket.framework/Versions/A/NewsURLBucket
+       0x265c56000 -        0x265ece3df  com.apple.mlpt.ODIE (1.0 - 1) <83ADD501-DE86-312A-AA82-AE2323CD1317> /System/Library/PrivateFrameworks/ODIE.framework/Versions/A/ODIE
+       0x265ed4000 -        0x265efdb1f  com.apple.OSEligibility (319.121.1) <5C282C8D-F611-3A3F-B0C2-A9F376FE029F> /System/Library/PrivateFrameworks/OSEligibility.framework/Versions/A/OSEligibility
+       0x266b60000 -        0x266c7885f  com.apple.ParsingInternal (0.0.1 - 5026.5.5) <7FD0C201-E1CC-3F69-AD54-681B3CD37313> /System/Library/PrivateFrameworks/ParsingInternal.framework/Versions/A/ParsingInternal
+       0x267260000 -        0x26726fa1f  com.apple.PassKitMacHelperTemp (1.0 - 1642.6.5) <BD673218-A22C-353B-B340-ABFE93B4065A> /System/Library/PrivateFrameworks/PassKitMacHelperTemp.framework/Versions/A/PassKitMacHelperTemp
+       0x267947000 -        0x268702c3f  com.apple.PegasusAPI (1.0 - 3525.4.2) <F9E65E73-36C2-3E58-8B67-6AF3F4752971> /System/Library/PrivateFrameworks/PegasusAPI.framework/Versions/A/PegasusAPI
+       0x268703000 -        0x268761bdf  com.apple.PegasusConfiguration (1.0 - 15000) <8CC113CD-5E95-3D7D-B0C1-76BD743CF117> /System/Library/PrivateFrameworks/PegasusConfiguration.framework/Versions/A/PegasusConfiguration
+       0x268d2f000 -        0x268e638ff  com.apple.PhotoLibraryServicesCore (1.0 - 851.0.103) <0BA45E14-F9D0-3576-AA15-C4B75147E9C3> /System/Library/PrivateFrameworks/PhotoLibraryServicesCore.framework/Versions/A/PhotoLibraryServicesCore
+       0x2698dc000 -        0x2699356bf  com.apple.PhotosIntelligenceCore (1.0 - 851.0.103) <0DA85298-5CF2-378A-B69C-6817A5E27131> /System/Library/PrivateFrameworks/PhotosIntelligenceCore.framework/Versions/A/PhotosIntelligenceCore
+       0x26a00d000 -        0x26a02ee1f  com.apple.accessibility.PhotosensitivityProcessing (1.0 - 1) <EA136E97-3E2F-371B-A65D-A0BD5E1898D8> /System/Library/PrivateFrameworks/PhotosensitivityProcessing.framework/Versions/A/PhotosensitivityProcessing
+       0x26a071000 -        0x26a15e4bf  com.apple.PlatformSSO (1.0 - 483.120.4) <C0FF84DE-F0AB-3CFA-A9DE-E29F376A58BA> /System/Library/PrivateFrameworks/PlatformSSO.framework/Versions/A/PlatformSSO
+       0x26a15f000 -        0x26a27005f  com.apple.PlatformSSOCore (1.0 - 483.120.4) <272E528F-1762-323C-AE86-56F4114F1E5E> /System/Library/PrivateFrameworks/PlatformSSOCore.framework/Versions/A/PlatformSSOCore
+       0x26a421000 -        0x26a45da3c  com.apple.PoirotSQLite (1.0 - 1) <F6CD54D6-1342-3624-9949-5690E8135D66> /System/Library/PrivateFrameworks/PoirotSQLite.framework/Versions/A/PoirotSQLite
+       0x26a45e000 -        0x26a4cb25f  com.apple.PoirotSchematizer (1.0 - 1) <31B04A5B-1569-37D6-B5E3-22CA260A9A41> /System/Library/PrivateFrameworks/PoirotSchematizer.framework/Versions/A/PoirotSchematizer
+       0x26a4cc000 -        0x26a501bff  com.apple.PoirotUDFs (1.0 - 1) <257AE39F-8DAA-36F7-A806-1A38920A0131> /System/Library/PrivateFrameworks/PoirotUDFs.framework/Versions/A/PoirotUDFs
+       0x26a502000 -        0x26a611a3f  com.apple.portrait.Portrait (1.0 - 18) <079264FA-9B47-3A19-8900-B84102B5C3D4> /System/Library/PrivateFrameworks/Portrait.framework/Versions/A/Portrait
+       0x26a6c3000 -        0x26a72aa9f  com.apple.PosterFoundation (1.0 - 1) <A95AA72B-3BFE-3250-A6FB-FAC8DB66E140> /System/Library/PrivateFrameworks/PosterFoundation.framework/Versions/A/PosterFoundation
+       0x26a72b000 -        0x26a75027f  com.apple.PosterFuturesKit (1.0 - 1) <F5849401-AB0E-3817-A502-3E83700DBAD7> /System/Library/PrivateFrameworks/PosterFuturesKit.framework/Versions/A/PosterFuturesKit
+       0x26a751000 -        0x26a75f71f  com.apple.PosterModel (1.0 - 1) <7573A9AB-8595-388C-94F0-7544315CD438> /System/Library/PrivateFrameworks/PosterModel.framework/Versions/A/PosterModel
+       0x26b69a000 -        0x26b7d611f  com.apple.ProDisplayLibrary (10.4.28 - 10.4.28) <C91E3E87-39F7-3515-8D68-33537486959D> /System/Library/PrivateFrameworks/ProDisplayLibrary.framework/Versions/A/ProDisplayLibrary
+       0x26b839000 -        0x26b86659f  com.apple.intelligenceflow.ProactiveDaemonSupport (1.0 - 3525.11.14) <E58BABD0-40BD-3A45-A45D-B918EB6F7431> /System/Library/PrivateFrameworks/ProactiveDaemonSupport.framework/Versions/A/ProactiveDaemonSupport
+       0x26be22000 -        0x26bfd195f  com.apple.GenerativeFunctions.PromptKit (1.0 - 222.43.2) <4BA07886-A309-3C61-8242-59D53F74E07C> /System/Library/PrivateFrameworks/PromptKit.framework/Versions/A/PromptKit
+       0x26c6e8000 -        0x26c7040ff  com.apple.RecapPerformanceTesting (50 - 50.0) <F6FAEA9C-75B9-3553-BC0E-AA2122B44A48> /System/Library/PrivateFrameworks/RecapPerformanceTesting.framework/Versions/A/RecapPerformanceTesting
+       0x26c790000 -        0x26c7984df  com.apple.ReflectionInternal (1.0.0 - 5026.5.5) <EA5C8DB0-0187-3AB8-80B0-5AC888E8CDB1> /System/Library/PrivateFrameworks/ReflectionInternal.framework/Versions/A/ReflectionInternal
+       0x26c799000 -        0x26c7b399f  com.apple.RegulatoryDomainFramework (1.0 - 1) <CBA10187-9554-3FD9-8250-0371A903E08F> /System/Library/PrivateFrameworks/RegulatoryDomain.framework/Versions/A/RegulatoryDomain
+       0x26cad7000 -        0x26cb5b9df  com.apple.RemoteManagementModel (1.0 - 2.0) <36A755E6-BA39-38FD-9579-0CED3ED27AF6> /System/Library/PrivateFrameworks/RemoteManagementModel.framework/Versions/A/RemoteManagementModel
+       0x26cb5c000 -        0x26cb6725f  com.apple.RemoteManagementProtocol (1.0 - 2.0) <7D6403CE-ABA5-3FC4-A528-1F31FA564C04> /System/Library/PrivateFrameworks/RemoteManagementProtocol.framework/Versions/A/RemoteManagementProtocol
+       0x26cb68000 -        0x26cbc075f  com.apple.RemoteManagementStore (1.0 - 2.0) <6E7A4087-BFCB-3E8A-A930-B1CFEA351FFE> /System/Library/PrivateFrameworks/RemoteManagementStore.framework/Versions/A/RemoteManagementStore
+       0x26cbd1000 -        0x26ceec1ff  com.apple.RemoteUI (1.0 - 4) <9D7840FD-B57A-3DAE-A529-F07F59D4695D> /System/Library/PrivateFrameworks/RemoteUI.framework/Versions/A/RemoteUI
+       0x26cf8b000 -        0x26d145d1f  com.apple.private.ReplicatorEngine (1.0 - 1) <29048A56-9861-3088-8FFA-18DB61814F37> /System/Library/PrivateFrameworks/ReplicatorEngine.framework/Versions/A/ReplicatorEngine
+       0x26d146000 -        0x26d2a131f  com.apple.private.ReplicatorServices (1.0 - 1) <75C836E2-5A7B-3DDE-BB73-383C7A5497FF> /System/Library/PrivateFrameworks/ReplicatorServices.framework/Versions/A/ReplicatorServices
+       0x26d6e3000 -        0x26d6f69d7  com.apple.RuntimeInternal (1.0.0 - 5026.5.5) <04ADBC99-92B0-32EE-98A8-A4D73DCCCE6C> /System/Library/PrivateFrameworks/RuntimeInternal.framework/Versions/A/RuntimeInternal
+       0x26d71b000 -        0x26d731aff  com.apple.SESShared (1.0 - 1) <342DB4E4-AF7B-3595-80A4-CFC62FB7264B> /System/Library/PrivateFrameworks/SESShared.framework/Versions/A/SESShared
+       0x26d7a4000 -        0x26d8ae5bf  com.apple.seservice (1.0 - 1) <12EEB6B9-8473-3DA9-8E46-895F17D180A1> /System/Library/PrivateFrameworks/SEService.framework/Versions/A/SEService
+       0x26d8af000 -        0x26d934a3f  com.apple.SFSymbolsFramework (1 - 190.4.0.1) <29FFE644-96BB-3DFB-98F6-17B7F0DD1605> /System/Library/PrivateFrameworks/SFSymbols.framework/Versions/A/SFSymbols
+       0x26d935000 -        0x26d9a2abf  com.apple.SILManager (53.19 - 53.19) <4D5E48C2-F64C-3E12-B831-9D3BAE05317F> /System/Library/PrivateFrameworks/SILManager.framework/Versions/A/SILManager
+       0x26da0d000 -        0x26da26dbf  com.apple.STSXPCHelperClient (1.0 - 1) <64B3EE98-19BF-3A15-A404-B864F1E7B3CA> /System/Library/PrivateFrameworks/STSXPCHelperClient.framework/Versions/A/STSXPCHelperClient
+       0x26efaa000 -        0x26f0970bf  com.apple.SensitiveContentAnalysisML (1) <3EA9136F-4E2F-3F3C-A7A7-0D68E3969306> /System/Library/PrivateFrameworks/SensitiveContentAnalysisML.framework/Versions/A/SensitiveContentAnalysisML
+       0x26f27a000 -        0x26f30c8ff  com.apple.SentencePieceInternal (57.3) <68BC8167-3BD9-3617-8C86-3E956EE8B67B> /System/Library/PrivateFrameworks/SentencePieceInternal.framework/Versions/A/SentencePieceInternal
+       0x26f5bb000 -        0x26f6785bf  com.apple.Settings (224.4.3 - 224.4.3) <F23DCA07-7352-36AF-A734-C0A96B48E7C5> /System/Library/PrivateFrameworks/Settings.framework/Versions/A/Settings
+       0x26fd90000 -        0x26fead13f  com.apple.siri.SiriAnalytics (1.0 - 1) <C72DA482-950E-36B9-9191-7531F4E25419> /System/Library/PrivateFrameworks/SiriAnalytics.framework/Versions/A/SiriAnalytics
+       0x270739000 -        0x27078c39f  com.apple.crossdevicearbitration (1.0 - 1) <A34DED16-F62E-3BFF-9781-E014A79DBB3F> /System/Library/PrivateFrameworks/SiriCrossDeviceArbitration.framework/Versions/A/SiriCrossDeviceArbitration
+       0x27078d000 -        0x2707fca1f  com.apple.crossdevicearbitration.feedback (1.0 - 1) <010D9C15-3366-36A5-9A44-E46F47D628BA> /System/Library/PrivateFrameworks/SiriCrossDeviceArbitrationFeedback.framework/Versions/A/SiriCrossDeviceArbitrationFeedback
+       0x27427d000 -        0x27428639f  com.apple.siri.SiriPowerInstrumentation (1 - 1.0) <F50B59B7-8D0B-3F51-823E-A67B4CBB25BB> /System/Library/PrivateFrameworks/SiriPowerInstrumentation.framework/Versions/A/SiriPowerInstrumentation
+       0x2756bd000 -        0x27603c4ff  com.apple.siri.tts.SiriTTS (1 - 1) <7DBF6A7E-5D98-34DD-9539-8061EFF78F25> /System/Library/PrivateFrameworks/SiriTTS.framework/Versions/A/SiriTTS
+       0x27603d000 -        0x27622dc1f  com.apple.siri.SiriTTSService (1.0 - 1) <54CA8C85-907D-3A6F-87C2-BA4CB3B3F0F9> /System/Library/PrivateFrameworks/SiriTTSService.framework/Versions/A/SiriTTSService
+       0x277920000 -        0x277a10ebf  com.apple.SonicFoundation (1.0 - 25640.26.16.301) <B90E0672-AE12-366A-A5A2-B8539139A410> /System/Library/PrivateFrameworks/SonicFoundation.framework/Versions/A/SonicFoundation
+       0x2784f7000 -        0x27852eb3f  com.apple.StatusKit (1.0 - 116.600.22) <04BF01AC-1C90-3454-BE75-B1E3B52C6C4B> /System/Library/PrivateFrameworks/StatusKit.framework/Versions/A/StatusKit
+       0x278809000 -        0x278b121df  com.apple.StocksCore (8.5 - 1968) <66513203-CC36-389C-A06C-DAFD348693E7> /System/Library/PrivateFrameworks/StocksCore.framework/Versions/A/StocksCore
+       0x278b13000 -        0x278b803bf  com.apple.StocksKit (1.0 - 1968) <FAE22429-F8C5-37AB-9086-66E0FE8B8F75> /System/Library/PrivateFrameworks/StocksKit.framework/Versions/A/StocksKit
+       0x278b81000 -        0x278b90269  com.apple.StorageContainersPrivate (1.0 - 1) <E0D0BD3A-2009-3C41-B592-7A1492A08EE6> /System/Library/PrivateFrameworks/StorageContainersPrivate.framework/Versions/A/StorageContainersPrivate
+       0x278e10000 -        0x278e3c4a1  com.apple.security.SwiftASN1Internal (1.0 - 1) <B9F3D5F5-9880-3CFB-B799-1A2DE78AD70B> /System/Library/PrivateFrameworks/SwiftASN1Internal.framework/Versions/A/SwiftASN1Internal
+       0x2794bf000 -        0x2794cc85f  com.apple.SymptomShared (2169.120.7) <91608D16-DE10-320C-83A1-E573C496875D> /System/Library/PrivateFrameworks/SymptomShared.framework/Versions/A/SymptomShared
+       0x2794cf000 -        0x2794e2adf  com.apple.SymptomAnalytics (1.0 - 2169.120.7) <0DC18DF7-F4CA-3749-B830-55F265F93B19> /System/Library/PrivateFrameworks/Symptoms.framework/Versions/A/Frameworks/SymptomAnalytics.framework/Versions/A/SymptomAnalytics
+       0x279784000 -        0x2797a899f  com.apple.SymptomPresentationFeed (1.0 - 2169.120.7) <647800AE-9BD4-3EBD-B2DC-4CF3A42EA551> /System/Library/PrivateFrameworks/Symptoms.framework/Versions/A/Frameworks/SymptomPresentationFeed.framework/Versions/A/SymptomPresentationFeed
+       0x2797ad000 -        0x27980941f  com.apple.Synapse (1.0 - 1) <805F284E-06FB-3643-8426-26E9AA4965CA> /System/Library/PrivateFrameworks/Synapse.framework/Versions/A/Synapse
+       0x27998b000 -        0x2799e66df  com.apple.SystemStatus (1.0 - 1) <521A5C2F-1ED1-31FA-A207-EDA67F8B81EB> /System/Library/PrivateFrameworks/SystemStatus.framework/Versions/A/SystemStatus
+       0x279a04000 -        0x279a1863f  com.apple.SystemWake (1.0 - 732.1.1) <5DCA046B-20EE-3D18-B60F-AC720B825ED7> /System/Library/PrivateFrameworks/SystemWake.framework/Versions/A/SystemWake
+       0x279cb5000 -        0x279cb6d1f  com.apple.tailspin.TailspinSymbolication (1.0 - 250.2) <EA43D529-31DD-3FE7-A659-919F31BCA24C> /System/Library/PrivateFrameworks/TailspinSymbolication.framework/Versions/A/TailspinSymbolication
+       0x279cb7000 -        0x279d192bf  com.apple.TeaDB (3.0 - 1428) <33B9B19E-85A7-3651-9CAC-A621F5803BF3> /System/Library/PrivateFrameworks/TeaDB.framework/Versions/A/TeaDB
+       0x279d1a000 -        0x279f0087f  com.apple.TeaFoundation (3.0 - 1428) <363640DF-7B2E-323C-B16E-7C580A16DA35> /System/Library/PrivateFrameworks/TeaFoundation.framework/Versions/A/TeaFoundation
+       0x279f01000 -        0x279f1f31f  com.apple.TeaSettings (3.0 - 1428) <B13B3285-17E9-33DA-AFC2-8361FC39CF87> /System/Library/PrivateFrameworks/TeaSettings.framework/Versions/A/TeaSettings
+       0x27a140000 -        0x27a26397f  com.apple.TextAnimationSupport (7.2.1 - 7.2.1) <05476705-3389-3ACE-86CC-6E76FBF78086> /System/Library/PrivateFrameworks/TextAnimationSupport.framework/Versions/A/TextAnimationSupport
+       0x27c263000 -        0x27c29f1df  com.apple.tightbeam (1.0 - 483.100.88) <AC90942B-457E-3814-959B-85EFAACBCA58> /System/Library/PrivateFrameworks/Tightbeam.framework/Versions/A/Tightbeam
+       0x27c3d5000 -        0x27c4bbb7f  com.apple.TipKitCore (26.5 - 120.5.1) <8A55057B-9DE4-3C32-8F8A-F68176C5CA4C> /System/Library/PrivateFrameworks/TipKitCore.framework/Versions/A/TipKitCore
+       0x27c768000 -        0x27c99f17f  com.apple.TokenGeneration (1.0 - 1) <85B779A3-DEF1-3E20-B8F4-CAF139C4C897> /System/Library/PrivateFrameworks/TokenGeneration.framework/Versions/A/TokenGeneration
+       0x27c9a0000 -        0x27cb6df3f  com.apple.TokenGenerationCore (1.0 - 1) <FD8D9034-6DB6-3E6D-9189-16E2B468EED9> /System/Library/PrivateFrameworks/TokenGenerationCore.framework/Versions/A/TokenGenerationCore
+       0x27cd7e000 -        0x27d2bafbf  com.apple.ToolKit (4610) <0DC72F8E-9B0B-3F90-B000-EF0DF3D4FE14> /System/Library/PrivateFrameworks/ToolKit.framework/Versions/A/ToolKit
+       0x27d683000 -        0x27d68b63f  com.apple.TranslationUIServices (1.0 - 365.11) <CA28521E-8B6D-3913-90E4-4B3336F40E56> /System/Library/PrivateFrameworks/TranslationUIServices.framework/Versions/A/TranslationUIServices
+       0x27e3b0000 -        0x27e4e651f  com.apple.UIIntelligenceSupport (1.0 - 1) <0BF21BC4-8127-3C85-9AE1-C33AEF6B69F7> /System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/Versions/A/UIIntelligenceSupport
+       0x27e951000 -        0x27e951539  com.apple.USDLib_FormatLoaderProxy (1.0 - 23.5.2) <F5E0EEC2-6FB5-3E5D-B569-B6EAB9F40759> /System/Library/PrivateFrameworks/USDLib_FormatLoaderProxy.framework/Versions/A/USDLib_FormatLoaderProxy
+       0x27ea8b000 -        0x27eb504bf  com.apple.UnifiedAssetFramework (1.0 - 1) <14550765-2953-33DD-B269-69D03813C91D> /System/Library/PrivateFrameworks/UnifiedAssetFramework.framework/Versions/A/UnifiedAssetFramework
+       0x27f2f9000 -        0x27f2fb1ff  com.apple.UpdateCycle (1 - 1) <0EFCE417-7412-3251-AEB9-1A80B071FD2F> /System/Library/PrivateFrameworks/UpdateCycle.framework/Versions/A/UpdateCycle
+       0x27f609000 -        0x27f60cf1f  com.apple.UserSafety (1.0 - 1) <DFEDED5D-1591-30CB-9557-7E20A1E68EB1> /System/Library/PrivateFrameworks/UserSafety.framework/Versions/A/UserSafety
+       0x27f613000 -        0x27f70ebc7  com.apple.VDAF (1.0 - 34.2) <2F01E3BB-A870-3566-A12B-1C938B46189A> /System/Library/PrivateFrameworks/VDAF.framework/Versions/A/VDAF
+       0x27f70f000 -        0x28075ce7f  com.apple.vfx (16.0 - 203.100.3) <5188C441-03CA-34CF-98B4-2F84197E8318> /System/Library/PrivateFrameworks/VFX.framework/Versions/A/VFX
+       0x280768000 -        0x2807ffbff  com.apple.vectordb.VectorSearch (1.0 - 48.3) <88D3EBEE-C43C-319A-9AF7-817B6358BE15> /System/Library/PrivateFrameworks/VectorSearch.framework/Versions/A/VectorSearch
+       0x2809d3000 -        0x2809d42cf  com.apple.VideoToolboxParavirtualizationSupport (64.4.7 - 64.4.7) <C881C3D9-A5B6-36D5-B11A-4EE6D037DD24> /System/Library/PrivateFrameworks/VideoToolboxParavirtualizationSupport.framework/Versions/A/VideoToolboxParavirtualizationSupport
+       0x2815e0000 -        0x28162c09f  com.apple.VisionCore (9.5.4 - 9.5.4) <028B39AE-BB64-3317-932B-79C1DC0BF743> /System/Library/PrivateFrameworks/VisionCore.framework/Versions/A/VisionCore
+       0x28162d000 -        0x28172557f  com.apple.VisionKitCore (1.0 - 3) <0EED0C48-190A-37C1-862B-2A1ACE8FC7B1> /System/Library/PrivateFrameworks/VisionKitCore.framework/Versions/A/VisionKitCore
+       0x282aeb000 -        0x282b93b9f  com.apple.wallpaper.framework (1.0 - 245.4.8) <E2B89B1F-C330-3307-84F2-82DCC615A48C> /System/Library/PrivateFrameworks/Wallpaper.framework/Versions/A/Wallpaper
+       0x282c7e000 -        0x282cdbc7f  com.apple.wallpaper.foundation.framework (1.0 - 245.4.8) <10754386-BFF8-3B0E-84F2-F398CE6713AE> /System/Library/PrivateFrameworks/WallpaperFoundation.framework/Versions/A/WallpaperFoundation
+       0x282cdd000 -        0x282d572bf  com.apple.wallpaper.types.framework (1.0 - 245.4.8) <11506DDC-F88C-36E2-8B86-12C5BEEA87D1> /System/Library/PrivateFrameworks/WallpaperTypes.framework/Versions/A/WallpaperTypes
+       0x283795000 -        0x283a3a8bf  com.apple.WebGPU (21624 - 21624.2.5.11.8) <998EED45-684D-3E9D-B3FD-3080F85900EC> /System/Library/PrivateFrameworks/WebGPU.framework/Versions/A/WebGPU
+       0x283d3f000 -        0x283d5f1bf  com.apple.WindowManagement (1.0 - 341.4.4) <080939D0-13CF-3107-87BA-F58B7CCB2C51> /System/Library/PrivateFrameworks/WindowManagement.framework/Versions/A/WindowManagement
+       0x284f44000 -        0x284f489ff  com.apple.WritingTools (1.0 - 1) <982E1912-B47F-3EBF-B9B6-4705E858E833> /System/Library/PrivateFrameworks/WritingTools.framework/Versions/A/WritingTools
+       0x28544b000 -        0x2854c6a7f  com.apple.internal.XPCDistributed (1.0 - 1) <42008B74-82CF-34F4-8F6A-5F125460633F> /System/Library/PrivateFrameworks/XPCDistributed.framework/Versions/A/XPCDistributed
+       0x285530000 -        0x2855372ff  com.apple.-AppIntentsServices.-AppIntents (1.0 - 40.5.2) <0A17D608-EE5C-3164-B439-A71F21A4C4BF> /System/Library/PrivateFrameworks/_AppIntentsServices_AppIntents.framework/Versions/A/_AppIntentsServices_AppIntents
+       0x285570000 -        0x28557f4df  com.apple.-IconServices-SwiftUI (1.0 - 743.5.2.400) <7276E7EA-5E4C-305B-BB33-97CFC9312EBC> /System/Library/PrivateFrameworks/_IconServices_SwiftUI.framework/Versions/A/_IconServices_SwiftUI
+       0x285580000 -        0x28571a9bf  com.apple.-JetEngine-SwiftUI (1.0 - 1) <195145B0-BEFC-31BB-9B1D-0644CF3E279B> /System/Library/PrivateFrameworks/_JetEngine_SwiftUI.framework/Versions/A/_JetEngine_SwiftUI
+       0x28616a000 -        0x28621403f  com.apple.iCloudQuota (1.0 - 1) <D31F7DF5-4BC8-3E18-8F76-3AB11EC4AEA0> /System/Library/PrivateFrameworks/iCloudQuota.framework/Versions/A/iCloudQuota
+       0x286218000 -        0x2862f4ebf  com.apple.iCloudQuotaUI (1.0 - 1) <30A931A4-D027-3965-80C6-869559E5B746> /System/Library/PrivateFrameworks/iCloudQuotaUI.framework/Versions/A/iCloudQuotaUI
+       0x288641000 -        0x28868afbf  com.apple.icloudMCCKit (1) <CAB9266C-F8CF-367F-AEF5-43D3B29086B1> /System/Library/PrivateFrameworks/icloudMCCKit.framework/Versions/A/icloudMCCKit
+       0x28ab19000 -        0x28ab1c89f  com.apple.UIUtilities (9126.5.5.2.401) <BA6F82A3-6E8E-3D57-8039-09038FD15F62> /System/Library/SubFrameworks/UIUtilities.framework/Versions/A/UIUtilities
+       0x28abfc000 -        0x28abfed5f  libAXSafeCategoryBundle.dylib (3191.34.1) <615B0A50-4113-380B-A06C-9E9E40045965> /usr/lib/libAXSafeCategoryBundle.dylib
+       0x28ac39000 -        0x28acd335f  libAppleArchive.dylib (450.100.4) <0FBEE8ED-BE69-3AC5-AC4E-6C28EEC29CF6> /usr/lib/libAppleArchive.dylib
+       0x28acd4000 -        0x28ace7f5f  libAppleSSE.dylib (320) <48696E2D-5B40-36B2-8CFA-3A8ABAB91538> /usr/lib/libAppleSSE.dylib
+       0x28ad79000 -        0x28ad7aa3f  libBASupport.dylib (227.120.3) <A132D95D-7A71-38DC-8BBA-0BED31173862> /usr/lib/libBASupport.dylib
+       0x28ad8e000 -        0x28ad9845f  libCoreEntitlements.dylib (80.100.6) <C9580199-FB51-35A3-AFCE-D4B3464E6E23> /usr/lib/libCoreEntitlements.dylib
+       0x28adc5000 -        0x28aee800f  libDisplayWarpSupport.dylib (191.100.4) <A71BF557-6A8A-3089-9DF9-83689D900FFE> /usr/lib/libDisplayWarpSupport.dylib
+       0x28aee9000 -        0x28aef35bb  libEndpointSecuritySystem.dylib (589.120.4) <9D2D1079-37C4-3EAF-88E3-A38F8425CB86> /usr/lib/libEndpointSecuritySystem.dylib
+       0x28af6c000 -        0x28af6dd1f  libInterpreterSecurity.dylib (726.121.1) <11408F95-3855-3E85-846D-CBD4661D1E84> /usr/lib/libInterpreterSecurity.dylib
+       0x28b084000 -        0x28b08b87f  libReverseProxyDevice.dylib (104.120.1.0.1) <37A5DD0C-9615-3BBD-8A88-0451A406D25F> /usr/lib/libReverseProxyDevice.dylib
+       0x28b08c000 -        0x28b093349  libRosetta.dylib (367.9) <8651ED4F-6506-3788-B56B-32EE414A85CA> /usr/lib/libRosetta.dylib
+       0x28b0f8000 -        0x28b0f835f  libSpatial.dylib (108) <EE409A01-DFC3-312D-B597-57F959F5DF7D> /usr/lib/libSpatial.dylib
+       0x28b0fb000 -        0x28b1043ff  libTLE.dylib (80.100.6) <207A2987-1BD0-3E47-B72C-E81934A6C74C> /usr/lib/libTLE.dylib
+       0x28b794000 -        0x28b798b00  libchannel.dylib (56.100.3) <FBC314DC-18BA-387D-B627-718D98283761> /usr/lib/libchannel.dylib
+       0x28b900000 -        0x28ba11b17  libcrypto.46.dylib (109.100.2) <F9685724-6622-3592-8336-B3811B583E83> /usr/lib/libcrypto.46.dylib
+       0x28bb4c000 -        0x28bb68762  libhvf.dylib (11) <43426C58-BE90-3643-9103-B9EE4A06A18A> /usr/lib/libhvf.dylib
+       0x28bf9c000 -        0x28bfa428a  libmrc.dylib (2881.120.11) <F8AA0B1C-3E5C-3D12-B8BD-55A51A45F9FD> /usr/lib/libmrc.dylib
+       0x28c410000 -        0x28c411007  librealtime_safety.dylib (56.100.3) <EA8F9952-F1AD-34E3-8EAF-C8B46B9FAEAB> /usr/lib/librealtime_safety.dylib
+       0x28c49f000 -        0x28c4d7527  libssl.48.dylib (109.100.2) <83762FDF-B375-3BB1-B568-854F8F11CF89> /usr/lib/libssl.48.dylib
+       0x28c512000 -        0x28c5400f7  libswiftPrespecialized.dylib (0) <E42D456E-7FB0-36E3-B32B-6C6E10D19E22> /usr/lib/libswiftPrespecialized.dylib
+       0x28c7b7000 -        0x28c7d6219  libswiftAppleArchive.dylib (450.100.4) <9DF4D743-A077-38BB-A503-5A775BC25542> /usr/lib/swift/libswiftAppleArchive.dylib
+       0x28c7d7000 -        0x28c7dae7f  libswiftCoreMediaIO.dylib (5617.100.5) <6119DE4D-AA08-3C8A-9578-DF940FCB0262> /usr/lib/swift/libswiftCoreMediaIO.dylib
+       0x28c7dc000 -        0x28c7ee043  libswiftDistributed.dylib (6.3.2 - 6.3.2.1.3) <67A11C98-0E0D-3DF8-846F-34276C54ECF3> /usr/lib/swift/libswiftDistributed.dylib
+       0x28c7f2000 -        0x28c7f2edb  libswiftGLKit.dylib (1.1) <2CF6F95F-ED2D-3725-8B4B-16CF587A4AC1> /usr/lib/swift/libswiftGLKit.dylib
+       0x28c7f6000 -        0x28c7fd31f  libswiftMLCompute.dylib (84) <F458A6D6-6DE5-3792-8B20-E60B833F27D1> /usr/lib/swift/libswiftMLCompute.dylib
+       0x28c7fe000 -        0x28c7ff2df  libswiftMetalKit.dylib (1.2) <A502832A-2D9D-3AF2-A135-601423CC0F65> /usr/lib/swift/libswiftMetalKit.dylib
+       0x28c800000 -        0x28c80345f  libswiftModelIO.dylib (1) <3F25450B-8825-39EE-A161-52AA1A86BF06> /usr/lib/swift/libswiftModelIO.dylib
+       0x28c805000 -        0x28c814ebc  libswiftObservation.dylib (6.3.2 - 6.3.2.1.3) <CE9EF53F-E72B-32EC-A1F9-8EBE59A4F1BA> /usr/lib/swift/libswiftObservation.dylib
+       0x28c816000 -        0x28c81e6df  libswiftPassKit.dylib (1642.6.5) <7407A7F7-E6BE-3556-AAED-4AD49A6538F5> /usr/lib/swift/libswiftPassKit.dylib
+       0x28c824000 -        0x28c830817  libswiftRegexBuilder.dylib (6.3.2 - 6.3.2.1.3) <ED12EC1F-4651-363B-BBAA-B42D23A9A2F7> /usr/lib/swift/libswiftRegexBuilder.dylib
+       0x28c8c3000 -        0x28c8c613f  libswiftSceneKit.dylib (1.2) <F9302884-21EF-30C1-9BBB-DAE03FFADFDB> /usr/lib/swift/libswiftSceneKit.dylib
+       0x28c8c7000 -        0x28c93d72f  libswiftSpatial.dylib (108) <A0300A47-5793-3228-AE62-19CAABCB0E4C> /usr/lib/swift/libswiftSpatial.dylib
+       0x28c941000 -        0x28c9548ef  libswiftSynchronization.dylib (6.3.2 - 6.3.2.1.3) <1A965373-0DB6-3B50-BE38-52C30D67A090> /usr/lib/swift/libswiftSynchronization.dylib
+       0x28c955000 -        0x28c96de60  libswiftSystem.dylib (75) <A4F80949-97A7-3A1A-A340-45D2D7A5AB89> /usr/lib/swift/libswiftSystem.dylib
+       0x28c96f000 -        0x28c98579f  libswiftVideoToolbox.dylib (3320.8.5.2) <7E497740-11CD-3B32-A69E-019CD415FCA7> /usr/lib/swift/libswiftVideoToolbox.dylib
+       0x28c987000 -        0x28c987669  libswift_Builtin_float.dylib (6.3.2.1.3) <15ED1E36-16BC-327E-8FAA-9130DE11923C> /usr/lib/swift/libswift_Builtin_float.dylib
+       0x28c988000 -        0x28ca13095  libswift_Concurrency.dylib (6.3.2 - 6.3.2.1.3) <E3545AA1-FF13-3698-8657-91BB23002DF9> /usr/lib/swift/libswift_Concurrency.dylib
+       0x28ca14000 -        0x28ca16f83  libswift_DarwinFoundation1.dylib (377.120.8) <2601FA08-2913-3370-89B6-C67DC05AC892> /usr/lib/swift/libswift_DarwinFoundation1.dylib
+       0x28ca17000 -        0x28ca17eeb  libswift_DarwinFoundation2.dylib (377.120.8) <38242BFE-54C8-3838-AE88-0083F7328580> /usr/lib/swift/libswift_DarwinFoundation2.dylib
+       0x28ca18000 -        0x28ca187a7  libswift_DarwinFoundation3.dylib (377.120.8) <6CFBAAE9-7293-3A51-83B9-E3988230EAC2> /usr/lib/swift/libswift_DarwinFoundation3.dylib
+       0x28ca19000 -        0x28cab749f  libswift_RegexParser.dylib (6.3.2 - 6.3.2.1.3) <2FED4499-861B-37B8-8C94-5ABC7FD49726> /usr/lib/swift/libswift_RegexParser.dylib
+       0x28cab8000 -        0x28cb440cd  libswift_StringProcessing.dylib (6.3.2 - 6.3.2.1.3) <13999576-EB4F-3A0D-874F-A95AD5D7F296> /usr/lib/swift/libswift_StringProcessing.dylib
+       0x28cb48000 -        0x28cb483cb  libswift_errno.dylib (377.120.8) <036B80ED-8851-3327-8E3F-69A9B1285563> /usr/lib/swift/libswift_errno.dylib
+       0x28cb4d000 -        0x28cb4d3d3  libswiftsys_time.dylib (377.120.8) <0996A2E4-4C36-3C6E-9844-F1CB1DE9FD49> /usr/lib/swift/libswiftsys_time.dylib
+       0x28cca9000 -        0x28ccaca4b  libsystem_darwindirectory.dylib (122) <CF277A2C-C818-3F16-8B3F-3C7B39FCD164> /usr/lib/system/libsystem_darwindirectory.dylib
+       0x28ccad000 -        0x28ccb65d3  libsystem_eligibility.dylib (319.121.1) <DDAC0531-0262-3DDC-8EC8-80EB9438847A> /usr/lib/system/libsystem_eligibility.dylib
+       0x28ccb7000 -        0x28ccbe88b  libsystem_sanitizers.dylib (26.1) <44C4234F-8B2D-38D3-A774-B4B3C75AF3A7> /usr/lib/system/libsystem_sanitizers.dylib
+       0x28ccbf000 -        0x28ccbfbb7  libsystem_trial.dylib (474.2.18.2) <68C583BA-AFF5-3916-86AE-6E38BFEF98D6> /usr/lib/system/libsystem_trial.dylib
+       0x28ccf3000 -        0x28cd476bf  libAppleTconUARPUpdater.dylib (1345.121.3) <61B73D9C-F78A-35FA-8747-C36A6D0B6BE9> /usr/lib/updaters/libAppleTconUARPUpdater.dylib
+       0x28ce88000 -        0x28ce9f9df  libT200Updater.dylib (1.0.0.7.66) <9B30A548-F401-3FC1-86D8-EC2AB98BCFF4> /usr/lib/updaters/libT200Updater.dylib
+       0x28cea0000 -        0x28ec1fb1f  libusd_ms.dylib (23.5.2) <553C9AED-46A4-314D-9A50-7B11582DEA18> /usr/lib/usd/libusd_ms.dylib

--- a/plans/issue-475-run-awaits-turn.md
+++ b/plans/issue-475-run-awaits-turn.md
@@ -1,0 +1,240 @@
+# Fix: `run()` awaits the turn (#475)
+
+**Issue:** [#475](https://github.com/tqbf/selfdrivingwiki/issues/475)
+**Branch:** `organic-moth` → new feature branch
+
+## Problem
+
+`AgentLauncher.run()` spawns the per-turn streaming loop as a fire-and-forget
+`Task` (line 867) and returns immediately. The comment says so explicitly:
+
+> *"fire-and-forget: run() returns after spawn commit; the stream is drained async."*
+
+Since `run()` is `async`, the entire queue call chain resolves in ~7s (spawn +
+preflight) while the agent streams for minutes:
+
+```
+QueueEngine.runWorker (:483)  → worker.execute (:483)
+  → AppQueueIngestionProvider.runIngestion (:160) → runAgent (:289)
+    → await launcher.run (:289)  ← returns after spawn, NOT after stream
+      → Task { for await event in stream { ... } }  ← fire-and-forget
+```
+
+`handleWorkerFinished (:504)` → `store.markCompleted (:510)` marks the item
+`completed` while the agent is still working.
+
+A second defect compounds this: `onAgentEvent` is a single per-launcher stored
+property (`:46`), not per-run keyed state. When two ingest items overlap:
+
+1. Item A's `run()` installs `onAgentEvent = callbackA` at `:708`
+2. `run()` fires off the stream `Task` and returns → item A is marked `completed`
+3. Item B's `run()` blocks on `awaitGenerationSlot(for: .ingest)` at `:680`
+   until item A's `finish()` releases the gate
+4. Item A's stream `Task` is still alive — all its events hit whatever callback
+   is installed (item A's, until item B's `resetRunArtifacts()` clears it at `:2082`)
+5. Item B acquires the gate, clears the callback, spawns, completes with 0 events
+
+Result: item A owns the entire transcript (17 events, 7.3s "duration"); item B
+has zero events and 215.8s "duration" — but is the one shown as the long-running
+ingest in the Activity window.
+
+## Root cause (verified)
+
+| Claim | Verified at |
+|-------|-------------|
+| `run()` returns before stream completes | `AgentLauncher.swift:855-882` — stream in `Task {}`, no `await` |
+| `run()` is `async` (awaited by queue) | `AgentLauncher.swift:664-675` |
+| Queue worker awaits `run()` → marks terminal on return | `QueueEngine.swift:483-491, 510` |
+| `onAgentEvent` is single per-launcher property | `AgentLauncher.swift:46` |
+| `resetRunArtifacts()` clears `onAgentEvent` | `AgentLauncher.swift:2082` |
+| Gate serializes one-shot runs (no overlap) | `AgentLauncher.swift:680` — `awaitGenerationSlot(for: lane)` |
+
+## Active callers of `run()`
+
+Only two, both queue-based:
+
+1. **`AppQueueIngestionProvider.runAgent`** (`:289`) — ingestion
+2. **`AppQueueIngestionProvider.runLintAgent`** (`:322`) — lint
+
+`AgentOperationRunner.runQuery` / `runLint` / `runLintPages` also call
+`launcher.run()` but have **zero active call sites** (superseded by the queue;
+grep confirmed no callers in `Sources/` or `Tests/`).
+
+`startInteractiveQuery` (`:1396`) is a completely separate path — it has its
+own spawn, its own `onExit`, does NOT call `run()`. Interactive turns use
+`sendInteractiveMessage` (`:1628`), which **already inlines the stream loop**:
+
+```swift
+let stream = await backend.send(TurnInput(userText: trimmed), into: session)
+for await event in stream {
+    self.mergeOrAppend(event)
+    if AgentEvent.endsGeneration(event) { ... }
+}
+```
+
+This is the pattern `run()` should follow.
+
+## Fix
+
+### Change 1: Inline the stream consumption in `run()` (primary fix)
+
+**File:** `Sources/WikiFSEngine/AgentLauncher.swift`, lines 855-882
+
+**Before:**
+```swift
+// Consume the per-turn stream in a background Task (fire-and-forget:
+// run() returns after spawn commit; the stream is drained async).
+Task { @MainActor [weak self] in
+    guard let self else { return }
+    let stream = await backend.send(
+        TurnInput(userText: promptText), into: session)
+    for await event in stream {
+        self.lastActivityAt = Date()
+        self.mergeOrAppend(event)
+        if AgentEvent.endsGeneration(event) {
+            self.setGenerating(false)
+            self.flushTranscript()
+            if generationGateReleasesPerTurn {
+                self.releaseGenerationSlot()
+            }
+        }
+    }
+}
+```
+
+**After:**
+```swift
+// Consume the per-turn stream INLINE so run() doesn't return until the
+// turn completes. The queue worker awaits run() to decide when the item
+// is done — an early return marks it completed while the agent is still
+// streaming (#475). Mirrors sendInteractiveMessage's pattern.
+let stream = await backend.send(
+    TurnInput(userText: promptText), into: session)
+for await event in stream {
+    self.lastActivityAt = Date()
+    self.mergeOrAppend(event)
+    if AgentEvent.endsGeneration(event) {
+        self.setGenerating(false)
+        self.flushTranscript()
+        if generationGateReleasesPerTurn {
+            self.releaseGenerationSlot()
+        }
+    }
+}
+
+// Stream ended (turn complete or process died). If onExit hasn't fired
+// yet (finish() not called), ensure teardown happens before run()
+// returns so the caller sees post-finish state: gate released, run
+// lifecycle decremented, onAgentEvent cleared. finish() is idempotent
+// (isRunning guard), so a later onExit-triggered finish() is a safe
+// no-op.
+if isRunning {
+    finish(status: exitStatus ?? 0)
+}
+```
+
+**Why this is safe:**
+
+- `run()` is `@MainActor` (class-level annotation). The `for await` suspends
+  the main actor per event — it does NOT block the main actor or the queue
+  engine's actor. Other main-actor work proceeds between events (exactly
+  like `sendInteractiveMessage`).
+- No `[weak self]` needed — `run()` is an instance method; the `await` keeps
+  `self` alive for the duration (same as any async method).
+- `finish()` is guarded by `isRunning` (line 1986) — calling it after the
+  stream ends is safe whether or not `onExit` already called it.
+- The watchdog (`startCompletionWatchdog`, `:1310`) still kills stuck
+  processes via `stopAgent()` → `finish(-1)` → stream ends → the post-loop
+  `finish(0)` is a no-op (isRunning already false).
+
+### Change 2: Misattribution is naturally fixed (no code change needed)
+
+With the inline await, two one-shot runs **cannot overlap**:
+
+```
+Item A: run() → gate acquire → spawn → for await stream → finish() → gate release → return
+Item B: run() → awaitGenerationSlot(BLOCKED) → gate acquire → spawn → for await → finish() → return
+```
+
+`onAgentEvent` is installed fresh per run (`:708` after `resetRunArtifacts`
+clears it at `:2082`) and cleared in `finish()` (`:2003`) before the next
+run's `resetRunArtifacts()` runs. No overlap = no cross-attribution.
+
+### Change 3 (optional, defense-in-depth): Key `onAgentEvent` per-run token
+
+Not strictly required — the gate serialization already prevents overlap.
+But if future changes break that guarantee, a stale callback could again
+receive events. A run-token check would make this impossible:
+
+```swift
+// In run(), capture alongside currentRunToken:
+let onEventToken = UUID()
+
+// Store both the callback AND the token:
+@ObservationIgnored private var onAgentEventEntry: (token: UUID, callback: @Sendable (AgentEvent) -> Void)?
+
+// In mergeOrAppend, only fire if the token matches the current run:
+if let entry = onAgentEventEntry, entry.token == currentRunToken {
+    entry.callback(event)
+}
+```
+
+**Defer** unless we want belt-and-suspenders. The inline await is the real fix.
+
+### Change 4 (optional, secondary): Replace `try?` with logged error at the write seam
+
+**File:** `Sources/WikiFSEngine/QueueEngine.swift`, line 362
+
+```swift
+// Before:
+try? store.appendItemEvent(itemID: id, event: event)
+
+// After:
+do {
+    try store.appendItemEvent(itemID: id, event: event)
+} catch {
+    DebugLog.store("QueueEngine: appendItemEvent failed for item=\(id): \(error)")
+}
+```
+
+The issue notes this isn't the cause (writes succeed, just against the wrong
+item) but flags it as the same silent-swallow pattern that lost transcripts
+before (documented at `QueueStore.swift:156-160`).
+
+## What NOT to change
+
+- **`startInteractiveQuery` / `sendInteractiveMessage`** — already correct
+  (inline stream consumption). No changes needed.
+- **`QueueEngine` dispatch / worker model** — the queue correctly awaits
+  `worker.execute()` and marks terminal on return. The bug was `run()`
+  returning early, not the queue logic.
+- **`onExit` callback** — still needed for the case where the process dies
+  before the stream's `for await` gets to consume all events (e.g., SIGKILL).
+  The post-stream `finish()` is the safety net for the normal case; `onExit`
+  handles the abnormal case.
+
+## Test plan
+
+### Regression test: `run()` does not return until the stream completes
+
+Add a test using a stub backend that:
+1. Returns a session from `start()`
+2. Returns an `AsyncStream` from `send()` that yields 3 events, then finishes
+3. Asserts the caller's continuation resumes only after all 3 events are
+   consumed (not after spawn)
+4. Asserts `finish()` was called (gate released, `isRunning == false`)
+
+### Existing tests to verify
+
+- `AgentLauncher` unit tests (stub backend) — should still pass since the
+  stream loop body is unchanged
+- `QueueEngine` tests — should still pass (worker still awaits `execute()`)
+- Fast tier: `swift test --skip 'EnumeratorDeletionTests|...'`
+
+## Risk assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Main actor blocked during long ingest | Low — `await` suspends, doesn't block | Medium | Same as `sendInteractiveMessage`; verified by existing interactive sessions |
+| `finish(status: 0)` before `onExit` fires hides real exit status | Low — stream completing means turn was done; post-turn crash is unusual | Low | `exitStatus` is UI display only; `onExit` `finish()` is a no-op |
+| Existing tests rely on `run()` early return | Low — no tests call `launcher.run` directly (grep confirmed) | Low | Run full test suite to verify |


### PR DESCRIPTION
Fixes #475

## Problem

`AgentLauncher.run()` spawned the per-turn streaming loop as a fire-and-forget `Task` and returned immediately after spawn. The queue worker awaits `run()` to decide when the item is done — an early return marks the item `completed` while the agent is still streaming for minutes. A second ingest's entire transcript was then attributed to the wrong (first) queue item because `onAgentEvent` is a single per-launcher property, not per-run keyed state.

## Fix

**Primary:** Inline the stream consumption loop in `run()` (removing the `Task { }` wrapper), mirroring the existing pattern in `sendInteractiveMessage`. Add a post-stream `finish()` safety net so teardown (gate release, `onAgentEvent` clear) happens before returning. `finish()` is idempotent (`isRunning` guard), so a later `onExit`-triggered `finish()` is a safe no-op.

With the inline await, two one-shot runs cannot overlap (the generation gate serializes them), so the misattribution disappears naturally — no per-run token needed.

**Secondary:** Replace silent `try?` on `store.appendItemEvent` with a logged `do/catch` so future write failures are visible (not swallowed, as documented in `QueueStore.swift:156-160` as having lost transcripts before).

**Test infrastructure:** Added `resolveBackend` injectable factory closure so tests can substitute a `FakeAgentBackend` that survives the `self.backend = ...` assignment in `run()`.

## Test plan

3 new regression tests in `RunAwaitsTurnTests`:
- `runForwardsAllEventsBeforeReturning` — all 4 events consumed and forwarded before `run()` returns (before the fix, this was 0)
- `runCallsFinishBeforeReturning` — `isRunning == false` and gate released after `run()` returns (before the fix, `isRunning` was still `true`)
- `secondRunProceedsWithoutDeadlock` — a second `run()` can proceed immediately after the first (before the fix, this deadlocked because the gate was held until `onExit` fired minutes later)

Full fast-tier suite: 2418 tests pass (3 new + 2415 existing).
