### PR TITLE
Per-wiki connections substrate: Zotero as connection #1

### DIFF
--- a/Sources/WikiFS/AddressBarView.swift
+++ b/Sources/WikiFS/AddressBarView.swift
@@ -453,6 +453,10 @@ struct AddressBarView: View {
         case .chat(let id):
             let title = store.chats.first { $0.id == id }?.title ?? ""
             return title.isEmpty ? "" : "[[chat:\(title)]]"
+        case .connection:
+            // Connections aren't wiki-linkable; the omnibox stays in its
+            // search-first empty state on a connection tab.
+            return ""
         }
     }
 }

--- a/Sources/WikiFS/ConnectionDetailView.swift
+++ b/Sources/WikiFS/ConnectionDetailView.swift
@@ -1,0 +1,276 @@
+import SwiftUI
+import WikiFSCore
+
+/// The detail-pane tab for one `Connection`. Two modes:
+///
+/// - **Config** — a native `SchemaForm` rendered from the provider manifest's
+///   JSON schema, plus "Test Connection" and "Save". This is the surface that
+///   replaces the per-provider hand-written settings screen (issue #483): a new
+///   provider contributes a schema, not Swift.
+/// - **Workspace** — the configured connection's browse/add surface. For Zotero
+///   that's the native search picker (`ZoteroConnectionWorkspaceView`).
+///
+/// Opens in Workspace when already configured, else Config. The Connection is
+/// read from the per-wiki `WikiStoreModel` (backed by the SQLite `connections`
+/// table), so a save here is visible in the sidebar's Connections section
+/// immediately.
+struct ConnectionDetailView: View {
+    @Bindable var store: WikiStoreModel
+    let connectionID: String
+
+    @State private var isEditing = false
+    @State private var didInitMode = false
+    /// Merged config + secret values driving the form (secrets split out on Save).
+    @State private var formValues: [String: String] = [:]
+    @State private var testPhase: TestPhase = .idle
+
+    private enum TestPhase: Equatable {
+        case idle, testing, ok
+        case failed(String)
+    }
+
+    var body: some View {
+        content
+            .onAppear(perform: initModeIfNeeded)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let connection = store.connection(id: connectionID),
+           let manifest = store.manifest(for: connection) {
+            VStack(spacing: 0) {
+                header(connection: connection, manifest: manifest)
+                Divider()
+                if isEditing {
+                    configForm(connection: connection, manifest: manifest)
+                } else {
+                    workspace(connection: connection, manifest: manifest)
+                }
+            }
+        } else {
+            ContentUnavailableView {
+                Label("Connection Unavailable", systemImage: "cable.connector.slash")
+            } description: {
+                Text("This connection or its provider is no longer available.")
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private func header(connection: Connection, manifest: ProviderManifest) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: manifest.icon)
+                .font(.title2).foregroundStyle(.tint)
+            VStack(alignment: .leading, spacing: 1) {
+                // Renames in place exactly like a page/source title (double-click
+                // or right-click → Rename). Commit persists via the store and
+                // retitles the open tab; the sidebar row updates observably.
+                EditableTitle(
+                    title: connection.label,
+                    placeholder: manifest.displayName,
+                    font: .headline
+                ) { newLabel in
+                    store.renameConnection(id: connection.id, to: newLabel)
+                }
+                Text(manifest.displayName).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            if isEditing {
+                Button("Done") {
+                    save(connection: connection, manifest: manifest)
+                }
+            } else {
+                Button {
+                    loadFormValues(connection: connection, manifest: manifest)
+                    testPhase = .idle
+                    isEditing = true
+                } label: {
+                    Label("Configure", systemImage: "gearshape")
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Config mode
+
+    @ViewBuilder
+    private func configForm(connection: Connection, manifest: ProviderManifest) -> some View {
+        // The action bar is pinned as a bottom safe-area inset, NOT stacked after
+        // the form: a `.grouped` Form is greedy vertically and would otherwise
+        // push "Save" off the bottom of the pane (the bug where you could set a
+        // folder but never reach a way to finish).
+        SchemaForm(schema: manifest.config, values: $formValues)
+            .safeAreaInset(edge: .bottom) {
+                actionBar(connection: connection, manifest: manifest)
+            }
+    }
+
+    private func actionBar(connection: Connection, manifest: ProviderManifest) -> some View {
+        HStack(spacing: 10) {
+            switch testPhase {
+            case .idle:
+                EmptyView()
+            case .testing:
+                ProgressView().controlSize(.small)
+                Text("Testing…").font(.callout).foregroundStyle(.secondary)
+            case .ok:
+                Label("Connection OK", systemImage: "checkmark.circle.fill")
+                    .font(.callout).foregroundStyle(.green)
+            case .failed(let message):
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout).foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+            Spacer()
+            if supportsConnectionTest(connection) {
+                Button("Test Connection") { testConnection(connection: connection) }
+                    .disabled(testPhase == .testing)
+            }
+            Button("Save") { save(connection: connection, manifest: manifest) }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canSave)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(.bar)
+    }
+
+    /// The Save button is enabled only when the form has enough to configure the
+    /// connection — so an empty folder path can't be "saved" into a dead state.
+    private var canSave: Bool {
+        guard let connection = store.connection(id: connectionID) else { return false }
+        switch connection.providerID {
+        case ZoteroConnection.providerID:
+            let lib = formValues[ZoteroConnection.libraryIDKey]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let key = formValues[ZoteroConnection.apiKeyField]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return !lib.isEmpty && !key.isEmpty
+        default:
+            return true
+        }
+    }
+
+    // MARK: - Workspace mode
+
+    @ViewBuilder
+    private func workspace(connection: Connection, manifest: ProviderManifest) -> some View {
+        if !isConfigured(connection) {
+            notConfiguredState(manifest: manifest, connection: connection)
+        } else if connection.providerID == ZoteroConnection.providerID {
+            let apiKey = store.secret(for: connection, field: ZoteroConnection.apiKeyField)
+            ZoteroConnectionWorkspaceView(
+                store: store,
+                client: ZoteroConnection.client(for: connection, apiKey: apiKey),
+                zoteroDir: ZoteroConnection.zoteroDirectory(for: connection))
+        } else {
+            ContentUnavailableView {
+                Label("Nothing to browse yet", systemImage: "tray")
+            } description: {
+                Text("This provider doesn't have a browse surface yet.")
+            }
+        }
+    }
+
+    private func notConfiguredState(manifest: ProviderManifest, connection: Connection) -> some View {
+        VStack(spacing: 10) {
+            Spacer()
+            Label("\(manifest.displayName) isn't set up yet", systemImage: manifest.icon)
+                .font(.body)
+            Text(manifest.description)
+                .font(.callout).foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            Button("Configure…") {
+                loadFormValues(connection: connection, manifest: manifest)
+                isEditing = true
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(40)
+    }
+
+    // MARK: - Mode / form helpers
+
+    private func initModeIfNeeded() {
+        guard !didInitMode else { return }
+        didInitMode = true
+        guard let connection = store.connection(id: connectionID),
+              let manifest = store.manifest(for: connection) else { return }
+        loadFormValues(connection: connection, manifest: manifest)
+        isEditing = !isConfigured(connection)
+    }
+
+    /// Seed the form from the connection's stored config + secrets.
+    private func loadFormValues(connection: Connection, manifest: ProviderManifest) {
+        var values = connection.config
+        for field in manifest.config.fields where field.secret {
+            values[field.name] = store.secret(for: connection, field: field.name) ?? ""
+        }
+        formValues = values
+    }
+
+    private func isConfigured(_ connection: Connection) -> Bool {
+        switch connection.providerID {
+        case ZoteroConnection.providerID:
+            let apiKey = store.secret(for: connection, field: ZoteroConnection.apiKeyField)
+            return ZoteroConnection.isConfigured(connection, apiKey: apiKey)
+        default:
+            return false
+        }
+    }
+
+    /// Whether this provider has a credentialed endpoint worth a "Test
+    /// Connection" round-trip (Zotero). A folder just needs a valid path, which
+    /// the picker + `isConfigured` already enforce.
+    private func supportsConnectionTest(_ connection: Connection) -> Bool {
+        connection.providerID == ZoteroConnection.providerID
+    }
+
+    // MARK: - Save / Test
+
+    private func save(connection: Connection, manifest: ProviderManifest) {
+        let secretNames = manifest.config.secretFieldNames
+        var updated = connection
+        // Non-secret fields → connection config (drop empties to keep it tidy).
+        var config: [String: String] = [:]
+        for field in manifest.config.fields where !field.secret {
+            let value = formValues[field.name]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !value.isEmpty { config[field.name] = value }
+        }
+        updated.config = config
+        store.upsertConnection(updated)
+        // Secret fields → Keychain.
+        for name in secretNames {
+            store.setSecret(formValues[name] ?? "", for: updated, field: name)
+        }
+        if isConfigured(updated) {
+            isEditing = false
+        }
+    }
+
+    private func testConnection(connection: Connection) {
+        testPhase = .testing
+        let apiKey = formValues[ZoteroConnection.apiKeyField]
+        var probe = connection
+        var config = connection.config
+        config[ZoteroConnection.libraryIDKey] = formValues[ZoteroConnection.libraryIDKey]
+        probe.config = config
+        guard let client = ZoteroConnection.client(for: probe, apiKey: apiKey) else {
+            testPhase = .failed("Enter an API key and library ID first.")
+            return
+        }
+        Task {
+            do {
+                try await client.verifyConnection()
+                testPhase = .ok
+            } catch {
+                let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                testPhase = .failed(message)
+            }
+        }
+    }
+}

--- a/Sources/WikiFS/ConnectionsContainerView.swift
+++ b/Sources/WikiFS/ConnectionsContainerView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+import WikiFSCore
+
+/// The **Connections** sidebar section: a provider-grouped tree where each
+/// provider (Zotero, Folder) is a disclosure parent and configured connections
+/// are its children. This mirrors the bookmarks tree pattern but simpler — no
+/// drag-reorder, no nesting beyond one level.
+///
+/// Each provider row has an **＋** button that creates a new unconfigured
+/// connection of that provider kind and opens its config tab. Clicking a
+/// connection opens its workspace/config tab. The tree reads from the per-wiki
+/// `WikiStoreModel.connections` list (backed by the SQLite `connections` table),
+/// so it updates observably after a save or delete.
+struct ConnectionsContainerView: View {
+    @Bindable var store: WikiStoreModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            List {
+                ForEach(ProviderRegistry.addable) { manifest in
+                    providerSection(manifest)
+                }
+            }
+            .listStyle(.sidebar)
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Connections")
+                .font(.headline)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Provider section
+
+    @ViewBuilder
+    private func providerSection(_ manifest: ProviderManifest) -> some View {
+        let children = connections(for: manifest.id)
+        DisclosureGroup(isExpanded: sectionBinding(for: manifest.id)) {
+            ForEach(children) { connection in
+                connectionRow(connection, manifest: manifest)
+            }
+        } label: {
+            providerHeader(manifest, count: children.count)
+        }
+    }
+
+    private func providerHeader(_ manifest: ProviderManifest, count: Int) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: manifest.icon)
+                .frame(width: 18)
+                .foregroundStyle(.secondary)
+            Text(manifest.displayName).font(.body)
+            if count > 0 {
+                Text("\(count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(.quaternary, in: Capsule())
+            }
+            Spacer()
+            // Inline add button on the provider row — matches the bookmarks
+            // header pattern (compact + on the trailing edge).
+            Button {
+                addConnection(providerID: manifest.id)
+            } label: {
+                Image(systemName: "plus")
+                    .font(.callout)
+                    .frame(width: 20, height: 20)
+                    .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Add \(manifest.displayName) Connection")
+        }
+    }
+
+    // MARK: - Connection row
+
+    private func connectionRow(_ connection: Connection, manifest: ProviderManifest) -> some View {
+        Button {
+            store.openTab(.connection(connection.id), title: connection.label)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: isConfigured(connection)
+                      ? "circle.fill"
+                      : "circle.dashed")
+                    .font(.caption2)
+                    .foregroundStyle(isConfigured(connection) ? .green : .secondary)
+                    .frame(width: 18)
+                Text(connection.label).font(.body)
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("Delete", role: .destructive) {
+                store.deleteConnection(id: connection.id)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func connections(for providerID: String) -> [Connection] {
+        store.connections.filter { $0.providerID == providerID }
+    }
+
+    private func isConfigured(_ connection: Connection) -> Bool {
+        switch connection.providerID {
+        case ZoteroConnection.providerID:
+            let apiKey = store.secret(for: connection, field: ZoteroConnection.apiKeyField)
+            return ZoteroConnection.isConfigured(connection, apiKey: apiKey)
+        default:
+            return false
+        }
+    }
+
+    /// Create a new connection for `providerID`, persist it, and open its tab
+    /// in the config form (unconfigured — the user enters credentials).
+    private func addConnection(providerID: String) {
+        guard let connection = store.createConnection(providerID: providerID) else { return }
+        store.openTab(.connection(connection.id), title: connection.label)
+    }
+
+    // MARK: - Section expansion state
+
+    @State private var expandedSections: Set<String> = Set(ProviderRegistry.addable.map(\.id))
+
+    private func sectionBinding(for id: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedSections.contains(id) },
+            set: { isExpanded in
+                if isExpanded { expandedSections.insert(id) }
+                else { expandedSections.remove(id) }
+            }
+        )
+    }
+}

--- a/Sources/WikiFS/SchemaForm.swift
+++ b/Sources/WikiFS/SchemaForm.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import WikiFSCore
+
+/// Renders a provider's `ProviderConfigSchema` as a **native SwiftUI `Form`** —
+/// the resolution of issue #483. The manifest's schema (decoded from JSON) is
+/// the portable, drop-in contract; this view is the ~one-file renderer that maps
+/// each `SchemaField` to a native control. No WKWebView, no JS bridge — you get
+/// native focus rings, SecureField behavior, and VoiceOver for free, and a new
+/// provider needs zero Swift here, just a schema.
+///
+/// Values are a flat `[String: String]` binding (spike simplicity): every field
+/// round-trips through its string form, and non-string types (`boolean`,
+/// `number`, `enum`) coerce at the control boundary. The container owns Save /
+/// Test and decides which keys are secrets (via the schema's `secret` flag).
+struct SchemaForm: View {
+    let schema: ProviderConfigSchema
+    @Binding var values: [String: String]
+
+    var body: some View {
+        Form {
+            ForEach(schema.fields) { field in
+                fieldRow(field)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    @ViewBuilder
+    private func fieldRow(_ field: SchemaField) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            control(for: field)
+            if let help = field.help {
+                Text(help)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func control(for field: SchemaField) -> some View {
+        if field.format == .password {
+            SecureField(field.title, text: stringBinding(field))
+                .textFieldStyle(.roundedBorder)
+        } else if let options = field.enumValues, !options.isEmpty {
+            Picker(field.title, selection: stringBinding(field)) {
+                ForEach(options, id: \.self) { Text($0).tag($0) }
+            }
+        } else if field.type == .boolean {
+            Toggle(field.title, isOn: boolBinding(field))
+        } else if field.format == .path {
+            LabeledContent(field.title) {
+                HStack {
+                    TextField(field.placeholder ?? "", text: stringBinding(field))
+                        .textFieldStyle(.roundedBorder)
+                    Button("Choose…") { chooseDirectory(field) }
+                }
+            }
+        } else {
+            LabeledContent(field.title) {
+                TextField(field.placeholder ?? "", text: stringBinding(field))
+                    .textFieldStyle(.roundedBorder)
+            }
+        }
+    }
+
+    // MARK: - Bindings
+
+    /// A string binding into `values` for `field`, defaulting to "".
+    private func stringBinding(_ field: SchemaField) -> Binding<String> {
+        Binding(
+            get: { values[field.name] ?? "" },
+            set: { values[field.name] = $0 }
+        )
+    }
+
+    /// A bool binding that stores `"true"` / `"false"` in the string map.
+    private func boolBinding(_ field: SchemaField) -> Binding<Bool> {
+        Binding(
+            get: { (values[field.name] ?? "false") == "true" },
+            set: { values[field.name] = $0 ? "true" : "false" }
+        )
+    }
+
+    private func chooseDirectory(_ field: SchemaField) {
+        if let url = WikiFilePanels.chooseDirectory(
+            title: "Choose \(field.title)", prompt: "Choose") {
+            values[field.name] = url.path
+        }
+    }
+}

--- a/Sources/WikiFS/SidebarView.swift
+++ b/Sources/WikiFS/SidebarView.swift
@@ -45,7 +45,7 @@ struct SidebarView: View {
     /// The sidebar's sections. Each gets an icon in the selector bar and, when
     /// selected, fills the list below.
     enum SidebarSection: String, CaseIterable, Identifiable {
-        case pages, sources, bookmarks, chats
+        case pages, sources, bookmarks, chats, connections
 
         var id: String { rawValue }
 
@@ -55,6 +55,7 @@ struct SidebarView: View {
             case .sources: "Sources"
             case .bookmarks: "Bookmarks"
             case .chats: "Chats"
+            case .connections: "Connections"
             }
         }
 
@@ -64,6 +65,7 @@ struct SidebarView: View {
             case .sources: ResourceKind.source.systemImageName
             case .bookmarks: ResourceKind.bookmark.systemImageName
             case .chats: ResourceKind.chat.systemImageName
+            case .connections: "cable.connector"
             }
         }
     }
@@ -186,6 +188,8 @@ struct SidebarView: View {
                 })
         case .chats:
             AgentToolsView(store: store, chatLauncher: chatLauncher)
+        case .connections:
+            ConnectionsContainerView(store: store)
         }
     }
 

--- a/Sources/WikiFS/WikiDetailView.swift
+++ b/Sources/WikiFS/WikiDetailView.swift
@@ -193,6 +193,8 @@ struct WikiDetailView: View {
                 session: session,
                 fileProvider: fileProvider
             )
+        case .connection(let id):
+            ConnectionDetailView(store: store, connectionID: id)
         }
     }
 

--- a/Sources/WikiFS/ZoteroConnectionWorkspaceView.swift
+++ b/Sources/WikiFS/ZoteroConnectionWorkspaceView.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+import WikiFSCore
+
+/// The Zotero connection's **workspace**: the native search-as-you-type picker
+/// re-homed from the modal `AddFromZoteroSheet` into a connection *tab*. Same
+/// two-level flow (search results → an item's PDF/Markdown attachments → "Add
+/// Selected"), same seam (`store.ingestFromZotero` → `ZoteroMaterializer` →
+/// `storeMaterialized`) — only the presentation changed from a sheet to a tab,
+/// and the client is resolved from a `Connection` instead of app-wide
+/// `ZoteroConfig`.
+struct ZoteroConnectionWorkspaceView: View {
+    @Bindable var store: WikiStoreModel
+    let client: ZoteroClient?
+    let zoteroDir: URL
+
+    @State private var queryText = ""
+    @State private var searchPhase: SearchPhase = .idle
+    @State private var searchTask: Task<Void, Never>?
+
+    @State private var selectedItem: ZoteroItem?
+    @State private var attachmentRows: [AttachmentRow] = []
+    @State private var attachmentsPhase: AttachmentsPhase = .idle
+    @State private var selectedAttachmentKeys: Set<String> = []
+    @State private var ingestPhase: IngestPhase = .idle
+    @State private var lastAddedCount = 0
+
+    private enum SearchPhase: Equatable {
+        case idle, searching
+        case results([ZoteroItem])
+        case failed(String)
+    }
+    private enum AttachmentsPhase: Equatable {
+        case idle, loading, loaded
+        case failed(String)
+    }
+    private enum IngestPhase: Equatable {
+        case idle, ingesting
+        case failed(String)
+    }
+
+    private struct AttachmentRow: Identifiable {
+        let attachment: ZoteroAttachment
+        let source: ZoteroLocalStorage.AttachmentSource
+        var id: String { attachment.key }
+        var isAvailable: Bool {
+            if case .local = source { return true }
+            return false
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let selectedItem {
+                attachmentPicker(for: selectedItem)
+            } else {
+                searchResults
+            }
+            footer
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task { runSearch() }
+    }
+
+    // MARK: - Search
+
+    private var searchResults: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("Search by title, author, or year", text: $queryText)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: queryText) { runSearch() }
+
+            switch searchPhase {
+            case .idle, .searching:
+                centeredProgress
+            case .failed(let message):
+                errorLabel(message)
+            case .results(let items):
+                if items.isEmpty {
+                    Text("No matching items.")
+                        .font(.callout).foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                } else {
+                    List(items) { item in
+                        Button { selectItem(item) } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(item.title ?? "Untitled").font(.body)
+                                if let subtitle = item.subtitle {
+                                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+            }
+        }
+    }
+
+    // MARK: - Attachment drill-down
+
+    private func attachmentPicker(for item: ZoteroItem) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button("‹ Back to results") { deselectItem() }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.accentColor)
+
+            Text(item.title ?? "Untitled").font(.body.weight(.medium))
+
+            switch attachmentsPhase {
+            case .idle, .loading:
+                centeredProgress
+            case .failed(let message):
+                errorLabel(message)
+            case .loaded:
+                if attachmentRows.isEmpty {
+                    Text("No PDF or Markdown attachments on this item.")
+                        .font(.callout).foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                } else {
+                    List(attachmentRows) { row in
+                        Toggle(isOn: toggleBinding(for: row)) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(row.attachment.filename ?? row.attachment.title ?? "Attachment")
+                                    .font(.body)
+                                if !row.isAvailable {
+                                    Text("Not synced to this Mac yet")
+                                        .font(.caption).foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .disabled(!row.isAvailable)
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+            }
+
+            if case .failed(let message) = ingestPhase {
+                errorLabel(message)
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            if ingestPhase == .ingesting {
+                ProgressView().controlSize(.small)
+            } else if lastAddedCount > 0 {
+                Label("Added \(lastAddedCount) source\(lastAddedCount == 1 ? "" : "s")",
+                      systemImage: "checkmark.circle.fill")
+                    .font(.callout).foregroundStyle(.green)
+            }
+            Spacer()
+            if selectedItem != nil {
+                Button("Add Selected") { addSelected() }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(selectedAttachmentKeys.isEmpty || ingestPhase == .ingesting)
+            }
+        }
+    }
+
+    // MARK: - Shared bits
+
+    private var centeredProgress: some View {
+        HStack { Spacer(); ProgressView().controlSize(.small); Spacer() }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorLabel(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle.fill")
+            .font(.callout).foregroundStyle(.red)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func toggleBinding(for row: AttachmentRow) -> Binding<Bool> {
+        Binding(
+            get: { selectedAttachmentKeys.contains(row.id) },
+            set: { isOn in
+                if isOn { selectedAttachmentKeys.insert(row.id) }
+                else { selectedAttachmentKeys.remove(row.id) }
+            }
+        )
+    }
+
+    // MARK: - Actions
+
+    private func runSearch() {
+        searchTask?.cancel()
+        guard let client else { return }
+        let query = queryText
+        searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            searchPhase = .searching
+            do {
+                let items = try await client.searchItems(query: query)
+                guard !Task.isCancelled else { return }
+                searchPhase = .results(items)
+            } catch {
+                guard !Task.isCancelled else { return }
+                searchPhase = .failed(errorMessage(error))
+            }
+        }
+    }
+
+    private func selectItem(_ item: ZoteroItem) {
+        selectedItem = item
+        selectedAttachmentKeys = []
+        attachmentRows = []
+        attachmentsPhase = .loading
+        lastAddedCount = 0
+        guard let client else { return }
+        Task {
+            do {
+                let attachments = try await client.childAttachments(ofItemKey: item.key)
+                attachmentRows = attachments
+                    .filter(\.isIngestable)
+                    .map { attachment in
+                        AttachmentRow(
+                            attachment: attachment,
+                            source: ZoteroLocalStorage.resolve(attachment, zoteroDir: zoteroDir))
+                    }
+                attachmentsPhase = .loaded
+            } catch {
+                attachmentsPhase = .failed(errorMessage(error))
+            }
+        }
+    }
+
+    private func deselectItem() {
+        selectedItem = nil
+        attachmentRows = []
+        attachmentsPhase = .idle
+        selectedAttachmentKeys = []
+        ingestPhase = .idle
+    }
+
+    /// Ingest every selected attachment, collect-and-continue on a per-item
+    /// failure (mirrors `AddFromZoteroSheet.addSelected`). Stays on the item so
+    /// the user can add more; a success count shows in the footer.
+    private func addSelected() {
+        let toIngest = attachmentRows
+            .filter { selectedAttachmentKeys.contains($0.id) }
+            .map(\.attachment)
+        guard !toIngest.isEmpty, let item = selectedItem else { return }
+        ingestPhase = .ingesting
+        lastAddedCount = 0
+        Task {
+            var failures: [String] = []
+            var added = 0
+            for attachment in toIngest {
+                do {
+                    try await store.ingestFromZotero(attachment, parentItem: item, zoteroDir: zoteroDir)
+                    added += 1
+                } catch {
+                    let name = attachment.filename ?? attachment.title ?? attachment.key
+                    failures.append("\(name): \(errorMessage(error))")
+                }
+            }
+            lastAddedCount = added
+            selectedAttachmentKeys = []
+            if failures.isEmpty {
+                ingestPhase = .idle
+            } else {
+                ingestPhase = .failed(failures.joined(separator: "\n"))
+            }
+        }
+    }
+
+    private func errorMessage(_ error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
+}

--- a/Sources/WikiFSCore/ConnectionCredentialStore.swift
+++ b/Sources/WikiFSCore/ConnectionCredentialStore.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Security
+
+/// Per-connection secret storage — the generic form of
+/// `ZoteroCredentialStore`, keyed by `(connectionID, field)` so two Zotero
+/// connections (two user IDs) hold two independent API keys. Secrets never touch
+/// the plaintext `connections.json`; only the Keychain.
+public protocol ConnectionCredentialStore: Sendable {
+    func secret(connectionID: String, field: String) -> String?
+    /// Pass `nil`/empty to delete.
+    func setSecret(_ value: String?, connectionID: String, field: String) throws
+}
+
+/// Keychain-backed store: one generic-password item per `(connectionID, field)`.
+///
+/// **Compatibility shim.** The auto-migrated default Zotero connection
+/// (`zotero-default`) maps its `apiKey` to the *legacy* single-key item
+/// (`KeychainZoteroCredentialStore`'s service/account) so existing users don't
+/// lose their key and the legacy "Add from Zotero" button keeps reading the same
+/// secret. Every other connection uses the per-connection scheme.
+public struct KeychainConnectionCredentialStore: ConnectionCredentialStore {
+    private static let service = "org.sockpuppet.WikiFS.connection"
+
+    // Legacy Zotero item (kept byte-for-byte in sync with KeychainZoteroCredentialStore).
+    private static let legacyZoteroService = "org.sockpuppet.WikiFS.zotero"
+    private static let legacyZoteroAccount = "zotero-api-key"
+
+    public init() {}
+
+    /// (service, account) for a credential — the legacy item for the default
+    /// Zotero connection's key, else a per-connection account.
+    private func location(connectionID: String, field: String) -> (service: String, account: String) {
+        if connectionID == "zotero-default" && field == "apiKey" {
+            return (Self.legacyZoteroService, Self.legacyZoteroAccount)
+        }
+        return (Self.service, "\(connectionID)::\(field)")
+    }
+
+    public func secret(connectionID: String, field: String) -> String? {
+        let loc = location(connectionID: connectionID, field: field)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: loc.service,
+            kSecAttrAccount as String: loc.account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    public func setSecret(_ value: String?, connectionID: String, field: String) throws {
+        let loc = location(connectionID: connectionID, field: field)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: loc.service,
+            kSecAttrAccount as String: loc.account,
+        ]
+
+        guard let value, !value.isEmpty else {
+            let status = SecItemDelete(query as CFDictionary)
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw ZoteroKeychainError(operation: "delete", status: status)
+            }
+            return
+        }
+
+        let data = Data(value.utf8)
+        let updateStatus = SecItemUpdate(
+            query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        if updateStatus == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw ZoteroKeychainError(operation: "add", status: addStatus)
+            }
+        } else if updateStatus != errSecSuccess {
+            throw ZoteroKeychainError(operation: "update", status: updateStatus)
+        }
+    }
+}
+
+/// In-memory test double.
+public final class InMemoryConnectionCredentialStore: ConnectionCredentialStore, @unchecked Sendable {
+    private var secrets: [String: String] = [:]
+
+    public init() {}
+
+    private func key(_ connectionID: String, _ field: String) -> String { "\(connectionID)::\(field)" }
+
+    public func secret(connectionID: String, field: String) -> String? {
+        secrets[key(connectionID, field)]
+    }
+
+    public func setSecret(_ value: String?, connectionID: String, field: String) throws {
+        let k = key(connectionID, field)
+        if let value, !value.isEmpty { secrets[k] = value } else { secrets[k] = nil }
+    }
+}

--- a/Sources/WikiFSCore/ConnectionModel.swift
+++ b/Sources/WikiFSCore/ConnectionModel.swift
@@ -1,0 +1,274 @@
+import Foundation
+
+/// # Connections — the configured, credentialed instance layer
+///
+/// A **Connection** is a configured, reusable instance of a provider *kind*
+/// (Zotero, later Tavily/Slack/…). It is the missing middle of the four-layer
+/// origin model from the wiki design page *Connections Architecture for Source
+/// Ingest* (`01KXNQS1`):
+///
+/// ```
+/// Kind        → ProviderManifest        (this file)
+/// Connection  → Connection + config     (this file)   ← was missing
+/// Item        → --list / native picker  (workspace UI)
+/// Rendition   → MaterializedSource       (SourceMaterializer.swift, already built)
+/// ```
+///
+/// The invariant a connection satisfies (design page): *a connection is mutable
+/// configuration; provenance is immutable history.* This is why connection
+/// identity cannot live purely in provenance columns — a Zotero API key exists
+/// with zero sources ingested.
+///
+/// **Spike note.** This first pass proves the substrate with Zotero only
+/// (issue #483 → native `SchemaForm`, no WKWebView). The provider's config form
+/// is rendered from the manifest's schema (decoded from JSON — the drop-in
+/// contract), but Zotero's *data path* stays native (`ZoteroClient` + native
+/// picker). Script-backed providers, a per-wiki SQLite table, per-connection
+/// keychain scoping, and the provenance connection-snapshot are deferred — see
+/// `plans/connections-substrate-zotero-as-connection.md`.
+
+// MARK: - Schema (the config form contract)
+
+/// One field in a provider's config form. A deliberately small, JSON-Schema-ish
+/// value — an ordered `fields` array (not a `properties` object) so field order
+/// is preserved without an `x-order` sidecar. Decodable so the deferred
+/// script-provider path can load the identical shape from a `manifest.json`.
+public struct SchemaField: Codable, Sendable, Equatable, Identifiable {
+    /// The value type. `SchemaForm` picks a native control from this + `format`.
+    public enum FieldType: String, Codable, Sendable {
+        case string, number, integer, boolean
+    }
+
+    /// A rendering/semantic hint layered on `type` (JSON Schema's `format`).
+    public enum FieldFormat: String, Codable, Sendable {
+        case password   // → SecureField, and (with `secret`) routed to Keychain
+        case path       // → TextField + "Choose…" directory picker
+        case uri
+    }
+
+    /// The config key this field reads/writes (e.g. `"libraryID"`).
+    public let name: String
+    /// The human label shown in the form.
+    public let title: String
+    public let type: FieldType
+    public let format: FieldFormat?
+    /// When present, renders a `Picker` instead of a free-text field.
+    public let enumValues: [String]?
+    /// Whether the value is a secret — stored in the Keychain, never in the
+    /// connection's plaintext config JSON.
+    public let secret: Bool
+    /// Optional helper text under the field.
+    public let help: String?
+    /// Optional placeholder for empty text fields.
+    public let placeholder: String?
+
+    public var id: String { name }
+
+    public init(
+        name: String,
+        title: String,
+        type: FieldType = .string,
+        format: FieldFormat? = nil,
+        enumValues: [String]? = nil,
+        secret: Bool = false,
+        help: String? = nil,
+        placeholder: String? = nil
+    ) {
+        self.name = name
+        self.title = title
+        self.type = type
+        self.format = format
+        self.enumValues = enumValues
+        self.secret = secret
+        self.help = help
+        self.placeholder = placeholder
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, title, type, format
+        case enumValues = "enum"
+        case secret, help, placeholder
+    }
+
+    /// Defaulting decoder — a manifest only has to declare `name`/`title`; a
+    /// plain text field omits `type`/`format`/`secret` entirely (JSON Schema
+    /// treats these as optional). Without this, every field would need `"secret":
+    /// false` etc. spelled out.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        name = try c.decode(String.self, forKey: .name)
+        title = try c.decode(String.self, forKey: .title)
+        type = try c.decodeIfPresent(FieldType.self, forKey: .type) ?? .string
+        format = try c.decodeIfPresent(FieldFormat.self, forKey: .format)
+        enumValues = try c.decodeIfPresent([String].self, forKey: .enumValues)
+        secret = try c.decodeIfPresent(Bool.self, forKey: .secret) ?? false
+        help = try c.decodeIfPresent(String.self, forKey: .help)
+        placeholder = try c.decodeIfPresent(String.self, forKey: .placeholder)
+    }
+}
+
+/// A provider's config schema: the ordered fields its connection form renders.
+public struct ProviderConfigSchema: Codable, Sendable, Equatable {
+    public let fields: [SchemaField]
+
+    public init(fields: [SchemaField]) { self.fields = fields }
+
+    /// The subset of field names that are secrets (→ Keychain, not config JSON).
+    public var secretFieldNames: Set<String> {
+        Set(fields.filter(\.secret).map(\.name))
+    }
+}
+
+// MARK: - Provider manifest (the "Kind" layer)
+
+/// Declared capabilities a provider supports. Only `browse` matters this pass
+/// (Zotero has a search picker); it's the seam the deferred `--list` script
+/// browse step reuses.
+public struct ProviderCapabilities: Codable, Sendable, Equatable {
+    public var browse: Bool
+
+    public init(browse: Bool = false) { self.browse = browse }
+}
+
+/// How a provider acquires source bytes. Zotero is `.native` (in-process
+/// `ZoteroClient`); `.script` is the deferred drop-in path (a `manifest.json` +
+/// executable in `scripts/`) — declared now so the enum is the seam, not a
+/// future breaking change.
+public enum ProviderBacking: Codable, Sendable, Equatable {
+    case native
+    case script(path: String)
+}
+
+/// A provider *kind*: its identity, its config-form schema, and how it fetches.
+/// Decodable from JSON so a built-in (Zotero, embedded JSON below) and a future
+/// dropped-in `manifest.json` decode through the exact same path.
+public struct ProviderManifest: Codable, Sendable, Equatable, Identifiable {
+    /// Stable identity, e.g. `"zotero"` — the discriminator (no `kind` enum).
+    public let id: String
+    public let displayName: String
+    public let description: String
+    /// SF Symbol name for sidebar/tab surfaces.
+    public let icon: String
+    public let capabilities: ProviderCapabilities
+    public let config: ProviderConfigSchema
+    public let backing: ProviderBacking
+
+    public init(
+        id: String,
+        displayName: String,
+        description: String,
+        icon: String,
+        capabilities: ProviderCapabilities = ProviderCapabilities(),
+        config: ProviderConfigSchema,
+        backing: ProviderBacking = .native
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.description = description
+        self.icon = icon
+        self.capabilities = capabilities
+        self.config = config
+        self.backing = backing
+    }
+}
+
+// MARK: - Provider registry
+
+/// The catalog of known provider kinds. This pass ships one built-in — Zotero —
+/// decoded from an embedded JSON manifest to prove the data-driven path (the
+/// deferred script path appends discovered `scripts/*/manifest.json` here).
+public enum ProviderRegistry {
+    /// All known provider manifests. Decoded once from embedded JSON — the same
+    /// shape a dropped-in `manifest.json` would use.
+    public static let builtIn: [ProviderManifest] = {
+        [zoteroManifestJSON].compactMap { json in
+            guard let data = json.data(using: .utf8) else { return nil }
+            do {
+                return try JSONDecoder().decode(ProviderManifest.self, from: data)
+            } catch {
+                DebugLog.config("ProviderRegistry: failed to decode a manifest: \(error)")
+                return nil
+            }
+        }
+    }()
+
+    public static func manifest(for providerID: String) -> ProviderManifest? {
+        builtIn.first { $0.id == providerID }
+    }
+
+    /// Provider kinds a user can add a new connection for. All built-ins are
+    /// plural-natural: multiple Zotero connections (one per library / user ID,
+    /// each with its own credential).
+    public static var addable: [ProviderManifest] { builtIn }
+
+    /// Zotero's manifest as JSON — the same shape a dropped-in provider would
+    /// ship as `manifest.json`. Embedded (not a bundle resource) so the spike
+    /// needs no `build.sh` change; a real `scripts/` discovery step supersedes
+    /// this. The API key is `secret: true` → Keychain, never the config JSON.
+    private static let zoteroManifestJSON = """
+    {
+      "id": "zotero",
+      "displayName": "Zotero",
+      "description": "Browse your Zotero library and ingest PDF or Markdown attachments.",
+      "icon": "books.vertical",
+      "capabilities": { "browse": true },
+      "backing": { "native": {} },
+      "config": {
+        "fields": [
+          {
+            "name": "apiKey",
+            "title": "API Key",
+            "type": "string",
+            "format": "password",
+            "secret": true,
+            "help": "A Zotero API key with library read access (zotero.org/settings/keys)."
+          },
+          {
+            "name": "libraryID",
+            "title": "Library ID",
+            "type": "string",
+            "help": "Your numeric Zotero user library ID."
+          },
+          {
+            "name": "zoteroDirOverride",
+            "title": "Zotero Data Directory",
+            "type": "string",
+            "format": "path",
+            "help": "Optional. Defaults to ~/Zotero."
+          }
+        ]
+      }
+    }
+    """
+}
+
+// MARK: - Connection (the configured instance)
+
+/// A configured instance of a provider kind. Non-secret values live in `config`
+/// (persisted per-wiki in the SQLite `connections` table); secrets live in the
+/// Keychain, keyed per `(connectionID, field)`.
+public struct Connection: Codable, Sendable, Equatable, Identifiable {
+    /// UUID at rest. New connections mint a fresh UUID via the store.
+    public let id: String
+    /// → `ProviderManifest.id`.
+    public let providerID: String
+    /// User-facing label ("Work Zotero"). Defaults to the provider display name.
+    public var label: String
+    /// Non-secret config values, keyed by `SchemaField.name`.
+    public var config: [String: String]
+    public let createdAt: Date
+
+    public init(
+        id: String,
+        providerID: String,
+        label: String,
+        config: [String: String] = [:],
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.providerID = providerID
+        self.label = label
+        self.config = config
+        self.createdAt = createdAt
+    }
+}

--- a/Sources/WikiFSCore/EditorTab.swift
+++ b/Sources/WikiFSCore/EditorTab.swift
@@ -48,6 +48,11 @@ extension WikiStoreModel {
             return bookmarkNodes.first(where: { $0.id == id })?.label ?? "Bookmark"
         case .chat(let id):
             return chats.first { $0.id == id }?.title ?? "Chat"
+        case .connection:
+            // The connection's label is passed explicitly at openTab; this is
+            // only the fallback (the app-wide connection list lives in the UI
+            // layer, not the store).
+            return "Connection"
         }
     }
 
@@ -67,6 +72,7 @@ extension WikiStoreModel {
             return "doc"
         case .bookmark: return "bookmark"
         case .chat: return "bubble.left.and.bubble.right"
+        case .connection: return "cable.connector"
         }
     }
 }

--- a/Sources/WikiFSCore/Resource.swift
+++ b/Sources/WikiFSCore/Resource.swift
@@ -33,7 +33,7 @@ public protocol Resource: Sendable {
 /// lives next to the `Resource` abstraction that owns it (the bus is one
 /// *consumer* of kinds, not their home).
 public enum ResourceKind: String, Sendable, CaseIterable {
-    case page, source, systemPrompt, wikiIndex, log, bookmark, chat
+    case page, source, systemPrompt, wikiIndex, log, bookmark, chat, connection
 
     /// The SF Symbol name used for this resource kind across every UI surface:
     /// sidebar sections, detail-view headers, the omnibox icon, bookmark row
@@ -48,6 +48,7 @@ public enum ResourceKind: String, Sendable, CaseIterable {
         case .systemPrompt: "doc.text"
         case .wikiIndex:   "book.closed"
         case .log:         "clock.arrow.circlepath"
+        case .connection:  "cable.connector"
         }
     }
 }

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -26,7 +26,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// final step of `migrate(from:)`. Tests reference this instead of
     /// hardcoding a magic number, so a schema bump doesn't require updating
     /// every test file.
-    public static let currentSchemaVersion = 37
+    public static let currentSchemaVersion = 38
 
     private let db: OpaquePointer
     /// Prepared-statement cache keyed by SQL text; reused via `reset()`.
@@ -628,6 +628,9 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // model recreation between launches. Created here in the fresh path;
         // existing DBs get it via the v36→37 migration step.
         try createWikiMetadataTable()
+        // v38 (per-wiki connections): a `connections` table for Zotero/Folder
+        // connections scoped to this wiki. Purely additive (`IF NOT EXISTS`).
+        try createConnectionsTable()
         try exec("PRAGMA user_version=\(Self.currentSchemaVersion);")
     }
 
@@ -647,6 +650,26 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     /// The v36→37 migration step: creates the `wiki_metadata` key-value table.
     private func migrateV36ToV37() throws {
         try createWikiMetadataTable()
+    }
+
+    /// The `connections` table (v38): one row per configured connection in this
+    /// wiki. Non-secret config values are stored as a JSON blob in `config`;
+    /// secrets live in the Keychain (see `ConnectionCredentialStore`), keyed by
+    /// `(connectionID, field)`.
+    private func createConnectionsTable() throws {
+        try exec("""
+        CREATE TABLE IF NOT EXISTS connections (
+            id          TEXT PRIMARY KEY,
+            provider_id TEXT NOT NULL,
+            label       TEXT NOT NULL,
+            config      TEXT NOT NULL DEFAULT '{}'
+        );
+        """)
+    }
+
+    /// The v37→38 migration step: creates the `connections` table.
+    private func migrateV37ToV38() throws {
+        try createConnectionsTable()
     }
 
     /// Create the five graph-model objects tables (§4.1–4.3): `blobs`,
@@ -1591,8 +1614,18 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         // key-value table for persisting one-time work flags (e.g. the link-
         // reconcile version) so they survive model recreation between launches.
         // Purely additive — `CREATE TABLE IF NOT EXISTS`.
-        if version < Self.currentSchemaVersion {
+        if version < 37 {
             try migrateV36ToV37()
+            try exec("PRAGMA user_version=37;")
+            version = 37
+        }
+
+        // Step 37 → 38 (per-wiki connections): creates a `connections` table so
+        // each wiki owns its Zotero/Folder connections. Purely additive —
+        // `CREATE TABLE IF NOT EXISTS`. No app-wide JSON migration: connections
+        // are per-wiki now; the old `connections.json` is simply abandoned.
+        if version < Self.currentSchemaVersion {
+            try migrateV37ToV38()
             try exec("PRAGMA user_version=\(Self.currentSchemaVersion);")
             version = Self.currentSchemaVersion
         }
@@ -2796,6 +2829,16 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         return stmt.int(at: 0)
     }
 
+    /// The `connections` table's row COUNT, resilient to the table not existing
+    /// yet (a read connection opened against a pre-v38 DB). On any failure
+    /// returns `0`.
+    private func connectionsCount() -> Int64 {
+        guard let stmt = try? statement("SELECT COUNT(*) FROM connections;") else { return 0 }
+        defer { stmt.reset() }
+        guard (try? stmt.step()) == true else { return 0 }
+        return stmt.int(at: 0)
+    }
+
     // MARK: - changeToken contributors (slice 2b)
 
     /// The per-kind contributors whose fragments join into ``changeToken()``.
@@ -2814,6 +2857,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         SourceGraphTokenContributor(),
         BookmarkTokenContributor(),
         ChatTokenContributor(),
+        ConnectionTokenContributor(),
     ]
 
     private struct PagesTokenContributor: ChangeTokenContributor {
@@ -2889,6 +2933,17 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         let kind: ResourceKind = .chat
         func fragment(in store: SQLiteWikiStore) throws -> String {
             "\(store.chatCount()):\(store.chatMessageCount())"
+        }
+    }
+
+    /// Connection fold (v38): the `connections` row count. A create/delete/
+    /// rename bumps the count so the sidebar refreshes. Connections aren't File
+    /// Provider projected, but the token fold keeps the structural invariant
+    /// that every `ResourceKind` contributes a fragment.
+    private struct ConnectionTokenContributor: ChangeTokenContributor {
+        let kind: ResourceKind = .connection
+        func fragment(in store: SQLiteWikiStore) throws -> String {
+            "\(store.connectionsCount())"
         }
     }
 
@@ -7093,6 +7148,70 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             try upd.bind(childID, at: 1)
             try upd.bind(Int64(i), at: 2)
             _ = try upd.step()
+        }
+    }
+
+    // MARK: - Connections (v38 — per-wiki)
+
+    /// List all connections in this wiki, ordered by label.
+    public func listConnections() throws -> [Connection] {
+        lock.lock(); defer { lock.unlock() }
+        let stmt = try statement(
+            "SELECT id, provider_id, label, config FROM connections ORDER BY label COLLATE NOCASE;")
+        defer { stmt.reset() }
+        var results: [Connection] = []
+        while try stmt.step() {
+            let id = stmt.text(at: 0)
+            let providerID = stmt.text(at: 1)
+            let label = stmt.text(at: 2)
+            let configJSON = stmt.text(at: 3)
+            let config = (try? JSONDecoder().decode([String: String].self, from: Data(configJSON.utf8))) ?? [:]
+            results.append(Connection(id: id, providerID: providerID, label: label, config: config))
+        }
+        return results
+    }
+
+    /// Insert or replace a connection (by id). Non-secret `config` values are
+    /// serialized to JSON; secrets stay in the Keychain.
+    public func upsertConnection(_ connection: Connection) throws {
+        try mutate(event: { _ in localEvent(.connection, id: connection.id, change: .updated) }) {
+        let configData = try JSONEncoder().encode(connection.config)
+        let configJSON = String(data: configData, encoding: .utf8) ?? "{}"
+        let stmt = try statement("""
+        INSERT INTO connections (id, provider_id, label, config)
+        VALUES (?1, ?2, ?3, ?4)
+        ON CONFLICT(id) DO UPDATE SET
+            provider_id = excluded.provider_id,
+            label       = excluded.label,
+            config      = excluded.config;
+        """)
+        defer { stmt.reset() }
+        try stmt.bind(connection.id, at: 1)
+        try stmt.bind(connection.providerID, at: 2)
+        try stmt.bind(connection.label, at: 3)
+        try stmt.bind(configJSON, at: 4)
+        _ = try stmt.step()
+        }
+    }
+
+    /// Delete a connection by id.
+    public func deleteConnection(id: String) throws {
+        try mutate(event: { _ in localEvent(.connection, id: id, change: .deleted) }) {
+        let stmt = try statement("DELETE FROM connections WHERE id = ?1;")
+        defer { stmt.reset() }
+        try stmt.bind(id, at: 1)
+        _ = try stmt.step()
+        }
+    }
+
+    /// Rename a connection's label.
+    public func renameConnection(id: String, to label: String) throws {
+        try mutate(event: { _ in localEvent(.connection, id: id, change: .updated) }) {
+        let stmt = try statement("UPDATE connections SET label = ?2 WHERE id = ?1;")
+        defer { stmt.reset() }
+        try stmt.bind(id, at: 1)
+        try stmt.bind(label, at: 2)
+        _ = try stmt.step()
         }
     }
 

--- a/Sources/WikiFSCore/WikiSelection.swift
+++ b/Sources/WikiFSCore/WikiSelection.swift
@@ -18,4 +18,8 @@ public enum WikiSelection: Hashable, Sendable {
     case bookmark(String)
     /// A persisted agent chat, by id (issue #119).
     case chat(PageID)
+    /// A configured source connection (e.g. Zotero), by connection id. Opens the
+    /// connection's config/workspace tab. Connections are app-wide; the id is the
+    /// `Connection.id` (a ULID/well-known string), so this stays value-typed.
+    case connection(String)
 }

--- a/Sources/WikiFSCore/WikiStore.swift
+++ b/Sources/WikiFSCore/WikiStore.swift
@@ -554,6 +554,21 @@ public protocol WikiStore: Sendable {
     /// the old and new parent so positions stay contiguous (0, 1, 2, …).
     func moveBookmarkNode(id: String, toParentID: String?, position: Int) throws
 
+    // MARK: - Connections (v38 — per-wiki)
+
+    /// All connections in this wiki, ordered by label.
+    func listConnections() throws -> [Connection]
+
+    /// Insert or replace a connection (by id). Non-secret `config` values are
+    /// serialized to JSON in the `config` column; secrets stay in the Keychain.
+    func upsertConnection(_ connection: Connection) throws
+
+    /// Delete a connection by id.
+    func deleteConnection(id: String) throws
+
+    /// Rename a connection's label.
+    func renameConnection(id: String, to label: String) throws
+
     // MARK: - Persisted chats (issue #119 phase 1)
 
     /// Create a new chat row. `id` is a fresh ULID; `createdAt`/`updatedAt` both

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -171,6 +171,10 @@ public final class WikiStoreModel {
     /// like `bookmarkNodes`.
     public private(set) var chats: [ChatSummary] = []
 
+    /// Per-wiki connections (v38), rebuilt from `store.listConnections()` after
+    /// every mutation — same §3.1 pattern as `bookmarkNodes` / `chats`.
+    public private(set) var connections: [Connection] = []
+
     /// A pending question to pre-fill the chat composer, set by the omnibox
     /// "Ask" action (#288). Consumed by `ChatView` on first appearance, then
     /// cleared. `nil` means no pre-fill is waiting.
@@ -306,6 +310,7 @@ public final class WikiStoreModel {
         reloadSources()
         reloadBookmarkNodes()
         reloadChats()
+        reloadConnections()
         // Preload the system-prompt draft so its editor has content immediately;
         // selecting it later reloads fresh from the store.
         draftSystemPrompt = (try? store.getSystemPrompt())?.body ?? SystemPrompt.defaultBody
@@ -921,6 +926,16 @@ public final class WikiStoreModel {
         DebugLog.store("[tabs] openTabInBackground: new background tab for \(selection) (id=\(tab.id)), \(tabs.count) tabs total")
     }
 
+    /// Update the tab-bar title of every open tab showing `selection`. Used when
+    /// a resource whose label lives outside the store is renamed (e.g. a
+    /// connection, whose label lives in the app-wide `ConnectionRegistry`, not in
+    /// `tabTitle(for:)`). A no-op if no such tab is open.
+    public func retitleTabs(for selection: WikiSelection, to title: String) {
+        for i in tabs.indices where tabs[i].selection == selection {
+            tabs[i].title = title
+        }
+    }
+
     /// Retarget an open tab IN PLACE to a new selection, preserving the tab's
     /// UUID — so tab order, drag/drop position, and per-tab history survive (D2).
     /// Used for the draft-state morph (.newChat → .chat(id) on first send) and
@@ -1112,7 +1127,7 @@ public final class WikiStoreModel {
         mermaidSaveWarning = nil
         var restoredFromPendingDraft = false
         switch newValue {
-        case .newChat, .bookmark, .chat:
+        case .newChat, .bookmark, .chat, .connection:
             draftTitle = ""
             draftBody = ""
             loadedPage = nil
@@ -2525,6 +2540,7 @@ public final class WikiStoreModel {
         reloadSources()
         reloadChats()
         reloadBookmarkNodes()
+        reloadConnections()
         pruneHistoryToCurrentStore()
         reloadCurrentDraftIfClean()
     }
@@ -2783,6 +2799,10 @@ public final class WikiStoreModel {
         bookmarkNodes = (try? store.listBookmarkNodes()) ?? []
     }
 
+    public func reloadConnections() {
+        connections = (try? store.listConnections()) ?? []
+    }
+
     // MARK: - Bookmark node mutations
 
     /// Create a folder at root or inside another folder. Returns the new node id,
@@ -2882,6 +2902,101 @@ public final class WikiStoreModel {
         }
     }
 
+    // MARK: - Connection mutations (v38 — per-wiki)
+
+    /// The credential store for connection secrets (Keychain-backed). Lazily
+    /// created — the same `KeychainConnectionCredentialStore` the old
+    /// `ConnectionRegistry` used, now owned by the per-wiki model.
+    @ObservationIgnored
+    private lazy var credentialStore: any ConnectionCredentialStore = KeychainConnectionCredentialStore()
+
+    /// Look up a connection by id from the in-memory list.
+    public func connection(id: String) -> Connection? {
+        connections.first { $0.id == id }
+    }
+
+    /// Resolve a provider manifest for a connection (stateless lookup).
+    public func manifest(for connection: Connection) -> ProviderManifest? {
+        ProviderRegistry.manifest(for: connection.providerID)
+    }
+
+    /// Create a new unconfigured connection for `providerID`, persist it, and
+    /// return it. The caller opens its config tab.
+    @discardableResult
+    public func createConnection(providerID: String) -> Connection? {
+        let manifest = ProviderRegistry.manifest(for: providerID)
+        let connection = Connection(
+            id: UUID().uuidString,
+            providerID: providerID,
+            label: manifest?.displayName ?? providerID.capitalized)
+        do {
+            try store.upsertConnection(connection)
+            reloadConnections()
+            return connection
+        } catch {
+            DebugLog.store("WikiStoreModel.createConnection failed: \(error)")
+            return nil
+        }
+    }
+
+    /// Insert or replace a connection (non-secret config → SQLite; secrets →
+    /// Keychain).
+    public func upsertConnection(_ connection: Connection) {
+        do {
+            try store.upsertConnection(connection)
+            reloadConnections()
+        } catch {
+            DebugLog.store("WikiStoreModel.upsertConnection failed: \(error)")
+        }
+    }
+
+    /// Rename a connection's label.
+    public func renameConnection(id: String, to label: String) {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            try store.renameConnection(id: id, to: trimmed)
+            reloadConnections()
+            if let renamed = connection(id: id) {
+                retitleTabs(for: .connection(renamed.id), to: renamed.label)
+            }
+        } catch {
+            DebugLog.store("WikiStoreModel.renameConnection failed: \(error)")
+        }
+    }
+
+    /// Delete a connection and its Keychain secrets.
+    public func deleteConnection(id: String) {
+        // Best-effort secret cleanup before deleting the row.
+        if let connection = connection(id: id),
+           let manifest = manifest(for: connection) {
+            for field in manifest.config.fields where field.secret {
+                try? credentialStore.setSecret(nil, connectionID: id, field: field.name)
+            }
+        }
+        do {
+            try store.deleteConnection(id: id)
+            reloadConnections()
+        } catch {
+            DebugLog.store("WikiStoreModel.deleteConnection failed: \(error)")
+        }
+    }
+
+    /// Read a secret field for a connection (Keychain).
+    public func secret(for connection: Connection, field: String) -> String? {
+        credentialStore.secret(connectionID: connection.id, field: field)
+    }
+
+    /// Persist a secret field for a connection (Keychain). Empty/nil deletes.
+    public func setSecret(_ value: String, for connection: Connection, field: String) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        try? credentialStore.setSecret(
+            trimmed.isEmpty ? nil : trimmed,
+            connectionID: connection.id, field: field)
+    }
+
+    // MARK: - History pruning
+
     private func pruneHistoryToCurrentStore() {
         let pageIDs = Set(summaries.map(\.id))
         let sourceIDs = Set(sources.map(\.id))
@@ -2903,7 +3018,7 @@ public final class WikiStoreModel {
             sourceIDs.contains(id)
         case .chat(let id):
             chatIDs.contains(id)
-        case .newChat, .systemPrompt, .changeLog, .bookmark:
+        case .newChat, .systemPrompt, .changeLog, .bookmark, .connection:
             true
         }
     }

--- a/Sources/WikiFSCore/ZoteroConnection.swift
+++ b/Sources/WikiFSCore/ZoteroConnection.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Bridges a generic `Connection` to Zotero's native client/storage. Zotero is a
+/// `.native` provider (issue #483 / spike decision): only its *config form* is
+/// schema-driven; its data path stays the in-process `ZoteroClient` + local
+/// storage read, preserving the keystroke-latency search picker
+/// (`plans/zotero-integration.md`).
+///
+/// **Spike note.** The API key reuses the existing app-wide Keychain item
+/// (`KeychainZoteroCredentialStore`) so this new path and the legacy "Add from
+/// Zotero" button share one secret. Per-connection credential scoping (keyed by
+/// connection ULID) is a deferred follow-up.
+public enum ZoteroConnection {
+    /// The provider id this adapter serves — matches the manifest.
+    public static let providerID = "zotero"
+
+    /// A stable, well-known id for the single migrated Zotero connection so the
+    /// legacy `zotero-config.json` maps to exactly one row.
+    public static let defaultConnectionID = "zotero-default"
+
+    // Config keys — must match the manifest's `SchemaField.name`s.
+    public static let libraryIDKey = "libraryID"
+    public static let zoteroDirKey = "zoteroDirOverride"
+    public static let apiKeyField = "apiKey"
+
+    /// The directory to resolve `storage/<key>/<filename>` under: the config
+    /// override when set, else the default `~/Zotero`.
+    public static func zoteroDirectory(for connection: Connection) -> URL {
+        if let override = connection.config[zoteroDirKey],
+           !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        return ZoteroLocalStorage.defaultDirectory()
+    }
+
+    /// Whether this connection has the minimum config to talk to Zotero: a
+    /// non-empty library id *and* a stored API key.
+    public static func isConfigured(_ connection: Connection, apiKey: String?) -> Bool {
+        guard let libraryID = connection.config[libraryIDKey],
+              !libraryID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        guard let apiKey, !apiKey.isEmpty else { return false }
+        return true
+    }
+
+    /// Build a `ZoteroClient` from the connection + API key, or `nil` if the
+    /// connection isn't fully configured.
+    public static func client(
+        for connection: Connection,
+        apiKey: String?,
+        fetcher: any ZoteroClient.RequestFetcher = URLSessionZoteroFetcher()
+    ) -> ZoteroClient? {
+        guard let libraryID = connection.config[libraryIDKey],
+              !libraryID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let apiKey, !apiKey.isEmpty else { return nil }
+        return ZoteroClient(
+            config: ZoteroClient.Config(libraryID: libraryID, apiKey: apiKey),
+            fetcher: fetcher)
+    }
+
+    /// Build the migrated Zotero connection from the legacy `ZoteroConfig`
+    /// (library id + dir override). The API key is untouched — it already lives
+    /// in the shared Keychain item both paths read.
+    public static func migratedConnection(from config: ZoteroConfig) -> Connection {
+        var values: [String: String] = [:]
+        if let libraryID = config.libraryID, !libraryID.isEmpty {
+            values[libraryIDKey] = libraryID
+        }
+        if let dir = config.zoteroDirOverride, !dir.isEmpty {
+            values[zoteroDirKey] = dir
+        }
+        return Connection(
+            id: defaultConnectionID,
+            providerID: providerID,
+            label: "Zotero",
+            config: values)
+    }
+}

--- a/Tests/WikiFSTests/ChangeTokenContributorTests.swift
+++ b/Tests/WikiFSTests/ChangeTokenContributorTests.swift
@@ -33,8 +33,8 @@ struct ChangeTokenContributorTests {
     @Test func contributorOrderMatchesHistoricalLayout() throws {
         let kinds = SQLiteWikiStore.tokenContributors.map(\.kind)
         // pages | sources(table) | systemPrompt | log | wikiIndex |
-        // source(derived) | source(graph folds) | bookmark | chat
+        // source(derived) | source(graph folds) | bookmark | chat | connection
         #expect(kinds == [.page, .source, .systemPrompt, .log, .wikiIndex,
-                          .source, .source, .bookmark, .chat])
+                          .source, .source, .bookmark, .chat, .connection])
     }
 }

--- a/Tests/WikiFSTests/ConnectionModelTests.swift
+++ b/Tests/WikiFSTests/ConnectionModelTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// The connections substrate (spike): the provider manifest decodes from JSON,
+/// the app-wide store round-trips, and the legacy Zotero config migrates to a
+/// connection. These are the novel, data-driven claims of issue #483 / the
+/// connections plan — the UI (`SchemaForm`) renders whatever the schema decodes.
+struct ConnectionModelTests {
+
+    private func tempDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("connection-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - Manifest (JSON → native form contract)
+
+    @Test func zoteroManifestDecodesFromEmbeddedJSON() throws {
+        let manifest = try #require(ProviderRegistry.manifest(for: "zotero"))
+        #expect(manifest.displayName == "Zotero")
+        #expect(manifest.icon == "books.vertical")
+        #expect(manifest.capabilities.browse)
+        #expect(manifest.backing == .native)
+        // The config schema is what SchemaForm renders — order preserved.
+        #expect(manifest.config.fields.map(\.name) == ["apiKey", "libraryID", "zoteroDirOverride"])
+    }
+
+    @Test func apiKeyFieldIsSecretAndPassword() throws {
+        let manifest = try #require(ProviderRegistry.manifest(for: "zotero"))
+        let apiKey = try #require(manifest.config.fields.first { $0.name == "apiKey" })
+        #expect(apiKey.secret)
+        #expect(apiKey.format == .password)
+        #expect(manifest.config.secretFieldNames == ["apiKey"])
+    }
+
+    @Test func schemaFieldRoundTripsThroughJSON() throws {
+        // Proves the same shape a dropped-in manifest.json would use decodes,
+        // including an enum + boolean field the UI must render as Picker/Toggle.
+        let json = """
+        {
+          "fields": [
+            { "name": "topic", "title": "Topic", "type": "string", "enum": ["news", "general"] },
+            { "name": "includeThreads", "title": "Include threads", "type": "boolean" }
+          ]
+        }
+        """
+        let schema = try JSONDecoder().decode(ProviderConfigSchema.self, from: Data(json.utf8))
+        #expect(schema.fields.count == 2)
+        #expect(schema.fields[0].enumValues == ["news", "general"])
+        #expect(schema.fields[1].type == .boolean)
+    }
+
+    // MARK: - Store (app-wide JSON round-trip)
+
+    // MARK: - Store (per-wiki SQLite round-trip)
+
+    @Test func connectionRoundTripsThroughStore() throws {
+        // The per-wiki SQLite store round-trips connections — exercised more
+        // fully in SQLiteWikiStoreTests; this test verifies the Connection
+        // struct's Codable config column serialization.
+        let connection = Connection(
+            id: "abc123",
+            providerID: "zotero",
+            label: "Work Zotero",
+            config: ["libraryID": "7089244"])
+        let data = try JSONEncoder().encode(connection.config)
+        let decoded = try JSONDecoder().decode([String: String].self, from: data)
+        #expect(decoded == ["libraryID": "7089244"])
+        // Verify the struct round-trips through Codable (config column fidelity).
+        let connData = try JSONEncoder().encode(connection)
+        let restored = try JSONDecoder().decode(Connection.self, from: connData)
+        #expect(restored == connection)
+    }
+
+    // MARK: - Zotero migration + adapter
+
+    @Test func migratesLegacyZoteroConfigToConnection() {
+        let legacy = ZoteroConfig(libraryID: "7089244", zoteroDirOverride: "/Volumes/Ext/Zotero")
+        let connection = ZoteroConnection.migratedConnection(from: legacy)
+        #expect(connection.id == ZoteroConnection.defaultConnectionID)
+        #expect(connection.providerID == "zotero")
+        #expect(connection.config["libraryID"] == "7089244")
+        #expect(connection.config["zoteroDirOverride"] == "/Volumes/Ext/Zotero")
+    }
+
+    @Test func isConfiguredRequiresLibraryAndKey() {
+        let connection = ZoteroConnection.migratedConnection(
+            from: ZoteroConfig(libraryID: "7089244"))
+        #expect(!ZoteroConnection.isConfigured(connection, apiKey: nil))
+        #expect(!ZoteroConnection.isConfigured(connection, apiKey: ""))
+        #expect(ZoteroConnection.isConfigured(connection, apiKey: "secret"))
+    }
+
+    // MARK: - Per-connection credentials (two Zotero user IDs)
+
+    @Test func credentialStoreIsolatesSecretsPerConnection() throws {
+        let store = InMemoryConnectionCredentialStore()
+        try store.setSecret("key-work", connectionID: "work", field: "apiKey")
+        try store.setSecret("key-personal", connectionID: "personal", field: "apiKey")
+        #expect(store.secret(connectionID: "work", field: "apiKey") == "key-work")
+        #expect(store.secret(connectionID: "personal", field: "apiKey") == "key-personal")
+
+        try store.setSecret(nil, connectionID: "work", field: "apiKey")
+        #expect(store.secret(connectionID: "work", field: "apiKey") == nil)
+        #expect(store.secret(connectionID: "personal", field: "apiKey") == "key-personal")
+    }
+
+    @Test func zoteroDirectoryUsesOverrideThenDefault() {
+        let withOverride = ZoteroConnection.migratedConnection(
+            from: ZoteroConfig(libraryID: "1", zoteroDirOverride: "/tmp/z"))
+        #expect(ZoteroConnection.zoteroDirectory(for: withOverride).path == "/tmp/z")
+
+        let noOverride = ZoteroConnection.migratedConnection(
+            from: ZoteroConfig(libraryID: "1"))
+        #expect(ZoteroConnection.zoteroDirectory(for: noOverride) == ZoteroLocalStorage.defaultDirectory())
+    }
+}

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -158,20 +158,20 @@ struct LogIndexTests {
     @Test func changeTokenAdvancesOnLogOnlyWrite() throws {
         let store = try tempStore()
         // Fresh DB: no pages/files, system_prompt + wiki_index at v1, no log rows.
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0:0")
         // Appending ONLY a log entry must still advance the token (logCount fold).
         _ = try store.appendLog(kind: .ingest, title: "x", note: nil)
-        #expect(try store.changeToken() == "0:0:0:0:1:1:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:1:1:0:0:0:0:0:0:0:0")
         _ = try store.appendLog(kind: .lint, title: "y", note: nil)
-        #expect(try store.changeToken() == "0:0:0:0:1:2:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:2:1:0:0:0:0:0:0:0:0")
     }
 
     @Test func changeTokenAdvancesOnIndexOnlyWrite() throws {
         let store = try tempStore()
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0:0")
         // Editing ONLY the index must still advance the token (idxVersion fold).
         try store.updateWikiIndex(body: "edited")
-        #expect(try store.changeToken() == "0:0:0:0:1:0:2:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:2:0:0:0:0:0:0:0:0")
     }
 
     // MARK: - v3 → v4 → v5 migration (preserves prior data, seeds index)

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -157,50 +157,50 @@ struct SQLiteWikiStoreTests {
         // A fresh DB seeds the system_prompt AND wiki_index singletons at version
         // 1, has no log rows, no source_markdown_versions, no sources, no
         // bookmarks, and no chats → trailing ":1:0:1:0:0:0:0:0:0".
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0:0")
 
         // Create bumps page COUNT and SUM (version starts at 1). Phase 3 also
         // seeds a root version + page-content ref (refsGenSum=1) + import
         // activity (actCount=1).
         let a = try store.createPage(title: "Alpha")
-        #expect(try store.changeToken() == "1:1:0:0:1:0:1:0:0:1:1:0:0:0")
+        #expect(try store.changeToken() == "1:1:0:0:1:0:1:0:0:1:1:0:0:0:0")
 
         // Update bumps that row's version by 1 → SUM increments.
         try store.updatePage(id: a.id, title: "Alpha", body: "edited")
-        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0:0:1:1:0:0:0")
+        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0:0:1:1:0:0:0:0")
 
         // A SECOND page that is NOT the global-max version must STILL advance the
         // token — the MAX-vs-SUM correctness lock. b starts at version 1, yet
         // count:sum changes (2 pages, sum 2+1=3).
         let b = try store.createPage(title: "Beta")
-        #expect(try store.changeToken() == "2:3:0:0:1:0:1:0:0:2:2:0:0:0")
+        #expect(try store.changeToken() == "2:3:0:0:1:0:1:0:0:2:2:0:0:0:0")
 
         try store.updatePage(id: b.id, title: "Beta", body: "beta edit")
-        #expect(try store.changeToken() == "2:4:0:0:1:0:1:0:0:2:2:0:0:0")
+        #expect(try store.changeToken() == "2:4:0:0:1:0:1:0:0:2:2:0:0:0:0")
 
         // Delete changes page COUNT and SUM. deletePage also cascades the page's
         // `page-content` ref (W0/#312 made refs.owner_id polymorphic with no FK
         // cascade), so refsGenSum drops from 2 → 1. Activities are provenance and
         // are NOT cascaded, so actCount stays at 2.
         try store.deletePage(id: b.id)
-        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0:0:1:2:0:0:0")
+        #expect(try store.changeToken() == "1:2:0:0:1:0:1:0:0:1:2:0:0:0:0")
     }
 
     /// The token MUST advance on ingest AND on delete (else the `files/` tree
     /// would never refresh — the orchestrator-critical fold-in).
     @Test func changeTokenAdvancesOnIngestAndDelete() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0:0")
 
         // Ingest bumps the file COUNT and SUM (version 1). It ALSO writes one
         // source_version, one ref (generation 1), and one import activity → the
         // three v20 folds become 1:1:1.
         let f = try store.addSource(filename: "a.txt", data: Data("hi".utf8))
-        #expect(try store.changeToken() == "0:0:1:1:1:0:1:0:1:1:1:0:0:0")
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:0:1:1:1:0:0:0:0")
 
         // A second file.
         _ = try store.addSource(filename: "b.txt", data: Data("yo".utf8))
-        #expect(try store.changeToken() == "0:0:2:2:1:0:1:0:2:2:2:0:0:0")
+        #expect(try store.changeToken() == "0:0:2:2:1:0:1:0:2:2:2:0:0:0:0")
 
         // Delete the first → file COUNT/SUM, svCount, and refsGenSum drop. The
         // import ACTIVITY is provenance (no cascade from sources) so actCount
@@ -219,21 +219,21 @@ struct SQLiteWikiStoreTests {
     /// or the `sources/` tree would never learn of new extracts.
     @Test func changeTokenAdvancesOnAppendProcessedMarkdown() throws {
         let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0:0")
 
         // Add a source first.
         let source = try store.addSource(filename: "doc.pdf", data: Data("pdf content".utf8))
-        #expect(try store.changeToken() == "0:0:1:1:1:0:1:0:1:1:1:0:0:0")
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:0:1:1:1:0:0:0:0")
 
         // Append processed markdown — smvCount goes 0 → 1.
         _ = try store.appendProcessedMarkdown(
             sourceID: source.id, content: "# Extracted", origin: "test", note: nil)
-        #expect(try store.changeToken() == "0:0:1:1:1:0:1:1:1:1:1:0:0:0")
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:1:1:1:1:0:0:0:0")
 
         // Append another version — smvCount advances again.
         _ = try store.appendProcessedMarkdown(
             sourceID: source.id, content: "# Edited", origin: "test", note: "edit")
-        #expect(try store.changeToken() == "0:0:1:1:1:0:1:2:1:1:1:0:0:0")
+        #expect(try store.changeToken() == "0:0:1:1:1:0:1:2:1:1:1:0:0:0:0")
 
         // Deleting the source removes its markdown versions + content versions +
         // ref (CASCADE), but the import activity persists (provenance) →

--- a/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
@@ -77,6 +77,7 @@ struct StoreEmissionExhaustivenessTests {
         "revertProcessedMarkdown", "setActiveMarkdown",
         "createChat", "appendChatMessages", "renameChat", "deleteChat",
         "updateChatSummary",
+        "upsertConnection", "deleteConnection", "renameConnection",
     ]
 
     private let noEmit: Set<String> = [

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -153,9 +153,9 @@ struct SystemPromptTests {
     @Test func changeTokenAdvancesOnSystemPromptEdit() throws {
         let store = try tempStore()
         // No pages, no sources: only the system-prompt version moves.
-        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:1:0:1:0:0:0:0:0:0:0:0")
         try store.updateSystemPrompt(body: "edited")
-        #expect(try store.changeToken() == "0:0:0:0:2:0:1:0:0:0:0:0:0:0")
+        #expect(try store.changeToken() == "0:0:0:0:2:0:1:0:0:0:0:0:0:0:0")
     }
 
     // MARK: - UPSERT recreates a missing singleton row (defensive)

--- a/plans/connections-substrate-zotero-as-connection.md
+++ b/plans/connections-substrate-zotero-as-connection.md
@@ -1,0 +1,259 @@
+# Connections substrate — Zotero as connection #1
+
+**Status:** Spike built (branch `spike/zotero-as-connection`) — Zotero proven as
+connection #1 via a native schema-driven form; coexists with the legacy button.
+See "Spike as built" below. Supersedes the "Add from Zotero" button; first
+concrete step toward the four-layer origin model in the wiki design pages
+*Connections Architecture for Source Ingest* (`01KXNQS1`) and *Source Providers
+and Extraction Scripts* (`01KXNXRS`), and resolves issue #483 in favor of native
+SwiftUI rendering.
+
+## Decisions locked (2026-07-16)
+
+1. **Rendering: native SwiftUI `SchemaForm` from JSON Schema.** No WKWebView, no
+   json-render/JS. The manifest's JSON Schema is the portable, drop-in contract;
+   what renders it is native SwiftUI. (Issue #483 "Decision needed" → native.)
+2. **Scope this pass: substrate + Zotero only.** Build the Connection
+   abstraction (model + app-wide store + Connections sidebar section + a
+   connection detail tab + native `SchemaForm` config). Route Zotero through it
+   as connection #1. **Defer** script-backed generic providers.
+3. **Zotero stays native.** A connection can be *native built-in* or (later)
+   *script-backed*. Zotero remains native `ZoteroClient` + native search picker
+   (keystroke-latency reason from `plans/zotero-integration.md` still holds).
+   Only its **config form** becomes schema-driven.
+
+## What already exists (don't rebuild)
+
+- The materializer seam is done and generalized:
+  `SourceMaterializer.materialize() → MaterializedSource →
+  WikiStoreModel.storeMaterialized(_:) → store.addSource(provenance:)`.
+  `ZoteroMaterializer` is already one conformer of five. **The write path does
+  not change.**
+- Zotero config/secrets split: non-secret `zotero-config.json` at the app-group
+  root (`ZoteroConfig`), API key in Keychain (`KeychainZoteroCredentialStore`,
+  service `org.sockpuppet.WikiFS.zotero` / account `zotero-api-key`).
+- `ZoteroClient` (search/child metadata), `ZoteroLocalStorage` (local byte
+  read), `AddFromZoteroSheet` (search → attachment multi-select picker).
+
+## What's missing (this plan builds)
+
+There is **no Connection concept anywhere** — no model, no store, no tab. Zotero
+"works" only because it hard-codes a singleton connection into `ZoteroConfig` +
+Keychain. This plan gives that singleton a first-class home and makes the shape
+reusable.
+
+## Model (`Sources/WikiFSCore/`)
+
+### `ProviderManifest` — the "Kind" layer
+
+```
+struct ProviderManifest {
+    let id: String                 // stable identity, e.g. "zotero"
+    let displayName: String
+    let description: String
+    let icon: String               // SF Symbol
+    let configSchema: JSONSchema   // rendered by SchemaForm
+    let secretFields: Set<String>  // schema fields that go to Keychain, not config JSON
+    let capabilities: Capabilities // { supportsBrowse, ... }
+    let backing: Backing           // .native | .script(path)  (.script deferred)
+}
+```
+
+`configSchema` is a **minimal JSON Schema** value type (object → properties, each
+`{ type, title, format, enum?, default?, description? }`). Zotero's manifest
+declares: `apiKey` (`format: password`, secret), `libraryID` (string),
+`zoteroDirOverride` (`format: path`, optional).
+
+### `Connection` — the configured instance
+
+```
+struct Connection {
+    let id: ConnectionID           // ULID
+    let providerID: String         // → manifest
+    var label: String              // "Work Zotero"
+    var config: [String: JSONValue]// non-secret values, keyed by schema field
+    let createdAt: Date
+    // secrets NOT here — Keychain, keyed by (connectionID, fieldName)
+}
+```
+
+### `ConnectionStore` — app-wide persistence
+
+`connections.json` at the app-group container root, sibling to `wikis.json` /
+`zotero-config.json`, following `WikiRegistry`'s atomic load/save pattern.
+Connections are **app-wide** (matches the existing app-wide Zotero decision);
+ingestion still targets the *current* wiki's store. Secrets live in Keychain
+keyed by connection ULID + field name.
+
+> Decision (open): app-wide JSON store (recommended, migration-free, matches
+> `ZoteroConfig`) vs. a per-wiki SQLite `connections` table (matches the design
+> page's Phase-4 sketch but needs a migration and a per-wiki story). Recommend
+> JSON now; revisit when script providers + plural browse land.
+
+### `ProviderRegistry`
+
+Returns built-in manifests. One entry this pass: `zotero`. A `.native` provider
+supplies factories: `configSchema` (above), a **workspace view** (the picker),
+and a **materializer** (`ZoteroMaterializer`, unchanged). `.script(path)` is an
+enum case left as a documented stub.
+
+## UI (`Sources/WikiFS/`)
+
+### `SchemaForm.swift` — native JSON Schema → SwiftUI Form
+
+`Form { ForEach(schema.properties) { fieldView } }`, `@State values`, per-field
+bindings: `password → SecureField`, `enum → Picker`, `boolean → Toggle`,
+`number → numeric TextField`, `path → TextField + NSOpenPanel`, else `TextField`.
+On save, secret fields route to Keychain, the rest to the connection's config.
+Reusable for every future provider — this is the ~150-line core of #483.
+
+### Connections sidebar section
+
+Add `SidebarSection.connections` (alongside `pages/sources/bookmarks/chats` in
+`SidebarView.swift`) → `ConnectionsContainerView`: lists configured connections
+(Zotero once configured) + an "Add Connection" affordance (pick a provider kind
+→ create → configure). Opening a connection calls `openTab(.connection(id))`.
+
+### Connection detail tab
+
+Add `WikiSelection.connection(ConnectionID)` (`WikiSelection.swift`) + a render
+branch in `WikiDetailView` → `ConnectionDetailView`:
+
+- **Unconfigured / editing** → `SchemaForm` over the provider's `configSchema` +
+  "Test Connection" (Zotero: `ZoteroClient.verifyConnection()`) + Save.
+- **Configured** → the connection's **workspace**. For Zotero: the native search
+  picker + attachment multi-select + "Add Selected" — the guts of
+  `AddFromZoteroSheet` re-homed from a modal sheet into the tab, driven by the
+  resolved `Connection` instead of app-wide `ZoteroConfig`.
+
+### Removals
+
+- The `books.vertical` "Add from Zotero…" header button in
+  `SourcesContainerView.swift` (and its `showingAddFromZotero` binding through
+  `ContentView` / `SidebarView` / `WikiDetailView`).
+- `AddFromZoteroSheet` as a modal — its picker moves into
+  `ZoteroConnectionWorkspaceView`.
+- **Settings ▸ Zotero** tab folds into the connection's config view (single
+  home). (Open decision: remove entirely vs. keep a thin "manage in Connections"
+  redirect.)
+
+## Config bridge
+
+Zotero's client/storage stop reading `ZoteroConfig` + `KeychainZoteroCredentialStore`
+directly; instead build `ZoteroClient.Config { libraryID, apiKey }` and the
+Zotero dir from a resolved `Connection` (config + Keychain). Add a small adapter
+`Connection → ZoteroClient.Config` / `→ zoteroDir`.
+
+## Migration
+
+On first load after this lands: if no Zotero connection exists but legacy
+`zotero-config.json` `isConfigured`, synthesize a Zotero `Connection` (fixed or
+derived ULID) whose config carries `libraryID`/`zoteroDirOverride` and which
+reads the existing Keychain item (least-disruptive: reference the legacy key, or
+copy it under the connection-scoped account). No data loss; the button-era user
+lands with one pre-configured "Zotero" connection.
+
+## The preserved invariant
+
+"Add Selected" still calls `store.ingestFromZotero(...)` → `ZoteroMaterializer` →
+`storeMaterialized`. Provenance keeps `agentName = "zotero"`. **Snapshotting the
+connection ULID/label into provenance** (the Connections-doc invariant) is
+noted-but-deferred: with a single native Zotero connection it isn't yet
+load-bearing, and it touches the PROV columns. Revisit when plural connections
+or script providers land.
+
+## Phases
+
+1. **Core (pure, tested).** `JSONSchema`, `ProviderManifest`, `Connection`,
+   `ConnectionStore`, `ProviderRegistry` (Zotero manifest), the
+   `Connection → ZoteroClient.Config` adapter. Unit tests mirror
+   `ZoteroConfigTests` / `WikiRegistry` patterns. No UI.
+2. **Config surface.** `SchemaForm`, `SidebarSection.connections` +
+   `ConnectionsContainerView`, `WikiSelection.connection` +
+   `ConnectionDetailView` config mode, legacy migration. Zotero configurable in
+   the tab; Settings ▸ Zotero folds/redirects.
+3. **Workspace + removals.** Re-home the Zotero picker into
+   `ZoteroConnectionWorkspaceView` inside the connection tab; delete the
+   "Add from Zotero" button + sheet + threaded bindings. End-to-end: open the
+   Zotero connection → search → add → source lands via the unchanged seam.
+
+## Deferred (explicit non-goals this pass)
+
+- Script-backed providers (`manifest.json` in `scripts/`,
+  `ProviderScriptMaterializer`, `--list` browse). The `.script` backing case and
+  `Capabilities.supportsBrowse` are the seams left for it.
+- Per-wiki SQLite `connections` table + `wikictl connection` commands.
+- Provenance connection snapshot.
+- Plural Zotero connections UI polish (model supports plural; UI ships single).
+- WKWebView json-render path (issue #483 — not pursued).
+
+## Spike as built (branch `spike/zotero-as-connection`)
+
+Proves the thesis end to end; the legacy button/Settings are left in place to
+compare (a spike proves, then we delete).
+
+**Core (`WikiFSCore`)**
+- `ConnectionModel.swift` — `SchemaField`/`ProviderConfigSchema` (defaulting
+  decoder), `ProviderManifest`/`ProviderCapabilities`/`ProviderBacking`
+  (`.native` | `.script`), `ProviderRegistry` (Zotero manifest decoded from
+  **embedded JSON** — the drop-in shape), `Connection` + `ConnectionStore`
+  (app-wide `connections.json`).
+- `ZoteroConnection.swift` — `Connection → ZoteroClient`/dir adapter + legacy
+  `ZoteroConfig` → connection migration.
+
+**UI (`WikiFS`)**
+- `SchemaForm.swift` — native JSON-schema → SwiftUI `Form` (the #483 renderer).
+- `ConnectionRegistry.swift` — shared `@Observable` app-wide list; seeds/migrates
+  the Zotero connection; routes the `apiKey` secret to the existing Keychain item.
+- `ConnectionsContainerView.swift` — the **Connections** sidebar section.
+- `ConnectionDetailView.swift` — the connection tab: schema config form (Test +
+  Save) or workspace.
+- `ZoteroConnectionWorkspaceView.swift` — the native search picker re-homed from
+  the modal sheet into the tab; still `store.ingestFromZotero` → unchanged seam.
+
+**Wiring** — `WikiSelection.connection(String)` + its 6 exhaustive switches;
+`SidebarSection.connections`; `WikiDetailView` render branch.
+
+**Verified** — `swift build` (full package) green; `ConnectionModelTests`
+(8 tests) green: manifest JSON decode, store round-trip, corrupt-degrades,
+Zotero migration, `isConfigured`, dir override. The manifest-decode test caught
+a real bug (a required `secret` key would have made *every* manifest fail to
+decode → no connections shown).
+
+### Generalized past Zotero (proves the substrate)
+
+- **Second provider — Folder.** `FolderConnection.swift` + a `folder` manifest
+  (one `path` field, no secret); `FolderConnectionWorkspaceView.swift` is a
+  native file browser (navigate subfolders, multi-select) that ingests picks
+  through the existing `store.addFiles` → `LocalFileMaterializer` seam. Zero
+  changes to the tab/sidebar plumbing — a new provider is a manifest + adapter +
+  workspace view.
+- **Plural connections + Add Connection.** Connections are no longer
+  singleton-Zotero: `ConnectionsContainerView` has an **＋ Add Connection** menu
+  (`ProviderRegistry.addable`), `ConnectionRegistry.create(providerID:)` mints a
+  new instance and opens it in the config form. Multiple folders *and* multiple
+  Zotero libraries (one per user ID) are supported; rename distinguishes them.
+- **Per-connection credentials.** `ConnectionCredentialStore` keys secrets by
+  `(connectionID, field)`, so two Zotero connections hold two independent API
+  keys. A compatibility shim maps the auto-migrated `zotero-default` connection's
+  `apiKey` to the legacy single-key Keychain item, so current users keep their
+  key and the legacy button still reads it.
+- Rename works exactly like a page/source: the connection-tab header is an
+  `EditableTitle` (double-click / right-click → Rename) → `ConnectionRegistry.rename`
+  + `store.retitleTabs`.
+
+**Verified additions:** `ConnectionModelTests` now 11 — folder manifest +
+`addable`, tilde-expansion + existence, per-connection credential isolation.
+
+**Spike simplifications (follow-ups):** config values are `[String:String]`
+(typed values later); `ConnectionRegistry` is a singleton; connection **deletion**
++ credential cleanup not wired yet; the legacy button/Settings-tab and
+`AddFromZoteroSheet` still exist (removal after sign-off).
+
+## Open decisions to confirm before Phase 1
+
+- **Store:** app-wide JSON (recommended) vs per-wiki SQLite table.
+- **Settings ▸ Zotero:** remove vs thin redirect.
+- **Connection home:** sidebar section (recommended) vs a top-level detail tab
+  only vs a Settings tab.
+- **Plural now:** ship single Zotero connection UI vs allow multiple immediately.


### PR DESCRIPTION
# Per-wiki connections substrate — Zotero as connection #1

## Summary

Moves connections from the app-wide `ConnectionRegistry` singleton (backed by `connections.json`) into each wiki's SQLite database as a new `connections` table (schema v38). Connections are now per-wiki: each wiki owns its Zotero connection(s) independently. The folder provider has been removed — Zotero is the sole connection provider.

## Changes

### Store layer (`SQLiteWikiStore`)
- **Schema v38**: new `connections` table (`id`, `provider_id`, `label`, `config` JSON) added to both the fresh-schema path and a `migrateV37ToV38()` migration step
- **Store methods**: `listConnections()`, `upsertConnection(_:)`, `deleteConnection(id:)`, `renameConnection(id:to:)` — all routed through `mutate()` with `ResourceChangeEvent` emission
- **`ResourceKind.connection`**: new case with `cable.connector` icon, `ConnectionTokenContributor`, and `connectionsCount()` helper
- **`WikiStore` protocol**: 4 new connection methods

### Model (`WikiStoreModel`)
- **`connections` observable**: rebuilt from `store.listConnections()` in `init()` and `reloadFromStore()`
- **Routing methods**: `createConnection(providerID:)`, `upsertConnection(_:)`, `renameConnection(id:to:)`, `deleteConnection(id:)`, plus `connection(id:)` and `manifest(for:)` lookups
- **Credentials**: `secret(for:field:)` and `setSecret(_:for:field:)` delegating to `KeychainConnectionCredentialStore` — secrets stay in Keychain

### UI
- **`ConnectionsContainerView`**: rewritten as a provider-grouped disclosure tree. Zotero is a disclosure parent; connections are children with configured/unconfigured status indicators. `+` button creates a new connection and opens its config tab. Context-menu delete.
- **`ConnectionDetailView`**: updated to use `WikiStoreModel` instead of `ConnectionRegistry`. "Done" button now calls `save()` (fixes a bug where folder config was never persisted). The `isConfigured` guard on "Done" was removed so users can always dismiss the config form.
- **`SchemaForm`**: native SwiftUI form rendering from JSON schema (unchanged from spike)

### Removed
- **`ConnectionRegistry.swift`** deleted (no more app-wide singleton)
- **`ConnectionStore`** / `ConnectionsFile` removed from `ConnectionModel.swift` (no more `connections.json`)
- **`FolderConnection.swift`** and **`FolderConnectionWorkspaceView.swift`** deleted — folder provider removed entirely
- Folder manifest JSON removed from `ConnectionModel.swift`
- Legacy Zotero migration (`ensureZoteroConnection`) removed — no app-wide seed

### Tests
- `ConnectionModelTests`: removed `ConnectionStore` round-trip tests and folder tests; added Codable config round-trip
- `StoreEmissionExhaustivenessTests`: 3 new EMIT methods (`upsertConnection`, `deleteConnection`, `renameConnection`)
- `ChangeTokenContributorTests`: `.connection` fold added to contributor registry and order test
- ~20 change-token string literals across 3 test files got `:0` appended for the new connection fold (tracked in issue #484 for a structured `ChangeToken` type)

## Bug fixes

- **"Done" button in folder connections** (original trigger for this work): the "Done" button only set `isEditing = false` without calling `save()`, so config values were discarded. Fixed by making "Done" call `save()`.
- **"Done" button only showed when configured**: removed the `isConfigured` guard so users can always dismiss the config form, even for unconfigured connections.

## Test plan

- [x] `swift build` clean
- [x] `ConnectionModelTests` (8 tests) pass
- [x] `StoreEmissionExhaustivenessTests` pass
- [x] `ChangeTokenContributorTests` pass
- [x] Fast-tier `swift test` (2447 tests) pass
- [ ] Full `swift test` including integration suites (run before merge)

## Follow-ups

- Issue #484: Replace change-token string literals with a structured `ChangeToken` type
