### PR TITLE
Fix #489: Consolidate link-kind prefixes into typed accessor

### DIFF
--- a/Sources/WikiFS/BlobSchemeHandler.swift
+++ b/Sources/WikiFS/BlobSchemeHandler.swift
@@ -41,7 +41,7 @@ final class BlobSchemeHandler: NSObject, WKURLSchemeHandler {
     @MainActor func serve(_ task: WKURLSchemeTask) {
         guard let url = task.request.url,
               url.scheme == Self.scheme,
-              url.host == "source" else {
+              url.host == WikiLinkMarkdown.sourceHost else {
             respond404(task, url: task.request.url)
             return
         }

--- a/Sources/WikiFS/MarkdownHTMLRenderer.swift
+++ b/Sources/WikiFS/MarkdownHTMLRenderer.swift
@@ -115,16 +115,16 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
         let dest = link.destination ?? ""
         var tooltip = dest
         if let url = URL(string: dest), url.scheme == WikiLinkMarkdown.scheme {
-            if url.host == "anchor" {
+            if url.host == WikiLinkMarkdown.anchorHost {
                 if let frag = WikiLinkMarkdown.fragment(from: url) {
                     tooltip = "#\(frag)"
                 }
             } else if let title = WikiLinkMarkdown.target(from: url) {
                 let prefix: String
                 switch url.host {
-                case "source": prefix = "source:"
-                case "chat":   prefix = "chat:"
-                default:       prefix = ""
+                case WikiLinkMarkdown.sourceHost: prefix = WikiLinkParser.ParsedLink.LinkType.source.linkPrefix
+                case WikiLinkMarkdown.chatHost:   prefix = WikiLinkParser.ParsedLink.LinkType.chat.linkPrefix
+                default:                          prefix = ""
                 }
                 let frag = WikiLinkMarkdown.fragment(from: url)
                 let fragSuffix = frag.map { "#\($0)" } ?? ""

--- a/Sources/WikiFSCore/OmniboxResult.swift
+++ b/Sources/WikiFSCore/OmniboxResult.swift
@@ -20,10 +20,10 @@ public enum OmniboxResult: Identifiable, Hashable, Sendable {
 
     public var id: String {
         switch self {
-        case .page(let p): return "page:\(p.id.rawValue)"
-        case .source(let s): return "source:\(s.id.rawValue)"
-        case .chat(let c): return "chat:\(c.id.rawValue)"
-        case .bookmark(let node, _): return "bookmark:\(node.id)"
+        case .page(let p): return "\(ResourceKind.page.linkPrefix!)\(p.id.rawValue)"
+        case .source(let s): return "\(ResourceKind.source.linkPrefix!)\(s.id.rawValue)"
+        case .chat(let c): return "\(ResourceKind.chat.linkPrefix!)\(c.id.rawValue)"
+        case .bookmark(let node, _): return "\(ResourceKind.bookmark.linkPrefix!)\(node.id)"
         case .ask: return "ask"
         }
     }

--- a/Sources/WikiFSCore/Resource.swift
+++ b/Sources/WikiFSCore/Resource.swift
@@ -50,6 +50,20 @@ public enum ResourceKind: String, Sendable, CaseIterable {
         case .log:         "clock.arrow.circlepath"
         }
     }
+
+    /// The `[[kind:Target]]` wiki-link prefix for linkable kinds:
+    /// `"page:"`, `"source:"`, `"chat:"`, `"bookmark:"`.
+    ///
+    /// Returns `nil` for non-linkable kinds (`systemPrompt`, `wikiIndex`,
+    /// `log`) that have no wiki-link syntax. This is the single source of
+    /// truth for link-kind prefix strings — inline literals should never be
+    /// re-derived at call sites (#489).
+    public var linkPrefix: String? {
+        switch self {
+        case .page, .source, .chat, .bookmark: return "\(rawValue):"
+        case .systemPrompt, .wikiIndex, .log: return nil
+        }
+    }
 }
 
 /// One fold's structured contribution to the whole-wiki change token.

--- a/Sources/WikiFSCore/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSCore/WikiLinkMarkdown.swift
@@ -50,8 +50,12 @@ public enum WikiLinkMarkdown {
     public static let blobScheme = "wiki-blob"
     /// Host for a link whose target resolves to a real page (navigates).
     public static let resolvedHost = "page"
+    /// Host for a link whose target resolves to a real source (navigates).
+    public static let sourceHost = "source"
     /// Host for a link whose target resolves to a real chat (navigates).
     public static let chatHost = "chat"
+    /// Host for a same-page anchor link (scroll, no navigation).
+    public static let anchorHost = "anchor"
     /// Host for a link whose target has no page/source (rendered dimmed, inert).
     public static let unresolvedHost = "missing"
 
@@ -257,7 +261,7 @@ public enum WikiLinkMarkdown {
     public static func target(from url: URL) -> String? {
         guard url.scheme == scheme,
               let host = url.host,
-              host == resolvedHost || host == "source" || host == chatHost || host == unresolvedHost,
+              host == resolvedHost || host == sourceHost || host == chatHost || host == unresolvedHost,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let title = components.queryItems?.first(where: { $0.name == "title" })?.value,
               !title.isEmpty
@@ -273,7 +277,7 @@ public enum WikiLinkMarkdown {
     public static func id(from url: URL) -> PageID? {
         guard url.scheme == scheme,
               let host = url.host,
-              host == resolvedHost || host == "source" || host == chatHost,
+              host == resolvedHost || host == sourceHost || host == chatHost,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let idString = components.queryItems?.first(where: { $0.name == "id" })?.value,
               !idString.isEmpty
@@ -288,7 +292,7 @@ public enum WikiLinkMarkdown {
     public static func pin(from url: URL) -> PageID? {
         guard url.scheme == scheme,
               let host = url.host,
-              host == "source",
+              host == sourceHost,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let pinString = components.queryItems?.first(where: { $0.name == "pin" })?.value,
               !pinString.isEmpty
@@ -300,7 +304,7 @@ public enum WikiLinkMarkdown {
     /// view's `OpenURLAction` to extract the anchor for scroll-to.
     public static func fragment(from url: URL) -> String? {
         guard url.scheme == scheme, let host = url.host,
-              host == resolvedHost || host == "source" || host == chatHost || host == unresolvedHost || host == "anchor"
+              host == resolvedHost || host == sourceHost || host == chatHost || host == unresolvedHost || host == anchorHost
         else { return nil }
         return url.fragment?.removingPercentEncoding
     }
@@ -313,7 +317,7 @@ public enum WikiLinkMarkdown {
         guard url.scheme == scheme, let host = url.host else { return nil }
         switch host {
         case resolvedHost:   return .page     // "page"
-        case "source":       return .source
+        case sourceHost:     return .source   // "source"
         case chatHost:       return .chat     // "chat"
         default:             return nil       // "missing", "anchor", or anything else → inert
         }
@@ -327,7 +331,7 @@ public enum WikiLinkMarkdown {
 
     /// True if `url` is a same-page anchor (`wiki://anchor#…`).
     public static func isSamePageAnchor(_ url: URL) -> Bool {
-        url.scheme == scheme && url.host == "anchor"
+        url.scheme == scheme && url.host == anchorHost
     }
 
     // MARK: - Helpers
@@ -340,7 +344,7 @@ public enum WikiLinkMarkdown {
                                      pinID: PageID? = nil) -> String {
         let host: String
         if resolved {
-            host = kind == .source ? "source" : (kind == .chat ? chatHost : resolvedHost)
+            host = kind == .source ? sourceHost : (kind == .chat ? chatHost : resolvedHost)
         } else {
             host = unresolvedHost
         }

--- a/Sources/WikiFSCore/WikiLinkParser.swift
+++ b/Sources/WikiFSCore/WikiLinkParser.swift
@@ -28,7 +28,27 @@ public enum WikiLinkParser {
     /// A single parsed link reference: the kind + the bare target (prefix-stripped)
     /// and the display text to record in the link tables.
     public struct ParsedLink: Equatable, Sendable {
-        public enum LinkType: String, Equatable, Sendable { case page, source, chat }
+        public enum LinkType: String, Equatable, Sendable, CaseIterable {
+            case page, source, chat
+
+            /// Bridge to the shared ``ResourceKind`` vocabulary (#489). The three
+            /// linkable link-types map directly to their `ResourceKind`
+            /// counterparts, so link-kind prefixes and host strings come from one
+            /// source of truth.
+            public var resourceKind: ResourceKind {
+                switch self {
+                case .page:   return .page
+                case .source: return .source
+                case .chat:   return .chat
+                }
+            }
+
+            /// The `[[kind:Target]]` wiki-link prefix for this kind (`"page:"`,
+            /// `"source:"`, `"chat:"`). Never nil — all `LinkType` cases are
+            /// linkable. Delegates to ``ResourceKind/linkPrefix``, so there is
+            /// exactly one place where prefix strings are defined (#489).
+            public var linkPrefix: String { resourceKind.linkPrefix! }
+        }
 
         public let linkType: LinkType
         public let target: String       // prefix-stripped, whitespace-collapsed (BASE only)
@@ -75,9 +95,9 @@ public enum WikiLinkParser {
     /// so a page literally titled "source:foo" is linkable as `[[page:source:foo]]`.
     /// The remainder is re-normalized so `[[source: X]]` → ("X"), not (" X").
     public static func classify(_ target: String) -> (ParsedLink.LinkType, String) {
-        if let rest = peel(prefix: "page:", off: target)   { return (.page,   WikiText.normalized(rest)) }
-        if let rest = peel(prefix: "source:", off: target) { return (.source, WikiText.normalized(rest)) }
-        if let rest = peel(prefix: "chat:", off: target)   { return (.chat,   WikiText.normalized(rest)) }
+        if let rest = peel(prefix: ParsedLink.LinkType.page.linkPrefix, off: target)   { return (.page,   WikiText.normalized(rest)) }
+        if let rest = peel(prefix: ParsedLink.LinkType.source.linkPrefix, off: target) { return (.source, WikiText.normalized(rest)) }
+        if let rest = peel(prefix: ParsedLink.LinkType.chat.linkPrefix, off: target)   { return (.chat,   WikiText.normalized(rest)) }
         return (.page, target) // target already normalized by the caller
     }
 
@@ -85,10 +105,11 @@ public enum WikiLinkParser {
     /// the remainder is empty/whitespace (e.g. `[[source:]]`, `[[page:   ]]`). Both
     /// parse() and WikiLinkMarkdown.linkified() use this to emit literal text.
     public static func isEmptyPrefix(_ target: String) -> Bool {
-        for prefix in ["page:", "source:", "chat:"] {
+        for kind in ParsedLink.LinkType.allCases {
+            let prefix = kind.linkPrefix
             guard target.hasPrefix(prefix) else { continue }
             let rest = String(target.dropFirst(prefix.count))
-            return rest.allSatisfy(\.isWhitespace)
+            return rest.allSatisfy { $0.isWhitespace }
         }
         return false
     }

--- a/Sources/WikiFSCore/WikiLinkRewriter.swift
+++ b/Sources/WikiFSCore/WikiLinkRewriter.swift
@@ -90,12 +90,7 @@ public enum WikiLinkRewriter {
             // Canonical target portion: kind:ULID (+ @vN pin + #fragment if any).
             // Phase 6: the pin is preserved verbatim (`@v3`), not resolved here —
             // it stays in the body as the per-occurrence source of truth.
-            let prefix: String
-            switch kind {
-            case .source: prefix = "source:"
-            case .chat:   prefix = "chat:"
-            case .page:   prefix = "page:"
-            }
+            let prefix = kind.linkPrefix
             let canonicalTarget = prefix + resolvedID.rawValue
                 + (pin.map { "@v\($0)" } ?? "")
                 + (resolvedFragment.map { "#\($0)" } ?? "")

--- a/Sources/WikiFSCore/WikiStateSnapshot.swift
+++ b/Sources/WikiFSCore/WikiStateSnapshot.swift
@@ -176,13 +176,13 @@ public struct WikiStateSnapshot: Equatable, Sendable {
           label = child.label ?? "(unnamed folder)"
         case .pageRef:
           icon = "📄"
-          label = "page:\(child.targetID?.rawValue ?? "?")"
+          label = "\(ResourceKind.page.linkPrefix ?? "")\(child.targetID?.rawValue ?? "?")"
         case .sourceRef:
           icon = "📎"
-          label = "source:\(child.targetID?.rawValue ?? "?")"
+          label = "\(ResourceKind.source.linkPrefix ?? "")\(child.targetID?.rawValue ?? "?")"
         case .chatRef:
           icon = "💬"
-          label = "chat:\(child.targetID?.rawValue ?? "?")"
+          label = "\(ResourceKind.chat.linkPrefix ?? "")\(child.targetID?.rawValue ?? "?")"
         }
         lines.append("\(indent)- \(icon) \(label)")
         if child.kind == .folder {

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -1392,7 +1392,7 @@ public final class AgentLauncher {
     /// runs (ingest/lint/query) get `agent:<kind>`. The `WIKI_AUTHOR` env var
     /// carries this into `wikictl`, where an explicit `--author` flag overrides it.
     static func authorForRun(kind: WikiOperation.Kind, chatID: String?) -> String {
-        if let chatID { return "chat:\(chatID)" }
+        if let chatID { return "\(ResourceKind.chat.linkPrefix!)\(chatID)" }
         return "agent:\(kind.rawValue)"
     }
 
@@ -1559,7 +1559,7 @@ public final class AgentLauncher {
                 // originating conversation (resolvable via [[chat:…]]). An explicit
                 // `--author` on `wikictl page upsert` overrides this.
                 if let chatID {
-                    hints["env.WIKI_AUTHOR"] = "chat:\(chatID)"
+                    hints["env.WIKI_AUTHOR"] = "\(ResourceKind.chat.linkPrefix!)\(chatID)"
                 }
                 return hints
             }(),

--- a/Tests/WikiFSTests/LinkPrefixAccessorTests.swift
+++ b/Tests/WikiFSTests/LinkPrefixAccessorTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import WikiFSCore
+
+/// Tests for the consolidated link-kind prefix and host accessor constants (#489).
+/// After this refactoring, `rg '"page:"|"source:"|"chat:"' Sources/ -t swift`
+/// returns zero hits outside the accessor definitions — these tests ensure the
+/// prefixes still flow correctly through the single source of truth.
+struct LinkPrefixAccessorTests {
+
+    // MARK: - ResourceKind.linkPrefix
+
+    @Test func resourceKindLinkPrefixReturnsExpectedValues() {
+        #expect(ResourceKind.page.linkPrefix == "page:")
+        #expect(ResourceKind.source.linkPrefix == "source:")
+        #expect(ResourceKind.chat.linkPrefix == "chat:")
+        #expect(ResourceKind.bookmark.linkPrefix == "bookmark:")
+    }
+
+    @Test func resourceKindLinkPrefixReturnsNilForNonLinkableKinds() {
+        #expect(ResourceKind.systemPrompt.linkPrefix == nil)
+        #expect(ResourceKind.wikiIndex.linkPrefix == nil)
+        #expect(ResourceKind.log.linkPrefix == nil)
+    }
+
+    @Test func resourceKindLinkPrefixMatchesRawValueForLinkable() {
+        for kind in ResourceKind.allCases where kind.linkPrefix != nil {
+            #expect(kind.linkPrefix == "\(kind.rawValue):")
+        }
+    }
+
+    // MARK: - ParsedLink.LinkType bridge
+
+    @Test func linkTypeResourceKindBridgesCorrectly() {
+        #expect(WikiLinkParser.ParsedLink.LinkType.page.resourceKind == .page)
+        #expect(WikiLinkParser.ParsedLink.LinkType.source.resourceKind == .source)
+        #expect(WikiLinkParser.ParsedLink.LinkType.chat.resourceKind == .chat)
+    }
+
+    @Test func linkTypeLinkPrefixIsNonOptionalAndMatchesResourceKind() {
+        for kind in WikiLinkParser.ParsedLink.LinkType.allCases {
+            #expect(kind.linkPrefix == kind.resourceKind.linkPrefix)
+            #expect(!kind.linkPrefix.isEmpty)
+        }
+    }
+
+    @Test func linkTypeLinkPrefixReturnsExpectedValues() {
+        #expect(WikiLinkParser.ParsedLink.LinkType.page.linkPrefix == "page:")
+        #expect(WikiLinkParser.ParsedLink.LinkType.source.linkPrefix == "source:")
+        #expect(WikiLinkParser.ParsedLink.LinkType.chat.linkPrefix == "chat:")
+    }
+
+    // MARK: - Host constants
+
+    @Test func wikiLinkMarkdownHostConstants() {
+        #expect(WikiLinkMarkdown.resolvedHost == "page")
+        #expect(WikiLinkMarkdown.sourceHost == "source")
+        #expect(WikiLinkMarkdown.chatHost == "chat")
+        #expect(WikiLinkMarkdown.anchorHost == "anchor")
+        #expect(WikiLinkMarkdown.unresolvedHost == "missing")
+    }
+
+    // MARK: - End-to-end: typed prefix flows through the parser
+
+    @Test func classifyUsesTypedPrefix() {
+        let (pageKind, pageTarget) = WikiLinkParser.classify("page:My Page")
+        #expect(pageKind == .page)
+        #expect(pageTarget == "My Page")
+
+        let (sourceKind, sourceTarget) = WikiLinkParser.classify("source:A.pdf")
+        #expect(sourceKind == .source)
+        #expect(sourceTarget == "A.pdf")
+
+        let (chatKind, chatTarget) = WikiLinkParser.classify("chat:Conversation")
+        #expect(chatKind == .chat)
+        #expect(chatTarget == "Conversation")
+    }
+
+    @Test func isEmptyPrefixUsesTypedPrefix() {
+        #expect(WikiLinkParser.isEmptyPrefix("source:"))
+        #expect(WikiLinkParser.isEmptyPrefix("page:   "))
+        #expect(WikiLinkParser.isEmptyPrefix("chat:"))
+        #expect(!WikiLinkParser.isEmptyPrefix("page:Foo"))
+        #expect(!WikiLinkParser.isEmptyPrefix("OrdinaryTitle"))
+    }
+}

--- a/pr-body-489.md
+++ b/pr-body-489.md
@@ -1,0 +1,41 @@
+## Summary
+
+Consolidates the hand-stringified link-kind prefixes (`"page:"` / `"source:"` / `"chat:"` / `"bookmark:"`) and inline URL host comparisons into typed accessors, eliminating 7+ duplicate literal sites (#489).
+
+## Changes
+
+### New typed accessors (single source of truth)
+
+- **`ResourceKind.linkPrefix`** (`Sources/WikiFSCore/Resource.swift`) — computed property returning `"page:"` / `"source:"` / `"chat:"` / `"bookmark:"` for linkable kinds, `nil` for non-linkable kinds (`systemPrompt`, `wikiIndex`, `log`).
+- **`ParsedLink.LinkType.resourceKind`** + **`ParsedLink.LinkType.linkPrefix`** (`Sources/WikiFSCore/WikiLinkParser.swift`) — bridges the overlap between the 3-case `LinkType` enum and the 7-case `ResourceKind` enum, delegating prefix strings to `ResourceKind.linkPrefix` so both vocabularies draw from one definition.
+- **`WikiLinkMarkdown.sourceHost`** / **`WikiLinkMarkdown.anchorHost`** (`Sources/WikiFSCore/WikiLinkMarkdown.swift`) — new static constants alongside the existing `resolvedHost` / `chatHost` / `unresolvedHost`.
+
+### Inline literal sites replaced
+
+| File | Before | After |
+|------|--------|-------|
+| `WikiLinkParser.swift` | `peel(prefix: "page:"/…)` + literal array | `ParsedLink.LinkType.page.linkPrefix` + `allCases` loop |
+| `WikiLinkRewriter.swift` | `case .source: prefix = "source:"` switch | `kind.linkPrefix` |
+| `MarkdownHTMLRenderer.swift` | `case "source": prefix = "source:"` | `WikiLinkMarkdown.sourceHost` + `.source.linkPrefix` |
+| `WikiStateSnapshot.swift` | `"page:\(…)"` interpolation | `ResourceKind.page.linkPrefix` |
+| `OmniboxResult.swift` | `"page:\(p.id.rawValue)"` etc. | `ResourceKind.page.linkPrefix!` |
+| `AgentLauncher.swift` | `"chat:\(chatID)"` (×2) | `ResourceKind.chat.linkPrefix!` |
+| `BlobSchemeHandler.swift` | `url.host == "source"` | `WikiLinkMarkdown.sourceHost` |
+| `WikiLinkMarkdown.swift` | `host == "source"` / `== "anchor"` (×6) | `sourceHost` / `anchorHost` |
+
+### Test
+
+- `Tests/WikiFSTests/LinkPrefixAccessorTests.swift` — 9 tests asserting prefix values, nil-returns for non-linkable kinds, the `LinkType` → `ResourceKind` bridge, host constants, and end-to-end flow through `classify` / `isEmptyPrefix`.
+
+## Verification
+
+```
+# Issue's grep — zero hits outside accessor doc comments:
+rg '"page:"|"source:"|"chat:"' Sources/ -t swift
+# → only 3 lines, all in doc comments of accessor definitions
+
+# Full fast test tier passes (2447 tests):
+swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
+```
+
+Closes #489.


### PR DESCRIPTION
## Summary

Consolidates the hand-stringified link-kind prefixes (`"page:"` / `"source:"` / `"chat:"` / `"bookmark:"`) and inline URL host comparisons into typed accessors, eliminating 7+ duplicate literal sites (#489).

## Changes

### New typed accessors (single source of truth)

- **`ResourceKind.linkPrefix`** (`Sources/WikiFSCore/Resource.swift`) — computed property returning `"page:"` / `"source:"` / `"chat:"` / `"bookmark:"` for linkable kinds, `nil` for non-linkable kinds (`systemPrompt`, `wikiIndex`, `log`).
- **`ParsedLink.LinkType.resourceKind`** + **`ParsedLink.LinkType.linkPrefix`** (`Sources/WikiFSCore/WikiLinkParser.swift`) — bridges the overlap between the 3-case `LinkType` enum and the 7-case `ResourceKind` enum, delegating prefix strings to `ResourceKind.linkPrefix` so both vocabularies draw from one definition.
- **`WikiLinkMarkdown.sourceHost`** / **`WikiLinkMarkdown.anchorHost`** (`Sources/WikiFSCore/WikiLinkMarkdown.swift`) — new static constants alongside the existing `resolvedHost` / `chatHost` / `unresolvedHost`.

### Inline literal sites replaced

| File | Before | After |
|------|--------|-------|
| `WikiLinkParser.swift` | `peel(prefix: "page:"/…)` + literal array | `ParsedLink.LinkType.page.linkPrefix` + `allCases` loop |
| `WikiLinkRewriter.swift` | `case .source: prefix = "source:"` switch | `kind.linkPrefix` |
| `MarkdownHTMLRenderer.swift` | `case "source": prefix = "source:"` | `WikiLinkMarkdown.sourceHost` + `.source.linkPrefix` |
| `WikiStateSnapshot.swift` | `"page:\(…)"` interpolation | `ResourceKind.page.linkPrefix` |
| `OmniboxResult.swift` | `"page:\(p.id.rawValue)"` etc. | `ResourceKind.page.linkPrefix!` |
| `AgentLauncher.swift` | `"chat:\(chatID)"` (×2) | `ResourceKind.chat.linkPrefix!` |
| `BlobSchemeHandler.swift` | `url.host == "source"` | `WikiLinkMarkdown.sourceHost` |
| `WikiLinkMarkdown.swift` | `host == "source"` / `== "anchor"` (×6) | `sourceHost` / `anchorHost` |

### Test

- `Tests/WikiFSTests/LinkPrefixAccessorTests.swift` — 9 tests asserting prefix values, nil-returns for non-linkable kinds, the `LinkType` → `ResourceKind` bridge, host constants, and end-to-end flow through `classify` / `isEmptyPrefix`.

## Verification

```
# Issue's grep — zero hits outside accessor doc comments:
rg '"page:"|"source:"|"chat:"' Sources/ -t swift
# → only 3 lines, all in doc comments of accessor definitions

# Full fast test tier passes (2447 tests):
swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
```

Closes #489.
