### PR TITLE
Use source effectiveName in ActivityWindowView

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -532,7 +532,7 @@ struct ActivityWindowView: View {
     private func sourceNames(for item: QueueItem) -> [String] {
         guard let store = sessionManager?.sessions[item.wikiID]?.store else { return [] }
         return item.payload.sourceIDs.compactMap { id in
-            store.sources.first { $0.id == id }?.filename
+            store.sources.first { $0.id == id }?.effectiveName
         }
     }
 


### PR DESCRIPTION
## What changed

Updated the `sourceNames` helper in ActivityWindowView to display `effectiveName` instead of `filename` when showing source information in the activity window.

## Why

`effectiveName` provides a more semantic and user-friendly display name for sources, as opposed to the raw filename. This aligns with the queue display's naming convention and improves clarity in the activity window UI.