### PR TITLE
Flip StoreBackend default to GRDB + deprecate SQLiteWikiStore

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,28 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-17 — Flip StoreBackend default to GRDB (branch `feature/grdb-default-backend`)
+
+**What changed:** The GRDB migration is complete — all 88 methods implemented
+(#545/#550), 37-version migration ladder (#557), and 2,480 parity tests pass
+(#561). `StoreBackend.current` now defaults to `.grdb` instead of `.sqlite`.
+Setting `WIKIFS_STORE_BACKEND=sqlite` opts back in to the legacy
+`SQLiteWikiStore` as an escape hatch.
+
+**Deprecation:** Added prominent `⚠️ DEPRECATED` doc comment headers to
+`SQLiteWikiStore`, `SQLiteStatement`, and `WikiReadPool`, noting that
+`GRDBWikiStore` is the default and these types will be removed in a future
+version. No `@available(*, deprecated)` markers were added — with
+`-warnings-as-errors` active and live production usage of `WikiReadPool`
+outside `SQLiteWikiStore`, compiler-enforced deprecation would break the build.
+Compiler-enforced deprecation will come in a follow-up PR when the files are
+actually deleted.
+
+**Tests:** Fast test tier (2,487 tests) passes against GRDB by default
+(`WIKIFS_STORE_BACKEND` unset). `SQLiteWikiStoreTests` (48 tests) still pass
+— they construct the store directly, not through the factory, confirming the
+deprecated code remains functional.
+
 ## 2026-07-17 — Enrich ingestion completion summary line (branch `scared-gopher`)
 
 **Problem:** When an ingestion finished, the Activity window showed "797 in · 203 out" — no unit, no model, no harness, no thinking signal, no start time, no duration. The user couldn't tell what the numbers meant or what ran.

--- a/Sources/WikiFSCore/Store/SQLiteStatement.swift
+++ b/Sources/WikiFSCore/Store/SQLiteStatement.swift
@@ -7,6 +7,10 @@ import SQLite3
 /// freed memory. The transient destructor is `(sqlite3_destructor_type)(-1)`.
 let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
+/// ⚠️ **DEPRECATED:** `GRDBWikiStore` is the default backend (#545–#561).
+/// The hand-rolled `SQLiteStatement` wrapper is no longer needed — GRDB's
+/// `Statement` type replaces it. This type will be removed in a future version.
+///
 /// Thin wrapper over a prepared `sqlite3_stmt`. One instance per distinct SQL
 /// string; reused across calls via `reset()` (which clears bindings). Owned and
 /// finalized by `SQLiteWikiStore`.

--- a/Sources/WikiFSCore/Store/SQLiteWikiStore.swift
+++ b/Sources/WikiFSCore/Store/SQLiteWikiStore.swift
@@ -5,6 +5,10 @@ import Darwin
 import CSqliteVec
 import CryptoKit
 
+/// ⚠️ **DEPRECATED:** `GRDBWikiStore` is the default backend as of the GRDB
+/// migration (#545–#561). `SQLiteWikiStore` will be removed in a future
+/// version. Set `WIKIFS_STORE_BACKEND=sqlite` to temporarily opt back in.
+///
 /// SQLite-backed `WikiStore`. Hand-wraps the system `SQLite3` C API — no
 /// third-party dependency (per the BRINGUP decision). Owns one serial
 /// connection with a prepared-statement cache.

--- a/Sources/WikiFSCore/Store/StoreBackend.swift
+++ b/Sources/WikiFSCore/Store/StoreBackend.swift
@@ -13,19 +13,21 @@ import Foundation
 /// export WIKIFS_STORE_BACKEND=grdb
 /// ```
 ///
-/// The default (unset / any other value) keeps the battle-tested
-/// `SQLiteWikiStore`, so production behaviour is unchanged unless explicitly
-/// opted in. This is the affordance used by the GRDB-parity test harness (#545,
-/// #550, #557): it exercises the 2,400+ test suite against `GRDBWikiStore` to
-/// verify identical behaviour before any rollout.
+/// The default is `GRDBWikiStore` — the GRDB migration is complete (all 88
+/// methods implemented #545/#550, 37-version migration ladder #557, 2,480
+/// parity tests pass #561). Set `WIKIFS_STORE_BACKEND=sqlite` to opt back in
+/// to the legacy `SQLiteWikiStore` (deprecated, will be removed in a future
+/// version). This escape hatch preserves the old behaviour for anyone who
+/// needs it during the deprecation period.
 public enum StoreBackend: String, Sendable {
     case sqlite
     case grdb
 
     /// The backend selected for this process. Reads `WIKIFS_STORE_BACKEND` once;
-    /// any value other than `"grdb"` resolves to `.sqlite`.
+    /// `"sqlite"` resolves to `.sqlite`, any other value (including unset)
+    /// resolves to `.grdb`.
     public static var current: StoreBackend {
-        ProcessInfo.processInfo.environment["WIKIFS_STORE_BACKEND"] == "grdb" ? .grdb : .sqlite
+        ProcessInfo.processInfo.environment["WIKIFS_STORE_BACKEND"] == "sqlite" ? .sqlite : .grdb
     }
 
     /// Construct a read/write store at `databaseURL`, mirroring

--- a/Sources/WikiFSCore/Store/WikiReadPool.swift
+++ b/Sources/WikiFSCore/Store/WikiReadPool.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// ⚠️ **DEPRECATED:** `GRDBWikiStore` is the default backend (#545–#561).
+/// The manual `WikiReadPool` connection pool is no longer needed — GRDB's
+/// `DatabasePool` replaces it. This type will be removed in a future version.
+///
 /// A pool of **read-only** snapshot connections over one wiki database, for
 /// reads that should not run on the main-actor write store (debounced search,
 /// bulk existence checks, future projection-style reads).


### PR DESCRIPTION
## Flip StoreBackend default to GRDB and deprecate SQLiteWikiStore

The GRDB migration is complete — all 88 methods implemented (#545/#550),
37-version migration ladder (#557), and 2,480 parity tests pass (#561). This PR
flips the default backend and starts the deprecation process.

### Changes

**1. Flip the default** (`StoreBackend.swift`)

`StoreBackend.current` now defaults to `.grdb` instead of `.sqlite`:

```swift
public static var current: StoreBackend {
    ProcessInfo.processInfo.environment["WIKIFS_STORE_BACKEND"] == "sqlite" ? .sqlite : .grdb
}
```

`WIKIFS_STORE_BACKEND=sqlite` remains as an escape hatch for anyone who needs
the legacy `SQLiteWikiStore` behavior.

**2. Deprecation doc comments** (`SQLiteWikiStore.swift`, `SQLiteStatement.swift`, `WikiReadPool.swift`)

Added prominent deprecation doc comment headers to all three types noting
that `GRDBWikiStore` is the default and these types will be removed in a future
version.

No `@available(*, deprecated)` markers were added. With `-warnings-as-errors`
active and live production usage of `WikiReadPool` outside `SQLiteWikiStore`
(`WikiSession.swift`, `WikiStoreModel.swift`), compiler-enforced deprecation
would fail the build. Compiler-enforced deprecation will come in a follow-up PR
when the files are actually deleted.

**3. No files deleted.** This PR only flips the default and adds doc comments.
The actual file deletion is a follow-up after the deprecation has been in place
for a release cycle.

### Test results

- **Fast test tier (2,487 tests):** all pass against GRDB by default
  (`WIKIFS_STORE_BACKEND` unset)
- **SQLiteWikiStoreTests (48 tests):** all pass — these construct the store
  directly, not through the factory, confirming the deprecated code remains
  functional

### Files changed

- `Sources/WikiFSCore/Store/StoreBackend.swift` — default flip + doc update
- `Sources/WikiFSCore/Store/SQLiteWikiStore.swift` — deprecation header
- `Sources/WikiFSCore/Store/SQLiteStatement.swift` — deprecation header
- `Sources/WikiFSCore/Store/WikiReadPool.swift` — deprecation header
- `PROGRESS.md` — progress entry

Closes #563
