### PR TITLE
ACP permission auto-reject timeout (#606) + per-operation policy split (#607)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -50,7 +50,12 @@ struct ChatView: View {
     @State private var quoteAnchor: ChatHighlightRequest? = nil
     /// The chat's always-ask/yolo mode (shared with the launcher, read at spawn).
     /// v1 app-wide, default off (yolo). Applies to the next conversation.
-    @AppStorage(AgentLauncher.permissionModeKey) private var permissionModeRaw = PermissionPolicy.bypass.rawValue
+    ///
+    /// #607: chat reads its OWN `chatPermissionMode` key (was the shared
+    /// `agentPermissionMode` before the per-operation split). Ingest/lint have
+    /// their own pickers in Settings → Agents → Permissions. This chip governs
+    /// interactive chat only.
+    @AppStorage(AgentLauncher.PermissionModeKey.chat) private var permissionModeRaw = PermissionPolicy.bypass.rawValue
 
     /// True when this surface is rendering the active live session (D2
     /// source-of-truth rule). The view sources from `launcher.events`; when

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -17,7 +17,9 @@ struct AgentsSettingsView: View {
     @State private var selectedProviderID: String?
     @State private var providerPendingDeletion: AgentProvider?
 
-    @AppStorage(AgentLauncher.permissionModeKey) private var permissionModeRaw = PermissionPolicy.bypass.rawValue
+    @AppStorage(AgentLauncher.PermissionModeKey.chat)   private var chatModeRaw   = PermissionPolicy.bypass.rawValue
+    @AppStorage(AgentLauncher.PermissionModeKey.ingest) private var ingestModeRaw = PermissionPolicy.bypass.rawValue
+    @AppStorage(AgentLauncher.PermissionModeKey.lint)   private var lintModeRaw   = PermissionPolicy.bypass.rawValue
 
     let containerDirectory: URL
     private let credentialStore: any ACPCredentialStore
@@ -408,9 +410,26 @@ struct AgentsSettingsView: View {
 
     // MARK: - Permission mode (moved from the old Agent tab)
 
+    /// #607: per-operation permission pickers. Pre-split, a single shared
+    /// `agentPermissionMode` key fed chat + ingest + lint — a user who chose
+    /// `alwaysAsk` for chat got the same gating applied to an unattended
+    /// ingest/lint, guaranteeing a stall on the first prompt needing a
+    /// permission (#606). Now three independent pickers. Extraction is
+    /// intentionally omitted — see `plans/acp-permissions.md` §5.1 (extraction
+    /// keeps its `.bypass` default on `ACPExtractionClient`).
     private var permissionSection: some View {
         Section {
-            Picker("Permission Mode", selection: $permissionModeRaw) {
+            Picker("Chat Permission Mode", selection: $chatModeRaw) {
+                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                    Text(mode.label).tag(mode.rawValue)
+                }
+            }
+            Picker("Ingest Permission Mode", selection: $ingestModeRaw) {
+                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                    Text(mode.label).tag(mode.rawValue)
+                }
+            }
+            Picker("Lint Permission Mode", selection: $lintModeRaw) {
                 ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
                     Text(mode.label).tag(mode.rawValue)
                 }
@@ -418,7 +437,7 @@ struct AgentsSettingsView: View {
         } header: {
             Text("Permissions")
         } footer: {
-            Text("Applies to every ACP provider. Bypass (default) applies writes automatically; the other modes gate them behind approval.")
+            Text("These control how the app responds to the agent's permission requests for each operation. Ingest and Lint run unattended — Bypass is recommended (the sandbox already confines writes; an unattended pipeline can't use Always Ask productively, and a stuck permission would auto-reject after 60s).")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -81,6 +81,12 @@ struct WikiFSApp: App {
         // it. Idempotent: copies `conversation.zoom` → `chat.zoom` only when the
         // new key is unset and the old key is set; no-op for fresh installs.
         AppStorageMigration.migrateZoomKey(in: .standard)
+        // #607: one-time migration of the pre-split `agentPermissionMode` key
+        // into `chatPermissionMode`. Idempotent: only copies when the new chat
+        // key has NEVER been written (object == nil check, not string == nil) and
+        // the legacy key is set + valid. The legacy key is orphaned (not deleted)
+        // — see `PermissionModeMigration` + `plans/acp-permissions.md` §5.3.
+        PermissionModeMigration.migrateOnce()
         // Install the app-only PDFKit title extractor into Core's injectable
         // seam. Core must not import PDFKit (it pulls AppKit into the File
         // Provider extension on macOS 26), so the real implementation lives in

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -227,6 +227,13 @@ public actor ACPBackend: AgentBackend {
     /// depends on the agent emitting `request_permission`, which not all do).
     private let permissionPolicy: PermissionPolicy
 
+    /// #606: the per-session auto-reject budget for deferred permission
+    /// requests. nil = no timer (interactive chat — current behavior); non-nil
+    /// = a stuck permission auto-rejects after this `Duration` so an unattended
+    /// pipeline (ingest/lint) can't stall for the full 1800s ceiling. Threaded
+    /// into `ACPPermissionDelegate` at `startProcess`.
+    private let permissionBudget: Duration?
+
     /// The client capabilities advertised at `initialize`. fs read/write +
     /// terminal (the structural second gate from the design doc).
     private let capabilities: ClientCapabilities
@@ -249,12 +256,14 @@ public actor ACPBackend: AgentBackend {
 
     init(
         permissionPolicy: PermissionPolicy = .bypass,
+        budget: Duration? = nil,
         capabilities: ClientCapabilities = ACPBackend.defaultCapabilities,
         turnCeilingTimeout: TimeInterval = TurnLivenessPolicy.defaultCeilingTimeout,
         watchdogPollInterval: TimeInterval = TurnLivenessPolicy.defaultPollInterval,
         maxConcurrentExecutors: Int = 1
     ) {
         self.permissionPolicy = permissionPolicy
+        self.permissionBudget = budget
         self.capabilities = capabilities
         self.turnCeilingTimeout = turnCeilingTimeout
         self.watchdogPollInterval = watchdogPollInterval
@@ -316,7 +325,9 @@ public actor ACPBackend: AgentBackend {
         let client = Client()
         // The permission delegate owns the always-ask/yolo policy. It is the
         // `ClientDelegate` that the agent's `session/request_permission` lands on.
-        let permissionDelegate = ACPPermissionDelegate(policy: permissionPolicy, debugLogger: debugLogger)
+        // #606: `permissionBudget` arms the auto-reject timer — nil (chat)
+        // means no timer; non-nil (ingest/lint) auto-rejects after the budget.
+        let permissionDelegate = ACPPermissionDelegate(policy: permissionPolicy, debugLogger: debugLogger, budget: permissionBudget)
         await client.setDelegate(permissionDelegate)
 
         DebugLog.agent("ACPBackend.startProcess: launching \(spawn.executablePath) \(spawn.arguments.joined(separator: " "))")

--- a/Sources/WikiFSEngine/ACPPermissions.swift
+++ b/Sources/WikiFSEngine/ACPPermissions.swift
@@ -309,6 +309,23 @@ public struct PendingPermission: Sendable, Equatable {
 /// `Sendable` without `@unchecked`. The pending map maps `toolCallId` → a
 /// `CheckedContinuation` that `resolve(optionId:)` resumes. No actor hop needed
 /// (the continuation + map are lock-protected), so resolution is immediate.
+///
+/// **#606 — bounded auto-reject budget:** a deferred permission request that is
+/// never resolved will hang a turn until the 1800s `TurnLivenessPolicy` ceiling.
+/// For unattended pipelines (ingest/lint) that is unacceptable — nobody is
+/// watching the transcript to click Approve/Reject. The `budget` parameter arms
+/// a detached `Task` that sleeps for the chosen `Duration` and, if the user
+/// hasn't resolved first, auto-rejects via `timeOut(toolCallId:)`. Interactive
+/// chat passes `budget: nil` (unbounded — preserves the prior behavior so the
+/// UI chip stays the source of truth). The race is safe by construction: the
+/// existing `removeValue`-then-resume discipline in `resolve` /
+/// `cancelAllPending` is mirrored by `timeOut` — whichever wins the race pulls
+/// the entry out of the map under the lock, so the others find nothing to
+/// resume (`CheckedContinuation` cannot be resumed twice). The `Task` handle is
+/// stored on `Pending` so `resolve`/`cancelAllPending` cancel it on the winning
+/// side, avoiding a stray timer firing after teardown.
+/// See `plans/acp-permissions.md` §4.1 for the load-bearing invariants + the
+/// TaskGroup-rejection rationale.
 public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
 
     /// A pending request's resolution channel.
@@ -317,9 +334,19 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
         let toolName: String?
         let inputSummary: String?
         let continuation: CheckedContinuation<RequestPermissionResponse, Never>
+        /// #606: the auto-reject timer Task, armed in `deferPermission` when a
+        /// non-nil `budget` is set. `resolve`/`cancelAllPending` cancel it when
+        /// they win the race; the timer task itself calls `timeOut(toolCallId:)`
+        /// when it wins. nil for interactive chat (`budget: nil`) — no timer.
+        let timer: Task<Void, Never>?
     }
 
     private let policy: PermissionPolicy
+    /// #606: the per-request auto-reject budget. nil = no timer (current
+    /// behavior — interactive chat). non-nil = a deferred permission auto-
+    /// rejects after the duration elapses. Threading: only read at
+    /// `handlePermissionRequest` entry (no lock needed — it's a `let`).
+    private let budget: Duration?
     /// The per-run debug logger, for capturing permission request/response
     /// exchanges to `permissions.jsonl`. nil when debug logging is disabled —
     /// all calls are no-ops via optional chaining.
@@ -333,9 +360,19 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     }
     private let lock = OSAllocatedUnfairLock<LockedState>(initialState: LockedState())
 
-    init(policy: PermissionPolicy, debugLogger: DebugRunLogger? = nil) {
+    /// - Parameters:
+    ///   - policy: the permission policy (`bypass`/`alwaysAsk`/`acceptEdits`/`plan`).
+    ///   - debugLogger: optional per-run permission-exchange logger.
+    ///   - budget: #606 auto-reject budget. nil (default) = no timer; non-nil =
+    ///     after this `Duration` elapses with no user resolution, the pending
+    ///     request is auto-rejected as `cancelled`. Interactive chat passes nil
+    ///     (preserves the prior indefinite-suspend behavior — the live UI is the
+    ///     release valve); ingest/lint pass `.seconds(60)` so an unattended
+    ///     pipeline can't stall on a stuck permission.
+    init(policy: PermissionPolicy, debugLogger: DebugRunLogger? = nil, budget: Duration? = nil) {
         self.policy = policy
         self.debugLogger = debugLogger
+        self.budget = budget
     }
 
     // MARK: - ClientDelegate: the permission seam
@@ -358,8 +395,10 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
                 DebugLog.agent("ACPBackend: acceptEdits auto-allow edit toolCallId=\(request.toolCall.toolCallId)")
                 response = RequestPermissionResponse(outcome: PermissionOutcome(optionId: allow.optionId))
             } else {
-                // Non-edit tool → defer to the user (same as alwaysAsk).
-                response = await Self.deferPermission(request: request, lock: lock)
+                // Non-edit tool → defer to the user (same as alwaysAsk). Same
+                // auto-reject budget applies — a stalled non-edit permission
+                // blocks the turn identically to an alwaysAsk stall (#606).
+                response = await Self.deferPermission(request: request, lock: lock, budget: budget)
             }
 
         case .plan:
@@ -371,7 +410,7 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
             // Defer: record pending and SUSPEND until resolve(optionId:). The
             // future UI calls ACPBackend.resolvePermission, which calls into
             // here. This is the pending-permission-blocking pattern from paseo.
-            response = await Self.deferPermission(request: request, lock: lock)
+            response = await Self.deferPermission(request: request, lock: lock, budget: budget)
         }
         // Debug: log the full request/response exchange to permissions.jsonl.
         debugLogger?.logPermission(request: request, response: response, policy: policy.rawValue)
@@ -381,25 +420,93 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     // MARK: - Shared helpers
 
     /// Defer a permission request to the user (alwaysAsk / acceptEdits-non-edit).
-    /// Records the pending continuation and returns when the user resolves it.
+    /// Records the pending continuation and returns when the user resolves it,
+    /// OR — if a `budget` is set and the user doesn't resolve in time — auto-
+    /// rejects as `cancelled` after the budget elapses (#606).
+    ///
+    /// **The race + lifecycle:** the single `CheckedContinuation` is resumed
+    /// EXACTLY once by one of three racers:
+    ///   1. `resolve(optionId:)` — the user clicked Approve/Reject.
+    ///   2. `cancelAllPending()` — full session teardown (drains everything).
+    ///   3. `timeOut(toolCallId:)` — the budget timer elapsed first.
+    /// All three racers do `state.pending.removeValue(forKey:)` (or
+    /// `removeAll()`) UNDER the lock before resuming. Whichever wins pulls the
+    /// entry out, so the others find nothing — `CheckedContinuation` cannot be
+    /// resumed twice (see `docs/skills/swift-concurrency-pro/SKILL.md`
+    /// `bug-patterns`: "Continuation resumed twice → restructure so only one
+    /// path reaches the continuation"). The detach-timer form is the committed
+    /// approach — a `withTaskGroup` sketch where a child task awaits
+    /// `group.next()` on the same group does not compile under Swift 6.0 strict
+    /// concurrency (non-Sendable + mutating access).
+    ///
+    /// **Why a `Task` and not a `TaskGroup`:** awaiting `group.next()` from
+    /// inside one of the group's own child tasks is a data race (the group is
+    /// non-`Sendable` and `next()` is mutating). The detached-timer form below
+    /// preserves the existing `removeValue`-then-resume discipline verbatim and
+    /// compiles cleanly. See `plans/acp-permissions.md` §4.1 note #5.
     private static func deferPermission(
         request: RequestPermissionRequest,
-        lock: OSAllocatedUnfairLock<LockedState>
+        lock: OSAllocatedUnfairLock<LockedState>,
+        budget: Duration?
     ) async -> RequestPermissionResponse {
         let toolCall = request.toolCall
         let toolName = Self.toolName(for: toolCall)
         let inputSummary = Self.toolSummary(for: toolCall)
         return await withCheckedContinuation { (continuation: CheckedContinuation<RequestPermissionResponse, Never>) in
+            // #606: arm the auto-reject timer when a budget is set. nil means
+            // interactive chat (unbounded — the UI is the release valve).
+            let timer: Task<Void, Never>? = budget.map { b in
+                Task { [toolCallId = request.toolCall.toolCallId] in
+                    do {
+                        try await Task.sleep(for: b)
+                    } catch {
+                        // CancellationError — expected when resolve() /
+                        // cancelAllPending() cancelled the timer first.
+                        // Cooperative lifecycle event, not a hidden failure
+                        // (§3 house-rule carve-out in plans/acp-permissions.md).
+                        return
+                    }
+                    // Budget elapsed before the user resolved → auto-reject.
+                    // `timeOut` mirrors `resolve`: removeValue under the lock,
+                    // then resume. If the user/teardown already won, the entry
+                    // is gone — `timeOut` no-ops.
+                    Self.timeOut(toolCallId: toolCallId, lock: lock)
+                }
+            }
             lock.withLock { state in
                 state.pending[request.toolCall.toolCallId] = Pending(
                     options: request.options,
                     toolName: toolName,
                     inputSummary: inputSummary,
-                    continuation: continuation
-                )
+                    continuation: continuation,
+                    timer: timer)
             }
-            DebugLog.agent("ACPBackend: deferring toolCallId=\(request.toolCall.toolCallId) (\(request.options.count) options)")
+            DebugLog.agent("ACPBackend: deferring toolCallId=\(request.toolCall.toolCallId) (\(request.options.count) options) budget=\(budget.map { "\($0.components.seconds)s" } ?? "nil")")
         }
+    }
+
+    /// #606: auto-reject a pending request when its budget elapses. Mirrors
+    /// `resolve(optionId:)`: pulls the pending entry out of the map UNDER the
+    /// lock (so a concurrent `resolve`/`cancelAllPending` that already won the
+    /// race finds nothing here — `guard let drained` no-ops), then resumes the
+    /// continuation as `cancelled` AFTER the lock is released (the existing
+    /// discipline — never resume under the lock, it can deadlock or trap on a
+    /// sync re-entrant call). The removed `timer` is returned but not cancelled
+    /// here (it's the running task itself — self-cancellation is a no-op).
+    private static func timeOut(
+        toolCallId: String,
+        lock: OSAllocatedUnfairLock<LockedState>
+    ) {
+        let drained = lock.withLock { state -> (CheckedContinuation<RequestPermissionResponse, Never>, Task<Void, Never>?)? in
+            guard let pending = state.pending.removeValue(forKey: toolCallId) else { return nil }
+            return (pending.continuation, pending.timer)
+        }
+        guard let (cont, _) = drained else {
+            // resolve() or cancelAllPending() already won the race — nothing to do.
+            return
+        }
+        DebugLog.agent("ACPBackend: permission budget exceeded — auto-reject toolCallId=\(toolCallId)")
+        cont.resume(returning: RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true)))
     }
 
     /// Heuristic: does this tool call look like a file edit/write? Used by
@@ -456,16 +563,20 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     /// is what the Approve/Reject UI calls.
     @discardableResult
     func resolve(optionId: String) -> Bool {
-        let resolved: CheckedContinuation<RequestPermissionResponse, Never>? = lock.withLock { state in
+        let resolved: (CheckedContinuation<RequestPermissionResponse, Never>, Task<Void, Never>?)? = lock.withLock { state in
             // Find the pending request that offers this option (a request is
             // identified by toolCallId; the UI passes the chosen option id).
             for (toolCallId, pending) in state.pending where pending.options.contains(where: { $0.optionId == optionId }) {
                 state.pending.removeValue(forKey: toolCallId)
-                return pending.continuation
+                // #606: cancel the auto-reject timer — the user won the race.
+                // Without this, the timer fires later, hits the now-empty map
+                // look-up in `timeOut`, and no-ops (harmless but wasteful).
+                return (pending.continuation, pending.timer)
             }
             return nil
         }
-        guard let continuation = resolved else { return false }
+        guard let (continuation, timer) = resolved else { return false }
+        timer?.cancel()
         continuation.resume(returning: RequestPermissionResponse(outcome: PermissionOutcome(optionId: optionId)))
         return true
     }
@@ -496,13 +607,16 @@ public final class ACPPermissionDelegate: ClientDelegate, @unchecked Sendable {
     /// the number of continuations resumed (for tests).
     @discardableResult
     func cancelAllPending() -> Int {
-        let drained = lock.withLock { state -> [(options: [PermissionOption], continuation: CheckedContinuation<RequestPermissionResponse, Never>)] in
+        let drained = lock.withLock { state -> [(options: [PermissionOption], continuation: CheckedContinuation<RequestPermissionResponse, Never>, timer: Task<Void, Never>?)] in
             let pending = state.pending
             state.pending.removeAll()
-            return pending.map { (toolCallId, value) in (value.options, value.continuation) }
+            return pending.map { (toolCallId, value) in (value.options, value.continuation, value.timer) }
         }
+        // #606: cancel every armed timer BEFORE resuming the continuation so no
+        // stray timer task fires after teardown (its `timeOut` would no-op
+        // against the emptied map anyway, but cancelling is the cleaner lifecycle).
         for item in drained {
-            _ = item.options  // toolCallId is implicit; nothing else needed
+            item.timer?.cancel()
             item.continuation.resume(returning: RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true)))
         }
         return drained.count

--- a/Sources/WikiFSEngine/AgentBackendFactory.swift
+++ b/Sources/WikiFSEngine/AgentBackendFactory.swift
@@ -14,8 +14,14 @@ import WikiFSCore
 public enum AgentBackendFactory {
 
     /// Construct the backend for a session. Every provider drives `ACPBackend`.
-    static func makeBackend(policy: PermissionPolicy) -> AgentBackend {
-        ACPBackend(permissionPolicy: policy)
+    ///
+    /// - Parameter budget: #606 auto-reject budget for deferred permission
+    ///   requests. nil (default) = no timer (interactive chat — current
+    ///   behavior); non-nil = a stuck permission auto-rejects after this
+    ///   `Duration` so unattended pipelines (ingest/lint) can't stall for the
+    ///   full 1800s ceiling.
+    static func makeBackend(policy: PermissionPolicy, budget: Duration? = nil) -> AgentBackend {
+        ACPBackend(permissionPolicy: policy, budget: budget)
     }
 
     /// Build the `providerHints` for an ACP provider from its PATH-resolved

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -184,19 +184,36 @@ public final class AgentLauncher {
 
     /// Factory closure that constructs the backend for a session. Called at
     /// spawn time in `run()` / `startInteractiveQuery()` so a fresh backend is
-    /// built per session with the current permission policy. Injectable so tests
-    /// can substitute a stub backend that survives the `self.backend = ...`
-    /// assignment in `run()` (setting `backend` directly is overwritten).
-    @ObservationIgnored var resolveBackend: (PermissionPolicy) -> AgentBackend = {
-        AgentBackendFactory.makeBackend(policy: $0)
+    /// built per session with the current permission policy + the operation's
+    /// auto-reject budget (#606). Injectable so tests can substitute a stub
+    /// backend that survives the `self.backend = ...` assignment in `run()`
+    /// (setting `backend` directly is overwritten).
+    ///
+    /// #606: second parameter is the deferred-permission budget — nil = no
+    /// timer (interactive chat), non-nil = auto-reject after this `Duration`.
+    /// Ingest/lint pass `.seconds(60)`; chat passes `nil`.
+    @ObservationIgnored var resolveBackend: (PermissionPolicy, Duration?) -> AgentBackend = {
+        AgentBackendFactory.makeBackend(policy: $0, budget: $1)
     }
 
-    /// The chat's permission mode (`@AppStorage("agentPermissionMode")`, default
-    /// `.bypass`). v1: app-wide persisted. Read at spawn time so it bakes into
-    /// the `ACPBackend`'s `PermissionPolicy`.
-    @ObservationIgnored var resolvePermissionMode: () -> PermissionPolicy = {
-        let raw = UserDefaults.standard.string(forKey: AgentLauncher.permissionModeKey) ?? ""
-        return PermissionPolicy(rawValue: raw) ?? .bypass
+    /// The permission policy, resolved per operation kind. #607: previously one
+    /// shared `agentPermissionMode` key was fed to chat + ingest + lint, so a
+    /// user who correctly chose `alwaysAsk` for interactive chat got the same
+    /// gating applied to an unattended ingest/lint — guaranteeing a stall on
+    /// the first prompt needing a permission. Now three independent keys:
+    /// `chatPermissionMode` / `ingestPermissionMode` / `lintPermissionMode`.
+    /// Extraction is intentionally NOT a kind here — see `plans/acp-permissions.md`
+    /// §5.1 (extraction keeps its `.bypass` default on `ACPExtractionClient`).
+    @ObservationIgnored var resolvePermissionMode: (PermissionOperationKind) -> PermissionPolicy = { op in
+        let key: String
+        let fallback: PermissionPolicy
+        switch op {
+        case .chat:   key = PermissionModeKey.chat;   fallback = .bypass
+        case .ingest: key = PermissionModeKey.ingest; fallback = .bypass
+        case .lint:   key = PermissionModeKey.lint;   fallback = .bypass
+        }
+        let raw = UserDefaults.standard.string(forKey: key) ?? ""
+        return PermissionPolicy(rawValue: raw) ?? fallback
     }
 
     /// The Keychain-backed store for the ACP agent's API key. Injectable so
@@ -454,8 +471,27 @@ public final class AgentLauncher {
     /// `setGenerating(false)` / `finish()` / `resetRunArtifacts()`.
     @ObservationIgnored private var pendingPollTask: Task<Void, Never>?
 
-    /// UserDefaults key shared with the `@AppStorage` bindings in Settings + ChatView.
-    public static let permissionModeKey = "agentPermissionMode"
+    /// #607: per-operation permission-mode UserDefaults keys. Replaces the single
+    /// shared `permissionModeKey = "agentPermissionMode"` that fed chat + ingest +
+    /// lint from one store — a user who chose `alwaysAsk` for chat got the same
+    /// gating applied to an unattended ingest/lint, guaranteeing a stall on the
+    /// first prompt needing a permission. These are UserDefaults string keys; the
+    /// `@AppStorage(PermissionModeKey.<x>)` bindings in Settings + ChatView + the
+    /// `resolvePermissionMode(for:)` closure here all read/write them.
+    ///
+    /// Extraction is intentionally NOT a kind in this PR — see `plans/acp-permissions.md`
+    /// §5.1 (extraction keeps its `.bypass` default on `ACPExtractionClient`).
+    public enum PermissionModeKey {
+        /// Interactive chat permission mode. Default `.bypass`.
+        public static let chat = "chatPermissionMode"
+        /// Multi-phase ingest permission mode (planner + executors + finalizer).
+        /// Default `.bypass` — the sandbox already confines writes; an unattended
+        /// pipeline can't use `alwaysAsk` productively.
+        public static let ingest = "ingestPermissionMode"
+        /// Lint permission mode (the `run()` single-session path for `.lint` /
+        /// `.lintPage`). Default `.bypass` — same unattended-pipeline rationale.
+        public static let lint = "lintPermissionMode"
+    }
     /// The active session handle (nil when no session is live). Replaces the
     /// old `process: Process?` — the launcher never touches a `Process` directly.
     @ObservationIgnored private var sessionHandle: SessionHandle?
@@ -874,15 +910,30 @@ public final class AgentLauncher {
         // restart.
         let dir = containerDirectory ?? (try? DatabaseLocation.appGroupContainerDirectory()) ?? FileManager.default.temporaryDirectory
 
-        // The chat's permission policy (default yolo). Constructed HERE so both
-        // `start` and the per-turn stream consumer capture the same backend.
-        let policy: PermissionPolicy = resolvePermissionMode()
+        // #607: per-operation permission policy. The kind is known from the
+        // `request` parameter (the staged `WikiOperation` isn't built yet, but
+        // the enum cases map 1:1 — `.ingest` → `.ingest`, `.lint`/`.lintPage`
+        // → `.lint`, else `.chat`). Pre-#607 a single shared key fed all
+        // three, so a user who chose `alwaysAsk` for chat got the same gating
+        // on an unattended ingest/lint — guaranteeing a stall (#606).
+        let permissionKind: PermissionOperationKind = {
+            switch request {
+            case .ingest: return .ingest
+            case .lint, .lintPage: return .lint
+            case .query: return .chat
+            }
+        }()
+        let policy: PermissionPolicy = resolvePermissionMode(permissionKind)
+        // #606: chat is interactive (unbounded — the UI chip is the release
+        // valve); ingest/lint are unattended and MUST auto-reject so a stuck
+        // permission can't burn the 1800s ceiling.
+        let permissionBudget: Duration? = (permissionKind == .chat) ? nil : .seconds(60)
 
         // #324: the launcher reads `agent-providers.json`, picks the default
         // (or selected) provider, and resolves its PATH command + Keychain key
         // into providerHints. The app is ACP-only.
         let provider = resolveSelectedProvider()
-        self.backend = resolveBackend(policy)
+        self.backend = resolveBackend(policy, permissionBudget)
 
         // Resolve the provider's spawn command (PATH-resolved because the
         // swift-acp SDK's launch() does NOT do PATH lookup) + the Keychain-backed
@@ -1118,6 +1169,7 @@ public final class AgentLauncher {
     private func resolveStageRouting(
         _ stage: IngestStage,
         policy: PermissionPolicy,
+        budget: Duration?,
         cache: inout [String: AgentBackend]
     ) -> StageRouting? {
         let (provider, modelId) = providersConfig().resolvedProvider(for: stage)
@@ -1138,7 +1190,7 @@ public final class AgentLauncher {
         if let cached = cache[cacheKey] {
             backend = cached
         } else {
-            backend = resolveBackend(policy)
+            backend = resolveBackend(policy, budget)
             cache[cacheKey] = backend
         }
         let providerHints = AgentBackendFactory.providerHints(
@@ -1186,7 +1238,15 @@ public final class AgentLauncher {
         // second+ call on the same backend) and `closeSession()` at the phase
         // boundary (frees session context, keeps the subprocess alive). The
         // subprocess is terminated via `backend.cancel()` only at the very end.
-        let policy: PermissionPolicy = resolvePermissionMode()
+        //
+        // #607: ingest policy reads its OWN `ingestPermissionMode` key, NOT the
+        // chat key — a user who chose `alwaysAsk` for chat no longer stalls an
+        // unattended ingest. #606: a deferred ingest permission auto-rejects
+        // after `.seconds(60)` so even a misconfigured ingest can't burn the
+        // 1800s ceiling (the sandbox already confines writes — `bypass` is the
+        // correct default for an unattended pipeline).
+        let policy: PermissionPolicy = resolvePermissionMode(.ingest)
+        let permissionBudget: Duration? = .seconds(60)
         var stageBackendCache: [String: AgentBackend] = [:]
 
         // Build a shared CLI profile closure (sets the env vars `ACPBackend`
@@ -1202,7 +1262,7 @@ public final class AgentLauncher {
         // --- Phase 1: Planner ---
         DebugLog.agent("runACPIngest: Phase 1 — Planner")
         currentIngestPhase = "planner"
-        guard let plannerRouting = resolveStageRouting(.planner, policy: policy, cache: &stageBackendCache) else {
+        guard let plannerRouting = resolveStageRouting(.planner, policy: policy, budget: permissionBudget, cache: &stageBackendCache) else {
             DebugLog.agent("runACPIngest: planner routing failed (\(preflightError ?? "?")) — aborting")
             finish(status: -1)
             return
@@ -1270,7 +1330,7 @@ public final class AgentLauncher {
         DebugLog.agent("runACPIngest: plan loaded — \(plan.pages.count) pages across \(plan.distinctSourceFiles.count) source file(s)")
 
         // --- Phase 2: Executors (one per source file) ---
-        if let executorRouting = resolveStageRouting(.executor, policy: policy, cache: &stageBackendCache) {
+        if let executorRouting = resolveStageRouting(.executor, policy: policy, budget: permissionBudget, cache: &stageBackendCache) {
             let executorProfile = BackendProfile(
                 providerHints: executorRouting.providerHints,
                 scratchDirectory: scratch,
@@ -1363,7 +1423,7 @@ public final class AgentLauncher {
         }
 
         // --- Phase 3: Finalizer ---
-        guard let finalizerRouting = resolveStageRouting(.finalizer, policy: policy, cache: &stageBackendCache) else {
+        guard let finalizerRouting = resolveStageRouting(.finalizer, policy: policy, budget: permissionBudget, cache: &stageBackendCache) else {
             DebugLog.agent("runACPIngest: finalizer routing failed (\(preflightError ?? "?")) — aborting")
             preflightError = nil
             finish(status: -1)
@@ -2028,8 +2088,14 @@ public final class AgentLauncher {
 
         // The chat's permission policy (default yolo). The ACP agent spawn is
         // threaded into providerHints below.
-        let policy: PermissionPolicy = resolvePermissionMode()
-        DebugLog.agent("startInteractiveQuery: permissionPolicy=\(policy)")
+        //
+        // #607: chat reads its OWN `chatPermissionMode` key — independent of
+        // ingest/lint. #606: chat is interactive, so no auto-reject budget —
+        // the UI chip is the release valve, preserving the prior indefinite-
+        // suspend behavior. (`nil` budget ⇒ no timer on `deferPermission`.)
+        let policy: PermissionPolicy = resolvePermissionMode(.chat)
+        let permissionBudget: Duration? = nil
+        DebugLog.agent("startInteractiveQuery: permissionPolicy=\(policy) budget=nil (interactive)")
 
         // #324: the launcher reads `agent-providers.json` and picks the
         // default (or selected) provider. The app is ACP-only.
@@ -2057,7 +2123,7 @@ public final class AgentLauncher {
             return
         }
 
-        self.backend = resolveBackend(policy)
+        self.backend = resolveBackend(policy, permissionBudget)
 
         // Resolve the provider's spawn command (PATH-resolved) + the
         // Keychain-backed API key (keyed by provider id).
@@ -2916,5 +2982,59 @@ public final class AgentLauncher {
     private func createSandboxTmpDir(in scratch: URL) {
         let tmp = scratch.appendingPathComponent(Self.tmpRelocationLeaf, isDirectory: true)
         try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+    }
+}
+
+// MARK: - #607: per-operation permission policy domain
+
+/// The operation kind the launcher resolves a permission policy for. Kept
+/// distinct from `WikiOperation.Kind` (the *run* kind) so the permission-
+/// policy domain stays independent (no coupling between the two enums). Mapping
+/// from a `WikiOperation.Kind` to a `PermissionOperationKind` happens at the
+/// launcher call site (`.lint`/`.lintPage` → `.lint`, `.ingest` → `.ingest`,
+/// else `.chat`).
+///
+/// Extraction is intentionally NOT a kind here — see `plans/acp-permissions.md`
+/// §5.1 (extraction keeps its `.bypass` default on `ACPExtractionClient` and its
+/// callers weren't fully enumerated; a follow-up PR can add `.extraction` once
+/// every `ACPExtractionClient()` construction threads the extraction key).
+public enum PermissionOperationKind: Sendable {
+    case chat
+    case ingest
+    case lint
+}
+
+// MARK: - #607: one-time legacy key migration
+
+/// One-shot migration of the pre-#607 `agentPermissionMode` UserDefaults key
+/// into the post-#607 `chatPermissionMode` key. Idempotent + injectable
+/// (`defaults` is a parameter) so it can be unit-tested against a throwaway
+/// `UserDefaults(suiteName:)` without touching the app's real `.standard`
+/// defaults — mirrors `AppStorageMigration.migrateZoomKey`'s shape.
+///
+/// **Why `object(forKey:) == nil` (not `string(forKey:) == nil`):** `UserDefaults
+/// .string(forKey:)` cannot distinguish "key absent" from "key present but empty
+/// string" — `object(forKey:) == nil` is the only correct key-presence check.
+/// This is the predicate test #9 in `plans/acp-permissions.md` §8.2 asserts.
+///
+/// **Idempotent:** after the first run, `object(forKey: PermissionModeKey.chat)`
+/// is non-nil (we just wrote it), so the guard fails on subsequent launches.
+///
+/// **Copy, not move:** the legacy `agentPermissionMode` is left in place
+/// (orphaned, like `sandbox-config.json`) — deleting a UserDefaults key has no
+/// rollback path, and a future downgrade would silently lose the user's pick.
+public enum PermissionModeMigration {
+    public static func migrateOnce(
+        from legacyKey: String = "agentPermissionMode",
+        to newKey: String = AgentLauncher.PermissionModeKey.chat,
+        in defaults: UserDefaults = .standard
+    ) {
+        // Only migrate if the new chat key has NEVER been written (object == nil).
+        guard defaults.object(forKey: newKey) == nil,
+              let legacy = defaults.string(forKey: legacyKey),
+              !legacy.isEmpty,
+              let policy = PermissionPolicy(rawValue: legacy) else { return }
+        defaults.set(policy.rawValue, forKey: newKey)
+        DebugLog.agent("PermissionModeMigration: copied legacy \(legacyKey)=\(policy.rawValue) -> \(newKey)")
     }
 }

--- a/Tests/WikiFSTests/ACPPermissionTimeoutTests.swift
+++ b/Tests/WikiFSTests/ACPPermissionTimeoutTests.swift
@@ -1,0 +1,181 @@
+import Testing
+import Foundation
+import ACPModel
+@testable import WikiFSEngine
+
+/// #606 regression suite: a deferred permission request (alwaysAsk, or
+/// acceptEdits on a non-edit tool) must auto-reject after the configured
+/// `budget` elapses WITHOUT a user resolution — instead of suspending
+/// indefinitely on `withCheckedContinuation` until the 1800s ceiling kills
+/// the turn. Mirrors the existing `ACPBackendTests` always-ask family's
+/// harness (suspend on a `Task` + await with a short timeout).
+///
+/// The race-safety invariant (exactly one `resume` per `CheckedContinuation`)
+/// is the load-bearing correctness property — covered by tests #2, #3, #6
+/// (`plans/acp-permissions.md` §4.1 note #1, §8.2).
+@Suite struct ACPPermissionTimeoutTests {
+
+    /// A two-option request the always-ask path defers (matches the existing
+    /// `ACPBackendTests.alwaysAskDefersUntilResolved` shape).
+    private func makeRequest(toolCallId: String, title: String = "Write file") -> RequestPermissionRequest {
+        RequestPermissionRequest(
+            options: [
+                PermissionOption(kind: "allow_always", name: "Allow", optionId: "opt-allow"),
+                PermissionOption(kind: "reject_once", name: "Reject", optionId: "opt-reject"),
+            ],
+            sessionId: SessionId("s1"),
+            toolCall: ToolCallUpdate(toolCallId: toolCallId, title: title, kind: .edit)
+        )
+    }
+
+    /// #1 — #606 repro-becomes-test: a deferred permission request that is
+    /// never resolved returns `cancelled` within `budget + ε`. The 1800s
+    /// ceiling backstop is no longer the only release.
+    @Test func deferPermissionAutoRejectsAfterBudget() async throws {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk, budget: .milliseconds(200))
+        let request = makeRequest(toolCallId: "tc-timeout")
+
+        let response = try await delegate.handlePermissionRequest(request: request)
+
+        // The agent treats `cancelled` as denied and adapts — same as a denied
+        // tool. This is the #606 auto-reject outcome.
+        #expect(response.outcome.outcome == "cancelled")
+        #expect(response.outcome.optionId == nil)
+        // Pending map is empty after the timeout drain (removeValue under the lock).
+        #expect(delegate.pendingSnapshot().isEmpty)
+    }
+
+    /// #2 — A user resolution that lands BEFORE the budget elapses wins the
+    /// race. The timer is cancelled by `resolve`; the response is the ALLOW
+    /// outcome, not `cancelled`.
+    @Test func deferPermissionUserResolveBeatsBudget() async throws {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk, budget: .milliseconds(500))
+        let request = makeRequest(toolCallId: "tc-race-user")
+
+        let requestTask = Task<RequestPermissionResponse, Error> {
+            try await delegate.handlePermissionRequest(request: request)
+        }
+
+        // Give the suspended continuation + armed timer a moment to register,
+        // then resolve ALLOW BEFORE the 500ms budget elapses.
+        try await Task.sleep(nanoseconds: 80_000_000)
+        #expect(delegate.pendingSnapshot().count == 1)
+        let resolved = delegate.resolve(optionId: "opt-allow")
+        #expect(resolved == true)
+
+        let response = try await requestTask.value
+        #expect(response.outcome.outcome == "selected")
+        #expect(response.outcome.optionId == "opt-allow")
+        #expect(delegate.pendingSnapshot().isEmpty)
+    }
+
+    /// #3 — Continuation-safety regression guard: after the user resolves
+    /// first AND the timer would have fired (waited past the budget), no
+    /// second resume / no crash. This is the §4.1 note #1 invariant.
+    @Test func deferPermissionUserResolveThenBudgetDoesNotDoubleFire() async throws {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk, budget: .milliseconds(150))
+        let request = makeRequest(toolCallId: "tc-no-double")
+
+        let requestTask = Task<RequestPermissionResponse, Error> {
+            try await delegate.handlePermissionRequest(request: request)
+        }
+
+        // Resolve BEFORE the 150ms budget elapses, then sleep WELL past it so
+        // the timer task wakes + tries to fire. If the single-resume invariant
+        // is correct, the timer task's `timeOut` finds the entry gone and no-ops.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(delegate.resolve(optionId: "opt-allow") == true)
+        let response = try await requestTask.value
+        #expect(response.outcome.optionId == "opt-allow")
+
+        // Wait past the budget + a generous margin so the detached timer task
+        // has had time to wake + execute its `timeOut` (which must no-op).
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Still empty — no double-resume, no trap. The fact that this test
+        // doesn't crash the process IS the assertion.
+        #expect(delegate.pendingSnapshot().isEmpty)
+    }
+
+    /// #4 — Interactive chat path: `budget: nil` = unbounded. Preserves the
+    /// prior behavior so the UI chip stays the release valve. Verifies the
+    /// request suspends (does NOT auto-reject) for an appreciable window.
+    @Test func budgetNilMeansUnboundedInteractiveBehaviorPreserved() async throws {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk, budget: nil)
+        let request = makeRequest(toolCallId: "tc-unbounded")
+
+        let requestTask = Task<RequestPermissionResponse, Error> {
+            try await delegate.handlePermissionRequest(request: request)
+        }
+
+        // Give a "budget" long enough that a 200ms-equivalent budget (test #1)
+        // would have fired by now. With nil budget, no timer is armed → the
+        // request must still be pending (the only release is an explicit resolve
+        // or cancelAllPending).
+        try await Task.sleep(nanoseconds: 250_000_000)
+        #expect(delegate.pendingSnapshot().count == 1)
+        #expect(requestTask.isCancelled == false)
+
+        // Clean up so the suspended continuation doesn't leak (a leaked
+        // CheckedContinuation warns/traps at task end).
+        _ = delegate.cancelAllPending()
+        _ = await requestTask.result
+    }
+
+    /// #5 — `acceptEdits` on a non-edit tool defers (the second deferring
+    /// callsite). A short budget auto-rejects it the same way `alwaysAsk` does.
+    @Test func acceptEditsNonEditToolAlsoAutoRejects() async throws {
+        let delegate = ACPPermissionDelegate(policy: .acceptEdits, budget: .milliseconds(150))
+        // `.execute` (Bash) is NOT an edit tool per `isEditTool` — it defers.
+        let request = RequestPermissionRequest(
+            options: [
+                PermissionOption(kind: "allow_always", name: "Allow", optionId: "opt-allow"),
+                PermissionOption(kind: "reject_once", name: "Reject", optionId: "opt-reject"),
+            ],
+            sessionId: SessionId("s1"),
+            toolCall: ToolCallUpdate(toolCallId: "tc-ae-timeout", title: "Run bash command", kind: .execute)
+        )
+
+        let response = try await delegate.handlePermissionRequest(request: request)
+
+        #expect(response.outcome.outcome == "cancelled")
+        #expect(delegate.pendingSnapshot().isEmpty)
+    }
+
+    /// #6 — After one request times out, `cancelAllPending()` drains the
+    /// SURVIVOR without double-resuming the already-timed-out entry. The race
+    /// between `timeOut` and `cancelAllPending` is safe.
+    @Test func cancelAllPendingStillDrainsAfterTimeout() async throws {
+        let delegate = ACPPermissionDelegate(policy: .alwaysAsk, budget: .milliseconds(150))
+
+        // Request #1 — will time out.
+        let r1 = makeRequest(toolCallId: "tc-timeout-1")
+        let t1 = Task<RequestPermissionResponse, Error> {
+            try await delegate.handlePermissionRequest(request: r1)
+        }
+        // Request #2 — still pending when #1 times out; the survivor.
+        let r2 = makeRequest(toolCallId: "tc-survivor")
+        let t2 = Task<RequestPermissionResponse, Error> {
+            try await delegate.handlePermissionRequest(request: r2)
+        }
+
+        // Wait long enough for #1's budget to elapse (auto-reject) but not #2's.
+        // The 150ms budget is shared (both pass the same delegate budget), so
+        // they will time out within nanoseconds of each other. To exercise the
+        // race deterministically, resolve #2 via cancelAllPending IMMEDIATELY
+        // after #1 times out — before #2's timer would have fired.
+        let r1Response = try await t1.value
+        #expect(r1Response.outcome.outcome == "cancelled")
+
+        // At this moment #2 may either still be pending (its timer hasn't fired
+        // yet) OR already auto-rejected (its timer fired in the same window).
+        // Either way, `cancelAllPending` must drain without double-resuming #1
+        // (drained count is 0 for empty / 1 for one survivor — never 2).
+        let drained = delegate.cancelAllPending()
+        #expect(drained <= 1)
+        // Drain #2's task — either the auto-reject OR the cancelAllPending resume
+        // surfaced there; either way the continuation was resumed exactly once.
+        _ = await t2.result
+        #expect(delegate.pendingSnapshot().isEmpty)
+    }
+}

--- a/Tests/WikiFSTests/AgentLauncherPermissionModeTests.swift
+++ b/Tests/WikiFSTests/AgentLauncherPermissionModeTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+import WikiFSEngine
+@testable import WikiFSEngine
+
+/// #607 regression suite: per-operation permission policy. Pre-split a single
+/// shared `agentPermissionMode` key fed chat + ingest + lint — a user who chose
+/// `alwaysAsk` for chat got the same gating on an unattended ingest/lint,
+/// guaranteeing a stall on the first prompt needing a permission. Now three
+/// independent keys (`PermissionModeKey.chat`/`.ingest`/`.lint`) feed three
+/// independent `resolvePermissionMode(for:)` branches.
+///
+/// Plus the one-time idempotent migration of the legacy `agentPermissionMode`
+/// value into `chatPermissionMode` (test #9). See `plans/acp-permissions.md`
+/// §5.1, §5.2, §5.3, §8.2 (#7-#10).
+@Suite @MainActor struct AgentLauncherPermissionModeTests {
+
+    /// A fresh, isolated defaults suite (unique per call so tests never observe
+    /// each other's writes). Mirrors `AppStorageMigrationTests`'s shape.
+    private func makeDefaults() -> UserDefaults {
+        let suite = "AgentLauncherPermissionModeTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            Issue.record("could not create UserDefaults suite")
+            return .standard
+        }
+        return defaults
+    }
+
+    /// A launcher whose `resolvePermissionMode` closure reads from an injected
+    /// `UserDefaults` (not `.standard`) so tests don't pollute the real app's
+    /// defaults or see cross-test interference.
+    private func makeLauncher(defaults: UserDefaults) -> AgentLauncher {
+        let launcher = AgentLauncher()
+        launcher.resolvePermissionMode = { op in
+            let key: String
+            let fallback: PermissionPolicy
+            switch op {
+            case .chat:   key = AgentLauncher.PermissionModeKey.chat;   fallback = .bypass
+            case .ingest: key = AgentLauncher.PermissionModeKey.ingest; fallback = .bypass
+            case .lint:   key = AgentLauncher.PermissionModeKey.lint;   fallback = .bypass
+            }
+            let raw = defaults.string(forKey: key) ?? ""
+            return PermissionPolicy(rawValue: raw) ?? fallback
+        }
+        return launcher
+    }
+
+    /// #7 — The diagnosed-bug state from #607, now fixed: chat=`alwaysAsk`,
+    /// ingest=`bypass`. `resolvePermissionMode(for: .ingest)` MUST return
+    /// `.bypass` — independent of the chat setting. Pre-split, both read the
+    /// same key and the wrong policy reached the unattended ingest.
+    @Test func ingestReadsOwnKeyNotChat() {
+        let defaults = makeDefaults()
+        defaults.set(PermissionPolicy.alwaysAsk.rawValue, forKey: AgentLauncher.PermissionModeKey.chat)
+        defaults.set(PermissionPolicy.bypass.rawValue,     forKey: AgentLauncher.PermissionModeKey.ingest)
+
+        let launcher = makeLauncher(defaults: defaults)
+
+        #expect(launcher.resolvePermissionMode(.ingest) == .bypass)
+    }
+
+    /// #8 — Symmetric to #7: the chat policy MUST stay `alwaysAsk` even when
+    /// ingest is `bypass`. The split is bidirectional.
+    @Test func chatPolicyIndependentOfIngest() {
+        let defaults = makeDefaults()
+        defaults.set(PermissionPolicy.alwaysAsk.rawValue, forKey: AgentLauncher.PermissionModeKey.chat)
+        defaults.set(PermissionPolicy.bypass.rawValue,     forKey: AgentLauncher.PermissionModeKey.ingest)
+
+        let launcher = makeLauncher(defaults: defaults)
+
+        #expect(launcher.resolvePermissionMode(.chat) == .alwaysAsk)
+        #expect(launcher.resolvePermissionMode(.ingest) == .bypass)
+        // Lint isn't set here either → defaults to .bypass (the §5.2 fallback).
+        #expect(launcher.resolvePermissionMode(.lint) == .bypass)
+    }
+
+    /// #9 — One-time migration: legacy `agentPermissionMode` →
+    /// `chatPermissionMode`. Idempotent: the second `migrateOnce()` is a no-op
+    /// (the guard predicate `object(forKey:) == nil` fails after the first run
+    /// because the new key is now written).
+    @Test func legacyKeyMigratesIntoChatOnce() {
+        let defaults = makeDefaults()
+        defaults.set(PermissionPolicy.alwaysAsk.rawValue, forKey: "agentPermissionMode")
+
+        // Pre-migration: chat key is unset (object == nil). The legacy key is set.
+        #expect(defaults.object(forKey: AgentLauncher.PermissionModeKey.chat) == nil)
+
+        PermissionModeMigration.migrateOnce(in: defaults)
+
+        // Chat key copies the legacy value.
+        #expect(defaults.string(forKey: AgentLauncher.PermissionModeKey.chat) == PermissionPolicy.alwaysAsk.rawValue)
+        // Copy, not move — the legacy key is left in place (orphaned, like
+        // sandbox-config.json — see plans/acp-permissions.md §5.3).
+        #expect(defaults.string(forKey: "agentPermissionMode") == PermissionPolicy.alwaysAsk.rawValue)
+
+        // Second run is a no-op — the chat key is already set, so the guard
+        // fails. (The legacy key is NOT re-copied; the chat key is NOT overwritten.)
+        PermissionModeMigration.migrateOnce(in: defaults)
+        #expect(defaults.string(forKey: AgentLauncher.PermissionModeKey.chat) == PermissionPolicy.alwaysAsk.rawValue)
+    }
+
+    /// #9b — Idempotent guard predicate is `object(forKey:) == nil`, NOT
+    /// `string(forKey:) == nil`. The two are indistinguishable for "key present
+    /// but empty string" — `object(forKey:)` is the only correct key-presence
+    /// check. A user who manually cleared the chat key to "" must not have it
+    /// overwritten by a re-migration.
+    @Test func migrationGuardUsesObjectForKeyNotNilString() {
+        let defaults = makeDefaults()
+        // Chat key is PRESENT but EMPTY (string == nil distinguishes nothing;
+        // object != nil distinguishes presence).
+        defaults.set("", forKey: AgentLauncher.PermissionModeKey.chat)
+        // Legacy key is also set with a valid value.
+        defaults.set(PermissionPolicy.alwaysAsk.rawValue, forKey: "agentPermissionMode")
+
+        PermissionModeMigration.migrateOnce(in: defaults)
+
+        // Guard correctly rejected: chat key is still "" (NOT overwritten with
+        // "alwaysAsk") because `object(forKey: chatKey)` is non-nil. The legacy
+        // value is left in place too (no migration).
+        #expect(defaults.string(forKey: AgentLauncher.PermissionModeKey.chat) == "")
+        #expect(defaults.string(forKey: "agentPermissionMode") == PermissionPolicy.alwaysAsk.rawValue)
+    }
+
+    /// #10 — Fresh install defaults: every kind resolves to `.bypass` when no
+    /// keys are set. The §5.2 read-time `?? fallback` is the second line of
+    /// defense; `@AppStorage`'s default (in Settings + ChatView) is the first.
+    @Test func defaultsWhenUnset() {
+        let defaults = makeDefaults()
+        let launcher = makeLauncher(defaults: defaults)
+
+        #expect(launcher.resolvePermissionMode(.chat) == .bypass)
+        #expect(launcher.resolvePermissionMode(.ingest) == .bypass)
+        #expect(launcher.resolvePermissionMode(.lint) == .bypass)
+    }
+}

--- a/Tests/WikiFSTests/RunAwaitsTurnTests.swift
+++ b/Tests/WikiFSTests/RunAwaitsTurnTests.swift
@@ -25,7 +25,9 @@ struct RunAwaitsTurnTests {
 
     private func makeLauncher(backend: any AgentBackend) -> AgentLauncher {
         let launcher = AgentLauncher()
-        launcher.resolveBackend = { _ in backend }
+        // #607: resolveBackend closure now takes (policy, budget) — ignore both
+        // (the fake backend ignores permission policy + budget).
+        launcher.resolveBackend = { _, _ in backend }
         launcher.resolveClaude = { .found(path: "/usr/bin/true") }
         launcher.acpCredentialStore = InMemoryACPCredentialStore()
         launcher.resolveSelectedProvider = {
@@ -145,7 +147,7 @@ struct RunAwaitsTurnTests {
         let backend2 = FakeAgentBackend(behaviors: [
             FakeSessionBehavior(events: [.messageStop])
         ])
-        launcher.resolveBackend = { _ in backend2 }
+        launcher.resolveBackend = { _, _ in backend2 }
 
         await runOneShot(launcher: launcher)
         #expect(launcher.isRunning == false)

--- a/plans/acp-permissions.md
+++ b/plans/acp-permissions.md
@@ -1,0 +1,728 @@
+# Plan: ACP permission auto-reject timeout (#606) + per-operation policy split (#607)
+
+> **Status:** Implementation-ready. Author: investigator/planner subagent.
+> **Scope:** Combined fix for GitHub issues **#606** (`bug,correctness`) and
+> **#607** (`bug`) — confirmed to be a **symptom + systemic-fix** pair, NOT
+> independent. See §"Scope decision" for the justification.
+> **Branch:** `feature/acp-permissions` (per CLAUDE.md — never commit to `main`).
+> **References:** `plans/acp-backend-and-permissions.md`, `plans/sandbox-always-on.md`,
+> `plans/sandbox-and-chat-modes.md`, `plans/event-bus.md`.
+> (Optional background: `tmp/ingestion-stall-diagnosis.md` reproduces the
+> root cause #1 + #2 — but §1 reproduces the root cause inline with
+> file:line citations, so the diagnosis file is NOT required for a Paseo
+> worktree that doesn't have it.)
+
+---
+
+## 1. Problem statement + root cause
+
+### 1.1 What stops working (#606)
+
+A single pending `alwaysAsk` (or `acceptEdits` non-edit) permission request
+**blocks an agent turn indefinitely**. In the 2026-07-18 ingestion stall,
+this burned ~48 of ~60 lost minutes: two back-to-back turns each stalled on
+an unapproved permission until the 1800s (30 min) `TurnLivenessPolicy`
+ceiling ceiling-killed them. Ingestion is unattended — nobody is watching
+the transcript to click Approve/Reject.
+
+### 1.2 Root cause (code)
+
+`Sources/WikiFSEngine/ACPPermissions.swift`:
+
+- **`deferPermission` (lines 385–403)** suspends on
+  `withCheckedContinuation` with **no timeout, no escalation, no
+  auto-reject**. The continuation only ever resumes via:
+  - `resolve(optionId:)` (line 458) — the UI's Approve/Reject click, or
+  - `cancelAllPending()` (line 498) — full session teardown in
+    `ACPBackend.cancel()`.
+- That's it. There is **no** time-bounded release for a *live* turn. The
+  only backstop is the 1800s turn ceiling.
+- Called from BOTH deferring policies: `.alwaysAsk` (line 374) AND
+  `.acceptEdits` non-edit tools (line 362).
+
+The ceiling-kill itself (`ACPBackend.send`, watchdog task at line 634,
+`case .ceilingExceeded` at line 653) does:
+`completionFlag.markDone()` → yield turn-end events → `continuation.finish()`
+→ `client.cancelSession(...)` (line 660). It does **not** call
+`cancelAllPending()`. The stuck `deferPermission` continuation is resumed
+indirectly when `cancelSession` tears down the prompt — but only after the
+full 1800s burned. The diagnosis's `permissions.jsonl` timestamps (21:45 and
+22:15, exactly 30 min apart) confirm the permission's `cancelled` outcome
+is written at the moment of ceiling-kill, not before.
+
+`Sources/WikiFSEngine/TurnLivenessPolicy.swift:62`:
+`defaultCeilingTimeout = 1800` (30 min) — **way too generous** for an
+unattended ingest whose only stall is a stuck permission. Even with a 60s
+permission budget, the ceiling is the structural backstop, so it must be
+lowered for queued/ingest operations (tracked separately as #609 — see §6).
+
+### 1.3 Why the wrong policy applied (#607 — the amplifier)
+
+`Sources/WikiFSEngine/AgentLauncher.swift`:
+
+- **`resolvePermissionMode` (lines 197–200)** reads a single shared key:
+  `UserDefaults.standard.string(forKey: AgentLauncher.permissionModeKey)`
+  where `permissionModeKey = "agentPermissionMode"` (line 458). Default
+  `.bypass`.
+- This one closure feeds **three unrelated operation kinds** at three call
+  sites, all of which construct the backend via
+  `resolveBackend(policy)` → `AgentBackendFactory.makeBackend(policy:)`
+  → `ACPBackend(permissionPolicy:)` → installed on the delegate at
+  `ACPBackend.startProcess` line 319:
+  1. **Interactive chat** — `startInteractiveQuery`, line 2020 (also the
+     `.ingest`/`.lint`/`.lintPage` single-session path at line 879 in
+     `run()`).
+  2. **Multi-phase ingest** — `runACPIngestPlannerExecutors`, line 1178
+     (planner + executors + finalizer all share the one `policy`).
+  3. **PDF/text extraction** — `ACPExtractionClient` line 151
+     (`AgentBackendFactory.makeBackend(policy: permissionPolicy)`), whose
+     `permissionPolicy` defaults to `.bypass` but is passed through from
+     the launcher context.
+- **Lint** routes through `AgentOperationRunner.runLint`/`runLintPages`
+  → `run()` → line 879. Same shared key.
+
+So a user who correctly chose "Always Ask" for **interactive chat** got
+`alwaysAsk` applied to a 4-page batch **ingestion** and to **lint**, where
+nobody is watching — guaranteeing a stall on the first prompt needing a
+permission. The sandbox profile (`plans/sandbox-always-on.md`) already
+confines writes to the scratch dir + active wiki DB; bash subprocess writes
+outside that allowlist are blocked by the OS regardless. `alwaysAsk` only
+has *structural* value in interactive chats where the user is reading the
+transcript in real time.
+
+### 1.4 The relationship — why this is ONE combined fix
+
+#607 is the **trigger** (wrong policy reaches an unattended pipeline) and
+#606 is the **consequence** (a pending permission then has no bounded
+release). The diagnosis ranks them as root cause #2 (policy mismatch) and
+root cause #1 (no timeout) of the *same* stall. Fixing only #606 leaves an
+unattended ingest still able to stall for the full 60s budget on every
+prompt — tolerable but wasteful, and a user who *intentionally* sets ingest
+to `alwaysAsk` would still hit it. Fixing only #607 removes the common case
+but leaves the core defect: *any* deferring policy (alwaysAsk, or
+acceptEdits on a non-edit tool) can hang a turn until the ceiling. **Both
+are needed.** See §6 for why the timeout is the belt-and-suspenders
+backstop that makes the policy split safe to ship.
+
+---
+
+## 2. Scope decision: COMBINED #606 + #607
+
+**Chosen:** Implement both in one PR on `feature/acp-permissions`.
+
+Rationale:
+- They are the #1 + #2 root causes of a single diagnosed incident. Shipping
+  them together retires the stall end-to-end and lets the PR description
+  tell one coherent story (issue cluster #606/#607).
+- The timeout (#606) is the load-bearing correctness fix and is small and
+  self-contained (one function + tests). The policy split (#607) is
+  config + one call-site each + a Settings UI change.
+- The two touch overlapping files (`ACPPermissions.swift`, the launcher,
+  Settings UI) minimally; doing them separately would churn the same lines
+  twice.
+
+**In scope:**
+- A bounded auto-reject budget on `deferPermission` (#606).
+- Per-operation permission keys: `chat` / `ingest` / `lint` (and
+  `extraction`) with sensible defaults (#607), plus a one-time migration
+  of the legacy `agentPermissionMode` value into `chatPermissionMode`.
+- Settings UI: replace the single Permission Mode picker with per-operation
+  pickers (or keep chat as the primary picker + explicit ingest/lint/extract
+  pickers — see §5.3 for the UI decision).
+- Diagnostics: log the timeout (DebugLog) so the failure is visible in
+  Console.app (never bare `try?` / never `print`).
+
+**NOT in scope** (separate issues — see §6):
+- #608 Activity-window surfacing of *pending* permissions (yellow row).
+- #609 lowering the queued-ingest turn ceiling (1800s → ~600s).
+- #610 ceiling-kill retry running blind into the same pending-permission
+  pattern.
+- Any prompt changes (`prompts/ingest-executor.md` scope drift — diagnosis
+  root cause #3/#4).
+- The stale `sandbox-config.json` orphan (already documented in
+  `plans/sandbox-always-on.md`).
+
+---
+
+## 3. House rules (Non-negotiable for the implementer)
+
+- **Branch:** `feature/acp-permissions`. Push the branch, open a PR. **Never
+  merge to `main` yourself** — merging happens after review + CI green.
+- **Diagnostics:** route ALL logging through `DebugLog` (os_log, subsystem
+  `com.selfdrivingwiki.debug`). **Never bare `try?`** to swallow errors —
+  use `do { try … } catch { DebugLog.agent(…) }` (see CLAUDE.md — bare
+  `try?` has already caused lost transcripts). **Never `print`** for
+  diagnostics (except real CLI stdout in `wikictl`).
+- **Read first:** `CLAUDE.md`, `SWIFTUI-RULES.md` (this touches Settings
+  UI). Load and follow the design skills before writing SwiftUI:
+  - `docs/skills/swiftui-pro/SKILL.md` (filter version-gated guidance to
+    macOS 15 / Swift 6.0 — it targets iOS 26 / Swift 6.2).
+  - `docs/skills/macos-design/SKILL.md` (translate CSS/web terms to SwiftUI;
+    `.regularMaterial`, points, system faces).
+  - `docs/skills/typography-designer/SKILL.md` (consistent type scales,
+    visual hierarchy — see the existing Settings picker style and match it).
+- **Tests:** prefer **Swift Testing** (`@Test func`) over XCTest for new
+  tests. Follow `docs/skills/swift-testing-pro/SKILL.md` (core-rules,
+  async-tests). Slow/new real-DB suites: tag `.integration` AND append to
+  the fast-tier `--skip` regex in `.github/workflows/ci.yml`.
+- **Concurrency:** this fix spans an `AsyncStream` (the turn stream in
+  `ACPBackend.send`) and `@unchecked Sendable` lock-protected state in
+  `ACPPermissionDelegate`. Consult
+  `docs/skills/swift-concurrency-pro/SKILL.md` (`actors`,
+  `unstructured`, `cancellation`, `bug-patterns`) before touching the
+  continuation/timer. See §7.
+- **SQLite:** this fix does **not** touch the store. The timeout is purely
+  in-process (`ACPPermissionDelegate`); the policy split is in UserDefaults
+  + the launcher. If for some reason a store write is introduced, EVERY new
+  public mutator on `SQLiteWikiStore` MUST route through `mutate()` and emit
+  a `ResourceChangeEvent` — see `plans/event-bus.md` and the
+  `StoreEmissionExhaustivenessTests` guard.
+
+---
+
+## 4. Implementation — #606: bounded auto-reject on `deferPermission`
+
+### 4.1 The timeout
+
+Replace the indefinite `withCheckedContinuation` in `deferPermission`
+(`Sources/WikiFSEngine/ACPPermissions.swift:385-403`) with a race between
+the user-resolution continuation and a budget timer. When the budget
+elapses first, auto-reject: remove the pending entry from the map and
+return a `cancelled` outcome (the agent treats `cancelled` as denied and
+adapts — it already does for denied tools).
+
+**Primary approach: detached-timer form (do NOT use a `TaskGroup`).**
+
+A `withTaskGroup` sketch was considered and **rejected** — awaiting
+`group.next()` from inside one of the group's own child tasks is a
+data race (the group is non-`Sendable` and `next()` is mutating) and will
+not compile cleanly under Swift 6.0 strict concurrency. The detached-timer
+form below is the path of least resistance because it preserves the
+existing `removeValue`-then-resume discipline verbatim.
+
+Sketch (refine at implementation):
+
+```swift
+private static func deferPermission(
+    request: RequestPermissionRequest,
+    lock: OSAllocatedUnfairLock<LockedState>,
+    budget: Duration? = .seconds(60)   // NEW default; nil = unbounded (interactive chat)
+) async -> RequestPermissionResponse {
+    // Single continuation — same shape as today, just with an armed timer.
+    return await withCheckedContinuation { (cont: CheckedContinuation<RequestPermissionResponse, Never>) in
+        let timer: Task<Void, Never>? = budget.map { b in
+            Task { [toolCallId = request.toolCall.toolCallId] in
+                do {
+                    try await Task.sleep(for: b)
+                } catch {
+                    // CancellationError — expected when resolve() / cancelAllPending()
+                    // cancelled the timer first. Cooperative lifecycle event, not a
+                    // hidden failure (see §3 house rule carve-out).
+                    return
+                }
+                // Budget elapsed before the user resolved → auto-reject.
+                // timeOut mirrors resolve: removeValue under the lock, then resume.
+                Self.timeOut(toolCallId: toolCallId, lock: lock)
+            }
+        }
+        lock.withLock { state in
+            state.pending[request.toolCall.toolCallId] = Pending(
+                options: request.options,
+                toolName: /* unchanged */ nil,
+                inputSummary: /* unchanged */ nil,
+                continuation: cont,
+                timer: timer)   // NEW field on Pending; store so resolve/cancel can cancel it
+        }
+    }
+}
+
+// NEW — mirror of resolve(optionId:) but resolving as `cancelled`.
+// Called from the detached-timer task when the budget elapses first.
+private static func timeOut(
+    toolCallId: String,
+    lock: OSAllocatedUnfairLock<LockedState>
+) {
+    let drained = lock.withLock { state -> (CheckedContinuation<RequestPermissionResponse, Never>, Task<Void, Never>?)? in
+        guard let pending = state.pending.removeValue(forKey: toolCallId) else { return nil }
+        return (pending.continuation, pending.timer)
+    }
+    guard let (cont, _) = drained else {
+        // resolve() or cancelAllPending() already won the race — nothing to do.
+        return
+    }
+    DebugLog.agent("ACPBackend: permission budget exceeded — auto-reject toolCallId=\(toolCallId)")
+    cont.resume(returning: RequestPermissionResponse(outcome: PermissionOutcome(cancelled: true)))
+}
+```
+
+**Wire the timer cancellation into `resolve` and `cancelAllPending`.**
+Both already do `removeValue` / `removeAll` under the lock before resuming
+(line ~462-466 resolve, ~498-509 cancelAllPending). Extend them to also
+cancel the stored timer on the removed `Pending`, so no stray timer fires
+after the user resolved first or after teardown:
+
+```swift
+// In resolve(optionId:) — inside the lock, after removeValue:
+if let timer = removedPending.timer { timer.cancel() }
+// … then resume removedPending.continuation as today.
+
+// In cancelAllPending() — inside the lock, after removeAll:
+for (_, pending) in removed { pending.timer?.cancel() }
+// … then resume each continuation as today.
+```
+
+> **Implementation note — the load-bearing invariants:**
+> 1. **Exactly one** `resume` per `CheckedContinuation` (a double-resume
+>    traps; a missed resume warns/traps at task end). The `removeValue`-
+>    then-resume discipline in `resolve` (line ~462-466), `cancelAllPending`
+>    (line ~498-509), AND the new `timeOut(toolCallId:)` is what guarantees
+>    this: whichever wins the race pulls the entry out of the map under the
+>    lock, so the others find nothing to resume. See
+>    `docs/skills/swift-concurrency-pro/SKILL.md` (`bug-patterns`:
+>    "Continuation resumed twice → restructure so only one path reaches the
+>    continuation").
+> 2. **Store the timer on `Pending`** so `resolve`/`cancelAllPending` can
+>    cancel it. Without this, a timer fires after teardown, hits the empty
+>    map look-up (the `guard let drained` no-op), and is harmless but
+>    wasteful — storing + cancelling is the cleaner lifecycle.
+> 3. `Pending` gains one field: `let timer: Task<Void, Never>?`. Existing
+>    call sites that construct `Pending` without a timer (if any outside
+>    `deferPermission`) pass `nil`.
+> 4. The `permissionTimedOut(toolCallId:)` signal (#608 surface) should be
+>    emitted from the `timeOut` branch so a future subscriber can show it —
+>    but the Activity-window rendering itself is #608 (out of scope). For
+>    now, the `DebugLog.agent` line in `timeOut` suffices.
+> 5. **TaskGroup approach: do NOT use.** A `withTaskGroup` sketch where a
+>    child task awaits `group.next()` on the same group does not compile
+>    under Swift 6.0 strict concurrency (non-Sendable + mutating access).
+>    The detached-timer form above is the committed approach.
+
+**§3 house-rule carve-out for `Task.sleep`:** `Task.sleep` only throws
+`CancellationError` (cooperative cancellation — expected when `resolve` or
+`cancelAllPending` cancels the timer). Writing `do { try await Task.sleep… }
+catch { return }` with the comment above is the idiomatic, letter-of-rule
+form (`docs/skills/swift-concurrency-pro/SKILL.md` `bug-patterns`:
+"Ignoring CancellationError in catch blocks"). Do **not** write bare
+`try? await Task.sleep(...)` — it contradicts §3's no-bare-`try?` rule even
+though the spirit holds.
+
+### 4.2 Propagating the timeout to the turn
+
+Today, on `cancelled`, the agent gets a denied-permission outcome and
+continues its turn (it adapts to denied tools). That is the desired
+behavior for #606 — the turn continues instead of burning the ceiling. No
+new error type strictly needs to propagate to `sendPrompt`; the `cancelled`
+outcome IS the auto-reject. (Issue #606's sketch mentioned a
+`PermissionTimedOut` error, but the existing `cancelled` path achieves the
+same agent recovery and avoids a new error case threading through the SDK.
+If the reviewer wants an explicit signal, add a `DebugLog` line + an
+optional callback hook `onPermissionTimeout: ((String) -> Void)?` on the
+delegate, wired to the launcher for #608's future use — but do not change
+the `RequestPermissionResponse` shape.)
+
+### 4.3 Where the budget is set
+
+Make `budget` a parameter with a sensible default, threaded from
+`ACPPermissionDelegate.init(policy:debugLogger:budget:)` so an interactive
+chat can pass a larger budget (or none → unbounded, preserving current
+behavior for the interactive case) while ingest/lint/extraction pass the
+default 60s. Concretely:
+- `ACPPermissionDelegate.init(policy:debugLogger:budget:)` — new
+  `budget: Duration?` (nil ⇒ no timer = current behavior; non-nil ⇒ auto-reject).
+- `ACPBackend.start` / `startProcess` (line 319) passes `permissionBudget`
+  (a new stored property on `ACPBackend`, set from `init`) into the delegate.
+- `ACPBackend.init(permissionPolicy:budget:)` gains a `budget: Duration?`.
+- `AgentBackendFactory.makeBackend(policy:budget:)` gains `budget:
+  Duration? = nil`.
+- The three launcher call sites pass the operation-appropriate budget (see
+  §5.4).
+
+> **Important:** `withCheckedContinuation`/`Task.sleep` run on a background
+> task and **do not** hop to the main actor — the delegate is deliberately
+> `@unchecked Sendable` with lock-protected state (see the class doc,
+> lines 306-311). Keep it that way. Do not introduce `@MainActor` isolation
+> on the delegate.
+
+---
+
+## 5. Implementation — #607: per-operation permission policy
+
+### 5.1 New keys
+
+Replace the single `agentPermissionMode` key with operation-scoped keys:
+
+```swift
+// AgentLauncher.swift — replace `permissionModeKey` (line 458)
+public enum PermissionModeKey {
+    public static let chat       = "chatPermissionMode"
+    public static let ingest      = "ingestPermissionMode"
+    public static let lint        = "lintPermissionMode"
+}
+```
+
+> **`extractionPermissionMode` is intentionally NOT added in this PR.**
+> `ACPExtractionClient.init` defaults its policy to `.bypass`
+> (`Sources/WikiFSEngine/ACPExtractionClient.swift:86`) and may be
+> constructed outside the launcher (e.g. from the queue path — exact call
+> sites not enumerated). Rather than ship a half-wired `extraction` key
+> whose callers haven't been confirmed to thread
+> `resolvePermissionMode(for: .extraction)`, leave extraction on its
+> existing `.bypass` default and drop the key from `PermissionModeKey`
+> until a caller actually needs it. This keeps the split strictly
+> chat/ingest/lint — three keys, three pickers, all verified end-to-end.
+> If enumeration later finds every `ACPExtractionClient()` construction
+> passes the extraction key, a follow-up PR can add it. Extraction is
+> read-heavy; `.bypass` is the correct default anyway.
+
+Defaults (per #607's rationale + sandbox-always-on):
+- `chat` → whatever the user set (default `.bypass`).
+- `ingest`  → `.bypass` (sandbox already confines writes; unattended pipeline).
+- `lint`    → `.bypass` (same).
+- `extraction` → `.bypass` (a one-shot read+convert; reads are ungated anyway).
+
+### 5.2 Split `resolvePermissionMode`
+
+Rename to `resolvePermissionMode(for operation: OperationKind) ->
+PermissionPolicy` (or three small closures, one per kind — match the
+existing injectable-closure style at lines 190-200 so tests can stub each).
+`OperationKind` = an enum `{ chat, ingest, lint, extraction }` (do NOT
+reuse `WikiOperation.Kind` — that's the *run* kind; the permission kind is
+a policy-domain concept; keep them separate to avoid coupling).
+
+Each branch reads its own UserDefaults key with its own default:
+```swift
+@ObservationIgnored var resolvePermissionMode:
+    (OperationKind) -> PermissionPolicy = { op in
+        let key: String
+        let fallback: PermissionPolicy
+        switch op {
+        case .chat:   key = PermissionModeKey.chat;   fallback = .bypass
+        case .ingest: key = PermissionModeKey.ingest; fallback = .bypass
+        case .lint:   key = PermissionModeKey.lint;   fallback = .bypass
+        }
+        let raw = UserDefaults.standard.string(forKey: key) ?? ""
+        return PermissionPolicy(rawValue: raw) ?? fallback
+    }
+```
+
+> **`OperationKind` = `{ chat, ingest, lint }` only** (no `.extraction`
+> case — extraction stays on its existing `.bypass` `ACPExtractionClient`
+> default; see §5.1). Do NOT reuse `WikiOperation.Kind` (that's the *run*
+> kind; the permission kind is a policy-domain concept; keep them separate
+> to avoid coupling).
+
+### 5.3 One-time migration of the legacy key
+
+On first launch after this change, if `chatPermissionMode` is unset AND the
+legacy `agentPermissionMode` has a value, copy it into
+`chatPermissionMode` and leave `agentPermissionMode` in place (don't delete
+— avoids surprises; it's just orphaned, like `sandbox-config.json`). Do this
+in a small `PermissionModeMigration.migrateOnce()` called from app startup
+(launcher init or `WikiFSApp`), guarded so it's idempotent. Log via
+`DebugLog.agent` when it migrates.
+
+```swift
+enum PermissionModeMigration {
+    static func migrateOnce() {
+        // Only migrate if the new chat key has NEVER been written (object == nil).
+        if UserDefaults.standard.object(forKey: PermissionModeKey.chat) == nil,
+           let legacy = UserDefaults.standard.string(forKey: "agentPermissionMode"),
+           !legacy.isEmpty,
+           let policy = PermissionPolicy(rawValue: legacy) {
+            UserDefaults.standard.set(policy.rawValue, forKey: PermissionModeKey.chat)
+            DebugLog.agent("PermissionModeMigration: copied legacy agentPermissionMode=\(policy.rawValue) -> chatPermissionMode")
+        }
+    }
+}
+```
+
+This is idempotent: after the first run, `object(forKey: PermissionModeKey.chat)`
+is non-nil (we just wrote it), so the guard fails on subsequent launches.
+
+The guard predicate (`object(forKey:) == nil`, NOT `string(forKey:) == nil`)
+matters because `string(forKey:)` cannot distinguish "key absent" from
+"key present but empty string" — `object(forKey:) == nil` is the only
+correct key-presence check. Test §8.2 #9 asserts this idempotency, so the
+implementation predicate must match.
+
+### 5.4 Wire the call sites
+
+Update the three call sites to request the right kind + budget:
+
+| Call site (AgentLauncher.swift)                  | Operation | Policy kind | Budget |
+|--------------------------------------------------|-----------|-------------|--------|
+| `startInteractiveQuery` line ~2020               | chat      | `.chat`     | nil (interactive — unbounded, current behavior) |
+| `run()` single-session path line ~879            | ingest/lint | derived from `operation` kind | `.seconds(60)` |
+| `runACPIngestPlannerExecutors` line ~1178        | ingest    | `.ingest`   | `.seconds(60)` |
+
+For `run()` (line 879), the operation kind is known from the `operation:
+WikiOperation` in scope — map `.lint`/`.lintPage` → `.lint`, `.ingest` →
+`.ingest`, else `.chat`. Pass the resolved budget into `resolveBackend`.
+
+> **`ACPExtractionClient` is NOT touched in this PR.** It keeps its existing
+> `permissionPolicy: .bypass` default (`ACPExtractionClient.swift:86`) and
+> its existing caller — extraction is read-heavy, `.bypass` is correct, and
+> the call sites weren't fully enumerated (see §5.1 note). A follow-up can
+> thread the extraction key if a caller needs configurable extraction policy.
+
+### 5.5 Settings UI
+
+- **File:** `Sources/WikiFS/Settings/AgentsSettingsView.swift` (currently a
+  single `@AppStorage(AgentLauncher.permissionModeKey)` picker at line 364).
+- Replace the single "Permission Mode" picker with per-operation pickers in
+  **Settings → Agents → Permissions**:
+  - "Chat Permission Mode" → `PermissionModeKey.chat`
+  - "Ingest Permission Mode" → `PermissionModeKey.ingest`
+  - "Lint Permission Mode" → `PermissionModeKey.lint`
+  - (No extraction picker — extraction has no user-facing key in this PR; see §5.1.)
+- Each picker reuses the existing `Picker(... ForEach(PermissionPolicy.allCases))`
+  pattern (line 364-366). Keep the help text (`PermissionPolicy.help`) per
+  picker.
+- **Each new `@AppStorage(PermissionModeKey.<x>)` binding MUST declare its
+  raw-value default exactly as the existing single picker does** — the
+  current code is
+  `@AppStorage(AgentLauncher.permissionModeKey) private var permissionModeRaw = PermissionPolicy.bypass.rawValue`
+  (`Sources/WikiFS/Chats/ChatView.swift:53`; same shape at
+  `Sources/WikiFS/Settings/AgentsSettingsView.swift:364`). That default
+  (`= PermissionPolicy.bypass.rawValue`) is load-bearing — without it the
+  picker's initial selection is undefined. For the split, declare one such
+  binding per key:
+  ```swift
+  @AppStorage(PermissionModeKey.chat)     private var chatModeRaw     = PermissionPolicy.bypass.rawValue
+  @AppStorage(PermissionModeKey.ingest)   private var ingestModeRaw   = PermissionPolicy.bypass.rawValue
+  @AppStorage(PermissionModeKey.lint)     private var lintModeRaw     = PermissionPolicy.bypass.rawValue
+  ```
+- Also update `Sources/WikiFS/Chats/ChatView.swift:53` — its
+  `@AppStorage(AgentLauncher.permissionModeKey)` chip (line 435
+  `PermissionModeSelector`) should point at `PermissionModeKey.chat` (the
+  in-chat composer only governs the chat policy now). Preserve the
+  `= PermissionPolicy.bypass.rawValue` default on the renamed binding.
+
+> **UI house rule:** follow `macos-design` + `typography-designer` + the
+> existing Settings visual language. A small grouped section with a header
+> explaining "These control how the app responds to the agent's permission
+> requests for each operation. Ingest and Lint run unattended — Bypass is
+> recommended." Keep type scale consistent with nearby pickers.
+
+---
+
+## 6. Cluster of issues — what this retires, what stays
+
+| Issue | Title | Status w/ this fix |
+|-------|-------|--------------------|
+| #606 | `alwaysAsk` blocks forever — auto-reject timeout | ** FIXED in scope** (§4). |
+| #607 | Permission policy shared chat/ingest/lint — split | ** FIXED in scope** (§5). |
+| #608 | Activity window silent on permission stalls | **OUT of scope** — the plumbing (a `DebugLog` line + an optional `onPermissionTimeout` hook on the delegate) is laid, but the `QueueActivityTracker.pendingPermission(for:)` + `ActivityWindowView` yellow row is its own PR. Leave #608 open with a comment noting the hook is present. |
+| #609 | Queued-ingest turn ceiling 1800s → ~600s | **OUT of scope** (separate issue). Even with the 60s permission budget, lowering the ceiling is a separate, independently-reviewable change to `TurnLivenessPolicy.defaultCeilingTimeout` (or a per-operation ceiling). Flag as the next follow-up. Do NOT change the ceiling here. |
+| #610 | Ceiling-kill retry runs blind into same pattern | **OUT of scope** — depends on #608 (pending-permission history surfaced to the retry). Leave open. |
+
+### In-scope vs. follow-up summary
+
+- **In scope:** #606 (timeout) + #607 (policy split). One PR.
+- **Follow-up #1:** #608 (pending-permission Activity surfacing) — build on
+  the `onPermissionTimeout` hook + `pendingSnapshot()` added here.
+- **Follow-up #2:** #609 (lower ingest ceiling).
+- **Follow-up #3:** #610 (retry awareness of pending-permission history).
+
+---
+
+## 7. Cross-cutting concerns
+
+### 7.1 Concurrency / Sendable / AsyncStream
+
+- **`ACPPermissionDelegate`** is `final class … @unchecked Sendable`
+  (lines 306-311). It holds all mutable state behind an
+  `OSAllocatedUnfairLock<LockedState>`. The timeout's `Task.sleep` runs on a
+  detached/background task and must only touch the delegate via the lock —
+  same discipline as `resolve`/`cancelAllPending`. Do NOT add `@MainActor`.
+- The timeout races inside `handlePermissionRequest`, which is called from
+  the SDK's `ClientDelegate` channel — NOT from the turn's `AsyncStream`
+  continuation directly. The turn stream (`ACPBackend.send`, line 614)
+  yields events; the permission suspend happens *inside* `sendPrompt`
+  (line 667+, the prompt task) which blocks on the delegate. So the timeout
+  releasing the continuation *unblocks the prompt task*, which then drives
+  the stream normally. No direct `AsyncStream` plumbing change.
+- **Continuation safety:** the single `resume` invariant (§4.1 note) is the
+  critical correctness property. A leaked or double-resumed
+  `CheckedContinuation` traps at task end. The `StoreEmissionTests`-
+  style exhaustiveness guard doesn't apply here (no store), but the test
+  plan (§8) covers the race explicitly.
+- Consult `docs/skills/swift-concurrency-pro/SKILL.md` (`unstructured`
+  tasks, `cancellation` for `Task.sleep`, and `bug-patterns` for
+  continuation pitfalls) before finalizing §4.1. The committed approach
+  is the detached-timer form (see §4.1) — do NOT use a `TaskGroup`.
+
+### 7.2 SQLite
+
+- **No store changes.** The permission policy + timeout live entirely in
+  UserDefaults + the in-process `ACPPermissionDelegate`. No new
+  `SQLiteWikiStore` public mutator. If an implementer is tempted to persist
+  permission history for #610 — that's #610's scope, not here, and would
+  require the full `mutate()` + `ResourceChangeEvent` discipline
+  (`plans/event-bus.md`).
+
+### 7.3 Retry / ceiling interaction
+
+- The 60s budget is **per permission request**, not per turn. A turn with
+  several deferred permissions could still accumulate, but each auto-rejects
+  at 60s, so the worst case is bounded per-request. The 1800s ceiling
+  remains the turn-level backstop (unchanged here — #609 lowers it).
+- On a ceiling-kill, the existing `cancelSession` (line 660) + the eventual
+  `ACPBackend.cancel()` → `cancelAllPending()` (line 975) still drain any
+  in-flight continuations — so the timeout doesn't change teardown safety.
+
+---
+
+## 8. Test plan
+
+### 8.1 Existing coverage to keep green (do NOT break)
+
+- `Tests/WikiFSTests/ACPBackendTests.swift` — the `@Test func alwaysAsk*` /
+  `yolo*` / `resolveUnknownOption*` family (lines ~202-346) constructs a
+  delegate + `RequestPermissionRequest`, suspends on a `Task`, and asserts
+  `pendingSnapshot()`/`resolve`. The timeout must not break these:
+  - `alwaysAskDefersUntilResolved` (256) — resolves before any budget
+    elapses; with a 60s default budget this still passes (no timeout fires).
+  - `alwaysAskResolvesDeny` (300), `resolveUnknownOptionReturnsFalse` (328)
+    — same.
+  - The new budget default MUST be large enough (or the tests must pass an
+    explicit `budget: nil`) so existing tests don't flake. Prefer: tests
+    construct the delegate with an explicit budget so they're deterministic.
+- `Tests/WikiFSTests/ACPWiringTests.swift`, `AgentProviderModelTests.swift`
+  — wiring; ensure the new `makeBackend(policy:budget:)` signature / key
+  changes don't break them (update call sites).
+- `AgentCASests.swift`, `ACPStallRecoveryTests.swift`,
+  `GenerationGate*Tests.swift`, `AgentOperationRunnerTests.swift` — run the
+  fast tier (`swift test --skip '...'` per CLAUDE.md) and ensure green.
+
+### 8.2 NEW tests (Swift Testing, `@Test func`)
+
+Add to a new `Tests/WikiFSTests/ACPPermissionTimeoutTests.swift` (fast-tier,
+no `.integration`):
+
+1. **`deferPermissionAutoRejectsAfterBudget`** — construct a delegate with
+   `policy: .alwaysAsk` and `budget: .milliseconds(200)`; call
+   `handlePermissionRequest`; never call `resolve`; assert the response
+   comes back with `outcome.cancelled == true` within ~250ms. (Mirror the
+   `alwaysAskDefersUntilResolved` harness — suspend on a `Task`, await with a
+   short timeout.) This is the #606 repro-becomes-test.
+2. **`deferPermissionUserResolveBeatsBudget`** — same delegate
+   (`budget: .milliseconds(200)`); call `resolve(optionId: "opt-allow")`
+   after ~50ms; assert the response is the ALLOW outcome (not cancelled)
+   — the budget timer lost the race.
+3. **`deferPermissionUserResolveThenBudgetDoesNotDoubleFire`** — resolve
+   fast; then wait past the budget; assert no crash / no second resume
+   (the continuation-safety invariant, §4.1 note 1). This is the regression
+   guard for the subtle race.
+4. **`budgetNilMeansUnboundedInteractiveBehaviorPreserved`** — delegate
+   with `budget: nil` + `.alwaysAsk`; assert it suspends indefinitely (as
+   before) — i.e. the interactive chat path is unchanged.
+5. **`acceptEditsNonEditToolAlsoAutoRejects`** — `.acceptEdits` policy on a
+   non-edit tool (so it defers, line 362) with a small budget; assert
+   auto-reject (covers the second deferring callsite).
+6. **`cancelAllPendingStillDrainsAfterTimeout`** — a timed-out request +
+   a still-pending one; `cancelAllPending()` drains the survivor without
+   double-resuming the already-timed-out one.
+
+Add to `Tests/WikiFSTests/AgentLauncherPermissionModeTests.swift` (fast-tier):
+
+7. **`ingestReadsOwnKeyNotChat`** — set
+   `chatPermissionMode = .alwaysAsk`, `ingestPermissionMode = .bypass`;
+   assert `resolvePermissionMode(for: .ingest) == .bypass`. (This is the
+   exact diagnosed-bug state from #607, now fixed.)
+8. **`chatPolicyIndependentOfIngest`** — set chat=`alwaysAsk`,
+   ingest=`bypass`; assert `resolvePermissionMode(for: .chat) ==
+   .alwaysAsk`.
+9. **`legacyKeyMigratesIntoChatOnce`** — set legacy
+   `agentPermissionMode = "alwaysAsk"`; run `PermissionModeMigration.migrateOnce()`;
+   assert `chatPermissionMode == "alwaysAsk"` and a second `migrateOnce()`
+   is a no-op (idempotent).
+10. **`defaultsWhenUnset`** — clear all keys; assert each kind resolves to
+    `.bypass`.
+
+### 8.3 What NOT to add
+
+- No live-agent integration test (needs a real ACP agent subprocess + creds —
+  the spike can't validate this end-to-end; the diagnosis already did the
+  empirical validation). Keep all new tests pure/unit.
+
+### 8.4 CI
+
+- `swift build` clean.
+- Fast tier: `swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'`
+  — green. If a new slow suite is introduced, tag `.integration` AND append
+  its name to the `--skip` regex in `.github/workflows/ci.yml` (both Swift
+  jobs run; the integration job is the gating one).
+- Full `swift test` locally before opening the PR (both jobs must be green
+  in CI).
+
+---
+
+## 9. Acceptance criteria (the PR must satisfy all)
+
+1. **#606 repro no longer hangs:** a deferred permission request that is
+   never resolved returns `cancelled` within `budget + ε` (≤ ~65s at the
+   default 60s budget), instead of blocking until the 1800s ceiling. Proven
+   by test #1 (§8.2).
+2. **No continuation leak / double-resume:** the race is safe — proven by
+   tests #2, #3, #6.
+3. **Interactive chat unchanged:** with `budget: nil`, `alwaysAsk`
+   suspends indefinitely (current behavior). Proven by test #4.
+4. **#607 policy split:** `resolvePermissionMode(for: .ingest)` reads
+   `ingestPermissionMode`, independent of chat. Proven by tests #7, #8.
+   Default for ingest/lint/extraction is `.bypass`.
+5. **Migration:** legacy `agentPermissionMode` migrates to
+   `chatPermissionMode` once, idempotently. Proven by test #9.
+6. **Settings UI:** three (or four) per-operation pickers replace the
+   single Permission Mode picker; the chat composer chip governs chat only.
+7. **Diagnostics:** the timeout logs via `DebugLog.agent` (visible in
+   Console.app). No bare `try?`, no `print`.
+8. **CI green** on BOTH Swift jobs (`swift` fast tier +
+   `swift-integration`).
+9. **No tree pollution:** the implementer works on `feature/acp-permissions`;
+   `main` stays pristine. No scratch files (`pr-body.md`, etc.) committed.
+10. **No regression** to existing `ACPBackendTests` permission family.
+
+---
+
+## 10. Risks / unknowns / things to verify at implementation time
+
+- **The continuation race (§4.1) is the hard part.** The committed
+  detached-timer form has correctness implications (single resume). The
+  existing `removeValue`-then-resume discipline in
+  `resolve`/`cancelAllPending` is the model; the new `timeOut(toolCallId:)`
+  mirrors it. Do NOT switch to a `TaskGroup` form — awaiting `group.next()`
+  from a child task of the same group does not compile under Swift 6.0
+  strict concurrency (see §4.1 note #5). If unsure, consult
+  `docs/skills/swift-concurrency-pro/SKILL.md` `bug-patterns`.
+- **Budget value.** 60s is the issue's proposed default. For *interactive*
+  chat, `nil` (unbounded) preserves current behavior — but consider whether
+  an interactive stall should ALSO get a generous interactive budget (e.g.
+  5 min) as a safety net. Out of strict scope but worth a flag for the
+  reviewer. Default to `nil` for chat to avoid behavior change unless
+  asked.
+- **`ACPExtractionClient` policy** currently defaults to `.bypass` (line
+  86) and may be constructed outside the launcher (e.g. from the queue).
+  Extraction is **intentionally NOT touched in this PR** (see §5.1 note) —
+  the call sites weren't fully enumerated, and `.bypass` is the correct
+  default for read-heavy extraction anyway. A follow-up PR can thread a
+  configurable `extractionPermissionMode` key if a caller needs it.
+- **`OperationKind` naming** — don't collide with `WikiOperation.Kind`.
+  Keep the permission-domain enum separate.
+- **Settings UI clutter** — three pickers (chat/ingest/lint) may be noisy.
+  The reviewer may prefer chat as primary + an "Advanced: per-operation"
+  disclosure. Implement the straightforward grouped version first; defer
+  the disclosure refactor if it reads as clutter.
+- **`onPermissionTimeout` hook** (optional, for #608) — adding it now is
+  cheap and sets up #608, but it's strictly plumbing. If the reviewer wants
+  to keep the PR minimal, drop the hook and rely on `DebugLog` alone;
+  #608 can add the hook when it builds the Activity row.
+- **Does the budget need to be cancellable on session teardown?** Yes — a
+  stray budget timer firing after `cancelAllPending()` is benign (it
+  `removeValue`s, finds nothing, no-ops) but should be cancelled for
+  cleanliness. The detached-timer form stores the `Task` on `Pending` and
+  cancels it in both `cancelAllPending` and `resolve` (see §4.1 "Wire the
+  timer cancellation"). This is specified, not an open question.
+- **No live end-to-end validation possible** in this environment (no ACP
+  agent + creds). The unit tests + the diagnosis's empirical trace are the
+  evidence. The implementer should not block on a live repro.


### PR DESCRIPTION
# ACP permission auto-reject timeout (#606) + per-operation policy split (#607)

Closes #606. Closes #607.

Plan: [`plans/acp-permissions.md`](plans/acp-permissions.md).

## Root cause

The 2026-07-18 ingestion stall lost ~48 of ~60 minutes to two back-to-back turns each blocking indefinitely on an unapproved permission — until the 1800s (30 min) `TurnLivenessPolicy` ceiling killed them. Two root causes (in order of severity, from `tmp/ingestion-stall-diagnosis.md`):

1. **#606 — no bounded release.** `ACPPermissionDelegate.deferPermission` (`Sources/WikiFSEngine/ACPPermissions.swift:385-403`) suspends on `withCheckedContinuation` with no timeout, no escalation, no auto-reject. The continuation only ever resumes via the UI's Approve/Reject click (`resolve(optionId:)`) or full session teardown (`cancelAllPending()`). For an unattended ingest/lint pipeline **nobody is watching the transcript** — the turn burns the full 1800s ceiling.

2. **#607 — one shared policy for unrelated operation kinds.** `AgentLauncher.resolvePermissionMode` read a single `@AppStorage("agentPermissionMode")` key and fed it to chat + ingest + lint at three call sites (`startInteractiveQuery` L2031, `run()` L879, `runACPIngestPlannerExecutors` L1189). A user who correctly chose "Always Ask" for interactive chat got `alwaysAsk` applied to an unattended 4-page ingestion AND to lint — guaranteeing the stall that #606 then had no bounded release for. The sandbox profile already confines writes to the scratch dir + active wiki DB; `alwaysAsk` only has structural value when the user is reading the transcript in real time.

They are a **symptom + systemic-fix** pair, not independent. Fixing only #606 leaves an unattended ingest able to stall for the full 60s budget on every prompt. Fixing only #607 removes the common case but leaves the core defect: any deferring policy (alwaysAsk, or acceptEdits on a non-edit tool) can hang a turn until the ceiling. **Both are needed.**

## The fix

### #606 — detached-timer auto-reject on `deferPermission`

`ACPPermissionDelegate` gains a `budget: Duration?` parameter (nil = no timer, preserves the prior indefinite-suspend behavior for interactive chat; non-nil = auto-reject after this duration). The three launcher call sites pass the operation-appropriate budget:

- **Interactive chat** (`startInteractiveQuery`): `budget: nil` — the UI chip is the release valve; the interactive turn suspends as before.
- **Multi-phase ingest** (`runACPIngestPlannerExecutors`): `budget: .seconds(60)`.
- **Lint / single-session `.lint`/`.lintPage`/`.query`** (`run()`): `budget: .seconds(60)`.

The timeout is implemented as a **detached `Task` that sleeps for `budget` and, if the user hasn't resolved first, calls `timeOut(toolCallId:)`** — a mirror of `resolve`:`removeValue` under the lock, then resume as `cancelled`. The `Task` handle is stored on a new `Pending.timer` field so `resolve`/`cancelAllPending` cancel it on the winning side.

The race is **safe by construction**: `resolve` (line ~462), `cancelAllPending` (line ~498), AND the new `timeOut(toolCallId:)` all do `removeValue`/`removeAll` UNDER the lock before resuming. Whichever wins the race pulls the entry out of the map, so the others find nothing to resume — `CheckedContinuation` cannot be resumed twice.

**The detached-timer form was chosen over a `withTaskGroup` form:** awaiting `group.next()` from inside one of the group's own child tasks is a data race (the group is non-`Sendable` and `next()` is mutating) and will not compile cleanly under Swift 6.0 strict concurrency. The detached-timer form preserves the existing `removeValue`-then-resume discipline verbatim. See `plans/acp-permissions.md` §4.1 note #5.

### #607 — per-operation policy split + legacy-key migration

Replaced the single `agentPermissionMode` key with three independent keys + a dedicated `PermissionOperationKind` enum (chat/ingest/lint — kept distinct from `WikiOperation.Kind` per plan §5.2 to avoid coupling):

| Key | Default | Budget |
|---|---|---|
| `chatPermissionMode` | `.bypass` | nil (unbounded — interactive) |
| `ingestPermissionMode` | `.bypass` | `.seconds(60)` |
| `lintPermissionMode` | `.bypass` | `.seconds(60)` |

`resolvePermissionMode(for: PermissionOperationKind) -> PermissionPolicy` takes a kind, reads its own key, falls back to `.bypass` when unset. `resolveBackend` closure signature widened to `(PermissionPolicy, Duration?)` so the launcher passes the budget through `AgentBackendFactory.makeBackend(policy:budget:)` → `ACPBackend.init(permissionPolicy:budget:)` → `ACPPermissionDelegate(policy:debugLogger:budget:)` → armed in `deferPermission`.

**One-time idempotent migration** (`PermissionModeMigration.migrateOnce()`): on first launch after this change, if `chatPermissionMode` is unset AND the legacy `agentPermissionMode` has a valid value, copy it into `chatPermissionMode` and leave the legacy key in place (orphaned, like `sandbox-config.json`). The guard predicate is `object(forKey:) == nil` (NOT `string(forKey:) == nil` — the latter cannot distinguish absent from present-but-empty-string; test #9b asserts this). Called from `WikiFSApp.init` alongside `AppStorageMigration.migrateZoomKey`.

**Settings UI**: replaced the single Permission Mode picker with three per-operation pickers (Chat/Ingest/Lint) in Settings → Agents → Permissions. Each `@AppStorage` binding declares the load-bearing `= PermissionPolicy.bypass.rawValue` default. The chat composer chip (`PermissionModeSelector`) now points at `PermissionModeKey.chat` only.

**`extractionPermissionMode` is intentionally NOT added** — `ACPExtractionClient.init` keeps its `.bypass` default (`ACPExtractionClient.swift:86`). Its call sites weren't fully enumerated (potential queue-path constructions), and `.bypass` is the correct default for read-heavy extraction anyway. A follow-up PR can add an extraction key once a caller needs it. See plan §5.1.