### PR TITLE
Fix relative link resolution in wiki reader

### DIFF
--- a/Sources/WikiFS/WikiReaderView.swift
+++ b/Sources/WikiFS/WikiReaderView.swift
@@ -1064,6 +1064,23 @@ internal struct WikiReaderRep: NSViewRepresentable {
                     decisionHandler(.cancel)
                     return
                 }
+                // Relative links in source markdown (e.g. `[Back to README](../README.md)`)
+                // are not `[[wikilinks]]`, so `RelativeLinkRewriter` leaves them as raw
+                // `<a href>`. WKWebView resolves them against the synthetic reader origin
+                // (`WikiReaderOrigin` → `https://reader.wikifs.invalid`). Try to navigate to
+                // a matching source by filename/display-name; if none found, cancel silently
+                // — never open the bogus `reader.wikifs.invalid` URL in the system browser.
+                if url.host == WikiReaderOrigin.url?.host {
+                    let targetName = url.lastPathComponent
+                    let openInNewTab = navigationAction.modifierFlags.contains(.command)
+                    if let store,
+                       let id = store.sourceID(forDisplayName: targetName)
+                               ?? store.sourceID(forDisplayName: (targetName as NSString).deletingPathExtension) {
+                        store.selectSource(byID: id, anchor: url.fragment, openInNewTab: openInNewTab)
+                    }
+                    decisionHandler(.cancel)
+                    return
+                }
                 // External links open in the system browser, not in the reader.
                 // Footnote references are same-page fragment links (`#wiki-fn-…`),
                 // so they fall through to `.allow` and WKWebView scrolls natively.

--- a/Sources/WikiFSCore/ExternalEmbed.swift
+++ b/Sources/WikiFSCore/ExternalEmbed.swift
@@ -63,7 +63,12 @@ public struct SourceEmbedDescriptor: Sendable, Equatable {
 /// syntactically valid https origin that the reader and the embed agree on.
 public enum WikiReaderOrigin {
     /// The origin string, e.g. stamped into `?origin=` on the YouTube embed URL.
-    public static let string = "https://reader.wikifs.local"
+    /// Uses `.invalid` (RFC 2606) so the host **never** resolves — `.local` is
+    /// mDNS/Bonjour-resolvable, so a device on the LAN could advertise this name
+    /// and intercept stray relative fetches/XHRs from the reader document.
+    /// YouTube's `?origin=` check is a string comparison against
+    /// `window.location.origin`, not a DNS lookup, so `.invalid` satisfies it.
+    public static let string = "https://reader.wikifs.invalid"
     /// The same origin as a `URL`, for `loadHTMLString(baseURL:)`.
     public static var url: URL? { URL(string: string) }
 }


### PR DESCRIPTION
## Summary

Handles relative links in markdown (e.g., `[Back to README](../README.md)`) by intercepting clicks and resolving them to matching sources within the wiki, rather than letting them point to the unreachable synthetic reader origin.

Also replaces the synthetic origin domain from `.local` (mDNS/Bonjour-resolvable, vulnerable to LAN interception) to `.invalid` (RFC 2606, guaranteed non-resolvable), preventing potential XHR hijacking while maintaining YouTube embed origin validation.

## Changes

- **WikiReaderView.swift**: Added navigation policy handler that intercepts clicks on the reader origin host and attempts to match the target filename against sources in the store. If a match is found, navigates to that source; otherwise cancels silently.
- **ExternalEmbed.swift**: Changed `WikiReaderOrigin` string from `reader.wikifs.local` to `reader.wikifs.invalid` with security rationale in comments.