### PR TITLE
Fix #491: Remove ~28 redundant per-mutator reload*() calls (Phase E follow-up)

### DIFF
--- a/Sources/WikiFSCore/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/WikiStoreModel.swift
@@ -1098,7 +1098,9 @@ public final class WikiStoreModel {
         do {
             let page = try store.createPage(title: title, createdBy: "user")
             try store.replaceLinks(from: page.id, parsedLinks: WikiLinkParser.parse(page.bodyMarkdown))
-            reloadSummaries()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write. The title is passed to openTab explicitly, so tabTitle
+            // (which reads `summaries`) is never called and needs no synchronous freshness.
             openTab(.page(page.id), title: title)
         } catch {
             DebugLog.store("WikiStoreModel.newPageInNewTab failed: \(error)")
@@ -1253,7 +1255,7 @@ public final class WikiStoreModel {
             // After a successful versioned save, refresh the head version id so
             // the next save CAS-expects the version we just wrote.
             loadedPageHeadVersionID = try? store.pageHeadVersionID(pageID: id)
-            reloadSummaries()
+            // No manual reload — the bus fires reloadFromStore() async after the upsert.
             // Non-blocking mermaid lint: the in-app save still succeeds (the
             // editor is the human escape from wikictl's hard block), but a broken
             // diagram is flagged so the author can fix it.
@@ -1386,7 +1388,7 @@ public final class WikiStoreModel {
         if didFix {
             do {
                 try PageUpsert.upsert(in: store, id: pageID, title: page.title, body: fixedBody)
-                reloadSummaries()
+                // No manual reload — the bus fires reloadFromStore() async after the upsert.
                 if loadedPage == pageID {
                     draftBody = fixedBody
                     isDraftDirty = false
@@ -1632,7 +1634,9 @@ public final class WikiStoreModel {
             // run it for uniformity with the save() path (and so a future
             // create-with-body wouldn't silently skip link indexing).
             try store.replaceLinks(from: page.id, parsedLinks: WikiLinkParser.parse(page.bodyMarkdown))
-            reloadSummaries()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write. The title is passed to openTab explicitly, so tabTitle
+            // (which reads `summaries`) is never called and needs no synchronous freshness.
             let newSelection = WikiSelection.page(page.id)
             recordHistoryTransition(from: loadedSelection, to: newSelection)
             openTab(newSelection, title: title)
@@ -1670,7 +1674,7 @@ public final class WikiStoreModel {
             let page = try store.getPage(id: id)
             let cleanBody = PageMarkdownFormat.stripped(body: page.bodyMarkdown, title: page.title)
             try store.updatePage(id: id, title: sanitizedTitle, body: cleanBody, lastEditedBy: nil)
-            reloadSummaries()
+            // No manual reload — the bus fires reloadFromStore() async after the update.
             if selection == .page(id) { draftTitle = sanitizedTitle }
             // Update any tab showing this renamed page.
             for i in tabs.indices where tabs[i].selection == .page(id) {
@@ -1687,13 +1691,9 @@ public final class WikiStoreModel {
     public func renameSource(id: PageID, to newDisplayName: String) {
         do {
             try store.renameSource(id: id, to: newDisplayName)
-            // Refresh BOTH lists: `sources` so the renamed source's display name
-            // updates in the sidebar + detail view (without this the rename commits
-            // to the DB but the live UI snaps back to the old name), and
-            // `summaries` because the rename rewrites inbound `[[source:…]]` links
-            // in the pages that reference it.
-            reloadSources()
-            reloadSummaries()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // rename, which reloads BOTH `sources` (display name in sidebar/detail)
+            // and `summaries` (the rename rewrites inbound `[[source:…]]` links).
             for i in tabs.indices where tabs[i].selection == .source(id) {
                 tabs[i].title = newDisplayName
             }
@@ -1710,7 +1710,8 @@ public final class WikiStoreModel {
             if let tab = tabs.first(where: { $0.selection == .page(id) }) {
                 closeTab(id: tab.id)
             }
-            reloadSummaries()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // delete. History and tab cleanup happen explicitly above.
         } catch {
             DebugLog.store("WikiStoreModel.delete failed: \(error)")
             storeError = StoreError(
@@ -1842,6 +1843,7 @@ public final class WikiStoreModel {
     /// `ingestingSourceIDs`). Issue #178.
     public func addFiles(_ fileURLs: [URL]) async {
         var lastSourceID: PageID?
+        var lastSourceName: String?
         var duplicateNames: [String] = []
         for url in fileURLs {
             // Skip directories — only flat files are ingested.
@@ -1868,6 +1870,7 @@ public final class WikiStoreModel {
             do {
                 let summary = try storeMaterialized(materialized, resolvedDisplayName: resolvedDisplayName)
                 lastSourceID = summary.id
+                lastSourceName = summary.effectiveName
             } catch WikiStoreError.duplicateContent(let existing) {
                 // Byte-identical to an already-stored source — skip rather than
                 // abort the rest of the drop batch; report it so the user isn't
@@ -1877,8 +1880,12 @@ public final class WikiStoreModel {
                 DebugLog.store("WikiStoreModel.addFiles store failed for \(url.lastPathComponent): \(error)")
             }
         }
-        reloadSources()
-        if let sourceID = lastSourceID {
+        // No manual reload — the bus fires reloadFromStore() async after the
+        // store writes. The tab title is passed explicitly to openTab so it
+        // doesn't read the stale `sources` array via tabTitle.
+        if let sourceID = lastSourceID, let name = lastSourceName {
+            openTab(.source(sourceID), title: name)
+        } else if let sourceID = lastSourceID {
             openTab(.source(sourceID))
         }
         if !duplicateNames.isEmpty {
@@ -1959,8 +1966,10 @@ public final class WikiStoreModel {
             let markdown = String(data: transcript.data, encoding: .utf8) ?? ""
             try store.appendProcessedMarkdown(
                 sourceID: summary.id, content: markdown, origin: "transcript", note: nil, technique: nil)
-            reloadSources()
-            openTab(.source(summary.id))
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write. The tab title is passed explicitly so tabTitle (which
+            // reads `sources`) needs no synchronous freshness.
+            openTab(.source(summary.id), title: summary.effectiveName)
             return URLFetchService.FetchOutcome(
                 filename: transcript.filename,
                 byteSize: transcript.data.count,
@@ -2006,8 +2015,10 @@ public final class WikiStoreModel {
                 externalRef: match.planURL,
                 externalIdentity: match.externalIdentity),
             role: .primary)
-        reloadSources()
-        openTab(.source(summary.id))
+        // No manual reload — the bus fires reloadFromStore() async after the
+        // store write. The tab title is passed explicitly so tabTitle (which
+        // reads `sources`) needs no synchronous freshness.
+        openTab(.source(summary.id), title: summary.effectiveName)
         return URLFetchService.FetchOutcome(
             filename: match.filename, byteSize: 0, kind: kind)
     }
@@ -2046,8 +2057,10 @@ public final class WikiStoreModel {
             let cleanTitle = (snapshot.page.filename as NSString).deletingPathExtension
             try? store.setSourceDisplayName(id: summary.id, displayName: cleanTitle)
         }
-        reloadSources()
-        openTab(.source(summary.id))
+        // No manual reload — the bus fires reloadFromStore() async after the
+        // store write. The tab title is passed explicitly so tabTitle (which
+        // reads `sources`) needs no synchronous freshness.
+        openTab(.source(summary.id), title: summary.effectiveName)
         return URLFetchService.FetchOutcome(
             filename: snapshot.plan.filename, byteSize: snapshot.plan.data.count,
             kind: URLFetchService.mapFormat(snapshot.plan.format))
@@ -2146,7 +2159,8 @@ public final class WikiStoreModel {
             try store.appendProcessedMarkdown(
                 sourceID: id, content: content, origin: "transcript", note: nil, technique: nil)
         }
-        reloadSources()
+        // No manual reload — the bus fires reloadFromStore() async after the
+        // version append.
         return "Refreshed \(origin.displayLabel) source."
     }
 
@@ -2158,7 +2172,8 @@ public final class WikiStoreModel {
                 filename: filename, data: data, zoteroItemKey: nil, zoteroItemTitle: nil,
                 mimeType: nil, provenance: nil, role: .primary,
                 originalPath: nil, activityID: nil)
-            reloadSources()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
         } catch WikiStoreError.duplicateContent(let existing) {
             storeError = StoreError(
                 title: "Duplicate File Skipped",
@@ -2194,8 +2209,10 @@ public final class WikiStoreModel {
             mimeType: materialized.mimeType, zoteroItemTitle: materialized.zoteroItemTitle)
         do {
             let summary = try storeMaterialized(materialized, resolvedDisplayName: resolvedDisplayName)
-            reloadSources()
-            openTab(.source(summary.id))
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write. The tab title is passed explicitly so tabTitle (which
+            // reads `sources`) needs no synchronous freshness.
+            openTab(.source(summary.id), title: summary.effectiveName)
         } catch {
             DebugLog.store("WikiStoreModel.ingestFromZotero failed: \(error)")
             throw error
@@ -2227,6 +2244,7 @@ public final class WikiStoreModel {
         var errorMessages: [String] = []
 
         var firstSourceID: PageID?
+        var firstSourceName: String?
         for file in result.files {
             let ext = (file.filename as NSString).pathExtension.lowercased()
             let mimeType = UTType(filenameExtension: ext)?.preferredMIMEType
@@ -2235,7 +2253,7 @@ public final class WikiStoreModel {
             do {
                 let materialized = try await provider.materialize()
                 let summary = try storeMaterialized(materialized)
-                if firstSourceID == nil { firstSourceID = summary.id }
+                if firstSourceID == nil { firstSourceID = summary.id; firstSourceName = summary.effectiveName }
                 imported += 1
             } catch WikiStoreError.duplicateContent(let existing) {
                 errorMessages.append("\(file.filename): duplicate of \(existing.effectiveName), skipped")
@@ -2248,8 +2266,12 @@ public final class WikiStoreModel {
                 ?? "\(walkError.path): unknown error")
         }
 
-        reloadSources()
-        if let sourceID = firstSourceID {
+        // No manual reload — the bus fires reloadFromStore() async after the
+        // store writes. The tab title is passed explicitly so tabTitle (which
+        // reads `sources`) needs no synchronous freshness.
+        if let sourceID = firstSourceID, let name = firstSourceName {
+            openTab(.source(sourceID), title: name)
+        } else if let sourceID = firstSourceID {
             openTab(.source(sourceID))
         }
         return (imported: imported, errors: errorMessages)
@@ -2265,7 +2287,8 @@ public final class WikiStoreModel {
             if let tab = tabs.first(where: { $0.selection == .source(id) }) {
                 closeTab(id: tab.id)
             }
-            reloadSources()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // delete. History and tab cleanup happen explicitly above.
         } catch {
             DebugLog.store("WikiStoreModel.deleteSource failed: \(error)")
         }
@@ -2795,7 +2818,8 @@ public final class WikiStoreModel {
             let node = try store.createBookmarkNode(
                 parentID: parentID, position: position, kind: .folder,
                 label: name, targetID: nil)
-            reloadBookmarkNodes()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
             return node.id
         } catch {
             DebugLog.store("WikiStoreModel.createFolder failed: \(error)")
@@ -2812,7 +2836,8 @@ public final class WikiStoreModel {
             _ = try store.createBookmarkNode(
                 parentID: parentID, position: pos, kind: .pageRef,
                 label: nil, targetID: pageID)
-            reloadBookmarkNodes()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
             let ms = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
             DebugLog.tabs("addPageRef: done in \(String(format: "%.1f", ms)) ms")
         } catch {
@@ -2828,7 +2853,8 @@ public final class WikiStoreModel {
             _ = try store.createBookmarkNode(
                 parentID: parentID, position: pos, kind: .sourceRef,
                 label: nil, targetID: sourceID)
-            reloadBookmarkNodes()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
         } catch {
             DebugLog.store("WikiStoreModel.addSourceRef failed: \(error)")
         }
@@ -2842,7 +2868,8 @@ public final class WikiStoreModel {
             _ = try store.createBookmarkNode(
                 parentID: parentID, position: pos, kind: .chatRef,
                 label: nil, targetID: chatID)
-            reloadBookmarkNodes()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
         } catch {
             DebugLog.store("WikiStoreModel.addChatRef failed: \(error)")
         }
@@ -2852,7 +2879,8 @@ public final class WikiStoreModel {
     public func renameBookmarkNode(id: String, to label: String) {
         do {
             try store.updateBookmarkNode(id: id, label: label)
-            reloadBookmarkNodes()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
         } catch {
             DebugLog.store("WikiStoreModel.renameBookmarkNode failed: \(error)")
         }
@@ -2862,7 +2890,8 @@ public final class WikiStoreModel {
     public func deleteBookmarkNode(id: String) {
         do {
             try store.deleteBookmarkNode(id: id)
-            reloadBookmarkNodes()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
         } catch {
             DebugLog.store("WikiStoreModel.deleteBookmarkNode failed: \(error)")
         }
@@ -2874,7 +2903,8 @@ public final class WikiStoreModel {
     public func moveBookmarkNode(id: String, toParentID: String?, position: Int) -> Bool {
         do {
             try store.moveBookmarkNode(id: id, toParentID: toParentID, position: position)
-            reloadBookmarkNodes()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write.
             return true
         } catch {
             DebugLog.store("WikiStoreModel.moveBookmarkNode failed: \(error)")
@@ -2925,7 +2955,12 @@ public final class WikiStoreModel {
             // already persisted (firstMessagePrePersisted) so it marks the event as
             // flushed and does NOT double-insert it on the first transcript flush.
             try store.appendChatMessages(chatID: chat.id, events: [.userText(firstMessage)])
-            reloadChats()
+            // Insert the single new chat into the local array instead of a full
+            // reloadChats(). The bus fires reloadFromStore() async after the store
+            // write, but the immediate caller (retargetActiveTabToChat →
+            // retargetTab → tabTitle) reads `chats` synchronously, so the row
+            // must be present NOW.
+            chats.insert(chat, at: 0)
             return chat
         } catch {
             DebugLog.store("WikiStoreModel.startChat failed: \(error)")
@@ -2945,7 +2980,8 @@ public final class WikiStoreModel {
         } catch {
             DebugLog.store("WikiStoreModel.rollbackChatCreation failed: \(error)")
         }
-        reloadChats()
+        // No manual reloadChats — the bus fires reloadFromStore() async after the
+        // delete. The tab retarget below doesn't depend on the chats array.
         // Revert the tab we retargeted to `.chat(id)` back to the draft composer.
         if let tab = tabs.first(where: { $0.selection == .chat(id) }) {
             retargetTab(id: tab.id, to: draft)
@@ -2959,7 +2995,8 @@ public final class WikiStoreModel {
         guard !persistable.isEmpty else { return }
         do {
             try store.appendChatMessages(chatID: chatID, events: persistable)
-            reloadChats()  // cheap — keeps updated_at ordering + counts live.
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // store write (keeps updated_at ordering + counts live).
         } catch {
             DebugLog.store("WikiStoreModel.appendChatEvents failed: \(error)")
         }
@@ -2972,7 +3009,8 @@ public final class WikiStoreModel {
     public func renameChat(id: PageID, to title: String) {
         do {
             try store.renameChat(id: id, to: title)
-            reloadChats()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // rename.
         } catch {
             DebugLog.store("WikiStoreModel.renameChat failed: \(error)")
             storeError = StoreError(
@@ -2984,7 +3022,8 @@ public final class WikiStoreModel {
     public func updateChatSummary(chatID: PageID, summary: String) {
         do {
             try store.updateChatSummary(chatID: chatID, summary: summary)
-            reloadChats()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // update.
         } catch {
             DebugLog.store("WikiStoreModel.updateChatSummary failed: \(error)")
         }
@@ -2998,7 +3037,8 @@ public final class WikiStoreModel {
             if let tab = tabs.first(where: { $0.selection == .chat(id) }) {
                 closeTab(id: tab.id)
             }
-            reloadChats()
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // delete. History and tab cleanup happen explicitly above.
         } catch {
             DebugLog.store("WikiStoreModel.deleteChat failed: \(error)")
             storeError = StoreError(

--- a/Tests/WikiFSTests/BookmarkInsertPositionTests.swift
+++ b/Tests/WikiFSTests/BookmarkInsertPositionTests.swift
@@ -28,7 +28,9 @@ struct BookmarkInsertPositionTests {
         let model = WikiStoreModel(store: store)
 
         model.addPageRef(parentID: nil, pageID: p1.id)
+        model.reloadBookmarkNodes()
         model.addPageRef(parentID: nil, pageID: p2.id)
+        model.reloadBookmarkNodes()
 
         let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
         #expect(nodes.map(\.position) == [0, 1])
@@ -44,6 +46,7 @@ struct BookmarkInsertPositionTests {
 
         let earlier = try store.createPage(title: "Earlier")
         model.addPageRef(parentID: nil, pageID: earlier.id, position: 0)
+        model.reloadBookmarkNodes()
 
         let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
         #expect(nodes.map(\.position) == [0, 1])
@@ -59,11 +62,15 @@ struct BookmarkInsertPositionTests {
         let c = try store.createPage(title: "C")
         let model = WikiStoreModel(store: store)
         model.addPageRef(parentID: nil, pageID: a.id) // 0
+        model.reloadBookmarkNodes()
         model.addPageRef(parentID: nil, pageID: b.id) // 1
+        model.reloadBookmarkNodes()
         model.addPageRef(parentID: nil, pageID: c.id) // 2
+        model.reloadBookmarkNodes()
 
         let mid = try store.createPage(title: "MID")
         model.addPageRef(parentID: nil, pageID: mid.id, position: 1)
+        model.reloadBookmarkNodes()
 
         let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
         #expect(nodes.map(\.position) == [0, 1, 2, 3])
@@ -80,10 +87,13 @@ struct BookmarkInsertPositionTests {
         let s2 = try store.addSource(filename: "b.pdf", data: Data("y".utf8))
         let model = WikiStoreModel(store: store)
         model.addSourceRef(parentID: nil, sourceID: s1.id) // 0
+        model.reloadBookmarkNodes()
         model.addSourceRef(parentID: nil, sourceID: s2.id) // 1
+        model.reloadBookmarkNodes()
 
         let between = try store.addSource(filename: "mid.pdf", data: Data("z".utf8))
         model.addSourceRef(parentID: nil, sourceID: between.id, position: 1)
+        model.reloadBookmarkNodes()
 
         let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
         #expect(nodes.map(\.position) == [0, 1, 2])
@@ -102,7 +112,9 @@ struct BookmarkInsertPositionTests {
         let a = try store.createPage(title: "A")
         let b = try store.createPage(title: "B")
         model.addPageRef(parentID: folder.id, pageID: a.id) // 0
+        model.reloadBookmarkNodes()
         model.addPageRef(parentID: folder.id, pageID: b.id) // 1
+        model.reloadBookmarkNodes()
 
         // Also a root-level ref, to confirm it's untouched.
         let root = try store.createPage(title: "Root")
@@ -110,6 +122,7 @@ struct BookmarkInsertPositionTests {
 
         let mid = try store.createPage(title: "MID")
         model.addPageRef(parentID: folder.id, pageID: mid.id, position: 0)
+        model.reloadBookmarkNodes()
 
         let folderChildren = model.bookmarkNodes
             .filter { $0.parentID == folder.id }
@@ -134,6 +147,7 @@ struct BookmarkInsertPositionTests {
         let b = try store.createPage(title: "B")
         // No siblings exist beyond position 0; position 5 is out of range.
         model.addPageRef(parentID: nil, pageID: b.id, position: 5)
+        model.reloadBookmarkNodes()
 
         let nodes = model.bookmarkNodes.sorted { $0.position < $1.position }
         #expect(nodes.map(\.position) == [0, 1],

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -762,6 +762,7 @@ struct EditorTabTests {
         let f1 = try store.addSource(filename: "report.pdf", data: Data("pdf".utf8))
         model.reloadFromStore()
         model.renameSource(id: f1.id, to: "My Custom Title")
+        model.reloadFromStore()
         #expect(model.tabTitle(for: .source(f1.id)) == "My Custom Title")
     }
 
@@ -773,6 +774,7 @@ struct EditorTabTests {
         #expect(model.tabs[0].title == "doc.pdf")
 
         model.renameSource(id: f1.id, to: "Annual Report")
+        model.reloadFromStore()
         #expect(model.tabs[0].title == "Annual Report")
     }
 

--- a/Tests/WikiFSTests/NavigationSaveTests.swift
+++ b/Tests/WikiFSTests/NavigationSaveTests.swift
@@ -26,6 +26,7 @@ struct NavigationSaveTests {
         let aID = model.selection!
         model.newPage(title: "B")
         let bID = model.selection!
+        model.reloadFromStore()
 
         // Select A, type into the body (no autosave — only explicit save).
         model.select(aID)
@@ -63,10 +64,12 @@ struct NavigationSaveTests {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage(title: "First")
         model.newPage(title: "Second")
+        model.reloadFromStore()
         #expect(model.summaries.count == 2)
 
         let firstID = model.summaries.first { $0.title == "First" }!.id
         model.delete(firstID)
+        model.reloadFromStore()
         // Rebuilt from source — not a stale cache.
         #expect(model.summaries.count == 1)
         #expect(model.summaries.allSatisfy { $0.title != "First" })
@@ -82,6 +85,7 @@ struct NavigationSaveTests {
         let aID = model.selection!
         model.newPage(title: "B")
         let bID = model.selection!
+        model.reloadFromStore()
 
         // Simulate List selecting A (binding writes selection, view fires onChange).
         model.selection = aID
@@ -102,10 +106,12 @@ struct NavigationSaveTests {
     @Test func renameUpdatesSummaryFromSource() throws {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage(title: "Old Name")
+        model.reloadFromStore()
         guard case let .page(id)? = model.selection else {
             Issue.record("expected a page selection"); return
         }
         model.rename(id, to: "New Name")
+        model.reloadFromStore()
         #expect(model.summaries.first { $0.id == id }?.title == "New Name")
         #expect(model.draftTitle == "New Name")
     }

--- a/Tests/WikiFSTests/ObservableTrackingTests.swift
+++ b/Tests/WikiFSTests/ObservableTrackingTests.swift
@@ -45,6 +45,9 @@ struct ObservableTrackingTests {
         #expect(model.bookmarkNodes.isEmpty)
 
         model.addPageRef(parentID: nil, pageID: page.id)
+        // The bus delivers reloads async; in tests without a bus, force the
+        // synchronous reload so the observation fires and the array is fresh.
+        model.reloadBookmarkNodes()
 
         #expect(box.fireCount == 1,
                 "addPageRef → reloadBookmarkNodes must fire the @Observable callback")
@@ -64,6 +67,7 @@ struct ObservableTrackingTests {
         }
 
         model.addSourceRef(parentID: nil, sourceID: source.id)
+        model.reloadBookmarkNodes()
 
         #expect(box.fireCount == 1,
                 "addSourceRef → reloadBookmarkNodes must fire the @Observable callback")
@@ -82,6 +86,7 @@ struct ObservableTrackingTests {
         }
 
         _ = model.createFolder(parentID: nil, name: "Research")
+        model.reloadBookmarkNodes()
 
         #expect(box.fireCount == 1,
                 "createFolder → reloadBookmarkNodes must fire the @Observable callback")
@@ -94,6 +99,7 @@ struct ObservableTrackingTests {
 
         // Seed: create a folder, then reload so the model has data.
         _ = model.createFolder(parentID: nil, name: "Temp")
+        model.reloadBookmarkNodes()
         #expect(model.bookmarkNodes.count == 1)
 
         let nodeID = model.bookmarkNodes.first!.id
@@ -106,6 +112,7 @@ struct ObservableTrackingTests {
         }
 
         model.deleteBookmarkNode(id: nodeID)
+        model.reloadBookmarkNodes()
 
         #expect(box.fireCount == 1,
                 "deleteBookmarkNode → reloadBookmarkNodes must fire the @Observable callback")
@@ -130,6 +137,7 @@ struct ObservableTrackingTests {
 
         model.addPageRef(parentID: nil, pageID: page.id)
         model.addPageRef(parentID: nil, pageID: page.id)
+        model.reloadBookmarkNodes()
 
         #expect(box.fireCount == 1,
                 "withObservationTracking fires once then unregisters (SwiftUI re-registers per body)")

--- a/Tests/WikiFSTests/OrphanChatSeedingTests.swift
+++ b/Tests/WikiFSTests/OrphanChatSeedingTests.swift
@@ -56,8 +56,9 @@ struct OrphanChatSeedingTests {
 
         let chat = try #require(model.startChat(kind: .edit, firstMessage: "Hello"))
 
-        // reloadChats() ran inside startChat, so the model's list reflects the
-        // seeded message (count 1, not 0).
+        // startChat inserts the row synchronously, but the messageCount field
+        // is only accurate after a full reload. Force it so the assertion sees 1.
+        model.reloadChats()
         let listed = try #require(model.chats.first { $0.id == chat.id })
         #expect(listed.messageCount == 1)
     }
@@ -113,11 +114,13 @@ struct OrphanChatSeedingTests {
         let (model, store) = try tempModel()
 
         let chat = try #require(model.startChat(kind: .edit, firstMessage: "doomed"))
+        model.reloadChats()
         #expect(try store.chatMessages(chatID: chat.id).count == 1)
         #expect(model.chats.contains { $0.id == chat.id })
 
         // The session never started (preflight/spawn failure) → roll back.
         model.rollbackChatCreation(id: chat.id, toDraft: .newChat)
+        model.reloadChats()
 
         // Row + cascaded message both gone; the model's chat list no longer
         // contains the orphan.
@@ -151,6 +154,7 @@ struct OrphanChatSeedingTests {
         // must leave the store untouched.
         let phantom = PageID(rawValue: "01PHANTOMCHAT0000000000Z")
         model.rollbackChatCreation(id: phantom, toDraft: .newChat)
+        model.reloadChats()
         #expect(try store.listChats().isEmpty)
         #expect(model.chats.isEmpty)
     }

--- a/Tests/WikiFSTests/PageTitleCollisionTests.swift
+++ b/Tests/WikiFSTests/PageTitleCollisionTests.swift
@@ -38,6 +38,7 @@ struct PageTitleCollisionTests {
     @Test func newPageWithoutExplicitTitleGetsTimestamp() throws {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage()
+        model.reloadFromStore()
         let summary = try #require(model.summaries.first)
         #expect(summary.title.hasPrefix("Untitled "))
         #expect(summary.title != "Untitled")
@@ -46,6 +47,7 @@ struct PageTitleCollisionTests {
     @Test func newPageInNewTabWithoutExplicitTitleGetsTimestamp() throws {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPageInNewTab()
+        model.reloadFromStore()
         let summary = try #require(model.summaries.first)
         #expect(summary.title.hasPrefix("Untitled "))
         #expect(summary.title != "Untitled")
@@ -57,12 +59,14 @@ struct PageTitleCollisionTests {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage(title: "First Page")
         model.newPage(title: "Second Page")
+        model.reloadFromStore()
         guard case let .page(secondID)? = model.selection else {
             Issue.record("expected a page selection"); return
         }
 
         // Try to rename Second Page → "First Page" (already exists).
         model.rename(secondID, to: "First Page")
+        model.reloadFromStore()
 
         // The rename should be blocked: title unchanged, conflict surfaced.
         #expect(model.summaries.first { $0.id == secondID }?.title == "Second Page")
@@ -72,12 +76,14 @@ struct PageTitleCollisionTests {
     @Test func renameToOwnTitleIsAllowed() throws {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage(title: "Same Title")
+        model.reloadFromStore()
         guard case let .page(id)? = model.selection else {
             Issue.record("expected a page selection"); return
         }
 
         // Renaming to the same title should not trigger a conflict.
         model.rename(id, to: "Same Title")
+        model.reloadFromStore()
         #expect(model.renameConflictingTitle == nil)
         #expect(model.summaries.first { $0.id == id }?.title == "Same Title")
     }
@@ -86,12 +92,14 @@ struct PageTitleCollisionTests {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage(title: "My Page")
         model.newPage(title: "Other Page")
+        model.reloadFromStore()
         guard case let .page(otherID)? = model.selection else {
             Issue.record("expected a page selection"); return
         }
 
         // "MY PAGE" should collide with "My Page" (case-insensitive).
         model.rename(otherID, to: "MY PAGE")
+        model.reloadFromStore()
         #expect(model.summaries.first { $0.id == otherID }?.title == "Other Page")
         #expect(model.renameConflictingTitle == "MY PAGE")
     }
@@ -100,11 +108,13 @@ struct PageTitleCollisionTests {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage(title: "Alpha")
         model.newPage(title: "Beta")
+        model.reloadFromStore()
         guard case let .page(betaID)? = model.selection else {
             Issue.record("expected a page selection"); return
         }
 
         model.rename(betaID, to: "Gamma")
+        model.reloadFromStore()
         #expect(model.renameConflictingTitle == nil)
         #expect(model.summaries.first { $0.id == betaID }?.title == "Gamma")
     }
@@ -113,6 +123,7 @@ struct PageTitleCollisionTests {
         let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
         model.newPage(title: "A")
         model.newPage(title: "B")
+        model.reloadFromStore()
         guard case let .page(bID)? = model.selection else {
             Issue.record("expected a page selection"); return
         }

--- a/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
@@ -33,6 +33,7 @@ struct WikiStoreModelAddURLTests {
             finalURL: URL(string: "https://example.com/doc")!))
 
         let outcome = try await model.addURL("example.com/doc", fetcher: fetcher)
+        model.reloadFromStore()
 
         #expect(outcome.kind == .htmlConverted)
         #expect(outcome.filename == "My Doc.md")
@@ -58,6 +59,7 @@ struct WikiStoreModelAddURLTests {
             finalURL: URL(string: "https://example.com/files/paper.pdf")!))
 
         let outcome = try await model.addURL("https://example.com/files/paper.pdf", fetcher: fetcher)
+        model.reloadFromStore()
         #expect(outcome.kind == .pdf)
         #expect(model.sources.first?.filename == "paper.pdf")
         let id = model.sources.first!.id

--- a/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
@@ -56,6 +56,7 @@ struct WikiStoreModelDropRoutingTests {
             finalURL: URL(string: "https://example.com/article")!))
 
         await model.addDroppedURLs([webloc], fetcher: fetcher)
+        model.reloadFromStore()
 
         // Routed through addURL → converted markdown, NOT the raw plist bytes.
         #expect(model.sources.count == 1)
@@ -77,6 +78,7 @@ struct WikiStoreModelDropRoutingTests {
         await model.addDroppedURLs(
             [URL(string: "https://example.com/page")!],
             fetcher: fetcher)
+        model.reloadFromStore()
 
         #expect(model.sources.count == 1)
         #expect(model.sources.first?.filename == "Page.md")
@@ -94,6 +96,7 @@ struct WikiStoreModelDropRoutingTests {
 
         await model.addDroppedURLs([file], fetcher: FakeFetcher(response: URLFetchService.FetchResponse(
             data: Data(), contentType: nil, finalURL: URL(string: "https://unused.example")!)))
+        model.reloadFromStore()
 
         #expect(model.sources.count == 1)
         #expect(model.sources.first?.filename == "notes.txt")
@@ -120,6 +123,7 @@ struct WikiStoreModelDropRoutingTests {
             finalURL: URL(string: "https://example.com/web")!))
 
         await model.addDroppedURLs([webloc, txt], fetcher: fetcher)
+        model.reloadFromStore()
 
         let names = model.sources.map(\.filename).sorted()
         #expect(names == ["Web.md", "doc.txt"])

--- a/Tests/WikiFSTests/WikiStoreModelMarkdownImportTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelMarkdownImportTests.swift
@@ -50,6 +50,7 @@ struct WikiStoreModelMarkdownImportTests {
         ])
 
         let result = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         #expect(result.imported == 3)
         #expect(result.errors.isEmpty)
         #expect(model.sources.count == 3)
@@ -64,6 +65,7 @@ struct WikiStoreModelMarkdownImportTests {
         ])
 
         _ = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         let filenames = Set(model.sources.map(\.filename))
         #expect(filenames == ["My Note.md", "Project Plan.md"])
     }
@@ -75,6 +77,7 @@ struct WikiStoreModelMarkdownImportTests {
         let dir = try tempMarkdownDir(files: ["note.md": body])
 
         _ = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         #expect(model.sources.count == 1)
         let id = model.sources.first!.id
         let storedContent = try store.sourceContent(id: id)
@@ -92,6 +95,7 @@ struct WikiStoreModelMarkdownImportTests {
         ])
 
         let result = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         #expect(result.imported == 1)
         #expect(model.sources.count == 1)
         #expect(model.sources.first?.filename == "note.md")
@@ -116,6 +120,7 @@ struct WikiStoreModelMarkdownImportTests {
         let dir = try tempMarkdownDir(files: [:])
 
         let result = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         #expect(result.imported == 0)
         #expect(result.errors.isEmpty)
         #expect(model.sources.isEmpty)
@@ -130,6 +135,7 @@ struct WikiStoreModelMarkdownImportTests {
         ])
 
         let result = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         #expect(result.imported == 0)
         #expect(model.sources.isEmpty)
     }
@@ -144,6 +150,7 @@ struct WikiStoreModelMarkdownImportTests {
         ])
 
         let result = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         #expect(result.imported == 3)
         #expect(result.errors.isEmpty)
         let filenames = Set(model.sources.map(\.filename))
@@ -174,6 +181,7 @@ struct WikiStoreModelMarkdownImportTests {
         let dir = try tempMarkdownDir(files: ["ObsidianNote.md": body])
 
         _ = await model.importFromMarkdownFolder(directory: dir)
+        model.reloadFromStore()
         #expect(model.sources.count == 1)
         let id = model.sources.first!.id
         let stored = try store.sourceContent(id: id)
@@ -205,6 +213,7 @@ struct WikiStoreModelMarkdownImportTests {
         try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
 
         let result = await model.importFromMarkdownFolder(directory: root)
+        model.reloadFromStore()
         #expect(result.imported == 1)
         #expect(model.sources.first?.filename == "visible.md")
     }
@@ -216,12 +225,14 @@ struct WikiStoreModelMarkdownImportTests {
         // First import
         let dir1 = try tempMarkdownDir(files: ["one.md": "# One"])
         let r1 = await model.importFromMarkdownFolder(directory: dir1)
+        model.reloadFromStore()
         #expect(r1.imported == 1)
         let countAfterFirst = model.sources.count
 
         // Second import
         let dir2 = try tempMarkdownDir(files: ["two.md": "# Two"])
         let r2 = await model.importFromMarkdownFolder(directory: dir2)
+        model.reloadFromStore()
         #expect(r2.imported == 1)
         #expect(model.sources.count == countAfterFirst + 1)
     }
@@ -249,6 +260,7 @@ struct WikiStoreModelMarkdownImportTests {
         let model = WikiStoreModel(store: store)
 
         model.addSource(filename: "note.md", data: Data("# Hello".utf8))
+        model.reloadFromStore()
         #expect(model.sources.count == 1)
         let source = model.sources[0]
 
@@ -275,6 +287,7 @@ struct WikiStoreModelMarkdownImportTests {
         let model = WikiStoreModel(store: store)
 
         model.addSource(filename: "data.bin", data: Data([0x00, 0x01, 0x02]))
+        model.reloadFromStore()
         #expect(model.sources.count == 1)
         let source = model.sources[0]
 

--- a/Tests/WikiFSTests/WikiStoreModelRenameSourceTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelRenameSourceTests.swift
@@ -20,9 +20,11 @@ struct WikiStoreModelRenameSourceTests {
     @Test func renameSourceRefreshesSourcesList() throws {
         let model = try makeModel()
         model.addSource(filename: "old-name.pdf", data: Data("pdf".utf8))
+        model.reloadFromStore()
         let id = try #require(model.sources.first?.id)
 
         model.renameSource(id: id, to: "Friendly Name")
+        model.reloadFromStore()
 
         let renamed = model.sources.first(where: { $0.id == id })
         #expect(renamed?.displayName == "Friendly Name")

--- a/Tests/WikiFSTests/WikiStoreModelZoteroIngestTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelZoteroIngestTests.swift
@@ -57,6 +57,7 @@ struct WikiStoreModelZoteroIngestTests {
         try await model.ingestFromZotero(
             attachment(key: "DJLXA7DG", filename: "report.pdf"),
             parentItem: parentItem(), zoteroDir: zoteroDir)
+        model.reloadFromStore()
 
         #expect(model.sources.count == 1)
         #expect(model.sources.first?.filename == "report.pdf")
@@ -78,6 +79,7 @@ struct WikiStoreModelZoteroIngestTests {
         try await model.ingestFromZotero(
             attachment(key: "DJLXA7DG", filename: "report.pdf"),
             parentItem: parentItem(key: "PARENT1", title: "The Road Not Taken"), zoteroDir: zoteroDir)
+        model.reloadFromStore()
 
         #expect(model.sources.count == 1)
         let summary = model.sources.first!
@@ -131,6 +133,7 @@ struct WikiStoreModelZoteroIngestTests {
             attachment(key: "K1", filename: "paper.pdf"), parentItem: parentItem(), zoteroDir: zoteroDir)
         try await model.ingestFromZotero(
             attachment(key: "K1", filename: "notes.md", contentType: "text/markdown"), parentItem: parentItem(), zoteroDir: zoteroDir)
+        model.reloadFromStore()
 
         #expect(model.sources.count == 2)
         let filenames = Set(model.sources.map(\.filename))

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,42 @@
+## Summary
+
+Remove ~28 redundant per-mutator `reload*()` calls from `WikiStoreModel.swift`. After the #129 event-bus landed (Phase E), the model subscribes to ALL `ResourceChangeEvent`s via `subscribeToChanges()`, which calls `reloadFromStore()` on every event. The bus delivers async (`Task { @MainActor in ... }`), so the manual reload doesn't replace the bus-driven one — it **doubles** it: 8 table scans + 2 history-prune passes per save where 4 suffice.
+
+## Changes
+
+### Production code (`WikiStoreModel.swift`)
+
+Removed `reloadSummaries()`, `reloadSources()`, `reloadBookmarkNodes()`, and `reloadChats()` calls from:
+- **Page mutators:** `save()`, `newPage()`, `newPageInNewTab()`, `rename()`, `delete()`, `preflightLint()`
+- **Source mutators:** `addFiles()`, `addURL()` (all paths), `addSource()`, `ingestFromZotero()`, `importFromMarkdownFolder()`, `renameSource()`, `deleteSource()`, `performRefresh()`
+- **Bookmark mutators:** `createFolder()`, `addPageRef()`, `addSourceRef()`, `addChatRef()`, `renameBookmarkNode()`, `deleteBookmarkNode()`, `moveBookmarkNode()`
+- **Chat mutators:** `startChat()`, `rollbackChatCreation()`, `appendChatEvents()`, `renameChat()`, `updateChatSummary()`, `deleteChat()`
+
+### Exceptions kept
+
+- **`agentRunEnded()`** (line ~1603): still calls `reloadFromStore()` — legit exception, updates run counts and is not driven by store events.
+- **`pageSortOrder.didSet`** and **`init`**: not mutators — sort change and initial load.
+- **`startChat()`**: instead of `reloadChats()`, inserts the single new row directly via `chats.insert(chat, at: 0)` — the immediate caller (`retargetActiveTabToChat → retargetTab → tabTitle`) reads `chats` synchronously.
+- **Mutators that `openTab(...)` the just-created row** (8 sites): the bus reload is async, but `tabTitle(for:)` reads the `summaries`/`sources` arrays synchronously. Fixed by passing the known title explicitly to `openTab(_:title:)` so `tabTitle` is never called, and capturing `effectiveName` from the returned `SourceSummary` for source-creating mutators.
+
+### Test fixes
+
+Tests without an event bus rely on the (now-removed) synchronous reloads. Fixed by adding explicit `model.reloadFromStore()` (or `model.reloadChats()`/`model.reloadBookmarkNodes()`) after mutations before checking model arrays. The bus itself is tested separately in `WikiChangeBridgeBusTests` / `WikiEventBusTests` with proper async polling.
+
+## Performance impact
+
+Each local mutation that previously triggered:
+- 1 synchronous reload (4 table scans + history prune) from the mutator
+- 1 async reload (4 table scans + prune + render-context rebuild) from the bus
+
+Now triggers only the async bus-driven reload. **~50% reduction in table scans per mutation.**
+
+## Test plan
+
+- [x] `swift build` passes
+- [x] Fast test tier passes (2438 tests, 0 failures):
+  ```
+  swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
+  ```
+
+Fixes #491


### PR DESCRIPTION
## Summary

Remove ~28 redundant per-mutator `reload*()` calls from `WikiStoreModel.swift`. After the #129 event-bus landed (Phase E), the model subscribes to ALL `ResourceChangeEvent`s via `subscribeToChanges()`, which calls `reloadFromStore()` on every event. The bus delivers async (`Task { @MainActor in ... }`), so the manual reload doesn't replace the bus-driven one — it **doubles** it: 8 table scans + 2 history-prune passes per save where 4 suffice.

## Changes

### Production code (`WikiStoreModel.swift`)

Removed `reloadSummaries()`, `reloadSources()`, `reloadBookmarkNodes()`, and `reloadChats()` calls from:
- **Page mutators:** `save()`, `newPage()`, `newPageInNewTab()`, `rename()`, `delete()`, `preflightLint()`
- **Source mutators:** `addFiles()`, `addURL()` (all paths), `addSource()`, `ingestFromZotero()`, `importFromMarkdownFolder()`, `renameSource()`, `deleteSource()`, `performRefresh()`
- **Bookmark mutators:** `createFolder()`, `addPageRef()`, `addSourceRef()`, `addChatRef()`, `renameBookmarkNode()`, `deleteBookmarkNode()`, `moveBookmarkNode()`
- **Chat mutators:** `startChat()`, `rollbackChatCreation()`, `appendChatEvents()`, `renameChat()`, `updateChatSummary()`, `deleteChat()`

### Exceptions kept

- **`agentRunEnded()`** (line ~1603): still calls `reloadFromStore()` — legit exception, updates run counts and is not driven by store events.
- **`pageSortOrder.didSet`** and **`init`**: not mutators — sort change and initial load.
- **`startChat()`**: instead of `reloadChats()`, inserts the single new row directly via `chats.insert(chat, at: 0)` — the immediate caller (`retargetActiveTabToChat → retargetTab → tabTitle`) reads `chats` synchronously.
- **Mutators that `openTab(...)` the just-created row** (8 sites): the bus reload is async, but `tabTitle(for:)` reads the `summaries`/`sources` arrays synchronously. Fixed by passing the known title explicitly to `openTab(_:title:)` so `tabTitle` is never called, and capturing `effectiveName` from the returned `SourceSummary` for source-creating mutators.

### Test fixes

Tests without an event bus rely on the (now-removed) synchronous reloads. Fixed by adding explicit `model.reloadFromStore()` (or `model.reloadChats()`/`model.reloadBookmarkNodes()`) after mutations before checking model arrays. The bus itself is tested separately in `WikiChangeBridgeBusTests` / `WikiEventBusTests` with proper async polling.

## Performance impact

Each local mutation that previously triggered:
- 1 synchronous reload (4 table scans + history prune) from the mutator
- 1 async reload (4 table scans + prune + render-context rebuild) from the bus

Now triggers only the async bus-driven reload. **~50% reduction in table scans per mutation.**

## Test plan

- [x] `swift build` passes
- [x] Fast test tier passes (2438 tests, 0 failures):
  ```
  swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
  ```

Fixes #491
