### PR TITLE
Remove idle stall detection, shift watchdog to observability-only

### DIFF
--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -191,10 +191,6 @@ public actor ACPBackend: AgentBackend {
     /// terminal (the structural second gate from the design doc).
     private let capabilities: ClientCapabilities
 
-    /// Turn inactivity watchdog: how long without a `session/update`
-    /// notification before declaring a stall (`plans/acp-stall-recovery.md` §1a).
-    private let turnIdleTimeout: TimeInterval
-
     /// Hard ceiling on total turn duration — backstop against a chatty agent
     /// that streams forever without finishing.
     private let turnCeilingTimeout: TimeInterval
@@ -214,14 +210,12 @@ public actor ACPBackend: AgentBackend {
     init(
         permissionPolicy: PermissionPolicy = .bypass,
         capabilities: ClientCapabilities = ACPBackend.defaultCapabilities,
-        turnIdleTimeout: TimeInterval = TurnLivenessPolicy.defaultIdleTimeout,
         turnCeilingTimeout: TimeInterval = TurnLivenessPolicy.defaultCeilingTimeout,
         watchdogPollInterval: TimeInterval = TurnLivenessPolicy.defaultPollInterval,
         maxConcurrentExecutors: Int = 1
     ) {
         self.permissionPolicy = permissionPolicy
         self.capabilities = capabilities
-        self.turnIdleTimeout = turnIdleTimeout
         self.turnCeilingTimeout = turnCeilingTimeout
         self.watchdogPollInterval = watchdogPollInterval
         self.maxConcurrentExecutors = max(1, maxConcurrentExecutors)
@@ -544,7 +538,6 @@ public actor ACPBackend: AgentBackend {
         let sessionId = session.sessionId
         let translator = ACPEventTranslator()
         let fanout = session.notificationFanout
-        let idleTimeout = turnIdleTimeout
         let ceilingTimeout = turnCeilingTimeout
         let pollInterval = watchdogPollInterval
         // Phase 4: per-session usage tracker. Captured by reference into the
@@ -566,12 +559,15 @@ public actor ACPBackend: AgentBackend {
             let processHealth = ProcessHealthFlag()
             let turnStartedAt = fanout.activityTimestamp
 
-            // --- Watchdog task (cause 5 fix, plans/acp-stall-recovery.md §1a) ---
-            // Polls every `pollInterval`; if the prompt hasn't completed AND no
-            // notification has arrived for `idleTimeout`, or the total duration
-            // exceeds `ceilingTimeout`, fail the turn: cancelSession best-effort,
-            // synthesize turn-end events, finish the continuation.
-            let watchdogTask = Task { [client, sessionId, fanout, completionFlag, processHealth] in
+            // --- Watchdog task ---
+            // Polls every `pollInterval`; if the prompt hasn't completed AND
+            // the total duration exceeds `ceilingTimeout`, fail the turn:
+            // cancelSession best-effort, synthesize turn-end events, finish the
+            // continuation. The idle/stall path was removed — ACP agents
+            // produce notifications for every activity (thinking, tool calls,
+            // sub-agent lifecycle), so a live agent is almost never truly idle.
+            // Process death is detected separately by `sendPrompt` throwing.
+            let watchdogTask = Task { [client, sessionId, completionFlag, processHealth] in
                 while !Task.isCancelled {
                     try? await Task.sleep(for: .seconds(pollInterval))
                     if Task.isCancelled { return }
@@ -585,38 +581,11 @@ public actor ACPBackend: AgentBackend {
                         now: Date(),
                         promptDone: completionFlag.isDone,
                         turnStartedAt: turnStartedAt,
-                        lastActivityAt: fanout.activityTimestamp,
-                        idleTimeout: idleTimeout,
                         ceilingTimeout: ceilingTimeout
                     )
                     switch decision {
                     case .healthy:
                         continue
-                    case .stalled(let idle):
-                        // Phase 2: before declaring a stall, check if the
-                        // subprocess actually died (issue #338 — silent death
-                        // looks like a stall because no notifications arrive).
-                        // `kill(pid, 0)` is a zero-signal liveness probe.
-                        if let pid = await client.processIdentifier(), pid > 0 {
-                            if kill(pid, 0) != 0 {
-                                DebugLog.agent("ACPBackend: process dead (kill(\(pid), 0) != 0) — marking for resume")
-                                processHealth.markDied()
-                                completionFlag.markDone()
-                                for event in Self.turnEndEvents(error: ACPBackendError.processDied) {
-                                    continuation.yield(event)
-                                }
-                                continuation.finish()
-                                return
-                            }
-                        }
-                        DebugLog.agent("ACPBackend: TURN STALLED — idle \(Int(idle))s, recovering (cancelSession + turnEnd)")
-                        completionFlag.markDone()
-                        for event in Self.turnEndEvents(error: ACPBackendError.turnStalled(idleSeconds: idle)) {
-                            continuation.yield(event)
-                        }
-                        continuation.finish()
-                        try? await client.cancelSession(sessionId: sessionId)
-                        return
                     case .ceilingExceeded(let total):
                         DebugLog.agent("ACPBackend: TURN CEILING exceeded (\(Int(total))s), recovering")
                         completionFlag.markDone()
@@ -1286,8 +1255,6 @@ public actor ACPBackend: AgentBackend {
         let reason: TurnFailureReason
         if let acpError = error as? ACPBackendError {
             switch acpError {
-            case .turnStalled(let idle):
-                reason = .stalled(idleSeconds: idle)
             case .turnCeilingExceeded(let total):
                 reason = .ceilingExceeded(totalSeconds: total)
             case .processDied:
@@ -1559,10 +1526,6 @@ enum ACPBackendError: Error, LocalizedError {
     case missingAPIKey
     /// `Client.authenticate` returned `success: false` (bad/expired key, etc.).
     case authenticationFailed(String?)
-    /// The turn went silent — no `session/update` notification arrived for
-    /// `idleSeconds`. The turn was cancelled; the user can retry.
-    /// (`plans/acp-stall-recovery.md` §1a.)
-    case turnStalled(idleSeconds: TimeInterval)
     /// The turn exceeded the hard ceiling duration — the agent was still
     /// streaming but took too long. The turn was cancelled.
     case turnCeilingExceeded(totalSeconds: TimeInterval)
@@ -1588,11 +1551,6 @@ enum ACPBackendError: Error, LocalizedError {
         case .authenticationFailed(let detail):
             let suffix = detail.map { " (\($0))" } ?? ""
             return "ACP agent authentication failed.\(suffix)"
-        case .turnStalled(let idle):
-            return """
-            ACP agent stalled — no activity for \(Int(idle))s. \
-            The turn was cancelled; try sending again.
-            """
         case .turnCeilingExceeded(let total):
             return """
             ACP agent exceeded the maximum turn duration (\(Int(total))s). \

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -118,6 +118,11 @@ public final class AgentLauncher {
     /// process with an old `lastActivityAt` is not necessarily dead, but the UI can
     /// name that it is quiet.
     public private(set) var lastActivityAt: Date?
+    /// The current ingestion phase ("planner", "executor[filename]", "finalizer"),
+    /// or nil when not ingesting or between phases. Surfaced so the UI and the
+    /// heartbeat watchdog can name *what* is running when page creation takes a
+    /// long time — beyond a context-free spinner.
+    public private(set) var currentIngestPhase: String?
     /// The spawned process ID while running, useful context when a run looks quiet.
     public private(set) var currentProcessID: Int32?
 
@@ -430,9 +435,9 @@ public final class AgentLauncher {
     /// Backstop poller that reconciles the UI if the process `terminationHandler`
     /// is ever missed (see `startCompletionWatchdog`). Cancelled on teardown.
     private var watchdogTask: Task<Void, Never>?
-    /// True once the launcher watchdog has escalated (stopAgent + kill sequence).
-    /// Prevents double-escalation. Reset in `resetRunArtifacts()`.
-    private var watchdogHasEscalated = false
+    /// True once the "still working" check-in has fired for the current quiet
+    /// period. Reset when activity resumes or in `resetRunArtifacts()`.
+    private var watchdogHasWarned = false
     /// True while the last row in `events` is an in-progress `.assistantText` row
     /// being grown by streamed `.assistantTextDelta` chunks (issue #121). Reset by
     /// any other event (a tool call, a turn boundary, …) so unrelated `.assistantText`
@@ -1076,6 +1081,7 @@ public final class AgentLauncher {
 
         // --- Phase 1: Planner ---
         DebugLog.agent("runACPIngest: Phase 1 — Planner")
+        currentIngestPhase = "planner"
         guard let plannerRouting = resolveStageRouting(.planner, policy: policy, cache: &stageBackendCache) else {
             DebugLog.agent("runACPIngest: planner routing failed (\(preflightError ?? "?")) — aborting")
             finish(status: -1)
@@ -1159,6 +1165,7 @@ public final class AgentLauncher {
                 // main actor as batches on each turn-end (avoiding interleaved
                 // streaming deltas that would garble the transcript).
                 DebugLog.agent("runACPIngest: Phase 2 — Parallel executors (maxConcurrent=\(maxConcurrent), \(plan.distinctSourceFiles.count) source file(s))")
+                currentIngestPhase = "executor[parallel]"
                 await runParallelExecutors(
                     executorRouting: executorRouting,
                     executorProfile: executorProfile,
@@ -1184,6 +1191,7 @@ public final class AgentLauncher {
                         allPageTitles: plan.allPageTitles,
                         sourceIDs: sourceIDs)
                     DebugLog.agent("runACPIngest: Phase 2 — Executor[\(sourceFile)] (\(assignments.count) page(s))")
+                    currentIngestPhase = "executor[\(sourceFile)]"
                     // Partial failure: log and continue to next executor.
                     // Phase 3: if the planner session is still alive, try to fork it
                     // so the executor inherits the planner's source context. If fork
@@ -1251,6 +1259,7 @@ public final class AgentLauncher {
             sourceFileNames: sourceFileNames,
             sourceIDs: sourceIDs)
         DebugLog.agent("runACPIngest: Phase 3 — Finalizer")
+        currentIngestPhase = "finalizer"
         if let session = await runPhase(
             backend: finalizerRouting.backend,
             profile: finalizerProfile,
@@ -1564,6 +1573,7 @@ public final class AgentLauncher {
         makeCLIProfile: (WikiOperation) -> CLIProfile,
         routing: StageRouting
     ) async {
+        currentIngestPhase = "fallback-single"
         let profile = BackendProfile(
             providerHints: routing.providerHints,
             scratchDirectory: scratch,
@@ -1646,46 +1656,31 @@ public final class AgentLauncher {
         return (resolvedCommand, acpCredentialStore.apiKey(forProvider: provider.id))
     }
 
-    /// Stall threshold for the launcher-level watchdog. More generous than the
-    /// ACPBackend's per-turn 120s `TurnLivenessPolicy` — this is the backstop
-    /// that fires when the backend watchdog's recovery fails (cancelSession
-    /// didn't unblock sendPrompt) and the process is truly wedged.
-    nonisolated static let watchdogStallThreshold: TimeInterval = 180
+    /// Warning threshold for the "still working" check-in. When the agent has
+    /// been idle (no notifications) for this long, the heartbeat logs a
+    /// prominent "still working" check-in so the operator (and Console.app)
+    /// can see that page creation is taking a long time. This does NOT kill
+    /// the process — it's observability only. The idle stall was removed
+    /// because ACP agents produce notifications for every activity, so a
+    /// silent agent is either dead (caught by `sendPrompt` throwing) or
+    /// genuinely working on something long.
+    nonisolated static let watchdogWarningThreshold: TimeInterval = 120
 
     /// Watchdog heartbeat poll interval (seconds). The loop sleeps this long
-    /// between idle-seconds checks.
+    /// between checks.
     nonisolated static let watchdogPollInterval: TimeInterval = 3
 
-    /// Grace period (seconds) after `stopAgent()` before escalating to SIGTERM.
-    nonisolated static let sigtermGracePeriod: TimeInterval = 10
-
-    /// Grace period (seconds) after SIGTERM before escalating to SIGKILL.
-    nonisolated static let sigkillGracePeriod: TimeInterval = 5
-
-    /// Pure stall-detection decision for the launcher watchdog. Extracted so
-    /// the threshold logic is unit-testable without driving launcher state.
-    /// - Returns: true if the watchdog should escalate (stopAgent + kill).
-    nonisolated static func shouldEscalateWatchdog(
-        isRunning: Bool,
-        idleSeconds: TimeInterval,
-        stallThreshold: TimeInterval,
-        alreadyEscalated: Bool
-    ) -> Bool {
-        isRunning && !alreadyEscalated && idleSeconds >= stallThreshold
-    }
-
-    /// Heartbeat logger + stall escalation. Replaces the old liveness-poller
-    /// (which polled `process?.isRunning` — impossible now that `Process` lives
-    /// behind the `AgentBackend` port). The backend's `onExit` callback is the
-    /// sole completion signal: it fires exactly once from `terminationHandler`
-    /// and drives `finish()`.
+    /// Heartbeat logger — observability only. The backend's `onExit` callback
+    /// is the sole completion signal: it fires exactly once from
+    /// `terminationHandler` and drives `finish()`.
     ///
-    /// **Phase 3 escalation (plans/acp-stall-recovery.md §3):** if the session
-    /// has been idle for `watchdogStallThreshold` (180s) and hasn't already
-    /// escalated, this watchdog calls `stopAgent()` (cancel + finish) and
-    /// spawns a separate kill-escalation task: wait 10s → `SIGTERM` the process
-    /// group → wait 5s → `SIGKILL`. The `terminationHandler` fires after the
-    /// kill → `onExit` → `finish()`.
+    /// This loop logs phase, idle time, and elapsed time every `pollInterval`
+    /// seconds, and emits a "still working" check-in when idle exceeds the
+    /// warning threshold. It does NOT kill the process for inactivity — the
+    /// idle stall was removed because ACP agents emit notifications for every
+    /// activity (thinking, tool calls, sub-agent lifecycle), so a live agent
+    /// is almost never truly idle. Process death is detected by `sendPrompt`
+    /// throwing; the turn ceiling (30 min) is the remaining hard backstop.
     private func startCompletionWatchdog() {
         watchdogTask?.cancel()
         watchdogTask = Task { @MainActor [weak self] in
@@ -1694,59 +1689,31 @@ public final class AgentLauncher {
                 guard let self, self.isRunning else { return }
                 let pid = self.currentProcessID ?? -1
                 let idle = self.lastActivityAt.map { Date().timeIntervalSince($0) } ?? -1
+                let phase = self.currentIngestPhase ?? "running"
+                let elapsed = self.runStartedAt.map { Date().timeIntervalSince($0) } ?? -1
                 DebugLog.agent(
-                    "heartbeat pid=\(pid) isRunning=\(self.isRunning) "
-                    + "events=\(self.events.count) idleSec=\(String(format: "%.1f", idle))")
+                    "heartbeat pid=\(pid) phase=\(phase) isRunning=\(self.isRunning) "
+                    + "events=\(self.events.count) idleSec=\(String(format: "%.1f", idle)) "
+                    + "elapsedSec=\(String(format: "%.1f", elapsed))")
 
-                // Stall escalation: if idle exceeds threshold, stop + kill.
-                if Self.shouldEscalateWatchdog(
-                    isRunning: self.isRunning,
-                    idleSeconds: idle,
-                    stallThreshold: Self.watchdogStallThreshold,
-                    alreadyEscalated: self.watchdogHasEscalated
-                ) {
-                    self.watchdogHasEscalated = true
-                    DebugLog.agent("watchdog: STALL detected (idle \(Int(idle))s pid=\(pid)) — escalating: stopAgent() + kill sequence")
-                    self.stopAgent()
-                    self.startKillEscalation(pid: pid)
+                // "Still working" check-in: idle has exceeded the warning
+                // threshold. Page creation can legitimately take minutes of
+                // reasoning — this assures the operator the process is alive
+                // and names which phase is long.
+                if idle >= Self.watchdogWarningThreshold && !self.watchdogHasWarned {
+                    self.watchdogHasWarned = true
+                    DebugLog.agent(
+                        "heartbeat: CHECK-IN — phase=\(phase) has been quiet for \(Int(idle))s "
+                        + "(elapsed \(Int(elapsed))s). Still working — page creation "
+                        + "may take several minutes.")
+                }
+                // Reset the warning flag when activity resumes so the check-in
+                // can fire again on the next long pause.
+                if idle < Self.watchdogWarningThreshold {
+                    self.watchdogHasWarned = false
                 }
             }
         }
-    }
-
-    /// After `stopAgent()`, if the process doesn't die within the escalation
-    /// timeouts, escalate to `SIGTERM` → `SIGKILL`. Runs as a separate Task
-    /// because `stopAgent()` sets `isRunning = false` (which exits the heartbeat
-    /// loop above). Checks `kill(pid, 0)` directly — not `isRunning` — to detect
-    /// whether the process is actually dead. Sends to the process GROUP
-    /// (`kill(-pid, ...)`) so agent-spawned children are also killed.
-    private func startKillEscalation(pid: Int32) {
-        guard pid > 0 else { return }
-        Task { @MainActor in
-            // Phase 1: wait for cancel to take effect.
-            try? await Task.sleep(for: .seconds(Self.sigtermGracePeriod))
-            if Self.isProcessAlive(pid) {
-                DebugLog.agent("watchdog: cancel didn't kill pid=\(pid), sending SIGTERM to process group")
-                kill(-pid, SIGTERM)
-
-                // Phase 2: wait for SIGTERM.
-                try? await Task.sleep(for: .seconds(Self.sigkillGracePeriod))
-                if Self.isProcessAlive(pid) {
-                    DebugLog.agent("watchdog: SIGTERM didn't kill pid=\(pid), sending SIGKILL to process group")
-                    kill(-pid, SIGKILL)
-                }
-            }
-            // After SIGKILL (or if already dead), the terminationHandler fires
-            // → onExit → finish(). No manual finish() needed here.
-            DebugLog.agent("watchdog: kill escalation complete for pid=\(pid)")
-        }
-    }
-
-    /// Check if a process is alive via `kill(pid, 0)`. Returns true if the
-    /// process exists (including if we don't have permission to signal it).
-    private static func isProcessAlive(_ pid: Int32) -> Bool {
-        if kill(pid, 0) == 0 { return true }
-        return errno == EPERM
     }
 
     /// Resolve the `created_by`/`last_edited_by` provenance string stamped on
@@ -2374,7 +2341,7 @@ public final class AgentLauncher {
         DebugLog.agent("finish: status=\(status) events=\(events.count) activeChatID=\(activeChatID ?? "nil")")
         watchdogTask?.cancel()
         watchdogTask = nil
-        watchdogHasEscalated = false
+        watchdogHasWarned = false
         // Session over: flush any remaining tail (a killed/died session still
         // persists its last events) THEN detach the sink — no further writes.
         flushTranscript()
@@ -2444,7 +2411,7 @@ public final class AgentLauncher {
         DebugLog.agent("resetRunArtifacts: clearing per-run artifacts (prior activeChatID=\(activeChatID ?? "nil"))")
         watchdogTask?.cancel()
         watchdogTask = nil
-        watchdogHasEscalated = false
+        watchdogHasWarned = false
         events = []
         eventTimestamps = []
         isStreamingAssistantRow = false
@@ -2457,6 +2424,7 @@ public final class AgentLauncher {
         runningKind = nil
         logFileURL = nil
         lastActivityAt = nil
+        currentIngestPhase = nil
         currentProcessID = nil
         sessionHandle = nil
         plannerSessionHandle = nil

--- a/Sources/WikiFSEngine/TurnLivenessPolicy.swift
+++ b/Sources/WikiFSEngine/TurnLivenessPolicy.swift
@@ -1,27 +1,26 @@
 import Foundation
 
 /// Pure decision helper for ACP turn liveness. Determines whether an in-flight
-/// `session/prompt` is healthy, stalled (no `session/update` notifications for
-/// too long), or past a hard ceiling (total turn duration).
+/// `session/prompt` is healthy or past a hard ceiling (total turn duration).
 ///
-/// This is NOT a flat prompt timeout — a turn legitimately running 6+ minutes
-/// of research work is healthy as long as notifications keep arriving. The
-/// correct failure signal is **inactivity**: the agent is healthy iff
-/// `session/update` notifications keep flowing.
+/// The idle/stall path was removed: ACP agents emit `session/update`
+/// notifications for every activity — thinking, text deltas, tool calls,
+/// sub-agent lifecycle — so a live, working agent almost always produces
+/// notifications. The only remaining failure signal is the **hard ceiling**
+/// (a turn that runs too long) and **process death** (detected separately via
+/// `kill(pid, 0)` in the watchdog task). A legitimate long reasoning chain
+/// during page creation should not be killed just because it went quiet.
 ///
 /// PURE — no actor, no clock side-effects, no I/O. Unit-tested directly.
 /// `ACPBackend.send` calls this from its watchdog task on every poll interval.
 ///
-/// See `plans/acp-stall-recovery.md` §1a.
+/// See `plans/acp-stall-recovery.md` §1a (idle path now removed).
 enum TurnLivenessPolicy {
 
     /// The watchdog's verdict for a single poll.
     enum Decision: Equatable {
         /// The turn is progressing — keep waiting.
         case healthy
-        /// No notification has arrived for `idleSeconds`. The turn should be
-        /// cancelled and surfaced as an error.
-        case stalled(idleSeconds: TimeInterval)
         /// Total turn duration exceeded the ceiling — even if notifications are
         /// flowing, the turn has run too long.
         case ceilingExceeded(totalSeconds: TimeInterval)
@@ -34,20 +33,13 @@ enum TurnLivenessPolicy {
     ///   - promptDone: Whether `sendPrompt` has already returned (the turn is
     ///     over). When true, always `.healthy` — the watchdog should stop.
     ///   - turnStartedAt: When the turn began (the prompt was sent).
-    ///   - lastActivityAt: When the most recent `session/update` notification
-    ///     arrived. At turn start this equals `turnStartedAt` (no notifications
-    ///     yet).
-    ///   - idleTimeout: How long without a notification before declaring a
-    ///     stall (default 120s).
     ///   - ceilingTimeout: Hard maximum turn duration (default 1800s / 30 min).
     /// - Returns: The decision. Precedence: `promptDone` > `ceilingExceeded`
-    ///   > `stalled` > `healthy`.
+    ///   > `healthy`.
     static func evaluate(
         now: Date,
         promptDone: Bool,
         turnStartedAt: Date,
-        lastActivityAt: Date,
-        idleTimeout: TimeInterval,
         ceilingTimeout: TimeInterval
     ) -> Decision {
         // If the prompt already completed, the turn is over — nothing to do.
@@ -60,29 +52,16 @@ enum TurnLivenessPolicy {
             return .ceilingExceeded(totalSeconds: totalElapsed)
         }
 
-        let idle = now.timeIntervalSince(lastActivityAt)
-
-        // Inactivity: the agent went silent.
-        if idle >= idleTimeout {
-            return .stalled(idleSeconds: idle)
-        }
-
         return .healthy
     }
 
     // MARK: - Defaults
 
-    /// Default idle timeout: 120 seconds. Generous because an agent may pause
-    /// between tool calls or while thinking. The observed stall had zero
-    /// notifications — this is the signal that distinguishes "thinking" from
-    /// "dead."
-    static let defaultIdleTimeout: TimeInterval = 120
-
     /// Default ceiling: 30 minutes. Backstop against an agent that streams
     /// heartbeat-ish updates forever without finishing.
     static let defaultCeilingTimeout: TimeInterval = 1800
 
-    /// Watchdog poll interval: 15 seconds. Balances responsiveness (a stall is
-    /// detected within 15s of the threshold) against actor pressure.
+    /// Watchdog poll interval: 15 seconds. Balances responsiveness (a ceiling
+    /// breach is detected within 15s of the threshold) against actor pressure.
     static let defaultPollInterval: TimeInterval = 15
 }

--- a/Tests/WikiFSTests/ACPStallRecoveryTests.swift
+++ b/Tests/WikiFSTests/ACPStallRecoveryTests.swift
@@ -85,15 +85,6 @@ import WikiFSEngine
         #expect(AgentEvent.endsGeneration(.messageStop) == true)
     }
 
-    /// `ACPBackendError.turnStalled` produces a user-readable error message.
-    @Test func turnStalledErrorIsDescriptive() {
-        let error = ACPBackendError.turnStalled(idleSeconds: 137)
-        let message = error.errorDescription ?? ""
-        #expect(message.contains("stalled"))
-        #expect(message.contains("137"))
-        #expect(message.contains("cancelled"))
-    }
-
     /// `ACPBackendError.turnCeilingExceeded` produces a user-readable error
     /// message.
     @Test func turnCeilingErrorIsDescriptive() {
@@ -101,30 +92,6 @@ import WikiFSEngine
         let message = error.errorDescription ?? ""
         #expect(message.contains("maximum"))
         #expect(message.contains("1800"))
-    }
-
-    /// `turnEndEvents` with a stall error produces the expected sequence:
-    /// a `.turnFailed(.stalled)` banner, then `.messageStop` — the exact
-    /// sequence the watchdog yields to end a stalled turn. The structured
-    /// reason persists and renders as an amber banner in the UI. (#422)
-    @Test func turnEndEventsForStallSynthesizeMessageStop() {
-        let error = ACPBackendError.turnStalled(idleSeconds: 120)
-        let events = ACPBackend.turnEndEvents(error: error)
-
-        #expect(events.count == 2)
-        // First: a .turnFailed carrying the idle seconds.
-        if case .turnFailed(let reason) = events[0] {
-            if case .stalled(let idle) = reason {
-                #expect(idle == 120)
-            } else {
-                Issue.record("expected .stalled reason, got \(reason)")
-            }
-        } else {
-            Issue.record("expected .turnFailed event, got \(events[0])")
-        }
-        // Second: .messageStop (the generation-ending event).
-        #expect(events[1] == .messageStop)
-        #expect(AgentEvent.endsGeneration(events[1]) == true)
     }
 
     /// `turnEndEvents` with a ceiling error also synthesizes `.messageStop`.

--- a/Tests/WikiFSTests/AgentEventCodableTests.swift
+++ b/Tests/WikiFSTests/AgentEventCodableTests.swift
@@ -77,6 +77,9 @@ import Foundation
     }
 
     @Test func turnFailedStalledRoundTrips() throws {
+        // The .stalled case is still in TurnFailureReason for backward
+        // compatibility with persisted chat history, even though the engine
+        // no longer produces it (idle stall was removed).
         let event = AgentEvent.turnFailed(reason: .stalled(idleSeconds: 130))
         #expect(try roundTrip(event) == event)
     }

--- a/Tests/WikiFSTests/TurnLivenessPolicyTests.swift
+++ b/Tests/WikiFSTests/TurnLivenessPolicyTests.swift
@@ -5,8 +5,12 @@ import WikiFSEngine
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// Pure unit tests for `TurnLivenessPolicy` — the turn inactivity watchdog
-/// decision helper (`plans/acp-stall-recovery.md` §1a).
+/// Pure unit tests for `TurnLivenessPolicy` — the turn ceiling watchdog
+/// decision helper.
+///
+/// The idle/stall path was removed: ACP agents emit notifications for every
+/// activity (thinking, tool calls, sub-agent lifecycle), so a live agent is
+/// almost never truly idle. Only the hard ceiling remains.
 ///
 /// No actor, no clock, no subprocess. Every test constructs explicit `Date`
 /// values and asserts the decision.
@@ -15,17 +19,14 @@ import WikiFSEngine
     // MARK: - Healthy
 
     @Test func healthyWhenPromptDone() {
-        // Even if idle and ceiling exceeded, promptDone wins.
+        // Even if ceiling exceeded, promptDone wins.
         let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 0)
         let now = start.addingTimeInterval(9999)
 
         let decision = TurnLivenessPolicy.evaluate(
             now: now,
             promptDone: true,
             turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
             ceilingTimeout: 1800
         )
         #expect(decision == .healthy)
@@ -33,87 +34,27 @@ import WikiFSEngine
 
     @Test func healthyWithRecentActivity() {
         let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 50) // active 50s ago
-        let now = start.addingTimeInterval(60)     // 60s elapsed, idle 10s
+        let now = start.addingTimeInterval(60)     // 60s elapsed
 
         let decision = TurnLivenessPolicy.evaluate(
             now: now,
             promptDone: false,
             turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
             ceilingTimeout: 1800
         )
         #expect(decision == .healthy)
-    }
-
-    // MARK: - Stalled
-
-    @Test func stalledAfterIdleTimeout() {
-        let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 30)  // last activity at 30s
-        let now = start.addingTimeInterval(200)       // 200s total, idle 170s
-
-        let decision = TurnLivenessPolicy.evaluate(
-            now: now,
-            promptDone: false,
-            turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
-            ceilingTimeout: 1800
-        )
-        #expect(decision == .stalled(idleSeconds: 170))
-    }
-
-    @Test func stalledWhenNeverActiveAndThresholdPassed() {
-        // lastActivityAt == turnStartedAt (no notifications yet).
-        let start = Date(timeIntervalSince1970: 0)
-        let now = start.addingTimeInterval(130) // 130s with zero activity
-
-        let decision = TurnLivenessPolicy.evaluate(
-            now: now,
-            promptDone: false,
-            turnStartedAt: start,
-            lastActivityAt: start,
-            idleTimeout: 120,
-            ceilingTimeout: 1800
-        )
-        #expect(decision == .stalled(idleSeconds: 130))
-    }
-
-    @Test func stalledReportsExactIdleSeconds() {
-        let start = Date(timeIntervalSince1970: 1000)
-        let last = Date(timeIntervalSince1970: 1050)
-        let now = Date(timeIntervalSince1970: 1200) // idle = 150s
-
-        let decision = TurnLivenessPolicy.evaluate(
-            now: now,
-            promptDone: false,
-            turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
-            ceilingTimeout: 1800
-        )
-        if case .stalled(let idle) = decision {
-            #expect(idle == 150)
-        } else {
-            Issue.record("expected .stalled, got \(decision)")
-        }
     }
 
     // MARK: - Ceiling
 
     @Test func ceilingExceededAfterMaxDuration() {
         let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 1790) // still active recently
         let now = start.addingTimeInterval(1810)     // 1810s > 1800s ceiling
 
         let decision = TurnLivenessPolicy.evaluate(
             now: now,
             promptDone: false,
             turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
             ceilingTimeout: 1800
         )
         #expect(decision == .ceilingExceeded(totalSeconds: 1810))
@@ -122,15 +63,12 @@ import WikiFSEngine
     @Test func ceilingNotTriggeredWhileActive() {
         // Active agent under the ceiling — healthy.
         let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 1790) // very recent
         let now = start.addingTimeInterval(1795)     // under 1800s
 
         let decision = TurnLivenessPolicy.evaluate(
             now: now,
             promptDone: false,
             turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
             ceilingTimeout: 1800
         )
         #expect(decision == .healthy)
@@ -138,69 +76,15 @@ import WikiFSEngine
 
     // MARK: - Precedence
 
-    @Test func ceilingTakesPrecedenceOverIdle() {
-        // Both idle AND ceiling exceeded — ceiling wins.
+    @Test func promptDoneTakesPrecedenceOverCeiling() {
+        // Even with ceiling exceeded, promptDone wins.
         let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 0) // never active
-        let now = start.addingTimeInterval(2000)  // 2000s total
-
-        let decision = TurnLivenessPolicy.evaluate(
-            now: now,
-            promptDone: false,
-            turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
-            ceilingTimeout: 1800
-        )
-        #expect(decision == .ceilingExceeded(totalSeconds: 2000))
-    }
-
-    @Test func promptDoneTakesPrecedenceOverAll() {
-        // Even with ceiling exceeded AND idle, promptDone wins.
-        let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 0)
         let now = start.addingTimeInterval(9999)
 
         let decision = TurnLivenessPolicy.evaluate(
             now: now,
             promptDone: true,
             turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
-            ceilingTimeout: 1800
-        )
-        #expect(decision == .healthy)
-    }
-
-    // MARK: - Boundary
-
-    @Test func stalledAtExactlyIdleTimeout() {
-        let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 0)
-        let now = start.addingTimeInterval(120) // exactly at threshold
-
-        let decision = TurnLivenessPolicy.evaluate(
-            now: now,
-            promptDone: false,
-            turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
-            ceilingTimeout: 1800
-        )
-        #expect(decision == .stalled(idleSeconds: 120))
-    }
-
-    @Test func healthyJustBelowIdleTimeout() {
-        let start = Date(timeIntervalSince1970: 0)
-        let last = Date(timeIntervalSince1970: 0)
-        let now = start.addingTimeInterval(119.9) // just under threshold
-
-        let decision = TurnLivenessPolicy.evaluate(
-            now: now,
-            promptDone: false,
-            turnStartedAt: start,
-            lastActivityAt: last,
-            idleTimeout: 120,
             ceilingTimeout: 1800
         )
         #expect(decision == .healthy)

--- a/Tests/WikiFSTests/WatchdogEscalationTests.swift
+++ b/Tests/WikiFSTests/WatchdogEscalationTests.swift
@@ -5,75 +5,21 @@ import WikiFSEngine
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// Unit tests for the launcher watchdog's stall-escalation decision
-/// (`plans/acp-stall-recovery.md` Phase 3 §3).
+/// Unit tests for the launcher watchdog constants.
 ///
-/// The decision is extracted as a PURE static so it's unit-testable without
-/// driving launcher state or spawning processes.
+/// The stall-escalation path (`shouldEscalateWatchdog`,
+/// `watchdogStallThreshold`) was removed — the idle stall was eliminated
+/// because ACP agents emit notifications for every activity, so a live agent
+/// is almost never truly idle. The watchdog is now observability-only.
 @Suite struct WatchdogEscalationTests {
-
-    // MARK: - Escalate
-
-    @Test func escalatesWhenIdleExceedsThreshold() {
-        #expect(AgentLauncher.shouldEscalateWatchdog(
-            isRunning: true,
-            idleSeconds: 181,
-            stallThreshold: 180,
-            alreadyEscalated: false
-        ) == true)
-    }
-
-    @Test func escalatesAtExactlyThreshold() {
-        #expect(AgentLauncher.shouldEscalateWatchdog(
-            isRunning: true,
-            idleSeconds: 180,
-            stallThreshold: 180,
-            alreadyEscalated: false
-        ) == true)
-    }
-
-    // MARK: - Don't escalate
-
-    @Test func noEscalateWhenNotRunning() {
-        #expect(AgentLauncher.shouldEscalateWatchdog(
-            isRunning: false,
-            idleSeconds: 9999,
-            stallThreshold: 180,
-            alreadyEscalated: false
-        ) == false)
-    }
-
-    @Test func noEscalateWhenIdleBelowThreshold() {
-        #expect(AgentLauncher.shouldEscalateWatchdog(
-            isRunning: true,
-            idleSeconds: 179,
-            stallThreshold: 180,
-            alreadyEscalated: false
-        ) == false)
-    }
-
-    @Test func noEscalateWhenAlreadyEscalated() {
-        #expect(AgentLauncher.shouldEscalateWatchdog(
-            isRunning: true,
-            idleSeconds: 9999,
-            stallThreshold: 180,
-            alreadyEscalated: true
-        ) == false)
-    }
-
-    @Test func noEscalateWhenNoActivityRecorded() {
-        // idleSeconds = -1 (no lastActivityAt) — should not escalate.
-        #expect(AgentLauncher.shouldEscalateWatchdog(
-            isRunning: true,
-            idleSeconds: -1,
-            stallThreshold: 180,
-            alreadyEscalated: false
-        ) == false)
-    }
 
     // MARK: - Threshold constant
 
-    @Test func defaultStallThresholdIs180() {
-        #expect(AgentLauncher.watchdogStallThreshold == 180)
+    @Test func warningThresholdIs120() {
+        #expect(AgentLauncher.watchdogWarningThreshold == 120)
+    }
+
+    @Test func pollIntervalIs3() {
+        #expect(AgentLauncher.watchdogPollInterval == 3)
     }
 }

--- a/prompts/ingest-executor.md
+++ b/prompts/ingest-executor.md
@@ -45,6 +45,9 @@ you read it), re-read the page once, reapply your edit, and retry. If it fails
 again, report the conflict rather than looping.
 
 IMPORTANT:
-- Do NOT dispatch sub-agents, background tasks, or async agents.
+- You MAY dispatch sub-agents via the Task tool to read and digest source
+  sections in parallel. Each sub-agent generates lifecycle notifications that
+  keep the host informed of progress. Workers must NOT write to the wiki —
+  only you write via `$WIKICTL`.
 - Do NOT use sleep or ScheduleWakeup.
 - Write ALL your assigned pages before stopping.


### PR DESCRIPTION
## Summary

Remove the idle-timeout stall detection path from the ACP watchdog and shift from automatic process escalation (SIGTERM → SIGKILL) to observability-only logging.

**Key change:** ACP agents emit `session/update` notifications for every activity (thinking, tool calls, sub-agent lifecycle), so a live, working agent is almost never truly idle. Idle silence now signals process death (detected separately via `kill(pid, 0)` in the watchdog) rather than a stall requiring recovery.

## Changes

### ACPBackend & TurnLivenessPolicy
- Remove `turnIdleTimeout` and idle timeout logic from per-turn watchdog
- Remove `.stalled` case from `TurnLivenessPolicy.Decision` and the idle-check logic that produced it
- Remove `ACPBackendError.turnStalled` error type
- Watchdog now only checks hard ceiling timeout (30 min) and defers process death detection to `sendPrompt` throwing

### AgentLauncher
- Remove stall-escalation decision (`shouldEscalateWatchdog`) and kill-escalation machinery (`startKillEscalation`, SIGTERM/SIGKILL timeouts)
- Rename `watchdogHasEscalated` → `watchdogHasWarned` to reflect new purpose
- Add `currentIngestPhase` property so heartbeat and UI can name which ingest phase (planner/executor/finalizer) is taking a long time
- Watchdog now logs "still working" check-in when idle exceeds 120s (observability only — does not kill)
- Heartbeat logs now include phase, elapsed time, and idle seconds for better observability

### Tests
- Remove all stall-detection tests (`ACPStallRecoveryTests`, `TurnLivenessPolicyTests` stall suite, `WatchdogEscalationTests` escalation tests)
- Keep ceiling timeout tests (hard backstop remains)
- Keep constants test for `watchdogWarningThreshold` and `watchdogPollInterval`
- Add comment to `AgentEventCodableTests.turnFailedStalledRoundTrips` noting backward compatibility

### Prompt update
- Clarify in `ingest-executor.md` that sub-agents ARE allowed (they emit lifecycle notifications that keep the host informed)