### PR TITLE
docs: sync AGENTS.md skip-list with actual CI config (remove phantom suites, add real ones)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ Persistent chats are two tables: `chats` (one row per conversation) and
 swift build          # compile
 swift test           # full suite (run locally before merge)
 # fast tier — what the CI `swift` job runs; skips the slow SQLite integration suites:
-swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'
+swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests'
 swift test --filter PdfExtractionServiceTests  # pdf extraction only
 ```
 

--- a/plans/acp-permissions.md
+++ b/plans/acp-permissions.md
@@ -649,7 +649,7 @@ Add to `Tests/WikiFSTests/AgentLauncherPermissionModeTests.swift` (fast-tier):
 ### 8.4 CI
 
 - `swift build` clean.
-- Fast tier: `swift test --skip 'EnumeratorDeletionTests|SQLiteWikiStoreTests|StoreEmissionTests|FreshSchemaParityTests|SQLiteStatementLifecycleIntegrationTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|ChatSummaryTests|ProjectionTreeTests'`
+- Fast tier: `swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests'`
   — green. If a new slow suite is introduced, tag `.integration` AND append
   its name to the `--skip` regex in `.github/workflows/ci.yml` (both Swift
   jobs run; the integration job is the gating one).


### PR DESCRIPTION
## Summary

Docs-only fix: syncs the stale `swift test --skip` fast-tier skip-list in `AGENTS.md` (and its duplicate in `plans/acp-permissions.md`) with the authoritative list in `.github/workflows/ci.yml`. **No CI behavior change** — `.github/workflows/ci.yml` is untouched (it is the source of truth; docs sync TO it, not the other way).

## The problem

The `AGENTS.md` Testing section (line ~212) reproduced the fast-tier `--skip` regex, but it had drifted from the CI config on two axes:

### 1. Three phantom suites (deleted in PR #578)

These three suite names appeared in the AGENTS.md skip-list but **do not exist on disk** in `Tests/` and are **not in CI**. They were deleted along with the hand-rolled `SQLiteWikiStore` / `SQLiteStatement` / `WikiReadPool` raw-SQLite plumbing in PR #578 ("Remove deprecated SQLiteWikiStore, SQLiteStatement, WikiReadPool raw-SQLite plumbing"):

- `SQLiteWikiStoreTests`
- `FreshSchemaParityTests`
- `SQLiteStatementLifecycleIntegrationTests`

### 2. Eight real suites omitted from AGENTS.md

These suites **are** in the CI skip-list (`SKIP` env, `.github/workflows/ci.yml` line 53) but were missing from the AGENTS.md copy, so the documented fast-tier command did not match what CI actually runs:

- `StoreEmissionReentrancyTests`
- `SplitDiffSnapshotTests`
- `FullTextSearchTests`
- `ChatSearchTests`
- `SessionManagerTests`
- `QuoteHighlightWebViewTests`
- `IngestGateTests`
- `SidebarDropBuilderIntegrationTests`

## The fix

Replaced the stale skip-list string in:

- `AGENTS.md` (Testing section, line 212)
- `plans/acp-permissions.md` (§8.4 CI, line 652) — an exact duplicate of the same stale string

with the current authoritative regex from `.github/workflows/ci.yml`:

```
EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests
```

The surrounding prose ("skips the slow SQLite integration suites") is generic and was already accurate — no rewrite needed.

## Scope note: historical references in other plan docs

A grep across `plans/*.md` found ~30 references to the three phantom suite names across 15 other plan/phase docs (e.g. `grdb-adoption.md`, `w0-page-versions-cas.md`, `chat-and-persistence.md`, `phase-6-pinning.md`, `issue-484-change-token-struct.md`). These are **intentionally left untouched** because they are frozen historical records — AC tables, design rationale, and named test contracts (e.g. `FreshSchemaParityTests.freshFastPathMatchesStepwiseLadder`) from completed phases, including a literal file path (`Tests/WikiFSTests/SQLiteWikiStoreTests.swift`). There is no clean 1:1 successor suite (the store moved to GRDB in PR #578), and genericizing these specific contract references would corrupt the historical record rather than fix an actionable instruction. The actionable phantom — the skip-list string duplicated in AGENTS.md and acp-permissions.md — is what this PR fixes.

## Verification

- `make version prompts` — regenerated gitignored codegen artifacts (not committed).
- `swift build` — **Build complete!** ✓
- No Swift source changes; no tests run (docs-only).

## Notes for reviewer

- Safe to merge — docs-only, no CI/behavior change.
- Do not expect the `swift` / `swift-integration` CI jobs to behave any differently; this change touches only `.md` files.
