### PR TITLE
Fix #553 #554: source cat --markdown + resolve --name by display name

### DIFF
--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -125,9 +125,11 @@ public enum ArgumentParser {
       search --query X [--limit N]           semantic search (cosine similarity);
                                              falls back to LIKE title match
       source list [--json]                    list sources (TSV, or JSON lines)
-      source cat  (--id X | --name N)         write raw source bytes to stdout
-      source export (--id X | --name N) [--out <path>]
-                                              materialize a source to disk, print its path
+      source cat  (--id X | --name N) [--markdown]
+                                              write raw source bytes (or extracted markdown
+                                              with --markdown) to stdout
+      source export (--id X | --name N) [--out <path>] [--markdown]
+                                              materialize a source to disk, print its path; --markdown exports the .md sibling
       source edit-markdown (--id X | --name N) (--content <md> | --file <path|->)
                                               replace the processed-markdown HEAD
       source search --query X [--limit N]    semantic search of sources (cosine;
@@ -325,18 +327,20 @@ public enum ArgumentParser {
     private static func parseSourceCommand(_ args: [String]) throws -> Command {
         guard let sub = args.first else { throw Failure.usage("source: missing subcommand") }
         let rest = Array(args.dropFirst())
-        let options = try Options(rest)
+        // `--markdown` applies to `cat` and `export`; include it here so the
+        // outer parse doesn't reject it as a value flag needing an argument.
+        let options = try Options(rest, booleanFlags: ["--json", "--markdown"])
 
         switch sub {
         case "list":
             return .source(.list(json: options.flag("--json")))
 
         case "cat":
-            return .source(.cat(try options.requireSourceSelector()))
+            return .source(.cat(try options.requireSourceSelector(), markdown: options.flag("--markdown")))
 
         case "export":
             let selector = try options.requireSourceSelector()
-            return .source(.export(selector, out: options.value("--out")))
+            return .source(.export(selector, out: options.value("--out"), markdown: options.flag("--markdown")))
 
         case "edit-markdown":
             return try parseSourceEditMarkdown(options)

--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -37,8 +37,8 @@ public enum SourceCommand {
 
     public enum Action: Equatable {
         case list(json: Bool)
-        case cat(Selector)
-        case export(Selector, out: String?)
+        case cat(Selector, markdown: Bool)
+        case export(Selector, out: String?, markdown: Bool)
         case editMarkdown(Selector, content: String)
         case rename(Selector, to: String)
         case search(query: String, limit: Int)
@@ -64,10 +64,10 @@ public enum SourceCommand {
         switch action {
         case .list(let json):
             return try list(in: store, json: json)
-        case .cat(let selector):
-            return try cat(selector, in: store)
-        case .export(let selector, let out):
-            return try export(selector, out: out, in: store, cwd: cwd)
+        case .cat(let selector, let markdown):
+            return try cat(selector, markdown: markdown, in: store)
+        case .export(let selector, let out, let markdown):
+            return try export(selector, out: out, markdown: markdown, in: store, cwd: cwd)
         case .editMarkdown(let selector, let content):
             return try editMarkdown(selector, content: content, in: store)
         case .rename(let selector, let to):
@@ -131,8 +131,15 @@ public enum SourceCommand {
 
     // MARK: - cat
 
-    private static func cat(_ selector: Selector, in store: WikiStore) throws -> Result {
+    private static func cat(
+        _ selector: Selector, markdown: Bool, in store: WikiStore
+    ) throws -> Result {
         let id = try resolve(selector, in: store)
+        if markdown, let head = try store.processedMarkdownHead(sourceID: id) {
+            // --markdown: print the extracted markdown HEAD instead of raw bytes.
+            // Falls through to the raw-bytes path below when no markdown chain exists. (#553)
+            return Result(payload: .text(head.content), didCommit: false)
+        }
         let data: Data
         do {
             data = try store.sourceContent(id: id)
@@ -147,10 +154,32 @@ public enum SourceCommand {
     private static func export(
         _ selector: Selector,
         out: String?,
+        markdown: Bool,
         in store: WikiStore,
         cwd: String
     ) throws -> Result {
         let id = try resolve(selector, in: store)
+
+        // --markdown: export the extracted markdown HEAD as a .md sibling
+        // instead of the raw blob. Falls back to raw bytes when no markdown
+        // chain exists. (#553)
+        if markdown, let head = try store.processedMarkdownHead(sourceID: id) {
+            let path: String
+            if let out {
+                path = out
+            } else {
+                // Default to .md so the exported file is immediately usable.
+                let summaries = try store.listSources()
+                let baseName = summaries.first(where: { $0.id == id })?.ext ?? ""
+                let leaf = baseName.isEmpty
+                    ? "file-\(id.rawValue).md"
+                    : "file-\(id.rawValue).\(baseName).md"
+                path = "\(cwd)/\(leaf)"
+            }
+            try Data(head.content.utf8).write(to: URL(fileURLWithPath: path), options: .atomic)
+            return Result(payload: .text(path), didCommit: false)
+        }
+
         let data: Data
         do {
             data = try store.sourceContent(id: id)
@@ -183,16 +212,22 @@ public enum SourceCommand {
             return id
         case .name(let name):
             let summaries = try store.listSources()
-            let matches = summaries.filter { $0.filename == name }
-            switch matches.count {
+            // Match by display name first (display_name ?? filename), then
+            // fall back to filename — mirrors `WikiStore.resolveSourceByName` and
+            // how `source list` labels sources, so the agent can use the name it
+            // just saw. (#554)
+            let byDisplay = summaries.filter { $0.effectiveName == name }
+            if byDisplay.count == 1 { return byDisplay[0].id }
+            let byFilename = summaries.filter { $0.filename == name }
+            if byFilename.count == 1 { return byFilename[0].id }
+            let candidates = byDisplay.isEmpty ? byFilename : byDisplay
+            switch candidates.count {
             case 0:
-                throw Failure.message("no file named \(name.debugDescription)")
-            case 1:
-                return matches[0].id
+                throw Failure.message("no source named \(name.debugDescription)")
             default:
-                let ids = matches.map { $0.id.rawValue }.sorted().joined(separator: ", ")
+                let ids = candidates.map { $0.id.rawValue }.sorted().joined(separator: ", ")
                 throw Failure.message(
-                    "multiple files named \(name.debugDescription) — resolve with --id: \(ids)"
+                    "multiple sources named \(name.debugDescription) — resolve with --id: \(ids)"
                 )
             }
         }

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -317,25 +317,25 @@ struct WikiCtlCommandTests {
     @Test func parsesFileCatByID() throws {
         let invocation = try ArgumentParser.parse(
             ["--wiki", "W", "source", "cat", "--id", "01ABC"], env: noEnv)
-        #expect(invocation.command == .source(.cat(.id(PageID(rawValue: "01ABC")))))
+        #expect(invocation.command == .source(.cat(.id(PageID(rawValue: "01ABC")), markdown: false)))
     }
 
     @Test func parsesFileCatByName() throws {
         let invocation = try ArgumentParser.parse(
             ["--wiki", "W", "source", "cat", "--name", "report.pdf"], env: noEnv)
-        #expect(invocation.command == .source(.cat(.name("report.pdf"))))
+        #expect(invocation.command == .source(.cat(.name("report.pdf"), markdown: false)))
     }
 
     @Test func parsesFileExportByID() throws {
         let invocation = try ArgumentParser.parse(
             ["--wiki", "W", "source", "export", "--id", "01Z"], env: noEnv)
-        #expect(invocation.command == .source(.export(.id(PageID(rawValue: "01Z")), out: nil)))
+        #expect(invocation.command == .source(.export(.id(PageID(rawValue: "01Z")), out: nil, markdown: false)))
     }
 
     @Test func parsesFileExportWithOut() throws {
         let invocation = try ArgumentParser.parse(
             ["--wiki", "W", "source", "export", "--id", "01Z", "--out", "/tmp/out.pdf"], env: noEnv)
-        #expect(invocation.command == .source(.export(.id(PageID(rawValue: "01Z")), out: "/tmp/out.pdf")))
+        #expect(invocation.command == .source(.export(.id(PageID(rawValue: "01Z")), out: "/tmp/out.pdf", markdown: false)))
     }
 
     @Test func fileRequiresSubcommand() {
@@ -440,7 +440,7 @@ struct WikiCtlCommandTests {
         // Binary fixture with non-UTF-8 bytes to prove the byte path works.
         let binary = Data([0x00, 0xFF, 0x89, 0x50, 0x4E, 0x47]) // includes PNG magic
         let ingested = try store.addSource(filename: "icon.png", data: binary)
-        let result = try SourceCommand.run(.cat(.id(ingested.id)), in: store, cwd: "/tmp")
+        let result = try SourceCommand.run(.cat(.id(ingested.id), markdown: false), in: store, cwd: "/tmp")
         #expect(!result.didCommit)
         #expect(result.payload == .bytes(binary))
     }
@@ -448,7 +448,7 @@ struct WikiCtlCommandTests {
     @Test func fileCatWithUnknownIDFails() throws {
         let store = try tempStore()
         #expect(throws: SourceCommand.Failure.self) {
-            try SourceCommand.run(.cat(.id(PageID(rawValue: "01NOPE"))), in: store, cwd: "/tmp")
+            try SourceCommand.run(.cat(.id(PageID(rawValue: "01NOPE")), markdown: false), in: store, cwd: "/tmp")
         }
     }
 
@@ -461,7 +461,7 @@ struct WikiCtlCommandTests {
 
         let data = Data("pdf content".utf8)
         let ingested = try store.addSource(filename: "doc.pdf", data: data)
-        let result = try SourceCommand.run(.export(.id(ingested.id), out: nil), in: store, cwd: tmpDir.path)
+        let result = try SourceCommand.run(.export(.id(ingested.id), out: nil, markdown: false), in: store, cwd: tmpDir.path)
         #expect(!result.didCommit)
         guard case .text(let path) = result.payload else {
             #expect(Bool(false), "expected .text payload"); return
@@ -485,7 +485,7 @@ struct WikiCtlCommandTests {
         let ingested = try store.addSource(filename: "notes.txt", data: data)
         let customPath = tmpDir.appendingPathComponent("custom-out.txt").path
         let result = try SourceCommand.run(
-            .export(.id(ingested.id), out: customPath), in: store, cwd: tmpDir.path)
+            .export(.id(ingested.id), out: customPath, markdown: false), in: store, cwd: tmpDir.path)
         guard case .text(let path) = result.payload else {
             #expect(Bool(false), "expected .text payload"); return
         }
@@ -498,14 +498,14 @@ struct WikiCtlCommandTests {
         let store = try tempStore()
         #expect(throws: SourceCommand.Failure.self) {
             try SourceCommand.run(
-                .export(.id(PageID(rawValue: "01NOPE")), out: nil), in: store, cwd: "/tmp")
+                .export(.id(PageID(rawValue: "01NOPE")), out: nil, markdown: false), in: store, cwd: "/tmp")
         }
     }
 
     @Test func fileNameResolutionResolvesUnambiguous() throws {
         let store = try tempStore()
         let ingested = try store.addSource(filename: "unique.md", data: Data("text".utf8))
-        let result = try SourceCommand.run(.cat(.name("unique.md")), in: store, cwd: "/tmp")
+        let result = try SourceCommand.run(.cat(.name("unique.md"), markdown: false), in: store, cwd: "/tmp")
         #expect(result.payload == .bytes(Data("text".utf8)))
         _ = ingested
     }
@@ -513,7 +513,7 @@ struct WikiCtlCommandTests {
     @Test func fileNameResolutionFailsWhenMissing() throws {
         let store = try tempStore()
         #expect(throws: SourceCommand.Failure.self) {
-            try SourceCommand.run(.cat(.name("ghost.pdf")), in: store, cwd: "/tmp")
+            try SourceCommand.run(.cat(.name("ghost.pdf"), markdown: false), in: store, cwd: "/tmp")
         }
     }
 
@@ -522,7 +522,133 @@ struct WikiCtlCommandTests {
         _ = try store.addSource(filename: "same.txt", data: Data("v1".utf8))
         _ = try store.addSource(filename: "same.txt", data: Data("v2".utf8))
         #expect(throws: SourceCommand.Failure.self) {
-            try SourceCommand.run(.cat(.name("same.txt")), in: store, cwd: "/tmp")
+            try SourceCommand.run(.cat(.name("same.txt"), markdown: false), in: store, cwd: "/tmp")
+        }
+    }
+
+    // MARK: - cat --markdown (#553)
+
+    @Test func parsesFileCatWithMarkdownFlag() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "cat", "--id", "01ABC", "--markdown"], env: noEnv)
+        #expect(invocation.command == .source(.cat(.id(PageID(rawValue: "01ABC")), markdown: true)))
+    }
+
+    @Test func parsesFileCatByNameWithMarkdownFlag() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "cat", "--name", "report.pdf", "--markdown"], env: noEnv)
+        #expect(invocation.command == .source(.cat(.name("report.pdf"), markdown: true)))
+    }
+
+    @Test func parsesFileExportWithMarkdownFlag() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "export", "--id", "01Z", "--markdown"], env: noEnv)
+        #expect(invocation.command == .source(.export(.id(PageID(rawValue: "01Z")), out: nil, markdown: true)))
+    }
+
+    @Test func catMarkdownReturnsExtractedMarkdown() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "paper.pdf", data: Data("%PDF-1.4".utf8))
+        _ = try store.appendProcessedMarkdown(
+            sourceID: ingested.id, content: "# Extracted Title\n\nBody text.", origin: .extraction, note: nil)
+        let result = try SourceCommand.run(.cat(.id(ingested.id), markdown: true), in: store, cwd: "/tmp")
+        #expect(!result.didCommit)
+        guard case .text(let output) = result.payload else {
+            #expect(Bool(false), "expected .text payload for --markdown"); return
+        }
+        #expect(output == "# Extracted Title\n\nBody text.")
+    }
+
+    @Test func catMarkdownFallsBackToRawBytesWhenNoExtraction() throws {
+        let store = try tempStore()
+        let binary = Data([0x25, 0x50, 0x44, 0x46]) // %PDF
+        let ingested = try store.addSource(filename: "raw.pdf", data: binary)
+        // No appendProcessedMarkdown — no markdown chain exists.
+        let result = try SourceCommand.run(.cat(.id(ingested.id), markdown: true), in: store, cwd: "/tmp")
+        #expect(result.payload == .bytes(binary))
+    }
+
+    @Test func catMarkdownResolvesByName() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "doc.pdf", data: Data("%PDF".utf8))
+        _ = try store.appendProcessedMarkdown(
+            sourceID: ingested.id, content: "markdown body", origin: .extraction, note: nil)
+        let result = try SourceCommand.run(.cat(.name("doc.pdf"), markdown: true), in: store, cwd: "/tmp")
+        guard case .text(let output) = result.payload else {
+            #expect(Bool(false), "expected .text payload"); return
+        }
+        #expect(output == "markdown body")
+    }
+
+    @Test func exportMarkdownWritesExtractedMarkdown() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "doc.pdf", data: Data("%PDF".utf8))
+        _ = try store.appendProcessedMarkdown(
+            sourceID: ingested.id, content: "# Title\n\nContent.", origin: .extraction, note: nil)
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-md-export-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let result = try SourceCommand.run(
+            .export(.id(ingested.id), out: nil, markdown: true), in: store, cwd: tmpDir.path)
+        guard case .text(let path) = result.payload else {
+            #expect(Bool(false), "expected .text payload"); return
+        }
+        #expect(path.hasSuffix(".pdf.md"))
+        let written = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(written == "# Title\n\nContent.")
+    }
+
+    @Test func exportMarkdownFallsBackToRawBytesWhenNoExtraction() throws {
+        let store = try tempStore()
+        let binary = Data("%PDF".utf8)
+        let ingested = try store.addSource(filename: "raw.pdf", data: binary)
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-md-export-fb-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let result = try SourceCommand.run(
+            .export(.id(ingested.id), out: nil, markdown: true), in: store, cwd: tmpDir.path)
+        guard case .text(let path) = result.payload else {
+            #expect(Bool(false), "expected .text payload"); return
+        }
+        // Falls back to raw bytes path — default uses stored ext (.pdf).
+        #expect(path.hasSuffix(".pdf"))
+        let written = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(written == binary)
+    }
+
+    // MARK: - resolve by display name (#554)
+
+    @Test func resolveByDisplayName() throws {
+        let store = try tempStore()
+        let ingested = try store.addSource(filename: "Matthews1999.pdf", data: Data("raw".utf8))
+        try store.renameSource(id: ingested.id, to: "Ericksonian Hypnosis: A Review")
+        // Agent sees display name in `source list`, should be able to use it.
+        let result = try SourceCommand.run(
+            .cat(.name("Ericksonian Hypnosis: A Review"), markdown: false), in: store, cwd: "/tmp")
+        #expect(result.payload == .bytes(Data("raw".utf8)))
+    }
+
+    @Test func resolveFallsBackToFilenameWhenDisplayNameNotSet() throws {
+        let store = try tempStore()
+        _ = try store.addSource(filename: "plain.txt", data: Data("data".utf8))
+        // No display name set — effectiveName falls back to filename.
+        let result = try SourceCommand.run(
+            .cat(.name("plain.txt"), markdown: false), in: store, cwd: "/tmp")
+        #expect(result.payload == .bytes(Data("data".utf8)))
+    }
+
+    @Test func resolveByDisplayNameAmbiguityFails() throws {
+        let store = try tempStore()
+        let a = try store.addSource(filename: "a.pdf", data: Data("v1".utf8))
+        let b = try store.addSource(filename: "b.pdf", data: Data("v2".utf8))
+        try store.renameSource(id: a.id, to: "Same Display Name")
+        try store.renameSource(id: b.id, to: "Same Display Name")
+        #expect(throws: SourceCommand.Failure.self) {
+            try SourceCommand.run(.cat(.name("Same Display Name"), markdown: false), in: store, cwd: "/tmp")
         }
     }
 

--- a/prompts/system-prompt-default.md
+++ b/prompts/system-prompt-default.md
@@ -221,9 +221,9 @@ $WIKICTL index set --body-file ./index.md   rewrite index.md wholesale
 $WIKICTL log append --kind ingest|query|lint --title "…" [--note "…"] [--source <file-id>]  record an action (--source marks an ingest done)
 $WIKICTL search --query "…" [--limit N]    semantic search — find pages by meaning; defaults to 10 results, max 100
 $WIKICTL source list [--json]               list all sources (TSV, or JSON lines)
-$WIKICTL source cat --id I | --name N       write raw source bytes to stdout
-$WIKICTL source export --id I | --name N [--out <path>]
-                                            materialize a source to disk, print its path
+$WIKICTL source cat --id I | --name N [--markdown]  write raw source bytes (or extracted markdown with --markdown) to stdout
+$WIKICTL source export --id I | --name N [--out <path>] [--markdown]
+                                            materialize a source to disk, print its path; --markdown exports the .md sibling
 $WIKICTL source search --query "…" [--limit N]   semantic search of sources — find source material by meaning; defaults to 10, max 100
 $WIKICTL chat list [--json]                   list chats (id / title / kind / message count)
 $WIKICTL chat get --id I | --title T          print a chat transcript as markdown
@@ -265,11 +265,15 @@ $ $WIKICTL search --query "continuous profiling with JFR"
 
 Most sources already have their text extracted. `$WIKICTL source list` shows
 metadata (including a `has_markdown` flag); to read a source's content, use
-`$WIKICTL source cat --id <id>` (or `--name <name>`) for text/markdown — it
-writes the source's content to stdout. For a PDF or other binary source, run
-`$WIKICTL source export --id <id>` (materializes to disk and prints the path),
-then `Read` that path — the `Read` tool handles text, images, and PDFs; for a
-PDF read the text first, and view any figures you need as images separately.
+`$WIKICTL source cat --id <id>` (or `--name <name>`) — it writes the source's
+raw bytes to stdout. For PDFs and other binary sources, pass `--markdown` to
+get the extracted markdown HEAD instead of binary:
+`$WIKICTL source cat --id <id> --markdown` (falls back to raw bytes if no
+extraction has been done). Alternatively, run `$WIKICTL source export --id <id>`
+(materializes to disk and prints the path), then `Read` that path — the `Read`
+tool handles text, images, and PDFs; for a PDF read the text first, and view
+any figures you need as images separately. `source export --markdown` exports
+the extracted `.md` sibling.
 Do NOT try to read or `cat` source files from the mount (`sources/…`) — use
 `wikictl source cat` / `source export`, which read the database directly and
 are always available. To find source **content** by meaning, use
@@ -289,8 +293,9 @@ When the user's message begins with `[[page:…]]`, `[[source:…]]`, or
 `[[chat:…]]` reference lines (dragged from the sidebar), READ the referenced
 resource via wikictl BEFORE answering:
 - `[[page:Title]]` → `$WIKICTL page get --title "Title"` (or `--id <id>`)
-- `[[source:Name]]` → `$WIKICTL source cat --name "Name"` (text) or
-  `$WIKICTL source export --name "Name"` then `Read` the path (PDF/binary)
+- `[[source:Name]]` → `$WIKICTL source cat --name "Name" --markdown` (extracted
+  text; drop `--markdown` for raw bytes), or `$WIKICTL source export --name "Name"
+  --markdown` then `Read` the path (PDF/binary)
 - `[[chat:Title]]` → `$WIKICTL chat get --title "Title"`
 
 Do NOT read these from the mount — use wikictl, which reads the database
@@ -299,8 +304,9 @@ directly and is always available.
 ## Workflows
 
 **Ingest** — bring one raw source into the wiki:
-1. Read the source via wikictl: `$WIKICTL source cat --id <id>` for text/markdown,
-   or `$WIKICTL source export --id <id>` then `Read` the path for PDFs/images.
+1. Read the source via wikictl: `$WIKICTL source cat --id <id> --markdown` for
+   extracted text, or `$WIKICTL source export --id <id>` then `Read` the path
+   for PDFs/images.
 2. Check for relevant prior discussion: `$WIKICTL chat search --query "…"` for
    the source's topic, and `$WIKICTL chat get --id I` on any promising hit —
    incorporate what the user already cared about into the pages you write, and


### PR DESCRIPTION
## Summary

Fixes #553 and #554 in one PR — both are about `wikictl source cat`/`source export` usability for the agent's lint workflow.

## #553: `source cat` returns raw bytes, no markdown flag

**Problem:** `SourceCommand.cat` always calls `store.sourceContent(id:)` which returns the raw blob bytes. For PDF sources, this dumps binary to stdout. The extracted markdown exists via `store.processedMarkdownHead(sourceID:)` but no wikictl command exposes it.

**Fix:** Added a `--markdown` flag to both `source cat` and `source export`:

```sh
wikictl source cat --id <id> --markdown      # extracted markdown, falls back to raw bytes
wikictl source export --id <id> --markdown   # exports .md sibling, falls back to raw file
```

- When `--markdown` is set: calls `store.processedMarkdownHead(sourceID:)` first, returns the markdown content as `.text` (for `cat`) or writes a `.md` file (for `export`)
- When no markdown chain exists, falls back to the current raw-bytes behavior
- When `--markdown` is NOT set: current behavior (raw bytes) is unchanged

## #554: `--name` resolves by filename, not display name

**Problem:** `source list` shows `effectiveName` (display_name ?? filename), but `source cat`/`source export` with `--name` resolved only by `filename`. The agent sees the display name but can't use it.

**Fix:** Changed `resolve()` to match by `effectiveName` first, then fall back to `filename` — mirroring `WikiStore.resolveSourceByName`. Affects all SourceCommand actions that use `Selector.name`: `cat`, `export`, `edit-markdown`, `rename`, `set-active`, `info`, `refresh`.

## System prompt

Updated `prompts/system-prompt-default.md` to document the `--markdown` flag in:
- The command reference table
- The Sources section (reading source content)
- The citation verification workflow
- The Ingest workflow

## Test plan

- [x] `swift build` succeeds
- [x] All 2498 fast-tier tests pass
- [x] New tests added: cat --markdown returns text, falls back to bytes; export --markdown writes .md sibling; resolve by display name, filename fallback, ambiguity error
