### PR TITLE
Route wikictl CLI + Find-Similar through Tantivy BM25 leg (#637)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # merge for fast iteration — see AGENTS.md.
         # To add a slow suite: tag it `.integration` AND append its name here.
         env:
-          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests'
+          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests'
         run: $SWIFT test --skip "$SKIP"
 
   swift-integration:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ Persistent chats are two tables: `chats` (one row per conversation) and
 swift build          # compile
 swift test           # full suite (run locally before merge)
 # fast tier — what the CI `swift` job runs; skips the slow SQLite integration suites:
-swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests'
+swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests'
 swift test --filter PdfExtractionServiceTests  # pdf extraction only
 ```
 

--- a/Sources/WikiCtlCore/CLITantivyLegResolver.swift
+++ b/Sources/WikiCtlCore/CLITantivyLegResolver.swift
@@ -1,0 +1,205 @@
+import Foundation
+import WikiFSCore
+
+/// Bridges the wikictl CLI's three search commands (`page search`,
+/// `source search`, `chat search`) onto the SAME Tantivy BM25 leg the app's
+/// sidebar / omnibox use (#637).
+///
+/// wikictl opens a `GRDBWikiStore` directly and prior to #637 called the
+/// 2-arg `store.searchSimilar(query:limit:)` overloads, which forward to the
+/// 3-arg path with `bm25Leg: nil` — meaning the store ran its OWN FTS5 leg and
+/// never queried the on-disk Tantivy index at
+/// `<appGroupContainer>/search-index/<wikiID>/`. That bypassed the Tantivy
+/// `fuzzyFields` (edit-distance 1 on title + body, already configured at
+/// `Sources/WikiFSSearch/TantivyIndexer.swift:108-111`) and would break under
+/// #634 (drop FTS5) where `bm25Leg: nil` has no BM25 leg at all.
+///
+/// This resolver constructs a CLI-owned `TantivySearchService` over the SAME
+/// on-disk index the app builds/maintains (the index is a derived artifact, so
+/// concurrently opening it read-only is safe — SQLite remains the source of
+/// truth), runs the kind-scoped search via the actor (bridged async→sync with
+/// a semaphore, mirroring `wikid`'s `runRefresh` pattern), and resolves the
+/// hits to typed summaries (`WikiPageSummary` / `SourceSummary` / `ChatSummary`)
+/// via the store's list APIs — preserving Tantivy's best-first rank order, the
+/// same mapping `WikiStoreModel.resolveTantivyLeg(query:kind:limit:catalog:)`
+/// performs for the sidebar.
+///
+/// Returns `nil` when Tantivy is unavailable, the index returned nothing, or
+/// every hit was missing from the catalog — the store falls back to FTS5 in
+/// all three cases (the Phase 2 contract for `bm25Leg: nil`). After #634
+/// drops FTS5, `nil` here means "no BM25 leg" — but the index is shared with
+/// the app, so as long as the wiki has been opened in the app at least once
+/// (the app kicks off the initial build via `TantivyShadowSync.start()`), the
+/// leg is populated. A wiki never opened in the app still has FTS5 to answer
+/// today; #634 lands later.
+public enum CLITantivyLegResolver {
+
+    /// Resolve a Tantivy BM25 leg for `wikictl page search`. Returns `nil`
+    /// when the index is unavailable/empty — the store then falls back to
+    /// FTS5 (Phase 2 behavior; #634 will retire this fallback path).
+    public static func resolvePageLeg(
+        wikiID: String,
+        containerDirectory: URL,
+        store: WikiStore,
+        query: String,
+        limit: Int
+    ) -> [WikiPageSummary]? {
+        guard let svc = makeService(wikiID: wikiID, containerDirectory: containerDirectory, store: store) else {
+            return nil
+        }
+        let hits = runSearch(svc: svc, query: query, kind: .page, limit: limit)
+        guard !hits.isEmpty else { return nil }
+        let catalog: [WikiPageSummary]
+        do {
+            catalog = try store.listPages(sortBy: .lastUpdated)
+        } catch {
+            DebugLog.store("wikictl: listPages(leg) failed for wiki \(wikiID): \(error)")
+            return nil
+        }
+        return resolveHits(hits, catalog: catalog)
+    }
+
+    /// Resolve a Tantivy BM25 leg for `wikictl source search`. Same contract
+    /// as ``resolvePageLeg(wikiID:containerDirectory:store:query:limit:)``.
+    public static func resolveSourceLeg(
+        wikiID: String,
+        containerDirectory: URL,
+        store: WikiStore,
+        query: String,
+        limit: Int
+    ) -> [SourceSummary]? {
+        guard let svc = makeService(wikiID: wikiID, containerDirectory: containerDirectory, store: store) else {
+            return nil
+        }
+        let hits = runSearch(svc: svc, query: query, kind: .source, limit: limit)
+        guard !hits.isEmpty else { return nil }
+        let catalog: [SourceSummary]
+        do {
+            catalog = try store.listSources()
+        } catch {
+            DebugLog.store("wikictl: listSources(leg) failed for wiki \(wikiID): \(error)")
+            return nil
+        }
+        return resolveHits(hits, catalog: catalog)
+    }
+
+    /// Resolve a Tantivy BM25 leg for `wikictl chat search`. Same contract as
+    /// ``resolvePageLeg(wikiID:containerDirectory:store:query:limit:)``.
+    public static func resolveChatLeg(
+        wikiID: String,
+        containerDirectory: URL,
+        store: WikiStore,
+        query: String,
+        limit: Int
+    ) -> [ChatSummary]? {
+        guard let svc = makeService(wikiID: wikiID, containerDirectory: containerDirectory, store: store) else {
+            return nil
+        }
+        let hits = runSearch(svc: svc, query: query, kind: .chat, limit: limit)
+        guard !hits.isEmpty else { return nil }
+        let catalog: [ChatSummary]
+        do {
+            catalog = try store.listChats()
+        } catch {
+            DebugLog.store("wikictl: listChats(leg) failed for wiki \(wikiID): \(error)")
+            return nil
+        }
+        return resolveHits(hits, catalog: catalog)
+    }
+
+    // MARK: - Internal
+
+    /// Construct a CLI-owned `TantivySearchService` over the same on-disk
+    /// index the app builds/maintains. `nil` (not an error) when the index
+    /// can't be opened — failures are logged via `DebugLog.store` so they're
+    /// visible in Console.app even from the CLI invocation.
+    private static func makeService(
+        wikiID: String,
+        containerDirectory: URL,
+        store: WikiStore
+    ) -> TantivySearchService? {
+        let contentSource = StoreBackedTantivyContentSource(store: store)
+        do {
+            return try TantivySearchService(
+                wikiID: wikiID,
+                containerDirectory: containerDirectory,
+                contentSource: contentSource
+            )
+        } catch {
+            DebugLog.store("wikictl: Tantivy search index unavailable for wiki \(wikiID): \(error)")
+            return nil
+        }
+    }
+
+    /// Bridge `TantivySearchService.search` to synchronous execution, mirroring
+    /// `wikictl`'s existing `runRefresh` async→sync semaphore pattern at
+    /// `Sources/wikictl/main.swift:180-200`. Safe because the search runs on
+    /// the `TantivyIndexer` actor (off-main); the dispatched `Task` signals
+    /// the semaphore from a thread that never needs the main thread.
+    ///
+    /// Calls `rebuildIfNeeded()` before querying — opening a fresh
+    /// `TantivySearchService` against an existing on-disk index can initially
+    /// report `count == 0` until the rebuild path runs (the index open seems
+    /// to need a kick for the in-memory state to reflect disk). The rebuild
+    /// is itself a no-op when the index already has documents (a single
+    /// `count()` call short-circuits) — so the steady-state cost is one
+    /// `count()` per CLI search invocation. When the index is empty or
+    /// missing (the wiki has been used via `wikictl` but never opened in the
+    /// app, so `TantivyShadowSync.start()` never ran), this is what surfaces
+    /// the content.
+    private static func runSearch(
+        svc: TantivySearchService,
+        query: String,
+        kind: TantivyDocumentKind,
+        limit: Int
+    ) -> [TantivyShadowSearchResult] {
+        let box = SearchBox()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            // Mirror TantivyShadowSync.start()'s rebuild-on-open: cheap
+            // (count-check) when the index is populated, essential when empty.
+            await svc.rebuildIfNeeded()
+            box.result = await svc.search(query: query, kinds: [kind], limit: limit)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return box.result ?? []
+    }
+
+    /// Map best-first Tantivy hits to typed summaries via the supplied catalog,
+    /// preserving Tantivy's rank order. Mirrors
+    /// `WikiStoreModel.resolveTantivyLeg(query:kind:limit:catalog:)` at
+    /// `Sources/WikiFSCore/Store/WikiStoreModel.swift:2938` — Tantivy scores
+    /// are dropped here because the store's `searchSimilar(query:limit:bm25Leg:)`
+    /// treats the leg as a pre-ranked BM25 source and fuses it with the
+    /// semantic cosine leg via `RankFusion.rrf`. Returns `nil` (not `[]`)
+    /// when nothing resolves so the store falls back to FTS5 rather than
+    /// querying an empty BM25 signal — this matches the model's contract and
+    /// is what #634's drop-FTS5 path will key off (a future Tantivy miss
+    /// becomes "no BM25 leg" rather than "BM25 returned no results").
+    private static func resolveHits<T: Identifiable & Sendable>(
+        _ hits: [TantivyShadowSearchResult],
+        catalog: [T]
+    ) -> [T]? where T.ID == PageID {
+        let byID = Dictionary(catalog.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+        let resolved = hits.compactMap { hit -> T? in
+            let id = PageID(rawValue: hit.ulid)
+            return byID[id]
+        }
+        return resolved.isEmpty ? nil : resolved
+    }
+}
+
+/// Thread-safe result box for the async→sync semaphore bridge. Mirrors
+/// `RefreshResultBox` at `Sources/wikictl/main.swift` — `@unchecked Sendable`
+/// is belt-and-suspenders; the semaphore guarantees the `Task`'s write
+/// happens-before the read after `semaphore.wait()` returns.
+private final class SearchBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _result: [TantivyShadowSearchResult]?
+
+    var result: [TantivyShadowSearchResult]? {
+        get { lock.lock(); defer { lock.unlock() }; return _result }
+        set { lock.lock(); defer { lock.unlock() }; _result = newValue }
+    }
+}

--- a/Sources/WikiCtlCore/ChatCommand.swift
+++ b/Sources/WikiCtlCore/ChatCommand.swift
@@ -48,14 +48,24 @@ public enum ChatCommand {
     }
 
     /// Run one action against `store`. Reads never commit; `rename` does.
-    public static func run(_ action: Action, in store: WikiStore) throws -> Result {
+    ///
+    /// `bm25Leg` is the pre-resolved Tantivy BM25 leg for the `.search` action
+    /// (#637). `nil` (the default) makes the store run its own FTS5; a non-nil
+    /// list is fused with the semantic cosine leg via RRF, REPLACING the FTS5
+    /// leg. Caller-resolved via `CLITantivyLegResolver.resolveChatLeg(...)` in
+    /// `wikictl`'s `execute()`.
+    public static func run(
+        _ action: Action,
+        in store: WikiStore,
+        bm25Leg: [ChatSummary]? = nil
+    ) throws -> Result {
         switch action {
         case .list(let json):
             return try list(in: store, json: json)
         case .get(let selector):
             return try get(selector, in: store)
         case .search(let query, let limit):
-            return try search(query: query, limit: limit, in: store)
+            return try search(query: query, limit: limit, bm25Leg: bm25Leg, in: store)
         case .rename(let selector, let newTitle):
             return try rename(selector, to: newTitle, in: store)
         }
@@ -105,9 +115,9 @@ public enum ChatCommand {
     /// their message text matches the query. Output is TSV
     /// (id <tab> title <tab> kind <tab> messages), best match first.
     private static func search(
-        query: String, limit: Int, in store: WikiStore
+        query: String, limit: Int, bm25Leg: [ChatSummary]?, in store: WikiStore
     ) throws -> Result {
-        let results = try store.searchSimilarChats(query: query, limit: limit)
+        let results = try store.searchSimilarChats(query: query, limit: limit, bm25Leg: bm25Leg)
         let output: String = results.map { chat in
             let title = chat.title.replacingOccurrences(of: "\t", with: " ")
             return "\(chat.id.rawValue)\t\(title)\t\(chat.kind.rawValue)\t\(chat.messageCount)"

--- a/Sources/WikiCtlCore/PageCommand.swift
+++ b/Sources/WikiCtlCore/PageCommand.swift
@@ -65,13 +65,20 @@ public enum PageCommand {
     ///
     /// `validator` injects the Mermaid validator (defaults to the bundled one) so
     /// the abort-before-write path is end-to-end testable without a bundle.
-    /// `linter` injects the Markdown linter (defaults to the bundled one) so the
-    /// auto-fix-before-write path is testable without a bundle.
+    /// `linter` injects the Markdown linter (defaults to the bundled one) so
+    /// the auto-fix-before-write path is testable without a bundle.
+    ///
+    /// `bm25Leg` is the pre-resolved Tantivy BM25 leg for the `.search` action
+    /// (#637). `nil` (the default) makes the store run its own FTS5; a non-nil
+    /// list is fused with the semantic cosine leg via RRF, REPLACING the FTS5
+    /// leg — which is what unblocks #634 (drop FTS5). Caller-resolved via
+    /// `CLITantivyLegResolver.resolvePageLeg(...)` in `wikictl`'s `execute()`.
     public static func run(
         _ action: Action,
         in store: WikiStore,
         validator: MermaidValidator? = MermaidValidator.loadDefault(),
-        linter: MarkdownLinter? = MarkdownLinter.loadDefault()
+        linter: MarkdownLinter? = MarkdownLinter.loadDefault(),
+        bm25Leg: [WikiPageSummary]? = nil
     ) throws -> Result {
         switch action {
         case .list(let json):
@@ -83,7 +90,7 @@ public enum PageCommand {
         case .delete(let id):
             return try delete(id: id, in: store)
         case .search(let query, let limit):
-            return try search(query: query, limit: limit, in: store)
+            return try search(query: query, limit: limit, bm25Leg: bm25Leg, in: store)
         case .history(let selector):
             return try history(selector, in: store)
         case .revert(let selector, let versionID):
@@ -301,9 +308,9 @@ public enum PageCommand {
     // MARK: - search
 
     private static func search(
-        query: String, limit: Int, in store: WikiStore
+        query: String, limit: Int, bm25Leg: [WikiPageSummary]?, in store: WikiStore
     ) throws -> Result {
-        let results = try store.searchSimilar(query: query, limit: limit)
+        let results = try store.searchSimilar(query: query, limit: limit, bm25Leg: bm25Leg)
         let output: String = results.map { summary in
             let title = summary.title.replacingOccurrences(of: "\t", with: " ")
             return "\(summary.id.rawValue)\t\(title)"

--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -60,7 +60,18 @@ public enum SourceCommand {
     /// Run one action against `store`. `cwd` is the directory for `export`'s
     /// default output path (injected for testability). All actions are pure
     /// reads — `didCommit` is always false.
-    public static func run(_ action: Action, in store: WikiStore, cwd: String) throws -> Result {
+    ///
+    /// `bm25Leg` is the pre-resolved Tantivy BM25 leg for the `.search` action
+    /// (#637). `nil` (the default) makes the store run its own FTS5; a non-nil
+    /// list is fused with the semantic cosine leg via RRF, REPLACING the FTS5
+    /// leg. Caller-resolved via `CLITantivyLegResolver.resolveSourceLeg(...)`
+    /// in `wikictl`'s `execute()`.
+    public static func run(
+        _ action: Action,
+        in store: WikiStore,
+        cwd: String,
+        bm25Leg: [SourceSummary]? = nil
+    ) throws -> Result {
         switch action {
         case .list(let json):
             return try list(in: store, json: json)
@@ -73,7 +84,7 @@ public enum SourceCommand {
         case .rename(let selector, let to):
             return try rename(selector, to: to, in: store)
         case .search(let query, let limit):
-            return try search(query: query, limit: limit, in: store)
+            return try search(query: query, limit: limit, bm25Leg: bm25Leg, in: store)
         case .setActive(let selector, let versionID):
             return try setActive(selector, versionID: versionID, in: store)
         case .info(let selector):
@@ -265,9 +276,9 @@ public enum SourceCommand {
     /// `PageCommand.search`. `name` is the display name, falling back to the
     /// filename (mirrors how sources are surfaced elsewhere). Read-only.
     private static func search(
-        query: String, limit: Int, in store: WikiStore
+        query: String, limit: Int, bm25Leg: [SourceSummary]?, in store: WikiStore
     ) throws -> Result {
-        let results = try store.searchSimilarSources(query: query, limit: limit)
+        let results = try store.searchSimilarSources(query: query, limit: limit, bm25Leg: bm25Leg)
         let output: String = results.map { summary in
             // `effectiveName` falls back to filename on nil OR empty display_name,
             // matching how sources are labeled app-wide (sidebar/file-provider).

--- a/Sources/WikiFS/Reader/WikiLinkMenuNSItems.swift
+++ b/Sources/WikiFS/Reader/WikiLinkMenuNSItems.swift
@@ -93,11 +93,18 @@ enum WikiLinkMenuNSItems {
     /// A submenu listing the closest pages to `query`; choosing one navigates to
     /// it. Shows a disabled "No similar pages" item when the search is empty so
     /// the submenu is never mysteriously blank.
+    ///
+    /// #637: builds with `store.searchSimilarResolvingTantivy(query:limit:)`
+    /// (rather than the FTS5-fallback `searchSimilar(query:limit:)`) so the menu
+    /// surfaces Tantivy-BM25-fused results — gaining the indexer's `fuzzyFields`
+    /// edit-distance-1 matches (already configured at
+    /// `TantivyIndexer.swift:108-111`) for free, and surviving #634's FTS5 drop
+    /// without regression.
     private static func similarPagesItem(
         title: String, query: String, store: WikiStoreModel
     ) -> NSMenuItem {
         let parent = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        let matches = query.isEmpty ? [] : store.searchSimilar(query: query, limit: 8)
+        let matches = query.isEmpty ? [] : store.searchSimilarResolvingTantivy(query: query, limit: 8)
         let menu = NSMenu()
         if matches.isEmpty {
             let none = NSMenuItem(title: "No similar pages", action: nil, keyEquivalent: "")

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -701,26 +701,43 @@ public protocol WikiStore: Sendable {
 
 // MARK: - searchSimilar default-argument convenience (Phase 2 bm25Leg)
 //
-// Protocol requirements can't carry default arguments, so the 2-arg legacy entry
-// points live here. Every caller that omits `bm25Leg` (wikictl, tests, the
-// model's sync `searchSimilar` wrappers) resolves to these and gets the FTS5
-// path — "zero caller breakage" for the Phase 2 cutover.
+// Protocol requirements can't carry default arguments, so the 2-arg legacy
+// entry points live here. As of #637 these are DEPRECATED: a `nil` bm25Leg
+// makes the store run its own FTS5 leg (the pre-Phase-2 path), bypassing the
+// Tantivy BM25 leg the sidebar/omnibox/`wikictl` now route through. After #634
+// drops FTS5, a `nil` bm25Leg has no BM25 leg at all — the legacy overloads
+// will go away entirely. Migrate to `searchSimilar(query:limit:bm25Leg:)`
+// (or the kind-specific equivalent) and resolve a Tantivy leg first.
 
 extension WikiStore {
     /// Legacy 2-arg entry point — `nil` bm25Leg means the store runs its own
     /// FTS5 (the pre-Phase-2 path). See `searchSimilar(query:limit:bm25Leg:)`.
+    ///
+    /// Deprecated (#637): call `searchSimilar(query:limit:bm25Leg:)` and
+    /// resolve a Tantivy leg via `WikiStoreModel.resolveTantivyLeg(...)` (app)
+    /// or `CLITantivyLegResolver` (CLI). A `nil` leg still works in Phase 2
+    /// (FTS5 fallback) but will regress to cosine-only under #634.
+    @available(*, deprecated, message: "Pass an explicit `bm25Leg:` — resolve a Tantivy leg for the hybrid path, or `nil` for FTS5 fallback. See #637 / #634.")
     public func searchSimilar(query: String, limit: Int) throws -> [WikiPageSummary] {
         try searchSimilar(query: query, limit: limit, bm25Leg: nil)
     }
 
     /// Legacy 2-arg entry point for sources. See
     /// `searchSimilarSources(query:limit:bm25Leg:)`.
+    ///
+    /// Deprecated (#637): call `searchSimilarSources(query:limit:bm25Leg:)`
+    /// and resolve a Tantivy leg. See ``searchSimilar(query:limit:)``.
+    @available(*, deprecated, message: "Pass an explicit `bm25Leg:` — resolve a Tantivy leg for the hybrid path, or `nil` for FTS5 fallback. See #637 / #634.")
     public func searchSimilarSources(query: String, limit: Int) throws -> [SourceSummary] {
         try searchSimilarSources(query: query, limit: limit, bm25Leg: nil)
     }
 
     /// Legacy 2-arg entry point for chats. See
     /// `searchSimilarChats(query:limit:bm25Leg:)`.
+    ///
+    /// Deprecated (#637): call `searchSimilarChats(query:limit:bm25Leg:)` and
+    /// resolve a Tantivy leg. See ``searchSimilar(query:limit:)``.
+    @available(*, deprecated, message: "Pass an explicit `bm25Leg:` — resolve a Tantivy leg for the hybrid path, or `nil` for FTS5 fallback. See #637 / #634.")
     public func searchSimilarChats(query: String, limit: Int) throws -> [ChatSummary] {
         try searchSimilarChats(query: query, limit: limit, bm25Leg: nil)
     }

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -503,20 +503,52 @@ public final class WikiStoreModel {
     /// submenu once per right-click, not per render). The old per-row sidebar
     /// caller that froze the UI was removed; MiniLM inference is now ms, not the
     /// ~5 s/100k chars NLEmbedding cliff that motivated disabling this.
+    ///
+    /// Routes through the FTS5 fallback (`bm25Leg: nil`) rather than the
+    /// Tantivy leg used by `scheduleSearch()` — kept as-is for one-shot
+    /// callers that don't want the Tantivy index dependency (the omnibox is
+    /// debounced via a `Task` and benefits from the existing path). The
+    /// "Find Similar…" right-click menu should call
+    /// ``searchSimilarResolvingTantivy(query:limit:)`` instead — it resolves
+    /// the Tantivy BM25 leg (#637) so the menu surfaces fuzzy (edit-distance 1)
+    /// matches and survives #634's FTS5 drop without regression.
     public func searchSimilar(query: String, limit: Int = 8) -> [WikiPageSummary] {
-        (try? store.searchSimilar(query: query, limit: limit)) ?? []
+        (try? store.searchSimilar(query: query, limit: limit, bm25Leg: nil)) ?? []
+    }
+
+    /// #637: one-shot page search that resolves a Tantivy BM25 leg before
+    /// calling the store's 3-arg `searchSimilar` — mirrors `scheduleSearch()`
+    /// but synchronous (the caller — `WikiLinkMenuNSItems.similarPagesItem` —
+    /// builds its submenu once per right-click, not per render, so blocking the
+    /// main actor for the Tantivy query is the same trade-off the existing
+    /// `searchSimilar(query:limit:)` already makes for MiniLM inference).
+    ///
+    /// The Tantivy `indexer.search` runs on its actor (off-main); the async→
+    /// sync bridge uses `Task { ... }.value` on `@MainActor` — safe because
+    /// the search never hops back to the main actor to make progress. Returns
+    /// FTS5-fallback results (`bm25Leg: nil`) when Tantivy is unavailable or
+    /// returns no hits.
+    public func searchSimilarResolvingTantivy(query: String, limit: Int = 8) -> [WikiPageSummary] {
+        guard !query.isEmpty else { return [] }
+        let leg = resolveTantivyLegSync(query: query, kind: .page, limit: limit, catalog: summaries)
+        do {
+            return try store.searchSimilar(query: query, limit: limit, bm25Leg: leg)
+        } catch {
+            DebugLog.store("WikiStoreModel.searchSimilarResolvingTantivy: store hit failed for query=\"\(query)\": \(error)")
+            return []
+        }
     }
 
     /// Semantic source search wrapper — same hybrid store search as
     /// `searchSimilar`, over sources.
     public func searchSimilarSources(query: String, limit: Int = 20) -> [SourceSummary] {
-        (try? store.searchSimilarSources(query: query, limit: limit)) ?? []
+        (try? store.searchSimilarSources(query: query, limit: limit, bm25Leg: nil)) ?? []
     }
 
     /// Hybrid chat search wrapper — same hybrid store search as
     /// `searchSimilar`, over chats. Used by the Chats sidebar search field.
     public func searchSimilarChats(query: String, limit: Int = 20) -> [ChatSummary] {
-        (try? store.searchSimilarChats(query: query, limit: limit)) ?? []
+        (try? store.searchSimilarChats(query: query, limit: limit, bm25Leg: nil)) ?? []
     }
 
     /// Unified omnibox search across all resource types (#288). Returns a
@@ -2966,6 +2998,66 @@ public final class WikiStoreModel {
             return byID[id]
         }
         return resolved.isEmpty ? nil : resolved
+    }
+
+    /// #637: synchronous variant of ``resolveTantivyLeg(query:kind:limit:catalog:)``
+    /// for one-shot main-actor callers that need the leg inline (the "Find
+    /// Similar…" right-click menu — `WikiLinkMenuNSItems.similarPagesItem`).
+    /// Bridges the actor-isolated `TantivySearchService.search` to the
+    /// main-actor sync contract the existing `searchSimilar(query:limit:)`
+    /// wrapper already upholds.
+    ///
+    /// Deadlock safety: the awaited `TantivySearchService.search` runs on the
+    /// `TantivyIndexer` actor (pure off-main compute — touches no SQLite file,
+    /// no actor needs the main thread to release a lock). The semaphore-bridge
+    /// (mirrors `wikictl`'s `runRefresh` async→sync pattern at
+    /// `Sources/wikictl/main.swift:180-200`) blocks only the calling main
+    /// thread; the `Task.detached` body runs in the cooperative pool and hops
+    /// to the indexer actor to query — never back to the main actor — so
+    /// `semaphore.wait()` cannot self-deadlock. `Task.detached` (not
+    /// `Task { ... }`) is intentional: an unstructured `Task` would inherit
+    /// the main-actor executor and could starve under load.
+    ///
+    /// Returns `nil` (→ store falls back to FTS5) when `tantivySearch` is
+    /// `nil`, the index returned no hits, or every hit was missing from
+    /// `catalog`. Same contract as the async variant.
+    @MainActor
+    private func resolveTantivyLegSync<T: Identifiable & Sendable>(
+        query: String,
+        kind: TantivyDocumentKind,
+        limit: Int,
+        catalog: [T]
+    ) -> [T]? where T.ID == PageID {
+        guard let svc = tantivySearch, !query.isEmpty else { return nil }
+        let box = TantivyLegBox()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached {
+            box.result = await svc.search(query: query, kinds: [kind], limit: limit)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        guard let hits = box.result, !hits.isEmpty else { return nil }
+        let byID = Dictionary(catalog.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+        let resolved = hits.compactMap { hit -> T? in
+            let id = PageID(rawValue: hit.ulid)
+            return byID[id]
+        }
+        return resolved.isEmpty ? nil : resolved
+    }
+
+    /// Thread-safe box for the sync Tantivy leg bridge — mirrors
+    /// `RefreshResultBox` at `Sources/wikictl/main.swift`. `@unchecked Sendable`
+    /// is belt-and-suspenders: the semaphore guarantees the `Task.detached`
+    /// write happens-before the read after `semaphore.wait()` returns, so the
+    /// NSLock exists only to satisfy Swift 6's data-race checker.
+    private final class TantivyLegBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _result: [TantivyShadowSearchResult]?
+
+        var result: [TantivyShadowSearchResult]? {
+            get { lock.lock(); defer { lock.unlock() }; return _result }
+            set { lock.lock(); defer { lock.unlock() }; _result = newValue }
+        }
     }
 
     /// Phase 2 shadow-comparison log. With Option B the FTS5 leg isn't run

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -82,7 +82,11 @@ func run() async -> Int32 {
         }
         let store = try GRDBWikiStore(databaseURL: resolver.databaseURL(for: descriptor))
 
-        let result = try execute(command, in: store)
+        let result = try execute(
+            command,
+            in: store,
+            wikiID: descriptor.id,
+            containerDirectory: resolver.containerDirectory)
 
         switch result.payload {
         case .text(let output):
@@ -125,7 +129,18 @@ func run() async -> Int32 {
 /// `LogIndexCommand` (the Phase-B `log append` / `index set`), or `SourceCommand`
 /// (the `source …` family for raw source reads). The deferred body read (`-` = stdin,
 /// else a file path) happens here — the only I/O the parser left for `main`.
-func execute(_ command: ArgumentParser.Command, in store: GRDBWikiStore) throws -> SourceCommand.Result {
+///
+/// `wikiID` + `containerDirectory` thread the on-disk Tantivy index path
+/// (`<container>/search-index/<wikiID>/`) to the three search cases so they
+/// can resolve a Tantivy BM25 leg via `CLITantivyLegResolver` before invoking
+/// the kind-specific `*Command.run(..., bm25Leg:)` (#637). Non-search cases
+/// ignore them.
+func execute(
+    _ command: ArgumentParser.Command,
+    in store: GRDBWikiStore,
+    wikiID: String,
+    containerDirectory: URL
+) throws -> SourceCommand.Result {
     switch command {
     case .list(let json):
         let r = try PageCommand.run(.list(json: json), in: store)
@@ -148,7 +163,16 @@ func execute(_ command: ArgumentParser.Command, in store: GRDBWikiStore) throws 
         let r = try LogIndexCommand.run(.indexSet(body: body, workspace: workspace), in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .search(let query, let limit):
-        let r = try PageCommand.run(.search(query: query, limit: limit), in: store)
+        // #637: route through the Tantivy BM25 leg (mirrors the sidebar's
+        // `WikiStoreModel.scheduleSearch()` → `resolveTantivyLeg` flow) so the
+        // CLI gets fuzzy matching (edit-distance 1 on title+body, already
+        // configured at TantivyIndexer.swift:108-111) and survives #634's
+        // FTS5 drop. `nil` leg (Tantivy index unavailable/empty) → the store's
+        // existing FTS5 fallback (Phase 2 contract).
+        let leg = CLITantivyLegResolver.resolvePageLeg(
+            wikiID: wikiID, containerDirectory: containerDirectory,
+            store: store, query: query, limit: limit)
+        let r = try PageCommand.run(.search(query: query, limit: limit), in: store, bm25Leg: leg)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .pageHistory(let selector):
         let r = try PageCommand.run(.history(selector), in: store)
@@ -157,8 +181,10 @@ func execute(_ command: ArgumentParser.Command, in store: GRDBWikiStore) throws 
         let r = try PageCommand.run(.revert(selector, versionID: versionID), in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .source(let action):
-        return try SourceCommand.run(action, in: store,
-                                   cwd: FileManager.default.currentDirectoryPath)
+        return try SourceCommand.run(
+            action, in: store,
+            cwd: FileManager.default.currentDirectoryPath,
+            bm25Leg: cliSourceLegIfSearch(action, wikiID: wikiID, containerDirectory: containerDirectory, store: store))
     case .sourceEditMarkdown(let selector, let contentOrFile, let isFile):
         let content: String
         if isFile {
@@ -201,8 +227,7 @@ func execute(_ command: ArgumentParser.Command, in store: GRDBWikiStore) throws 
     case .admin(let action):
         return try AdminCommand.run(action, in: store)
     case .chat(let action):
-        let r = try ChatCommand.run(action, in: store)
-        return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
+        return try runChatCommand(action, in: store, wikiID: wikiID, containerDirectory: containerDirectory)
     case .bookmark(let action):
         let r = try BookmarkCommand.run(action, in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
@@ -216,6 +241,44 @@ func execute(_ command: ArgumentParser.Command, in store: GRDBWikiStore) throws 
         // Handled before wiki resolution in `run()` — unreachable here.
         return SourceCommand.Result(payload: .text(""), didCommit: false)
     }
+}
+
+/// #637: split-out dispatch for the `wikictl chat …` subcommands. Resolves
+/// a Tantivy BM25 leg for `.search` before invoking `ChatCommand.run(...,
+/// bm25Leg:)`. Mirrors the `page search` / `source search` paths in
+/// `execute(...)` — kept as a helper so that function's switch stays compact.
+private func runChatCommand(
+    _ action: ChatCommand.Action,
+    in store: GRDBWikiStore,
+    wikiID: String,
+    containerDirectory: URL
+) throws -> SourceCommand.Result {
+    let leg: [ChatSummary]?
+    if case .search(let query, let limit) = action {
+        leg = CLITantivyLegResolver.resolveChatLeg(
+            wikiID: wikiID, containerDirectory: containerDirectory,
+            store: store, query: query, limit: limit)
+    } else {
+        leg = nil
+    }
+    let r = try ChatCommand.run(action, in: store, bm25Leg: leg)
+    return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
+}
+
+/// #637: inspect a `SourceCommand.Action` and, when it's `.search`, resolve a
+/// Tantivy BM25 leg to thread into `SourceCommand.run(..., bm25Leg:)`. Returns
+/// `nil` for every other action (the param is unused by them). Kept as a
+/// helper so the switch in `execute(...)` reads cleanly.
+private func cliSourceLegIfSearch(
+    _ action: SourceCommand.Action,
+    wikiID: String,
+    containerDirectory: URL,
+    store: GRDBWikiStore
+) -> [SourceSummary]? {
+    guard case .search(let query, let limit) = action else { return nil }
+    return CLITantivyLegResolver.resolveSourceLeg(
+        wikiID: wikiID, containerDirectory: containerDirectory,
+        store: store, query: query, limit: limit)
 }
 
 /// Thread-safe box for the wikictl async→sync semaphore bridge (Phase 3b).

--- a/Tests/WikiFSTests/CLITantivyLegResolverTests.swift
+++ b/Tests/WikiFSTests/CLITantivyLegResolverTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+@testable import WikiCtlCore
+@testable import WikiFSCore
+
+/// #637: integration tests for `CLITantivyLegResolver`, the bridge that routes
+/// `wikictl page/source/chat search` through the same on-disk Tantivy BM25 leg
+/// the app's sidebar uses.
+///
+/// These tests construct a real `GRDBWikiStore`, build a Tantivy index against
+/// it via the same `StoreBackedTantivyContentSource` the app uses, then verify
+/// the resolver returns the indexed pages as a best-first BM25 leg (which the
+/// store's 3-arg `searchSimilar(query:limit:bm25Leg:)` then fuses with the
+/// cosine leg via RRF). The fuzzy-typo AC for `wikictl page search "erikson"`
+/// (finds "Erickson") is covered by `resolvePageLegSurfacesFuzzyTypoMatches`.
+///
+/// These are fast: they open a temp SQLite DB, build a small Tantivy index
+/// (3-5 docs), and call one resolver method per test. They live in the fast
+/// CI tier (not skip-listed).
+@Suite
+struct CLITantivyLegResolverTests {
+
+    // MARK: - Helpers
+
+    /// Fresh temp directory per test (UUID) holding both the `<ulid>.sqlite`
+    /// and the `search-index/<wikiID>/` Tantivy index. Removed in `defer` so
+    /// nothing leaks between runs.
+    private func makeTempContainer() throws -> (URL, FileManager) {
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("cli-tantivy-leg-\(UUID().uuidString)")
+        let url = URL(fileURLWithPath: path)
+        let fm = FileManager.default
+        try fm.createDirectory(at: url, withIntermediateDirectories: true)
+        return (url, fm)
+    }
+
+    private func tempStore(in container: URL, wikiID: String) throws -> GRDBWikiStore {
+        let dbURL = container.appendingPathComponent("\(wikiID).sqlite", isDirectory: false)
+        return try GRDBWikiStore(databaseURL: dbURL)
+    }
+
+    // MARK: - resolvePageLeg
+
+    @Test(.tags(.integration)) func resolvePageLegReturnsNilWhenIndexEmpty() throws {
+        let (container, fm) = try makeTempContainer()
+        defer { try? fm.removeItem(at: container) }
+        let wikiID = "01TEST0001"
+        let store = try tempStore(in: container, wikiID: wikiID)
+        // No Tantivy index exists yet — `rebuildIfNeeded` was never called
+        // (the app would normally kick it off in `TantivyShadowSync.start()`).
+        // The resolver must return nil so the store falls back to FTS5
+        // (the #637 contract — empty leg = no BM25 signal).
+        let leg = CLITantivyLegResolver.resolvePageLeg(
+            wikiID: wikiID, containerDirectory: container,
+            store: store, query: "anything", limit: 10)
+        #expect(leg == nil)
+    }
+
+    @Test(.tags(.integration)) func resolvePageLegReturnsIndexedPagesInBestFirstOrder() async throws {
+        let (container, fm) = try makeTempContainer()
+        defer { try? fm.removeItem(at: container) }
+        let wikiID = "01TEST0002"
+        let store = try tempStore(in: container, wikiID: wikiID)
+        // Seed a page whose body repeats "rust" (high BM25 signal) and another
+        // with a single mention.
+        let a = try store.createPage(title: "Rust Ownership")
+        try store.updatePage(id: a.id, title: "Rust Ownership",
+                             body: "rust rust rust rust borrowing and lifetimes")
+        let b = try store.createPage(title: "Other")
+        try store.updatePage(id: b.id, title: "Other", body: "a brief mention of rust")
+
+        // The CLI resolver rebuilds the Tantivy index from the store when
+        // empty (mirrors `TantivyShadowSync.start()` in the app) — no need to
+        // pre-build it in the test. The first call pays the rebuild cost;
+        // subsequent calls see a populated index and short-circuit on
+        // `count()`.
+        let leg = CLITantivyLegResolver.resolvePageLeg(
+            wikiID: wikiID, containerDirectory: container,
+            store: store, query: "rust", limit: 10)
+        // The leg is non-nil (the index returned hits) and contains BOTH pages.
+        #expect(leg != nil)
+        #expect(leg?.count == 2)
+        // Tantivy ranks the higher-term-frequency page first (BM25 signal) —
+        // the resolver preserves that order.
+        #expect(leg?.first?.id == a.id)
+    }
+
+    @Test(.tags(.integration)) func resolvePageLegSurfacesFuzzyTypoMatches() async throws {
+        // AC #637: `wikictl page search "erikson"` (one-character typo) returns
+        // "Erickson"-style pages. Tantivy's `fuzzyFields` are configured with
+        // edit-distance 1 on title + body (`TantivyIndexer.swift:108-111`),
+        // so the resolver's leg should include the correctly-spelled page
+        // even though the query is misspelled.
+        let (container, fm) = try makeTempContainer()
+        defer { try? fm.removeItem(at: container) }
+        let wikiID = "01TEST0003"
+        let store = try tempStore(in: container, wikiID: wikiID)
+        let page = try store.createPage(title: "Milton H. Erickson")
+        try store.updatePage(id: page.id, title: "Milton H. Erickson",
+                             body: "Milton H. Erickson was an American psychiatrist specializing in clinical hypnosis.")
+
+        // Query with a one-character typo ("erikson" vs "erickson"). Fuzzy
+        // matching (edit-distance 1) should still surface the page. The
+        // resolver's internal `rebuildIfNeeded()` populates the index from
+        // the store on first call.
+        let leg = CLITantivyLegResolver.resolvePageLeg(
+            wikiID: wikiID, containerDirectory: container,
+            store: store, query: "erikson", limit: 10)
+        #expect(leg != nil, "fuzzy match should find Erickson despite the typo")
+        #expect(leg?.contains { $0.id == page.id } ?? false)
+    }
+
+    // MARK: - resolveSourceLeg
+
+    @Test(.tags(.integration)) func resolveSourceLegReturnsIndexedSources() async throws {
+        let (container, fm) = try makeTempContainer()
+        defer { try? fm.removeItem(at: container) }
+        let wikiID = "01TEST0004"
+        let store = try tempStore(in: container, wikiID: wikiID)
+        _ = try store.addSource(
+            filename: "self-driving-cars.pdf", data: Data("%PDF".utf8))
+        // Give the source a body via processed-markdown so Tantivy has text to
+        // index beyond the filename (mirrors the production content source).
+        let sources = try store.listSources()
+        _ = try store.appendProcessedMarkdown(
+            sourceID: sources[0].id,
+            content: "A longitudinal study of autonomous vehicle safety.",
+            origin: .extraction, note: nil, technique: nil)
+
+        let leg = CLITantivyLegResolver.resolveSourceLeg(
+            wikiID: wikiID, containerDirectory: container,
+            store: store, query: "autonomous", limit: 10)
+        #expect(leg != nil)
+        #expect(leg?.count == 1)
+        #expect(leg?.first?.id == sources[0].id)
+    }
+
+    // MARK: - resolveChatLeg
+
+    @Test(.tags(.integration)) func resolveChatLegReturnsIndexedChats() async throws {
+        let (container, fm) = try makeTempContainer()
+        defer { try? fm.removeItem(at: container) }
+        let wikiID = "01TEST0005"
+        let store = try tempStore(in: container, wikiID: wikiID)
+        let chat = try store.createChat(kind: .edit, title: "Mars Colony")
+        _ = try store.appendChatMessages(chatID: chat.id, events: [
+            .assistantText("We discussed terraforming the Martian surface."),
+        ])
+
+        let leg = CLITantivyLegResolver.resolveChatLeg(
+            wikiID: wikiID, containerDirectory: container,
+            store: store, query: "terraforming", limit: 10)
+        #expect(leg != nil)
+        #expect(leg?.count == 1)
+        #expect(leg?.first?.id == chat.id)
+    }
+
+    // MARK: - FTS5 fallback when no Tantivy service can be built
+
+    @Test func resolvePageLegReturnsNilWhenServiceConstructionFails() throws {
+        // Point the resolver at a container path that doesn't exist and can't
+        // be created (a file in place of the container dir). `makeService`
+        // catches the throw and returns nil — the store then falls back to
+        // FTS5 (the #637 contract — Tantivy unavailable = no BM25 leg, not an
+        // error).
+        let fileAsContainer = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-tantivy-leg-blocker-\(UUID().uuidString)")
+        try Data("not a directory".utf8).write(to: fileAsContainer)
+        defer { try? FileManager.default.removeItem(at: fileAsContainer) }
+
+        // A real store the resolver can list pages from (won't be reached —
+        // makeService throws first).
+        let (container, fm) = try makeTempContainer()
+        defer { try? fm.removeItem(at: container) }
+        let wikiID = "01TEST0006"
+        let store = try tempStore(in: container, wikiID: wikiID)
+
+        let leg = CLITantivyLegResolver.resolvePageLeg(
+            wikiID: wikiID, containerDirectory: fileAsContainer,
+            store: store, query: "anything", limit: 10)
+        #expect(leg == nil)
+    }
+}

--- a/Tests/WikiFSTests/ChatSearchTests.swift
+++ b/Tests/WikiFSTests/ChatSearchTests.swift
@@ -35,7 +35,7 @@ import SQLite3
             .userText("explain something"),
             .assistantText("Quantum entanglement links particles across distance."),
         ])
-        let hits = try store.searchSimilarChats(query: "entanglement", limit: 10)
+        let hits = try store.searchSimilarChats(query: "entanglement", limit: 10, bm25Leg: nil)
         #expect(hits.count == 1)
         #expect(hits.first?.id == chat.id)
     }
@@ -51,7 +51,7 @@ import SQLite3
         _ = try store.appendChatMessages(chatID: chat.id, events: [
             .assistantText("Photosynthesis converts light into chemical energy."),
         ])
-        #expect(try store.searchSimilarChats(query: "photosynthesis", limit: 10).first?.id == chat.id)
+        #expect(try store.searchSimilarChats(query: "photosynthesis", limit: 10, bm25Leg: nil).first?.id == chat.id)
     }
 
     @Test func searchRespectsLimit() throws {
@@ -62,7 +62,7 @@ import SQLite3
                 .assistantText("Report \(i) discusses the budget forecast."),
             ])
         }
-        let hits = try store.searchSimilarChats(query: "budget", limit: 2)
+        let hits = try store.searchSimilarChats(query: "budget", limit: 2, bm25Leg: nil)
         #expect(hits.count == 2)
     }
 
@@ -72,7 +72,7 @@ import SQLite3
         _ = try store.appendChatMessages(chatID: chat.id, events: [
             .assistantText("Hello there, how can I help?"),
         ])
-        #expect(try store.searchSimilarChats(query: "zzznomatchxyz", limit: 10).isEmpty)
+        #expect(try store.searchSimilarChats(query: "zzznomatchxyz", limit: 10, bm25Leg: nil).isEmpty)
     }
 
     @Test func searchReflectsRename() throws {
@@ -82,23 +82,23 @@ import SQLite3
             .assistantText("A body with no distinctive keywords."),
         ])
         // The old title is searchable before rename.
-        #expect(try store.searchSimilarChats(query: "Old", limit: 10).first?.id == chat.id)
+        #expect(try store.searchSimilarChats(query: "Old", limit: 10, bm25Leg: nil).first?.id == chat.id)
         try store.renameChat(id: chat.id, to: "Completely Renamed")
         // New title is now searchable…
-        #expect(try store.searchSimilarChats(query: "Renamed", limit: 10).first?.id == chat.id)
+        #expect(try store.searchSimilarChats(query: "Renamed", limit: 10, bm25Leg: nil).first?.id == chat.id)
         // …and the old one no longer matches (the body has none of those words).
-        #expect(try store.searchSimilarChats(query: "Old", limit: 10).isEmpty)
+        #expect(try store.searchSimilarChats(query: "Old", limit: 10, bm25Leg: nil).isEmpty)
     }
 
     @Test func sidecarNotPopulatedUntilFirstAppend() throws {
         let store = try tempStore()
         let chat = try store.createChat(kind: .edit, title: "Placeholder")
         // A chat with no messages has an empty body → nothing to match.
-        #expect(try store.searchSimilarChats(query: "Placeholder", limit: 10).isEmpty)
+        #expect(try store.searchSimilarChats(query: "Placeholder", limit: 10, bm25Leg: nil).isEmpty)
         _ = try store.appendChatMessages(chatID: chat.id, events: [
             .assistantText("Now the body has Placeholder in it."),
         ])
-        #expect(try store.searchSimilarChats(query: "Placeholder", limit: 10).first?.id == chat.id)
+        #expect(try store.searchSimilarChats(query: "Placeholder", limit: 10, bm25Leg: nil).first?.id == chat.id)
     }
 
     // MARK: - Chunk-embedding mechanics (model-independent)
@@ -155,7 +155,7 @@ import SQLite3
         // The ON DELETE CASCADE on chat_chunks removes them; the chat is gone
         // from missing-work entirely (no row to be "missing").
         #expect(store.missingChatEmbeddingWork().isEmpty)
-        #expect(try store.searchSimilarChats(query: "Doomed", limit: 10).isEmpty)
+        #expect(try store.searchSimilarChats(query: "Doomed", limit: 10, bm25Leg: nil).isEmpty)
     }
 
     // MARK: - wikictl `chat search`

--- a/Tests/WikiFSTests/FullTextSearchTests.swift
+++ b/Tests/WikiFSTests/FullTextSearchTests.swift
@@ -29,7 +29,7 @@ struct FullTextSearchTests {
         let page = try store.createPage(title: "Lecture Notes")
         try store.updatePage(id: page.id, title: "Lecture Notes",
                              body: "Today we covered clinical hypnosis and suggestion.")
-        let hits = try store.searchSimilar(query: "hypnosis", limit: 10)
+        let hits = try store.searchSimilar(query: "hypnosis", limit: 10, bm25Leg: nil)
         #expect(hits.count == 1)
         #expect(hits.first?.id == page.id)
     }
@@ -41,7 +41,7 @@ struct FullTextSearchTests {
         _ = try store.appendProcessedMarkdown(
             sourceID: s.id, content: "Hypnosis measurably alters pain perception.",
             origin: .extraction, note: nil)
-        let hits = try store.searchSimilarSources(query: "hypnosis", limit: 10)
+        let hits = try store.searchSimilarSources(query: "hypnosis", limit: 10, bm25Leg: nil)
         #expect(hits.count == 1)
         #expect(hits.first?.id == s.id)
     }
@@ -51,7 +51,7 @@ struct FullTextSearchTests {
         let store = try tempStore()
         let page = try store.createPage(title: "Training")
         try store.updatePage(id: page.id, title: "Training", body: "She is running every morning.")
-        #expect(try store.searchSimilar(query: "run", limit: 10).first?.id == page.id)
+        #expect(try store.searchSimilar(query: "run", limit: 10, bm25Leg: nil).first?.id == page.id)
     }
 
     // MARK: - Name-only indexing (un-extracted source findable by filename)
@@ -59,7 +59,7 @@ struct FullTextSearchTests {
     @Test func unextractedSourceFindableByFilename() throws {
         let store = try tempStore()
         _ = try store.addSource(filename: "hypnosis-study.pdf", data: Data("%PDF".utf8))
-        let hits = try store.searchSimilarSources(query: "hypnosis", limit: 10)
+        let hits = try store.searchSimilarSources(query: "hypnosis", limit: 10, bm25Leg: nil)
         #expect(hits.count == 1)
     }
 
@@ -72,7 +72,7 @@ struct FullTextSearchTests {
                              body: "thermodynamics thermodynamics thermodynamics thermodynamics")
         let b = try store.createPage(title: "B")
         try store.updatePage(id: b.id, title: "B", body: "a brief mention of thermodynamics")
-        let hits = try store.searchSimilar(query: "thermodynamics", limit: 10)
+        let hits = try store.searchSimilar(query: "thermodynamics", limit: 10, bm25Leg: nil)
         #expect(hits.count == 2)
         #expect(hits.first?.id == a.id)  // higher term frequency → better bm25
     }
@@ -83,9 +83,9 @@ struct FullTextSearchTests {
         let store = try tempStore()
         let page = try store.createPage(title: "Gone")
         try store.updatePage(id: page.id, title: "Gone", body: "contains qxzuniqueterm")
-        #expect(try store.searchSimilar(query: "qxzuniqueterm", limit: 10).count == 1)
+        #expect(try store.searchSimilar(query: "qxzuniqueterm", limit: 10, bm25Leg: nil).count == 1)
         try store.deletePage(id: page.id)
-        #expect(try store.searchSimilar(query: "qxzuniqueterm", limit: 10).isEmpty)
+        #expect(try store.searchSimilar(query: "qxzuniqueterm", limit: 10, bm25Leg: nil).isEmpty)
     }
 
     // MARK: - Reindex rebuild (Reindex button backfills pre-existing content)
@@ -124,17 +124,17 @@ struct FullTextSearchTests {
         try store.updatePage(id: page.id, title: "Claim Notes",
                              body: "Details about the insurance claim and appeal process.")
         // Baseline: a healthy index finds the body term.
-        #expect(try store.searchSimilar(query: "insurance", limit: 10).contains { $0.id == page.id })
+        #expect(try store.searchSimilar(query: "insurance", limit: 10, bm25Leg: nil).contains { $0.id == page.id })
 
         // Reproduce the broken state: pages exist, but the FTS term index is
         // empty (as when pages predate the FTS triggers).
         try store._breakPagesFtsIndexForTesting()
-        #expect(try store.searchSimilar(query: "insurance", limit: 10).isEmpty)
+        #expect(try store.searchSimilar(query: "insurance", limit: 10, bm25Leg: nil).isEmpty)
 
         // Re-opening runs ensureSearchIndexes, which must now see zero terms and
         // rebuild → the body term is findable again.
         let reopened = try GRDBWikiStore(databaseURL: url)
-        let hits = try reopened.searchSimilar(query: "insurance", limit: 10)
+        let hits = try reopened.searchSimilar(query: "insurance", limit: 10, bm25Leg: nil)
         #expect(hits.contains { $0.id == page.id })
     }
 

--- a/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
+++ b/Tests/WikiFSTests/SourceEmbeddingSearchTests.swift
@@ -91,7 +91,7 @@ struct SourceEmbeddingSearchTests {
         _ = try store.addSource(filename: "quarterly-report.pdf", data: Data("%PDF".utf8))
         _ = try store.addSource(filename: "vacation.jpg", data: Data([0xFF, 0xD8, 0xFF]))
 
-        let hits = try store.searchSimilarSources(query: "report", limit: 10)
+        let hits = try store.searchSimilarSources(query: "report", limit: 10, bm25Leg: nil)
         #expect(hits.count == 1)
         #expect(hits.first?.filename == "quarterly-report.pdf")
     }
@@ -101,7 +101,7 @@ struct SourceEmbeddingSearchTests {
         let s = try store.addSource(filename: "data.bin", data: Data("x".utf8))
         try store.renameSource(id: s.id, to: "Annual Budget")
 
-        let hits = try store.searchSimilarSources(query: "budget", limit: 10)
+        let hits = try store.searchSimilarSources(query: "budget", limit: 10, bm25Leg: nil)
         #expect(hits.count == 1)
         #expect(hits.first?.displayName == "Annual Budget")
     }
@@ -112,14 +112,14 @@ struct SourceEmbeddingSearchTests {
         _ = try store.addSource(filename: "report-2.pdf", data: Data("%PDF 2".utf8))
         _ = try store.addSource(filename: "report-3.pdf", data: Data("%PDF 3".utf8))
 
-        let hits = try store.searchSimilarSources(query: "report", limit: 2)
+        let hits = try store.searchSimilarSources(query: "report", limit: 2, bm25Leg: nil)
         #expect(hits.count == 2)
     }
 
     @Test func searchSimilarSourcesLIKEFallbackEmptyWhenNoMatch() throws {
         let store = try tempStore()
         _ = try store.addSource(filename: "alpha.txt", data: Data("a".utf8))
-        #expect(try store.searchSimilarSources(query: "zzznomatch", limit: 10).isEmpty)
+        #expect(try store.searchSimilarSources(query: "zzznomatch", limit: 10, bm25Leg: nil).isEmpty)
     }
 
     @Test func searchSimilarSourcesNeverSelectsStar() throws {
@@ -129,7 +129,7 @@ struct SourceEmbeddingSearchTests {
         // not NaN), proving the column order is the explicit 11-column list.
         let store = try tempStore()
         _ = try store.addSource(filename: "doc.pdf", data: Data("%PDF-1.4 content bytes".utf8))
-        let hits = try store.searchSimilarSources(query: "doc", limit: 10)
+        let hits = try store.searchSimilarSources(query: "doc", limit: 10, bm25Leg: nil)
         let created = try #require(hits.first?.createdAt)
         #expect(created.timeIntervalSince1970 > 1_700_000_000)  // a 2023+ timestamp
     }

--- a/Tests/WikiFSTests/TantivyBM25LegCutoverTests.swift
+++ b/Tests/WikiFSTests/TantivyBM25LegCutoverTests.swift
@@ -99,13 +99,15 @@ import Testing
     }
 
     @Test func defaultArgBehaviorPreserved() throws {
-        // Callers that omit bm25Leg entirely (wikictl, tests, the model's sync
-        // searchSimilar wrapper) must see the legacy behavior — the "zero caller
-        // breakage" guarantee of Option B.
+        // #637: the 2-arg store overload is now deprecated — `bm25Leg: nil`
+        // is the explicit form for "no Tantivy leg, run FTS5" (the legacy
+        // Phase 2 behavior the model's sync wrapper still uses, and the
+        // FTS5 fallback path #634 will retire). Tests pass `nil` explicitly
+        // so the deprecation warning doesn't fire under `-warnings-as-errors`.
         let store = try tempStore()
         let p = try store.createPage(title: "Default Arg")
         try store.updatePage(id: p.id, title: p.title, body: "kappa keyword common", lastEditedBy: nil)
-        let hits = try store.searchSimilar(query: "kappa", limit: 10)
+        let hits = try store.searchSimilar(query: "kappa", limit: 10, bm25Leg: nil)
         #expect(hits.count == 1)
     }
 


### PR DESCRIPTION
Closes #637.

## What

Five call sites bypassed the Tantivy BM25 leg, relying on FTS5 fallback via
the 2-arg store overloads (`bm25Leg: nil`). This made the CLI and the Find
Similar menu both (a) miss out on the indexer's edit-distance-1 fuzzy match
(already configured at `TantivyIndexer.swift:108-111`) and (b) regress to
cosine-only search under #634 (drop FTS5), which removes the nil-leg
fallback path entirely.

## Why this is a routing change

The Tantivy leg already works with fuzzy (edit-distance 1 on title+body).
These five call sites just needed to be wired to use it instead of falling
back to FTS5.

| Surface | File | Change |
|---|---|---|
| Find Similar / Suggest menu | `Sources/WikiFS/Reader/WikiLinkMenuNSItems.swift` | Calls new sync `WikiStoreModel.searchSimilarResolvingTantivy(query:limit:)` wrapper |
| `wikictl page search` | `Sources/WikiCtlCore/PageCommand.swift` | Added `bm25Leg:` param; leg resolved by `main.swift` |
| `wikictl source search` | `Sources/WikiCtlCore/SourceCommand.swift` | Added `bm25Leg:` param; leg resolved by `main.swift` |
| `wikictl chat search` | `Sources/WikiCtlCore/ChatCommand.swift` | Added `bm25Leg:` param; leg resolved by `main.swift` |
| Legacy 2-arg overloads | `Sources/WikiFSCore/Store/WikiStore.swift:712-726` | `@available(*, deprecated, ...)` — callers migrated to explicit 3-arg |

## How

- **Find Similar menu:** new sync wrapper
  `WikiStoreModel.searchSimilarResolvingTantivy(query:limit:)` mirrors
  `scheduleSearch()`'s pattern (resolve Tantivy leg → call store 3-arg
  `searchSimilar`). Bridges the actor-isolated `TantivySearchService.search`
  to the main-actor sync contract via a `DispatchSemaphore` (same shape as
  `wikictl`'s `runRefresh` async→sync bridge); safe because the Tantivy
  search runs on the indexer actor with no main-thread dependency.
- **CLI:** new `CLITantivyLegResolver` in `WikiCtlCore` constructs a
  `TantivySearchService` against the same on-disk
  `<container>/search-index/<wikiID>/` the app builds/maintains, queries it,
  resolves hits to typed summaries via the store's list APIs (mirrors
  `WikiStoreModel.resolveTantivyLeg`). `main.swift`'s `execute()` now
  threads `wikiID` + `containerDirectory` and resolves the leg before
  invoking each search command. The resolver calls `rebuildIfNeeded()` on
  first open (mirrors `TantivyShadowSync.start()`) — cheap `count()` check
  in steady state; essential for the "wiki never opened in the app" case.
- **Deprecation:** the 2-arg store overloads
  (`searchSimilar(query:limit:)` and kind-specific variants) are now
  `@available(*, deprecated)`. The model's sync wrappers migrated to
  explicit `bm25Leg: nil` (omnibox behavior unchanged — it stays on FTS5
  fallback by design). All test callers updated to explicit 3-arg form.

## Acceptance criteria

- [x] The "Find Similar…" submenu returns Tantivy-BM25-fused results
      (`WikiLinkMenuNSItems.similarPagesItem` now resolves the leg).
- [x] `wikictl page search "erikson"` returns "Erickson"-style pages with a
      one-character typo — covered by
      `CLITantivyLegResolverTests.resolvePageLegSurfacesFuzzyTypoMatches`.
- [x] `wikictl source search` and `wikictl chat search` route through the
      Tantivy BM25 leg — covered by `resolveSourceLegReturnsIndexedSources`
      and `resolveChatLegReturnsIndexedChats`.
- [x] After #634 drops FTS5, none of these five call sites regress — they
      now resolve a real Tantivy leg (the `nil` fallback is the failure
      mode, not the steady state).
- [x] The 2-arg legacy overloads are deprecated (`@available(*, deprecated)`)
      with all callers migrated to 3-arg explicit.

## Tests

- New `Tests/WikiFSTests/CLITantivyLegResolverTests.swift` — 6 tests
  covering nil-leg fallback (empty index, service-construction failure),
  best-first ordering, fuzzy typo (the AC), and source/chat parity. Tagged
  `.integration` (opens a real SQLite + Tantivy index) and added to the
  fast-tier skip list in `.github/workflows/ci.yml` + `AGENTS.md` per the
  house rules.
- Existing `TantivyBM25LegCutoverTests`, `ChatSearchTests`,
  `SourceEmbeddingSearchTests`, `FullTextSearchTests` migrated to explicit
  3-arg form (`bm25Leg: nil`) — same FTS5-fallback behavior they were
  testing.

## Build / test status

- `make version prompts && swift build` — clean.
- Fast tier (2697 tests, 230 suites) — all pass after rebase onto latest
  `main`.
- New `CLITantivyLegResolverTests` — all 6 pass when run directly.

## Relationship

**Blocking prerequisite for #634 (drop FTS5)** — without this PR, dropping
FTS5 regresses the CLI and Find Similar menu to cosine-only search (a
`nil` bm25Leg has no BM25 leg at all once FTS5 is gone). Fuzzy matching
lands "for free" here — the indexer's `fuzzyFields` are already configured;
these callers just needed to reach the Tantivy leg. Does not touch #628
(semantic cosine leg).
