### PR TITLE
Extract named constants for ACPBackend + AgentLauncher magic numbers

### DIFF
--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -1187,6 +1187,18 @@ public actor ACPBackend: AgentBackend {
             environment: environment)
     }
 
+    /// Named constants for the environment-variable keys and values that
+    /// `buildAgentEnv` exports into the agent subprocess. Centralizes the raw
+    /// string literals so typos are caught at compile time — same pattern as
+    /// `HintKey` (issue #509).
+    private enum AgentEnvKey {
+        static let wikiDB = "WIKI_DB"
+        static let wikictl = "WIKICTL"
+        static let path = "PATH"
+        static let defaultPath = "/usr/bin:/bin"
+        static let pathSeparator = ":"
+    }
+
     /// Builds the environment dict for the agent subprocess. Exports `WIKI_DB`,
     /// `WIKICTL`, and prepends the wikictl directory to `PATH`. `WIKI_ROOT` is
     /// intentionally NOT exported — the mount is optional; wikictl is the primary
@@ -1199,16 +1211,27 @@ public actor ACPBackend: AgentBackend {
         spawnEnvironment: [String: String]
     ) -> [String: String] {
         var env = baseEnv
-        env["WIKI_DB"] = cli.wikiID
+        env[AgentEnvKey.wikiDB] = cli.wikiID
         // WIKI_ROOT is intentionally NOT exported — mount is optional; wikictl is the primary read surface (#441).
-        env["WIKICTL"] = cli.wikictlDirectory + "/wikictl"
-        let existingPath = env["PATH"] ?? "/usr/bin:/bin"
-        env["PATH"] = cli.wikictlDirectory + ":" + existingPath
+        env[AgentEnvKey.wikictl] = cli.wikictlDirectory + "/wikictl"
+        let existingPath = env[AgentEnvKey.path] ?? AgentEnvKey.defaultPath
+        env[AgentEnvKey.path] = cli.wikictlDirectory + AgentEnvKey.pathSeparator + existingPath
         for (key, value) in spawnEnvironment {
             env[key] = value
         }
         return env
     }
+
+    /// Filenames the agent reads for system context from its working directory
+    /// (spec models system context as `CLAUDE.md`/`AGENTS.md` in cwd). Both are
+    /// written by `deliverSystemPrompt` so the agent reads from whichever it
+    /// supports.
+    private static let systemPromptFilenames = ["CLAUDE.md", "AGENTS.md"]
+
+    /// Delimiter separating the injected system prompt from the user task.
+    private static let systemPromptDelimiter = "---"
+    /// Header marking the start of the user task beneath the system prompt.
+    private static let taskHeader = "# YOUR TASK"
 
     /// Writes the system prompt to the agent's working directory as both
     /// `CLAUDE.md` and `AGENTS.md` — the spec-compliant delivery mechanism.
@@ -1226,7 +1249,7 @@ public actor ACPBackend: AgentBackend {
     static func deliverSystemPrompt(_ systemPrompt: String, to workingDir: String) {
         guard !systemPrompt.isEmpty else { return }
         let dirURL = URL(fileURLWithPath: workingDir)
-        for filename in ["CLAUDE.md", "AGENTS.md"] {
+        for filename in Self.systemPromptFilenames {
             let url = dirURL.appendingPathComponent(filename)
             do {
                 try systemPrompt.write(to: url, atomically: true, encoding: .utf8)
@@ -1250,8 +1273,8 @@ public actor ACPBackend: AgentBackend {
         return """
         \(systemPrompt)
 
-        ---
-        # YOUR TASK
+        \(Self.systemPromptDelimiter)
+        \(Self.taskHeader)
         \(userText)
         """
     }

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -1439,6 +1439,16 @@ public final class AgentLauncher {
     /// didn't unblock sendPrompt) and the process is truly wedged.
     nonisolated static let watchdogStallThreshold: TimeInterval = 180
 
+    /// Watchdog heartbeat poll interval (seconds). The loop sleeps this long
+    /// between idle-seconds checks.
+    nonisolated static let watchdogPollInterval: TimeInterval = 3
+
+    /// Grace period (seconds) after `stopAgent()` before escalating to SIGTERM.
+    nonisolated static let sigtermGracePeriod: TimeInterval = 10
+
+    /// Grace period (seconds) after SIGTERM before escalating to SIGKILL.
+    nonisolated static let sigkillGracePeriod: TimeInterval = 5
+
     /// Pure stall-detection decision for the launcher watchdog. Extracted so
     /// the threshold logic is unit-testable without driving launcher state.
     /// - Returns: true if the watchdog should escalate (stopAgent + kill).
@@ -1467,7 +1477,7 @@ public final class AgentLauncher {
         watchdogTask?.cancel()
         watchdogTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(3))
+                try? await Task.sleep(for: .seconds(Self.watchdogPollInterval))
                 guard let self, self.isRunning else { return }
                 let pid = self.currentProcessID ?? -1
                 let idle = self.lastActivityAt.map { Date().timeIntervalSince($0) } ?? -1
@@ -1501,13 +1511,13 @@ public final class AgentLauncher {
         guard pid > 0 else { return }
         Task { @MainActor in
             // Phase 1: wait for cancel to take effect.
-            try? await Task.sleep(for: .seconds(10))
+            try? await Task.sleep(for: .seconds(Self.sigtermGracePeriod))
             if Self.isProcessAlive(pid) {
                 DebugLog.agent("watchdog: cancel didn't kill pid=\(pid), sending SIGTERM to process group")
                 kill(-pid, SIGTERM)
 
                 // Phase 2: wait for SIGTERM.
-                try? await Task.sleep(for: .seconds(5))
+                try? await Task.sleep(for: .seconds(Self.sigkillGracePeriod))
                 if Self.isProcessAlive(pid) {
                     DebugLog.agent("watchdog: SIGTERM didn't kill pid=\(pid), sending SIGKILL to process group")
                     kill(-pid, SIGKILL)


### PR DESCRIPTION
## Summary

Second cleanup pass extracting magic numbers and raw string literals in `ACPBackend.swift` and `AgentLauncher.swift` into named constants — the same pattern used for `HintKey` (#509) and `TurnLivenessPolicy`.

## Changes

### AgentLauncher — kill-escalation timeouts

Three `Task.sleep(for: .seconds(N))` calls replaced with named constants alongside the existing `watchdogStallThreshold`:

| Constant | Value | Usage |
|---|---|---|
| `watchdogPollInterval` | 3s | Heartbeat loop sleep between idle checks |
| `sigtermGracePeriod` | 10s | Grace period after `stopAgent()` before SIGTERM |
| `sigkillGracePeriod` | 5s | Grace period after SIGTERM before SIGKILL |

### ACPBackend — env-var string keys

Raw string literals in `buildAgentEnv` replaced with a `private enum AgentEnvKey` (matching the `HintKey` pattern):

- `WIKI_DB` → `AgentEnvKey.wikiDB`
- `WIKICTL` → `AgentEnvKey.wikictl`
- `PATH` → `AgentEnvKey.path`
- `/usr/bin:/bin` → `AgentEnvKey.defaultPath`
- `:` separator → `AgentEnvKey.pathSeparator`

### ACPBackend — system-prompt constants

- `["CLAUDE.md", "AGENTS.md"]` inline array → `systemPromptFilenames`
- `---` delimiter → `systemPromptDelimiter`
- `# YOUR TASK` header → `taskHeader`

## Testing

- `make version prompts && swift build` — clean
- Fast test tier (2461 tests) — all passed
