### PR TITLE
Fix media attribution tag for byteless media providers (#618)

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -692,8 +692,39 @@ struct SourceDetailView: View {
             } else {
                 Label("Apple Podcast", systemImage: "waveform")
             }
+        case "youtube", "vimeo", "spotify", "soundcloud", "remote-media":
+            // Phase 4b byteless media providers. The watch/listen URL lives on
+            // `origin.plan` (the pasted link, normalized); never "File" — these
+            // sources carry no file bytes. (Issue #618.)
+            let info = mediaProviderInfo(origin.agentName)
+            let urlString = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
+            if let url = URL(string: urlString), url.scheme != nil {
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    Label(info.label, systemImage: info.systemImage)
+                }
+                .buttonStyle(.link)
+                .help("\(info.helpVerb): \(urlString)")
+            } else {
+                Label(info.label, systemImage: info.systemImage)
+            }
         default:
             Label("File", systemImage: "doc")
+        }
+    }
+
+    /// Provider-correct display text, SF Symbol, and tooltip verb for the
+    /// Phase 4b byteless media providers (`youtube`/`vimeo`/`spotify`/
+    /// `soundcloud`/`remote-media`). Used by `providerOriginTag(_:)`.
+    private func mediaProviderInfo(_ agentName: String) -> (label: String, systemImage: String, helpVerb: String) {
+        switch agentName {
+        case "youtube":      return ("YouTube", "play.rectangle", "Open video")
+        case "vimeo":        return ("Vimeo", "play.rectangle", "Open video")
+        case "spotify":      return ("Spotify", "music.note", "Open track")
+        case "soundcloud":   return ("SoundCloud", "waveform", "Open track")
+        case "remote-media": return ("Media", "music.note", "Open media")
+        default:             return ("Media", "music.note", "Open media")
         }
     }
 


### PR DESCRIPTION
Closes #618

## Summary

`SourceDetailView.providerOriginTag(_:)` was missing a case for the Phase 4b byteless media provider agent names (`youtube` / `vimeo` / `spotify` / `soundcloud` / `remote-media`), so they fell through to the `default` arm and rendered `Label("File", systemImage: "doc")` — wrong label, and no click target because the `default` arm is a bare `Label`. The provenance shape was already correct (the Media-tab embed player is unaffected); only the display-layer switch had the gap.

This fixes both symptoms called out in #618 — the wrong label *and* the missing click handler — in one change, because `origin.plan` already holds the watch URL.

## What changed

`Sources/WikiFS/Sources/SourceDetailView.swift`:

- Added a new `case "youtube", "vimeo", "spotify", "soundcloud", "remote-media":` arm to `providerOriginTag(_:)` that mirrors the existing `website` / `apple-podcast` pattern:
  - Reads `origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""`.
  - If the URL parses with a scheme, wraps a provider-appropriate `Label` in
    `Button { NSWorkspace.shared.open(url) }.buttonStyle(.link)` with a `.help(...)`
    tooltip.
  - Falls back to a plain provider `Label` when the URL fails to parse (mirrors the
    `website` arm's else branch).
- Added a small private helper `mediaProviderInfo(_:)` returning `(label, systemImage, helpVerb)`
  per provider so the five arms don't repeat ~12 lines of near-identical markup.
- The `default` arm (`Label("File", systemImage: "doc")`) is **unchanged** — genuine
  `local-file` / `legacy-import` sources still render "File" with no click target.

Provider labels / icons (per the issue's recommended fix):

| agentName           | label       | SF Symbol       | tooltip verb  |
|---------------------|-------------|-----------------|---------------|
| `youtube`           | YouTube     | `play.rectangle`| Open video    |
| `vimeo`             | Vimeo       | `play.rectangle`| Open video    |
| `spotify`           | Spotify     | `music.note`    | Open track    |
| `soundcloud`        | SoundCloud  | `waveform`      | Open track    |
| `remote-media`      | Media       | `music.note`    | Open media    |

## Out of scope

- `SourceOrigin.displayLabel` in `SourceMaterializer.swift` is explicitly called out
  in #618 as an optional follow-up (CLI `wikictl source info` would still show
  "Youtube" until updated). Per the issue ("Out of scope for the UI fix"), left
  untouched here.
- Embed player (Media tab) is untouched — provenance shape preserved.

## Acceptance criteria (#618)

- [x] YouTube watch / `youtu.be` / `/embed/` / `/shorts/` URL renders the origin tag as **"YouTube"** with a sensible icon.
- [x] Clicking the YouTube origin tag opens the original watch URL in the default browser (same behavior as the Website tag).
- [x] A YouTube URL with no transcript (embed-only) still shows the correct tag and click target — the arm doesn't read transcript state.
- [x] YouTube embed player (Media tab) still renders (provenance shape untouched; `BytelessEmbedIntegrationTests.embedDescriptorsReturnsBytelessMediaOnly` + `YouTubeEmbedWebViewTests.hostedYouTubeEmbedLoadsUnderRealOriginWithMatchingEmbedURL` pass).
- [x] Vimeo / Spotify / SoundCloud / direct-remote media sources show provider-correct labels + clickable URLs (all five routed through the new arm).
- [x] Existing `website` / `apple-podcast` / `markdown-folder` / Zotero origin tags are unchanged (no edits to those arms).
- [x] Non-YouTube local files still show "File" with no click target (`default` arm preserved).

## Build / test

- `make version prompts` — OK.
- `swift build` — OK.
- Fast-tier `swift test` (with the skip filter from CI) — **2634 tests in 227 suites passed**. Includes `BytelessEmbedIntegrationTests`, `MediaEmbedURLTests`, `MediaEmbedPlayerTests`, `YouTubeEmbedWebViewTests`.
