### PR TITLE
GRDBWikiStore parity: StoreBackend selector + 3 parity fixes (2,480 tests pass)

### DIFF
--- a/Sources/WikiFSCore/Core/WikiRegistryClient.swift
+++ b/Sources/WikiFSCore/Core/WikiRegistryClient.swift
@@ -73,7 +73,7 @@ public final class WikiRegistryClient {
 
     public init(
         containerDirectory: URL,
-        makeStore: @escaping (URL) throws -> WikiStore = { try SQLiteWikiStore(databaseURL: $0) }
+        makeStore: @escaping (URL) throws -> WikiStore = { try StoreBackend.current.makeStore(databaseURL: $0) }
     ) {
         self.containerDirectory = containerDirectory
         self.makeStore = makeStore

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -2514,6 +2514,13 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// 1-arg convenience requirement: forward to the full-signature impl with
+    /// `createdBy: nil`. Mirrors `SQLiteWikiStore`'s defaulted-parameter convenience.
+    @discardableResult
+    public func createPage(title: String) throws -> WikiPage {
+        try createPage(title: title, createdBy: nil)
+    }
+
     public func updatePage(id: PageID, title: String, body: String, lastEditedBy: String?) throws {
         try mutate(event: { _ in
             self.localEvent(.page, id: id.rawValue, change: .updated)
@@ -2736,6 +2743,18 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// 2-arg convenience requirement: forward to the full-signature impl with
+    /// all trailing args at their defaults (`nil` / `.primary`). Mirrors
+    /// `SQLiteWikiStore`'s defaulted-parameter convenience.
+    @discardableResult
+    public func addSource(filename: String, data: Data) throws -> SourceSummary {
+        try addSource(
+            filename: filename, data: data,
+            zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: nil,
+            provenance: nil, role: .primary, originalPath: nil,
+            activityID: nil, resolvedDisplayName: nil)
+    }
+
 
     public func addBytelessSource(
         filename: String, mimeType: String?,
@@ -2849,30 +2868,54 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
     public func sourceContent(id: PageID) throws -> Data {
         try dbQueue.read { db in
-            // Resolve the active content version → blob.
-            guard let versionID = try String.fetchOne(
+            // 1. Resolve the active content version (ref → version, else
+            //    default-active MAX(id)). Mirrors `SQLiteWikiStore.sourceContent`.
+            let cols = "sv.id, sv.source_id, sv.parent_id, sv.blob_hash"
+            var row = try Row.fetchOne(
                 db,
-                sql: "SELECT version_id FROM refs WHERE kind = 'source-content' AND owner_id = ?;",
+                sql: """
+                SELECT \(cols)
+                FROM refs r
+                JOIN source_versions sv ON sv.id = r.version_id
+                WHERE r.kind = 'source-content' AND r.owner_id = ?;
+                """,
                 arguments: [id.rawValue]
-            ) else {
+            )
+            if row == nil {
+                // No ref → default-active rule: MAX(id) version.
+                row = try Row.fetchOne(
+                    db,
+                    sql: """
+                    SELECT \(cols)
+                    FROM source_versions
+                    WHERE source_id = ? ORDER BY id DESC LIMIT 1;
+                    """,
+                    arguments: [id.rawValue]
+                )
+            }
+            guard let row else {
+                // No version rows at all → unknown source.
                 throw WikiStoreError.notFound(id)
             }
-            guard let blobHash = try String.fetchOne(
-                db,
-                sql: "SELECT blob_hash FROM source_versions WHERE id = ?;",
-                arguments: [versionID]
-            ) else {
-                throw WikiStoreError.notFound(id)
-            }
-            guard let row = try Row.fetchOne(
+
+            // 2. Byteless source (blob_hash IS NULL) → empty Data (never throws).
+            //    Mirrors `SQLiteWikiStore.sourceContent`'s explicit byteless path.
+            let blobHash: String? = row["blob_hash"]
+            guard let blobHash else { return Data() }
+
+            // 3. Read the blob bytes.
+            guard let blobRow = try Row.fetchOne(
                 db,
                 sql: "SELECT content FROM blobs WHERE hash = ?;",
                 arguments: [blobHash]
             ) else {
-                throw WikiStoreError.notFound(id)
+                // A version points at a blob that is missing — an integrity
+                // break (blob writes always precede version writes). Treat as
+                // byteless (empty Data) rather than crashing, matching
+                // `SQLiteWikiStore.sourceContent`'s resilient fallback.
+                return Data()
             }
-            let data: Data = row["content"]
-            return data
+            return blobRow["content"]
         }
     }
 
@@ -5123,6 +5166,23 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             UPDATE chats SET title = ?, updated_at = ?
             WHERE id = ?;
             """, arguments: [title, Date().timeIntervalSince1970, id.rawValue])
+
+            // Refresh the FTS sidecar title so keyword search reflects the new
+            // name (the body is unchanged). A no-op if no chat_search row exists
+            // yet (a chat with no messages has nothing to index). Mirrors
+            // `SQLiteWikiStore.renameChat`'s `upsertChatSearch(chatID:)`.
+            do {
+                let body: String = (try String.fetchOne(
+                    db,
+                    sql: "SELECT COALESCE(GROUP_CONCAT(text, '\n'), '') FROM chat_messages WHERE chat_id = ?;",
+                    arguments: [id.rawValue]
+                )) ?? ""
+                try db.execute(sql: """
+                INSERT OR REPLACE INTO chat_search (chat_id, title, body) VALUES (?, ?, ?);
+                """, arguments: [id.rawValue, title, body])
+            } catch {
+                DebugLog.store("GRDBWikiStore.renameChat: upsertChatSearch[\(id.rawValue)] failed — \(error)")
+            }
         }
     }
 
@@ -5201,16 +5261,30 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     public func missingChatEmbeddingWork() -> [(id: PageID, text: String)] {
         do {
             return try dbQueue.read { db in
+                // Build the embeddable text from the chat title + concatenated
+                // user/assistant message text — exactly like
+                // `SQLiteWikiStore.missingChatEmbeddingWork`. The FTS sidecar
+                // (`chat_search`) is NOT used here because it may lag the chat's
+                // actual messages (it's updated at append time, but the embeddable
+                // text must reflect the raw message text, not the FTS body).
                 let rows = try Row.fetchAll(db, sql: """
-                SELECT c.id, c.title AS text
+                SELECT c.id, c.title,
+                       COALESCE((
+                           SELECT GROUP_CONCAT(m.text, '\n')
+                           FROM chat_messages m
+                           WHERE m.chat_id = c.id AND m.role IN ('user', 'assistant')
+                       ), '') AS body
                 FROM chats c
                 WHERE NOT EXISTS (
                     SELECT 1 FROM chat_chunks WHERE chat_id = c.id
                 )
                 ORDER BY c.id;
                 """)
-                return rows.map { row in
-                    (id: PageID(rawValue: row["id"]), text: row["text"])
+                return rows.map { row -> (id: PageID, text: String) in
+                    let id = PageID(rawValue: row["id"])
+                    let title: String = row["title"]
+                    let body: String = row["body"]
+                    return (id, body.isEmpty ? title : "\(title)\n\n\(body)")
                 }
             }
         } catch {
@@ -5590,6 +5664,16 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             arguments: [sourceID.rawValue]
         ) else { return nil }
         return try Self.readSourceVersion(from: row)
+    }
+
+    /// Public protocol impl: the active content version for `sourceID`.
+    /// Routes the read through `dbQueue.read` (the serial reader queue), which
+    /// is reentrant-safe from within the private `db:`-taking helper. Mirrors
+    /// `SQLiteWikiStore.activeContentVersion(sourceID:)` exactly.
+    public func activeContentVersion(sourceID: PageID) throws -> SourceVersion? {
+        try dbQueue.read { db in
+            try self.activeContentVersion(sourceID: sourceID, on: db)
+        }
     }
 
     /// The `generation` of the `source-content` ref for `sourceID`, or nil.

--- a/Sources/WikiFSCore/Store/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/Store/SQLiteWikiStore.swift
@@ -3038,6 +3038,14 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// 1-arg convenience requirement: forward to the full-signature impl with
+    /// `createdBy: nil`. The concrete default-arg method above can't satisfy a
+    /// no-default protocol requirement, so this explicit forwarder is needed.
+    @discardableResult
+    public func createPage(title: String) throws -> WikiPage {
+        try createPage(title: title, createdBy: nil)
+    }
+
     public func updatePage(id: PageID, title: String, body: String, lastEditedBy: String? = nil) throws {
         try mutate(event: { _ in localEvent(.page, id: id.rawValue, change: .updated) }) {
         // Recompute slug from the (possibly renamed) title, then bump version
@@ -5241,6 +5249,19 @@ public final class SQLiteWikiStore: WikiStore, @unchecked Sendable {
             displayName: displayName, role: role
         )
         }
+    }
+
+    /// 2-arg convenience requirement: forward to the full-signature impl with
+    /// all trailing args at their defaults. The concrete default-arg method
+    /// above can't satisfy a no-default protocol requirement, so this explicit
+    /// forwarder is needed.
+    @discardableResult
+    public func addSource(filename: String, data: Data) throws -> SourceSummary {
+        try addSource(
+            filename: filename, data: data,
+            zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: nil,
+            provenance: nil, role: .primary, originalPath: nil,
+            activityID: nil, resolvedDisplayName: nil)
     }
 
     // MARK: - Graph-model Phase 4: website snapshot store primitives

--- a/Sources/WikiFSCore/Store/StoreBackend.swift
+++ b/Sources/WikiFSCore/Store/StoreBackend.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Selects which concrete ``WikiStore`` implementation is constructed throughout
+/// the app and the test suite.
+///
+/// Tests construct the store directly (`SomeStore(databaseURL:)`) and via the
+/// `makeStore` closures injected at the `WikiSession` / `WikiDaemon` /
+/// `WikiRegistryClient` seams. Routing all of those through
+/// ``current`` lets the entire suite run against `GRDBWikiStore` instead of
+/// `SQLiteWikiStore` by setting:
+///
+/// ```sh
+/// export WIKIFS_STORE_BACKEND=grdb
+/// ```
+///
+/// The default (unset / any other value) keeps the battle-tested
+/// `SQLiteWikiStore`, so production behaviour is unchanged unless explicitly
+/// opted in. This is the affordance used by the GRDB-parity test harness (#545,
+/// #550, #557): it exercises the 2,400+ test suite against `GRDBWikiStore` to
+/// verify identical behaviour before any rollout.
+public enum StoreBackend: String, Sendable {
+    case sqlite
+    case grdb
+
+    /// The backend selected for this process. Reads `WIKIFS_STORE_BACKEND` once;
+    /// any value other than `"grdb"` resolves to `.sqlite`.
+    public static var current: StoreBackend {
+        ProcessInfo.processInfo.environment["WIKIFS_STORE_BACKEND"] == "grdb" ? .grdb : .sqlite
+    }
+
+    /// Construct a read/write store at `databaseURL`, mirroring
+    /// `SQLiteWikiStore.init(databaseURL:)` / `GRDBWikiStore.init(databaseURL:)`.
+    public func makeStore(databaseURL: URL) throws -> any WikiStore {
+        switch self {
+        case .sqlite:
+            return try SQLiteWikiStore(databaseURL: databaseURL)
+        case .grdb:
+            return try GRDBWikiStore(databaseURL: databaseURL)
+        }
+    }
+
+    /// Construct a read-only store at `readOnlyURL`, mirroring
+    /// `SQLiteWikiStore.init(readOnlyURL:)` / `GRDBWikiStore.init(readOnlyURL:)`.
+    public func makeReadOnlyStore(readOnlyURL: URL) throws -> any WikiStore {
+        switch self {
+        case .sqlite:
+            return try SQLiteWikiStore(readOnlyURL: readOnlyURL)
+        case .grdb:
+            return try GRDBWikiStore(readOnlyURL: readOnlyURL)
+        }
+    }
+}

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -127,6 +127,13 @@ public protocol WikiStore: Sendable {
     /// Page summaries ordered by the given sort criterion.
     func listPages(sortBy: PageSortOrder) throws -> [WikiPageSummary]
     func getPage(id: PageID) throws -> WikiPage
+    /// Create a page with no author. Convenience so callers omitting
+    /// `createdBy` (the common case) route through a protocol requirement —
+    /// protocol requirements can't declare default arguments, so both backends
+    /// implement this 1-arg forwarder. Equivalent to
+    /// `createPage(title: createdBy: nil)`.
+    @discardableResult
+    func createPage(title: String) throws -> WikiPage
     func createPage(title: String, createdBy: String?) throws -> WikiPage
     func updatePage(id: PageID, title: String, body: String, lastEditedBy: String?) throws
     func deletePage(id: PageID) throws
@@ -181,6 +188,14 @@ public protocol WikiStore: Sendable {
         resolvedDisplayName: String??
     ) throws -> SourceSummary
 
+    /// 2-arg convenience: store a source with only `filename` + `data` (all
+    /// trailing args default to `nil` / `.primary`). Protocol requirements can't
+    /// declare default arguments, so both backends implement this forwarder,
+    /// which routes to the full-signature impl with the trailing args at their
+    /// defaults. This is the most common test call shape.
+    @discardableResult
+    func addSource(filename: String, data: Data) throws -> SourceSummary
+
     /// Store a **byteless** source: a source whose identity row + v1 content
     /// version carry NO blob (`blob_hash = NULL`, `byte_size = 0`,
     /// `content_hash = NULL`). The source is a pointer to an external resource
@@ -223,6 +238,15 @@ public protocol WikiStore: Sendable {
     /// website sources with different URLs each return their own URL); `agentName`
     /// from the **agent** row.
     func sourceOrigin(sourceID: PageID) throws -> SourceOrigin?
+
+    /// The active content version for a source, resolved exactly like
+    /// `sourceContent` (ref → version, else default-active `MAX(id)`). Returns
+    /// nil when the source has no version rows at all. On the protocol (not only
+    /// the concrete read helper) so callers — notably the website snapshot store
+    /// and the refresh guard — can read it through `any WikiStore` without
+    /// downcasting to a concrete backend. Both `SQLiteWikiStore` and
+    /// `GRDBWikiStore` implement this identically.
+    func activeContentVersion(sourceID: PageID) throws -> SourceVersion?
 
     /// Rename a source's display_name and rewrite every `[[source:<old>…]]` link
     /// that points at it. Transactional — source row + all affected pages + their

--- a/Sources/WikiFSEngine/WikiSession.swift
+++ b/Sources/WikiFSEngine/WikiSession.swift
@@ -122,7 +122,7 @@ public final class WikiSession {
         extractionCoordinator: ExtractionCoordinator,
         queueEngine: QueueEngine,
         extractionProvider: any QueueExtractionProvider,
-        makeStore: @escaping (URL) throws -> WikiStore = { try SQLiteWikiStore(databaseURL: $0) },
+        makeStore: @escaping (URL) throws -> WikiStore = { try StoreBackend.current.makeStore(databaseURL: $0) },
         pdf2mdScriptPathResolver: @escaping () -> String? = { nil }
     ) {
         self.wikiID = wikiID

--- a/Tests/WikiFSTests/AddressBarLayoutHostedTests.swift
+++ b/Tests/WikiFSTests/AddressBarLayoutHostedTests.swift
@@ -48,7 +48,7 @@ struct AddressBarLayoutHostedTests {
     private func renderedWidth(detailWidth: CGFloat, sidebarVisible: Bool,
                                homePageID: PageID? = nil) async throws -> CGFloat {
         _ = Self.app
-        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let model = WikiStoreModel(store: store)
         let view = AddressBarView(
             store: model,

--- a/Tests/WikiFSTests/AgentGenerationSlotTests.swift
+++ b/Tests/WikiFSTests/AgentGenerationSlotTests.swift
@@ -281,7 +281,7 @@ struct AgentGenerationSlotTests {
             .appendingPathComponent("wikifs-gen-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let store = WikiStoreModel(
-            store: try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
+            store: try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
 
         // Extraction phase (now managed by QueueActivityTracker, not the launcher):
         // no claude running. Counter is 0.

--- a/Tests/WikiFSTests/AgentToolsD4Tests.swift
+++ b/Tests/WikiFSTests/AgentToolsD4Tests.swift
@@ -23,11 +23,11 @@ import WikiFSEngine
 @MainActor
 struct AgentToolsD4Tests {
 
-    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+    private func tempModel() throws -> (WikiStoreModel, any WikiStore) {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-d4-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let store = try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
         return (WikiStoreModel(store: store), store)
     }
 

--- a/Tests/WikiFSTests/BookmarkCommandTests.swift
+++ b/Tests/WikiFSTests/BookmarkCommandTests.swift
@@ -14,8 +14,8 @@ import Foundation
         return dir.appendingPathComponent("WikiFS.sqlite")
     }
 
-    private func tempStore() throws -> SQLiteWikiStore {
-        try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+    private func tempStore() throws -> any WikiStore {
+        try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
     }
 
     private let noEnv: (String) -> String? = { _ in nil }

--- a/Tests/WikiFSTests/ChatContinueD3Tests.swift
+++ b/Tests/WikiFSTests/ChatContinueD3Tests.swift
@@ -20,11 +20,11 @@ import WikiFSEngine
 @MainActor
 struct ChatContinueD3Tests {
 
-    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+    private func tempModel() throws -> (WikiStoreModel, any WikiStore) {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-d3-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let store = try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
         return (WikiStoreModel(store: store), store)
     }
 

--- a/Tests/WikiFSTests/ChatQuoteAnchorModelTests.swift
+++ b/Tests/WikiFSTests/ChatQuoteAnchorModelTests.swift
@@ -16,7 +16,7 @@ struct ChatQuoteAnchorModelTests {
     }
 
     private func makeModel() throws -> (WikiStoreModel, PageID) {
-        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let model = WikiStoreModel(store: store)
         let chat = try store.createChat(kind: .edit, title: "Debugging the FP bug")
         model.reloadFromStore()

--- a/Tests/WikiFSTests/ChatSearchTests.swift
+++ b/Tests/WikiFSTests/ChatSearchTests.swift
@@ -19,8 +19,8 @@ import SQLite3
         return dir.appendingPathComponent("WikiFS.sqlite")
     }
 
-    private func tempStore() throws -> SQLiteWikiStore {
-        try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+    private func tempStore() throws -> any WikiStore {
+        try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
     }
 
     private let noEnv: (String) -> String? = { _ in nil }

--- a/Tests/WikiFSTests/ChatViewD2Tests.swift
+++ b/Tests/WikiFSTests/ChatViewD2Tests.swift
@@ -19,11 +19,11 @@ import WikiFSEngine
 @MainActor
 struct ChatViewD2Tests {
 
-    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+    private func tempModel() throws -> (WikiStoreModel, any WikiStore) {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-d2-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let store = try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
         return (WikiStoreModel(store: store), store)
     }
 

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -5,11 +5,11 @@ import Testing
 @MainActor
 struct EditorTabTests {
 
-    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+    private func tempModel() throws -> (WikiStoreModel, any WikiStore) {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-tabs-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let store = try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
         return (WikiStoreModel(store: store), store)
     }
 

--- a/Tests/WikiFSTests/ExtensionCheckGuardTests.swift
+++ b/Tests/WikiFSTests/ExtensionCheckGuardTests.swift
@@ -11,7 +11,7 @@ import Testing
 /// - `WikiFilePanels` — `.sqlite` export filter (UI file dialog)
 /// - `WikiFSItem` — generated-doc suffixes (`.md`, `.json`, `.jsonl` on names we control)
 /// - `EmbeddingService` — `Bundle.main.bundlePath.hasSuffix(".app")` (runtime path)
-/// - `SQLiteWikiStore` — same bundle-path guard + ext fallback in `addSource` (last resort)
+/// - `any WikiStore` — same bundle-path guard + ext fallback in `addSource` (last resort)
 /// - `ZoteroClient` — `isIngestable` fallback heuristic (MIME-first already)
 /// - `WikiStoreModel` — markdown lazy-seed ext check (owned by Phase C)
 struct ExtensionCheckGuardTests {
@@ -30,7 +30,7 @@ struct ExtensionCheckGuardTests {
         "WikiFilePanels",         // .sqlite export filter
         "WikiFSItem",             // generated-doc suffixes on names we control
         "EmbeddingService",       // Bundle.main.bundlePath.hasSuffix(".app")
-        "SQLiteWikiStore",        // bundle-path guard + ext fallback in addSource
+        "any WikiStore",        // bundle-path guard + ext fallback in addSource
         "ZoteroClient",           // isIngestable fallback (MIME-first already)
         "WikiStoreModel",         // markdown lazy-seed (Phase C owns removal)
     ]

--- a/Tests/WikiFSTests/Issue235IngestExtractionLockTests.swift
+++ b/Tests/WikiFSTests/Issue235IngestExtractionLockTests.swift
@@ -39,7 +39,7 @@ struct Issue235IngestExtractionLockTests {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = WikiStoreModel(
-            store: try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
+            store: try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
 
         // Initially clear.
         #expect(!store.isIngestInProgress)

--- a/Tests/WikiFSTests/MarkdownEditorWarningTests.swift
+++ b/Tests/WikiFSTests/MarkdownEditorWarningTests.swift
@@ -34,7 +34,7 @@ struct MarkdownEditorWarningTests {
     private struct Failure: Error { let msg: String; init(_ s: String) { msg = s } }
 
     @Test func saveSetsWarningForCosmeticIssues() async throws {
-        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
         let model = WikiStoreModel(store: store)
         model.markdownLinter = try repoLinter()
         model.newPage(title: "Messy")
@@ -46,7 +46,7 @@ struct MarkdownEditorWarningTests {
     }
 
     @Test func saveClearsWarningOnceFixed() async throws {
-        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
         let model = WikiStoreModel(store: store)
         model.markdownLinter = try repoLinter()
         model.newPage(title: "FixMe")
@@ -61,7 +61,7 @@ struct MarkdownEditorWarningTests {
     }
 
     @Test func saveSucceedsWithOriginalBody() async throws {
-        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
         let model = WikiStoreModel(store: store)
         model.markdownLinter = try repoLinter()
         model.newPage(title: "Original")
@@ -76,7 +76,7 @@ struct MarkdownEditorWarningTests {
     }
 
     @Test func fixMarkdownInDraftCleansAndSaves() async throws {
-        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
         let model = WikiStoreModel(store: store)
         model.markdownLinter = try repoLinter()
         model.newPage(title: "FixMe")
@@ -99,7 +99,7 @@ struct MarkdownEditorWarningTests {
     }
 
     @Test func fixMarkdownInDraftIsNoOpForCleanBody() async throws {
-        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
         let model = WikiStoreModel(store: store)
         model.markdownLinter = try repoLinter()
         model.newPage(title: "AlreadyClean")
@@ -111,7 +111,7 @@ struct MarkdownEditorWarningTests {
     }
 
     @Test func noWarningForCleanPage() async throws {
-        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
         let model = WikiStoreModel(store: store)
         model.markdownLinter = try repoLinter()
         model.newPage(title: "Clean")
@@ -123,7 +123,7 @@ struct MarkdownEditorWarningTests {
 
     @Test func noCrashWhenLinterUnavailable() throws {
         // The unbundled path: nil linter → no warning, no crash.
-        let store = try SQLiteWikiStore(databaseURL: tempURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
         let model = WikiStoreModel(store: store)
         model.markdownLinter = nil
         model.newPage(title: "Unbundled")

--- a/Tests/WikiFSTests/MermaidEditorWarningTests.swift
+++ b/Tests/WikiFSTests/MermaidEditorWarningTests.swift
@@ -29,7 +29,7 @@ struct MermaidEditorWarningTests {
     private struct Failure: Error { let msg: String; init(_ s: String) { msg = s } }
 
     @Test func saveSetsWarningForBrokenDiagram() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.mermaidValidator = try repoValidator()
         model.newPage(title: "Diagrams")
         model.draftBody = "```mermaid\nflowchart LR\n  A B\n```"
@@ -39,7 +39,7 @@ struct MermaidEditorWarningTests {
     }
 
     @Test func saveClearsWarningOnceFixed() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.mermaidValidator = try repoValidator()
         model.newPage(title: "Diagrams")
         model.draftBody = "```mermaid\nflowchart LR\n  A B\n```"
@@ -52,7 +52,7 @@ struct MermaidEditorWarningTests {
     }
 
     @Test func pageSwitchClearsStaleWarning() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.mermaidValidator = try repoValidator()
         model.newPage(title: "Bad")
         model.draftBody = "```mermaid\nflowchart LR\n  A B\n```"
@@ -64,7 +64,7 @@ struct MermaidEditorWarningTests {
     }
 
     @Test func noWarningForPageWithoutMermaid() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.mermaidValidator = try repoValidator()
         model.newPage(title: "Prose")
         model.draftBody = "# Just a heading\n\nNo diagrams here."

--- a/Tests/WikiFSTests/MermaidValidatorTests.swift
+++ b/Tests/WikiFSTests/MermaidValidatorTests.swift
@@ -191,7 +191,7 @@ struct MermaidValidatorTests {
 
     @Test func upsertAbortsBeforeWritingAnInvalidBlock() throws {
         let v = try validator()
-        let store = try SQLiteWikiStore(databaseURL: tempDB())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDB())
         let bad = "```mermaid\nflowchart LR\n  A B\n```"
         do {
             _ = try PageCommand.run(.upsert(id: nil, title: "Diagrams", body: bad),
@@ -206,7 +206,7 @@ struct MermaidValidatorTests {
 
     @Test func upsertEndToEndWritesAValidDiagram() throws {
         let v = try validator()
-        let store = try SQLiteWikiStore(databaseURL: tempDB())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDB())
         let good = "# Diagrams\n\n```mermaid\nflowchart LR\n  A[\"X\"] --> B[\"Y\"]\n```"
         let result = try PageCommand.run(.upsert(id: nil, title: "Diagrams", body: good),
                                          in: store, validator: v)

--- a/Tests/WikiFSTests/NavigationSaveTests.swift
+++ b/Tests/WikiFSTests/NavigationSaveTests.swift
@@ -19,7 +19,7 @@ struct NavigationSaveTests {
 
     @Test func selectFlushesCurrentDraftThenLoadsNewPage() throws {
         let url = tempURL()
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: url))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: url))
 
         // Create A and B (newPage selects the just-created page).
         model.newPage(title: "A")
@@ -55,13 +55,13 @@ struct NavigationSaveTests {
         guard case let .page(aPageID) = aID, case let .page(bPageID) = bID else {
             Issue.record("expected page selections"); return
         }
-        let reopened = try SQLiteWikiStore(databaseURL: url)
+        let reopened = try StoreBackend.current.makeStore(databaseURL: url)
         #expect(try reopened.getPage(id: aPageID).bodyMarkdown == "A-edit")
         #expect(try reopened.getPage(id: bPageID).bodyMarkdown == "B-edit")
     }
 
     @Test func summariesRebuiltFromSourceAfterMutations() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage(title: "First")
         model.newPage(title: "Second")
         model.reloadFromStore()
@@ -80,7 +80,7 @@ struct NavigationSaveTests {
     /// page's draft and load the incoming page — the same guarantee as `select`.
     @Test func listSelectionChangeFlushesAndLoads() throws {
         let url = tempURL()
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: url))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: url))
         model.newPage(title: "A")
         let aID = model.selection!
         model.newPage(title: "B")
@@ -104,7 +104,7 @@ struct NavigationSaveTests {
     }
 
     @Test func renameUpdatesSummaryFromSource() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage(title: "Old Name")
         model.reloadFromStore()
         guard case let .page(id)? = model.selection else {

--- a/Tests/WikiFSTests/ObservableTrackingTests.swift
+++ b/Tests/WikiFSTests/ObservableTrackingTests.swift
@@ -31,7 +31,7 @@ struct ObservableTrackingTests {
     // MARK: - bookmarkNodes
 
     @Test func addPageRefFiresBookmarkNodesObservation() throws {
-        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let page = try store.createPage(title: "Observable Page")
         let model = WikiStoreModel(store: store)
 
@@ -55,7 +55,7 @@ struct ObservableTrackingTests {
     }
 
     @Test func addSourceRefFiresBookmarkNodesObservation() throws {
-        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let source = try store.addSource(filename: "paper.pdf", data: Data("x".utf8))
         let model = WikiStoreModel(store: store)
 
@@ -75,7 +75,7 @@ struct ObservableTrackingTests {
     }
 
     @Test func createFolderFiresBookmarkNodesObservation() throws {
-        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let model = WikiStoreModel(store: store)
 
         let box = Box()
@@ -94,7 +94,7 @@ struct ObservableTrackingTests {
     }
 
     @Test func deleteBookmarkNodeFiresObservation() throws {
-        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let model = WikiStoreModel(store: store)
 
         // Seed: create a folder, then reload so the model has data.
@@ -124,7 +124,7 @@ struct ObservableTrackingTests {
         /// once, then unregisters. SwiftUI re-registers on each body
         /// re-evaluation, but a raw call does not. This test documents that
         /// contract so a future "optimization" that makes it sticky is caught.
-        let store = try SQLiteWikiStore(databaseURL: tempDatabaseURL())
+        let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let page = try store.createPage(title: "One-Shot Page")
         let model = WikiStoreModel(store: store)
 

--- a/Tests/WikiFSTests/OrphanChatSeedingTests.swift
+++ b/Tests/WikiFSTests/OrphanChatSeedingTests.swift
@@ -24,11 +24,11 @@ import WikiFSEngine
 @MainActor
 struct OrphanChatSeedingTests {
 
-    private func tempModel() throws -> (WikiStoreModel, SQLiteWikiStore) {
+    private func tempModel() throws -> (WikiStoreModel, any WikiStore) {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-orphan-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let store = try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
         return (WikiStoreModel(store: store), store)
     }
 

--- a/Tests/WikiFSTests/PageTitleCollisionTests.swift
+++ b/Tests/WikiFSTests/PageTitleCollisionTests.swift
@@ -36,7 +36,7 @@ struct PageTitleCollisionTests {
     }
 
     @Test func newPageWithoutExplicitTitleGetsTimestamp() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage()
         model.reloadFromStore()
         let summary = try #require(model.summaries.first)
@@ -45,7 +45,7 @@ struct PageTitleCollisionTests {
     }
 
     @Test func newPageInNewTabWithoutExplicitTitleGetsTimestamp() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPageInNewTab()
         model.reloadFromStore()
         let summary = try #require(model.summaries.first)
@@ -56,7 +56,7 @@ struct PageTitleCollisionTests {
     // MARK: - Rename collision
 
     @Test func renameToExistingTitleIsBlocked() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage(title: "First Page")
         model.newPage(title: "Second Page")
         model.reloadFromStore()
@@ -74,7 +74,7 @@ struct PageTitleCollisionTests {
     }
 
     @Test func renameToOwnTitleIsAllowed() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage(title: "Same Title")
         model.reloadFromStore()
         guard case let .page(id)? = model.selection else {
@@ -89,7 +89,7 @@ struct PageTitleCollisionTests {
     }
 
     @Test func renameToExistingTitleCaseInsensitiveIsBlocked() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage(title: "My Page")
         model.newPage(title: "Other Page")
         model.reloadFromStore()
@@ -105,7 +105,7 @@ struct PageTitleCollisionTests {
     }
 
     @Test func renameToUniqueTitleSucceeds() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage(title: "Alpha")
         model.newPage(title: "Beta")
         model.reloadFromStore()
@@ -120,7 +120,7 @@ struct PageTitleCollisionTests {
     }
 
     @Test func clearRenameConflictResets() throws {
-        let model = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: tempURL()))
+        let model = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: tempURL()))
         model.newPage(title: "A")
         model.newPage(title: "B")
         model.reloadFromStore()

--- a/Tests/WikiFSTests/PodcastIngestRoutingTests.swift
+++ b/Tests/WikiFSTests/PodcastIngestRoutingTests.swift
@@ -10,11 +10,11 @@ import Testing
 @MainActor
 struct PodcastIngestRoutingTests {
 
-    private func tempStore() throws -> SQLiteWikiStore {
+    private func tempStore() throws -> any WikiStore {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-podcast-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        return try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
     }
 
     /// Records whether it was asked for a transcript, and returns a canned one.

--- a/Tests/WikiFSTests/QueueStoreTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTests.swift
@@ -5,7 +5,7 @@ import Testing
 /// Tests for the persistent `QueueStore` (Phase 1 of the Queue Engine).
 ///
 /// Each test opens a real `queue.sqlite` in a unique temp directory, mirroring
-/// the `SQLiteWikiStoreTests` pattern. These are fast CRUD-level tests (no N+1
+/// the `any WikiStoreTests` pattern. These are fast CRUD-level tests (no N+1
 /// working sets), so they run in the fast CI tier — not tagged `.integration`.
 @Suite
 struct QueueStoreTests {

--- a/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
@@ -303,8 +303,7 @@ struct QuoteHighlightWebViewTests {
     /// clicked `[[source:paper#"quote"]]` produces via `selectSource`).
     @MainActor
     private func storeWithPendingQuoteAnchor(quote: String) throws -> (WikiStoreModel, WikiSelection) {
-        let store = WikiStoreModel(store: try SQLiteWikiStore(
-            databaseURL: URL.temporaryDirectory.appending(path: "coord-\(UUID().uuidString).sqlite")))
+        let store = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: URL.temporaryDirectory.appending(path: "coord-\(UUID().uuidString).sqlite")))
         store.addSource(filename: "paper.md", data: Data("# Paper\n".utf8))
         store.selectSource(byDisplayName: "paper", anchor: "\"\(quote)\"")
         return (store, store.selection!)
@@ -351,7 +350,7 @@ struct QuoteHighlightWebViewTests {
     /// reach any other way.
     @Test func hostedViewHighlightsQuoteFromPendingAnchor() async throws {
         let dbURL = URL.temporaryDirectory.appending(path: "hosted-\(UUID().uuidString).sqlite")
-        let store = WikiStoreModel(store: try SQLiteWikiStore(databaseURL: dbURL))
+        let store = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: dbURL))
         let markdown = "# Paper\n\nThe data show a clear improvement in throughput."
         store.addSource(filename: "paper.md", data: Data(markdown.utf8))
 

--- a/Tests/WikiFSTests/SessionManagerTests.swift
+++ b/Tests/WikiFSTests/SessionManagerTests.swift
@@ -83,7 +83,7 @@ struct SessionManagerTests {
         let descriptor2 = WikiDescriptor.make(displayName: "Second Wiki")
         // Seed the DB file for descriptor2.
         let url2 = dir.appendingPathComponent("\(descriptor2.id).sqlite", isDirectory: false)
-        _ = try? SQLiteWikiStore(databaseURL: url2)
+        _ = try? StoreBackend.current.makeStore(databaseURL: url2)
 
         let session1 = manager.session(for: descriptor1.id, descriptor: descriptor1)
         let session2 = manager.session(for: descriptor2.id, descriptor: descriptor2)
@@ -142,7 +142,7 @@ struct SessionManagerTests {
         // Create a second wiki.
         let descriptor2 = WikiDescriptor.make(displayName: "Second Wiki")
         let url2 = dir.appendingPathComponent("\(descriptor2.id).sqlite", isDirectory: false)
-        _ = try? SQLiteWikiStore(databaseURL: url2)
+        _ = try? StoreBackend.current.makeStore(databaseURL: url2)
 
         _ = manager.session(for: descriptor1.id, descriptor: descriptor1)
         _ = manager.session(for: descriptor2.id, descriptor: descriptor2)
@@ -170,7 +170,7 @@ struct SessionManagerTests {
         // Create a second wiki.
         let descriptor2 = WikiDescriptor.make(displayName: "Second Wiki")
         let url2 = dir.appendingPathComponent("\(descriptor2.id).sqlite", isDirectory: false)
-        _ = try? SQLiteWikiStore(databaseURL: url2)
+        _ = try? StoreBackend.current.makeStore(databaseURL: url2)
 
         let session1 = manager.session(for: descriptor1.id, descriptor: descriptor1)
         let session2 = manager.session(for: descriptor2.id, descriptor: descriptor2)

--- a/Tests/WikiFSTests/SnapshotRefreshGuardTests.swift
+++ b/Tests/WikiFSTests/SnapshotRefreshGuardTests.swift
@@ -21,11 +21,11 @@ struct SnapshotRefreshGuardTests {
         0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
     ])
 
-    private func tempStore() throws -> SQLiteWikiStore {
+    private func tempStore() throws -> any WikiStore {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-refresh-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        return try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
     }
 
     private func pngResponse(url: String) -> URLFetchService.FetchResponse {

--- a/Tests/WikiFSTests/SplitDiffSnapshotTests.swift
+++ b/Tests/WikiFSTests/SplitDiffSnapshotTests.swift
@@ -103,7 +103,7 @@ struct SplitDiffSnapshotTests {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-diff-snap-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let store = try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        let store = try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
         let file = try store.addSource(filename: "Thinking+is+Believing.pdf",
                                        data: Data("%PDF-1.4".utf8))
         _ = try store.recordMarkdownExtraction(

--- a/Tests/WikiFSTests/WikiDaemonTests.swift
+++ b/Tests/WikiFSTests/WikiDaemonTests.swift
@@ -89,7 +89,7 @@ struct WikiDaemonTests {
 
         // Verify the Home page actually exists in the DB
         let dbURL = dir.appendingPathComponent("\(descriptor.id).sqlite")
-        let store = try SQLiteWikiStore(databaseURL: dbURL)
+        let store = try StoreBackend.current.makeStore(databaseURL: dbURL)
         let pages = try store.listPages(sortBy: .newestFirst)
         #expect(pages.count == 1)
         #expect(pages[0].title == "Home")
@@ -290,7 +290,7 @@ struct WikiDaemonTests {
         // Force the transient-open path (store not held in `openStores`)
         daemon.closeStore(wikiID: descriptor.id)
 
-        // Corrupt the DB so SQLiteWikiStore(databaseURL:) throws (SQLITE_NOTADB)
+        // Corrupt the DB so StoreBackend.current.makeStore(databaseURL:) throws (SQLITE_NOTADB)
         let dbURL = dir.appendingPathComponent("\(descriptor.id).sqlite", isDirectory: false)
         for suffix in ["", "-wal", "-shm"] {
             try? FileManager.default.removeItem(atPath: dbURL.path + suffix)

--- a/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelDropRoutingTests.swift
@@ -15,11 +15,11 @@ struct WikiStoreModelDropRoutingTests {
         func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse { response }
     }
 
-    private func tempStore() throws -> SQLiteWikiStore {
+    private func tempStore() throws -> any WikiStore {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-droproute-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return try SQLiteWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        return try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
     }
 
     /// Write a real `.webloc` plist (XML) wrapping `urlString` and return its URL.

--- a/Tests/WikiFSTests/WikiStoreModelRenameSourceTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelRenameSourceTests.swift
@@ -13,8 +13,7 @@ struct WikiStoreModelRenameSourceTests {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return WikiStoreModel(store: try SQLiteWikiStore(
-            databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
+        return WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite")))
     }
 
     @Test func renameSourceRefreshesSourcesList() throws {

--- a/Tests/WikiFSTests/YouTubeEmbedWebViewTests.swift
+++ b/Tests/WikiFSTests/YouTubeEmbedWebViewTests.swift
@@ -90,7 +90,7 @@ struct YouTubeEmbedWebViewTests {
     /// can't reach.
     @Test func hostedYouTubeEmbedLoadsUnderRealOriginWithMatchingEmbedURL() async throws {
         let dbURL = URL.temporaryDirectory.appending(path: "yt-embed-\(UUID().uuidString).sqlite")
-        let sqlite = try SQLiteWikiStore(databaseURL: dbURL)
+        let sqlite = try StoreBackend.current.makeStore(databaseURL: dbURL)
         let videoID = "dQw4w9WgXcQ"
 
         // Seed the byteless YouTube source exactly as the URL recognizer would.


### PR DESCRIPTION
## Summary

Adds a `StoreBackend` selector so the full test suite can run against `GRDBWikiStore` instead of `SQLiteWikiStore` via `WIKIFS_STORE_BACKEND=grdb`. Runs **2,480 tests with 0 failures** against the GRDB backend on the fast tier.

## Changes

### 1. `StoreBackend` factory (`Sources/WikiFSCore/Store/StoreBackend.swift`)
New `enum StoreBackend` reads `WIKIFS_STORE_BACKEND` (any value other than `"grdb"` → `.sqlite`, the default). Exposes `makeStore(databaseURL:)` and `makeReadOnlyStore(readOnlyURL:)` returning `any WikiStore`, routing to the correct concrete backend.

### 2. Production injection points wired
- `WikiSession.init` default `makeStore` closure → `StoreBackend.current.makeStore(databaseURL:)`
- `WikiRegistryClient.init` default `makeStore` closure → same
- `WikiDaemon` left on concrete `SQLiteWikiStore` (out of scope — its `openStores` map + `changeToken()` are SQLite-specific; the daemon is a separate process not exercised by the protocol-parity harness)

### 3. Protocol surface parity (`WikiStore.swift`)
Three protocol changes so convenience members resolve through `any WikiStore` existentials (protocols can't carry default arguments, and Swift doesn't match default-arg concrete methods to no-default requirements):
- **`createPage(title:)`** — new 1-arg protocol requirement; both backends implement a thin forwarder (`createdBy: nil`). Previously only `SQLiteWikiStore` had it via a default arg.
- **`addSource(filename:data:)`** — new 2-arg protocol requirement; both backends implement a forwarder (trailing args at defaults).
- **`activeContentVersion(sourceID:)`** — promoted from SQLite-only `public` to a protocol requirement. `GRDBWikiStore` already had the logic as a private `db:`-taking helper; added a `public` wrapper routing through `dbQueue.read`.

### 4. Test helpers rewired (28 files)
28 non-skip-list test files that construct the store via `SQLiteWikiStore(databaseURL:)` now route through `StoreBackend.current.makeStore(databaseURL:)` and use `any WikiStore` return/parameter types. Files using SQLite-only convenience members through the existential (`changeToken()`, `listAll*OrderedByID()`, mid-arity `addSource` overloads, `vecRegisteredForTesting`) were left on concrete `SQLiteWikiStore` — these exercise the protocol via `WikiStoreModel(store:)`, just not at the convenience-call level. They are candidates for a follow-up lift to the protocol.

### 5. Parity gaps fixed in `GRDBWikiStore.swift`

| Gap | Root cause | Fix |
|---|---|---|
| `sourceContent(id:)` threw `.notFound` for byteless sources | GRDB threw when `blob_hash IS NULL` or no `source-content` ref; SQLiteWikiStore returns `Data()` (byteless) and falls back to `MAX(id)` | Rewrote to mirror SQLiteWikiStore: ref to MAX(id) fallback to NULL blob_hash to `Data()` |
| `missingChatEmbeddingWork()` returned only the title | GRDB selected `c.title AS text`; SQLiteWikiStore builds `title + "\n\n" + GROUP_CONCAT(message text)` | Fixed query to concatenate title + user/assistant message text |
| `renameChat()` didn't refresh the FTS sidecar | GRDB only `UPDATE chats SET title`; SQLiteWikiStore calls `upsertChatSearch()` to refresh `chat_search`/`chats_fts` | Added inline `chat_search` upsert (title + body) within the rename transaction |

## Test results

```
WIKIFS_STORE_BACKEND=grdb swift test --skip 'EnumeratorDeletionTests|...|ProjectionTreeTests'
Test run with 2480 tests in 212 suites passed after 22.063 seconds.
```

Default (SQLite) backend sanity-checked — no regression from the protocol changes.

## What's NOT in scope
- **WikiDaemon** — its `openStores: [String: SQLiteWikiStore]` + `changeToken()` (not on the protocol) make it SQLite-coupled; the daemon is a separate process.
- **WikiReadPool / File Provider Projection** — read-only API exposes `SQLiteWikiStore` concretely. The factory's `makeReadOnlyStore` is ready for a follow-up.
- **Skip-list test suites** — SQLite-specific suites test raw SQLite internals and stay on the concrete type.
