### PR TITLE
Wire Settings window via OpenWindowBridge.openSettings

### DIFF
--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -223,8 +223,13 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
 
         // Settings — moved here from the "Self Driving Wiki" app menu (the
         // status item is reachable even in accessory mode; the app menu
-        // isn't). Opens the Settings scene via the same selector the gear
-        // buttons use (`showSettingsWindow:`).
+        // isn't). Opens the Settings scene via the `OpenWindowBridge`
+        // `openSettings` closure, which is wired from `@Environment(\.openSettings)`
+        // — the same supported SwiftUI API the gear buttons use. The old
+        // `sendAction(showSettingsWindow:)` selector was unreliable: it walks
+        // the responder chain, which has no handler when all windows are
+        // closed (accessory mode) or after the auto-generated Settings menu
+        // item was removed by `removeRedundantAppMenuItems`.
         let settingsItem = NSMenuItem(
             title: "Settings…",
             action: #selector(openSettings(_:)),
@@ -303,12 +308,13 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         activateWikiWindow()
     }
 
-    /// Open the Settings window. Sends the Settings scene's action
-    /// (`showSettingsWindow:`) — the same selector the activity-window gear
-    /// buttons use — so a single code path opens Settings everywhere.
+    /// Open the Settings window. Calls the `OpenWindowBridge`'s
+    /// `openSettings` closure — wired from `@Environment(\.openSettings)`
+    /// inside `WindowBridgeProbe` — so a single supported code path opens
+    /// Settings everywhere (gear buttons, "Open Settings…", status item).
     @objc private func openSettings(_ sender: NSMenuItem?) {
         NSApplication.shared.activate(ignoringOtherApps: true)
-        NSApplication.shared.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        openWindowBridge.openSettings?()
     }
 
     /// Bring a wiki window to the front. `openTab` switches the tab inside

--- a/Sources/WikiFS/Window/OpenWindowBridge.swift
+++ b/Sources/WikiFS/Window/OpenWindowBridge.swift
@@ -30,6 +30,12 @@ final class OpenWindowBridge {
     /// as a fallback from `applicationShouldHandleReopen`. Set by
     /// `WindowBridgeProbe` via `openWindow(id: "main")`.
     var openMain: (() -> Void)?
+
+    /// Opens the Settings window via SwiftUI's `@Environment(\.openSettings)`
+    /// action. Set by `WindowBridgeProbe` from a SwiftUI view that has access
+    /// to the environment value. Used by `MenuBarItemController` (the status
+    /// item is AppKit and can't read SwiftUI environment values directly).
+    var openSettings: (() -> Void)?
 }
 
 /// Invisible helper view that captures `@Environment(\.openWindow)` (only
@@ -43,6 +49,7 @@ final class OpenWindowBridge {
 struct WindowBridgeProbe: View {
     let bridge: OpenWindowBridge
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         Color.clear
@@ -60,6 +67,16 @@ struct WindowBridgeProbe: View {
         // `openWindow(id: "main")` targets the main `WindowGroup(id: "main")`.
         bridge.openMain = {
             openWindow(id: "main")
+        }
+        // `openSettings()` opens the Settings scene — the supported SwiftUI
+        // API (macOS 14+). Captured by value like `openWindow`, so it remains
+        // callable from the menu bar even after the hosting window closes
+        // (accessory mode). Replaces the fragile private `showSettingsWindow:`
+        // selector that the responder chain can't reliably deliver when no
+        // key window exists or when the auto-generated Settings menu item was
+        // removed by `removeRedundantAppMenuItems`.
+        bridge.openSettings = {
+            openSettings()
         }
     }
 }


### PR DESCRIPTION
Replace the fragile `showSettingsWindow:` selector with SwiftUI's supported `@Environment(\.openSettings)` API.

## Problem
The old approach sent a private selector down the responder chain, which fails when:
- All windows are closed (accessory mode)
- The auto-generated Settings menu item was removed by `removeRedundantAppMenuItems`

This made the Settings menu item unreliable, especially in accessory mode where the status item is the only UI available.

## Solution
Capture `@Environment(\.openSettings)` in `WindowBridgeProbe` and store it in `OpenWindowBridge`, making it available to AppKit code (which can't read SwiftUI environment values directly). The menu bar's Settings action now calls this closure.

## Benefits
- Uses the supported macOS 14+ SwiftUI API
- Single unified code path for opening Settings (gear buttons, menu item, status item)
- Reliable in all window states, including accessory mode
- Closure is captured by value, so it remains callable even after windows close