### PR TITLE
fix(quit-dialog): name lint operation correctly on quit confirmation

### DIFF
--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -325,7 +325,16 @@ struct WikiFSApp: App {
             if activityTracker?.isExtracting == true {
                 return "A PDF extraction"
             }
-            if activityTracker?.isIngesting == true {
+            // A lint runs through the `.ingestion` queue kind with empty
+            // `sourceIDs` and a non-nil `lintPageIDs`, so `isIngesting` is
+            // true for both ingestion and lint. Distinguish a lint-only run
+            // via the tracker's source/lint ID sets so the quit dialog names
+            // the operation actually in flight (not always "ingestion").
+            if let tracker = activityTracker, tracker.isIngesting {
+                if !tracker.lintingItemIDs.isEmpty
+                    && tracker.ingestingSourceIDs.isEmpty {
+                    return "A lint"
+                }
                 return "A source ingestion"
             }
             if let sm = sessionManager {


### PR DESCRIPTION
## Summary

Fixes the quit-confirmation dialog showing the wrong operation type. When the user hit ⌘Q (or any quit path) during a **lint** operation, the dialog said *"A source ingestion is still running"* — it now correctly says *"A lint is still running."*

## Root cause

The quit-confirmation message is generated by the `activeOperationDescription` closure in `WikiFSApp.swift`. That closure checked `activityTracker?.isIngesting`, which returns `true` for **both** ingestion and lint runs:

```swift
// QueueActivityTracker.swift
var isIngesting: Bool { !ingestingSourceIDs.isEmpty || !lintingItemIDs.isEmpty }
```

A lint is an `.ingestion` queue item with empty `sourceIDs` and a non-nil `lintPageIDs`, so it lands in `lintingItemIDs` — tripping `isIngesting` and surfacing the hardcoded *"A source ingestion"* noun.

## Fix

In the `activeOperationDescription` closure, when `isIngesting` is true, distinguish a **lint-only** run (non-empty `lintingItemIDs` and empty `ingestingSourceIDs`) from a real ingestion:

- lint-only → `A lint`
- otherwise → `A source ingestion` (pure ingest, or both ingest + lint running together)

The dialog renders this as e.g. `"A lint is still running and will be cancelled. Are you sure you want to quit?"`, matching the existing noun style ("A PDF extraction", "A chat session", …).

## Why the queue-engine state (not `AgentLauncher.runningKind`)

The lint runs through the queue engine, which the `QueueActivityTracker` observes authoritatively. The tracker already exposes `lintingItemIDs` and `ingestingSourceIDs` as readable `private(set)` collections, so deriving the noun from those sets is the most accurate, lowest-risk fix. The launcher-based branch (`"An agent operation"` / `"A chat session"`) is unchanged since lints are caught by the `isIngesting` branch first.

## Verification

- `make version prompts` → regenerated gitignored artifacts.
- `swift build` → Build complete.
- Fast test tier → 2537 tests passed, 0 failures.

```
swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
```

## Files changed

- `Sources/WikiFS/Window/WikiFSApp.swift` — `activeOperationDescription` closure now distinguishes lint-only from ingestion.

Do not merge — leaving for reviewer.
