### PR TITLE
Add complete debug logging for ingestion/lint jobs — debug/ folder of JSON files

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -228,6 +228,12 @@ struct ChatView: View {
                             NSWorkspace.shared.activateFileViewerSelecting([logURL])
                         }
                     }
+                    if let debugURL = launcher.debugFolderURL {
+                        Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
+                            NSWorkspace.shared.activateFileViewerSelecting([debugURL])
+                        }
+                        .help("Open the complete debug trace folder (ACP messages, permissions, usage)")
+                    }
                 } label: {
                     Label("Activity", systemImage: "ellipsis.circle")
                 }

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -173,6 +173,12 @@ public actor ACPBackend: AgentBackend {
 
     private var warmProcess: WarmProcess?
 
+    /// The per-run debug logger (verbose ACP wire trace). Created in
+    /// `startProcess()` from `profile.debugLogURL`. nil when debug logging is
+    /// disabled or the folder can't be created. Captured into off-actor tasks
+    /// (drain/prompt/permission) — it's `Sendable`.
+    private var debugLogger: DebugRunLogger?
+
     /// Phase 2: the ACP `SessionId` of the last active session, tracked for
     /// crash recovery. Set in `createSession()`, cleared in `closeSession()`
     /// (intentional close — not a crash) and `cancel()` (full teardown).
@@ -276,10 +282,15 @@ public actor ACPBackend: AgentBackend {
             throw ACPBackendError.noAgentConfigured
         }
 
+        // Create the verbose debug logger (complete ACP wire trace) from the
+        // profile's debugLogURL. Returns nil (no-op) when disabled or the
+        // folder can't be created — the run proceeds regardless.
+        self.debugLogger = DebugRunLogger(folderURL: profile.debugLogURL)
+
         let client = Client()
         // The permission delegate owns the always-ask/yolo policy. It is the
         // `ClientDelegate` that the agent's `session/request_permission` lands on.
-        let permissionDelegate = ACPPermissionDelegate(policy: permissionPolicy)
+        let permissionDelegate = ACPPermissionDelegate(policy: permissionPolicy, debugLogger: debugLogger)
         await client.setDelegate(permissionDelegate)
 
         DebugLog.agent("ACPBackend.startProcess: launching \(spawn.executablePath) \(spawn.arguments.joined(separator: " "))")
@@ -372,12 +383,13 @@ public actor ACPBackend: AgentBackend {
         // Forward agent stderr to DebugLog.agent + run.stderr.log (via the CLI
         // profile's onStderrChunk callback). Best-effort: the stream finishes
         // on terminate, so this task exits naturally.
-        let stderrTask = Task { [client, onStderrChunk] in
+        let stderrTask = Task { [client, onStderrChunk, debugLogger] in
             guard let stderrStream = await client.stderrLines() else { return }
             for await line in stderrStream {
                 if Task.isCancelled { break }
                 DebugLog.agent("ACP stderr: \(line)")
                 onStderrChunk?(line + "\n")
+                debugLogger?.logStderr(line + "\n")
             }
         }
 
@@ -462,6 +474,9 @@ public actor ACPBackend: AgentBackend {
         let discoveredCount = modelsInfo?.availableModels.count ?? 0
         let currentModel = modelsInfo?.currentModelId ?? "(none)"
         DebugLog.agent("ACPBackend.createSession: discovered \(discoveredCount) model(s), current=\(currentModel)")
+        // Capture the full session/new response (model, capabilities,
+        // configOptions) in the debug folder for post-hoc analysis.
+        debugLogger?.logSessionNew(session, sessionId: sessionId, workingDirectory: workingDir)
         // #566: capture the config options the agent advertised (e.g. a
         // `thought_level` select). nil when the agent advertises none — the UI
         // hides the Thinking dropdown in that case.
@@ -561,6 +576,12 @@ public actor ACPBackend: AgentBackend {
         // drain task (UsageUpdate) and prompt task (Usage). Same
         // @unchecked Sendable pattern as TurnCompletionFlag / ProcessHealthFlag.
         let usageState = usageStates[handle.id]
+        // Debug: assign this turn's 1-based index and capture the logger for
+        // off-actor use in the drain/prompt tasks. nil when debug logging is
+        // disabled — all logger calls are no-ops via optional chaining.
+        let debugLogger = self.debugLogger
+        let debugTurn = debugLogger?.nextTurn()
+        debugLogger?.logPromptRequest(text: promptText, sessionId: sessionId, turn: debugTurn ?? 0)
 
         // `.unbounded` buffering — the @MainActor consumer drains promptly and
         // no events may be dropped (same invariant as the CLI backend).
@@ -622,7 +643,7 @@ public actor ACPBackend: AgentBackend {
             // stopReason), while notifications stream in via the fanout
             // subscription. The prompt task and watchdog are both cancelled on
             // consumer termination.
-            let promptTask = Task { [client, sessionId, fanout, completionFlag, processHealth, promptText, usageState, handle] in
+            let promptTask = Task { [client, sessionId, fanout, completionFlag, processHealth, promptText, usageState, handle, debugLogger, debugTurn] in
                 // Subscribe to the session-lifetime fanout (NOT the SDK's
                 // `client.notifications` — that's single-consumer; re-acquiring
                 // it per turn was cause 6). Turns are serialized by the
@@ -631,6 +652,10 @@ public actor ACPBackend: AgentBackend {
                 let drainTask = Task {
                     for await notification in updates {
                         if Task.isCancelled { return }
+                        // Debug: write the full notification to turn-N-updates.jsonl.
+                        if let debugTurn {
+                            debugLogger?.logUpdate(notification, turn: debugTurn)
+                        }
                         guard notification.method == "session/update" else { continue }
                         guard let params = notification.params else { continue }
                         let result = ACPBackend.translateNotification(params: params, sessionId: sessionId, translator: translator)
@@ -680,6 +705,9 @@ public actor ACPBackend: AgentBackend {
                     guard !completionFlag.isDone else { return }
                     completionFlag.markDone()
                     DebugLog.agent("ACPBackend: prompt completed stopReason=\(response.stopReason.rawValue)")
+                    if let debugTurn {
+                        debugLogger?.logPromptResponse(response, turn: debugTurn)
+                    }
                     for event in Self.turnEndEvents(error: nil) {
                         continuation.yield(event)
                     }
@@ -695,6 +723,9 @@ public actor ACPBackend: AgentBackend {
                     // attempt resume().
                     processHealth.markDied()
                     DebugLog.agent("ACPBackend: prompt failed: \(error.localizedDescription)")
+                    if let debugTurn {
+                        debugLogger?.logPromptError(error, turn: debugTurn)
+                    }
                     for event in Self.turnEndEvents(error: error) {
                         continuation.yield(event)
                     }
@@ -921,6 +952,10 @@ public actor ACPBackend: AgentBackend {
             await record.client.terminate()
             record.permissionDelegate.fireOnExit(status: 0)
         }
+        // Clear the debug logger — a new run creates a fresh one via a new
+        // `startProcess` call. The debug files on disk remain for "Reveal
+        // Debug Folder" after the run.
+        debugLogger = nil
     }
 
     /// Close a session WITHOUT terminating the subprocess. Frees the session's
@@ -1049,6 +1084,16 @@ public actor ACPBackend: AgentBackend {
 
         DebugLog.agent("ACPBackend.forkSession: forked session \(forkedSessionId.value) (handle \(sessionID)) ready")
         return SessionHandle(id: sessionID)
+    }
+
+    // MARK: - Debug logging
+
+    /// Write the run-level summary to `debug/summary.json`. Called by the
+    /// launcher after a run completes (in `finish()`). No-op when debug logging
+    /// is disabled. The logger already owns the file writes; this reuses the
+    /// same instance so all debug files land in the same folder.
+    func writeDebugSummary(_ summary: DebugRunSummary) {
+        debugLogger?.logSummary(summary)
     }
 
     // MARK: - Usage tracking (Phase 4)

--- a/Sources/WikiFSEngine/ACPPermissions.swift
+++ b/Sources/WikiFSEngine/ACPPermissions.swift
@@ -320,6 +320,10 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     }
 
     private let policy: PermissionPolicy
+    /// The per-run debug logger, for capturing permission request/response
+    /// exchanges to `permissions.jsonl`. nil when debug logging is disabled —
+    /// all calls are no-ops via optional chaining.
+    private let debugLogger: DebugRunLogger?
     /// Synchronized state (pending map + one-shot onExit). A dedicated struct
     /// (not a tuple) — `OSAllocatedUnfairLock`'s tuple initializer can't infer
     /// the heterogeneous element types, so a named struct is the clean form.
@@ -329,42 +333,49 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     }
     private let lock = OSAllocatedUnfairLock<LockedState>(initialState: LockedState())
 
-    init(policy: PermissionPolicy) {
+    init(policy: PermissionPolicy, debugLogger: DebugRunLogger? = nil) {
         self.policy = policy
+        self.debugLogger = debugLogger
     }
 
     // MARK: - ClientDelegate: the permission seam
 
     public func handlePermissionRequest(request: RequestPermissionRequest) async throws -> RequestPermissionResponse {
+        let response: RequestPermissionResponse
         switch policy {
         case .bypass:
             // Auto-approve: resolve immediately with the request's allow option.
             if let allow = Self.allowOption(in: request.options) {
                 DebugLog.agent("ACPBackend: bypass auto-allow toolCallId=\(request.toolCall.toolCallId)")
-                return RequestPermissionResponse(outcome: PermissionOutcome(optionId: allow.optionId))
+                response = RequestPermissionResponse(outcome: PermissionOutcome(optionId: allow.optionId))
+            } else {
+                response = RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true))
             }
-            return RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true))
 
         case .acceptEdits:
             // Auto-approve tools that look like file edits/writes; defer others.
             if Self.isEditTool(request.toolCall), let allow = Self.allowOption(in: request.options) {
                 DebugLog.agent("ACPBackend: acceptEdits auto-allow edit toolCallId=\(request.toolCall.toolCallId)")
-                return RequestPermissionResponse(outcome: PermissionOutcome(optionId: allow.optionId))
+                response = RequestPermissionResponse(outcome: PermissionOutcome(optionId: allow.optionId))
+            } else {
+                // Non-edit tool → defer to the user (same as alwaysAsk).
+                response = await Self.deferPermission(request: request, lock: lock)
             }
-            // Non-edit tool → defer to the user (same as alwaysAsk).
-            return await Self.deferPermission(request: request, lock: lock)
 
         case .plan:
             // Deny all writes — auto-cancel every permission request.
             DebugLog.agent("ACPBackend: plan auto-deny toolCallId=\(request.toolCall.toolCallId)")
-            return RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true))
+            response = RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true))
 
         case .alwaysAsk:
             // Defer: record pending and SUSPEND until resolve(optionId:). The
             // future UI calls ACPBackend.resolvePermission, which calls into
             // here. This is the pending-permission-blocking pattern from paseo.
-            return await Self.deferPermission(request: request, lock: lock)
+            response = await Self.deferPermission(request: request, lock: lock)
         }
+        // Debug: log the full request/response exchange to permissions.jsonl.
+        debugLogger?.logPermission(request: request, response: response, policy: policy.rawValue)
+        return response
     }
 
     // MARK: - Shared helpers

--- a/Sources/WikiFSEngine/AgentBackend.swift
+++ b/Sources/WikiFSEngine/AgentBackend.swift
@@ -73,19 +73,27 @@ public struct BackendProfile: Sendable {
     /// `WIKI_DB`/`WIKICTL` visible. nil for sessions that don't
     /// need them (none today — every launcher call site sets it).
     public var cli: CLIProfile?
+    /// The `debug/` folder URL under the scratch dir. When set, `ACPBackend`
+    /// captures the complete ACP wire trace (session/new, per-turn
+    /// prompt/updates/response, permissions, stderr) as machine-readable JSON
+    /// files for post-hoc debugging — the verbose companion to the lightweight
+    /// `run.jsonl`. nil = debug logging disabled.
+    public var debugLogURL: URL?
 
     public init(
         model: String? = nil,
         providerHints: [String: String] = [:],
         scratchDirectory: URL? = nil,
         isReadOnly: Bool = false,
-        cli: CLIProfile? = nil
+        cli: CLIProfile? = nil,
+        debugLogURL: URL? = nil
     ) {
         self.model = model
         self.providerHints = providerHints
         self.scratchDirectory = scratchDirectory
         self.isReadOnly = isReadOnly
         self.cli = cli
+        self.debugLogURL = debugLogURL
     }
 }
 

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -111,6 +111,26 @@ public final class AgentLauncher {
     /// `run.stderr.log` holds the agent's stderr. The UI offers a "Reveal Log"
     /// affordance via `logFileURL`.
     public private(set) var logFileURL: URL?
+    /// The per-run `debug/` folder URL (verbose, complete ACP wire trace).
+    /// The companion to `logFileURL`: where `logFileURL` is the lightweight
+    /// `run.jsonl`, `debugFolderURL` is the full `session/new` +
+    /// per-turn `turn-N-prompt.json` / `turn-N-updates.jsonl` /
+    /// `turn-N-response.json` + `permissions.jsonl` + `stderr.log` +
+    /// `summary.json` folder a user can zip and share for debugging. nil
+    /// when no run has started or the folder couldn't be created. Survives
+    /// `finish()` so the UI can reveal it after the run completes.
+    public private(set) var debugFolderURL: URL?
+    /// The wall-clock start time of the current/last run, captured at spawn
+    /// commit so `summary.json`'s duration is accurate even if `runStartedAt`
+    /// (set inside `setGenerating(true)`) is reset.nil when no run has started.
+    private var runCommitedAt: Date?
+    /// The provider label/id for the current/last run — captured at spawn commit
+    /// so `finish()` can write it to `summary.json`. nil when no run has started.
+    private var runProviderLabel: String?
+    /// The model id the current/last run's session used — captured after
+    /// `backend.start` (from the ACP session's advertised models) so `finish()`
+    /// can write it to `summary.json`. nil when not yet resolved.
+    private var runModelId: String?
     /// Wall-clock start time for the current/last run. Used by the UI to show a
     /// heartbeat instead of a context-free spinner.
     public private(set) var runStartedAt: Date?
@@ -872,6 +892,8 @@ public final class AgentLauncher {
         let now = Date()
         runningKind = operation.kind
         lastActivityAt = now
+        runCommitedAt = now
+        runProviderLabel = provider.id
         openLogFiles(in: scratch)
         // A one-shot run is "generating" for its whole duration. The edit lock
         // for one-shot runs is owned by `onLock`/`onUnlock` around the spawn.
@@ -934,7 +956,8 @@ public final class AgentLauncher {
             providerHints: providerHints,
             scratchDirectory: scratch,
             isReadOnly: false,
-            cli: cli)
+            cli: cli,
+            debugLogURL: debugFolderURL)
 
         do {
             DebugLog.agent("run: spawning kind=\(operation.kind.rawValue) wikiID=\(wikiID) exe=\(resolvedPath)")
@@ -1141,7 +1164,7 @@ public final class AgentLauncher {
             providerHints: plannerRouting.providerHints,
             scratchDirectory: scratch,
             isReadOnly: false,
-            cli: makeCLIProfile(operation))
+            cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
         let plannerPrompt = ACPIngestPrompts.plannerPrompt(
             stateFilePath: stateFilePath,
             stagedSourcePaths: stagedSourcePaths,
@@ -1205,7 +1228,7 @@ public final class AgentLauncher {
                 providerHints: executorRouting.providerHints,
                 scratchDirectory: scratch,
                 isReadOnly: false,
-                cli: makeCLIProfile(operation))
+                cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
             let maxConcurrent = await (executorRouting.backend as? ACPBackend)?.maxConcurrentExecutorCount() ?? 1
 
             if maxConcurrent > 1 && plan.distinctSourceFiles.count > 1 {
@@ -1234,7 +1257,7 @@ public final class AgentLauncher {
                         providerHints: executorRouting.providerHints,
                         scratchDirectory: scratch,
                         isReadOnly: false,
-                        cli: makeCLIProfile(operation))
+                        cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
                     let executorPrompt = ACPIngestPrompts.executorPrompt(
                         stateFilePath: stateFilePath,
                         assignments: assignments,
@@ -1303,7 +1326,7 @@ public final class AgentLauncher {
             providerHints: finalizerRouting.providerHints,
             scratchDirectory: scratch,
             isReadOnly: false,
-            cli: makeCLIProfile(operation))
+            cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
         let finalizerPrompt = ACPIngestPrompts.finalizerPrompt(
             stateFilePath: stateFilePath,
             sourceFileNames: sourceFileNames,
@@ -1628,7 +1651,7 @@ public final class AgentLauncher {
             providerHints: routing.providerHints,
             scratchDirectory: scratch,
             isReadOnly: false,
-            cli: makeCLIProfile(operation))
+            cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
         var promptText = operation.prompt(wikiRoot: wikiRoot)
         promptText += "\n\nIMPORTANT: Do NOT dispatch sub-agents, background tasks, or async agents. Do NOT use sleep or ScheduleWakeup. Read all sources, process them, and write all wiki pages directly in THIS session — everything must complete before you stop."
 
@@ -1964,6 +1987,8 @@ public final class AgentLauncher {
         let now = Date()
         runningKind = operation.kind
         lastActivityAt = now
+        runCommitedAt = now
+        runProviderLabel = provider.id
         openLogFiles(in: scratch)
         // SPAWN COMMIT: a query chat never ingests, so the agent-phase flag
         // is empty — clearing any stale value (mirrors `run`'s spawn-commit).
@@ -2027,7 +2052,8 @@ public final class AgentLauncher {
             }(),
             scratchDirectory: scratch,
             isReadOnly: false,
-            cli: cli)
+            cli: cli,
+            debugLogURL: debugFolderURL)
         DebugLog.agent("startInteractiveQuery: profile built providerHints keys=\(profile.providerHints.keys.sorted()) scratch=\(scratch.lastPathComponent)")
 
         do {
@@ -2498,6 +2524,11 @@ public final class AgentLauncher {
         // store with the last turn's events still missing → truncated flash.)
         activeChatID = nil
         closeLogFiles()
+        // Write the verbose debug summary (summary.json) capturing provider,
+        // model, kind, duration, and total usage. No-op when no debug folder
+        // was created for this run. The model id is read from the backend's
+        // last session (a detached task so finish doesn't block on the actor).
+        writeDebugSummary(finishedAt: Date(), status: status)
         exitStatus = status
         // Clear process-alive state.
         isRunning = false
@@ -2559,6 +2590,10 @@ public final class AgentLauncher {
         setGenerating(false)
         runningKind = nil
         logFileURL = nil
+        debugFolderURL = nil
+        runCommitedAt = nil
+        runProviderLabel = nil
+        runModelId = nil
         lastActivityAt = nil
         currentIngestPhase = nil
         currentProcessID = nil
@@ -2587,8 +2622,9 @@ public final class AgentLauncher {
     // MARK: - Backend log files
 
     /// Create `run.jsonl` (raw stream-json) and `run.stderr.log` under the run's
-    /// scratch dir and open append handles. Best-effort: if a handle can't open, the
-    /// in-memory transcript still works.
+    /// scratch dir and open append handles. Also creates the `debug/` folder for
+    /// the verbose ACP wire trace (see `DebugRunLogger`). Best-effort: if a
+    /// handle can't open, the in-memory transcript still works.
     private func openLogFiles(in scratch: URL) {
         let jsonl = scratch.appendingPathComponent("run.jsonl", isDirectory: false)
         let stderrLog = scratch.appendingPathComponent("run.stderr.log", isDirectory: false)
@@ -2598,11 +2634,53 @@ public final class AgentLauncher {
         logHandle = try? FileHandle(forWritingTo: jsonl)
         stderrLogHandle = try? FileHandle(forWritingTo: stderrLog)
         logFileURL = jsonl
+        // Create the debug/ subfolder. `DebugRunLogger` creates the actual
+        // `debug/` + `debug/turns/` directories lazily when instantiated in
+        // `ACPBackend.startProcess` from this URL; we just expose the path here
+        // so the UI can reveal it and the backend profile can carry it.
+        debugFolderURL = scratch.appendingPathComponent("debug", isDirectory: true)
     }
 
     private func writeLog(_ text: String, to handle: FileHandle?) {
         guard let handle, let data = text.data(using: .utf8) else { return }
         try? handle.write(contentsOf: data)
+    }
+
+    /// Write `summary.json` to the run's `debug/` folder with provider, model,
+    /// kind, duration, and total usage. Reads the model id from the backend (a
+    /// short actor hop) and the accumulated usage from `runTotalUsage`. Runs as
+    /// a detached `@MainActor` task so `finish()` doesn't block on the actor hop
+    /// — the debug folder persists on disk, the task writes to it if it still
+    /// exists. Best-effort: non-fatal if the write fails (logged via DebugLog).
+    private func writeDebugSummary(finishedAt: Date, status: Int32) {
+        guard debugFolderURL != nil else { return }
+        let startedAt = runCommitedAt
+        let providerLabel = runProviderLabel
+        let kind = runningKind
+        let totalUsage = runTotalUsage
+        let session = sessionHandle
+        let backend = self.backend
+        Task { @MainActor in
+            // Try to read the model id from the ACP backend (last session's
+            // advertised current model). Non-fatal if nil — the field is
+            // optional in the summary.
+            var modelId: String?
+            if let session, let acp = backend as? ACPBackend {
+                modelId = await acp.sessionUsage(for: session)?.modelId
+            }
+            let summary = DebugRunSummary.from(
+                provider: providerLabel,
+                model: modelId,
+                kind: kind?.rawValue,
+                startedAt: startedAt,
+                finishedAt: finishedAt,
+                usage: totalUsage,
+                phases: [])
+            DebugLog.agent("writeDebugSummary: writing summary.json provider=\(providerLabel ?? "nil") model=\(modelId ?? "nil") kind=\(kind?.rawValue ?? "nil")")
+            if let acp = backend as? ACPBackend {
+                await acp.writeDebugSummary(summary)
+            }
+        }
     }
 
     private func closeLogFiles() {

--- a/Sources/WikiFSEngine/DebugRunLogger.swift
+++ b/Sources/WikiFSEngine/DebugRunLogger.swift
@@ -1,0 +1,343 @@
+import Foundation
+import ACPModel
+import WikiFSCore
+
+/// Best-effort per-run debug logger that captures the **complete** ACP
+/// wire-level trace for a single agent run into `<scratch>/debug/`.
+///
+/// Every write is best-effort — failures are logged via `DebugLog` and never
+/// thrown, so a logging failure can never break an agent run. The logger is
+/// `@unchecked Sendable` with an internal lock (same pattern as
+/// `SessionUsageState` / `NotificationFanout`) so it can be captured by the
+/// off-actor drain/prompt tasks inside `ACPBackend.send`.
+///
+/// Folder layout (per the debug-logs task):
+/// ```
+/// <scratch>/debug/
+/// ├── session-new.json          — session/new response (model, capabilities, configOptions)
+/// ├── turns/
+/// │   ├── turn-1-prompt.json    — session/prompt request (full content)
+/// │   ├── turn-1-updates.jsonl  — every session/update notification (one JSON per line)
+/// │   ├── turn-1-response.json  — session/prompt response (stopReason, usage)
+/// │   └── turn-2-…
+/// ├── permissions.jsonl         — every request_permission + the client's response
+/// ├── stderr.log                — full agent stderr
+/// └── summary.json              — run metadata (written by the launcher after the run)
+/// ```
+///
+/// The existing lightweight `run.jsonl`/`run.stderr.log` are NOT touched —
+/// this is the verbose, complete, machine-readable companion.
+final class DebugRunLogger: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private let folderURL: URL
+    private let turnsURL: URL
+    private var turnCounter = 0
+    private var sessionCounter = 0
+
+    /// Pretty-printed encoder for single-message `.json` files.
+    private let prettyEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    /// Compact encoder for `.jsonl` files (one JSON object per line).
+    private let compactEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    /// Create the `debug/` + `debug/turns/` directories. Returns nil when
+    /// `folderURL` is nil (debug logging disabled) or if the directories
+    /// cannot be created — the caller proceeds without debug logging.
+    init?(folderURL: URL?) {
+        guard let folderURL else { return nil }
+        let turns = folderURL.appendingPathComponent("turns", isDirectory: true)
+        let manager = FileManager.default
+        do {
+            try manager.createDirectory(at: folderURL, withIntermediateDirectories: true)
+            try manager.createDirectory(at: turns, withIntermediateDirectories: true)
+        } catch {
+            DebugLog.agent("DebugRunLogger: could not create debug folder at \(folderURL.path): \(error.localizedDescription)")
+            return nil
+        }
+        self.folderURL = folderURL
+        self.turnsURL = turns
+    }
+
+    // MARK: - Session-level
+
+    /// Write the `session/new` response (model, capabilities, configOptions)
+    /// to `session-new.json`. For the first session the file is
+    /// `session-new.json`; for subsequent sessions (multi-phase ingest —
+    /// planner/executors/finalizer) it is `session-new-2.json`,
+    /// `session-new-3.json`, etc. so no session's data is lost.
+    func logSessionNew(
+        _ response: NewSessionResponse,
+        sessionId: SessionId,
+        workingDirectory: String?
+    ) {
+        let index = nextSessionIndex()
+        let name = index == 1 ? "session-new" : "session-new-\(index)"
+        let url = folderURL.appendingPathComponent("\(name).json", isDirectory: false)
+        let payload: [String: Any?] = [
+            "sessionId": sessionId.value,
+            "workingDirectory": workingDirectory,
+            "response": encodeToAny(response),
+        ]
+        writeJSON(payload, to: url, encoder: prettyEncoder)
+    }
+
+    // MARK: - Turns
+
+    /// Increment and return the 1-based turn index. Called at the top of each
+    /// `ACPBackend.send` before the prompt goes out. Turn numbers are
+    /// per-run (continue across multi-phase sessions) since a run's turns
+    /// are serialized by the generation gate.
+    func nextTurn() -> Int {
+        lock.lock()
+        turnCounter += 1
+        let n = turnCounter
+        lock.unlock()
+        return n
+    }
+
+    /// Write the `session/prompt` request for `turn` to
+    /// `turn-N-prompt.json`. The content blocks are captured as their text
+    /// representation (the primary content type sent today).
+    func logPromptRequest(text: String, sessionId: SessionId, turn: Int) {
+        let url = turnFile(turn, suffix: "prompt", ext: "json")
+        let payload: [String: Any?] = [
+            "turn": turn,
+            "sessionId": sessionId.value,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "content": [
+                ["type": "text", "text": text],
+            ],
+        ]
+        writeJSON(payload, to: url, encoder: prettyEncoder)
+    }
+
+    /// Append a `session/update` notification to `turn-N-updates.jsonl` (one
+    /// compact JSON object per line). Called from the per-turn drain task for
+    /// every notification the agent sends.
+    func logUpdate(_ notification: JSONRPCNotification, turn: Int) {
+        let url = turnFile(turn, suffix: "updates", ext: "jsonl")
+        let payload: [String: Any?] = [
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "method": notification.method,
+            "params": encodeToAny(notification.params),
+        ]
+        appendJSONLine(payload, to: url)
+    }
+
+    /// Write the `session/prompt` response for `turn` to
+    /// `turn-N-response.json`. Captures stopReason, usage, and any _meta.
+    func logPromptResponse(_ response: SessionPromptResponse, turn: Int) {
+        let url = turnFile(turn, suffix: "response", ext: "json")
+        let payload: [String: Any?] = [
+            "turn": turn,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "response": encodeToAny(response),
+        ]
+        writeJSON(payload, to: url, encoder: prettyEncoder)
+    }
+
+    /// Write a prompt error for `turn` to `turn-N-response.json` (when
+    /// `sendPrompt` throws, no `SessionPromptResponse` is available).
+    func logPromptError(_ error: Error, turn: Int) {
+        let url = turnFile(turn, suffix: "response", ext: "json")
+        let payload: [String: Any?] = [
+            "turn": turn,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "error": error.localizedDescription,
+        ]
+        writeJSON(payload, to: url, encoder: prettyEncoder)
+    }
+
+    // MARK: - Permissions
+
+    /// Append a permission request + the client's response + the policy that
+    /// drove the decision to `permissions.jsonl` (one compact JSON per line).
+    func logPermission(
+        request: RequestPermissionRequest,
+        response: RequestPermissionResponse,
+        policy: String
+    ) {
+        let url = folderURL.appendingPathComponent("permissions.jsonl", isDirectory: false)
+        let payload: [String: Any?] = [
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "policy": policy,
+            "request": encodeToAny(request),
+            "response": encodeToAny(response),
+        ]
+        appendJSONLine(payload, to: url)
+    }
+
+    // MARK: - Stderr
+
+    /// Append a line of agent stderr to `debug/stderr.log`.
+    func logStderr(_ line: String) {
+        let url = folderURL.appendingPathComponent("stderr.log", isDirectory: false)
+        guard let data = line.data(using: .utf8) else { return }
+        append(data, to: url)
+    }
+
+    // MARK: - Summary (written by the launcher)
+
+    /// Write run-level metadata to `summary.json`. Called by the launcher
+    /// after the run completes (in `finish()`).
+    func logSummary(_ summary: DebugRunSummary) {
+        let url = folderURL.appendingPathComponent("summary.json", isDirectory: false)
+        writeJSON(encodeToAny(summary), to: url, encoder: prettyEncoder)
+    }
+
+    /// The absolute path to the `debug/` folder (for the "Reveal Debug Folder"
+    /// UI affordance).
+    var folderPath: URL { folderURL }
+
+    // MARK: - Private helpers
+
+    private func nextSessionIndex() -> Int {
+        lock.lock()
+        sessionCounter += 1
+        let n = sessionCounter
+        lock.unlock()
+        return n
+    }
+
+    private func turnFile(_ turn: Int, suffix: String, ext: String) -> URL {
+        turnsURL.appendingPathComponent("turn-\(turn)-\(suffix)", isDirectory: false)
+            .appendingPathExtension(ext)
+    }
+
+    /// Encode an `Encodable` to an `Any` suitable for nesting inside a
+    /// `[String: Any]` that gets serialized by `JSONSerialization`. Returns
+    /// nil on failure — the field is omitted rather than crashing.
+    private func encodeToAny<T: Encodable>(_ value: T?) -> Any? {
+        guard let value else { return nil }
+        guard let data = try? prettyEncoder.encode(value) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: [.allowFragments])
+    }
+
+    /// Encode a `[String: Any?]` dictionary to pretty-printed JSON and write to
+    /// `url`. Best-effort: failures are logged, never thrown.
+    private func writeJSON(_ payload: Any?, to url: URL, encoder _: JSONEncoder) {
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: payload ?? [String: Any](),
+                options: [.prettyPrinted, .sortedKeys, .fragmentsAllowed])
+            try data.write(to: url, options: .atomic)
+        } catch {
+            DebugLog.agent("DebugRunLogger: writeJSON failed \(url.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+
+    /// Encode a `[String: Any?]` dictionary to compact JSON and append as one
+    /// line to `url` (`.jsonl`). Best-effort.
+    private func appendJSONLine(_ payload: [String: Any?], to url: URL) {
+        let unwrapped = payload.mapValues { $0 ?? NSNull() }
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: unwrapped, options: [.sortedKeys, .fragmentsAllowed])
+            var line = data
+            line.append(0x0A) // \n
+            append(line, to: url)
+        } catch {
+            DebugLog.agent("DebugRunLogger: appendJSONLine failed \(url.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+
+    /// Append raw `Data` to `url`, creating the file if needed. Best-effort.
+    private func append(_ data: Data, to url: URL) {
+        let manager = FileManager.default
+        if !manager.fileExists(atPath: url.path) {
+            manager.createFile(atPath: url.path, contents: nil)
+        }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } catch {
+            DebugLog.agent("DebugRunLogger: append failed \(url.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - Summary model
+
+/// Run-level metadata written to `debug/summary.json` after a run completes.
+/// Codable so it round-trips through `JSONEncoder` for a stable, sorted
+/// JSON output.
+struct DebugRunSummary: Codable, Sendable {
+    struct PhaseBreakdown: Codable, Sendable {
+        var name: String
+        var durationSeconds: Double?
+        var inputTokens: Int?
+        var outputTokens: Int?
+        var totalTokens: Int?
+        var cost: Double?
+    }
+
+    var provider: String?
+    var model: String?
+    var kind: String?
+    var startedAt: String?
+    var finishedAt: String?
+    var durationSeconds: Double?
+    var usage: UsageSnapshot?
+    var phases: [PhaseBreakdown]
+
+    struct UsageSnapshot: Codable, Sendable {
+        var inputTokens: Int
+        var outputTokens: Int
+        var totalTokens: Int
+        var cachedReadTokens: Int?
+        var thoughtTokens: Int?
+        var cost: Double?
+        var currency: String?
+        var contextUsed: Int
+        var contextSize: Int
+    }
+
+    static func from(
+        provider: String?,
+        model: String?,
+        kind: String?,
+        startedAt: Date?,
+        finishedAt: Date?,
+        usage: SessionUsage?,
+        phases: [PhaseBreakdown]
+    ) -> DebugRunSummary {
+        let fmt = ISO8601DateFormatter()
+        var duration: Double?
+        if let s = startedAt, let f = finishedAt {
+            duration = f.timeIntervalSince(s)
+        }
+        var snap: UsageSnapshot?
+        if let u = usage {
+            snap = UsageSnapshot(
+                inputTokens: u.inputTokens,
+                outputTokens: u.outputTokens,
+                totalTokens: u.totalTokens,
+                cachedReadTokens: u.cachedReadTokens,
+                thoughtTokens: u.thoughtTokens,
+                cost: u.cost,
+                currency: u.currency,
+                contextUsed: u.contextUsed,
+                contextSize: u.contextSize)
+        }
+        return DebugRunSummary(
+            provider: provider,
+            model: model,
+            kind: kind,
+            startedAt: startedAt.map { fmt.string(from: $0) },
+            finishedAt: finishedAt.map { fmt.string(from: $0) },
+            durationSeconds: duration,
+            usage: snap,
+            phases: phases)
+    }
+}

--- a/Tests/WikiFSTests/DebugRunLoggerTests.swift
+++ b/Tests/WikiFSTests/DebugRunLoggerTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+import Foundation
+import ACPModel
+@testable import WikiFSEngine
+
+/// Unit tests for `DebugRunLogger` — verifies the folder structure, JSON
+/// validity, and best-effort behavior (no throw on failure).
+final class DebugRunLoggerTests: XCTestCase {
+
+    var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DebugRunLoggerTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testNilFolderReturnsNil() {
+        // When folderURL is nil, the logger is disabled (returns nil).
+        XCTAssertNil(DebugRunLogger(folderURL: nil))
+    }
+
+    func testCreatesDebugFolderStructure() throws {
+        let debugURL = tempDir.appendingPathComponent("debug", isDirectory: true)
+        let logger = DebugRunLogger(folderURL: debugURL)
+        XCTAssertNotNil(logger)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: debugURL.path))
+        let turnsURL = debugURL.appendingPathComponent("turns", isDirectory: true)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: turnsURL.path))
+    }
+
+    func testTurnFilesAreWritten() throws {
+        let debugURL = tempDir.appendingPathComponent("debug", isDirectory: true)
+        guard let logger = DebugRunLogger(folderURL: debugURL) else {
+            return XCTFail("Logger should be created")
+        }
+        let turn = logger.nextTurn()
+        XCTAssertEqual(turn, 1)
+
+        // Write a prompt request.
+        let sessionId = SessionId("test-session")
+        logger.logPromptRequest(text: "Hello, agent", sessionId: sessionId, turn: turn)
+
+        // Write an update notification.
+        let notification = JSONRPCNotification(method: "session/update", params: nil)
+        logger.logUpdate(notification, turn: turn)
+
+        // Write a prompt response.
+        let response = SessionPromptResponse(stopReason: .endTurn, usage: nil, _meta: nil)
+        logger.logPromptResponse(response, turn: turn)
+
+        // Verify the prompt file exists and is valid JSON.
+        let promptURL = debugURL.appendingPathComponent("turns", isDirectory: true)
+            .appendingPathComponent("turn-1-prompt.json", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: promptURL.path))
+        let promptData = try Data(contentsOf: promptURL)
+        let promptObj = try JSONSerialization.jsonObject(with: promptData)
+        XCTAssertNotNil(promptObj as? [String: Any])
+
+        // Verify the updates file exists, has one JSON line, and is valid.
+        let updatesURL = debugURL.appendingPathComponent("turns", isDirectory: true)
+            .appendingPathComponent("turn-1-updates.jsonl", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: updatesURL.path))
+        let updatesData = try Data(contentsOf: updatesURL)
+        let updatesStr = String(data: updatesData, encoding: .utf8) ?? ""
+        let lines = updatesStr.split(separator: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 1)
+        let updateObj = try JSONSerialization.jsonObject(
+            with: lines[0].data(using: .utf8)!)
+        XCTAssertNotNil(updateObj as? [String: Any])
+
+        // Verify the response file exists and is valid JSON.
+        let responseURL = debugURL.appendingPathComponent("turns", isDirectory: true)
+            .appendingPathComponent("turn-1-response.json", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: responseURL.path))
+        let responseData = try Data(contentsOf: responseURL)
+        let responseObj = try JSONSerialization.jsonObject(with: responseData)
+        XCTAssertNotNil(responseObj as? [String: Any])
+    }
+
+    func testTurnCounterIncrements() {
+        let debugURL = tempDir.appendingPathComponent("debug", isDirectory: true)
+        guard let logger = DebugRunLogger(folderURL: debugURL) else {
+            return XCTFail("Logger should be created")
+        }
+        XCTAssertEqual(logger.nextTurn(), 1)
+        XCTAssertEqual(logger.nextTurn(), 2)
+        XCTAssertEqual(logger.nextTurn(), 3)
+    }
+
+    func testStderrAppend() throws {
+        let debugURL = tempDir.appendingPathComponent("debug", isDirectory: true)
+        guard let logger = DebugRunLogger(folderURL: debugURL) else {
+            return XCTFail("Logger should be created")
+        }
+        logger.logStderr("line 1\n")
+        logger.logStderr("line 2\n")
+        let stderrURL = debugURL.appendingPathComponent("stderr.log", isDirectory: false)
+        let content = try String(contentsOf: stderrURL, encoding: .utf8)
+        XCTAssertTrue(content.contains("line 1"))
+        XCTAssertTrue(content.contains("line 2"))
+    }
+
+    func testSummaryIsWritten() throws {
+        let debugURL = tempDir.appendingPathComponent("debug", isDirectory: true)
+        guard let logger = DebugRunLogger(folderURL: debugURL) else {
+            return XCTFail("Logger should be created")
+        }
+        let summary = DebugRunSummary.from(
+            provider: "claude",
+            model: "sonnet",
+            kind: "ingest",
+            startedAt: Date(timeIntervalSince1970: 1000),
+            finishedAt: Date(timeIntervalSince1970: 1010),
+            usage: nil,
+            phases: [])
+        logger.logSummary(summary)
+        let summaryURL = debugURL.appendingPathComponent("summary.json", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: summaryURL.path))
+        let data = try Data(contentsOf: summaryURL)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["provider"] as? String, "claude")
+        XCTAssertEqual(obj?["kind"] as? String, "ingest")
+        XCTAssertEqual(obj?["durationSeconds"] as? Double, 10.0)
+    }
+
+    func testSessionNewIsWritten() throws {
+        let debugURL = tempDir.appendingPathComponent("debug", isDirectory: true)
+        guard let logger = DebugRunLogger(folderURL: debugURL) else {
+            return XCTFail("Logger should be created")
+        }
+        let session = NewSessionResponse(sessionId: SessionId("s1"))
+        logger.logSessionNew(session, sessionId: SessionId("s1"), workingDirectory: "/tmp")
+        let url = debugURL.appendingPathComponent("session-new.json", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testSessionNewSecondSessionUsesIndex() throws {
+        let debugURL = tempDir.appendingPathComponent("debug", isDirectory: true)
+        guard let logger = DebugRunLogger(folderURL: debugURL) else {
+            return XCTFail("Logger should be created")
+        }
+        let session = NewSessionResponse(sessionId: SessionId("s1"))
+        logger.logSessionNew(session, sessionId: SessionId("s1"), workingDirectory: nil)
+        logger.logSessionNew(session, sessionId: SessionId("s2"), workingDirectory: nil)
+        let url1 = debugURL.appendingPathComponent("session-new.json", isDirectory: false)
+        let url2 = debugURL.appendingPathComponent("session-new-2.json", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url1.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url2.path))
+    }
+}


### PR DESCRIPTION
## Summary

Add complete debug logging for ingestion/lint/query jobs — a folder of machine-readable JSON files capturing every ACP wire-level interaction for post-hoc debugging and sharing.

When an agent run executes, a `<scratch-dir>/debug/` folder is created containing the full ACP trace:

```
<scratch-dir>/debug/
├── session-new.json          — session/new response (model, capabilities, configOptions)
├── turns/
│   ├── turn-1-prompt.json    — session/prompt request (full content)
│   ├── turn-1-updates.jsonl  — every session/update notification (one JSON per line)
│   ├── turn-1-response.json  — session/prompt response (stopReason, usage)
│   └── turn-2-…
├── permissions.jsonl         — every request_permission + the client's response
├── stderr.log                — full agent stderr
└── summary.json              — run metadata: provider, model, kind, duration, total usage
```

## Changes

- **New `DebugRunLogger`** (`Sources/WikiFSEngine/DebugRunLogger.swift`): a `@unchecked Sendable` best-effort logger that owns the `debug/` folder. Writes pretty-printed JSON for single-message files, compact JSON for `.jsonl` lines. All I/O is best-effort (failures logged via `DebugLog`, never thrown).

- **`BackendProfile`**: new `debugLogURL: URL?` field. When set, `ACPBackend` captures the complete wire trace.

- **`ACPBackend`**:
  - `startProcess()` creates a `DebugRunLogger` from `profile.debugLogURL`
  - `createSession()` writes `session-new.json`
  - `send()` writes turn prompt requests, drain notifications, and responses
  - Agent stderr is mirrored to `debug/stderr.log` alongside the existing `run.stderr.log`
  - `writeDebugSummary()` writes `summary.json` from the launcher after the run

- **`ACPPermissionDelegate`**: logs each `request_permission` + the client's response + the policy to `permissions.jsonl`

- **`AgentLauncher`**:
  - Creates the `debug/` folder under each run's scratch dir
  - Passes `debugLogURL` to every `BackendProfile` (run, multi-phase ingest, interactive query)
  - Writes `summary.json` in `finish()` with provider, model, kind, duration, usage
  - Exposes `debugFolderURL` as a `@Observable` property for the UI

- **`ChatView`**: the Activity menu now offers both "Reveal Log" (the existing lightweight `run.jsonl`) and "Reveal Debug Folder" (opens the `debug/` folder in Finder).

- **Tests**: `DebugRunLoggerTests` (8 tests) covering folder creation, JSON validity, turn counter, session-new indexing, stderr append, summary writing, and nil-folder disabling.

## Design notes

- The existing `run.jsonl` / `run.stderr.log` are **not removed** — they're the lightweight per-run logs. The `debug/` folder is the verbose, complete companion.
- Always-on, not opt-in: JSON is compact, the scratch dir is cleaned up unless the user reveals it. No user-facing setting needed.
- Multi-phase ingest (planner → executors → finalizer) shares one `debug/` folder; sessions are indexed (`session-new.json`, `session-new-2.json`, etc.) so no session's data is lost.
- Best-effort I/O throughout — a logging failure can never break an agent run.

## Test plan

- [x] `make version prompts` + `swift build` — succeeds
- [x] `swift test --filter DebugRunLoggerTests` — 8/8 pass
- [x] Fast test tier (`swift test --skip ...`) — 2548 tests pass
- [ ] Manual: run an ingestion, reveal the debug folder, verify the JSON files are present and valid
