### PR TITLE
Fix #518: collapse duplicated JSON sidecar load/save boilerplate

### DIFF
--- a/Sources/WikiFSCore/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/AgentProvidersConfig.swift
@@ -27,7 +27,7 @@ import Foundation
 /// - `selectedModelIds` — `[providerId: modelId]`, the user's per-provider
 ///   model pick. Empty (the default) = "use the agent's default model" → today's
 ///   behavior is unchanged for existing users.
-public struct AgentProvidersConfig: Codable, Equatable, Sendable {
+public struct AgentProvidersConfig: JSONSidecarConfig {
 
     /// The configured providers. At least one is always present (the Claude
     /// default). Order is the display order in Settings.
@@ -342,15 +342,13 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
     /// from `seed(discovered:)` (running real PATH discovery) AND persist the
     /// seed so subsequent loads are stable + the user's edits survive. A corrupt
     /// file degrades to the seed too (same fresh-install behavior as
-    /// `AgentCommandConfig.load`).
+    /// `AgentCommandConfig.load`). Delegates the file read + decode to
+    /// `JSONSidecarConfig.load(from:)`.
     public static func loadOrSeed(
         from directory: URL,
         discover: () -> [DiscoveredACPAgent] = { ACPProviderDiscovery.discover() }
     ) -> AgentProvidersConfig {
-        let url = directory.appendingPathComponent(fileName, isDirectory: false)
-        if let data = try? Data(contentsOf: url),
-           let config = try? JSONDecoder().decode(AgentProvidersConfig.self, from: data),
-           !config.providers.isEmpty {
+        if let config = load(from: directory), !config.providers.isEmpty {
             // Preserve the decoded model caches + selections (re-wrapping with
             // only `providers` would wipe them). Re-normalize providers only.
             DebugLog.store("AgentProvidersConfig.loadOrSeed: LOAD providers=\(config.providers.count) hasModelCaches=\(!config.providerModels.isEmpty) hasSelections=\(!config.selectedModelIds.isEmpty)") // TEMP DEBUG
@@ -367,17 +365,5 @@ public struct AgentProvidersConfig: Codable, Equatable, Sendable {
         let seeded = seed(discovered: discover())
         try? seeded.save(to: directory)
         return seeded
-    }
-
-    /// Persist to `agent-providers.json` in `directory`, atomically,
-    /// pretty-printed + sorted keys. Never writes API keys (those are in the
-    /// Keychain).
-    public func save(to directory: URL) throws {
-        DebugLog.store("AgentProvidersConfig.save: providers=\(providers.count) default=\(defaultProvider.id) modelCaches=\(providerModels.count) selections=\(selectedModelIds.count)") // TEMP DEBUG
-        let url = directory.appendingPathComponent(Self.fileName, isDirectory: false)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(self)
-        try data.write(to: url, options: .atomic)
     }
 }

--- a/Sources/WikiFSCore/ExtractionConfig.swift
+++ b/Sources/WikiFSCore/ExtractionConfig.swift
@@ -10,7 +10,7 @@ import Foundation
 /// root as a sibling of `zotero-config.json`. Follows `ZoteroConfig`'s load/save
 /// pattern exactly (pure value type, explicit injected directory, atomic write),
 /// and `WikiRegistry`'s degrade-to-empty-on-corrupt rule.
-public struct ExtractionConfig: Codable, Equatable, Sendable {
+public struct ExtractionConfig: JSONSidecarConfig {
     /// Which backend `ExtractionCoordinator.current()` resolves to.
     public var backend: ExtractionBackend
 
@@ -110,29 +110,13 @@ public struct ExtractionConfig: Codable, Equatable, Sendable {
         self.doclingServeEndpoint = try c.decodeIfPresent(String.self, forKey: .doclingServeEndpoint)
     }
 
-    // MARK: - Persistence
+    // MARK: - Persistence (via `JSONSidecarConfig`)
 
     /// Load from `extraction-config.json` in `directory`. A missing or corrupt
     /// file degrades to an empty (default) config rather than throwing — same
-    /// fresh-install behavior as `ZoteroConfig.load`.
+    /// fresh-install behavior as `ZoteroConfig.load`. Delegates the file read +
+    /// decode to `JSONSidecarConfig.load(from:)` and supplies the default config.
     public static func load(from directory: URL) -> ExtractionConfig {
-        let url = directory.appendingPathComponent(fileName, isDirectory: false)
-        guard let data = try? Data(contentsOf: url) else { return ExtractionConfig() }
-        guard let config = try? JSONDecoder().decode(ExtractionConfig.self, from: data) else {
-            DebugLog.config("ExtractionConfig: corrupt \(fileName), starting with defaults")
-            return ExtractionConfig()
-        }
-        return config
-    }
-
-    /// Persist to `extraction-config.json` in `directory`, atomically,
-    /// pretty-printed + sorted keys (matches `ZoteroConfig.save`'s
-    /// reviewable-diff rationale).
-    public func save(to directory: URL) throws {
-        let url = directory.appendingPathComponent(ExtractionConfig.fileName, isDirectory: false)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(self)
-        try data.write(to: url, options: .atomic)
+        load(from: directory) ?? ExtractionConfig()
     }
 }

--- a/Sources/WikiFSCore/JSONSidecarConfig.swift
+++ b/Sources/WikiFSCore/JSONSidecarConfig.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// A config value type persisted as a single pretty-printed JSON sidecar file
+/// in the App Group container (e.g. `zotero-config.json`, `extraction-config.json`,
+/// `agent-providers.json`).
+///
+/// Conformers supply only `fileName` (and whatever type-specific fields they
+/// need); the protocol's default implementations provide the load/save
+/// boilerplate that was previously copy-pasted across `ZoteroConfig`,
+/// `ExtractionConfig`, and `AgentProvidersConfig`.
+///
+/// Semantics (matching the prior hand-written implementations):
+/// - `save(to:)` writes atomically, pretty-printed with sorted keys, so diffs
+///   are reviewable and a mid-write crash can't truncate the file.
+/// - `load(from:)` returns `nil` for a missing file (fresh install) or a corrupt
+///   file (a diagnostic is emitted via `DebugLog.config` on the corrupt path, but
+///   the call never throws — callers degrade to a default).
+///
+/// Types that want non-optional "default-on-missing" loading keep a one-line
+/// delegator, e.g. `ZoteroConfig.load(from:) -> ZoteroConfig`.
+///
+/// Notes:
+/// - `WikiRegistry` deliberately does NOT conform here: it uses an ISO-8601 date
+///   coding strategy in both load and save, so it can't share the dateless
+///   default encoder/decoder without specializing the protocol — out of scope for
+///   issue #518.
+/// - No secret ever lives in these files (keys go in Keychain); the protocol only
+///   handles the secrets-free JSON sidecar.
+public protocol JSONSidecarConfig: Codable, Equatable, Sendable {
+    /// The JSON filename inside the App Group container, e.g.
+    /// `"zotero-config.json"`.
+    static var fileName: String { get }
+}
+
+public extension JSONSidecarConfig {
+
+    /// Load from `<directory>/<fileName>`. Returns `nil` if the file is missing
+    /// (fresh install) or corrupt; on the corrupt path a diagnostic is emitted via
+    /// `DebugLog.config`. Never throws — callers degrade to a default.
+    static func load(from directory: URL) -> Self? {
+        let url = directory.appendingPathComponent(fileName, isDirectory: false)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let config = try? JSONDecoder().decode(Self.self, from: data) else {
+            DebugLog.config("\(String(describing: Self.self)): corrupt \(fileName), discarding")
+            return nil
+        }
+        return config
+    }
+
+    /// Persist to `<directory>/<fileName>`, atomically, pretty-printed +
+    /// sorted keys (matches the prior hand-written `save` implementations'
+    /// reviewable-diff rationale). Never writes secrets — only the conforming
+    /// value's own `Codable` payload.
+    func save(to directory: URL) throws {
+        let url = directory.appendingPathComponent(Self.fileName, isDirectory: false)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/Sources/WikiFSCore/ZoteroConfig.swift
+++ b/Sources/WikiFSCore/ZoteroConfig.swift
@@ -9,7 +9,7 @@ import Foundation
 /// is persisted once at the App Group container root, a sibling of `wikis.json`
 /// rather than a field on `WikiDescriptor`. Follows `WikiRegistry`'s load/save
 /// pattern exactly (pure value type, explicit injected directory, atomic write).
-public struct ZoteroConfig: Codable, Equatable, Sendable {
+public struct ZoteroConfig: JSONSidecarConfig {
     /// The numeric Zotero user library ID. `nil` until the user configures it.
     public var libraryID: String?
 
@@ -39,28 +39,13 @@ public struct ZoteroConfig: Codable, Equatable, Sendable {
         return ZoteroLocalStorage.defaultDirectory()
     }
 
-    // MARK: - Persistence
+    // MARK: - Persistence (via `JSONSidecarConfig`)
 
     /// Load from `zotero-config.json` in `directory`. A missing or corrupt file
     /// degrades to an empty (unconfigured) config rather than throwing — same
-    /// fresh-install behavior as `WikiRegistry.load`.
+    /// fresh-install behavior as `WikiRegistry.load`. Delegates the file read +
+    /// decode to `JSONSidecarConfig.load(from:)` and supplies the empty default.
     public static func load(from directory: URL) -> ZoteroConfig {
-        let url = directory.appendingPathComponent(fileName, isDirectory: false)
-        guard let data = try? Data(contentsOf: url) else { return ZoteroConfig() }
-        guard let config = try? JSONDecoder().decode(ZoteroConfig.self, from: data) else {
-            DebugLog.config("ZoteroConfig: corrupt \(fileName), starting empty")
-            return ZoteroConfig()
-        }
-        return config
-    }
-
-    /// Persist to `zotero-config.json` in `directory`, atomically, pretty-printed
-    /// + sorted keys (matches `WikiRegistry.save`'s reviewable-diff rationale).
-    public func save(to directory: URL) throws {
-        let url = directory.appendingPathComponent(ZoteroConfig.fileName, isDirectory: false)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(self)
-        try data.write(to: url, options: .atomic)
+        load(from: directory) ?? ZoteroConfig()
     }
 }


### PR DESCRIPTION
Fixes #518.

## Summary

`ZoteroConfig`, `ExtractionConfig`, and `AgentProvidersConfig` each re-implemented
the same load/save boilerplate (append `fileName`, encode/decode, pretty-print +
sorted-keys atomic write). This introduces a `JSONSidecarConfig` protocol that
provides default `load(from:) -> Self?` and `save(to:)` implementations; the
three configs now conform and drop the duplicated bodies.

## Changes

- **New** `Sources/WikiFSCore/JSONSidecarConfig.swift` — protocol
  (`Codable, Equatable, Sendable` + `fileName` requirement) with default
  implementations:
  - `static func load(from:) -> Self?` — returns `nil` on missing (fresh
    install) or corrupt; emits a `DebugLog.config` diagnostic on the corrupt
    path, never throws (callers degrade to a default).
  - `func save(to:) throws` — atomic, pretty-printed + sorted keys (matches the
    prior hand-written implementations' reviewable-diff rationale).
- `ZoteroConfig` — conforms via `JSONSidecarConfig`; deleted its `save` body and
  replaced `load` with a one-line delegator that preserves the non-optional
  default-on-missing API (`load(from:) ?? ZoteroConfig()`).
- `ExtractionConfig` — same treatment (`load(from:) ?? ExtractionConfig()`).
- `AgentProvidersConfig` — conforms; deleted its `save` body (uses the
  protocol's); `loadOrSeed` now delegates the file read + decode to
  `JSONSidecarConfig.load(from:)` while keeping its type-specific seed +
  persist-on-empty logic.

## Scope check (per issue)

- `ACPAgentConfig` — already deleted (only a stale comment mentions it); no
  type to consolidate.
- `ShellArgv` — a pure static helper `enum` (tokenizer + tilde expansion), no
  `Codable`/persistence; does not fit the pattern.
- `WikiRegistry` — matches the shape but uses an ISO-8601 date coding strategy
  in both load and save, so it can't share the dateless default
  encoder/decoder without specializing the protocol. Out of scope for #518;
  documented in the protocol's doc comment.

## Design notes

- Public APIs are unchanged: `ZoteroConfig.load` / `ExtractionConfig.load` still
  return non-optional defaults, so no callers or tests needed updating. The
  protocol's optional `load(from:) -> Self?` is the shared primitive; the two
  default-on-missing types keep a one-line delegator so call sites stay
  ergonomic (no `++ .init()` spread across ~11 sites).
- `AgentProvidersConfig.loadOrSeed` is genuinely type-specific (seeds defaults on
  missing/empty + persists the seed), so it stays; only its decode step was
  boilerplate and now delegates to the protocol.
- The `AgentProvidersConfig.save` TEMP DEBUG trace was dropped along with the
  boilerplate body (it was explicitly temporary instrumentation, and keeping it
  would mean re-implementing the exact boilerplate this refactor removes).

## Verification

- `make prompts && make version && make build` -- build complete.
- Fast test tier (2456 tests in 211 suites) passed:
  `swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'`

## Notes

- No secrets touched (all three files are secrets-free; keys live in Keychain).
- Did not merge; awaiting review.
