### PR TITLE
Fix #502: dedup keychain boilerplate, HTML escape, slug algorithm

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,44 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-17 — Issue #502: Cross-module dedup — keychain boilerplate, HTML escape, slug algorithm (branch `cross-module-dedup`, PR #504)
+
+**Shipped (PR #504, open — NOT merged).** Three cross-module dedup fixes; net
+**−122 lines** of duplicated boilerplate (8 files modified, 2 new shared modules).
+
+**L1 — Keychain `SecItem` boilerplate (3 stores → 1).** New
+`Sources/WikiFSCore/KeychainSecretStore.swift` centralizes the generic-password
+query/add/update/delete mechanics (`read(service:account:)`,
+`write(service:account:value:error:)`). `KeychainZoteroCredentialStore`,
+`KeychainACPCredentialStore`, `KeychainExtractionCredentialStore` now delegate;
+each keeps only its `service`/`account` mapping and its own typed error. ACP's
+pre-existing local `read`/`write` helpers removed. `write` takes an
+`error: (String, OSStatus) -> Error` factory so each store throws its own
+`*KeychainError` with the exact `operation`/`status` formatting it always had —
+behavior preserved.
+
+**L2 — byte-identical HTML escape.** Added `HTMLEntities.escapeHTML(_:)` (enum
+made `public` so the `WikiFS` target can reach it; `decode` stays module-
+internal). `ChatWebView.escape` and `MarkdownHTMLRenderer.escape` now delegate;
+the `escapeAttribute`/`escapePreservingBreaks`/`htmlAttributeEscape` wrappers
+are unchanged. `HTMLMarkdownRenderer.escapeInline` (markdown `[`/`]`) is
+different logic — left alone.
+
+**L3 — duplicated slug algorithm.** New `Sources/WikiFSCore/SlugUtils.swift`
+holds the shared `slugBase(_:)` normalization (lowercase → whitespace→`-` →
+keep letters/numbers/`-` → collapse). `AnchorBlock.makeSlug` and
+`SQLiteWikiStore.slugify` delegate, keeping their own fallback
+(`"heading"`/`"untitled"`) and suffix logic. `slugBase` matches `makeSlug`'s
+Unicode-permissive behavior, so the heading-anchor/`resolveAnchor` path is
+byte-identical; `slugify` now also keeps non-ASCII letters/whitespace (existing
+DB slugs read verbatim; only new/renamed titles change). `PodcastEpisodeURL.slug`
+is path-based — deliberately separate. Note: the issue assumed the two slugs
+were "the same algorithm" — they differed subtly (ASCII-only vs Unicode).
+
+**Build/tests:** `swift build` clean; fast tier **2444 tests/210 suites passed**;
+targeted `slugifyStripsPunctuationAndCollapsesDashes` (in the skipped
+`SQLiteWikiStoreTests`) passes with the changed `slugify`.
+
 ## 2026-07-17 — Issue #488: Delete dead content-sniff forwarder shims (branch `cleanup/dead-sniff-forwarders`)
 
 **Shipped.** Removed 81 lines of dead forwarder shims left over from the

--- a/Sources/WikiFS/ChatWebView.swift
+++ b/Sources/WikiFS/ChatWebView.swift
@@ -678,9 +678,7 @@ struct ChatWebView: NSViewRepresentable {
         }
 
         private static func escape(_ s: String) -> String {
-            s.replacingOccurrences(of: "&", with: "&amp;")
-                .replacingOccurrences(of: "<", with: "&lt;")
-                .replacingOccurrences(of: ">", with: "&gt;")
+            HTMLEntities.escapeHTML(s)
         }
 
         /// JavaScript that highlights the first occurrence of `quote` in the

--- a/Sources/WikiFS/MarkdownHTMLRenderer.swift
+++ b/Sources/WikiFS/MarkdownHTMLRenderer.swift
@@ -184,9 +184,7 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
     }
 
     private func escape(_ s: String) -> String {
-        s.replacingOccurrences(of: "&", with: "&amp;")
-         .replacingOccurrences(of: "<", with: "&lt;")
-         .replacingOccurrences(of: ">", with: "&gt;")
+        HTMLEntities.escapeHTML(s)
     }
 
     private func escapeAttribute(_ s: String) -> String {

--- a/Sources/WikiFSCore/ACPCredentialStore.swift
+++ b/Sources/WikiFSCore/ACPCredentialStore.swift
@@ -57,74 +57,35 @@ public struct KeychainACPCredentialStore: ACPCredentialStore {
     public init() {}
 
     public func apiKey() -> String? {
-        Self.read(account: Self.account)
+        KeychainSecretStore.read(service: Self.service, account: Self.account)
     }
 
     public func setAPIKey(_ value: String?) throws {
-        try Self.write(account: Self.account, value: value)
+        try KeychainSecretStore.write(
+            service: Self.service, account: Self.account, value: value,
+            error: { operation, status in
+                ACPKeychainError(operation: "\(operation)(\(Self.account))", status: status)
+            })
     }
 
     // MARK: - Per-provider (#324)
 
     public func apiKey(forProvider id: String) -> String? {
-        Self.read(account: Self.providerAccount(id))
+        KeychainSecretStore.read(service: Self.service, account: Self.providerAccount(id))
     }
 
     public func setAPIKey(_ value: String?, forProvider id: String) throws {
-        try Self.write(account: Self.providerAccount(id), value: value)
+        let account = Self.providerAccount(id)
+        try KeychainSecretStore.write(
+            service: Self.service, account: account, value: value,
+            error: { operation, status in
+                ACPKeychainError(operation: "\(operation)(\(account))", status: status)
+            })
     }
 
     /// Namespace a per-provider account so each provider's key is isolated.
     private static func providerAccount(_ id: String) -> String {
         "acp-provider:\(id)"
-    }
-
-    // MARK: - Shared Keychain helpers
-
-    private static func read(account: String) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess, let data = item as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
-    }
-
-    private static func write(account: String, value: String?) throws {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-        ]
-
-        guard let value, !value.isEmpty else {
-            let status = SecItemDelete(query as CFDictionary)
-            guard status == errSecSuccess || status == errSecItemNotFound else {
-                throw ACPKeychainError(operation: "delete(\(account))", status: status)
-            }
-            return
-        }
-
-        let data = Data(value.utf8)
-        // Try update first (the common "user is changing their key" case); if
-        // nothing exists yet, add it.
-        let updateStatus = SecItemUpdate(
-            query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
-        if updateStatus == errSecItemNotFound {
-            var addQuery = query
-            addQuery[kSecValueData as String] = data
-            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-            guard addStatus == errSecSuccess else {
-                throw ACPKeychainError(operation: "add(\(account))", status: addStatus)
-            }
-        } else if updateStatus != errSecSuccess {
-            throw ACPKeychainError(operation: "update(\(account))", status: updateStatus)
-        }
     }
 }
 

--- a/Sources/WikiFSCore/AnchorBlock.swift
+++ b/Sources/WikiFSCore/AnchorBlock.swift
@@ -130,14 +130,7 @@ public struct AnchorBlock: Equatable, Sendable {
     /// GFM-style heading slug: lowercased, spaces→`-`, drop punctuation,
     /// collapse runs, dedup with `-1/-2` suffix.
     public static func makeSlug(_ headingText: String, counts: inout [String: Int]) -> String {
-        let base = String(
-            headingText
-                .lowercased()
-                .map { $0.isWhitespace ? "-" : $0 }
-                .filter { $0.isLetter || $0.isNumber || $0 == "-" }
-                .split(separator: "-", omittingEmptySubsequences: true)
-                .joined(separator: "-")
-        )
+        let base = SlugUtils.slugBase(headingText)
         guard !base.isEmpty else { return "heading" }
         let count = counts[base, default: 0]
         counts[base] = count + 1

--- a/Sources/WikiFSCore/ExtractionCredentialStore.swift
+++ b/Sources/WikiFSCore/ExtractionCredentialStore.swift
@@ -42,50 +42,16 @@ public struct KeychainExtractionCredentialStore: ExtractionCredentialStore {
     }
 
     public func secret(_ secret: ExtractionSecret) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account(for: secret),
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess, let data = item as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
+        KeychainSecretStore.read(service: Self.service, account: account(for: secret))
     }
 
     public func setSecret(_ value: String?, _ secret: ExtractionSecret) throws {
         let account = account(for: secret)
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account,
-        ]
-
-        guard let value, !value.isEmpty else {
-            let status = SecItemDelete(query as CFDictionary)
-            guard status == errSecSuccess || status == errSecItemNotFound else {
-                throw ExtractionKeychainError(operation: "delete(\(account))", status: status)
-            }
-            return
-        }
-
-        let data = Data(value.utf8)
-        // Try update first (the common "user is changing their key" case); if
-        // nothing exists yet, add it.
-        let updateStatus = SecItemUpdate(
-            query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
-        if updateStatus == errSecItemNotFound {
-            var addQuery = query
-            addQuery[kSecValueData as String] = data
-            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-            guard addStatus == errSecSuccess else {
-                throw ExtractionKeychainError(operation: "add(\(account))", status: addStatus)
-            }
-        } else if updateStatus != errSecSuccess {
-            throw ExtractionKeychainError(operation: "update(\(account))", status: updateStatus)
-        }
+        try KeychainSecretStore.write(
+            service: Self.service, account: account, value: value,
+            error: { operation, status in
+                ExtractionKeychainError(operation: "\(operation)(\(account))", status: status)
+            })
     }
 }
 

--- a/Sources/WikiFSCore/HTMLEntities.swift
+++ b/Sources/WikiFSCore/HTMLEntities.swift
@@ -9,7 +9,19 @@ import Foundation
 /// cases the spec flags (`&amp; &lt; &gt; &quot; &#39; &nbsp;` …). Tolerant: an
 /// unterminated or unrecognized `&…` is left verbatim rather than dropped or
 /// crashing.
-enum HTMLEntities {
+public enum HTMLEntities {
+
+    /// Escape `&`, `<`, `>` for safe embedding in HTML text. The single source of
+    /// truth for the three-char escape formerly duplicated as private `escape(_:)`
+    /// in `ChatWebView` and `MarkdownHTMLRenderer` (and the
+    /// `escapeAttribute`/`escapePreservingBreaks` wrappers that build on it).
+    /// `public` so the `WikiFS` app target can reach it; `decode` stays module-
+    /// internal. See issue #502 (cross-module dedup, L2).
+    public static func escapeHTML(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
 
     /// The named entities we recognize. Lowercase-keyed; lookups are case-sensitive
     /// for named entities (matching how browsers treat e.g. `&AMP;` vs `&amp;` —

--- a/Sources/WikiFSCore/KeychainSecretStore.swift
+++ b/Sources/WikiFSCore/KeychainSecretStore.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Security
+
+/// Shared generic-password Keychain read/write for the three
+/// `Keychain*CredentialStore` structs (`Zotero`, `ACP`, `Extraction`). The
+/// SecItem query/add/update/delete boilerplate lives here once; each store keeps
+/// only its `service`/`account` mapping and its own typed error.
+///
+/// `write` takes an `error` factory so each store can throw its own error type
+/// (preserving the per-store `operation`/`status` formatting it always has) while
+/// the SecItem mechanics stay shared. `read` returns `nil` for any miss or error —
+/// the same "missing secret = nil" contract the stores always exposed.
+///
+/// See issue #502 (cross-module dedup, L1).
+enum KeychainSecretStore {
+
+    /// Read a generic-password secret. Returns `nil` if the item is absent or any
+    /// lookup error occurs — matching the prior per-store "missing = nil" behavior.
+    static func read(service: String, account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Write (set or delete) a generic-password secret. On a non-success
+    /// `OSStatus` the failing `(operation, status)` is passed to `error` and
+    /// whatever it throws propagates; a delete of a missing item is a no-op
+    /// success. `operation` is the bare verb (`"delete"`, `"add"`, `"update"`) so
+    /// each store can decorate it (e.g. with the account) exactly as it always has.
+    static func write(
+        service: String,
+        account: String,
+        value: String?,
+        error makeError: (_ operation: String, _ status: OSStatus) -> Error
+    ) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        guard let value, !value.isEmpty else {
+            let status = SecItemDelete(query as CFDictionary)
+            if status == errSecSuccess || status == errSecItemNotFound { return }
+            throw makeError("delete", status)
+        }
+
+        let data = Data(value.utf8)
+        // Try update first (the common "user is changing their key" case); if
+        // nothing exists yet, add it.
+        let updateStatus = SecItemUpdate(
+            query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        if updateStatus == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                throw makeError("add", addStatus)
+            }
+        } else if updateStatus != errSecSuccess {
+            throw makeError("update", updateStatus)
+        }
+    }
+}

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -6783,23 +6783,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
     }
 
     static func slugify(_ title: String) -> String {
-        let lowered = title.lowercased()
-        var chars: [Character] = []
-        for ch in lowered {
-            if ch == " " || ch == "\t" || ch == "\n" {
-                chars.append("-")
-            } else if ch.isLetter, ch.isASCII {
-                chars.append(ch)
-            } else if ch.isNumber, ch.isASCII {
-                chars.append(ch)
-            } else if ch == "-" {
-                chars.append(ch)
-            }
-        }
-        // Collapse runs of '-' and trim leading/trailing ones.
-        let collapsed = String(chars)
-            .split(separator: "-", omittingEmptySubsequences: true)
-            .joined(separator: "-")
+        let collapsed = SlugUtils.slugBase(title)
         return collapsed.isEmpty ? "untitled" : collapsed
     }
 

--- a/Sources/WikiFSCore/SlugUtils.swift
+++ b/Sources/WikiFSCore/SlugUtils.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Shared slug *base* for the two slug callers in the app:
+/// - `SQLiteWikiStore.slugify` (page-title slugs → DB `pages.slug`)
+/// - `AnchorBlock.makeSlug` (in-memory heading anchor ids)
+///
+/// `slugBase` is the pure normalization both share: lowercase → whitespace→`-`
+/// → keep letters/numbers/`-` → collapse `-` runs (and trim the ends). Each caller
+/// then adds its own empty-fallback (`"untitled"` / `"heading"`) and suffix logic
+/// (ULID dedup / `-N` dedup) on top — that differing tail is why this is *base*-only.
+///
+/// Behaviour note: this matches `AnchorBlock.makeSlug`'s Unicode-permissive
+/// normalization (all whitespace → `-`; any `.isLetter`/`.isNumber` kept, not just
+/// ASCII). `slugify` previously dropped non-ASCII letters and ignored most
+/// whitespace; it now keeps them too. Existing page slugs in the DB are unchanged
+/// (read verbatim); only newly-created/renamed titles get the normalized slug.
+/// `PodcastEpisodeURL.slug` is path-based and deliberately separate — not here.
+///
+/// See issue #502 (cross-module dedup, L3).
+enum SlugUtils {
+
+    static func slugBase(_ s: String) -> String {
+        String(
+            s.lowercased()
+                .map { $0.isWhitespace ? "-" : $0 }
+                .filter { $0.isLetter || $0.isNumber || $0 == "-" }
+                .split(separator: "-", omittingEmptySubsequences: true)
+                .joined(separator: "-")
+        )
+    }
+}

--- a/Sources/WikiFSCore/ZoteroCredentialStore.swift
+++ b/Sources/WikiFSCore/ZoteroCredentialStore.swift
@@ -28,49 +28,15 @@ public struct KeychainZoteroCredentialStore: ZoteroCredentialStore {
     public init() {}
 
     public func apiKey() -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: Self.account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess, let data = item as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
+        KeychainSecretStore.read(service: Self.service, account: Self.account)
     }
 
     public func setAPIKey(_ key: String?) throws {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: Self.account,
-        ]
-
-        guard let key, !key.isEmpty else {
-            let status = SecItemDelete(query as CFDictionary)
-            guard status == errSecSuccess || status == errSecItemNotFound else {
-                throw ZoteroKeychainError(operation: "delete", status: status)
-            }
-            return
-        }
-
-        let data = Data(key.utf8)
-        // Try update first (the common "user is changing their key" case); if
-        // nothing exists yet, add it.
-        let updateStatus = SecItemUpdate(
-            query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
-        if updateStatus == errSecItemNotFound {
-            var addQuery = query
-            addQuery[kSecValueData as String] = data
-            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-            guard addStatus == errSecSuccess else {
-                throw ZoteroKeychainError(operation: "add", status: addStatus)
-            }
-        } else if updateStatus != errSecSuccess {
-            throw ZoteroKeychainError(operation: "update", status: updateStatus)
-        }
+        try KeychainSecretStore.write(
+            service: Self.service, account: Self.account, value: key,
+            error: { operation, status in
+                ZoteroKeychainError(operation: operation, status: status)
+            })
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #502 — three cross-module dedup fixes in one batch. Net **−122 lines** of duplicated boilerplate (8 files modified, 2 new shared modules).

## L1 — Keychain `SecItem` boilerplate (3 stores → 1)

`KeychainZoteroCredentialStore`, `KeychainACPCredentialStore`, and
`KeychainExtractionCredentialStore` each re-implemented the same
generic-password SecItem query/add/update/delete dance (~45 lines each).

- New `Sources/WikiFSCore/KeychainSecretStore.swift` holds the SecItem mechanics
  once: `read(service:account:) -> String?` and `write(service:account:value:error:) throws`.
- All three stores now delegate; each keeps only its `service`/`account`
  mapping and its own typed error. ACP's pre-existing local `read`/`write`
  helpers are removed.
- `write` takes an `error: (String, OSStatus) -> Error` factory so each store
  throws its own `*KeychainError` with the **exact** `operation`/`status`
  formatting it always had (e.g. `"delete(acp-agent-api-key)"` vs the Zotero
  bare `"delete"`). Observable behavior preserved; no tests asserted on those
  strings.

## L2 — byte-identical HTML escape

`ChatWebView.escape` and `MarkdownHTMLRenderer.escape` were byte-identical
(`&`->`&amp;`, `<`->`&lt;`, `>`->`&gt;`).

- Added `HTMLEntities.escapeHTML(_:)` (the enum is now `public` so the `WikiFS`
  app target can reach it; `decode` stays module-internal).
- Both `escape` functions now delegate. The `escapeAttribute` /
  `escapePreservingBreaks` / `htmlAttributeEscape` wrappers that build on
  `escape` are unchanged.
- `HTMLMarkdownRenderer.escapeInline` escapes **markdown** `[`/`]`, not HTML —
  genuinely different logic, left alone (as the issue anticipated).

## L3 — duplicated slug algorithm

`SQLiteWikiStore.slugify` and `AnchorBlock.makeSlug` are two copies of the same
slug algorithm; they differed subtly (`slugify` was ASCII-only + limited
whitespace; `makeSlug` was Unicode-permissive + all whitespace).

- New `Sources/WikiFSCore/SlugUtils.swift` holds the shared normalization
  `slugBase(_:)` (lowercase -> whitespace->`-` -> keep letters/numbers/`-` ->
  collapse `-` runs).
- `makeSlug` and `slugify` delegate, keeping their own empty-fallback
  (`"heading"` / `"untitled"`) and suffix logic (`-N` dedup / ULID dedup).
- `slugBase` matches `makeSlug`'s Unicode-permissive behavior, so the heading
  anchor / `resolveAnchor` path is **byte-identical**; `slugify` now also keeps
  non-ASCII letters and all whitespace. Existing page slugs in the DB are
  unchanged (read verbatim); only newly-created/renamed titles get the
  normalized slug. `PodcastEpisodeURL.slug` is path-based and deliberately
  separate — not consolidated.

## Verification

- `swift build` — clean (no errors/warnings).
- Fast test tier (the CI `swift` job), skipping the slow integration suites:
  **2444 tests in 210 suites passed.**
- Targeted `slugifyStripsPunctuationAndCollapsesDashes` (in the skipped
  `SQLiteWikiStoreTests`) passes with the changed `slugify`.
- `AnchorBlock.makeSlug` tests run in the fast tier and pass (unchanged path).

The slow integration suites (`SQLiteWikiStoreTests`, etc.) will run in the
`swift-integration` CI job.
