### PR TITLE
Add Open Page navigation from lint job results in Activity window

### DIFF
--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -35,6 +35,14 @@ struct PageDetailView: View {
     @Environment(FindModel.self) private var findModel
     @State private var findVersion = 0
 
+    /// The app-wide queue activity tracker — used to reflect an in-flight lint
+    /// on this page's "Lint" button (icon + disable + warning when tapped).
+    @Environment(QueueActivityTracker.self) private var activityTracker
+    /// Shown when the Lint button is tapped while a lint is already running on
+    /// this page (whole-wiki or page-level). Explains the running state rather
+    /// than silently enqueuing a duplicate.
+    @State private var isShowingLintActiveAlert = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header — title always visible; date + action buttons expandable.
@@ -76,17 +84,8 @@ struct PageDetailView: View {
                         Button("Edit",
                                systemImage: "pencil") { isEditing = true }
                             .help("Edit this page manually")
-                        if case .page(let id) = store.selection {
-                            Button("Lint", systemImage: "checkmark.seal") {
-                                Task {
-                                    try? await session.queueEngine.enqueue(QueueItemRequest(
-                                        queue: .ingestion,
-                                        wikiID: session.wikiID,
-                                        payload: QueueItemPayload(sourceIDs: [], lintPageIDs: [id])
-                                    ))
-                                }
-                            }
-                            .help("Fix [[wiki-link]] syntax and run LLM lint on this page")
+                        if case .page = store.selection {
+                            lintButton
                         }
                         if case .page(let pageID) = store.selection {
                             Button("Show in List", systemImage: "sidebar.left") {
@@ -143,6 +142,11 @@ struct PageDetailView: View {
         }
         .background(Color(nsColor: .textBackgroundColor))
         .frame(minWidth: PageEditorMetrics.detailMinWidth)
+        .alert("Lint Already Running", isPresented: $isShowingLintActiveAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("A lint job is already running on this page. It will appear in the Activity window when it finishes.")
+        }
         .onAppear { lastKnownActiveTabID = store.activeTabID }
         .onChange(of: store.selection) {
             // In-tab navigation (wiki-link click, sidebar navigation within the
@@ -193,6 +197,44 @@ struct PageDetailView: View {
             if let title = store.renameConflictingTitle {
                 Text("A page with the title “\(title)” already exists. Please choose a different name.")
             }
+        }
+    }
+
+    // MARK: - Lint button
+
+    /// The page-level "Lint" action button. Reflects an in-flight lint on this
+    /// page: when a lint (whole-wiki or page-level) is running, the button swaps
+    /// to a filled "Linting…" state, disables itself, and would warn if tapped
+    /// — though `.disabled` prevents the tap. The alert covers the keyboard /
+    /// accessibility path where the action could still fire.
+    @ViewBuilder
+    private var lintButton: some View {
+        if case .page(let id) = store.selection {
+            let pageIsLinting = activityTracker.isLinting(
+                pageID: id, wikiID: session.wikiID)
+            Button(pageIsLinting ? "Linting…" : "Lint",
+                   systemImage: pageIsLinting
+                   ? "checkmark.seal.fill"
+                   : "checkmark.seal") {
+                if pageIsLinting {
+                    // A lint is already active for this page (whole-wiki or
+                    // page-level) — warn instead of enqueuing a duplicate.
+                    isShowingLintActiveAlert = true
+                    DebugLog.ingest("Lint button: already running for page \(id) in wiki \(session.wikiID.prefix(8)); warning shown")
+                } else {
+                    Task {
+                        try? await session.queueEngine.enqueue(QueueItemRequest(
+                            queue: .ingestion,
+                            wikiID: session.wikiID,
+                            payload: QueueItemPayload(sourceIDs: [], lintPageIDs: [id])
+                        ))
+                    }
+                }
+            }
+            .disabled(pageIsLinting)
+            .help(pageIsLinting
+                  ? "A lint is already running on this page"
+                  : "Fix [[wiki-link]] syntax and run LLM lint on this page")
         }
     }
 

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -349,6 +349,10 @@ struct ActivityWindowView: View {
             VStack(spacing: 0) {
                 detailHeader(for: item)
                 Divider()
+                if item.payload.lintPageIDs != nil {
+                    lintedPagesSection(for: item)
+                    Divider()
+                }
                 transcriptContent(for: item)
             }
             .task(id: itemID) {
@@ -493,6 +497,110 @@ struct ActivityWindowView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+    }
+
+    // MARK: - Lint page navigation
+
+    /// Lint jobs carry `lintPageIDs` in their payload. For a page-level lint we
+    /// list every linted page with an "Open" action that opens it in the wiki's
+    /// main window (the shared `WikiStoreModel`); for a whole-wiki lint
+    /// (`lintPageIDs == []`) we show "All pages linted" with a "Browse Pages"
+    /// button that focuses the wiki window on its Pages sidebar.
+    @ViewBuilder
+    private func lintedPagesSection(for item: QueueItem) -> some View {
+        let pageIDs = item.payload.lintPageIDs ?? []
+        VStack(alignment: .leading, spacing: 8) {
+            Text(pageIDs.isEmpty ? "Lint Scope" : "Linted Pages")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            if pageIDs.isEmpty {
+                HStack(spacing: 6) {
+                    Image(systemName: "books.vertical")
+                        .foregroundStyle(.secondary)
+                    Text("All pages linted")
+                        .font(.callout)
+                    Spacer(minLength: 4)
+                    Button("Browse Pages", systemImage: "sidebar.left") {
+                        browsePages(in: item.wikiID)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help("Switch to the Pages list in the wiki window")
+                }
+            } else {
+                VStack(spacing: 6) {
+                    ForEach(pageIDs, id: \.self) { pageID in
+                        lintPageRow(pageID: pageID, wikiID: item.wikiID)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    /// A single linted page: title (resolved from the wiki's store) with an
+    /// "Open" button. Pages deleted since the lint ran resolve to a placeholder.
+    @ViewBuilder
+    private func lintPageRow(pageID: PageID, wikiID: String) -> some View {
+        let title = pageTitle(pageID, wikiID: wikiID) ?? "Deleted page"
+        HStack(spacing: 6) {
+            Image(systemName: "doc.text")
+                .foregroundStyle(.secondary)
+            Text(title)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(title)
+            Spacer(minLength: 4)
+            Button("Open", systemImage: "arrow.up.forward.app") {
+                openPage(pageID, in: wikiID)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .help("Open this page in the wiki window")
+        }
+    }
+
+    /// Resolve a page ID to its current title via the wiki's store, or `nil`
+    /// if the page no longer exists / the session isn't live.
+    private func pageTitle(_ pageID: PageID, wikiID: String) -> String? {
+        sessionManager?.sessions[wikiID]?.store
+            .summaries.first { $0.id == pageID }?.title
+    }
+
+    /// Open a linted page in its wiki's main window. The `WikiStoreModel` is
+    /// shared across windows (one session per wiki), so `openTab` mutates the
+    /// same model the main window observes; `openWiki` then focuses that window
+    /// — mirroring the bookmark "Go to Original" navigation (#570).
+    private func openPage(_ pageID: PageID, in wikiID: String) {
+        guard let store = sessionManager?.sessions[wikiID]?.store else {
+            DebugLog.tabs("Lint Open Page: no live session for wiki \(wikiID.prefix(8)); cannot open page")
+            return
+        }
+        store.openTab(.page(pageID))
+        openWindowBridge?.openWiki?(wikiID)
+        DebugLog.tabs("Lint Open Page: opened page \(pageID) in wiki \(wikiID.prefix(8))")
+    }
+
+    /// Whole-wiki lint "Browse Pages": reveal the wiki's home page (switches the
+    /// shared model's sidebar to the Pages section via the same
+    /// `requestSidebarReveal` mechanism the bookmark "Go to Original" action
+    /// uses, #570), then focus the wiki window. Falls back to the first page if
+    /// there's no home page, and to focusing the window only if the wiki has no
+    /// pages / no live session.
+    private func browsePages(in wikiID: String) {
+        let session = sessionManager?.sessions[wikiID]
+        let store = session?.store
+        if store != nil, let homeID = session?.descriptor.homePageID {
+            store?.requestSidebarReveal(.page(homeID))
+            DebugLog.tabs("Lint Browse Pages: revealed home page in wiki \(wikiID.prefix(8))")
+        } else if let firstID = store?.summaries.first?.id {
+            store?.requestSidebarReveal(.page(firstID))
+            DebugLog.tabs("Lint Browse Pages: revealed first page in wiki \(wikiID.prefix(8))")
+        } else {
+            DebugLog.tabs("Lint Browse Pages: no pages to reveal in wiki \(wikiID.prefix(8)); focusing window only")
+        }
+        openWindowBridge?.openWiki?(wikiID)
     }
 
     // MARK: - Copy

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -64,11 +64,34 @@ final class QueueActivityTracker {
     /// `isIngesting` covers lint-only runs.
     private(set) var lintingItemIDs: Set<QueueItem.ID> = []
 
+    /// Page IDs currently being linted by a page-level lint (`.ingestion`
+    /// items with non-empty `lintPageIDs`). Page IDs are ULIDs — globally
+    /// unique across wikis — so this set is wiki-agnostic like
+    /// `extractingSourceIDs` / `ingestingSourceIDs`. Used to reflect the
+    /// running state on a page's "Lint" button.
+    private(set) var lintingPageIDs: Set<PageID> = []
+
+    /// Wiki IDs with an active whole-wiki lint (`.ingestion` items with
+    /// `lintPageIDs == []`). A whole-wiki lint covers every page in that
+    /// wiki, so every page-detail "Lint" button in that wiki should reflect
+    /// the running state. Wiki-scoped (not page-scoped) so a whole-wiki
+    /// lint on one wiki doesn't mark another wiki's pages as linting.
+    private(set) var wholeWikiLintingWikiIDs: Set<String> = []
+
     /// True while any extraction is running. Drives the sidebar spinner.
     var isExtracting: Bool { !extractingSourceIDs.isEmpty }
 
     /// True while any ingestion or lint is running.
     var isIngesting: Bool { !ingestingSourceIDs.isEmpty || !lintingItemIDs.isEmpty }
+
+    /// True if a lint job (page-level or whole-wiki) is actively processing
+    /// `pageID` in `wikiID`. A whole-wiki lint (`lintPageIDs == []`) covers
+    /// every page in its wiki. Used by `PageDetailView` to disable its Lint
+    /// button and reflect the running state. Page IDs are ULIDs (globally
+    /// unique), so the page-level branch needs no wiki check.
+    func isLinting(pageID: PageID, wikiID: String) -> Bool {
+        lintingPageIDs.contains(pageID) || wholeWikiLintingWikiIDs.contains(wikiID)
+    }
 
     /// Per-item typed agent events, for the Activity window's transcript view.
     /// Bounded — pruned only when items are pruned from history (not on
@@ -163,6 +186,8 @@ final class QueueActivityTracker {
         extractingSourceIDs = []
         ingestingSourceIDs = []
         lintingItemIDs = []
+        lintingPageIDs = []
+        wholeWikiLintingWikiIDs = []
         extractionLog = ""
         extractionPID = nil
         currentExtractionItemID = nil
@@ -315,9 +340,18 @@ final class QueueActivityTracker {
                 currentExtractionItemID = item.id
                 progressLogs[item.id] = ""
             case .ingestion:
-                if item.payload.lintPageIDs != nil {
+                if let pageIDs = item.payload.lintPageIDs {
                     // Lint item — track separately (empty sourceIDs).
                     lintingItemIDs.insert(item.id)
+                    if pageIDs.isEmpty {
+                        // Whole-wiki lint: covers every page in this wiki.
+                        wholeWikiLintingWikiIDs.insert(item.wikiID)
+                        DebugLog.ingest("LintActivity: started whole-wiki lint for wiki \(item.wikiID.prefix(8)) (item \(item.id.prefix(8)))")
+                    } else {
+                        // Page-level lint: track the specific pages.
+                        lintingPageIDs.formUnion(pageIDs)
+                        DebugLog.ingest("LintActivity: started page-level lint for \(pageIDs.count) page(s) in wiki \(item.wikiID.prefix(8)) (item \(item.id.prefix(8)))")
+                    }
                 } else {
                     ingestingSourceIDs.formUnion(sourceIDs)
                 }
@@ -385,6 +419,16 @@ final class QueueActivityTracker {
         }
         // Lint items are tracked separately — always remove on terminal state.
         lintingItemIDs.remove(item.id)
+        if let pageIDs = item.payload.lintPageIDs {
+            if pageIDs.isEmpty {
+                // Whole-wiki lint. Safe to remove by wiki ID: the `.ingest`
+                // lane limit is 1 per session, so at most one whole-wiki lint
+                // runs per wiki at a time — this item was the only one.
+                wholeWikiLintingWikiIDs.remove(item.wikiID)
+            } else {
+                for pageID in pageIDs { lintingPageIDs.remove(pageID) }
+            }
+        }
         if currentExtractionItemID == item.id {
             currentExtractionItemID = nil
         }


### PR DESCRIPTION
## Summary

Two related changes to the lint workflow, both on the `open-page-from-lint` branch:

1. **Open Page from lint results** — the Activity window's lint detail view now lists the linted pages with an "Open" button (or "All pages linted" + "Browse Pages" for whole-wiki lint).
2. **Reflect active lint state on the page Lint button** — when a lint is running on a page, the Lint button swaps to a filled "Linting…" state, disables itself, and warns if the action somehow still fires.

## What changed

### 1. Open Page navigation — `Sources/WikiFS/Queue/ActivityWindowView.swift`

Adds a "Linted Pages" section to the detail pane (between the header and the transcript), rendered only for lint items (`payload.lintPageIDs != nil`):

- **Page-level lint** (`lintPageIDs` non-empty): lists each linted page with its title and an **Open** button. Clicking calls `store.openTab(.page(pageID))` then focuses the wiki's main window via `openWindowBridge.openWiki?(wikiID)` — the same navigation pattern as the bookmark "Go to Original" action (#570).
- **Whole-wiki lint** (`lintPageIDs == []`): shows "All pages linted" with a **Browse Pages** button that reveals the wiki's home page via `store.requestSidebarReveal(.page(homeID))` and focuses the wiki window.

Pages deleted since the lint ran resolve to the placeholder "Deleted page".

### 2. Active lint state — `Sources/WikiFS/Queue/QueueActivityTracker.swift` + `Sources/WikiFS/Pages/PageDetailView.swift`

**Tracker:** tracks per-page lint state alongside the existing `lintingItemIDs`:
- `lintingPageIDs: Set<PageID>` — page-level lints (page IDs are ULIDs, globally unique).
- `wholeWikiLintingWikiIDs: Set<String>` — whole-wiki lints (wiki-scoped, since a whole-wiki lint covers every page in that wiki).
- `isLinting(pageID:wikiID:)` → true if a page-level or whole-wiki lint is running on that page.
- Populated in the `.started` event handler; cleaned up in `removeItem` (terminal states) and `stop()`.

**PageDetailView:** reads the tracker via `@Environment(QueueActivityTracker.self)` and reflects an in-flight lint on the page's Lint button:
- Icon swaps `checkmark.seal` → `checkmark.seal.fill`, label `Lint` → `Linting…`.
- `.disabled(pageIsLinting)` prevents enqueueing a duplicate.
- An `.alert("Lint Already Running")` covers the keyboard/accessibility path where the action could still fire.

## How it works

`WikiSession` is shared across windows via `SessionManager` (one session per wiki), so `store.openTab` / `requestSidebarReveal` mutate the **same** `WikiStoreModel` the main window observes. The tracker is injected into the SwiftUI environment at the app level.

All diagnostics route through `DebugLog.ingest` / `DebugLog.tabs` (subsystem `com.selfdrivingwiki.debug`) — no `print`.

## Verification

- `make version prompts` + `swift build` — builds clean.
- Fast test tier: `swift test --skip '<integration suites>'` — 2581 tests in 219 suites passed.

## Design notes

- Native macOS idiom: bordered small buttons, filled SF Symbol for the running state, `.help` tooltips, `.alert` for the warning.
- Reuses existing, documented navigation seams (`openTab`, `requestSidebarReveal`, `openWindowBridge.openWiki`) — no new state plumbing beyond the tracker sets.
- Whole-wiki lint cleanup by wiki ID is safe: the `.ingest` lane limit is 1 per session, so at most one whole-wiki lint runs per wiki at a time.

## Out of scope

- Parsing free-form page references out of the agent transcript text. The payload's `lintPageIDs` is the authoritative, structured source and is what this uses.

## Checklist

- [x] Works on feature branch `open-page-from-lint` (not `main`)
- [x] `make version prompts` run before build
- [x] Fast test tier passes
- [x] Diagnostics via `DebugLog`, not `print`
- [ ] PR not merged by author
