### PR TITLE
Require explicit model selection before agent spawn

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,66 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-18 — Require explicit model selection before agent spawn (branch `fix/require-explicit-model`)
+
+**Problem:** The 2026-07-18 "Working Hypnotically with Children" ingestion stall
+(`tmp/ingestion-stall-diagnosis.md`) had multiple causes; this fix targets one of
+them — the OpenCode provider was `isDefault: true` with no entry in
+`selectedModelIds`, so the launcher passed `nil` to `providerHints`, and the ACP
+subprocess silently fell through to its first-listed upstream —
+`opencode/big-pickle`, a free model nobody chose (diagnosis root cause #6, an
+amplifier of the stall). The dominant cause — `alwaysAsk` permission prompts
+with no timeout — is out of scope here (see Scope Boundaries in
+`plan-001.md`) and tracked as a separate follow-up.
+
+**Fix:** Added a pure `SpawnModelGuard.validate(provider:modelId:)` helper
+(`Sources/WikiFSEngine/SpawnModelGuard.swift`) that returns an actionable
+preflight error when the resolved provider has no `selectedModelId`. Wired into
+both spawn paths:
+- `AgentLauncher.resolveStageRouting` — covers all three ingest stages
+  (planner / executor / finalizer) through one choke-point. Placed AFTER the
+  PATH-preflight so the more-fundamental "executable missing" error wins when
+  both are wrong.
+- `AgentLauncher.startInteractiveQuery` — interactive chat. Placed BEFORE the
+  PATH-preflight (missing model is a configuration issue we surface first).
+
+The error message includes the provider's label (actionable) and
+"Settings → Agents" (discoverable).
+
+Also added a yellow warning caption to the provider row in `AgentsSettingsView`
+(`Sources/WikiFS/Settings/AgentsSettingsView.swift`) when no model is selected,
+gated by a pure static `modelWarning(for:in:)` helper. Non-blocking — models are
+discovered live on first spawn, so blocking save would break new-provider
+onboarding. Disabled providers show no caption (they can't spawn anyway).
+
+**Fresh-install safety:** the shipped `AgentProvidersConfig.seed` now pairs the
+`claude-acp` default with `selectedModelIds["claude-acp"] = "sonnet"` so a fresh
+install can spawn chat/ingest on day one — without this the guard would create a
+hard circularity (you must spawn to discover models, but the guard refuses to
+spawn until a model is picked). The `loadOrSeed` backfill mirrors this for
+existing `claude-acp`-default installs whose `selectedModelIds` was empty —
+upgrade-safety only, does NOT touch non-default providers or an existing
+non-empty `claude-acp` entry.
+
+**Behavior change:** All providers now require an explicit model selection
+before they will spawn, including `claude-acp` (which historically accepted nil
+and defaulted to its first-listed model — effectively Sonnet, now the seeded
+default). Existing configs with no `selectedModelIds["<id>"]` entry for the
+resolved provider must set one via Agents settings before chat or ingest will
+run; the preflight error points the user there.
+
+**Accepted UX wrinkle (tracked for follow-up):** a freshly-added provider (not
+the shipped seed) has no cached models until its first successful spawn — but
+the guard refuses that first spawn. The yellow caption ("No model captured yet
+— chat with this provider once to discover models") is the guidance for this
+state; a future dry-run `session/new` on Save would close the loop.
+
+**Tests:** `SpawnModelGuardTests` (pure helper), `AgentsSettingsViewWarningTests`
+(pure `modelWarning` helper), `AgentProvidersConfigSeedBackfillTests` (seed +
+backfill preserve/non-default), a new `AgentLauncherSpawnRefusalTests`
+(chat-path refusal with injected config), and an extension to
+`AgentProviderModelTests` (the bug-precondition: nil modelId when no selection).
+
 ## 2026-07-18 — Issue #583: per-model usage breakdown in menu bar + Activity window (branch `feature/usage-breakdown-by-model`)
 
 **Problem:** The menu bar's "Today: 76K tokens · $1.23" is a single aggregate. Token pricing/kind varies wildly per model, so the aggregate hides the real signal — a "76K" day could be one Opus run or thirty Sonnet runs.

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -151,12 +151,61 @@ struct AgentsSettingsView: View {
                     .fontDesign(.monospaced)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                // Orange "no model picked" caption. The launcher now refuses to
+                // spawn without an explicit `selectedModelId` (see
+                // `SpawnModelGuard`), so surface the missing selection here.
+                // NON-BLOCKING — models are discovered live on first spawn
+                // (`AgentsSettingsView`'s editor comment at line ~503), so we
+                // let the user save a provider without a model and just remind
+                // them to pick one before running. Disabled providers show no
+                // caption (they can't spawn anyway).
+                if let warning = Self.modelWarning(for: provider, in: config) {
+                    Label(warning, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
             }
 
             Spacer()
         }
         .padding(.vertical, 2)
         .tag(provider.id)
+    }
+
+    /// Returns a warning string when `provider` is enabled, has no selected
+    /// model, and the launcher will therefore refuse to spawn it (see
+    /// `SpawnModelGuard`). Returns `nil` for disabled providers (they can't
+    /// spawn anyway) and providers with a selected model.
+    ///
+    /// Two warning shapes:
+    /// - When the provider has cached models to pick from → the user must
+    ///   pick one before running ("No model selected — pick one before running.").
+    /// - When the provider has no cached models yet → the editor's
+    ///   "No models captured yet" caption and the launcher need a first
+    ///   successful spawn to capture them; surface a gentle guidance line
+    ///   ("No model captured yet — chat with this provider once to discover
+    ///   models."). The launcher will still refuse spawn in this state — that
+    ///   is an accepted UX wrinkle tracked in `PROGRESS.md` (a future
+    ///   dry-run `session/new` on Save would close it).
+    ///
+    /// PURE + STATIC so it can be unit-tested without rendering. The row reads
+    /// the same `config` source the view stores in its `@State`, so passing it
+    /// in as a parameter captures the identical value the row would render.
+    ///
+    /// `nonisolated`: a SwiftUI `View` is implicitly `@MainActor`, but this
+    /// helper touches no view state — only the pure `AgentProvidersConfig`
+    /// argument. Marking it `nonisolated` lets the test suite call it
+    /// synchronously (without `@MainActor`) while the row's call site
+    /// (`Self.modelWarning(for:in:)`) continues to work identically.
+    nonisolated static func modelWarning(for provider: AgentProvider, in config: AgentProvidersConfig) -> String? {
+        guard provider.enabled else { return nil }
+        let modelId = config.selectedModelId(forProvider: provider.id)
+        if let modelId, !modelId.isEmpty { return nil }
+        let models = config.cachedModels(forProvider: provider.id)
+        if models.isEmpty {
+            return "No model captured yet — chat with this provider once to discover models."
+        }
+        return "No model selected — pick one before running."
     }
 
     private func enabledBinding(for provider: AgentProvider) -> Binding<Bool> {

--- a/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
@@ -332,8 +332,20 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
     /// Seed the initial config: the three Phase-1 default providers (Claude —
     /// default, Hermes, OpenCode). Discovered agents are not auto-added; the
     /// user opts in via Settings.
+    ///
+    /// **Default model for the default provider:** the shipped `claude-acp`
+    /// seed is paired with `selectedModelIds["claude-acp"] = "sonnet"` so a
+    /// fresh install can spawn chat/ingest immediately. The launcher's
+    /// `SpawnModelGuard` (see `Sources/WikiFSEngine/SpawnModelGuard.swift`)
+    /// refuses to spawn without an explicit `selectedModelId`; without this
+    /// seed entry a fresh install would hit a hard circularity (you must
+    /// spawn to discover models, but the guard refuses to spawn until a model
+    /// is picked). `"sonnet"` is claude-acp's standard short-name advertised on
+    /// the first live `session/new`. See `tmp/ingestion-stall-diagnosis.md`.
     public static func seed(discovered: [DiscoveredACPAgent]) -> AgentProvidersConfig {
-        AgentProvidersConfig(providers: [.claudeAcpDefault, .hermesDefault, .opencodeDefault])
+        AgentProvidersConfig(
+            providers: [.claudeAcpDefault, .hermesDefault, .opencodeDefault],
+            selectedModelIds: ["claude-acp": "sonnet"])
     }
 
     // MARK: - Persistence
@@ -352,10 +364,27 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             // Preserve the decoded model caches + selections (re-wrapping with
             // only `providers` would wipe them). Re-normalize providers only.
             DebugLog.store("AgentProvidersConfig.loadOrSeed: LOAD providers=\(config.providers.count) hasModelCaches=\(!config.providerModels.isEmpty) hasSelections=\(!config.selectedModelIds.isEmpty)")
+            var selectedModelIds = config.selectedModelIds
+            // Backfill: upgrade-safety for existing `claude-acp`-default installs
+            // (which silently defaulted to Sonnet before the
+            // `SpawnModelGuard` existed). Only injects when `claude-acp` is the
+            // default provider AND no model is picked for it — OpenCode/Hermes
+            // and any deliberately-emptied non-default provider are unaffected,
+            // so the guard still refuses spawn for the actual diagnosed-bug
+            // state (OpenCode default with no selection). See
+            // `tmp/ingestion-stall-diagnosis.md` and
+            // `SpawnModelGuard.validate(provider:modelId:)`.
+            if config.providers.first(where: { $0.isDefault && $0.id == "claude-acp" }) != nil,
+               config.selectedModelId(forProvider: "claude-acp") == nil {
+                DebugLog.store("AgentProvidersConfig.loadOrSeed: BACKFILL claude-acp default-model='sonnet'")
+                selectedModelIds = selectedModelIds.merging(
+                    ["claude-acp": "sonnet"],
+                    uniquingKeysWith: { current, _ in current })
+            }
             return AgentProvidersConfig(
                 providers: config.providers,
                 providerModels: config.providerModels,
-                selectedModelIds: config.selectedModelIds,
+                selectedModelIds: selectedModelIds,
                 favoriteModelIds: config.favoriteModelIds,
                 stageAssignments: config.stageAssignments,
                 maxConcurrent: config.maxConcurrent)

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -1122,6 +1122,17 @@ public final class AgentLauncher {
     ) -> StageRouting? {
         let (provider, modelId) = providersConfig().resolvedProvider(for: stage)
         guard let spawn = resolveACPProviderSpawn(provider) else { return nil }
+        // Refuse to spawn without an explicit `selectedModelId`. Without this,
+        // the ACP subprocess silently falls through to its own first-listed
+        // upstream model (e.g. `opencode/big-pickle`, a free model nobody chose)
+        // — the diagnosed 2026-07-18 ingestion-stall root cause #6. Placed
+        // AFTER `resolveACPProviderSpawn` so the PATH-preflight error wins when
+        // both are wrong (a missing executable is more fundamental). See
+        // `tmp/ingestion-stall-diagnosis.md` and `SpawnModelGuard.swift`.
+        if let msg = SpawnModelGuard.validate(provider: provider, modelId: modelId) {
+            preflightError = msg
+            return nil
+        }
         let cacheKey = "\(provider.id)|\(modelId ?? "")"
         let backend: AgentBackend
         if let cached = cache[cacheKey] {
@@ -2025,6 +2036,27 @@ public final class AgentLauncher {
         let provider = resolveSelectedProvider()
         let resolvedSelectedModel = providersConfig().selectedModelId(forProvider: provider.id)
         DebugLog.agent("startInteractiveQuery: provider=\(provider.id) selectedModel=\(resolvedSelectedModel ?? "nil")")
+
+        // Refuse to spawn without an explicit `selectedModelId`. Mirrors the
+        // ingest path's `resolveStageRouting` guard. Without this, chat silently
+        // falls through to the ACP subprocess's first-listed upstream model. See
+        // `tmp/ingestion-stall-diagnosis.md` and `SpawnModelGuard.swift`.
+        //
+        // State contract: this early-return site is in the PREFLIGHT section
+        // (the comment at the top of this function — "no gate held — early
+        // returns here don't need gate release"). Mirror `resolveACPProviderSpawn`'s
+        // existing failure two lines below: set `preflightError` and bare
+        // `return`. Do NOT touch `isRunning` or `releaseGenerationSlot()` —
+        // neither is held here (unlike the one-shot `run()` path's preflight
+        // at line ~890, which DOES hold both, and that's why that path does
+        // the cleanup). Placed BEFORE the PATH-preflight so the missing-model
+        // message wins when both are wrong (we want the user to fix the model
+        // selection even before we attempt to resolve the executable).
+        if let msg = SpawnModelGuard.validate(provider: provider, modelId: resolvedSelectedModel) {
+            preflightError = msg
+            return
+        }
+
         self.backend = resolveBackend(policy)
 
         // Resolve the provider's spawn command (PATH-resolved) + the

--- a/Sources/WikiFSEngine/SpawnModelGuard.swift
+++ b/Sources/WikiFSEngine/SpawnModelGuard.swift
@@ -1,0 +1,27 @@
+import Foundation
+import WikiFSCore
+
+/// Pure validation that a provider has an explicitly selected model before the
+/// launcher will spawn an ACP subprocess on its behalf.
+///
+/// Background: without an explicit `selectedModelId`, the launcher passed `nil`
+/// to `providerHints`, and the ACP subprocess picked its own first-listed
+/// upstream model. For OpenCode that was `opencode/big-pickle` (a free model) —
+/// silently, with no UI signal. This guard refuses to spawn instead, setting
+/// `AgentLauncher.preflightError` to an actionable message that points the user
+/// at Agents settings. See `tmp/ingestion-stall-diagnosis.md` (2026-07-18).
+///
+/// PURE — no actor, no I/O. Unit-tested directly. Called from two launch sites:
+/// - `AgentLauncher.resolveStageRouting` (ingest — covers planner/executor/
+///   finalizer through one choke-point)
+/// - `AgentLauncher.startInteractiveQuery` (interactive chat)
+enum SpawnModelGuard {
+    /// Returns `nil` when spawning is allowed (a non-empty `modelId` is set for
+    /// `provider`); otherwise a human-readable preflight error message that
+    /// names the provider and points the user at Settings → Agents.
+    static func validate(provider: AgentProvider, modelId: String?) -> String? {
+        if let modelId, !modelId.isEmpty { return nil }
+        return "No model selected for provider ‘\(provider.label)’. "
+             + "Open Settings → Agents and pick a model before running."
+    }
+}

--- a/Tests/WikiFSTests/AgentLauncherSpawnRefusalTests.swift
+++ b/Tests/WikiFSTests/AgentLauncherSpawnRefusalTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import Foundation
+@testable import WikiFSEngine
+import WikiFSCore
+@testable import WikiFS
+
+/// AC.2 — the interactive chat spawn path (`startInteractiveQuery`) refuses to
+/// spawn a session when the resolved provider has no `selectedModelId`,
+/// setting `preflightError` to the same wording as the ingest path's guard
+/// and returning without spawning.
+///
+/// Construction pattern mirrors `QueryNewChatTests.makeLauncher()` (line 14-
+/// 18): the launcher is a `@MainActor` plain class with injectable seams
+/// (`resolveSelectedProvider`, `resolveProvidersContainerDirectory`). The
+/// `startInteractiveQuery` early-return site lives in the PREFLIGHT section
+/// (comment at the function's start: "no gate held — early returns here don't
+/// need gate release"), so the observable contract is: `preflightError != nil`
+/// + `isRunning` stays false (only the one-shot `run()` path sets `isRunning =
+/// true` early — the chat path sets it later, past our guard).
+@MainActor
+struct AgentLauncherSpawnRefusalTests {
+
+    /// Build a launcher whose `providersConfig()` returns the freshly-seeded
+    /// config from a throwaway tmp dir (so claude-acp has "sonnet", but the
+    /// test's chosen provider — opencode — has NO selected model). The guard
+    /// therefore refuses spawn on opencode.
+    private func makeRefusingLauncher() throws -> AgentLauncher {
+        let launcher = AgentLauncher()
+        // Point `providersConfig()` at a fresh tmp dir so the seeded default
+        // ("claude-acp": "sonnet") is loaded — but nothing is set for opencode.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("spawn-refusal-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        // NOTE: tmp is intentionally NOT cleaned up here — `loadOrSeed` writes
+        // a seed file into it on first read, and we don't want a follow-up
+        // `providersConfig()` call to re-seed mid-test. The OS reaps temp.
+        launcher.resolveProvidersContainerDirectory = { tmp }
+        // Override the provider so we exercise opencode's nil-modelId state,
+        // independent of whatever the user happens to have configured as
+        // default in the real App Group container.
+        launcher.resolveSelectedProvider = { .opencodeDefault }
+        return launcher
+    }
+
+    @Test func startInteractiveQueryRefusesSpawnWithNoModel() async throws {
+        let launcher = try makeRefusingLauncher()
+
+        // Sanity: launcher starts idle with no preflightError.
+        #expect(launcher.preflightError == nil)
+        #expect(launcher.isRunning == false)
+
+        // Drive the chat path. The guard fires before the backend/PATH/
+        // scratch-dir work, so the closures stay as no-ops.
+        await launcher.startInteractiveQuery(
+            firstMessage: "hello",
+            stateMarkdown: "",
+            wikiID: "wiki-test",
+            wikiRoot: "/tmp/wiki-test",
+            systemPrompt: "",
+            wikictlDirectory: "/tmp/wiki-test",
+            onLock: { },
+            onUnlock: { }
+        )
+
+        // AC.2 contract: preflightError set, isRunning still false. We can't
+        // directly observe `sessionHandle` (it's private), but `isRunning ==
+        // false` + `preflightError != nil` together pin the preflight-abort
+        // contract — `isRunning` is only set `true` LATER in
+        // `startInteractiveQuery` (past the guard + scratch-dir creation),
+        // so `false` here means the spawn path never advanced.
+        #expect(launcher.preflightError != nil)
+        #expect(launcher.preflightError?.contains("No model selected") == true)
+        #expect(launcher.preflightError?.contains("OpenCode") == true)
+        #expect(launcher.preflightError?.contains("Settings → Agents") == true)
+        #expect(launcher.isRunning == false)
+    }
+
+    @Test func startInteractiveQuerySpawnsWhenModelIsSelected() throws {
+        // AC.5 (chat-side): when a model IS selected, the guard returns nil
+        // and preflightError stays nil — the launcher proceeds past the guard.
+        // We can't drive the rest of `startInteractiveQuery` (it needs a real
+        // ACP subprocess + scratch dir), so this test asserts only the
+        // observable EARLY contract: that a model-selected config does NOT
+        // trip the guard's preflightError.
+        //
+        // We exercise the contract via the same shared guard (the launcher's
+        // call site is just `SpawnModelGuard.validate(...)`); the dedicated
+        // `SpawnModelGuardTests.returnsNilWhenModelIdIsNonEmpty` pins the
+        // guard itself. This test pins the LAUNCHER wiring: that a
+        // model-selected config produces a nil guard result the launcher
+        // would use.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("spawn-allowed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Pre-populate with a config whose opencode provider has a model.
+        var opencodeDefault = AgentProvider.opencodeDefault
+        opencodeDefault.isDefault = true
+        let configWithModel = AgentProvidersConfig(
+            providers: [opencodeDefault],
+            selectedModelIds: ["opencode": "glm-4.7"])
+        try configWithModel.save(to: tmp)
+
+        let launcher = AgentLauncher()
+        launcher.resolveProvidersContainerDirectory = { tmp }
+        launcher.resolveSelectedProvider = { opencodeDefault }
+
+        // Read what the chat path would resolve: provider + its modelId.
+        let provider = launcher.resolveSelectedProvider()
+        let modelId = launcher.providersConfig().selectedModelId(forProvider: provider.id)
+        // Pin the chat path's guard input contract — what
+        // `startInteractiveQuery` actually feeds into `SpawnModelGuard.validate`.
+        #expect(provider.id == "opencode")
+        #expect(modelId == "glm-4.7")
+        #expect(SpawnModelGuard.validate(provider: provider, modelId: modelId) == nil)
+    }
+}

--- a/Tests/WikiFSTests/AgentProviderModelTests.swift
+++ b/Tests/WikiFSTests/AgentProviderModelTests.swift
@@ -215,6 +215,30 @@ import ACPModel
         let loaded = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
         #expect(loaded.isFavoriteModel("opus", forProvider: "claude-acp"))
     }
+
+    // MARK: - SpawnModelGuard precondition (diagnosed 2026-07-18 bug state)
+
+    @Test func resolvedProviderReturnsNilModelWhenNothingConfigured() {
+        // Reproduce the diagnosed-bug precondition: the resolved provider has
+        // no `selectedModelIds` entry, so `resolvedProvider(for:)` returns a
+        // nil `modelId`. The launcher's `SpawnModelGuard` keys on exactly this
+        // state to refuse spawn — this test pins the precondition so the guard
+        // has a stable contract.
+        //
+        // The state: opencode is the default provider (the user manually set
+        // `isDefault = true` — note `.opencodeDefault` ships with
+        // `isDefault: false`, so we override) AND has no `selectedModelIds`
+        // entry. `resolvedProvider(for:)` falls back to `selectedProvider()`
+        // (the stage assignment is empty) → returns `(opencode, nil)`.
+        var opencodeAsDefault = AgentProvider.opencodeDefault
+        opencodeAsDefault.isDefault = true
+        let config = AgentProvidersConfig(providers: [opencodeAsDefault])
+        let resolved = config.resolvedProvider(for: .planner)
+        #expect(resolved.provider.id == "opencode")
+        #expect(resolved.modelId == nil)
+        // This is the exact state `SpawnModelGuard.validate` refuses to spawn on
+        // — confirmed by `SpawnModelGuardTests.returnsErrorMessageWhenModelIdIsNil`.
+    }
 }
 
 @Suite struct AgentProviderCatalogTests {

--- a/Tests/WikiFSTests/AgentProvidersConfigSeedBackfillTests.swift
+++ b/Tests/WikiFSTests/AgentProvidersConfigSeedBackfillTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// Pure-logic tests for the seed + `loadOrSeed` backfill that guarantees a
+/// fresh install (or a freshly-loaded-but-empty-config install) has an
+/// explicit `selectedModelId` for the default `claude-acp` provider — the
+/// contract that lets `SpawnModelGuard.validate` refuse spawn without making
+/// a fresh install unspawnable on day one.
+///
+/// These tests run in the fast CI tier (no live agent subprocess, no ACP).
+@Suite("AgentProvidersConfig seed/backfill")
+struct AgentProvidersConfigSeedBackfillTests {
+
+    // MARK: - AC.6a — fresh-install seed includes the default model
+
+    @Test func seedIncludesDefaultModelForDefaultProvider() {
+        // A fresh install seeds "sonnet" for the claude-acp default provider
+        // so the launcher doesn't immediately refuse spawn on day one.
+        let config = AgentProvidersConfig.seed(discovered: [])
+        #expect(config.selectedModelId(forProvider: "claude-acp") == "sonnet")
+    }
+
+    @Test func seedDoesNotSeedModelsForNonDefaultProviders() {
+        // Only the default claude-acp gets a seed model — Hermes/OpenCode stay
+        // nil so the actual diagnosed-bug state (default provider with no
+        // model) is still reachable for them (the user opts in explicitly).
+        let config = AgentProvidersConfig.seed(discovered: [])
+        #expect(config.selectedModelId(forProvider: "hermes") == nil)
+        #expect(config.selectedModelId(forProvider: "opencode") == nil)
+    }
+
+    // MARK: - AC.6b — `loadOrSeed` backfills empty claude-acp-default configs
+
+    @Test func loadOrSeedBackfillsEmptyClaudeAcpDefaultButPreservesExisting() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-providers-backfill-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Case 1: a claude-acp-default config with empty selectedModelIds.
+        // This is what a pre-guard install looks like. Backfill should inject
+        // "claude-acp": "sonnet".
+        let preGuard = AgentProvidersConfig(
+            providers: [.claudeAcpDefault],
+            selectedModelIds: [:])
+        try preGuard.save(to: tmp)
+        let backfilled = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        #expect(backfilled.selectedModelId(forProvider: "claude-acp") == "sonnet")
+
+        // Case 2: a claude-acp-default config with a user-chosen model. The
+        // backfill MUST NOT overwrite the user's explicit pick.
+        try FileManager.default.removeItem(at: tmp.appendingPathComponent(AgentProvidersConfig.fileName))
+        let withPick = AgentProvidersConfig(
+            providers: [.claudeAcpDefault],
+            selectedModelIds: ["claude-acp": "opus"])
+        try withPick.save(to: tmp)
+        let preserved = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        #expect(preserved.selectedModelId(forProvider: "claude-acp") == "opus")
+    }
+
+    @Test func loadOrSeedDoesNotBackfillWhenDefaultIsNotClaudeAcp() throws {
+        // The backfill is scoped to `claude-acp`-default installs. A
+        // non-claude-acp default (e.g. opencode) with no model must NOT be
+        // injected — that's exactly the diagnosed-bug state, and the guard
+        // should refuse spawn there. The backfill is upgrade-safety only, not
+        // a "fix every config" pass.
+        //
+        // Fixture note: `.claudeAcpDefault` ships with `isDefault: true`, and
+        // `normalized()` keeps the FIRST default provider — so an
+        // `[.claudeAcpDefault, opencodeAsDefault]` list would leave
+        // claude-acp as default and trigger the backfill. We demote
+        // claude-acp explicitly so opencode is the sole default.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-providers-no-backfill-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        var opencodeDefault = AgentProvider.opencodeDefault
+        opencodeDefault.isDefault = true
+        var claudeNonDefault = AgentProvider.claudeAcpDefault
+        claudeNonDefault.isDefault = false
+        let configWithOpencodeDefault = AgentProvidersConfig(
+            providers: [claudeNonDefault, opencodeDefault],
+            selectedModelIds: [:])
+        try configWithOpencodeDefault.save(to: tmp)
+        let loaded = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        #expect(loaded.selectedModelId(forProvider: "opencode") == nil)
+        // claude-acp is NOT default here → its selection is left untouched
+        // (empty as written). The guard will refuse spawn on opencode here.
+        #expect(loaded.selectedModelId(forProvider: "claude-acp") == nil)
+    }
+}

--- a/Tests/WikiFSTests/AgentsSettingsViewWarningTests.swift
+++ b/Tests/WikiFSTests/AgentsSettingsViewWarningTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+@testable import WikiFS
+import WikiFSCore
+
+/// Pure-logic tests for `AgentsSettingsView.modelWarning(for:in:)`.
+///
+/// The helper drives the orange "no model picked" caption shown below a
+/// provider's command line in Settings → Agents. Extracted as a STATIC pure
+/// function (taking the config as a parameter) so it can be tested without
+/// rendering. The row calls `Self.modelWarning(for: provider, in: config)`
+/// with the same `@State var config` source the view stores.
+@Suite("AgentsSettingsView modelWarning")
+struct AgentsSettingsViewWarningTests {
+
+    // MARK: - Returns nil when no warning is needed
+
+    @Test func returnsNilWhenProviderDisabled() {
+        // A disabled provider can't spawn, so the warning is redundant.
+        let disabledClaude = AgentProvider(
+            id: "claude-acp", label: "Claude",
+            command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"],
+            env: [:], enabled: false, isDefault: false)
+        let config = AgentProvidersConfig(providers: [disabledClaude])
+        #expect(AgentsSettingsView.modelWarning(for: disabledClaude, in: config) == nil)
+    }
+
+    @Test func returnsNilWhenModelSelected() {
+        // An enabled provider with a selected model has nothing to warn about.
+        let claude = AgentProvider.claudeAcpDefault
+        let config = AgentProvidersConfig(
+            providers: [claude],
+            selectedModelIds: ["claude-acp": "sonnet"])
+        #expect(AgentsSettingsView.modelWarning(for: claude, in: config) == nil)
+    }
+
+    @Test func returnsNilWhenEmptyStringModelSelectedIsTreatedAsNoModelButStillWarns() {
+        // An empty-string model id collapses to nil at the config layer
+        // (`selectedModelId(forProvider:)` returns nil for empty), so the
+        // warning should fire — pinning the contract.
+        let claude = AgentProvider.claudeAcpDefault
+        let config = AgentProvidersConfig(
+            providers: [claude],
+            // We don't set the empty string directly because setting mutators
+            // strip empties; mirror what a hand-edited file with an empty
+            // selectedModelId value would decode to.
+            selectedModelIds: ["claude-acp": ""])
+        #expect(AgentsSettingsView.modelWarning(for: claude, in: config) != nil)
+    }
+
+    // MARK: - "No model captured yet" — the friendly discovery hint
+
+    @Test func returnsNoModelCapturedWhenEnabledNoSelectionNoCache() {
+        // The first state: enabled + no model + no cached models. The friendly
+        // guidance line ("chat with this provider once to discover models")
+        // is what users of a freshly-added provider see.
+        let opencode = AgentProvider.opencodeDefault
+        let config = AgentProvidersConfig(providers: [opencode])
+        let msg = AgentsSettingsView.modelWarning(for: opencode, in: config)
+        #expect(msg != nil)
+        #expect(msg?.contains("No model captured yet") == true)
+        #expect(msg?.contains("discover models") == true)
+    }
+
+    // MARK: - "No model selected" — the actionable "pick one" message
+
+    @Test func returnsNoModelSelectedWhenEnabledNoSelectionHasCache() {
+        // The second state: enabled + no model + cached models exist. The user
+        // has discoverable models and just needs to pick one. Warning is the
+        // more direct "pick one before running".
+        let opencode = AgentProvider.opencodeDefault
+        let config = AgentProvidersConfig(
+            providers: [opencode],
+            providerModels: [
+                "opencode": [
+                    CachedModelInfo(modelId: "glm-4.7", name: "GLM-4.7"),
+                    CachedModelInfo(modelId: "opencode/big-pickle", name: "Big Pickle"),
+                ]
+            ])
+        let msg = AgentsSettingsView.modelWarning(for: opencode, in: config)
+        #expect(msg != nil)
+        #expect(msg?.contains("No model selected") == true)
+        #expect(msg?.contains("pick one before running") == true)
+    }
+
+    // MARK: - Provider-label independence (the warning is action-shaped, not label-shaped)
+
+    @Test func warningIsStableAcrossProvidersWithSameState() {
+        // Two providers with the same (enabled, no-model, no-cache) state get
+        // the same warning string. Pins the format so UI snapshot tests could
+        // pin it without surprising changes per-provider.
+        let opencode = AgentProvider.opencodeDefault
+        let hermes = AgentProvider.hermesDefault
+        let config = AgentProvidersConfig(providers: [opencode, hermes])
+        #expect(
+            AgentsSettingsView.modelWarning(for: opencode, in: config)
+            == AgentsSettingsView.modelWarning(for: hermes, in: config))
+    }
+}

--- a/Tests/WikiFSTests/SpawnModelGuardTests.swift
+++ b/Tests/WikiFSTests/SpawnModelGuardTests.swift
@@ -1,0 +1,84 @@
+import Testing
+import Foundation
+@testable import WikiFSEngine
+import WikiFSCore
+
+/// Pure-logic tests for `SpawnModelGuard.validate(provider:modelId:)`.
+///
+/// The guard is the shared contract behind two spawn-refusal sites in
+/// `AgentLauncher`:
+/// - `resolveStageRouting` (ingest — planner/executor/finalizer through one
+///   choke-point)
+/// - `startInteractiveQuery` (interactive chat)
+///
+/// These tests do NOT exercise the wiring; they pin the message contract
+/// and the nil/empty/allows-non-empty decision. The wiring is exercised by
+/// `AgentLauncherSpawnRefusalTests` (chat path) and `AgentProviderModelTests`
+/// (the precondition: empty selection → nil modelId).
+@Suite("SpawnModelGuard")
+struct SpawnModelGuardTests {
+    /// Inline fixture: no `.testDefault` factory exists on `AgentProvider` —
+    /// the type defines only `claudeAcpDefault`, `hermesDefault`,
+    /// `opencodeDefault`, and the `acp(from:)` factory. Construct inline so
+    /// the test is independent of those seeds.
+    private let claude = AgentProvider(
+        id: "claude-acp",
+        label: "Claude",
+        command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"],
+        env: [:],
+        enabled: true,
+        isDefault: true)
+
+    @Test func returnsNilWhenModelIdIsNonEmpty() {
+        // Any non-empty model id is acceptable — the guard is provider-agnostic.
+        #expect(SpawnModelGuard.validate(provider: claude, modelId: "sonnet") == nil)
+        #expect(SpawnModelGuard.validate(provider: claude, modelId: "glm-5.2") == nil)
+        #expect(SpawnModelGuard.validate(provider: claude, modelId: "x") == nil)
+    }
+
+    @Test func returnsErrorMessageWhenModelIdIsNil() {
+        let msg = SpawnModelGuard.validate(provider: claude, modelId: nil)
+        #expect(msg != nil)
+        // Three required message fragments per AC.1/AC.2 — actionable
+        // ("No model selected"), identifies the provider (its label), and
+        // points the user where to fix it ("Settings → Agents").
+        #expect(msg?.contains("No model selected") == true)
+        #expect(msg?.contains(claude.label) == true)
+        #expect(msg?.contains("Settings → Agents") == true)
+    }
+
+    @Test func returnsErrorMessageWhenModelIdIsEmptyString() {
+        // An empty string is treated identically to nil (the same shape
+        // `AgentProvidersConfig.selectedModelId(forProvider:)` collapses to nil).
+        #expect(SpawnModelGuard.validate(provider: claude, modelId: "") != nil)
+        let msg = SpawnModelGuard.validate(provider: claude, modelId: "")
+        #expect(msg?.contains(claude.label) == true)
+    }
+
+    @Test func errorMessageIncludesProviderLabelForActionability() {
+        // The provider label is what the user sees in Settings → Agents, so the
+        // error message must use it (not the internal `id`) to be actionable.
+        let opencode = AgentProvider(
+            id: "opencode",
+            label: "OpenCode",
+            command: ["opencode", "acp"],
+            env: [:],
+            enabled: true,
+            isDefault: true)
+        let msg = SpawnModelGuard.validate(provider: opencode, modelId: nil)
+        #expect(msg?.contains("OpenCode") == true)
+        // And the internal id should NOT leak (the user doesn't know it).
+        #expect(msg?.contains("provider id") == false)
+    }
+
+    @Test func messageIsStableAcrossProvidersForSnapshotStability() {
+        // The wording is templated by label only — two providers with the same
+        // label produce identical messages, so a snapshot/regression test can
+        // pin the format.
+        let a = AgentProvider(id: "x", label: "Hermes", command: ["hermes", "acp"])
+        let b = AgentProvider(id: "y", label: "Hermes", command: ["hermes2", "acp"])
+        #expect(
+            SpawnModelGuard.validate(provider: a, modelId: nil)
+            == SpawnModelGuard.validate(provider: b, modelId: nil))
+    }
+}


### PR DESCRIPTION
# Require explicit model selection before agent spawn

Fixes the OpenCode-specific slice of the 2026-07-18 ingestion stall
diagnosed in `tmp/ingestion-stall-diagnosis.md` (root cause #6, an
amplifier of the stall).

## What

Adds a pure `SpawnModelGuard.validate(provider:modelId:)` helper that
refuses to spawn an ACP agent when the resolved provider has no
`selectedModelId`, instead of silently letting the ACP subprocess
fall through to its own first-listed upstream model. For OpenCode
that was `opencode/big-pickle` — a free model nobody chose.

Wired into BOTH spawn paths:

- `AgentLauncher.resolveStageRouting` — covers all three ingest stages
  (planner / executor / finalizer) through one choke-point. Placed
  AFTER the PATH-preflight so the more-fundamental "executable
  missing" error wins when both are wrong.
- `AgentLauncher.startInteractiveQuery` — interactive chat. Placed
  BEFORE the PATH-preflight (missing model is a configuration issue
  we surface first).

The error message includes the provider's label (actionable) and
"Settings → Agents" (discoverable).

## UI

Orange warning caption in **Settings → Agents** → provider row when
the provider is enabled, has no selected model, and the launcher will
therefore refuse to spawn it. Two shapes:

- **"No model captured yet"** (no cached models) — guidance for
  freshly-added providers; the first successful spawn discovers them.
- **"No model selected — pick one before running"** (cached models
  exist) — actionable.

Driven by a pure `nonisolated static func modelWarning(for:in:)`
helper so it's unit-testable without rendering. Disabled providers
show no caption (they can't spawn anyway). Non-blocking — models are
discovered live on first spawn, so blocking Save would break
new-provider onboarding.

## Fresh-install safety

The shipped `AgentProvidersConfig.seed` now pairs the `claude-acp`
default with `selectedModelIds["claude-acp"] = "sonnet"` so a fresh
install can spawn chat/ingest on day one — without this, the guard
would create a hard circularity (you must spawn to discover models,
but the guard refuses to spawn until a model is picked). `"sonnet"`
is `claude-acp`'s standard short-name advertised on the first live
`session/new`.

The `loadOrSeed` backfill mirrors this for existing `claude-acp`
-default installs whose `selectedModelIds` was empty — upgrade-safety
only. It does NOT touch non-default providers or an existing non-empty
`claude-acp` entry (`uniquingKeysWith: { current, _ in current }`
preserves it).

## Behavior change

All providers now require an explicit model selection before they
will spawn, **including `claude-acp`** (which historically accepted
nil and defaulted to its first-listed model — effectively Sonnet,
now the seeded default). Existing configs with no
`selectedModelIds["<id>"]` entry for the resolved provider must set
one via Agents settings before chat or ingest will run; the
preflight error points the user there.

## Accepted UX wrinkle

A freshly-added provider (not the shipped seed) has no cached models
until its first successful spawn — but the guard refuses that first
spawn. The yellow caption is the guidance for this state; a future
dry-run `session/new` on Save would close the loop. Tracked in
`PROGRESS.md`.

## Out of scope

- The dominant stall cause — `alwaysAsk` permission prompts with no
  timeout — is tracked as a separate follow-up (see Scope Boundaries
  in the plan).
- Permission-policy-per-stage and turn-ceiling changes from the
  diagnosis are also separate follow-ups.
- No schema change to `agent-providers.json`. No migration.

## Tests

Pure-logic, fast-tier (no live ACP subprocess, no `.tags(.integration)`):

- `SpawnModelGuardTests` — the pure helper (AC.1/AC.5).
- `AgentProvidersConfigSeedBackfillTests` — seed + `loadOrSeed`
  backfill, including preserve-existing and do-not-touch-non-default
  (AC.6).
- `AgentsSettingsViewWarningTests` — `modelWarning(for:in:)` (AC.3).
- `AgentLauncherSpawnRefusalTests` — chat-path refusal with injected
  config (AC.2).
- `AgentProviderModelTests.resolvedProviderReturnsNilModelWhenNothingConfigured`
  — the diagnosed-bug precondition (no selection → nil modelId).
- The full existing `AgentProviderModelTests` suite continues to pass
  (AC.4).

`swift test --filter 'SpawnModelGuardTests|AgentProviderModelTests|AgentsSettingsViewWarningTests|AgentProvidersConfigSeedBackfillTests|AgentLauncherSpawnRefusalTests'`
→ 62/62 pass. Full fast tier (2,645 tests) passes.

## References

- Diagnosis: `tmp/ingestion-stall-diagnosis.md` (root cause #6).
- PROGRESS.md entry under 2026-07-18.
