### PR TITLE
Add "Go to Original" bookmark context-menu action (#192)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,44 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-18 — Issue #192: "Go to Original" bookmark context-menu action (branch `bookmark-go-to-original`)
+
+**Problem:** Right-clicking a bookmark offered only Open / Open in Background /
+Open With / Edit / Delete. To reach the page/source itself the user had to
+double-click → open the bookmark detail → click "Show in List" — two clicks plus
+a view switch.
+
+**Fix:** Added a single-selection "Go to Original" item at the top of the
+bookmarks context menu. It reveals the bookmark's target in its sidebar section
+(Pages / Sources / Chats) without opening a reader tab, reusing the existing
+"Show in List" reveal mechanism (`WikiStoreModel.requestSidebarReveal(_:)`)
+that `PageDetailView` / `SourceDetailView` / `ChatView` already use — it
+switches the sidebar tab, clears any search hiding the target, and scrolls to +
+selects the row.
+
+Wiring: an `onGoToOriginal: (WikiSelection) -> Void` callback was threaded
+through `BookmarksCallbacks` and `BookmarksOutlineView` (both `.init` sites in
+the representable) and connected in `BookmarksContainerView` to
+`store.requestSidebarReveal(selection)`. The VC's `goToOriginalAction` resolves
+the clicked node's target to a `WikiSelection` via a shared
+`revealSelection(for:)` helper (also used to DRY up `openableSelections`).
+Gated single-selection + openable leaf only (pageRef / sourceRef / chatRef);
+hidden for folders and multi-selection batches.
+
+Changes:
+- `Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift` — new menu item + action,
+  `revealSelection(for:)` helper; `BookmarksCallbacks` and `BookmarksOutlineView`
+  gain `onGoToOriginal`; `openableSelections` refactored to reuse
+  `revealSelection`.
+- `Sources/WikiFS/Bookmarks/BookmarksContainerView.swift` — wire
+  `onGoToOriginal` → `store.requestSidebarReveal(selection)`.
+- `Tests/WikiFSTests/BookmarksMultiSelectMenuTests.swift` — updated the 3
+  `BookmarksCallbacks(...)` call sites for the new field; added 5 tests
+  (visibility for leaf/folder/batch + page/chat target reveal mapping).
+
+**Build/Tests:** `make version prompts && swift build` clean; fast test tier
+2,503 tests in 213 suites pass.
+
 ## 2026-07-17 — Fli## 2026-07-18 — Tantivy Phase 0 build spike (branch `spike/tantivy-build-verification`)
 
 **What changed:** Added `botisan-ai/tantivy.swift` (`from: "0.3.4"`) as an SPM
@@ -32,7 +70,7 @@ with macro-synthesized `CodingKeys`. No `SnippetGenerator` exposed (confirms
 design doc §4.3 fallback: client-side highlighting for Phase 1).
 
 **Not done here:** Tantivy is NOT wired into the search pipeline. No production
-code in `Sources/WikiFSSearch/` imports it yet — only the smoke test does.
+code in `Sources/WikiFSCore/` imports it yet — only the smoke test does.
 Phase 1 implements `TantivySearchService` + `TantivyIndexer` +
 `WikiSearchDocument` + event bus subscription.
 

--- a/Sources/WikiFS/Bookmarks/BookmarksContainerView.swift
+++ b/Sources/WikiFS/Bookmarks/BookmarksContainerView.swift
@@ -41,6 +41,9 @@ struct BookmarksContainerView: View {
                 onOpenBackground: { selections in
                     for sel in selections { store.openTabInBackground(sel) }
                 },
+                onGoToOriginal: { selection in
+                    store.requestSidebarReveal(selection)
+                },
                 onEdit: { onEdit($0) },
                 onDelete: { ids in
                     for id in ids { store.deleteBookmarkNode(id: id) }

--- a/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
@@ -24,6 +24,7 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
     let fileProvider: FileProviderFacade
     var onOpen: ([WikiSelection]) -> Void
     var onOpenBackground: ([WikiSelection]) -> Void
+    var onGoToOriginal: (WikiSelection) -> Void
     var onEdit: (String) -> Void
     var onDelete: ([String]) -> Void
     var onAddPage: (String?) -> Void
@@ -37,6 +38,7 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
         vc.fileProvider = fileProvider
         vc.callbacks = .init(
             onOpen: onOpen, onOpenBackground: onOpenBackground,
+            onGoToOriginal: onGoToOriginal,
             onEdit: onEdit, onDelete: onDelete,
             onAddPage: onAddPage, onAddSource: onAddSource,
             onNewFolder: onNewFolder, onNewSubfolder: onNewSubfolder
@@ -51,6 +53,7 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
         vc.fileProvider = fileProvider
         vc.callbacks = .init(
             onOpen: onOpen, onOpenBackground: onOpenBackground,
+            onGoToOriginal: onGoToOriginal,
             onEdit: onEdit, onDelete: onDelete,
             onAddPage: onAddPage, onAddSource: onAddSource,
             onNewFolder: onNewFolder, onNewSubfolder: onNewSubfolder
@@ -69,6 +72,7 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
 struct BookmarksCallbacks {
     var onOpen: ([WikiSelection]) -> Void
     var onOpenBackground: ([WikiSelection]) -> Void
+    var onGoToOriginal: (WikiSelection) -> Void
     var onEdit: (String) -> Void
     var onDelete: ([String]) -> Void
     var onAddPage: (String?) -> Void
@@ -660,6 +664,20 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
 
         let menu = NSMenu()
 
+        // "Go to Original" — reveal the bookmark's target in its sidebar
+        // section (Pages/Sources/Chats) without opening a reader tab. Uses the
+        // same "Show in List" mechanism (requestSidebarReveal) as the
+        // detail-view buttons. Single selection only, openable leaves only
+        // (pageRef / sourceRef / chatRef) — folders have no target, and batches
+        // are ambiguous about which item to reveal.
+        if !isBatch, !openableNodes.isEmpty {
+            menu.addItem(menuItem("Go to Original",
+                                  systemImage: "arrow.turn.up.right",
+                                  action: #selector(goToOriginalAction(_:)),
+                                  payload: payload))
+            menu.addItem(.separator())
+        }
+
         // Open / Open in Background — only when there are openable leaves.
         if !openableNodes.isEmpty {
             menu.addItem(menuItem(
@@ -751,15 +769,27 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
 
     /// Filters effective nodes to openable leaves and maps them to `WikiSelection`.
     private func openableSelections(from nodes: [BookmarkNode]) -> [WikiSelection] {
-        nodes.compactMap { node -> WikiSelection? in
-            guard let targetID = node.targetID else { return nil }
-            switch node.kind {
-            case .pageRef: return .page(targetID)
-            case .sourceRef: return .source(targetID)
-            case .chatRef: return .chat(targetID)
-            case .folder: return nil
-            }
+        nodes.compactMap { revealSelection(for: $0) }
+    }
+
+    /// Maps a single bookmark node to the `WikiSelection` its target represents.
+    /// Returns `nil` for folders or nodes missing a target id. Shared by "Open"
+    /// and "Go to Original" so the kind→selection mapping lives in one place.
+    private func revealSelection(for node: BookmarkNode) -> WikiSelection? {
+        guard let targetID = node.targetID else { return nil }
+        switch node.kind {
+        case .pageRef:   return .page(targetID)
+        case .sourceRef: return .source(targetID)
+        case .chatRef:   return .chat(targetID)
+        case .folder:    return nil
         }
+    }
+
+    @objc private func goToOriginalAction(_ sender: NSMenuItem) {
+        guard let payload = sender.representedObject as? BookmarksMenuPayload,
+              let sel = revealSelection(for: payload.clicked) else { return }
+        DebugLog.tabs("Bookmarks goToOriginal: kind=\(payload.clicked.kind) targetID=\(payload.clicked.targetID?.rawValue ?? "nil")")
+        callbacks?.onGoToOriginal(sel)
     }
 
     @objc private func openWithAppAction(_ sender: NSMenuItem) {

--- a/Tests/WikiFSTests/BookmarksMultiSelectMenuTests.swift
+++ b/Tests/WikiFSTests/BookmarksMultiSelectMenuTests.swift
@@ -25,6 +25,7 @@ struct BookmarksMultiSelectMenuTests {
         vc.fileProvider = nil
         vc.callbacks = BookmarksCallbacks(
             onOpen: { _ in }, onOpenBackground: { _ in },
+            onGoToOriginal: { _ in },
             onEdit: { _ in }, onDelete: { _ in },
             onAddPage: { _ in }, onAddSource: { _ in },
             onNewFolder: {}, onNewSubfolder: { _ in }
@@ -194,6 +195,7 @@ struct BookmarksMultiSelectMenuTests {
         var deletedIDs: [String] = []
         vc.callbacks = BookmarksCallbacks(
             onOpen: { _ in }, onOpenBackground: { _ in },
+            onGoToOriginal: { _ in },
             onEdit: { _ in },
             onDelete: { ids in deletedIDs = ids },
             onAddPage: { _ in }, onAddSource: { _ in },
@@ -222,6 +224,7 @@ struct BookmarksMultiSelectMenuTests {
         vc.callbacks = BookmarksCallbacks(
             onOpen: { sels in openedSelections = sels },
             onOpenBackground: { _ in },
+            onGoToOriginal: { _ in },
             onEdit: { _ in }, onDelete: { _ in },
             onAddPage: { _ in }, onAddSource: { _ in },
             onNewFolder: {}, onNewSubfolder: { _ in }
@@ -241,5 +244,82 @@ struct BookmarksMultiSelectMenuTests {
             #expect(openedSelections.contains(.page(PageID(rawValue: "target"))))
             #expect(openedSelections.contains(.source(PageID(rawValue: "target"))))
         }
+    }
+
+    // MARK: - "Go to Original" action
+
+    @Test func goToOriginalShownForSingleLeaf() {
+        let nodes = [leaf("n1")]
+        let vc = makeVC(nodes: nodes)
+        let titles = menuTitles(vc, clicked: nodes[0])
+
+        #expect(titles.contains("Go to Original"))
+    }
+
+    @Test func goToOriginalHiddenForFolder() {
+        let nodes = [folder("f1")]
+        let vc = makeVC(nodes: nodes)
+        let titles = menuTitles(vc, clicked: nodes[0])
+
+        #expect(!titles.contains("Go to Original"))
+    }
+
+    @Test func goToOriginalHiddenForBatch() {
+        let nodes = [leaf("n1"), leaf("n2")]
+        let vc = makeVC(nodes: nodes)
+        let outline = vc.outlineView!
+
+        outline.selectRowIndexes(IndexSet(integersIn: 0..<2), byExtendingSelection: false)
+
+        let titles = menuTitles(vc, clicked: nodes[0])
+
+        // Batches are ambiguous about which item to reveal.
+        #expect(!titles.contains("Go to Original"))
+    }
+
+    @Test func goToOriginalRevealsPageTarget() {
+        let nodes = [leaf("n1", kind: .pageRef, targetID: "page-1")]
+        let vc = makeVC(nodes: nodes)
+        let outline = vc.outlineView!
+
+        var revealed: WikiSelection?
+        vc.callbacks = BookmarksCallbacks(
+            onOpen: { _ in }, onOpenBackground: { _ in },
+            onGoToOriginal: { sel in revealed = sel },
+            onEdit: { _ in }, onDelete: { _ in },
+            onAddPage: { _ in }, onAddSource: { _ in },
+            onNewFolder: {}, onNewSubfolder: { _ in }
+        )
+
+        let buildMenu: (NSOutlineView, Any) -> NSMenu? = vc.outlineView(_:menuFor:)
+        let menu = buildMenu(outline, nodes[0])!
+        let item = menu.items.first { $0.title == "Go to Original" }!
+
+        _ = vc.perform(item.action, with: item)
+
+        #expect(revealed == .page(PageID(rawValue: "page-1")))
+    }
+
+    @Test func goToOriginalRevealsChatTarget() {
+        let nodes = [leaf("n1", kind: .chatRef, targetID: "chat-1")]
+        let vc = makeVC(nodes: nodes)
+        let outline = vc.outlineView!
+
+        var revealed: WikiSelection?
+        vc.callbacks = BookmarksCallbacks(
+            onOpen: { _ in }, onOpenBackground: { _ in },
+            onGoToOriginal: { sel in revealed = sel },
+            onEdit: { _ in }, onDelete: { _ in },
+            onAddPage: { _ in }, onAddSource: { _ in },
+            onNewFolder: {}, onNewSubfolder: { _ in }
+        )
+
+        let buildMenu: (NSOutlineView, Any) -> NSMenu? = vc.outlineView(_:menuFor:)
+        let menu = buildMenu(outline, nodes[0])!
+        let item = menu.items.first { $0.title == "Go to Original" }!
+
+        _ = vc.perform(item.action, with: item)
+
+        #expect(revealed == .chat(PageID(rawValue: "chat-1")))
     }
 }


### PR DESCRIPTION
## What

Closes #192. Adds a **"Go to Original"** context-menu action to bookmarks — right-click a bookmark → one click reveals its target (page/source/chat) in the sidebar, instead of opening the bookmark detail and then clicking "Show in List".

## Why

Before this change, reaching a bookmarked page/source from the Bookmarks sidebar took two clicks plus a view switch: double-click to open the bookmark detail, then click "Show in List" to reveal it in the Pages/Sources outline. The issue asks for a direct one-click "Go to Original" from the bookmark's own context menu.

## How

- **New menu item** at the top of the bookmarks context menu (`BookmarksOutlineView`): "Go to Original" with the `arrow.turn.up.right` SF Symbol. Single-selection only, openable leaves only (`pageRef` / `sourceRef` / `chatRef`); hidden for folders and multi-selection batches.
- **Navigation** reuses the existing "Show in List" reveal mechanism — `WikiStoreModel.requestSidebarReveal(_:)` — the same path `PageDetailView`, `SourceDetailView`, and `ChatView` already use. It opens the sidebar if collapsed, switches to the matching section (Pages / Sources / Chats), clears any active search hiding the target, then scrolls to and selects the row — **without opening a reader tab**.
- **Wiring:** a new `onGoToOriginal: (WikiSelection) -> Void` callback is threaded through `BookmarksCallbacks` and `BookmarksOutlineView` (both `.init` sites) and connected in `BookmarksContainerView` to `store.requestSidebarReveal(selection)`. The VC's `goToOriginalAction` resolves the clicked node's target to a `WikiSelection` via a new shared `revealSelection(for:)` helper (which also DRYs up `openableSelections`).

## Behavior by bookmark kind

| Kind | "Go to Original" | Result |
|------|------------------|--------|
| `pageRef` | shown | reveals the page in the Pages outline |
| `sourceRef` | shown | reveals the source in the Sources outline |
| `chatRef` | shown | reveals the chat in the Chats outline |
| `folder` | hidden | folders have no single target |
| multi-selection | hidden | ambiguous which item to reveal |

## Testing

`BookmarksMultiSelectMenuTests` — updated the 3 existing `BookmarksCallbacks(...)` construction call sites for the new `onGoToOriginal` field, and added 5 tests:

- `goToOriginalShownForSingleLeaf`
- `goToOriginalHiddenForFolder`
- `goToOriginalHiddenForBatch`
- `goToOriginalRevealsPageTarget` (pageRef → `.page(id)`)
- `goToOriginalRevealsChatTarget` (chatRef → `.chat(id)`)

## Verification

- `make version prompts && swift build` — clean.
- `swift test --filter BookmarksMultiSelectMenuTests` — 15/15 pass.
- Fast test tier (`swift test --skip '...'`) — 2,503 tests in 213 suites pass.

## Notes

- Gating follows the established `Open` items' convention (kind-only, single selection) rather than a stricter "target still exists" check, keeping behavior consistent with double-click / Open and testable without a live store. The underlying reveal no-ops gracefully for a stale (deleted-target) bookmark.
- Progress recorded in `PROGRESS.md`.
