### PR TITLE
fix(queue): persist Activity-window usage/log/progress across app restart

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -53,6 +53,85 @@ inlines the vendored Mermaid lib + bootstrap when a page contains a
 fast tier **2603 tests / 221 suites passed** (+13 new in
 `MermaidSourceDetectorTests`).
 
+## 2026-07-18 — Persist queue activity (usage, log/debug paths, progress) across app restart (branch `fix/queue-activity-persistence`)
+
+**Problem:** In the Activity window (Queue / agent view), per-item info about
+**ingestion + lint** runs — the usage summary line ("2:32 PM · 1m 3s · Claude ·
+797 tokens in · …"), the "Reveal Log"/"Reveal Debug Folder" buttons, and the
+extraction progress text — was shown while the app ran but **lost on restart**.
+Quit + relaunch and all that activity info vanished.
+
+**Root cause confirmed:** `QueueActivityTracker` (a `@MainActor @Observable`
+class) holds ALL per-item activity in in-memory dictionaries
+(`itemUsage`, `itemLogURLs`, `itemDebugURLs`, `progressLogs`, `transcripts`)
+that are cleared on `stop()` and never rehydrated on launch. The transcripts
+were the **partial exception**: write-through already existed
+(`QueueEngine.makeEmitTranscript` → `QueueStore.appendItemEvent`) and the
+detail view already lazy-loaded them via `engine.loadTranscript(for:)` on
+open. But **usage, log/debug URLs, and progress logs were neither written to
+the DB nor rehydrated** — so they evaporated with the process. (`todayUsage`
+already persisted via UserDefaults; the transient running-state sets
+`extractingSourceIDs`/`ingestingSourceIDs`/`lintingItemIDs`/… are correctly
+not persisted — they rebuild from live `.started` events after
+`resetRunningToQueued()`.)
+
+**Fix:** made the engine write those three streams through to `QueueStore`
+as they arrive, and rehydrate them into the tracker at launch.
+
+- **v4 GRDB migration (`v4_add_item_activity`)** — new `queue_item_activity`
+  table keyed by `item_id` (FK → `queue_items(id) ON DELETE CASCADE`, so rows
+  vanish with their item on `pruneHistory` — mirrors `queue_item_events`):
+  `usage_json TEXT`, `log_url TEXT`, `debug_url TEXT`, `progress_log TEXT`,
+  `updated_at INTEGER`.
+- **Module boundary:** `SessionUsage` lives in `WikiFSEngine`; `QueueStore`
+  lives in `WikiFSCore` (which `WikiFSEngine` depends on, not vice-versa). So
+  the store stores `usage_json` as an opaque `String` (a new
+  `QueueStore.QueueItemActivity` DTO of raw `String?`s); the engine
+  encodes/decodes `SessionUsage` ↔ JSON (`SessionUsage` gained `Codable`).
+- **Write-through seams (engine emit closures):**
+  - `makeEmitUsage` → `upsertItemActivity(usageJSON:)` (final cumulative usage).
+  - `makeEmitLogPaths` → `upsertItemActivity(logURL:debugURL:)` (absoluteString).
+  - `makeEmitProgress` → `appendItemProgress(line:)` (newline-appended, mirrors
+    the tracker's in-memory accumulation).
+  - The upsert is COALESCE-partial — each field is set by a different event
+    (usage fires once on `.usage`, paths once on `.runPaths`), so updating one
+    never clobbers the others.
+- **Rehydrate seam:** `QueueActivityTracker.rehydrate(from:)` (called at launch
+  in `WikiFSApp` right after `attach`, in a `Task`) calls
+  `QueueEngine.loadAllActivitySnapshots()` (which reads
+  `store.loadAllActivity()` and decodes usage JSON / reconstructs URLs) and
+  repopulates `itemUsage`/`itemLogURLs`/`itemDebugURLs`/`progressLogs`. The
+  tracker stays the single owner of observable UI state. Typed **transcripts**
+  are deliberately NOT bulk-loaded — the detail view already lazy-loads each
+  item's transcript via `engine.loadTranscript(for:)`, avoiding pulling
+  `recentLimit × maxTranscriptEvents` events into memory at launch.
+
+**Concurrency:** `rehydrate` is `@MainActor async` — it awaits the engine actor
+for the read (returns a `[ID: ActivitySnapshot]` of `Sendable` values), then
+mutates MainActor dicts. The emit closures capture `store` (`@unchecked
+Sendable`, GRDB-serialized) and write from worker Tasks — the same pattern
+`makeEmitTranscript` already used. Errors are `do/catch` → `DebugLog.store`
+(no bare `try?`).
+
+**Known limitation (pre-existing, not introduced):** on `retryItem`, old
+activity (and old transcript events) are not cleared, so a retried run's
+summary/progress can show stale-then-new data. Matches the existing transcript
+behavior; clearing on retry is a separate follow-up.
+
+**Tests added:**
+- `QueueStoreTests` (+5): activity survives close+reopen; COALESCE preserves
+  existing fields; progress appends with newline; activity cascades on prune
+  (`maxPerQueue: 0`); `loadAllActivity` returns all rows.
+- `QueueActivityTrackerRehydrateTests` (+2): a fresh engine+tracker over the
+  SAME `queue.sqlite` rehydrates usage (JSON→`SessionUsage` round-trip),
+  log/debug URLs (`absoluteString`→`URL`), and progress; empty DB leaves the
+  tracker empty.
+
+**Build/Tests:** `make version prompts` ✓; `swift build` clean (181s); targeted
+QueueStore/tracker suites 31/31 pass; fast tier **2603 tests / 222 suites**
+pass; full `swift test` **2789 tests / 235 suites pass** (incl. the 13
+integration suites — 0 failures).
+
 ## 2026-07-18 — Add "Reveal Debug Folder" + "Reveal Log" UI to the Activity window (branch `feature/reveal-debug-folder-ui`)
 
 **Problem:** PR #580 added `DebugRunLogger` (a verbose ACP wire-trace under

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -200,6 +200,30 @@ final class QueueActivityTracker {
         start(events: engine.events)
     }
 
+    /// Rehydrate per-item activity (usage, log/debug URLs, progress logs) from
+    /// the persisted store so the Activity window shows completed/failed/
+    /// cancelled ingestion + lint runs after an app restart. Called once at
+    /// launch after ``attach(engine:)``.
+    ///
+    /// Only the activity metadata dictionaries are bulk-loaded here. Typed
+    /// agent-event **transcripts** are NOT bulk-loaded — the detail view
+    /// already lazy-loads each item's transcript via
+    /// `engine.loadTranscript(for:)` when opened, which avoids pulling up to
+    /// `recentLimit` × `maxTranscriptEvents` events into memory at launch.
+    /// Transient running-state sets (`extractingSourceIDs`, `ingestingSourceIDs`,
+    /// `lintingItemIDs`, …) are deliberately NOT rehydrated — on restart,
+    /// `.running` items are reset to `.queued` by `resetRunningToQueued()`, so
+    /// these sets rebuild naturally from live `.started` events.
+    func rehydrate(from engine: QueueEngine) async {
+        let snapshots = await engine.loadAllActivitySnapshots()
+        for (id, snap) in snapshots {
+            if let usage = snap.usage { itemUsage[id] = usage }
+            if let logURL = snap.logURL { itemLogURLs[id] = logURL }
+            if let debugURL = snap.debugURL { itemDebugURLs[id] = debugURL }
+            if !snap.progressLog.isEmpty { progressLogs[id] = snap.progressLog }
+        }
+    }
+
     /// Start consuming `events`. Spawns a `@MainActor` Task that iterates the
     /// stream and dispatches each event to `handle(_:)`.
     func start(events: AsyncStream<QueueEvent>) {

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -191,6 +191,11 @@ struct WikiFSApp: App {
         // extraction state directly via @Environment.
         let activityTracker = QueueActivityTracker()
         activityTracker.attach(engine: queueEngine)
+        // Rehydrate persisted activity metadata (usage, log/debug URLs, progress
+        // logs) so the Activity window shows completed/failed/cancelled
+        // ingestion + lint runs immediately after launch — before any new
+        // events arrive. Transcripts lazy-load from the DB on detail-view open.
+        Task { await activityTracker.rehydrate(from: queueEngine) }
         _queueEngine = State(initialValue: queueEngine)
         _extractionProvider = State(initialValue: extractionProvider)
         _ingestionProvider = State(initialValue: ingestionProvider)

--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -175,6 +175,8 @@ public final class QueueStore: @unchecked Sendable {
     ///   without a migration step; existing v1 DBs silently lacked it — #450).
     /// - v3: Namespace `QueueRunState.running` rawValue from `"running"` to
     ///   `"queue-running"` to disambiguate from `QueueItemState.running` (#508).
+    /// - v4: `queue_item_activity` table — per-item usage JSON, log/debug URLs,
+    ///   and progress-log text (persisted Activity-window metadata).
     private static let migrator: DatabaseMigrator = {
         var m = DatabaseMigrator()
 
@@ -257,6 +259,30 @@ public final class QueueStore: @unchecked Sendable {
 
         m.registerMigration("v3_namespace_run_state") { db in
             try db.execute(sql: "UPDATE queue_state SET state = 'queue-running' WHERE state = 'running';")
+        }
+
+        // v4: per-item Activity-window metadata — cumulative token/cost usage
+        // (JSON), the run's `run.jsonl` log URL + `debug/` folder URL, and the
+        // accumulated progress-log text. Persisted so the Activity window can
+        // show completed/failed/cancelled ingestion + lint runs (usage summary,
+        // "Reveal Log" / "Reveal Debug Folder", progress) after an app restart.
+        // Keyed by `item_id` with `ON DELETE CASCADE` so rows vanish when the
+        // item is pruned by `pruneHistory` (mirrors `queue_item_events`).
+        // `usage_json` is an opaque string here — `QueueStore` lives in
+        // `WikiFSCore` and cannot reference `SessionUsage` (in `WikiFSEngine`);
+        // the engine encodes/decodes it.
+        m.registerMigration("v4_add_item_activity") { db in
+            try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS queue_item_activity (
+                item_id       TEXT PRIMARY KEY,
+                usage_json    TEXT,
+                log_url       TEXT,
+                debug_url     TEXT,
+                progress_log  TEXT,
+                updated_at    INTEGER NOT NULL,
+                FOREIGN KEY (item_id) REFERENCES queue_items(id) ON DELETE CASCADE
+            );
+            """)
         }
 
         return m
@@ -781,6 +807,140 @@ public final class QueueStore: @unchecked Sendable {
                 try db.execute(
                     sql: "DELETE FROM queue_item_events WHERE item_id = ?;",
                     arguments: [itemID])
+            }
+        }
+    }
+
+    // MARK: - Public API: Item activity (usage / paths / progress)
+
+    /// Persisted per-item Activity-window metadata: cumulative token/cost usage
+    /// (encoded JSON), the run's `run.jsonl` log URL + `debug/` folder URL, and
+    /// the accumulated progress-log text.
+    ///
+    /// Stored as raw `String?`s so this type lives in `WikiFSCore` without
+    /// depending on `SessionUsage` (which is in `WikiFSEngine`). The engine
+    /// layer encodes/decodes `usageJSON` to/from `SessionUsage`. Persisted so
+    /// the Activity window can show completed/failed/cancelled ingestion + lint
+    /// runs (usage summary, "Reveal Log"/"Reveal Debug Folder", progress) after
+    /// an app restart. Rows cascade-delete with their item (`pruneHistory`).
+    public struct QueueItemActivity: Sendable, Equatable {
+        public let usageJSON: String?
+        public let logURL: String?
+        public let debugURL: String?
+        public let progressLog: String?
+
+        public init(usageJSON: String?, logURL: String?, debugURL: String?, progressLog: String?) {
+            self.usageJSON = usageJSON
+            self.logURL = logURL
+            self.debugURL = debugURL
+            self.progressLog = progressLog
+        }
+    }
+
+    /// Upsert per-item activity metadata. Each parameter is optional; a `nil`
+    /// argument leaves the existing value untouched (COALESCE), so callers can
+    /// update one field (e.g. just usage) without clobbering the others. Safe
+    /// to call from a background thread — the store serializes via GRDB.
+    public func upsertItemActivity(
+        itemID: QueueItem.ID,
+        usageJSON: String?,
+        logURL: String?,
+        debugURL: String?
+    ) throws {
+        let now = Self.nowMillis()
+        try Self.wrap {
+            let queue = try self.queue()
+            try queue.write { db in
+                try db.execute(
+                    sql: """
+                    INSERT INTO queue_item_activity
+                        (item_id, usage_json, log_url, debug_url, progress_log, updated_at)
+                    VALUES (?, ?, ?, ?, NULL, ?)
+                    ON CONFLICT(item_id) DO UPDATE SET
+                        usage_json = COALESCE(excluded.usage_json, queue_item_activity.usage_json),
+                        log_url    = COALESCE(excluded.log_url, queue_item_activity.log_url),
+                        debug_url  = COALESCE(excluded.debug_url, queue_item_activity.debug_url),
+                        updated_at = excluded.updated_at;
+                    """,
+                    arguments: [itemID, usageJSON, logURL, debugURL, now])
+            }
+        }
+    }
+
+    /// Append a progress line to an item's accumulated progress log. The first
+    /// line sets the column; subsequent lines append with a newline separator
+    /// (mirrors `QueueActivityTracker`'s in-memory accumulation). Safe to call
+    /// from a background thread.
+    public func appendItemProgress(itemID: QueueItem.ID, line: String) throws {
+        let now = Self.nowMillis()
+        try Self.wrap {
+            let queue = try self.queue()
+            try queue.write { db in
+                try db.execute(
+                    sql: """
+                    INSERT INTO queue_item_activity
+                        (item_id, usage_json, log_url, debug_url, progress_log, updated_at)
+                    VALUES (?, NULL, NULL, NULL, ?, ?)
+                    ON CONFLICT(item_id) DO UPDATE SET
+                        progress_log = CASE
+                            WHEN queue_item_activity.progress_log IS NULL
+                              OR queue_item_activity.progress_log = ''
+                            THEN excluded.progress_log
+                            ELSE queue_item_activity.progress_log || char(10) || excluded.progress_log
+                        END,
+                        updated_at = excluded.updated_at;
+                    """,
+                    arguments: [itemID, line, now])
+            }
+        }
+    }
+
+    /// Load the persisted activity metadata for a single item, or `nil`.
+    public func loadItemActivity(itemID: QueueItem.ID) throws -> QueueItemActivity? {
+        try Self.wrap {
+            let queue = try self.queue()
+            return try queue.read { db in
+                guard let row = try Row.fetchOne(
+                    db,
+                    sql: """
+                    SELECT usage_json, log_url, debug_url, progress_log
+                    FROM queue_item_activity WHERE item_id = ?;
+                    """,
+                    arguments: [itemID]) else { return nil }
+                return QueueItemActivity(
+                    usageJSON: row["usage_json"],
+                    logURL: row["log_url"],
+                    debugURL: row["debug_url"],
+                    progressLog: row["progress_log"])
+            }
+        }
+    }
+
+    /// Load all persisted activity rows, keyed by item ID. Used by the Activity
+    /// tracker to rehydrate after an app restart. Bounded by `pruneHistory`
+    /// (rows cascade-delete with their item, so only existing terminal items
+    /// have rows).
+    public func loadAllActivity() throws -> [QueueItem.ID: QueueItemActivity] {
+        try Self.wrap {
+            let queue = try self.queue()
+            return try queue.read { db in
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                    SELECT item_id, usage_json, log_url, debug_url, progress_log
+                    FROM queue_item_activity;
+                    """)
+                var result: [QueueItem.ID: QueueItemActivity] = [:]
+                result.reserveCapacity(rows.count)
+                for row in rows {
+                    let id: String = row["item_id"]
+                    result[id] = QueueItemActivity(
+                        usageJSON: row["usage_json"],
+                        logURL: row["log_url"],
+                        debugURL: row["debug_url"],
+                        progressLog: row["progress_log"])
+                }
+                return result
             }
         }
     }

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -1563,7 +1563,7 @@ public actor ACPBackend: AgentBackend {
 /// Created in `createSession()` / `registerResumedSession()` — one per
 /// `SessionHandle`. The thread-safe `SessionUsageState` (internal) is the
 /// live accumulator; this snapshot struct is what callers read.
-public struct SessionUsage: Sendable {
+public struct SessionUsage: Sendable, Codable {
     /// Cumulative input tokens across all turns (from `Usage.inputTokens`).
     public let inputTokens: Int
     /// Cumulative output tokens across all turns (from `Usage.outputTokens`).

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -341,8 +341,16 @@ public actor QueueEngine {
     /// actor-isolated). The broadcaster is `Sendable`, so this is safe to
     /// call from the worker's detached `Task`.
     public func makeEmitProgress() -> @Sendable (QueueItem.ID, String) -> Void {
-        return { [broadcaster] id, line in
+        return { [broadcaster, store] id, line in
             broadcaster.yield(.progress(id, line: line))
+            // Persist progress lines (primarily extraction output) so the
+            // Activity window can show them after an app restart. Mirrors the
+            // per-event persistence in `makeEmitTranscript`.
+            do {
+                try store.appendItemProgress(itemID: id, line: line)
+            } catch {
+                DebugLog.store("QueueEngine: persist progress failed for item=\(id): \(error)")
+            }
         }
     }
 
@@ -371,8 +379,19 @@ public actor QueueEngine {
     /// events onto the engine's broadcaster. #528 spike — surfaces per-run
     /// token/cost usage to the activity tracker (no persistence needed).
     public func makeEmitUsage() -> @Sendable (QueueItem.ID, SessionUsage) -> Void {
-        return { [broadcaster] id, usage in
+        return { [broadcaster, store] id, usage in
             broadcaster.yield(.usage(id, usage))
+            // Persist the final cumulative usage so the Activity window can
+            // show the per-run summary line after an app restart. The store
+            // holds it as an opaque JSON string (it cannot reference
+            // `SessionUsage`, which lives in this module).
+            do {
+                let data = try JSONEncoder().encode(usage)
+                let json = String(data: data, encoding: .utf8)
+                try store.upsertItemActivity(itemID: id, usageJSON: json, logURL: nil, debugURL: nil)
+            } catch {
+                DebugLog.store("QueueEngine: persist usage failed for item=\(id): \(error)")
+            }
         }
     }
 
@@ -392,8 +411,19 @@ public actor QueueEngine {
     /// Activity window can offer "Reveal Log" / "Reveal Debug Folder" (no
     /// persistence needed — URLs are runtime-only).
     public func makeEmitLogPaths() -> @Sendable (QueueItem.ID, URL?, URL?) -> Void {
-        return { [broadcaster] id, logURL, debugURL in
+        return { [broadcaster, store] id, logURL, debugURL in
             broadcaster.yield(.runPaths(id, logURL: logURL, debugURL: debugURL))
+            // Persist the run's log/debug URLs so "Reveal Log"/"Reveal Debug
+            // Folder" survive an app restart.
+            do {
+                try store.upsertItemActivity(
+                    itemID: id,
+                    usageJSON: nil,
+                    logURL: logURL?.absoluteString,
+                    debugURL: debugURL?.absoluteString)
+            } catch {
+                DebugLog.store("QueueEngine: persist log paths failed for item=\(id): \(error)")
+            }
         }
     }
 
@@ -408,6 +438,57 @@ public actor QueueEngine {
     /// Delete persisted events for an item (e.g. on retry).
     public func clearTranscript(for itemID: QueueItem.ID) async {
         try? store.deleteItemEvents(itemID: itemID)
+    }
+
+    /// Decoded per-item activity metadata for rehydration. The engine layer
+    /// decodes the opaque `usageJSON` blob that `QueueStore` persists (the
+    /// store lives in `WikiFSCore` and cannot reference `SessionUsage`).
+    public struct ActivitySnapshot: Sendable {
+        public let usage: SessionUsage?
+        public let logURL: URL?
+        public let debugURL: URL?
+        public let progressLog: String
+
+        public init(usage: SessionUsage?, logURL: URL?, debugURL: URL?, progressLog: String) {
+            self.usage = usage
+            self.logURL = logURL
+            self.debugURL = debugURL
+            self.progressLog = progressLog
+        }
+    }
+
+    /// Load persisted activity metadata for all items with recorded activity,
+    /// decoded into typed values. Used by the Activity tracker to rehydrate
+    /// `itemUsage` / `itemLogURLs` / `itemDebugURLs` / `progressLogs` after an
+    /// app restart so the Activity window shows completed/failed/cancelled runs
+    /// (usage summary, "Reveal Log"/"Reveal Debug Folder", progress). Bounded
+    /// by `pruneHistory` (rows cascade-delete with their item). A decode
+    /// failure for one row leaves that field `nil` rather than aborting the
+    /// whole rehydration.
+    public func loadAllActivitySnapshots() async -> [QueueItem.ID: ActivitySnapshot] {
+        let raw = (try? store.loadAllActivity()) ?? [:]
+        var result: [QueueItem.ID: ActivitySnapshot] = [:]
+        result.reserveCapacity(raw.count)
+        for (id, activity) in raw {
+            let usage: SessionUsage?
+            if let json = activity.usageJSON,
+               let data = json.data(using: .utf8) {
+                do {
+                    usage = try JSONDecoder().decode(SessionUsage.self, from: data)
+                } catch {
+                    DebugLog.store("QueueEngine.loadAllActivitySnapshots: usage decode failed for item=\(id): \(error)")
+                    usage = nil
+                }
+            } else {
+                usage = nil
+            }
+            result[id] = ActivitySnapshot(
+                usage: usage,
+                logURL: activity.logURL.flatMap { URL(string: $0) },
+                debugURL: activity.debugURL.flatMap { URL(string: $0) },
+                progressLog: activity.progressLog ?? "")
+        }
+        return result
     }
 
     // MARK: - Dispatch (internal)

--- a/Tests/WikiFSTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSTests/QueueIngestionTests.swift
@@ -662,3 +662,92 @@ struct StubWorkerFactory: QueueWorkerFactory {
         return W()
     }
 }
+
+// MARK: - QueueActivityTracker rehydration (persistence across "restart")
+
+/// Proves that activity data written in one `QueueStore` session is rehydrated
+/// into a fresh `QueueActivityTracker` over the same DB — the closest analog to
+/// an app restart testable without a running GUI.
+@Suite("QueueActivityTracker rehydration")
+struct QueueActivityTrackerRehydrateTests {
+
+    private func tempDB() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-rehydrate-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("queue.sqlite")
+    }
+
+    @MainActor
+    @Test("Rehydrate populates usage, paths, and progress from the store")
+    func rehydratePopulatesActivity() async throws {
+        let db = tempDB()
+        let usage = SessionUsage(
+            inputTokens: 797, outputTokens: 203, totalTokens: 1000,
+            cachedReadTokens: nil, thoughtTokens: 412,
+            cost: 0.34, currency: "USD", contextUsed: 100, contextSize: 200,
+            providerLabel: "Claude", modelId: "sonnet-4", thinkingLevel: nil)
+        let logURL = URL(fileURLWithPath: "/tmp/scratch/run.jsonl")
+        let debugURL = URL(fileURLWithPath: "/tmp/scratch/debug", isDirectory: true)
+
+        let itemID: QueueItem.ID
+        // Persist activity directly via the store, mirroring the strings the
+        // engine's emit closures write (usage JSON + absoluteString URLs).
+        do {
+            let store = try QueueStore(databaseURL: db)
+            let item = try store.enqueue(QueueItemRequest(
+                queue: .ingestion, wikiID: "w1",
+                payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "src1")])))
+            itemID = item.id
+            try store.markRunning(id: itemID, providerID: "p1")
+            try store.markCompleted(id: itemID)
+            let data = try JSONEncoder().encode(usage)
+            let usageJSON = String(data: data, encoding: .utf8)!
+            try store.upsertItemActivity(itemID: itemID, usageJSON: usageJSON,
+                                         logURL: nil, debugURL: nil)
+            try store.upsertItemActivity(itemID: itemID, usageJSON: nil,
+                                         logURL: logURL.absoluteString,
+                                         debugURL: debugURL.absoluteString)
+            try store.appendItemProgress(itemID: itemID, line: "extraction output")
+            store.close()
+        }
+
+        // New "app session": fresh engine + tracker over the SAME database.
+        let store = try QueueStore(databaseURL: db)
+        let engine = QueueEngine(store: store, workerFactory: StubWorkerFactory())
+        await engine.start()
+        let tracker = QueueActivityTracker()
+        tracker.attachForTesting(events: AsyncStream { _ in })
+        await tracker.rehydrate(from: engine)
+
+        // Usage round-trips (JSON → SessionUsage). Compare fields since
+        // SessionUsage isn't Equatable.
+        let rehydratedUsage = tracker.usage(for: itemID)
+        #expect(rehydratedUsage?.inputTokens == 797)
+        #expect(rehydratedUsage?.outputTokens == 203)
+        #expect(rehydratedUsage?.thoughtTokens == 412)
+        #expect(rehydratedUsage?.cost == 0.34)
+        #expect(rehydratedUsage?.providerLabel == "Claude")
+
+        // Paths round-trip via absoluteString → URL(string:).
+        #expect(tracker.logURL(for: itemID)?.path == "/tmp/scratch/run.jsonl")
+        #expect(tracker.debugURL(for: itemID)?.path == "/tmp/scratch/debug")
+        // Progress log round-trips verbatim.
+        #expect(tracker.progressLog(for: itemID) == "extraction output")
+    }
+
+    @MainActor
+    @Test("Rehydrate with no persisted activity leaves the tracker empty")
+    func rehydrateEmpty() async throws {
+        let store = try QueueStore(databaseURL: tempDB())
+        let engine = QueueEngine(store: store, workerFactory: StubWorkerFactory())
+        await engine.start()
+        let tracker = QueueActivityTracker()
+        tracker.attachForTesting(events: AsyncStream { _ in })
+        await tracker.rehydrate(from: engine)
+
+        #expect(tracker.usage(for: "never-existed") == nil)
+        #expect(tracker.logURL(for: "never-existed") == nil)
+        #expect(tracker.progressLog(for: "never-existed") == "")
+    }
+}

--- a/Tests/WikiFSTests/QueueStoreTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTests.swift
@@ -545,4 +545,98 @@ struct QueueStoreTests {
         let count2 = try store.resetRunningToQueued()
         #expect(count2 == 0)
     }
+
+    // MARK: - Item activity persistence (usage / paths / progress)
+
+    @Test func testActivityPersistsAcrossReopen() throws {
+        let url = tempDatabaseURL()
+        let itemID: QueueItem.ID
+        let usageJSON = #"{"inputTokens":797,"outputTokens":203}"#
+        do {
+            let store = try QueueStore(databaseURL: url)
+            let item = try store.enqueue(
+                QueueItemRequest(queue: .ingestion, wikiID: "w1", payload: makePayload()))
+            itemID = item.id
+            try store.markRunning(id: itemID, providerID: "p1")
+            try store.markCompleted(id: itemID)
+            // Write usage + paths as separate upserts, exactly as the engine's
+            // emit closures do (usage on `.usage`, paths on `.runPaths`).
+            try store.upsertItemActivity(itemID: itemID, usageJSON: usageJSON, logURL: nil, debugURL: nil)
+            try store.upsertItemActivity(itemID: itemID, usageJSON: nil,
+                                         logURL: "/tmp/scratch/run.jsonl",
+                                         debugURL: "/tmp/scratch/debug")
+            store.close()
+        }
+
+        // Reopen — the closest analog to an app restart testable without a GUI.
+        let reopened = try QueueStore(databaseURL: url)
+        let activity = try reopened.loadItemActivity(itemID: itemID)
+        #expect(activity != nil)
+        #expect(activity?.usageJSON == usageJSON)
+        #expect(activity?.logURL == "/tmp/scratch/run.jsonl")
+        #expect(activity?.debugURL == "/tmp/scratch/debug")
+    }
+
+    @Test func testActivityUpsertCOALESCEPreservesExistingFields() throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+        let item = try store.enqueue(
+            QueueItemRequest(queue: .ingestion, wikiID: "w1", payload: makePayload()))
+
+        // usage only.
+        try store.upsertItemActivity(itemID: item.id, usageJSON: "{}", logURL: nil, debugURL: nil)
+        // paths only — must NOT clobber the usage written above (COALESCE).
+        try store.upsertItemActivity(itemID: item.id, usageJSON: nil,
+                                     logURL: "/tmp/log", debugURL: nil)
+
+        let activity = try store.loadItemActivity(itemID: item.id)
+        #expect(activity?.usageJSON == "{}")
+        #expect(activity?.logURL == "/tmp/log")
+    }
+
+    @Test func testProgressAppendJoinsWithNewline() throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+        let item = try store.enqueue(
+            QueueItemRequest(queue: .extraction, wikiID: "w1", payload: makePayload()))
+        try store.appendItemProgress(itemID: item.id, line: "line one")
+        try store.appendItemProgress(itemID: item.id, line: "line two")
+        try store.appendItemProgress(itemID: item.id, line: "line three")
+
+        let activity = try store.loadItemActivity(itemID: item.id)
+        // Mirrors the tracker's in-memory accumulation (newline-joined).
+        #expect(activity?.progressLog == "line one\nline two\nline three")
+    }
+
+    @Test func testActivityCascadesOnPrune() throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+        let item = try store.enqueue(
+            QueueItemRequest(queue: .extraction, wikiID: "w1", payload: makePayload()))
+        try store.markRunning(id: item.id, providerID: "p1")
+        try store.markCompleted(id: item.id)
+        try store.upsertItemActivity(itemID: item.id, usageJSON: "{}",
+                                     logURL: "/tmp/log", debugURL: nil)
+        // Sanity: the row exists while the item exists.
+        #expect(try store.loadItemActivity(itemID: item.id) != nil)
+
+        // Prune ALL terminal items (maxPerQueue: 0) → item row deleted → FK
+        // cascade removes the activity row (mirrors queue_item_events).
+        try store.pruneHistory(maxPerQueue: 0)
+        #expect(try store.getItem(item.id) == nil)
+        #expect(try store.loadItemActivity(itemID: item.id) == nil)
+    }
+
+    @Test func testLoadAllActivity() throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+        let item1 = try store.enqueue(
+            QueueItemRequest(queue: .ingestion, wikiID: "w1", payload: makePayload()))
+        let item2 = try store.enqueue(
+            QueueItemRequest(queue: .extraction, wikiID: "w1", payload: makePayload()))
+        try store.upsertItemActivity(itemID: item1.id, usageJSON: "{}",
+                                     logURL: "/a", debugURL: nil)
+        try store.appendItemProgress(itemID: item2.id, line: "progress")
+
+        let all = try store.loadAllActivity()
+        #expect(all.count == 2)
+        #expect(all[item1.id]?.logURL == "/a")
+        #expect(all[item2.id]?.progressLog == "progress")
+    }
 }


### PR DESCRIPTION
## Problem

In the Activity window (Queue / agent view), per-item info about **ingestion + lint** runs — the usage summary line ("2:32 PM · 1m 3s · Claude · 797 tokens in · …"), the "Reveal Log"/"Reveal Debug Folder" buttons, and the extraction progress text — was shown while the app ran but **lost on restart**. Quit + relaunch and all that activity info vanished.

## Root cause (confirmed)

`QueueActivityTracker` (a `@MainActor @Observable` class) holds ALL per-item activity in in-memory dictionaries (`itemUsage`, `itemLogURLs`, `itemDebugURLs`, `progressLogs`, `transcripts`) that are cleared on `stop()` and never rehydrated on launch.

- **Transcripts** were the partial exception: write-through already existed (`makeEmitTranscript` → `appendItemEvent`) and the detail view already lazy-loaded them via `engine.loadTranscript(for:)` on open.
- **Usage, log/debug URLs, and progress logs** were neither written to the DB nor rehydrated → evaporated with the process.
- `todayUsage` already persisted (UserDefaults); the transient running-state sets are correctly not persisted (rebuild from live `.started` after `resetRunningToQueued()`).

## Fix

Write the three streams through to `QueueStore` as they arrive, and rehydrate into the tracker at launch.

- **v4 GRDB migration (`v4_add_item_activity`)** — new `queue_item_activity` table keyed by `item_id` (FK → `queue_items(id) ON DELETE CASCADE`, so rows vanish on `pruneHistory` — mirrors `queue_item_events`): `usage_json`, `log_url`, `debug_url`, `progress_log`, `updated_at`.
- **Module boundary:** `SessionUsage` lives in `WikiFSEngine`; `QueueStore` lives in `WikiFSCore` (which depends on `WikiFSEngine`, not vice-versa). So the store stores `usage_json` as an opaque `String` (`QueueStore.QueueItemActivity` DTO); the engine encodes/decodes `SessionUsage` ↔ JSON (`SessionUsage` gained `Codable`).
- **Write-through seams (engine emit closures):** `makeEmitUsage` → upsert usage; `makeEmitLogPaths` → upsert `absoluteString` URLs; `makeEmitProgress` → append progress line (newline-joined). COALESCE-partial upsert — each field is set by a different event, so updating one never clobbers the others.
- **Rehydrate seam:** `QueueActivityTracker.rehydrate(from:)` (called at launch in `WikiFSApp` right after `attach`) calls `QueueEngine.loadAllActivitySnapshots()` and repopulates the dicts. Transcripts are deliberately NOT bulk-loaded — the detail view already lazy-loads each item's transcript, avoiding pulling `recentLimit × maxTranscriptEvents` events into memory at launch.

## Concurrency

`rehydrate` is `@MainActor async` — awaits the engine actor for the read (returns `Sendable` snapshots), then mutates MainActor dicts. Emit closures capture `store` (`@unchecked Sendable`, GRDB-serialized) and write from worker Tasks — the same pattern `makeEmitTranscript` already used. Errors are `do/catch` → `DebugLog.store` (no bare `try?`).

## Known limitation (pre-existing, not introduced)

On `retryItem`, old activity (and old transcript events) aren't cleared, so a retried run's summary/progress can show stale-then-new data. Matches the existing transcript behavior; clearing on retry is a separate follow-up.

## Tests

- `QueueStoreTests` (+5): activity survives close+reopen; COALESCE preserves existing fields; progress appends with newline; activity cascades on prune (`maxPerQueue: 0`); `loadAllActivity` returns all rows.
- `QueueActivityTrackerRehydrateTests` (+2): a fresh engine+tracker over the SAME `queue.sqlite` rehydrates usage (JSON→`SessionUsage` round-trip), log/debug URLs (`absoluteString`→`URL`), and progress; empty DB leaves the tracker empty.

`make version prompts` ✓ · `swift build` clean · targeted QueueStore/tracker suites 31/31 pass · fast tier **2603 / 222 suites** pass · full `swift test` **2789 / 235 suites pass (0 failures)**.
