### PR TITLE
feat(sources): Mermaid diagram tabs — Reader / Rendered / Split

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,57 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-18 — Mermaid diagram tabs: Reader / Rendered / Split (branch `mermaid-source-detail-tabs`)
+
+**Problem:** Mermaid diagram sources (`.mmd` files or markdown containing
+```mermaid fenced blocks) rendered like ordinary markdown — a single Reader tab.
+A diagram source had no dedicated "rendered SVG" view or side-by-side
+source/rendered split, unlike PDFs (Reader/PDF/Split) and media
+(Reader/Media/Split, from #586/#590).
+
+**What changed (4 files), rebased onto the post-#590 `main`:**
+
+1. **`MimeType`** (`Sources/WikiFSTypes/MimeType.swift`) — added `text/mermaid` +
+   `text/x-mermaid` constants, a `mermaidVariants` set, and `isMermaid(_:)`
+   (case-insensitive predicate, `nil` → false). Mirrors the markdown predicates.
+
+2. **`MermaidSourceDetector`** (`Sources/WikiFSCore/Sources/MermaidSourceDetector.swift`,
+   new) — pure, unit-tested gate. `isMermaidSource(mimeType:filename:content:)`
+   is true when the MIME is a mermaid variant, the filename ends in `.mmd`, or
+   the content contains a fenced ```mermaid block (reuses
+   `MermaidValidator.mermaidBlocks`, the pure line scanner — no JS).
+   `renderableMarkdown(from:)` wraps a standalone `.mmd` source in a ```mermaid
+   fence so the reader's render pipeline picks it up, and passes embedded-mermaid
+   markdown through unchanged (so headings/outline stay intact).
+
+3. **`SourceDetailView`** (`Sources/WikiFS/Sources/SourceDetailView.swift`),
+   adapted to #590's `availableTabs` / `tabLabel` system:
+   - Added `.rendered` to `FileContentTab` (rawValue "Rendered"). The existing
+     `tabLabel` returns its `rawValue` for non-media tabs, so no label helper
+     change was needed.
+   - `availableTabs` gains a mermaid branch → `[.reader, .rendered, .split]`,
+     placed after the PDF branch so a PDF whose extracted text mentions mermaid
+     stays a PDF.
+   - `tabbedContent` handles `.rendered`; `splitContent`'s right pane branches
+     to `renderedMermaidContent` for mermaid (vs the player/PDF).
+   - `renderedMermaidContent` draws the diagram by wrapping the source and
+     handing it to the existing `WikiReaderView` (Mermaid 10.9.6 in WKWebView) —
+     no separate web view or JS wiring.
+   - `markdownContent` now renders a native source's raw bytes via the reader
+     when there's no processed-markdown head, so a `.mmd` Reader tab shows its
+     source instead of "No Processed Markdown".
+   - Edit button sources its buffer from `currentMarkdownContent` (so a native
+     `.mmd` edits its raw source) and switches off the `.rendered` tab when
+     editing (mirrors the PDF/Media guard).
+
+**Rendering note:** no new WKWebView or Mermaid JS plumbing. The reader already
+inlines the vendored Mermaid lib + bootstrap when a page contains a
+`language-mermaid` code block; the Rendered tab just feeds it a fenced source.
+
+**Build/Tests:** `make version prompts` ✓; `swift build` clean ✓;
+fast tier **2603 tests / 221 suites passed** (+13 new in
+`MermaidSourceDetectorTests`).
+
 ## 2026-07-18 — Add "Reveal Debug Folder" + "Reveal Log" UI to the Activity window (branch `feature/reveal-debug-folder-ui`)
 
 **Problem:** PR #580 added `DebugRunLogger` (a verbose ACP wire-trace under

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -97,6 +97,10 @@ struct SourceDetailView: View {
     private enum FileContentTab: String, CaseIterable {
         case reader = "Reader"
         case pdf = "PDF"
+        /// The rendered Mermaid diagram (inline SVG). Only shown for Mermaid
+        /// sources (`.mmd` or markdown containing a ```mermaid block); the raw
+        /// value is the picker label.
+        case rendered = "Rendered"
         /// The embedded media player pane — covers both video (YouTube/Vimeo/
         /// direct-remote `<video>`) and audio (Apple Podcasts/Spotify/
         /// SoundCloud/direct-remote `<audio>`). The picker label is dynamic
@@ -115,6 +119,18 @@ struct SourceDetailView: View {
     private var isPDF: Bool { MimeType.isPDF(file.mimeType) }
 
     private var hasMarkdown: Bool { headVersion != nil }
+
+    /// Whether this source should expose the Mermaid diagram tabs
+    /// (Reader / Rendered / Split). Detection is content-aware: a standalone
+    /// `.mmd` file or a `text/mermaid` source is always a Mermaid source, and a
+    /// markdown document carrying a fenced ` ```mermaid ` block becomes one once
+    /// its content loads. See `MermaidSourceDetector` (pure + unit-tested).
+    private var isMermaidSource: Bool {
+        MermaidSourceDetector.isMermaidSource(
+            mimeType: file.mimeType,
+            filename: file.filename,
+            content: currentMarkdownContent)
+    }
 
     /// Mirrors `WikiStoreModel.canIngest` — the single "can this source be
     /// ingested?" rule shared with the sources outline context menu and the
@@ -208,6 +224,13 @@ struct SourceDetailView: View {
         }
         if isPDF && hasMarkdown {
             return [.reader, .pdf, .split]
+        }
+        // A Mermaid source (standalone `.mmd` / `text/mermaid`, or markdown
+        // carrying a fenced ```mermaid block): Reader (raw source) ⇄ Rendered
+        // (the SVG diagram) ⇄ Split (both). Checked after PDF so a PDF whose
+        // extracted text happens to mention mermaid stays a PDF.
+        if isMermaidSource {
+            return [.reader, .rendered, .split]
         }
         return []
     }
@@ -507,13 +530,19 @@ struct SourceDetailView: View {
                     HStack(spacing: 10) {
                         if isMarkdownEditable {
                             Button("Edit", systemImage: "pencil") {
-                                editBuffer = headVersion?.content ?? ""
+                                // Source the buffer from the resolved content so
+                                // a native `.mmd` (no processed-markdown head)
+                                // edits its raw diagram source, not an empty
+                                // buffer. `currentMarkdownContent` falls back to
+                                // the raw bytes for native text sources.
+                                editBuffer = currentMarkdownContent ?? ""
                                 isEditing = true
                                 // #211: focus the editor even if the user had
-                                // switched to the PDF or Media tab, where the
-                                // markdown editor isn't rendered. Leave Split
-                                // alone — the editor is already visible there.
-                                if selectedTab == .pdf || selectedTab == .media {
+                                // switched to the PDF, Media, or Rendered tab,
+                                // where the markdown editor isn't rendered.
+                                // Leave Split alone — the editor is already
+                                // visible there.
+                                if selectedTab == .pdf || selectedTab == .media || selectedTab == .rendered {
                                     selectedTab = .reader
                                 }
                             }
@@ -806,6 +835,8 @@ struct SourceDetailView: View {
             markdownContent
             if isBytelessEmbedWithPlayer {
                 videoPlayerContent
+            } else if isMermaidSource {
+                renderedMermaidContent
             } else {
                 pdfView
             }
@@ -825,6 +856,8 @@ struct SourceDetailView: View {
             }
         case .pdf:
             pdfView
+        case .rendered:
+            renderedMermaidContent
         case .media:
             videoPlayerContent
         case .split:
@@ -860,6 +893,17 @@ struct SourceDetailView: View {
                             findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
                 .zoomShortcuts($readerZoom)
                 .zoomScroll($readerZoom)
+        } else if let content = currentMarkdownContent {
+            // A native text source with no processed-markdown head (e.g. a
+            // `.mmd` Mermaid diagram) renders its raw bytes as readable text —
+            // the source code for a diagram, or the body of a `.txt`. Binary
+            // sources never reach here (they hit `binaryFallback`).
+            WikiReaderView(markdown: content,
+                            currentSelection: store.selection,
+                            store: store,
+                            findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
+                .zoomShortcuts($readerZoom)
+                .zoomScroll($readerZoom)
         } else {
             ContentUnavailableView {
                 Label("No Processed Markdown", systemImage: "doc.plaintext")
@@ -886,6 +930,34 @@ struct SourceDetailView: View {
                     Text("The source bytes for this file could not be read.")
                 }
             }
+        }
+    }
+
+    // MARK: Rendered Mermaid diagram
+
+    /// The "Rendered" tab (and the right pane of the Mermaid split view): draws
+    /// the source's Mermaid diagram as inline SVG. A standalone `.mmd` source is
+    /// wrapped in a ` ```mermaid ` fence by `MermaidSourceDetector.renderableMarkdown`
+    /// so the reader's existing render pipeline (Mermaid 10.9.6 in WKWebView)
+    /// picks it up unchanged — no separate web view or JS wiring. Embedded
+    /// mermaid markdown passes through as-is so surrounding prose stays intact.
+    /// Falls back to a calm placeholder when there's nothing to draw.
+    @ViewBuilder
+    private var renderedMermaidContent: some View {
+        if let content = currentMarkdownContent,
+           let renderable = MermaidSourceDetector.renderableMarkdown(from: content) {
+            WikiReaderView(markdown: renderable,
+                           currentSelection: store.selection,
+                           store: store)
+                .zoomShortcuts($readerZoom)
+                .zoomScroll($readerZoom)
+        } else {
+            ContentUnavailableView {
+                Label("No Diagram", systemImage: "flowchart.fill")
+            } description: {
+                Text("This source has no Mermaid diagram to render yet.")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 

--- a/Sources/WikiFSCore/Sources/MermaidSourceDetector.swift
+++ b/Sources/WikiFSCore/Sources/MermaidSourceDetector.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Pure detection of whether a source should expose the Mermaid diagram tabs
+/// (Source / Rendered / Split) in `SourceDetailView`.
+///
+/// A source is a "Mermaid source" when any of these hold:
+/// - its MIME type is a recognized Mermaid variant (`text/mermaid`,
+///   `text/x-mermaid`),
+/// - its filename ends in `.mmd`, or
+/// - its content contains at least one fenced ` ```mermaid ` block.
+///
+/// The fence scan reuses `MermaidValidator.mermaidBlocks(in:)` (a pure line
+/// scanner with no JS dependency), so this stays cheap and side-effect-free.
+/// Pure + unit-tested; the view threads in the resolved mime/filename/content.
+public enum MermaidSourceDetector {
+
+    /// `.mmd` — the conventional standalone Mermaid source extension.
+    public static let mermaidExtension = "mmd"
+
+    /// Whether `(mimeType, filename, content)` describes a Mermaid source.
+    ///
+    /// `content` may be `nil` when the source bytes haven't loaded yet — the
+    /// mime/extension checks still run, so a `.mmd` file shows its diagram tabs
+    /// before the text arrives.
+    public static func isMermaidSource(
+        mimeType: String?,
+        filename: String?,
+        content: String?
+    ) -> Bool {
+        if MimeType.isMermaid(mimeType) { return true }
+        if let filename {
+            let lower = filename.lowercased()
+            if lower.hasSuffix(".\(mermaidExtension)") || lower == mermaidExtension {
+                return true
+            }
+        }
+        if let content, !MermaidValidator.mermaidBlocks(in: content).isEmpty {
+            return true
+        }
+        return false
+    }
+
+    /// The mermaid source the "Rendered" tab should draw: when `content` is a
+    /// standalone `.mmd` file (no fenced block), wrap the raw text in a
+    /// ` ```mermaid ` fence so the reader's render pipeline picks it up; when the
+    /// content already carries fenced mermaid blocks (an embedded markdown doc),
+    /// pass it through unchanged so headings/outline still apply.
+    ///
+    /// Returns `nil` only when `content` is empty/whitespace (nothing to render).
+    public static func renderableMarkdown(from content: String) -> String? {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        // Already has a fenced mermaid block → render the document as-is so any
+        // surrounding prose/headings stay intact (and the outline is meaningful).
+        if !MermaidValidator.mermaidBlocks(in: content).isEmpty { return content }
+        // Standalone source (`.mmd` or `text/mermaid`): wrap once in a fence so
+        // the reader converts it to `<pre><code class="language-mermaid">` and
+        // inlines the Mermaid library + bootstrap.
+        return "```mermaid\n\(trimmed)\n```"
+    }
+}

--- a/Sources/WikiFSTypes/MimeType.swift
+++ b/Sources/WikiFSTypes/MimeType.swift
@@ -39,6 +39,13 @@ public enum MimeType {
     /// `text/html`.
     public static let html = "text/html"
 
+    /// `text/mermaid` — the conventional MIME type for a standalone Mermaid
+    /// diagram source (`.mmd`).
+    public static let mermaid = "text/mermaid"
+
+    /// `text/x-mermaid` — the `x-` variant some tools emit for Mermaid sources.
+    public static let mermaidX = "text/x-mermaid"
+
     /// `application/xhtml+xml`.
     public static let xhtml = "application/xhtml+xml"
 
@@ -55,6 +62,9 @@ public enum MimeType {
 
     /// The recognized Markdown MIME variants (`text/markdown`, `text/x-markdown`).
     public static let markdownVariants: Set<String> = [markdown, markdownX]
+
+    /// The recognized Mermaid MIME variants (`text/mermaid`, `text/x-mermaid`).
+    public static let mermaidVariants: Set<String> = [mermaid, mermaidX]
 
     // MARK: - Predicates
 
@@ -75,5 +85,12 @@ public enum MimeType {
     public static func isMarkdown(_ mime: String?) -> Bool {
         guard let mime else { return false }
         return markdownVariants.contains(mime.lowercased())
+    }
+
+    /// Whether `mime` is one of the recognized Mermaid variants
+    /// (`text/mermaid` / `text/x-mermaid`, case-insensitive). `nil` is `false`.
+    public static func isMermaid(_ mime: String?) -> Bool {
+        guard let mime else { return false }
+        return mermaidVariants.contains(mime.lowercased())
     }
 }

--- a/Tests/WikiFSTests/MermaidSourceDetectorTests.swift
+++ b/Tests/WikiFSTests/MermaidSourceDetectorTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+import WikiFSTypes
+@testable import WikiFSCore
+
+/// Tests for `MermaidSourceDetector` — the pure gate that decides whether a
+/// source exposes the Source / Rendered / Split Mermaid tabs in
+/// `SourceDetailView`, plus the renderable-markdown wrapping it feeds the
+/// reader. Also covers `MimeType.isMermaid`.
+struct MermaidSourceDetectorTests {
+
+    // MARK: - MimeType.isMermaid
+
+    @Test func mimeTypeIsMermaidRecognizesVariants() {
+        #expect(MimeType.isMermaid("text/mermaid"))
+        #expect(MimeType.isMermaid("text/x-mermaid"))
+        // Case-insensitive (RFC 2045).
+        #expect(MimeType.isMermaid("TEXT/Mermaid"))
+        #expect(!MimeType.isMermaid("text/markdown"))
+        #expect(!MimeType.isMermaid("text/plain"))
+        #expect(!MimeType.isMermaid(nil))
+    }
+
+    // MARK: - isMermaidSource: MIME
+
+    @Test func detectsByMime() {
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: "text/mermaid", filename: "diagram", content: nil))
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: "text/x-mermaid", filename: nil, content: nil))
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: "TEXT/MERMAID", filename: nil, content: nil))
+    }
+
+    // MARK: - isMermaidSource: extension
+
+    @Test func detectsByMmdExtension() {
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "flow.mmd", content: nil))
+        // Case-insensitive extension.
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "Flow.MMD", content: nil))
+        // A bare "mmd" (no dot) also counts.
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "mmd", content: nil))
+    }
+
+    @Test func doesNotFalsePositiveOnSimilarExtensions() {
+        #expect(!MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "notes.md", content: nil))
+        #expect(!MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "data.mmdx", content: nil))
+        // ".mmd" must be the terminal extension, not a substring.
+        #expect(!MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "readme.mmetadata", content: nil))
+    }
+
+    // MARK: - isMermaidSource: fenced content
+
+    @Test func detectsFencedMermaidBlockInMarkdown() {
+        let md = """
+        # Architecture
+
+        ```mermaid
+        flowchart TD
+            A --> B
+        ```
+
+        Done.
+        """
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: "text/markdown", filename: "arch.md", content: md))
+    }
+
+    @Test func detectsTildeFence() {
+        let md = "~~~mermaid\ngraph TD\n  A --> B\n~~~\n"
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: "text/plain", filename: "g.txt", content: md))
+    }
+
+    @Test func doesNotMatchMermaidMentionedAsProse() {
+        // The word "mermaid" in prose (no fence) is not a diagram.
+        let md = "We use mermaid diagrams elsewhere.\nflowchart TD"
+        #expect(!MermaidSourceDetector.isMermaidSource(
+            mimeType: "text/markdown", filename: "notes.md", content: md))
+    }
+
+    @Test func emptyContentIsNotMermaidUnlessMimeOrExt() {
+        #expect(!MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "blank.txt", content: ""))
+        #expect(!MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "blank.txt", content: nil))
+        // But a .mmd with empty content still counts (it's a mermaid file).
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: nil, filename: "blank.mmd", content: ""))
+    }
+
+    // MARK: - renderableMarkdown
+
+    @Test func wrapsStandaloneSourceInFence() {
+        let raw = "flowchart TD\n    A --> B\n    B --> C"
+        let rendered = MermaidSourceDetector.renderableMarkdown(from: raw)
+        #expect(rendered == "```mermaid\nflowchart TD\n    A --> B\n    B --> C\n```")
+    }
+
+    @Test func wrapsStandaloneSourcePreservingTrailingNewlineTrim() {
+        let raw = "graph LR\n  X --> Y\n\n\n"
+        let rendered = MermaidSourceDetector.renderableMarkdown(from: raw)
+        // Trailing blank lines are trimmed before wrapping.
+        #expect(rendered == "```mermaid\ngraph LR\n  X --> Y\n```")
+    }
+
+    @Test func passesThroughEmbeddedMermaidUnchanged() {
+        // Content that already carries a fenced mermaid block is returned as-is
+        // so surrounding prose/headings (and the outline) stay intact.
+        let md = """
+        # Design
+
+        ```mermaid
+        sequenceDiagram
+            A->>B: hi
+        ```
+
+        Notes.
+        """
+        #expect(MermaidSourceDetector.renderableMarkdown(from: md) == md)
+    }
+
+    @Test func renderableMarkdownNilForEmptyOrWhitespace() {
+        #expect(MermaidSourceDetector.renderableMarkdown(from: "") == nil)
+        #expect(MermaidSourceDetector.renderableMarkdown(from: "   \n\t ") == nil)
+    }
+
+    @Test func renderableMarkdownWrapsContentWithoutFenceEvenIfLooksLikeProse() {
+        // A standalone `.mmd` whose body happens to contain the word "mermaid"
+        // but no fence is still wrapped (the source is the diagram definition).
+        let raw = "%% this is a mermaid diagram\nflowchart TD\n  A --> B"
+        let rendered = MermaidSourceDetector.renderableMarkdown(from: raw)
+        #expect(rendered == "```mermaid\n%% this is a mermaid diagram\nflowchart TD\n  A --> B\n```")
+    }
+}


### PR DESCRIPTION
## Summary

Mermaid diagram sources (`.mmd` files or markdown containing ` ```mermaid ` fenced blocks) now get the same three-tab treatment as PDFs (#586) and media (#590): **Reader / Rendered / Split**.

- **Reader** — the raw diagram source code (or the containing markdown)
- **Rendered** — the diagram drawn as inline SVG
- **Split** — source and rendered diagram side-by-side

This builds directly on #590's unified tab system (`availableTabs` / `tabLabel`), adding a `.rendered` case alongside `.media`.

## Detection

A source is a "Mermaid source" when any of these hold (pure `MermaidSourceDetector`, unit-tested):
- its MIME type is `text/mermaid` / `text/x-mermaid`, **or**
- its filename ends in `.mmd`, **or**
- its content contains a fenced ` ```mermaid ` block (reuses the existing `MermaidValidator.mermaidBlocks` line scanner — no JS)

## How it renders

No new WKWebView or Mermaid JS plumbing. The reader already inlines the vendored Mermaid 10.9.6 library + bootstrap when a page contains a `language-mermaid` code block. The Rendered tab just wraps a standalone `.mmd` source in a ` ```mermaid ` fence and hands it to the existing `WikiReaderView`; embedded-mermaid markdown passes through unchanged so surrounding prose/headings stay intact.

## Changes (4 files)

- **`Sources/WikiFSTypes/MimeType.swift`** — `text/mermaid` + `text/x-mermaid` constants, `mermaidVariants`, `isMermaid(_:)`.
- **`Sources/WikiFSCore/Sources/MermaidSourceDetector.swift`** (new) — pure detection + `renderableMarkdown(from:)` fence-wrapping.
- **`Sources/WikiFS/Sources/SourceDetailView.swift`** — `.rendered` tab case; `availableTabs` mermaid branch -> `[.reader, .rendered, .split]`; `renderedMermaidContent` view; mermaid-aware `splitContent`; `markdownContent` renders native-source bytes (so a `.mmd` Reader tab shows its source instead of "No Processed Markdown"); Edit button sources its buffer from `currentMarkdownContent` and switches off the Rendered tab.
- **`Tests/WikiFSTests/MermaidSourceDetectorTests.swift`** (new) — 13 tests.

## Test plan

- [x] `make version prompts` -> `swift build` clean
- [x] Fast test tier: **2603 tests / 221 suites pass** (+13 new)
- [x] `MermaidSourceDetectorTests`: MIME/extension/fence detection, false-positive guards, fence-wrapping behavior

No schema, store, or File Provider changes.
