### PR TITLE
Tantivy Phase 1: shadow index

### DIFF
--- a/Sources/WikiFSCore/Store/StoreBackedTantivyContentSource.swift
+++ b/Sources/WikiFSCore/Store/StoreBackedTantivyContentSource.swift
@@ -1,0 +1,261 @@
+import Foundation
+import WikiFSTypes
+import WikiFSSearch
+
+// MARK: - StoreBackedTantivyContentSource
+
+/// `TantivyContentSource` backed by `WikiStore`. Lives in `WikiFSCore` (where
+/// the store + event bus live); produces `TantivyContentSnapshot`s that the
+/// `TantivyIndexer` (in `WikiFSSearch`) converts into Tantivy documents.
+///
+/// **Reads are synchronous throws** (the store is a non-actor
+/// `@unchecked Sendable` class guarded by its own recursive lock), surfaced as
+/// `async` to satisfy the protocol. Per the SQLite concurrency discipline,
+/// these reads happen on the indexer actor's executor, off the main actor —
+/// the lock serializes them and no statement handle crosses a boundary.
+///
+/// **Phase 1 shadow index** (plans/tantivy-search-sidecar.md §2.3): the index
+/// reflects only the *active* state — pages' current `bodyMarkdown`, sources'
+/// processed-markdown HEAD, chats' concatenated message plain text.
+final public class StoreBackedTantivyContentSource: TantivyContentSource {
+    private let store: WikiStore
+
+    public init(store: WikiStore) {
+        self.store = store
+    }
+
+    // MARK: - TantivyContentSource
+
+    public func snapshot(ulid: String, kind: TantivyDocumentKind) async throws -> TantivyContentSnapshot? {
+        let id = PageID(rawValue: ulid)
+        do {
+            switch kind {
+            case .page:
+                let page = try store.getPage(id: id)
+                return TantivyContentSnapshot(
+                    ulid: ulid,
+                    kind: .page,
+                    title: page.title,
+                    body: page.bodyMarkdown,
+                    updatedAt: page.updatedAt,
+                    versionSum: UInt64(max(0, page.version))
+                )
+            case .source:
+                // `listSources` is the cheap lookup; processedMarkdownHead
+                // gives the active HEAD body (§2.3 — only active version is
+                // indexed). A missing HEAD (no extracted markdown yet) is NOT
+                // a delete — index the source with an empty body so its title
+                // is searchable; the version will re-index when markdown lands.
+                let sources = try store.listSources()
+                guard let source = sources.first(where: { $0.id == id }) else { return nil }
+                let body: String
+                if let head = try store.processedMarkdownHead(sourceID: id) {
+                    body = head.content
+                } else {
+                    body = ""
+                }
+                return TantivyContentSnapshot(
+                    ulid: ulid,
+                    kind: .source,
+                    title: source.effectiveName,
+                    body: body,
+                    updatedAt: source.updatedAt,
+                    versionSum: UInt64(max(0, source.version))
+                )
+            case .chat:
+                let chats = try store.listChats()
+                guard let chat = chats.first(where: { $0.id == id }) else { return nil }
+                let body = chatBody(chatID: id)
+                return TantivyContentSnapshot(
+                    ulid: ulid,
+                    kind: .chat,
+                    title: chat.title,
+                    body: body,
+                    updatedAt: chat.updatedAt,
+                    versionSum: UInt64(max(0, chat.messageCount))
+                )
+            }
+        } catch WikiStoreError.notFound {
+            // Race: the resource was deleted between the event emit and this
+            // read. Return nil so the indexer mirrors the delete — this is the
+            // expected signal, not an error to log.
+            return nil
+        } catch {
+            // A genuine read failure — log it (never bare try?) and treat as
+            // "no snapshot available" so the indexer skips this cycle.
+            DebugLog.store("StoreBackedTantivyContentSource: snapshot(\(kind) \(ulid)) read failed: \(error)")
+            return nil
+        }
+    }
+
+    public func allSnapshots() async throws -> [TantivyContentSnapshot] {
+        var snapshots: [TantivyContentSnapshot] = []
+        // Pages
+        let pageSummaries: [WikiPageSummary]
+        do {
+            pageSummaries = try store.listPages(sortBy: .newestFirst)
+        } catch {
+            DebugLog.store("StoreBackedTantivyContentSource: listPages failed: \(error)")
+            pageSummaries = []
+        }
+        for summary in pageSummaries {
+            do {
+                let page = try store.getPage(id: summary.id)
+                snapshots.append(TantivyContentSnapshot(
+                    ulid: summary.id.rawValue,
+                    kind: .page,
+                    title: page.title,
+                    body: page.bodyMarkdown,
+                    updatedAt: page.updatedAt,
+                    versionSum: UInt64(max(0, page.version))
+                ))
+            } catch {
+                DebugLog.store("StoreBackedTantivyContentSource: page \(summary.id.rawValue) skipped in build: \(error)")
+            }
+        }
+        // Sources
+        let sources: [SourceSummary]
+        do {
+            sources = try store.listSources()
+        } catch {
+            DebugLog.store("StoreBackedTantivyContentSource: listSources failed: \(error)")
+            sources = []
+        }
+        for source in sources {
+            // Missing HEAD (no extraction yet) → empty body; title still
+            // searchable. A missing HEAD is not an error worth aborting the
+            // build over.
+            var body = ""
+            if let head = try? store.processedMarkdownHead(sourceID: source.id) {
+                body = head.content
+            }
+            snapshots.append(TantivyContentSnapshot(
+                ulid: source.id.rawValue,
+                kind: .source,
+                title: source.effectiveName,
+                body: body,
+                updatedAt: source.updatedAt,
+                versionSum: UInt64(max(0, source.version))
+            ))
+        }
+        // Chats
+        let chats: [ChatSummary]
+        do {
+            chats = try store.listChats()
+        } catch {
+            DebugLog.store("StoreBackedTantivyContentSource: listChats failed: \(error)")
+            chats = []
+        }
+        for chat in chats {
+            snapshots.append(TantivyContentSnapshot(
+                ulid: chat.id.rawValue,
+                kind: .chat,
+                title: chat.title,
+                body: chatBody(chatID: chat.id),
+                updatedAt: chat.updatedAt,
+                versionSum: UInt64(max(0, chat.messageCount))
+            ))
+        }
+        return snapshots
+    }
+
+    // MARK: - Private
+
+    /// Concatenate the plain text of every chat message (user/assistant/tool
+    /// events) into one searchable body. `AgentEvent.plainText` already
+    /// produces a human-readable rendering per event kind.
+    private func chatBody(chatID: PageID) -> String {
+        let messages: [ChatMessage]
+        do {
+            messages = try store.chatMessages(chatID: chatID)
+        } catch {
+            // A chat with no retrievable messages (e.g. race during deletion)
+            // indexes empty body — the title is still searchable. This is an
+            // intentional fallback, not a swallowed error: the next event for
+            // this chat re-indexes with the real content.
+            DebugLog.store("StoreBackedTantivyContentSource: chatMessages(\(chatID.rawValue)) failed: \(error)")
+            return ""
+        }
+        return messages.map(\.event.plainText)
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+}
+
+// MARK: - TantivyShadowSync
+
+/// Wires the `WikiEventBus` to the `TantivySearchService`'s indexer. Subscribes
+/// to all resource-change events and forwards kind-specific create/update/
+/// delete to the indexer; coarse `.external` events (kind == nil) trigger a
+/// full rebuild (plans/tantivy-search-sidecar.md §3.5 — Phase 1: simple,
+/// correct; Phase 2+: diff-and-reindex optimization).
+///
+/// **Lifecycle:** created per wiki session alongside `WikiSession`; owns its
+/// subscription token and unsubscribes on `detach()`. Mirrors the
+/// `FileProviderFacade.subscribeBus` pattern.
+@MainActor
+final public class TantivyShadowSync {
+    private let service: TantivySearchService
+    private let bus: WikiEventBus
+    private var token: SubscriptionToken?
+
+    public init(service: TantivySearchService, bus: WikiEventBus) {
+        self.service = service
+        self.bus = bus
+    }
+
+    /// Subscribe to the bus and (best-effort) ensure the index is populated.
+    /// The initial build runs on a detached task so it never blocks wiki open.
+    public func start() {
+        let token = bus.subscribe(nil) { [weak self] event in
+            self?.handle(event)
+        }
+        self.token = token
+        // Kick off the initial/empty-index rebuild off the call site. Shadow
+        // mode — failures are logged, never fatal.
+        Task.detached { [service] in
+            await service.rebuildIfNeeded()
+        }
+    }
+
+    /// Cancel the subscription (call on session teardown / wiki switch).
+    public func detach() {
+        if let token { bus.unsubscribe(token) }
+        token = nil
+    }
+
+    // MARK: - Private
+
+    /// Runs on the MainActor (bus dispatches via `@MainActor`). Forwards to
+    /// the indexer on the actor's executor via a fire-and-forget `Task` so the
+    /// main thread is never blocked by a Tantivy write.
+    private func handle(_ event: ResourceChangeEvent) {
+        // Coarse / external event (wikictl, cross-process): we can't tell what
+        // changed — rebuild from SQLite (§3.5 Phase 1 recommendation).
+        guard let kind = event.kind else {
+            Task.detached { [service] in await service.rebuild() }
+            return
+        }
+        // Map ResourceKind → TantivyDocumentKind. Only page/source/chat are
+        // searched; bookmark/systemPrompt/wikiIndex/log are skipped.
+        guard let docKind = Self.docKind(for: kind) else { return }
+        let ulid = event.id
+        Task.detached { [service] in
+            switch event.change {
+            case .created, .updated:
+                await service.indexer.upsert(ulid: ulid, kind: docKind)
+            case .deleted:
+                await service.indexer.delete(ulid: ulid, kind: docKind)
+            }
+        }
+    }
+
+    private static func docKind(for kind: ResourceKind) -> TantivyDocumentKind? {
+        switch kind {
+        case .page: return .page
+        case .source: return .source
+        case .chat: return .chat
+        case .bookmark, .systemPrompt, .wikiIndex, .log: return nil
+        }
+    }
+}

--- a/Sources/WikiFSEngine/WikiSession.swift
+++ b/Sources/WikiFSEngine/WikiSession.swift
@@ -92,6 +92,15 @@ public final class WikiSession {
     /// blob and activity orphans; cleared on Cancel / Vacuum.
     public var pendingVacuumAll: VacuumReport?
 
+    /// Phase 1 Tantivy SHADOW search index (plans/tantivy-search-sidecar.md).
+    /// EXPERIMENTAL: built and kept in sync alongside FTS5, but NOT wired into
+    /// the production search path yet — FTS5 + sqlite-vec + RRF remains
+    /// primary. `nil` if construction failed (session never breaks over a
+    /// derived index). Retained for the lifetime of the session so the
+    /// `TantivyShadowSync` bus subscription stays alive.
+    public let tantivyShadowSearch: TantivySearchService?
+    @ObservationIgnored private var tantivyShadowSync: TantivyShadowSync?
+
     // MARK: - Init
 
     /// Open `wikiID`'s DB and stand up the model + launchers for one wiki.
@@ -136,6 +145,10 @@ public final class WikiSession {
 
         let url = containerDirectory.appendingPathComponent("\(wikiID).sqlite", isDirectory: false)
         let model: WikiStoreModel
+        // Captured across both store-open branches (file-backed + in-memory
+        // fallback) so the Phase 1 Tantivy shadow service can read from the
+        // same `WikiStore` the model wraps (the model keeps it `private`).
+        var shadowStore: WikiStore?
         do {
             // `var`: the bus is set via the protocol's computed setter, which
             // the compiler treats as mutating through the `WikiStore`
@@ -146,6 +159,7 @@ public final class WikiSession {
             // File Provider signaler and the change bridge subscribe to the
             // same bus from the app layer. See `plans/event-bus.md`.
             store.eventBus = WikiEventBus(wikiID: wikiID)
+            shadowStore = store
             model = WikiStoreModel(store: store)
             // Seed a Home page when the store is empty (mirrors
             // `openActive` lines 334–341 + `createWiki`'s #315
@@ -180,10 +194,39 @@ public final class WikiSession {
                 fatalError("WikiSession: in-memory fallback store failed to open for wiki \(wikiID): \(error)")
             }
             memory.eventBus = WikiEventBus(wikiID: wikiID)
+            shadowStore = memory
             model = WikiStoreModel(store: memory)
         }
         self.store = model
         self.descriptor = sessionDescriptor
+
+        // Phase 1 Tantivy SHADOW index (plans/tantivy-search-sidecar.md).
+        // Built and synced alongside FTS5; NOT wired into the production
+        // search path. Failures are non-fatal — the session never breaks over
+        // a derived, rebuildable index; a failed start just means no shadow
+        // results (FTS5 still answers). Reads happen off-main on the indexer
+        // actor; the content source reads committed SQLite state through its
+        // own recursive lock (no statement handle crosses a boundary).
+        var shadowSearch: TantivySearchService?
+        var shadowSync: TantivyShadowSync?
+        if let shadowStore, let bus = shadowStore.eventBus {
+            do {
+                let contentSource = StoreBackedTantivyContentSource(store: shadowStore)
+                let svc = try TantivySearchService(
+                    wikiID: wikiID,
+                    containerDirectory: containerDirectory,
+                    contentSource: contentSource
+                )
+                let sync = TantivyShadowSync(service: svc, bus: bus)
+                sync.start()
+                shadowSearch = svc
+                shadowSync = sync
+            } catch {
+                DebugLog.store("WikiSession: Tantivy shadow index disabled for wiki \(wikiID): \(error)")
+            }
+        }
+        self.tantivyShadowSearch = shadowSearch
+        self.tantivyShadowSync = shadowSync
 
         // Per-session gate: lane limits match the app-wide gate the launchers
         // previously shared. Each session gets its own so cross-wiki

--- a/Sources/WikiFSSearch/TantivyIndexer.swift
+++ b/Sources/WikiFSSearch/TantivyIndexer.swift
@@ -1,0 +1,172 @@
+import Foundation
+import TantivySwift
+
+// MARK: - TantivyIndexer
+
+/// Actor that owns the on-disk `TantivySwiftIndex<TantivySearchDocument>` and
+/// performs all index mutations + queries (plans/tantivy-search-sidecar.md §3).
+///
+/// **Concurrency model (SQLite discipline):** the actor holds only the
+/// *Tantivy* index. It never touches SQLite directly. Reads of committed
+/// state happen inside `TantivyContentSource` (the store adapter), off the
+/// main actor; the Tantivy write happens here, on the actor's executor.
+/// This respects "no inference/network inside a transaction" and "no
+/// statement handle crossing a boundary" — the two concerns are on different
+/// threads/locks entirely.
+///
+/// **Phase 1:** the indexer is built and kept up to date, but search results
+/// are not surfaced to the user yet (FTS5 stays primary). The `search(...)`
+/// method exists for shadow-mode validation and the smoke test.
+public actor TantivyIndexer {
+    /// The underlying Tantivy index. `nil` when the index failed to open or
+    /// was marked for rebuild; callers degrade gracefully (shadow mode — a
+    /// missing index just means no shadow results, FTS5 still answers).
+    private var index: TantivySwiftIndex<TantivySearchDocument>?
+    private let indexPath: String
+    private let contentSource: any TantivyContentSource
+
+    public init(indexDirectory: URL, contentSource: any TantivyContentSource) throws {
+        let path = indexDirectory.path
+        let fm = FileManager.default
+        // Tantivy expects to create the directory itself; make sure the parent
+        // exists so a fresh `<container>/search-index/<wikiID>/` path works
+        // even when neither component exists yet.
+        try fm.createDirectory(at: indexDirectory, withIntermediateDirectories: true)
+        self.indexPath = path
+        self.contentSource = contentSource
+
+        do {
+            self.index = try TantivySwiftIndex<TantivySearchDocument>(path: path)
+        } catch {
+            // Don't crash the app over a derived, rebuildable index. Log and
+            // degrade; rebuildIndex() can retry. (Never use bare try? — see
+            // project rules. This catch logs via DebugLog.store.)
+            DebugLog.store("TantivyIndexer: failed to open index at \(path): \(error)")
+            self.index = nil
+        }
+    }
+
+    // MARK: - Mutations (driven by the event bus)
+
+    /// Index (upsert) a single document by kind+ulid. Reads the current
+    /// snapshot from the content source; if the source returns `nil`, the
+    /// resource was deleted upstream and we delete it from the index too.
+    public func upsert(ulid: String, kind: TantivyDocumentKind) async {
+        guard let index else { return }
+        do {
+            if let snapshot = try await contentSource.snapshot(ulid: ulid, kind: kind) {
+                try await index.index(doc: .from(snapshot))
+            } else {
+                // Already gone upstream — mirror the delete so the index
+                // doesn't retain a stale doc.
+                await delete(ulid: ulid, kind: kind)
+            }
+        } catch {
+            DebugLog.store("TantivyIndexer: upsert(\(kind) \(ulid)) failed: \(error)")
+        }
+    }
+
+    /// Remove a document from the index by kind+ulid.
+    public func delete(ulid: String, kind: TantivyDocumentKind) async {
+        guard let index else { return }
+        let id = kind.documentID(for: ulid)
+        do {
+            try await index.deleteDoc(id: DocumentField(name: "id", value: .text(id)))
+        } catch {
+            DebugLog.store("TantivyIndexer: delete(\(kind) \(ulid)) failed: \(error)")
+        }
+    }
+
+    /// Remove every document from the index (segment store is reset). Used by
+    /// the rebuild path and the corruption self-heal.
+    public func clear() async throws {
+        guard let index else { return }
+        try await index.clear()
+    }
+
+    // MARK: - Search
+
+    /// Shadow-mode search. Returns hits for a free-text query, optionally
+    /// restricted to one kind via the `kind` facet path.
+    ///
+    /// Uses `TantivySwiftSearchQuery` with `defaultFields` = title + body
+    /// (both unicode-tokenized) and `fuzzyFields` for typo tolerance. The kind
+    /// filter can't be expressed as a facet term clause on
+    /// `TantivySwiftSearchQuery` (it has no facet clause field), so we
+    /// over-fetch and post-filter by kind in Swift — the index is small in
+    /// Phase 1. A Phase 2 optimization builds a `TantivyQuery.boolean` clause
+    /// with a `.term` on the `kind` facet field so the engine filters before
+    /// scoring/limit.
+    public func search(query: String, kind: TantivyDocumentKind?, limit: Int) async throws -> [TantivyShadowSearchResult] {
+        guard let index, !query.isEmpty else { return [] }
+        let fetchLimit = kind == nil ? limit : limit * 5
+        var q = TantivySwiftSearchQuery<TantivySearchDocument>(
+            queryStr: query,
+            defaultFields: [.title, .body],
+            limit: UInt32(max(1, min(fetchLimit, 1_000)))
+        )
+        q.fuzzyFields = [
+            .init(field: .title, prefix: true, distance: 1),
+            .init(field: .body, prefix: false, distance: 1),
+        ]
+        let results = try await index.search(query: q)
+        return Array(results.docs.compactMap { hit -> TantivyShadowSearchResult? in
+            let kindEnum = TantivyDocumentKind.allCases.first { $0.facetPath == hit.doc.kind }
+            guard let kindEnum else { return nil }
+            if let kind, kindEnum != kind { return nil }
+            return TantivyShadowSearchResult(
+                documentID: hit.doc.id,
+                kind: kindEnum,
+                title: hit.doc.title,
+                score: hit.score
+            )
+        }.prefix(limit))
+    }
+
+    // MARK: - Rebuild / initial build
+
+    /// Number of indexed documents. Used by the service to detect an empty
+    /// index that needs an initial build.
+    public func count() async -> UInt64 {
+        guard let index else { return 0 }
+        return await index.count()
+    }
+
+    /// Full rebuild from the content source: clear, then index every snapshot
+    /// in one batch commit. Used for the initial build and for crash-recovery
+    /// self-heal (plans/tantivy-search-sidecar.md §3.3–§3.4).
+    public func rebuild() async throws {
+        // If the index never opened, retry once after deleting the (possibly
+        // corrupt) on-disk directory. If reopen still fails, give up (shadow
+        // mode — FTS5 still answers).
+        if index == nil {
+            try await reopen()
+        }
+        guard let index else { return }
+        try await index.clear()
+        let snapshots = try await contentSource.allSnapshots()
+        if snapshots.isEmpty { return }
+        // Batch index + single commit — far cheaper than N single-doc commits
+        // (each single-doc index(doc:) auto-commits and creates a segment).
+        let docs = snapshots.map(TantivySearchDocument.from)
+        try await index.index(docs: docs)
+    }
+
+    // MARK: - Private
+
+    /// Re-open the index after `index` was nilled (e.g. on open failure or
+    /// corruption recovery). Deletes the on-disk directory first so a corrupt
+    /// segment store can't poison the reopen.
+    private func reopen() async throws {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: indexPath) {
+            do {
+                try fm.removeItem(atPath: indexPath)
+            } catch {
+                DebugLog.store("TantivyIndexer: could not remove corrupt index dir \(indexPath): \(error)")
+            }
+        }
+        try fm.createDirectory(atPath: indexPath, withIntermediateDirectories: true)
+        self.index = try TantivySwiftIndex<TantivySearchDocument>(path: indexPath)
+    }
+}

--- a/Sources/WikiFSSearch/TantivySearchDocument.swift
+++ b/Sources/WikiFSSearch/TantivySearchDocument.swift
@@ -1,0 +1,167 @@
+import Foundation
+import TantivySwift
+
+// MARK: - TantivyDocumentKind
+
+/// The kind vocabulary for the shadow index. Independent of `ResourceKind`
+/// (which lives in `WikiFSTypes`): this is the search module's own enum so the
+/// FacetField value is always a well-formed hierarchical path (`"/page"`,
+/// not `"page"`).
+public enum TantivyDocumentKind: String, Sendable, CaseIterable {
+    case page, source, chat
+
+    /// The hierarchical facet path Tantivy expects (`"/page"`, `"/source"`,
+    /// `"/chat"`). Tantivy facets use the leading-slash path convention.
+    public var facetPath: String { "/\(rawValue)" }
+
+    /// The `<kind>:` prefix used in the composite document id.
+    public var idPrefix: String { "\(rawValue):" }
+
+    /// Builds a composite document id: `"<kind>:<ULID>"`.
+    public func documentID(for ulid: String) -> String { "\(idPrefix)\(ulid)" }
+}
+
+// MARK: - TantivyContentSnapshot
+
+/// A neutral, plain value-type snapshot of one searchable resource. This is
+/// the cross-module boundary between the store adapter (in `WikiFSCore`) and
+/// the Tantivy indexer (in `WikiFSSearch`).
+///
+/// **Why this exists:** the actual Tantivy document (`TantivySearchDocument`,
+/// an `@TantivyDocument` macro type) is `internal` to `WikiFSSearch` by design
+/// (plans/tantivy-search-sidecar.md §8.1: "the store and model interact via the
+/// search service's result types, not the raw Tantivy document"). The macro
+/// generates an internal `CodingKeys`, so the document struct cannot be made
+/// `public` without forking the upstream package. Instead, the store adapter
+/// produces these plain snapshots and the indexer converts them to Tantivy
+/// documents internally — keeping the Tantivy-specific schema an
+/// implementation detail of the search module.
+public struct TantivyContentSnapshot: Sendable, Equatable {
+    public let ulid: String
+    public let kind: TantivyDocumentKind
+    public let title: String
+    public let body: String
+    public let updatedAt: Date
+    public let versionSum: UInt64
+
+    public init(
+        ulid: String,
+        kind: TantivyDocumentKind,
+        title: String,
+        body: String,
+        updatedAt: Date,
+        versionSum: UInt64
+    ) {
+        self.ulid = ulid
+        self.kind = kind
+        self.title = title
+        self.body = body
+        self.updatedAt = updatedAt
+        self.versionSum = versionSum
+    }
+}
+
+// MARK: - TantivyContentSource
+
+/// The protocol seam between the search module and the store.
+///
+/// `WikiFSSearch` depends only on `WikiFSTypes` — it cannot see `WikiEventBus`,
+/// `ResourceChangeEvent`, or `WikiStore` (those live in `WikiFSCore`). Rather
+/// than add a heavyweight dependency, the `TantivyIndexer` consumes abstract
+/// `TantivyContentSnapshot`s produced by a concrete conforming type. The
+/// concrete `StoreBackedTantivyContentSource` lives in `WikiFSCore` and reads
+/// from `WikiStore`; it also subscribes to the event bus and forwards events
+/// to the indexer. This keeps the search module reusable and testable in
+/// isolation (plans/tantivy-search-sidecar.md §8.1).
+///
+/// All methods are `async throws` so a conforming store adapter can read
+/// off-main (the store's `WikiReadPool`) without blocking the indexer actor.
+public protocol TantivyContentSource: Sendable {
+    /// Snapshot of a single resource, or `nil` if the resource no longer
+    /// exists (already deleted upstream — the indexer treats `nil` as a
+    /// delete).
+    func snapshot(ulid: String, kind: TantivyDocumentKind) async throws -> TantivyContentSnapshot?
+
+    /// Every snapshot in the source, for the initial full build / rebuild.
+    func allSnapshots() async throws -> [TantivyContentSnapshot]
+}
+
+// MARK: - TantivySearchDocument (internal — Tantivy-specific schema)
+
+/// The single Tantivy index document for the Phase 1 shadow index
+/// (plans/tantivy-search-sidecar.md §2.2).
+///
+/// Internal to `WikiFSSearch` — the macro-generated `CodingKeys` is internal
+/// (the upstream `@TantivyDocument` macro doesn't emit `public`), so the store
+/// adapter instead produces `TantivyContentSnapshot`s and the indexer converts
+/// them here. One unified index holds every searchable resource — pages,
+/// sources, and chats — distinguished by the `kind` facet field. The `id` is
+/// `"<kind>:<ULID>"` so it is globally unique *across kinds in the same
+/// index*, which is what Tantivy's `deleteDoc(id:)` matches against.
+///
+/// **Phase 1 only.** FTS5 + sqlite-vec + RRF remains the primary search path.
+@TantivyDocument
+struct TantivySearchDocument: Sendable {
+    /// `"<kind>:<ULID>"` — globally unique within the single index.
+    @IDField var id: String
+    /// `page.title` | `source.effectiveName` | `chat.title`.
+    @TextField var title: String
+    /// `page.bodyMarkdown` | `source` processed markdown HEAD |
+    /// concatenated chat message plain text.
+    @TextField var body: String
+    /// Facet path: `"/page"` | `"/source"` | `"/chat"`.
+    @FacetField var kind: String
+    /// Last modification time of the underlying resource.
+    @DateField var updatedAt: Date
+    /// `source.version`, or the page/chat version, for staleness detection.
+    @U64Field var versionSum: UInt64
+
+    init(
+        id: String,
+        title: String,
+        body: String,
+        kind: String,
+        updatedAt: Date,
+        versionSum: UInt64
+    ) {
+        self.id = id
+        self.title = title
+        self.body = body
+        self.kind = kind
+        self.updatedAt = updatedAt
+        self.versionSum = versionSum
+    }
+}
+
+extension TantivySearchDocument {
+    /// Convert a neutral store snapshot into the Tantivy schema document.
+    static func from(_ snapshot: TantivyContentSnapshot) -> TantivySearchDocument {
+        TantivySearchDocument(
+            id: snapshot.kind.documentID(for: snapshot.ulid),
+            title: snapshot.title,
+            body: snapshot.body,
+            kind: snapshot.kind.facetPath,
+            updatedAt: snapshot.updatedAt,
+            versionSum: snapshot.versionSum
+        )
+    }
+}
+
+// MARK: - Public search result
+
+/// A search hit returned by `TantivySearchService`. Decoupled from the raw
+/// `TantivySearchResult<TantivySearchDocument>` so callers in `WikiFSCore` /
+/// the app layer don't depend on the TantivySwift types directly.
+public struct TantivyShadowSearchResult: Sendable, Equatable {
+    public let documentID: String
+    public let kind: TantivyDocumentKind
+    public let title: String
+    public let score: Float
+
+    public init(documentID: String, kind: TantivyDocumentKind, title: String, score: Float) {
+        self.documentID = documentID
+        self.kind = kind
+        self.title = title
+        self.score = score
+    }
+}

--- a/Sources/WikiFSSearch/TantivySearchService.swift
+++ b/Sources/WikiFSSearch/TantivySearchService.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// MARK: - TantivySearchService
+
+/// Owns the `TantivyIndexer` actor and the per-wiki lifecycle of the on-disk
+/// Tantivy shadow index (plans/tantivy-search-sidecar.md §3.3–§3.4, §6.2).
+///
+/// **Index location** (§6.2): `<appGroupContainer>/search-index/<wikiID>/`.
+/// The index is a derived artifact — SQLite is always the source of truth —
+/// so any corruption is recovered by a full rebuild from the content source.
+///
+/// **Phase 1:** this service is EXPERIMENTAL. It builds and maintains the
+/// index in shadow mode (FTS5 remains the primary search path). Callers
+/// should not surface `search(...)` results to the user yet — use it only for
+/// validation / the smoke test.
+public final class TantivySearchService: Sendable {
+    public let indexer: TantivyIndexer
+    public let wikiID: String
+    private let indexDirectory: URL
+
+    public init(wikiID: String, containerDirectory: URL, contentSource: any TantivyContentSource) throws {
+        self.wikiID = wikiID
+        // `<container>/search-index/<wikiID>/` — per-wiki, alongside the
+        // `.sqlite` files (same TCC-protected container the app already
+        // owns, so no extra entitlement work).
+        let dir = containerDirectory
+            .appendingPathComponent("search-index", isDirectory: true)
+            .appendingPathComponent(wikiID, isDirectory: true)
+        self.indexDirectory = dir
+        self.indexer = try TantivyIndexer(indexDirectory: dir, contentSource: contentSource)
+    }
+
+    // MARK: - Shadow-mode search
+
+    /// Free-text search over the Tantivy index, optionally restricted to one
+    /// kind. Returns empty on any error (the caller falls back to FTS5 in
+    /// Phase 2; in Phase 1 the result is logged for comparison, not shown).
+    public func search(query: String, kinds: [TantivyDocumentKind] = [], limit: Int = 20) async -> [TantivyShadowSearchResult] {
+        do {
+            // Single-kind fast path: ask the indexer to filter.
+            if kinds.count == 1, let only = kinds.first {
+                return try await indexer.search(query: query, kind: only, limit: limit)
+            }
+            // No filter, or multi-kind: query unfiltered then post-filter to
+            // the allowed kinds. (Phase 1 indexes are small; a Phase 2
+            // boolean query removes this.)
+            let raw = try await indexer.search(query: query, kind: nil, limit: limit)
+            if kinds.isEmpty { return raw }
+            let allowed = Set(kinds)
+            return raw.filter { allowed.contains($0.kind) }
+        } catch {
+            DebugLog.store("TantivySearchService: search(\"\(query)\") failed: \(error)")
+            return []
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Ensure the shadow index is populated. On first open (empty index) or
+    /// after corruption, run a full rebuild from the content source. Safe to
+    /// call on every wiki open — it short-circuits when the index already has
+    /// documents.
+    ///
+    /// **Concurrency:** runs on a detached task so the wiki open path is not
+    /// blocked by a potentially large initial build. `await`-free on the
+    /// caller; callers that need the build complete can `await rebuildIfNeeded()`.
+    public func rebuildIfNeeded() async {
+        do {
+            let n = await indexer.count()
+            if n == 0 {
+                DebugLog.store("TantivySearchService[\(wikiID)]: index empty — rebuilding from store")
+                try await indexer.rebuild()
+                let after = await indexer.count()
+                DebugLog.store("TantivySearchService[\(wikiID)]: rebuild complete (\(after) docs)")
+            }
+        } catch {
+            DebugLog.store("TantivySearchService[\(wikiID)]: rebuild failed: \(error)")
+        }
+    }
+
+    /// Force a full rebuild (used after corruption detection or an external
+    /// coarse `.external` event where we can't tell what changed).
+    public func rebuild() async {
+        do {
+            try await indexer.rebuild()
+        } catch {
+            DebugLog.store("TantivySearchService[\(wikiID)]: forced rebuild failed: \(error)")
+        }
+    }
+
+    /// Delete the on-disk index entirely (wiki removal path). Best-effort —
+    /// a leftover dir is rebuilt-from-scratch-safe since SQLite is the source
+    /// of truth.
+    public func deleteIndex() {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: indexDirectory.path) {
+            do {
+                try fm.removeItem(at: indexDirectory)
+            } catch {
+                DebugLog.store("TantivySearchService[\(wikiID)]: could not delete index dir: \(error)")
+            }
+        }
+    }
+}

--- a/Tests/WikiFSTests/TantivyShadowIndexTests.swift
+++ b/Tests/WikiFSTests/TantivyShadowIndexTests.swift
@@ -1,0 +1,197 @@
+import Testing
+import Foundation
+import WikiFSSearch
+
+/// Phase 1 shadow-index smoke test (plans/tantivy-search-sidecar.md).
+///
+/// Exercises the `TantivyIndexer` + `TantivySearchService` end-to-end with an
+/// in-memory `TantivyContentSource` (no SQLite, no event bus) so it runs in
+/// the fast CI tier. Validates: document upsert, kind-filtered search, delete,
+/// and the initial full build from `allSnapshots()`.
+///
+/// This does NOT wire into the production search path — it's shadow-mode
+/// validation only. FTS5 + sqlite-vec + RRF remains primary.
+@Suite
+struct TantivyShadowIndexTests {
+
+    // MARK: - In-memory content source
+
+    /// A minimal `TantivyContentSource` backed by an actor's dictionary — lets
+    /// the test drive upsert/delete/rebuild without a real `WikiStore`. Using
+    /// an actor (not `NSLock`) keeps it Swift-6-clean from async contexts.
+    private actor InMemoryContentSource: TantivyContentSource {
+        private var docs: [String: TantivyContentSnapshot] = [:]
+
+        func upsert(_ snapshot: TantivyContentSnapshot) {
+            let key = "\(snapshot.kind.rawValue):\(snapshot.ulid)"
+            docs[key] = snapshot
+        }
+
+        func remove(ulid: String, kind: TantivyDocumentKind) {
+            docs.removeValue(forKey: "\(kind.rawValue):\(ulid)")
+        }
+
+        // MARK: TantivyContentSource
+
+        func snapshot(ulid: String, kind: TantivyDocumentKind) async throws -> TantivyContentSnapshot? {
+            docs["\(kind.rawValue):\(ulid)"]
+        }
+
+        func allSnapshots() async throws -> [TantivyContentSnapshot] {
+            Array(docs.values)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Fresh temp index directory per test run (UUID) so nothing leaks between
+    /// runs. Removed in `defer`.
+    private func makeTempDir() -> (URL, FileManager) {
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("tantivy-shadow-\(UUID().uuidString)")
+        let url = URL(fileURLWithPath: path)
+        let fm = FileManager.default
+        return (url, fm)
+    }
+
+    private func makeSnapshot(
+        ulid: String,
+        kind: TantivyDocumentKind,
+        title: String,
+        body: String
+    ) -> TantivyContentSnapshot {
+        TantivyContentSnapshot(
+            ulid: ulid,
+            kind: kind,
+            title: title,
+            body: body,
+            updatedAt: Date(),
+            versionSum: 1
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test func upsertAndSearchRoundTrip() async throws {
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try TantivySearchService(
+            wikiID: "test-wiki",
+            containerDirectory: indexDir,
+            contentSource: source
+        )
+
+        // Index three documents: two pages, one source.
+        let page1 = makeSnapshot(ulid: "01PAGE0001", kind: .page, title: "Rust Ownership", body: "Borrowing and lifetimes in the Rust language.")
+        let page2 = makeSnapshot(ulid: "01PAGE0002", kind: .page, title: "Swift Concurrency", body: "Actors and structured concurrency.")
+        let source1 = makeSnapshot(ulid: "01SRC00001", kind: .source, title: "Tantivy Docs", body: "Full text search engine written in Rust.")
+        await source.upsert(page1)
+        await source.upsert(page2)
+        await source.upsert(source1)
+
+        await service.indexer.upsert(ulid: page1.ulid, kind: .page)
+        await service.indexer.upsert(ulid: page2.ulid, kind: .page)
+        await service.indexer.upsert(ulid: source1.ulid, kind: .source)
+
+        let count = await service.indexer.count()
+        #expect(count == 3, "three documents should be indexed")
+
+        // Search for "rust" — should match the Rust page AND the Tantivy source
+        // (body contains "Rust"). Both are lexical BM25 hits.
+        let rustResults = await service.search(query: "rust", limit: 10)
+        #expect(rustResults.count >= 2, "search for 'rust' should match the Rust page and the Tantivy source")
+        #expect(rustResults.contains { $0.kind == .page && $0.title == "Rust Ownership" })
+        #expect(rustResults.contains { $0.kind == .source && $0.title == "Tantivy Docs" })
+
+        // Kind-filtered search: only pages.
+        let pageOnly = await service.search(query: "rust", kinds: [.page], limit: 10)
+        #expect(pageOnly.allSatisfy { $0.kind == .page }, "kind filter should exclude non-page results")
+        #expect(pageOnly.contains { $0.title == "Rust Ownership" })
+        #expect(!pageOnly.contains { $0.title == "Tantivy Docs" }, "source should be excluded by the page filter")
+
+        // Fuzzy search: "concurency" (typo) should still match "Concurrency".
+        let fuzzyResults = await service.search(query: "concurency", limit: 10)
+        #expect(fuzzyResults.contains { $0.title == "Swift Concurrency" }, "fuzzy match should find 'Swift Concurrency' despite the typo")
+    }
+
+    @Test func deleteRemovesFromIndex() async throws {
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try TantivySearchService(
+            wikiID: "test-wiki",
+            containerDirectory: indexDir,
+            contentSource: source
+        )
+
+        let page = makeSnapshot(ulid: "01PAGE0099", kind: .page, title: "Delete Me", body: "This page will be removed from the index.")
+        await source.upsert(page)
+        await service.indexer.upsert(ulid: page.ulid, kind: .page)
+        #expect(await service.indexer.count() == 1)
+
+        // Delete from the index (simulates a `.deleted` event).
+        await service.indexer.delete(ulid: page.ulid, kind: .page)
+        #expect(await service.indexer.count() == 0, "deleted document should be gone from the index")
+
+        let results = await service.search(query: "delete", limit: 10)
+        #expect(results.isEmpty, "no results should be returned after deletion")
+    }
+
+    @Test func rebuildFromContentSource() async throws {
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        // Pre-populate the source (simulating existing SQLite content).
+        await source.upsert(makeSnapshot(ulid: "01PAGE0101", kind: .page, title: "Existing Page", body: "Already in the store before the index existed."))
+        await source.upsert(makeSnapshot(ulid: "01CHAT0001", kind: .chat, title: "Existing Chat", body: "A conversation about search engines."))
+
+        let service = try TantivySearchService(
+            wikiID: "test-wiki",
+            containerDirectory: indexDir,
+            contentSource: source
+        )
+
+        // rebuildIfNeeded() should detect the empty index and build it.
+        await service.rebuildIfNeeded()
+        let count = await service.indexer.count()
+        #expect(count == 2, "rebuild should index both pre-existing snapshots")
+
+        // The chat should be searchable.
+        let chatResults = await service.search(query: "search engines", kinds: [.chat], limit: 10)
+        #expect(chatResults.count == 1)
+        #expect(chatResults.first?.title == "Existing Chat")
+
+        // The page should be searchable.
+        let pageResults = await service.search(query: "store", kinds: [.page], limit: 10)
+        #expect(pageResults.count == 1)
+        #expect(pageResults.first?.title == "Existing Page")
+    }
+
+    @Test func upsertOfDeletedSourceMirrorsDelete() async throws {
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try TantivySearchService(
+            wikiID: "test-wiki",
+            containerDirectory: indexDir,
+            contentSource: source
+        )
+
+        // Index a page, then remove it from the source (simulating a race
+        // where the resource was deleted between the event emit and the
+        // read). The upsert should mirror the delete (snapshot returns nil).
+        let page = makeSnapshot(ulid: "01PAGE0200", kind: .page, title: "Transient", body: "This will disappear.")
+        await source.upsert(page)
+        await service.indexer.upsert(ulid: page.ulid, kind: .page)
+        #expect(await service.indexer.count() == 1)
+
+        await source.remove(ulid: page.ulid, kind: .page)
+        await service.indexer.upsert(ulid: page.ulid, kind: .page)
+        #expect(await service.indexer.count() == 0, "upsert of a nil snapshot should delete the doc")
+    }
+}


### PR DESCRIPTION
## Tantivy Phase 1: Shadow index

Implements the Phase 1 shadow search index from `plans/tantivy-search-sidecar.md`. The Tantivy index is built and kept in sync alongside the existing FTS5 + sqlite-vec + RRF search, but is **NOT wired into the production search path** — FTS5 remains primary. Phase 2 will cut over.

### What's new

**`Sources/WikiFSSearch/`** (search module — the natural home per §8.1):
- `TantivySearchDocument.swift` — `@TantivyDocument` schema (id/title/body/kind-facet/updatedAt/versionSum), `TantivyDocumentKind` enum, `TantivyContentSnapshot` (neutral cross-module boundary), `TantivyContentSource` protocol (the seam), and `TantivyShadowSearchResult`.
- `TantivyIndexer.swift` — actor owning `TantivySwiftIndex<TantivySearchDocument>`; upsert/delete/search/rebuild. Reads happen off-main via `TantivyContentSource`; writes happen on the actor's executor (no SQLite lock held during index writes).
- `TantivySearchService.swift` — wraps the indexer, owns the per-wiki index at `<container>/search-index/<wikiID>/`, handles initial build + corruption self-heal (delete + rebuild from SQLite).

**`Sources/WikiFSCore/`** (the bridge to the store + event bus):
- `StoreBackedTantivyContentSource.swift` — `TantivyContentSource` backed by `WikiStore` (reads page/source/chat snapshots), plus `TantivyShadowSync` (`@MainActor` — subscribes to `WikiEventBus`, forwards kind-specific create/update/delete to the indexer, full rebuild on coarse `.external` events per §3.5 Phase 1 recommendation).

**`Sources/WikiFSEngine/WikiSession.swift`**:
- Wires `TantivySearchService` + `TantivyShadowSync` into the session lifecycle. Failures are non-fatal (shadow mode — a failed start just means no shadow results; FTS5 still answers).

**`Tests/WikiFSTests/TantivyShadowIndexTests.swift`** (fast tier, no SQLite):
- 4 tests: upsert + kind-filtered/fuzzy search round-trip, delete removes from index, rebuild from content source, upsert of a nil snapshot mirrors delete.

### Architecture decisions

- **Protocol seam, not a direct dependency.** `WikiFSSearch` depends only on `WikiFSTypes` (+ `TantivySwift`) — it cannot see `WikiEventBus`/`WikiStore` (those live in `WikiFSCore`). The `TantivyContentSource` protocol is the seam; the concrete store-backed adapter lives in `WikiFSCore`. This keeps the search module reusable and testable in isolation (§8.1).
- **`@TantivyDocument` is internal to `WikiFSSearch`.** The upstream macro generates an internal `CodingKeys`, so the document struct can't be `public`. The store adapter produces neutral `TantivyContentSnapshot`s; the indexer converts them internally.
- **Coarse events trigger a full rebuild** (§3.5 Phase 1: simple, correct). A Phase 2+ optimization will do diff-and-reindex.
- **Kind filtering is post-fetch in Swift** for now — `TantivySwiftSearchQuery` has no facet clause field. A Phase 2 optimization builds a `TantivyQuery.boolean` with a `.term` on the `kind` facet field so the engine filters before scoring/limit.

### SQLite concurrency

The indexer never touches SQLite — reads of committed state happen inside `TantivyContentSource` (off the main actor, through the store's own recursive lock), and the Tantivy write happens on the actor's executor. No statement handle crosses a boundary, no inference runs inside a transaction.

### Testing

- `swift test --filter TantivyShadowIndexTests` — all 4 tests pass.
- Fast tier (`swift test --skip ...`) — all 2503 tests pass.

### Not in this PR (Phase 2+)

- Cutover: `searchSimilar` / `searchSimilarSources` / `searchSimilarChats` still use FTS5.
- Unified `search(query:kinds:limit:)` on `WikiStore` (§4.2 Option B).
- Native snippet/highlight support (§4.3).
- Omnibox cross-kind search (§4.5).
- Diff-and-reindex for coarse events (§3.5 Option B).

Ref: #526
