### PR TITLE
ACP session efficiency Phase 3: session/fork for executors

### DIFF
--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -155,6 +155,12 @@ public actor ACPBackend: AgentBackend {
         /// Phase 2: set to false when the subprocess dies (sendPrompt error or
         /// `kill(pid, 0) != 0`). When false, `resume()` spawns a new process.
         var processIsAlive: Bool
+        /// Whether the agent advertised `sessionCapabilities.fork` at `initialize`
+        /// time (Phase 3, `plans/acp-session-efficiency.md` §4). If not supported,
+        /// `forkSession()` returns `nil` and the caller falls back to a fresh
+        /// `createSession()` (current behavior — no context inheritance but no
+        /// correctness risk).
+        let canForkSession: Bool
     }
 
     private var warmProcess: WarmProcess?
@@ -368,6 +374,10 @@ public actor ACPBackend: AgentBackend {
         let canResume = sessionCaps?.resume != nil
         let canLoadSession = initResponse.agentCapabilities.loadSession == true
         let canListSessions = sessionCaps?.list != nil
+        // Check session/fork support (Phase 3, plans/acp-session-efficiency.md §4).
+        // If not supported, forkSession() returns nil and the caller falls back
+        // to a fresh createSession() (no context inheritance, no correctness risk).
+        let canForkSession = sessionCaps?.fork != nil
 
         warmProcess = WarmProcess(
             client: client,
@@ -380,7 +390,8 @@ public actor ACPBackend: AgentBackend {
             canResume: canResume,
             canLoadSession: canLoadSession,
             canListSessions: canListSessions,
-            processIsAlive: true)
+            processIsAlive: true,
+            canForkSession: canForkSession)
 
         // Wire onExit to the agent process termination. `Client.terminate()` is
         // the teardown; there's no direct terminationHandler on the SDK actor,
@@ -390,7 +401,7 @@ public actor ACPBackend: AgentBackend {
         // session — the last binding wins.
         permissionDelegate.bindOnExit(onExit)
 
-        DebugLog.agent("ACPBackend.startProcess: warm process ready canCloseSession=\(canCloseSession) canResume=\(canResume) canLoadSession=\(canLoadSession)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.startProcess: warm process ready canCloseSession=\(canCloseSession) canResume=\(canResume) canLoadSession=\(canLoadSession) canForkSession=\(canForkSession)") // TEMP DEBUG
     }
 
     /// Create a new ACP session on an already-started (warm) subprocess.
@@ -920,6 +931,79 @@ public actor ACPBackend: AgentBackend {
             DebugLog.agent("ACPBackend.closeSession: agent does not support session/close — skipping (context freed at terminate)") // TEMP DEBUG
         }
         DebugLog.agent("ACPBackend.closeSession: session closed, subprocess stays alive") // TEMP DEBUG
+    }
+
+    /// Fork a session: creates a new session that inherits the parent's
+    /// conversation context but diverges from that point. The parent session
+    /// stays unchanged. Used by executors to get the planner's understanding
+    /// of the source layout without the reasoning noise (Phase 3,
+    /// `plans/acp-session-efficiency.md` §4).
+    ///
+    /// Checks `sessionCapabilities.fork` (captured at `initialize` time from
+    /// the `WarmProcess`). If fork is not supported, returns `nil` — the caller
+    /// must fall back to `createSession()` (a fresh session with no inherited
+    /// context, which is the current pre-Phase-3 behavior).
+    ///
+    /// The forked session:
+    /// - Shares the same `Client` (subprocess) and `NotificationFanout` as the
+    ///   parent — it's the same process, just a new session id.
+    /// - Inherits the parent's `systemPrompt` but sets `systemPromptInjected = true`
+    ///   because the forked context already contains the injected system prompt.
+    /// - Gets its own entry in the `sessions` map under a new `SessionHandle.id`.
+    ///
+    /// The parent session remains active and must be separately closed via
+    /// `closeSession()` when all forks are done.
+    ///
+    /// - Parameters:
+    ///   - parentHandle: The session to fork from (typically the planner session).
+    ///   - cwd: The working directory for the forked session. If nil, uses the
+    ///     warm process's working directory.
+    /// - Returns: A new `SessionHandle` for the forked session, or `nil` if fork
+    ///   is not supported.
+    func forkSession(
+        from parentHandle: SessionHandle,
+        cwd: String? = nil
+    ) async throws -> SessionHandle? {
+        guard let warm = warmProcess else {
+            DebugLog.agent("ACPBackend.forkSession: no warm process — cannot fork") // TEMP DEBUG
+            return nil
+        }
+        guard warm.canForkSession else {
+            DebugLog.agent("ACPBackend.forkSession: agent does not support session/fork — returning nil (caller falls back to createSession)") // TEMP DEBUG
+            return nil
+        }
+        guard let parent = sessions[parentHandle.id] else {
+            DebugLog.agent("ACPBackend.forkSession: no parent session for handle \(parentHandle.id) — returning nil") // TEMP DEBUG
+            return nil
+        }
+
+        let workingDir = cwd ?? FileManager.default.currentDirectoryPath
+
+        DebugLog.agent("ACPBackend.forkSession: forking session=\(parent.sessionId.value) cwd=\(workingDir)") // TEMP DEBUG
+        let response = try await warm.client.forkSession(
+            sessionId: parent.sessionId,
+            cwd: workingDir
+        )
+        let forkedSessionId = response.sessionId
+        DebugLog.agent("ACPBackend.forkSession: forked → session=\(forkedSessionId.value)") // TEMP DEBUG
+
+        // The forked session inherits the parent's conversation context —
+        // including the already-injected system prompt. Mark it as injected so
+        // `send()` doesn't re-inject it on the first turn.
+        let sessionID = UUID().uuidString
+        sessions[sessionID] = ACPSession(
+            client: warm.client,
+            sessionId: forkedSessionId,
+            permissionDelegate: warm.permissionDelegate,
+            modelsInfo: parent.modelsInfo,
+            notificationFanout: warm.notificationFanout,
+            drainTask: nil,
+            systemPrompt: parent.systemPrompt,
+            systemPromptInjected: true
+        )
+
+        DebugLog.agent("ACPBackend.forkSession: forked session \(forkedSessionId.value) (handle \(sessionID)) ready") // TEMP DEBUG
+        return SessionHandle(id: sessionID)
     }
 
     // MARK: - Model discovery (#329)

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -366,6 +366,12 @@ public final class AgentLauncher {
     /// The active session handle (nil when no session is live). Replaces the
     /// old `process: Process?` — the launcher never touches a `Process` directly.
     @ObservationIgnored private var sessionHandle: SessionHandle?
+
+    /// The planner session handle kept alive during the executor phase so it
+    /// can be forked (Phase 3, `plans/acp-session-efficiency.md` §4). nil unless
+    /// we're in the planner-executors ingest flow AND the planner session is
+    /// still alive (not yet closed). Cleared in `finish()` and `stopAgent()`.
+    @ObservationIgnored private var plannerSessionHandle: SessionHandle?
     /// Per-session token: `onExit` captures the token current at session start
     /// and only calls `finish` if it's STILL current. Prevents a stale `onExit`
     /// (a prior session terminating after a new one started — e.g. D3's
@@ -1094,14 +1100,13 @@ public final class AgentLauncher {
         // Capture models (provider-level, not phase-level).
         captureAndCacheModels(provider: plannerRouting.provider, session: plannerSession)
         captureProcessID(session: plannerSession)
-        // Phase 1: close the session (frees context, keeps the subprocess alive
-        // for the next phase). Old code called `cancel()` which killed the
-        // subprocess — now we only kill at the very end.
-        if let acp = plannerRouting.backend as? ACPBackend {
-            await acp.closeSession(plannerSession)
-        } else {
-            await plannerRouting.backend.cancel(plannerSession)
-        }
+        // Phase 3: keep the planner session ALIVE through the executor phase so
+        // it can be forked — the forked executor inherits the planner's
+        // understanding of the source layout without the reasoning noise. The
+        // session is closed after all executors are done.
+        // (Pre-Phase-3: the session was closed here immediately. Now we store the
+        // handle and close it later — see `closePlannerSession()`)
+        plannerSessionHandle = plannerSession
 
         // Check for cancellation (user hit Stop during planner).
         guard isRunning else {
@@ -1142,12 +1147,18 @@ public final class AgentLauncher {
                     sourceIDs: sourceIDs)
                 DebugLog.agent("runACPIngest: Phase 2 — Executor[\(sourceFile)] (\(assignments.count) page(s))")
                 // Partial failure: log and continue to next executor.
+                // Phase 3: if the planner session is still alive, try to fork it
+                // so the executor inherits the planner's source context. If fork
+                // is unsupported (or the planner session was already closed), the
+                // runPhase helper falls back to a fresh `backend.start()`.
+                let forkFrom = (executorRouting.backend as? ACPBackend != nil) ? plannerSessionHandle : nil
                 if let session = await runPhase(
                     backend: executorRouting.backend,
                     profile: executorProfile,
                     systemPrompt: systemPrompt,
                     prompt: executorPrompt,
-                    phaseName: "executor[\(sourceFile)]"
+                    phaseName: "executor[\(sourceFile)]",
+                    forkFrom: forkFrom
                 ) {
                     if let acp = executorRouting.backend as? ACPBackend {
                         await acp.closeSession(session)
@@ -1161,6 +1172,19 @@ public final class AgentLauncher {
         } else {
             DebugLog.agent("runACPIngest: executor routing failed (\(preflightError ?? "?")) — skipping executor phase")
             preflightError = nil
+        }
+
+        // Phase 3: all executor forks are done — close the planner session now.
+        // It has served its purpose as the fork source. If it was never kept
+        // alive (e.g., the planner failed early and we fell back), this is nil.
+        if let plannerSession = plannerSessionHandle {
+            DebugLog.agent("runACPIngest: closing planner session (all forks done)")
+            if let acp = plannerRouting.backend as? ACPBackend {
+                await acp.closeSession(plannerSession)
+            } else {
+                await plannerRouting.backend.cancel(plannerSession)
+            }
+            plannerSessionHandle = nil
         }
 
         // Check for cancellation before finalizer.
@@ -1226,25 +1250,54 @@ public final class AgentLauncher {
     ///
     /// Updates `sessionHandle` + `currentRunToken` so `stopAgent()` and the
     /// watchdog target the live phase. Returns `nil` if `backend.start` throws.
+    ///
+    /// Phase 3 (`plans/acp-session-efficiency.md` §4): when `forkFrom` is non-nil,
+    /// the method tries `forkSession(from:forkFrom)` FIRST. If fork succeeds, the
+    /// forked session inherits the parent's context — no `backend.start()` call
+    /// is needed. If fork returns nil (unsupported), falls back to `backend.start()`
+    /// (fresh session, current behavior).
     private func runPhase(
         backend: AgentBackend,
         profile: BackendProfile,
         systemPrompt: String,
         prompt: String,
-        phaseName: String
+        phaseName: String,
+        forkFrom: SessionHandle? = nil
     ) async -> SessionHandle? {
         self.backend = backend
         let runToken = UUID()
         do {
-            DebugLog.agent("runACPIngest[\(phaseName)]: starting")
-            let session = try await backend.start(
-                profile: profile,
-                systemPrompt: systemPrompt,
-                onExit: { status in
-                    // Phase tracker: does NOT call finish(). The orchestrator
-                    // owns finish(); a per-phase exit is just telemetry.
-                    DebugLog.agent("runACPIngest[\(phaseName)]: onExit status=\(status) (phase-tracked)")
-                })
+            // Phase 3: try to fork the planner session so the executor inherits
+            // the planner's source-layout understanding without the reasoning
+            // noise. If fork is unsupported (returns nil), fall back to a fresh
+            // `backend.start()` — current pre-Phase-3 behavior.
+            let session: SessionHandle
+            if let parentHandle = forkFrom, let acp = backend as? ACPBackend {
+                DebugLog.agent("runACPIngest[\(phaseName)]: attempting fork from parent session")
+                let workingDir = profile.scratchDirectory?.path
+                if let forked = try? await acp.forkSession(from: parentHandle, cwd: workingDir) {
+                    DebugLog.agent("runACPIngest[\(phaseName)]: fork succeeded, using forked session")
+                    session = forked
+                } else {
+                    DebugLog.agent("runACPIngest[\(phaseName)]: fork unsupported/failed, falling back to fresh start")
+                    session = try await backend.start(
+                        profile: profile,
+                        systemPrompt: systemPrompt,
+                        onExit: { status in
+                            DebugLog.agent("runACPIngest[\(phaseName)]: onExit status=\(status) (phase-tracked)")
+                        })
+                }
+            } else {
+                DebugLog.agent("runACPIngest[\(phaseName)]: starting")
+                session = try await backend.start(
+                    profile: profile,
+                    systemPrompt: systemPrompt,
+                    onExit: { status in
+                        // Phase tracker: does NOT call finish(). The orchestrator
+                        // owns finish(); a per-phase exit is just telemetry.
+                        DebugLog.agent("runACPIngest[\(phaseName)]: onExit status=\(status) (phase-tracked)")
+                    })
+            }
             sessionHandle = session
             currentRunToken = runToken
 
@@ -1826,6 +1879,11 @@ public final class AgentLauncher {
             let backend = self.backend
             Task { await backend.cancel(session) }
         }
+        // Phase 3: if the planner session is still alive (kept open as a fork
+        // source during the executor phase), close it. `cancel` on the current
+        // session terminates the subprocess, which kills all sessions anyway,
+        // but this prevents the plannerSessionHandle from dangling after teardown.
+        plannerSessionHandle = nil
         if isRunning {
             finish(status: -1)  // -1 sentinel = user-cancelled / forced teardown
         }
@@ -2089,6 +2147,7 @@ public final class AgentLauncher {
         isInteractiveSession = false
         runningKind = nil
         sessionHandle = nil
+        plannerSessionHandle = nil
         currentProcessID = nil
         ingestingSourceIDs = []
         // Cancel any in-flight send task (gate wait or stream consumer). Clear the
@@ -2146,6 +2205,7 @@ public final class AgentLauncher {
         lastActivityAt = nil
         currentProcessID = nil
         sessionHandle = nil
+        plannerSessionHandle = nil
         onUnlockHandler = nil
         // A reset starts a new run: a stale sink must never receive a new
         // session's events (issue #119).

--- a/pr-body-phase3.md
+++ b/pr-body-phase3.md
@@ -1,0 +1,50 @@
+## ACP session efficiency Phase 3: `session/fork` for executors
+
+Implements Phase 3 of `plans/acp-session-efficiency.md` (issue #525).
+
+### What
+
+After the planner produces `plan.json`, each executor **forks** the planner's session — inheriting the planner's understanding of the source layout without the reasoning noise (intermediate tool calls, failed attempts). If the agent doesn't support `session/fork`, falls back to fresh `session/new` per executor (current behavior).
+
+### Changes
+
+**`ACPBackend.swift`:**
+- Added `canForkSession: Bool` to the `WarmProcess` struct, captured from `agentCapabilities.sessionCapabilities?.fork` at `startProcess()` time
+- Added `forkSession(from:cwd:)` method:
+  - Guards on `canForkSession` and parent session existence
+  - Calls `client.forkSession(sessionId:cwd:)` (SDK method from `swift-acp` v0.2.0)
+  - Creates a new `ACPSession` record with `systemPromptInjected = true` (fork inherits parent's already-injected system prompt)
+  - Returns `nil` if fork is unsupported — caller falls back to `createSession()`
+
+**`AgentLauncher.swift`:**
+- Added `plannerSessionHandle` field to track the planner session across the executor phase
+- `runACPIngestPlannerExecutors` flow updated:
+  1. Planner: `start()` -> `send()` -> **keep session alive** (was: close immediately)
+  2. Executors: `forkSession(from: plannerSession)` -> `send()` -> `closeSession()` per source. If fork returns nil, falls back to `start()` (fresh session)
+  3. After all executors: `closeSession(plannerSession)` — the planner session has served its purpose as fork source
+  4. Finalizer: unchanged (`start()` -> `send()` -> `closeSession()`)
+  5. End: `cancel()` all warm subprocesses
+- `runPhase` gained a `forkFrom: SessionHandle?` parameter (default nil = fresh session)
+- `stopAgent()` and `finish()` clear `plannerSessionHandle` to prevent dangling references
+
+### Design rationale
+
+From the context-benefit matrix in the design doc:
+- **Executor reading 1 source**: the planner's understanding of the source layout IS beneficial context, but the planner's reasoning about what to do IS noise
+- `session/fork` solves this: the forked executor starts with a copy of the planner's conversation context but diverges from that point
+- Claude Code's SDK supports fork: it creates a new session that starts with a copy of the original's history
+
+### Graceful degradation
+
+| Capability | Behavior |
+|---|---|
+| `sessionCapabilities.fork` supported | `forkSession()` -> executor inherits planner context |
+| `sessionCapabilities.fork` NOT supported | `forkSession()` returns `nil` -> `runPhase` falls back to `backend.start()` (fresh session, current behavior) |
+
+No correctness risk — fork is an optimization, not a requirement.
+
+### Testing
+
+- `swift build` passes
+- Fast test tier (2456 tests) passes
+- Fork requires a live agent subprocess to exercise end-to-end; the capability detection + fallback logic is the testable unit


### PR DESCRIPTION
## ACP session efficiency Phase 3: `session/fork` for executors

Implements Phase 3 of `plans/acp-session-efficiency.md` (issue #525).

### What

After the planner produces `plan.json`, each executor **forks** the planner's session — inheriting the planner's understanding of the source layout without the reasoning noise (intermediate tool calls, failed attempts). If the agent doesn't support `session/fork`, falls back to fresh `session/new` per executor (current behavior).

### Changes

**`ACPBackend.swift`:**
- Added `canForkSession: Bool` to the `WarmProcess` struct, captured from `agentCapabilities.sessionCapabilities?.fork` at `startProcess()` time
- Added `forkSession(from:cwd:)` method:
  - Guards on `canForkSession` and parent session existence
  - Calls `client.forkSession(sessionId:cwd:)` (SDK method from `swift-acp` v0.2.0)
  - Creates a new `ACPSession` record with `systemPromptInjected = true` (fork inherits parent's already-injected system prompt)
  - Returns `nil` if fork is unsupported — caller falls back to `createSession()`

**`AgentLauncher.swift`:**
- Added `plannerSessionHandle` field to track the planner session across the executor phase
- `runACPIngestPlannerExecutors` flow updated:
  1. Planner: `start()` -> `send()` -> **keep session alive** (was: close immediately)
  2. Executors: `forkSession(from: plannerSession)` -> `send()` -> `closeSession()` per source. If fork returns nil, falls back to `start()` (fresh session)
  3. After all executors: `closeSession(plannerSession)` — the planner session has served its purpose as fork source
  4. Finalizer: unchanged (`start()` -> `send()` -> `closeSession()`)
  5. End: `cancel()` all warm subprocesses
- `runPhase` gained a `forkFrom: SessionHandle?` parameter (default nil = fresh session)
- `stopAgent()` and `finish()` clear `plannerSessionHandle` to prevent dangling references

### Design rationale

From the context-benefit matrix in the design doc:
- **Executor reading 1 source**: the planner's understanding of the source layout IS beneficial context, but the planner's reasoning about what to do IS noise
- `session/fork` solves this: the forked executor starts with a copy of the planner's conversation context but diverges from that point
- Claude Code's SDK supports fork: it creates a new session that starts with a copy of the original's history

### Graceful degradation

| Capability | Behavior |
|---|---|
| `sessionCapabilities.fork` supported | `forkSession()` -> executor inherits planner context |
| `sessionCapabilities.fork` NOT supported | `forkSession()` returns `nil` -> `runPhase` falls back to `backend.start()` (fresh session, current behavior) |

No correctness risk — fork is an optimization, not a requirement.

### Testing

- `swift build` passes
- Fast test tier (2456 tests) passes
- Fork requires a live agent subprocess to exercise end-to-end; the capability detection + fallback logic is the testable unit
