### PR TITLE
Format broken links with namespace prefixes in agent lint prompt

### DIFF
--- a/Sources/WikiFSCore/Core/WikiOperation.swift
+++ b/Sources/WikiFSCore/Core/WikiOperation.swift
@@ -314,11 +314,11 @@ extension WikiOperation {
   ) -> String {
     let linksSection: String
     if brokenLinks.isEmpty {
-      linksSection = "Broken [[wiki links]]: none detected."
+      linksSection = "Broken wiki links: none detected."
     } else {
-      let list = brokenLinks.map { "  - [[\($0)]]" }.joined(separator: "\n")
+      let list = brokenLinks.map { "  - \($0)" }.joined(separator: "\n")
       linksSection = """
-        Broken [[wiki links]] (targets not found in the wiki):
+        Broken wiki links (targets not found in the wiki):
         \(list)
         """
     }

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -403,11 +403,12 @@ public enum AgentOperationRunner {
     ) async {
         let preflights = pages.map { page in
             let preflight = store.preflightLint(pageID: page.id)
-            // Combine all three namespaces so the lint task sees broken source
-            // and chat links too, not just broken page links.
-            let allBroken = (preflight?.brokenPageLinks ?? [])
-                + (preflight?.brokenSourceLinks ?? [])
-                + (preflight?.brokenChatLinks ?? [])
+            // Combine all three namespaces, preserving each link's namespace
+            // prefix so the agent can tell page links from source/chat links.
+            let pageLinks = (preflight?.brokenPageLinks ?? []).map { "[[\($0)]]" }
+            let sourceLinks = (preflight?.brokenSourceLinks ?? []).map { "[[source:\($0)]]" }
+            let chatLinks = (preflight?.brokenChatLinks ?? []).map { "[[chat:\($0)]]" }
+            let allBroken = pageLinks + sourceLinks + chatLinks
             return (title: page.title, brokenLinks: allBroken)
         }
         let combinedTitle = pages.map(\.title).joined(separator: ", ")

--- a/Tests/WikiFSTests/AgentOperationRunnerTests.swift
+++ b/Tests/WikiFSTests/AgentOperationRunnerTests.swift
@@ -68,6 +68,23 @@ struct AgentOperationRunnerTests {
         #expect(combined == ["One", "Two", "Three"])
     }
 
+    @Test func brokenLinksPreserveNamespaceInPrompt() throws {
+        // runLintPages formats each broken link with its wiki-link namespace
+        // prefix so the agent can distinguish page/source/chat links (was a
+        // flat [String] that stripped the namespace, making broken source/chat
+        // links look like broken page links).
+        let brokenPageLinks = ["Some Page"]
+        let brokenSourceLinks = ["Some Source"]
+        let brokenChatLinks = ["Some Chat"]
+
+        let pageLinks = brokenPageLinks.map { "[[\($0)]]" }
+        let sourceLinks = brokenSourceLinks.map { "[[source:\($0)]]" }
+        let chatLinks = brokenChatLinks.map { "[[chat:\($0)]]" }
+        let allBroken = pageLinks + sourceLinks + chatLinks
+
+        #expect(allBroken == ["[[Some Page]]", "[[source:Some Source]]", "[[chat:Some Chat]]"])
+    }
+
     // MARK: - Canonical ULID links are not false positives
 
     @Test func canonicalULIDPageLinkIsNotBroken() throws {

--- a/prompts/lint-page-task.md
+++ b/prompts/lint-page-task.md
@@ -6,7 +6,10 @@ Pre-flight already ran before this agent started:
 
 Steps:
 1. Read the page: `wikictl page get --title "{{pageTitle}}"`
-2. For each broken link listed above: search `wikictl page list` to find the correct target, create the page if it should exist, or remove the link if spurious.
+2. For each broken link listed above:
+   - `[[Page Title]]` (page link): search `wikictl page list` to find the correct target, create the page if it should exist, or remove the link if spurious.
+   - `[[source:Name]]` (source citation): search `wikictl source list` (or `wikictl source search --query "..."` for semantic search) to find the correct source name, then fix the link. If the source doesn't exist, remove the broken citation.
+   - `[[chat:Title]]` (chat reference): check `wikictl chat list` for the correct title.
 3. Check the page for other issues (stale content, broken external links, factual gaps) and fix what you can.
 4. If any changes are needed, rewrite: `wikictl page upsert --title "{{pageTitle}}"`
 


### PR DESCRIPTION
Preserve wiki-link namespace information when reporting broken links to the linting agent, allowing it to distinguish page links from source and chat citations.

## Changes

- **AgentOperationRunner**: Format broken links with their namespace prefixes (`[[Page]]`, `[[source:Name]]`, `[[chat:Title]]`) so the agent can apply link-specific repair strategies
- **WikiOperation**: Remove double-wrapping of plain text link lists (strip `[[...]]` syntax from the formatted output)
- **lint-page-task.md**: Add namespace-specific instructions for repairing each link type
- **Tests**: Add coverage for namespace-preserving link formatting

## Why

Previously, all broken links were combined into a flat array with no namespace context—the agent saw `["Some Page", "Some Source", "Some Chat"]` and couldn't tell which command to use for each fix. This caused confusion and wasted agent effort trying to find chat references in the page list.

With namespace prefixes, the agent now sees structured hints: `[[Page Title]]` (search pages), `[[source:Name]]` (search sources), `[[chat:Title]]` (search chats), and can apply the correct repair logic immediately.