### PR TITLE
Tighten ingest-executor prompt: drop sub-agent hint, add scope boundary (#611)

### DIFF
--- a/prompts/ingest-executor.md
+++ b/prompts/ingest-executor.md
@@ -8,6 +8,10 @@ A snapshot of the current wiki state is at: {{STATE_FILE_PATH}}
 
 {{ASSIGNED_PAGES}}
 
+> **Scope boundary:** Write ONLY the pages assigned above. Do NOT update
+> `Home`, `index.md`, `log.md`, or any existing page — the Finalizer owns
+> those. Once all assigned pages are written and verified, stop.
+
 ## All pages in this ingest (for cross-linking)
 
 {{ALL_PAGE_TITLES}}
@@ -42,12 +46,10 @@ For EACH assigned page:
 `head_version_id`, then pass `--expect-head <that id>` to
 `$WIKICTL page upsert`. On exit code 3 (CAS conflict — the page was edited after
 you read it), re-read the page once, reapply your edit, and retry. If it fails
-again, report the conflict rather than looping.
+again, report the conflict rather than looping. Do NOT invent `python3 -c`
+or `/tmp`-redirecting shell pipelines to read `head_version_id` —
+`$WIKICTL page get … --json` is the only supported read path.
 
 IMPORTANT:
-- You MAY dispatch sub-agents via the Task tool to read and digest source
-  sections in parallel. Each sub-agent generates lifecycle notifications that
-  keep the host informed of progress. Workers must NOT write to the wiki —
-  only you write via `$WIKICTL`.
 - Do NOT use sleep or ScheduleWakeup.
 - Write ALL your assigned pages before stopping.


### PR DESCRIPTION
## Summary

Implements #611 — prompt-content-only tightening of `prompts/ingest-executor.md` to prevent the executor from drifting outside its assigned scope (root cause of the 2026-07-18 ingestion stall that hit an `alwaysAsk` permission timeout).

No Swift changes. `GeneratedPrompts.swift` is regenerated by `make prompts` (gitignored derived artifact).

## Changes

Three edits to `prompts/ingest-executor.md`:

1. **Delete the sub-agent hint.** Removed the "You MAY dispatch sub-agents via the Task tool…" bullet (was lines 47-51). For a 4-page ingest from a single 48 KB source, sub-agents are pure overhead, and in the stall trace they pushed the agent to explore outward into scratch folders of *other* wikis (`bv.md`, `html.md`, `index.md`, `upd-*.md` in turn-2 output are from OTHER wikis' scratch dirs).

2. **Add an explicit scope boundary** directly after the assigned-pages list:

   > **Scope boundary:** Write ONLY the pages assigned above. Do NOT update
   > `Home`, `index.md`, `log.md`, or any existing page — the Finalizer owns
   > those. Once all assigned pages are written and verified, stop.

   This prevents the executor from conflating its scope with the heavier `AGENTS.md` standalone-Ingest workflow ("§Ingest step 4 — Rewrite `index.md` via `$WIKICTL` index set"), which the Finalizer owns (see `prompts/ingest-finalizer.md`).

3. **Reinforce the existing CAS-discipline pattern** (optional point from the issue). Added a line to the CAS-discipline block warning the executor not to invent `python3 -c` / `/tmp`-redirecting shell pipelines to read `head_version_id` — `$WIKICTL page get … --json` is the only supported read path (root cause #5: the model invented such a pipeline and triggered `alwaysAsk`).

## Scope boundaries (from issue)

- This issue is **prompt-content only** — no Swift changes.
- It does not fix the underlying stall (the permission timeout + per-op policy are the structural fixes, addressed separately in #614). It reduces the *likelihood* of hitting one by keeping the executor inside its assigned scope.
- Did not re-enable sub-agents for the large-ingest case (e.g. a 200-page folder import) — that's a separate optimization.

## Verification

- The prompt diff deletes the sub-agent block and adds the boundary (see commit).
- Wider check: `grep -niE 'home|index\.md|log\.md|\blog\b' prompts/ingest-executor.md` returns only the new boundary block — no other place in the file references Home / index / log as executor responsibilities.
- `make version prompts` regenerated `Sources/WikiFSCore/GeneratedPrompts.swift` (gitignored — not committed); verified the regenerated content contains the new boundary and omits the sub-agent bullet.
- `swift build` — clean.
- Fast-tier test suite (2634 tests in 227 suites) — all passed:
  ```
  swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|...|SidebarDropBuilderIntegrationTests'
  ```

## Commit

- `b55e147` Tighten ingest-executor prompt: drop sub-agent hint, add scope boundary (#611)

Closes #611.
