### PR TITLE
Strip TEMP DEBUG comments + fix bare try? in QueueStore.loadItemEvents

### DIFF
--- a/Sources/WikiFS/Settings/ProviderSelector.swift
+++ b/Sources/WikiFS/Settings/ProviderSelector.swift
@@ -367,7 +367,7 @@ struct ProviderSelector: View {
         let parts = rowID.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
         guard parts.count == 2, let provider = config.provider(id: String(parts[0])) else { return }
         let modelId: String? = parts[1] == "default" ? nil : String(parts[1])
-        DebugLog.agent("ProviderSelector.selectRow: provider=\(provider.id) modelId=\(modelId ?? "nil") (nil=Default/agent-default)") // TEMP DEBUG
+        DebugLog.agent("ProviderSelector.selectRow: provider=\(provider.id) modelId=\(modelId ?? "nil") (nil=Default/agent-default)")
         config = launcher.setSelectedModelAndDefault(modelId, provider: provider)
         isPresented = false
         searchText = ""

--- a/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
@@ -241,7 +241,7 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         } else {
             cache[providerId] = models
         }
-        DebugLog.store("AgentProvidersConfig.settingCachedModels: provider=\(providerId) count=\(models.isEmpty ? 0 : models.count)") // TEMP DEBUG
+        DebugLog.store("AgentProvidersConfig.settingCachedModels: provider=\(providerId) count=\(models.isEmpty ? 0 : models.count)")
         return AgentProvidersConfig(
             providers: providers,
             providerModels: cache,
@@ -262,7 +262,7 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         } else {
             selections.removeValue(forKey: providerId)
         }
-        DebugLog.store("AgentProvidersConfig.settingSelectedModel: provider=\(providerId) modelId=\(modelId ?? "nil")") // TEMP DEBUG
+        DebugLog.store("AgentProvidersConfig.settingSelectedModel: provider=\(providerId) modelId=\(modelId ?? "nil")")
         return AgentProvidersConfig(
             providers: providers,
             providerModels: providerModels,
@@ -351,7 +351,7 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         if let config = load(from: directory), !config.providers.isEmpty {
             // Preserve the decoded model caches + selections (re-wrapping with
             // only `providers` would wipe them). Re-normalize providers only.
-            DebugLog.store("AgentProvidersConfig.loadOrSeed: LOAD providers=\(config.providers.count) hasModelCaches=\(!config.providerModels.isEmpty) hasSelections=\(!config.selectedModelIds.isEmpty)") // TEMP DEBUG
+            DebugLog.store("AgentProvidersConfig.loadOrSeed: LOAD providers=\(config.providers.count) hasModelCaches=\(!config.providerModels.isEmpty) hasSelections=\(!config.selectedModelIds.isEmpty)")
             return AgentProvidersConfig(
                 providers: config.providers,
                 providerModels: config.providerModels,
@@ -361,7 +361,7 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
                 maxConcurrent: config.maxConcurrent)
         }
         // Missing / corrupt / empty → seed + persist.
-        DebugLog.store("AgentProvidersConfig.loadOrSeed: SEED (file missing/corrupt/empty)") // TEMP DEBUG
+        DebugLog.store("AgentProvidersConfig.loadOrSeed: SEED (file missing/corrupt/empty)")
         let seeded = seed(discovered: discover())
         try? seeded.save(to: directory)
         return seeded

--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -759,10 +759,15 @@ public final class QueueStore: @unchecked Sendable {
                     db,
                     sql: "SELECT event_json FROM queue_item_events WHERE item_id = ? ORDER BY seq;",
                     arguments: [itemID])
-                return rows.compactMap { row in
+                return rows.compactMap { row -> AgentEvent? in
                     let json: String = row["event_json"]
                     guard let data = json.data(using: .utf8) else { return nil }
-                    return try? JSONDecoder().decode(AgentEvent.self, from: data)
+                    do {
+                        return try JSONDecoder().decode(AgentEvent.self, from: data)
+                    } catch {
+                        DebugLog.store("QueueStore.loadItemEvents: decode failed for event row — \(error.localizedDescription)")
+                        return nil
+                    }
                 }
             }
         }

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -237,17 +237,13 @@ public actor ACPBackend: AgentBackend {
     )
 
 // MARK: - AgentBackend
-// TEMP DEBUG: ACPBackend.start/send/cancel carry verbose lifecycle logging
-// TEMP DEBUG: (launch, initialize, auth, model discovery, setModel, per-turn
-// TEMP DEBUG: prompt). Each DebugLog.agent line is tagged TEMP DEBUG for a
-// TEMP DEBUG: later `grep -n "TEMP DEBUG"` strip.
 
     public func start(
         profile: BackendProfile,
         systemPrompt: String,
         onExit: @escaping @Sendable (Int) -> Void
     ) async throws -> SessionHandle {
-        DebugLog.agent("ACPBackend.start: enter providerHints=\(profile.providerHints)") // TEMP DEBUG (existed; re-tagged)
+        DebugLog.agent("ACPBackend.start: enter providerHints=\(profile.providerHints)")
         // Warm-subprocess reuse (Phase 1, plans/acp-session-efficiency.md): if a
         // warm process already exists (spawned by a prior `start()` call on this
         // backend), skip the expensive launch+initialize+authenticate and just
@@ -274,7 +270,7 @@ public actor ACPBackend: AgentBackend {
         onExit: @escaping @Sendable (Int) -> Void
     ) async throws {
         guard let spawn = Self.resolveSpawnConfig(from: profile) else {
-            DebugLog.agent("ACPBackend.startProcess: FAIL noAgentConfigured") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.startProcess: FAIL noAgentConfigured")
             throw ACPBackendError.noAgentConfigured
         }
 
@@ -284,7 +280,7 @@ public actor ACPBackend: AgentBackend {
         let permissionDelegate = ACPPermissionDelegate(policy: permissionPolicy)
         await client.setDelegate(permissionDelegate)
 
-        DebugLog.agent("ACPBackend.startProcess: launching \(spawn.executablePath) \(spawn.arguments.joined(separator: " "))") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.startProcess: launching \(spawn.executablePath) \(spawn.arguments.joined(separator: " "))")
         // Build the environment so the agent can find wikictl + the wiki DB.
         // Exports WIKI_DB/WIKICTL/PATH (NOT WIKI_ROOT — mount is optional;
         // wikictl is the primary read surface, issue #441).
@@ -305,7 +301,7 @@ public actor ACPBackend: AgentBackend {
             environment: env
         )
 
-        DebugLog.agent("ACPBackend.startProcess: process launched, sending initialize") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.startProcess: process launched, sending initialize")
         // Slice 3: initialize, then authenticate if the agent advertises
         // authMethods. The DECISION is a pure helper (`ACPAuthResolver.resolve`)
         // so it's unit-tested directly; here we just execute it. A key is never
@@ -315,14 +311,14 @@ public actor ACPBackend: AgentBackend {
             capabilities: capabilities,
             clientInfo: ClientInfo(name: "SelfDrivingWiki", title: "Self Driving Wiki", version: GeneratedVersion.appVersion)
         )
-        DebugLog.agent("ACPBackend.startProcess: initialize OK agent=\(initResponse.agentInfo?.name ?? "?") authMethods=\(initResponse.authMethods?.count ?? 0)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.startProcess: initialize OK agent=\(initResponse.agentInfo?.name ?? "?") authMethods=\(initResponse.authMethods?.count ?? 0)")
 
         switch ACPAuthResolver.resolve(authMethods: initResponse.authMethods, apiKey: spawn.apiKey) {
         case .skip:
             // Agent needs no auth — proceed straight to newSession.
-            DebugLog.agent("ACPBackend.startProcess: agent advertised no authMethods, skipping authenticate") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.startProcess: agent advertised no authMethods, skipping authenticate")
         case .authenticate(let methodId, let credentials):
-            DebugLog.agent("ACPBackend.startProcess: authenticating method=\(methodId)") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.startProcess: authenticating method=\(methodId)")
             let authResponse = try await client.authenticate(
                 authMethodId: methodId,
                 credentials: credentials
@@ -337,7 +333,7 @@ public actor ACPBackend: AgentBackend {
             // client-provided key. Skip client-side `authenticate` and proceed to
             // newSession; if the agent truly requires client creds, the prompt will
             // surface that error (clearer than blocking at start).
-            DebugLog.agent("ACPBackend.startProcess: no API key configured — skipping client auth (agent may self-authenticate)") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.startProcess: no API key configured — skipping client auth (agent may self-authenticate)")
         }
 
         // Capture the CLI profile's log callbacks so ACP stderr and notifications
@@ -369,7 +365,7 @@ public actor ACPBackend: AgentBackend {
             }
             fanout.finish()
         }
-        DebugLog.agent("ACPBackend.startProcess: process-lifetime notification drain started") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.startProcess: process-lifetime notification drain started")
 
         // Forward agent stderr to DebugLog.agent + run.stderr.log (via the CLI
         // profile's onStderrChunk callback). Best-effort: the stream finishes
@@ -419,7 +415,7 @@ public actor ACPBackend: AgentBackend {
         // session — the last binding wins.
         permissionDelegate.bindOnExit(onExit)
 
-        DebugLog.agent("ACPBackend.startProcess: warm process ready canCloseSession=\(canCloseSession) canResume=\(canResume) canLoadSession=\(canLoadSession) canForkSession=\(canForkSession)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.startProcess: warm process ready canCloseSession=\(canCloseSession) canResume=\(canResume) canLoadSession=\(canLoadSession) canForkSession=\(canForkSession)")
     }
 
     /// Create a new ACP session on an already-started (warm) subprocess.
@@ -456,13 +452,13 @@ public actor ACPBackend: AgentBackend {
         // unsigned dev builds; this makes delivery reliable regardless. Both
         // files match the projection (same `currentSystemPromptBody()` source).
         Self.deliverSystemPrompt(systemPrompt, to: workingDir)
-        DebugLog.agent("ACPBackend.createSession: newSession cwd=\(workingDir)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.createSession: newSession cwd=\(workingDir)")
         let session = try await client.newSession(workingDirectory: workingDir)
         let sessionId = session.sessionId
         let modelsInfo = session.models
         let discoveredCount = modelsInfo?.availableModels.count ?? 0
         let currentModel = modelsInfo?.currentModelId ?? "(none)"
-        DebugLog.agent("ACPBackend.createSession: discovered \(discoveredCount) model(s), current=\(currentModel)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.createSession: discovered \(discoveredCount) model(s), current=\(currentModel)")
 
         // #329: if the user picked a model for this provider, apply it right
         // after newSession — BEFORE the first prompt — so the agent uses a
@@ -480,17 +476,17 @@ public actor ACPBackend: AgentBackend {
                 currentModelId: modelsInfo?.currentModelId,
                 advertisedModelIds: advertisedIds)
             if case .apply(let id) = decision {
-                DebugLog.agent("ACPBackend.createSession: setModel \(id)") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.createSession: setModel \(id)")
                 do {
                     _ = try await client.setModel(sessionId: sessionId, modelId: id)
                 } catch {
                     // setModel failed — log and proceed to the prompt anyway; the
                     // agent's default may still work, and a clearer error will
                     // surface from the prompt if not. Non-fatal by design.
-                    DebugLog.agent("ACPBackend.createSession: setModel \(id) failed: \(error.localizedDescription)") // TEMP DEBUG
+                    DebugLog.agent("ACPBackend.createSession: setModel \(id) failed: \(error.localizedDescription)")
                 }
             } else {
-                DebugLog.agent("ACPBackend.createSession: keeping agent default model (selected=\(selectedModelId) → \(decision))") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.createSession: keeping agent default model (selected=\(selectedModelId) → \(decision))")
             }
         }
 
@@ -520,14 +516,14 @@ public actor ACPBackend: AgentBackend {
         resumableSessionId = sessionId
         savedOnExit = onExit
 
-        DebugLog.agent("ACPBackend.createSession: session \(sessionId.value) (handle \(sessionID)) ready") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.createSession: session \(sessionId.value) (handle \(sessionID)) ready")
         return SessionHandle(id: sessionID)
     }
 
     public func send(_ turn: TurnInput, into handle: SessionHandle) async -> AsyncStream<AgentEvent> {
         guard var session = sessions[handle.id] else {
             // Session gone (cancelled/finished) — return an empty, finished stream.
-            DebugLog.agent("ACPBackend.send: no session for handle \(handle.id) — empty stream") // TEMP DEBUG (existed; re-tagged)
+            DebugLog.agent("ACPBackend.send: no session for handle \(handle.id) — empty stream")
             return AsyncStream { $0.finish() }
         }
         // Inject the system prompt into the first turn's user text — agent-agnostic
@@ -542,7 +538,7 @@ public actor ACPBackend: AgentBackend {
             sessions[handle.id] = session
             DebugLog.agent("ACPBackend.send: injected system prompt (\(session.systemPrompt.count) chars) into first turn")
         }
-        DebugLog.agent("ACPBackend.send: turn=\"\(turn.userText.prefix(80))\" handle=\(handle.id)") // TEMP DEBUG (existed; re-tagged)
+        DebugLog.agent("ACPBackend.send: turn=\"\(turn.userText.prefix(80))\" handle=\(handle.id)")
 
         let client = session.client
         let sessionId = session.sessionId
@@ -603,7 +599,7 @@ public actor ACPBackend: AgentBackend {
                         // `kill(pid, 0)` is a zero-signal liveness probe.
                         if let pid = await client.processIdentifier(), pid > 0 {
                             if kill(pid, 0) != 0 {
-                                DebugLog.agent("ACPBackend: process dead (kill(\(pid), 0) != 0) — marking for resume") // TEMP DEBUG
+                                DebugLog.agent("ACPBackend: process dead (kill(\(pid), 0) != 0) — marking for resume")
                                 processHealth.markDied()
                                 completionFlag.markDone()
                                 for event in Self.turnEndEvents(error: ACPBackendError.processDied) {
@@ -613,7 +609,7 @@ public actor ACPBackend: AgentBackend {
                                 return
                             }
                         }
-                        DebugLog.agent("ACPBackend: TURN STALLED — idle \(Int(idle))s, recovering (cancelSession + turnEnd)") // TEMP DEBUG (existed; re-tagged)
+                        DebugLog.agent("ACPBackend: TURN STALLED — idle \(Int(idle))s, recovering (cancelSession + turnEnd)")
                         completionFlag.markDone()
                         for event in Self.turnEndEvents(error: ACPBackendError.turnStalled(idleSeconds: idle)) {
                             continuation.yield(event)
@@ -622,7 +618,7 @@ public actor ACPBackend: AgentBackend {
                         try? await client.cancelSession(sessionId: sessionId)
                         return
                     case .ceilingExceeded(let total):
-                        DebugLog.agent("ACPBackend: TURN CEILING exceeded (\(Int(total))s), recovering") // TEMP DEBUG (existed; re-tagged)
+                        DebugLog.agent("ACPBackend: TURN CEILING exceeded (\(Int(total))s), recovering")
                         completionFlag.markDone()
                         for event in Self.turnEndEvents(error: ACPBackendError.turnCeilingExceeded(totalSeconds: total)) {
                             continuation.yield(event)
@@ -652,7 +648,7 @@ public actor ACPBackend: AgentBackend {
                         guard notification.method == "session/update" else { continue }
                         guard let params = notification.params else { continue }
                         let result = ACPBackend.translateNotification(params: params, sessionId: sessionId, translator: translator)
-                        DebugLog.agent("ACPBackend: session/update → \(result.events.count) AgentEvent(s)") // TEMP DEBUG (existed; re-tagged)
+                        DebugLog.agent("ACPBackend: session/update → \(result.events.count) AgentEvent(s)")
                         for event in result.events {
                             continuation.yield(event)
                         }
@@ -670,7 +666,7 @@ public actor ACPBackend: AgentBackend {
                 defer { drainTask.cancel() }
 
                 do {
-                    DebugLog.agent("ACPBackend: sending session/prompt (\(promptText.count) chars)") // TEMP DEBUG (existed; re-tagged)
+                    DebugLog.agent("ACPBackend: sending session/prompt (\(promptText.count) chars)")
                     let response = try await client.sendPrompt(
                         sessionId: sessionId,
                         content: [.text(TextContent(text: promptText))]
@@ -690,7 +686,7 @@ public actor ACPBackend: AgentBackend {
                     // just as sendPrompt returned), skip — continuation is done.
                     guard !completionFlag.isDone else { return }
                     completionFlag.markDone()
-                    DebugLog.agent("ACPBackend: prompt completed stopReason=\(response.stopReason.rawValue)") // TEMP DEBUG (existed; re-tagged)
+                    DebugLog.agent("ACPBackend: prompt completed stopReason=\(response.stopReason.rawValue)")
                     for event in Self.turnEndEvents(error: nil) {
                         continuation.yield(event)
                     }
@@ -705,7 +701,7 @@ public actor ACPBackend: AgentBackend {
                     // and surface a .processDied error so the caller knows to
                     // attempt resume().
                     processHealth.markDied()
-                    DebugLog.agent("ACPBackend: prompt failed: \(error.localizedDescription)") // TEMP DEBUG (existed; re-tagged)
+                    DebugLog.agent("ACPBackend: prompt failed: \(error.localizedDescription)")
                     for event in Self.turnEndEvents(error: error) {
                         continuation.yield(event)
                     }
@@ -747,7 +743,7 @@ public actor ACPBackend: AgentBackend {
     /// On success, a new `ACPSession` record is created for the resumed
     /// session (same ACP `SessionId`, new `SessionHandle`).
     public func resume(sessionID: String, profile: BackendProfile) async throws -> SessionHandle? {
-        DebugLog.agent("ACPBackend.resume: sessionID=\(sessionID)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.resume: sessionID=\(sessionID)")
 
         // 1. If the warm process is alive and has this session, no resume needed.
         if let warm = warmProcess, warm.processIsAlive {
@@ -755,7 +751,7 @@ public actor ACPBackend: AgentBackend {
             // If the process is alive and we have a session record, the session
             // is still usable — no resume.
             if sessions.values.contains(where: { $0.sessionId.value == sessionID }) {
-                DebugLog.agent("ACPBackend.resume: process alive + session active — no resume needed") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.resume: process alive + session active — no resume needed")
                 return nil
             }
         }
@@ -763,7 +759,7 @@ public actor ACPBackend: AgentBackend {
         // 2. Mark the old warm process as dead (if not already) and clean it up.
         // The old process's drain/fanout are dead; we need a fresh subprocess.
         if let oldWarm = warmProcess {
-            DebugLog.agent("ACPBackend.resume: tearing down dead warm process") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.resume: tearing down dead warm process")
             oldWarm.drainTask.cancel()
             oldWarm.stderrTask?.cancel()
             oldWarm.notificationFanout.finish()
@@ -778,7 +774,7 @@ public actor ACPBackend: AgentBackend {
         try await startProcess(profile: profile, onExit: onExit)
 
         guard let newWarm = warmProcess else {
-            DebugLog.agent("ACPBackend.resume: startProcess failed to create warm process") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.resume: startProcess failed to create warm process")
             return nil
         }
 
@@ -792,12 +788,12 @@ public actor ACPBackend: AgentBackend {
         if newWarm.canResume {
             // Fastest path: resumeSession restores context without replay.
             do {
-                DebugLog.agent("ACPBackend.resume: attempting resumeSession sessionId=\(sessionID) cwd=\(cwd)") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.resume: attempting resumeSession sessionId=\(sessionID) cwd=\(cwd)")
                 let response = try await client.resumeSession(
                     sessionId: acpSessionId,
                     cwd: cwd
                 )
-                DebugLog.agent("ACPBackend.resume: resumeSession succeeded models=\(response.models?.availableModels.count ?? 0)") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.resume: resumeSession succeeded models=\(response.models?.availableModels.count ?? 0)")
                 return registerResumedSession(
                     acpSessionId: acpSessionId,
                     warm: newWarm,
@@ -806,19 +802,19 @@ public actor ACPBackend: AgentBackend {
             } catch {
                 // Resume failed (session GC'd, protocol error). Fall through to
                 // loadSession if supported.
-                DebugLog.agent("ACPBackend.resume: resumeSession failed: \(error.localizedDescription) — trying fallback") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.resume: resumeSession failed: \(error.localizedDescription) — trying fallback")
             }
         }
 
         if newWarm.canLoadSession {
             // Slower path: loadSession replays history as notifications.
             do {
-                DebugLog.agent("ACPBackend.resume: attempting loadSession sessionId=\(sessionID) cwd=\(cwd)") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.resume: attempting loadSession sessionId=\(sessionID) cwd=\(cwd)")
                 let response = try await client.loadSession(
                     sessionId: acpSessionId,
                     cwd: cwd
                 )
-                DebugLog.agent("ACPBackend.resume: loadSession succeeded models=\(response.models?.availableModels.count ?? 0)") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.resume: loadSession succeeded models=\(response.models?.availableModels.count ?? 0)")
                 // loadSession may return a new sessionId (some agents), or nil.
                 let resumedId = response.sessionId ?? acpSessionId
                 return registerResumedSession(
@@ -827,14 +823,14 @@ public actor ACPBackend: AgentBackend {
                     modelsInfo: response.models
                 )
             } catch {
-                DebugLog.agent("ACPBackend.resume: loadSession failed: \(error.localizedDescription) — giving up") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.resume: loadSession failed: \(error.localizedDescription) — giving up")
             }
         }
 
         // 5. Neither resume nor load is supported (or both failed).
         // Return nil — the caller falls back to start() (fresh session, no
         // context). Log that context was lost so it's visible in Console.
-        DebugLog.agent("ACPBackend.resume: agent does not support resume or load — context lost, caller should use fresh start") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.resume: agent does not support resume or load — context lost, caller should use fresh start")
         return nil
     }
 
@@ -862,7 +858,7 @@ public actor ACPBackend: AgentBackend {
         // Phase 4: create a usage tracker for this resumed session.
         usageStates[sessionID] = SessionUsageState()
         resumableSessionId = acpSessionId
-        DebugLog.agent("ACPBackend.resume: resumed session \(acpSessionId.value) (handle \(sessionID)) ready") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.resume: resumed session \(acpSessionId.value) (handle \(sessionID)) ready")
         return SessionHandle(id: sessionID)
     }
 
@@ -898,9 +894,9 @@ public actor ACPBackend: AgentBackend {
         // was already closed via closeSession but the process is still alive.
         // Tear down the warm process if present.
         if record == nil {
-            DebugLog.agent("ACPBackend.cancel: no session for handle \(session.id)") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.cancel: no session for handle \(session.id)")
         }
-        DebugLog.agent("ACPBackend.cancel: cancelling session=\(record?.sessionId.value ?? "(none)") handle=\(session.id)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.cancel: cancelling session=\(record?.sessionId.value ?? "(none)") handle=\(session.id)")
         // Drain any in-flight always-ask continuations BEFORE tearing down, so a
         // pending `request_permission` never leaks its `CheckedContinuation`
         // (leaked continuations warn/trap at task end). The agent receives a
@@ -910,7 +906,7 @@ public actor ACPBackend: AgentBackend {
         // Tear down the warm process (drain + stderr + fanout + terminate).
         // This is the full teardown — the warm subprocess is killed.
         if let warm = warmProcess {
-            DebugLog.agent("ACPBackend.cancel: tearing down warm process") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.cancel: tearing down warm process")
             warm.drainTask.cancel()
             warm.stderrTask?.cancel()
             warm.notificationFanout.finish()
@@ -948,7 +944,7 @@ public actor ACPBackend: AgentBackend {
     /// return an empty stream (the turn is done).
     func closeSession(_ handle: SessionHandle) async {
         guard let record = sessions.removeValue(forKey: handle.id) else {
-            DebugLog.agent("ACPBackend.closeSession: no session for handle \(handle.id) — no-op") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.closeSession: no session for handle \(handle.id) — no-op")
             return
         }
         // Phase 4: clean up the usage tracker for this session.
@@ -959,7 +955,7 @@ public actor ACPBackend: AgentBackend {
         if resumableSessionId?.value == record.sessionId.value {
             resumableSessionId = nil
         }
-        DebugLog.agent("ACPBackend.closeSession: closing session=\(record.sessionId.value) handle=\(handle.id)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.closeSession: closing session=\(record.sessionId.value) handle=\(handle.id)")
         // Drain any in-flight always-ask continuations so a pending
         // `request_permission` never leaks its `CheckedContinuation`.
         record.permissionDelegate.cancelAllPending()
@@ -969,19 +965,19 @@ public actor ACPBackend: AgentBackend {
         // Otherwise degrade gracefully — the session context is leaked until
         // the process terminates (fine for Phase 1: one process per run).
         if warmProcess?.canCloseSession ?? false {
-            DebugLog.agent("ACPBackend.closeSession: sending session/close") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.closeSession: sending session/close")
             do {
                 _ = try await record.client.closeSession(sessionId: record.sessionId)
             } catch {
                 // closeSession failed — log and proceed; the session is already
                 // removed from the map, so no further sends will use it. The
                 // context will be freed on process termination.
-                DebugLog.agent("ACPBackend.closeSession: session/close failed: \(error.localizedDescription)") // TEMP DEBUG
+                DebugLog.agent("ACPBackend.closeSession: session/close failed: \(error.localizedDescription)")
             }
         } else {
-            DebugLog.agent("ACPBackend.closeSession: agent does not support session/close — skipping (context freed at terminate)") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.closeSession: agent does not support session/close — skipping (context freed at terminate)")
         }
-        DebugLog.agent("ACPBackend.closeSession: session closed, subprocess stays alive") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.closeSession: session closed, subprocess stays alive")
     }
 
     /// Fork a session: creates a new session that inherits the parent's
@@ -1016,27 +1012,27 @@ public actor ACPBackend: AgentBackend {
         cwd: String? = nil
     ) async throws -> SessionHandle? {
         guard let warm = warmProcess else {
-            DebugLog.agent("ACPBackend.forkSession: no warm process — cannot fork") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.forkSession: no warm process — cannot fork")
             return nil
         }
         guard warm.canForkSession else {
-            DebugLog.agent("ACPBackend.forkSession: agent does not support session/fork — returning nil (caller falls back to createSession)") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.forkSession: agent does not support session/fork — returning nil (caller falls back to createSession)")
             return nil
         }
         guard let parent = sessions[parentHandle.id] else {
-            DebugLog.agent("ACPBackend.forkSession: no parent session for handle \(parentHandle.id) — returning nil") // TEMP DEBUG
+            DebugLog.agent("ACPBackend.forkSession: no parent session for handle \(parentHandle.id) — returning nil")
             return nil
         }
 
         let workingDir = cwd ?? FileManager.default.currentDirectoryPath
 
-        DebugLog.agent("ACPBackend.forkSession: forking session=\(parent.sessionId.value) cwd=\(workingDir)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.forkSession: forking session=\(parent.sessionId.value) cwd=\(workingDir)")
         let response = try await warm.client.forkSession(
             sessionId: parent.sessionId,
             cwd: workingDir
         )
         let forkedSessionId = response.sessionId
-        DebugLog.agent("ACPBackend.forkSession: forked → session=\(forkedSessionId.value)") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.forkSession: forked → session=\(forkedSessionId.value)")
 
         // The forked session inherits the parent's conversation context —
         // including the already-injected system prompt. Mark it as injected so
@@ -1053,7 +1049,7 @@ public actor ACPBackend: AgentBackend {
             systemPromptInjected: true
         )
 
-        DebugLog.agent("ACPBackend.forkSession: forked session \(forkedSessionId.value) (handle \(sessionID)) ready") // TEMP DEBUG
+        DebugLog.agent("ACPBackend.forkSession: forked session \(forkedSessionId.value) (handle \(sessionID)) ready")
         return SessionHandle(id: sessionID)
     }
 

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -228,7 +228,7 @@ public final class AgentLauncher {
         guard !models.isEmpty else { return }
         let dir = resolveProvidersContainerDirectory()
         let updated = providersConfig().settingCachedModels(models, forProvider: providerId)
-        DebugLog.store("cacheDiscoveredModels: provider=\(providerId) count=\(models.count) → save") // TEMP DEBUG
+        DebugLog.store("cacheDiscoveredModels: provider=\(providerId) count=\(models.count) → save")
         do {
             try updated.save(to: dir)
         } catch {
@@ -245,7 +245,7 @@ public final class AgentLauncher {
     public func setSelectedModel(_ modelId: String?, forProvider providerId: String) -> AgentProvidersConfig {
         let dir = resolveProvidersContainerDirectory()
         let updated = providersConfig().settingSelectedModel(modelId, forProvider: providerId)
-        DebugLog.store("setSelectedModel: provider=\(providerId) modelId=\(modelId ?? "nil") → save") // TEMP DEBUG
+        DebugLog.store("setSelectedModel: provider=\(providerId) modelId=\(modelId ?? "nil") → save")
         do {
             try updated.save(to: dir)
         } catch {
@@ -266,7 +266,7 @@ public final class AgentLauncher {
         _ modelId: String?, provider: AgentProvider
     ) -> AgentProvidersConfig {
         let dir = resolveProvidersContainerDirectory()
-        DebugLog.store("setSelectedModelAndDefault: provider=\(provider.id) modelId=\(modelId ?? "nil") → save") // TEMP DEBUG
+        DebugLog.store("setSelectedModelAndDefault: provider=\(provider.id) modelId=\(modelId ?? "nil") → save")
         let updated = providersConfig()
             .settingDefault(id: provider.id)
             .settingSelectedModel(modelId, forProvider: provider.id)
@@ -311,21 +311,21 @@ public final class AgentLauncher {
     /// a detached `@MainActor` Task so it never delays the first turn.
     public func captureAndCacheModels(provider: AgentProvider, session: SessionHandle) {
         guard let acp = backend as? ACPBackend else {
-            DebugLog.agent("captureAndCacheModels: skip (provider=\(provider.id) backend not ACP)") // TEMP DEBUG
+            DebugLog.agent("captureAndCacheModels: skip (provider=\(provider.id) backend not ACP)")
             return
         }
-        DebugLog.agent("captureAndCacheModels: enter provider=\(provider.id) session=\(session.id)") // TEMP DEBUG
+        DebugLog.agent("captureAndCacheModels: enter provider=\(provider.id) session=\(session.id)")
         Task { @MainActor [weak self] in
             guard let self else { return }
             let models = await acp.availableModels(for: session)
             guard !models.isEmpty else {
-                DebugLog.agent("captureAndCacheModels: no models discovered for provider=\(provider.id)") // TEMP DEBUG
+                DebugLog.agent("captureAndCacheModels: no models discovered for provider=\(provider.id)")
                 return
             }
             let cached = models.map {
                 CachedModelInfo(modelId: $0.modelId, name: $0.name, description: $0.description)
             }
-            DebugLog.agent("captureAndCacheModels: captured \(cached.count) model(s) for provider=\(provider.id) ids=\(cached.map(\.modelId))") // TEMP DEBUG
+            DebugLog.agent("captureAndCacheModels: captured \(cached.count) model(s) for provider=\(provider.id) ids=\(cached.map(\.modelId))")
             self.cacheDiscoveredModels(cached, forProvider: provider.id)
         }
     }
@@ -341,7 +341,7 @@ public final class AgentLauncher {
             let pid = await acp.processIdentifier(for: session)
             if let pid {
                 self.currentProcessID = pid
-                DebugLog.agent("captureProcessID: pid=\(pid)") // TEMP DEBUG
+                DebugLog.agent("captureProcessID: pid=\(pid)")
             }
         }
     }
@@ -1579,7 +1579,7 @@ public final class AgentLauncher {
             events = historySeed
             persistedEventCount = historySeed.count
         }
-        DebugLog.agent("startInteractiveQuery: enter firstMsg=\"\(firstMessage.prefix(80))\" chatID=\(chatID ?? "nil") wikiID=\(wikiID) historySeed=\(historySeed.count)") // TEMP DEBUG
+        DebugLog.agent("startInteractiveQuery: enter firstMsg=\"\(firstMessage.prefix(80))\" chatID=\(chatID ?? "nil") wikiID=\(wikiID) historySeed=\(historySeed.count)")
         // Consumed by the first `sendInteractiveMessage` to skip re-persisting
         // the user message the model already seeded at chat creation.
         self.firstMessagePrePersisted = firstMessagePrePersisted
@@ -1590,19 +1590,19 @@ public final class AgentLauncher {
         // The chat's permission policy (default yolo). The ACP agent spawn is
         // threaded into providerHints below.
         let policy: PermissionPolicy = resolvePermissionMode()
-        DebugLog.agent("startInteractiveQuery: permissionPolicy=\(policy)") // TEMP DEBUG
+        DebugLog.agent("startInteractiveQuery: permissionPolicy=\(policy)")
 
         // #324: the launcher reads `agent-providers.json` and picks the
         // default (or selected) provider. The app is ACP-only.
         let provider = resolveSelectedProvider()
         let resolvedSelectedModel = providersConfig().selectedModelId(forProvider: provider.id)
-        DebugLog.agent("startInteractiveQuery: provider=\(provider.id) selectedModel=\(resolvedSelectedModel ?? "nil")") // TEMP DEBUG
+        DebugLog.agent("startInteractiveQuery: provider=\(provider.id) selectedModel=\(resolvedSelectedModel ?? "nil")")
         self.backend = resolveBackend(policy)
 
         // Resolve the provider's spawn command (PATH-resolved) + the
         // Keychain-backed API key (keyed by provider id).
         guard let spawn = resolveACPProviderSpawn(provider) else {
-            DebugLog.agent("startInteractiveQuery: ACP exe missing — \(preflightError ?? "?")") // TEMP DEBUG
+            DebugLog.agent("startInteractiveQuery: ACP exe missing — \(preflightError ?? "?")")
             return
         }
         let resolvedACPCommand = spawn.command
@@ -1706,10 +1706,10 @@ public final class AgentLauncher {
             scratchDirectory: scratch,
             isReadOnly: false,
             cli: cli)
-        DebugLog.agent("startInteractiveQuery: profile built providerHints keys=\(profile.providerHints.keys.sorted()) scratch=\(scratch.lastPathComponent)") // TEMP DEBUG
+        DebugLog.agent("startInteractiveQuery: profile built providerHints keys=\(profile.providerHints.keys.sorted()) scratch=\(scratch.lastPathComponent)")
 
         do {
-            DebugLog.agent("startInteractiveQuery: backend.start provider=\(provider.id) exe=\(resolvedPath) args=\(provider.command ?? [])") // TEMP DEBUG (existed; re-tagged)
+            DebugLog.agent("startInteractiveQuery: backend.start provider=\(provider.id) exe=\(resolvedPath) args=\(provider.command ?? [])")
             let runToken = UUID()
             let session = try await backend.start(
                 profile: profile,
@@ -1730,14 +1730,14 @@ public final class AgentLauncher {
             // SPAWN COMMIT: process is alive. isRunning = true (process alive across turns).
             isInteractiveSession = true
             isRunning = true
-            DebugLog.agent("startInteractiveQuery: spawn-commit session=\(session.id) isInteractive=true") // TEMP DEBUG
+            DebugLog.agent("startInteractiveQuery: spawn-commit session=\(session.id) isInteractive=true")
             // #329: cache the agent's advertised models per-provider for the
             // picker. Done here (after spawn commit) so the session record is
             // populated; it runs as a detached task and never blocks the first
             // turn.
             captureAndCacheModels(provider: provider, session: session)
             captureProcessID(session: session)
-            DebugLog.agent("startInteractiveQuery: spawned") // TEMP DEBUG (existed; re-tagged)
+            DebugLog.agent("startInteractiveQuery: spawned")
             // Start the first turn — this acquires the generation gate for turn 1.
             // Compose the full task prompt (chat.md, write rules, citation rules,
             // don't-rediscover directive) + the user's message — same composition
@@ -1755,7 +1755,7 @@ public final class AgentLauncher {
             // when the OS reports the process gone, so a live idle session is safe.
             startCompletionWatchdog()
         } catch {
-            DebugLog.agent("startInteractiveQuery: backend.start FAILED provider=\(provider.id): \(error)") // TEMP DEBUG (existed; re-tagged)
+            DebugLog.agent("startInteractiveQuery: backend.start FAILED provider=\(provider.id): \(error)")
             preflightError = "Failed to launch claude: \(error.localizedDescription)"
             closeLogFiles()
             try? FileManager.default.removeItem(at: scratch)
@@ -1790,10 +1790,10 @@ public final class AgentLauncher {
             isAwaitingGenerationSlot: isAwaitingGenerationSlot,
             message: trimmed
         ) else {
-            DebugLog.agent("sendInteractiveMessage: GUARD bail (isRunning=\(isRunning) isInteractive=\(isInteractiveSession) isGenerating=\(isGenerating) isAwaitingSlot=\(isAwaitingGenerationSlot) empty=\(trimmed.isEmpty)") // TEMP DEBUG
+            DebugLog.agent("sendInteractiveMessage: GUARD bail (isRunning=\(isRunning) isInteractive=\(isInteractiveSession) isGenerating=\(isGenerating) isAwaitingSlot=\(isAwaitingGenerationSlot) empty=\(trimmed.isEmpty)")
             return
         }
-        DebugLog.agent("sendInteractiveMessage: queuing turn chars=\(trimmed.count) displayChars=\((displayText ?? trimmed).count)") // TEMP DEBUG
+        DebugLog.agent("sendInteractiveMessage: queuing turn chars=\(trimmed.count) displayChars=\((displayText ?? trimmed).count)")
 
         // Signal that we're waiting for the gate. The UI shows a hint; canSend = false.
         isAwaitingGenerationSlot = true
@@ -1806,14 +1806,14 @@ public final class AgentLauncher {
         interactiveSendTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let ok = await self.awaitGenerationSlot()
-            DebugLog.agent("sendInteractiveMessage: gate acquire ok=\(ok)") // TEMP DEBUG
+            DebugLog.agent("sendInteractiveMessage: gate acquire ok=\(ok)")
             self.isAwaitingGenerationSlot = false
             guard ok, !Task.isCancelled, self.isInteractiveSession,
                   let session else {
                 // Acquired the gate then bailed (cancelled or session ended) — give
                 // it back so a queued peer isn't stranded.
                 if ok { self.releaseGenerationSlot() }
-                DebugLog.agent("sendInteractiveMessage: bail after gate (cancelled=\(Task.isCancelled) isInteractive=\(self.isInteractiveSession) session=\(session != nil)") // TEMP DEBUG
+                DebugLog.agent("sendInteractiveMessage: bail after gate (cancelled=\(Task.isCancelled) isInteractive=\(self.isInteractiveSession) session=\(session != nil)")
                 return
             }
             // Display the user's message (or the displayText override — D3's
@@ -1838,7 +1838,7 @@ public final class AgentLauncher {
                 self.firstMessagePrePersisted = false
             }
             self.setGenerating(true)    // UI flag: ChatView banner + send guard
-            DebugLog.agent("sendInteractiveMessage: turn start (setGenerating=true)") // TEMP DEBUG
+            DebugLog.agent("sendInteractiveMessage: turn start (setGenerating=true)")
             self.lastActivityAt = Date()
             // Send the turn and consume the per-turn stream. The backend writes
             // the NDJSON line to stdin; the stream finishes at `.messageStop`
@@ -1852,11 +1852,11 @@ public final class AgentLauncher {
                     self.setGenerating(false)
                     self.flushTranscript()
                     self.generateChatSummary()
-                    DebugLog.agent("sendInteractiveMessage: turn end (endsGeneration) → flushTranscript") // TEMP DEBUG
+                    DebugLog.agent("sendInteractiveMessage: turn end (endsGeneration) → flushTranscript")
                     if Self.releasesGenerationSlotPerTurn(
                         isInteractiveSession: self.isInteractiveSession) {
                         self.releaseGenerationSlot()
-                        DebugLog.agent("sendInteractiveMessage: generation slot released (interactive)") // TEMP DEBUG
+                        DebugLog.agent("sendInteractiveMessage: generation slot released (interactive)")
                     }
                 }
             }
@@ -2145,10 +2145,10 @@ public final class AgentLauncher {
     /// `stdoutLineBuffer` drain moved to the backend's terminationHandler).
     private func finish(status: Int32) {
         guard isRunning else {
-            DebugLog.agent("finish: ignored (already torn down) status=\(status)") // TEMP DEBUG (existed; re-tagged)
+            DebugLog.agent("finish: ignored (already torn down) status=\(status)")
             return
         }
-        DebugLog.agent("finish: status=\(status) events=\(events.count) activeChatID=\(activeChatID ?? "nil")") // TEMP DEBUG (existed; re-tagged + chatID)
+        DebugLog.agent("finish: status=\(status) events=\(events.count) activeChatID=\(activeChatID ?? "nil")")
         watchdogTask?.cancel()
         watchdogTask = nil
         watchdogHasEscalated = false
@@ -2218,7 +2218,7 @@ public final class AgentLauncher {
     /// touch `isRunning` — process lifetime is managed explicitly. Called right
     /// before staging/preflight at the top of each launch path.
     private func resetRunArtifacts() {
-        DebugLog.agent("resetRunArtifacts: clearing per-run artifacts (prior activeChatID=\(activeChatID ?? "nil"))") // TEMP DEBUG
+        DebugLog.agent("resetRunArtifacts: clearing per-run artifacts (prior activeChatID=\(activeChatID ?? "nil"))")
         watchdogTask?.cancel()
         watchdogTask = nil
         watchdogHasEscalated = false

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -39,9 +39,9 @@ public enum AgentOperationRunner {
         wikictlDirectory: String
     ) async {
         let trimmed = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-        DebugLog.agent("startChat: enter msg=\"\(trimmed.prefix(80))\" provider=\(launcher.resolveSelectedProvider().id)") // TEMP DEBUG
+        DebugLog.agent("startChat: enter msg=\"\(trimmed.prefix(80))\" provider=\(launcher.resolveSelectedProvider().id)")
         guard !trimmed.isEmpty else {
-            DebugLog.agent("startChat: early-return — empty message") // TEMP DEBUG
+            DebugLog.agent("startChat: early-return — empty message")
             return
         }
 
@@ -51,7 +51,7 @@ public enum AgentOperationRunner {
         // removed — CAS (page versions, W0) prevents data races.
         if Self.shouldBlockEditStart(
             isIngestInProgress: store.isIngestInProgress) {
-            DebugLog.agent("startChat: edit-blocked (isIngestInProgress=\(store.isIngestInProgress))") // TEMP DEBUG
+            DebugLog.agent("startChat: edit-blocked (isIngestInProgress=\(store.isIngestInProgress))")
             launcher.preflightError = "An ingestion is in progress. Wait for it to finish before starting a chat."
             return
         }
@@ -78,7 +78,7 @@ public enum AgentOperationRunner {
         // Start the interactive session. The agent-run lifecycle is ref-counted
         // (agentRunStarted/agentRunEnded) for sidebar reload on last-run-end;
         // no edit lock — CAS (page versions, W0) prevents data races.
-        DebugLog.agent("startChat: calling launcher.startInteractiveQuery wikiID=\(wikiID) chatID=\(chat?.id.rawValue ?? "nil")") // TEMP DEBUG
+        DebugLog.agent("startChat: calling launcher.startInteractiveQuery wikiID=\(wikiID) chatID=\(chat?.id.rawValue ?? "nil")")
         await launcher.startInteractiveQuery(
             firstMessage: trimmed,
             stateMarkdown: store.currentStateSnapshot().renderStateFile(),
@@ -112,10 +112,10 @@ public enum AgentOperationRunner {
         // immediately isn't caught here, but seeding guarantees that chat still
         // holds its first message — never titled-but-empty.)
         if let chat, launcher.preflightError != nil {
-            DebugLog.agent("startChat: ROLLBACK chat=\(chat.id.rawValue) preflightError=\(launcher.preflightError ?? "?")") // TEMP DEBUG
+            DebugLog.agent("startChat: ROLLBACK chat=\(chat.id.rawValue) preflightError=\(launcher.preflightError ?? "?")")
             store.rollbackChatCreation(id: chat.id, toDraft: .newChat)
         }
-        DebugLog.agent("startChat: done preflightError=\(launcher.preflightError ?? "nil")") // TEMP DEBUG
+        DebugLog.agent("startChat: done preflightError=\(launcher.preflightError ?? "nil")")
     }
 
     // MARK: - Pure predicates
@@ -299,9 +299,9 @@ public enum AgentOperationRunner {
         wikictlDirectory: String
     ) async {
         let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
-        DebugLog.agent("continueChat: enter chatID=\(chatID.rawValue) msg=\"\(trimmed.prefix(80))\" provider=\(launcher.resolveSelectedProvider().id)") // TEMP DEBUG
+        DebugLog.agent("continueChat: enter chatID=\(chatID.rawValue) msg=\"\(trimmed.prefix(80))\" provider=\(launcher.resolveSelectedProvider().id)")
         guard !trimmed.isEmpty else {
-            DebugLog.agent("continueChat: early-return — empty message") // TEMP DEBUG
+            DebugLog.agent("continueChat: early-return — empty message")
             return
         }
 
@@ -313,10 +313,10 @@ public enum AgentOperationRunner {
             isInteractiveSession: launcher.isInteractiveSession,
             isGenerating: launcher.isGenerating,
             isAwaitingGenerationSlot: launcher.isAwaitingGenerationSlot)
-        DebugLog.agent("continueChat: takeover decision=\(decision) (isRunning=\(launcher.isRunning) isInteractiveSession=\(launcher.isInteractiveSession) isGenerating=\(launcher.isGenerating) isAwaitingGenerationSlot=\(launcher.isAwaitingGenerationSlot))") // TEMP DEBUG
+        DebugLog.agent("continueChat: takeover decision=\(decision) (isRunning=\(launcher.isRunning) isInteractiveSession=\(launcher.isInteractiveSession) isGenerating=\(launcher.isGenerating) isAwaitingGenerationSlot=\(launcher.isAwaitingGenerationSlot))")
         switch decision {
         case .refused:
-            DebugLog.agent("continueChat: refused — launcher mid-generation") // TEMP DEBUG (existed; re-tagged)
+            DebugLog.agent("continueChat: refused — launcher mid-generation")
             return
         case .betweenTurns:
             // End the OTHER chat's session first. stopAgent() cancels any
@@ -324,10 +324,10 @@ public enum AgentOperationRunner {
             // finish(-1) SYNCHRONOUSLY on the main actor — which runs the final
             // flushTranscript() (persisting the other chat's tail) and clears its
             // transcriptSink + activeChatID before we take over. Nothing is lost.
-            DebugLog.agent("continueChat: ending between-turns session before takeover") // TEMP DEBUG (existed; re-tagged)
+            DebugLog.agent("continueChat: ending between-turns session before takeover")
             launcher.stopAgent()
         case .idle:
-            DebugLog.agent("continueChat: idle — taking over directly") // TEMP DEBUG
+            DebugLog.agent("continueChat: idle — taking over directly")
         }
 
         // Refuse if an ingest is in progress (issue #235). The old
@@ -335,7 +335,7 @@ public enum AgentOperationRunner {
         // prevents data races, so concurrent agent runs are fine.
         if Self.shouldBlockEditStart(
             isIngestInProgress: store.isIngestInProgress) {
-            DebugLog.agent("continueChat: edit-blocked (isIngestInProgress=\(store.isIngestInProgress))") // TEMP DEBUG
+            DebugLog.agent("continueChat: edit-blocked (isIngestInProgress=\(store.isIngestInProgress))")
             launcher.preflightError = "An ingestion is in progress. Wait for it to finish before starting a chat."
             return
         }
@@ -347,13 +347,13 @@ public enum AgentOperationRunner {
         // Build the condensed transcript + new message as the first prompt.
         let history = store.chatMessages(chatID: chatID)
         let firstMessage = continuationPreamble(from: history, newMessage: trimmed)
-        DebugLog.agent("continueChat: historyRows=\(history.count) preambleChars=\(firstMessage.count) displayMsg=\(trimmed.count)") // TEMP DEBUG
+        DebugLog.agent("continueChat: historyRows=\(history.count) preambleChars=\(firstMessage.count) displayMsg=\(trimmed.count)")
 
         // Start a fresh session writing to the SAME chat row. activeChatID = chat.id
         // flips ChatView to live for this tab (seq continues, title
         // preserved, updatedAt bumps on the first persisted append). The sink is
         // keyed by chatID and appends to the same row.
-        DebugLog.agent("continueChat: calling launcher.startInteractiveQuery wikiID=\(wikiID) chatID=\(chatID.rawValue)") // TEMP DEBUG
+        DebugLog.agent("continueChat: calling launcher.startInteractiveQuery wikiID=\(wikiID) chatID=\(chatID.rawValue)")
         await launcher.startInteractiveQuery(
             firstMessage: firstMessage,
             firstMessageDisplay: trimmed,


### PR DESCRIPTION
## Summary

Two small surgical fixes. No change to logging output behavior.

### 1. Strip `TEMP DEBUG` comments

The codebase carried temporary `// TEMP DEBUG` tag comments, self-documented for a later `grep` strip. This removes all of them:

- **ACPBackend.swift** — the 4-line `// TEMP DEBUG:` header block (originally lines 240–243) documenting the temporary logging, **plus** trailing tags on its `DebugLog.agent(...)` lines.
- **AgentLauncher.swift**, **AgentOperationRunner.swift**, **ProviderSelector.swift**, **AgentProvidersConfig.swift** — trailing `// TEMP DEBUG` tags on `DebugLog.agent(...)` lines.

**All `DebugLog.agent(...)` calls are preserved unchanged.** Only the temporary tag suffixes and the header block are removed. No other comments were touched.

> The task estimated ~77 sites; the actual count was **103 matching lines** across the 5 files (each `// TEMP DEBUG` is an end-of-line Swift comment, so stripping the tag cleanly leaves the call intact). All were stripped and verified — `rg 'TEMP DEBUG' Sources/` returns nothing.

### 2. Fix bare `try?` in `QueueStore.loadItemEvents`

`loadItemEvents` decoded each persisted event with `return try? JSONDecoder().decode(...)`, silently dropping any row that failed to decode — violating the repo's "never bare `try?`" rule (#475/#492). On an `AgentEvent` schema evolution, every unparsable event would be silently lost with no diagnostic.

Replaced with a `do/catch` that routes the failure through `DebugLog.store` and returns `nil` (preserving `compactMap`'s filtering semantics). The actual code was a `compactMap` closure (not the `if let` shape in the task description), so the fix was adapted accordingly:

```swift
return rows.compactMap { row -> AgentEvent? in
    let json: String = row["event_json"]
    guard let data = json.data(using: .utf8) else { return nil }
    do {
        return try JSONDecoder().decode(AgentEvent.self, from: data)
    } catch {
        DebugLog.store("QueueStore.loadItemEvents: decode failed for event row — \(error.localizedDescription)")
        return nil
    }
}
```

## Verification

- `make version prompts && swift build` — ✅ Build complete (165s)
- Fast test tier (`swift test --skip 'EnumeratorDeletionTests|…|ProjectionTreeTests'`) — ✅ 2461 tests, 211 suites, all passing

## Notes

- Generated `GeneratedVersion.swift` / `GeneratedPrompts.swift` are gitignored; not in the changeset.
- The diff stat is `99 insertions, 103 deletions` = 99 line-modifications (tag stripped, call kept) + 4 pure deletions (the header block). Zero newly-empty lines introduced.
