### PR TITLE
Populate new wiki index.md with friendly welcome content + template

### DIFF
--- a/Sources/WikiFSSearch/WikiIndex.swift
+++ b/Sources/WikiFSSearch/WikiIndex.swift
@@ -30,9 +30,37 @@ public struct WikiIndex: Equatable, Sendable {
     /// dependency: WikiFSSearch → WikiFSCore → WikiFSSearch. Update both if
     /// the copy changes (it rarely does — it's a one-time seed).
     public static let defaultBody: String = #"""
-# Index
+# Welcome to Your Wiki
 
-This is the wiki's curated index. The maintaining agent rewrites it on each
-ingest to catalog the pages worth knowing about.
+This is the home page (`index.md`). The agent maintains it — edit it directly
+or ask the agent to update it. When you ingest sources, the agent rewrites this
+catalog to list the resulting pages.
+
+## Getting Started
+
+- **Add sources** — drop PDFs or Markdown files, or paste a URL (YouTube,
+  websites) into the Sources panel.
+- **Ingest** — the agent reads each source and writes wiki pages, cross-linked
+  with `[[wiki links]]`, then rewrites this page to catalog them.
+- **Ask questions** — use the Ask tab to chat with the agent about your wiki's
+  content; it searches and cites from what's here.
+- **Edit pages** — double-click any page to edit; changes save automatically.
+
+## Wiki Structure
+
+- `index.md` — this page, the home page and curated catalog.
+- `log.md` — chronological changelog of agent activity (ingests, queries, lints).
+- `CLAUDE.md` / `AGENTS.md` — the agent's system prompt (one file, two names).
+- **Pages** — your content, connected with `[[wiki links]]`.
+- **Sources** — original materials (PDFs, URLs, transcripts), stored verbatim.
+
+## Recent Changes
+
+*(The agent appends to `log.md` and refreshes this catalog after each ingest or
+edit. Check `log.md` for the full history.)*
+
+## Quick Links
+
+*(Add your most-used pages here with `[[Page Title]]` links once you have them.)*
 """#
 }

--- a/prompts/system-prompt-default.md
+++ b/prompts/system-prompt-default.md
@@ -53,6 +53,9 @@ them to the user in chat.
 - `sources/by-name/`, `sources/by-id/` — raw sources, IMMUTABLE and
   verbatim (the bytes the user added). Cite a source by its `sources/…` path.
 - `index.md` — the curated catalog you maintain (rewritten wholesale on ingest).
+  A new wiki's `index.md` starts as a welcome template (Getting Started, Wiki
+  Structure, Recent Changes, Quick Links). Your first ingest REPLACES that
+  template with a real catalog of pages — do not preserve the template sections.
 - `log.md` — the append-only chronological log of ingests/queries/lints.
 - `WIKI-STRUCTURE.md` — an orientation map of this layout plus live page/file
   counts (only if the projection is available).

--- a/prompts/wiki-index-default.md
+++ b/prompts/wiki-index-default.md
@@ -1,4 +1,32 @@
-# Index
+# Welcome to Your Wiki
 
-This is the wiki's curated index. The maintaining agent rewrites it on each
-ingest to catalog the pages worth knowing about.
+This is the home page (`index.md`). The agent maintains it — edit it directly
+or ask the agent to update it. When you ingest sources, the agent rewrites this
+catalog to list the resulting pages.
+
+## Getting Started
+
+- **Add sources** — drop PDFs or Markdown files, or paste a URL (YouTube,
+  websites) into the Sources panel.
+- **Ingest** — the agent reads each source and writes wiki pages, cross-linked
+  with `[[wiki links]]`, then rewrites this page to catalog them.
+- **Ask questions** — use the Ask tab to chat with the agent about your wiki's
+  content; it searches and cites from what's here.
+- **Edit pages** — double-click any page to edit; changes save automatically.
+
+## Wiki Structure
+
+- `index.md` — this page, the home page and curated catalog.
+- `log.md` — chronological changelog of agent activity (ingests, queries, lints).
+- `CLAUDE.md` / `AGENTS.md` — the agent's system prompt (one file, two names).
+- **Pages** — your content, connected with `[[wiki links]]`.
+- **Sources** — original materials (PDFs, URLs, transcripts), stored verbatim.
+
+## Recent Changes
+
+*(The agent appends to `log.md` and refreshes this catalog after each ingest or
+edit. Check `log.md` for the full history.)*
+
+## Quick Links
+
+*(Add your most-used pages here with `[[Page Title]]` links once you have them.)*


### PR DESCRIPTION
## Summary

Populate a new wiki's `index.md` home page with a friendly welcome + template, replacing the minimal placeholder seed.

Previously, `WikiIndex.defaultBody` (the seed for every fresh wiki's `index.md`) was a two-line placeholder:

```
# Index

This is the wiki's curated index. The maintaining agent rewrites it on each
ingest to catalog the pages worth knowing about.
```

A brand-new wiki now opens with a scannable welcome page: what the wiki is, how to get started (Add sources → Ingest → Ask → Edit), the wiki structure, and empty "Recent Changes" / "Quick Links" sections that orient the first-time user.

## Changes

- **`prompts/wiki-index-default.md`** — the canonical source for the index seed body; rewrote as the welcome template.
- **`Sources/WikiFSSearch/WikiIndex.swift`** — the inlined `defaultBody` literal kept in sync with the prompt file (per the existing doc-comment contract; both are the one-time seed used by `SQLiteWikiStore` and `GRDBWikiStore` at fresh-DB creation).
- **`prompts/system-prompt-default.md`** — added a note under the `index.md` description so the agent knows a new wiki's `index.md` starts as a welcome template and that the **first ingest REPLACES** the template with a real page catalog — preventing the agent from preserving placeholder sections when it rewrites the catalog wholesale.

## Link handling

Wiki-links (`[[…]]`) resolve only against the `pages` and `sources` tables — missing targets render as red "ghost" links. Since `index.md`, `log.md`, and `CLAUDE.md` are root-level singleton documents (not pages in the `pages/` namespace), references to them use **code spans** (`index.md`), not `[[index]]`/`[[log]]` bracket links. This avoids shipping broken red links on the very first screen a user sees.

`[[wiki links]]` / `[[Page Title]]` appear **inside code spans** in the welcome content, where they're shown as conceptual examples. The linkifier skips wiki-link detection inside protected code spans (`WikiLinkSpan.protectedCodeRanges`), so they render as inert code text — no ghost links, no premature linkification. Once the user has real pages, the agent rewrites this page into a page catalog with live `[[Page Title]]` links.

## Lifecycle

This is an **empty-state seed**. On the wiki's first ingest, the agent rewrites `index.md` wholesale into a page catalog (existing behavior, unchanged), and the welcome template is replaced. The system-prompt note added here makes that transition explicit so the agent doesn't try to preserve the "Recent Changes"/"Quick Links" placeholder sections.

## Testing

- `make version prompts` + `swift build` — clean.
- Fast test tier (2548 tests) — all pass.
- `GeneratedPromptsParityTests` (incl. `wikiIndexDefaultMatchesFile`) — pass (codegenned constant matches the prompt file).
- `FreshSchemaParityTests` (incl. the seed row == `WikiIndex.defaultBody` assertion) — pass.

## What's not in this PR

- No schema/migration change — the seed is a seed value, not a migration. Existing wikis keep whatever `index.md` body they already have.
- No change to the agent's wholesale-rewrite-on-ingest behavior.
