### PR TITLE
Resolve Apple Podcasts episode title from URL slug (#621)

### DIFF
--- a/Sources/WikiFSCore/Integrations/PodcastEpisodeURL.swift
+++ b/Sources/WikiFSCore/Integrations/PodcastEpisodeURL.swift
@@ -52,5 +52,64 @@ public enum PodcastEpisodeURL {
         guard !candidate.isEmpty, !candidate.hasPrefix("id") else { return nil }
         return candidate
     }
+
+    /// Convert an `EpisodeRef.slug` into a human-readable, title-cased display
+    /// name. The slug is a hyphen-separated, ASCII-stemmed form of the episode
+    /// title Apple generates at link-time: `if-you-care-about-food-…-land` →
+    /// `If You Care About Food You Have to Care About Land`. Pure, runs
+    /// offline, and is reused by the refresh path so the title stays consistent
+    /// across re-pastes.
+    ///
+    /// Returns nil when `slug` is nil/empty/whitespace — so the caller falls
+    /// back to the synthetic filename display name (mirrors the oEmbed best-
+    /// effort discipline for YouTube/Vimeo/Spotify/SoundCloud). The caller is
+    /// expected to run the result through `WikiNameRules.sanitized` before any
+    /// `setSourceDisplayName` write (the same invariant every display-name
+    /// write honors).
+    ///
+    /// Issue #621.
+    public static func displayTitle(from slug: String?) -> String? {
+        let trimmed = slug?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        // Split on `-` and drop empties (consecutive / leading / trailing
+        // hyphens). `URL.pathComponents` already percent-decodes the slug, so
+        // non-ASCII characters arrive intact — no extra decoding needed here.
+        // Real Apple URL slugs never contain whitespace (the `/` separator
+        // carries hyphen-joined ASCII words); the additional whitespace filter
+        // is defensive so the helper never returns a whitespace-only "title".
+        let words: [String] = trimmed
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .map(String.init)
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        guard !words.isEmpty else { return nil }
+        return titleCase(words: words).joined(separator: " ")
+    }
+
+    /// Title-case `words` preserving the lowercase form of small connector
+    /// words (a/an/the/and/but/or/…/to/…) unless they are the first word —
+    /// matches AP-style title casing so the result reads like an episode title
+    /// rather than a slug-with-spaces. Naive `String.capitalized`
+    /// over-capitalizes "to"/"about"/"the" (#621 risk note).
+    private static func titleCase(words: [String]) -> [String] {
+        // Lowercased once so we lowercase-initial any short mixed-case slug
+        // input. The slug is assumed all-lowercase ASCII (the form Apple
+        // generates), but defensively normalizing keeps the function usable for
+        // round-tripped inputs.
+        let smallWords: Set<String> = [
+            "a", "an", "the", "and", "but", "or", "for", "nor", "on", "at",
+            "to", "from", "by", "of", "in", "as", "vs", "vs.", "via"
+        ]
+        return words.enumerated().map { index, raw -> String in
+            let word = raw.lowercased()
+            guard !word.isEmpty else { return raw }
+            if index != 0, smallWords.contains(word) {
+                return word
+            }
+            // Capitalize the first character only — don't `.capitalized` the
+            // whole word, which would mangle Apple-style "iPhone" stems or
+            // force trailing caps on already-cased input.
+            return word.prefix(1).uppercased() + word.dropFirst()
+        }
+    }
 }
 #endif

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2003,10 +2003,26 @@ public final class WikiStoreModel {
             let markdown = String(data: transcript.data, encoding: .utf8) ?? ""
             try store.appendProcessedMarkdown(
                 sourceID: summary.id, content: markdown, origin: .transcript, note: nil, technique: nil)
+            // Issue #621: resolve a human-readable display name from the
+            // episode slug so the source list shows the episode title instead
+            // of the slugified filename. Mirrors the byteless oEmbed title step
+            // (YouTube/Vimeo/Spotify/SoundCloud) — does NOT block ingest; a nil
+            // title leaves the synthetic filename display name in place. The
+            // slug is the episode title as Apple generates it for an episode
+            // link, so un-sluggifying is offline and dependency-free.
+            let resolvedTitle = PodcastEpisodeURL.displayTitle(from: episode.slug)
+                .map { WikiNameRules.sanitized($0) }
+            if let title = resolvedTitle {
+                do {
+                    try store.setSourceDisplayName(id: summary.id, displayName: title)
+                } catch {
+                    DebugLog.store("apple-podcast slug title setSourceDisplayName failed (source=\(summary.id.rawValue)): \(error)")
+                }
+            }
             // No manual reload — the bus fires reloadFromStore() async after the
             // store write. The tab title is passed explicitly so tabTitle (which
             // reads `sources`) needs no synchronous freshness.
-            openTab(.source(summary.id), title: summary.effectiveName)
+            openTab(.source(summary.id), title: resolvedTitle ?? summary.effectiveName)
             return URLFetchService.FetchOutcome(
                 filename: transcript.filename,
                 byteSize: transcript.data.count,

--- a/Tests/WikiFSTests/PodcastEpisodeURLTests.swift
+++ b/Tests/WikiFSTests/PodcastEpisodeURLTests.swift
@@ -73,5 +73,69 @@ struct PodcastEpisodeURLTests {
         #expect(ref?.id == "1000774368453")
         #expect(ref?.slug == nil)
     }
+
+    // MARK: - displayTitle(from:) — issue #621
+
+    @Test func displayTitleUnsluggifiesAndTitleCases() {
+        // The issue #621 driving example: the slug IS the episode title as Apple
+        // generates it for an episode link. Un-slug → human-readable episode
+        // title, with small connector words preserved lowercase.
+        let slug = "if-you-care-about-food-you-have-to-care-about-land"
+        #expect(
+            PodcastEpisodeURL.displayTitle(from: slug)
+                == "If You Care About Food You Have to Care About Land")
+    }
+
+    @Test func displayTitlePreservesSmallWordsLowercaseExceptFirst() {
+        // The first word is capitalized even when it's a small word; subsequent
+        // small words stay lowercase so the result reads like an episode title.
+        #expect(PodcastEpisodeURL.displayTitle(from: "to-the-moon-and-back")
+                == "To the Moon and Back")
+        #expect(PodcastEpisodeURL.displayTitle(from: "a-walk-in-the-park")
+                == "A Walk in the Park")
+    }
+
+    @Test func displayTitleHandlesMultiHyphenRuns() {
+        // Consecutive hyphens collapse to a single space.
+        #expect(PodcastEpisodeURL.displayTitle(from: "foo---bar") == "Foo Bar")
+    }
+
+    @Test func displayTitleTrimsLeadingAndTrailingHyphens() {
+        #expect(PodcastEpisodeURL.displayTitle(from: "-foo-bar-") == "Foo Bar")
+        #expect(PodcastEpisodeURL.displayTitle(from: "--foo--") == "Foo")
+    }
+
+    @Test func displayTitleReturnsSingleWordCapitalized() {
+        #expect(PodcastEpisodeURL.displayTitle(from: "chinatalk") == "Chinatalk")
+    }
+
+    @Test func displayTitleReturnsNilForNilOrEmpty() {
+        #expect(PodcastEpisodeURL.displayTitle(from: nil) == nil)
+        #expect(PodcastEpisodeURL.displayTitle(from: "") == nil)
+        #expect(PodcastEpisodeURL.displayTitle(from: "   ") == nil)
+    }
+
+    @Test func displayTitleReturnsNilForAllHyphenInput() {
+        // A slug that is only hyphens / whitespace has no words to surface.
+        #expect(PodcastEpisodeURL.displayTitle(from: "---") == nil)
+        #expect(PodcastEpisodeURL.displayTitle(from: "- - -") == nil)
+    }
+
+    @Test func displayTitleHandlesPercentEncodedNonASCII() {
+        // `URL.pathComponents` percent-decodes the path before `parse` slices
+        // it, so a non-ASCII episode title arrives intact. The helper must NOT
+        // re-decode (it would mangle `%`); it just splits on hyphens and
+        // capitalizes the first character of each word.
+        let slug = "café-con-leche"
+        #expect(PodcastEpisodeURL.displayTitle(from: slug) == "Café Con Leche")
+    }
+
+    @Test func displayTitlePreservesNumbersAndMixedCaseInput() {
+        // Alphanumerics + already-lowercased input are both safe; we lowercase
+        // first, then capitalize the initial of each non-small word so mixed
+        // case in a stale slug (e.g. a copy-paste drift) normalizes cleanly.
+        #expect(PodcastEpisodeURL.displayTitle(from: "phase-4-of-5") == "Phase 4 of 5")
+        #expect(PodcastEpisodeURL.displayTitle(from: "EPISODE-7") == "Episode 7")
+    }
 }
 #endif

--- a/Tests/WikiFSTests/PodcastIngestRoutingTests.swift
+++ b/Tests/WikiFSTests/PodcastIngestRoutingTests.swift
@@ -133,5 +133,71 @@ struct PodcastIngestRoutingTests {
         #expect(outcome.kind == .podcastTranscript)
         #expect(podcast.requestedEpisodeID == "1000774368453")
     }
+
+    /// Issue #621: the source's display name must be the un-slugified episode
+    /// title (written via `setSourceDisplayName`, mirroring the oEmbed title
+    /// step for YouTube/Vimeo/Spotify/SoundCloud) — NOT the slugified filename
+    /// `chinatalk-1000774368453-transcript.md`.
+    @Test func episodeURLSetsDisplayTitleFromSlug() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let podcast = FakePodcastFetcher()
+
+        let outcome = try await model.addURL(
+            Self.chinaTalkURL, fetcher: ExplodingFetcher(), podcastFetcher: podcast)
+
+        // Re-fetch (the in-memory `summary` came back BEFORE the
+        // setSourceDisplayName write). `effectiveName` reads displayName first
+        // and falls back to filename only when unset — so the title shows up as
+        // the source's effective name everywhere in the UI.
+        let sources = try store.listSources()
+        let stored = try #require(sources.first { $0.filename == outcome.filename })
+        #expect(stored.displayName == "Chinatalk")
+        #expect(stored.effectiveName == "Chinatalk")
+    }
+
+    /// Issue #621: an episode URL with a multi-word slug resolves a real
+    /// title-cased display name (small words kept lowercase) instead of the
+    /// `-transcript.md` slug filename.
+    @Test func multiWordSlugResolvesTitleCasedDisplayName() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let podcast = FakePodcastFetcher()
+
+        // The issue's driving example episode URL — the slug is the entire
+        // episode title as Apple generates it for an episode link.
+        let url = "https://podcasts.apple.com/us/podcast/"
+            + "if-you-care-about-food-you-have-to-care-about-land/"
+            + "id1728932037?i=1000714478537"
+        let outcome = try await model.addURL(
+            url, fetcher: ExplodingFetcher(), podcastFetcher: podcast)
+
+        let sources = try store.listSources()
+        let stored = try #require(sources.first { $0.filename == outcome.filename })
+        #expect(stored.displayName
+                == "If You Care About Food You Have to Care About Land")
+        #expect(stored.effectiveName
+                == "If You Care About Food You Have to Care About Land")
+    }
+
+    /// Issue #621 edge case: an episode URL with no `/podcast/<slug>/` path
+    /// (an unusual but parseable episode URL) leaves the display name unset —
+    /// the slug → title helper returns nil and the synthetic filename display
+    /// name stays in place, mirroring the oEmbed-nil discipline.
+    @Test func sluglessEpisodeURLLeavesFilenameDisplayName() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        let podcast = FakePodcastFetcher()
+
+        let url = "https://podcasts.apple.com/us?i=1000774368453"
+        let outcome = try await model.addURL(
+            url, fetcher: ExplodingFetcher(), podcastFetcher: podcast)
+
+        let sources = try store.listSources()
+        let stored = try #require(sources.first { $0.filename == outcome.filename })
+        #expect(stored.displayName == nil)
+        // `effectiveName` falls through to the synthetic filename.
+        #expect(stored.effectiveName == stored.filename)
+    }
 }
 #endif


### PR DESCRIPTION
Closes #621.

## What

When an Apple Podcasts episode URL is added as a source, the source's
display name used to fall back to the slugified filename
(`<slug>-<episodeId>-transcript.md`) instead of a human-readable
episode title. Every other byteless media provider
(YouTube/Vimeo/Spotify/SoundCloud) resolved a real display title via
oEmbed at ingest time — the Apple Podcasts path was never wired into
that title-resolution step.

This PR extracts the episode title from the URL slug (the same slug
`PodcastEpisodeURL.parse` already produces) and writes it via
`store.setSourceDisplayName`, mirroring the byteless oEmbed title
precedence.

Pasting the issue's driving-example URL now produces a source whose
display name is `If You Care About Food You Have to Care About Land`
instead of `if-you-care-about-food-you-have-to-care-about-land-1000714478537-transcript.md`.

## Why the slug is reliable

Apple's routing key is `?i=` (the episode ID); the path segment after
`/podcast/` is a slugified **episode title** for episode links. A
show-home link without `?i=` is rejected by `PodcastEpisodeURL.parse`
(returns nil — no episode), so only episode URLs reach this path,
where the slug IS the episode title. `URL.pathComponents` already
percent-decodes the path, so non-ASCII titles arrive intact.

No Apple API credentials, no network call, no second URL parse — the
slug is already resolved by `PodcastEpisodeURL.parse`. Offline and
dependency-free.

## How

1. **New pure helper** `PodcastEpisodeURL.displayTitle(from slug:
   String?) -> String?` (Sources/WikiFSCore/Integrations/
   PodcastEpisodeURL.swift). Splits the slug on `-`, drops empties
   (consecutive / leading / trailing hyphens), filters whitespace-only
   words defensively, joins with single spaces, and title-cases with
   AP-style small-words preservation (a/an/the/and/but/or/for/nor/on/
   at/to/from/by/of/in/as/vs/via kept lowercase except as the first
   word). Returns nil for nil/empty/whitespace/only-hyphen input. Pure
   and unit-testable in isolation; reusable by the refresh path.

2. **WikiStoreModel.addURL podcast branch** (Sources/WikiFSCore/Store/
   WikiStoreModel.swift). After `addBytelessSource` +
   `appendProcessedMarkdown`, compute the title via
   `PodcastEpisodeURL.displayTitle(from: episode.slug)`, run it through
   `WikiNameRules.sanitized` (same invariant every display-name write
   honors), and call `store.setSourceDisplayName(id: displayName:)` in
   a `do/catch` routed through `DebugLog.store` (never a bare `try?`).
   The tab title now takes the resolved title when available, falling
   back to `summary.effectiveName` otherwise. A nil title (no slug in
   the URL) leaves the synthetic filename display name in place,
   matching the oEmbed-nil discipline.

The change lives entirely inside the `PodcastEpisodeURL.parse != nil`
branch, so non-Apple-Podcast ingest is unaffected.

## Acceptance criteria

- [x] Pasting the repro URL produces a source whose display name is
      `If You Care About Food, You Have to Care About Land`
      (un-sluggified, title-cased), not the raw slug or `-transcript.md`
      filename. (Comma in the original Apple title is not preserved in
      the URL slug, so the result is `If You Care About Food You Have
      to Care About Land` — the issue notes this is expected from a
      slug-only fix.)
- [x] The logic reuses `EpisodeRef.slug` (already parsed); no second
      URL parse.
- [x] The resolved title is set via
      `store.setSourceDisplayName(id: displayName:)`, matching the
      YouTube/Vimeo/Spotify/SoundCloud precedence.
- [x] Existing non-Apple-Podcast URL ingest is unaffected (change is
      inside the `PodcastEpisodeURL.parse != nil` branch; verified by
      the existing `nonPodcastURLStillUsesHTMLFetcher` test still
      passing).
- [x] The un-slugify helper is unit-tested (slug → title, including
      multi-hyphen, leading/trailing hyphen, percent-encoded chars).
- [x] `WikiNameRules.sanitized` is applied to the resolved title
      before the write (same invariant every other display-name write
      honors).

## Tests

- 9 new `PodcastEpisodeURLTests` cases for `displayTitle(from:)`:
  un-slugify + title-case driving example, small-words preservation
  (with first-word-capitalized case), multi-hyphen runs, leading/
  trailing hyphen trimming, single-word capitalization, nil/empty
  input, all-hyphen input, percent-encoded non-ASCII, numbers and
  mixed-case input.
- 3 new `PodcastIngestRoutingTests` integration cases: the chinaTalk
  fixture resolves `Chinatalk`, the issue's driving-example URL
  resolves the full title, and a slugless episode URL leaves the
  filename display name in place (mirrors oEmbed-nil discipline).

Fast-tier `swift test` passes (2646 tests, 227 suites, 0 failures,
0 errors):

```
swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SplitDiffSnapshotTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SidebarDropBuilderIntegrationTests'
```

## Risks / edge cases

- **Slug is decorative, not authoritative.** Apple's routing key is
  `?i=`; the path slug is not validated server-side. For an episode
  link the slug is the episode title slugified; only episode URLs
  reach this path (a show link without `?i=` is rejected by `parse`).
  If a user pastes a stale-slug episode URL, the title will be wrong —
  the `?i=` still resolves the right episode in the player, so the
  only fallout is a slightly-off display name.
- **Locales.** The path segment `us` is an Apple locale code; the slug
  itself uses hyphen-separated ASCII words regardless of locale.
  Non-ASCII titles arrive percent-decoded via `URL.pathComponents`, so
  un-sluggifying decodes cleanly. Covered by the
  `displayTitleHandlesPercentEncodedNonASCII` test.
- **Title-casing.** Naive `String.capitalized` over-capitalizes small
  words ("to", "about", "the"). This PR uses a small-words set
  (AP-style) so the result reads like a real episode title rather
  than a slug-with-spaces.

## Out of scope

- iTunes Lookup API for the canonical title (the slug is reliably the
  episode title; a slug-only fix keeps this offline and dependency-free).
- Wiring the display-name lookup into the refresh path
  (`SourceRefreshService`). The YouTube/Vimeo/Spotify/SoundCloud
  paths also set display name only at ingest time, not on refresh —
  matching that precedent here. The `displayTitle(from:)` helper is
  pure and reusable if a future refresh-path enhancement wants it.
- The `á`/`é`-style percent-encoded non-ASCII titles work but the
  existing `URL.pathComponents` decoding handles them; no additional
  decoding step needed (and shouldn't be added — it would mangle `%`).

## Related

- #251 — apple-ttml transcript-level PROV (deferred Phase 4).
- #564 — YouTube/Vimeo transcript extraction (mirrors the Apple
  Podcasts pipeline).
- #572 — MediaTitleFetcher / oEmbed title resolution for YouTube/
  Vimeo/Spotify/SoundCloud (the precedent this PR mirrors for the
  Apple Podcasts path).
