### PR TITLE
Implement ingest gate preventing sources without content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # merge for fast iteration — see AGENTS.md.
         # To add a slow suite: tag it `.integration` AND append its name here.
         env:
-          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|QuoteHighlightWebViewTests'
+          SKIP: 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|QuoteHighlightWebViewTests'
         run: $SWIFT test --skip "$SKIP"
 
   swift-integration:

--- a/Sources/WikiFS/Queue/QueueIngestionHelper.swift
+++ b/Sources/WikiFS/Queue/QueueIngestionHelper.swift
@@ -9,6 +9,14 @@ import WikiFSEngine
 /// ingestion item. For non-PDFs or PDFs with existing markdown, enqueues
 /// ingestion directly.
 ///
+/// **Markdown/content gate (chokepoint):** after any extraction step, a
+/// source with neither processed markdown nor raw bytes is dropped
+/// (`canIngest` check). This is the single enforcement of "don't ingest
+/// sources without content" — every entry point funnels through here, so a
+/// byteless source (e.g. a YouTube video with no transcript) can never be
+/// enqueued no matter which UI path originated the request. The UI predicate
+/// (`WikiStoreModel.canIngest`) mirrors this for affordance gating.
+///
 /// **Deduplication:** before enqueuing, checks the engine's active items
 /// (`.queued` or `.running`) for this wiki. Sources already active in either
 /// the extraction or ingestion queue are skipped — a user tapping Ingest
@@ -44,12 +52,15 @@ func enqueueIngestion(
     var ingestionSourceIDs: [PageID] = []
 
     for sourceID in newSourceIDs {
-        // Check if this source needs extraction first.
-        if let source = store.sources.first(where: { $0.id == sourceID }),
-           MimeType.isPDF(source.mimeType),
+        guard let source = store.sources.first(where: { $0.id == sourceID }) else {
+            DebugLog.ingest("enqueueIngestion: unknown source \(sourceID.rawValue) — skipped")
+            continue
+        }
+
+        // PDF without extracted markdown → enqueue extraction, wait for it,
+        // then include in ingestion batch (extraction produces the markdown).
+        if MimeType.isPDF(source.mimeType),
            store.processedMarkdownHead(for: source) == nil {
-            // PDF without extracted markdown → enqueue extraction, wait
-            // for it, then include in ingestion batch.
             let request = QueueItemRequest(
                 queue: .extraction,
                 wikiID: wikiID,
@@ -60,6 +71,21 @@ func enqueueIngestion(
             } catch {
                 DebugLog.ingest("enqueueIngestion: extraction failed for \(sourceID.rawValue) — \(error.localizedDescription)")
             }
+        }
+
+        // ── Chokepoint ───────────────────────────────────────────────────
+        // The single enforcement of "don't ingest sources without content."
+        // `canIngest` is true when the source has processed markdown (a
+        // transcript, extracted PDF) **or** raw bytes (`byteSize > 0`) the
+        // staging path reads directly. A byteless source with no processed
+        // markdown — e.g. a YouTube video whose transcript never arrived —
+        // has neither, so it is dropped here rather than enqueuing a run the
+        // staging path would hand empty bytes to. Every UI entry point
+        // (detail view, list context menu, batch ingest) funnels through
+        // here, so the rule is *guaranteed* regardless of origin.
+        guard store.canIngest(source) else {
+            DebugLog.ingest("enqueueIngestion: dropped \(sourceID.rawValue) — no markdown or bytes to ingest")
+            continue
         }
         ingestionSourceIDs.append(sourceID)
     }

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -988,7 +988,8 @@ struct SourceDetailView: View {
         // the queue. `isRunning` still blocks when a *chat* agent is running
         // (no ingest active) to avoid a launcher preflight refusal.
         .disabled((isRunning && !isAnySourceIngesting)
-                  || isEditLockedExternally)
+                  || isEditLockedExternally
+                  || !hasMarkdown)
         .confirmationDialog(
             "Ingest Again?",
             isPresented: $showReingestConfirmation,
@@ -1003,11 +1004,12 @@ struct SourceDetailView: View {
         }
 
         // Ingested → a calm green "done" affordance. Otherwise prominent only
-        // when Ingest is the actual next step; when a PDF has no markdown yet,
-        // Extract is the call-to-action, so Ingest stays secondary here.
+        // when Ingest is the actual next step; a source without markdown (an
+        // unextracted PDF, or a byteless video with no transcript) can't be
+        // ingested, so Ingest stays secondary here and is disabled above.
         if hasBeenIngested {
             button.tint(.green)
-        } else if isPDF, !hasMarkdown {
+        } else if !hasMarkdown {
             button
         } else {
             button.buttonStyle(.borderedProminent)

--- a/Sources/WikiFS/Sources/SourcesListView.swift
+++ b/Sources/WikiFS/Sources/SourcesListView.swift
@@ -443,10 +443,24 @@ extension SourcesListViewController {
                               action: #selector(revealAction(_:)), payload: payload))
         }
 
-        menu.addItem(.separator())
-        menu.addItem(item(
-            title: isMulti ? "Ingest \(count) Sources" : "Ingest",
-            systemImage: "text.badge.plus", action: #selector(ingestAction(_:)), payload: payload))
+        // Ingest is offered only for ingestible sources — gate on the shared
+        // `canIngest` (mirrors the `enqueueIngestion` chokepoint). Hides the
+        // item entirely for a selection with no ingestible source (e.g. a
+        // byteless YouTube video with no transcript), rather than offering a
+        // no-op the chokepoint would drop anyway.
+        let ingestible = effective.filter { canIngest($0) }
+        if isMulti {
+            if !ingestible.isEmpty {
+                menu.addItem(.separator())
+                menu.addItem(item(title: "Ingest \(ingestible.count) Sources",
+                                  systemImage: "text.badge.plus", action: #selector(ingestAction(_:)),
+                                  payload: payload))
+            }
+        } else if canIngest(clicked) {
+            menu.addItem(.separator())
+            menu.addItem(item(title: "Ingest", systemImage: "text.badge.plus",
+                              action: #selector(ingestAction(_:)), payload: payload))
+        }
 
         let extractable = effective.filter { canExtract($0) }
         if isMulti {
@@ -476,6 +490,15 @@ extension SourcesListViewController {
     private func canExtract(_ source: SourceSummary) -> Bool {
         MimeType.isPDF(source.mimeType)
             && store?.processedMarkdownHead(for: source) == nil
+    }
+
+    /// Mirrors the chokepoint rule in `enqueueIngestion` (via
+    /// `WikiStoreModel.canIngest`): a source is ingestible iff it has
+    /// processed markdown to ingest or raw bytes the staging path reads.
+    /// Used to hide the Ingest item for sources that can never be ingested
+    /// (e.g. a byteless YouTube video with no transcript).
+    private func canIngest(_ source: SourceSummary) -> Bool {
+        store?.canIngest(source) ?? false
     }
 
     private func item(title: String, systemImage: String,

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2419,6 +2419,21 @@ public final class WikiStoreModel {
         (try? store.hasProcessedMarkdown(sourceID: sourceID)) ?? false
     }
 
+    /// The single predicate naming the "can this source be ingested?" rule.
+    /// A source is ingestible iff it has content the staging path can hand the
+    /// agent — either a processed-markdown version (extracted PDF, transcript,
+    /// edited text) that `processedMarkdownHead` resolves, **or** raw bytes
+    /// (`byteSize > 0`) that the staging reads directly for native markdown /
+    /// images / PDFs / … A **byteless** source with no processed markdown —
+    /// e.g. a YouTube video whose transcript never arrived — has neither and
+    /// returns `false`: there is nothing to stage, so ingestion must not run.
+    /// Enforcement of the drop lives in `enqueueIngestion`; the UI gates
+    /// (`SourceDetailView`, `SourcesListView`) consult this so the affordance
+    /// reflects the truth.
+    public func canIngest(_ source: SourceSummary) -> Bool {
+        hasProcessedMarkdown(for: source.id) || source.byteSize > 0
+    }
+
     /// All versions for a source, newest first. Empty if none.
     public func processedMarkdownHistory(for sourceID: PageID) -> [SourceMarkdownVersion] {
         (try? store.processedMarkdownHistory(sourceID: sourceID)) ?? []

--- a/Tests/WikiFSTests/IngestGateTests.swift
+++ b/Tests/WikiFSTests/IngestGateTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Testing
+import WikiFSEngine
+@testable import WikiFS
+@testable import WikiFSCore
+@testable import WikiFSEngine
+
+/// Tests for the centralized "don't ingest sources without content" gate.
+///
+/// The rule lives in two coordinated places:
+/// - **`WikiStoreModel.canIngest(_:)`** — the shared predicate a source is
+///   ingestible iff it has processed markdown (a transcript, extracted PDF)
+///   **or** raw bytes (`byteSize > 0`) the staging path reads directly.
+/// - **`enqueueIngestion`** — the single chokepoint every UI entry point
+///   (detail-view button, list context menu, batch re-ingest) funnels
+///   through; it drops a non-ingestible source rather than enqueuing a run
+///   the staging path would hand empty bytes to.
+///
+/// A **byteless** source (e.g. a YouTube video, `video/youtube` mime,
+/// `byteSize == 0`) whose transcript never arrived has neither, so it must
+/// not be ingested. That is the regression these tests pin down.
+@MainActor
+@Suite(.tags(.integration))
+struct IngestGateTests {
+
+    private func tempStore() throws -> SQLiteWikiStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ingestgate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+    }
+
+    /// A byteless YouTube source — synthetic mime `video/youtube`,
+    /// `byteSize == 0`, no blob. This is the regression source.
+    @discardableResult
+    private func addBytelessYouTube(to store: SQLiteWikiStore) throws -> SourceSummary {
+        try store.addBytelessSource(
+            filename: "youtube-dQw4w9WgXcQ",
+            mimeType: "video/youtube",
+            provenance: SourceProvenance(
+                agentName: "youtube", activityKind: "fetch",
+                plan: "https://youtu.be/dQw4w9WgXcQ",
+                externalRef: "https://youtu.be/dQw4w9WgXcQ",
+                externalIdentity: "dQw4w9WgXcQ"),
+            role: .primary)
+    }
+
+    // MARK: - canIngest predicate
+
+    @Test func bytelessYouTubeWithoutTranscriptIsNotIngestible() throws {
+        let store = try tempStore()
+        _ = try addBytelessYouTube(to: store)
+        let model = WikiStoreModel(store: store)
+        model.reloadFromStore()
+
+        let yt = try #require(model.sources.first)
+        #expect(yt.byteSize == 0)
+        #expect(!model.canIngest(yt))
+    }
+
+    @Test func nativeMarkdownFileIsIngestible() throws {
+        let model = WikiStoreModel(store: try tempStore())
+        model.addSource(filename: "notes.md", data: Data("# Heading\n\nbody".utf8))
+        model.reloadFromStore()
+
+        let md = try #require(model.sources.first)
+        #expect(md.byteSize > 0)
+        #expect(model.canIngest(md))
+    }
+
+    @Test func pdfWithBytesIsIngestible() throws {
+        let model = WikiStoreModel(store: try tempStore())
+        // Raw PDF bytes (header only) — the staging path extracts markdown
+        // first, but `canIngest` is true because there are bytes to act on.
+        model.addSource(filename: "paper.pdf", data: Data("%PDF-1.4\n".utf8))
+        model.reloadFromStore()
+
+        let pdf = try #require(model.sources.first)
+        #expect(pdf.byteSize > 0)
+        #expect(model.canIngest(pdf))
+    }
+
+    @Test func bytelessSourceWithTranscriptIsIngestible() throws {
+        let store = try tempStore()
+        let yt = try addBytelessYouTube(to: store)
+        // The transcript arrives as a processed-markdown version.
+        _ = try store.appendProcessedMarkdown(
+            sourceID: yt.id,
+            content: "# Transcript\n\ntranscript body",
+            origin: .transcript, note: nil, technique: nil)
+
+        let model = WikiStoreModel(store: store)
+        model.reloadFromStore()
+
+        let source = try #require(model.sources.first(where: { $0.id == yt.id }))
+        #expect(source.byteSize == 0)  // still byteless…
+        #expect(model.hasProcessedMarkdown(for: source.id))  // …but has a transcript
+        #expect(model.canIngest(source))
+    }
+
+    // MARK: - enqueueIngestion chokepoint
+
+    /// A no-op worker factory: workers succeed but do nothing. We only care
+    /// whether a `.ingestion` queue item is created for the source at all.
+    private struct NoopWorkerFactory: QueueWorkerFactory {
+        func providerID(for item: QueueItem) async -> String? { "test-ingest" }
+        func worker(for item: QueueItem) async throws -> any QueueWorker {
+            struct W: QueueWorker { func execute(_ item: QueueItem) async throws {} }
+            return W()
+        }
+    }
+
+    private func makeEngine() throws -> QueueEngine {
+        let queueStore = try QueueStore(
+            databaseURL: URL(fileURLWithPath: ":memory:"))
+        return QueueEngine(store: queueStore, workerFactory: NoopWorkerFactory())
+    }
+
+    @Test func chokepointDropsBytelessYouTubeFromIngestionQueue() async throws {
+        let store = try tempStore()
+        let yt = try addBytelessYouTube(to: store)
+        let model = WikiStoreModel(store: store)
+        model.reloadFromStore()
+        let engine = try makeEngine()
+
+        // The detail-view button / list menu would call this with the
+        // byteless YouTube source. No extraction is needed (it's not a PDF),
+        // and it has no markdown — the chokepoint must drop it.
+        await enqueueIngestion(
+            sourceIDs: [yt.id],
+            store: model,
+            wikiID: "test-wiki",
+            queueEngine: engine)
+
+        let snapshot = await engine.snapshot()
+        let ingestionItemsForYT = snapshot.activeItems.filter {
+            $0.queue == .ingestion
+                && $0.payload.sourceIDs.contains(yt.id)
+        }
+        #expect(ingestionItemsForYT.isEmpty,
+               "a byteless source with no markdown must not be enqueued for ingestion")
+    }
+
+    @Test func chokepointKeepsNativeMarkdown() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        model.addSource(filename: "notes.md", data: Data("# Heading\n\nbody".utf8))
+        model.reloadFromStore()
+        let md = try #require(model.sources.first)
+        let engine = try makeEngine()
+
+        await enqueueIngestion(
+            sourceIDs: [md.id],
+            store: model,
+            wikiID: "test-wiki",
+            queueEngine: engine)
+
+        let snapshot = await engine.snapshot()
+        let ingestionItems = snapshot.activeItems.filter {
+            $0.queue == .ingestion
+                && $0.payload.sourceIDs.contains(md.id)
+        }
+        #expect(ingestionItems.count == 1,
+               "a native markdown file must pass the chokepoint and be enqueued")
+    }
+
+    @Test func chokepointDropsBytelessKeepsMarkdownInBatch() async throws {
+        // A mixed batch: one byteless YouTube (drop) + one markdown file (keep).
+        // Only the markdown file should reach the ingestion queue.
+        let store = try tempStore()
+        let yt = try addBytelessYouTube(to: store)
+        let model = WikiStoreModel(store: store)
+        model.addSource(filename: "notes.md", data: Data("# body".utf8))
+        model.reloadFromStore()
+        let md = try #require(model.sources.first(where: { $0.id != yt.id }))
+        let engine = try makeEngine()
+
+        await enqueueIngestion(
+            sourceIDs: [yt.id, md.id],
+            store: model,
+            wikiID: "test-wiki",
+            queueEngine: engine)
+
+        let snapshot = await engine.snapshot()
+        let ingestionItems = snapshot.activeItems.filter { $0.queue == .ingestion }
+        let stagedIDs = Set(ingestionItems.flatMap { $0.payload.sourceIDs })
+        #expect(!stagedIDs.contains(yt.id),
+               "the byteless YouTube source must be dropped from the batch")
+        #expect(stagedIDs.contains(md.id),
+               "the markdown file in the same batch must still be enqueued")
+    }
+}


### PR DESCRIPTION
## Summary

Add a centralized gate to prevent ingestion of sources that have neither processed markdown nor raw bytes — specifically byteless sources like YouTube videos without transcripts.

**The rule:** A source is ingestible iff it has processed markdown (extracted PDF, transcript, edited text) *or* raw bytes (`byteSize > 0`) that the staging path reads directly. A byteless source with no processed markdown has neither and must not be ingested.

## Implementation

- **Shared predicate** (`WikiStoreModel.canIngest`): Names the single "is this source ingestible?" rule for both enforcement and UI affordance.
- **Enforcement chokepoint** (`enqueueIngestion`): Every UI entry point (detail view button, list context menu, batch re-ingest) funnels through here. The function now drops non-ingestible sources before enqueuing, so a byteless source can never reach the ingestion queue regardless of origin.
- **UI gates** (`SourceDetailView`, `SourcesListView`): Consult `canIngest` to disable/hide the Ingest action for sources that can't be ingested, reflecting the truth of the chokepoint.

## Testing

New comprehensive test suite (`IngestGateTests`) verifies:
- Byteless YouTube sources without transcripts are not ingestible
- Native markdown and PDFs with bytes remain ingestible
- Byteless sources *with* processed markdown (transcript arrived) are ingestible
- The chokepoint drops byteless sources from ingestion queue
- Mixed batches correctly separate ingestible from non-ingestible sources

Marked as `.integration` test and skipped in the fast CI lane per project convention.