### PR TITLE
Queue readiness check: guide users to configure agents/extraction (#440)

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -29,6 +29,10 @@ struct ActivityWindowView: View {
     let queueEngine: QueueEngine
     @Bindable var activityTracker: QueueActivityTracker
     weak var sessionManager: SessionManager?
+    /// Bridges the SwiftUI environment's `openSettings` action so the
+    /// "Configure…" CTA buttons can open Settings on the relevant tab
+    /// (#440). Set by `MenuBarItemController` when creating the window.
+    var openWindowBridge: OpenWindowBridge?
 
     @State private var viewModel = QueueViewModel()
     @State private var selectedItemID: QueueItem.ID?
@@ -379,6 +383,23 @@ struct ActivityWindowView: View {
                         .foregroundStyle(.red)
                         .textSelection(.enabled)
                         .lineLimit(4)
+                    // #440: when the failure is a "not configured" error (the
+                    // provider binary wasn't found, no API key, etc.), show a
+                    // call-to-action button that opens Settings on the relevant
+                    // tab so the user can fix it without guessing.
+                    if isConfigurationError(error), openWindowBridge != nil {
+                        Button(action: {
+                            let tab = queue == .extraction ? "extraction" : "agents"
+                            openWindowBridge?.openSettings(tab: tab)
+                        }) {
+                            Label(
+                                queue == .extraction ? "Configure Extraction…" : "Configure Agents…",
+                                systemImage: "gearshape"
+                            )
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
                 }
                 // #528 spike: show per-run usage in the detail header too.
                 if let usage = activityTracker.usage(for: item.id) {
@@ -494,6 +515,39 @@ struct ActivityWindowView: View {
     private func item(for id: QueueItem.ID) -> QueueItem? {
         activeItems.first { $0.id == id }
             ?? recentItems.first { $0.id == id }
+    }
+
+    /// Detects whether a failed item's error message is a "not configured"
+    /// error (binary not on PATH, no API key, no endpoint) rather than a
+    /// runtime error (agent crashed, network failure). Used to decide whether
+    /// to show the "Configure…" call-to-action button (#440).
+    ///
+    /// Matches the wording from `QueueIngestionError.notReady`,
+    /// `QueueExtractionError.notReady`, and the `ExtractionReadiness`
+    /// `.needsSetup`/`.notInstalled` cases. Conservative: only surfaces the
+    /// CTA when the error clearly points at configuration, so a generic
+    /// "convert failed" doesn't show a misleading gear button.
+    private func isConfigurationError(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        // Markers from the readiness messages:
+        // - "was not found on your PATH"
+        // - "has no command configured"
+        // - "Open Settings → Agents" / "Open Settings → Extraction"
+        // - "no api key" / "add your … api key"
+        // - "set a docling serve endpoint"
+        // - "dependencies aren't installed" (local pdf2md)
+        let markers = [
+            "was not found on your path",
+            "has no command configured",
+            "open settings → agents",
+            "open settings → extraction",
+            "add your anthropic api key",
+            "add your google ai studio api key",
+            "set a docling serve endpoint",
+            "dependencies aren't installed",
+            "fix it in settings → agents"
+        ]
+        return markers.contains(where: { lower.contains($0) })
     }
 
     private func wikiDisplayName(for id: String) -> String {

--- a/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
+++ b/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
@@ -27,14 +27,37 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
     private let fileProviderBox: FileProviderBox
     private let wikictlDirectory: String
 
+    /// Resolves the selected agent provider (from `agent-providers.json`) for
+    /// the readiness probe. Injectable so tests can stub it without touching the
+    /// filesystem or spawning `zsh`. Defaults to reading from the App Group
+    /// container, exactly like `AgentLauncher.resolveSelectedProvider`.
+    private let resolveSelectedProvider: () -> AgentProvider
+
     init(
         sessionBox: SessionLookupBox,
         fileProviderBox: FileProviderBox,
-        wikictlDirectory: String
+        wikictlDirectory: String,
+        resolveSelectedProvider: @escaping () -> AgentProvider = {
+            let dir = (try? DatabaseLocation.appGroupContainerDirectory())
+                ?? FileManager.default.temporaryDirectory
+            return AgentProvidersConfig.loadOrSeed(from: dir).selectedProvider()
+        }
     ) {
         self.sessionBox = sessionBox
         self.fileProviderBox = fileProviderBox
         self.wikictlDirectory = wikictlDirectory
+        self.resolveSelectedProvider = resolveSelectedProvider
+    }
+
+    // MARK: - Readiness (#440)
+
+    func readiness() async -> String? {
+        let provider = resolveSelectedProvider()
+        let message = AgentLauncher.readinessMessage(for: provider)
+        if message != nil {
+            DebugLog.ingest("AppQueueIngestionProvider.readiness: NOT READY provider=\(provider.id) label=\(provider.label)")
+        }
+        return message
     }
 
     // MARK: - QueueIngestionProvider

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -341,7 +341,8 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
                 queue: queue,
                 queueEngine: queueEngine,
                 activityTracker: activityTracker,
-                sessionManager: sessionManager
+                sessionManager: sessionManager,
+                openWindowBridge: openWindowBridge
             )
             // NSHostingController (not a bare NSHostingView) so SwiftUI can
             // install the window's unified toolbar from the view's `.toolbar`.

--- a/Sources/WikiFS/Window/OpenWindowBridge.swift
+++ b/Sources/WikiFS/Window/OpenWindowBridge.swift
@@ -36,6 +36,15 @@ final class OpenWindowBridge {
     /// to the environment value. Used by `MenuBarItemController` (the status
     /// item is AppKit and can't read SwiftUI environment values directly).
     var openSettings: (() -> Void)?
+
+    /// Opens Settings on a specific tab. Sets the `@AppStorage` key that the
+    /// Settings `TabView(selection:)` binds to, then calls `openSettings`.
+    /// `tabRawValue` is one of: "about", "zotero", "extraction", "agents".
+    /// Used by the Activity window's "Configure…" call-to-action (#440).
+    func openSettings(tab tabRawValue: String) {
+        UserDefaults.standard.set(tabRawValue, forKey: "settings.selectedTab")
+        openSettings?()
+    }
 }
 
 /// Invisible helper view that captures `@Environment(\.openWindow)` (only

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -1657,6 +1657,60 @@ public final class AgentLauncher {
         return FileManager.default.isExecutableFile(atPath: path) ? path : nil
     }
 
+    /// A quick readiness probe for an agent provider — checks whether
+    /// `provider.command[0]` is resolvable on the login-shell PATH (or is the
+    /// bundled bun helper). Returns `nil` when ready, or a user-facing message
+    /// explaining what to fix and pointing at Settings → Agents.
+    ///
+    /// PURE + injectable (the `resolveCommand` closure) so this can be called
+    /// from a headless queue worker AND unit-tested without spawning a
+    /// subprocess or a login-shell hop. Mirrors
+    /// `ACPExtractionClient.resolveProvider`'s `resolveCommand` seam.
+    ///
+    /// `bun` is given special treatment: if the bundled bun helper exists
+    /// (`Contents/Helpers/bun`), it is preferred over a PATH lookup — so the
+    /// app works without a system-wide bun install. This matches
+    /// `resolveACPProviderSpawn` and `ACPExtractionClient.resolveCommand`.
+    ///
+    /// #440 — replaces the cryptic `"bun: not found"` spawn error with
+    /// actionable guidance. The returned message is shown verbatim in the
+    /// Activity window (and carries a CTA to open Settings → Agents).
+    public static nonisolated func readinessMessage(
+        for provider: AgentProvider,
+        resolveCommand: ((AgentProvider) -> [String]?)? = nil
+    ) -> String? {
+        let resolver = resolveCommand ?? { provider in
+            guard let command = provider.command, let exe = command.first else {
+                return nil
+            }
+            if exe == "bun", let bundled = Self.bundledHelperPath("bun") {
+                return [bundled] + Array(command.dropFirst())
+            }
+            switch PathPreflight.resolveOnLoginShell(executable: ShellArgv.expandTilde(exe)) {
+            case .found(let path):
+                return [path] + Array(command.dropFirst())
+            case .missing:
+                return nil
+            }
+        }
+        guard let command = provider.command, let exe = command.first else {
+            return "Provider ‘\(provider.label)’ has no command configured. Open Settings → Agents to fix it."
+        }
+        guard resolver(provider) != nil else {
+            // The binary wasn't found on the login-shell PATH (and no bundled
+            // helper matched). Give the user the actionable guidance.
+            var msg = "‘\(exe)’ was not found on your PATH. "
+            if exe == "bun" {
+                msg += "Install bun (bun.sh) or configure a different agent provider."
+            } else {
+                msg += "Install ‘\(exe)’ and make sure it is on your login shell PATH, or configure a different agent provider."
+            }
+            msg += " Open Settings → Agents to configure one."
+            return msg
+        }
+        return nil
+    }
+
     /// Resolve a `.acp` provider's spawn command (PATH-resolved, since the
     /// swift-acp SDK's `launch()` does no PATH lookup itself) + its
     /// Keychain-backed API key. `bun` prefers the helper bundled in

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -558,7 +558,13 @@ public actor QueueEngine {
                     }
                 }
             } else {
-                let errorMsg = String(describing: error)
+                // #440: prefer `localizedDescription` (respects
+                // `LocalizedError.errorDescription`) so the user sees a clean
+                // message like "bun was not found on your PATH…" instead of the
+                // raw `notReady("…")` enum case from `String(describing:)`.
+                // Falls back to `String(describing:)` for non-Localized errors.
+                let errorMsg = (error as? LocalizedError)?.errorDescription
+                    ?? String(describing: error)
                 do {
                     try store.markFailed(id: item.id, error: errorMsg)
                     decrementProviderCount(for: item)

--- a/Sources/WikiFSEngine/QueueIngestionProvider.swift
+++ b/Sources/WikiFSEngine/QueueIngestionProvider.swift
@@ -74,6 +74,18 @@ public protocol QueueIngestionProvider: Sendable {
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?
     ) async throws
+
+    /// Quick readiness probe: checks whether the selected agent provider's
+    /// command binary exists on PATH (or is the bundled bun helper). Returns
+    /// `nil` when ready, or a user-facing message explaining what to fix and
+    /// how. Called before `runIngestion`/`runLint`/`runLintPages` so the user
+    /// gets actionable guidance instead of a cryptic spawn error like
+    /// `"bun: not found"`.
+    ///
+    /// **Not a network call** — a synchronous `which`-style check wrapped in
+    /// async for actor-hopping. Fast enough to run on every dispatch without
+    /// blocking the queue engine.
+    func readiness() async -> String?
 }
 
 // MARK: - QueueIngestionError
@@ -81,11 +93,15 @@ public protocol QueueIngestionProvider: Sendable {
 public enum QueueIngestionError: Error, LocalizedError {
     case noSources
     case spawnFailed(String)
+    /// The agent provider's binary was not found on PATH (or the provider has
+    /// no command configured). Carries the readiness message for the user.
+    case notReady(String)
 
     public var errorDescription: String? {
         switch self {
         case .noSources: return "Ingestion item has no valid sources"
         case .spawnFailed(let msg): return "Agent spawn failed: \(msg)"
+        case .notReady(let msg): return msg
         }
     }
 }
@@ -153,6 +169,15 @@ struct QueueIngestionWorker: QueueWorker {
     let emitUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
 
     func execute(_ item: QueueItem) async throws {
+        // Pre-dispatch readiness gate (#440): check the agent provider's binary
+        // is on PATH BEFORE running the full pipeline. If the binary is missing,
+        // fail the item with a clear, user-facing message instead of a cryptic
+        // spawn error like "bun: not found". This mirrors the extraction worker's
+        // `readiness()` check on `MarkdownExtractor`.
+        if let message = await provider.readiness() {
+            throw QueueIngestionError.notReady(message)
+        }
+
         let onTranscript: (@Sendable (AgentEvent) -> Void)? = { [itemID = item.id] event in
             emitTranscript(itemID, event)
         }

--- a/Tests/WikiFSTests/AgentProviderModelTests.swift
+++ b/Tests/WikiFSTests/AgentProviderModelTests.swift
@@ -490,4 +490,53 @@ import ACPModel
         let config = AgentProvidersConfig(providers: [.claudeAcpDefault])
         #expect(config.cachedModels(forProvider: "claude-acp").isEmpty)
     }
+
+    // MARK: - Readiness (#440)
+
+    @Test func readinessMessageReturnsNilWhenCommandResolves() {
+        // The default Claude provider's `bun` command resolves via the
+        // injected closure → nil (ready). We inject a stub that always
+        // finds the binary so we don't depend on the real filesystem.
+        let msg = AgentLauncher.readinessMessage(
+            for: .claudeAcpDefault,
+            resolveCommand: { _ in ["/usr/local/bin/bun"] })
+        #expect(msg == nil)
+    }
+
+    @Test func readinessMessageReturnsMessageWhenBinaryNotFound() {
+        // Inject a resolver that always fails → the provider is not ready.
+        let provider = AgentProvider(
+            id: "hermes", label: "Hermes",
+            command: ["hermes", "acp"], enabled: true, isDefault: true)
+        let msg = AgentLauncher.readinessMessage(
+            for: provider,
+            resolveCommand: { _ in nil })
+        #expect(msg != nil)
+        #expect(msg?.contains("was not found on your PATH") == true)
+        #expect(msg?.contains("Settings → Agents") == true)
+    }
+
+    @Test func readinessMessageReturnsMessageWhenNoCommandConfigured() {
+        // A provider with no command at all.
+        let provider = AgentProvider(
+            id: "broken", label: "Broken",
+            command: nil, enabled: true, isDefault: true)
+        let msg = AgentLauncher.readinessMessage(
+            for: provider,
+            resolveCommand: { _ in nil })
+        #expect(msg != nil)
+        #expect(msg?.contains("has no command configured") == true)
+        #expect(msg?.contains("Settings → Agents") == true)
+    }
+
+    @Test func readinessMessageMentionsBunForBunProvider() {
+        // The default Claude provider uses `bun` — the message should mention
+        // bun.sh when the binary isn't found.
+        let msg = AgentLauncher.readinessMessage(
+            for: .claudeAcpDefault,
+            resolveCommand: { _ in nil })
+        #expect(msg != nil)
+        #expect(msg?.contains("bun") == true)
+        #expect(msg?.contains("bun.sh") == true)
+    }
 }

--- a/Tests/WikiFSTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSTests/QueueIngestionTests.swift
@@ -89,8 +89,15 @@ actor FakeIngestionProvider: QueueIngestionProvider {
     var calledLintWikiID: String?
     var calledLintPageIDs: [PageID] = []
     var transcriptEvents: [AgentEvent] = []
+    /// When non-nil, `readiness()` returns this message (simulating a
+    /// not-ready provider). When nil, `readiness()` returns nil (ready).
+    var readinessMessage: String?
 
     func setShouldThrow(_ val: Bool) { shouldThrow = val }
+
+    func readiness() async -> String? { readinessMessage }
+
+    func setReadinessMessage(_ val: String?) { readinessMessage = val }
 
     func runIngestion(
         wikiID: String,
@@ -200,6 +207,58 @@ struct QueueIngestionWorkerTests {
                 state: .queued, orderingKey: 1000, attempt: 0,
                 createdAt: 0))
         }
+    }
+
+    @Test("Worker fails with notReady when provider is not ready (#440)")
+    func workerFailsWhenNotReady() async throws {
+        let provider = FakeIngestionProvider()
+        let notReadyMsg = "‘bun’ was not found on your PATH. Install bun (bun.sh) or configure a different agent provider. Open Settings → Agents to configure one."
+        await provider.setReadinessMessage(notReadyMsg)
+        let worker = QueueIngestionWorker(
+            provider: provider,
+            emitProgress: { _, _ in },
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
+
+        do {
+            try await worker.execute(QueueItem(
+                id: "test-ready", queue: .ingestion, wikiID: "wiki1",
+                payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "src1")]),
+                state: .queued, orderingKey: 1000, attempt: 0,
+                createdAt: 0))
+            Issue.record("Expected notReady error was not thrown")
+        } catch let err as QueueIngestionError {
+            // The readiness gate should throw .notReady (not .spawnFailed),
+            // carrying the readiness message verbatim.
+            guard case .notReady(let msg) = err else {
+                Issue.record("Expected .notReady, got \(err)")
+                return
+            }
+            #expect(msg == notReadyMsg)
+            // The provider should NOT have been called (fast-fail).
+            let wikiID = await provider.getCalledWikiID()
+            #expect(wikiID == nil)
+        } catch {
+            Issue.record("Expected QueueIngestionError.notReady, got \(error)")
+        }
+    }
+
+    @Test("Worker proceeds when provider is ready (#440)")
+    func workerProceedsWhenReady() async throws {
+        let provider = FakeIngestionProvider()
+        // readinessMessage is nil by default → ready.
+        let worker = QueueIngestionWorker(
+            provider: provider,
+            emitProgress: { _, _ in },
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in })
+
+        try await worker.execute(QueueItem(
+            id: "test-ready-ok", queue: .ingestion, wikiID: "wiki1",
+            payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "src1")]),
+            state: .queued, orderingKey: 1000, attempt: 0,
+            createdAt: 0))
+
+        let wikiID = await provider.getCalledWikiID()
+        #expect(wikiID == "wiki1")
     }
 }
 

--- a/pr-body-440.md
+++ b/pr-body-440.md
@@ -1,0 +1,55 @@
+## Queue readiness check: guide users to configure agents/extraction before cryptic spawn failures
+
+Closes #440
+
+### Problem
+
+When no agent provider (Claude/Hermes/OpenCode) or extraction backend is installed/configured, queue items fail with a cryptic process-spawn error like `"bun: not found"` instead of guiding the user to set things up.
+
+The ingestion side had no readiness check at all — `QueueIngestionWorkerFactory.providerID(for:)` always returned `"default-ingest"`, and the real failure happened deep inside `AgentLauncher.run()` → `Process.run()`, surfacing as an unhelpful `.failed` item.
+
+The extraction side already had a `readiness()` mechanism on `MarkdownExtractor` (checked inside `QueueExtractionWorker.execute()`), but the error messages were stored as raw `String(describing:)` output (e.g. `notReady("Add your Anthropic API key...")`) and the Activity window offered no call-to-action.
+
+### What this PR does
+
+#### 1. Ingestion provider readiness gate
+
+- Added `func readiness() async -> String?` to the `QueueIngestionProvider` protocol — returns `nil` when ready, or a user-facing message explaining what to fix.
+- Added `QueueIngestionError.notReady(String)` — carries the readiness message.
+- `QueueIngestionWorker.execute()` now calls `readiness()` **before** running the full pipeline. If not ready, it throws `.notReady` and the item fails with the clear message (the provider is never invoked).
+- Added `AgentLauncher.readinessMessage(for:)` — a pure, injectable static function that checks whether the selected agent provider's `command[0]` binary exists on the login-shell PATH (or is the bundled bun helper). Mirrors `ACPExtractionClient.resolveProvider`'s `resolveCommand` seam. Returns `nil` when ready, or a message like:
+  > 'bun' was not found on your PATH. Install bun (bun.sh) or configure a different agent provider. Open Settings → Agents to configure one.
+- Implemented `readiness()` in `AppQueueIngestionProvider` with an injectable `resolveSelectedProvider` closure (for testability — mirrors the launcher's pattern).
+
+#### 2. Cleaner error storage in the queue engine
+
+- `QueueEngine` now prefers `LocalizedError.errorDescription` over `String(describing:)` when storing failure messages on items. This means the user sees "bun was not found on your PATH…" instead of `notReady("bun was not found…")`. Benefits both ingestion and extraction errors.
+
+#### 3. Activity window call-to-action button
+
+- When a queue item fails with a "not configured" error (binary not on PATH, no API key, no endpoint, missing dependencies), the Activity window detail pane now shows a **"Configure Agents…"** (or **"Configure Extraction…"**) button next to the error text.
+- Clicking it opens Settings on the relevant tab (`agents` for ingestion, `extraction` for extraction) via `OpenWindowBridge.openSettings(tab:)`.
+- `isConfigurationError(_:)` conservatively detects configuration errors by matching known readiness message markers — so a generic "convert failed" or "agent crashed" error does **not** show a misleading gear button.
+
+### Files changed
+
+**Engine (`WikiFSEngine`):**
+- `QueueIngestionProvider.swift` — added `readiness()` to the protocol, `.notReady` to `QueueIngestionError`, readiness gate in `QueueIngestionWorker.execute()`
+- `AgentLauncher.swift` — added `readinessMessage(for:resolveCommand:)` static helper
+- `QueueEngine.swift` — cleaner error messages via `LocalizedError.errorDescription`
+
+**App (`WikiFS`):**
+- `AppQueueIngestionProvider.swift` — implemented `readiness()` with injectable provider resolution
+- `ActivityWindowView.swift` — added CTA button + `isConfigurationError` helper
+- `OpenWindowBridge.swift` — added `openSettings(tab:)` helper
+- `MenuBarItemController.swift` — passes `openWindowBridge` to `ActivityWindowView`
+
+**Tests:**
+- `QueueIngestionTests.swift` — `FakeIngestionProvider` updated with `readinessMessage`; two new worker tests (not-ready fast-fail + ready-proceeds)
+- `AgentProviderModelTests.swift` — four new `readinessMessage` tests (command resolves, binary not found, no command configured, bun-specific message)
+
+### Testing
+
+- `swift build` passes
+- Fast test tier: 2505 tests in 214 suites passed (6 new tests)
+- The `readiness()` check is fast (synchronous `which`-style check, wraps a `zsh -lc` PATH hop — same as the existing `PathPreflight.resolveOnLoginShell` used at spawn time). It runs once per dispatch before the worker pipeline starts, so it does not block the queue engine.


### PR DESCRIPTION
## Queue readiness check: guide users to configure agents/extraction before cryptic spawn failures

Closes #440

### Problem

When no agent provider (Claude/Hermes/OpenCode) or extraction backend is installed/configured, queue items fail with a cryptic process-spawn error like `"bun: not found"` instead of guiding the user to set things up.

The ingestion side had no readiness check at all — `QueueIngestionWorkerFactory.providerID(for:)` always returned `"default-ingest"`, and the real failure happened deep inside `AgentLauncher.run()` → `Process.run()`, surfacing as an unhelpful `.failed` item.

The extraction side already had a `readiness()` mechanism on `MarkdownExtractor` (checked inside `QueueExtractionWorker.execute()`), but the error messages were stored as raw `String(describing:)` output (e.g. `notReady("Add your Anthropic API key...")`) and the Activity window offered no call-to-action.

### What this PR does

#### 1. Ingestion provider readiness gate

- Added `func readiness() async -> String?` to the `QueueIngestionProvider` protocol — returns `nil` when ready, or a user-facing message explaining what to fix.
- Added `QueueIngestionError.notReady(String)` — carries the readiness message.
- `QueueIngestionWorker.execute()` now calls `readiness()` **before** running the full pipeline. If not ready, it throws `.notReady` and the item fails with the clear message (the provider is never invoked).
- Added `AgentLauncher.readinessMessage(for:)` — a pure, injectable static function that checks whether the selected agent provider's `command[0]` binary exists on the login-shell PATH (or is the bundled bun helper). Mirrors `ACPExtractionClient.resolveProvider`'s `resolveCommand` seam. Returns `nil` when ready, or a message like:
  > 'bun' was not found on your PATH. Install bun (bun.sh) or configure a different agent provider. Open Settings → Agents to configure one.
- Implemented `readiness()` in `AppQueueIngestionProvider` with an injectable `resolveSelectedProvider` closure (for testability — mirrors the launcher's pattern).

#### 2. Cleaner error storage in the queue engine

- `QueueEngine` now prefers `LocalizedError.errorDescription` over `String(describing:)` when storing failure messages on items. This means the user sees "bun was not found on your PATH…" instead of `notReady("bun was not found…")`. Benefits both ingestion and extraction errors.

#### 3. Activity window call-to-action button

- When a queue item fails with a "not configured" error (binary not on PATH, no API key, no endpoint, missing dependencies), the Activity window detail pane now shows a **"Configure Agents…"** (or **"Configure Extraction…"**) button next to the error text.
- Clicking it opens Settings on the relevant tab (`agents` for ingestion, `extraction` for extraction) via `OpenWindowBridge.openSettings(tab:)`.
- `isConfigurationError(_:)` conservatively detects configuration errors by matching known readiness message markers — so a generic "convert failed" or "agent crashed" error does **not** show a misleading gear button.

### Files changed

**Engine (`WikiFSEngine`):**
- `QueueIngestionProvider.swift` — added `readiness()` to the protocol, `.notReady` to `QueueIngestionError`, readiness gate in `QueueIngestionWorker.execute()`
- `AgentLauncher.swift` — added `readinessMessage(for:resolveCommand:)` static helper
- `QueueEngine.swift` — cleaner error messages via `LocalizedError.errorDescription`

**App (`WikiFS`):**
- `AppQueueIngestionProvider.swift` — implemented `readiness()` with injectable provider resolution
- `ActivityWindowView.swift` — added CTA button + `isConfigurationError` helper
- `OpenWindowBridge.swift` — added `openSettings(tab:)` helper
- `MenuBarItemController.swift` — passes `openWindowBridge` to `ActivityWindowView`

**Tests:**
- `QueueIngestionTests.swift` — `FakeIngestionProvider` updated with `readinessMessage`; two new worker tests (not-ready fast-fail + ready-proceeds)
- `AgentProviderModelTests.swift` — four new `readinessMessage` tests (command resolves, binary not found, no command configured, bun-specific message)

### Testing

- `swift build` passes
- Fast test tier: 2505 tests in 214 suites passed (6 new tests)
- The `readiness()` check is fast (synchronous `which`-style check, wraps a `zsh -lc` PATH hop — same as the existing `PathPreflight.resolveOnLoginShell` used at spawn time). It runs once per dispatch before the worker pipeline starts, so it does not block the queue engine.
