### PR TITLE
Surface ingestion cost/token usage in UI (spike for #528)

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -193,6 +193,14 @@ struct ActivityWindowView: View {
                         .lineLimit(1)
                         .help(error)
                 }
+                // #528 spike: show per-run token/cost usage on completed rows.
+                if item.state == .completed,
+                   let usage = activityTracker.usage(for: item.id) {
+                    Text(UsageFormatter.summary(usage: usage))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
             Spacer(minLength: 4)
             rowAction(for: item)
@@ -368,6 +376,12 @@ struct ActivityWindowView: View {
                         .foregroundStyle(.red)
                         .textSelection(.enabled)
                         .lineLimit(4)
+                }
+                // #528 spike: show per-run usage in the detail header too.
+                if let usage = activityTracker.usage(for: item.id) {
+                    Text(UsageFormatter.summary(usage: usage))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
                 }
             }
             Spacer()

--- a/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
+++ b/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
@@ -43,7 +43,8 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
         wikiID: String,
         sourceIDs: [PageID],
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws {
         guard let store = sessionBox.resolve(wikiID: wikiID) else {
             throw QueueIngestionError.spawnFailed("No session for wikiID=\(wikiID)")
@@ -169,6 +170,12 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
             )
         }
 
+        // #528 spike: read the launcher's accumulated run-total usage after
+        // the run completes and forward it to the worker (which emits a
+        // `.usage` queue event). Done here, after `run()` returns, so the
+        // usage reflects all phases (planner → executors → finalizer).
+        onUsage?(launcher.runTotalUsage)
+
         // If the agent never spawned (cancelled, preflight failure), clear
         // the ingest flag. The tracker's ingestingSourceIDs will be cleared
         // by the queue event when the item reaches a terminal state.
@@ -182,7 +189,8 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
     func runLint(
         wikiID: String,
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws {
         guard let store = sessionBox.resolve(wikiID: wikiID) else {
             throw QueueIngestionError.spawnFailed("No session for wikiID=\(wikiID)")
@@ -208,13 +216,15 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
             onProgress: onProgress,
             onTranscript: onTranscript
         )
+        onUsage?(launcher.runTotalUsage)
     }
 
     func runLintPages(
         wikiID: String,
         pageIDs: [PageID],
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws {
         guard let store = sessionBox.resolve(wikiID: wikiID) else {
             throw QueueIngestionError.spawnFailed("No session for wikiID=\(wikiID)")
@@ -262,6 +272,7 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
             onProgress: onProgress,
             onTranscript: onTranscript
         )
+        onUsage?(launcher.runTotalUsage)
     }
 
     // MARK: - Private

--- a/Sources/WikiFS/Queue/OperationNotifier.swift
+++ b/Sources/WikiFS/Queue/OperationNotifier.swift
@@ -84,7 +84,7 @@ final class OperationNotifier {
         case .failed(let item, let error):
             post(item: item, outcome: .failed(error))
         // Cancelled is user-initiated — not worth a notification.
-        case .cancelled, .enqueued, .started, .progress, .transcript,
+        case .cancelled, .enqueued, .started, .progress, .transcript, .usage,
              .runStateChanged, .reordered:
             break
         }

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -17,6 +17,14 @@ final class TranscriptEmitBox: @unchecked Sendable {
     var emit: (@Sendable (QueueItem.ID, AgentEvent) -> Void)?
 }
 
+/// A mutable box for a `@Sendable` usage-emit closure. Same pattern as
+/// `ProgressEmitBox`/`TranscriptEmitBox` — breaks the circular dependency
+/// between the ingestion worker factory (needs the closure) and the engine
+/// (provides it). #528 spike.
+final class UsageEmitBox: @unchecked Sendable {
+    var emit: (@Sendable (QueueItem.ID, SessionUsage) -> Void)?
+}
+
 /// Observes `QueueEngine.events` and maintains `@Observable` UI state for
 /// extraction activity. Replaces the launcher's extraction slot machinery
 /// (`isExtracting`, `extractionLog`, `extractionPID`,
@@ -70,6 +78,16 @@ final class QueueActivityTracker {
     /// Per-item accumulated progress text (for extraction items that produce
     /// progress strings, not typed `AgentEvent`s). Keyed by item ID.
     private(set) var progressLogs: [QueueItem.ID: String] = [:]
+
+    /// Per-item cumulative token/cost usage for completed runs (#528 spike).
+    /// Keyed by item ID. Set once when a `.usage` event arrives. The Activity
+    /// window reads this to append "12.4K in · 3.2K out · $0.34" to completed rows.
+    private(set) var itemUsage: [QueueItem.ID: SessionUsage] = [:]
+
+    /// Today's cumulative token usage across all completed runs (#528 spike).
+    /// Persists to UserDefaults with a date key so it survives app restarts
+    /// and resets daily. Driven by `.usage` events.
+    private(set) var todayUsage: DailyUsage = DailyUsage.load()
 
     /// Accumulated progress log for the most recent extraction. Cleared on
     /// `.started`, appended on `.progress`. Drives the sidebar log text.
@@ -151,6 +169,7 @@ final class QueueActivityTracker {
         itemToSourceIDs.removeAll()
         transcripts.removeAll()
         progressLogs.removeAll()
+        itemUsage.removeAll()
         streamingTranscriptItemIDs.removeAll()
         streamingThinkingItemIDs.removeAll()
     }
@@ -254,6 +273,7 @@ final class QueueActivityTracker {
     func pruneTranscripts(for itemID: QueueItem.ID) {
         transcripts.removeValue(forKey: itemID)
         progressLogs.removeValue(forKey: itemID)
+        itemUsage.removeValue(forKey: itemID)
         streamingTranscriptItemIDs.remove(itemID)
         streamingThinkingItemIDs.remove(itemID)
     }
@@ -266,6 +286,12 @@ final class QueueActivityTracker {
     /// The accumulated progress log for a given item ID (may be empty).
     func progressLog(for itemID: QueueItem.ID) -> String {
         progressLogs[itemID] ?? ""
+    }
+
+    /// The cumulative token/cost usage for a completed item, or `nil` if the
+    /// backend didn't report usage. Read by the Activity window rows.
+    func usage(for itemID: QueueItem.ID) -> SessionUsage? {
+        itemUsage[itemID]
     }
 
     // MARK: - Event handling
@@ -299,6 +325,13 @@ final class QueueActivityTracker {
 
         case .transcript(let id, let agentEvent):
             appendTranscriptEvent(itemID: id, event: agentEvent)
+
+        case .usage(let id, let usage):
+            // #528 spike: store per-item usage for the Activity window, and
+            // accumulate today's daily total (persists to UserDefaults).
+            itemUsage[id] = usage
+            todayUsage.add(usage)
+            DailyUsage.save(todayUsage)
 
         case .progress(let id, let line):
             // Accumulate per-item progress (for extraction items and any
@@ -366,5 +399,127 @@ final class QueueActivityTracker {
         if let pid = Int32(cleaned) {
             extractionPID = pid
         }
+    }
+}
+
+// MARK: - DailyUsage (#528 spike)
+
+/// A lightweight daily token/cost accumulator that persists to UserDefaults
+/// and resets at midnight. Stores the date so stale data from a prior day is
+/// discarded on load. Not a full `usage_log` table — just enough for the menu
+/// bar's "Today: X tokens · $Y" line.
+struct DailyUsage: Sendable, Equatable {
+    var inputTokens: Int = 0
+    var outputTokens: Int = 0
+    var totalTokens: Int = 0
+    var cost: Double = 0
+    var currency: String? = nil
+    /// The calendar day this total covers (yyyy-MM-dd). On load, if this
+    /// doesn't match today, the struct is reset.
+    var date: String
+
+    private static let storageKey = "sdw_dailyUsage_v1"
+
+    /// Load today's usage from UserDefaults. If the stored date is stale
+    /// (yesterday or older), returns a fresh zero total for today.
+    static func load() -> DailyUsage {
+        let today = Self.todayString()
+        guard let dict = UserDefaults.standard.dictionary(forKey: storageKey),
+              let storedDate = dict["date"] as? String,
+              storedDate == today
+        else {
+            return DailyUsage(date: today)
+        }
+        return DailyUsage(
+            inputTokens: dict["inputTokens"] as? Int ?? 0,
+            outputTokens: dict["outputTokens"] as? Int ?? 0,
+            totalTokens: dict["totalTokens"] as? Int ?? 0,
+            cost: dict["cost"] as? Double ?? 0,
+            currency: dict["currency"] as? String,
+            date: storedDate
+        )
+    }
+
+    /// Persist to UserDefaults. Called after each `.usage` event.
+    static func save(_ usage: DailyUsage) {
+        UserDefaults.standard.set([
+            "inputTokens": usage.inputTokens,
+            "outputTokens": usage.outputTokens,
+            "totalTokens": usage.totalTokens,
+            "cost": usage.cost,
+            "currency": usage.currency as Any,
+            "date": usage.date
+        ] as [String: Any], forKey: storageKey)
+    }
+
+    /// Accumulate a run's usage into this daily total.
+    mutating func add(_ usage: SessionUsage) {
+        // Guard against double-counting if the date rolled over mid-session.
+        if date != Self.todayString() {
+            self = DailyUsage(date: Self.todayString())
+        }
+        inputTokens += usage.inputTokens
+        outputTokens += usage.outputTokens
+        totalTokens += usage.totalTokens
+        if let c = usage.cost { cost += c }
+        if currency == nil { currency = usage.currency }
+    }
+
+    /// True if anything was tracked today (non-zero tokens).
+    var hasData: Bool {
+        totalTokens > 0 || cost > 0
+    }
+
+    private static func todayString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = .current
+        return formatter.string(from: Date())
+    }
+}
+
+// MARK: - Usage formatting (#528 spike)
+
+/// Pure formatting helpers for token/cost usage display. No UI — just
+/// number → string so views stay declarative and the logic is testable.
+enum UsageFormatter {
+    /// Format a token count as "12.4K" or "1.2M" (compact). Below 1,000 shows
+    /// the raw integer. Uses the "K"/"M" suffixes the issue spec mentions.
+    static func tokens(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        } else if count >= 1_000 {
+            return String(format: "%.1fK", Double(count) / 1_000)
+        }
+        return "\(count)"
+    }
+
+    /// Format a cost as "$0.34" or "$1,234.56". Returns nil if cost is 0 or nil.
+    static func cost(_ amount: Double?, currency: String?) -> String? {
+        guard let amount, amount > 0 else { return nil }
+        let symbol = currency == "USD" || currency == nil ? "$" : ""
+        let suffix = (currency != nil && currency != "USD") ? " \(currency!)" : ""
+        return String(format: "%@%.2f%@", symbol, amount, suffix)
+    }
+
+    /// A compact one-line summary: "12.4K in · 3.2K out · $0.34". Omits the
+    /// cost segment when nil/zero. Uses middle-dot separator (macOS convention).
+    static func summary(usage: SessionUsage) -> String {
+        var parts: [String] = []
+        parts.append("\(tokens(usage.inputTokens)) in")
+        parts.append("\(tokens(usage.outputTokens)) out")
+        if let cost = cost(usage.cost, currency: usage.currency) {
+            parts.append(cost)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// A daily total line: "Today: 45.2K tokens · $1.23". Omits cost when nil.
+    static func dailySummary(usage: DailyUsage) -> String {
+        var parts: [String] = ["Today: \(tokens(usage.totalTokens)) tokens"]
+        if usage.cost > 0 {
+            parts.append(cost(usage.cost, currency: usage.currency) ?? "")
+        }
+        return parts.joined(separator: " · ")
     }
 }

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -195,6 +195,17 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
 
+        // #528 spike: today's cumulative token/cost usage.
+        if activityTracker.todayUsage.hasData {
+            let usageItem = NSMenuItem(
+                title: UsageFormatter.dailySummary(usage: activityTracker.todayUsage),
+                action: nil,
+                keyEquivalent: "")
+            usageItem.isEnabled = false
+            menu.addItem(usageItem)
+            menu.addItem(.separator())
+        }
+
         // Wiki maintenance actions.
         let maintenanceItem = NSMenuItem(
             title: "Maintenance",

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -152,13 +152,15 @@ struct WikiFSApp: App {
         // closure, engine needs the factory).
         let progressBox = ProgressEmitBox()
         let transcriptBox = TranscriptEmitBox()
+        let usageBox = UsageEmitBox()
         let extractionFactory = QueueExtractionWorkerFactory(
             provider: extractionProvider,
             emitProgress: { id, line in progressBox.emit?(id, line) })
         let ingestionFactory = QueueIngestionWorkerFactory(
             provider: ingestionProvider,
             emitProgress: { id, line in progressBox.emit?(id, line) },
-            emitTranscript: { id, event in transcriptBox.emit?(id, event) })
+            emitTranscript: { id, event in transcriptBox.emit?(id, event) },
+            emitUsage: { id, usage in usageBox.emit?(id, usage) })
         let workerFactory = CompositeWorkerFactory(factories: [
             .extraction: extractionFactory,
             .ingestion: ingestionFactory
@@ -171,6 +173,7 @@ struct WikiFSApp: App {
         // dispatched yet at this point in init).
         Task { progressBox.emit = await queueEngine.makeEmitProgress() }
         Task { transcriptBox.emit = await queueEngine.makeEmitTranscript() }
+        Task { usageBox.emit = await queueEngine.makeEmitUsage() }
         // Start the engine (rehydrate + crash recovery + initial dispatch).
         // Detached so the app's init isn't blocked; the engine is an actor so
         // `start()` is safe to call concurrently.

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -1365,6 +1365,30 @@ public struct SessionUsage: Sendable {
         self.contextUsed = contextUsed
         self.contextSize = contextSize
     }
+
+    /// Merge two usage snapshots for run-total accumulation (#528 spike).
+    /// Token counts are summed; context window + cost reflect the most recent
+    /// snapshot (they are point-in-time, not cumulative across phases).
+    /// `existing == nil` returns `new` directly.
+    public static func merging(_ existing: SessionUsage?, _ new: SessionUsage) -> SessionUsage {
+        guard let existing else { return new }
+        let mergedCost: Double?
+        if let e = existing.cost, let n = new.cost {
+            mergedCost = e + n
+        } else {
+            mergedCost = new.cost ?? existing.cost
+        }
+        return SessionUsage(
+            inputTokens: existing.inputTokens + new.inputTokens,
+            outputTokens: existing.outputTokens + new.outputTokens,
+            totalTokens: existing.totalTokens + new.totalTokens,
+            cachedReadTokens: (existing.cachedReadTokens ?? 0) + (new.cachedReadTokens ?? 0),
+            thoughtTokens: (existing.thoughtTokens ?? 0) + (new.thoughtTokens ?? 0),
+            cost: mergedCost,
+            currency: new.currency ?? existing.currency,
+            contextUsed: new.contextUsed,
+            contextSize: new.contextSize)
+    }
 }
 
 /// Thread-safe accumulator for per-session usage data. Captured in the

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -367,6 +367,13 @@ public final class AgentLauncher {
     /// old `process: Process?` — the launcher never touches a `Process` directly.
     @ObservationIgnored private var sessionHandle: SessionHandle?
 
+    /// Cumulative token/cost usage across ALL ACP phases in the current run
+    /// (#528 spike). Accumulated from each phase's `sessionUsage(for:)` before
+    /// the phase session is closed (since `closeSession` removes the usage
+    /// state). Read by `AppQueueIngestionProvider` after `run(...)` returns.
+    /// nil when no usage has been captured (non-ACP backend or empty run).
+    @ObservationIgnored private(set) public var runTotalUsage: SessionUsage?
+
     /// The planner session handle kept alive during the executor phase so it
     /// can be forked (Phase 3, `plans/acp-session-efficiency.md` §4). nil unless
     /// we're in the planner-executors ingest flow AND the planner session is
@@ -929,6 +936,13 @@ public final class AgentLauncher {
             // returns so callers see post-finish state: gate released, run
             // lifecycle decremented, onAgentEvent cleared. finish() is idempotent
             // (isRunning guard), so a later onExit-triggered finish() is a no-op.
+            //
+            // #528 spike: capture per-session usage before finish() nils the
+            // session handle. The ACPBackend retains the usage state until the
+            // session is closed/cancelled, but finish() drops our handle ref.
+            if isRunning, let handle = sessionHandle {
+                await capturePhaseUsage(backend: self.backend, session: handle)
+            }
             if isRunning {
                 finish(status: exitStatus ?? 0)
             }
@@ -1160,6 +1174,7 @@ public final class AgentLauncher {
                     phaseName: "executor[\(sourceFile)]",
                     forkFrom: forkFrom
                 ) {
+                    await capturePhaseUsage(backend: executorRouting.backend, session: session)
                     if let acp = executorRouting.backend as? ACPBackend {
                         await acp.closeSession(session)
                     } else {
@@ -1179,6 +1194,7 @@ public final class AgentLauncher {
         // alive (e.g., the planner failed early and we fell back), this is nil.
         if let plannerSession = plannerSessionHandle {
             DebugLog.agent("runACPIngest: closing planner session (all forks done)")
+            await capturePhaseUsage(backend: plannerRouting.backend, session: plannerSession)
             if let acp = plannerRouting.backend as? ACPBackend {
                 await acp.closeSession(plannerSession)
             } else {
@@ -1217,6 +1233,7 @@ public final class AgentLauncher {
             prompt: finalizerPrompt,
             phaseName: "finalizer"
         ) {
+            await capturePhaseUsage(backend: finalizerRouting.backend, session: session)
             if let acp = finalizerRouting.backend as? ACPBackend {
                 await acp.closeSession(session)
             } else {
@@ -1351,11 +1368,25 @@ public final class AgentLauncher {
         ) {
             captureAndCacheModels(provider: routing.provider, session: session)
             captureProcessID(session: session)
+            await capturePhaseUsage(backend: routing.backend, session: session)
             await routing.backend.cancel(session)
             finish(status: 0)
         } else {
             finish(status: -1)
         }
+    }
+
+    // MARK: - Usage accumulation (#528 spike)
+
+    /// Read per-session usage from an `ACPBackend` phase and merge it into
+    /// `runTotalUsage`. MUST be called BEFORE `closeSession`/`cancel` — once
+    /// the session is closed, the usage state is removed from the backend.
+    /// Non-ACP backends are a silent no-op (no usage data available).
+    private func capturePhaseUsage(backend: AgentBackend, session: SessionHandle) async {
+        guard let acp = backend as? ACPBackend else { return }
+        guard let usage = await acp.sessionUsage(for: session) else { return }
+        runTotalUsage = SessionUsage.merging(runTotalUsage, usage)
+        DebugLog.agent("runTotalUsage: captured phase usage in=\(usage.inputTokens) out=\(usage.outputTokens) cost=\(usage.cost ?? 0)")
     }
 
     /// Resolve the path to a binary bundled in `Contents/Helpers/`, or nil if
@@ -2206,6 +2237,7 @@ public final class AgentLauncher {
         currentProcessID = nil
         sessionHandle = nil
         plannerSessionHandle = nil
+        runTotalUsage = nil
         onUnlockHandler = nil
         // A reset starts a new run: a stale sink must never receive a new
         // session's events (issue #119).

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -367,6 +367,15 @@ public actor QueueEngine {
         }
     }
 
+    /// A `Sendable` closure the worker factory captures to yield `.usage`
+    /// events onto the engine's broadcaster. #528 spike — surfaces per-run
+    /// token/cost usage to the activity tracker (no persistence needed).
+    public func makeEmitUsage() -> @Sendable (QueueItem.ID, SessionUsage) -> Void {
+        return { [broadcaster] id, usage in
+            broadcaster.yield(.usage(id, usage))
+        }
+    }
+
     /// Load persisted agent events (transcript) for a queue item from the DB.
     /// Used by the Activity tracker to show transcripts for items rehydrated
     /// from a previous session. Deltas are folded into whole rows on the way

--- a/Sources/WikiFSEngine/QueueEventLog.swift
+++ b/Sources/WikiFSEngine/QueueEventLog.swift
@@ -16,6 +16,7 @@ enum QueueEventType: String, Codable, Sendable {
     case cancelled
     case progress
     case transcript
+    case usage
     case runStateChanged
     case reordered
 }
@@ -202,6 +203,25 @@ struct QueueLogRecord: Codable, Sendable {
             self.finishedAt = nil
             self.durationMs = nil
 
+        case .usage:
+            // Usage events carry cumulative token/cost data per run (#528
+            // spike). Consumed live by the Activity window, NOT logged to
+            // JSONL. The write() method skips this case (high-volume-ish +
+            // SessionUsage is not Codable here).
+            self.eventType = .usage
+            self.itemID = nil
+            self.queue = nil
+            self.wikiID = nil
+            self.providerID = nil
+            self.itemState = nil
+            self.runState = nil
+            self.orderingKey = nil
+            self.attempt = nil
+            self.error = nil
+            self.startedAt = nil
+            self.finishedAt = nil
+            self.durationMs = nil
+
         case .runStateChanged(let queue, let state):
             self.eventType = .runStateChanged
             self.itemID = nil
@@ -338,6 +358,7 @@ public actor QueueEventLog {
         // UI consumes them live via the event stream.
         if case .progress = event { return }
         if case .transcript = event { return }
+        if case .usage = event { return }
 
         ensureOpenForToday()
         guard let handle = fileHandle else { return }

--- a/Sources/WikiFSEngine/QueueIngestionProvider.swift
+++ b/Sources/WikiFSEngine/QueueIngestionProvider.swift
@@ -33,11 +33,15 @@ public protocol QueueIngestionProvider: Sendable {
     ///   - onTranscript: Called with each typed agent event for this item,
     ///     so the tracker can build a per-item transcript for the Activity
     ///     window. `nil` for callers that don't need transcript forwarding.
+    ///   - onUsage: Called once after the run finishes with the cumulative
+    ///     token/cost usage (`SessionUsage`), if captured. `nil` when the
+    ///     backend did not report usage data. #528 spike.
     func runIngestion(
         wikiID: String,
         sourceIDs: [PageID],
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws
 
     /// Run a whole-wiki lint health-check. Returns when the agent finishes.
@@ -46,10 +50,12 @@ public protocol QueueIngestionProvider: Sendable {
     ///   - wikiID: The wiki to lint.
     ///   - onProgress: Called with progress lines to emit as `.progress` events.
     ///   - onTranscript: Called with each typed agent event for this item.
+    ///   - onUsage: Called after the run with cumulative usage, if captured.
     func runLint(
         wikiID: String,
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws
 
     /// Run a page-level lint health-check for the given pages. Returns when
@@ -60,11 +66,13 @@ public protocol QueueIngestionProvider: Sendable {
     ///   - pageIDs: The page IDs to lint.
     ///   - onProgress: Called with progress lines to emit as `.progress` events.
     ///   - onTranscript: Called with each typed agent event for this item.
+    ///   - onUsage: Called after the run with cumulative usage, if captured.
     func runLintPages(
         wikiID: String,
         pageIDs: [PageID],
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws
 }
 
@@ -96,15 +104,18 @@ public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
     private let provider: any QueueIngestionProvider
     private let emitProgress: @Sendable (QueueItem.ID, String) -> Void
     private let emitTranscript: @Sendable (QueueItem.ID, AgentEvent) -> Void
+    private let emitUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
 
     public init(
         provider: any QueueIngestionProvider,
         emitProgress: @escaping @Sendable (QueueItem.ID, String) -> Void,
-        emitTranscript: @escaping @Sendable (QueueItem.ID, AgentEvent) -> Void
+        emitTranscript: @escaping @Sendable (QueueItem.ID, AgentEvent) -> Void,
+        emitUsage: @escaping @Sendable (QueueItem.ID, SessionUsage) -> Void
     ) {
         self.provider = provider
         self.emitProgress = emitProgress
         self.emitTranscript = emitTranscript
+        self.emitUsage = emitUsage
     }
 
     public func providerID(for item: QueueItem) async -> String? {
@@ -121,7 +132,7 @@ public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
     }
 
     public func worker(for item: QueueItem) async throws -> any QueueWorker {
-        QueueIngestionWorker(provider: provider, emitProgress: emitProgress, emitTranscript: emitTranscript)
+        QueueIngestionWorker(provider: provider, emitProgress: emitProgress, emitTranscript: emitTranscript, emitUsage: emitUsage)
     }
 }
 
@@ -139,10 +150,15 @@ struct QueueIngestionWorker: QueueWorker {
     let provider: any QueueIngestionProvider
     let emitProgress: @Sendable (QueueItem.ID, String) -> Void
     let emitTranscript: @Sendable (QueueItem.ID, AgentEvent) -> Void
+    let emitUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
 
     func execute(_ item: QueueItem) async throws {
         let onTranscript: (@Sendable (AgentEvent) -> Void)? = { [itemID = item.id] event in
             emitTranscript(itemID, event)
+        }
+        let onUsage: (@Sendable (SessionUsage?) -> Void)? = { [itemID = item.id] usage in
+            guard let usage else { return }
+            emitUsage(itemID, usage)
         }
 
         if let pageIDs = item.payload.lintPageIDs, !pageIDs.isEmpty {
@@ -151,14 +167,16 @@ struct QueueIngestionWorker: QueueWorker {
                 wikiID: item.wikiID,
                 pageIDs: pageIDs,
                 onProgress: { [itemID = item.id] line in emitProgress(itemID, line) },
-                onTranscript: onTranscript
+                onTranscript: onTranscript,
+                onUsage: onUsage
             )
         } else if item.payload.lintPageIDs != nil {
             // lintPageIDs is non-nil but empty → whole-wiki lint.
             try await provider.runLint(
                 wikiID: item.wikiID,
                 onProgress: { [itemID = item.id] line in emitProgress(itemID, line) },
-                onTranscript: onTranscript
+                onTranscript: onTranscript,
+                onUsage: onUsage
             )
         } else {
             // Normal ingestion.
@@ -170,7 +188,8 @@ struct QueueIngestionWorker: QueueWorker {
                 wikiID: item.wikiID,
                 sourceIDs: sourceIDs,
                 onProgress: { [itemID = item.id] line in emitProgress(itemID, line) },
-                onTranscript: onTranscript
+                onTranscript: onTranscript,
+                onUsage: onUsage
             )
         }
     }

--- a/Sources/WikiFSEngine/QueueWorker.swift
+++ b/Sources/WikiFSEngine/QueueWorker.swift
@@ -80,6 +80,10 @@ public enum QueueEvent: Sendable {
     /// Carries the item ID + the event. Used by the Activity window to
     /// build per-item transcripts (decoupled from the launcher instance).
     case transcript(QueueItem.ID, AgentEvent)
+    /// Final cumulative token/cost usage for a completed ingestion or lint
+    /// run. Emitted once, after the run finishes. #528 spike — surfaces
+    /// per-run usage in the Activity window and aggregates a daily total.
+    case usage(QueueItem.ID, SessionUsage)
     /// An item transitioned to `.completed`.
     case completed(QueueItem)
     /// An item transitioned to `.failed`. Carries the error message.
@@ -100,7 +104,7 @@ public enum QueueEvent: Sendable {
             return i
         case .failed(let i, _):
             return i
-        case .progress, .transcript, .runStateChanged:
+        case .progress, .transcript, .usage, .runStateChanged:
             return nil
         }
     }

--- a/Tests/WikiFSTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSTests/QueueIngestionTests.swift
@@ -96,7 +96,8 @@ actor FakeIngestionProvider: QueueIngestionProvider {
         wikiID: String,
         sourceIDs: [PageID],
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws {
         calledWikiID = wikiID
         calledSourceIDs = sourceIDs
@@ -108,7 +109,8 @@ actor FakeIngestionProvider: QueueIngestionProvider {
     func runLint(
         wikiID: String,
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws {
         calledLintWikiID = wikiID
         calledLintPageIDs = []
@@ -121,7 +123,8 @@ actor FakeIngestionProvider: QueueIngestionProvider {
         wikiID: String,
         pageIDs: [PageID],
         onProgress: @escaping @Sendable (String) -> Void,
-        onTranscript: (@Sendable (AgentEvent) -> Void)?
+        onTranscript: (@Sendable (AgentEvent) -> Void)?,
+        onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws {
         calledLintWikiID = wikiID
         calledLintPageIDs = pageIDs
@@ -145,7 +148,7 @@ struct QueueIngestionWorkerTests {
         let factory = QueueIngestionWorkerFactory(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "test1", queue: .ingestion, wikiID: "wiki1",
             payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "src1")]),
@@ -170,7 +173,7 @@ struct QueueIngestionWorkerTests {
         let worker = QueueIngestionWorker(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
 
         await #expect(throws: QueueIngestionError.self) {
             try await worker.execute(QueueItem(
@@ -188,7 +191,7 @@ struct QueueIngestionWorkerTests {
         let worker = QueueIngestionWorker(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
 
         await #expect(throws: QueueIngestionError.self) {
             try await worker.execute(QueueItem(
@@ -352,7 +355,7 @@ struct LintIngestionDispatchTests {
         let factory = QueueIngestionWorkerFactory(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "lint1", queue: .ingestion, wikiID: "w1",
             payload: QueueItemPayload(sourceIDs: [], lintPageIDs: [PageID(rawValue: "p1")]),
@@ -377,7 +380,7 @@ struct LintIngestionDispatchTests {
         let factory = QueueIngestionWorkerFactory(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "lint2", queue: .ingestion, wikiID: "w1",
             payload: QueueItemPayload(sourceIDs: [], lintPageIDs: []),
@@ -400,7 +403,7 @@ struct LintIngestionDispatchTests {
         let factory = QueueIngestionWorkerFactory(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "ing1", queue: .ingestion, wikiID: "w1",
             payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "s1")]),


### PR DESCRIPTION
# Surface ingestion cost/token usage in UI (spike for #528)

## Summary

ACP Phase 4 (PR #544) added SessionUsage capture at the ACPBackend seam — per-session inputTokens, outputTokens, totalTokens, cachedReadTokens, thoughtTokens, cost, currency, contextUsed, contextSize. The data was captured but never shown to the user.

This spike surfaces it in two places:
- Activity window — completed ingestion/lint rows show "12.4K in · 3.2K out · $0.34"
- Menu bar dropdown — a disabled line showing today's cumulative usage: "Today: 45.2K tokens · $1.23"

## What's implemented

### 1. QueueEvent.usage — new event case
Added .usage(QueueItem.ID, SessionUsage) to the QueueEvent enum. Emitted once per run, after the run finishes. Not logged to the JSONL audit trail (like .progress/.transcript — it's display data, not a state transition).

### 2. Run-total usage accumulation in AgentLauncher
Added runTotalUsage: SessionUsage? (public, observable-ignored) to AgentLauncher. Accumulated across all ACP phases (planner → executors → finalizer) via capturePhaseUsage(backend:session:) — called before each closeSession/cancel (since closeSession removes the usage state from ACPBackend). Reset in resetRunArtifacts().

Covers all run paths:
- Multi-phase (runACPIngestPlannerExecutors) — captures after each phase
- Single-session fallback (runACPIngestFallback)
- Small ingest + lint (run() single-session path)

Added SessionUsage.merging(_:_:) to sum token counts across phases (cost is summed; context window reflects the most recent snapshot).

### 3. onUsage callback wired through the provider → worker → engine
- QueueIngestionProvider protocol: runIngestion/runLint/runLintPages gain onUsage: (@Sendable (SessionUsage?) -> Void)?
- AppQueueIngestionProvider: after launcher.run(...) returns, calls onUsage?(launcher.runTotalUsage)
- QueueIngestionWorker: forwards to emitUsage(itemID, usage)
- QueueIngestionWorkerFactory: gains emitUsage closure
- QueueEngine.makeEmitUsage(): yields .usage onto the broadcaster
- UsageEmitBox: breaks the factory↔engine circular dependency (same pattern as ProgressEmitBox/TranscriptEmitBox)
- Wired in WikiFSApp.swift

### 4. Per-item + daily usage tracking in QueueActivityTracker
- itemUsage: [QueueItem.ID: SessionUsage] — per-item, set on .usage event
- todayUsage: DailyUsage — cumulative daily total, persists to UserDefaults with a date key (resets daily)
- DailyUsage struct: load/save/add, with date-rollover protection
- UsageFormatter enum: pure formatting ("12.4K in · 3.2K out · $0.34", "Today: 45.2K tokens · $1.23")

### 5. UI display
- Activity window rows: completed items show usage summary in caption
- Activity window detail header: selected item shows usage in callout
- Menu bar dropdown: disabled menu item with daily total (only shown when todayUsage.hasData)

## What's NOT implemented (out of scope for this spike)
- Configurable spend caps (BudgetConfig)
- usage_log SQLite table (daily total uses UserDefaults, not a DB)
- Settings UI for caps
- Auto-pause on budget exhaustion
- Warning thresholds
- Provider model fallback on budget pressure

## Test plan
- [x] swift build passes
- [x] Fast test tier passes (2461 tests, 0 failures)
- [ ] Manual: run an ingestion, verify the Activity window row shows "X in · Y out · $Z"
- [ ] Manual: verify menu bar shows "Today: ..." after a run

Closes #528 (spike portion — full budget enforcement deferred).
