### PR TITLE
Fix Window menu: open-windows list + Show Previous/Next Tab (#567)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,22 +2,147 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
-## 2026-07-18 — Fix missing activity ingestion details: thinking-level dropped in enrichment (branch `fix/missing-activity-details`)
+## 2026-07-18 — Fix Window menu: open-windows list + Show Previous/Next Tab (#567)
 
-**Problem:** The Activity window lost the thinking-effort level segment ("high"/"medium"/"low") for completed ingestion/lint runs. The user reported that rich run metadata (model name, token counts, cost, timing) had partially regressed — the thinking-effort segment introduced in #566 was always blank.
+**Problem:** The Window menu was missing two standard macOS features: (1) the
+list of open windows below "Bring All to Front", and (2) the "Show Previous/Next
+Tab" items (⇧⌘[ / ⇧⌘]) for cycling editor tabs within a window.
 
-**Root cause:** PR #569 (`Surface thinking effort level in UI`) added `thinkingLevel: String?` to `SessionUsage` and wired it through `ACPBackend.sessionUsage(for:)` and `UsageFormatter.fullSummary`, but the enrichment hop in `AgentLauncher.capturePhaseUsage` (which reattaches the configured `providerLabel`) reconstructed `SessionUsage` with an explicit memberwise init that omitted the `thinkingLevel` parameter — defaulting it to `nil` on every call. Since every `capturePhaseUsage` call site passes a non-nil `providerLabel`, the `if let providerLabel` branch always ran, and `thinkingLevel` was always lost. `SessionUsage.merging` then propagated `nil` through `runTotalUsage` → `onUsage` → the `.usage` queue event → `QueueActivityTracker.itemUsage`, so the Activity window's `fullSummary` rendered without the thinking-effort segment.
+**Root cause:** Nothing was *suppressing* the auto window list — `.commands`
+only replaced `.newItem`, and `removeRedundantAppMenuItems` strips only
+About/Settings items. SwiftUI's value-driven `WindowGroup(for: String.self)`
+just doesn't reliably surface value-typed windows in the standard Window-menu
+list, so the list was empty. The tab-cycling commands simply didn't exist.
 
-**Investigation (pipeline trace):** Verified the full usage pipeline is structurally intact — `ACPBackend.sessionUsage` → `capturePhaseUsage` → `runTotalUsage` → `AppQueueIngestionProvider.onUsage?(launcher.runTotalUsage)` × 3 sites → `emitUsage` → `QueueEngine.makeEmitUsage` broadcaster → `QueueActivityTracker.handle(.usage)` → `itemUsage` → `ActivityWindowView.fullSummary`. The display code (row + header) is present and correct. The #565/#571/#572/#573 merges did not break the wiring in `WikiFSApp.swift` (the `UsageEmitBox` seam). The only dropped field was `thinkingLevel` in `capturePhaseUsage`.
+**Fix:** Added `WindowMenuCommands` (`Sources/WikiFS/Window/WindowMenuCommands.swift`):
+- `CommandGroup(after: .windowList)` renders an open-windows list driven by a
+  small `@MainActor @Observable WindowListTracker` that re-derives from
+  `NSApplication.shared.windows` on `NSWindow` lifecycle notifications (become
+  key/main, occlusion-state change, will-close, app activation). Wiki window
+  titles resolve from the `wiki:` identifier → `WikiRegistryClient` display
+  name (falling back to the AppKit title). `after:` (not `replacing:`) can't
+  clobber the system Minimize/Zoom/Bring-All-to-Front items; the auto list is
+  observed-empty so there's no duplication.
+- "Show Previous Tab" / "Show Next Tab" `Button`s with `.keyboardShortcut`
+  (`[`/`]`, `.command + .shift`) placed in the Window menu where macOS puts
+  them. The action targets `SessionManager.frontmostSession?.store`, cycles
+  `WikiStoreModel.tabs` with wrap-around (Euclidean modulo), and self-guards
+  (no-op with no frontmost session / <2 tabs) so the shortcuts always fire.
 
-**Fix:** One-line addition — pass `thinkingLevel: usage.thinkingLevel` through the enrichment `SessionUsage` init in `capturePhaseUsage`. The `else` branch (no `providerLabel`) already passed `usage` directly. Added 3 regression tests covering `SessionUsage.merging` thinking-level latest-wins + existing-preserved, and `UsageFormatter.fullSummary` thinking-level inclusion between model and tokens.
+Wired via `WikiFSApp.commands`; the tracker is `@State`-owned, started in
+`startStatusItem()` alongside the status-item controller.
+
+Verified: `make version prompts` → `swift build` (clean) → fast test tier
+(2569 tests passed).
+
+## 2026-07-18 — Fix EXC_BAD_ACCESS crash in Activity window when cancelling a lint job
+
+**Problem:** App crashed with `EXC_BAD_ACCESS (SIGSEGV)` in
+`objc_msgSend` → `swift_getObjectType` → `swift_task_isMainExecutorImpl` inside
+`ActivityWindowView.sidebar.getter` → `ForEachChild.updateValue` →
+`ObservationCenter._withObservation`. Triggered by cancelling a lint job from
+the Agent Queue activity window. The crash dereferenced a garbage pointer
+(`0x225005b4c20` — freed heap, not a tagged pointer) during a Swift runtime
+`@MainActor` isolation check.
+
+**Root cause:** The `ForEach` row body in `itemRow(_:)` read `@MainActor
+@Observable` properties on three objects — `SessionManager.sessions`,
+`WikiStoreModel.sources`/`.summaries`, and `QueueActivityTracker.itemUsage` —
+once per row on every re-evaluation. Each read triggers
+`swift_task_isMainExecutorImpl` (the runtime's "am I on MainActor?" check)
+inside `ObservationCenter._withObservation` → `ForEachChild.updateValue`. When
+the queue engine emits a `.cancelled` event, `QueueActivityTracker.handle(_:)`
+mutates `ingestingSourceIDs`/`lintingItemIDs` (observable writes) while the
+`ForEach` re-renders rows that read those same observables. Under this
+concurrent-mutation + isolation-check window, the runtime constructs a
+`SerialExecutorRef` from freed/bogus object metadata → crash. This is a known
+Swift runtime bug class (swiftlang/swift#89197, related #87097/PR #87163) in
+which the `SerialExecutorRef` handed to `isMainExecutor()` is constructed from
+bogus bits.
+
+**Fix:** Precompute all `@Observable`-derived display data into plain values
+*before* the `ForEach`, so the row body has zero `@Observable` property accesses.
+New `RowDisplayData` struct + `buildRowDisplayData(for:)` snapshots
+`sessionManager.sessions`, `activityTracker.itemUsage`, and the per-store
+`sources`/`summaries` lookups once at the sidebar level (where observation
+tracking is correct and the isolation check runs once, not per-row). The
+`itemRow(_:)` body now reads only from `QueueItem` (value) and `RowDisplayData`
+(value). The detail pane's helpers (`rowTitle(for:)`, `rowSubtitle(for:)`,
+`targetNames(for:)`) still read observables — they're outside the
+`ForEachChild.updateValue` path so they're not at risk.
+
+**Files changed:**
+- `Sources/WikiFS/Queue/ActivityWindowView.swift` — new `RowDisplayData` struct,
+  `buildRowDisplayData(for:)`, `computeRowTitle(for:wikiName:names:)`,
+  `computeRowSubtitle(for:wikiName:)` pure functions; `sidebar` getter
+  precomputes display data; `itemRow` takes `RowDisplayData?` and reads only
+  plain values; old `rowTitle`/`rowSubtitle` refactored as thin wrappers around
+  the pure functions for the detail pane's use.
+
+**Build/Tests:** `swift build` clean (72s); fast test tier 2542 tests in 216
+suites pass. Verified zero `@Observable` reads in `itemRow` body via
+`rg 'activityTracker\.|sessionManager\?|\.sessions\[|\.sources\b|\.summaries\b'`
+inside the function — no matches.
+## 2026-07-18 — Issue #572: YouTube/Vimeo URL ingest UX — video title as display name + embed player in source detail (branch `feature/youtube-embed-title-ux`)
+
+**Problem:** Pasting a YouTube/Vimeo URL created a byteless embed source whose
+display name was the synthetic `youtube-<videoId>` (not the real video title),
+and `SourceDetailView` routed byteless sources to the inert "Raw Source"
+fallback — the transcript markdown (from #564) and the embed player were never
+shown in the detail view. Only the in-page reader (`![[source:…]]` directive)
+rendered the iframe.
+
+**Fix (three parts):**
+
+1. **Video title via oEmbed** (`Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift`):
+   a pure `title(for:fetcher:)` that builds each provider's oEmbed endpoint URL
+   (YouTube/Vimeo/Spotify/SoundCloud — `remote-media` has none), fetches the JSON
+   off-main via the injected `URLResourceFetcher` seam, and parses the `title`
+   field. Never throws — a network/decode failure returns `nil` so the synthetic
+   name stays in place (mirrors the `YouTubeTranscriptService` best-effort
+   discipline). Wired into both byteless paths in `WikiStoreModel`:
+   `bytelessMediaOutcome` and `youtubeEmbedAndTranscriptOutcome` now call
+   `fetchMediaTitle` (a detached `Task` helper) and `setSourceDisplayName` on
+   success, threading the resolved title to every `openTab` call.
+
+2. **Embed start-time** (`ExternalEmbed.youTubeStartTime(from:)`): parses
+   YouTube's `&t=` / `?start=` (integer + clock form `1m30s`/`1h2m30s`) into
+   integer seconds and stamps `&start=` onto the embed URL so the player
+   resumes at the pasted timestamp.
+
+3. **Embed player + transcript in `SourceDetailView`**
+   (`Sources/WikiFS/Sources/MediaEmbedPlayerView.swift`): a self-contained
+   `WKWebView` (`NSViewRepresentable`) that renders one provider iframe, loaded
+   under `WikiReaderOrigin` (the same synthetic https origin the reader uses) so
+   YouTube's parent-origin check passes (no 153-error). The iframe attributes
+   mirror `WikiLinkMarkdown.embedHTML` exactly (YouTube eager-loads + forwards
+   the referrer; others lazy-load). A pure `MediaEmbedPlayerHTML.document(for:)`
+   builds the HTML so it is unit-testable without a WKWebView. `SourceDetailView`
+   gains `embedDescriptor`/`embedTarget` computed from the loaded `origin` + the
+   source mime, branches `contentArea` to a new `embedContent(target:)` layout
+   (player on top, transcript below in the existing `WikiReaderView`), and a
+   "No Transcript Available" placeholder when no capped/markdown exists.
 
 Changes:
-- `Sources/WikiFSEngine/AgentLauncher.swift` (`capturePhaseUsage`) — pass `thinkingLevel: usage.thinkingLevel` in the providerLabel enrichment init.
-- `Tests/WikiFSTests/ACPBackendTests.swift` — added `thinkingLevel: "high"` assertion to `sessionUsageStructCarriesAllFields`; 2 new tests (`mergingCarriesLatestThinkingLevel`, `mergingPreservesExistingThinkingLevelWhenNewIsNil`).
-- `Tests/WikiFSTests/UsageFormatterTests.swift` — 2 new tests (`fullSummaryIncludesThinkingLevelBetweenModelAndTokens`, `fullSummaryOmitsThinkingLevelWhenNil`).
+- `Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift` — new pure oEmbed
+  title fetcher (URL builder + JSON parse).
+- `Sources/WikiFSCore/Integrations/ExternalEmbed.swift` — `youTubeStartTime` +
+  `parseClockDuration` helpers, stamped into the YouTube embed URL.
+- `Sources/WikiFSCore/Store/WikiStoreModel.swift` — `bytelessMediaOutcome` +
+  `youtubeEmbedAndTranscriptOutcome` now async + take the URL fetcher and apply
+  the oEmbed title; new `fetchMediaTitle` detached-Task helper.
+- `Sources/WikiFS/Sources/MediaEmbedPlayerView.swift` — new standalone player
+  view + pure HTML builder.
+- `Sources/WikiFS/Sources/SourceDetailView.swift` — `embedDescriptor`/
+  `embedTarget`/`isBytelessEmbedWithPlayer` computed; `embedContent(target:)`
+  section; `origin` already loaded by `.onAppear`/`.task`.
+- `Tests/WikiFSTests/MediaEmbedPlayerTests.swift` — 17 pure tests (start-time
+  parsing, oEmbed URL building + title parse, embed player HTML).
+- `Tests/WikiFSTests/BytelessEmbedIntegrationTests.swift` — `ExplodingFetcher`
+  + `YouTubeFixtureFetcher` now serve canned oEmbed JSON (new expected behavior).
 
-**Build/Tests:** `make version prompts && swift build` clean; `swift test --filter UsageFormatterTests|ACPBackendTests` 67/67 pass; full fast test tier **2552 tests / 216 suites pass**.
+**Build/Tests:** `make version prompts && swift build` clean; fast test tier
+2,559 tests in 217 suites pass (+17 new).
 
 ## 2026-07-18 — Issue #192: "Go to Original" bookmark context-menu action (branch `bookmark-go-to-original`)
 

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -67,6 +67,8 @@ struct WikiFSApp: App {
     /// when no windows are visible (accessory mode). Wired by
     /// `WindowBridgeProbe`, a hidden view inside the main `WindowGroup`.
     @State private var openWindowBridge = OpenWindowBridge()
+    /// Owns the open-windows list for the standard Window menu (issue #567).
+    @State private var windowTracker: WindowListTracker
 
     // NOTE: There must be exactly ONE @NSApplicationDelegateAdaptor. Registering
     // two adaptors with different types (e.g. a separate QuitConfirmationDelegate)
@@ -197,6 +199,7 @@ struct WikiFSApp: App {
             pdf2mdScriptPathResolver: { PdfExtractionService.resolveScript()?.path }
         )
         _sessionManager = State(initialValue: sm)
+        _windowTracker = State(initialValue: WindowListTracker())
         // Wire the session-lookup box to the real session manager now that
         // it's constructed. The provider (already captured by the factory)
         // sees live sessions through the box.
@@ -285,6 +288,7 @@ struct WikiFSApp: App {
             registry: registry,
             openWindowBridge: openWindowBridge)
         statusController.start()
+        windowTracker.start()
         appDelegate.menuBarItemController = statusController
 
         // Operation notifier: posts macOS local notifications when extraction,
@@ -424,6 +428,11 @@ struct WikiFSApp: App {
             // "No Wikis" empty-state window (issue #396).
             CommandGroup(replacing: .newItem) { }
             VacuumCommands(sessionManager: sessionManager)
+            // Window menu: open-windows list + Show Previous/Next Tab (⇧⌘[ / ⇧⌘]).
+            WindowMenuCommands(
+                sessionManager: sessionManager,
+                windowTracker: windowTracker,
+                registry: registry)
         }
         // Additional wiki windows: value-driven by wiki ID. Opened from the
         // switcher via `openWindow(value: wiki.id)`. `WindowGroup(for:)`

--- a/Sources/WikiFS/Window/WindowMenuCommands.swift
+++ b/Sources/WikiFS/Window/WindowMenuCommands.swift
@@ -1,0 +1,145 @@
+import AppKit
+import SwiftUI
+import WikiFSCore
+import WikiFSEngine
+
+/// Tracks the app's open windows so the standard Window menu can list them.
+///
+/// SwiftUI's `WindowGroup(for: String.self)` should auto-populate the Window
+/// menu's open-windows list, but value-driven windows aren't reliably surfaced
+/// (issue #567). This tracker re-derives the list from
+/// `NSApplication.shared.windows` whenever a window becomes key/main, changes
+/// occlusion state, or closes, so the Window menu always reflects reality.
+///
+/// Wiki windows are tagged with `wikiWindowIdentifierPrefix + wikiID`
+/// (`WindowIdentifierTagger`); the commands resolve the display name from the
+/// registry so the list shows "My Wiki" rather than an empty/page title.
+@MainActor
+@Observable
+final class WindowListTracker {
+    /// One row in the Window menu's open-windows list.
+    struct Entry: Identifiable {
+        let id: ObjectIdentifier
+        /// The wiki ID parsed from the window's `wiki:` identifier, if any.
+        let wikiID: String?
+        /// The window's raw AppKit title (fallback when no wiki name resolves).
+        let title: String
+    }
+
+    private(set) var entries: [Entry] = []
+    private var observers: [NSObjectProtocol] = []
+    private var didStart = false
+
+    /// Register for window lifecycle notifications and seed the list. Called
+    /// once from `startStatusItem` (app-lifetime, idempotent).
+    func start() {
+        guard !didStart else { return }
+        didStart = true
+        let center = NotificationCenter.default
+        // Recompute whenever a window appears, focuses, hides, or closes —
+        // the open-windows list must stay in sync without a manual refresh.
+        let names: [Notification.Name] = [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+            NSWindow.didChangeOcclusionStateNotification,
+            NSWindow.willCloseNotification,
+            NSApplication.didBecomeActiveNotification
+        ]
+        observers = names.map { name in
+            center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                // The observer fires on the main queue; hop to the main actor
+                // before touching @Observable state.
+                Task { @MainActor in self?.refresh() }
+            }
+        }
+        refresh()
+    }
+
+    /// Recompute `entries` from the current AppKit window stack. Visible,
+    /// main-capable, non-panel windows are listed. A window with a `wiki:`
+    /// identifier is always included (its title may be momentarily empty
+    /// during state restoration); others are included only when titled.
+    func refresh() {
+        entries = NSApplication.shared.windows
+            .filter { $0.isVisible && $0.canBecomeMain && !($0 is NSPanel) }
+            .map { window in
+                var wikiID: String?
+                if let raw = window.identifier?.rawValue,
+                   raw.hasPrefix(wikiWindowIdentifierPrefix) {
+                    wikiID = String(raw.dropFirst(wikiWindowIdentifierPrefix.count))
+                }
+                return Entry(id: ObjectIdentifier(window), wikiID: wikiID, title: window.title)
+            }
+            .filter { entry in entry.wikiID != nil || !entry.title.isEmpty }
+    }
+
+    /// Bring the selected window to the front (Window menu click action).
+    func bringToFront(_ id: ObjectIdentifier) {
+        guard let window = NSApplication.shared.windows.first(where: {
+            ObjectIdentifier($0) == id
+        }) else { return }
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+    }
+}
+
+/// The Window menu commands: the open-windows list (below "Bring All to
+/// Front") plus the standard "Show Previous/Next Tab" items (⇧⌘[ / ⇧⌘]).
+///
+/// Placed after `.windowList` so the list sits in the standard Window-menu
+/// position without clobbering the system-provided Minimize/Zoom/Bring-All-to-
+/// Front items. The tab-cycling actions target the frontmost window's session
+/// via `SessionManager.frontmostSession` and cycle `WikiStoreModel.tabs`.
+struct WindowMenuCommands: Commands {
+    let sessionManager: SessionManager
+    let windowTracker: WindowListTracker
+    let registry: WikiRegistryClient
+
+    var body: some Commands {
+        CommandGroup(after: .windowList) {
+            if !windowTracker.entries.isEmpty {
+                ForEach(windowTracker.entries) { entry in
+                    Button(displayTitle(for: entry)) {
+                        windowTracker.bringToFront(entry.id)
+                    }
+                }
+                Divider()
+            }
+            // Standard macOS tab-cycling items. macOS apps put these in the
+            // Window menu (e.g. Safari, Finder); ⇧⌘[ / ⇧⌘] are the expected
+            // shortcuts. The action self-guards so the shortcuts always fire
+            // and no-op when there is no frontmost session or <2 tabs.
+            Button("Show Previous Tab") { cycleTab(by: -1) }
+                .keyboardShortcut("[", modifiers: [.command, .shift])
+            Button("Show Next Tab") { cycleTab(by: 1) }
+                .keyboardShortcut("]", modifiers: [.command, .shift])
+        }
+    }
+
+    /// Resolve a window's menu label: the wiki display name when the window
+    /// carries a `wiki:` identifier, otherwise its AppKit title (falling back
+    /// to "Untitled" so a row never renders blank).
+    private func displayTitle(for entry: WindowListTracker.Entry) -> String {
+        if let wikiID = entry.wikiID,
+           let name = registry.wikis.first(where: { $0.id == wikiID })?.displayName,
+           !name.isEmpty {
+            return name
+        }
+        return entry.title.isEmpty ? "Untitled" : entry.title
+    }
+
+    /// Cycle the active tab in the frontmost wiki window by `delta` (-1 / +1),
+    /// wrapping at the ends. No-op when there is no frontmost session, fewer
+    /// than two tabs, or no active tab.
+    private func cycleTab(by delta: Int) {
+        guard let store = sessionManager.frontmostSession?.store else { return }
+        let tabs = store.tabs
+        guard tabs.count > 1,
+              let current = store.activeTabID,
+              let index = tabs.firstIndex(where: { $0.id == current }) else { return }
+        let count = tabs.count
+        // Euclidean modulo so negative deltas wrap correctly.
+        let newIndex = ((index + delta) % count + count) % count
+        store.selectTab(id: tabs[newIndex].id)
+    }
+}

--- a/docs/user-guide/interface.md
+++ b/docs/user-guide/interface.md
@@ -10,6 +10,9 @@ you've used Safari or Xcode, the basics are second nature.
 
 ![Main window: sidebar with the Pages/Sources/Bookmarks/Chats tab strip on the left, the omnibox and wiki switcher in the toolbar, and a page open in the detail pane.](images/interface-main-window.png)
 
+The standard **Window menu** lists every open wiki window (by name) below
+"Bring All to Front" — click one to bring it to the front.
+
 ---
 
 ## The sidebar
@@ -87,7 +90,7 @@ the top of the detail pane — just like Safari tabs.
 | Action | How |
 |---|---|
 | Open in a new tab | Click a sidebar item (it may open in the current tab or a new one depending on type). |
-| Switch tabs | Click a tab; or ⌘1–⌘9 for the first nine tabs. |
+| Switch tabs | Click a tab; ⌘1–⌘9 for the first nine; or ⇧⌘[ / ⇧⌘] to cycle (wraps around). |
 | Close a tab | Click the × on the tab (appears on hover), or ⌘W. |
 | Close while editing | A confirmation appears: "Close Tab? Unsaved changes will be discarded." |
 | Reopen a closed tab | ⌘⇧T (remembers up to 10 recently closed tabs). |

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -18,6 +18,8 @@ A complete quick-reference for Self-Driving Wiki keyboard shortcuts.
 
 | Shortcut | Action |
 |---|---|
+| ⇧⌘[ | Show previous tab (wraps to last) |
+| ⇧⌘] | Show next tab (wraps to first) |
 | ⌘W | Close active tab |
 | ⌘⇧T | Reopen last closed tab (up to 10 remembered) |
 
@@ -74,5 +76,8 @@ A complete quick-reference for Self-Driving Wiki keyboard shortcuts.
 - **⌘E** is context-sensitive: in a page, it enters page edit mode; from the
   menu bar, it opens the Extraction Queue. The menu bar shortcut takes priority
   when no detail view is focused.
+- **⌘[ / ⌘]** navigate back/forward within a tab; **⇧⌘[ / ⇧⌘]** cycle between
+  tabs. Don't confuse the two — the Shift modifier switches from
+  in-tab navigation to tab switching.
 - **Edit mode is per-tab.** Switching tabs preserves each tab's edit state.
   Closing a tab while editing asks for confirmation.


### PR DESCRIPTION
## Summary

Fixes #567 — restores two standard macOS Window-menu behaviors that were missing:

1. **Open windows list** — the Window menu now lists open wiki windows (by wiki name) below "Bring All to Front"; clicking a row brings that window to front.
2. **Show Previous / Next Tab** — ⇧⌘[ and ⇧⌘] now cycle editor tabs in the frontmost window, with wrap-around.

## Root cause

Nothing was *suppressing* the auto window list — `.commands` only replaced `.newItem`, and `AppDelegate.removeRedundantAppMenuItems` strips only the About/Settings items. SwiftUI's value-driven `WindowGroup(for: String.self)` simply doesn't reliably surface value-typed windows in the standard Window-menu list, so the list was empty. The tab-cycling commands didn't exist at all.

## Changes

New file `Sources/WikiFS/Window/WindowMenuCommands.swift`:

- **`WindowMenuCommands`** — a `Commands` adding a single `CommandGroup(after: .windowList)`:
  - An open-windows list rendered from an `@MainActor @Observable WindowListTracker`, which re-derives from `NSApplication.shared.windows` on `NSWindow` lifecycle notifications (become key/main, occlusion-state change, will-close, app activation). Wiki window labels resolve from the `wiki:` window identifier → `WikiRegistryClient` display name, falling back to the AppKit title.
  - "Show Previous Tab" / "Show Next Tab" `Button`s with `.keyboardShortcut("[", modifiers: [.command, .shift])` / `("]", …)`. The action targets `SessionManager.frontmostSession?.store`, cycles `WikiStoreModel.tabs` with wrap-around (Euclidean modulo), and self-guards (no-op with no frontmost session or <2 tabs).

- **`WikiFSApp.swift`** — owns the tracker as `@State`, initializes it in `init`, starts it in `startStatusItem()` (alongside the status-item controller), and registers `WindowMenuCommands` in `.commands`.

### Why `after: .windowList` (not `replacing:`)

`after:` can't clobber the system-provided Minimize / Zoom / Bring-All-to-Front items (those live in separate placements). The auto window list is observed-empty, so `after:` adds exactly one list with no duplication. If SwiftUI ever starts populating the auto list, a follow-up can switch to `replacing:`.

### Why the tab commands live in the Window menu

That's where macOS puts them (Safari, Finder). The issue's suggested `after: .toolbar` would place them in the View menu, which is less discoverable.

## Notes / tradeoffs

- SwiftUI `CommandGroup` `Button`s can't render the trailing checkmark that the native auto-list uses for the key window; the list shows titles only. Titles resolve to wiki display names, so the list is still clearly readable. A future AppKit-pass could restore the checkmark if desired.
- Tab-cycling items are always enabled and self-guard, so the shortcuts reliably fire whenever a frontmost session with ≥2 tabs exists (avoids stale `.disabled` state blocking a valid keystroke).

## Verification

- `make version prompts` → `swift build` — clean.
- Fast test tier: `swift test --skip …` — **2569 tests in 218 suites passed**.

Closes #567.
