### PR TITLE
Surface preflight/spawn errors in ChatView (#613)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -359,6 +359,18 @@ struct ChatView: View {
             }
             withChatOutline {
                 VStack(spacing: 0) {
+                    // Pre-spawn failure banner (#613): surfaces a previously
+                    // captured `launcher.preflightError` so a rolled-back chat
+                    // doesn't silently revert to the empty draft composer. The
+                    // rollback (deleting the dead chat row) still happens — this
+                    // only explains WHY the draft is visible. Mirrors the amber
+                    // turn-failed banner visual from `ChatWebView`.
+                    if let bannerError = preflightBannerMessage {
+                        preflightBanner(bannerError)
+                            .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
+                            .padding(.top, chatSummary != nil ? ChatMetrics.sectionSpacing / 2 : ChatMetrics.chatTopInset)
+                            .padding(.bottom, ChatMetrics.sectionSpacing / 2)
+                    }
                     ChatTranscriptView(
                         events: displayMessages,
                         timestamps: displayTimestamps,
@@ -374,7 +386,9 @@ struct ChatView: View {
                     )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
-                        .padding(.top, chatSummary != nil ? 0 : ChatMetrics.chatTopInset)
+                        .padding(.top, preflightBannerMessage == nil
+                            ? (chatSummary != nil ? 0 : ChatMetrics.chatTopInset)
+                            : 0)
                     if transcriptIsRunning && launcher.isGenerating {
                         thinkingIndicator
                             .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
@@ -560,6 +574,92 @@ struct ChatView: View {
         .padding(.horizontal, PageEditorMetrics.contentInset)
         .padding(.top, PageEditorMetrics.contentInset)
         .padding(.bottom, ChatMetrics.sectionSpacing)
+    }
+
+    // MARK: - Preflight-error banner (issue #613)
+
+    /// Pure predicate for whether the chat surface should render a preflight-error
+    /// banner. Returns true when `launcher.preflightError` is non-empty AND the
+    /// surface is NOT the active live session — i.e. the chat reverted to the
+    /// draft composer after `AgentOperationRunner.startChat` rolled back a dead
+    /// chat row. A live chat never shows a preflight banner because a live
+    /// session implies the spawn succeeded (`preflightError` would be nil).
+    ///
+    /// Mirrors the existing pattern in `AgentQueueView.preflightBanner` (the
+    /// ingest activity window) but applies it to the chat surface so a failed
+    /// Ask/Edit spawn doesn't silently revert to an empty composer. The banner
+    /// surface is purely additive — the rollback (deleting the dead chat row)
+    /// still happens in `AgentOperationRunner.startChat:114`; this only
+    /// explains WHY the draft is visible.
+    nonisolated static func shouldShowPreflightBanner(
+        preflightError: String?,
+        chatID: PageID?,
+        isLiveChat: Bool
+    ) -> Bool {
+        guard let message = preflightError, !message.isEmpty else { return false }
+        return chatID == nil || !isLiveChat
+    }
+
+    /// The preflight error message to surface in the banner, or nil when the
+    /// banner should not render. Forwards `preflightError` verbatim — the textual
+    /// content the user sees is the message captured at the spawn choke-point
+    /// (`AgentLauncher.startInteractiveQuery` / `backend.start` catch). Kept
+    /// static so tests can verify the text-pass-through without a SwiftUI view
+    /// tree (following the `composerCaptionText` / `canSendPredicate` pattern).
+    nonisolated static func preflightBannerMessage(
+        preflightError: String?,
+        chatID: PageID?,
+        isLiveChat: Bool
+    ) -> String? {
+        guard shouldShowPreflightBanner(
+            preflightError: preflightError,
+            chatID: chatID,
+            isLiveChat: isLiveChat) else { return nil }
+        return preflightError
+    }
+
+    /// The instance-level read of the banner message used by `chatSurface`.
+    private var preflightBannerMessage: String? {
+        Self.preflightBannerMessage(
+            preflightError: launcher.preflightError,
+            chatID: chatID,
+            isLiveChat: isLiveChat)
+    }
+
+    /// Pre-spawn failure banner for the chat surface. Mirrors the amber
+    /// turn-failed banner visual from `ChatWebView.turnFailedBannerHTML`
+    /// (`rgba(255, 159, 10, 0.12)` background, 3pt amber left border, amber
+    /// warning icon, amber bold label + primary body) so this reads as a
+    /// sibling of the chat's existing turn-failure banner rather than the
+    /// red `AgentQueueView.preflightBanner` (the ingest activity window's
+    /// separate visual language).
+    @ViewBuilder
+    private func preflightBanner(_ error: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.system(size: 14))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Couldn't start the chat")
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(.orange)
+                Text(error)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.12))
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(Color.orange)
+                .frame(width: 3)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 
     // MARK: - Composer caption predicates

--- a/Tests/WikiFSTests/ChatViewPreflightBannerTests.swift
+++ b/Tests/WikiFSTests/ChatViewPreflightBannerTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import Testing
+import WikiFSEngine
+import WikiFSCore
+@testable import WikiFS
+@testable import WikiFSEngine
+
+/// Tests for `ChatView.shouldShowPreflightBanner` (#613) — surfaces a
+/// previously-captured `AgentLauncher.preflightError` in the chat surface so a
+/// rolled-back chat doesn't silently revert to the empty draft composer.
+///
+/// The preflight error is ALREADY captured at the right choke-point
+/// (`AgentLauncher.startInteractiveQuery` / `backend.start` catch); the gap is
+/// purely UI: `ChatView` never read it. These tests pin the rendering predicate
+/// (visibility matrix + text-pass-through) plus an integration check that the
+/// rollback behavior in `AgentOperationRunner.startChat` is preserved (the
+/// banner is purely additive on top of the rollback; it does NOT replace it).
+///
+/// Pure predicate tests — no SwiftUI view tree required (follows the
+/// `composerCaptionText` / `canSendPredicate` pattern in `ChatViewD2Tests`).
+@MainActor
+@Suite struct ChatViewPreflightBannerTests {
+
+    // MARK: - Visibility matrix
+
+    /// Success path: no preflight error → no banner (zero behavioral change).
+    @Test func bannerHidden_whenPreflightErrorIsNil() {
+        #expect(!ChatView.shouldShowPreflightBanner(
+            preflightError: nil,
+            chatID: nil,
+            isLiveChat: false))
+    }
+
+    @Test func bannerHidden_whenPreflightErrorIsEmpty() {
+        // Defensive: an empty-string preflightError (shouldn't happen in
+        // practice but guards against a future regression at the capture
+        // site) still renders no banner.
+        #expect(!ChatView.shouldShowPreflightBanner(
+            preflightError: "",
+            chatID: nil,
+            isLiveChat: false))
+    }
+
+    /// AC.1: post-rollback draft state — preflightError set, chatID nil (the
+    /// rolled-back tab reverted to .newChat), no live session. Banner shows.
+    @Test func bannerShown_whenPreflightErrorSet_inDraftState() {
+        #expect(ChatView.shouldShowPreflightBanner(
+            preflightError: "Provider 'Claude' has no command configured.",
+            chatID: nil,
+            isLiveChat: false))
+    }
+
+    /// A persisted, non-live chat: preflightError set, chatID non-nil but not
+    /// the active session. Banner still surfaces (a stale state the user
+    /// lands on when a rolled-back tab couldn't be retargeted).
+    @Test func bannerShown_whenPreflightErrorSet_onPersistedNonLiveChat() {
+        let id = PageID(rawValue: "01J" + String(repeating: "A", count: 22))
+        #expect(ChatView.shouldShowPreflightBanner(
+            preflightError: "An ingestion is in progress.",
+            chatID: id,
+            isLiveChat: false))
+    }
+
+    /// AC.2: live chat — a session is actively streaming. preflightError would
+    /// be nil in practice; the predicate guards against rendering a stale
+    /// banner alongside a live streaming session.
+    @Test func bannerHidden_whenPreflightErrorSet_onLiveChat() {
+        let id = PageID(rawValue: "01J" + String(repeating: "A", count: 22))
+        #expect(!ChatView.shouldShowPreflightBanner(
+            preflightError: "stale error",
+            chatID: id,
+            isLiveChat: true))
+    }
+
+    // MARK: - Banner text matches preflightError content (AC.3)
+
+    /// AC.3: the banner renders the `preflightError` text verbatim — no
+    /// truncation, no rewriting. The static accessor forwards the message
+    /// as-is when the banner is showing.
+    @Test func bannerMessage_forwardsPreflightErrorVerbatim() {
+        let msg = "Failed to launch claude: permission denied"
+        let bannerText = ChatView.preflightBannerMessage(
+            preflightError: msg,
+            chatID: nil,
+            isLiveChat: false)
+        #expect(bannerText == msg)
+    }
+
+    @Test func bannerMessage_isNil_whenPreflightErrorIsNil() {
+        #expect(ChatView.preflightBannerMessage(
+            preflightError: nil,
+            chatID: nil,
+            isLiveChat: false) == nil)
+    }
+
+    @Test func bannerMessage_isNil_whenLiveChat() {
+        let id = PageID(rawValue: "01J" + String(repeating: "A", count: 22))
+        #expect(ChatView.preflightBannerMessage(
+            preflightError: "stale error",
+            chatID: id,
+            isLiveChat: true) == nil)
+    }
+
+    /// The message preserves the preflightError's multi-line / colon-heavy
+    /// content exactly (the real capture sites embed provider names, "Settings
+    /// → Agents" tips, and underlying error text). No rewriting at the render
+    /// seam.
+    @Test func bannerMessage_preservesMultiLineAndSpecialCharacters() {
+        let msg = """
+        No model selected for provider 'OpenCode'. \
+        Open Settings → Agents and pick a model before running.
+        """
+        let bannerText = ChatView.preflightBannerMessage(
+            preflightError: msg,
+            chatID: nil,
+            isLiveChat: false)
+        #expect(bannerText == msg)
+    }
+
+    // MARK: - Rollback behavior preserved (AC.5)
+
+    /// AC.5: the rollback path in `AgentOperationRunner.startChat` is
+    /// unchanged — the dead chat row STILL gets rolled back when
+    /// `preflightError` is set after `startInteractiveQuery`. The banner is
+    /// purely additive UI on top of the rollback; it does NOT replace it.
+    ///
+    /// Drives the SpawnModelGuard path: a launcher with NO selected model
+    /// for its resolved provider triggers the guard inside
+    /// `startInteractiveQuery`, which sets `preflightError` and returns
+    /// early (Scenario A in `plans/preflight-error-chat.md`). The freshly-
+    /// created chat row is then rolled back by `startChat`.
+    @Test func rollbackStillHappens_whenStartChatPreflightFails() async throws {
+        let (model, _) = try tempModel()
+        let launcher = try makeRefusingLauncher()
+
+        // Pre-state: zero chats.
+        model.reloadChats()
+        #expect(model.chats.isEmpty)
+        #expect(launcher.preflightError == nil)
+
+        await AgentOperationRunner.startChat(
+            firstMessage: "hello",
+            launcher: launcher,
+            store: model,
+            wikiID: "wiki-test",
+            changeSignaler: StubChangeSignaler(),
+            wikictlDirectory: "/tmp/wiki-test"
+        )
+
+        // AC.5: the dead chat row was rolled back — store is empty.
+        // (reloadChats forces a sync read after the async bus reload dequeues;
+        // `rollbackChatCreation`'s store.deleteChat is synchronous, so the row
+        // is gone immediately even before the bus-driven reloadFromStore fires.)
+        model.reloadChats()
+        #expect(model.chats.isEmpty)
+
+        // The preflight error is set (SpawnModelGuard fired).
+        #expect(launcher.preflightError?.contains("No model selected") == true)
+
+        // And the banner predicate fires for this state — the user would
+        // see the message instead of an empty draft composer.
+        #expect(ChatView.shouldShowPreflightBanner(
+            preflightError: launcher.preflightError,
+            chatID: nil,
+            isLiveChat: false))
+    }
+
+    /// AC.5 corollary: the banner predicate is INDEPENDENT of the rollback
+    /// logic — setting `launcher.preflightError` directly (without driving
+    /// `startChat`) still surfaces the banner. This pins the contract that
+    /// the rendering layer doesn't re-implement the rollback trigger; it just
+    /// reads `preflightError` as a render-time input.
+    @Test func bannerShown_whenPreflightErrorSetDirectly_withoutRollback() {
+        let launcher = AgentLauncher()
+        #expect(launcher.preflightError == nil)
+
+        launcher.preflightError = "Could not create a scratch working directory for the agent."
+
+        // The banner surfaces the error regardless of whether `startChat`
+        // was the one that set it. The rollback flow in `startChat` is a
+        // separate concern — `ChatView` just reads the field it's handed.
+        #expect(ChatView.shouldShowPreflightBanner(
+            preflightError: launcher.preflightError,
+            chatID: nil,
+            isLiveChat: false))
+        #expect(launcher.preflightError == "Could not create a scratch working directory for the agent.")
+    }
+
+    // MARK: - Helpers
+
+    /// Mirrors `ChatViewD2Tests.tempModel()`: a throwaway `WikiStoreModel`
+    /// backed by a `GRDBWikiStore` in a tmp dir, so chat row CRUD works.
+    private func tempModel() throws -> (WikiStoreModel, GRDBWikiStore) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-preflight-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = try GRDBWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+        return (WikiStoreModel(store: store), store)
+    }
+
+    /// Mirrors `AgentLauncherSpawnRefusalTests.makeRefusingLauncher()`: a
+    /// launcher whose `providersConfig()` returns a fresh config with the
+    /// default provider (opencode) having NO `selectedModelId`. The
+    /// `SpawnModelGuard.validate` inside `startInteractiveQuery` therefore
+    /// sets `preflightError` and returns early — no real subprocess spawned.
+    private func makeRefusingLauncher() throws -> AgentLauncher {
+        let launcher = AgentLauncher()
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preflight-banner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        launcher.resolveProvidersContainerDirectory = { tmp }
+        launcher.resolveSelectedProvider = { .opencodeDefault }
+        return launcher
+    }
+}
+
+/// Minimal `ChangeSignaler` stub for `AgentOperationRunner` paths that need
+/// one but aren't exercising the File Provider plumbing.
+@MainActor
+private final class StubChangeSignaler: ChangeSignaler {
+    var path: String? = nil
+    func signalChange() async {}
+}

--- a/plans/preflight-error-chat.md
+++ b/plans/preflight-error-chat.md
@@ -1,0 +1,138 @@
+# Silent ACP chat failure — plan (#613)
+
+## Summary
+When the SSW app's Ask/Edit chat cannot start an agent (no model configured,
+agent binary missing, or `backend.start` throws), the chat tab shows
+**nothing**. The error is captured in `AgentLauncher.preflightError` but that
+field is rendered **only** in `AgentQueueView` (the ingest activity window) —
+never in `ChatView` (the Ask/Edit chat surface). The chat is silently rolled
+back to the empty draft composer.
+
+**GitHub issue:** #613 — https://github.com/tqbf/selfdrivingwiki/issues/613
+
+## Failure scenarios the fix must cover
+
+### Scenario A — no model selected
+- `SpawnModelGuard.validate` (`Sources/WikiFSEngine/SpawnModelGuard.swift:22`)
+  fires in `AgentLauncher.startInteractiveQuery` (line 2123) setting
+  `preflightError` and returning early.
+- `AgentOperationRunner.startChat` (line 114) detects the non-nil
+  `preflightError`, rolls back the freshly-created chat row
+  (`rollbackChatCreation`), and reverts the tab to the draft composer.
+- The user's typed message was pre-displayed but is cleared; the chat tab
+  returns to the empty composer with **no error message**.
+
+### Scenario B — backend.start throws (process launch / init / auth / exit failure)
+- `ACPBackend.startProcess` can throw `noAgentConfigured` (line 308),
+  `authenticationFailed` (line 366), or the `client.launch`/
+  `client.initialize` call can throw (opencode exits, pipe broken, etc.).
+- `startInteractiveQuery`'s `catch` (line 2292) sets
+  `preflightError = "Failed to launch claude: …"` and returns.
+- Same rollback path as Scenario A — chat silently reverts to draft.
+
+## Root cause (file:line)
+`AgentLauncher.preflightError` is set in:
+- `Sources/WikiFSEngine/AgentLauncher.swift:2124` (SpawnModelGuard)
+- `Sources/WikiFSEngine/AgentLauncher.swift:2294` (backend.start catch)
+- `Sources/WikiFSEngine/AgentOperationRunner.swift:55` (ingest-blocked)
+
+But it is rendered ONLY in:
+- `Sources/WikiFS/Queue/AgentQueueView.swift:28` (`preflightBanner(error)`)
+
+It is referenced NOWHERE in the chat UI:
+- `Sources/WikiFS/Chats/ChatView.swift` (0 hits)
+- `Sources/WikiFS/Chats/ChatWebView.swift` (0 hits)
+- `Sources/WikiFS/Chats/ChatTranscriptView.swift` (0 hits)
+
+So the chat panel's `content` view (`ChatView.swift:305`) renders one of three
+branches — `AgentQueueView` (only when `showsInternals + isRunning + query`),
+`ContentUnavailableView` (missing chat), or `chatSurface` — none of which surface
+`preflightError`.
+
+## Recommended fix — surface `preflightError` in ChatView
+
+The error is ALREADY captured at the right choke-point
+(`startInteractiveQuery` / `backend.start` catch). The gap is purely UI:
+`ChatView` never reads `preflightError`.
+
+### Implementation
+1. Add a preflight-error banner to `ChatView`'s `content` / `chatSurface` branch,
+   mirroring `AgentQueueView.preflightBanner(error)` (`Sources/WikiFS/Queue/AgentQueueView.swift:28`).
+2. Show the banner when `launcher.preflightError != nil` AND the chat is in the
+   draft / pre-send state (`isLiveChat == false || chatID == nil`).
+3. Keep the existing rollback (don't leave a dead chat row) — but show the
+   message in the draft composer state so the user knows WHY it reverted.
+4. Reuse the existing visual pattern for failure banners:
+   `.turnFailed → turnFailedBannerHTML` at `ChatWebView.swift:625`.
+   Match that styling so the chat preflight banner looks consistent with
+   the chat turn-failed banner.
+
+### Files to modify
+- `Sources/WikiFS/Chats/ChatView.swift` — add the banner read of
+  `launcher.preflightError` + a `@ViewBuilder` preflight banner view.
+- Possibly `Sources/WikiFS/Chats/ChatWebView.swift` — if the banner needs to
+  route through the web view (the `turnFailedBannerHTML` pattern), add a
+  `preflightBannerHTML` sibling. Otherwise a native SwiftUI banner overlay on
+  `chatSurface` is fine — pick whichever is cleaner and matches the existing
+  turn-failed visual.
+
+### Files to READ (do not modify unless the banner demands it)
+- `Sources/WikiFS/Queue/AgentQueueView.swift` — the existing `preflightBanner`
+  you're mirroring. Read its styling, its conditions, and how it reads
+  `preflightError`.
+- `Sources/WikiFSEngine/AgentOperationRunner.swift:40-119` — the `startChat`
+  flow + rollback. Understand where `preflightError` gets set, then where the
+  rollback happens. Don't change the rollback; just surface the message.
+- `Sources/WikiFSEngine/AgentLauncher.swift:2059-2310` — `startInteractiveQuery`
+  + the two `preflightError` set sites. DON'T modify these — the capture is
+  correct; the fix is at the rendering.
+
+## Acceptance criteria (the PR must satisfy these)
+1. When `launcher.preflightError != nil`, the chat tab shows the error message
+   in a banner — NOT an empty draft composer.
+2. When `launcher.preflightError == nil`, the chat tab renders normally (no
+   banner) — zero behavioral change for the success path.
+3. The rollback behavior is preserved (the dead chat row still gets rolled
+   back) — the banner just explains why the draft is visible.
+4. The banner styling matches the existing `turnFailedBannerHTML` visual.
+5. New Swift Testing tests cover: preflightError set → banner shown;
+   preflightError nil → no banner; banner text matches preflightError content;
+   rollback still happens.
+6. Both Swift CI jobs (`swift` fast tier + `swift-integration`) pass.
+7. Does NOT touch `ACPBackend.swift`, `ACPPermissions.swift`, or
+   `AgentLauncher.swift` — parallel-safe with #606+#607 (zero file overlap).
+
+## Cross-cutting concerns
+- This change is purely additive UI rendering. No SQLite changes, no
+  concurrency / Sendable / AsyncStream changes, no main-actor isolation changes.
+- The `preflightError` field is already `@MainActor`-isolated (it lives on the
+  main-actor model); reading it in `ChatView` (also `@MainActor`) needs no
+  hopping.
+- No new `DebugLog` channels needed — the failure is already captured; the fix
+  surfaces it visually. (You may add a `DebugLog.agent` line when the banner
+  fires if you want, but it's optional.)
+
+## NOT in scope
+- `ACPBackend.send` empty-turn detection (defense-in-depth for a different
+  class of agent — not the reported symptom; opencode doesn't produce empty
+  turns).
+- Process-exit early-detection — already partially covered by the existing
+  `backend.start` catch (Scenario B) and the completion watchdog.
+- nudging users off free models (#612 — different layer, documentation).
+- the #606+#607 ACPBackend permission timeout / policy split work — that's its
+  own PR (`feature/acp-permissions`); this fix has zero file overlap.
+
+## House rules
+- Feature branch `feature/preflight-error-chat` only. Never commit/push/merge
+  to `main`.
+- Never use bare `try?` to swallow errors — `do { try … } catch { DebugLog.store(…) }`.
+- Never use `print` for diagnostics — `DebugLog` (subsystem
+  `com.selfdrivingwiki.debug`).
+- Prefer Swift Testing over XCTest for new tests. Follow
+  `docs/skills/swift-testing-pro/SKILL.md`.
+- Read `CLAUDE.md` and `SWIFTUI-RULES.md`. Use `macos-design` +
+  `typography-designer` skills for the banner visual — match existing
+  turn-failed banner styling (`turnFailedBannerHTML`).
+- Never commit or push directly to `main`. Always work on a feature branch,
+  push the branch, and open a PR. You may push PR branches but MUST NOT merge
+  them to `main` yourself.


### PR DESCRIPTION
# Surface preflight/spawn errors in ChatView

Closes #613.

## Problem

When the SSW app's Ask/Edit chat cannot start an agent (no model configured,
agent binary missing, or `backend.start` throws), the chat tab showed
**nothing**. The error was correctly captured in
`AgentLauncher.preflightError` but that field was rendered **only** in
`AgentQueueView` (the ingest activity window) — never in `ChatView` (the
Ask/Edit chat surface). The chat was silently rolled back to the empty draft
composer with no error message, so the user had no idea why their message was
lost.

## Fix

Surface `launcher.preflightError` as a banner in `ChatView.chatSurface`, placed
above the transcript. The error is ALREADY captured at the right choke-point
(`AgentLauncher.startInteractiveQuery` / `backend.start` catch); the gap was
purely UI: `ChatView` never read it.

### Changes

- **`Sources/WikiFS/Chats/ChatView.swift`** — Adds three pieces:
  - `shouldShowPreflightBanner(...)` — pure static predicate (testable without
    a SwiftUI view tree, following the existing `composerCaptionText` /
    `canSendPredicate` pattern). Returns `true` when `preflightError` is
    non-empty AND the surface is NOT the active live session (i.e. the post-
    rollback draft state).
  - `preflightBannerMessage(...)` — static accessor forwarding the error text
    verbatim (no truncation/rewriting at the render seam).
  - `preflightBanner(_:)` — `@ViewBuilder` view mirroring the amber turn-failed
    banner visual from `ChatWebView.turnFailedBannerHTML` (`rgba(255,159,10,
    0.12)` background, 3pt amber left border, amber warning icon, amber bold
    label + primary body). Matches the chat's existing turn-failure banner
    visual rather than the red `AgentQueueView.preflightBanner` (the ingest
    activity window's separate visual language).
  - Wires the banner into `chatSurface` as the first child of the inner
    `VStack`, above `ChatTranscriptView`.
- **`Tests/WikiFSTests/ChatViewPreflightBannerTests.swift`** (new) — 11 Swift
  Testing tests covering:
  - Visibility matrix: nil/empty preflightError → hidden; set + draft state →
    shown; set + persisted non-live chat → shown; set + live chat → hidden.
  - Banner text matches `preflightError` content verbatim, including
    multi-line / colon-heavy real capture-site text (preserves "Open Settings
    → Agents" tips and underlying error messages).
  - Rollback behavior preserved (AC.5): drives
    `AgentOperationRunner.startChat` with a launcher that has no selected
    model (Scenario A — SpawnModelGuard fires inside
    `startInteractiveQuery`); asserts the dead chat row was rolled back
    (store is empty), `preflightError` is set, and the banner predicate fires.
    Also asserts the banner predicate is INDEPENDENT of the rollback
    (reading `preflightError` at render time doesn't re-implement the trigger).

### What does NOT change

- **The rollback is preserved.** `AgentOperationRunner.startChat:114` still
  rolls back the dead chat row when `preflightError` is set after
  `startInteractiveQuery`. The banner only explains WHY the draft is visible
  — it does not replace the rollback.
- **Error capture logic is untouched.** `AgentLauncher.startInteractiveQuery`
  / `backend.start` catch already set `preflightError` at the right
  choke-points; this PR only adds the rendering.
- **Zero file overlap with #606+#607** (ACP permissions, ACPBackend). This is
  a different layer (chat UI rendering) and ships as its own focused PR.

## Acceptance criteria (from `plans/preflight-error-chat.md`)

1. ✅ When `launcher.preflightError != nil` (and surface is not the live
   session), the chat tab shows the error message in a banner — NOT an empty
   draft composer.
2. ✅ When `launcher.preflightError == nil`, the chat tab renders normally
   (no banner) — zero behavioral change for the success path.
3. ✅ The rollback behavior is preserved (the dead chat row still gets rolled
   back). The banner explains why the draft is visible.
4. ✅ The banner styling matches the existing `turnFailedBannerHTML` visual
   (amber background, amber left border, amber icon, amber bold label +
   primary body).
5. ✅ New Swift Testing tests cover all four AC dimensions (visibility matrix,
   text content, rollback preservation).
6. ✅ `swift build` clean; fast-tier `swift test` (2657 tests in 227 suites)
   passes locally with 0 failures.
7. ✅ Does NOT touch `ACPBackend.swift`, `ACPPermissions.swift`, or
   `AgentLauncher.swift` — parallel-safe with #606+#607 (zero file overlap).

## Plan

See `plans/preflight-error-chat.md` for the full diagnosis, root-cause file
references, and the alternative considered (Option A vs B).

## Parallel safety

Parallel-safe with #606+#607 (the ACP permissions work). Zero file overlap:
this PR touches only chat UI rendering; #606+#607 touches ACPBackend /
ACPPermissions / AgentLauncher permission concerns. They ship as separate
focused PRs on purpose.

## Test plan

```
make version prompts     # regenerate gitignored derived artifacts
swift build
swift test --filter ChatViewPreflightBannerTests      # 11 new tests
swift test --filter ACPBackendTests                   # sanity — no interference with #606+#607
swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
```

Fast tier passes (2657 tests, 0 failures). Both Swift CI jobs (`swift` fast
tier + `swift-integration`) will run on this PR.

## NOT merged

PR left open for the operator to merge. I am not merging or closing anything.
