### PR TITLE
Fix #487: stop swallowing WikiDaemon.changeToken errors with bare try?

### DIFF
--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -149,17 +149,46 @@ final class WikiDaemon {
         }
     }
 
+    /// Sentinel returned by ``changeToken(wikiID:)`` when reading the store's
+    /// change token throws. A genuine change token is always colon-joined
+    /// integers (e.g. `"0:0:0:…"`), so this is syntactically distinguishable
+    /// from a real "no changes" token — and it never matches a previously
+    /// cached anchor, so callers (the File Provider enumerator) treat it as
+    /// "changed" and re-sync rather than silently skipping an update (#487).
+    /// Contrast with `""`, which means the wikiID is unknown (not registered).
+    static let errorTokenSentinel = "<<changeToken-read-error>>"
+
     func changeToken(wikiID: String) -> String {
         queue.sync { () -> String in
-            // If the store is open, read the token directly
+            // If the store is open, read the token directly.
+            // Never swallow a thrown error as `""` (which would be reported to
+            // the File Provider as "no changes" → stale projections, #487).
             if let store = openStores[wikiID] {
-                return (try? store.changeToken())?.rawString ?? ""
+                do {
+                    return try store.changeToken().rawString
+                } catch {
+                    DebugLog.store("wikid: changeToken() failed for \(wikiID) (open store): \(error)")
+                    return Self.errorTokenSentinel
+                }
             }
-            // Store not held open — open it transiently to read the token
+            // Store not held open — open it transiently to read the token.
+            // Unknown wiki → "" (genuine "not registered"); any thrown error
+            // during open/read → sentinel (logs + forces caller re-sync).
             guard registry.descriptor(id: wikiID) != nil else { return "" }
             let dbURL = databaseURL(forWikiID: wikiID)
-            guard let store = try? SQLiteWikiStore(databaseURL: dbURL) else { return "" }
-            return (try? store.changeToken())?.rawString ?? ""
+            let store: SQLiteWikiStore
+            do {
+                store = try SQLiteWikiStore(databaseURL: dbURL)
+            } catch {
+                DebugLog.store("wikid: changeToken() failed to open transient store for \(wikiID): \(error)")
+                return Self.errorTokenSentinel
+            }
+            do {
+                return try store.changeToken().rawString
+            } catch {
+                DebugLog.store("wikid: changeToken() failed for \(wikiID) (transient store): \(error)")
+                return Self.errorTokenSentinel
+            }
         }
     }
 

--- a/Tests/WikiFSTests/WikiDaemonTests.swift
+++ b/Tests/WikiFSTests/WikiDaemonTests.swift
@@ -276,6 +276,35 @@ struct WikiDaemonTests {
         #expect(token.isEmpty)
     }
 
+    /// When the store's `changeToken()` (or its transient open) throws, the
+    /// daemon must NOT swallow the error as `""` ("no changes" → stale File
+    /// Provider projection, #487). It must log and return a sentinel the caller
+    /// can distinguish from a genuine token — and that never matches a cached
+    /// anchor, so the enumerator re-syncs.
+    @Test func changeTokenReturnsSentinelOnStoreError() throws {
+        let dir = tempDirectory()
+        let daemon = makeDaemon(dir: dir)
+        let data = try #require(daemon.createWiki(name: "Corrupt Test"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
+
+        // Force the transient-open path (store not held in `openStores`)
+        daemon.closeStore(wikiID: descriptor.id)
+
+        // Corrupt the DB so SQLiteWikiStore(databaseURL:) throws (SQLITE_NOTADB)
+        let dbURL = dir.appendingPathComponent("\(descriptor.id).sqlite", isDirectory: false)
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: dbURL.path + suffix)
+        }
+        try Data("not a sqlite database".utf8).write(to: dbURL)
+
+        let token = daemon.changeToken(wikiID: descriptor.id)
+        #expect(token == WikiDaemon.errorTokenSentinel)
+        // Sentinel is distinguishable from both a genuine token (colon-joined
+        // integers) and from `""` (unknown wiki).
+        #expect(!token.isEmpty)
+        #expect(!token.contains(":"))
+    }
+
     // MARK: - Multiple wikis
 
     @Test func multipleWikisAreIndependent() throws {


### PR DESCRIPTION
## Fix #487: WikiDaemon.changeToken swallows store errors with bare `try?`

Closes #487.

### Problem

`WikiDaemon.changeToken(wikiID:)` used bare `try? ... ?? ""` at two sites (the
open-store read and the transient-store read). If `store.changeToken()` threw,
the daemon silently reported `""` ("no changes") to the File Provider over XPC,
causing **stale projections** — the enumerator skipped an update it should have
processed, and content on the mount went silently out of sync with SQLite.

This is the exact pattern banned in `CLAUDE.md`:

> Never use bare `try?` to swallow errors silently — it hides failures and has
> already caused lost transcripts and misattributed queue items (#475).

### Fix

Replace both bare `try?` with explicit `do/catch` blocks that:

1. **Log the failure** via `DebugLog.store(...)` (subsystem
   `com.selfdrivingwiki.debug`), with context distinguishing open-store vs
   transient-store and open-vs-read failure.
2. **Return a known-invalid sentinel** (`WikiDaemon.errorTokenSentinel`,
   `"<<changeToken-read-error>>"`) the caller can distinguish from a genuine
   "no changes" token.

A genuine change token is always colon-joined integers
(e.g. `0:0:0:…`). The sentinel is syntactically distinguishable and **never
matches a previously-cached anchor**, so a consumer that diffs anchors treats
it as "changed" and re-syncs — the safe behavior when the token can't be read —
rather than silently skipping.

The genuine "unknown wiki" case (not in the registry) still returns `""`,
unchanged, so existing semantics are preserved.

Note: the XPC protocol (`WikiDaemonProtocol.changeToken(wikiID:reply:)`) only
carries a `String`, with no error channel. Returning a known-invalid token is
the minimal, non-breaking way to surface the failure to callers without
changing the protocol shape.

### Why a sentinel over XPC error propagation?

Propagating the error over XPC would require changing the protocol signature
(adding an `Error`/`String?` to the reply), the daemon method, the XPC handler
in `main.swift`, and `WikiDaemonConnection`. That's a larger breaking change
out of scope for this bug. The sentinel achieves the correctness goal — callers
can detect failure and never confuse it with a real "no changes" token — with a
focused, low-risk change.

### Tests

Added `changeTokenReturnsSentinelOnStoreError` to `WikiDaemonTests`:
registers a wiki, closes the held store (forces the transient-open path),
corrupts the DB file, and asserts `changeToken(wikiID:)` returns the sentinel
(not `""`). Existing tests (`changeTokenReturnsEmptyForUnknownWiki`,
`changeTokenReturnsNonEmptyForOpenStore`, `multipleWikisAreIndependent`)
continue to pass unchanged.

### Verification

- `swift build` ✓
- Fast test tier (`swift test --skip '...'`) ✓ — 2439 tests, 209 suites passed
