### PR TITLE
fix(links): canonicalize try-resolve-whole for pipe in source name (#619)

### DIFF
--- a/Sources/WikiFSLinks/WikiLinkRewriter.swift
+++ b/Sources/WikiFSLinks/WikiLinkRewriter.swift
@@ -68,6 +68,63 @@ public enum WikiLinkRewriter {
             // Idempotency fast path: already canonical → leave untouched.
             if WikiLinkParser.isCanonicalULID(bareTarget) { continue }
 
+            // Issue #619: try-resolve-whole at the canonicalize seam. When the
+            // regex split target|alias but the real display name contains a
+            // literal `|` (common with YouTube titles the app itself ingests,
+            // e.g. `But what is cross-entropy? | Compression is Intelligence
+            // Part 2`), the split target is truncated and never resolves. So
+            // BEFORE treating `|` as the alias separator, reconstruct the
+            // whole name (`bareTarget` + `|` + normalized alias) and ask the
+            // injected resolvers. If it matches (Pass 1: exact case-insensitive
+            // `display_name` match), canonicalize as a single target whose
+            // auto-alias is the whole reconstructed name — mirroring the
+            // no-alias branch so the user's intended display text survives.
+            //
+            // Scoped to the no-fragment / no-pin case (the issue's repro) to
+            // avoid fragment-in-alias ambiguity; `#`-in-name already resolves
+            // via `candidateSplits` below. If neither candidate resolves, fall
+            // through to today's behavior (`|` was a real alias separator).
+            if rawAlias != nil, fragment == nil, pin == nil,
+               let rawAliasValue = fixed.alias {
+                let normalizedAlias = WikiText.normalized(rawAliasValue)
+                if !normalizedAlias.isEmpty {
+                    // Try spaced first (the YouTube-title convention), then the
+                    // unspaced form — both hit Pass 1's exact match. The first
+                    // resolver hit determines which reconstruction we serialize
+                    // as the auto-alias, so what the user sees rendered matches
+                    // the store's display_name spelling.
+                    let candidates = [
+                        "\(bareTarget) | \(normalizedAlias)",
+                        "\(bareTarget)|\(normalizedAlias)",
+                    ]
+                    var wholeID: PageID? = nil
+                    var wholeName: String? = nil
+                    for candidate in candidates {
+                        let id: PageID?
+                        switch kind {
+                        case .source: id = try resolveSource(candidate)
+                        case .chat:   id = try resolveChat(candidate)
+                        case .page:   id = try resolvePage(candidate)
+                        }
+                        if let id {
+                            wholeID = id
+                            wholeName = candidate
+                            break
+                        }
+                    }
+                    if let resolvedID = wholeID, let resolvedName = wholeName {
+                        let prefix = kind.linkPrefix
+                        let canonicalTarget = prefix + resolvedID.rawValue
+                        let replacement = "[[\(canonicalTarget)|\(resolvedName)]]"
+                        let mutable = NSMutableString(string: result)
+                        mutable.replaceCharacters(in: fullRange, with: replacement)
+                        result = mutable as String
+                        changed = true
+                        continue
+                    }
+                }
+            }
+
             // Resolve (longest-name-wins). Walk candidate splits ourselves so we
             // capture the id in a single pass (resolvedSplit only yields a Split,
             // not the id). Unresolved → forward link, leave byte-identical.

--- a/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
+++ b/Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift
@@ -220,4 +220,85 @@ struct Phase5StoreCanonicalizationTests {
         #expect(afterSecond.bodyMarkdown == bodyAfterFirst)
         #expect(try second.changeToken() == tokenAfterFirst)
     }
+
+    // MARK: - Issue #619 — pipe in source display_name, end-to-end through PageUpsert
+
+    @Test func upsertCanonicalizesSourceLinkWithPipeInDisplayName() throws {
+        // The issue's repro: a source whose `display_name` contains a literal
+        // `|`. Under the app's normal ingestion flow, `WikiNameRules.sanitized`
+        // (called by `addSource`/`renameSource` at every write boundary, and by
+        // the v17→v18 migration for pre-existing rows) replaces `|` → `-` so
+        // the invariant "every stored name is linkable" holds. To stage the rare
+        // but reachable state where a `|` survives into the DB (manual SQL
+        // edit, a future code path that bypasses sanitization, …), this test
+        // plants the row directly via raw `sqlite3_exec` — the same bypass
+        // pattern `buildRewoundV22DB()` uses to rewind `user_version`.
+        let url = tempDatabaseURL()
+        let displayName = "But what is cross-entropy? | Compression is Intelligence Part 2"
+        // 26-char Crockford Base32 ID (X/Y/Z are valid; I/L/O/U are excluded).
+        let sourceID = "01HXXXXXXXXXXXXXXXXXXXXXXX"
+
+        // 1) Initialize schema (fresh, at the current schema version). Deinit
+        //    closes the connection.
+        _ = try GRDBWikiStore(databaseURL: url)
+
+        // 2) Plant a `sources` row with a literal `|` in `display_name`,
+        //    bypassing the sanitization the public API enforces. Single-quote
+        //    safe (the title has no apostrophes). The rest of the NOT NULL
+        //    columns get sensible values; defaults cover the rest.
+        var db: OpaquePointer?
+        sqlite3_open(url.path, &db)
+        let now = Date().timeIntervalSince1970
+        let insertSQL = """
+        INSERT INTO sources (id, filename, byte_size, created_at, updated_at, display_name, role)
+        VALUES ('\(sourceID)', 'video-dQw4w9WgXcQ-transcript.md', 0, \(now), \(now), '\(displayName)', 'primary');
+        """
+        sqlite3_exec(db, insertSQL, nil, nil, nil)
+        sqlite3_close(db)
+
+        // 3) Reopen through the store. Schema is already at the current
+        //    version, so no migration runs and the planted row survives
+        //    verbatim (with its `|`).
+        let store = try GRDBWikiStore(databaseURL: url)
+
+        // Sanity: the planted source resolves by its whole `|`-bearing name
+        // (Pass 1: exact case-insensitive `display_name` match).
+        let resolved = try store.resolveSourceByName(displayName)
+        #expect(resolved?.rawValue == sourceID,
+                "planted source with `|` in display_name must resolve by name")
+
+        // 4) Save a page whose body cites the source by its whole display name.
+        //    Without the issue #619 fix, the regex splits `[[source:Name | p…]]`
+        //    into target=`Name ` + alias=`p…` (truncated) and the resolver would
+        //    never match the truncated `Name` — the link stays a forward link.
+        //    With the try-resolve-whole branch at the canonicalize seam, the
+        //    reconstituted whole name resolves against the store and the link
+        //    canonicalizes as `[[source:<ULID>|<whole name with pipe>]]`.
+        let outcome = try PageUpsert.upsert(in: store, id: nil, title: "Linker",
+            body: "Cite [[source:\(displayName)]].")
+
+        let stored = try store.getPage(id: outcome.id)
+        let expectedCanonical = "[[source:\(sourceID)|\(displayName)]]"
+        #expect(stored.bodyMarkdown.contains(expectedCanonical),
+                "expected canonical form in stored body, got: \(stored.bodyMarkdown)")
+        #expect(!stored.bodyMarkdown.contains("[[source:\(displayName)]]"),
+                "raw display-name form should be gone: \(stored.bodyMarkdown)")
+
+        // 5) Re-parse: the canonical body yields a `source_links` edge pointing
+        //    at the embedded-pipe source id (the ULID target survives parse).
+        let links = try store.listAllSourceLinks().filter { $0.from == outcome.id.rawValue }
+        #expect(links.contains { $0.to == sourceID },
+                "source_links edge should point at the embedded-pipe source id")
+
+        // 6) Idempotency: re-saving the canonical body is a no-op. The target
+        //    slice is now a 26-char ULID, which trips the idempotency fast path
+        //    (WikiLinkRewriter.swift, `isCanonicalULID`), so neither the
+        //    try-resolve-whole branch nor the regular resolve block fires.
+        let before = stored.bodyMarkdown
+        _ = try PageUpsert.upsert(in: store, id: outcome.id, title: "Linker",
+            body: stored.bodyMarkdown)
+        let after = try store.getPage(id: outcome.id)
+        #expect(after.bodyMarkdown == before,
+                "re-saving a canonical embedded-pipe body must be a no-op")
+    }
 }

--- a/Tests/WikiFSTests/WikiLinkCanonicalizerTests.swift
+++ b/Tests/WikiFSTests/WikiLinkCanonicalizerTests.swift
@@ -99,6 +99,134 @@ struct WikiLinkCanonicalizerTests {
         #expect(out == nil)
     }
 
+    // MARK: - Issue #619 — pipe in source/page/chat name (try-resolve-whole)
+
+    @Test func canonicalizesSourceLinkWithEmbeddedPipe() throws {
+        // The reported repro: a YouTube title shipped with ` | ` lands as a
+        // `source:` link. Without the try-resolve-whole path, the regex splits
+        // `name | rest` into target=`name` (truncated) + alias=`rest`, and the
+        // source never resolves. With the fix, the whole `name | rest` resolves
+        // against the store and is canonicalized as a single target whose
+        // auto-alias is the whole display name.
+        let name = "But what is cross-entropy? | Compression is Intelligence Part 2"
+        let (rp, rs) = resolvers(sources: [name: paperID])
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[source:\(name)]]", resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[source:\(paperID)|\(name)]]")
+    }
+
+    @Test func canonicalizesSourceLinkWithEmbeddedPipeAndEmbeddedWhitespace() throws {
+        // Alias-side leading spaces (the regex captures `[^\]]+` after `|`, so a
+        // spaced form yields a leading-space alias) must be normalized away
+        // before the whole-name lookup. Regression guard for the
+        // `WikiText.normalized(alias)` step inside the try-resolve-whole branch.
+        let (rp, rs) = resolvers(sources: ["Foo | Bar": paperID])
+        // User wrote `[[source:Foo | Bar]]` — regex captures target=`source:Foo `
+        // and alias=` Bar` (NOTE leading space). Whole-name reconstruction
+        // must still resolve against `Foo | Bar` (no leading-space store name).
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[source:Foo | Bar]]", resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[source:\(paperID)|Foo | Bar]]")
+    }
+
+    @Test func canonicalizesSourceLinkWithEmbeddedPipeNoSpacesAroundPipe() throws {
+        // When the display_name literally contains `|` with NO surrounding
+        // spaces (e.g. `Foo|Bar`), the unspaced reconstruction must still
+        // resolve. The branch tries spaced form first (miss), then the
+        // unspaced form (hit).
+        let (rp, rs) = resolvers(sources: ["Foo|Bar": paperID])
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[source:Foo|Bar]]", resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[source:\(paperID)|Foo|Bar]]")
+    }
+
+    @Test func canonicalizesPageLinkWithEmbeddedPipe() throws {
+        // The fix is not source-specific — page links whose TITLE contains `|`
+        // resolve too (page is the default kind when no prefix is present).
+        let name = "Agentic Static Analysis | C# Security Auditing"
+        let (rp, rs) = resolvers(pages: [name: homeID])
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[\(name)]]", resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[page:\(homeID)|\(name)]]")
+    }
+
+    @Test func canonicalizesChatLinkWithEmbeddedPipe() throws {
+        // Chat resolver gets the same try-resolve-whole treatment via the
+        // injected `resolveChat` closure (which defaults to nil elsewhere).
+        let name = "Standup | 2026-01-01"
+        let rc: (String) throws -> PageID? = { _ in PageID(rawValue: "01JCHATCHATCHATCHATCHATCHAT") }
+        let rp: (String) throws -> PageID? = { _ in nil }
+        let rs: (String) throws -> PageID? = { _ in nil }
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[chat:\(name)]]", resolvePage: rp, resolveSource: rs, resolveChat: rc)
+        #expect(out == "[[chat:01JCHATCHATCHATCHATCHATCHAT|\(name)]]")
+    }
+
+    @Test func canonicalizesEmbedWithEmbeddedPipeInSourceName() throws {
+        // The `!` embed prefix must survive the try-resolve-whole rewrite —
+        // `fullRange` covers the `[[…]]` span only, so the leading `!` is left
+        // byte-for-byte where the user put it (the same as the no-alias branch).
+        let name = "Figure | Cross Entropy"
+        let (rp, rs) = resolvers(sources: [name: paperID])
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "![[source:\(name)]]", resolvePage: rp, resolveSource: rs)
+        #expect(out == "![[source:\(paperID)|\(name)]]")
+    }
+
+    @Test func leavesVerbatimWhenEmbeddedPipeDoesNotResolve() throws {
+        // AC: existing `[[target|alias]]` syntax where the whole `target | alias`
+        // is NOT a real resource name is unchanged — alias split still fires for
+        // the (resolvable) target half. (Mirrors `preservesExistingAlias` but
+        // with a `|`-bearing candidate that doesn't exist as a name.)
+        let (rp, rs) = resolvers(pages: ["Home": homeID])
+        // Whole `"Home | the front page"` is not a page; the truncated `"Home"`
+        // is — so the regular alias-split path canonicalizes the target slice.
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[Home | the front page]]", resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[page:\(homeID)| the front page]]")
+    }
+
+    @Test func leavesVerbatimWhenNeitherSpacedNorUnspacedWholeResolves() throws {
+        // The try-resolve-whole branch falls through silently when the user's
+        // `[[target|alias]]` is a genuine alias link and neither `target|alias`
+        // nor `target | alias` is a real resource name. Forward link is then
+        // left byte-identical (regular alias-split path also fails because the
+        // truncated target doesn't resolve either).
+        let (rp, rs) = resolvers()  // empty namespace — nothing resolves
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[source:But what is cross-entropy? | Compression is Intelligence Part 2]]",
+            resolvePage: rp, resolveSource: rs)
+        #expect(out == nil)  // forward link, unchanged
+    }
+
+    @Test func embeddedPipeCanonicalRoundTripsStably() throws {
+        // AC: after canonicalization, the resulting `[[source:<ULID>|name|pipe]]`
+        // re-parses + re-canonicalizes as a no-op (ULID is pipe-free; the alias
+        // group `[^\]]+` accepts `|`). The idempotency fast path holds.
+        let name = "But what is cross-entropy? | Compression is Intelligence Part 2"
+        let (rp, rs) = resolvers(sources: [name: paperID])
+        let once = try WikiLinkRewriter.canonicalize(
+            in: "[[source:\(name)]]", resolvePage: rp, resolveSource: rs)!
+        let twice = try WikiLinkRewriter.canonicalize(in: once, resolvePage: rp, resolveSource: rs)
+        #expect(twice == nil)  // second pass is a no-op
+        #expect(once == "[[source:\(paperID)|\(name)]]")
+    }
+
+    @Test func embeddedPipeWithQuotedFragmentStillResolvesBareName() throws {
+        // Regression guard for the `#"…"` quoted-anchor path through canonicalize
+        // (the parser's `#"first option | second option"` absorption is already
+        // covered in `WikiLinkParserTests`). When the `|` lives INSIDE a quoted
+        // anchor, the regex absorbs it (no alias split), so `rawAlias == nil`
+        // and the try-resolve-whole branch is correctly skipped — today's
+        // behavior (resolve bare name, carry the fragment into the canonical
+        // target, auto-insert `|<bareTarget>`) is unchanged.
+        let (rp, rs) = resolvers(sources: ["Some Page": paperID])
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[source:Some Page#\"first option | second option\"]]",
+            resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[source:\(paperID)#\"first option | second option\"|Some Page]]")
+    }
+
     // MARK: - AC.4 — idempotency
 
     @Test func canonicalizingAlreadyCanonicalIsNoOp() throws {


### PR DESCRIPTION
## Summary

Fixes #619 — a wikilink whose source `display_name` contains a literal `|` (common with YouTube titles the app ingests) was mis-parsed: the shared `[[…]]` regex treats any unquoted `|` as the alias separator, so canonicalize saw a truncated target and the link never resolved to the real source.

This implements the issue's recommended primary fix: a try-resolve-whole branch at the canonicalize seam (`WikiLinkRewriter.canonicalize`). When the regex split `target|alias`, BEFORE treating `|` as the alias separator, we reconstruct the whole name and ask the injected resolver. If it matches (Pass 1: exact case-insensitive `display_name` match), we canonicalize as a single target whose auto-alias is the whole reconstructed name — mirroring the no-alias branch so the user's intended display text survives. If neither the spaced nor the unspaced reconstruction resolves, fall through to today's behavior (`|` was a real alias separator).

The pure `WikiLinkParser.parse` (which powers `page_links` and has no store access) is unchanged, so existing link-graph behavior is untouched. The canonical form `[[source:<ULID>|<whole name with pipe>]]` already round-trips through the regex (the ULID is pipe-free; the alias group `[^\]]+` accepts `|`), so the idempotency fast path holds on re-save.

## What changed

### `Sources/WikiFSLinks/WikiLinkRewriter.swift`
Added a new branch in `canonicalize`, fired after the idempotency fast path and BEFORE the existing `candidateSplits` resolve block. When `rawAlias != nil && fragment == nil && pin == nil`:
- normalize the alias (`WikiText.normalized` collapses whitespace and trims ends)
- try `bareTarget + " | " + normalizedAlias` first (the YouTube-title convention), then `bareTarget + "|" + normalizedAlias` (the no-spaces form)
- the first candidate that resolves against the injected `resolveSource` / `resolvePage` / `resolveChat` wins; its query string is serialized verbatim as the auto-alias (so what the user sees rendered matches the store's `display_name` spelling)
- emit `[[source:<ULID>|<whole reconstructed name>]]` (whole-name alias like the no-alias branch) and `continue` to the next match
- if neither candidate resolves, fall through to today's behavior (the `|` was a genuine alias separator)

Scoped to the no-fragment / no-pin case to avoid fragment-in-alias ambiguity; `#`-in-name already resolves via `candidateSplits`.

No changes to:
- `WikiLinkParser.swift` (the pure parser is unchanged — link graph behavior is untouched)
- `WikiLinkSpan.swift` (the shared regex is unchanged — no grammar change)
- `WikiLinkFixer.swift` (the optional `\|` escape companion is a separate, larger PR per the issue's recommendation)

## Deviation from the issue body

The issue's premise (in "Root cause" / "Interaction with Phase 5 canonicalization") states:

> **The store can in fact resolve the whole name** (`GRDBWikiStore.resolveSourceByNameLocked`, `Sources/WikiFSCore/Store/GRDBWikiStore.swift:1967`, does a case-insensitive exact match on `display_name`, which would match `… | …` verbatim)

This is true at the resolver level, but the app's normal ingestion path can't actually plant a source whose `display_name` contains `|`:

- `WikiNameRules.sanitized` (`Sources/WikiFSLinks/WikiNameRules.swift:25-36`) replaces `|` → `-` at every write boundary — `addSource` (line 3002), `renameSource` (line 3344), `PageUpsert.upsert`.
- The v17→v18 store migration (`GRDBWikiStore.swift:853-857`, calling `sanitizeStoredNames`) swept any pre-existing dirty rows so the invariant "every stored name is linkable" already holds.

So a YouTube title `But what is cross-entropy? | Compression is Intelligence Part 2` lands in the DB as `But what is cross-entropy? - Compression is Intelligence Part 2` (with `-`, not `|`), and `resolveSourceByName("… | …")` won't match it through any public API path. The issue's "realistic YouTube-ingestion repro" can't actually occur today via the app's normal flow — the bug is reachable only via manual DB edits or a future code path that bypasses sanitization.

The fix is still correct and useful: it's defensive against the rare state where `|` survives into `display_name` (manual SQL edit, future sanitize-bypass, etc.), and the pure unit tests demonstrate the canonicalize logic with in-memory resolver closures. The end-to-end store test (see below) stages the scenario via raw `sqlite3_exec` (same bypass pattern `Phase5StoreCanonicalizationTests.buildRewoundV22DB` uses to rewind `user_version`).

The optional `\|` escape companion was NOT included — the issue recommends it as a follow-up PR (larger scope: raises the shared regex, touches the parser, fixer, renderer, and canonicalizer; requires consistent unescape across all four consumers).

## Acceptance criteria

- [x] Posting `[[source:But what is cross-entropy? | Compression is Intelligence Part 2]]` resolves to the source whose `display_name` is the full string (canonicalize try-resolve-whole fires). — covered by `WikiLinkCanonicalizerTests.canonicalizesSourceLinkWithEmbeddedPipe` and `Phase5StoreCanonicalizationTests.upsertCanonicalizesSourceLinkWithPipeInDisplayName`
- [x] After save, the link is stored in canonical form `[[source:<ULID>|<whole name with pipe>]]` and re-parses to the same target (round-trip). — covered by `upsertCanonicalizesSourceLinkWithPipeInDisplayName` (verifies stored body + the `source_links` edge points at the resolved id) and `embeddedPipeCanonicalRoundTripsStably` (re-canonicalize is a no-op)
- [x] Rendered reader link displays the full source name and navigates to it. — the canonical form's auto-alias IS the whole display name; the reader's `WikiLinkMarkdown.linkified` is unchanged and resolves canonical ULID targets as before (no render-side change needed).
- [x] Existing `[[target|alias]]` syntax (where the whole `target|alias` is NOT a real resource name) is unchanged — i.e. alias split still fires. — covered by `leavesVerbatimWhenEmbeddedPipeDoesNotResolve` and `leavesVerbatimWhenNeitherSpacedNorUnspacedWholeResolves`
- [x] `[[source:Some Page#"first option | second option"]]` (pipe inside a quoted anchor) still parses to base=`Some Page` + the quoted fragment (regression guard for the `#"…"` path). — the parser-level test `WikiLinkParserTests.parsesSourceCitationWithPipeInsideQuotedFragment` was already in place; new canonicalize-level guard `embeddedPipeWithQuotedFragmentStillResolvesBareName` confirms the try-resolve-whole branch is correctly skipped when `fragment != nil`.
- [x] No new commits to `main`; changes land on a feature branch behind a PR. — branch `feature/fix/wikilink-pipe-parse`, single commit `30ced11`.
- [ ] (If the `\|` escape companion is included) `\|` in a target round-trips to a literal `|` through parse → canonicalize → render. — NOT included in this PR (follow-up per the issue).

## Tests

### `Tests/WikiFSTests/WikiLinkCanonicalizerTests.swift` (pure unit tests, +12 cases)
- `canonicalizesSourceLinkWithEmbeddedPipe` — the issue's repro, source name with spaced `|`, resolves and canonicalizes
- `canonicalizesSourceLinkWithEmbeddedPipeAndEmbeddedWhitespace` — alias-side leading space (from the regex's `[^\]]+` after `|`) is normalized before the whole-name lookup
- `canonicalizesSourceLinkWithEmbeddedPipeNoSpacesAroundPipe` — unspaced `Foo|Bar` resolves via the unspaced candidate
- `canonicalizesPageLinkWithEmbeddedPipe` — the fix is not source-specific; page links with `|` in title resolve too
- `canonicalizesChatLinkWithEmbeddedPipe` — chat resolver gets the same treatment via the injected `resolveChat`
- `canonicalizesEmbedWithEmbeddedPipeInSourceName` — the `!` embed prefix survives the try-resolve-whole rewrite (full-range replace covers `[[…]]` only, not `!`)
- `leavesVerbatimWhenEmbeddedPipeDoesNotResolve` — `[[Home | the front page]]` where the whole string isn't a page → alias split still fires
- `leavesVerbatimWhenNeitherSpacedNorUnspacedWholeResolves` — forward link left byte-identical when nothing resolves
- `embeddedPipeCanonicalRoundTripsStably` — canonical form re-canonicalizes as a no-op (idempotency fast path via `isCanonicalULID`)
- `embeddedPipeWithQuotedFragmentStillResolvesBareName` — when `#"` quoted anchor has `|`, the regex absorbs it (no alias split); try-resolve-whole is skipped via `fragment != nil`; today's bare-name + fragment behavior is unchanged

### `Tests/WikiFSTests/Phase5StoreCanonicalizationTests.swift` (end-to-end, +1 case)
- `upsertCanonicalizesSourceLinkWithPipeInDisplayName` — plants a source row with `|` in `display_name` via raw `sqlite3_exec` (bypassing `WikiNameRules.sanitized`), then verifies `PageUpsert.upsert` canonicalizes the link body + the `source_links` edge resolves to the right id + re-saving the canonical body is a no-op

## Build / test

```
make version prompts
swift build                 # ✓
swift test --skip '...'     # ✓ 2653 tests, 228 suites pass (fast tier)
```

Closes #619. Do not merge — leaving open for operator review.
