### PR TITLE
Fix #509: route legacy-extraction through enum, typed HintKey for hints dict

### DIFF
--- a/Sources/WikiFS/SourceDetailView.swift
+++ b/Sources/WikiFS/SourceDetailView.swift
@@ -785,7 +785,7 @@ struct SourceDetailView: View {
                         headVersion = store.processedMarkdownHead(for: file)
                     } label: {
                         Label {
-                            Text("\(Self.backendDisplayName(forAgent: agent)) — \(version.createdAt, style: .date)")
+                            Text("\(ExtractionAlternative.backendDisplayName(agentName: agent)) — \(version.createdAt, style: .date)")
                         } icon: {
                             Image(systemName: version.id.rawValue == headID
                                   ? "checkmark.circle.fill" : "doc.text")
@@ -837,17 +837,9 @@ struct SourceDetailView: View {
         case .user: return "Edited"
         case .revert: return "Reverted"
         default:
-            if let agent { return backendDisplayName(forAgent: agent) }
+            if let agent { return ExtractionAlternative.backendDisplayName(agentName: agent) }
             return "Extraction"
         }
-    }
-
-    /// Human-facing backend name for an `agents.name` value: the legacy
-    /// migration stub reads "Legacy", known backends use their display name,
-    /// and anything else falls back to the raw name.
-    private static func backendDisplayName(forAgent agent: String) -> String {
-        if agent == "legacy-extraction" { return "Legacy" }
-        return ExtractionBackend.from(agentName: agent)?.displayName ?? agent
     }
 
     /// Re-extract the source with a chosen backend, appending a coexisting
@@ -867,7 +859,7 @@ struct SourceDetailView: View {
                 queue: .extraction, wikiID: store.eventBus?.wikiID ?? "",
                 payload: QueueItemPayload(
                     sourceIDs: [file.id],
-                    stageRouting: ["backend": backend.rawValue]))
+                    stageRouting: [StageRoutingKey.backend.rawValue: backend.rawValue]))
             let itemID = try await queueEngine.enqueue(request)
             let result = await queueEngine.waitForCompletion(of: itemID)
 

--- a/Sources/WikiFSCore/ExtractionAlternative.swift
+++ b/Sources/WikiFSCore/ExtractionAlternative.swift
@@ -53,7 +53,7 @@ extension ExtractionAlternative {
         if let backend = ExtractionBackend.from(agentName: agentName) {
             return backend.displayName
         }
-        if agentName == "legacy-extraction" { return "Legacy" }
+        if agentName == ExtractionBackend.legacyAgentName { return "Legacy" }
         // Capitalize only the first character (predictable for hyphenated names
         // like "future-tool" → "Future-tool"; `.capitalized` would also upper
         // case after the hyphen).

--- a/Sources/WikiFSCore/MarkdownExtractor.swift
+++ b/Sources/WikiFSCore/MarkdownExtractor.swift
@@ -101,6 +101,14 @@ public enum ExtractionBackend: String, Sendable, CaseIterable, Codable {
         }
     }
 
+    /// The PROV `agents.name` for the pre-v21 legacy migration stub agent.
+    /// Pre-v21 rows that had inline `content` (no separate extraction) are
+    /// backfilled with a synthetic agent of this name so provenance is
+    /// consistent. `ExtractionBackend.from(agentName:)` returns `nil` for
+    /// this value (the stub has no corresponding modern backend); callers
+    /// fall back to a "Legacy" label via `ExtractionAlternative.backendDisplayName`.
+    public static let legacyAgentName = "legacy-extraction"
+
     /// The PROV `agents.name` this backend maps to (§4.7). Used by
     /// `recordMarkdownExtraction` so an extraction's provenance recovers to the
     /// backend that produced it. Stable strings, never user-facing.

--- a/Sources/WikiFSCore/QueueTypes.swift
+++ b/Sources/WikiFSCore/QueueTypes.swift
@@ -2,6 +2,15 @@ import Foundation
 
 // MARK: - Queue kinds
 
+/// Compile-time-checked keys for `QueueItemPayload.stageRouting` — the dict
+/// that threads stage-specific overrides (e.g. re-extraction backend choice)
+/// from the UI to the queue workers. Using the enum's `rawValue` instead of a
+/// bare string literal prevents typos that silently produce `nil` lookups.
+public enum StageRoutingKey: String, Sendable {
+    /// Backend override for re-extraction (value is an `ExtractionBackend.rawValue`).
+    case backend
+}
+
 /// The two persistent processing queues. Each `QueueItem` belongs to exactly
 /// one queue, and each queue has its own independent run state (running /
 /// paused) and ordering-key sequence.

--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -1765,7 +1765,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             //    reusing it if already present (idempotent for rewound DBs).
             let legacyAgentID: String
             let existing = try? statement(
-                "SELECT id FROM agents WHERE name='legacy-extraction' LIMIT 1;")
+                "SELECT id FROM agents WHERE name='\(ExtractionBackend.legacyAgentName)' LIMIT 1;")
             let found = existing.flatMap { stmt -> Bool in
                 (try? stmt.step()) ?? false
             } ?? false
@@ -1775,7 +1775,7 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             } else {
                 legacyAgentID = ULID.generate()
                 let ins = try statement(
-                    "INSERT INTO agents (id, kind, name) VALUES (?1, 'software', 'legacy-extraction');")
+                    "INSERT INTO agents (id, kind, name) VALUES (?1, 'software', '\(ExtractionBackend.legacyAgentName)');")
                 ins.reset()
                 try ins.bind(legacyAgentID, at: 1)
                 _ = try ins.step()

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -265,7 +265,7 @@ public actor ACPBackend: AgentBackend {
         // without a subprocess; here we just execute it. A bad/stale selection
         // falls back to the agent default (no setModel) — never reproduces the
         // 404 the picker exists to prevent.
-        if let selectedModelId = profile.providerHints["acpSelectedModelId"],
+        if let selectedModelId = profile.providerHints[HintKey.acpSelectedModelId.rawValue],
            !selectedModelId.isEmpty {
             let advertisedIds = modelsInfo?.availableModels.map(\.modelId) ?? []
             let decision = ACPModelSelectionResolver.resolve(
@@ -601,15 +601,17 @@ public actor ACPBackend: AgentBackend {
     /// unit-testable from `@testable import WikiFSEngine` without spawning a
     /// subprocess (`ACPWiringTests`).
     static func resolveSpawnConfig(from profile: BackendProfile) -> AgentSpawnConfig? {
-        let path = profile.providerHints["acpAgentPath"] ?? profile.model
+        let path = profile.providerHints[HintKey.acpAgentPath.rawValue] ?? profile.model
         guard let path, !path.isEmpty else { return nil }
-        let args = ShellArgv.tokenize(profile.providerHints["acpAgentArgs"] ?? "")
+        let args = ShellArgv.tokenize(profile.providerHints[HintKey.acpAgentArgs.rawValue] ?? "")
             .filter { !$0.isEmpty }
         let cwd = profile.scratchDirectory?.path
-        let apiKey = profile.providerHints["acpAgentApiKey"]
+        let apiKey = profile.providerHints[HintKey.acpAgentApiKey.rawValue]
         var environment: [String: String] = [:]
-        for (key, value) in profile.providerHints where key.hasPrefix("env.") {
-            environment[String(key.dropFirst(4))] = value
+        for (key, value) in profile.providerHints {
+            if let envKey = HintKey.envKey(from: key) {
+                environment[envKey] = value
+            }
         }
         return AgentSpawnConfig(
             executablePath: path, arguments: args, workingDirectory: cwd, apiKey: apiKey,
@@ -775,7 +777,7 @@ enum ACPBackendError: Error, LocalizedError {
         case .noAgentConfigured:
             return """
             ACPBackend requires an agent path. Set BackendProfile.providerHints\
-            ["acpAgentPath"] (or `model`) to an ACP agent executable, \
+            ["\(HintKey.acpAgentPath.rawValue)"] (or `model`) to an ACP agent executable, \
             e.g. /path/to/claude-agent-acp.
             """
         case .missingAPIKey:

--- a/Sources/WikiFSEngine/AgentBackendFactory.swift
+++ b/Sources/WikiFSEngine/AgentBackendFactory.swift
@@ -38,16 +38,16 @@ public enum AgentBackendFactory {
     ) -> [String: String] {
         guard !resolvedCommand.isEmpty else { return [:] }
         var hints: [String: String] = [:]
-        hints["acpAgentPath"] = resolvedCommand[0]
+        hints[HintKey.acpAgentPath.rawValue] = resolvedCommand[0]
         let args = resolvedCommand.dropFirst()
         if !args.isEmpty {
-            hints["acpAgentArgs"] = args.joined(separator: " ")
+            hints[HintKey.acpAgentArgs.rawValue] = args.joined(separator: " ")
         }
         if let apiKey, !apiKey.isEmpty {
-            hints["acpAgentApiKey"] = apiKey
+            hints[HintKey.acpAgentApiKey.rawValue] = apiKey
         }
         if let selectedModelId, !selectedModelId.isEmpty {
-            hints["acpSelectedModelId"] = selectedModelId
+            hints[HintKey.acpSelectedModelId.rawValue] = selectedModelId
         }
         // Phase 2 (plans/acp-multi-provider.md): thread the provider's extra
         // environment into the spawn via the established `env.`-prefix
@@ -55,7 +55,7 @@ public enum AgentBackendFactory {
         // process environment, e.g. the Phase-7 `WIKI_WORKSPACE` injection).
         // Non-secret knobs only — API keys stay in `acpAgentApiKey`/the Keychain.
         for (key, value) in provider.env {
-            hints["env.\(key)"] = value
+            hints[HintKey.env(key)] = value
         }
         return hints
     }

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -855,13 +855,13 @@ public final class AgentLauncher {
                 apiKey: acpAPIKey,
                 selectedModelId: providersConfig().selectedModelId(forProvider: provider.id))
         if let wsID = workspaceID {
-            providerHints["env.WIKI_WORKSPACE"] = wsID
+            providerHints[HintKey.env("WIKI_WORKSPACE")] = wsID
         }
         // #397: inject the author provenance into the child env so agent-written
         // pages carry created_by/last_edited_by "for free" — no agent action needed.
         // The launcher resolves it from the operation kind (one-shot runs) or the
         // chatID (interactive runs). An explicit `--author` on wikictl still wins.
-        providerHints["env.WIKI_AUTHOR"] = Self.authorForRun(kind: operation.kind, chatID: nil)
+        providerHints[HintKey.env("WIKI_AUTHOR")] = Self.authorForRun(kind: operation.kind, chatID: nil)
         let profile = BackendProfile(
             providerHints: providerHints,
             scratchDirectory: scratch,
@@ -1589,7 +1589,7 @@ public final class AgentLauncher {
                 // originating conversation (resolvable via [[chat:…]]). An explicit
                 // `--author` on `wikictl page upsert` overrides this.
                 if let chatID {
-                    hints["env.WIKI_AUTHOR"] = "\(ResourceKind.chat.linkPrefix!)\(chatID)"
+                    hints[HintKey.env("WIKI_AUTHOR")] = "\(ResourceKind.chat.linkPrefix!)\(chatID)"
                 }
                 return hints
             }(),

--- a/Sources/WikiFSEngine/HintKey.swift
+++ b/Sources/WikiFSEngine/HintKey.swift
@@ -1,0 +1,31 @@
+/// Compile-time-checked keys for `BackendProfile.providerHints` — the dict
+/// that threads ACP spawn config from `AgentBackendFactory` to
+/// `ACPBackend.resolveSpawnConfig`. Using the enum's `rawValue` instead of a
+/// bare string literal prevents typos that silently route to `nil`.
+public enum HintKey: String, Sendable {
+    /// The resolved ACP agent executable path.
+    case acpAgentPath
+    /// Extra argv for the ACP agent (joined; tokenized by the reader).
+    case acpAgentArgs
+    /// The Keychain-backed API key for the ACP agent.
+    case acpAgentApiKey
+    /// The user's per-provider model selection (threads into `session/set_model`).
+    case acpSelectedModelId
+
+    /// Prefix for environment-variable hints expanded into the child process
+    /// environment by `ACPBackend.resolveSpawnConfig`.
+    public static let envPrefix = "env."
+
+    /// Build an environment hint key, e.g. `HintKey.env("WIKI_WORKSPACE")`
+    /// → `"env.WIKI_WORKSPACE"`.
+    public static func env(_ key: String) -> String {
+        envPrefix + key
+    }
+
+    /// Strip the `env.` prefix from a hint key, returning the environment
+    /// variable name. Returns `nil` if the key does not have the prefix.
+    public static func envKey(from hintKey: String) -> String? {
+        guard hintKey.hasPrefix(envPrefix) else { return nil }
+        return String(hintKey.dropFirst(envPrefix.count))
+    }
+}

--- a/Sources/WikiFSEngine/QueueExtractionWorker.swift
+++ b/Sources/WikiFSEngine/QueueExtractionWorker.swift
@@ -39,7 +39,7 @@ public struct QueueExtractionWorkerFactory: QueueWorkerFactory {
         // backend the worker will actually use.
         guard let sourceID = item.payload.sourceIDs.first else { return nil }
 
-        let override = item.payload.stageRouting?["backend"].flatMap {
+        let override = item.payload.stageRouting?[StageRoutingKey.backend.rawValue].flatMap {
             ExtractionBackend(rawValue: $0)
         }
 
@@ -95,7 +95,7 @@ struct QueueExtractionWorker: QueueWorker {
         }
 
         // Resolve the backend override from the payload (re-extraction).
-        let backendOverride = item.payload.stageRouting?["backend"].flatMap {
+        let backendOverride = item.payload.stageRouting?[StageRoutingKey.backend.rawValue].flatMap {
             ExtractionBackend(rawValue: $0)
         }
 

--- a/Tests/WikiFSTests/ACPIngestPlanTests.swift
+++ b/Tests/WikiFSTests/ACPIngestPlanTests.swift
@@ -268,8 +268,8 @@ import ACPModel
             resolvedCommand: ["/usr/local/bin/hermes", "acp"],
             apiKey: nil,
             selectedModelId: nil)
-        #expect(hints["env.ZAI_API_KEY"] == "secretish")
-        #expect(hints["env.HERMES_MODE"] == "fast")
+        #expect(hints[HintKey.env("ZAI_API_KEY")] == "secretish")
+        #expect(hints[HintKey.env("HERMES_MODE")] == "fast")
     }
 
     /// The per-stage resolved model id (`resolvedProvider(for:).modelId`) is
@@ -283,7 +283,7 @@ import ACPModel
             resolvedCommand: ["/usr/local/bin/opencode", "acp"],
             apiKey: nil,
             selectedModelId: "anthropic/claude-sonnet")
-        #expect(hints["acpSelectedModelId"] == "anthropic/claude-sonnet")
+        #expect(hints[HintKey.acpSelectedModelId.rawValue] == "anthropic/claude-sonnet")
     }
 
     // MARK: - FakeAgentBackend recording
@@ -375,10 +375,10 @@ import ACPModel
             FakeSessionBehavior(),
         ])
 
-        let hints1 = BackendProfile(providerHints: ["acpSelectedModelId": "opus-4"])
+        let hints1 = BackendProfile(providerHints: [HintKey.acpSelectedModelId.rawValue: "opus-4"])
         _ = try await fake.start(profile: hints1, systemPrompt: "") { _ in }
 
-        let hints2 = BackendProfile(providerHints: ["acpSelectedModelId": "sonnet-4"])
+        let hints2 = BackendProfile(providerHints: [HintKey.acpSelectedModelId.rawValue: "sonnet-4"])
         _ = try await fake.start(profile: hints2, systemPrompt: "") { _ in }
 
         let recorded = await fake.startModelHints

--- a/Tests/WikiFSTests/ACPSmokeTests.swift
+++ b/Tests/WikiFSTests/ACPSmokeTests.swift
@@ -66,10 +66,10 @@ struct ACPSmokeTests {
         defer { try? FileManager.default.removeItem(at: scratch) }
 
         var hints: [String: String] = [
-            "acpAgentPath": resolvedAgentPath,
-            "acpAgentArgs": agentArgs,
+            HintKey.acpAgentPath.rawValue: resolvedAgentPath,
+            HintKey.acpAgentArgs.rawValue: agentArgs,
         ]
-        if let apiKey { hints["acpAgentApiKey"] = apiKey }
+        if let apiKey { hints[HintKey.acpAgentApiKey.rawValue] = apiKey }
 
         let profile = BackendProfile(
             model: nil,

--- a/Tests/WikiFSTests/ACPWiringTests.swift
+++ b/Tests/WikiFSTests/ACPWiringTests.swift
@@ -47,8 +47,8 @@ import ACPModel
             provider: provider,
             resolvedCommand: ["/usr/local/bin/npx", "--yes", "@agentclientprotocol/claude-agent-acp"],
             apiKey: nil)
-        #expect(hints["acpAgentPath"] == "/usr/local/bin/npx")
-        #expect(hints["acpAgentArgs"] == "--yes @agentclientprotocol/claude-agent-acp")
+        #expect(hints[HintKey.acpAgentPath.rawValue] == "/usr/local/bin/npx")
+        #expect(hints[HintKey.acpAgentArgs.rawValue] == "--yes @agentclientprotocol/claude-agent-acp")
     }
 
     /// An empty resolved command yields an empty dict (→ `ACPBackend` throws
@@ -66,7 +66,7 @@ import ACPModel
         let hints = AgentBackendFactory.providerHints(
             provider: provider, resolvedCommand: ["/bin/agent"], apiKey: nil)
         #expect(hints.count == 1)
-        #expect(hints["acpAgentPath"] == "/bin/agent")
+        #expect(hints[HintKey.acpAgentPath.rawValue] == "/bin/agent")
     }
 
     // MARK: - AgentSpawnConfig.environment (Phase 2, plans/acp-multi-provider.md)
@@ -78,10 +78,10 @@ import ACPModel
     /// process environment.
     @Test func resolveSpawnConfigCollectsEnvPrefixedHints() {
         let profile = BackendProfile(providerHints: [
-            "acpAgentPath": "/usr/local/bin/hermes",
-            "acpAgentArgs": "acp",
-            "env.ZAI_API_KEY": "secretish",
-            "env.HERMES_MODE": "fast",
+            HintKey.acpAgentPath.rawValue: "/usr/local/bin/hermes",
+            HintKey.acpAgentArgs.rawValue: "acp",
+            HintKey.env("ZAI_API_KEY"): "secretish",
+            HintKey.env("HERMES_MODE"): "fast",
         ])
         let spawn = ACPBackend.resolveSpawnConfig(from: profile)
         #expect(spawn?.executablePath == "/usr/local/bin/hermes")
@@ -91,7 +91,7 @@ import ACPModel
     /// No `env.`-prefixed hints → empty environment (no merge, unchanged
     /// behavior for providers with no extra env).
     @Test func resolveSpawnConfigEmptyEnvironmentWhenUnconfigured() {
-        let profile = BackendProfile(providerHints: ["acpAgentPath": "/bin/agent"])
+        let profile = BackendProfile(providerHints: [HintKey.acpAgentPath.rawValue: "/bin/agent"])
         let spawn = ACPBackend.resolveSpawnConfig(from: profile)
         #expect(spawn?.environment.isEmpty == true)
     }

--- a/Tests/WikiFSTests/AgentProviderModelPickerTests.swift
+++ b/Tests/WikiFSTests/AgentProviderModelPickerTests.swift
@@ -227,8 +227,8 @@ import WikiFSCore
             resolvedCommand: ["/usr/local/bin/hermes", "acp"],
             apiKey: "secret",
             selectedModelId: "glm-4.7")
-        #expect(hints["acpSelectedModelId"] == "glm-4.7")
-        #expect(hints["acpAgentPath"] == "/usr/local/bin/hermes")
+        #expect(hints[HintKey.acpSelectedModelId.rawValue] == "glm-4.7")
+        #expect(hints[HintKey.acpAgentPath.rawValue] == "/usr/local/bin/hermes")
     }
 
     @Test func providerHintsOmitsSelectedModelIdWhenNil() {
@@ -238,7 +238,7 @@ import WikiFSCore
             resolvedCommand: ["/usr/local/bin/hermes", "acp"],
             apiKey: nil,
             selectedModelId: nil)
-        #expect(hints["acpSelectedModelId"] == nil)
+        #expect(hints[HintKey.acpSelectedModelId.rawValue] == nil)
     }
 
     @Test func providerHintsEmptyWhenCommandUnresolved() {

--- a/Tests/WikiFSTests/AgentProviderModelTests.swift
+++ b/Tests/WikiFSTests/AgentProviderModelTests.swift
@@ -276,9 +276,9 @@ import ACPModel
             provider: provider,
             resolvedCommand: ["/usr/local/bin/gemini", "--acp"],
             apiKey: "secret")
-        #expect(hints["acpAgentPath"] == "/usr/local/bin/gemini")
-        #expect(hints["acpAgentArgs"] == "--acp")
-        #expect(hints["acpAgentApiKey"] == "secret")
+        #expect(hints[HintKey.acpAgentPath.rawValue] == "/usr/local/bin/gemini")
+        #expect(hints[HintKey.acpAgentArgs.rawValue] == "--acp")
+        #expect(hints[HintKey.acpAgentApiKey.rawValue] == "secret")
     }
 
     @Test func providerHintsEmptyForCLIProvider() {
@@ -305,7 +305,7 @@ import ACPModel
             provider: provider,
             resolvedCommand: ["/usr/local/bin/gemini", "--acp"],
             apiKey: nil)
-        #expect(hints["acpAgentApiKey"] == nil)
+        #expect(hints[HintKey.acpAgentApiKey.rawValue] == nil)
     }
 }
 

--- a/Tests/WikiFSTests/FakeAgentBackend.swift
+++ b/Tests/WikiFSTests/FakeAgentBackend.swift
@@ -89,7 +89,7 @@ actor FakeAgentBackend: AgentBackend {
             : FakeSessionBehavior()
         behaviorIndex += 1
 
-        startModelHints.append(profile.providerHints["acpSelectedModelId"])
+        startModelHints.append(profile.providerHints[HintKey.acpSelectedModelId.rawValue])
 
         if behavior.shouldFailOnStart {
             throw FakeBackendError.startFailed

--- a/Tests/WikiFSTests/ProcessedMarkdownTests.swift
+++ b/Tests/WikiFSTests/ProcessedMarkdownTests.swift
@@ -572,7 +572,7 @@ struct ProcessedMarkdownTests {
                == "Claude (Anthropic API)")
         #expect(ExtractionAlternative.backendDisplayName(agentName: "pdf2md")
                == "Local pdf2md")
-        #expect(ExtractionAlternative.backendDisplayName(agentName: "legacy-extraction")
+        #expect(ExtractionAlternative.backendDisplayName(agentName: ExtractionBackend.legacyAgentName)
                == "Legacy")
         #expect(ExtractionAlternative.backendDisplayName(agentName: "future-tool")
                == "Future-tool")
@@ -584,7 +584,7 @@ struct ProcessedMarkdownTests {
         #expect(ExtractionBackend.from(agentName: "gemini") == .gemini)
         #expect(ExtractionBackend.from(agentName: "pdf2md") == .localPdf2md)
         #expect(ExtractionBackend.from(agentName: "docling-serve") == .doclingServe)
-        #expect(ExtractionBackend.from(agentName: "legacy-extraction") == nil)
+        #expect(ExtractionBackend.from(agentName: ExtractionBackend.legacyAgentName) == nil)
         #expect(ExtractionBackend.from(agentName: "nope") == nil)
     }
 

--- a/Tests/WikiFSTests/QueueExtractionTests.swift
+++ b/Tests/WikiFSTests/QueueExtractionTests.swift
@@ -349,7 +349,7 @@ struct QueueExtractionTests {
         // Enqueue with a backend override in the payload's stageRouting.
         let payload = QueueItemPayload(
             sourceIDs: [PageID(rawValue: "SRC1")],
-            stageRouting: ["backend": "anthropic"])
+            stageRouting: [StageRoutingKey.backend.rawValue: "anthropic"])
         _ = try await engine.enqueue(
             QueueItemRequest(queue: .extraction, wikiID: "wiki1", payload: payload))
 

--- a/pr-body-509.md
+++ b/pr-body-509.md
@@ -1,0 +1,38 @@
+## Summary
+
+Fixes #509 — two typing gaps in the agent launch configuration layer.
+
+### R7: Route `legacy-extraction` through `ExtractionBackend.legacyAgentName`
+
+The raw `"legacy-extraction"` agent-name literal was duplicated outside the `ExtractionBackend` enum at multiple call sites. Added a single `ExtractionBackend.legacyAgentName` constant and routed all checks through it.
+
+**Changed sites:**
+- `ExtractionBackend.legacyAgentName` constant added to `MarkdownExtractor.swift`
+- `ExtractionAlternative.backendDisplayName(agentName:)` — uses the constant instead of raw string
+- `SourceDetailView.swift` — removed duplicate `backendDisplayName(forAgent:)` method (it duplicated `ExtractionAlternative.backendDisplayName`); both call sites now delegate to the canonical implementation
+- `SQLiteWikiStore.swift` — SQL literals now interpolate the constant
+
+### R8: Typed `HintKey` + `StageRoutingKey` enums for magic string keys
+
+`BackendProfile.providerHints` and `QueueItemPayload.stageRouting` used bare string-literal keys (`"acpAgentPath"`, `"acpAgentArgs"`, `"acpAgentApiKey"`, `"acpSelectedModelId"`, `"env." + key`, `"backend"`) that were not compile-time-checked.
+
+**New types:**
+- `HintKey` enum (`Sources/WikiFSEngine/HintKey.swift`) — cases for `acpAgentPath`, `acpAgentArgs`, `acpAgentApiKey`, `acpSelectedModelId`, plus `env(_:)` builder and `envKey(from:)` extractor for the `env.<key>` dynamic form
+- `StageRoutingKey` enum (`Sources/WikiFSCore/QueueTypes.swift`) — `backend` case for re-extraction override
+
+**Changed sites:**
+- `AgentBackendFactory.providerHints` — writes via `HintKey`
+- `ACPBackend.resolveSpawnConfig` — reads via `HintKey` (including `envKey(from:)` for env-prefix extraction)
+- `ACPBackend.start` — reads `acpSelectedModelId` via `HintKey`
+- `ACPBackendError.noAgentConfigured` — error message interpolates `HintKey`
+- `AgentLauncher` — `env.WIKI_WORKSPACE` and `env.WIKI_AUTHOR` writes via `HintKey.env(_:)`
+- `QueueExtractionWorker` — `stageRouting?["backend"]` via `StageRoutingKey.backend.rawValue`
+- `SourceDetailView` — `["backend": ...]` via `StageRoutingKey.backend.rawValue`
+
+All test files referencing these string keys also updated to use the typed enums.
+
+## Test plan
+
+- [x] `swift build` passes
+- [x] Fast test tier passes (2444 tests):
+      `swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'`


### PR DESCRIPTION
## Summary

Fixes #509 — two typing gaps in the agent launch configuration layer.

### R7: Route `legacy-extraction` through `ExtractionBackend.legacyAgentName`

The raw `"legacy-extraction"` agent-name literal was duplicated outside the `ExtractionBackend` enum at multiple call sites. Added a single `ExtractionBackend.legacyAgentName` constant and routed all checks through it.

**Changed sites:**
- `ExtractionBackend.legacyAgentName` constant added to `MarkdownExtractor.swift`
- `ExtractionAlternative.backendDisplayName(agentName:)` — uses the constant instead of raw string
- `SourceDetailView.swift` — removed duplicate `backendDisplayName(forAgent:)` method (it duplicated `ExtractionAlternative.backendDisplayName`); both call sites now delegate to the canonical implementation
- `SQLiteWikiStore.swift` — SQL literals now interpolate the constant

### R8: Typed `HintKey` + `StageRoutingKey` enums for magic string keys

`BackendProfile.providerHints` and `QueueItemPayload.stageRouting` used bare string-literal keys (`"acpAgentPath"`, `"acpAgentArgs"`, `"acpAgentApiKey"`, `"acpSelectedModelId"`, `"env." + key`, `"backend"`) that were not compile-time-checked.

**New types:**
- `HintKey` enum (`Sources/WikiFSEngine/HintKey.swift`) — cases for `acpAgentPath`, `acpAgentArgs`, `acpAgentApiKey`, `acpSelectedModelId`, plus `env(_:)` builder and `envKey(from:)` extractor for the `env.<key>` dynamic form
- `StageRoutingKey` enum (`Sources/WikiFSCore/QueueTypes.swift`) — `backend` case for re-extraction override

**Changed sites:**
- `AgentBackendFactory.providerHints` — writes via `HintKey`
- `ACPBackend.resolveSpawnConfig` — reads via `HintKey` (including `envKey(from:)` for env-prefix extraction)
- `ACPBackend.start` — reads `acpSelectedModelId` via `HintKey`
- `ACPBackendError.noAgentConfigured` — error message interpolates `HintKey`
- `AgentLauncher` — `env.WIKI_WORKSPACE` and `env.WIKI_AUTHOR` writes via `HintKey.env(_:)`
- `QueueExtractionWorker` — `stageRouting?["backend"]` via `StageRoutingKey.backend.rawValue`
- `SourceDetailView` — `["backend": ...]` via `StageRoutingKey.backend.rawValue`

All test files referencing these string keys also updated to use the typed enums.

## Test plan

- [x] `swift build` passes
- [x] Fast test tier passes (2444 tests):
      `swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'`
