### PR TITLE
Surface thinking effort level in UI (#566)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -425,6 +425,7 @@ struct ChatView: View {
             // Inside ContentView the session is always non-nil (a wiki is
             // open), so the provider/model chips are always shown.
             ProviderSelector(launcher: launcher)
+            ThinkingEffortSelector(launcher: launcher)
             PermissionModeSelector(rawValue: $permissionModeRaw)
             Spacer(minLength: 0)
             if showsStopButton {

--- a/Sources/WikiFS/Chats/ThinkingEffortSelector.swift
+++ b/Sources/WikiFS/Chats/ThinkingEffortSelector.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import WikiFSEngine
+
+/// #566: The "Thinking" dropdown for the chat composer toolbar.
+///
+/// Surfaces the agent's `thought_level` config option (high/medium/low) so the
+/// user can change how hard the agent reasons, mid-session. Capability-gated:
+/// the view renders nothing when `launcher.thinkingOption` is `nil` (agent
+/// advertises no `thought_level` — older agents, or those that don't switch
+/// model variants). This is the agent-dependent hide rule from the issue.
+///
+/// **UI shape:** a compact borderless chip next to `ProviderSelector`, showing
+/// a brain glyph + the current level + a chevron. Tapping opens a native
+/// `Menu` (the level list is short — 2–4 fixed entries — so the
+/// ProviderSelector-style search popover would be overkill and less native).
+/// A checkmark marks the active level. Selecting one calls
+/// `launcher.setThinkingEffort(_:)`, which optimistically flips the chip and
+/// fires `session/set_config_option`; a `config_option_update` confirms it.
+///
+/// Mirrors `ProviderSelector`'s trigger styling (.callout font, secondary
+/// foreground, tertiary chevron) so the two chips read as siblings.
+struct ThinkingEffortSelector: View {
+    @Bindable var launcher: AgentLauncher
+
+    var body: some View {
+        // Capability gate: render nothing when the agent advertises no
+        // `thought_level`. This keeps the toolbar uncluttered for agents that
+        // don't support thinking-effort switching.
+        if let option = launcher.thinkingOption {
+            Menu {
+                ForEach(option.choices) { choice in
+                    Button {
+                        launcher.setThinkingEffort(choice.value)
+                    } label: {
+                        if choice.value == option.currentValue {
+                            Label(choice.label, systemImage: "checkmark")
+                        } else {
+                            Text(choice.label)
+                        }
+                    }
+                }
+            } label: {
+                trigger(option: option)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("Thinking effort — how hard the agent reasons before answering")
+        }
+    }
+
+    /// The compact chip: brain glyph + current level + chevron. Styled to sit
+    /// beside `ProviderSelector` as a sibling secondary control.
+    private func trigger(option: ThinkingEffortOption) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "brain.head.profile")
+                .foregroundStyle(Color.purple)
+            Text(option.currentValue)
+                .foregroundStyle(.secondary)
+            Image(systemName: "chevron.up.chevron.down")
+                .imageScale(.small)
+                .foregroundStyle(.tertiary)
+        }
+        .font(.callout)
+        .contentShape(Rectangle())
+    }
+}

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -588,6 +588,13 @@ enum UsageFormatter {
             parts.append(model)
         }
 
+        // #566: thinking-effort level (high/medium/low) — between the model and
+        // the token counts, matching the issue's example line:
+        // "Sonnet 4 · high · 797 tokens in · 203 tokens out · 412 thought".
+        if let level = usage.thinkingLevel, !level.isEmpty {
+            parts.append(level)
+        }
+
         // Token usage with explicit units.
         parts.append(tokenSummary(usage: usage))
 

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -100,6 +100,14 @@ public actor ACPBackend: AgentBackend {
         /// list (older agents). Captured at start so the launcher can cache them
         /// per-provider for the model picker (#329).
         let modelsInfo: ModelsInfo?
+        /// The config options the agent advertised (`session/new` →
+        /// `NewSessionResponse.configOptions`), e.g. the `thought_level`
+        /// select (high/medium/low). nil when the agent advertises none. Captured
+        /// at start so the launcher can surface the current thinking effort in
+        /// the chat toolbar + Activity window (#566). Updated in-place when a
+        /// `.configOptionUpdate` notification arrives (the session record is a
+        /// struct stored in the actor's `sessions` map, so we reassign).
+        var configOptions: [SessionConfigOption]?
         /// Session-lifetime notification fanout (cause 6 fix,
         /// `plans/acp-stall-recovery.md` §1b). Replaces the per-turn
         /// re-acquisition of `client.notifications`.
@@ -450,9 +458,17 @@ public actor ACPBackend: AgentBackend {
         let session = try await client.newSession(workingDirectory: workingDir)
         let sessionId = session.sessionId
         let modelsInfo = session.models
+        let configOptions = session.configOptions
         let discoveredCount = modelsInfo?.availableModels.count ?? 0
         let currentModel = modelsInfo?.currentModelId ?? "(none)"
         DebugLog.agent("ACPBackend.createSession: discovered \(discoveredCount) model(s), current=\(currentModel)")
+        // #566: capture the config options the agent advertised (e.g. a
+        // `thought_level` select). nil when the agent advertises none — the UI
+        // hides the Thinking dropdown in that case.
+        if let configOptions, !configOptions.isEmpty {
+            let ids = configOptions.map { $0.id.value }.joined(separator: ", ")
+            DebugLog.agent("ACPBackend.createSession: agent advertised \(configOptions.count) config option(s): \(ids)")
+        }
 
         // #329: if the user picked a model for this provider, apply it right
         // after newSession — BEFORE the first prompt — so the agent uses a
@@ -490,6 +506,7 @@ public actor ACPBackend: AgentBackend {
             sessionId: sessionId,
             permissionDelegate: permissionDelegate,
             modelsInfo: modelsInfo,
+            configOptions: configOptions,
             notificationFanout: fanout,
             drainTask: nil,
             systemPrompt: systemPrompt,
@@ -605,7 +622,7 @@ public actor ACPBackend: AgentBackend {
             // stopReason), while notifications stream in via the fanout
             // subscription. The prompt task and watchdog are both cancelled on
             // consumer termination.
-            let promptTask = Task { [client, sessionId, fanout, completionFlag, processHealth, promptText, usageState] in
+            let promptTask = Task { [client, sessionId, fanout, completionFlag, processHealth, promptText, usageState, handle] in
                 // Subscribe to the session-lifetime fanout (NOT the SDK's
                 // `client.notifications` — that's single-consumer; re-acquiring
                 // it per turn was cause 6). Turns are serialized by the
@@ -629,6 +646,13 @@ public actor ACPBackend: AgentBackend {
                                 size: usageUpdate.size,
                                 cost: usageUpdate.cost?.amount,
                                 currency: usageUpdate.cost?.currency)
+                        }
+                        // #566: write the refreshed config options back to the
+                        // session record so the `thought_level` current value
+                        // the toolbar displays tracks `config_option_update`s.
+                        // The drain runs off-actor; hop back to update `sessions`.
+                        if let configOptions = result.configOptions {
+                            await updateConfigOptions(for: handle, options: configOptions)
                         }
                     }
                 }
@@ -766,7 +790,8 @@ public actor ACPBackend: AgentBackend {
                 return registerResumedSession(
                     acpSessionId: acpSessionId,
                     warm: newWarm,
-                    modelsInfo: response.models
+                    modelsInfo: response.models,
+                    configOptions: response.configOptions
                 )
             } catch {
                 // Resume failed (session GC'd, protocol error). Fall through to
@@ -789,7 +814,8 @@ public actor ACPBackend: AgentBackend {
                 return registerResumedSession(
                     acpSessionId: resumedId,
                     warm: newWarm,
-                    modelsInfo: response.models
+                    modelsInfo: response.models,
+                    configOptions: response.configOptions
                 )
             } catch {
                 DebugLog.agent("ACPBackend.resume: loadSession failed: \(error.localizedDescription) — giving up")
@@ -811,7 +837,8 @@ public actor ACPBackend: AgentBackend {
     private func registerResumedSession(
         acpSessionId: SessionId,
         warm: WarmProcess,
-        modelsInfo: ModelsInfo?
+        modelsInfo: ModelsInfo?,
+        configOptions: [SessionConfigOption]? = nil
     ) -> SessionHandle {
         let sessionID = UUID().uuidString
         sessions[sessionID] = ACPSession(
@@ -819,6 +846,7 @@ public actor ACPBackend: AgentBackend {
             sessionId: acpSessionId,
             permissionDelegate: warm.permissionDelegate,
             modelsInfo: modelsInfo,
+            configOptions: configOptions,
             notificationFanout: warm.notificationFanout,
             drainTask: nil,
             systemPrompt: "",
@@ -1012,6 +1040,7 @@ public actor ACPBackend: AgentBackend {
             sessionId: forkedSessionId,
             permissionDelegate: warm.permissionDelegate,
             modelsInfo: parent.modelsInfo,
+            configOptions: parent.configOptions,
             notificationFanout: warm.notificationFanout,
             drainTask: nil,
             systemPrompt: parent.systemPrompt,
@@ -1036,7 +1065,11 @@ public actor ACPBackend: AgentBackend {
         // Enrich with the session's current model id (the actual model used),
         // if the agent advertised one. Provider label is attached by the
         // launcher's capturePhaseUsage (it knows the configured provider).
-        let modelId = sessions[sessionHandle.id]?.modelsInfo?.currentModelId
+        let session = sessions[sessionHandle.id]
+        let modelId = session?.modelsInfo?.currentModelId
+        // #566: surface the active `thought_level` value (if advertised) in the
+        // Activity window between the model id and the token counts.
+        let thinkingLevel = session.flatMap { Self.currentThoughtLevel(from: $0.configOptions) }
         return SessionUsage(
             inputTokens: snapshot.inputTokens,
             outputTokens: snapshot.outputTokens,
@@ -1048,7 +1081,24 @@ public actor ACPBackend: AgentBackend {
             contextUsed: snapshot.contextUsed,
             contextSize: snapshot.contextSize,
             providerLabel: nil,
-            modelId: modelId)
+            modelId: modelId,
+            thinkingLevel: thinkingLevel)
+    }
+
+    /// #566: read the `thought_level` option's current value from a config
+    /// option set. Matches by `id.value == "thought_level"` OR
+    /// `category == "thought_level"` (the daemon vs the spec use different
+    /// conventions). Returns the select's `currentValue.value` (e.g.
+    /// `"high"`), or `nil` when the agent advertises no such option.
+    private static func currentThoughtLevel(
+        from configOptions: [SessionConfigOption]?
+    ) -> String? {
+        guard let configOptions,
+              let option = configOptions.first(where: { $0.id.value == "thought_level" || $0.category == "thought_level" }),
+              case .select(let select) = option.kind else {
+            return nil
+        }
+        return select.currentValue.value
     }
 
     /// The current context window usage for a session — `used` tokens consumed
@@ -1086,6 +1136,99 @@ public actor ACPBackend: AgentBackend {
     func availableModels(for sessionHandle: SessionHandle) async -> [ModelInfo] {
         guard let session = sessions[sessionHandle.id] else { return [] }
         return session.modelsInfo?.availableModels ?? []
+    }
+
+    // MARK: - Session config options (#566 — thinking effort)
+
+    /// The config options the agent advertised for a session (`session/new` →
+    /// `NewSessionResponse.configOptions` + refreshed by
+    /// `config_option_update` notifications). Includes the `thought_level`
+    /// select (high/medium/low) when the agent supports it. The launcher / UI
+    /// reads this to render the "Thinking" dropdown; an empty return hides the
+    /// affordance (agent-dependent capability detection).
+    func sessionConfigOptions(for sessionHandle: SessionHandle) async -> [SessionConfigOption] {
+        guard let session = sessions[sessionHandle.id] else { return [] }
+        return session.configOptions ?? []
+    }
+
+    /// Set a config option value on the agent — e.g. the `thought_level`
+    /// select (high/medium/low). The agent responds with the refreshed config
+    /// option set, which it then broadcasts as a `config_option_update`
+    /// notification; `updateConfigOptions(for:options:)` writes that snapshot
+    /// back here so the toolbar reflects the new value. Throws if the agent
+    /// rejects the value (it propagates the SDK's `ClientError`).
+    func setConfigOption(
+        sessionHandle: SessionHandle,
+        configId: String,
+        value: String
+    ) async throws {
+        guard let session = sessions[sessionHandle.id] else {
+            throw ACPBackendError.noAgentConfigured
+        }
+        let configIdValue = SessionConfigId(value)
+        let valueId = SessionConfigValueId(value)
+        DebugLog.agent("ACPBackend.setConfigOption: configId=\(configId) value=\(value) session=\(session.sessionId.value)")
+        _ = try await session.client.setConfigOption(
+            sessionId: session.sessionId,
+            configId: configIdValue,
+            value: valueId
+        )
+        // Optimistically patch the local snapshot so the toolbar flips
+        // immediately — the `config_option_update` that follows confirms it
+        // (or corrects it if the agent rewrote the value).
+        if var session = sessions[sessionHandle.id] {
+            session.configOptions = patchConfigOption(
+                in: session.configOptions ?? [],
+                configId: configId,
+                newValue: value)
+            sessions[sessionHandle.id] = session
+        }
+    }
+
+    /// Merge a refreshed `config_option_update` payload into the session record.
+    /// Called off-actor from the per-turn drain task. No-op if the session is
+    /// gone (cancelled/finished) — the update is informational, not load-bearing.
+    private func updateConfigOptions(
+        for handle: SessionHandle,
+        options: [SessionConfigOption]
+    ) async {
+        guard var session = sessions[handle.id] else { return }
+        // The notification carries the FULL option set (per ACP spec), so we
+        // replace wholesale rather than merge — simplest correct behavior.
+        session.configOptions = options
+        sessions[handle.id] = session
+        let changed = options.first(where: { $0.id.value == "thought_level" })
+        if case .select(let sel) = changed?.kind {
+            DebugLog.agent("ACPBackend: thought_level now \(sel.currentValue.value)")
+        }
+    }
+
+    /// Return a copy of `options` with the select option identified by
+    /// `configId` updated to carry `newValue` as its current value. Used for
+    /// the optimistic local patch in `setConfigOption`. Options that aren't a
+    /// matching `.select`, or whose select options list doesn't contain the
+    /// value, are passed through unchanged.
+    private func patchConfigOption(
+        in options: [SessionConfigOption],
+        configId: String,
+        newValue: String
+    ) -> [SessionConfigOption] {
+        options.map { option in
+            guard option.id.value == configId else { return option }
+            switch option.kind {
+            case .select(var select):
+                select.currentValue = SessionConfigValueId(newValue)
+                return SessionConfigOption(
+                    id: option.id,
+                    name: option.name,
+                    description: option.description,
+                    category: option.category,
+                    kind: .select(select),
+                    _meta: option._meta)
+            case .boolean:
+                return option
+            }
+        }
     }
 
     /// The agent process identifier for a session (SDK fork Fix 4). nil when
@@ -1298,18 +1441,25 @@ public actor ACPBackend: AgentBackend {
         params: AnyCodable,
         sessionId: SessionId,
         translator: ACPEventTranslator
-    ) -> (events: [AgentEvent], usageUpdate: UsageUpdate?) {
+    ) -> (events: [AgentEvent], usageUpdate: UsageUpdate?, configOptions: [SessionConfigOption]?) {
         do {
             let data = try JSONEncoder().encode(params)
             let envelope = try JSONDecoder().decode(SessionUpdateNotification.self, from: data)
             // Scope to our session (the shared notification stream is global).
-            guard envelope.sessionId.value == sessionId.value else { return ([], nil) }
+            guard envelope.sessionId.value == sessionId.value else { return ([], nil, nil) }
             let events = translator.translate(envelope.update)
             // Phase 4: extract the UsageUpdate for context/cost monitoring.
             let usageUpdate = envelope.update.usage
-            return (events, usageUpdate)
+            // #566: extract the refreshed config options from a
+            // `config_option_update`. The agent sends these after a
+            // `set_config_option` request succeeds (and sometimes unprompted
+            // when the model switches variants). The backend writes them back
+            // to the session record so the `thought_level` current value the
+            // toolbar displays stays in sync.
+            let configOptions = envelope.update.configOptions
+            return (events, usageUpdate, configOptions)
         } catch {
-            return ([.raw("ACP session/update decode error: \(error.localizedDescription)")], nil)
+            return ([.raw("ACP session/update decode error: \(error.localizedDescription)")], nil, nil)
         }
     }
 }
@@ -1350,6 +1500,11 @@ public struct SessionUsage: Sendable {
     /// The model id the session actually used (`ModelsInfo.currentModelId`),
     /// if reported. Point-in-time — latest non-nil wins on merge.
     public let modelId: String?
+    /// #566: the active thinking-effort level (`thought_level` config option's
+    /// current value, e.g. `"high"`/`"medium"`/`"low"`), if the agent advertises
+    /// one. Point-in-time — latest non-nil wins on merge. Surfaced in the
+    /// Activity window between the model id and the token counts.
+    public let thinkingLevel: String?
 
     public init(
         inputTokens: Int,
@@ -1362,7 +1517,8 @@ public struct SessionUsage: Sendable {
         contextUsed: Int,
         contextSize: Int,
         providerLabel: String? = nil,
-        modelId: String? = nil
+        modelId: String? = nil,
+        thinkingLevel: String? = nil
     ) {
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
@@ -1375,6 +1531,7 @@ public struct SessionUsage: Sendable {
         self.contextSize = contextSize
         self.providerLabel = providerLabel
         self.modelId = modelId
+        self.thinkingLevel = thinkingLevel
     }
 
     /// Merge two usage snapshots for run-total accumulation (#528 spike).
@@ -1400,7 +1557,8 @@ public struct SessionUsage: Sendable {
             contextUsed: new.contextUsed,
             contextSize: new.contextSize,
             providerLabel: new.providerLabel ?? existing.providerLabel,
-            modelId: new.modelId ?? existing.modelId)
+            modelId: new.modelId ?? existing.modelId,
+            thinkingLevel: new.thinkingLevel ?? existing.thinkingLevel)
     }
 }
 

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -351,6 +351,48 @@ public final class AgentLauncher {
         }
     }
 
+    /// #566: After a successful `backend.start`, mirror the agent-advertised
+    /// config options into `thinkingOption` so the chat toolbar can render a
+    /// "Thinking" dropdown. Non-blocking: runs as a detached `@MainActor` Task.
+    /// Sets `thinkingOption` to `nil` when the agent advertises no
+    /// `thought_level` select (capability detection → the toolbar hides the
+    /// affordance). Mirrors `captureAndCacheModels` / `captureProcessID`.
+    public func captureThinkingOption(session: SessionHandle) {
+        guard let acp = backend as? ACPBackend else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let options = await acp.sessionConfigOptions(for: session)
+            self.thinkingOption = ThinkingEffortOption.from(configOptions: options)
+        }
+    }
+
+    /// #566: Set the `thought_level` config option on the live ACP session.
+    /// Called by the chat toolbar's "Thinking" dropdown. No-op when no session
+    /// is live or the backend isn't ACP. Errors are logged (not surfaced) —
+    /// the dropdown optimistically flips and a `config_option_update` confirms
+    /// or reverts; surfacing a modal on every error is heavier than warranted.
+    public func setThinkingEffort(_ value: String) {
+        guard let acp = backend as? ACPBackend,
+              let handle = sessionHandle,
+              let option = thinkingOption else { return }
+        DebugLog.agent("setThinkingEffort: value=\(value) configId=\(option.configId)")
+        // Optimistic local flip — the backend also patches its snapshot, but
+        // updating here keeps the dropdown snappy before the actor hop returns.
+        thinkingOption = option.withCurrentValue(value)
+        Task { @MainActor [weak self] in
+            do {
+                try await acp.setConfigOption(
+                    sessionHandle: handle,
+                    configId: option.configId,
+                    value: value)
+            } catch {
+                DebugLog.agent("setThinkingEffort: failed value=\(value) \(error.localizedDescription)")
+                // Revert the optimistic flip on failure.
+                self?.thinkingOption = option
+            }
+        }
+    }
+
     /// The currently-pending write-permission requests surfaced from the backend
     /// (always-ask mode). When non-empty AND this surface is the live chat, the
     /// UI renders an inline Approve/Reject affordance (slice 2). Mirrors how
@@ -358,6 +400,14 @@ public final class AgentLauncher {
     /// state → `ChatView`. Refreshed by `pendingPollTask` while a turn generates.
     /// Empty for the CLI backend (no permission channel) and while idle.
     public var pendingPermissions: [PendingPermission] = []
+
+    /// #566: the live thinking-effort config option for the current ACP
+    /// session, mirrored from `ACPBackend.sessionConfigOptions(for:)`. The
+    /// chat toolbar's "Thinking" dropdown binds to this — it's `nil` when no
+    /// session is live OR the agent doesn't advertise a `thought_level`
+    /// option (capability detection: only show UI when present). Refreshed
+    /// after `backend.start` and (future) on `config_option_update`.
+    public var thinkingOption: ThinkingEffortOption?
 
     /// Backstop poller that refreshes `pendingPermissions` from the backend while
     /// a turn is generating (always-ask blocks the turn until resolved, so no
@@ -1955,6 +2005,10 @@ public final class AgentLauncher {
             // turn.
             captureAndCacheModels(provider: provider, session: session)
             captureProcessID(session: session)
+            // #566: mirror the agent-advertised config options (e.g. the
+            // `thought_level` select) so the chat toolbar can render a
+            // "Thinking" dropdown. No-op for agents that advertise none.
+            captureThinkingOption(session: session)
             DebugLog.agent("startInteractiveQuery: spawned")
             // Start the first turn — this acquires the generation gate for turn 1.
             // Compose the full task prompt (chat.md, write rules, citation rules,
@@ -2457,6 +2511,7 @@ public final class AgentLauncher {
         sessionHandle = nil
         plannerSessionHandle = nil
         runTotalUsage = nil
+        thinkingOption = nil
         onUnlockHandler = nil
         // A reset starts a new run: a stale sink must never receive a new
         // session's events (issue #119).

--- a/Sources/WikiFSEngine/ThinkingEffortOption.swift
+++ b/Sources/WikiFSEngine/ThinkingEffortOption.swift
@@ -1,0 +1,98 @@
+import ACPModel
+import Foundation
+
+/// #566: A UI-facing projection of the agent's `thought_level` config option.
+///
+/// The raw ACP type (`SessionConfigOption`) is SDK-shaped and carries booleans,
+/// grouped selects, `_meta`, etc. — more than the toolbar needs. This struct
+/// narrows it to exactly what the "Thinking" dropdown binds to:
+///
+/// - `configId` (the option id, usually `"thought_level"`) — needed to call
+///   `session/set_config_option`.
+/// - `currentValue` (the active level, e.g. `"high"`) — the dropdown's checkmark.
+/// - `choices` (the selectable values + their display names) — the menu items.
+///
+/// Built via `from(configOptions:)`, which scans the advertised options for a
+/// `select` whose `id.value == "thought_level"` (or whose `category == "thought_level"`
+/// — the polytoken-acp daemon uses the latter). Returns `nil` when the agent
+/// advertises no such option, so the calling UI hides the affordance (capability
+/// detection is agent-dependent: Claude, GLM, etc. advertise it; older agents
+/// don't).
+public struct ThinkingEffortOption: Equatable, Sendable {
+    /// The config option id the toolbar passes back to `setConfigOption`
+    /// (usually `"thought_level"`).
+    public let configId: String
+    /// The currently-selected level value id (e.g. `"high"`, `"medium"`, `"low"`).
+    public var currentValue: String
+    /// The selectable levels, in the order the agent advertised them. Each
+    /// carries the value id (sent on selection) and a display name.
+    public let choices: [Choice]
+
+    public struct Choice: Equatable, Sendable, Identifiable {
+        /// The value id to send to `setConfigOption` when this choice is picked.
+        public let value: String
+        /// A human-readable label for the menu item.
+        public let label: String
+        public var id: String { value }
+
+        public init(value: String, label: String) {
+            self.value = value
+            self.label = label
+        }
+    }
+
+    public init(configId: String, currentValue: String, choices: [Choice]) {
+        self.configId = configId
+        self.currentValue = currentValue
+        self.choices = choices
+    }
+
+    /// Returns a copy with `currentValue` replaced. Used for the optimistic
+    /// local flip in `AgentLauncher.setThinkingEffort` so the dropdown updates
+    /// before the `setConfigOption` round-trip completes.
+    public func withCurrentValue(_ value: String) -> ThinkingEffortOption {
+        ThinkingEffortOption(configId: configId, currentValue: value, choices: choices)
+    }
+
+    /// Scan an agent's advertised `configOptions` for the `thought_level`
+    /// select and project it. Returns `nil` when the agent advertises no such
+    /// option (capability detection → the toolbar hides the dropdown).
+    ///
+    /// Matches by `id.value == "thought_level"` OR `category == "thought_level"`
+    /// — the daemon and the spec use different conventions, so we accept both.
+    /// Only `.select` kinds are surfaced (a `thought_level` boolean doesn't
+    /// make sense; if an agent advertises one, we ignore it).
+    public static func from(configOptions: [SessionConfigOption]) -> ThinkingEffortOption? {
+        guard let option = configOptions.first(where: { isThoughtLevel($0) }),
+              case .select(let select) = option.kind else {
+            return nil
+        }
+        let choices = flatChoices(from: select.options)
+        guard !choices.isEmpty else { return nil }
+        return ThinkingEffortOption(
+            configId: option.id.value,
+            currentValue: select.currentValue.value,
+            choices: choices)
+    }
+
+    /// Match heuristic: `thought_level` by id or by category.
+    private static func isThoughtLevel(_ option: SessionConfigOption) -> Bool {
+        option.id.value == "thought_level" || option.category == "thought_level"
+    }
+
+    /// Flatten the SDK's `ungrouped`/`grouped` select options into a single
+    /// `[Choice]` list. Grouped options preserve the agent's ordering within
+    /// each group but drop the group headings (the toolbar is a flat Menu).
+    private static func flatChoices(
+        from options: SessionConfigSelectOptions
+    ) -> [Choice] {
+        switch options {
+        case .ungrouped(let opts):
+            return opts.map { Choice(value: $0.value.value, label: $0.name) }
+        case .grouped(let groups):
+            return groups.flatMap { group in
+                group.options.map { Choice(value: $0.value.value, label: $0.name) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces the agent's thinking-effort level (high/medium/low) in the UI and lets the user change it mid-session, per #566.

ACP Phase 4 (#544) already captures `thoughtTokens` and streams thinking deltas — both displayed. But the **effort level** the agent uses wasn't surfaced, and the user couldn't change it. ACP exposes it as a config option (`category: "thought_level"`); this PR captures, surfaces, and switches it.

## What changed

### Backend (`ACPBackend.swift`)
- **Capture configOptions**: added `configOptions` field to `ACPSession`; captured in `createSession()`, `registerResumedSession()` (resume + load paths), and `forkSession()` (fork inherits the parent's options).
- **Handle `.configOptionUpdate`**: `translateNotification` now extracts the refreshed config options (alongside the existing `UsageUpdate` extraction); the per-turn drain loop writes them back to the session record via `updateConfigOptions(for:options:)` so the `thought_level` current value stays in sync after a switch.
- **New accessors**: `sessionConfigOptions(for:)` (read) and `setConfigOption(sessionHandle:configId:value:)` (wraps `client.setConfigOption`); the latter optimistically patches the local snapshot so the toolbar flips immediately.
- **`SessionUsage.thinkingLevel`**: new point-in-time field (latest-wins on merge), populated from the `thought_level` option's current value in `sessionUsage(for:)`.

### Launcher (`AgentLauncher.swift`)
- New `@Observable thinkingOption: ThinkingEffortOption?` — binds the toolbar; `nil` hides the dropdown (capability detection).
- `captureThinkingOption(session:)` mirrors `captureAndCacheModels`, called after `startInteractiveQuery` spawn; cleared in `resetRunArtifacts`.
- `setThinkingEffort(_:)` optimistically flips the option, calls the backend, and reverts on error (the `config_option_update` confirms or corrects).

### UI
- **`ThinkingEffortOption`** (`Sources/WikiFSEngine/`): a UI-facing projection of the SDK's `SessionConfigOption` select — just `configId`, `currentValue`, and `choices`. Capability-gated via `from(configOptions:)`, matching by `id.value == "thought_level"` **or** `category == "thought_level"` (the daemon and the spec use different conventions).
- **`ThinkingEffortSelector`** (`Sources/WikiFS/Chats/`): a native `Menu` chip in the chat toolbar (brain glyph + current level + chevron), styled to sit beside `ProviderSelector`. A native `Menu` (not the ProviderSelector search-popover) because the level list is short (2-4 fixed entries). Renders nothing when the agent advertises no `thought_level`.
- **`QueueActivityTracker.fullSummary`**: renders the level between the model and the token counts, matching the issue's example:
  `Sonnet 4 · high · 797 tokens in · 203 tokens out · 412 thought · $0.34`

## Capability detection

Not all agents advertise `thought_level`. The dropdown only appears when `configOptions` contains an option with `id.value == "thought_level"` or `category == "thought_level"` (and it's a `.select`). Older agents or those that don't switch model variants on effort → no dropdown, zero behavior change.

## Validation

- `make version prompts` OK
- `swift build` OK (one initial error: `await` on a non-async actor method — fixed by marking `updateConfigOptions` `async`)
- Fast test tier (`swift test --skip '...'`) OK — 2498 tests passed in 213 suites (31.8s)

## Files

| File | Change |
| --- | --- |
| `Sources/WikiFSEngine/ACPBackend.swift` | Capture configOptions; handle configOptionUpdate; add accessors; `thinkingLevel` on SessionUsage |
| `Sources/WikiFSEngine/AgentLauncher.swift` | `thinkingOption` state; capture/set wrapper methods |
| `Sources/WikiFSEngine/ThinkingEffortOption.swift` | **New** — UI-facing projection of the SDK select |
| `Sources/WikiFS/Chats/ThinkingEffortSelector.swift` | **New** — native Menu chip for the chat toolbar |
| `Sources/WikiFS/Chats/ChatView.swift` | Wire the selector into the composer toolbar |
| `Sources/WikiFS/Queue/QueueActivityTracker.swift` | Render the level in `fullSummary` |

Closes #566.
