### PR TITLE
Fix #511: Unify duplicate link-map computation via shared WikiLinkIndex builder

### DIFF
--- a/Sources/WikiFSCore/WikiLinkIndex.swift
+++ b/Sources/WikiFSCore/WikiLinkIndex.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+// MARK: - WikiLinkIndex
+
+/// Pure-data snapshot of all linkable entities (pages, sources, chats) with
+/// pre-computed normalization maps, built once from pre-fetched rows.
+///
+/// Both `WikiRenderContext.build` (the in-app reader) and
+/// `Projection.makeLinkMaps` (the File Provider projection) derive their own
+/// shape from this shared core — the former builds existence sets and
+/// `id → name` dicts, the latter builds `name → Target` and
+/// `id → Target` dicts. Centralizing the iteration and normalization here
+/// eliminates duplicate computation and ensures the two consumers apply the
+/// same `WikiNameRules.looseMatchKey` / ext-stripping rules (issue #511).
+///
+/// **Threading.** The builder is a pure function over value-type entries —
+/// no store access, no actor isolation. Each caller fetches rows on its own
+/// thread/actor (main actor for `WikiRenderContext`, the File Provider's read
+/// store for `Projection`) and passes the pre-fetched data here.
+public struct WikiLinkIndex: Sendable, Equatable {
+
+    // MARK: - Entry types
+
+    /// A page's link-relevant fields.
+    public struct PageEntry: Sendable, Equatable {
+        public let id: String
+        public let title: String
+
+        public init(id: String, title: String) {
+            self.id = id
+            self.title = title
+        }
+    }
+
+    /// A source's link-relevant fields.
+    public struct SourceEntry: Sendable, Equatable {
+        public let id: String
+        public let filename: String
+        /// Lowercased extension with no leading dot (`""` when the name has none).
+        public let ext: String
+        /// Best-effort MIME type; `nil` when unknown.
+        public let mime: String?
+        /// User-editable display name; `nil` falls back to `filename`.
+        public let displayName: String?
+
+        /// The name used for link resolution: display name if set, else filename.
+        public var humanName: String { displayName ?? filename }
+
+        public init(id: String, filename: String, ext: String,
+                    mime: String?, displayName: String?) {
+            self.id = id
+            self.filename = filename
+            self.ext = ext
+            self.mime = mime
+            self.displayName = displayName
+        }
+    }
+
+    /// A chat's link-relevant fields.
+    public struct ChatEntry: Sendable, Equatable {
+        public let id: String
+        public let title: String
+
+        public init(id: String, title: String) {
+            self.id = id
+            self.title = title
+        }
+    }
+
+    // MARK: - Raw entries
+
+    /// All pages, in store iteration order (ULID-ascending).
+    public let pages: [PageEntry]
+    /// All sources, in store iteration order.
+    public let sources: [SourceEntry]
+    /// All chats, in store iteration order.
+    public let chats: [ChatEntry]
+
+    // MARK: - Pre-computed shared maps
+
+    /// Lowercased source name variants (displayName, filename, and each with
+    /// the path extension stripped) — the exact-match existence tier for the
+    /// in-app reader's `isResolved` closure. Mirrors the variants the reader
+    /// historically built inline.
+    public let sourceLowerNameVariants: Set<String>
+
+    /// Collision-free `looseMatchKey → humanName` map for sources. A key that
+    /// two or more sources share is omitted (ambiguous → no match), mirroring
+    /// `resolveSourceByName` pass 3 (unique-only constraint).
+    ///
+    /// The in-app reader derives `uniqueLooseKeys` as `Set(sourceByLooseKey.keys)`.
+    /// The File Provider maps each humanName to its `RelativeLinkRewriter.Target`.
+    public let sourceByLooseKey: [String: String]
+
+    /// Collision-free `looseMatchKey → title` map for chats (same collision
+    /// rule as `sourceByLooseKey`). The File Provider uses this for loose chat
+    /// resolution; the in-app reader currently does not.
+    public let chatByLooseKey: [String: String]
+
+    /// Sibling-image maps: `sourceID → [originalPath → sibling sourceID]`.
+    /// Both consumers consult these to rewrite relative image `src` attributes
+    /// inside a source's own markdown.
+    public let siblingImages: [PageID: [String: PageID]]
+
+    // MARK: - Derived
+
+    /// Loose-match keys unique across sources — the lenient tier mirroring
+    /// `resolveSourceByName` pass 3. Equivalent to `Set(sourceByLooseKey.keys)`
+    /// since a collision-free key is, by construction, unique.
+    public var uniqueSourceLooseKeys: Set<String> {
+        Set(sourceByLooseKey.keys)
+    }
+
+    // MARK: - Init
+
+    /// Initialize with pre-built entries and pre-computed maps. Prefer
+    /// ``WikiLinkIndex/build(pages:sources:chats:siblingImages:)`` which
+    /// constructs the maps from the entries.
+    public init(
+        pages: [PageEntry],
+        sources: [SourceEntry],
+        chats: [ChatEntry],
+        sourceLowerNameVariants: Set<String>,
+        sourceByLooseKey: [String: String],
+        chatByLooseKey: [String: String],
+        siblingImages: [PageID: [String: PageID]]
+    ) {
+        self.pages = pages
+        self.sources = sources
+        self.chats = chats
+        self.sourceLowerNameVariants = sourceLowerNameVariants
+        self.sourceByLooseKey = sourceByLooseKey
+        self.chatByLooseKey = chatByLooseKey
+        self.siblingImages = siblingImages
+    }
+
+    // MARK: - Build (pure)
+
+    /// Build a `WikiLinkIndex` from pre-fetched rows. Pure — performs no store
+    /// access. Both `WikiRenderContext.build` and `Projection.makeLinkMaps`
+    /// call this to share the normalization computation, then adapt the output
+    /// to their own `Target` / existence-set shapes.
+    public static func build(
+        pages: [PageEntry],
+        sources: [SourceEntry],
+        chats: [ChatEntry],
+        siblingImages: [PageID: [String: PageID]]
+    ) -> WikiLinkIndex {
+        // Lowercased source name variants (displayName, filename, ext-stripped).
+        // Mirrors resolveSourceByName's fallback so a [[source:Paper]] link also
+        // resolves against a source whose filename is "Paper.pdf".
+        var sourceLowerNameVariants = Set<String>()
+        for source in sources {
+            let names = [source.displayName, source.filename].compactMap { $0 }
+            let stripped = names.map { ($0 as NSString).deletingPathExtension }
+            for name in (names + stripped).map({ $0.lowercased() }) {
+                sourceLowerNameVariants.insert(name)
+            }
+        }
+
+        // Source loose-key map: collision-free (unique-only), mirroring
+        // resolveSourceByName pass 3 (unique-only).
+        var sourceByLooseKey: [String: String] = [:]
+        var seenSourceKeys = Set<String>()
+        for source in sources {
+            let key = WikiNameRules.looseMatchKey(source.humanName)
+            if seenSourceKeys.contains(key) {
+                sourceByLooseKey.removeValue(forKey: key)   // collision → ambiguous
+            } else {
+                seenSourceKeys.insert(key)
+                sourceByLooseKey[key] = source.humanName
+            }
+        }
+
+        // Chat loose-key map: same collision rule.
+        var chatByLooseKey: [String: String] = [:]
+        var seenChatKeys = Set<String>()
+        for chat in chats {
+            let key = WikiNameRules.looseMatchKey(chat.title)
+            if seenChatKeys.contains(key) {
+                chatByLooseKey.removeValue(forKey: key)
+            } else {
+                seenChatKeys.insert(key)
+                chatByLooseKey[key] = chat.title
+            }
+        }
+
+        return WikiLinkIndex(
+            pages: pages,
+            sources: sources,
+            chats: chats,
+            sourceLowerNameVariants: sourceLowerNameVariants,
+            sourceByLooseKey: sourceByLooseKey,
+            chatByLooseKey: chatByLooseKey,
+            siblingImages: siblingImages
+        )
+    }
+}

--- a/Sources/WikiFSCore/WikiRenderContext.swift
+++ b/Sources/WikiFSCore/WikiRenderContext.swift
@@ -128,34 +128,40 @@ public struct WikiRenderContext: Sendable {
     /// render task — the derived closures never touch the store.
     @MainActor
     public static func build(from store: WikiStoreModel) -> WikiRenderContext {
-        // --- Existence sets (reader lines ~820–846) ---
-        let pageTitles = Set(store.summaries.map { $0.title.lowercased() })
-        let pageIDToName = Dictionary(
-            uniqueKeysWithValues: store.summaries.map { ($0.id, $0.title) })
+        // Build the shared link index from the model's already-fetched rows.
+        // Centralizes source name-variant / loose-key / sibling-image
+        // computation so this and Projection.makeLinkMaps agree on normalization
+        // (#511). Each consumer then adapts the neutral entries to its own shape.
+        let index = WikiLinkIndex.build(
+            pages: store.summaries.map {
+                WikiLinkIndex.PageEntry(id: $0.id.rawValue, title: $0.title) },
+            sources: store.sources.map {
+                WikiLinkIndex.SourceEntry(
+                    id: $0.id.rawValue, filename: $0.filename, ext: $0.ext,
+                    mime: $0.mimeType, displayName: $0.displayName) },
+            chats: store.chats.map {
+                WikiLinkIndex.ChatEntry(id: $0.id.rawValue, title: $0.title) },
+            siblingImages: store.siblingImageResolvers())
 
-        let sourceNames = Set(store.sources.flatMap { source -> [String] in
-            let names = [source.displayName, source.filename].compactMap { $0 }
-            let stripped = names.map { ($0 as NSString).deletingPathExtension }
-            return (names + stripped).map { $0.lowercased() }
-        })
+        // --- Existence sets + id→name dicts (derived from the shared index) ---
+        let pageTitles = Set(index.pages.map { $0.title.lowercased() })
+        let pageIDToName = Dictionary(
+            uniqueKeysWithValues:
+                index.pages.map { (PageID(rawValue: $0.id), $0.title) })
+
+        let sourceNames = index.sourceLowerNameVariants
         let sourceIDToName = Dictionary(
             uniqueKeysWithValues:
-                store.sources.map { ($0.id, $0.displayName ?? $0.filename) })
+                index.sources.map { (PageID(rawValue: $0.id), $0.humanName) })
 
-        let chatTitles = Set(store.chats.map { $0.title.lowercased() })
+        let chatTitles = Set(index.chats.map { $0.title.lowercased() })
         let chatIDToName = Dictionary(
-            uniqueKeysWithValues: store.chats.map { ($0.id, $0.title) })
+            uniqueKeysWithValues:
+                index.chats.map { (PageID(rawValue: $0.id), $0.title) })
 
-        // Lenient tier mirroring resolveSourceByName pass 3: loose keys
-        // (extension + trailing "(…)" stripped) UNIQUE across sources.
-        var looseKeyCounts: [String: Int] = [:]
-        for source in store.sources {
-            let effective = source.displayName ?? source.filename
-            looseKeyCounts[WikiNameRules.looseMatchKey(effective), default: 0] += 1
-        }
-        let uniqueLooseKeys = Set(looseKeyCounts.filter { $0.value == 1 }.keys)
+        let uniqueLooseKeys = index.uniqueSourceLooseKeys
 
-        // --- Embed map (reader lines ~848–873) ---
+        // --- Embed map (reader lines ~848–873; WRC-specific — per-source) ---
         let embedDescriptorMap = store.embedDescriptors()
         var embedMap: [String: WikiLinkMarkdown.SourceEmbedInfo] = [:]
         for source in store.sources {
@@ -171,9 +177,9 @@ public struct WikiRenderContext: Sendable {
             embedMap[source.id.rawValue.lowercased()] = info
         }
 
-        // --- Phase 6 chain + Phase 4 sibling maps ---
+        // --- Phase 6 chain + Phase 4 sibling maps (WRC-specific) ---
         let sourceDerivedChain = store.sourceDerivedChains()
-        let siblingMaps = store.siblingImageResolvers()
+        let siblingMaps = index.siblingImages
 
         return WikiRenderContext(
             pageTitles: pageTitles,

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -1363,44 +1363,66 @@ struct Projection {
     private func makeLinkMaps() -> LinkMaps {
         let store = openReadStore()
 
+        // Build the shared link index from pre-fetched rows. Centralizes source
+        // name-variant / loose-key / sibling-image computation so this and
+        // WikiRenderContext.build agree on normalization (#511). The index is
+        // a neutral intermediate; we adapt its entries to RelativeLinkRewriter
+        // .Target below — the file-path logic is Projection-specific.
+        let siblingImages = (try? store?.siblingImageResolvers()) ?? [:]
+        let index = WikiLinkIndex.build(
+            pages: ((try? store?.listAllPagesOrderedByID()) ?? []).map {
+                WikiLinkIndex.PageEntry(id: $0.id.rawValue, title: $0.title) },
+            sources: ((try? store?.listAllSourcesOrderedByID()) ?? []).map {
+                WikiLinkIndex.SourceEntry(
+                    id: $0.id, filename: $0.filename, ext: $0.ext,
+                    mime: $0.mime, displayName: $0.displayName) },
+            chats: ((try? store?.listAllChatsOrderedByID()) ?? []).map {
+                WikiLinkIndex.ChatEntry(id: $0.id.rawValue, title: $0.title) },
+            siblingImages: siblingImages)
+
+        // Heads map — Projection-specific: determines whether each source
+        // target points at the readable .md sibling or the raw verbatim file.
+        let heads = (try? store?.processedMarkdownHeadsBySource()) ?? [:]
+
         var pageByTitle: [String: RelativeLinkRewriter.Target] = [:]
         var pageByID: [String: RelativeLinkRewriter.Target] = [:]
-        for page in (try? store?.listAllPagesOrderedByID()) ?? [] {
-            let file = FilenameEscaping.byTitleFilename(title: page.title, pageID: page.id.rawValue)
-            let target = RelativeLinkRewriter.Target(path: Self.pagesByTitleDir + [file], title: page.title)
-            pageByTitle[page.title] = target
-            pageByID[page.id.rawValue.uppercased()] = target
+        for entry in index.pages {
+            let file = FilenameEscaping.byTitleFilename(title: entry.title, pageID: entry.id)
+            let target = RelativeLinkRewriter.Target(path: Self.pagesByTitleDir + [file], title: entry.title)
+            pageByTitle[entry.title] = target
+            pageByID[entry.id.uppercased()] = target
         }
 
         var sourceByName: [String: RelativeLinkRewriter.Target] = [:]
         var sourceByID: [String: RelativeLinkRewriter.Target] = [:]
-        let heads = (try? store?.processedMarkdownHeadsBySource()) ?? [:]
-        for row in (try? store?.listAllSourcesOrderedByID()) ?? [] {
-            let humanName = row.displayName ?? row.filename
+        for entry in index.sources {
             // Sibling eligibility mirrors `sourceNodes`: a processed head AND a
             // non-`text/*` mime yields the `.md` sibling; otherwise the verbatim file.
-            let hasSibling = heads[row.id] != nil && (row.mime.map { !$0.hasPrefix("text/") } ?? false)
+            let hasSibling = heads[entry.id] != nil
+                && (entry.mime.map { !$0.hasPrefix("text/") } ?? false)
             let file = hasSibling
-                ? FilenameEscaping.byNameSourceFilename(filename: humanName, ext: "md", sourceID: row.id)
-                : FilenameEscaping.byNameSourceFilename(filename: humanName, ext: row.ext, sourceID: row.id)
-            let target = RelativeLinkRewriter.Target(path: Self.sourcesByNameDir + [file], title: humanName)
-            sourceByName[humanName] = target
-            sourceByID[row.id.uppercased()] = target
+                ? FilenameEscaping.byNameSourceFilename(filename: entry.humanName, ext: "md", sourceID: entry.id)
+                : FilenameEscaping.byNameSourceFilename(filename: entry.humanName, ext: entry.ext, sourceID: entry.id)
+            let target = RelativeLinkRewriter.Target(path: Self.sourcesByNameDir + [file], title: entry.humanName)
+            sourceByName[entry.humanName] = target
+            sourceByID[entry.id.uppercased()] = target
         }
 
         var chatByTitle: [String: RelativeLinkRewriter.Target] = [:]
         var chatByID: [String: RelativeLinkRewriter.Target] = [:]
-        for chat in (try? store?.listAllChatsOrderedByID()) ?? [] {
-            let file = FilenameEscaping.byTitleFilename(title: chat.title, pageID: chat.id.rawValue)
-            let target = RelativeLinkRewriter.Target(path: Self.chatsByNameDir + [file], title: chat.title)
-            chatByTitle[chat.title] = target
-            chatByID[chat.id.rawValue.uppercased()] = target
+        for entry in index.chats {
+            let file = FilenameEscaping.byTitleFilename(title: entry.title, pageID: entry.id)
+            let target = RelativeLinkRewriter.Target(path: Self.chatsByNameDir + [file], title: entry.title)
+            chatByTitle[entry.title] = target
+            chatByID[entry.id.uppercased()] = target
         }
 
-        let siblingImages = (try? store?.siblingImageResolvers()) ?? [:]
-
-        let sourceByLooseKey = Self.buildLooseKeyMap(sourceByName)
-        let chatByLooseKey   = Self.buildLooseKeyMap(chatByTitle)
+        // Loose-key maps: adapt from the shared index's collision-free
+        // looseMatchKey → name maps. Each name is guaranteed to be a key in
+        // the corresponding name → Target dict above (both were built from the
+        // same entries), so compactMapValues never drops a valid entry.
+        let sourceByLooseKey = index.sourceByLooseKey.compactMapValues { sourceByName[$0] }
+        let chatByLooseKey = index.chatByLooseKey.compactMapValues { chatByTitle[$0] }
 
         return LinkMaps(pageByTitle: pageByTitle, pageByID: pageByID,
                         sourceByName: sourceByName, sourceByID: sourceByID,
@@ -1408,26 +1430,6 @@ struct Projection {
                         siblingImages: siblingImages,
                         sourceByLooseKey: sourceByLooseKey,
                         chatByLooseKey: chatByLooseKey)
-    }
-
-    /// Build a loose-key → target map from a name → target dict. Collisions
-    /// (two names with the same `WikiNameRules.looseMatchKey`) are omitted,
-    /// matching the store's `resolveSourceByName` pass-3 unique-only constraint
-    /// — an ambiguous match resolves to nothing rather than picking arbitrarily.
-    private static func buildLooseKeyMap(_ entries: [String: RelativeLinkRewriter.Target])
-        -> [String: RelativeLinkRewriter.Target] {
-        var out: [String: RelativeLinkRewriter.Target] = [:]
-        var seen = Set<String>()
-        for (name, target) in entries {
-            let key = WikiNameRules.looseMatchKey(name)
-            if seen.contains(key) {
-                out.removeValue(forKey: key)   // collision → ambiguous, remove
-            } else {
-                seen.insert(key)
-                out[key] = target
-            }
-        }
-        return out
     }
 
     /// Rewrite `[[wikilinks]]` in `raw` to relative Markdown links, computing

--- a/Tests/WikiFSTests/WikiLinkIndexTests.swift
+++ b/Tests/WikiFSTests/WikiLinkIndexTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Unit tests for the shared `WikiLinkIndex` builder (#511).
+/// The builder is a pure function over pre-fetched entries — no store access —
+/// so these tests exercise it directly without a SQLite database.
+struct WikiLinkIndexTests {
+
+    // MARK: - Entry construction + pass-through
+
+    @Test func entriesArePreservedInOrder() {
+        let index = WikiLinkIndex.build(
+            pages: [
+                .init(id: "01AAA", title: "Home"),
+                .init(id: "01BBB", title: "About"),
+            ],
+            sources: [
+                .init(id: "01SRC", filename: "Paper.pdf", ext: "pdf",
+                      mime: "application/pdf", displayName: "My Paper"),
+            ],
+            chats: [
+                .init(id: "01CHT", title: "Discussion"),
+            ],
+            siblingImages: [:]
+        )
+        #expect(index.pages.count == 2)
+        #expect(index.pages[0].title == "Home")
+        #expect(index.pages[1].title == "About")
+        #expect(index.sources.count == 1)
+        #expect(index.sources[0].humanName == "My Paper")
+        #expect(index.chats.count == 1)
+        #expect(index.chats[0].title == "Discussion")
+    }
+
+    @Test func emptyInputsProduceEmptyIndex() {
+        let index = WikiLinkIndex.build(
+            pages: [], sources: [], chats: [], siblingImages: [:])
+        #expect(index.pages.isEmpty)
+        #expect(index.sources.isEmpty)
+        #expect(index.chats.isEmpty)
+        #expect(index.sourceLowerNameVariants.isEmpty)
+        #expect(index.sourceByLooseKey.isEmpty)
+        #expect(index.chatByLooseKey.isEmpty)
+        #expect(index.siblingImages.isEmpty)
+        #expect(index.uniqueSourceLooseKeys.isEmpty)
+    }
+
+    @Test func siblingImagesArePassedThrough() {
+        let sib: [PageID: [String: PageID]] = [
+            PageID(rawValue: "01SRC"): ["img/photo.jpg": PageID(rawValue: "02SIB")]
+        ]
+        let index = WikiLinkIndex.build(
+            pages: [], sources: [], chats: [], siblingImages: sib)
+        #expect(index.siblingImages == sib)
+    }
+
+    // MARK: - Source name variants
+
+    @Test func sourceNameVariantsIncludeDisplayNameFilenameAndExtStripped() {
+        let index = WikiLinkIndex.build(
+            pages: [],
+            sources: [
+                .init(id: "01", filename: "Paper.pdf", ext: "pdf",
+                      mime: "application/pdf", displayName: "My Paper"),
+            ],
+            chats: [],
+            siblingImages: [:])
+        // displayName "My Paper" → lowercased "my paper"
+        #expect(index.sourceLowerNameVariants.contains("my paper"))
+        // filename "Paper.pdf" → lowercased "paper.pdf" + ext-stripped "paper"
+        #expect(index.sourceLowerNameVariants.contains("paper.pdf"))
+        #expect(index.sourceLowerNameVariants.contains("paper"))
+    }
+
+    @Test func sourceNameVariantsWhenDisplayNameIsNil() {
+        let index = WikiLinkIndex.build(
+            pages: [],
+            sources: [
+                .init(id: "01", filename: "Doc.txt", ext: "txt",
+                      mime: "text/plain", displayName: nil),
+            ],
+            chats: [],
+            siblingImages: [:])
+        // Only filename "Doc.txt" → "doc.txt" + ext-stripped "doc"
+        // No displayName variants (nil is skipped by compactMap)
+        #expect(index.sourceLowerNameVariants.contains("doc.txt"))
+        #expect(index.sourceLowerNameVariants.contains("doc"))
+        #expect(!index.sourceLowerNameVariants.contains("doc.txt".uppercased()))
+    }
+
+    // MARK: - Loose-key maps (sources)
+
+    @Test func uniqueSourceLooseKeyIsIncluded() {
+        let index = WikiLinkIndex.build(
+            pages: [],
+            sources: [
+                .init(id: "01", filename: "Unique Paper.pdf", ext: "pdf",
+                      mime: nil, displayName: nil),
+            ],
+            chats: [],
+            siblingImages: [:])
+        let key = WikiNameRules.looseMatchKey("Unique Paper.pdf")
+        #expect(index.sourceByLooseKey[key] == "Unique Paper.pdf")
+        #expect(index.uniqueSourceLooseKeys.contains(key))
+    }
+
+    @Test func collidingSourceLooseKeysAreOmitted() {
+        // Two sources whose loose keys collide (different names, same loose key).
+        let index = WikiLinkIndex.build(
+            pages: [],
+            sources: [
+                .init(id: "01", filename: "Paper.pdf", ext: "pdf",
+                      mime: nil, displayName: "Some Paper (2020)"),
+                .init(id: "02", filename: "paper.docx", ext: "docx",
+                      mime: nil, displayName: "Some Paper (2021)"),
+            ],
+            chats: [],
+            siblingImages: [:])
+        // Both names normalize to the same loose key → collision → omitted.
+        let key = WikiNameRules.looseMatchKey("Some Paper (2020)")
+        #expect(index.sourceByLooseKey[key] == nil)
+        #expect(!index.uniqueSourceLooseKeys.contains(key))
+    }
+
+    @Test func uniqueSourceLooseKeysEqualsSourceByLooseKeyKeys() {
+        // The unique set is, by construction, the keys of the collision-free map.
+        let index = WikiLinkIndex.build(
+            pages: [],
+            sources: [
+                .init(id: "01", filename: "Alpha.pdf", ext: "pdf",
+                      mime: nil, displayName: nil),
+                .init(id: "02", filename: "Beta.md", ext: "md",
+                      mime: nil, displayName: nil),
+                .init(id: "03", filename: "Gamma.txt", ext: "txt",
+                      mime: nil, displayName: nil),
+            ],
+            chats: [],
+            siblingImages: [:])
+        #expect(index.uniqueSourceLooseKeys == Set(index.sourceByLooseKey.keys))
+    }
+
+    // MARK: - Loose-key maps (chats)
+
+    @Test func uniqueChatLooseKeyIsIncluded() {
+        let index = WikiLinkIndex.build(
+            pages: [], sources: [],
+            chats: [.init(id: "01", title: "My Discussion")],
+            siblingImages: [:])
+        let key = WikiNameRules.looseMatchKey("My Discussion")
+        #expect(index.chatByLooseKey[key] == "My Discussion")
+    }
+
+    @Test func collidingChatLooseKeysAreOmitted() {
+        let index = WikiLinkIndex.build(
+            pages: [], sources: [],
+            chats: [
+                .init(id: "01", title: "Talk (2026)"),
+                .init(id: "02", title: "Talk (2025)"),
+            ],
+            siblingImages: [:])
+        let key = WikiNameRules.looseMatchKey("Talk (2026)")
+        #expect(index.chatByLooseKey[key] == nil)
+    }
+
+    // MARK: - Consistency with WRC and Projection shapes
+
+    @Test func sourceByLooseKeyValuesAreHumanNames() {
+        // The loose-key map values must be humanNames so the Projection adapter
+        // can look up the Target via sourceByName[humanName].
+        let index = WikiLinkIndex.build(
+            pages: [],
+            sources: [
+                .init(id: "01", filename: "file.pdf", ext: "pdf",
+                      mime: nil, displayName: "Display Name"),
+            ],
+            chats: [],
+            siblingImages: [:])
+        let key = WikiNameRules.looseMatchKey("Display Name")
+        #expect(index.sourceByLooseKey[key] == "Display Name")
+        // humanName is displayName when non-nil, not filename
+        #expect(index.sourceByLooseKey[key] != "file.pdf")
+    }
+
+    @Test func chatByLooseKeyValuesAreTitles() {
+        let index = WikiLinkIndex.build(
+            pages: [], sources: [],
+            chats: [.init(id: "01", title: "Chat Title")],
+            siblingImages: [:])
+        let key = WikiNameRules.looseMatchKey("Chat Title")
+        #expect(index.chatByLooseKey[key] == "Chat Title")
+    }
+}


### PR DESCRIPTION
## Fix #511: Shared WikiLinkIndex builder — unify duplicate link-map computation

### Problem

`WikiRenderContext.build` (in-app reader) and `Projection.makeLinkMaps` (File Provider projection) independently built the same page/source/chat title-to-target maps, source name variants, and sibling-image maps from scratch — same data computed in two places with slightly different shapes and duplicate normalization logic.

### Fix

Extracted a shared `WikiLinkIndex` builder — a pure function over pre-fetched value-type entries — into `Sources/WikiFSCore/WikiLinkIndex.swift`. Both consumers now:

1. Map their store rows into neutral `PageEntry` / `SourceEntry` / `ChatEntry` types
2. Call `WikiLinkIndex.build(...)` to get the shared normalization (source lowercased name variants, collision-free loose-key maps, sibling images)
3. Adapt the neutral output to their own shapes

**What moved to the shared builder:**
- Source lowercased name-variant computation (displayName, filename, ext-stripped)
- Source loose-key map (collision-free, unique-only — mirroring `resolveSourceByName` pass 3)
- Chat loose-key map (same collision rule)
- Sibling-image pass-through

**What stayed consumer-specific:**
- WRC: existence sets (`Set<String>`), `PageID -> name` dicts, embed map (requires `embedDescriptors()` + `ExternalEmbed.target`), `@vN` chains, blob scheme
- Projection: `name -> RelativeLinkRewriter.Target` / `id -> Target` dicts (requires `FilenameEscaping` + directory constants + `heads` map for `.md` sibling eligibility), `LinkMaps.resolver`

The removed `Projection.buildLooseKeyMap` static method is now redundant — the shared builder produces collision-free `looseMatchKey -> name` maps, and Projection adapts them via `compactMapValues`.

### Files changed

- **New:** `Sources/WikiFSCore/WikiLinkIndex.swift` — shared builder + neutral entry types
- **Modified:** `Sources/WikiFSCore/WikiRenderContext.swift` — `build(from:)` now calls `WikiLinkIndex.build` then derives its fields
- **Modified:** `Sources/WikiFSFileProvider/Projection.swift` — `makeLinkMaps()` now calls `WikiLinkIndex.build` then derives `LinkMaps`; removed dead `buildLooseKeyMap`
- **New:** `Tests/WikiFSTests/WikiLinkIndexTests.swift` — 12 unit tests covering entries, name variants, loose-key collisions, sibling images

### Testing

- `swift build` passes
- Fast tier (2456 tests) passes
- `ProjectionTreeTests` (44 tests, slow) passes
- `WikiRenderContextTests` (11 tests, WRC behavior preservation) passes
- `RelativeLinkRewriterTests` (31 tests, link rewriting behavior) passes
- `WikiLinkIndexTests` (12 new tests) passes

### Notes

- PR #496 (issue #490) already cached `makeLinkMaps()` per `ReadScope` — this PR unifies the BUILD logic, not the caching (that's done).
- The two consumers' `Target` shapes differ (`RelativeLinkRewriter.Target` for Projection vs existence sets for WRC), so the shared builder produces a neutral intermediate that both map from.
