### PR TITLE
Fix #519: SQLite PRAGMA tuning (synchronous=NORMAL, mmap_size, cache_size, temp_store=MEMORY)

### DIFF
--- a/Sources/WikiFSCore/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/SQLiteWikiStore.swift
@@ -131,6 +131,11 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         do {
             try exec("PRAGMA busy_timeout=5000;")
             try exec("PRAGMA query_only=ON;")
+            // Performance PRAGMAs (#519). This connection inherits WAL mode from
+            // the DB file (set by the writer); synchronous=NORMAL is safe and a
+            // no-op for committed reads. cache_size/mmap_size/temp_store all
+            // improve read throughput for pooled readers (`WikiReadPool`).
+            try applyPerformancePragmas()
             registerVec(on: db)
         } catch {
             sqlite3_close(db)
@@ -183,6 +188,35 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         }
         try exec("PRAGMA foreign_keys=ON;")
         try exec("PRAGMA busy_timeout=5000;")
+        // Performance PRAGMAs (#519). MUST come after journal_mode=WAL above:
+        // synchronous=NORMAL is only corruption-safe in WAL mode (in rollback
+        // journal mode it can lose a committed transaction on power loss).
+        try applyPerformancePragmas()
+    }
+
+    /// Performance PRAGMAs recommended for WAL-mode applications (#519).
+    /// Applied to BOTH read-write and read-only connections so reads benefit
+    /// from the larger cache and mmap too.
+    ///
+    /// - `synchronous=NORMAL`: in WAL mode this is **safe against corruption**
+    ///   and eliminates most fsync syscalls (2–5× burst write throughput). The
+    ///   only theoretical risk is losing the last in-flight transaction on a
+    ///   power-loss crash — acceptable for a local-only app whose File Provider
+    ///   projection is rebuilt from the DB.
+    /// - `mmap_size=268435456` (256 MB): memory-map the DB file for faster
+    ///   random access (link resolution, page lookups, source-by-id reads). A
+    ///   hint only — the OS page cache manages actual memory; no-op when the DB
+    ///   is smaller than the cap.
+    /// - `cache_size=-65536` (64 MB): the default ~2 MB per-connection cache is
+    ///   too small for `WikiReadPool`'s several readers; more page-index and row
+    ///   data stays resident between queries.
+    /// - `temp_store=MEMORY`: temp tables and B-tree sorting (ORDER BY in
+    ///   `listAllPagesOrderedByID`, FTS5 BM25 ranking, RRF fusion) stay in RAM.
+    private func applyPerformancePragmas() throws {
+        try exec("PRAGMA synchronous=NORMAL;")
+        try exec("PRAGMA mmap_size=268435456;")
+        try exec("PRAGMA cache_size=-65536;")
+        try exec("PRAGMA temp_store=MEMORY;")
     }
 
     /// Stepwise, idempotent schema migration keyed on `PRAGMA user_version`.

--- a/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
+++ b/Tests/WikiFSTests/SQLiteWikiStoreTests.swift
@@ -52,6 +52,22 @@ struct SQLiteWikiStoreTests {
         #expect(scalarText(db, "PRAGMA journal_mode;").lowercased() == "wal")
         #expect(store.pragmaValue("foreign_keys") == "1")
 
+        // #519: performance PRAGMAs applied to the read-write connection. These
+        // are per-connection settings, so read them from the store's own
+        // connection (not the external `db` handle, which has SQLite defaults).
+        #expect(store.pragmaValue("synchronous") == "1")        // NORMAL
+        #expect(store.pragmaValue("mmap_size") == "268435456") // 256 MB
+        #expect(store.pragmaValue("cache_size") == "-65536")    // 64 MB
+        #expect(store.pragmaValue("temp_store") == "2")         // MEMORY
+
+        // #519: the same PRAGMAs apply to pooled read-only connections
+        // (`WikiReadPool` members), which share `applyPerformancePragmas()`.
+        let reader = try SQLiteWikiStore(readOnlyURL: url)
+        #expect(reader.pragmaValue("synchronous") == "1")
+        #expect(reader.pragmaValue("mmap_size") == "268435456")
+        #expect(reader.pragmaValue("cache_size") == "-65536")
+        #expect(reader.pragmaValue("temp_store") == "2")
+
         let tables = Set(rows(db,
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"))
         #expect(tables.isSuperset(of:


### PR DESCRIPTION
## Summary

Adds four SQLite-recommended performance PRAGMAs to connection init, applied to **both** the read-write writer connection and the read-only pooled-reader connections. Closes #519.

The store already set `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000`, but omitted the four well-understood WAL-mode tunings below. These affect every read and write.

## Changes

New private helper `applyPerformancePragmas()` in `SQLiteWikiStore.swift`, called from both init paths:

| PRAGMA | Value | Effect |
| --- | --- | --- |
| `synchronous` | `NORMAL` | In WAL mode this is **safe against corruption** (SQLite docs). Eliminates most fsync syscalls → 2–5× burst write throughput. Only theoretical risk: losing the last in-flight transaction on a power-loss crash — acceptable for a local-only app whose File Provider projection rebuilds from the DB. |
| `mmap_size` | `268435456` (256 MB) | Memory-map the DB file instead of `read()` syscalls. Faster random access (link resolution, page lookups, source-by-id reads). A hint only — the OS page cache manages actual memory; no-op when the DB is smaller than the cap. |
| `cache_size` | `-65536` (64 MB) | Default ~2 MB per-connection cache is tiny given `WikiReadPool` opens several readers; more page-index/row data stays resident between queries. |
| `temp_store` | `MEMORY` | Temp tables and B-tree sorting (ORDER BY in `listAllPagesOrderedById`, FTS5 BM25 ranking, RRF fusion) stay in RAM. |

### Init paths updated

- **Read-write** — `configurePragmas()` (already sets WAL/foreign_keys/busy_timeout): the performance PRAGMAs are applied *after* `journal_mode=WAL`, because `synchronous=NORMAL` is only corruption-safe under WAL.
- **Read-only** — `init(readOnlyURL:)` (sets busy_timeout/query_only): this connection inherits WAL from the DB file; `synchronous=NORMAL` is safe and a no-op for committed reads, while cache_size/mmap_size/temp_store improve pooled-reader throughput.
- **`WikiReadPool`** has no separate connection init path — its members are opened via `init(readOnlyURL:)`, so they inherit the tuning automatically. No change needed there.

### Regression test

Extends `pragmasAndSchema` in `SQLiteWikiStoreTests` to assert all four PRAGMAs on **both** a read-write store and a pooled read-only reader (using the existing `pragmaValue(_:)` test hook, which reads from the store's own connection — the correct place since these are per-connection settings).

## Safety notes

- `synchronous=NORMAL` in WAL mode does **not** risk corruption — only the last in-flight transaction could be lost on a power-loss crash. The File Provider projection is rebuilt from the DB, so durability loss is recoverable.
- `mmap_size` is a hint the OS manages via the page cache; if the DB is smaller than 256 MB it's effectively a no-op.
- `cache_size` + `temp_store=MEMORY` raise per-connection memory, but the connection count is bounded (one writer + a handful of `WikiReadPool` readers) → bounded worst case (~256 MB full allocation).

## Testing

- `make version prompts` + `swift build` — compiles clean.
- Fast test tier: **2456 tests in 211 suites passed.**
  ```
  swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifetimeIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
  ```
- SQLite integration: `swift test --filter SQLiteWikiStoreTests` — **48 tests passed** (including the new PRAGMA assertions on both connection paths).
- Concurrency discipline: `swift test --filter StoreConcurrencyTests` — **10 tests passed** (`poolConnectionsAreReadOnly`, `concurrentReadersAndWriterDoNotCorrupt`, `poolReusesIdleConnections`, nested-transaction rollback, etc.).

## Constraints honored

- Worked on a feature branch; PR targets `main`; will not merge.
- Used `rg` for code searches; diagnostics via `DebugLog` (no `print`); no inference/network inside transactions; the store's method-atomic + recursive-lock discipline is untouched.
