### PR TITLE
Fix empty Mermaid tabs for standalone .mmd sources (#620)

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -267,6 +267,22 @@ struct SourceDetailView: View {
         if isMarkdownNative, let data = store.sourceBytes(id: file.id) {
             return String(data: data, encoding: .utf8)
         }
+        // #620: defense-in-depth — when a Mermaid-detected source arrives
+        // without a text MIME (e.g. a pre-existing NULL-mime `.mmd` row from
+        // before the `addSource` extension fallback, or any future ingest path
+        // that bypasses it), still surface the raw diagram bytes so the Reader
+        // and Rendered tabs render instead of empty states. Calls the static
+        // detector with `content: nil` (mime+filename arms only) — NOT the
+        // `isMermaidSource` computed property, which reads this same property
+        // and would recurse. The content-scan arm is irrelevant here: this
+        // branch is only reached when `isMarkdownNative` is false, and a
+        // fenced-block-only source (no `.mmd`, no `text/mermaid` mime) already
+        // had nowhere to read its bytes from before #620.
+        if MermaidSourceDetector.isMermaidSource(
+               mimeType: file.mimeType, filename: file.filename, content: nil),
+           let data = store.sourceBytes(id: file.id) {
+            return String(data: data, encoding: .utf8)
+        }
         return nil
     }
 

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -2995,6 +2995,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         let mime = mimeType
             ?? ContentSniff.mimeType(of: data)
             ?? (ext.isEmpty ? nil : UTType(filenameExtension: ext)?.preferredMIMEType)
+            ?? MimeType.mime(forExtension: ext)  // #620: .mmd → text/mermaid (UTType can't resolve it)
         let displayName: String?
         if let resolved = resolvedDisplayName ?? DisplayNameResolver.resolve(
             filename: filename, data: data, mimeType: mime,

--- a/Sources/WikiFSTypes/MimeType.swift
+++ b/Sources/WikiFSTypes/MimeType.swift
@@ -93,4 +93,25 @@ public enum MimeType {
         guard let mime else { return false }
         return mermaidVariants.contains(mime.lowercased())
     }
+
+    /// Extension-derived MIME for known text-by-extension cases that
+    /// `UTType.preferredMIMEType` cannot resolve (it returns a dynamic UTI tag
+    /// for unregistered extensions like `.mmd`, and `nil` for its MIME).
+    ///
+    /// This is the last-resort fallback in `GRDBWikiStore.addSource`'s MIME
+    /// chain — without it, a standalone `.mmd` Mermaid source ingests with
+    /// `mime_type = NULL`, which breaks `SourceDetailView.isMarkdownNative`
+    /// (`MimeType.isText(nil) == false`) and leaves every Mermaid tab empty
+    /// (issue #620). The canonical extension string is
+    /// `MermaidSourceDetector.mermaidExtension` (kept here as a literal because
+    /// `WikiFSTypes` can't depend on `WikiFSCore`).
+    ///
+    /// Lowercased input is assumed (callers lower-case extensions); the switch
+    /// is case-insensitive anyway. Returns `nil` for unrecognized extensions.
+    public static func mime(forExtension ext: String) -> String? {
+        switch ext.lowercased() {
+        case "mmd", "mermaid": return mermaid
+        default: return nil
+        }
+    }
 }

--- a/Tests/WikiFSTests/SourcesTests.swift
+++ b/Tests/WikiFSTests/SourcesTests.swift
@@ -88,6 +88,145 @@ struct SourcesTests {
         #expect(source.mimeType?.contains("markdown") == true)
     }
 
+    // MARK: - .mmd Mermaid source MIME resolution (#620)
+
+    /// A `.mmd` file has no registered UTType (UTType returns a dynamic
+    /// `dyn.…` tag, `preferredMIMEType == nil`), and its text has no magic
+    /// bytes — so before #620 the source row was written with `mime_type NULL`,
+    /// which broke `SourceDetailView.isMarkdownNative` and left every Mermaid
+    /// tab empty. The fix #1 fallback `MimeType.mime(forExtension:)` must
+    /// catch it.
+    @Test func mmdExtensionResolvesToTextMermaid() throws {
+        let store = try tempStore()
+        let diagram = Data("flowchart TD\n    A --> B\n    B --> C\n".utf8)
+        let source = try store.addSource(
+            filename: "architecture.mmd", data: diagram, mimeType: nil)
+        #expect(source.ext == "mmd")
+        #expect(source.mimeType == MimeType.mermaid)
+        // The gate `SourceDetailView.isMarkdownNative` reads — text/* prefix.
+        #expect(MimeType.isText(source.mimeType) == true)
+        #expect(MimeType.isMermaid(source.mimeType) == true)
+    }
+
+    @Test func mmdExtensionUpperCasedResolvesToTextMermaid() throws {
+        // The ext is lowercased by `addSource` before the fallback runs; the
+        // `.MMD` filename must still resolve.
+        let store = try tempStore()
+        let source = try store.addSource(
+            filename: "Flow.MMD", data: Data("graph TD\n  X --> Y\n".utf8))
+        #expect(source.ext == "mmd")
+        #expect(source.mimeType == MimeType.mermaid)
+    }
+
+    @Test func mermaidExtensionAlsoResolvesToTextMermaid() throws {
+        // The less common `.mermaid` extension is recognized too.
+        let store = try tempStore()
+        let source = try store.addSource(
+            filename: "seq.mermaid", data: Data("sequenceDiagram\n  A->>B: hi\n".utf8))
+        #expect(source.ext == "mermaid")
+        #expect(source.mimeType == MimeType.mermaid)
+    }
+
+    @Test func explicitMimeStillWinsOverMmdExtension() throws {
+        // The `mimeType:` parameter is the first fallback tried; a caller that
+        // says "this is application/custom" must win over the `.mmd` map.
+        let store = try tempStore()
+        let source = try store.addSource(
+            filename: "custom.mmd", data: Data("flowchart TD\n".utf8),
+            mimeType: "application/custom")
+        #expect(source.mimeType == "application/custom")
+    }
+
+    @Test func mmdWithExplicitTextMermaidMimeRoundTrips() throws {
+        // A caller that passes `text/mermaid` explicitly (e.g. a future
+        // materializer that recognizes `.mmd`) must round-trip unchanged.
+        let store = try tempStore()
+        let source = try store.addSource(
+            filename: "explicit.mmd", data: Data("graph LR\n  A --> B\n".utf8),
+            mimeType: MimeType.mermaid)
+        #expect(source.mimeType == MimeType.mermaid)
+    }
+
+    /// The gap that shipped #620: PR #601's pure-detector tests passed
+    /// (`isMermaidSource(mime: nil, filename: "flow.mmd", content: nil)` → true)
+    /// but no test wired the *content path* — a nil-MIME `.mmd` source going
+    /// through `addSource` → `sourceContent` → `String(data:encoding:)` →
+    /// `MermaidSourceDetector.renderableMarkdown` to produce a fence the
+    /// Rendered tab actually renders. This test closes that gap.
+    @Test func nilMimeMmdSourceRoundTripsThroughViewContentPath() throws {
+        let store = try tempStore()
+        let rawDiagram = "flowchart TD\n    A --> B\n    B --> C\n"
+        let summary = try store.addSource(
+            filename: "design.mmd", data: Data(rawDiagram.utf8), mimeType: nil)
+
+        // 1. Fix #1 — stored mime is now `text/mermaid` (was NULL pre-fix),
+        //    so `SourceDetailView.isMarkdownNative` (`MimeType.isText`) is
+        //    true and the existing `if isMarkdownNative` branch in
+        //    `currentMarkdownContent` runs.
+        #expect(summary.mimeType == MimeType.mermaid)
+        #expect(MimeType.isText(summary.mimeType) == true)
+
+        // 2. The bytes the view reads via `store.sourceBytes(id:)` /
+        //    `sourceContent(id:)` match the original diagram.
+        let bytes = try store.sourceContent(id: summary.id)
+        let decoded = try #require(String(data: bytes, encoding: .utf8))
+        #expect(decoded == rawDiagram)
+
+        // 3. With content loaded, `MermaidSourceDetector.isMermaidSource`
+        //    (the view's `isMermaidSource` computed property — drives the
+        //    tab picker) returns true for this source.
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: summary.mimeType,
+            filename: summary.filename,
+            content: decoded) == true)
+
+        // 4. And the cheap mime+filename arms alone (no content) also return
+        //    true — this is the gate fix #2's defense-in-depth branch uses to
+        //    decide whether to read bytes for a source whose MIME is still
+        //    nil (e.g. a pre-fix row that wasn't re-ingested).
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: summary.mimeType,
+            filename: summary.filename,
+            content: nil) == true)
+
+        // 5. `renderableMarkdown(from:)` must wrap the standalone diagram in a
+        //    fenced ```mermaid block so `WikiReaderView`'s render pipeline
+        //    inlines `mermaid.min.js` + the bootstrap. This is the exact
+        //    transform `SourceDetailView.renderedMermaidContent` feeds the
+        //    reader; without it, the Rendered tab shows "No Diagram".
+        let renderable = try #require(
+            MermaidSourceDetector.renderableMarkdown(from: decoded))
+        #expect(renderable == "```mermaid\nflowchart TD\n    A --> B\n    B --> C\n```")
+        #expect(renderable.contains("```mermaid\n") == true)
+    }
+
+    /// Regression: `.md` sources carrying a fenced mermaid block are NOT
+    /// affected by fix #1 — they continue to resolve to a Markdown MIME via
+    /// UTType and stay on the existing `isMarkdownNative` path.
+    @Test func markdownWithEmbeddedMermaidRemainsUnaffected() throws {
+        let store = try tempStore()
+        let md = """
+        # Architecture
+
+        ```mermaid
+        flowchart TD
+            A --> B
+        ```
+        """
+        let source = try store.addSource(filename: "arch.md", data: Data(md.utf8))
+        // The `.md` extension resolves via UTType, NOT the new .mmd map.
+        #expect(source.mimeType?.hasPrefix("text/") == true)
+        #expect(source.mimeType?.contains("markdown") == true)
+        #expect(source.mimeType != MimeType.mermaid)
+
+        // Embedded-mermaid markdown is still detected (content-scan arm).
+        #expect(MermaidSourceDetector.isMermaidSource(
+            mimeType: source.mimeType, filename: source.filename, content: md) == true)
+        // And `renderableMarkdown` passes the doc through unchanged (so headings
+        // and outline survive).
+        #expect(MermaidSourceDetector.renderableMarkdown(from: md) == md)
+    }
+
     // MARK: - Zotero provenance (v8 → v9)
 
     /// A drag-drop / URL ingest passes no Zotero provenance, so the two new


### PR DESCRIPTION
Closes #620.

## Summary

A standalone `.mmd` Mermaid source opened in the source-detail view showed empty states across all three Mermaid tabs — **Reader** ("No Processed Markdown"), **Rendered** ("No Diagram"), and **Split** (both) — even though the tab picker rendered correctly.

**Root cause:** a `.mmd` file ingested via drag-drop stored `mime_type = NULL`, because `UTType(filenameExtension: "mmd")?.preferredMIMEType == nil` (`.mmd` has no registered UTType) and `ContentSniff` has no magic bytes for it. NULL mime then broke `SourceDetailView.isMarkdownNative` (`MimeType.isText(nil) == false`), so `currentMarkdownContent` returned `nil` and the raw diagram bytes were never read — even though `store.sourceBytes(id:)` would have returned them.

## The fix

Two complementary changes, exactly as the issue recommended:

### 1. `MimeType.mime(forExtension:)` — extension→MIME fallback (PRIMARY)

New last-resort term in `GRDBWikiStore.addSource`'s MIME chain:

```swift
let mime = mimeType
    ?? ContentSniff.mimeType(of: data)
    ?? (ext.isEmpty ? nil : UTType(filenameExtension: ext)?.preferredMIMEType)
    ?? MimeType.mime(forExtension: ext)   // ← NEW: .mmd → text/mermaid
```

`MimeType.mime(forExtension:)` maps `"mmd"` / `"mermaid"` → `MimeType.mermaid` (`"text/mermaid"`), `nil` otherwise. Co-located with the existing `MimeType.mermaid` constant in `WikiFSTypes/MimeType.swift` for one source of truth (the canonical extension string `MermaidSourceDetector.mermaidExtension` lives in `WikiFSCore`, which can't be referenced from the leaf `WikiFSTypes` target — kept as a literal with a cross-reference comment).

With this, a `.mmd` source ingests with `mime_type = "text/mermaid"`, `MimeType.isText("text/mermaid") == true` (prefix match), `isMarkdownNative` flips to `true`, `currentMarkdownContent` reads the raw bytes via the existing `isMarkdownNative` branch, and both the **Reader** (raw text via `WikiReaderView`) and **Rendered** (via `MermaidSourceDetector.renderableMarkdown` wrapping the standalone source in a ` ```mermaid ` fence → existing render pipeline inlines `mermaid.min.js` + the bootstrap) tabs render content.

### 2. View-level guard in `SourceDetailView.currentMarkdownContent` (DEFENSE-IN-DEPTH)

```swift
// #620: when a Mermaid-detected source arrives without a text MIME
// (e.g. a pre-existing NULL-mime `.mmd` row from before the addSource
// fallback, or a future ingest path that bypasses it), still surface
// the raw diagram bytes so the tabs render.
if MermaidSourceDetector.isMermaidSource(
       mimeType: file.mimeType, filename: file.filename, content: nil),
   let data = store.sourceBytes(id: file.id) {
    return String(data: data, encoding: .utf8)
}
```

This covers pre-existing NULL-mime `.mmd` rows in the wild that would otherwise need a re-ingest or a manual `UPDATE sources SET mime_type='text/mermaid' WHERE ext='mmd' AND mime_type IS NULL` backfill.

**Recursion note:** this calls the *static* `MermaidSourceDetector.isMermaidSource(...)` with `content: nil` (mime + filename arms only — the cheap checks), NOT the `isMermaidSource` *computed property* on the view. The computed var reads `currentMarkdownContent` to feed the content-scan arm, so calling it from `currentMarkdownContent` would be infinite recursion (Swift evaluates arguments eagerly before the function short-circuits). The content-scan arm is irrelevant at this branch anyway: this code is only reached when `isMarkdownNative` is false, and a fenced-block-only source with no `.mmd` filename and no `text/mermaid` mime had nowhere to read its bytes from before #620 either.

## Test coverage

Closes the gap that shipped #601: PR #601's tests (`MermaidSourceDetectorTests`) only exercised the pure detector (`isMermaidSource(mime: nil, filename: "flow.mmd", content: nil)` → true) — they never asserted that a nil-MIME `.mmd` source actually resolved content through the view's `currentMarkdownContent → sourceBytes` path.

New tests in `Tests/WikiFSTests/SourcesTests.swift` (regular `struct`, runs in the fast tier):

- **`nilMimeMmdSourceRoundTripsThroughViewContentPath`** — the load-bearing round-trip test the issue requested: creates a `.mmd` source via `addSource(filename:data:mimeType: nil)` (simulating drag-drop), then asserts the full content path the view reads — stored `mime_type == "text/mermaid"` (fix #1), `MimeType.isText(stored.mimeType) == true` (the `isMarkdownNative` gate), `sourceContent(id:)` returns the original diagram bytes, `MermaidSourceDetector.isMermaidSource(mime:filename:content:)` is true both with and without content (the cheap mime+filename gate fix #2 uses, plus the tab-picker gate with content), and `renderableMarkdown(from:)` produces the exact ` ```mermaid\n...``` ` fenced block the Rendered tab feeds `WikiReaderView`.
- **`mmdExtensionResolvesToTextMermaid`** / **`mmdExtensionUpperCasedResolvesToTextMermaid`** / **`mermaidExtensionAlsoResolvesToTextMermaid`** — focused tests on the extension map (lowercased, uppercased input, and the `.mermaid` extension).
- **`explicitMimeStillWinsOverMmdExtension`** / **`mmdWithExplicitTextMermaidMimeRoundTrips`** — the `mimeType:` parameter still takes priority, and an explicit `text/mermaid` round-trips unchanged.
- **`markdownWithEmbeddedMermaidRemainsUnaffected`** — the embedded-mermaid markdown case (a `.md` carrying a fenced ` ```mermaid ` block) is unaffected: still resolves to a Markdown MIME via UTType, content-scan still detects it, `renderableMarkdown` still passes through unchanged so prose/headings survive.

## Scope

~25 lines of source (fix #1: 1 new `MimeType.mime(forExtension:)` + 1 `??` term; fix #2: a 15-line branch with comment) + 7 tests. No schema migration, no UI redesign — strictly the issue's recommended fix.

## Verification

- `make version prompts` ✓
- `swift build` ✓ (clean, no warnings under `-warnings-as-errors`)
- Fast-tier `swift test --skip '...'` ✓ — 2641 tests in 227 suites passed
- `swift test --filter 'SourcesTests'` ✓ — 45 tests passed (incl. the 7 new ones)
- `swift test --filter 'MermaidSourceDetectorTests|ContentSniffTests'` ✓ — no regression

## Acceptance criteria

- [x] Reader tab for a `.mmd` source shows the raw mermaid diagram text.
- [x] Rendered tab for a `.mmd` source shows the rendered inline SVG (loaded via the vendored `mermaid.js` + the existing `mermaidBootstrapJS`, gated on `body.contains("class=\"language-mermaid\"")` in `WikiReaderView.documentHTML`).
- [x] Split tab shows the raw text (left) and the rendered SVG (right) side-by-side.
- [x] Embedded-mermaid markdown sources (a `.md` containing a ` ```mermaid ` block) remain unaffected — `markdownWithEmbeddedMermaidRemainsUnaffected`.
- [x] Non-mermaid sources (PDF, HTML, plain `.md`, images, byteless media) unaffected — `explicitMimeStillWinsOverMmdExtension` plus the entire existing `SourcesTests` / `ContentSniffTests` / `MediaEmbedURLTests` suite still passes.
- [x] A new round-trip test covers a nil-MIME `.mmd` source — `nilMimeMmdSourceRoundTripsThroughViewContentPath`.
