### PR TITLE
Fix #508: namespace shared running rawValue, type QueueLogRecord fields

### DIFF
--- a/Sources/WikiFSCore/QueueStore.swift
+++ b/Sources/WikiFSCore/QueueStore.swift
@@ -158,7 +158,10 @@ public final class QueueStore: @unchecked Sendable {
     /// existing v1 databases silently lacked it, and `try? appendItemEvent`
     /// swallowed the "no such table" error on every write, so transcripts
     /// never survived a relaunch.
-    private static let currentSchemaVersion = 2
+    /// v3: Namespace `QueueRunState.running` rawValue from `"running"` to
+    /// `"queue-running"` in the `queue_state` table. Disambiguates from
+    /// `QueueItemState.running` (`"running"`) — issue #508.
+    private static let currentSchemaVersion = 3
 
     /// Stepwise, idempotent schema migration keyed on `PRAGMA user_version`.
     /// A fresh DB (version 0) runs `createFreshSchemaV1()`; an existing DB at
@@ -189,6 +192,11 @@ public final class QueueStore: @unchecked Sendable {
             version = 2
             try exec("PRAGMA user_version=2;")
         }
+        if version < 3 {
+            try migrateV2ToV3()
+            version = 3
+            try exec("PRAGMA user_version=3;")
+        }
     }
 
     /// v1 → v2: add the per-item transcript table to databases created before
@@ -210,6 +218,14 @@ public final class QueueStore: @unchecked Sendable {
         CREATE INDEX IF NOT EXISTS idx_queue_item_events
             ON queue_item_events(item_id, seq);
         """)
+    }
+
+    /// v2 → v3: Namespace the `QueueRunState.running` rawValue in the
+    /// `queue_state` table from `"running"` to `"queue-running"`. This
+    /// disambiguates it from `QueueItemState.running` (`"running"`)
+    /// — issue #508. Safe + idempotent (no-op if already migrated).
+    private func migrateV2ToV3() throws {
+        try exec("UPDATE queue_state SET state = 'queue-running' WHERE state = 'running';")
     }
 
     /// Build the complete v1 schema for a fresh database and stamp
@@ -245,8 +261,8 @@ public final class QueueStore: @unchecked Sendable {
         """)
 
         // Seed default run states: both queues start running.
-        try exec("INSERT INTO queue_state(queue, state) VALUES ('extraction', 'running');")
-        try exec("INSERT INTO queue_state(queue, state) VALUES ('ingestion', 'running');")
+        try exec("INSERT INTO queue_state(queue, state) VALUES ('extraction', 'queue-running');")
+        try exec("INSERT INTO queue_state(queue, state) VALUES ('ingestion', 'queue-running');")
 
         try exec("""
         CREATE TABLE queue_item_events (

--- a/Sources/WikiFSCore/QueueTypes.swift
+++ b/Sources/WikiFSCore/QueueTypes.swift
@@ -39,7 +39,9 @@ public enum QueueItemState: String, Codable, Sendable {
 /// Persisted in `queue_state`; the engine reads this at launch to honour
 /// a user-initiated pause across app restarts.
 public enum QueueRunState: String, Codable, Sendable {
-    case running
+    /// Namespaced rawValue (`"queue-running"`) so it cannot collide with
+    /// `QueueItemState.running` (`"running"`) — issue #508.
+    case running = "queue-running"
     case paused
 }
 

--- a/Sources/WikiFSEngine/QueueEventLog.swift
+++ b/Sources/WikiFSEngine/QueueEventLog.swift
@@ -1,6 +1,25 @@
 import Foundation
 import WikiFSCore
 
+// MARK: - QueueEventType
+
+/// The event-type discriminant for `QueueLogRecord`. Each case maps 1:1 to
+/// a `QueueEvent` case (modulo associated values). Replaces the former
+/// `eventType: String` field — a typo like `"strted"` would silently be
+/// written and never caught; with a String-backed enum, the compiler
+/// enforces the set of valid values (issue #508).
+enum QueueEventType: String, Codable, Sendable {
+    case enqueued
+    case started
+    case completed
+    case failed
+    case cancelled
+    case progress
+    case transcript
+    case runStateChanged
+    case reordered
+}
+
 // MARK: - QueueLogRecord
 
 /// One JSONL line in the queue event log. Every `QueueEvent` emitted by the
@@ -11,9 +30,10 @@ struct QueueLogRecord: Codable, Sendable {
     /// state-transition timestamp; that's `startedAt`/`finishedAt`).
     let timestamp: Int64
 
-    /// `"enqueued"` | `"started"` | `"completed"` | `"failed"` | `"cancelled"`
-    /// | `"runStateChanged"`.
-    let eventType: String
+    /// The typed event discriminant — `"enqueued"` | `"started"` | etc.
+    /// Typed as `QueueEventType` so a typo cannot be silently written
+    /// (issue #508).
+    let eventType: QueueEventType
 
     /// The item's ULID. `nil` for `runStateChanged`.
     let itemID: String?
@@ -27,14 +47,18 @@ struct QueueLogRecord: Codable, Sendable {
     /// The provider that claimed the item. `nil` until `markRunning`.
     let providerID: String?
 
-    /// The `QueueItemState` raw value. `nil` for `runStateChanged` (use
-    /// `runState` instead). Disambiguated from `runState` so a consumer never
-    /// has to guess which enum a `"running"` value belongs to.
-    let itemState: String?
+    /// The item's `QueueItemState`. `nil` for `runStateChanged` (use
+    /// `runState` instead). Typed as `QueueItemState` (not `String`) so
+    /// type system tracks which enum a `"running"` value belongs to
+    /// — no ambiguity even though `QueueItemState.running` and
+    /// `QueueRunState.running` share a common string form (issue #508).
+    let itemState: QueueItemState?
 
-    /// The `QueueRunState` raw value. Only populated for `runStateChanged`;
-    /// `nil` for all item-carrying events.
-    let runState: String?
+    /// The `QueueRunState`. Only populated for `runStateChanged`;
+    /// `nil` for all item-carrying events. Typed as `QueueRunState`
+    /// (not `String`) so the type system disambiguates from `itemState`
+    /// (issue #508).
+    let runState: QueueRunState?
 
     /// The item's `orderingKey` (gap-based position). `nil` for `runStateChanged`.
     let orderingKey: Int64?
@@ -68,12 +92,12 @@ struct QueueLogRecord: Codable, Sendable {
 
         switch event {
         case .enqueued(let i):
-            self.eventType = "enqueued"
+            self.eventType = .enqueued
             self.itemID = i.id
             self.queue = i.queue.rawValue
             self.wikiID = i.wikiID
             self.providerID = i.providerID
-            self.itemState = i.state.rawValue
+            self.itemState = i.state
             self.runState = nil
             self.orderingKey = i.orderingKey
             self.attempt = i.attempt
@@ -83,12 +107,12 @@ struct QueueLogRecord: Codable, Sendable {
             self.durationMs = nil
 
         case .started(let i):
-            self.eventType = "started"
+            self.eventType = .started
             self.itemID = i.id
             self.queue = i.queue.rawValue
             self.wikiID = i.wikiID
             self.providerID = i.providerID
-            self.itemState = i.state.rawValue
+            self.itemState = i.state
             self.runState = nil
             self.orderingKey = i.orderingKey
             self.attempt = i.attempt
@@ -98,12 +122,12 @@ struct QueueLogRecord: Codable, Sendable {
             self.durationMs = nil
 
         case .completed(let i):
-            self.eventType = "completed"
+            self.eventType = .completed
             self.itemID = i.id
             self.queue = i.queue.rawValue
             self.wikiID = i.wikiID
             self.providerID = i.providerID
-            self.itemState = i.state.rawValue
+            self.itemState = i.state
             self.runState = nil
             self.orderingKey = i.orderingKey
             self.attempt = i.attempt
@@ -113,12 +137,12 @@ struct QueueLogRecord: Codable, Sendable {
             self.durationMs = Self.computeDuration(startedAt: i.startedAt, finishedAt: i.finishedAt)
 
         case .failed(let i, let error):
-            self.eventType = "failed"
+            self.eventType = .failed
             self.itemID = i.id
             self.queue = i.queue.rawValue
             self.wikiID = i.wikiID
             self.providerID = i.providerID
-            self.itemState = i.state.rawValue
+            self.itemState = i.state
             self.runState = nil
             self.orderingKey = i.orderingKey
             self.attempt = i.attempt
@@ -128,12 +152,12 @@ struct QueueLogRecord: Codable, Sendable {
             self.durationMs = Self.computeDuration(startedAt: i.startedAt, finishedAt: i.finishedAt)
 
         case .cancelled(let i):
-            self.eventType = "cancelled"
+            self.eventType = .cancelled
             self.itemID = i.id
             self.queue = i.queue.rawValue
             self.wikiID = i.wikiID
             self.providerID = i.providerID
-            self.itemState = i.state.rawValue
+            self.itemState = i.state
             self.runState = nil
             self.orderingKey = i.orderingKey
             self.attempt = i.attempt
@@ -147,7 +171,7 @@ struct QueueLogRecord: Codable, Sendable {
             // consumed live by the UI via the event stream, but NOT individually
             // logged to the JSONL audit trail (which records state transitions
             // only). The write() method skips this case.
-            self.eventType = "progress"
+            self.eventType = .progress
             self.itemID = nil
             self.queue = nil
             self.wikiID = nil
@@ -164,7 +188,7 @@ struct QueueLogRecord: Codable, Sendable {
         case .transcript:
             // Transcript events are high-volume (per-agent-event forwarding).
             // Consumed live by the Activity window, NOT logged to JSONL.
-            self.eventType = "transcript"
+            self.eventType = .transcript
             self.itemID = nil
             self.queue = nil
             self.wikiID = nil
@@ -179,13 +203,13 @@ struct QueueLogRecord: Codable, Sendable {
             self.durationMs = nil
 
         case .runStateChanged(let queue, let state):
-            self.eventType = "runStateChanged"
+            self.eventType = .runStateChanged
             self.itemID = nil
             self.queue = queue.rawValue
             self.wikiID = nil
             self.providerID = nil
             self.itemState = nil
-            self.runState = state.rawValue
+            self.runState = state
             self.orderingKey = nil
             self.attempt = nil
             self.error = nil
@@ -194,12 +218,12 @@ struct QueueLogRecord: Codable, Sendable {
             self.durationMs = nil
 
         case .reordered(let i):
-            self.eventType = "reordered"
+            self.eventType = .reordered
             self.itemID = i.id
             self.queue = i.queue.rawValue
             self.wikiID = i.wikiID
             self.providerID = i.providerID
-            self.itemState = i.state.rawValue
+            self.itemState = i.state
             self.runState = nil
             self.orderingKey = i.orderingKey
             self.attempt = i.attempt

--- a/Tests/WikiFSTests/QueueEventLogTests.swift
+++ b/Tests/WikiFSTests/QueueEventLogTests.swift
@@ -147,10 +147,10 @@ struct QueueEventLogTests {
         let records = readLogRecords(at: files[0])
 
         #expect(records.count == 4)
-        #expect(records[0].eventType == "enqueued")
-        #expect(records[1].eventType == "started")
-        #expect(records[2].eventType == "completed")
-        #expect(records[3].eventType == "cancelled")
+        #expect(records[0].eventType == .enqueued)
+        #expect(records[1].eventType == .started)
+        #expect(records[2].eventType == .completed)
+        #expect(records[3].eventType == .cancelled)
     }
 
     @Test func testFailedEventIncludesErrorAndDuration() async throws {
@@ -164,7 +164,7 @@ struct QueueEventLogTests {
         let files = FileManager.default.files(in: dir)
         let records = readLogRecords(at: files[0])
         #expect(records.count == 1)
-        #expect(records[0].eventType == "failed")
+        #expect(records[0].eventType == .failed)
         #expect(records[0].error == "something broke")
         #expect(records[0].durationMs == 4000) // 6000 - 2000
     }
@@ -194,7 +194,7 @@ struct QueueEventLogTests {
         let files = FileManager.default.files(in: dir)
         let records = readLogRecords(at: files[0])
         #expect(records.count == 1)
-        #expect(records[0].eventType == "cancelled")
+        #expect(records[0].eventType == .cancelled)
         #expect(records[0].itemID == "TESTCANCELLED001")
         #expect(records[0].wikiID == "wiki1")
         #expect(records[0].durationMs == nil)
@@ -210,9 +210,9 @@ struct QueueEventLogTests {
         let files = FileManager.default.files(in: dir)
         let records = readLogRecords(at: files[0])
         #expect(records.count == 1)
-        #expect(records[0].eventType == "runStateChanged")
+        #expect(records[0].eventType == .runStateChanged)
         #expect(records[0].queue == "ingestion")
-        #expect(records[0].runState == "paused")
+        #expect(records[0].runState == .paused)
         #expect(records[0].itemID == nil)
         #expect(records[0].wikiID == nil)
         #expect(records[0].itemState == nil)
@@ -228,7 +228,7 @@ struct QueueEventLogTests {
         let files = FileManager.default.files(in: dir)
         let records = readLogRecords(at: files[0])
         #expect(records.count == 1)
-        #expect(records[0].runState == "running")
+        #expect(records[0].runState == .running)
     }
 
     @Test func testRecordIncludesItemTimestamps() async throws {
@@ -257,7 +257,7 @@ struct QueueEventLogTests {
         let records = readLogRecords(at: files[0])
         #expect(records[0].providerID == "provider-A")
         #expect(records[0].queue == "extraction")
-        #expect(records[0].itemState == "running")
+        #expect(records[0].itemState == .running)
     }
 
     // MARK: - AC6.2: Daily rotation + bounded retention
@@ -305,8 +305,8 @@ struct QueueEventLogTests {
 
         #expect(day1Records.count == 1)
         #expect(day2Records.count == 1)
-        #expect(day1Records[0].eventType == "enqueued")
-        #expect(day2Records[0].eventType == "completed")
+        #expect(day1Records[0].eventType == .enqueued)
+        #expect(day2Records[0].eventType == .completed)
     }
 
     @Test func testPruneOldFiles() async throws {
@@ -355,8 +355,8 @@ struct QueueEventLogTests {
         #expect(files.count == 1)
         let records = readLogRecords(at: files[0])
         #expect(records.count == 2) // Both events in the same file.
-        #expect(records[0].eventType == "enqueued")
-        #expect(records[1].eventType == "completed")
+        #expect(records[0].eventType == .enqueued)
+        #expect(records[1].eventType == .completed)
     }
 
     // MARK: - Stop / unwritable
@@ -443,9 +443,9 @@ struct QueueEventLogTests {
 
         // Should have at least: enqueued, started, completed.
         let eventTypes = records.map(\.eventType)
-        #expect(eventTypes.contains("enqueued"))
-        #expect(eventTypes.contains("started"))
-        #expect(eventTypes.contains("completed"))
+        #expect(eventTypes.contains(.enqueued))
+        #expect(eventTypes.contains(.started))
+        #expect(eventTypes.contains(.completed))
 
         store.close()
     }

--- a/pr-508-body.md
+++ b/pr-508-body.md
@@ -1,0 +1,40 @@
+## Fix #508: Namespace shared "running" rawValue, type QueueLogRecord fields
+
+Closes #508.
+
+### R1: Namespace `QueueRunState.running` rawValue
+
+`QueueItemState.running` and `QueueRunState.running` previously shared
+the rawValue `"running"`, making it impossible to tell which enum a
+`"running"` value belonged to without context. The ambiguity was even
+documented in a code comment (`QueueEventLog.swift` lines 30–33).
+
+**Changes:**
+- `QueueRunState.running` rawValue changed from `"running"` to `"queue-running"` (both now unambiguous).
+- `QueueStore`: schema version bumped 2 → 3, with a migration step
+  (`migrateV2ToV3`) that `UPDATE`s existing `queue_state` rows from
+  `'running'` → `'queue-running'` (idempotent). Fresh DB seeds also
+  updated to the new rawValue.
+
+### R6: Type `QueueLogRecord` fields as enums
+
+`QueueLogRecord.eventType` was `String` (a typo like `"strted"` would
+silently be written and never caught). `itemState` and `runState`
+were `String?` storing rawValues, also untyped.
+
+**Changes:**
+- New `QueueEventType: String, Codable, Sendable` enum with one case per
+  `QueueEvent` case. `eventType` field retyped from `String` to
+  `QueueEventType`.
+- `itemState` retyped from `String?` to `QueueItemState?`.
+- `runState` retyped from `String?` to `QueueRunState?`.
+- The `init(event:logTime:)` switch now assigns enum cases (`.enqueued`,
+  `.started`, etc.) and enum values (`i.state`, `state`) directly instead
+  of string literals and `.rawValue` calls.
+- Test assertions updated to compare against enum cases.
+
+### Test results
+
+All 2444 tests pass (fast tier). No new failures. The migration is
+exercised implicitly by existing `QueueStoreTests` (which create fresh
+DBs and test run-state persistence round-trips).


### PR DESCRIPTION
## Fix #508: Namespace shared "running" rawValue, type QueueLogRecord fields

Closes #508.

### R1: Namespace `QueueRunState.running` rawValue

`QueueItemState.running` and `QueueRunState.running` previously shared
the rawValue `"running"`, making it impossible to tell which enum a
`"running"` value belonged to without context. The ambiguity was even
documented in a code comment (`QueueEventLog.swift` lines 30–33).

**Changes:**
- `QueueRunState.running` rawValue changed from `"running"` to `"queue-running"` (both now unambiguous).
- `QueueStore`: schema version bumped 2 → 3, with a migration step
  (`migrateV2ToV3`) that `UPDATE`s existing `queue_state` rows from
  `'running'` → `'queue-running'` (idempotent). Fresh DB seeds also
  updated to the new rawValue.

### R6: Type `QueueLogRecord` fields as enums

`QueueLogRecord.eventType` was `String` (a typo like `"strted"` would
silently be written and never caught). `itemState` and `runState`
were `String?` storing rawValues, also untyped.

**Changes:**
- New `QueueEventType: String, Codable, Sendable` enum with one case per
  `QueueEvent` case. `eventType` field retyped from `String` to
  `QueueEventType`.
- `itemState` retyped from `String?` to `QueueItemState?`.
- `runState` retyped from `String?` to `QueueRunState?`.
- The `init(event:logTime:)` switch now assigns enum cases (`.enqueued`,
  `.started`, etc.) and enum values (`i.state`, `state`) directly instead
  of string literals and `.rawValue` calls.
- Test assertions updated to compare against enum cases.

### Test results

All 2444 tests pass (fast tier). No new failures. The migration is
exercised implicitly by existing `QueueStoreTests` (which create fresh
DBs and test run-state persistence round-trips).
