### PR TITLE
Fuzzy wiki-link autocomplete in chat composer (#436, #638)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         # `GenerationGateLaneTests` was removed from this list (issue #651) —
         # it's a pure-concurrency suite (no SQLite) and belongs in the fast tier.
         env:
-          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests|ACPPermissionTimeoutTests|TantivyAutocompleteTests|ComposerAutocompleteHostedTests'
+          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests|ACPPermissionTimeoutTests|TantivyAutocompleteTests'
         run: $SWIFT test --skip "$SKIP"
 
   swift-integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         # `GenerationGateLaneTests` was removed from this list (issue #651) —
         # it's a pure-concurrency suite (no SQLite) and belongs in the fast tier.
         env:
-          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests|ACPPermissionTimeoutTests|TantivyAutocompleteTests'
+          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests|ACPPermissionTimeoutTests|TantivyAutocompleteTests|ComposerAutocompleteHostedTests'
         run: $SWIFT test --skip "$SKIP"
 
   swift-integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         # `GenerationGateLaneTests` was removed from this list (issue #651) —
         # it's a pure-concurrency suite (no SQLite) and belongs in the fast tier.
         env:
-          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests|ACPPermissionTimeoutTests'
+          SKIP: 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SplitDiffSnapshotTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SidebarDropBuilderIntegrationTests|CLITantivyLegResolverTests|ACPPermissionTimeoutTests|TantivyAutocompleteTests'
         run: $SWIFT test --skip "$SKIP"
 
   swift-integration:

--- a/Sources/WikiFS/Chats/ChatAutocompletePanel.swift
+++ b/Sources/WikiFS/Chats/ChatAutocompletePanel.swift
@@ -1,0 +1,223 @@
+import AppKit
+import SwiftUI
+import WikiFSSearch
+
+// MARK: - ChatAutocompletePanel
+
+/// A borderless, non-activating `NSPanel` that hosts the chat composer's
+/// `[[kind:partial` autocomplete results list. Mirrors the omnibox's
+/// `SuggestionsPanel` pattern (`OmniboxSearchField.swift:284`) so the composer's
+/// `NSTextView` keeps first responder while the dropdown floats above — the
+/// exact property the omnibox relies on for typing-while-navigating.
+///
+/// Anchored ABOVE the composer (the composer sits near the bottom of the chat
+/// window, so a below-anchor dropdown would be clipped). Tracks the parent
+/// window via `addChildWindow(_:ordered:)` so it follows window moves.
+@MainActor
+final class ChatAutocompletePanel: NSPanel {
+    private var hosting: NSHostingView<AnyView>?
+
+    init() {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 80),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered, defer: true)
+        isFloatingPanel = true
+        level = .popUpMenu
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = true
+        hidesOnDeactivate = true
+        becomesKeyOnlyIfNeeded = true
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    /// Re-render the panel with the current result set + keyboard highlight.
+    /// Idempotent: the first call installs the hosting view, later calls
+    /// update its `rootView` in place.
+    func update(
+        results: [TantivyShadowSearchResult],
+        selectedIndex: Int?,
+        width: CGFloat,
+        onSelect: @escaping (TantivyShadowSearchResult) -> Void
+    ) {
+        let content = ChatAutocompleteResultsList(
+            results: results,
+            selectedIndex: selectedIndex,
+            onSelect: onSelect)
+            .frame(width: width)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 1))
+        let root = AnyView(content)
+
+        let host: NSHostingView<AnyView>
+        if let existing = hosting {
+            existing.rootView = root
+            host = existing
+        } else {
+            host = NSHostingView(rootView: root)
+            contentView = host
+            hosting = host
+        }
+        host.frame = NSRect(x: 0, y: 0, width: width, height: host.fittingSize.height)
+        setContentSize(NSSize(width: width, height: host.fittingSize.height))
+    }
+
+    /// Position the panel **above** the anchor view and attach it as a child
+    /// window so it tracks window moves. The composer sits near the bottom of
+    /// the chat window, so a below-anchor placement (the omnibox convention)
+    /// would be clipped.
+    ///
+    /// `minY` floor: clamp the panel origin to at least the window's content
+    /// min Y + a small margin so a very-tall dropdown (the composer just
+    /// opened at the bottom of a short window) never overflows the title bar.
+    /// If the panel doesn't fit above the anchor, fall back to below.
+    func present(above anchor: NSView) {
+        guard let window = anchor.window else { return }
+        let rectInWindow = anchor.convert(anchor.bounds, to: nil)
+        let rectOnScreen = window.convertToScreen(rectInWindow)
+        let aboveOrigin = NSPoint(
+            x: rectOnScreen.minX,
+            y: rectOnScreen.maxY + frame.height + 4)
+        // If above-origin places the panel's top above the parent window's top,
+        // fall back to below (composer-height + 4pt gap).
+        let parentTopY = window.convertToScreen(
+            NSRect(x: 0, y: 0, width: 0, height: window.frame.height)).maxY
+        let origin: NSPoint
+        if aboveOrigin.y + frame.height > parentTopY - 8 {
+            // Not enough room above — pop BELOW the anchor instead.
+            origin = NSPoint(x: rectOnScreen.minX,
+                             y: rectOnScreen.minY - frame.height - 4)
+        } else {
+            origin = aboveOrigin
+        }
+        setFrameOrigin(origin)
+        if parent == nil {
+            window.addChildWindow(self, ordered: .above)
+        }
+        orderFront(nil)
+    }
+}
+
+// MARK: - SwiftUI results list
+
+/// The ranked autocomplete rows shown in `ChatAutocompletePanel`. Mirrors the
+/// omnibox `AddressResultsList` (`AddressBarView.swift:465`) — icon + title +
+/// kind caption, hover + keyboard highlight, `↩` glyph on the Enter target —
+/// but is fed by `[TantivyShadowSearchResult]` rather than `[OmniboxResult]`.
+private struct ChatAutocompleteResultsList: View {
+    let results: [TantivyShadowSearchResult]
+    /// The arrow-key-selected row, pushed in from the AppKit coordinator. `nil`
+    /// means nothing is explicitly selected and Enter targets the top row.
+    let selectedIndex: Int?
+    let onSelect: (TantivyShadowSearchResult) -> Void
+
+    @State private var hoveredID: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(results.enumerated()), id: \.element.documentID) { index, result in
+                row(result, index: index)
+                if result.documentID != results.last?.documentID {
+                    Divider()
+                        .padding(.leading, 34)
+                        .opacity(0.25)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func row(_ result: TantivyShadowSearchResult, index: Int) -> some View {
+        let hovered = hoveredID == result.documentID
+        let keyboardSelected = selectedIndex == index
+        // Hover wins over keyboard (same as the omnibox) so the two don't fight.
+        let highlighted = hovered || (hoveredID == nil && keyboardSelected)
+        let isEnterTarget = keyboardSelected || (selectedIndex == nil && index == 0)
+        Button {
+            onSelect(result)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: result.kind.systemImageName)
+                    .font(.caption)
+                    .foregroundStyle(highlighted ? Color.accentColor : .secondary)
+                    .frame(width: 16)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(result.title)
+                        .lineLimit(1)
+                        .font(.callout)
+                    Text(result.kind.rawValue.capitalized)
+                        .lineLimit(1)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer(minLength: 8)
+                if isEnterTarget {
+                    Image(systemName: "return")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(highlighted ? Color.accentColor.opacity(0.14) : Color.clear)
+                    .padding(.horizontal, 4)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { inside in
+            if inside {
+                hoveredID = result.documentID
+            } else if hoveredID == result.documentID {
+                hoveredID = nil
+            }
+        }
+    }
+}
+
+// MARK: - Kind → icon mapping
+
+private extension TantivyDocumentKind {
+    /// SF Symbol name for this kind — matches `ResourceKind.systemImageName`'s
+    /// choices for the three linkable kinds (page/source/chat) so the dropdown
+    /// row icons match the sidebar/omnibox. Duplicated here as a small leaf
+    /// (`WikiFSSearch` doesn't depend on the app layer's `ResourceKind`); the
+    /// shapes are stable (a kind-prefix rename is a breaking change).
+    var systemImageName: String {
+        switch self {
+        case .page:   "doc.text"
+        case .source: "tray.full"
+        case .chat:   "bubble.left.and.bubble.right"
+        }
+    }
+}
+
+// MARK: - Selection advancement (pure, testable)
+
+/// Pure, testable keyboard-highlight advancement for the chat autocomplete
+/// dropdown. Mirrors `OmniboxSelection.advance` (`OmniboxSearchField.swift:270`)
+/// — same clamping behavior (no wrap, first ↓ → row 0, first ↑ → last row) —
+/// extracted as its own type so the chat composer's tests don't need to reach
+/// into the omnibox's namespace. Stays in this file because there's only one
+/// caller (the composer coordinator); if a third consumer emerges, promote it
+/// to a shared file.
+enum ChatAutocompleteSelection {
+    /// Returns the new selected index, or `nil` if there is nothing to select
+    /// (empty list). When `current == nil`, the first down selects row 0 and
+    /// the first up selects the last row.
+    static func advance(current: Int?, count: Int, delta: Int) -> Int? {
+        guard count > 0 else { return nil }
+        guard let current else { return delta > 0 ? 0 : count - 1 }
+        return max(0, min(count - 1, current + delta))
+    }
+}

--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -701,6 +701,56 @@ struct ChatView: View {
         return base.withSize(base.pointSize * CGFloat(chatZoom))
     }
 
+    /// Wiki-link autocomplete hooks (#436 / #638). Returns `nil` when no
+    /// Tantivy service is attached (no wiki open) — the composer then behaves
+    /// exactly as before. The `fetch` closure runs the distance-2 fuzzy query
+    /// on the live Tantivy index; `format` builds the canonical
+    /// `[[kind:ULID|Title]]` form via `DroppedLinkFormatter`. The coordinator
+    /// wraps `fetch` in a debounced + cancellable Task (AC #5).
+    private var chatAutocompleteHooks: ComposerTextView.AutocompleteHooks? {
+        guard let search = store.tantivySearch else { return nil }
+        return ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in
+                let tantivyKind = Self.tantivyKind(for: kind)
+                return await search.autocomplete(
+                    partial: partial,
+                    kinds: [tantivyKind],
+                    distance: 2,
+                    limit: 8)
+            },
+            format: { hit in
+                // Map the search hit back to a ParsedLink.LinkType for the
+                // formatter (single source of truth for the `[[kind:ULID|…]]`
+                // prefix string).
+                let linkType = Self.linkType(for: hit.kind)
+                return DroppedLinkFormatter.link(
+                    for: linkType,
+                    id: hit.ulid,
+                    displayName: hit.title)
+            }
+        )
+    }
+
+    /// Pure: map `ParsedLink.LinkType` (the prefix vocabulary) →
+    /// `TantivyDocumentKind` (the search index vocabulary). Single source of
+    /// truth so a prefix-rename hits both sides. `nonisolated` for test reach.
+    nonisolated static func tantivyKind(for kind: ParsedLink.LinkType) -> TantivyDocumentKind {
+        switch kind {
+        case .page:   return .page
+        case .source: return .source
+        case .chat:   return .chat
+        }
+    }
+
+    /// Pure inverse of ``tantivyKind(for:)``. Same single-source-of-truth goal.
+    nonisolated static func linkType(for kind: TantivyDocumentKind) -> ParsedLink.LinkType {
+        switch kind {
+        case .page:   return .page
+        case .source: return .source
+        case .chat:   return .chat
+        }
+    }
+
     private func composer(enabled: Bool) -> some View {
         let sendActive = canSend && enabled
         // Paseo-style: ONE rounded box wrapping the text (top) and a toolbar row
@@ -716,7 +766,8 @@ struct ChatView: View {
                 font: composerFont,
                 onSubmit: sendMessage,
                 measuredHeight: $composerHeight,
-                autoFocus: chatID == nil
+                autoFocus: chatID == nil,
+                autocomplete: chatAutocompleteHooks
             )
                 .frame(height: composerHeight)
                 .frame(maxWidth: .infinity)

--- a/Sources/WikiFS/Editor/ComposerTextView.swift
+++ b/Sources/WikiFS/Editor/ComposerTextView.swift
@@ -107,6 +107,27 @@ struct ComposerTextView: NSViewRepresentable {
     /// The coordinator reads this fresh on every schedule.
     var debounce: UInt64 = ComposerTextView.autocompleteDebounce
 
+    /// Cancellable handle for one scheduled debounce work. Mirrors the
+    /// `ChangeCoalescer.Handle` pattern (`Sources/WikiFSCore/Store/ChangeCoalescer.swift:23`):
+    /// the coordinator cancels the prior handle on each reschedule so only
+    /// the latest survives. Production's handle calls `task.cancel()`; a test
+    /// manual scheduler's handle just removes the work from a pending dict.
+    final class DebounceHandle {
+        let cancel: () -> Void
+        init(cancel: @escaping () -> Void) { self.cancel = cancel }
+    }
+
+    /// Optional debounce scheduler seam (issue #661). When `nil` (default), the
+    /// coordinator uses a built-in `Task.sleep`-based scheduler (production
+    /// behavior — unchanged from before this seam). Tests inject a manual
+    /// scheduler that captures work for an explicit `fireAll()` call so timing
+    /// is fully deterministic with no real `Task.sleep`: the prior
+    /// `Task.sleep`-based approach deadlocked CI for 6 hours under heavy
+    /// integration-tier load because the `@MainActor`-isolated Task bodies
+    /// never got scheduled within the polling timeout. Pattern mirrors
+    /// `Tests/WikiFSTests/ChangeCoalescerTests.swift`'s `ManualScheduler`.
+    var scheduleDebounce: ((UInt64, @escaping () async -> Void) -> DebounceHandle)? = nil
+
     // MARK: - Height clamping (pure, testable)
 
     /// Clamp + inset constants. `verticalInsetPerSide` is applied to the text
@@ -310,10 +331,14 @@ struct ComposerTextView: NSViewRepresentable {
         /// via `doCommandBy:`, so a local `NSEvent` monitor is the only path.
         /// Mirrors `OmniboxSearchField.swift:242-252`.
         private var keyMonitor: Any?
-        /// The in-flight autocomplete Task. Cancelled and replaced on every
-        /// keystroke that lands inside an open-link trigger (AC #5). Visible
-        /// to tests so they can assert it was cancelled.
-        fileprivate var autocompleteTask: Task<Void, Never>?
+        /// The in-flight autocomplete schedule handle. Cancelled and replaced on
+        /// every keystroke that lands inside an open-link trigger (AC #5). When
+        /// `parent.scheduleDebounce` is nil (production), this is a
+        /// `DebounceHandle { task.cancel() }` wrapping a real `Task.sleep` Task.
+        /// When a test manual scheduler is injected, this is a handle that just
+        /// removes the work from the scheduler's pending dict (so the work is
+        /// never run until the test calls `fireAll()`).
+        fileprivate var pendingHandle: ComposerTextView.DebounceHandle?
 
         init(_ parent: ComposerTextView) {
             self.parent = parent
@@ -373,8 +398,18 @@ struct ComposerTextView: NSViewRepresentable {
 
         /// Cancel any in-flight query and start a fresh debounced one for
         /// `trigger`. AC #5: typing fast cancels stale in-flight queries.
+        ///
+        /// Routes the post-debounce work through `parent.scheduleDebounce`
+        /// (when injected — tests) or an inline `Task.sleep`-based scheduler
+        /// (production / default, kept inline here so the Task body inherits
+        /// `@MainActor` from `scheduleAutocomplete` — same as pre-#661). Issue
+        /// #661: extracting the debounce sleep into a seam lets tests drive
+        /// the timing deterministically with a `ManualScheduler` rather than
+        /// relying on `Task.sleep` (which deadlocked CI under heavy
+        /// integration-tier load).
         fileprivate func scheduleAutocomplete(trigger: WikiLinkPrefixScanner.OpenWikiLink) {
-            autocompleteTask?.cancel()
+            pendingHandle?.cancel()
+            pendingHandle = nil
             guard let hooks = parent.autocomplete else { return }
             // Capture the partial at schedule time — a later keystroke that
             // reschedules will see a different trigger and cancel this one
@@ -382,25 +417,43 @@ struct ComposerTextView: NSViewRepresentable {
             let partial = trigger.partial
             let kind = trigger.kind
             let debounce = parent.debounce
-            autocompleteTask = Task { [weak self] in
+            // The post-debounce work: fetch + apply-if-still-current. Shared
+            // between the test manual scheduler and the production default.
+            let work: () async -> Void = { [weak self] in
                 guard let self else { return }
-                do {
-                    try await Task.sleep(for: .milliseconds(debounce))
-                } catch {
-                    // Cancelled during the sleep — bail without applying.
-                    return
-                }
-                guard !Task.isCancelled else { return }
                 let results = await hooks.fetch(partial, kind)
-                guard !Task.isCancelled else { return }
                 // Only apply if this trigger is still current (a later keystroke
-                // may have replaced us and already shown its own results).
+                // may have replaced us and already shown its own results). The
+                // MainActor.run hop guarantees self access is isolated
+                // regardless of which scheduler ran us.
                 await MainActor.run { [weak self] in
                     guard let self,
                           self.currentTrigger?.partial == partial,
                           self.currentTrigger?.kind == kind else { return }
                     self.applyResults(results)
                 }
+            }
+            if let scheduler = parent.scheduleDebounce {
+                // Test path: the manual scheduler captures `work` for an
+                // explicit `fireAll()` — no real `Task.sleep`, no Task body
+                // scheduling race under load.
+                pendingHandle = scheduler(debounce, work)
+            } else {
+                // Production default: Task.sleep + Task body (inherits
+                // `@MainActor` from `scheduleAutocomplete` so coordinator
+                // access from `work` is isolated). Cancelled via task.cancel()
+                // — same shape as `WikiChangeBridge.schedule()` at
+                // `Sources/WikiFS/Window/WikiChangeBridge.swift:116-122`.
+                let task = Task {
+                    do {
+                        try await Task.sleep(for: .milliseconds(debounce))
+                    } catch {
+                        return  // cancelled during the sleep — bail without applying
+                    }
+                    guard !Task.isCancelled else { return }
+                    await work()
+                }
+                pendingHandle = DebounceHandle { task.cancel() }
             }
         }
 
@@ -453,8 +506,8 @@ struct ComposerTextView: NSViewRepresentable {
         /// hosting view can't leak across view rebuilds.
         @MainActor
         fileprivate func teardownAutocomplete() {
-            autocompleteTask?.cancel()
-            autocompleteTask = nil
+            pendingHandle?.cancel()
+            pendingHandle = nil
             removeKeyMonitor()
             currentTrigger = nil
             autocompleteResults = []

--- a/Sources/WikiFS/Editor/ComposerTextView.swift
+++ b/Sources/WikiFS/Editor/ComposerTextView.swift
@@ -1,5 +1,7 @@
 import AppKit
 import SwiftUI
+import WikiFSLinks
+import WikiFSSearch
 
 /// NSTextView-backed chat composer, replacing the SwiftUI
 /// `TextField(..., axis: .vertical).lineLimit(1...6)` that previously backed
@@ -41,8 +43,59 @@ struct ComposerTextView: NSViewRepresentable {
     /// start typing immediately after clicking "Add chat".
     var autoFocus: Bool = false
 
+    // MARK: - Wiki-link autocomplete (#436 / #638)
+
+    /// Optional autocomplete integration. When non-nil, the coordinator runs
+    /// a debounced query for each keystroke that lands inside an open
+    /// `[[kind:partial` trigger, surfaces the results in a dropdown, and
+    /// inserts the canonical `[[kind:ULID|Title]]` form on selection.
+    ///
+    /// Three injected closures so the AppKit coordinator stays pure about the
+    /// engine + formatter (it doesn't import `WikiFSCore` / `DroppedLinkFormatter`
+    /// directly — the SwiftUI parent wires those in from `ChatView`):
+    ///   - `fetch`: runs the Tantivy `autocomplete(partial:kinds:...)` query.
+    ///     Must be async-cancellable on the caller side (the coordinator cancels
+    ///     the prior in-flight Task before each new keystroke — AC #5). Returns
+    ///     the ranked hits for the dropdown.
+    ///   - `format`: builds the canonical `[[kind:ULID|Title]]` string for the
+    ///     selected hit (`DroppedLinkFormatter.link(for:id:displayName:)`). The
+    ///     coordinator does the actual range-replace in the text view.
+    ///   - `geometry`: returns the anchor `NSView` the dropdown should track
+    ///     (the composer's text view). Called each time the dropdown is shown.
+    var autocomplete: AutocompleteHooks?
+
+    /// Closures injected by `ChatView` so the coordinator stays decoupled from
+    /// `WikiFSCore` (the store handle) and `WikiFSLinks` (the formatter). Both
+    /// are optional — `nil` means autocomplete is disabled (the composer
+    /// behaves exactly as it did before #436). The Coordinator uses its own
+    /// captured text view as the dropdown anchor (no closure needed).
+    struct AutocompleteHooks {
+        /// Runs the Tantivy `autocomplete(partial:kinds:...)` query for one
+        /// kind (`[[page:` → `[.page]`, etc.). The coordinator wraps this in a
+        /// debounced + cancellable `Task` (AC #5).
+        var fetch: (String, ParsedLink.LinkType) async -> [TantivyShadowSearchResult]
+        /// Builds the canonical `[[kind:ULID|Title]]` string to insert for a
+        /// selected hit. Wraps `DroppedLinkFormatter.link(...)`.
+        var format: (TantivyShadowSearchResult) -> String
+
+        init(
+            fetch: @escaping (String, ParsedLink.LinkType) async -> [TantivyShadowSearchResult],
+            format: @escaping (TantivyShadowSearchResult) -> String
+        ) {
+            self.fetch = fetch
+            self.format = format
+        }
+    }
+
     nonisolated static let accessibilityLabel = "Message"
     private let placeholderText = "Ask a question, or ask the Agent to update the wiki…"
+
+    /// Debounce window for the autocomplete query (AC #5). 150 ms is fast
+    /// enough to feel instant while keeping per-keystroke Tantivy queries from
+    /// stacking up. Sidebar search uses 300 ms; autocomplete feels more
+    /// time-critical so it's tighter. Override per-test by setting this to a
+    /// tiny value (the coordinator reads it fresh on each schedule).
+    nonisolated static let autocompleteDebounce: UInt64 = 150
 
     // MARK: - Height clamping (pure, testable)
 
@@ -73,12 +126,30 @@ struct ComposerTextView: NSViewRepresentable {
         clampedHeight(contentHeight: 0, lineHeight: NSLayoutManager().defaultLineHeight(for: font))
     }
 
+    /// Pure: convert a UTF-16 (NSTextView) caret offset to a Swift
+    /// `String.Index`/`Character`-count offset the prefix scanner expects.
+    /// Clamps to `[0, text.count]`. The scanner rebuilds via `Array(text)` so
+    /// the offset must count `Character`s, not UTF-16 units. ASCII wiki-link
+    /// prefixes are BMP-stable so the two are equal for the common case;
+    /// non-ASCII is still correct because the scanner handles it on its side.
+    nonisolated static func clampedSwiftOffset(utf16Offset: Int, in text: String) -> Int {
+        guard utf16Offset > 0 else { return 0 }
+        let utf16 = Array(text.utf16)
+        guard utf16Offset <= utf16.count else { return text.count }
+        let prefix = String(decoding: utf16.prefix(utf16Offset), as: UTF16.self)
+        return prefix.count
+    }
+
     // MARK: - Key handling (pure, testable)
 
     nonisolated enum ComposerKeyAction {
         case send
         case insertNewline
         case unhandled
+        /// Plain Return while the autocomplete dropdown is open with results:
+        /// the coordinator should insert the canonical link for the selected
+        /// (or top) row and consume the keystroke (no message send).
+        case insertAutocomplete
     }
 
     /// Pure: decide what a `doCommandBy:` selector + the live modifier flags
@@ -88,11 +159,19 @@ struct ComposerTextView: NSViewRepresentable {
     /// Cmd+Return falls through (`.unhandled`) so the send button's own
     /// `.keyboardShortcut(.return, modifiers: .command)` is the single path —
     /// otherwise a Cmd+Return keystroke would send twice.
-    nonisolated static func keyAction(for selector: Selector, modifiers: NSEvent.ModifierFlags) -> ComposerKeyAction {
+    ///
+    /// When `autocompleteOpen` is true AND results are present, plain Return
+    /// returns `.insertAutocomplete` instead of `.send` so the coordinator
+    /// inserts the canonical link rather than sending the message.
+    nonisolated static func keyAction(
+        for selector: Selector,
+        modifiers: NSEvent.ModifierFlags,
+        autocompleteOpen: Bool = false
+    ) -> ComposerKeyAction {
         guard selector == #selector(NSResponder.insertNewline(_:)) else { return .unhandled }
         if modifiers.contains(.shift) || modifiers.contains(.option) { return .insertNewline }
         if modifiers.contains(.command) { return .unhandled }
-        return .send
+        return autocompleteOpen ? .insertAutocomplete : .send
     }
 
     // MARK: - NSViewRepresentable
@@ -171,6 +250,7 @@ struct ComposerTextView: NSViewRepresentable {
 
     static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
         coordinator.stopObservingFrameChanges()
+        coordinator.teardownAutocomplete()
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
@@ -198,27 +278,272 @@ struct ComposerTextView: NSViewRepresentable {
         private var frameObserver: NSObjectProtocol?
         private var lastObservedWidth: CGFloat?
 
+        // MARK: - Autocomplete state (#436 / #638)
+
+        /// The current dropdown results. Empty when the dropdown is hidden.
+        private var autocompleteResults: [TantivyShadowSearchResult] = []
+        /// The keyboard-highlighted row in the dropdown. `nil` = nothing
+        /// explicitly selected; Enter targets the top row.
+        private var selectedIndex: Int? = nil
+        /// The trigger for the currently-shown dropdown, kept so a stale
+        /// in-flight query that returns after the dropdown was dismissed
+        /// can detect it shouldn't apply.
+        private var currentTrigger: WikiLinkPrefixScanner.OpenWikiLink? = nil
+        /// The non-activating panel hosting the dropdown. Lazily created on
+        /// first show; reused across keystrokes.
+        private var panel: ChatAutocompletePanel?
+        /// The live text view, captured in `textDidChange` so the local event
+        /// monitor and the click handler can mutate it without a notification.
+        private weak var textView: NSTextView?
+        /// Local key monitor (installed while the dropdown is up) — consumes
+        /// ↑/↓/Escape. Per reviewer correction #2: Escape is NOT delivered
+        /// via `doCommandBy:`, so a local `NSEvent` monitor is the only path.
+        /// Mirrors `OmniboxSearchField.swift:242-252`.
+        private var keyMonitor: Any?
+        /// The in-flight autocomplete Task. Cancelled and replaced on every
+        /// keystroke that lands inside an open-link trigger (AC #5). Visible
+        /// to tests so they can assert it was cancelled.
+        fileprivate var autocompleteTask: Task<Void, Never>?
+
         init(_ parent: ComposerTextView) {
             self.parent = parent
         }
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            self.textView = textView
             if parent.text != textView.string {
                 parent.text = textView.string
             }
             recomputeHeight(for: textView)
+            evaluateAutocomplete(for: textView)
         }
 
         func textView(_ textView: NSTextView, doCommandBy selector: Selector) -> Bool {
+            self.textView = textView
             let modifiers = (NSApp.currentEvent?.modifierFlags ?? []).intersection(.deviceIndependentFlagsMask)
-            switch ComposerTextView.keyAction(for: selector, modifiers: modifiers) {
+            let open = !autocompleteResults.isEmpty
+            switch ComposerTextView.keyAction(for: selector, modifiers: modifiers, autocompleteOpen: open) {
             case .send:
                 parent.onSubmit()
+                return true
+            case .insertAutocomplete:
+                // Plain Return while the dropdown is up: insert the selected
+                // (or top) row's canonical link and consume. Shift/Option/Cmd
+                // still fall through to insert-newline / unhandled via keyAction.
+                commitAutocomplete()
                 return true
             case .insertNewline, .unhandled:
                 return false
             }
+        }
+
+        // MARK: - Autocomplete pipeline
+
+        /// Per-keystroke: detect an open `[[kind:partial` trigger at the caret
+        /// and (re)schedule a debounced Tantivy query. Dismisses the dropdown
+        /// when no trigger is present.
+        private func evaluateAutocomplete(for textView: NSTextView) {
+            guard parent.autocomplete != nil else { return }
+            let caret = textView.selectedRange().location
+            let text = textView.string
+            // The scanner uses `String.Index` offsets; convert the NSTextView's
+            // UTF-16 caret to a Swift `Character`-count offset (the text view
+            // stores a UTF-16 string, so for ASCII-only wiki-links the two are
+            // equal; for non-ASCII the conversion is still correct because the
+            // scanner rebuilds via `Array(text)`).
+            let swiftCaret = clampedSwiftOffset(utf16Offset: caret, in: text)
+            guard let trigger = WikiLinkPrefixScanner.openLink(at: swiftCaret, in: text) else {
+                hideAutocomplete()
+                return
+            }
+            currentTrigger = trigger
+            scheduleAutocomplete(trigger: trigger)
+        }
+
+        /// Cancel any in-flight query and start a fresh debounced one for
+        /// `trigger`. AC #5: typing fast cancels stale in-flight queries.
+        fileprivate func scheduleAutocomplete(trigger: WikiLinkPrefixScanner.OpenWikiLink) {
+            autocompleteTask?.cancel()
+            guard let hooks = parent.autocomplete else { return }
+            // Capture the partial at schedule time — a later keystroke that
+            // reschedules will see a different trigger and cancel this one
+            // before its query lands.
+            let partial = trigger.partial
+            let kind = trigger.kind
+            let debounce = ComposerTextView.autocompleteDebounce
+            autocompleteTask = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await Task.sleep(for: .milliseconds(debounce))
+                } catch {
+                    // Cancelled during the sleep — bail without applying.
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                let results = await hooks.fetch(partial, kind)
+                guard !Task.isCancelled else { return }
+                // Only apply if this trigger is still current (a later keystroke
+                // may have replaced us and already shown its own results).
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.currentTrigger?.partial == partial,
+                          self.currentTrigger?.kind == kind else { return }
+                    self.applyResults(results)
+                }
+            }
+        }
+
+        /// Apply a fresh result set: reset selection, render the panel. Runs on
+        /// the main actor (panel hosting is main-actor-isolated).
+        @MainActor
+        private func applyResults(_ results: [TantivyShadowSearchResult]) {
+            autocompleteResults = results
+            selectedIndex = nil
+            if results.isEmpty {
+                hideAutocomplete()
+            } else {
+                presentPanel()
+            }
+        }
+
+        /// Show (or refresh) the dropdown above the composer. Installs the
+        /// local ↑/↓/Escape monitor (reviewer correction #2).
+        @MainActor
+        private func presentPanel() {
+            guard parent.autocomplete != nil else { return }
+            guard let anchor = self.textView else { return }
+            let panel = self.panel ?? ChatAutocompletePanel()
+            self.panel = panel
+            panel.update(results: autocompleteResults,
+                         selectedIndex: selectedIndex,
+                         width: anchor.bounds.width) { [weak self] result in
+                MainActor.assumeIsolated {
+                    self?.commitSelection(result)
+                }
+            }
+            panel.present(above: anchor)
+            installKeyMonitor()
+        }
+
+        @MainActor
+        fileprivate func hideAutocomplete() {
+            removeKeyMonitor()
+            currentTrigger = nil
+            autocompleteResults = []
+            selectedIndex = nil
+            guard let panel else { return }
+            panel.parent?.removeChildWindow(panel)
+            panel.orderOut(nil)
+        }
+
+        /// Final teardown on dismantle: cancel in-flight query, drop the monitor,
+        /// close the panel. Distinct from `hideAutocomplete` because we also
+        /// want the panel *released* (not just hidden) so a stale SwiftUI
+        /// hosting view can't leak across view rebuilds.
+        @MainActor
+        fileprivate func teardownAutocomplete() {
+            autocompleteTask?.cancel()
+            autocompleteTask = nil
+            removeKeyMonitor()
+            currentTrigger = nil
+            autocompleteResults = []
+            selectedIndex = nil
+            if let panel {
+                panel.parent?.removeChildWindow(panel)
+                panel.orderOut(nil)
+                self.panel = nil
+            }
+        }
+
+        /// Commit a specific hit (click or Return), then dismiss the dropdown.
+        /// Replaces the trigger's `range` with the canonical `[[kind:ULID|Title]]`
+        /// string built by the parent's `format` closure, syncs the SwiftUI
+        /// `text` binding, and recomputes height.
+        @MainActor
+        private func commitSelection(_ hit: TantivyShadowSearchResult) {
+            guard let hooks = parent.autocomplete,
+                  let textView,
+                  let trigger = currentTrigger else { return }
+            let link = hooks.format(hit)
+            // Range-replace in the live text view. NSTextView uses UTF-16
+            // offsets; `NSRange(_:in:)` converts a `Range<String.Index>` to the
+            // matching UTF-16 NSRange against the current string contents.
+            let current = textView.string
+            let range = NSRange(trigger.range, in: current)
+            textView.replaceCharacters(in: range, with: link)
+            // Move the caret to just after the inserted `]]`.
+            let newCaret = range.location + (link as NSString).length
+            textView.setSelectedRange(NSRange(location: newCaret, length: 0))
+            // Sync the SwiftUI binding so the model sees the canonical form.
+            parent.text = textView.string
+            recomputeHeight(for: textView)
+            hideAutocomplete()
+        }
+
+        /// Commit the keyboard-selected row (or top row when nothing is
+        /// explicitly selected). Called from `doCommandBy:` `.insertAutocomplete`.
+        @MainActor
+        fileprivate func commitAutocomplete() {
+            let idx = selectedIndex ?? 0
+            guard autocompleteResults.indices.contains(idx) else {
+                hideAutocomplete()
+                return
+            }
+            commitSelection(autocompleteResults[idx])
+        }
+
+        // MARK: - Local key monitor (↑/↓/Escape — reviewer correction #2)
+
+        /// Installs a local keyDown monitor (idempotent). Removed in
+        /// `hideAutocomplete` so the keys fall through to the text view
+        /// normally when the dropdown isn't showing. Mirrors
+        /// `OmniboxSearchField.swift:220-226`.
+        private func installKeyMonitor() {
+            guard keyMonitor == nil else { return }
+            keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self else { return event }
+                return self.handleAutocompleteKey(event)
+            }
+        }
+
+        private func removeKeyMonitor() {
+            guard let keyMonitor else { return }
+            NSEvent.removeMonitor(keyMonitor)
+            self.keyMonitor = nil
+        }
+
+        /// Consumes ↑/↓/Escape while the dropdown is showing; passes every
+        /// other event through untouched. The monitor is installed only while
+        /// the panel is up, so by the time we're here the composer text view
+        /// holds first responder. Local monitors deliver on the main thread —
+        /// the `@MainActor` panel update runs synchronously via
+        /// `MainActor.assumeIsolated`.
+        private func handleAutocompleteKey(_ event: NSEvent) -> NSEvent? {
+            guard !autocompleteResults.isEmpty else { return event }
+            switch event.keyCode {
+            case 125: // Down arrow
+                MainActor.assumeIsolated { self.applyArrow(delta: 1) }
+                return nil
+            case 126: // Up arrow
+                MainActor.assumeIsolated { self.applyArrow(delta: -1) }
+                return nil
+            case 53: // Escape (reviewer correction #2 — NOT a doCommandBy: selector)
+                MainActor.assumeIsolated { self.hideAutocomplete() }
+                return nil
+            default:
+                return event
+            }
+        }
+
+        @MainActor
+        private func applyArrow(delta: Int) {
+            guard let next = ChatAutocompleteSelection.advance(
+                current: selectedIndex,
+                count: autocompleteResults.count,
+                delta: delta) else { return }
+            selectedIndex = next
+            presentPanel()
         }
 
         /// Measures content height and writes the clamped result back to the

--- a/Sources/WikiFS/Editor/ComposerTextView.swift
+++ b/Sources/WikiFS/Editor/ComposerTextView.swift
@@ -93,9 +93,19 @@ struct ComposerTextView: NSViewRepresentable {
     /// Debounce window for the autocomplete query (AC #5). 150 ms is fast
     /// enough to feel instant while keeping per-keystroke Tantivy queries from
     /// stacking up. Sidebar search uses 300 ms; autocomplete feels more
-    /// time-critical so it's tighter. Override per-test by setting this to a
-    /// tiny value (the coordinator reads it fresh on each schedule).
+    /// time-critical so it's tighter. This is the canonical production value
+    /// (read by ``debounce``'s default). Tests override ``debounce`` to a much
+    /// smaller value (e.g. 5 ms) so the schedule/cancel timing is deterministic
+    /// without long `Task.sleep` waits — see `ComposerAutocompleteHostedTests`.
     nonisolated static let autocompleteDebounce: UInt64 = 150
+
+    /// Per-instance debounce override (microseconds... no — milliseconds,
+    /// matching ``autocompleteDebounce``'s unit). Tests pass a small value
+    /// (e.g. 5 ms) so the debounce window is tight and the cancel/collapse
+    /// logic is exercised without relying on CI-timing-sensitive `Task.sleep`
+    /// tolerances. Production leaves the default (``autocompleteDebounce``).
+    /// The coordinator reads this fresh on every schedule.
+    var debounce: UInt64 = ComposerTextView.autocompleteDebounce
 
     // MARK: - Height clamping (pure, testable)
 
@@ -371,7 +381,7 @@ struct ComposerTextView: NSViewRepresentable {
             // before its query lands.
             let partial = trigger.partial
             let kind = trigger.kind
-            let debounce = ComposerTextView.autocompleteDebounce
+            let debounce = parent.debounce
             autocompleteTask = Task { [weak self] in
                 guard let self else { return }
                 do {

--- a/Sources/WikiFSLinks/WikiLinkPrefixScanner.swift
+++ b/Sources/WikiFSLinks/WikiLinkPrefixScanner.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Pure, AppKit-free detector for an **open** (in-progress) `[[kind:partial`
+/// wiki-link trigger at the caret. The autocomplete's per-keystroke entry point:
+/// given the full composer text and a caret offset, returns the open-link trigger
+/// to query Tantivy for, or `nil` when the caret is not inside an open link.
+///
+/// Why this exists alongside `WikiLinkParser`: `WikiLinkParser` only matches
+/// **closed** `[[…]]` spans (its regex requires the closing `]]`); while the
+/// user is typing `[[page:Erl` there is no `]]`, so the parser is blind. This
+/// scanner is the caret-based counterpart that fires the autocomplete.
+///
+/// Lives in `WikiFSLinks` (Foundation-only; depends only on `WikiFSTypes` for
+/// `ParsedLink.LinkType.linkPrefix`) so it is trivially unit-testable without
+/// AppKit or the store. The composer coordinator calls this from
+/// `textDidChange`, then hands the result to the Tantivy autocomplete service.
+public enum WikiLinkPrefixScanner {
+
+    /// The maximum length of the `[[…partial` substring the scanner will accept
+    /// before bailing. Guards against a long paste (e.g. dropping 200 lines of
+    /// markdown that happens to begin with `[[page:`) spuriously firing the
+    /// autocomplete. 80 chars comfortably covers realistic page titles while
+    /// catching the paste case (issue #638 reviewer correction #4).
+    public static let maxPartialSpan: Int = 80
+
+    /// The open-link trigger returned by ``openLink(at:in:)``.
+    public struct OpenWikiLink: Equatable, Sendable {
+        public let kind: ParsedLink.LinkType   // .page/.source/.chat, from the `kind:` prefix
+        public let partial: String             // text after "kind:" up to the caret, trimmed
+        /// Span of `[[kind:partial` in the source string to replace on
+        /// selection. The caller replaces this exact range with the canonical
+        /// `[[kind:ULID|Title]]` form (`DroppedLinkFormatter.link(...)`).
+        public let range: Range<String.Index>
+
+        public init(kind: ParsedLink.LinkType, partial: String, range: Range<String.Index>) {
+            self.kind = kind
+            self.partial = partial
+            self.range = range
+        }
+    }
+
+    /// Detect an open `[[kind:partial` trigger ending at `caret` in `text`.
+    ///
+    /// Rules (mirror `WikiLinkParser`'s grammar so they can't drift):
+    /// 1. Scan backward from the caret for the most recent `[[`.
+    /// 2. If a `]]` or `|` appears after that `[[` and before the caret, it's
+    ///    a closed/aliased link → return `nil`.
+    /// 3. Take the substring between `[[` and the caret.
+    ///    - **Reviewer correction #4:** if it contains a newline OR is longer
+    ///      than ``maxPartialSpan``, return `nil` (multi-line + paste guard).
+    /// 4. Match an optional kind prefix (`page:`/`source:`/`chat:`) using the
+    ///    `ParsedLink.LinkType.linkPrefix` strings. If none matches, default
+    ///    `kind = .page` (bare `[[Foo` is a page link, per
+    ///    `WikiLinkParser.classify` `:52`).
+    /// 5. `partial` = the remainder after the prefix, whitespace-trimmed.
+    ///    Return `nil` when `partial` is empty (don't fire on bare `[[page:`).
+    public static func openLink(at caret: Int, in text: String) -> OpenWikiLink? {
+        guard caret >= 0, caret <= text.count else { return nil }
+        let characters = Array(text)
+        guard caret <= characters.count else { return nil }
+
+        // Scan backward from the caret for the most recent `[[`.
+        var openBraceIndex: Int? = nil
+        var i = caret - 1
+        while i >= 1 {
+            if characters[i] == "]" && i >= 1 && characters[i - 1] == "]" {
+                // Closed link before the caret — we're outside any open link.
+                return nil
+            }
+            if characters[i] == "[" && characters[i - 1] == "[" {
+                openBraceIndex = i - 1
+                break
+            }
+            i -= 1
+        }
+        guard let openIdx = openBraceIndex else { return nil }
+
+        // Substring between `[[` (exclusive) and caret (exclusive).
+        // After this point characters[openIdx] == "[" and characters[openIdx+1] == "[".
+        let innerStart = openIdx + 2
+        if innerStart > caret { return nil }
+
+        // Reviewer correction #4: bail on newline or over-cap substring (paste /
+        // multi-line guard). Use the inner span length first as a cheap reject.
+        let innerLength = caret - innerStart
+        if innerLength > maxPartialSpan { return nil }
+        if innerLength <= 0 { return nil }
+
+        // Build the inner substring; reject newlines and pipe (alias start).
+        // `|` would mean we've crossed into the alias of a closed-shaped link.
+        var inner = ""
+        inner.reserveCapacity(innerLength)
+        for j in innerStart..<caret {
+            let c = characters[j]
+            if c == "\n" || c == "\r" { return nil }
+            if c == "|" { return nil }
+            inner.append(c)
+        }
+
+        // Strip a trailing `]]` (the user may have just closed the link; we
+        // don't want to fire autocomplete once the link is complete and the
+        // caret is past it). Actually the backward scan already bailed on `]]`
+        // before the caret — but a trailing `]` inside `inner` could still
+        // exist if the caret sits between two `]`s. Be defensive.
+        if inner.hasSuffix("]") { return nil }
+
+        // Match an optional kind prefix.
+        var kind: ParsedLink.LinkType = .page
+        var remainder = inner
+        for candidate in ParsedLink.LinkType.allCases {
+            let prefix = candidate.linkPrefix // "page:" / "source:" / "chat:"
+            if remainder.hasPrefix(prefix) {
+                kind = candidate
+                remainder = String(remainder.dropFirst(prefix.count))
+                break
+            }
+        }
+
+        // Trim and require non-empty.
+        let partial = remainder.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !partial.isEmpty else { return nil }
+
+        // Convert the open-link span to String.Index range for the caller's
+        // range-replace API.
+        guard let lower = text.index(text.startIndex,
+                                     offsetBy: openIdx,
+                                     limitedBy: text.endIndex),
+              let upper = text.index(text.startIndex,
+                                     offsetBy: caret,
+                                     limitedBy: text.endIndex) else {
+            return nil
+        }
+        return OpenWikiLink(
+            kind: kind,
+            partial: partial,
+            range: lower..<upper)
+    }
+}

--- a/Sources/WikiFSSearch/TantivyIndexer.swift
+++ b/Sources/WikiFSSearch/TantivyIndexer.swift
@@ -123,6 +123,62 @@ public actor TantivyIndexer {
         }.prefix(limit))
     }
 
+    // MARK: - Autocomplete (composer wiki-link fuzzy)
+
+    /// Title-only fuzzy autocomplete scoped to one or more kinds. Used by the
+    /// chat composer's `[[kind:partial` autocomplete (issues #436 / #638).
+    ///
+    /// **Reviewer correction #1 (load-bearing):** uses the **query-string path**
+    /// (`TantivySwiftSearchQuery` + `TantivySwiftFuzzyField`), NOT the structured
+    /// `TantivyQuery.fuzzy` enum. The structured `.fuzzy` case has no `prefix`
+    /// parameter, and without `prefix: true` distance-2 fuzzy on a short
+    /// partial like `"Erl"` will not surface `"Erickson"` (whole-token edit
+    /// distance 6). The query-string path's `TantivySwiftFuzzyField` exposes
+    /// both `distance: UInt8` AND `prefix: Bool` — this is the same path the
+    /// shipped sidebar search uses (`search(query:kind:limit:)` above), with
+    /// `distance: 2` instead of `1` and `prefix: true` on title only.
+    ///
+    /// Kind scoping is a **Swift post-filter** (same shape as `search()` at
+    /// `:113-116`) since the query-string path carries no facet clause. The
+    /// engine-level kind facet (`.term(.facet)` on `kind`) was a nice-to-have
+    /// optimization dropped in review — it is not required by any AC.
+    ///
+    /// Title only (not body): the user is typing a title/name; body fuzzy
+    /// would surface noise. distance 1–2 (default 2 — AC #638 headline case).
+    public func autocomplete(
+        partial: String,
+        kinds: Set<TantivyDocumentKind>,
+        distance: UInt8 = 2,
+        limit: Int = 8
+    ) async throws -> [TantivyShadowSearchResult] {
+        guard let index, !partial.isEmpty, !kinds.isEmpty else { return [] }
+        // Over-fetch to give the Swift-side kind post-filter a fair pool to
+        // draw from (same shape as `search()` `:102`). `min(limit*5, 1_000)`
+        // matches the existing cap.
+        let fetchLimit = max(1, min(limit * 5, 1_000))
+        var q = TantivySwiftSearchQuery<TantivySearchDocument>(
+            queryStr: partial,
+            defaultFields: [.title],
+            limit: UInt32(fetchLimit)
+        )
+        // prefix:true is load-bearing — see method doc and §3c nuance.
+        q.fuzzyFields = [
+            .init(field: .title, prefix: true, distance: distance),
+        ]
+        let results = try await index.search(query: q)
+        let allowed = kinds
+        return Array(results.docs.compactMap { hit -> TantivyShadowSearchResult? in
+            let kindEnum = TantivyDocumentKind.allCases.first { $0.facetPath == hit.doc.kind }
+            guard let kindEnum, allowed.contains(kindEnum) else { return nil }
+            return TantivyShadowSearchResult(
+                documentID: hit.doc.id,
+                kind: kindEnum,
+                title: hit.doc.title,
+                score: hit.score
+            )
+        }.prefix(max(0, limit)))
+    }
+
     // MARK: - Rebuild / initial build
 
     /// Number of indexed documents. Used by the service to detect an empty

--- a/Sources/WikiFSSearch/TantivySearchService.swift
+++ b/Sources/WikiFSSearch/TantivySearchService.swift
@@ -54,6 +54,32 @@ public final class TantivySearchService: Sendable {
         }
     }
 
+    // MARK: - Autocomplete (composer wiki-link fuzzy)
+
+    /// Title-only fuzzy autocomplete scoped to one or more kinds. Drives the
+    /// chat composer's `[[kind:partial` autocomplete (issues #436 / #638).
+    /// Returns empty on any error (never throws — autocomplete is best-effort).
+    ///
+    /// Defaults: distance 2, limit 8. `kinds` is a Set so the composer can
+    /// pre-scope to one kind (`[[page:` → `[.page]`) or open it up later.
+    /// See `TantivyIndexer.autocomplete(...)` for the query-string-path
+    /// rationale (prefix-true on title is load-bearing for the
+    /// `"Erl" → "Erickson"` headline case).
+    public func autocomplete(
+        partial: String,
+        kinds: Set<TantivyDocumentKind>,
+        distance: UInt8 = 2,
+        limit: Int = 8
+    ) async -> [TantivyShadowSearchResult] {
+        do {
+            return try await indexer.autocomplete(
+                partial: partial, kinds: kinds, distance: distance, limit: limit)
+        } catch {
+            DebugLog.store("TantivySearchService: autocomplete(\"\(partial)\") failed: \(error)")
+            return []
+        }
+    }
+
     // MARK: - Lifecycle
 
     /// Ensure the shadow index is populated. On first open (empty index) or

--- a/Tests/WikiFSTests/ChatAutocompleteSelectionTests.swift
+++ b/Tests/WikiFSTests/ChatAutocompleteSelectionTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import AppKit
+import Testing
+@testable import WikiFS
+
+/// Pure-function unit tests for the chat autocomplete's pure helpers
+/// (`ChatAutocompleteSelection.advance`, the extended `ComposerTextView.keyAction`
+/// autocomplete-aware variant, and `ComposerTextView.clampedSwiftOffset`).
+///
+/// All tests are pure (no live panel, no store, no Tantivy) — fast tier only.
+/// Mirrors `OmniboxSelectionTests` in shape. The hosted-window integration is
+/// covered by the `ComposerAutocompleteHostedTests` suite.
+struct ChatAutocompleteSelectionTests {
+
+    // MARK: - ChatAutocompleteSelection.advance (mirrors OmniboxSelection)
+
+    @Test func emptyListReturnsNil() {
+        #expect(ChatAutocompleteSelection.advance(current: nil, count: 0, delta: 1) == nil)
+        #expect(ChatAutocompleteSelection.advance(current: nil, count: 0, delta: -1) == nil)
+        // Even with a non-nil current, an empty list yields nothing.
+        #expect(ChatAutocompleteSelection.advance(current: 2, count: 0, delta: 1) == nil)
+    }
+
+    @Test func firstDownFromNilSelectsRowZero() {
+        #expect(ChatAutocompleteSelection.advance(current: nil, count: 5, delta: 1) == 0)
+    }
+
+    @Test func firstUpFromNilSelectsLastRow() {
+        #expect(ChatAutocompleteSelection.advance(current: nil, count: 5, delta: -1) == 4)
+    }
+
+    @Test func advanceMovesByOne() {
+        #expect(ChatAutocompleteSelection.advance(current: 2, count: 5, delta: 1) == 3)
+        #expect(ChatAutocompleteSelection.advance(current: 2, count: 5, delta: -1) == 1)
+    }
+
+    @Test func clampsAtLowerBound() {
+        #expect(ChatAutocompleteSelection.advance(current: 0, count: 5, delta: -1) == 0)
+    }
+
+    @Test func clampsAtUpperBound() {
+        #expect(ChatAutocompleteSelection.advance(current: 4, count: 5, delta: 1) == 4)
+    }
+
+    @Test func singleRowListClampsBothDirections() {
+        #expect(ChatAutocompleteSelection.advance(current: nil, count: 1, delta: 1) == 0)
+        #expect(ChatAutocompleteSelection.advance(current: nil, count: 1, delta: -1) == 0)
+        #expect(ChatAutocompleteSelection.advance(current: 0, count: 1, delta: 1) == 0)
+        #expect(ChatAutocompleteSelection.advance(current: 0, count: 1, delta: -1) == 0)
+    }
+
+    // MARK: - ComposerTextView.keyAction autocomplete-aware variant
+
+    private let insertNewline = #selector(NSResponder.insertNewline(_:))
+
+    @Test func plainReturnSendsWhenAutocompleteClosed() {
+        #expect(ComposerTextView.keyAction(
+            for: insertNewline, modifiers: [], autocompleteOpen: false) == .send)
+    }
+
+    @Test func plainReturnInsertsAutocompleteWhenOpen() {
+        #expect(ComposerTextView.keyAction(
+            for: insertNewline, modifiers: [], autocompleteOpen: true) == .insertAutocomplete)
+    }
+
+    @Test func shiftReturnStillInsertsNewlineEvenWhenAutocompleteOpen() {
+        // Modifier-key Returns bypass autocomplete — they're explicit newline
+        // requests, so the user can still type a multi-line message while the
+        // dropdown is showing.
+        #expect(ComposerTextView.keyAction(
+            for: insertNewline, modifiers: .shift, autocompleteOpen: true) == .insertNewline)
+        #expect(ComposerTextView.keyAction(
+            for: insertNewline, modifiers: .option, autocompleteOpen: true) == .insertNewline)
+    }
+
+    @Test func commandReturnFallsThroughEvenWhenAutocompleteOpen() {
+        // Cmd+Return belongs to the send button's keyboard shortcut — never
+        // consumed by autocomplete.
+        #expect(ComposerTextView.keyAction(
+            for: insertNewline, modifiers: .command, autocompleteOpen: true) == .unhandled)
+    }
+
+    // MARK: - clampedSwiftOffset (UTF-16 → Character offset conversion)
+
+    @Test func asciiTextPreservesOffset() {
+        // For ASCII-only text (the common wiki-link case), UTF-16 offsets ==
+        // Character offsets.
+        let text = "[[page:Erl"
+        #expect(ComposerTextView.clampedSwiftOffset(utf16Offset: 5, in: text) == 5)
+        #expect(ComposerTextView.clampedSwiftOffset(utf16Offset: 10, in: text) == 10)
+    }
+
+    @Test func negativeOffsetClampsToZero() {
+        #expect(ComposerTextView.clampedSwiftOffset(utf16Offset: -3, in: "abc") == 0)
+    }
+
+    @Test func overlongOffsetClampsToCount() {
+        // Beyond the UTF-16 length → clamp to text.count (the scanner will
+        // then re-clamp on its side).
+        #expect(ComposerTextView.clampedSwiftOffset(utf16Offset: 99, in: "abc") == 3)
+    }
+
+    @Test func nonBMPEmojiIsOneCharacterNotTwoUTF16Units() {
+        // "👍" is outside the BMP: two UTF-16 units, one Character. The offset
+        // conversion must treat it as ONE Swift Character so the prefix
+        // scanner (which uses `Array(text)`) sees the right caret position.
+        let text = "👍abc"
+        // UTF-16 offset 2 points PAST the emoji (it spans units 0 and 1).
+        // The Character offset for that position is 1 (the 'a').
+        #expect(ComposerTextView.clampedSwiftOffset(utf16Offset: 2, in: text) == 1)
+        #expect(ComposerTextView.clampedSwiftOffset(utf16Offset: 5, in: text) == 4)
+    }
+}

--- a/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
+++ b/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
@@ -23,8 +23,14 @@ import Testing
 /// real `Task.sleep` waits — running them in parallel (the default) saturates
 /// the cooperative pool and starves the debounce Tasks, making the timing
 /// assertions flaky. Serial execution keeps each test's waits deterministic.
+///
+/// `.tags(.integration)` because the Task-scheduler timing is not reliable
+/// under heavy cooperative-pool load — the suite deadlocked CI for 6 hours
+/// when run alongside the full integration tier. The fast CI tier skips it;
+/// `swift-integration` runs it (where its serial + polling approach is
+/// reliable enough). The deterministic-clock rewrite is tracked as follow-up.
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .tags(.integration))
 struct ComposerAutocompleteHostedTests {
 
     // MARK: - Hosted composer builder

--- a/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
+++ b/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
@@ -74,15 +74,23 @@ struct ComposerAutocompleteHostedTests {
     private func makeHostedComposer(
         text: Binding<String>,
         autocomplete: ComposerTextView.AutocompleteHooks?,
-        measuredHeight: Binding<CGFloat>
+        measuredHeight: Binding<CGFloat>,
+        debounce: UInt64 = 5
     ) -> (window: NSWindow, textView: NSTextView, coordinator: ComposerTextView.Coordinator) {
+        // `debounce` defaults to 5 ms (vs. the 150 ms production default) so
+        // the schedule/cancel timing is deterministic without long `Task.sleep`
+        // waits — the suite is heavy (2700+ tests competing for the
+        // cooperative pool) and a tight 5 ms debounce window makes the cancel
+        // assertion insensitive to pool saturation. Production gets the 150 ms
+        // default via `ComposerTextView.debounce`'s default.
         let parent = ComposerTextView(
             text: text,
             isEditable: true,
             font: bodyFont,
             onSubmit: {},
             measuredHeight: measuredHeight,
-            autocomplete: autocomplete
+            autocomplete: autocomplete,
+            debounce: debounce
         )
         let coordinator = ComposerTextView.Coordinator(parent)
         let textView = ComposerTextView.makeConfiguredTextView(font: bodyFont)
@@ -111,33 +119,27 @@ struct ComposerAutocompleteHostedTests {
     @Test func debouncedQueryCancelsStaleInFlightPartial() async {
         // Drive the coordinator's schedule with two partials in quick
         // succession. The first must be cancelled before its fetch lands; only
-        // the second partial's result is applied.
+        // the second partial's fetch fires.
+        //
+        // Robustness: under heavy cooperative-pool load (this suite runs
+        // alongside 2700+ others), a fixed `Task.sleep` wait can return
+        // BEFORE the second schedule's @MainActor-isolated Task body gets a
+        // chance to run — which looks like "no fetch ran" (false failure).
+        // The poll loop below waits adaptively: it exits as soon as the
+        // second partial ("Erl") lands in `fetchCalls`, with a generous 3s
+        // ceiling so a slow CI runner still completes.
         var text = ""
         var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
-        // Make the FIRST fetch slow enough that the second schedule arrives
-        // before it returns. The debounce (150ms) plus this delay must exceed
-        // the gap between the two schedules.
-        var fetchCount = 0
+        let fake = FakeAutocomplete()
+        await fake.setNextResult([
+            TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
+                                      title: "Erickson", score: 1.0),
+        ])
         let hooks = ComposerTextView.AutocompleteHooks(
-            fetch: { partial, _ in
-                let captured = fetchCount
-                fetchCount += 1
-                if captured == 0 {
-                    // First fetch — slow. Should be cancelled before its
-                    // `await` returns. If we get here uncancelled, the sentinel
-                    // title lets the assertion detect it.
-                    try? await Task.sleep(for: .milliseconds(400))
-                    return [TantivyShadowSearchResult(
-                        documentID: "page:FIRST", kind: .page,
-                        title: "First Should Not Appear", score: 1.0)]
-                }
-                return [TantivyShadowSearchResult(
-                    documentID: "page:SECOND", kind: .page,
-                    title: "Second Wins", score: 1.0)]
-            },
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
             format: Self.formatHit
         )
 
@@ -156,17 +158,38 @@ struct ComposerAutocompleteHostedTests {
         // completes, so the first `hooks.fetch` never runs.
         type("[[page:Erl", into: textView, coordinator: coordinator)
 
-        // Wait long enough for the debounce + the second fetch to settle.
-        // (First fetch's 400ms delay would land at ~550ms; we wait 700ms to
-        // be sure, but the cancel prevents it from applying.)
-        try? await Task.sleep(for: .milliseconds(700))
+        // Poll for the SECOND partial ("Erl") to land in fetchCalls. If the
+        // cancel worked, "Erl" is the ONLY entry (the first fetch never
+        // ran). If the cancel failed, BOTH "Er" and "Erl" land — the
+        // assertion below catches that.
+        let calls = await Self.waitForPartial("Erl", in: fake, timeout: .seconds(3))
 
-        // The headline check: fetchCount is exactly 1 (the second), proving
-        // the first schedule was cancelled BEFORE its `await hooks.fetch`
-        // ran. This is what AC#5 requires: cancel stale in-flight *queries* —
-        // the second schedule's cancel landed during the first schedule's
-        // debounce sleep, so the first fetch never started.
-        #expect(fetchCount == 1, "the second schedule should have cancelled the first BEFORE its fetch ran; got \(fetchCount)")
+        // The headline check: exactly one fetch ran, for the SECOND partial.
+        // This proves the first schedule was cancelled BEFORE its fetch ran
+        // (AC #5: cancel stale in-flight queries — the second schedule's
+        // cancel landed during the first schedule's debounce sleep).
+        #expect(calls.count == 1, "the second schedule should have cancelled the first BEFORE its fetch ran; got \(calls)")
+        #expect(calls.first?.partial == "Erl")
+        #expect(calls.first?.kind == .page)
+    }
+
+    /// Poll `fake.fetchCalls` until it contains an entry with `partial`, or
+    /// `timeout` elapses. Returns the snapshot at exit. Adaptive so the cancel
+    /// test doesn't flake under heavy cooperative-pool load (a fixed
+    /// `Task.sleep` can return before the @MainActor Task body gets to run).
+    private static func waitForPartial(
+        _ partial: String,
+        in fake: FakeAutocomplete,
+        timeout: Duration
+    ) async -> [(partial: String, kind: ParsedLink.LinkType)] {
+        let deadline = Date().addingTimeInterval(Double(timeout.components.seconds))
+        var snapshot: [(partial: String, kind: ParsedLink.LinkType)] = []
+        while Date() < deadline {
+            snapshot = await fake.fetchCalls
+            if snapshot.contains(where: { $0.partial == partial }) { return snapshot }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return snapshot
     }
 
     @Test func onlyLatestPartialTriggersAFetchWhenTypingRapidly() async {
@@ -194,13 +217,12 @@ struct ComposerAutocompleteHostedTests {
             type(prefix, into: textView, coordinator: coordinator)
         }
 
-        // Wait generously past the debounce so the final schedule's fetch
-        // has time to land. The suite is heavy (2700+ tests competing for the
-        // cooperative pool), so a tight window flakes — see commit history.
-        try? await Task.sleep(for: .milliseconds(1_000))
+        // Poll for the FINAL partial ("Erl") to land — adaptive so the test
+        // doesn't flake under heavy cooperative-pool load (a fixed
+        // `Task.sleep` can return before the @MainActor Task body runs).
+        let calls = await Self.waitForPartial("Erl", in: fake, timeout: .seconds(3))
 
         // Exactly one fetch should have run, for the final partial.
-        let calls = await fake.fetchCalls
         #expect(calls.count == 1, "rapid typing should debounce to one fetch; got \(calls)")
         #expect(calls.first?.partial == "Erl")
     }
@@ -229,9 +251,7 @@ struct ComposerAutocompleteHostedTests {
             text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
 
         type("[[page:Erl", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(1_000))
-
-        let calls = await fake.fetchCalls
+        let calls = await Self.waitForPartial("Erl", in: fake, timeout: .seconds(3))
         #expect(calls.count == 1)
         #expect(calls.first?.partial == "Erl")
         #expect(calls.first?.kind == .page)
@@ -255,7 +275,7 @@ struct ComposerAutocompleteHostedTests {
             text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
 
         type("Just a regular message", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(1_000))
+        try? await Task.sleep(for: .milliseconds(500))
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "no fetch should fire without an open-link trigger")
@@ -277,7 +297,7 @@ struct ComposerAutocompleteHostedTests {
             text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
 
         type("[[page:Erickson]]", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(1_000))
+        try? await Task.sleep(for: .milliseconds(500))
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "no fetch should fire for a closed link")
@@ -302,7 +322,7 @@ struct ComposerAutocompleteHostedTests {
 
         // Multi-line text with a `[[` on one line and content on the next.
         type("[[page:Erl\nmore stuff", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(1_000))
+        try? await Task.sleep(for: .milliseconds(500))
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "newline in the trigger should bail (paste/multi-line guard)")
@@ -326,7 +346,7 @@ struct ComposerAutocompleteHostedTests {
         // Paste: `[[page:` + maxPartialSpan+1 chars → over the cap.
         let long = String(repeating: "a", count: WikiLinkPrefixScanner.maxPartialSpan + 1)
         type("[[page:\(long)", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(1_000))
+        try? await Task.sleep(for: .milliseconds(500))
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "overlong partial should bail (paste guard)")

--- a/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
+++ b/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
@@ -6,31 +6,21 @@ import Testing
 @testable import WikiFSLinks
 @testable import WikiFSSearch
 
-/// Hosted-window integration tests for the chat composer's autocomplete
-/// pipeline: prefix detection → debounced Tantivy query → result application.
-/// Issues #436 / #638, plan §6a/§6d.
-///
-/// **Reviewer correction #3:** includes a dedicated debounce-cancel test
-/// (AC #5) that drives the Coordinator's schedule with two partials in
-/// quick succession and asserts only the final partial's result is applied.
-///
-/// The composer's NSTextView is hosted in a real `NSWindow` so the
-/// delegate/notification paths fire end-to-end (`reproducing-live-ui-bugs`
-/// skill: ground-truth via the real delegate seam, not a mocked one).
+/// Deterministic tests for the chat composer's autocomplete pipeline:
+/// prefix detection → debounced Tantivy query → result application.
+/// Issues #436 / #638, plan §6a/§6d. Issue #661: the prior real-`Task.sleep`
+/// approach deadlocked CI under heavy integration-tier load — these tests use
+/// an injected `ManualScheduler` (pattern from
+/// `Tests/WikiFSTests/ChangeCoalescerTests.swift`) so the coordinator captures
+/// the post-debounce work without running it, and the test fires it
+/// explicitly via `fireAll()`. No `Task.sleep` anywhere in this file.
 ///
 /// `@MainActor` because AppKit + SwiftUI hosting is main-actor-isolated.
-/// `.serialized` because each test drives the main-actor Task scheduler with
-/// real `Task.sleep` waits — running them in parallel (the default) saturates
-/// the cooperative pool and starves the debounce Tasks, making the timing
-/// assertions flaky. Serial execution keeps each test's waits deterministic.
-///
-/// `.tags(.integration)` because the Task-scheduler timing is not reliable
-/// under heavy cooperative-pool load — the suite deadlocked CI for 6 hours
-/// when run alongside the full integration tier. The fast CI tier skips it;
-/// `swift-integration` runs it (where its serial + polling approach is
-/// reliable enough). The deterministic-clock rewrite is tracked as follow-up.
+/// `.serialized` because the `ManualScheduler` instances are suite-local —
+/// serial keeps each test's state isolated from the next (also it's the
+/// natural shape for an actor-driven `fireAll()`).
 @MainActor
-@Suite(.serialized, .tags(.integration))
+@Suite(.serialized)
 struct ComposerAutocompleteHostedTests {
 
     // MARK: - Hosted composer builder
@@ -47,8 +37,8 @@ struct ComposerAutocompleteHostedTests {
 
     /// Records `fetch` calls and injects canned results. Captured by the
     /// autocomplete closures so tests can observe the coordinator's behavior.
-    /// An `actor` so it's `Sendable`-safe to call from the coordinator's
-    /// detached `Task` (Swift 6 strict concurrency).
+    /// An `actor` so it's `Sendable`-safe to call from the captured work
+    /// closure (Swift 6 strict concurrency).
     actor FakeAutocomplete {
         /// Recorded (partial, kind) pairs in fetch-call order.
         private(set) var fetchCalls: [(partial: String, kind: ParsedLink.LinkType)] = []
@@ -62,6 +52,68 @@ struct ComposerAutocompleteHostedTests {
         func fetch(_ partial: String, _ kind: ParsedLink.LinkType) async -> [TantivyShadowSearchResult] {
             fetchCalls.append((partial, kind))
             return nextResult
+        }
+    }
+
+    /// Captures scheduled debounce work so the test can fire it on demand —
+    /// the same pattern `ChangeCoalescerTests` uses, with one addition: this
+    /// is a `@unchecked Sendable` class (crosses isolation boundaries between
+    /// the @MainActor test body, the schedule seam closure stored in
+    /// ComposerTextView, and the captured async work) with an NSLock guarding
+    /// its state. Mirrors `OmniboxSearchField.Coordinator`'s `@unchecked
+    /// Sendable` shape for the same reason.
+    final class ManualScheduler: @unchecked Sendable {
+        private let lock = NSLock()
+        private var pending: [Int: () async -> Void] = [:]
+        private var nextID = 0
+        private var _cancelledIDs: [Int] = []
+
+        var pendingCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return pending.count
+        }
+
+        var cancelledIDs: [Int] {
+            lock.lock(); defer { lock.unlock() }
+            return _cancelledIDs
+        }
+
+        func schedule(_ debounce: UInt64, _ work: @escaping () async -> Void) -> ComposerTextView.DebounceHandle {
+            lock.lock()
+            let id = nextID
+            nextID += 1
+            pending[id] = work
+            lock.unlock()
+            return ComposerTextView.DebounceHandle { [weak self] in
+                self?.cancel(id: id)
+            }
+        }
+
+        private func cancel(id: Int) {
+            lock.lock()
+            pending[id] = nil
+            _cancelledIDs.append(id)
+            lock.unlock()
+        }
+
+        /// Drain pending work under the lock (sync — `NSLock.unlock()` is
+        /// unavailable from async contexts in Swift 6).
+        private func drainPending() -> [() async -> Void] {
+            lock.lock()
+            let items = pending.sorted { $0.key < $1.key }.map(\.value)
+            pending.removeAll()
+            lock.unlock()
+            return items
+        }
+
+        /// Fire every still-pending scheduled item (in scheduling order). The
+        /// captured work runs to completion (its `await`s resolve).
+        func fireAll() async {
+            // Drain under the lock so concurrent schedules can't observe
+            // half-fired state. Work closures themselves run outside the lock
+            // so they can't deadlock against a reschedule.
+            let items = drainPending()
+            for work in items { await work() }
         }
     }
 
@@ -81,14 +133,12 @@ struct ComposerAutocompleteHostedTests {
         text: Binding<String>,
         autocomplete: ComposerTextView.AutocompleteHooks?,
         measuredHeight: Binding<CGFloat>,
-        debounce: UInt64 = 5
+        scheduler: ManualScheduler
     ) -> (window: NSWindow, textView: NSTextView, coordinator: ComposerTextView.Coordinator) {
-        // `debounce` defaults to 5 ms (vs. the 150 ms production default) so
-        // the schedule/cancel timing is deterministic without long `Task.sleep`
-        // waits — the suite is heavy (2700+ tests competing for the
-        // cooperative pool) and a tight 5 ms debounce window makes the cancel
-        // assertion insensitive to pool saturation. Production gets the 150 ms
-        // default via `ComposerTextView.debounce`'s default.
+        // Inject the manual scheduler so the coordinator captures work for
+        // `fireAll()` instead of creating a real `Task.sleep` Task. Production
+        // leaves `scheduleDebounce = nil` (the default) and gets the inline
+        // Task.sleep path.
         let parent = ComposerTextView(
             text: text,
             isEditable: true,
@@ -96,7 +146,8 @@ struct ComposerAutocompleteHostedTests {
             onSubmit: {},
             measuredHeight: measuredHeight,
             autocomplete: autocomplete,
-            debounce: debounce
+            debounce: 150,  // production value — the schedule seam means this is never actually slept
+            scheduleDebounce: { _, work in scheduler.schedule(0, work) }
         )
         let coordinator = ComposerTextView.Coordinator(parent)
         let textView = ComposerTextView.makeConfiguredTextView(font: bodyFont)
@@ -120,25 +171,22 @@ struct ComposerAutocompleteHostedTests {
         coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
     }
 
-    // MARK: - AC #5: debounce + cancel (reviewer correction #3)
+    // MARK: - AC #5: debounce + cancel (reviewer correction #3 — now deterministic via #661)
 
     @Test func debouncedQueryCancelsStaleInFlightPartial() async {
         // Drive the coordinator's schedule with two partials in quick
-        // succession. The first must be cancelled before its fetch lands; only
-        // the second partial's fetch fires.
-        //
-        // Robustness: under heavy cooperative-pool load (this suite runs
-        // alongside 2700+ others), a fixed `Task.sleep` wait can return
-        // BEFORE the second schedule's @MainActor-isolated Task body gets a
-        // chance to run — which looks like "no fetch ran" (false failure).
-        // The poll loop below waits adaptively: it exits as soon as the
-        // second partial ("Erl") lands in `fetchCalls`, with a generous 3s
-        // ceiling so a slow CI runner still completes.
+        // succession. The first must be cancelled before its fetch runs; only
+        // the second partial's fetch fires. This was previously flaky under
+        // heavy cooperative-pool load (the @MainActor-isolated Task body
+        // created by the real Task.sleep scheduler never got scheduled within
+        // the polling timeout — see issue #661). The injected `ManualScheduler`
+        // makes it fully deterministic: schedule work, cancel, fire.
         var text = ""
         var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
+        let scheduler = ManualScheduler()
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
@@ -150,64 +198,38 @@ struct ComposerAutocompleteHostedTests {
         )
 
         let (_, textView, coordinator) = makeHostedComposer(
-            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
 
-        // First keystroke (inside the first debounce window).
+        // First keystroke: schedule #1 is captured in the manual scheduler.
         type("[[page:Er", into: textView, coordinator: coordinator)
-        // Yield ONCE so the scheduler's Task is allocated. Do NOT wait out
-        // the debounce — we want the second keystroke to land inside the
-        // debounce window.
-        await Task.yield()
+        #expect(scheduler.pendingCount == 1)
+        #expect(scheduler.cancelledIDs.isEmpty)
 
-        // Second keystroke — still inside the first's debounce window. Its
-        // `scheduleAutocomplete` cancels the first Task before its sleep
-        // completes, so the first `hooks.fetch` never runs.
+        // Second keystroke: cancels #1, schedules #2. No fetch ran yet — the
+        // manual scheduler doesn't run work until `fireAll()`.
         type("[[page:Erl", into: textView, coordinator: coordinator)
+        #expect(scheduler.pendingCount == 1, "exactly one schedule alive (the second; the first was cancelled)")
+        #expect(scheduler.cancelledIDs == [0], "the first schedule was cancelled before its work ran")
 
-        // Poll for the SECOND partial ("Erl") to land in fetchCalls. If the
-        // cancel worked, "Erl" is the ONLY entry (the first fetch never
-        // ran). If the cancel failed, BOTH "Er" and "Erl" land — the
-        // assertion below catches that.
-        let calls = await Self.waitForPartial("Erl", in: fake, timeout: .seconds(3))
+        // Fire pending work — only #2's fetch should run because #1 was cancelled.
+        await scheduler.fireAll()
 
-        // The headline check: exactly one fetch ran, for the SECOND partial.
-        // This proves the first schedule was cancelled BEFORE its fetch ran
-        // (AC #5: cancel stale in-flight queries — the second schedule's
-        // cancel landed during the first schedule's debounce sleep).
+        let calls = await fake.fetchCalls
         #expect(calls.count == 1, "the second schedule should have cancelled the first BEFORE its fetch ran; got \(calls)")
         #expect(calls.first?.partial == "Erl")
         #expect(calls.first?.kind == .page)
     }
 
-    /// Poll `fake.fetchCalls` until it contains an entry with `partial`, or
-    /// `timeout` elapses. Returns the snapshot at exit. Adaptive so the cancel
-    /// test doesn't flake under heavy cooperative-pool load (a fixed
-    /// `Task.sleep` can return before the @MainActor Task body gets to run).
-    private static func waitForPartial(
-        _ partial: String,
-        in fake: FakeAutocomplete,
-        timeout: Duration
-    ) async -> [(partial: String, kind: ParsedLink.LinkType)] {
-        let deadline = Date().addingTimeInterval(Double(timeout.components.seconds))
-        var snapshot: [(partial: String, kind: ParsedLink.LinkType)] = []
-        while Date() < deadline {
-            snapshot = await fake.fetchCalls
-            if snapshot.contains(where: { $0.partial == partial }) { return snapshot }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        return snapshot
-    }
-
     @Test func onlyLatestPartialTriggersAFetchWhenTypingRapidly() async {
         // Stronger version of the cancel test: type three partials in rapid
-        // succession (faster than the debounce). Only the LAST one should
-        // trigger a fetch — the debounce collapses the first two into the
-        // third.
+        // succession (faster than the debounce — captured, not run). Only the
+        // LAST one should trigger a fetch — the debounce cancels the first two.
         var text = ""
         var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
+        let scheduler = ManualScheduler()
         let fake = FakeAutocomplete()
         let hooks = ComposerTextView.AutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -215,20 +237,22 @@ struct ComposerAutocompleteHostedTests {
         )
 
         let (_, textView, coordinator) = makeHostedComposer(
-            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
 
         // Type three keystrokes inside the debounce window. No `await` between
-        // them — each schedule arrives inside the prior's debounce sleep.
+        // them. Each schedule arrives inside the prior's debounce window.
         for prefix in ["[[page:E", "[[page:Er", "[[page:Erl"] {
             type(prefix, into: textView, coordinator: coordinator)
         }
 
-        // Poll for the FINAL partial ("Erl") to land — adaptive so the test
-        // doesn't flake under heavy cooperative-pool load (a fixed
-        // `Task.sleep` can return before the @MainActor Task body runs).
-        let calls = await Self.waitForPartial("Erl", in: fake, timeout: .seconds(3))
+        // Two cancellations (the first two were superseded); one pending.
+        #expect(scheduler.cancelledIDs == [0, 1], "the first two schedules were cancelled on reschedule")
+        #expect(scheduler.pendingCount == 1, "only the final schedule is alive")
 
-        // Exactly one fetch should have run, for the final partial.
+        // Fire pending work — only the final partial's fetch should run.
+        await scheduler.fireAll()
+
+        let calls = await fake.fetchCalls
         #expect(calls.count == 1, "rapid typing should debounce to one fetch; got \(calls)")
         #expect(calls.first?.partial == "Erl")
     }
@@ -241,6 +265,7 @@ struct ComposerAutocompleteHostedTests {
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
+        let scheduler = ManualScheduler()
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
@@ -254,10 +279,15 @@ struct ComposerAutocompleteHostedTests {
         )
 
         let (_, textView, coordinator) = makeHostedComposer(
-            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
 
         type("[[page:Erl", into: textView, coordinator: coordinator)
-        let calls = await Self.waitForPartial("Erl", in: fake, timeout: .seconds(3))
+        #expect(scheduler.pendingCount == 1)
+        #expect(scheduler.cancelledIDs.isEmpty)
+
+        await scheduler.fireAll()
+
+        let calls = await fake.fetchCalls
         #expect(calls.count == 1)
         #expect(calls.first?.partial == "Erl")
         #expect(calls.first?.kind == .page)
@@ -271,6 +301,7 @@ struct ComposerAutocompleteHostedTests {
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
+        let scheduler = ManualScheduler()
         let fake = FakeAutocomplete()
         let hooks = ComposerTextView.AutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -278,10 +309,13 @@ struct ComposerAutocompleteHostedTests {
         )
 
         let (_, textView, coordinator) = makeHostedComposer(
-            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
 
+        // Plain text — no `[[` trigger. Nothing is scheduled.
         type("Just a regular message", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(500))
+        #expect(scheduler.pendingCount == 0, "no schedule should be created without an open-link trigger")
+
+        await scheduler.fireAll()
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "no fetch should fire without an open-link trigger")
@@ -293,6 +327,7 @@ struct ComposerAutocompleteHostedTests {
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
+        let scheduler = ManualScheduler()
         let fake = FakeAutocomplete()
         let hooks = ComposerTextView.AutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -300,10 +335,12 @@ struct ComposerAutocompleteHostedTests {
         )
 
         let (_, textView, coordinator) = makeHostedComposer(
-            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
 
         type("[[page:Erickson]]", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(500))
+        #expect(scheduler.pendingCount == 0, "no schedule should be created for a closed link")
+
+        await scheduler.fireAll()
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "no fetch should fire for a closed link")
@@ -317,6 +354,7 @@ struct ComposerAutocompleteHostedTests {
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
+        let scheduler = ManualScheduler()
         let fake = FakeAutocomplete()
         let hooks = ComposerTextView.AutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -324,11 +362,13 @@ struct ComposerAutocompleteHostedTests {
         )
 
         let (_, textView, coordinator) = makeHostedComposer(
-            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
 
         // Multi-line text with a `[[` on one line and content on the next.
         type("[[page:Erl\nmore stuff", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(500))
+        #expect(scheduler.pendingCount == 0, "newline in the trigger should bail (paste/multi-line guard)")
+
+        await scheduler.fireAll()
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "newline in the trigger should bail (paste/multi-line guard)")
@@ -340,6 +380,7 @@ struct ComposerAutocompleteHostedTests {
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
+        let scheduler = ManualScheduler()
         let fake = FakeAutocomplete()
         let hooks = ComposerTextView.AutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -347,14 +388,45 @@ struct ComposerAutocompleteHostedTests {
         )
 
         let (_, textView, coordinator) = makeHostedComposer(
-            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
 
         // Paste: `[[page:` + maxPartialSpan+1 chars → over the cap.
         let long = String(repeating: "a", count: WikiLinkPrefixScanner.maxPartialSpan + 1)
         type("[[page:\(long)", into: textView, coordinator: coordinator)
-        try? await Task.sleep(for: .milliseconds(500))
+        #expect(scheduler.pendingCount == 0, "overlong partial should bail (paste guard)")
+
+        await scheduler.fireAll()
 
         let calls = await fake.fetchCalls
         #expect(calls.isEmpty, "overlong partial should bail (paste guard)")
+    }
+
+    // MARK: - Schedule-not-fired → no fetch (proves work is captured, not run eagerly)
+
+    @Test func scheduleWithoutFireDoesNotRunFetch() async {
+        // The ManualScheduler captures work without running it. So scheduling
+        // without firing must NOT call fetch — this is the load-bearing
+        // property that makes issue #661's fix deterministic: no real
+        // `Task.sleep`, no Task body scheduling race, just capture-and-fire.
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let scheduler = ManualScheduler()
+        let fake = FakeAutocomplete()
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
+
+        type("[[page:Erl", into: textView, coordinator: coordinator)
+        #expect(scheduler.pendingCount == 1)
+        // No fireAll — fetch must not have run.
+        let calls = await fake.fetchCalls
+        #expect(calls.isEmpty, "scheduled work must not run until fireAll()")
     }
 }

--- a/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
+++ b/Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift
@@ -1,0 +1,334 @@
+import Foundation
+import AppKit
+import SwiftUI
+import Testing
+@testable import WikiFS
+@testable import WikiFSLinks
+@testable import WikiFSSearch
+
+/// Hosted-window integration tests for the chat composer's autocomplete
+/// pipeline: prefix detection → debounced Tantivy query → result application.
+/// Issues #436 / #638, plan §6a/§6d.
+///
+/// **Reviewer correction #3:** includes a dedicated debounce-cancel test
+/// (AC #5) that drives the Coordinator's schedule with two partials in
+/// quick succession and asserts only the final partial's result is applied.
+///
+/// The composer's NSTextView is hosted in a real `NSWindow` so the
+/// delegate/notification paths fire end-to-end (`reproducing-live-ui-bugs`
+/// skill: ground-truth via the real delegate seam, not a mocked one).
+///
+/// `@MainActor` because AppKit + SwiftUI hosting is main-actor-isolated.
+/// `.serialized` because each test drives the main-actor Task scheduler with
+/// real `Task.sleep` waits — running them in parallel (the default) saturates
+/// the cooperative pool and starves the debounce Tasks, making the timing
+/// assertions flaky. Serial execution keeps each test's waits deterministic.
+@MainActor
+@Suite(.serialized)
+struct ComposerAutocompleteHostedTests {
+
+    // MARK: - Hosted composer builder
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 400),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+    }
+
+    private var bodyFont: NSFont { .preferredFont(forTextStyle: .body) }
+
+    /// Records `fetch` calls and injects canned results. Captured by the
+    /// autocomplete closures so tests can observe the coordinator's behavior.
+    /// An `actor` so it's `Sendable`-safe to call from the coordinator's
+    /// detached `Task` (Swift 6 strict concurrency).
+    actor FakeAutocomplete {
+        /// Recorded (partial, kind) pairs in fetch-call order.
+        private(set) var fetchCalls: [(partial: String, kind: ParsedLink.LinkType)] = []
+        /// The result the next fetch should return.
+        var nextResult: [TantivyShadowSearchResult] = []
+
+        func setNextResult(_ results: [TantivyShadowSearchResult]) {
+            self.nextResult = results
+        }
+
+        func fetch(_ partial: String, _ kind: ParsedLink.LinkType) async -> [TantivyShadowSearchResult] {
+            fetchCalls.append((partial, kind))
+            return nextResult
+        }
+    }
+
+    /// Mirrors `ChatView.chatAutocompleteHooks.format` so the test's inserted
+    /// string matches production shape. Pure / Sendable.
+    static func formatHit(_ hit: TantivyShadowSearchResult) -> String {
+        let kind: ParsedLink.LinkType
+        switch hit.kind {
+        case .page:   kind = .page
+        case .source: kind = .source
+        case .chat:   kind = .chat
+        }
+        return "[[\(kind.linkPrefix)\(hit.ulid)|\(hit.title)]]"
+    }
+
+    private func makeHostedComposer(
+        text: Binding<String>,
+        autocomplete: ComposerTextView.AutocompleteHooks?,
+        measuredHeight: Binding<CGFloat>
+    ) -> (window: NSWindow, textView: NSTextView, coordinator: ComposerTextView.Coordinator) {
+        let parent = ComposerTextView(
+            text: text,
+            isEditable: true,
+            font: bodyFont,
+            onSubmit: {},
+            measuredHeight: measuredHeight,
+            autocomplete: autocomplete
+        )
+        let coordinator = ComposerTextView.Coordinator(parent)
+        let textView = ComposerTextView.makeConfiguredTextView(font: bodyFont)
+        textView.delegate = coordinator
+        textView.isEditable = true
+        textView.string = text.wrappedValue
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+        scrollView.documentView = textView
+
+        let window = makeWindow()
+        window.contentView?.addSubview(scrollView)
+
+        return (window, textView, coordinator)
+    }
+
+    /// Convenience: drive a textDidChange + caret-to-end on the hosted view.
+    private func type(_ value: String, into textView: NSTextView, coordinator: ComposerTextView.Coordinator) {
+        textView.string = value
+        textView.setSelectedRange(NSRange(location: (value as NSString).length, length: 0))
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+    }
+
+    // MARK: - AC #5: debounce + cancel (reviewer correction #3)
+
+    @Test func debouncedQueryCancelsStaleInFlightPartial() async {
+        // Drive the coordinator's schedule with two partials in quick
+        // succession. The first must be cancelled before its fetch lands; only
+        // the second partial's result is applied.
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        // Make the FIRST fetch slow enough that the second schedule arrives
+        // before it returns. The debounce (150ms) plus this delay must exceed
+        // the gap between the two schedules.
+        var fetchCount = 0
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, _ in
+                let captured = fetchCount
+                fetchCount += 1
+                if captured == 0 {
+                    // First fetch — slow. Should be cancelled before its
+                    // `await` returns. If we get here uncancelled, the sentinel
+                    // title lets the assertion detect it.
+                    try? await Task.sleep(for: .milliseconds(400))
+                    return [TantivyShadowSearchResult(
+                        documentID: "page:FIRST", kind: .page,
+                        title: "First Should Not Appear", score: 1.0)]
+                }
+                return [TantivyShadowSearchResult(
+                    documentID: "page:SECOND", kind: .page,
+                    title: "Second Wins", score: 1.0)]
+            },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+
+        // First keystroke (inside the first debounce window).
+        type("[[page:Er", into: textView, coordinator: coordinator)
+        // Yield ONCE so the scheduler's Task is allocated. Do NOT wait out
+        // the debounce — we want the second keystroke to land inside the
+        // debounce window.
+        await Task.yield()
+
+        // Second keystroke — still inside the first's debounce window. Its
+        // `scheduleAutocomplete` cancels the first Task before its sleep
+        // completes, so the first `hooks.fetch` never runs.
+        type("[[page:Erl", into: textView, coordinator: coordinator)
+
+        // Wait long enough for the debounce + the second fetch to settle.
+        // (First fetch's 400ms delay would land at ~550ms; we wait 700ms to
+        // be sure, but the cancel prevents it from applying.)
+        try? await Task.sleep(for: .milliseconds(700))
+
+        // The headline check: fetchCount is exactly 1 (the second), proving
+        // the first schedule was cancelled BEFORE its `await hooks.fetch`
+        // ran. This is what AC#5 requires: cancel stale in-flight *queries* —
+        // the second schedule's cancel landed during the first schedule's
+        // debounce sleep, so the first fetch never started.
+        #expect(fetchCount == 1, "the second schedule should have cancelled the first BEFORE its fetch ran; got \(fetchCount)")
+    }
+
+    @Test func onlyLatestPartialTriggersAFetchWhenTypingRapidly() async {
+        // Stronger version of the cancel test: type three partials in rapid
+        // succession (faster than the debounce). Only the LAST one should
+        // trigger a fetch — the debounce collapses the first two into the
+        // third.
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let fake = FakeAutocomplete()
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+
+        // Type three keystrokes inside the debounce window. No `await` between
+        // them — each schedule arrives inside the prior's debounce sleep.
+        for prefix in ["[[page:E", "[[page:Er", "[[page:Erl"] {
+            type(prefix, into: textView, coordinator: coordinator)
+        }
+
+        // Wait generously past the debounce so the final schedule's fetch
+        // has time to land. The suite is heavy (2700+ tests competing for the
+        // cooperative pool), so a tight window flakes — see commit history.
+        try? await Task.sleep(for: .milliseconds(1_000))
+
+        // Exactly one fetch should have run, for the final partial.
+        let calls = await fake.fetchCalls
+        #expect(calls.count == 1, "rapid typing should debounce to one fetch; got \(calls)")
+        #expect(calls.first?.partial == "Erl")
+    }
+
+    // MARK: - Happy path: trigger detected → fetch → result applied
+
+    @Test func openTriggerFiresFetchAndAppliesResults() async {
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let fake = FakeAutocomplete()
+        await fake.setNextResult([
+            TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
+                                      title: "Erickson", score: 1.0),
+            TantivyShadowSearchResult(documentID: "page:01PAGE0002", kind: .page,
+                                      title: "Erlang Guide", score: 0.9),
+        ])
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+
+        type("[[page:Erl", into: textView, coordinator: coordinator)
+        try? await Task.sleep(for: .milliseconds(1_000))
+
+        let calls = await fake.fetchCalls
+        #expect(calls.count == 1)
+        #expect(calls.first?.partial == "Erl")
+        #expect(calls.first?.kind == .page)
+    }
+
+    // MARK: - No trigger → no fetch
+
+    @Test func noOpenTriggerDoesNotFireFetch() async {
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let fake = FakeAutocomplete()
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+
+        type("Just a regular message", into: textView, coordinator: coordinator)
+        try? await Task.sleep(for: .milliseconds(1_000))
+
+        let calls = await fake.fetchCalls
+        #expect(calls.isEmpty, "no fetch should fire without an open-link trigger")
+    }
+
+    @Test func closingTheBracketsHidesTheTriggerAndDoesNotFetch() async {
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let fake = FakeAutocomplete()
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+
+        type("[[page:Erickson]]", into: textView, coordinator: coordinator)
+        try? await Task.sleep(for: .milliseconds(1_000))
+
+        let calls = await fake.fetchCalls
+        #expect(calls.isEmpty, "no fetch should fire for a closed link")
+    }
+
+    // MARK: - Reviewer correction #4: newline/paste guards
+
+    @Test func newlineInTriggerDoesNotFireFetch() async {
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let fake = FakeAutocomplete()
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+
+        // Multi-line text with a `[[` on one line and content on the next.
+        type("[[page:Erl\nmore stuff", into: textView, coordinator: coordinator)
+        try? await Task.sleep(for: .milliseconds(1_000))
+
+        let calls = await fake.fetchCalls
+        #expect(calls.isEmpty, "newline in the trigger should bail (paste/multi-line guard)")
+    }
+
+    @Test func overlongPartialDoesNotFireFetch() async {
+        var text = ""
+        var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
+        let textBinding = Binding(get: { text }, set: { text = $0 })
+        let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+
+        let fake = FakeAutocomplete()
+        let hooks = ComposerTextView.AutocompleteHooks(
+            fetch: { partial, kind in await fake.fetch(partial, kind) },
+            format: Self.formatHit
+        )
+
+        let (_, textView, coordinator) = makeHostedComposer(
+            text: textBinding, autocomplete: hooks, measuredHeight: heightBinding)
+
+        // Paste: `[[page:` + maxPartialSpan+1 chars → over the cap.
+        let long = String(repeating: "a", count: WikiLinkPrefixScanner.maxPartialSpan + 1)
+        type("[[page:\(long)", into: textView, coordinator: coordinator)
+        try? await Task.sleep(for: .milliseconds(1_000))
+
+        let calls = await fake.fetchCalls
+        #expect(calls.isEmpty, "overlong partial should bail (paste guard)")
+    }
+}

--- a/Tests/WikiFSTests/TantivyAutocompleteTests.swift
+++ b/Tests/WikiFSTests/TantivyAutocompleteTests.swift
@@ -1,0 +1,211 @@
+import Testing
+import Foundation
+import WikiFSSearch
+
+/// Integration tests for `TantivyIndexer.autocomplete(...)` /
+/// `TantivySearchService.autocomplete(...)` (issues #436 / #638, plan §6b/§6c).
+///
+/// Mirrors `TantivyShadowIndexTests` (in-memory content source + temp index
+/// dir per test). The headline AC is `"Erl"` → `"Erickson"` via distance-2
+/// prefix-fuzzy on title (the #638 case the plan-reviewer corrected us on:
+/// MUST use the query-string path with `prefix: true`, NOT the structured
+/// `.fuzzy` enum which has no `prefix`).
+///
+/// Marked `.integration` (opens a real Tantivy index) AND added to the
+/// fast-tier `--skip` regex in `.github/workflows/ci.yml` per the testing
+/// rules. The `swift-integration` job runs them to gate merges.
+@Suite(.tags(.integration))
+struct TantivyAutocompleteTests {
+
+    // MARK: - In-memory content source (mirror of TantivyShadowIndexTests)
+
+    private actor InMemoryContentSource: TantivyContentSource {
+        private var docs: [String: TantivyContentSnapshot] = [:]
+
+        func upsert(_ snapshot: TantivyContentSnapshot) {
+            docs["\(snapshot.kind.rawValue):\(snapshot.ulid)"] = snapshot
+        }
+
+        func snapshot(ulid: String, kind: TantivyDocumentKind) async throws -> TantivyContentSnapshot? {
+            docs["\(kind.rawValue):\(ulid)"]
+        }
+
+        func allSnapshots() async throws -> [TantivyContentSnapshot] {
+            Array(docs.values)
+        }
+    }
+
+    private func makeTempDir() -> (URL, FileManager) {
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("tantivy-autocomplete-\(UUID().uuidString)")
+        let url = URL(fileURLWithPath: path)
+        let fm = FileManager.default
+        return (url, fm)
+    }
+
+    private func makeSnapshot(
+        ulid: String,
+        kind: TantivyDocumentKind,
+        title: String,
+        body: String = ""
+    ) -> TantivyContentSnapshot {
+        TantivyContentSnapshot(
+            ulid: ulid, kind: kind, title: title, body: body,
+            updatedAt: Date(), versionSum: 1)
+    }
+
+    private func makeService(source: InMemoryContentSource, dir: URL) throws -> TantivySearchService {
+        try TantivySearchService(
+            wikiID: "autocomplete-test",
+            containerDirectory: dir,
+            contentSource: source)
+    }
+
+    // MARK: - AC #1: "Erl" → "Erickson" (the #638 headline case)
+
+    @Test func shortPrefixSurfacesLongerTitleViaPrefixFuzzy() async throws {
+        // This is the headline AC of #638. A naive whole-token edit-distance
+        // query would score "Erl" as distance-6 from "Erickson" and miss it.
+        // The query-string path with `prefix: true` (the reviewer correction)
+        // is what makes this work — the fuzzy automaton expands as a prefix.
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try makeService(source: source, dir: indexDir)
+
+        await source.upsert(makeSnapshot(ulid: "01PAGE00001", kind: .page, title: "Erickson"))
+        await source.upsert(makeSnapshot(ulid: "01PAGE00002", kind: .page, title: "Erlang"))
+        await source.upsert(makeSnapshot(ulid: "01PAGE00003", kind: .page, title: "Erie"))
+        await service.indexer.upsert(ulid: "01PAGE00001", kind: .page)
+        await service.indexer.upsert(ulid: "01PAGE00002", kind: .page)
+        await service.indexer.upsert(ulid: "01PAGE00003", kind: .page)
+
+        let hits = await service.autocomplete(
+            partial: "Erl", kinds: [.page], distance: 2, limit: 8)
+
+        #expect(hits.contains { $0.title == "Erickson" },
+                "AC #1: 'Erl' must surface 'Erickson' via prefix-fuzzy — the #638 headline")
+        #expect(hits.contains { $0.title == "Erlang" })
+        #expect(hits.contains { $0.title == "Erie" })
+    }
+
+    // MARK: - AC #2: typo tolerance (distance 1–2)
+
+    @Test func typoDistanceOneSurfacesTarget() async throws {
+        // `Erlckson` is edit-distance 1 from `Erickson` (extra `l`).
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try makeService(source: source, dir: indexDir)
+
+        await source.upsert(makeSnapshot(ulid: "01PAGE00010", kind: .page, title: "Erickson"))
+        await service.indexer.upsert(ulid: "01PAGE00010", kind: .page)
+
+        let hits = await service.autocomplete(
+            partial: "Erlckson", kinds: [.page], distance: 2, limit: 8)
+
+        #expect(hits.contains { $0.title == "Erickson" },
+                "AC #2: a distance-1 typo on a longer title should still resolve")
+    }
+
+    // MARK: - AC #3: kind scoping (post-filter in Swift — reviewer correction #1)
+
+    @Test func kindScopingFiltersToOnlyRequestedKind() async throws {
+        // Same title across kinds: the page should appear in the `[.page]`
+        // query, the source in the `[.source]` query — never crossed.
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try makeService(source: source, dir: indexDir)
+
+        await source.upsert(makeSnapshot(ulid: "01PAGE00100", kind: .page,   title: "Erlang Guide"))
+        await source.upsert(makeSnapshot(ulid: "01SRC00100",  kind: .source, title: "Erlang Spec"))
+        await service.indexer.upsert(ulid: "01PAGE00100", kind: .page)
+        await service.indexer.upsert(ulid: "01SRC00100",  kind: .source)
+
+        let pageHits = await service.autocomplete(partial: "Erlang", kinds: [.page], limit: 8)
+        #expect(pageHits.allSatisfy { $0.kind == .page })
+        #expect(pageHits.contains { $0.title == "Erlang Guide" })
+        #expect(!pageHits.contains { $0.title == "Erlang Spec" },
+               "AC #3: page-scoped query must not return sources")
+
+        let sourceHits = await service.autocomplete(partial: "Erlang", kinds: [.source], limit: 8)
+        #expect(sourceHits.allSatisfy { $0.kind == .source })
+        #expect(sourceHits.contains { $0.title == "Erlang Spec" })
+        #expect(!sourceHits.contains { $0.title == "Erlang Guide" },
+               "AC #3: source-scoped query must not return pages")
+    }
+
+    @Test func emptyKindsReturnsEmptyResults() async throws {
+        // Defensive: callers should always pass at least one kind, but the
+        // indexer must not crash on an empty set.
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try makeService(source: source, dir: indexDir)
+        await source.upsert(makeSnapshot(ulid: "01PAGE00200", kind: .page, title: "Anything"))
+        await service.indexer.upsert(ulid: "01PAGE00200", kind: .page)
+
+        let hits = await service.autocomplete(partial: "Any", kinds: [], limit: 8)
+        #expect(hits.isEmpty)
+    }
+
+    // MARK: - Distance-2 actually does work (vs the path's existing distance-1)
+
+    @Test func distanceTwoToleratesTwoEdits() async throws {
+        // `Conc` is fine at distance 1. `Canc` (substitute o→a, e→a — depends
+        // on tokenizer) is a distance-2 typo of `Conc` — exercise distance 2.
+        // Index "Concurrency" and query "Concurrencey" (typo + extra char).
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try makeService(source: source, dir: indexDir)
+
+        await source.upsert(makeSnapshot(ulid: "01PAGE00300", kind: .page, title: "Concurrency"))
+        await service.indexer.upsert(ulid: "01PAGE00300", kind: .page)
+
+        let hits = await service.autocomplete(
+            partial: "Concurrecny", kinds: [.page], distance: 2, limit: 8)
+        // Distance-2 typo of "Concurrency" — "Concurrecny" has two transposed
+        // letters near the end.
+        #expect(hits.contains { $0.title == "Concurrency" },
+                "distance-2 fuzzy should tolerate a 2-char edit on a long title")
+    }
+
+    // MARK: - Empty / edge inputs
+
+    @Test func emptyPartialReturnsEmpty() async throws {
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try makeService(source: source, dir: indexDir)
+        await source.upsert(makeSnapshot(ulid: "01PAGE00400", kind: .page, title: "Anything"))
+        await service.indexer.upsert(ulid: "01PAGE00400", kind: .page)
+
+        let hits = await service.autocomplete(partial: "", kinds: [.page], limit: 8)
+        #expect(hits.isEmpty, "empty partial must not trigger autocomplete")
+    }
+
+    @Test func limitIsRespected() async throws {
+        let (indexDir, fm) = makeTempDir()
+        defer { try? fm.removeItem(at: indexDir) }
+
+        let source = InMemoryContentSource()
+        let service = try makeService(source: source, dir: indexDir)
+        // Index 10 pages that all match the "Page" prefix.
+        for i in 0..<10 {
+            let ulid = String(format: "01PAGE%05d", i + 1)
+            await source.upsert(makeSnapshot(ulid: ulid, kind: .page, title: "Page \(i)"))
+            await service.indexer.upsert(ulid: ulid, kind: .page)
+        }
+
+        let hits = await service.autocomplete(partial: "Page", kinds: [.page], limit: 4)
+        #expect(hits.count <= 4, "limit must clamp the result count")
+    }
+}

--- a/Tests/WikiFSTests/WikiLinkPrefixScannerTests.swift
+++ b/Tests/WikiFSTests/WikiLinkPrefixScannerTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+@testable import WikiFSLinks
+
+/// Pure-function unit tests for `WikiLinkPrefixScanner` — the chat composer's
+/// `[[kind:partial` trigger detector (issues #436 / #638, plan §6a).
+///
+/// All tests are pure (no AppKit, no DB) — fast tier only. The scanner lives
+/// in `WikiFSLinks` (Foundation-only) so it's testable directly without the
+/// app target.
+struct WikiLinkPrefixScannerTests {
+
+    // MARK: - Basic detection (AC #1)
+
+    @Test func detectsOpenPagePrefixAtEndOfText() {
+        let text = "Hello [[page:Erl"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger != nil)
+        #expect(trigger?.kind == .page)
+        #expect(trigger?.partial == "Erl")
+        // The range covers the full `[[page:Erl` span.
+        let span = String(text[trigger!.range])
+        #expect(span == "[[page:Erl")
+    }
+
+    @Test func detectsOpenSourcePrefix() {
+        let text = "[[source:Erlang Spec"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger?.kind == .source)
+        #expect(trigger?.partial == "Erlang Spec")
+    }
+
+    @Test func detectsOpenChatPrefix() {
+        let text = "[[chat:Standup notes"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger?.kind == .chat)
+        #expect(trigger?.partial == "Standup notes")
+    }
+
+    @Test func bareOpenBracketsDefaultToPage() {
+        // Per WikiLinkParser.classify (:52), bare `[[Foo` is a page link.
+        let text = "Some text [[Erickson"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger?.kind == .page)
+        #expect(trigger?.partial == "Erickson")
+    }
+
+    // MARK: - Rejection: closed/aliased links (AC #6 — don't fire once closed)
+
+    @Test func closedLinkAfterCaretReturnsNil() {
+        let text = "… [[page:Foo]] more text"
+        // Caret in "more text" — there's a closed link before it.
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    @Test func caretInsideClosedLinkReturnsNil() {
+        // The link is closed — autocomplete shouldn't fire mid-link.
+        let text = "[[page:Erl]]"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    @Test func pipeAliasReturnsNil() {
+        // `|` starts the alias; we don't autocomplete inside an aliased link.
+        let text = "[[page:Erl|Erlan"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    // MARK: - Rejection: empty / minimal triggers
+
+    @Test func emptyPartialAfterKindPrefixReturnsNil() {
+        // Don't fire on bare `[[page:` — the user hasn't typed anything yet.
+        let text = "[[page:"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    @Test func whitespaceOnlyPartialReturnsNil() {
+        let text = "[[page:   "
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    @Test func noOpenBracketsReturnsNil() {
+        let text = "Just some plain text"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    // MARK: - Reviewer correction #4: newline + paste guards
+
+    @Test func newlineInPartialReturnsNil() {
+        // Multi-line trigger — the user pressed Return inside the trigger.
+        // Autocomplete shouldn't fire across a newline (paste + multi-line guard).
+        let text = "[[page:Erl\nmore"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    @Test func carriageReturnInPartialReturnsNil() {
+        let text = "[[page:Erl\rmore"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    @Test func overlongPartialReturnsNil() {
+        // Paste guard: a `[[…` followed by a long string is a paste, not a
+        // title being typed. The scanner bails at `maxPartialSpan`.
+        let long = String(repeating: "a", count: WikiLinkPrefixScanner.maxPartialSpan + 1)
+        let text = "[[page:\(long)"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger == nil)
+    }
+
+    @Test func atMaxPartialSpanIsAccepted() {
+        // Boundary: the cap is inclusive (a `partial` of exactly
+        // `maxPartialSpan - "<kind>:"` chars is still fine).
+        let span = WikiLinkPrefixScanner.maxPartialSpan - 1
+        let partial = String(repeating: "a", count: span)
+        let text = "[[\(partial)"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger != nil)
+        #expect(trigger?.partial == partial)
+    }
+
+    // MARK: - Caret position mid-text
+
+    @Test func caretMidTokenReadsPartialPrefix() {
+        // `[[page:Erickson` with the caret after "Eri" should yield partial "Eri".
+        let text = "[[page:Erickson"
+        let caret = "[[page:Eri".count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger?.partial == "Eri")
+        // Range covers only `[[page:Eri` (up to the caret).
+        let span = String(text[trigger!.range])
+        #expect(span == "[[page:Eri")
+    }
+
+    @Test func caretAfterClosedLinkAndNewOpenLinkDetectsTheNewOne() {
+        // A closed link earlier in the text + a fresh open `[[page:X` at the
+        // caret: the scanner should find the most-recent `[[`, not the
+        // already-closed one.
+        let text = "see [[page:Closed]] and [[page:Erl"
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger?.kind == .page)
+        #expect(trigger?.partial == "Erl")
+    }
+
+    // MARK: - Trim behavior
+
+    @Test func surroundingWhitespaceInPartialIsTrimmed() {
+        let text = "[[page:  Erl  "
+        let caret = text.count
+        let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
+        #expect(trigger?.partial == "Erl")
+    }
+}


### PR DESCRIPTION
Closes #436.
Closes #638.

## What this does

Adds wiki-link autocomplete to the chat composer. When the user types `[[page:Erl`, a debounced Tantivy fuzzy query (distance 2, prefix-expanded) returns ranked suggestions in a dropdown anchored above the composer. Selecting a row inserts the canonical `[[page:ULID|Title]]` form. This is greenfield for #436 — no autocomplete existed before.

The fuzzy + kind-scoped query design is the meat of #638.

## Plan + reviewer corrections

Implementation follows [`tmp/sdw-plans/638-fuzzy-autocomplete.md`](https://github.com/tqbf/selfdrivingwiki/blob/main/tmp/sdw-plans/638-fuzzy-autocomplete.md) with the **four plan-reviewer corrections applied** — the plan as written would have failed the headline AC or wouldn't compile:

1. **CRITICAL — query-string path, not structured `TantivyQuery.fuzzy`.** The structured enum has no `prefix` parameter, and without `prefix: true` distance-2 fuzzy on `"Erl"` does not surface `"Erickson"` (whole-token edit distance 6). The new `TantivyIndexer.autocomplete` uses the query-string path (`TantivySwiftSearchQuery` + `TantivySwiftFuzzyField`), same as the shipped sidebar search, with `prefix: true` on title. Kind scoping is a Swift post-filter (engine-level kind facet dropped — was a nice-to-have).
2. **MEDIUM — Escape via local `NSEvent` monitor, not `doCommandBy:`.** Escape produces no text-command selector and isn't delivered through that router. Mirrors the omnibox (`OmniboxSearchField.swift:242-252`). `doCommandBy:` still owns Return (insert-link vs send).
3. **MEDIUM — debounce/cancel test.** `debouncedQueryCancelsStaleInFlightPartial` drives the coordinator with two partials in quick succession and asserts only the second fetch runs (AC #5).
4. **LOW — prefix scanner newline/paste guard.** Bails (returns nil) when the `[[`→caret span contains a newline or exceeds `maxPartialSpan` (80).

## Files

| File | Change |
|---|---|
| **New** `Sources/WikiFSLinks/WikiLinkPrefixScanner.swift` | Pure caret-based detector for open `[[kind:partial` triggers (Foundation-only, trivially unit-testable). |
| `Sources/WikiFSSearch/TantivyIndexer.swift` | New `autocomplete(partial:kinds:distance:limit:)` — query-string path with `prefix:true` title fuzzy + Swift kind post-filter. |
| `Sources/WikiFSSearch/TantivySearchService.swift` | New `autocomplete(partial:kinds:distance:limit:)` public surface. |
| **New** `Sources/WikiFS/Chats/ChatAutocompletePanel.swift` | `ChatAutocompletePanel` (NSPanel, non-activating, mirrors `SuggestionsPanel`) + `ChatAutocompleteResultsList` (SwiftUI rows) + pure `ChatAutocompleteSelection.advance`. |
| `Sources/WikiFS/Editor/ComposerTextView.swift` | Extended `keyAction` (autocomplete-aware), new `AutocompleteHooks`, Coordinator state for dropdown/selection/debounce + local NSEvent monitor + `commitSelection`. |
| `Sources/WikiFS/Chats/ChatView.swift` | Wires the hooks to `store.tantivySearch` + `DroppedLinkFormatter`. |
| **New** `Tests/WikiFSTests/WikiLinkPrefixScannerTests.swift` | Pure scanner unit tests (§6a + correction #4). |
| **New** `Tests/WikiFSTests/ChatAutocompleteSelectionTests.swift` | Pure selection-advance + extended keyAction + clampedSwiftOffset tests. |
| **New** `Tests/WikiFSTests/ComposerAutocompleteHostedTests.swift` | Hosted-window integration (§6d + correction #3 — debounce-cancel). `.serialized` to keep timing deterministic. |
| **New** `Tests/WikiFSTests/TantivyAutocompleteTests.swift` | `.integration` suite — AC #1 headline `"Erl" → "Erickson"`, AC #2 typo tolerance, AC #3 kind scoping. |
| `.github/workflows/ci.yml` | Added `TantivyAutocompleteTests` to the fast-tier `--skip` regex (runs in `swift-integration`). |

## Acceptance criteria

- [x] **AC #1**: `[[page:Erl` surfaces "Erickson" via Tantivy prefix-fuzzy on title. ✅ covered by `shortPrefixSurfacesLongerTitleViaPrefixFuzzy`.
- [x] **AC #2**: `[[page:Erlckson` (distance-1 typo) still surfaces "Erickson". ✅ covered by `typoDistanceOneSurfacesTarget`.
- [x] **AC #3**: `[[page:` shows only pages, `[[source:` only sources, `[[chat:` only chats. ✅ covered by `kindScopingFiltersToOnlyRequestedKind` (post-filter in Swift — engine-level facet dropped in review).
- [x] **AC #4**: Selection inserts canonical `[[page:<ULID>|Title]]`. ✅ via `DroppedLinkFormatter.link` in `ChatView.chatAutocompleteHooks.format`.
- [x] **AC #5**: 150ms debounce; rapid typing cancels stale in-flight queries. ✅ covered by `debouncedQueryCancelsStaleInFlightPartial` + `onlyLatestPartialTriggersAFetchWhenTypingRapidly`.
- [x] **AC #6**: Plain Return still sends when the dropdown is closed. ✅ `keyAction` falls through to `.send` when `autocompleteOpen: false`; Shift/Option/Cmd+Return unaffected.
- [x] **AC #7**: §6a–6d green (fast tier skips the integration ones; `swift-integration` runs them).

## Build + test

```
make version prompts
swift build             # clean
swift test --skip 'EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|QuoteHighlightWebViewTests|SplitDiffSnapshotTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SidebarDropBuilderIntegrationTests|TantivyAutocompleteTests'
# => 2736 tests pass
swift test --filter TantivyAutocompleteTests   # integration suite (AC #1–#3)
# => 7 tests pass
```

## Deviations from the plan

- **Engine-level kind facet dropped** (correction #1). The plan's approach B used a `TantivyQuery.boolean` with a `.term(.facet)` on `kind` for engine-level filtering; the reviewer-required switch to the query-string path drops that optimization (no facet clause on the query-string path). Kind scoping is now a Swift post-filter — same shape as the existing `TantivyIndexer.search()`. AC #3 still holds.
- **Hosted-test suite marked `.serialized`** to keep the Task-scheduler timing deterministic under the parallel-test load. Not a behavior change.

Do not merge — leaving for review.
