### PR TITLE
Add Reveal Log / Reveal Debug Folder to Activity window

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,56 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-18 — Add "Reveal Debug Folder" + "Reveal Log" UI to the Activity window (branch `feature/reveal-debug-folder-ui`)
+
+**Problem:** PR #580 added `DebugRunLogger` (a verbose ACP wire-trace under
+`<scratch>/debug/`), and `ChatView` already had "Reveal Log" / "Reveal Debug
+Folder" buttons in its activity menu. But the standalone **Activity window**
+(`ActivityWindowView`) — where users view ingestion/lint transcripts across all
+wikis — had no way to reveal either the lightweight `run.jsonl` log or the
+verbose `debug/` folder. The launcher's `logFileURL` / `debugFolderURL` existed
+(`public private(set)`) but were only reachable from the chat view's direct
+launcher reference; the Activity window works with `QueueItem` objects and the
+`QueueActivityTracker`, with no per-item log-path state.
+
+**Fix:** Threaded the run's `logFileURL` + `debugFolderURL` through the queue
+event system — mirroring the existing `.usage` / `.liveUsage` event plumbing —
+so the tracker stores per-item paths that the Activity window can reveal.
+
+**Data flow:** `AppQueueIngestionProvider` → `onLogPaths` callback →
+`QueueIngestionWorker` → `emitLogPaths` (via `LogPathsEmitBox`) →
+`QueueEngine.makeEmitLogPaths()` → `.runPaths(QueueItem.ID, logURL:, debugURL:)`
+event → `QueueActivityTracker` → `ActivityWindowView`.
+
+**New `QueueEvent.runPaths`** case (Sendable, NOT logged to JSONL — URLs are
+runtime-only, not Codable audit data). Added `runPaths` to `QueueEventType`,
+`QueueLogRecord.init` (all nil fields), and the `write()` skip list — same
+treatment as `.usage`.
+
+**`QueueActivityTracker`** gained `itemLogURLs` / `itemDebugURLs` dictionaries
++ `logURL(for:)` / `debugURL(for:)` accessors. Paths persist after terminal
+state (same as transcripts) so users can reveal them for recently-completed
+items; cleared on prune / stop.
+
+**`ActivityWindowView`** gained two affordances:
+1. A compact `ellipsis.circle` menu (`revealMenu`) in the detail header —
+   "Reveal Log" (`doc.text.magnifyingglass`) + "Reveal Debug Folder"
+   (`folder.badge.gearshape`). Only shown when at least one path exists.
+2. The same two items in the row context menu (after "Copy Transcript",
+   behind a divider).
+
+Both use `NSWorkspace.shared.activateFileViewerSelecting([url])` — matching
+`ChatView`'s existing behavior exactly.
+
+**Tests:** 4 new `QueueActivityTrackerRunPathsTests` (stored per-item, survive
+terminal state, cleared on prune, nil paths produce nil accessors). Updated all
+8 `QueueIngestionWorkerFactory` / `QueueIngestionWorker` constructor call sites
++ the `FakeIngestionProvider` mock in `QueueIngestionTests.swift`.
+
+**Build/Tests:** `make version prompts` ✓; `swift build` clean (16s);
+fast test tier **2581 tests / 219 suites pass** (4 new).
+
+
 ## 2026-07-18 — Unify audio podcast source detail with the video Reader/Media/Split tab pattern (branch `feature/audio-podcast-detail-tabs`)
 
 **Problem.** PR #586 (open, `unify-video-pdf-source-tabs`) unified *video*

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -300,6 +300,21 @@ struct ActivityWindowView: View {
                 copyTranscript(for: item)
             }
         }
+        let logURL = activityTracker.logURL(for: item.id)
+        let debugURL = activityTracker.debugURL(for: item.id)
+        if logURL != nil || debugURL != nil {
+            Divider()
+            if let logURL {
+                Button("Reveal Log", systemImage: "doc.text.magnifyingglass") {
+                    NSWorkspace.shared.activateFileViewerSelecting([logURL])
+                }
+            }
+            if let debugURL {
+                Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
+                    NSWorkspace.shared.activateFileViewerSelecting([debugURL])
+                }
+            }
+        }
         switch item.state {
         case .running, .queued:
             Button("Cancel") {
@@ -462,6 +477,7 @@ struct ActivityWindowView: View {
                 }
                 .help("Copy transcript as plain text")
             }
+            revealMenu(for: item)
             switch item.state {
             case .running, .queued:
                 Button("Cancel") {
@@ -642,6 +658,39 @@ struct ActivityWindowView: View {
             DebugLog.tabs("Lint Browse Pages: no pages to reveal in wiki \(wikiID.prefix(8)); focusing window only")
         }
         openWindowBridge?.openWiki?(wikiID)
+    }
+
+    // MARK: - Reveal log / debug folder
+
+    /// A compact menu offering "Reveal Log" and "Reveal Debug Folder" for the
+    /// selected item. Only shown when at least one path is available — items
+    /// that never spawned an agent (preflight failure, cancelled before run)
+    /// won't have either. Mirrors the ChatView's activity menu.
+    @ViewBuilder
+    private func revealMenu(for item: QueueItem) -> some View {
+        let logURL = activityTracker.logURL(for: item.id)
+        let debugURL = activityTracker.debugURL(for: item.id)
+        if logURL != nil || debugURL != nil {
+            Menu {
+                if let logURL {
+                    Button("Reveal Log", systemImage: "doc.text.magnifyingglass") {
+                        NSWorkspace.shared.activateFileViewerSelecting([logURL])
+                    }
+                    .help("Reveal the lightweight run.jsonl log in Finder")
+                }
+                if let debugURL {
+                    Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
+                        NSWorkspace.shared.activateFileViewerSelecting([debugURL])
+                    }
+                    .help("Open the complete debug trace folder (ACP messages, permissions, usage)")
+                }
+            } label: {
+                Label("Reveal", systemImage: "ellipsis.circle")
+            }
+            .labelStyle(.iconOnly)
+            .menuStyle(.borderlessButton)
+            .help("Reveal log files in Finder")
+        }
     }
 
     // MARK: - Copy

--- a/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
+++ b/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
@@ -68,7 +68,8 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws {
         guard let store = sessionBox.resolve(wikiID: wikiID) else {
             throw QueueIngestionError.spawnFailed("No session for wikiID=\(wikiID)")
@@ -202,6 +203,7 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
         // `.usage` queue event). Done here, after `run()` returns, so the
         // usage reflects all phases (planner → executors → finalizer).
         onUsage?(launcher.runTotalUsage)
+        onLogPaths?(launcher.logFileURL, launcher.debugFolderURL)
 
         // If the agent never spawned (cancelled, preflight failure), clear
         // the ingest flag. The tracker's ingestingSourceIDs will be cleared
@@ -218,7 +220,8 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws {
         guard let store = sessionBox.resolve(wikiID: wikiID) else {
             throw QueueIngestionError.spawnFailed("No session for wikiID=\(wikiID)")
@@ -246,6 +249,7 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
             onLiveUsage: onLiveUsage
         )
         onUsage?(launcher.runTotalUsage)
+        onLogPaths?(launcher.logFileURL, launcher.debugFolderURL)
     }
 
     func runLintPages(
@@ -254,7 +258,8 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws {
         guard let store = sessionBox.resolve(wikiID: wikiID) else {
             throw QueueIngestionError.spawnFailed("No session for wikiID=\(wikiID)")
@@ -304,6 +309,7 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
             onLiveUsage: onLiveUsage
         )
         onUsage?(launcher.runTotalUsage)
+        onLogPaths?(launcher.logFileURL, launcher.debugFolderURL)
     }
 
     // MARK: - Private

--- a/Sources/WikiFS/Queue/OperationNotifier.swift
+++ b/Sources/WikiFS/Queue/OperationNotifier.swift
@@ -85,7 +85,7 @@ final class OperationNotifier {
             post(item: item, outcome: .failed(error))
         // Cancelled is user-initiated — not worth a notification.
         case .cancelled, .enqueued, .started, .progress, .transcript, .liveUsage,
-              .usage, .runStateChanged, .reordered:
+              .usage, .runPaths, .runStateChanged, .reordered:
             break
         }
     }

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -34,6 +34,15 @@ final class LiveUsageEmitBox: @unchecked Sendable {
     var emit: (@Sendable (QueueItem.ID, SessionUsage) -> Void)?
 }
 
+/// A mutable box for a `@Sendable` log-paths-emit closure. Same pattern as
+/// the other emit boxes — breaks the circular dependency between the ingestion
+/// worker factory (needs the closure) and the engine (provides it). Carries
+/// the run's `run.jsonl` log URL and `debug/` folder URL so the Activity
+/// window can offer "Reveal Log" / "Reveal Debug Folder".
+final class LogPathsEmitBox: @unchecked Sendable {
+    var emit: (@Sendable (QueueItem.ID, URL?, URL?) -> Void)?
+}
+
 /// Observes `QueueEngine.events` and maintains `@Observable` UI state for
 /// extraction activity. Replaces the launcher's extraction slot machinery
 /// (`isExtracting`, `extractionLog`, `extractionPID`,
@@ -122,6 +131,15 @@ final class QueueActivityTracker {
     /// show running token counts + model name before the run completes. The
     /// final cumulative totals come from `itemUsage` via the `.usage` event.
     private(set) var liveUsage: [QueueItem.ID: SessionUsage] = [:]
+
+    /// Per-item lightweight log file URL (`run.jsonl`) — the raw stream-json
+    /// trace. Set once when `.runPaths` arrives after the run starts.
+    private(set) var itemLogURLs: [QueueItem.ID: URL] = [:]
+
+    /// Per-item verbose debug folder URL (`debug/`) — the complete ACP wire
+    /// trace (per-turn JSON, permissions, stderr, summary). Set once when
+    /// `.runPaths` arrives after the run starts.
+    private(set) var itemDebugURLs: [QueueItem.ID: URL] = [:]
 
     /// Today's cumulative token usage across all completed runs (#528 spike).
     /// Persists to UserDefaults with a date key so it survives app restarts
@@ -212,6 +230,8 @@ final class QueueActivityTracker {
         progressLogs.removeAll()
         itemUsage.removeAll()
         liveUsage.removeAll()
+        itemLogURLs.removeAll()
+        itemDebugURLs.removeAll()
         streamingTranscriptItemIDs.removeAll()
         streamingThinkingItemIDs.removeAll()
     }
@@ -317,6 +337,8 @@ final class QueueActivityTracker {
         progressLogs.removeValue(forKey: itemID)
         itemUsage.removeValue(forKey: itemID)
         liveUsage.removeValue(forKey: itemID)
+        itemLogURLs.removeValue(forKey: itemID)
+        itemDebugURLs.removeValue(forKey: itemID)
         streamingTranscriptItemIDs.remove(itemID)
         streamingThinkingItemIDs.remove(itemID)
     }
@@ -342,6 +364,18 @@ final class QueueActivityTracker {
     /// live token counts + model name during a run (#544 live progress).
     func liveUsage(for itemID: QueueItem.ID) -> SessionUsage? {
         liveUsage[itemID]
+    }
+
+    /// The lightweight `run.jsonl` log file URL for an item, or `nil` if the
+    /// run didn't create one. Read by the Activity window for "Reveal Log".
+    func logURL(for itemID: QueueItem.ID) -> URL? {
+        itemLogURLs[itemID]
+    }
+
+    /// The verbose `debug/` folder URL for an item, or `nil` if the run
+    /// didn't create one. Read by the Activity window for "Reveal Debug Folder".
+    func debugURL(for itemID: QueueItem.ID) -> URL? {
+        itemDebugURLs[itemID]
     }
 
     // MARK: - Event handling
@@ -401,6 +435,13 @@ final class QueueActivityTracker {
             // usage_update carries the current cumulative totals + the latest
             // model/cost). Cleared on terminal state in removeItem().
             liveUsage[id] = usage
+
+        case .runPaths(let id, let logURL, let debugURL):
+            // Store the run's log/debug URLs so the Activity window can offer
+            // "Reveal Log" / "Reveal Debug Folder". Either may be nil if the
+            // run didn't create the files (not started, preflight failure).
+            if let logURL { itemLogURLs[id] = logURL }
+            if let debugURL { itemDebugURLs[id] = debugURL }
 
         case .progress(let id, let line):
             // Accumulate per-item progress (for extraction items and any

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -156,6 +156,7 @@ struct WikiFSApp: App {
         let transcriptBox = TranscriptEmitBox()
         let usageBox = UsageEmitBox()
         let liveUsageBox = LiveUsageEmitBox()
+        let logPathsBox = LogPathsEmitBox()
         let extractionFactory = QueueExtractionWorkerFactory(
             provider: extractionProvider,
             emitProgress: { id, line in progressBox.emit?(id, line) })
@@ -164,7 +165,8 @@ struct WikiFSApp: App {
             emitProgress: { id, line in progressBox.emit?(id, line) },
             emitTranscript: { id, event in transcriptBox.emit?(id, event) },
             emitUsage: { id, usage in usageBox.emit?(id, usage) },
-            emitLiveUsage: { id, usage in liveUsageBox.emit?(id, usage) })
+            emitLiveUsage: { id, usage in liveUsageBox.emit?(id, usage) },
+            emitLogPaths: { id, logURL, debugURL in logPathsBox.emit?(id, logURL, debugURL) })
         let workerFactory = CompositeWorkerFactory(factories: [
             .extraction: extractionFactory,
             .ingestion: ingestionFactory
@@ -179,6 +181,7 @@ struct WikiFSApp: App {
         Task { transcriptBox.emit = await queueEngine.makeEmitTranscript() }
         Task { usageBox.emit = await queueEngine.makeEmitUsage() }
         Task { liveUsageBox.emit = await queueEngine.makeEmitLiveUsage() }
+        Task { logPathsBox.emit = await queueEngine.makeEmitLogPaths() }
         // Start the engine (rehydrate + crash recovery + initial dispatch).
         // Detached so the app's init isn't blocked; the engine is an actor so
         // `start()` is safe to call concurrently.

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -386,6 +386,17 @@ public actor QueueEngine {
         }
     }
 
+    /// A `Sendable` closure the worker factory captures to yield `.runPaths`
+    /// events onto the engine's broadcaster. Surfaces the run's `run.jsonl`
+    /// log file URL and `debug/` folder URL to the activity tracker so the
+    /// Activity window can offer "Reveal Log" / "Reveal Debug Folder" (no
+    /// persistence needed — URLs are runtime-only).
+    public func makeEmitLogPaths() -> @Sendable (QueueItem.ID, URL?, URL?) -> Void {
+        return { [broadcaster] id, logURL, debugURL in
+            broadcaster.yield(.runPaths(id, logURL: logURL, debugURL: debugURL))
+        }
+    }
+
     /// Load persisted agent events (transcript) for a queue item from the DB.
     /// Used by the Activity tracker to show transcripts for items rehydrated
     /// from a previous session. Deltas are folded into whole rows on the way

--- a/Sources/WikiFSEngine/QueueEventLog.swift
+++ b/Sources/WikiFSEngine/QueueEventLog.swift
@@ -20,6 +20,7 @@ enum QueueEventType: String, Codable, Sendable {
     case usage
     case runStateChanged
     case reordered
+    case runPaths
 }
 
 // MARK: - QueueLogRecord
@@ -241,6 +242,25 @@ struct QueueLogRecord: Codable, Sendable {
             self.finishedAt = nil
             self.durationMs = nil
 
+        case .runPaths:
+            // Run-path events carry the run's log/debug folder URLs so the
+            // Activity window can offer "Reveal Log" / "Reveal Debug Folder".
+            // NOT logged to JSONL (URLs are runtime-only, not Codable audit
+            // data). The write() method skips this case.
+            self.eventType = .runPaths
+            self.itemID = nil
+            self.queue = nil
+            self.wikiID = nil
+            self.providerID = nil
+            self.itemState = nil
+            self.runState = nil
+            self.orderingKey = nil
+            self.attempt = nil
+            self.error = nil
+            self.startedAt = nil
+            self.finishedAt = nil
+            self.durationMs = nil
+
         case .runStateChanged(let queue, let state):
             self.eventType = .runStateChanged
             self.itemID = nil
@@ -379,6 +399,7 @@ public actor QueueEventLog {
         if case .transcript = event { return }
         if case .liveUsage = event { return }
         if case .usage = event { return }
+        if case .runPaths = event { return }
 
         ensureOpenForToday()
         guard let handle = fileHandle else { return }

--- a/Sources/WikiFSEngine/QueueIngestionProvider.swift
+++ b/Sources/WikiFSEngine/QueueIngestionProvider.swift
@@ -40,13 +40,17 @@ public protocol QueueIngestionProvider: Sendable {
     ///     run with the in-progress token/cost snapshot. `nil` for callers
     ///     that don't need live progress (#544). May never fire if the backend
     ///     doesn't stream usage updates.
+    ///   - onLogPaths: Called after the run with the run's `run.jsonl` log URL
+    ///     and `debug/` folder URL (either may be nil if the run didn't
+    ///     create them). `nil` for callers that don't need log-reveal UI.
     func runIngestion(
         wikiID: String,
         sourceIDs: [PageID],
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws
 
     /// Run a whole-wiki lint health-check. Returns when the agent finishes.
@@ -62,7 +66,8 @@ public protocol QueueIngestionProvider: Sendable {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws
 
     /// Run a page-level lint health-check for the given pages. Returns when
@@ -81,7 +86,8 @@ public protocol QueueIngestionProvider: Sendable {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws
 
     /// Quick readiness probe: checks whether the selected agent provider's
@@ -131,19 +137,22 @@ public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
     private let emitTranscript: @Sendable (QueueItem.ID, AgentEvent) -> Void
     private let emitUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
     private let emitLiveUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
+    private let emitLogPaths: @Sendable (QueueItem.ID, URL?, URL?) -> Void
 
     public init(
         provider: any QueueIngestionProvider,
         emitProgress: @escaping @Sendable (QueueItem.ID, String) -> Void,
         emitTranscript: @escaping @Sendable (QueueItem.ID, AgentEvent) -> Void,
         emitUsage: @escaping @Sendable (QueueItem.ID, SessionUsage) -> Void,
-        emitLiveUsage: @escaping @Sendable (QueueItem.ID, SessionUsage) -> Void
+        emitLiveUsage: @escaping @Sendable (QueueItem.ID, SessionUsage) -> Void,
+        emitLogPaths: @escaping @Sendable (QueueItem.ID, URL?, URL?) -> Void
     ) {
         self.provider = provider
         self.emitProgress = emitProgress
         self.emitTranscript = emitTranscript
         self.emitUsage = emitUsage
         self.emitLiveUsage = emitLiveUsage
+        self.emitLogPaths = emitLogPaths
     }
 
     public func providerID(for item: QueueItem) async -> String? {
@@ -160,7 +169,7 @@ public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
     }
 
     public func worker(for item: QueueItem) async throws -> any QueueWorker {
-        QueueIngestionWorker(provider: provider, emitProgress: emitProgress, emitTranscript: emitTranscript, emitUsage: emitUsage, emitLiveUsage: emitLiveUsage)
+        QueueIngestionWorker(provider: provider, emitProgress: emitProgress, emitTranscript: emitTranscript, emitUsage: emitUsage, emitLiveUsage: emitLiveUsage, emitLogPaths: emitLogPaths)
     }
 }
 
@@ -180,6 +189,7 @@ struct QueueIngestionWorker: QueueWorker {
     let emitTranscript: @Sendable (QueueItem.ID, AgentEvent) -> Void
     let emitUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
     let emitLiveUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
+    let emitLogPaths: @Sendable (QueueItem.ID, URL?, URL?) -> Void
 
     func execute(_ item: QueueItem) async throws {
         // Pre-dispatch readiness gate (#440): check the agent provider's binary
@@ -203,6 +213,11 @@ struct QueueIngestionWorker: QueueWorker {
         let onLiveUsage: (@Sendable (SessionUsage) -> Void)? = { [itemID = item.id] usage in
             emitLiveUsage(itemID, usage)
         }
+        // Run paths: forward the run's log/debug URLs so the Activity window
+        // can offer "Reveal Log" / "Reveal Debug Folder".
+        let onLogPaths: (@Sendable (URL?, URL?) -> Void)? = { [itemID = item.id] logURL, debugURL in
+            emitLogPaths(itemID, logURL, debugURL)
+        }
 
         if let pageIDs = item.payload.lintPageIDs, !pageIDs.isEmpty {
             // Page-level lint.
@@ -212,7 +227,8 @@ struct QueueIngestionWorker: QueueWorker {
                 onProgress: { [itemID = item.id] line in emitProgress(itemID, line) },
                 onTranscript: onTranscript,
                 onUsage: onUsage,
-                onLiveUsage: onLiveUsage
+                onLiveUsage: onLiveUsage,
+                onLogPaths: onLogPaths
             )
         } else if item.payload.lintPageIDs != nil {
             // lintPageIDs is non-nil but empty → whole-wiki lint.
@@ -221,7 +237,8 @@ struct QueueIngestionWorker: QueueWorker {
                 onProgress: { [itemID = item.id] line in emitProgress(itemID, line) },
                 onTranscript: onTranscript,
                 onUsage: onUsage,
-                onLiveUsage: onLiveUsage
+                onLiveUsage: onLiveUsage,
+                onLogPaths: onLogPaths
             )
         } else {
             // Normal ingestion.
@@ -235,7 +252,8 @@ struct QueueIngestionWorker: QueueWorker {
                 onProgress: { [itemID = item.id] line in emitProgress(itemID, line) },
                 onTranscript: onTranscript,
                 onUsage: onUsage,
-                onLiveUsage: onLiveUsage
+                onLiveUsage: onLiveUsage,
+                onLogPaths: onLogPaths
             )
         }
     }

--- a/Sources/WikiFSEngine/QueueWorker.swift
+++ b/Sources/WikiFSEngine/QueueWorker.swift
@@ -101,6 +101,11 @@ public enum QueueEvent: Sendable {
     /// A queued item was reordered (dragged to a new position). Carries the
     /// updated item with its new `orderingKey`.
     case reordered(QueueItem)
+    /// The run's lightweight log file (`run.jsonl`) and verbose debug folder
+    /// (`debug/`) URLs, forwarded from the launcher after the run starts so
+    /// the Activity window can offer "Reveal Log" / "Reveal Debug Folder".
+    /// `nil` when the run didn't create them (not started, preflight failure).
+    case runPaths(QueueItem.ID, logURL: URL?, debugURL: URL?)
 
     /// The item this event pertains to (if any).
     public var item: QueueItem? {
@@ -110,7 +115,7 @@ public enum QueueEvent: Sendable {
             return i
         case .failed(let i, _):
             return i
-        case .progress, .transcript, .liveUsage, .usage, .runStateChanged:
+        case .progress, .transcript, .liveUsage, .usage, .runPaths, .runStateChanged:
             return nil
         }
     }

--- a/Tests/WikiFSTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSTests/QueueIngestionTests.swift
@@ -105,7 +105,8 @@ actor FakeIngestionProvider: QueueIngestionProvider {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws {
         calledWikiID = wikiID
         calledSourceIDs = sourceIDs
@@ -119,7 +120,8 @@ actor FakeIngestionProvider: QueueIngestionProvider {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws {
         calledLintWikiID = wikiID
         calledLintPageIDs = []
@@ -134,7 +136,8 @@ actor FakeIngestionProvider: QueueIngestionProvider {
         onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?,
         onUsage: (@Sendable (SessionUsage?) -> Void)?,
-        onLiveUsage: (@Sendable (SessionUsage) -> Void)?
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)?,
+        onLogPaths: (@Sendable (URL?, URL?) -> Void)?
     ) async throws {
         calledLintWikiID = wikiID
         calledLintPageIDs = pageIDs
@@ -159,7 +162,7 @@ struct QueueIngestionWorkerTests {
             provider: provider,
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in },
-            emitLiveUsage: { _, _ in })
+            emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "test1", queue: .ingestion, wikiID: "wiki1",
             payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "src1")]),
@@ -184,7 +187,7 @@ struct QueueIngestionWorkerTests {
         let worker = QueueIngestionWorker(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
 
         await #expect(throws: QueueIngestionError.self) {
             try await worker.execute(QueueItem(
@@ -202,7 +205,7 @@ struct QueueIngestionWorkerTests {
         let worker = QueueIngestionWorker(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
 
         await #expect(throws: QueueIngestionError.self) {
             try await worker.execute(QueueItem(
@@ -221,7 +224,7 @@ struct QueueIngestionWorkerTests {
         let worker = QueueIngestionWorker(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
 
         do {
             try await worker.execute(QueueItem(
@@ -253,7 +256,7 @@ struct QueueIngestionWorkerTests {
         let worker = QueueIngestionWorker(
             provider: provider,
             emitProgress: { _, _ in },
-            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in })
+            emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
 
         try await worker.execute(QueueItem(
             id: "test-ready-ok", queue: .ingestion, wikiID: "wiki1",
@@ -419,7 +422,7 @@ struct LintIngestionDispatchTests {
             provider: provider,
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in },
-            emitLiveUsage: { _, _ in })
+            emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "lint1", queue: .ingestion, wikiID: "w1",
             payload: QueueItemPayload(sourceIDs: [], lintPageIDs: [PageID(rawValue: "p1")]),
@@ -445,7 +448,7 @@ struct LintIngestionDispatchTests {
             provider: provider,
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in },
-            emitLiveUsage: { _, _ in })
+            emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "lint2", queue: .ingestion, wikiID: "w1",
             payload: QueueItemPayload(sourceIDs: [], lintPageIDs: []),
@@ -469,7 +472,7 @@ struct LintIngestionDispatchTests {
             provider: provider,
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in },
-            emitLiveUsage: { _, _ in })
+            emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in })
         let worker = try await factory.worker(for: QueueItem(
             id: "ing1", queue: .ingestion, wikiID: "w1",
             payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "s1")]),
@@ -564,6 +567,90 @@ struct QueueActivityTrackerTranscriptTests {
         let log = tracker.progressLog(for: "prog-1")
         #expect(log.contains("line 1"))
         #expect(log.contains("line 2"))
+    }
+}
+
+// MARK: - Run paths (log/debug folder URL) forwarding tests
+
+@Suite("QueueActivityTracker run paths")
+struct QueueActivityTrackerRunPathsTests {
+
+    private func makeItem(
+        id: String = "paths-item",
+        queue: QueueKind = .ingestion,
+        sourceIDs: [PageID] = [PageID(rawValue: "src1")],
+        state: QueueItemState = .running
+    ) -> QueueItem {
+        QueueItem(
+            id: id, queue: queue, wikiID: "wiki1",
+            payload: QueueItemPayload(sourceIDs: sourceIDs),
+            state: state, orderingKey: 1000, attempt: 0,
+            createdAt: 0)
+    }
+
+    @MainActor
+    @Test("Run paths stored per-item")
+    func runPathsStoredPerItem() {
+        let tracker = QueueActivityTracker()
+        let itemID = "paths-item"
+        let item = makeItem(id: itemID)
+        let logURL = URL(fileURLWithPath: "/tmp/scratch/run.jsonl")
+        let debugURL = URL(fileURLWithPath: "/tmp/scratch/debug", isDirectory: true)
+
+        tracker.handleForTesting(.started(item))
+        tracker.handleForTesting(.runPaths(itemID, logURL: logURL, debugURL: debugURL))
+
+        #expect(tracker.logURL(for: itemID) == logURL)
+        #expect(tracker.debugURL(for: itemID) == debugURL)
+    }
+
+    @MainActor
+    @Test("Run paths survive terminal state")
+    func runPathsSurviveCompletion() {
+        let tracker = QueueActivityTracker()
+        let itemID = "paths-item"
+        let item = makeItem(id: itemID)
+        let logURL = URL(fileURLWithPath: "/tmp/scratch/run.jsonl")
+
+        tracker.handleForTesting(.started(item))
+        tracker.handleForTesting(.runPaths(itemID, logURL: logURL, debugURL: nil))
+
+        let completed = makeItem(id: itemID, state: .completed)
+        tracker.handleForTesting(.completed(completed))
+
+        // Paths persist after completion (same as transcripts) so the user can
+        // reveal them for recently-completed items.
+        #expect(tracker.logURL(for: itemID) == logURL)
+        #expect(tracker.debugURL(for: itemID) == nil)
+    }
+
+    @MainActor
+    @Test("Run paths cleared on prune")
+    func runPathsClearedOnPrune() {
+        let tracker = QueueActivityTracker()
+        let itemID = "paths-item"
+        let item = makeItem(id: itemID)
+        let logURL = URL(fileURLWithPath: "/tmp/scratch/run.jsonl")
+        let debugURL = URL(fileURLWithPath: "/tmp/scratch/debug", isDirectory: true)
+
+        tracker.handleForTesting(.started(item))
+        tracker.handleForTesting(.runPaths(itemID, logURL: logURL, debugURL: debugURL))
+        tracker.pruneTranscripts(for: itemID)
+
+        #expect(tracker.logURL(for: itemID) == nil)
+        #expect(tracker.debugURL(for: itemID) == nil)
+    }
+
+    @MainActor
+    @Test("Nil paths produce nil accessors")
+    func nilPathsProduceNil() {
+        let tracker = QueueActivityTracker()
+        let itemID = "never-ran"
+
+        tracker.handleForTesting(.runPaths(itemID, logURL: nil, debugURL: nil))
+
+        #expect(tracker.logURL(for: itemID) == nil)
+        #expect(tracker.debugURL(for: itemID) == nil)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds **"Reveal Log"** and **"Reveal Debug Folder"** affordances to the standalone **Activity window** — the place where users view ingestion/lint transcripts across all wikis. PR #580 added `DebugRunLogger` (verbose ACP wire traces under `<scratch>/debug/`), and `ChatView` already had both buttons in its activity menu, but the Activity window had no way to access either log location.

## What changed

**New `QueueEvent.runPaths` event** — threads the run's `run.jsonl` log URL and `debug/` folder URL through the queue event system, mirroring the existing `.usage` / `.liveUsage` plumbing. The event is `Sendable` but **not** logged to the JSONL audit trail (URLs are runtime-only, not Codable audit data).

**Data flow:** `AppQueueIngestionProvider` → `onLogPaths` callback → `QueueIngestionWorker` → `emitLogPaths` (`LogPathsEmitBox`) → `QueueEngine.makeEmitLogPaths()` → `.runPaths` event → `QueueActivityTracker` → `ActivityWindowView`.

**`QueueActivityTracker`** — new `itemLogURLs` / `itemDebugURLs` dictionaries + `logURL(for:)` / `debugURL(for:)` accessors. Paths persist after terminal state (same as transcripts) so users can reveal them for recently-completed items.

**`ActivityWindowView`** — two new affordances:
- A compact `ellipsis.circle` menu in the detail header with "Reveal Log" + "Reveal Debug Folder" (only shown when at least one path exists)
- The same two items in the row context menu (after "Copy Transcript", behind a divider)

Both use `NSWorkspace.shared.activateFileViewerSelecting([url])`, matching `ChatView`'s existing behavior.

## Files

| File | Change |
|------|--------|
| `QueueWorker.swift` | New `.runPaths` event case |
| `QueueEventLog.swift` | `runPaths` in `QueueEventType` + `QueueLogRecord` (skip JSONL) |
| `QueueEngine.swift` | `makeEmitLogPaths()` |
| `QueueIngestionProvider.swift` | `onLogPaths` param on protocol + `emitLogPaths` on factory/worker |
| `AppQueueIngestionProvider.swift` | Call `onLogPaths?(launcher.logFileURL, launcher.debugFolderURL)` after each run |
| `QueueActivityTracker.swift` | `LogPathsEmitBox`, `itemLogURLs`/`itemDebugURLs`, `.runPaths` handler, accessors |
| `WikiFSApp.swift` | Wire `LogPathsEmitBox` to factory + engine |
| `ActivityWindowView.swift` | `revealMenu(for:)` + context menu items |
| `OperationNotifier.swift` | Exhaustive switch updated |
| `QueueIngestionTests.swift` | 4 new tracker tests + mock/constructor updates |

## Test plan

- `make version prompts` ✓
- `swift build` clean ✓
- Fast test tier: **2581 tests / 219 suites pass** (4 new) ✓
- New tests cover: per-item storage, survival past terminal state, prune clearing, nil-paths edge case
