### PR TITLE
Detect broken source and chat links with dash normalization

### DIFF
--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -101,7 +101,11 @@ public enum SourceCommand {
                     byteSize: summary.byteSize,
                     createdAt: summary.createdAt,
                     updatedAt: summary.updatedAt,
-                    version: summary.version
+                    version: summary.version,
+                    displayName: summary.displayName
+                    // hasMarkdown defaults to false — the authoritative
+                    // sources.jsonl (on the mount) carries that field; the
+                    // WikiStore protocol's listSources() doesn't expose it.
                 )
             }
             let data = IndexGenerators.sourcesJSONL(sources: rows)
@@ -111,9 +115,13 @@ public enum SourceCommand {
             )
         }
         // TSV: id <tab> name <tab> size <tab> mime, one file per line.
+        // `name` is the display name when set, falling back to filename —
+        // matching sourcesJSONL and how sources are labeled app-wide, so the
+        // agent sees the same name it should use in [[source:Name]] citations.
         let lines = summaries.map { summary in
             let mime = summary.mimeType ?? ""
-            return "\(summary.id.rawValue)\t\(summary.filename)\t\(summary.byteSize)\t\(mime)"
+            let name = summary.effectiveName
+            return "\(summary.id.rawValue)\t\(name)\t\(summary.byteSize)\t\(mime)"
         }
         return Result(
             payload: .text(lines.joined(separator: "\n")),

--- a/Sources/WikiFS/AppQueueIngestionProvider.swift
+++ b/Sources/WikiFS/AppQueueIngestionProvider.swift
@@ -242,7 +242,10 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
         // AgentOperationRunner.runLintPages but with progress + transcript.
         let preflights = pages.map { page in
             let preflight = store.preflightLint(pageID: page.id)
-            return (title: page.title, brokenLinks: preflight?.brokenPageLinks ?? [])
+            let allBroken = (preflight?.brokenPageLinks ?? [])
+                + (preflight?.brokenSourceLinks ?? [])
+                + (preflight?.brokenChatLinks ?? [])
+            return (title: page.title, brokenLinks: allBroken)
         }
         let combinedTitle = pages.map(\.title).joined(separator: ", ")
         let combinedBroken = preflights.flatMap(\.brokenLinks)

--- a/Sources/WikiFSCore/WikiNameRules.swift
+++ b/Sources/WikiFSCore/WikiNameRules.swift
@@ -51,6 +51,13 @@ public enum WikiNameRules {
     /// near-miss never silently picks between two plausible sources.
     public static func looseMatchKey(_ name: String) -> String {
         var s = WikiText.normalized(name).lowercased()
+        // Normalize Unicode dash variants and ASCII hyphens to spaces so that
+        // "Self-Driving Wiki — User Guide" and "Self-Driving Wiki User Guide"
+        // produce the same key. Dashes are used interchangeably in document
+        // titles, and the unique-only constraint prevents false matches.
+        s = s.replacingOccurrences(of: "\u{2014}", with: " ")   // em dash
+             .replacingOccurrences(of: "\u{2013}", with: " ")   // en dash
+             .replacingOccurrences(of: "-", with: " ")           // hyphen-minus
         // One trailing ".ext" — only if it looks like a real file extension
         // (1–5 alphanumerics), so "v2.5" style names lose at most a digit and
         // both sides lose it identically.

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1359,15 +1359,21 @@ public final class WikiStoreModel {
     }
 
     /// Pre-flight checks run before an LLM page-lint: apply `WikiLinkFixer` fixes and
-    /// detect broken `[[page links]]`. Reads fresh from the store so it works for any
+    /// detect broken `[[wiki links]]`. Reads fresh from the store so it works for any
     /// page, not just the loaded draft. If the current page is loaded, also syncs the
     /// draft (without marking it dirty). Returns `nil` when the page cannot be read.
     public struct LintPreflight: Sendable {
         /// `true` when `WikiLinkFixer.applyFixes` rewrote one or more `\]]` brackets.
         public let didFixLinks: Bool
         /// Page titles referenced by `[[wiki links]]` in the page that do not resolve
-        /// to an existing page. Source links (`[[source:X]]`) are excluded.
+        /// to an existing page.
         public let brokenPageLinks: [String]
+        /// Source display names referenced by `[[source:…]]` in the page that do not
+        /// resolve to an existing source.
+        public let brokenSourceLinks: [String]
+        /// Chat titles referenced by `[[chat:…]]` in the page that do not resolve
+        /// to an existing chat.
+        public let brokenChatLinks: [String]
     }
 
     public func preflightLint(pageID: PageID) -> LintPreflight? {
@@ -1390,25 +1396,88 @@ public final class WikiStoreModel {
             }
         }
 
-        // Detect broken page links (source links are intentionally excluded).
+        // Detect broken wiki links across all three namespaces.
         let body = didFix ? fixedBody : original
-        let links = WikiLinkParser.parse(body)
+        let ns = body as NSString
+        let codeRanges = WikiLinkSpan.protectedCodeRanges(in: body)
+        let matches = WikiLinkSpan.regex.matches(
+            in: body, range: NSRange(location: 0, length: ns.length))
         let knownTitles = Set(summaries.map { $0.title })
+        let knownPageIDs = Set(summaries.map { $0.id.rawValue.uppercased() })
+        let allChats = (try? store.listAllChatsOrderedByID()) ?? []
+        let knownChatTitles = Set(allChats.map { $0.title })
+        let knownChatIDs = Set(allChats.map { $0.id.rawValue.uppercased() })
         // Mirror replaceLinks: a link is broken only when NO candidate reading
         // of its raw target (per WikiLinkResolver — handles `#` in titles)
-        // names an existing page. Unique the output — two parsed links can
+        // names an existing resource. Unique the output — two parsed links can
         // share a base since parse() de-dupes by raw target.
         var seenBroken = Set<String>()
-        let broken = links
-            .filter { $0.linkType == .page }
-            .compactMap { link -> String? in
-                let raw = link.fragment.map { "\(link.target)#\($0)" } ?? link.target
-                guard WikiLinkResolver.resolvedSplit(of: raw, isKnown: { knownTitles.contains($0) }) == nil
-                else { return nil }
-                return seenBroken.insert(link.target).inserted ? link.target : nil
+        var brokenPages: [String] = []
+        var brokenSources: [String] = []
+        var brokenChats: [String] = []
+        for match in matches {
+            let fullRange = match.range
+            // Skip links inside code spans / fenced blocks — `[[Like This]]`
+            // in backticks is example text, not a real link.
+            guard !WikiLinkSpan.isProtected(fullRange, by: codeRanges) else { continue }
+
+            let rawTarget = ns.substring(with: match.range(at: 1))
+            let aliasRange = match.range(at: 2)
+            let rawAlias = aliasRange.location != NSNotFound ? ns.substring(with: aliasRange) : nil
+            let fixed = WikiLinkFixer.fix(target: rawTarget, alias: rawAlias)
+            let collapsed = WikiText.normalized(fixed.target)
+            guard !collapsed.isEmpty else { continue }
+
+            let (base, fragment) = WikiLinkParser.splitFragment(collapsed)
+            guard !base.isEmpty else { continue }
+            let (bareBase, _) = WikiLinkParser.splitVersionPin(base)
+            let (kind, bareTarget) = WikiLinkParser.classify(bareBase)
+            guard !bareTarget.isEmpty, !WikiLinkParser.isEmptyPrefix(bareBase) else { continue }
+
+            let raw = fragment.map { "\(bareTarget)#\($0)" } ?? bareTarget
+
+            let known: (String) -> Bool
+            let knownIDs: Set<String>
+            switch kind {
+            case .page:
+                known = { knownTitles.contains($0) }
+                knownIDs = knownPageIDs
+            case .source:
+                // For source links, also check looseMatchKey so a name with a
+                // dash variant still counts as resolved (mirrors the store's
+                // resolveSourceByName pass 3 and the projection's LinkMaps).
+                known = { [self] name in
+                    self.sources.contains { $0.effectiveName == name }
+                    || self.sources.contains { WikiNameRules.looseMatchKey($0.effectiveName) == WikiNameRules.looseMatchKey(name) }
+                }
+                knownIDs = Set(sources.map { $0.id.rawValue.uppercased() })
+            case .chat:
+                known = { knownChatTitles.contains($0) }
+                knownIDs = knownChatIDs
             }
 
-        return LintPreflight(didFixLinks: didFix, brokenPageLinks: broken)
+            // Canonical ULID links (resolved at save time) are never broken —
+            // the ULID is a stable id, not a title to look up by name.
+            if WikiLinkParser.isCanonicalULID(bareTarget) {
+                guard !knownIDs.contains(bareTarget.uppercased()) else { continue }
+            } else {
+                guard WikiLinkResolver.resolvedSplit(of: raw, isKnown: known) == nil else { continue }
+            }
+
+            let label = fixed.alias.map { WikiText.normalized($0) } ?? bareTarget
+            let dedupLabel = label.isEmpty ? bareTarget : label
+            guard seenBroken.insert("\(kind.rawValue):\(dedupLabel)").inserted else { continue }
+            switch kind {
+            case .page:   brokenPages.append(dedupLabel)
+            case .source: brokenSources.append(dedupLabel)
+            case .chat:   brokenChats.append(dedupLabel)
+            }
+        }
+
+        return LintPreflight(didFixLinks: didFix,
+                             brokenPageLinks: brokenPages,
+                             brokenSourceLinks: brokenSources,
+                             brokenChatLinks: brokenChats)
     }
 
     /// Cancel any pending debounce and save synchronously. Called on page

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -403,7 +403,12 @@ public enum AgentOperationRunner {
     ) async {
         let preflights = pages.map { page in
             let preflight = store.preflightLint(pageID: page.id)
-            return (title: page.title, brokenLinks: preflight?.brokenPageLinks ?? [])
+            // Combine all three namespaces so the lint task sees broken source
+            // and chat links too, not just broken page links.
+            let allBroken = (preflight?.brokenPageLinks ?? [])
+                + (preflight?.brokenSourceLinks ?? [])
+                + (preflight?.brokenChatLinks ?? [])
+            return (title: page.title, brokenLinks: allBroken)
         }
         let combinedTitle = pages.map(\.title).joined(separator: ", ")
         let combinedBroken = preflights.flatMap(\.brokenLinks)

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -1246,12 +1246,28 @@ struct Projection {
         let chatByID:     [String: RelativeLinkRewriter.Target]
         let siblingImages: [PageID: [String: PageID]]   // sourceID -> [originalPath -> sibling sourceID]
 
+        /// Loose-key fallback maps for sources and chats. When an exact name
+        /// lookup fails (e.g. an agent cited "Self-Driving Wiki User Guide" but
+        /// the source is named "Self-Driving Wiki — User Guide" with an em
+        /// dash), the loose key — which normalizes dashes, strips extensions
+        /// and parenthetical suffixes — still resolves. Collisions (two
+        /// entries with the same loose key) are omitted, mirroring the store's
+        /// `resolveSourceByName` pass-3 unique-only constraint.
+        let sourceByLooseKey: [String: RelativeLinkRewriter.Target]
+        let chatByLooseKey:   [String: RelativeLinkRewriter.Target]
+
         func resolver(baseDir: [String]) -> RelativeLinkRewriter.Resolver {
             RelativeLinkRewriter.Resolver(
                 baseDir: baseDir,
                 page:   { t, isID in isID ? pageByID[t.uppercased()]   : pageByTitle[t] },
-                source: { t, isID in isID ? sourceByID[t.uppercased()] : sourceByName[t] },
-                chat:   { t, isID in isID ? chatByID[t.uppercased()]   : chatByTitle[t] }
+                source: { t, isID in
+                    if isID { return sourceByID[t.uppercased()] }
+                    return sourceByName[t] ?? sourceByLooseKey[WikiNameRules.looseMatchKey(t)]
+                },
+                chat:   { t, isID in
+                    if isID { return chatByID[t.uppercased()] }
+                    return chatByTitle[t] ?? chatByLooseKey[WikiNameRules.looseMatchKey(t)]
+                }
             )
         }
 
@@ -1310,10 +1326,35 @@ struct Projection {
 
         let siblingImages = (try? store?.siblingImageResolvers()) ?? [:]
 
+        let sourceByLooseKey = Self.buildLooseKeyMap(sourceByName)
+        let chatByLooseKey   = Self.buildLooseKeyMap(chatByTitle)
+
         return LinkMaps(pageByTitle: pageByTitle, pageByID: pageByID,
                         sourceByName: sourceByName, sourceByID: sourceByID,
                         chatByTitle: chatByTitle, chatByID: chatByID,
-                        siblingImages: siblingImages)
+                        siblingImages: siblingImages,
+                        sourceByLooseKey: sourceByLooseKey,
+                        chatByLooseKey: chatByLooseKey)
+    }
+
+    /// Build a loose-key → target map from a name → target dict. Collisions
+    /// (two names with the same `WikiNameRules.looseMatchKey`) are omitted,
+    /// matching the store's `resolveSourceByName` pass-3 unique-only constraint
+    /// — an ambiguous match resolves to nothing rather than picking arbitrarily.
+    private static func buildLooseKeyMap(_ entries: [String: RelativeLinkRewriter.Target])
+        -> [String: RelativeLinkRewriter.Target] {
+        var out: [String: RelativeLinkRewriter.Target] = [:]
+        var seen = Set<String>()
+        for (name, target) in entries {
+            let key = WikiNameRules.looseMatchKey(name)
+            if seen.contains(key) {
+                out.removeValue(forKey: key)   // collision → ambiguous, remove
+            } else {
+                seen.insert(key)
+                out[key] = target
+            }
+        }
+        return out
     }
 
     /// Rewrite `[[wikilinks]]` in `raw` to relative Markdown links, computing

--- a/Tests/WikiFSTests/AgentOperationRunnerTests.swift
+++ b/Tests/WikiFSTests/AgentOperationRunnerTests.swift
@@ -67,4 +67,88 @@ struct AgentOperationRunnerTests {
         let combined = preflights.flatMap(\.brokenLinks)
         #expect(combined == ["One", "Two", "Three"])
     }
+
+    // MARK: - Canonical ULID links are not false positives
+
+    @Test func canonicalULIDPageLinkIsNotBroken() throws {
+        let (model, store) = try tempStore()
+        let target = try store.createPage(title: "Target Page")
+        let page = try store.createPage(title: "Linker")
+        // A canonical [[page:<ULID>|alias]] link should NOT be reported broken.
+        try store.updatePage(id: page.id, title: "Linker",
+            body: "See [[page:\(target.id.rawValue)#Intro|Target Page]].")
+        model.reloadFromStore()
+
+        let preflight = model.preflightLint(pageID: page.id)
+        #expect(preflight?.brokenPageLinks.isEmpty == true)
+    }
+
+    // MARK: - Links inside code spans are not checked
+
+    @Test func linksInsideCodeSpansAreNotBroken() throws {
+        let (model, store) = try tempStore()
+        let page = try store.createPage(title: "Docs")
+        // `[[Like This]]` inside backticks is example text, not a real link.
+        try store.updatePage(id: page.id, title: "Docs",
+            body: "Use `[[Like This]]` to link pages.")
+        model.reloadFromStore()
+
+        let preflight = model.preflightLint(pageID: page.id)
+        #expect(preflight?.brokenPageLinks.isEmpty == true)
+    }
+
+    @Test func linksInsideFencedBlocksAreNotBroken() throws {
+        let (model, store) = try tempStore()
+        let page = try store.createPage(title: "Docs")
+        try store.updatePage(id: page.id, title: "Docs", body: """
+        Example:
+
+        ```
+        [[Nonexistent Page]]
+        ```
+        """)
+        model.reloadFromStore()
+
+        let preflight = model.preflightLint(pageID: page.id)
+        #expect(preflight?.brokenPageLinks.isEmpty == true)
+    }
+
+    // MARK: - Source links are checked
+
+    @Test func brokenSourceLinkIsDetected() throws {
+        let (model, store) = try tempStore()
+        let page = try store.createPage(title: "Citing Page")
+        try store.updatePage(id: page.id, title: "Citing Page",
+            body: "[^1]: [[source:Nonexistent Source#\"quote\"]]\n\nText.[^1]")
+        model.reloadFromStore()
+
+        let preflight = model.preflightLint(pageID: page.id)
+        #expect(preflight?.brokenSourceLinks.contains("Nonexistent Source") == true)
+    }
+
+    @Test func resolvedSourceLinkIsNotBroken() throws {
+        let (model, store) = try tempStore()
+        _ = try store.addSource(filename: "Guide.md", data: Data("# Guide".utf8))
+        let page = try store.createPage(title: "Citing Page")
+        try store.updatePage(id: page.id, title: "Citing Page",
+            body: "[^1]: [[source:Guide#\"intro\"]]\n\nText.[^1]")
+        model.reloadFromStore()
+
+        let preflight = model.preflightLint(pageID: page.id)
+        #expect(preflight?.brokenSourceLinks.isEmpty == true)
+    }
+
+    @Test func sourceLinkWithDashMismatchIsNotBroken() throws {
+        let (model, store) = try tempStore()
+        let src = try store.addSource(filename: "Guide.md", data: Data("# Guide".utf8))
+        try store.renameSource(id: src.id, to: "Self-Driving Wiki \u{2014} User Guide")
+        let page = try store.createPage(title: "Citing Page")
+        // Agent cited the name without the em dash — looseMatchKey should resolve it.
+        try store.updatePage(id: page.id, title: "Citing Page",
+            body: "[^1]: [[source:Self-Driving Wiki User Guide#\"intro\"]]\n\nText.[^1]")
+        model.reloadFromStore()
+
+        let preflight = model.preflightLint(pageID: page.id)
+        #expect(preflight?.brokenSourceLinks.isEmpty == true)
+    }
 }

--- a/Tests/WikiFSTests/RelativeLinkRewriterTests.swift
+++ b/Tests/WikiFSTests/RelativeLinkRewriterTests.swift
@@ -119,6 +119,42 @@ struct RelativeLinkRewriterTests {
         #expect(rewrite("[[source:missing.pdf]]") == "[[source:missing.pdf]]")
     }
 
+    @Test func sourceLinkWithDashMismatchResolvesViaLooseKey() {
+        // The agent cited "Self-Driving Wiki User Guide" but the source is
+        // named "Self-Driving Wiki — User Guide" (em dash). The resolver's
+        // loose-key fallback should still resolve it. This mirrors the
+        // production LinkMaps.resolver which falls back to looseMatchKey.
+        let storedName = "Self-Driving Wiki \u{2014} User Guide"
+        var looseSources: [String: Target] = [:]
+        var seen = Set<String>()
+        for (name, target) in Self.sources {
+            let key = WikiNameRules.looseMatchKey(name)
+            if !seen.insert(key).inserted { looseSources.removeValue(forKey: key) }
+            else { looseSources[key] = target }
+        }
+        let storedTarget = Target(path: ["sources", "by-name", "Self-Driving Wiki \u{2014} User Guide--01CCCCCC.md"],
+                                  title: storedName)
+        var sources = Self.sources
+        sources[storedName] = storedTarget
+        looseSources[WikiNameRules.looseMatchKey(storedName)] = storedTarget
+
+        let resolver = RelativeLinkRewriter.Resolver(
+            baseDir: ["pages", "by-title"],
+            page:   { t, isID in isID ? Self.pagesByID[t.uppercased()] : Self.pages[t] },
+            source: { t, isID in
+                if isID { return Self.sourcesByID[t.uppercased()] }
+                return sources[t] ?? looseSources[WikiNameRules.looseMatchKey(t)]
+            },
+            chat:   { t, isID in isID ? Self.chatsByID[t.uppercased()] : Self.chats[t] }
+        )
+        let out = RelativeLinkRewriter.rewrite(
+            "[[source:Self-Driving Wiki User Guide#Launch the app]]",
+            resolver: resolver)
+        #expect(out.contains("../../sources/by-name/"))
+        #expect(out.contains("--01CCCCCC.md"))
+        #expect(!out.contains("[[source:"))
+    }
+
     // MARK: - Chat links → chats/by-name (cross-namespace)
 
     @Test func canonicalChatLinkResolvesToRelativePath() {

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -387,6 +387,19 @@ struct WikiCtlCommandTests {
         #expect(lines[1].contains("alpha.txt"))
     }
 
+    @Test func fileListShowsDisplayNameAfterRename() throws {
+        let store = try tempStore()
+        let src = try store.addSource(filename: "User Guide.md", data: Data("# Guide".utf8))
+        try store.renameSource(id: src.id, to: "Self-Driving Wiki — User Guide")
+        let result = try SourceCommand.run(.list(json: false), in: store, cwd: "/tmp")
+        guard case .text(let output) = result.payload else {
+            #expect(Bool(false), "expected .text payload"); return
+        }
+        // Text mode should show the display name, not the filename.
+        #expect(output.contains("Self-Driving Wiki — User Guide"))
+        #expect(!output.contains("User Guide.md"))
+    }
+
     @Test func fileListJSONMatchesFilesJSONL() throws {
         let store = try tempStore()
         _ = try store.addSource(filename: "one.txt", data: Data("aaa".utf8))
@@ -402,7 +415,8 @@ struct WikiCtlCommandTests {
             IndexGenerators.SourceIndexRow(
                 id: s.id.rawValue, filename: s.filename, ext: s.ext,
                 mime: s.mimeType, byteSize: s.byteSize,
-                createdAt: s.createdAt, updatedAt: s.updatedAt, version: s.version
+                createdAt: s.createdAt, updatedAt: s.updatedAt, version: s.version,
+                displayName: s.displayName
             )
         }
         let expected = String(decoding: IndexGenerators.sourcesJSONL(sources: rows), as: UTF8.self)

--- a/Tests/WikiFSTests/WikiNameRulesTests.swift
+++ b/Tests/WikiFSTests/WikiNameRulesTests.swift
@@ -70,4 +70,33 @@ struct WikiNameRulesTests {
         // A 6+ char or non-alphanumeric tail is not a file extension.
         #expect(WikiNameRules.looseMatchKey("release.candidate") == "release.candidate")
     }
+
+    // MARK: - dash normalization
+
+    @Test func looseKeyNormalizesEmDashToSpace() {
+        // "Self-Driving Wiki — User Guide" (em dash) should match
+        // "Self-Driving Wiki User Guide" (no dash at all).
+        let withEmDash = WikiNameRules.looseMatchKey("Self-Driving Wiki \u{2014} User Guide")
+        let noDash = WikiNameRules.looseMatchKey("Self-Driving Wiki User Guide")
+        #expect(withEmDash == noDash)
+    }
+
+    @Test func looseKeyNormalizesEnDashToSpace() {
+        let withEnDash = WikiNameRules.looseMatchKey("Foo \u{2013} Bar")
+        let noDash = WikiNameRules.looseMatchKey("Foo Bar")
+        #expect(withEnDash == noDash)
+    }
+
+    @Test func looseKeyNormalizesHyphenToSpace() {
+        let withHyphen = WikiNameRules.looseMatchKey("Self-Driving Wiki")
+        let noDash = WikiNameRules.looseMatchKey("Self Driving Wiki")
+        #expect(withHyphen == noDash)
+    }
+
+    @Test func looseKeyNormalizesMixedDashVariants() {
+        // Em dash, en dash, and hyphen-minus all normalize to space.
+        let mixed = WikiNameRules.looseMatchKey("A\u{2014}B\u{2013}C-D")
+        let allSpaces = WikiNameRules.looseMatchKey("A B C D")
+        #expect(mixed == allSpaces)
+    }
 }


### PR DESCRIPTION
## Summary

Expand link linting to detect broken source (`[[source:…]]`) and chat (`[[chat:…]]`) links in addition to page links. Improve link resolution with dash-tolerant matching so that names like "Self-Driving Wiki — User Guide" (em dash) and "Self-Driving Wiki User Guide" (no dash) are treated as equivalent.

## Changes

### Core link detection
- Rewrote `WikiStoreModel.preflightLint()` to detect broken links across all three namespaces (pages, sources, chats) using regex matching
- Added protection for links inside code spans and fenced blocks—`[[Like This]]` in backticks is example text, not a real link
- Support both canonical ULID links (resolved at save time) and name-based links

### Dash normalization
- Added `WikiNameRules.looseMatchKey()` normalization for em dashes (U+2014), en dashes (U+2013), and hyphens to spaces
- This allows "Self-Driving Wiki — User Guide" and "Self-Driving Wiki User Guide" to match via `looseMatchKey` fallback
- Applied to both source and chat link resolution in `Projection.LinkMaps`

### Display naming
- Sources now use `effectiveName` (display name) instead of filename in CLI output and agent-visible labels
- Ensures agents see consistent names across sources.jsonl and wikictl output

### Lint reporting
- `LintPreflight` now exposes separate `brokenSourceLinks` and `brokenChatLinks` fields
- Both ingestion providers and agent runner now report all three types of broken links to lint tasks

## Tests
- Canonical ULID links are not false positives
- Links inside code spans and fenced blocks are correctly skipped
- Source and chat link detection and resolution
- Dash normalization (em dash, en dash, hyphen, mixed variants)
- Display name appears in file list after rename