### PR TITLE
Wire interactive chat (Ask/Edit) usage into daily token tracking + menu bar display

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -218,6 +218,34 @@ Changes:
 
 **Build/Tests:** `make version prompts && swift build` clean; full fast test tier **2573 tests / 218 suites pass**; `swift test --filter UsageFormatterTests` 40/40 pass.
 
+## 2026-07-18 — Wire interactive chat usage into the daily token tracking + menu bar display (branch `feature/chat-usage-tracking`)
+
+**Problem:** The "Today: X tokens" menu bar item only counted usage from queue-based runs (ingest/lint). Interactive chat sessions (Ask/Edit tabs) go through `AgentLauncher.startInteractiveQuery` + `sendInteractiveMessage`, which did NOT emit usage via the `onUsage` callback — a long chat burning 50K tokens didn't show up in the daily total. The `ACPBackend` already captures `SessionUsage` for ALL sessions via `SessionUsageState`; the gap was that `AgentLauncher` only called `capturePhaseUsage` + emitted `onUsage` from the queue-based `run()` path, not from the interactive `sendInteractiveMessage` path.
+
+**Key correctness challenge — no double-counting across turns.** The backend's `sessionUsage(for:)` returns **cumulative** per-session totals (tokens across all turns of one session), and `DailyUsage.add` is **additive**. The queue path reads each phase session's usage **once** (no double-count, since each phase is a separate session). Interactive chat reuses ONE session across many turns, so naively emitting the cumulative snapshot after each turn and adding it would re-add the full total on every turn. The fix emits the **per-turn delta** (`current cumulative − last-emitted baseline`) so the daily total only gains the marginal tokens for that turn.
+
+**Approach — Option A (callback).** Matches the existing `onAgentEvent` callback on `AgentLauncher` and the closure-injection threading (`WikiFSApp` → `SessionManager.init` → `WikiSession.init`). Keeps capture in the `@MainActor` `sendInteractiveMessage` turn-end branch (naturally main-actor safe). Avoids adding a new `AgentEvent` case (which would complicate the transcript drain + persistence + the `StoreEmissionExhaustivenessTests` partition).
+
+Changes:
+
+- **`Sources/WikiFSEngine/ACPBackend.swift`** — added `SessionUsage.delta(from:to:)` static helper next to `merging`. Computes the incremental usage between two cumulative snapshots of the same session: token counts are subtracted (`to − from`, clamped to ≥0); cost is a delta (`to.cost − from.cost`, clamped ≥0); context window is point-in-time (takes `to`); provider label/model id/thinking level are latest-non-nil-wins (matching `merging`). `from == nil` returns `to` directly (first turn's delta == full snapshot).
+- **`Sources/WikiFSEngine/AgentLauncher.swift`**:
+  - New `@ObservationIgnored public var onInteractiveUsage: (@MainActor (SessionUsage) -> Void)?` callback (installed by the app layer; `nil` = no-op so headless/daemon callers are unaffected).
+  - New `@ObservationIgnored private var lastInteractiveUsageSnapshot: SessionUsage?` per-session baseline.
+  - New `captureInteractiveUsage()` async method: reads `backend.sessionUsage(for: sessionHandle)` (while the session is still alive, before `cancel`/`closeSession`), attaches the configured `runProviderLabel`, computes `delta(from: lastInteractiveUsageSnapshot, to:)`, updates the baseline, and forwards the delta via `onInteractiveUsage`. Silent no-op for non-ACP backends or when the callback is nil. Only forwards when `totalTokens > 0 || cost != nil`.
+  - Call site: `sendInteractiveMessage`'s turn-end (`endsGeneration`) branch now calls `await self.captureInteractiveUsage()` after `flushTranscript()`/`generateChatSummary()`.
+  - Reset: `lastInteractiveUsageSnapshot = nil` in `resetRunArtifacts()` (per-run fresh start) and `onInteractiveUsage = nil` + `lastInteractiveUsageSnapshot = nil` in `finish()` (session teardown).
+- **`Sources/WikiFS/Queue/QueueActivityTracker.swift`** — added `recordInteractiveUsage(_ usage: SessionUsage)` that accumulates the delta into `todayUsage` and persists. Deliberately does NOT create an `itemUsage` entry (interactive chat has no queue item); only the daily total — which the menu bar reads — is updated. The existing `.usage` queue event handler is unchanged.
+- **`Sources/WikiFSEngine/WikiSession.swift`** — new `interactiveUsageRecorder: @MainActor (SessionUsage) -> Void` init parameter (default no-op); installed onto BOTH `agentLauncher` and `chatLauncher` so interactive queries AND chats report usage.
+- **`Sources/WikiFSEngine/SessionManager.swift`** — new `interactiveUsageRecorder` init param threaded through to `WikiSession`.
+- **`Sources/WikiFS/Window/WikiFSApp.swift`** — passes `interactiveUsageRecorder: { [weak activityTracker] usage in activityTracker?.recordInteractiveUsage(usage) }` at `SessionManager` construction (the tracker is created just before the manager).
+
+**No double-count with queued runs.** A single `AgentLauncher` runs EITHER a queue `run()` OR an interactive `startInteractiveQuery` (never both); `resetRunArtifacts()` is called at the start of each and clears `lastInteractiveUsageSnapshot`. The queue path never calls `captureInteractiveUsage` (only `sendInteractiveMessage` does), and the interactive path never emits a queue `.usage` event. So a session that is both queued AND interactive (theoretically possible via takeover) counts once per path.
+
+**Tests:** Added 4 `SessionUsage.delta` tests (`deltaWithNilBaselineReturnsFullSnapshot`, `deltaSubtractsBaselineTokens`, `deltaCarriesMetadataFromBaselineWhenMissing`, `deltaClampsToZero`) in `ACPBackendTests.swift`, and 1 `QueueActivityTracker.recordInteractiveUsage` accumulation test in `QueueIngestionTests.swift`. The tracker test captures + restores the persisted `DailyUsage` so it doesn't pollute the real menu bar count.
+
+**Build/Tests:** `make version prompts && swift build` clean; fast test tier **2578 tests / 219 suites pass**.
+
 ## 2026-07-18 — Fix missing activity ingestion details: thinking-level dropped in enrichment (branch `fix/missing-activity-details`)
 
 **Problem:** The Activity window lost the thinking-effort level segment ("high"/"medium"/"low") for completed ingestion/lint runs. The user reported that rich run metadata (model name, token counts, cost, timing) had partially regressed — the thinking-effort segment introduced in #566 was always blank.

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -540,6 +540,24 @@ final class QueueActivityTracker {
         }
     }
 
+    /// Accumulate interactive (Ask/Edit chat) usage into today's daily total.
+    ///
+    /// Interactive chat sessions don't go through the queue — they use
+    /// `AgentLauncher.sendInteractiveMessage`, which reads the ACP backend's
+    /// per-session usage and emits the per-turn DELTA (not cumulative) via
+    /// `AgentLauncher.onInteractiveUsage`. This method is the receiving end:
+    /// the app wires the launcher's callback to it.
+    ///
+    /// There is no queue item (and thus no `itemUsage` entry) for interactive
+    /// sessions — only the daily total (`todayUsage`) is updated, which is
+    /// what the menu bar "Today: X tokens" line reads. The queue path's
+    /// `.usage` event handler (`itemUsage[id] = usage`) is intentionally NOT
+    /// replicated here.
+    func recordInteractiveUsage(_ usage: SessionUsage) {
+        todayUsage.add(usage)
+        DailyUsage.save(todayUsage)
+    }
+
     /// Remove an item from the active set and clean up its mapping.
     private func removeItem(_ item: QueueItem) {
         if let sourceIDs = itemToSourceIDs.removeValue(forKey: item.id) {

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -642,14 +642,15 @@ struct DailyUsage: Sendable, Equatable {
 
     /// Persist to UserDefaults. Called after each `.usage` event.
     static func save(_ usage: DailyUsage) {
-        UserDefaults.standard.set([
+        var dict: [String: Any] = [
             "inputTokens": usage.inputTokens,
             "outputTokens": usage.outputTokens,
             "totalTokens": usage.totalTokens,
             "cost": usage.cost,
-            "currency": usage.currency as Any,
             "date": usage.date
-        ] as [String: Any], forKey: storageKey)
+        ]
+        if let currency = usage.currency { dict["currency"] = currency }
+        UserDefaults.standard.set(dict, forKey: storageKey)
     }
 
     /// Accumulate a run's usage into this daily total.

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -207,7 +207,12 @@ struct WikiFSApp: App {
             extractionCoordinator: coordinator,
             queueEngine: queueEngine,
             extractionProvider: extractionProvider,
-            pdf2mdScriptPathResolver: { PdfExtractionService.resolveScript()?.path }
+            pdf2mdScriptPathResolver: { PdfExtractionService.resolveScript()?.path },
+            interactiveUsageRecorder: { [weak activityTracker] usage in
+                // Interactive chat (Ask/Edit) usage delta → daily total so the
+                // menu bar "Today: X tokens" includes chat, not just queue runs.
+                activityTracker?.recordInteractiveUsage(usage)
+            }
         )
         _sessionManager = State(initialValue: sm)
         _windowTracker = State(initialValue: WindowListTracker())

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -1668,6 +1668,46 @@ public struct SessionUsage: Sendable, Codable {
             modelName: new.modelName ?? existing.modelName,
             thinkingLevel: new.thinkingLevel ?? existing.thinkingLevel)
     }
+
+    /// Compute the incremental usage between two cumulative snapshots of the
+    /// SAME session (`from` = an earlier `sessionUsage(for:)` result, `to` = a
+    /// later one). The backend's `sessionUsage(for:)` returns cumulative
+    /// session totals (tokens across all turns, last-reported cost). Emitting
+    /// those after each interactive turn and adding them into `DailyUsage.add`
+    /// would double-count — so the interactive path emits this delta.
+    ///
+    /// Semantics:
+    /// - Token counts (cumulative across turns): `to − from`. `from == nil`
+    ///   (first turn) returns `to` directly.
+    /// - `cost` / `currency`: cost is point-in-time (last reported) but
+    ///   represents cumulative session cost; delta = `to.cost − from.cost`
+    ///   (both present), else the new cost. Currency takes the latest.
+    /// - `contextUsed` / `contextSize`: point-in-time snapshot, not
+    ///   cumulative — takes `to`'s values.
+    /// - `providerLabel` / `modelId` / `thinkingLevel`: point-in-time
+    ///   metadata — latest non-nil wins, matching `merging`.
+    static func delta(from: SessionUsage?, to new: SessionUsage) -> SessionUsage {
+        guard let from else { return new }
+        let deltaCost: Double?
+        if let f = from.cost, let n = new.cost {
+            deltaCost = max(0, n - f)
+        } else {
+            deltaCost = new.cost
+        }
+        return SessionUsage(
+            inputTokens: max(0, new.inputTokens - from.inputTokens),
+            outputTokens: max(0, new.outputTokens - from.outputTokens),
+            totalTokens: max(0, new.totalTokens - from.totalTokens),
+            cachedReadTokens: max(0, (new.cachedReadTokens ?? 0) - (from.cachedReadTokens ?? 0)),
+            thoughtTokens: max(0, (new.thoughtTokens ?? 0) - (from.thoughtTokens ?? 0)),
+            cost: deltaCost,
+            currency: new.currency ?? from.currency,
+            contextUsed: new.contextUsed,
+            contextSize: new.contextSize,
+            providerLabel: new.providerLabel ?? from.providerLabel,
+            modelId: new.modelId ?? from.modelId,
+            thinkingLevel: new.thinkingLevel ?? from.thinkingLevel)
+    }
 }
 
 /// Thread-safe accumulator for per-session usage data. Captured in the

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -62,6 +62,16 @@ public final class AgentLauncher {
     /// Set in `run(...)` from the resolved provider; cleared in `finish()` and
     /// `resetRunArtifacts()`. Nil for runs without ACP backend usage data.
     @ObservationIgnored private var liveUsageProviderLabel: String?
+
+    /// Receives the per-turn token/cost delta for an interactive (Ask/Edit)
+    /// chat session. The app layer installs this so the menu bar's "Today:
+    /// X tokens" daily total includes interactive chat, not just queue-based
+    /// ingest/lint runs. The delta is computed against the last snapshot read
+    /// for THIS session (the backend reports cumulative session totals), so
+    /// accumulating into `DailyUsage.add` doesn't double-count across turns.
+    /// `nil` (no-op) when the app hasn't wired it — interactive usage is
+    /// simply untracked. Set/cleared in `resetRunArtifacts()` / `finish()`.
+    @ObservationIgnored public var onInteractiveUsage: (@MainActor (SessionUsage) -> Void)?
     /// The raw combined transcript (raw stream-json stdout + stderr) kept alongside
     /// the typed `events`, so the UI / a debugger can see exactly what the CLI
     /// emitted. This is the in-memory mirror of the on-disk `run.jsonl`.
@@ -466,6 +476,14 @@ public final class AgentLauncher {
     /// state). Read by `AppQueueIngestionProvider` after `run(...)` returns.
     /// nil when no usage has been captured (non-ACP backend or empty run).
     @ObservationIgnored private(set) public var runTotalUsage: SessionUsage?
+
+    /// The cumulative usage snapshot last emitted for the interactive
+    /// session, used to compute the per-turn delta. The backend's
+    /// `sessionUsage(for:)` returns cumulative session totals (tokens across
+    /// all turns); emitting those after each turn would double-count when
+    /// accumulated by `DailyUsage.add`. Reset in `resetRunArtifacts()` so
+    /// each interactive session starts fresh.
+    @ObservationIgnored private var lastInteractiveUsageSnapshot: SessionUsage?
 
     /// The planner session handle kept alive during the executor phase so it
     /// can be forked (Phase 3, `plans/acp-session-efficiency.md` §4). nil unless
@@ -1796,6 +1814,56 @@ public final class AgentLauncher {
         }
     }
 
+    /// Read the interactive session's cumulative usage after a turn finishes
+    /// (the turn stream drained at `.messageStop`/`.result`) and emit the
+    /// per-turn DELTA via `onInteractiveUsage`. MUST be called while the
+    /// session is still alive (before `cancel`/`closeSession`) — the backend
+    /// removes usage state on close.
+    ///
+    /// The backend's `sessionUsage(for:)` returns cumulative session totals
+    /// (tokens across all turns). Accumulating those directly via
+    /// `DailyUsage.add` would double-count on every turn after the first, so
+    /// we emit `SessionUsage.delta(from: lastInteractiveUsageSnapshot, to:)`.
+    /// Non-ACP backends or a missing/nil callback are silent no-ops (no usage
+    /// data, nothing to forward). The configured `runProviderLabel` is
+    /// attached so the daily summary can show "Claude" etc. — the backend
+    /// doesn't know the provider.
+    private func captureInteractiveUsage() async {
+        guard onInteractiveUsage != nil else { return }
+        guard let acp = backend as? ACPBackend, let session = sessionHandle else { return }
+        guard let current = await acp.sessionUsage(for: session) else {
+            DebugLog.agent("captureInteractiveUsage: no usage snapshot for session (nil)")
+            return
+        }
+        // Attach the configured provider label (set at spawn-commit). The
+        // backend's snapshot has providerLabel == nil (it doesn't know it).
+        let enriched: SessionUsage
+        if let providerLabel = runProviderLabel {
+            enriched = SessionUsage(
+                inputTokens: current.inputTokens,
+                outputTokens: current.outputTokens,
+                totalTokens: current.totalTokens,
+                cachedReadTokens: current.cachedReadTokens,
+                thoughtTokens: current.thoughtTokens,
+                cost: current.cost,
+                currency: current.currency,
+                contextUsed: current.contextUsed,
+                contextSize: current.contextSize,
+                providerLabel: providerLabel,
+                modelId: current.modelId,
+                thinkingLevel: current.thinkingLevel)
+        } else {
+            enriched = current
+        }
+        let delta = SessionUsage.delta(from: lastInteractiveUsageSnapshot, to: enriched)
+        lastInteractiveUsageSnapshot = enriched
+        // Only forward when there's something to count — avoids noise on a
+        // turn that produced no usage yet.
+        guard delta.totalTokens > 0 || delta.cost != nil else { return }
+        onInteractiveUsage?(delta)
+        DebugLog.agent("captureInteractiveUsage: emitted delta in=\(delta.inputTokens) out=\(delta.outputTokens) cost=\(delta.cost ?? 0) model=\(delta.modelId ?? "nil") provider=\(delta.providerLabel ?? "nil") (cumulative session in=\(enriched.inputTokens) out=\(enriched.outputTokens))")
+    }
+
     /// Resolve the path to a binary bundled in `Contents/Helpers/`, or nil if
     /// not present or not executable.
     ///
@@ -2287,6 +2355,11 @@ public final class AgentLauncher {
                     self.setGenerating(false)
                     self.flushTranscript()
                     self.generateChatSummary()
+                    // Capture the per-turn usage delta and forward it to the
+                    // menu bar tracker (if wired). Reads the backend's
+                    // cumulative session snapshot and emits the delta vs the
+                    // last turn, so the daily total doesn't double-count.
+                    await self.captureInteractiveUsage()
                     DebugLog.agent("sendInteractiveMessage: turn end (endsGeneration) → flushTranscript")
                     if Self.releasesGenerationSlotPerTurn(
                         isInteractiveSession: self.isInteractiveSession) {
@@ -2603,6 +2676,10 @@ public final class AgentLauncher {
         // provider's onUsagecallback.
         onLiveUsage = nil
         liveUsageProviderLabel = nil
+        // Interactive usage tracking: detach the callback and clear the
+        // snapshot baseline so a new run starts fresh (no stale delta base).
+        onInteractiveUsage = nil
+        lastInteractiveUsageSnapshot = nil
         // D2 flip-timing: clear activeChatID AFTER flushTranscript() has
         // committed the final tail.
         // transcriptSink?(tail) which runs store.appendChatEvents on the main
@@ -2689,6 +2766,9 @@ public final class AgentLauncher {
         sessionHandle = nil
         plannerSessionHandle = nil
         runTotalUsage = nil
+        // Interactive usage: clear the per-session baseline so each
+        // interactive run starts fresh (the first turn's delta == full usage).
+        lastInteractiveUsageSnapshot = nil
         thinkingOption = nil
         onUnlockHandler = nil
         // A reset starts a new run: a stale sink must never receive a new

--- a/Sources/WikiFSEngine/SessionManager.swift
+++ b/Sources/WikiFSEngine/SessionManager.swift
@@ -53,18 +53,27 @@ public final class SessionManager {
     /// The app passes a closure delegating to `PdfExtractionService.resolveScript()`.
     public let pdf2mdScriptPathResolver: () -> String?
 
+    /// Receives per-turn interactive (Ask/Edit chat) usage deltas from each
+    /// session's launchers so the menu bar daily total includes chat, not
+    /// just queue runs. The app wires this to
+    /// `QueueActivityTracker.recordInteractiveUsage`. Default no-op so
+    /// headless/daemon callers (which have no UI tracker) are unaffected.
+    public let interactiveUsageRecorder: @MainActor (SessionUsage) -> Void
+
     public init(
         containerDirectory: URL,
         extractionCoordinator: ExtractionCoordinator,
         queueEngine: QueueEngine,
         extractionProvider: any QueueExtractionProvider,
-        pdf2mdScriptPathResolver: @escaping () -> String?
+        pdf2mdScriptPathResolver: @escaping () -> String?,
+        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
     ) {
         self.containerDirectory = containerDirectory
         self.extractionCoordinator = extractionCoordinator
         self.queueEngine = queueEngine
         self.extractionProvider = extractionProvider
         self.pdf2mdScriptPathResolver = pdf2mdScriptPathResolver
+        self.interactiveUsageRecorder = interactiveUsageRecorder
     }
 
     // MARK: - Session lifecycle
@@ -86,7 +95,8 @@ public final class SessionManager {
             extractionCoordinator: extractionCoordinator,
             queueEngine: queueEngine,
             extractionProvider: extractionProvider,
-            pdf2mdScriptPathResolver: pdf2mdScriptPathResolver
+            pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
+            interactiveUsageRecorder: interactiveUsageRecorder
         )
         // Transfer any deferred wiki-link click (registered by
         // `applyOrStashWikiLink` for a wiki whose window wasn't open yet)

--- a/Sources/WikiFSEngine/WikiSession.swift
+++ b/Sources/WikiFSEngine/WikiSession.swift
@@ -144,7 +144,8 @@ public final class WikiSession {
         queueEngine: QueueEngine,
         extractionProvider: any QueueExtractionProvider,
         makeStore: @escaping (URL) throws -> WikiStore = { try StoreBackend.current.makeStore(databaseURL: $0) },
-        pdf2mdScriptPathResolver: @escaping () -> String? = { nil }
+        pdf2mdScriptPathResolver: @escaping () -> String? = { nil },
+        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
     ) {
         self.wikiID = wikiID
         self.extractionCoordinator = extractionCoordinator
@@ -255,10 +256,14 @@ public final class WikiSession {
         // different wiki's session runs independently.
         let agent = AgentLauncher(generationGate: gate, extractionCoordinator: extractionCoordinator)
         agent.pdf2mdScriptPathResolver = pdf2mdScriptPathResolver
+        // Interactive (non-queue) query runs via `agentLauncher` also report
+        // their per-turn usage delta to the menu bar tracker when wired.
+        agent.onInteractiveUsage = interactiveUsageRecorder
         self.agentLauncher = agent
 
         let chat = AgentLauncher(generationGate: gate, extractionCoordinator: extractionCoordinator)
         chat.pdf2mdScriptPathResolver = pdf2mdScriptPathResolver
+        chat.onInteractiveUsage = interactiveUsageRecorder
         self.chatLauncher = chat
     }
 

--- a/Tests/WikiFSTests/ACPBackendTests.swift
+++ b/Tests/WikiFSTests/ACPBackendTests.swift
@@ -662,6 +662,114 @@ import ACPModel
         #expect(merged.modelId == "opencode-1")
     }
 
+    // MARK: - SessionUsage.delta (interactive usage, no double-count)
+
+    /// `delta(from: nil, to: new)` returns `new` directly — the first interactive
+    /// turn's delta is the full cumulative session usage. Guards against dropping
+    /// the first turn from the daily total.
+    @Test
+    func deltaWithNilBaselineReturnsFullSnapshot() {
+        let current = SessionUsage(
+            inputTokens: 100, outputTokens: 50, totalTokens: 150,
+            cachedReadTokens: 20, thoughtTokens: 30,
+            cost: 0.05, currency: "USD", contextUsed: 4000, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4",
+            thinkingLevel: "high")
+        let d = SessionUsage.delta(from: nil, to: current)
+        #expect(d.inputTokens == 100)
+        #expect(d.outputTokens == 50)
+        #expect(d.totalTokens == 150)
+        #expect(d.cachedReadTokens == 20)
+        #expect(d.thoughtTokens == 30)
+        #expect(d.cost == 0.05)
+        #expect(d.providerLabel == "Claude")
+    }
+
+    /// `delta` subtracts the baseline's cumulative token counts so accumulating
+    /// per-turn deltas into `DailyUsage.add` doesn't double-count across turns
+    /// of the SAME session. This is the core correctness guarantee for the
+    /// interactive-usage wiring: the backend reports cumulative session totals,
+    /// but the daily total must only gain THIS turn's marginal tokens.
+    @Test
+    func deltaSubtractsBaselineTokens() {
+        let baseline = SessionUsage(
+            inputTokens: 1000, outputTokens: 500, totalTokens: 1500,
+            cachedReadTokens: 100, thoughtTokens: 200,
+            cost: 1.00, currency: "USD", contextUsed: 3000, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4",
+            thinkingLevel: "high")
+        let current = SessionUsage(
+            inputTokens: 1300, outputTokens: 700, totalTokens: 2000,
+            cachedReadTokens: 150, thoughtTokens: 350,
+            cost: 1.40, currency: "USD", contextUsed: 6000, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4",
+            thinkingLevel: "high")
+        let d = SessionUsage.delta(from: baseline, to: current)
+        #expect(d.inputTokens == 300)
+        #expect(d.outputTokens == 200)
+        #expect(d.totalTokens == 500)
+        #expect(d.cachedReadTokens == 50)
+        #expect(d.thoughtTokens == 150)
+        // Cost delta is a Double subtraction (1.40 − 1.00) — use approximate
+        // equality to avoid float-precision false failures.
+        #expect(abs((d.cost ?? 0) - 0.40) < 0.001)
+        // Context window is point-in-time, not cumulative.
+        #expect(d.contextUsed == 6000)
+        #expect(d.contextSize == 10000)
+    }
+
+    /// `delta` takes the latest non-nil point-in-time metadata
+    /// (providerLabel/modelId/thinkingLevel), matching `merging`'s rule.
+    /// A turn that drops the model id must inherit it from the baseline.
+    @Test
+    func deltaCarriesMetadataFromBaselineWhenMissing() {
+        let baseline = SessionUsage(
+            inputTokens: 100, outputTokens: 50, totalTokens: 150,
+            cachedReadTokens: nil, thoughtTokens: nil,
+            cost: nil, currency: nil, contextUsed: 0, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4",
+            thinkingLevel: "high")
+        let current = SessionUsage(
+            inputTokens: 200, outputTokens: 100, totalTokens: 300,
+            cachedReadTokens: nil, thoughtTokens: nil,
+            cost: nil, currency: nil, contextUsed: 5000, contextSize: 10000,
+            providerLabel: nil, modelId: nil,
+            thinkingLevel: nil)
+        let d = SessionUsage.delta(from: baseline, to: current)
+        #expect(d.providerLabel == "Claude")
+        #expect(d.modelId == "sonnet-4")
+        #expect(d.thinkingLevel == "high")
+    }
+
+    /// `delta` never returns negative token counts even if the backend reports
+    /// a lower cumulative total on a later turn (shouldn't happen in practice,
+    /// but guards against a session-restart that reuses a stale baseline).
+    @Test
+    func deltaClampsToZero() {
+        let baseline = SessionUsage(
+            inputTokens: 500, outputTokens: 400, totalTokens: 900,
+            cachedReadTokens: 100, thoughtTokens: 50,
+            cost: 2.00, currency: "USD", contextUsed: 5000, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4",
+            thinkingLevel: "high")
+        // A LOWER cumulative (e.g. after a session restart reusing a stale
+        // baseline). Delta must clamp to 0, not negative.
+        let current = SessionUsage(
+            inputTokens: 100, outputTokens: 50, totalTokens: 150,
+            cachedReadTokens: 10, thoughtTokens: 5,
+            cost: 0.50, currency: "USD", contextUsed: 1000, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4",
+            thinkingLevel: "high")
+        let d = SessionUsage.delta(from: baseline, to: current)
+        #expect(d.inputTokens == 0)
+        #expect(d.outputTokens == 0)
+        #expect(d.totalTokens == 0)
+        #expect(d.cachedReadTokens == 0)
+        #expect(d.thoughtTokens == 0)
+        // Cost delta clamps to 0 too (current is lower than baseline).
+        #expect(d.cost == 0)
+    }
+
     // MARK: - Phase 4: Default config
 
     /// Parallel executors default to 1 (serial — conservative; requires Phase 3

--- a/Tests/WikiFSTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSTests/QueueIngestionTests.swift
@@ -654,6 +654,49 @@ struct QueueActivityTrackerRunPathsTests {
     }
 }
 
+// MARK: - Interactive usage tracking
+
+@Suite("QueueActivityTracker interactive usage")
+struct QueueActivityTrackerInteractiveUsageTests {
+
+    /// `recordInteractiveUsage` accumulates the per-turn delta into `todayUsage`
+    /// (the menu bar daily total), without creating an `itemUsage` entry —
+    /// interactive chat has no queue item. This is the receiving end of the
+    /// `AgentLauncher.onInteractiveUsage` → `recordInteractiveUsage` wiring.
+    @MainActor
+    @Test("Interactive usage accumulates into todayUsage without an itemUsage entry")
+    func interactiveUsageAccumulates() async {
+        let tracker = QueueActivityTracker()
+        // Capture + restore the persisted daily total so this test doesn't
+        // pollute the real menu bar count (DailyUsage persists to
+        // UserDefaults.standard with a fixed key).
+        let savedDaily = tracker.todayUsage
+        let baseline = savedDaily.inputTokens
+
+        let firstTurn = SessionUsage(
+            inputTokens: 1000, outputTokens: 300, totalTokens: 1300,
+            cachedReadTokens: 100, thoughtTokens: 50,
+            cost: 0.05, currency: "USD", contextUsed: 4000, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4")
+        tracker.recordInteractiveUsage(firstTurn)
+
+        let secondTurn = SessionUsage(
+            inputTokens: 800, outputTokens: 200, totalTokens: 1000,
+            cachedReadTokens: 60, thoughtTokens: 30,
+            cost: 0.03, currency: "USD", contextUsed: 5000, contextSize: 10000,
+            providerLabel: "Claude", modelId: "sonnet-4")
+        tracker.recordInteractiveUsage(secondTurn)
+
+        #expect(tracker.todayUsage.inputTokens == baseline + 1800)
+        #expect(tracker.todayUsage.outputTokens == savedDaily.outputTokens + 500)
+        #expect(tracker.todayUsage.totalTokens == savedDaily.totalTokens + 2300)
+        // No queue item → no per-item usage entry is created.
+        #expect(tracker.transcripts["any-interactive"] == nil)
+
+        DailyUsage.save(savedDaily)
+    }
+}
+
 /// A stub factory that never dispatches (providerID returns nil).
 struct StubWorkerFactory: QueueWorkerFactory {
     func providerID(for item: QueueItem) async -> String? { nil }


### PR DESCRIPTION
## Summary

The "Today: X tokens" menu bar item only counted usage from queue-based runs (ingest/lint). Interactive chat sessions (Ask/Edit tabs via `AgentLauncher.startInteractiveQuery` + `sendInteractiveMessage`) did **not** emit usage, so a long chat burning 50K tokens was invisible in the daily total.

This wires interactive chat into the same daily token tracking the menu bar reads.

## Problem

`ACPBackend` already captures `SessionUsage` for **all** sessions via `SessionUsageState`. The gap: `AgentLauncher` only called `capturePhaseUsage` + emitted `onUsage` from the queue-based `run()` path, not the interactive `sendInteractiveMessage` path.

## Key challenge — no double-counting across turns

The backend's `sessionUsage(for:)` returns **cumulative per-session** totals (tokens across all turns of one session), and `DailyUsage.add` is **additive**:

- The **queue path** reads each phase session's usage **once** (each phase = separate session) → no double-count.
- **Interactive chat** reuses **one** session across many turns → naively emitting the cumulative snapshot after each turn and adding it would re-add the full total on every turn after the first.

The fix emits the **per-turn delta** (`current cumulative − last-emitted baseline`) so the daily total only gains the marginal tokens for that turn.

## Approach — callback (Option A)

Matches the existing `onAgentEvent` callback on `AgentLauncher` and the closure-injection threading (`WikiFSApp` → `SessionManager.init` → `WikiSession.init`). Keeps capture in the `@MainActor` `sendInteractiveMessage` turn-end branch (naturally main-actor safe). Avoids a new `AgentEvent` case (which would complicate the transcript drain + persistence + `StoreEmissionExhaustivenessTests` partition).

## Changes

- **`ACPBackend.swift`** — new `SessionUsage.delta(from:to:)` static helper next to `merging`. Token counts subtracted (`to − from`, clamped ≥0); cost delta (`to.cost − from.cost`, clamped ≥0); context window is point-in-time (takes `to`); provider label/model id/thinking level are latest-non-nil-wins. `from == nil` returns `to` (first turn = full snapshot).
- **`AgentLauncher.swift`**:
  - `onInteractiveUsage: (@MainActor (SessionUsage) -> Void)?` callback (app-installed; `nil` = no-op).
  - `lastInteractiveUsageSnapshot` per-session baseline.
  - `captureInteractiveUsage()` — reads `backend.sessionUsage(for:)` while alive, attaches `runProviderLabel`, computes delta, forwards via callback. No-op for non-ACP backends / nil callback.
  - Call site: `sendInteractiveMessage` turn-end (`endsGeneration`) branch.
  - Reset in `resetRunArtifacts()` (per-run) + `finish()` (session teardown).
- **`QueueActivityTracker.swift`** — `recordInteractiveUsage(_:)` accumulates the delta into `todayUsage` + persists. **No** `itemUsage` entry (interactive chat has no queue item).
- **`WikiSession.swift`** — `interactiveUsageRecorder` init param installed onto **both** `agentLauncher` and `chatLauncher`.
- **`SessionManager.swift`** — threads `interactiveUsageRecorder` through.
- **`WikiFSApp.swift`** — passes the recorder capturing `activityTracker`.

## No double-count with queued runs

A single `AgentLauncher` runs **either** a queue `run()` **or** an interactive `startInteractiveQuery` (never both); `resetRunArtifacts()` is called at the start of each and clears `lastInteractiveUsageSnapshot`. The queue path never calls `captureInteractiveUsage` (only `sendInteractiveMessage` does), and the interactive path never emits a queue `.usage` event. So even a takeover (queued + interactive on the same launcher) counts once per path.

## Tests

- 4 `SessionUsage.delta` tests (`ACPBackendTests`): nil-baseline = full snapshot, subtracts baseline tokens, carries metadata from baseline when missing, clamps to zero on a lower cumulative.
- 1 `QueueActivityTracker.recordInteractiveUsage` accumulation test (`QueueIngestionTests`): two deltas accumulate into `todayUsage` with no `itemUsage` entry; captures + restores persisted `DailyUsage` so it doesn't pollute the real menu bar count.

## Build / Tests

- `make version prompts && swift build` clean.
- Fast tier: **2578 tests / 219 suites pass**.
