### PR TITLE
Fix #488: delete dead content-sniff forwarder shims

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,38 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-17 — Issue #488: Delete dead content-sniff forwarder shims (branch `cleanup/dead-sniff-forwarders`)
+
+**Shipped.** Removed 81 lines of dead forwarder shims left over from the
+`ContentSniff` extraction. All real callers use `ContentSniff.mimeType(of:)`
+(or `FormatMaterializer.dispatch`, which now calls it directly).
+
+**Deleted from `URLFetchService.swift`** (zero production callers — only
+tests/forwarders referenced them):
+- `shouldSniff`, `sniffContentType` — 1-line forwarders to FormatMaterializer.
+- `stemFromURL` — dead; comment admitted "backward compat"; `nameHint(for:)`
+  is the production path.
+- `sanitizeStem`, `ensureExtension`, `textExtension` — dead forwarders (only
+  test callers or zero callers); canonical copies live on `FormatMaterializer`.
+
+**Kept** (real production callers): `URLFetchService.normalizedMIME`
+(WebsiteSnapshotExtractor), `decodeText` (SourceMaterializer),
+`binaryExtension` (WebsiteSnapshotExtractor).
+
+**`FormatMaterializer.swift`:** inlined the `sniffContentType` forwarder —
+`dispatch` now calls `ContentSniff.mimeType(of:)` directly. Kept `shouldSniff`
+(real switch logic, not a forwarder; used internally by `dispatch`). Note:
+the issue's premise that the FormatMaterializer methods were "only called by
+the dead shim" was incorrect — they have an internal caller (`dispatch`);
+only the `URLFetchService` versions were truly dead.
+
+**Tests:** deleted duplicate `URLFetchServiceTests` copies (canonical versions
+already exist in `FormatMaterializerTests`). Migrated
+`stemFromURLPrefersPathThenHost` → `nameHintPrefersPathThenHost` (tests the
+production replacement). Migrated `FormatMaterializerTests.sniffContentType`
+to call `ContentSniff.mimeType(of:)` directly. Removed `URLFetchService` from
+the `ExtensionCheckGuardTests` allowlist (no longer contains extension checks).
+
 ## 2026-07-17 — Issue #484: Structured ChangeToken type (branch `hardcore-bulldog`)
 
 **Shipped.** Replaced the positional colon-joined `changeToken()` string

--- a/Sources/WikiFSCore/FormatMaterializer.swift
+++ b/Sources/WikiFSCore/FormatMaterializer.swift
@@ -71,7 +71,7 @@ public enum FormatMaterializer {
         // carry a known binary magic number, store them verbatim as the sniffed
         // type instead of running HTML→Markdown on binary garbage. A specific
         // declared type is trusted as-is.
-        if shouldSniff(mime), let sniffed = sniffContentType(data) {
+        if shouldSniff(mime), let sniffed = ContentSniff.mimeType(of: data) {
             let ext = binaryExtension(forMIME: sniffed, extensionHint: extensionHint)
             let filename = ext.isEmpty ? sanitizeStem(stem) : ensureExtension(sanitizeStem(stem), ext: ext)
             let format: SourceFormat = sniffed == "application/pdf" ? .pdf : .binary
@@ -115,12 +115,6 @@ public enum FormatMaterializer {
         default:
             return false
         }
-    }
-
-    /// Detect a known binary content type from leading magic-number bytes, else
-    /// `nil`. Delegates to the shared `ContentSniff` helper.
-    static func sniffContentType(_ data: Data) -> String? {
-        ContentSniff.mimeType(of: data)
     }
 
     // MARK: - Helpers (pure)

--- a/Sources/WikiFSCore/URLFetchService.swift
+++ b/Sources/WikiFSCore/URLFetchService.swift
@@ -195,16 +195,6 @@ public struct URLFetchService {
         return StorePlan(filename: fp.filename, data: fp.data, kind: mapFormat(fp.format))
     }
 
-    // MARK: - Content sniffing (thin forwarders to FormatMaterializer)
-
-    static func shouldSniff(_ mime: String?) -> Bool {
-        FormatMaterializer.shouldSniff(mime)
-    }
-
-    static func sniffContentType(_ data: Data) -> String? {
-        FormatMaterializer.sniffContentType(data)
-    }
-
     // MARK: - Helpers (thin forwarders to FormatMaterializer)
 
     static func normalizedMIME(_ raw: String?) -> String? {
@@ -213,35 +203,6 @@ public struct URLFetchService {
 
     static func decodeText(_ data: Data) -> String {
         FormatMaterializer.decodeText(data)
-    }
-
-    /// The filename stem from a URL: the last path component without its extension,
-    /// else the host. Kept here for backward compat (its test calls it directly);
-    /// `plan(for:)` uses `nameHint(for:)` instead.
-    static func stemFromURL(_ url: URL) -> String {
-        let last = url.lastPathComponent
-        if !last.isEmpty, last != "/" {
-            let ns = last as NSString
-            let stem = ns.deletingPathExtension
-            if !stem.isEmpty { return stem }
-        }
-        if let host = url.host, !host.isEmpty {
-            return host
-        }
-        return "download"
-    }
-
-    static func sanitizeStem(_ stem: String) -> String {
-        FormatMaterializer.sanitizeStem(stem)
-    }
-
-    static func ensureExtension(_ stem: String, ext: String) -> String {
-        FormatMaterializer.ensureExtension(stem, ext: ext)
-    }
-
-    static func textExtension(forMIME mime: String, url: URL) -> String {
-        let ext = (url.lastPathComponent as NSString).pathExtension.lowercased()
-        return FormatMaterializer.textExtension(forMIME: mime, extensionHint: ext.isEmpty ? nil : ext)
     }
 
     static func binaryExtension(forMIME mime: String?, url: URL) -> String {

--- a/Tests/WikiFSTests/ContentSniffTests.swift
+++ b/Tests/WikiFSTests/ContentSniffTests.swift
@@ -2,10 +2,9 @@ import Foundation
 import Testing
 @testable import WikiFSCore
 
-/// Direct tests for the shared `ContentSniff.mimeType(of:)` helper. Previously
-/// these were only exercised through `URLFetchService.sniffContentType`, but
-/// `addSource` now depends on `ContentSniff` directly for the MIME-first path
-/// (content-type-over-extension plan).
+/// Direct tests for the shared `ContentSniff.mimeType(of:)` helper — the
+/// canonical magic-number sniffer used by `FormatMaterializer.dispatch` and
+/// `addSource` (content-type-over-extension plan).
 struct ContentSniffTests {
 
     @Test func pdfMagicBytes() {

--- a/Tests/WikiFSTests/ExtensionCheckGuardTests.swift
+++ b/Tests/WikiFSTests/ExtensionCheckGuardTests.swift
@@ -12,7 +12,6 @@ import Testing
 /// - `WikiFSItem` — generated-doc suffixes (`.md`, `.json`, `.jsonl` on names we control)
 /// - `EmbeddingService` — `Bundle.main.bundlePath.hasSuffix(".app")` (runtime path)
 /// - `SQLiteWikiStore` — same bundle-path guard + ext fallback in `addSource` (last resort)
-/// - `URLFetchService` — `ensureExtension` (filename construction, not behavior)
 /// - `ZoteroClient` — `isIngestable` fallback heuristic (MIME-first already)
 /// - `WikiStoreModel` — markdown lazy-seed ext check (owned by Phase C)
 struct ExtensionCheckGuardTests {
@@ -32,7 +31,6 @@ struct ExtensionCheckGuardTests {
         "WikiFSItem",             // generated-doc suffixes on names we control
         "EmbeddingService",       // Bundle.main.bundlePath.hasSuffix(".app")
         "SQLiteWikiStore",        // bundle-path guard + ext fallback in addSource
-        "URLFetchService",       // ensureExtension (filename construction)
         "ZoteroClient",           // isIngestable fallback (MIME-first already)
         "WikiStoreModel",         // markdown lazy-seed (Phase C owns removal)
     ]

--- a/Tests/WikiFSTests/FormatMaterializerTests.swift
+++ b/Tests/WikiFSTests/FormatMaterializerTests.swift
@@ -209,10 +209,10 @@ struct FormatMaterializerTests {
     }
 
     @Test func sniffContentTypeMagicNumbers() {
-        #expect(FormatMaterializer.sniffContentType(Data("%PDF-1.4".utf8)) == "application/pdf")
-        #expect(FormatMaterializer.sniffContentType(Data([0x89, 0x50, 0x4E, 0x47])) == "image/png")
-        #expect(FormatMaterializer.sniffContentType(Data("<!DOCTYPE html>".utf8)) == nil)
-        #expect(FormatMaterializer.sniffContentType(Data()) == nil)
+        #expect(ContentSniff.mimeType(of: Data("%PDF-1.4".utf8)) == "application/pdf")
+        #expect(ContentSniff.mimeType(of: Data([0x89, 0x50, 0x4E, 0x47])) == "image/png")
+        #expect(ContentSniff.mimeType(of: Data("<!DOCTYPE html>".utf8)) == nil)
+        #expect(ContentSniff.mimeType(of: Data()) == nil)
     }
 
     // MARK: - AC.7: FormatMaterializer has no URL-type dependency

--- a/Tests/WikiFSTests/URLFetchServiceTests.swift
+++ b/Tests/WikiFSTests/URLFetchServiceTests.swift
@@ -223,28 +223,6 @@ struct URLFetchServiceTests {
         #expect(collector.data == pdf)
     }
 
-    @Test func sniffContentTypeMagicNumbers() {
-        #expect(URLFetchService.sniffContentType(Data("%PDF-1.4".utf8)) == "application/pdf")
-        #expect(URLFetchService.sniffContentType(Data([0x89, 0x50, 0x4E, 0x47])) == "image/png")
-        #expect(URLFetchService.sniffContentType(Data([0xFF, 0xD8, 0xFF, 0xE0])) == "image/jpeg")
-        #expect(URLFetchService.sniffContentType(Data("GIF89a".utf8)) == "image/gif")
-        #expect(URLFetchService.sniffContentType(Data([0x50, 0x4B, 0x03, 0x04])) == "application/zip")
-        // Plain text / HTML carries no magic → nil (falls back to declared type).
-        #expect(URLFetchService.sniffContentType(Data("<!DOCTYPE html>".utf8)) == nil)
-        #expect(URLFetchService.sniffContentType(Data("hello".utf8)) == nil)
-        #expect(URLFetchService.sniffContentType(Data()) == nil)
-    }
-
-    @Test func shouldSniffOnlyAmbiguousTypes() {
-        #expect(URLFetchService.shouldSniff(nil))
-        #expect(URLFetchService.shouldSniff("text/html"))
-        #expect(URLFetchService.shouldSniff("application/octet-stream"))
-        // A specific declared type is trusted, not sniffed.
-        #expect(!URLFetchService.shouldSniff("application/pdf"))
-        #expect(!URLFetchService.shouldSniff("image/png"))
-        #expect(!URLFetchService.shouldSniff("text/plain"))
-    }
-
     // MARK: - Errors
 
     @Test func nonHTTPSuccessSurfacedAsError() async throws {
@@ -334,22 +312,11 @@ struct URLFetchServiceTests {
         #expect(URLFetchService.normalizedMIME(nil) == nil)
     }
 
-    @Test func ensureExtensionDoesNotDouble() {
-        #expect(URLFetchService.ensureExtension("file", ext: "md") == "file.md")
-        #expect(URLFetchService.ensureExtension("file.md", ext: "md") == "file.md")
-        #expect(URLFetchService.ensureExtension("file.MD", ext: "md") == "file.MD")
-    }
-
-    @Test func stemFromURLPrefersPathThenHost() {
-        #expect(URLFetchService.stemFromURL(URL(string: "https://a.com/x/report.pdf")!) == "report")
-        #expect(URLFetchService.stemFromURL(URL(string: "https://a.com/")!) == "a.com")
-        #expect(URLFetchService.stemFromURL(URL(string: "https://a.com")!) == "a.com")
-    }
-
-    @Test func sanitizeStemCapsAndCleans() {
-        let long = String(repeating: "x", count: 200)
-        #expect(URLFetchService.sanitizeStem(long).count <= 80)
-        #expect(URLFetchService.sanitizeStem("a/b:c") == "a-b-c")
-        #expect(URLFetchService.sanitizeStem("   ") == "untitled")
+    @Test func nameHintPrefersPathThenHost() {
+        let path = URLFetchService.nameHint(for: URL(string: "https://a.com/x/report.pdf")!)
+        #expect(path.stem == "report")
+        #expect(path.ext == "pdf")
+        #expect(URLFetchService.nameHint(for: URL(string: "https://a.com/")!).stem == "a.com")
+        #expect(URLFetchService.nameHint(for: URL(string: "https://a.com")!).stem == "a.com")
     }
 }


### PR DESCRIPTION
## Summary

Fixes #488 — deletes dead content-sniff forwarder shims left over from the `ContentSniff` extraction. Net **−81 lines** of dead code. All real callers use `ContentSniff.mimeType(of:)` (or `FormatMaterializer.dispatch`, which now calls it directly).

## What was deleted

### `URLFetchService.swift` — 6 dead forwarders (zero production callers)

| Method | Why dead |
|--------|----------|
| `shouldSniff` | 1-line forwarder; only test callers |
| `sniffContentType` | 1-line forwarder; only test callers |
| `stemFromURL` | comment admitted "backward compat"; `nameHint(for:)` is the production path |
| `sanitizeStem` | forwarder; only test caller (canonical copy on `FormatMaterializer`) |
| `ensureExtension` | forwarder; only test caller |
| `textExtension` | forwarder; **zero** callers |

### `FormatMaterializer.swift` — inlined 1 forwarder
- **`sniffContentType`** — was a 1-line forwarder to `ContentSniff.mimeType(of:)`. `dispatch` now calls `ContentSniff.mimeType(of:)` directly.

## What was kept (and why)

**`URLFetchService`** — kept `normalizedMIME` (caller: `WebsiteSnapshotExtractor`), `decodeText` (caller: `SourceMaterializer`), `binaryExtension` (caller: `WebsiteSnapshotExtractor`). These have real production callers.

**`FormatMaterializer.shouldSniff`** — kept. This has real logic (a `switch` over ambiguous MIME types) and is called internally by `dispatch`. It is **not** a forwarder.

> **Note on the issue's premise:** the issue stated `FormatMaterializer.sniffContentType` and `shouldSniff` had "only caller is the dead `URLFetchService` shim." That was incorrect — both are called internally by `FormatMaterializer.dispatch` (line 74). Only the `URLFetchService` versions were truly dead. `sniffContentType` was still a pointless indirection (forwarder to `ContentSniff`), so it was inlined; `shouldSniff` has real logic and was retained.

## Test changes

- **Deleted duplicate `URLFetchServiceTests`** copies of `sniffContentTypeMagicNumbers`, `shouldSniffOnlyAmbiguousTypes`, `ensureExtensionDoesNotDouble`, `sanitizeStemCapsAndCleans` — canonical versions already exist in `FormatMaterializerTests`.
- **Migrated** `stemFromURLPrefersPathThenHost` → `nameHintPrefersPathThenHost` (tests the production replacement `nameHint(for:)`).
- **Migrated** `FormatMaterializerTests.sniffContentTypeMagicNumbers` to call `ContentSniff.mimeType(of:)` directly.
- **Removed** `URLFetchService` from the `ExtensionCheckGuardTests` allowlist (it no longer contains any extension-check code).
- **Updated** a stale comment in `ContentSniffTests` that referenced the deleted `URLFetchService.sniffContentType`.

## Verification

- `make build` ✅ (Build complete + app assembled/signed)
- Fast test tier ✅ (2434 tests; the single failure — `QueueEngineTests.testAtMostOneIngestionPerWiki` — is a known-flaky timing test unrelated to this change; confirmed passing on isolated re-run)
- Affected suites ✅: `FormatMaterializerTests`, `URLFetchServiceTests`, `ContentSniffTests`, `ExtensionCheckGuardTests` — all 50 tests pass

Closes #488
