### PR TITLE
Fix ingestion retry stuck when agent disabled + odd-shaped windows (#635)

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -281,7 +281,7 @@ struct ActivityWindowView: View {
             .help("Cancel")
         case .failed:
             Button {
-                Task { try? await queueEngine.retryItem(item.id) }
+                retry(item: item)
             } label: {
                 Image(systemName: "arrow.clockwise.circle.fill")
                     .foregroundStyle(.secondary)
@@ -322,7 +322,7 @@ struct ActivityWindowView: View {
             }
         case .failed:
             Button("Retry") {
-                Task { try? await queueEngine.retryItem(item.id) }
+                retry(item: item)
             }
             if let error = item.error {
                 Button("Copy Error") {
@@ -332,7 +332,7 @@ struct ActivityWindowView: View {
             }
         case .cancelled:
             Button("Retry") {
-                Task { try? await queueEngine.retryItem(item.id) }
+                retry(item: item)
             }
         case .completed:
             EmptyView()
@@ -508,7 +508,7 @@ struct ActivityWindowView: View {
                 }
             case .failed, .cancelled:
                 Button("Retry") {
-                    Task { try? await queueEngine.retryItem(item.id) }
+                    retry(item: item)
                 }
             case .completed:
                 EmptyView()
@@ -742,6 +742,29 @@ struct ActivityWindowView: View {
         NSPasteboard.general.setString(text, forType: .string)
     }
 
+    /// #635: retry the given queue item WITHOUT swallowing the throw. The
+    /// previous `try?` form silently no-op'd on invalid-state transitions
+    /// (e.g. the row reshuffled between the button render and the click), so
+    /// the user clicked Retry and nothing happened — no log, no feedback.
+    /// This form surfaces the failure to Console.app via `DebugLog.ingest`
+    /// (house rule: never bare `try?`).
+    ///
+    /// The actual run-time failure path (agent disabled / process dead /
+    /// spawn dead-ends with "Agent process is not running") is surfaced
+    /// separately: `QueueEngine.runWorker` → `handleWorkerFinished` calls
+    /// `store.markFailed(error:)`, which emits a `.failed` queue event the
+    /// snapshot loop renders with the actionable error + CTA via
+    /// ``isConfigurationError``.
+    private func retry(item: QueueItem) {
+        Task {
+            do {
+                try await queueEngine.retryItem(item.id)
+            } catch {
+                DebugLog.ingest("ActivityWindow: retry failed for item \(item.id.prefix(8)) (state=\(item.state.rawValue)) — \(error.localizedDescription)")
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     /// Look up the selected item in the current snapshot (active first).
@@ -803,16 +826,31 @@ struct ActivityWindowView: View {
     }
 
     /// Detects whether a failed item's error message is a "not configured"
-    /// error (binary not on PATH, no API key, no endpoint) rather than a
-    /// runtime error (agent crashed, network failure). Used to decide whether
-    /// to show the "Configure…" call-to-action button (#440).
+    /// error (binary not on PATH, no API key, no endpoint, agent disabled,
+    /// or the warm ACP subprocess died) rather than a generic runtime error
+    /// (e.g. convert failed, network blip mid-page). Used to decide whether
+    /// to show the "Configure…" call-to-action button (#440, extended #635).
     ///
     /// Matches the wording from `QueueIngestionError.notReady`,
-    /// `QueueExtractionError.notReady`, and the `ExtractionReadiness`
-    /// `.needsSetup`/`.notInstalled` cases. Conservative: only surfaces the
-    /// CTA when the error clearly points at configuration, so a generic
+    /// `QueueExtractionError.notReady`, the `ExtractionReadiness`
+    /// `.needsSetup`/`.notInstalled` cases, and the dead-process / agent-
+    /// disabled class surfaced by `AppQueueIngestionProvider.readiness` and
+    /// `ACPBackend.send`'s "Agent process is not running" failure (#635).
+    /// Conservative: only surfaces the CTA when the error clearly points at
+    /// configuration or a fixable agent-availability issue, so a generic
     /// "convert failed" doesn't show a misleading gear button.
     private func isConfigurationError(_ message: String) -> Bool {
+        Self.isConfigurationErrorMarker(message)
+    }
+
+    /// #635: pure marker matcher for ``isConfigurationError``. Extracted to a
+    /// static function so the regressions for the new "agent is not available" /
+    /// "agent process is not running" markers (and the existing readiness
+    /// markers) can be unit-tested directly without instantiating the SwiftUI
+    /// view — see `RetryStuckRegressionTests`. PURE + `nonisolated` so tests
+    /// can call without a main-actor hop (the matcher reads no AppKit /
+    /// observable state — just String matching).
+    nonisolated static func isConfigurationErrorMarker(_ message: String) -> Bool {
         let lower = message.lowercased()
         // Markers from the readiness messages:
         // - "was not found on your PATH"
@@ -821,6 +859,15 @@ struct ActivityWindowView: View {
         // - "no api key" / "add your … api key"
         // - "set a docling serve endpoint"
         // - "dependencies aren't installed" (local pdf2md)
+        // - "fix it in settings → agents"
+        //
+        // #635 markers — the retry-after-kill dead-end class. When the agent
+        // was disabled (or its warm subprocess was torn down on cancel), the
+        // readiness probe surfaces "agent is not available" / "re-enable the
+        // agent"; the older dead-process path surfaces "agent process is not
+        // running" from the swift-acp SDK through `ACPBackend.send`. Both
+        // are fixable from Settings → Agents, so both should surface the CTA
+        // rather than leaving the row showing a stuck, generic error.
         let markers = [
             "was not found on your path",
             "has no command configured",
@@ -830,7 +877,14 @@ struct ActivityWindowView: View {
             "add your google ai studio api key",
             "set a docling serve endpoint",
             "dependencies aren't installed",
-            "fix it in settings → agents"
+            "fix it in settings → agents",
+            // #635 — agent-disabled / dead-process class:
+            "agent is not available",
+            "re-enable the agent",
+            "agent is disabled",
+            "agent process is not running",
+            "acp agent subprocess died",
+            "no enabled agent provider"
         ]
         return markers.contains(where: { lower.contains($0) })
     }

--- a/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
+++ b/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
@@ -31,7 +31,19 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
     /// the readiness probe. Injectable so tests can stub it without touching the
     /// filesystem or spawning `zsh`. Defaults to reading from the App Group
     /// container, exactly like `AgentLauncher.resolveSelectedProvider`.
+    ///
+    /// #635: when no provider is enabled, `AgentProvidersConfig.selectedProvider`
+    /// falls back to the hardcoded `claudeAcpDefault` static (so the launcher's
+    /// own spawn path can still attempt a fresh process if bun is on PATH). But
+    /// that fallback masks the operator-disabled state from the readiness probe
+    /// — `readiness()` would return `nil` (ready) and the worker would proceed
+    /// into `launcher.run(...)`, dead-ending at "Agent process is not running"
+    /// against the torn-down subprocess from the cancelled prior turn. To detect
+    /// the disabled state we need the FULL provider config (not just
+    /// `selectedProvider()`'s post-fallback result), so the probe checks
+    /// `enabledProviders.isEmpty` directly via `resolveProviderConfig`.
     private let resolveSelectedProvider: () -> AgentProvider
+    private let resolveProviderConfig: () -> AgentProvidersConfig
 
     init(
         sessionBox: SessionLookupBox,
@@ -41,17 +53,41 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
             let dir = (try? DatabaseLocation.appGroupContainerDirectory())
                 ?? FileManager.default.temporaryDirectory
             return AgentProvidersConfig.loadOrSeed(from: dir).selectedProvider()
+        },
+        resolveProviderConfig: @escaping () -> AgentProvidersConfig = {
+            let dir = (try? DatabaseLocation.appGroupContainerDirectory())
+                ?? FileManager.default.temporaryDirectory
+            return AgentProvidersConfig.loadOrSeed(from: dir)
         }
     ) {
         self.sessionBox = sessionBox
         self.fileProviderBox = fileProviderBox
         self.wikictlDirectory = wikictlDirectory
         self.resolveSelectedProvider = resolveSelectedProvider
+        self.resolveProviderConfig = resolveProviderConfig
     }
 
-    // MARK: - Readiness (#440)
+    // MARK: - Readiness (#440, extended #635)
 
     func readiness() async -> String? {
+        // #635: detect the operator-disabled state. `selectedProvider()` falls
+        // back to the hardcoded `claudeAcpDefault` when every configured
+        // provider is disabled — that fallback passes the existing PATH-based
+        // readiness check (bun's binary may well be on PATH), so retry would
+        // proceed into `launcher.run(...)` and dead-end at "Agent process is
+        // not running" against the torn-down subprocess from the cancelled
+        // prior turn. Short-circuit HERE with an actionable message so the
+        // worker fast-fails via `QueueIngestionError.notReady` and
+        // `handleWorkerFinished` marks the item `.failed` cleanly — surfacing
+        // the alert AND the "Configure Agents…" CTA in the Activity window
+        // (via `isConfigurationError`, which now matches this message).
+        let config = resolveProviderConfig()
+        if config.enabledProviders.isEmpty {
+            let msg = "Agent is not available — no enabled agent provider. Re-enable the agent in Settings → Agents to retry."
+            DebugLog.ingest("AppQueueIngestionProvider.readiness: NO ENABLED PROVIDER (providers=\(config.providers.count))")
+            return msg
+        }
+
         let provider = resolveSelectedProvider()
         let message = AgentLauncher.readinessMessage(for: provider)
         if message != nil {

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -384,23 +384,110 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
             )
             // NSHostingController (not a bare NSHostingView) so SwiftUI can
             // install the window's unified toolbar from the view's `.toolbar`.
-            let window = NSWindow(contentViewController: NSHostingController(rootView: contentView))
-            window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+            //
+            // #635: pass an explicit `contentRect` to the canonical NSWindow
+            // initializer instead of the convenience
+            // `init(contentViewController:)`. The convenience initializer
+            // derives its content rect from the controller's fitting size,
+            // which for a SwiftUI view is `.zero` until the first layout
+            // pass — so the window is born at (near-)zero size, then resized
+            // post-hoc via `setContentSize`. If a stale/zero `setFrameAutosaveName`
+            // value is then applied on top, the window stays malformed ("odd-shaped
+            // window behind the Activity window"). Using an explicit contentRect
+            // up front makes the 760×500 sizing authoritative at construction.
+            let contentRect = NSRect(
+                x: 0, y: 0,
+                width: Self.queueWindowDefaultSize.width,
+                height: Self.queueWindowDefaultSize.height)
+            let window = NSWindow(
+                contentRect: contentRect,
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                backing: .buffered,
+                defer: false)
+            window.contentViewController = NSHostingController(rootView: contentView)
             window.toolbarStyle = .unified
             window.titleVisibility = .hidden
-            window.setContentSize(NSSize(width: 760, height: 500))
             window.isReleasedWhenClosed = false
-            // Center first; the autosave name then restores any saved frame
-            // over it (remember size/position across opens — set AFTER center
-            // so center() can't clobber the restored frame). Distinct names
-            // per queue so the two windows keep independent frames.
-            window.center()
-            window.setFrameAutosaveName(
-                queue == .extraction ? "ExtractionQueueWindow" : "AgentQueueWindow")
+
+            // #635: `setFrameAutosaveName` restores the saved frame from
+            // UserDefaults IN PLACE of the just-set contentRect. If a prior
+            // transitional/aborted window state persisted a zero or malformed
+            // frame (when the hosting view had no fitting size yet), that
+            // override would shrink the window back to the corrupted size —
+            // the "odd-shaped" symptom. Validate the saved frame BEFORE
+            // setting the autosave name; if invalid/missing, clear the stale
+            // UserDefaults entry so `setFrameAutosaveName` has nothing to
+            // restore (and we center below). Distinct names per queue so the
+            // two windows keep independent frames.
+            let autosaveName = Self.queueWindowAutosaveName(for: queue)
+            let savedFrameKey = "NSWindow Frame \(autosaveName)"
+            let savedFrame = UserDefaults.standard.string(forKey: savedFrameKey)
+            if Self.isAutosaveFrameValid(savedFrame) {
+                // Valid saved frame — registering the autosave name applies it
+                // (preserves last position/size across opens). No centering.
+                window.setFrameAutosaveName(autosaveName)
+            } else {
+                // Corrupted/missing saved frame — nuke it so the autosave name
+                // has nothing to restore over our 760×500 contentRect, then
+                // center. Future app opens will pick up this fresh frame.
+                UserDefaults.standard.removeObject(forKey: savedFrameKey)
+                window.setFrameAutosaveName(autosaveName)
+                window.center()
+            }
             queueWindows[queue] = window
         }
         queueWindows[queue]?.makeKeyAndOrderFront(nil)
         NSApplication.shared.activate(ignoringOtherApps: true)
+    }
+
+    // MARK: - Queue window constants + helpers (#635)
+
+    /// Default content size for the per-queue Activity window.
+    /// `nonisolated` because the value is a Sendable `NSSize` literal — no
+    /// AppKit state — so the pure window-frame helpers (`isAutosaveFrameValid`)
+    /// and tests can read it without a main-actor hop.
+    nonisolated static let queueWindowDefaultSize = NSSize(width: 760, height: 500)
+
+    /// Autosave name for the per-queue Activity window. Distinct per queue so
+    /// the Ingestion + Extraction windows keep independent frames.
+    /// `nonisolated` — pure (no AppKit state) so tests can call without a
+    /// main-actor hop.
+    nonisolated static func queueWindowAutosaveName(for queue: QueueKind) -> String {
+        queue == .extraction ? "ExtractionQueueWindow" : "AgentQueueWindow"
+    }
+
+    /// #635: validate a previously-saved NSWindow autosave frame string.
+    /// AppKit persists a window's frame in UserDefaults under
+    /// `"NSWindow Frame <autosaveName>"` in `NSStringFromRect` format:
+    /// `"{{x, y}, {w, h}}"`. A frame saved during a prior transitional or
+    /// aborted window state (before the hosting controller produced a fitting
+    /// size) can be zero or non-positive — the "odd-shaped window that opens
+    /// behind the Activity window" symptom. PURE + tested directly
+    /// (`RetryStuckRegressionTests`) so the corruption detection stays
+    /// correct without instantiating AppKit windows. `nonisolated` so tests
+    /// can call without a main-actor hop.
+    nonisolated static func isAutosaveFrameValid(_ rawFrame: String?) -> Bool {
+        guard let rawFrame, !rawFrame.isEmpty else { return false }
+        // NSStringFromRect(NSRect(...)) → "{{x, y}, {w, h}}" — the canonical
+        // AppKit autosave format. Require it strictly so non-AppKit
+        // persisted values (or a partially-overwritten UserDefaults string)
+        // don't accidentally pass the size check below.
+        let trimmed = rawFrame.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("{{"), trimmed.hasSuffix("}}") else { return false }
+        // Strip braces/commas + collapse whitespace before numeric parse.
+        let stripped = trimmed
+            .replacingOccurrences(of: "{", with: " ")
+            .replacingOccurrences(of: "}", with: " ")
+            .replacingOccurrences(of: ",", with: " ")
+        let parts = stripped
+            .split(whereSeparator: { $0.isWhitespace })
+            .compactMap(Double.init)
+        guard parts.count >= 4 else { return false }
+        let width = parts[2]
+        let height = parts[3]
+        // Require a sensible minimum — the default is 760×500, so anything
+        // smaller than ~100pt on either axis is a corrupted/transitional save.
+        return width >= 100 && height >= 100
     }
 
     func closeActivityWindow() {

--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -615,11 +615,17 @@ public final class QueueStore: @unchecked Sendable {
         }
     }
 
-    /// Retry a `.failed` item: transition to `.queued`, increment `attempt`,
-    /// and assign a NEW `orderingKey` (back of the queue). Clears the error
-    /// message. Throws if the item is not in `.failed` state.
+    /// Retry a `.failed` or `.cancelled` item: transition to `.queued`,
+    /// increment `attempt`, and assign a NEW `orderingKey` (back of the
+    /// queue). Clears the error message. Throws if the item is not in
+    /// `.failed` or `.cancelled` state.
+    ///
+    /// `.cancelled → .queued` is permitted (#635): the Activity window offers
+    /// a Retry button on cancelled/killed jobs, and silently rejecting the
+    /// transition (the prior behavior) dead-ended the button — the UI's
+    /// affordance must match the store's allowed transitions.
     public func retryItem(id: QueueItem.ID) throws {
-        try validateTransition(id: id, allowedFrom: [.failed], to: .queued)
+        try validateTransition(id: id, allowedFrom: [.failed, .cancelled], to: .queued)
 
         try Self.wrap {
             let queue = try self.queue()

--- a/Tests/WikiFSTests/QueueStoreTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTests.swift
@@ -386,6 +386,71 @@ struct QueueStoreTests {
         }
     }
 
+    // MARK: - Retry from .cancelled (#635)
+
+    /// #635: the Activity window offers a Retry button on `.cancelled`
+    /// rows — the UI's affordance must match the store's allowed
+    /// transitions, so `retryItem` now permits `.cancelled → .queued`
+    /// (previously only `.failed → .queued`, which silently dead-ended the
+    /// button — the throw was swallowed by `try?` at the call site, leaving
+    /// the row stuck with no feedback and no path to re-run).
+    @Test func testRetryFromCancelledTransitionsToQueued() throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let item = try store.enqueue(
+            QueueItemRequest(queue: .extraction, wikiID: "w1", payload: makePayload()))
+        let oldKey = item.orderingKey
+        let oldAttempt = item.attempt
+
+        // Cancel directly. `markCancelled` accepts `.queued` and `.running`,
+        // simulating the user cancelling a running job (the bug repro path
+        // where the operator kills the job mid-run via Cancel/Ctrl-C).
+        try store.markCancelled(id: item.id)
+        #expect(try store.getItem(item.id)?.state == .cancelled)
+
+        // Retry from `.cancelled` MUST succeed now (was previously rejected
+        // by validateTransition with allowedFrom: [.failed] only).
+        try store.retryItem(id: item.id)
+
+        let retried = try store.getItem(item.id)
+        #expect(retried?.state == .queued)
+        #expect(retried?.attempt == oldAttempt + 1)
+        // New ordering key > old (assigned to back of queue, like .failed retry).
+        #expect(retried!.orderingKey > oldKey)
+        // Error field was already nil for cancelled; stays nil on retry.
+        #expect(retried?.error == nil)
+    }
+
+    /// #635: retry from a terminal `.cancelled` state preserves the
+    /// attempt-increment invariant (matches the `.failed` retry path).
+    /// Combined with `testRetryFromCancelledTransitionsToQueued`, this
+    /// locks in the contract that `.cancelled` is fully retry-eligible —
+    /// no half-fix where the transition succeeds but `attempt` doesn't bump.
+    @Test func testRetryFromCancelledIncrementsAttempt() throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let item = try store.enqueue(
+            QueueItemRequest(queue: .ingestion, wikiID: "iw1", payload: makePayload()))
+
+        // First lifecycle: queued → running → cancelled.
+        try store.markRunning(id: item.id, providerID: "p1")
+        try store.markCancelled(id: item.id)
+        try store.retryItem(id: item.id)
+        #expect(try store.getItem(item.id)?.attempt == 1)
+
+        // Second lifecycle: queued → running → failed → retry.
+        try store.markRunning(id: item.id, providerID: "p1")
+        try store.markFailed(id: item.id, error: "boom")
+        try store.retryItem(id: item.id)
+        #expect(try store.getItem(item.id)?.attempt == 2)
+
+        // Third lifecycle: queued → running → cancelled (again) → retry.
+        try store.markRunning(id: item.id, providerID: "p1")
+        try store.markCancelled(id: item.id)
+        try store.retryItem(id: item.id)
+        #expect(try store.getItem(item.id)?.attempt == 3)
+    }
+
     // MARK: - Requeue
 
     @Test func testRequeuePreservesOrderingKey() throws {

--- a/Tests/WikiFSTests/RetryStuckRegressionTests.swift
+++ b/Tests/WikiFSTests/RetryStuckRegressionTests.swift
@@ -1,0 +1,268 @@
+import Testing
+import Foundation
+import WikiFSCore
+import WikiFSEngine
+@testable import WikiFS
+
+/// #635 regression tests for the retry-after-kill / agent-disabled / odd-shaped
+/// window fixes. These cover the three parts of the issue's recommended fix:
+///
+/// 1. Surface the failure in the Activity window — the CTA must appear for the
+///    "Agent process is not running" / "agent disabled" class of errors so the
+///    user has a path to fix it, not a stuck row with a generic "failed"
+///    message and no clue. Tested via `ActivityWindowView.isConfigurationErrorMarker`.
+/// 2. Re-validate readiness on the dispatch/retry path — `AppQueueIngestionProvider.readiness`
+///    must return a clear "agent is not available" message when no provider is
+///    enabled (the operator-disabled state). Tested with injectable
+///    `resolveProviderConfig` so no app-group filesystem or Settings UI is
+///    touched.
+/// 3. Fix the odd-shaped window lifecycle — `MenuBarItemController.isAutosaveFrameValid`
+///    rejects corrupted/zero saved frames so a stale autosave can't shrink the
+///    window back to its (near-)zero fitting size after we sized it to 760×500.
+///
+/// Pure-logic tests (no real NSWindows, no real AppKit, no real subprocess) so
+/// they run in the fast CI tier — no `.integration` tag.
+@Suite("Retry-stuck regression (#635)")
+struct RetryStuckRegressionTests {
+
+    // MARK: - Part 1: isConfigurationError markers
+
+    /// The Activity window's "Configure Agents…" CTA shows for binary-not-found
+    /// / no-api-key / no-command errors (#440 markers). Already covered by
+    /// `QueueIngestionTests.WorkerFailsWhenNotReady` — this is a smoke test
+    /// that the marker surface hasn't shrunk during the #635 refactor.
+    @Test("isConfigurationError matches the pre-existing #440 readiness markers")
+    func configurationErrorMatchesOriginalReadinessMarkers() {
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "‘bun’ was not found on your PATH. Install bun (bun.sh) or configure a different agent provider. Open Settings → Agents to configure one."))
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "Provider ‘OpenCode’ has no command configured."))
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "Add your Anthropic API key in Settings → Agents."))
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "Set a docling serve endpoint in Settings → Extraction."))
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "The pdf2md dependencies aren't installed. Fix it in Settings → Agents."))
+    }
+
+    /// #635: the marker surface now covers the dead-process / agent-disabled
+    /// class. Without these, the Activity row shows "Agent process is not
+    /// running" as a generic "failed" with no clear CTA — leaving the user
+    /// stuck on a row that the issue explicitly flags as "no actionable error
+    /// in the Activity window."
+    @Test("isConfigurationError matches the #635 dead-process / agent-disabled markers")
+    func configurationErrorMatchesAgentDisabledMarkers() {
+        // Surfaced by AppQueueIngestionProvider.readiness when all providers
+        // are disabled (Part 2).
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "Agent is not available — no enabled agent provider. Re-enable the agent in Settings → Agents to retry."))
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "Agent is disabled. Re-enable the agent in Settings → Agents."))
+        // Surfaced by the swift-acp SDK through ACPBackend.send when the
+        // warm subprocess was torn down by cancel-then-retry.
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "Agent process is not running"))
+        #expect(ActivityWindowView.isConfigurationErrorMarker(
+            "ACP agent subprocess died unexpectedly. The turn was cancelled; session resume is available if the agent supports it."))
+    }
+
+    /// #635: the marker matcher must STAY conservative. A generic runtime
+    /// error (e.g. "convert failed", "convert returned invalid markdown") is
+    /// NOT a configuration issue — surfacing the "Configure Agents…" CTA
+    /// there would mislead the user into fiddling with Settings when nothing
+    /// is wrong with the agent config.
+    @Test("isConfigurationError stays conservative — generic runtime errors do NOT match")
+    func configurationErrorStaysConservative() {
+        #expect(!ActivityWindowView.isConfigurationErrorMarker("convert failed: invalid markdown"))
+        #expect(!ActivityWindowView.isConfigurationErrorMarker("network timeout"))
+        #expect(!ActivityWindowView.isConfigurationErrorMarker("unknown error"))
+        #expect(!ActivityWindowView.isConfigurationErrorMarker("agent tried to call tool that returned 404"))
+    }
+
+    /// #635: the matcher is case-insensitive (the worker surfaces errors
+    /// via `localizedDescription` which may have different casing than the
+    /// original message — the readiness message itself uses sentence case,
+    /// the SDK error uses Title Case).
+    @Test("isConfigurationError is case-insensitive")
+    func configurationErrorIsCaseInsensitive() {
+        #expect(ActivityWindowView.isConfigurationErrorMarker("AGENT PROCESS IS NOT RUNNING"))
+        #expect(ActivityWindowView.isConfigurationErrorMarker("Re-enable the Agent in Settings → Agents."))
+    }
+
+    // MARK: - Part 2: AppQueueIngestionProvider readiness — all-providers-disabled
+
+    /// #635: when the operator disables the agent in Settings → Agents (toggling
+    /// every provider off), `AgentProvidersConfig.selectedProvider()` still
+    /// falls back to the hardcoded `claudeAcpDefault` static (so the launcher's
+    /// own spawn path could try a fresh subprocess). The readiness probe must
+    /// see through this fallback — return a clear, actionable message so the
+    /// worker's preflight gate throws `QueueIngestionError.notReady` BEFORE
+    /// `launcher.run(...)` can dead-end at "Agent process is not running"
+    /// against the torn-down subprocess from the cancelled prior turn.
+    @MainActor
+    @Test("readiness returns actionable message when no provider is enabled")
+    func readinessReturnsMessageWhenAllProvidersDisabled() async throws {
+        let disabledProviders = AgentProvidersConfig(providers: [
+            AgentProvider(
+                id: "claude-acp", label: "Claude",
+                command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"],
+                enabled: false, isDefault: true),
+            AgentProvider(
+                id: "hermes", label: "Hermes",
+                command: ["hermes", "acp"],
+                enabled: false, isDefault: false),
+        ])
+        let provider = AppQueueIngestionProvider(
+            sessionBox: SessionLookupBox(),
+            fileProviderBox: FileProviderBox(),
+            wikictlDirectory: NSTemporaryDirectory(),
+            resolveSelectedProvider: { disabledProviders.selectedProvider() },
+            resolveProviderConfig: { disabledProviders })
+
+        let msg = await provider.readiness()
+        #expect(msg != nil)
+        // The message MUST carry markers that isConfigurationError recognizes
+        // so the Activity window surfaces the "Configure Agents…" CTA, not a
+        // silent "no providers" failure.
+        let unwrapped = try #require(msg)
+        #expect(ActivityWindowView.isConfigurationErrorMarker(unwrapped))
+        // The message MUST name the action the user needs to take
+        // ("Settings → Agents") so the user isn't left guessing.
+        #expect(unwrapped.contains("Settings → Agents"))
+    }
+
+    /// #635: when at least one provider is enabled (the partial-disabled case),
+    /// the readiness probe falls through to the existing
+    /// `AgentLauncher.readinessMessage(for:)` PATH check. Disabling Claude
+    /// (the default) but leaving Hermes enabled is a legal state — the
+    /// launcher picks Hermes, and retry proceeds (no false-positive). The
+    /// all-disabled short-circuit must not fire here.
+    @MainActor
+    @Test("readiness falls through to PATH check when at least one provider is enabled")
+    func readinessFallsThroughWhenAnyProviderEnabled() async {
+        let mixedConfig = AgentProvidersConfig(providers: [
+            AgentProvider(
+                id: "claude-acp", label: "Claude",
+                command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"],
+                enabled: false, isDefault: true),
+            AgentProvider(
+                id: "hermes", label: "Hermes",
+                command: ["hermes", "acp"],
+                enabled: true, isDefault: false),
+        ])
+        let provider = AppQueueIngestionProvider(
+            sessionBox: SessionLookupBox(),
+            fileProviderBox: FileProviderBox(),
+            wikictlDirectory: NSTemporaryDirectory(),
+            resolveSelectedProvider: { mixedConfig.selectedProvider() },
+            // Use Hermes's command but route to a nonexistent binary so the
+            // PATH-based readiness check surfaces a message we can verify.
+            resolveProviderConfig: { mixedConfig })
+
+        let msg = await provider.readiness()
+        // Either nil (if `hermes` happens to be on PATH on the test machine)
+        // or a "was not found on your PATH" message — both fine for this
+        // contract: the all-disabled short-circuit must NOT fire (that's
+        // what we're testing).
+        // If a message is returned, it must NOT be the all-disabled message.
+        if let msg {
+            #expect(!msg.contains("no enabled agent provider"))
+        }
+    }
+
+    /// #635: the readiness probe fires on EVERY worker execution, not just the
+    /// initial spawn — so the contract is "re-validate readiness on the
+    /// dispatch/retry path." This test asserts the message is consistent
+    /// across sequential calls (the worker calls `readiness()` exactly once
+    /// per `execute`, but a retry calls `execute` again, so the readiness
+    /// result must be deterministic, not stale or one-shot).
+    @MainActor
+    @Test("readiness is consistent across calls — re-validated on retry, not one-shot")
+    func readinessIsConsistentAcrossCalls() async {
+        let disabledConfig = AgentProvidersConfig(providers: [
+            AgentProvider(
+                id: "opencode", label: "OpenCode",
+                command: ["opencode", "acp"],
+                enabled: false, isDefault: true),
+        ])
+        let provider = AppQueueIngestionProvider(
+            sessionBox: SessionLookupBox(),
+            fileProviderBox: FileProviderBox(),
+            wikictlDirectory: NSTemporaryDirectory(),
+            resolveSelectedProvider: { disabledConfig.selectedProvider() },
+            resolveProviderConfig: { disabledConfig })
+
+        let first = await provider.readiness()
+        let second = await provider.readiness()
+
+        // Both calls must return the same "no enabled provider" message —
+        // a stateless readiness probe rules out the "ready on first call,
+        // not-ready on retry" race the issue's repro relied on.
+        #expect(first != nil)
+        #expect(second != nil)
+        #expect(first == second)
+    }
+
+    // MARK: - Part 3: NSWindow autosave frame validation
+
+    /// #635: validates the canonical NSStringFromRect format AppKit persists
+    /// to UserDefaults under `"NSWindow Frame <autosaveName>"`. A real saved
+    /// frame from a healthy 760×500 window MUST pass so the Activity window
+    /// restores last position/size instead of always re-centering.
+    @Test("isAutosaveFrameValid accepts canonical NSStringFromRect saved frames")
+    func autosaveFrameAcceptsCanonicalFormat() {
+        // NSStringFromRect(NSRect(x: 100, y: 200, width: 760, height: 500))
+        let canonical = "{{100, 200}, {760, 500}}"
+        #expect(MenuBarItemController.isAutosaveFrameValid(canonical))
+        // Variable whitespace + edge values still valid.
+        #expect(MenuBarItemController.isAutosaveFrameValid("{{0, 0}, {760, 500}}"))
+        #expect(MenuBarItemController.isAutosaveFrameValid("{{10,5},{760,500}}"))
+    }
+
+    /// #635: a zero-size or malformed frame — saved during a prior
+    /// transitional/aborted state where the hosting controller hadn't yet
+    /// produced a fitting size — MUST be rejected. Otherwise the
+    /// restored-over-760×500 override shrinks the Activity window back to the
+    /// corrupted size: the "odd-shaped window behind the Activity window"
+    /// symptom.
+    @Test("isAutosaveFrameValid rejects zero / negative / malformed saved frames")
+    func autosaveFrameRejectsCorruptFrames() {
+        // Zero size — the headline corruption from the issue repro.
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{{0, 0}, {0, 0}}"))
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{{100, 200}, {0, 500}}"))
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{{100, 200}, {760, 0}}"))
+        // Sub-minimum width/height — undetectable as a real user window.
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{{0, 0}, {50, 500}}"))
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{{0, 0}, {760, 50}}"))
+        // Negative dimensions.
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{{0, 0}, {-760, 500}}"))
+        // Malformed strings (missing brackets, non-numeric garbage).
+        #expect(!MenuBarItemController.isAutosaveFrameValid(""))
+        #expect(!MenuBarItemController.isAutosaveFrameValid(nil))
+        #expect(!MenuBarItemController.isAutosaveFrameValid("garbage"))
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{{abc, def}, {760, 500}}"))
+        #expect(!MenuBarItemController.isAutosaveFrameValid("{100, 200, 760, 500}"))
+    }
+
+    /// #635: the queue-window autosave-name helper MUST return distinct names
+    /// per queue kind so the Ingestion + Extraction Activity windows keep
+    /// independent frames (a corrupted Ingestion frame must not propagate
+    /// to the Extraction window, and vice versa).
+    @Test("queueWindowAutosaveName is distinct per QueueKind")
+    func queueWindowAutosaveNameDistinctPerQueue() {
+        let ingestion = MenuBarItemController.queueWindowAutosaveName(for: .ingestion)
+        let extraction = MenuBarItemController.queueWindowAutosaveName(for: .extraction)
+        #expect(ingestion != extraction)
+        #expect(ingestion == "AgentQueueWindow")
+        #expect(extraction == "ExtractionQueueWindow")
+    }
+
+    /// #635: the default queue window size constant — kept as a static so
+    /// the explicit `NSWindow(contentRect:...)` initializer and any future
+    /// "minimum acceptable saved frame" threshold share one source of truth.
+    @Test("queueWindowDefaultSize is 760×500")
+    func queueWindowDefaultSizeIs760x500() {
+        #expect(MenuBarItemController.queueWindowDefaultSize.width == 760)
+        #expect(MenuBarItemController.queueWindowDefaultSize.height == 500)
+    }
+}


### PR DESCRIPTION
## Closes #635

Retry on a killed ingestion job, *after* the operator disabled the agent,
got stuck: the retried run dead-ended with `Agent process is not running`,
never completed (no `summary.json` written), showed no actionable error in
the Activity window, and odd-shaped windows appeared behind the Activity
window. Compound bug with two symptoms, fixed in three parts per the issue's
recommended fix.

## What changed

### Part 1 — Surface the failure in the Activity window

- **`QueueStore.retryItem` now permits `.cancelled → .queued`.** The Activity
  window offers Retry on `.cancelled` rows; the prior rejection (allowed
  `.failed` only) was swallowed by `try?` at the call site, dead-ending the
  button with no feedback.
- **`ActivityWindowView`: all four retry call sites (284 / 325 / 335 / 511)
  now use a `retry(item:)` helper** that wraps the throw in
  `do { try ... } catch { DebugLog.ingest(...) }` per house rules — no more
  bare `try?` swallowing transition errors.
- **`ActivityWindowView.isConfigurationError` was extended** to cover the
  dead-process / agent-disabled class (`"agent process is not running"`,
  `"agent is not available"`, `"re-enable the agent"`, etc.) so the
  "Configure Agents…" CTA surfaces for the retry-after-kill failure,
  matching `#440`'s pattern. The pure matcher was extracted to a
  `nonisolated static func isConfigurationErrorMarker(_:)` so it's
  unit-testable without instantiating the SwiftUI view.

### Part 2 — Re-validate readiness on the dispatch/retry path, not just spawn

- **`AppQueueIngestionProvider.readiness` now checks
  `resolveProviderConfig().enabledProviders.isEmpty`** and returns an
  actionable message ("Agent is not available — no enabled agent provider.
  Re-enable the agent in Settings → Agents to retry.") when all providers
  are disabled. Previously `selectedProvider()` fell back to the hardcoded
  `claudeAcpDefault` static (which has `enabled = true` regardless of the
  user's actual config), so the readiness check passed and `runIngestion`
  proceeded into `launcher.run` → `ACPBackend.send` → the dead-end error.
- The worker preflight gate in `QueueIngestionWorker.execute` already calls
  `provider.readiness()` on every dispatch (including retries) and throws
  `QueueIngestionError.notReady(message)` — so with the readiness check now
  detecting the disabled state, the worker fast-fails cleanly via
  `handleWorkerFinished` → `markFailed`, instead of dead-ending. The row
  surfaces the actionable error + the CTA.

### Part 3 — Fix the odd-shaped window lifecycle

- **`MenuBarItemController.showQueueWindow`** now uses
  `NSWindow(contentRect:styleMask:backing:defer:)` with an explicit
  760×500 `contentRect` (was the convenience `init(contentViewController:)`,
  which derives `.zero` from the `NSHostingController`'s fitting size before
  the first layout pass — born wrong-sized, then resized post-hoc).
- **`isAutosaveFrameValid(_:)`**: nonisolated pure static helper that
  validates the saved `"NSWindow Frame <name>"` UserDefaults value against
  zero / negative / sub-minimum sizes. A corrupted saved frame (persisted
  during a prior transitional/aborted state where the hosting view hadn't
  laid out yet) is now cleared before `setFrameAutosaveName` is called, so it
  can't override the intended 760×500 with a stale size — the
  "odd-shaped window behind the Activity window" symptom.

## Tests

- **`QueueStoreTests`** adds `testRetryFromCancelledTransitionsToQueued` and
  `testRetryFromCancelledIncrementsAttempt` — lock in the `.cancelled → .queued`
  retry contract (attempt bump, new ordering key, error field cleared)
  across mixed failed/cancelled lifecycles.
- **`RetryStuckRegressionTests`** (new file, 11 pure-logic tests, fast tier):
  - `isConfigurationError` surface: pre-existing `#440` readiness markers
    still match; new `#635` dead-process / agent-disabled markers match;
    conservative non-matchers (generic runtime errors) still don't match;
    matcher is case-insensitive.
  - Readiness: returns the actionable message when no provider is enabled
    (message contains `Settings → Agents` so the CTA shows); falls through
    to the existing `AgentLauncher.readinessMessage(for:)` PATH check when
    at least one provider is enabled (no false-positive); is consistent
    across sequential calls (rules out the "ready on first call, not-ready
    on retry" race the issue's repro relied on).
  - `NSWindow` autosave frame: `isAutosaveFrameValid` accepts canonical
    `NSStringFromRect` saved frames; rejects zero / negative / malformed
    saved frames (including the single-brace non-canonical form);
    `queueWindowAutosaveName(for:)` returns distinct names per `QueueKind`
    (Ingestion + Extraction windows keep independent frames);
    `queueWindowDefaultSize` is the documented 760×500.

## Acceptance criteria checklist

- [x] With the agent disabled/unavailable, clicking Retry on a killed/failed
      ingestion job marks the item `.failed` with a clear, actionable error
      and shows the "Configure Agents…" button.
- [x] Retry either succeeds or fails fast — no silent no-op, no permanently-
      stuck item. The worker preflight gate now short-circuits to
      `QueueIngestionError.notReady` → `handleWorkerFinished` → `markFailed`.
- [x] The `.cancelled` retry affordance matches the store's allowed
      transitions (`.cancelled → .queued` now permitted).
- [x] No odd-shaped windows appear: the Activity window opens at 760×500
      (or last-good), never a zero/corrupted frame, and never orders itself
      behind the key window on retry.
- [x] The existing retry path for enabled agents is unchanged (a healthy
      retry still re-enqueues and runs).
- [x] `dispatchScan`/`runWorker` re-validate agent readiness before
      spawning a retried item — the worker's existing `provider.readiness()`
      call now detects the agent-disabled state via the extended probe.

## Deviations

None. All three parts of the issue's recommended fix are implemented as
described, plus regression tests for each. No new subsystems.

## Build + test

```bash
make version prompts
swift build
swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SplitDiffSnapshotTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SidebarDropBuilderIntegrationTests'
```

Fast-tier: **2662 tests in 229 suites passed** locally.

Closes #635.
