### PR TITLE
Lower queued-ingestion turn ceiling from 1800s to 600s (#609)

### DIFF
--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -1309,6 +1309,16 @@ public actor ACPBackend: AgentBackend {
         maxConcurrentExecutors
     }
 
+    /// The turn ceiling (seconds) this backend was constructed with. #609:
+    /// `TurnLivenessPolicy.ceiling(for:)` decides per context — the launcher
+    /// threads the chosen value here, so a stalled ingest turn burns 600s
+    /// (queued) rather than 1800s (interactive default). Exposed for tests
+    /// (the launcher wiring + the factory threading). Mirrors the
+    /// `maxConcurrentExecutorCount()` accessor shape.
+    func ceilingTimeout() -> TimeInterval {
+        turnCeilingTimeout
+    }
+
     // MARK: - Model discovery (#329)
 
     /// The models the agent advertised for a session (`session/new` →

--- a/Sources/WikiFSEngine/AgentBackendFactory.swift
+++ b/Sources/WikiFSEngine/AgentBackendFactory.swift
@@ -15,13 +15,27 @@ public enum AgentBackendFactory {
 
     /// Construct the backend for a session. Every provider drives `ACPBackend`.
     ///
-    /// - Parameter budget: #606 auto-reject budget for deferred permission
-    ///   requests. nil (default) = no timer (interactive chat — current
-    ///   behavior); non-nil = a stuck permission auto-rejects after this
-    ///   `Duration` so unattended pipelines (ingest/lint) can't stall for the
-    ///   full 1800s ceiling.
-    static func makeBackend(policy: PermissionPolicy, budget: Duration? = nil) -> AgentBackend {
-        ACPBackend(permissionPolicy: policy, budget: budget)
+    /// - Parameters:
+    ///   - budget: #606 auto-reject budget for deferred permission
+    ///     requests. nil (default) = no timer (interactive chat — current
+    ///     behavior); non-nil = a stuck permission auto-rejects after this
+    ///     `Duration` so unattended pipelines (ingest/lint) can't stall for the
+    ///     full 1800s ceiling.
+    ///   - turnCeilingTimeout: #609 hard ceiling on total turn duration. The
+    ///     caller picks this per context via `TurnLivenessPolicy.ceiling(for:)`:
+    ///     `.chat` (interactive) → `defaultCeilingTimeout` (1800s);
+    ///     `.ingest`/`.lint` (queued) → `queuedIngestCeiling` (600s). Defaults
+    ///     to the interactive value for callers that don't differentiate
+    ///     (matching the underlying `ACPBackend.init` default).
+    static func makeBackend(
+        policy: PermissionPolicy,
+        budget: Duration? = nil,
+        turnCeilingTimeout: TimeInterval = TurnLivenessPolicy.defaultCeilingTimeout
+    ) -> AgentBackend {
+        ACPBackend(
+            permissionPolicy: policy,
+            budget: budget,
+            turnCeilingTimeout: turnCeilingTimeout)
     }
 
     /// Build the `providerHints` for an ACP provider from its PATH-resolved

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -202,8 +202,12 @@ public final class AgentLauncher {
     /// #606: second parameter is the deferred-permission budget — nil = no
     /// timer (interactive chat), non-nil = auto-reject after this `Duration`.
     /// Ingest/lint pass `.seconds(60)`; chat passes `nil`.
-    @ObservationIgnored var resolveBackend: (PermissionPolicy, Duration?) -> AgentBackend = {
-        AgentBackendFactory.makeBackend(policy: $0, budget: $1)
+    ///
+    /// #609: third parameter is the turn ceiling — `TurnLivenessPolicy.ceiling(for:)`
+    /// decides per kind: `.chat` → 1800s (interactive default), `.ingest`/`.lint`
+    /// → 600s (unattended pipelines must not burn 30 minutes on a stall).
+    @ObservationIgnored var resolveBackend: (PermissionPolicy, Duration?, TimeInterval) -> AgentBackend = {
+        AgentBackendFactory.makeBackend(policy: $0, budget: $1, turnCeilingTimeout: $2)
     }
 
     /// The permission policy, resolved per operation kind. #607: previously one
@@ -946,12 +950,18 @@ public final class AgentLauncher {
         // valve); ingest/lint are unattended and MUST auto-reject so a stuck
         // permission can't burn the 1800s ceiling.
         let permissionBudget: Duration? = (permissionKind == .chat) ? nil : .seconds(60)
+        // #609: queued-ingestion ceiling is tighter than the interactive
+        // default so a stalled ingest/lint turn burns 10 minutes, not 30.
+        // `runACPIngestPlannerExecutors` (large-source ingest) reuses this
+        // `self.backend` — so the ceiling chosen here is the ceiling that
+        // planner/executor/finalizer phases run under.
+        let turnCeiling = TurnLivenessPolicy.ceiling(for: permissionKind)
 
         // #324: the launcher reads `agent-providers.json`, picks the default
         // (or selected) provider, and resolves its PATH command + Keychain key
         // into providerHints. The app is ACP-only.
         let provider = resolveSelectedProvider()
-        self.backend = resolveBackend(policy, permissionBudget)
+        self.backend = resolveBackend(policy, permissionBudget, turnCeiling)
 
         // Resolve the provider's spawn command (PATH-resolved because the
         // swift-acp SDK's launch() does NOT do PATH lookup) + the Keychain-backed
@@ -2139,9 +2149,13 @@ public final class AgentLauncher {
         // ingest/lint. #606: chat is interactive, so no auto-reject budget —
         // the UI chip is the release valve, preserving the prior indefinite-
         // suspend behavior. (`nil` budget ⇒ no timer on `deferPermission`.)
+        // #609: chat uses the interactive 1800s ceiling — long reasoning
+        // chains are legitimate in a user-attended session, and the user can
+        // cancel via the UI chip.
         let policy: PermissionPolicy = resolvePermissionMode(.chat)
         let permissionBudget: Duration? = nil
-        DebugLog.agent("startInteractiveQuery: permissionPolicy=\(policy) budget=nil (interactive)")
+        let turnCeiling = TurnLivenessPolicy.ceiling(for: .chat)
+        DebugLog.agent("startInteractiveQuery: permissionPolicy=\(policy) budget=nil (interactive) ceiling=\(turnCeiling)s")
 
         // #324: the launcher reads `agent-providers.json` and picks the
         // default (or selected) provider. The app is ACP-only.
@@ -2171,7 +2185,7 @@ public final class AgentLauncher {
             return
         }
 
-        self.backend = resolveBackend(policy, permissionBudget)
+        self.backend = resolveBackend(policy, permissionBudget, turnCeiling)
 
         // Resolve the provider's spawn command (PATH-resolved) + the
         // Keychain-backed API key (keyed by provider id).

--- a/Sources/WikiFSEngine/TurnLivenessPolicy.swift
+++ b/Sources/WikiFSEngine/TurnLivenessPolicy.swift
@@ -57,11 +57,41 @@ enum TurnLivenessPolicy {
 
     // MARK: - Defaults
 
-    /// Default ceiling: 30 minutes. Backstop against an agent that streams
-    /// heartbeat-ish updates forever without finishing.
+    /// Default (interactive) ceiling: 30 minutes. Backstop against an agent
+    /// that streams heartbeat-ish updates forever without finishing. Used by
+    /// `startInteractiveQuery` (interactive chat — long reasoning chains are
+    /// legitimate, and the UI chip is the user-facing release valve).
     static let defaultCeilingTimeout: TimeInterval = 1800
+
+    /// Queued-ingestion ceiling: 10 minutes. Used by unattended pipelines
+    /// (ingest — including `runACPIngestPlannerExecutors` — and lint runs).
+    /// Lower than the interactive default so a single stalled ingestion turn
+    /// burns 10 minutes, not 30 (issue #609: a 4-page ingest twice hit the
+    /// 1800s ceiling on 2026-07-18, costing ~60 minutes of dead time). The
+    /// companion #606 permission auto-reject budget (60s) is the primary
+    /// backstop; this ceiling is a wider safety net for non-permission stalls.
+    static let queuedIngestCeiling: TimeInterval = 600
 
     /// Watchdog poll interval: 15 seconds. Balances responsiveness (a ceiling
     /// breach is detected within 15s of the threshold) against actor pressure.
     static let defaultPollInterval: TimeInterval = 15
+
+    // MARK: - Per-context ceiling selection
+
+    /// Resolve the ceiling a turn should use given the operation kind:
+    /// - `.chat` — the interactive 1800s default (long reasoning chains are
+    ///   legitimate in a user-attended chat).
+    /// - `.ingest` / `.lint` — the queued-ingestion 600s ceiling (unattended
+    ///   batch pipelines that must not burn 30 minutes on a stall).
+    ///
+    /// Single decision point the launcher consults at backend construction.
+    /// Mirrors the `permissionBudget` split (`nil` for chat, `.seconds(60)`
+    /// for ingest/lint) at the symmetric call site — same rationale:
+    /// unattended pipelines need tighter backstops than interactive chat.
+    static func ceiling(for kind: PermissionOperationKind) -> TimeInterval {
+        switch kind {
+        case .chat:                return defaultCeilingTimeout
+        case .ingest, .lint:       return queuedIngestCeiling
+        }
+    }
 }

--- a/Tests/WikiFSTests/ACPBackendTests.swift
+++ b/Tests/WikiFSTests/ACPBackendTests.swift
@@ -796,4 +796,40 @@ import ACPModel
         let max = await backend.maxConcurrentExecutorCount()
         #expect(max == 1)
     }
+
+    // MARK: - #609: turn ceiling threading
+
+    /// The default `ACPBackend()` ceiling is the interactive 1800s — preserved
+    /// pre-#609 behavior. Chat (`startInteractiveQuery`) relies on this default
+    /// (passed explicitly via `TurnLivenessPolicy.ceiling(for: .chat)`).
+    @Test
+    func ceilingTimeoutDefaultsToInteractive() async {
+        let backend = ACPBackend()
+        let ceiling = await backend.ceilingTimeout()
+        #expect(ceiling == TurnLivenessPolicy.defaultCeilingTimeout)
+        #expect(ceiling == 1800)
+    }
+
+    /// An explicit `turnCeilingTimeout: 600` threads through untouched — the
+    /// value the launcher passes for ingest/lint (queued pipelines). Pinned so
+    /// a future refactor can't accidentally ignore the parameter and fall back
+    /// to the default.
+    @Test
+    func ceilingTimeoutExplicitValueThreaded() async {
+        let backend = ACPBackend(turnCeilingTimeout: 600)
+        let ceiling = await backend.ceilingTimeout()
+        #expect(ceiling == 600)
+    }
+
+    /// #609 contract: the queued-ingestion ceiling (600s) is lower than the
+    /// interactive default (1800s). Pinned at the construction level so the
+    /// two values cannot drift equal at the type level either.
+    @Test
+    func queuedCeilingLowerThanInteractive() async {
+        let interactive = ACPBackend()
+        let queued = ACPBackend(turnCeilingTimeout: TurnLivenessPolicy.queuedIngestCeiling)
+        let interactiveCeiling = await interactive.ceilingTimeout()
+        let queuedCeiling = await queued.ceilingTimeout()
+        #expect(queuedCeiling < interactiveCeiling)
+    }
 }

--- a/Tests/WikiFSTests/ACPIngestPlanTests.swift
+++ b/Tests/WikiFSTests/ACPIngestPlanTests.swift
@@ -403,7 +403,9 @@ struct ACPIngestCollapsedRoutingTests {
         tempDir: URL
     ) -> AgentLauncher {
         let launcher = AgentLauncher()
-        launcher.resolveBackend = { _, _ in
+        // #609: resolveBackend now takes (policy, budget, ceiling) — ignore
+        // all three; the #604 collapse pin only counts invocations, not args.
+        launcher.resolveBackend = { _, _, _ in
             counter.increment()
             return backend
         }

--- a/Tests/WikiFSTests/ACPWiringTests.swift
+++ b/Tests/WikiFSTests/ACPWiringTests.swift
@@ -36,6 +36,29 @@ import ACPModel
         #expect(alwaysAsk is ACPBackend)
     }
 
+    /// #609: `makeBackend` exposes `turnCeilingTimeout` and threads it into the
+    /// `ACPBackend` constructor untouched. The launcher picks the value via
+    /// `TurnLivenessPolicy.ceiling(for:)`; this test pins the factory plumbing
+    /// (default interactive → 1800s; explicit 600s → the queued-ingestion
+    /// ceiling) so a future refactor can't silently drop the parameter.
+    @Test func factoryThreadsTurnCeilingTimeout() async {
+        // Default (omitted) = interactive 1800s — preserves pre-#609 behavior
+        // for callers that don't differentiate (and matches the underlying
+        // `ACPBackend.init` default).
+        let interactive = AgentBackendFactory.makeBackend(policy: .bypass)
+        let interactiveACP = await (interactive as! ACPBackend).ceilingTimeout()
+        #expect(interactiveACP == TurnLivenessPolicy.defaultCeilingTimeout)
+        #expect(interactiveACP == 1800)
+
+        // Explicit queued-ingestion ceiling (600s) — what ingest/lint pass.
+        let queued = AgentBackendFactory.makeBackend(
+            policy: .bypass,
+            turnCeilingTimeout: TurnLivenessPolicy.queuedIngestCeiling)
+        let queuedACP = await (queued as! ACPBackend).ceilingTimeout()
+        #expect(queuedACP == TurnLivenessPolicy.queuedIngestCeiling)
+        #expect(queuedACP == 600)
+    }
+
     // MARK: - ACP provider hints (AgentProvider → profile)
 
     /// The resolved executable path becomes `acpAgentPath`; the rest of the

--- a/Tests/WikiFSTests/AgentLauncherCeilingWiringTests.swift
+++ b/Tests/WikiFSTests/AgentLauncherCeilingWiringTests.swift
@@ -1,0 +1,188 @@
+import Testing
+import Foundation
+import WikiFSEngine
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// #609 wiring pin: the launcher routes the right `turnCeilingTimeout` to the
+/// `ACPBackend` per operation kind, via `TurnLivenessPolicy.ceiling(for:)`:
+/// - `.ingest` (one-shot + `runACPIngestPlannerExecutors`) and `.lint` runs —
+///   the 600s queued-ingestion ceiling.
+/// - `.chat` (interactive `startInteractiveQuery`) — the 1800s interactive
+///   default.
+///
+/// These tests drive the actual `run()` / `startInteractiveQuery()` call sites
+/// (NOT just `TurnLivenessPolicy.ceiling(for:)` in isolation), so a future
+/// refactor that swaps the launcher's `ceiling(for:)` call to a hardcoded
+/// `defaultCeilingTimeout` would fail here — the per-kind wiring is the
+/// contract the issue asks for ("ceiling used by `runACPIngestPlannerExecutors`
+/// is the queued-ingestion value (600s), and the interactive path keeps using
+/// 1800s").
+///
+/// The tests early-return at `resolveACPProviderSpawn` because the test
+/// provider has `command = nil` (after `resolveBackend` is called) — so the
+/// captured ceiling is observable WITHOUT spawning a real subprocess.
+@MainActor
+@Suite("AgentLauncher ceiling wiring (#609)")
+struct AgentLauncherCeilingWiringTests {
+
+    /// Thread-safe box for the LAST `turnCeilingTimeout` value the launcher
+    /// passed to `resolveBackend`. `@unchecked Sendable` so the `@Sendable`
+    /// closure body (run on the main actor) can write into it.
+    private final class CapturedCeiling: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value: TimeInterval?
+        func record(_ ceiling: TimeInterval) {
+            lock.lock(); _value = ceiling; lock.unlock()
+        }
+        var value: TimeInterval? {
+            lock.lock(); defer { lock.unlock() }
+            return _value
+        }
+        var callCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _value == nil ? 0 : 1
+        }
+    }
+
+    /// A provider with `command = nil` so `resolveACPProviderSpawn` returns nil
+    /// (early-return AFTER `resolveBackend` was called). The provider's
+    /// `selectedModelId` is pre-seeded in the test config so the chat path's
+    /// `SpawnModelGuard.validate` (which fires before `resolveBackend`) passes.
+    private let noCommandProvider = AgentProvider(
+        id: "fake-no-cmd",
+        label: "FakeNoCommand",
+        command: nil,
+        env: [:],
+        enabled: true,
+        isDefault: true
+    )
+
+    /// Build a launcher wired so `resolveBackend` records the ceiling it was
+    /// called with, and `run()` / `startInteractiveQuery()` early-return at
+    /// `resolveACPProviderSpawn` (no spawn attempted). The fake-acp provider
+    /// has a model selected (`fake-model`) so the chat path's
+    /// `SpawnModelGuard` lets the run reach `resolveBackend`.
+    private func makeLauncher(captured: CapturedCeiling, tempDir: URL) -> AgentLauncher {
+        let launcher = AgentLauncher()
+        launcher.resolveBackend = { _, _, ceiling in
+            captured.record(ceiling)
+            return FakeAgentBackend()
+        }
+        launcher.acpCredentialStore = InMemoryACPCredentialStore()
+        launcher.resolveSelectedProvider = { noCommandProvider }
+        let config = AgentProvidersConfig(
+            providers: [noCommandProvider],
+            selectedModelIds: [noCommandProvider.id: "fake-model"])
+        do {
+            try config.save(to: tempDir)
+        } catch {
+            Issue.record("Failed to save provider config to temp dir: \(error)")
+        }
+        launcher.resolveProvidersContainerDirectory = { tempDir }
+        launcher.containerDirectory = tempDir
+        return launcher
+    }
+
+    /// The ingest path (`run(.ingest(...))`) routes to `runACPIngestPlannerExecutors`
+    /// for large sources AND stays on the single-session path for small ones —
+    /// both reuse the backend `run()` constructed with `permissionKind = .ingest`.
+    /// That kind feeds `TurnLivenessPolicy.ceiling(for:)` → the 600s
+    /// queued-ingestion ceiling. Pinned: a single stalled ingest turn burns 10
+    /// minutes, not 30 (issue #609 symptom on 2026-07-18).
+    @Test func ingestPathPassesQueuedCeiling() async throws {
+        let captured = CapturedCeiling()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ceiling-ingest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let launcher = makeLauncher(captured: captured, tempDir: tempDir)
+
+        await launcher.run(
+            request: .ingest(
+                sources: [OperationRequest.StagedSource(
+                    bytes: Data("# Test\n".utf8),
+                    ext: "md",
+                    displayPath: "sources/by-id/test.md"
+                )],
+                stateMarkdown: "# State"),
+            wikiID: "test-wiki",
+            wikiRoot: "/tmp",
+            systemPrompt: "sys",
+            wikictlDirectory: "/tmp",
+            ingestingSourceIDs: [],
+            onLock: {},
+            onUnlock: {}
+        )
+
+        // The launcher called `resolveBackend` exactly once (at run() :964).
+        #expect(captured.callCount == 1)
+        // It passed the queued-ingestion ceiling (600s), NOT the interactive
+        // 1800s default — exactly the wiring #609 prescribes for the path
+        // `runACPIngestPlannerExecutors` runs under.
+        #expect(captured.value == TurnLivenessPolicy.queuedIngestCeiling)
+        #expect(captured.value == 600)
+    }
+
+    /// The lint path is the other unattended pipeline kind — it shares the
+    /// same `.ingest` permission-kind routing for the budget, and the ceiling
+    /// splits identically: `.lint` → 600s, NOT 1800s. Pinned so a future
+    /// refactor can't accidentally widen the lint ceiling back to interactive.
+    @Test func lintPathPassesQueuedCeiling() async throws {
+        let captured = CapturedCeiling()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ceiling-lint-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let launcher = makeLauncher(captured: captured, tempDir: tempDir)
+
+        await launcher.run(
+            request: .lint(stateMarkdown: "# State"),
+            wikiID: "test-wiki",
+            wikiRoot: "/tmp",
+            systemPrompt: "sys",
+            wikictlDirectory: "/tmp",
+            ingestingSourceIDs: [],
+            onLock: {},
+            onUnlock: {}
+        )
+
+        #expect(captured.callCount == 1)
+        #expect(captured.value == TurnLivenessPolicy.queuedIngestCeiling)
+        #expect(captured.value == 600)
+    }
+
+    /// The interactive chat path (`startInteractiveQuery`) routes the 1800s
+    /// interactive default — long reasoning chains are legitimate in a
+    /// user-attended session, and the UI chip is the release valve. This is
+    /// the "interactive path keeps using 1800s" half of the #609 verification.
+    @Test func interactivePathPassesInteractiveCeiling() async throws {
+        let captured = CapturedCeiling()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ceiling-chat-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let launcher = makeLauncher(captured: captured, tempDir: tempDir)
+
+        await launcher.startInteractiveQuery(
+            firstMessage: "hello",
+            stateMarkdown: "",
+            wikiID: "test-wiki",
+            wikiRoot: "/tmp",
+            systemPrompt: "",
+            wikictlDirectory: "/tmp",
+            onLock: {},
+            onUnlock: {}
+        )
+
+        // The chat path's `resolveBackend` is at `startInteractiveQuery` :2188,
+        // AFTER `SpawnModelGuard.validate` (passes because fake-model is
+        // pre-seeded) and BEFORE `resolveACPProviderSpawn` (returns nil — no
+        // command, early return). So the ceiling is observable WITHOUT a
+        // real subprocess.
+        #expect(captured.callCount == 1)
+        #expect(captured.value == TurnLivenessPolicy.defaultCeilingTimeout)
+        #expect(captured.value == 1800)
+    }
+}

--- a/Tests/WikiFSTests/RunAwaitsTurnTests.swift
+++ b/Tests/WikiFSTests/RunAwaitsTurnTests.swift
@@ -25,9 +25,11 @@ struct RunAwaitsTurnTests {
 
     private func makeLauncher(backend: any AgentBackend) -> AgentLauncher {
         let launcher = AgentLauncher()
-        // #607: resolveBackend closure now takes (policy, budget) — ignore both
+        // #607: resolveBackend closure takes (policy, budget) — ignore both
         // (the fake backend ignores permission policy + budget).
-        launcher.resolveBackend = { _, _ in backend }
+        // #609: closure now also takes turnCeilingTimeout — ignore (the fake
+        // backend doesn't enforce the ceiling either).
+        launcher.resolveBackend = { _, _, _ in backend }
         launcher.resolveClaude = { .found(path: "/usr/bin/true") }
         launcher.acpCredentialStore = InMemoryACPCredentialStore()
         launcher.resolveSelectedProvider = {
@@ -147,7 +149,7 @@ struct RunAwaitsTurnTests {
         let backend2 = FakeAgentBackend(behaviors: [
             FakeSessionBehavior(events: [.messageStop])
         ])
-        launcher.resolveBackend = { _, _ in backend2 }
+        launcher.resolveBackend = { _, _, _ in backend2 }
 
         await runOneShot(launcher: launcher)
         #expect(launcher.isRunning == false)

--- a/Tests/WikiFSTests/TurnLivenessPolicyTests.swift
+++ b/Tests/WikiFSTests/TurnLivenessPolicyTests.swift
@@ -89,4 +89,57 @@ import WikiFSEngine
         )
         #expect(decision == .healthy)
     }
+
+    // MARK: - Per-context ceiling selection (#609)
+
+    /// The queued-ingestion ceiling constant exists and is the value the issue
+    /// prescribes (600s = 10 min). A pre-#609 installation had only
+    /// `defaultCeilingTimeout` (1800s); a stall in `runACPIngestPlannerExecutors`
+    /// burned 30 minutes per turn before the watchdog killed it (issue #609
+    /// symptom on 2026-07-18: two ceiling kills = ~60 min lost).
+    @Test func queuedIngestCeilingIs600Seconds() {
+        #expect(TurnLivenessPolicy.queuedIngestCeiling == 600)
+    }
+
+    /// The interactive default stays at 1800s (30 min). The fix is split *who
+    /// reads* the constant, NOT a change to the constant itself — interactive
+    /// chat keeps the long chain backstop. Pinned so the split isn't lost.
+    @Test func interactiveCeilingStays1800Seconds() {
+        #expect(TurnLivenessPolicy.defaultCeilingTimeout == 1800)
+    }
+
+    /// `ceiling(for: .chat)` resolves to the 1800s interactive default — the
+    /// value `startInteractiveQuery` MUST pass when constructing its backend.
+    /// Long reasoning chains are legitimate in a user-attended chat, and the
+    /// UI chip is the release valve.
+    @Test func ceilingForChatIsInteractiveDefault() {
+        #expect(TurnLivenessPolicy.ceiling(for: .chat) == TurnLivenessPolicy.defaultCeilingTimeout)
+        #expect(TurnLivenessPolicy.ceiling(for: .chat) == 1800)
+    }
+
+    /// `ceiling(for: .ingest)` resolves to the 600s queued-ingestion ceiling.
+    /// This is the value `runACPIngestPlannerExecutors` runs under — exactly the
+    /// wiring #609 asserts: "ceiling used by `runACPIngestPlannerExecutors` is
+    /// the queued-ingestion value (600s)". `runACPIngestPlannerExecutors`
+    /// reuses the backend `run()` constructed (which selects the kind as
+    /// `.ingest`), so this decision gates all planner/executor/finalizer phases.
+    @Test func ceilingForIngestIsQueuedCeiling() {
+        #expect(TurnLivenessPolicy.ceiling(for: .ingest) == TurnLivenessPolicy.queuedIngestCeiling)
+        #expect(TurnLivenessPolicy.ceiling(for: .ingest) == 600)
+    }
+
+    /// `ceiling(for: .lint)` also uses the 600s ceiling — lint runs are the
+    /// other unattended pipeline kind. Same rationale as `.ingest`: nobody is
+    /// watching, the UI chip doesn't apply, so a stall must not burn 30 minutes.
+    @Test func ceilingForLintIsQueuedCeiling() {
+        #expect(TurnLivenessPolicy.ceiling(for: .lint) == TurnLivenessPolicy.queuedIngestCeiling)
+        #expect(TurnLivenessPolicy.ceiling(for: .lint) == 600)
+    }
+
+    /// Regression guard: queued-ingestion and interactive ceilings MUST differ.
+    /// If a future refactor merges them (deliberately or by typo), the whole
+    /// point of #609 is silently lost — assert the contract directly.
+    @Test func queuedCeilingIsLowerThanInteractive() {
+        #expect(TurnLivenessPolicy.queuedIngestCeiling < TurnLivenessPolicy.defaultCeilingTimeout)
+    }
 }


### PR DESCRIPTION
Closes #609.

## Problem

A single stalled ingestion turn burned **1800 seconds (30 minutes)** before the
`TurnLivenessPolicy` ceiling watchdog killed it. On 2026-07-18 this happened
twice back-to-back (one ceiling kill at 21:45, another at 22:15) = ~60 minutes
of dead time on a 4-page ingest. The interactive 1800s default is appropriate
for chat (long reasoning chains are legitimate, the UI chip is the release
valve), but the queue is a batch pipeline — 1800s just inflates the cost of a
single stall.

## Fix

Lower the queued-ingestion ceiling to **600s (10 min)**, keeping the interactive
default at **1800s**. Per-issue scope: this is a backstop (the #606 permission
auto-reject budget at 60s is the primary stall backstop); does NOT change the
interactive ceiling and does NOT change the watchdog poll interval.

### Where

- `Sources/WikiFSEngine/TurnLivenessPolicy.swift` — new `queuedIngestCeiling = 600`
  constant + new `ceiling(for: PermissionOperationKind) -> TimeInterval`
  selector (chat → 1800s; ingest/lint → 600s). The pre-existing
  `defaultCeilingTimeout` constant is left as-is (interactive-appropriate).
- `Sources/WikiFSEngine/AgentBackendFactory.swift` — `makeBackend` gains a
  `turnCeilingTimeout` parameter, threaded through to `ACPBackend.init`. Default
  stays `defaultCeilingTimeout` so callers that don't differentiate preserve
  pre-#609 behavior.
- `Sources/WikiFSEngine/AgentLauncher.swift` —
  - `resolveBackend` closure gains a third arg (the ceiling).
  - `run()` computes `TurnLivenessPolicy.ceiling(for: permissionKind)` —
    this is the value `runACPIngestPlannerExecutors` runs under, since it
    reuses the backend `run()` constructed. Same wiring feeds single-session
    ingest + lint (`request: .ingest`/`.lint`/`.lintPage`).
  - `startInteractiveQuery()` passes `TurnLivenessPolicy.ceiling(for: .chat)`.
- `Sources/WikiFSEngine/ACPBackend.swift` — `internal` `ceilingTimeout()`
  accessor mirrors the `maxConcurrentExecutorCount()` shape for tests.

## Tests

- `TurnLivenessPolicyTests` (added 6 tests):
  - Constants pinned: `queuedIngestCeiling == 600`, `defaultCeilingTimeout == 1800`,
    `queuedIngestCeiling < defaultCeilingTimeout`.
  - Per-kind selector: `ceiling(for: .chat) == 1800`, `ceiling(for: .ingest) == 600`,
    `ceiling(for: .lint) == 600`.
- `ACPWiringTests.factoryThreadsTurnCeilingTimeout` — factory passes the param
  through untouched (default → 1800s; explicit 600s → 600s).
- `ACPBackendTests` — `ACPBackend()` defaults to 1800s; explicit
  `turnCeilingTimeout: 600` threads through; queued < interactive at the
  construction level.
- `AgentLauncherCeilingWiringTests` (new suite, 3 tests) — drives
  `run(.ingest)`, `run(.lint)`, and `startInteractiveQuery()` end-to-end
  with a captured `resolveBackend`, asserting the launcher passes 600s for
  ingest/lint and 1800s for chat. Pinned so a future refactor that swaps
  to `defaultCeilingTimeout` always (a #609 regression) would fail here.
- Updated existing `resolveBackend` overrides in `RunAwaitsTurnTests` and
  `ACPIngestPlanTests` for the new 3-arg closure signature.

## Verification

```
swift build                                               # ✓ Build complete!
swift test --filter 'TurnLivenessPolicyTests|AgentLauncherCeilingWiringTests|ACPWiringTests|ACPBackendTests'
# 75 tests in 4 suites passed
```

Fast-tier `swift test` (the CI `swift` job suite, with the standard skip list):
```
swift test --skip 'EnumeratorDeletionTests|...|SidebarDropBuilderIntegrationTests'
# ✓ Test run with 2647 tests in 228 suites passed
```

## Scope boundaries (per issue)

- This is a **backstop**, not the primary fix. The companion #606 (60s permission
  auto-reject budget) is the dominant stall killer — at 600s, a stuck permission
  is already auto-rejected long before the ceiling fires.
- Does NOT change the interactive ceiling — kept at 1800s for chat.
- Does NOT change the watchdog poll interval (the +5s in "1805s" in the error
  message).
- Does NOT change `TurnLivenessPolicy.defaultCeilingTimeout` itself — only adds
  a second constant and routes by operation kind at the call sites.
