### PR TITLE
Fix #492: replace silent-swallow try? on persistence writes

### DIFF
--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -7269,7 +7269,14 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             return
         }
         DebugLog.store("reembedChatMessages[\(chatID.rawValue)] msgs=\(texts.count) chunks=\(chunks.count)")
-        try? appendChatChunks(chatID: chatID, chunks: chunks)
+        do {
+            try appendChatChunks(chatID: chatID, chunks: chunks)
+        } catch {
+            // #475/#492: appendChatChunks is the persistence write for the MLX
+            // embedding compute above; swallowing the throw would discard all of
+            // it with no trace. Log so the lost write is visible in Console.app.
+            DebugLog.store("reembedChatMessages appendChatChunks failed (chat=\(chatID.rawValue) chunks=\(chunks.count)): \(error)")
+        }
     }
 
     public func listChats() throws -> [ChatSummary] {

--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -2044,7 +2044,13 @@ public final class WikiStoreModel {
         // the UI shows "How to Do Thing" instead of "How to Do Thing.md".
         if snapshot.plan.format == .htmlConverted {
             let cleanTitle = (snapshot.page.filename as NSString).deletingPathExtension
-            try? store.setSourceDisplayName(id: summary.id, displayName: cleanTitle)
+            do {
+                try store.setSourceDisplayName(id: summary.id, displayName: cleanTitle)
+            } catch {
+                // #475/#492: don't silently swallow — the display name would silently
+                // revert to "Foo.md" with no Console.app trace of why.
+                DebugLog.store("WikiStoreModel.importURLSource setSourceDisplayName failed (source=\(summary.id.rawValue)): \(error)")
+            }
         }
         reloadSources()
         openTab(.source(summary.id))
@@ -2374,8 +2380,15 @@ public final class WikiStoreModel {
         guard let mime = file.mimeType, mime.hasPrefix("text/") else { return nil }
         guard let bytes = try? store.sourceContent(id: file.id),
               let text = String(data: bytes, encoding: .utf8) else { return nil }
-        return try? store.appendProcessedMarkdown(
-            sourceID: file.id, content: text, origin: "source", note: nil, technique: nil)
+        do {
+            return try store.appendProcessedMarkdown(
+                sourceID: file.id, content: text, origin: "source", note: nil, technique: nil)
+        } catch {
+            // #475/#492: seeding v1 from verbatim bytes is a persistence write;
+            // swallowing the throw silently drops the first version with no trace.
+            DebugLog.store("WikiStoreModel.processedMarkdownHead appendProcessedMarkdown (seed v1) failed (source=\(file.id.rawValue)): \(error)")
+            return nil
+        }
     }
 
     /// True when at least one processed-markdown version exists for this source.
@@ -2446,8 +2459,15 @@ public final class WikiStoreModel {
     /// keystroke spam.
     @discardableResult
     public func saveProcessedMarkdown(for sourceID: PageID, content: String) -> SourceMarkdownVersion? {
-        try? store.appendProcessedMarkdown(
-            sourceID: sourceID, content: content, origin: "user", note: nil, technique: nil)
+        do {
+            return try store.appendProcessedMarkdown(
+                sourceID: sourceID, content: content, origin: "user", note: nil, technique: nil)
+        } catch {
+            // #475/#492: the user's source-markdown edit is lost if this write
+            // throws; log so it's visible in Console.app instead of vanishing.
+            DebugLog.store("WikiStoreModel.saveProcessedMarkdown failed (source=\(sourceID.rawValue)): \(error)")
+            return nil
+        }
     }
 
     /// Seed the first processed-markdown version for a PDF from extraction
@@ -2462,9 +2482,16 @@ public final class WikiStoreModel {
         if let head = try? store.processedMarkdownHead(sourceID: sourceID) {
             return head
         }
-        return try? store.recordMarkdownExtraction(
-            sourceID: sourceID, content: content, backend: backend,
-            sourceVersionID: nil, note: nil, modelVersion: modelVersion)
+        do {
+            return try store.recordMarkdownExtraction(
+                sourceID: sourceID, content: content, backend: backend,
+                sourceVersionID: nil, note: nil, modelVersion: modelVersion)
+        } catch {
+            // #475/#492: PDF extraction output (expensive) is lost if this write
+            // throws; log so it's visible in Console.app instead of vanishing.
+            DebugLog.store("WikiStoreModel.seedPdfMarkdown recordMarkdownExtraction failed (source=\(sourceID.rawValue)): \(error)")
+            return nil
+        }
     }
 
     /// Re-extract a source's content with a given extractor + backend, appending
@@ -2484,10 +2511,17 @@ public final class WikiStoreModel {
             pdfData: data, filename: filename, onProgress: onProgress) else {
             return nil
         }
-        return try? store.recordMarkdownExtraction(
-            sourceID: sourceID, content: markdown, backend: backend,
-            sourceVersionID: nil, note: "re-extract via \(backend.agentName)",
-            modelVersion: modelVersion)
+        do {
+            return try store.recordMarkdownExtraction(
+                sourceID: sourceID, content: markdown, backend: backend,
+                sourceVersionID: nil, note: "re-extract via \(backend.agentName)",
+                modelVersion: modelVersion)
+        } catch {
+            // #475/#492: re-extraction is seconds-minutes of MLX/PDF compute;
+            // swallowing the throw silently discards it with no trace.
+            DebugLog.store("WikiStoreModel.reExtractMarkdown recordMarkdownExtraction failed (source=\(sourceID.rawValue)): \(error)")
+            return nil
+        }
     }
 
     /// Nominate an existing processed-markdown row as the active HEAD for a

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -207,7 +207,13 @@ public final class AgentLauncher {
     public func setDefaultProvider(id: String) -> AgentProvidersConfig {
         let dir = resolveProvidersContainerDirectory()
         let updated = providersConfig().settingDefault(id: id)
-        try? updated.save(to: dir)
+        do {
+            try updated.save(to: dir)
+        } catch {
+            // #475/#492: persisting the default-provider choice is a mutation;
+            // swallowing the throw silently reverts the choice on next launch.
+            DebugLog.store("AgentLauncher.setDefaultProvider save failed (provider=\(id)): \(error)")
+        }
         return updated
     }
 
@@ -223,7 +229,13 @@ public final class AgentLauncher {
         let dir = resolveProvidersContainerDirectory()
         let updated = providersConfig().settingCachedModels(models, forProvider: providerId)
         DebugLog.store("cacheDiscoveredModels: provider=\(providerId) count=\(models.count) → save") // TEMP DEBUG
-        try? updated.save(to: dir)
+        do {
+            try updated.save(to: dir)
+        } catch {
+            // #475/#492: the cached model list silently disappears on next launch
+            // if this write throws; log so it's visible in Console.app.
+            DebugLog.store("AgentLauncher.cacheDiscoveredModels save failed (provider=\(providerId)): \(error)")
+        }
     }
 
     /// Set + persist the user's model selection for `providerId`, then return
@@ -234,7 +246,13 @@ public final class AgentLauncher {
         let dir = resolveProvidersContainerDirectory()
         let updated = providersConfig().settingSelectedModel(modelId, forProvider: providerId)
         DebugLog.store("setSelectedModel: provider=\(providerId) modelId=\(modelId ?? "nil") → save") // TEMP DEBUG
-        try? updated.save(to: dir)
+        do {
+            try updated.save(to: dir)
+        } catch {
+            // #475/#492: the user's model selection silently reverts on next
+            // launch if this write throws; log so it's visible in Console.app.
+            DebugLog.store("AgentLauncher.setSelectedModel save failed (provider=\(providerId) modelId=\(modelId ?? "nil")): \(error)")
+        }
         return updated
     }
 
@@ -252,7 +270,13 @@ public final class AgentLauncher {
         let updated = providersConfig()
             .settingDefault(id: provider.id)
             .settingSelectedModel(modelId, forProvider: provider.id)
-        try? updated.save(to: dir)
+        do {
+            try updated.save(to: dir)
+        } catch {
+            // #475/#492: provider+model selection must land together; swallowing
+            // the throw silently reverts both on next launch.
+            DebugLog.store("AgentLauncher.setSelectedModelAndDefault save failed (provider=\(provider.id) modelId=\(modelId ?? "nil")): \(error)")
+        }
         return updated
     }
 
@@ -271,7 +295,13 @@ public final class AgentLauncher {
     public func toggleFavoriteModel(_ modelId: String, forProvider providerId: String) -> AgentProvidersConfig {
         let dir = resolveProvidersContainerDirectory()
         let updated = providersConfig().togglingFavoriteModel(modelId, forProvider: providerId)
-        try? updated.save(to: dir)
+        do {
+            try updated.save(to: dir)
+        } catch {
+            // #475/#492: the favorite toggle silently reverts if this write
+            // throws; log so it's visible in Console.app.
+            DebugLog.store("AgentLauncher.toggleFavoriteModel save failed (provider=\(providerId) model=\(modelId)): \(error)")
+        }
         return updated
     }
 


### PR DESCRIPTION
## Summary

Fixes #492.

Several mutating/persistence writes used bare `try?` that silently discarded the result without logging — the exact `#475` anti-pattern that `CLAUDE.md` bans. Expensive work (MLX/PDF extraction taking seconds-to-minutes, user edits, provider/model selections, chat embeddings) would vanish if the write threw, with no trace in Console.app.

## Changes

Replaced each listed `try?` with `do { try ... } catch { DebugLog.store(...) }` so failures surface in Console.app (subsystem `com.selfdrivingwiki.debug`). Each `catch` includes a `#475/#492` comment explaining what is lost and a contextual log message (source/page/chat IDs, provider/model).

**`Sources/WikiFSCore/WikiStoreModel.swift`** (5 sites)
- `setSourceDisplayName` — HTML-converted source's clean display name
- `appendProcessedMarkdown` (seed v1 from verbatim bytes)
- `appendProcessedMarkdown` (user source-markdown edit)
- `recordMarkdownExtraction` (PDF extraction result, expensive)
- `recordMarkdownExtraction` (re-extraction, seconds-minutes of MLX/PDF compute)

**`Sources/WikiFSEngine/AgentLauncher.swift`** (5 sites)
- `setDefaultProvider` — provider choice lost
- `cacheDiscoveredModels` — cached models lost
- `setSelectedModel` — model selection reverts on next launch
- `setSelectedModelAndDefault` — same, atomically-set pair
- `toggleFavoriteModel` — favorite toggle lost

**`Sources/WikiFSCore/SQLiteWikiStore.swift`** (1 site)
- `appendChatChunks` (`reembedChatMessages`) — MLX embedding compute entirely lost

## Scope discipline

Only the throwing mutation/persistence call sites listed in #492 are touched. The ~360 legitimate read-path optional-coalescing and cleanup `try?` calls (e.g. `try? store.listPages() ?? []`, `try? await Task.sleep`, `try? handle.close()`) are intentionally left alone.

## Verification

- `make build` — builds + signs
- Fast test tier (`swift test --skip ...integration suites`) — 2438 tests in 209 suites passed

## Testing notes

No behavior change on the success path — the `do/try` block returns the same value `try?` would have produced. On the failure path, these sites previously returned `nil`/silently continued; they still do, but now emit a `DebugLog.store` entry so the lost write is diagnosable.
