### PR TITLE
Generate synthetic markdown for byteless sources (#646)

### DIFF
--- a/Sources/WikiFSCore/Integrations/MediaMarkdownSynthesizer.swift
+++ b/Sources/WikiFSCore/Integrations/MediaMarkdownSynthesizer.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Pure synthesizer that renders a readable synthetic-markdown page for a
+/// **byteless** source (YouTube / Vimeo / Spotify / SoundCloud / remote-media)
+/// from the pasted URL, optional oEmbed metadata, and an optional transcript.
+///
+/// The output is stored as the source's processed-markdown head via
+/// `appendProcessedMarkdown(origin: .transcript)`, so the reader, the File
+/// Provider's `.md` sibling, and Tantivy all see it through the existing
+/// storage path (Projection.swift emits the sibling automatically because the
+/// synthetic mimes — `video/youtube`, `audio/spotify`, … — are non-`text/*`).
+///
+/// Why a pure function: the synthesizer has no I/O, no actor hops, no error
+/// paths — the same fixture-driven discipline as `MediaEmbedURL` and
+/// `MediaTitleFetcher.parseMetadata`. Issue #646.
+public enum MediaMarkdownSynthesizer {
+
+    /// Render the synthetic markdown.
+    ///
+    /// - Parameters:
+    ///   - url: The pasted source URL (always present). Rendered as a clickable
+    ///     link near the top, and used as the heading fallback when no title is
+    ///     available.
+    ///   - metadata: The oEmbed metadata blob, when the provider's oEmbed
+    ///     endpoint was reachable. `nil` for `remote-media` (no oEmbed) or a
+    ///     best-effort fetch failure.
+    ///   - fallbackTitle: A fallback heading when `metadata.title` is nil —
+    ///     typically the source's display name or filename. The caller already
+    ///     has this; passing it in keeps the synthesizer pure.
+    ///   - transcript: Optional transcript markdown body (e.g. YouTube captions
+    ///     already rendered as markdown, or podcast TTML → markdown). When
+    ///     present, appended under a `## Transcript` heading.
+    /// - Returns: The synthesized markdown string. Always non-empty.
+    public static func synthesize(
+        url: String,
+        metadata: MediaTitleFetcher.MediaOEmbedMetadata?,
+        fallbackTitle: String,
+        transcript: String? = nil
+    ) -> String {
+        let title = metadata?.title ?? fallbackTitle
+        var lines: [String] = []
+        lines.append("# \(title)")
+        lines.append("")
+        lines.append("[\(url)](\(url))")
+        lines.append("")
+
+        // Metadata block — bold "key: value" pairs, only for fields we have.
+        // Track whether we wrote anything so the trailing blank line is
+        // conditional (avoids a double-blank gap when the block is empty).
+        var wroteMetadata = false
+        if let provider = metadata?.providerName, !provider.isEmpty {
+            lines.append("**Provider:** \(provider)")
+            wroteMetadata = true
+        }
+        if let author = metadata?.authorName, !author.isEmpty {
+            if let authorURL = metadata?.authorURL, !authorURL.isEmpty {
+                lines.append("**Author:** [\(author)](\(authorURL))")
+            } else {
+                lines.append("**Author:** \(author)")
+            }
+            wroteMetadata = true
+        }
+        if let seconds = metadata?.durationSeconds, seconds > 0 {
+            lines.append("**Duration:** \(formatDuration(seconds))")
+            wroteMetadata = true
+        }
+        if wroteMetadata {
+            lines.append("")
+        }
+
+        if let description = metadata?.descriptionText, !description.isEmpty {
+            lines.append(description)
+            lines.append("")
+        }
+
+        if let transcript, !transcript.isEmpty {
+            lines.append("---")
+            lines.append("")
+            lines.append("## Transcript")
+            lines.append("")
+            lines.append(transcript)
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Format a duration in seconds as `H:MM:SS` (or `M:SS` when under an hour).
+    /// Pure.
+    static func formatDuration(_ totalSeconds: Int) -> String {
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}

--- a/Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift
+++ b/Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift
@@ -6,15 +6,49 @@ import Foundation
 /// — so a pasted `youtube.com/watch?v=…` URL shows the real video title as the
 /// source's display name instead of a synthetic `youtube-<id>`.
 ///
-/// **Never blocks ingest.** `title(for:fetcher:)` swallows every failure
+/// **Never blocks ingest.** Every entry point swallows each failure
 /// (network, non-2xx, malformed JSON) and returns `nil`, so a missing/unreached
 /// oEmbed just leaves the synthetic name in place (mirrors the
 /// `YouTubeTranscriptService` best-effort discipline). The GET runs via the
 /// injected `URLFetchService.URLResourceFetcher` seam — CI uses a fake, the app
 /// uses `URLSessionFetcher` — so the call site can keep it off the main actor.
 ///
-/// Issue #572 (YouTube/Vimeo URL ingest UX).
+/// Issue #572 (YouTube/Vimeo URL ingest UX). Issue #646 extends the decoder to
+/// surface the full oEmbed metadata (author, provider, thumbnail, description,
+/// duration) so `MediaMarkdownSynthesizer` can render a readable synthetic
+/// markdown page for byteless sources.
 public enum MediaTitleFetcher {
+
+    /// Best-effort oEmbed metadata for a byteless media match. Every field is
+    /// optional — providers vary in what they return. Issue #646.
+    public struct MediaOEmbedMetadata: Sendable, Equatable {
+        public let title: String?
+        public let authorName: String?
+        public let authorURL: String?
+        public let providerName: String?
+        public let thumbnailURL: String?
+        public let descriptionText: String?
+        /// Duration in seconds, when the provider includes it (Vimeo does).
+        public let durationSeconds: Int?
+
+        public init(
+            title: String?,
+            authorName: String?,
+            authorURL: String?,
+            providerName: String?,
+            thumbnailURL: String?,
+            descriptionText: String?,
+            durationSeconds: Int?
+        ) {
+            self.title = title
+            self.authorName = authorName
+            self.authorURL = authorURL
+            self.providerName = providerName
+            self.thumbnailURL = thumbnailURL
+            self.descriptionText = descriptionText
+            self.durationSeconds = durationSeconds
+        }
+    }
 
     /// The oEmbed-provided title for `match.planURL`, or `nil` on any failure
     /// (non-2xx, network error, decode failure, unsupported provider). Pure
@@ -23,6 +57,18 @@ public enum MediaTitleFetcher {
         for match: MediaEmbedMatch,
         fetcher: any URLFetchService.URLResourceFetcher
     ) async -> String? {
+        // Thin wrapper over `metadata(for:fetcher:)` so the title-only callers
+        // (existing tests, the display-name step) keep their simple contract.
+        await metadata(for: match, fetcher: fetcher).flatMap { trim($0.title) }
+    }
+
+    /// The full oEmbed metadata blob for `match.planURL`, or `nil` on any
+    /// failure (non-2xx, network error, decode failure, unsupported provider).
+    /// Pure dispatch + the fetch + JSON decode; never throws. Issue #646.
+    public static func metadata(
+        for match: MediaEmbedMatch,
+        fetcher: any URLFetchService.URLResourceFetcher
+    ) async -> MediaOEmbedMetadata? {
         guard let oembedURL = oembedURL(for: match) else { return nil }
         let data: Data
         do {
@@ -33,7 +79,7 @@ public enum MediaTitleFetcher {
             DebugLog.ingest("MediaTitleFetcher: oEmbed fetch failed (\(match.agentName)): \(error.localizedDescription)")
             return nil
         }
-        return parseTitle(from: data)
+        return parseMetadata(from: data)
     }
 
     /// Build the oEmbed endpoint URL for the provider's pasted URL, or `nil`
@@ -66,9 +112,44 @@ public enum MediaTitleFetcher {
     /// returns a top-level `{"title": "…", "author_name": "…"}`. Pure; returns
     /// `nil` for empty/absent/undecodable titles.
     public static func parseTitle(from data: Data) -> String? {
-        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let title = obj["title"] as? String else { return nil }
-        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        trim((try? JSONSerialization.jsonObject(with: data) as? [String: Any])?["title"] as? String)
+    }
+
+    /// Parse the full oEmbed metadata blob from a JSON response. Tolerant of
+    /// missing fields — every property is optional. Pure; returns `nil` only
+    /// when the bytes aren't a JSON object at all. Issue #646.
+    public static func parseMetadata(from data: Data) -> MediaOEmbedMetadata? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return MediaOEmbedMetadata(
+            title: trim(obj["title"] as? String),
+            authorName: trim(obj["author_name"] as? String),
+            authorURL: trim(obj["author_url"] as? String),
+            providerName: trim(obj["provider_name"] as? String),
+            thumbnailURL: trim(obj["thumbnail_url"] as? String),
+            descriptionText: trim(obj["description"] as? String),
+            // Vimeo returns `duration` as a number (seconds). Other providers
+            // omit it. `Int(any)` accepts Int/NSNumber/Double-as-Int safely.
+            durationSeconds: duration(from: obj["duration"]))
+    }
+
+    /// Coerce oEmbed `duration` (Vimeo returns Int; some providers send a
+    /// numeric string) into seconds. Returns `nil` when absent / unparsable.
+    private static func duration(from value: Any?) -> Int? {
+        switch value {
+        case let n as Int: return n
+        case let n as NSNumber: return n.intValue
+        case let s as String: return Int(s.trimmingCharacters(in: .whitespacesAndNewlines))
+        default: return nil
+        }
+    }
+
+    /// Trim + reject-whitespace-only strings so a `"   "` title is treated as
+    /// missing. Pure.
+    private static func trim(_ s: String?) -> String? {
+        guard let s else { return nil }
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -322,6 +322,12 @@ public final class WikiStoreModel {
     @ObservationIgnored private var isApplyingTabSelection = false
     private static let navigationHistoryLimit = 100
     private static let maxRecentlyClosedTabs = 10
+    /// Technique label for synthetic byteless-source markdown written from oEmbed
+    /// metadata + URL (no transcript). Issue #646.
+    private static let bytelessMetadataTechnique = "byteless-oembed-synthetic"
+    /// Technique label for synthetic byteless-source markdown written from oEmbed
+    /// metadata + URL + a transcript (e.g. YouTube captions). Issue #646.
+    private static let bytelessTranscriptTechnique = "byteless-oembed-transcript"
 
     public init(store: WikiStore) {
         self.store = store
@@ -2078,22 +2084,34 @@ public final class WikiStoreModel {
                 externalRef: match.planURL,
                 externalIdentity: match.externalIdentity),
             role: .primary)
-        // Best-effort provider display title via oEmbed (YouTube/Vimeo/Spotify/
-        // SoundCloud). Runs off-main, never blocks the embed; a nil title leaves
-        // the synthetic `youtube-<id>` name in place. Issue #572.
-        let resolvedTitle = await fetchMediaTitle(for: match, urlFetcher: urlFetcher)
-        if let title = resolvedTitle {
+        // Best-effort provider oEmbed metadata (YouTube/Vimeo/Spotify/
+        // SoundCloud). Runs off-main, never blocks the embed; a nil blob
+        // leaves the synthetic `youtube-<id>` name + a minimal markdown page
+        // in place. Issue #572 (display title); #646 extends to full metadata.
+        let metadata = await fetchMediaMetadata(for: match, urlFetcher: urlFetcher)
+        if let title = metadata?.title {
             do {
                 try store.setSourceDisplayName(id: summary.id, displayName: title)
             } catch {
                 DebugLog.store("byteless oEmbed title setSourceDisplayName failed (source=\(summary.id.rawValue)): \(error)")
             }
         }
+        // Issue #646: synthesize a readable markdown page from the URL + oEmbed
+        // metadata so the reader, File Provider `.md` sibling, and Tantivy all
+        // see real content for this byteless source. Best-effort: a write
+        // failure is logged, not thrown (the embed itself already landed).
+        writeSyntheticBytelessMarkdown(
+            sourceID: summary.id,
+            url: match.planURL,
+            metadata: metadata,
+            fallbackTitle: summary.effectiveName,
+            transcript: nil,
+            technique: Self.bytelessMetadataTechnique)
         // No manual reload — the bus fires reloadFromStore() async after each
-        // store write (addBytelessSource + setSourceDisplayName). The tab title
-        // is passed explicitly (the resolved title when available) so it needs
-        // no synchronous freshness.
-        openTab(.source(summary.id), title: resolvedTitle ?? summary.effectiveName)
+        // store write (addBytelessSource + setSourceDisplayName +
+        // appendProcessedMarkdown). The tab title is passed explicitly (the
+        // resolved title when available) so it needs no synchronous freshness.
+        openTab(.source(summary.id), title: metadata?.title ?? summary.effectiveName)
         return URLFetchService.FetchOutcome(
             filename: match.filename, byteSize: 0, kind: kind)
     }
@@ -2107,9 +2125,11 @@ public final class WikiStoreModel {
     ///
     /// Best-effort: a transcript failure (no captions, network, restricted video)
     /// is logged via `DebugLog` but NEVER blocks the embed — the embed source is
-    /// created first, then the transcript fetch runs off-main. Returns `nil` for
-    /// non-YouTube URLs so the caller falls through to `bytelessMediaOutcome`.
-    /// Issue #564 / #572.
+    /// created first, then the transcript fetch runs off-main. When the transcript
+    /// is unavailable, a metadata-only synthetic markdown page is written so the
+    /// source still has readable content in the reader + File Provider + Tantivy
+    /// (issue #646). Returns `nil` for non-YouTube URLs so the caller falls
+    /// through to `bytelessMediaOutcome`. Issue #564 / #572 / #646.
     private func youtubeEmbedAndTranscriptOutcome(
         _ rawInput: String,
         urlFetcher: any URLFetchService.URLResourceFetcher,
@@ -2132,22 +2152,29 @@ public final class WikiStoreModel {
                 externalIdentity: match.externalIdentity),
             role: .primary)
 
-        // Best-effort oEmbed title for the display name (#572). Runs off-main and
-        // never blocks: a nil leaves the synthetic `youtube-<id>` name in place.
-        // Fetched ONCE here and threaded to every return path so the title store
-        // write + tab title stay consistent regardless of the transcript outcome.
-        let resolvedTitle = await fetchMediaTitle(for: match, urlFetcher: urlFetcher)
-        if let title = resolvedTitle {
+        // Best-effort oEmbed metadata for the display name + the synthetic
+        // markdown page (#572 + #646). Runs off-main and never blocks: a nil
+        // blob leaves the synthetic `youtube-<id>` name in place. Fetched ONCE
+        // here and threaded to every return path so the title store write +
+        // tab title stay consistent regardless of the transcript outcome.
+        let metadata = await fetchMediaMetadata(for: match, urlFetcher: urlFetcher)
+        if let title = metadata?.title {
             do {
                 try store.setSourceDisplayName(id: summary.id, displayName: title)
             } catch {
                 DebugLog.store("YouTube oEmbed title setSourceDisplayName failed (source=\(summary.id.rawValue)): \(error)")
             }
         }
-        let tabTitle = resolvedTitle ?? summary.effectiveName
+        let tabTitle = metadata?.title ?? summary.effectiveName
 
         // No transcript fetcher → embed-only (e.g. app-store build, or a test).
+        // The source still gets a synthetic metadata markdown page so the
+        // reader has something to show (#646).
         guard let fetcher = youtubeFetcher else {
+            writeSyntheticBytelessMarkdown(
+                sourceID: summary.id, url: match.planURL, metadata: metadata,
+                fallbackTitle: tabTitle, transcript: nil,
+                technique: Self.bytelessMetadataTechnique)
             openTab(.source(summary.id), title: tabTitle)
             return URLFetchService.FetchOutcome(
                 filename: match.filename, byteSize: 0, kind: .videoEmbed)
@@ -2177,9 +2204,13 @@ public final class WikiStoreModel {
                     origin: .transcript, note: nil, technique: "youtube-captions")
             } catch {
                 // #475: don't silently swallow — the transcript would be lost
-                // with no trace. The embed source is already saved, so this is a
-                // partial-failure log, not a throw.
+                // with no trace. Fall back to the metadata-only synthetic page
+                // so the reader still has SOMETHING to show (#646).
                 DebugLog.store("YouTube transcript store failed (source=\(summary.id.rawValue)): \(error)")
+                writeSyntheticBytelessMarkdown(
+                    sourceID: summary.id, url: match.planURL, metadata: metadata,
+                    fallbackTitle: tabTitle, transcript: nil,
+                    technique: Self.bytelessMetadataTechnique)
                 openTab(.source(summary.id), title: tabTitle)
                 return URLFetchService.FetchOutcome(
                     filename: match.filename, byteSize: 0, kind: .videoEmbed)
@@ -2190,25 +2221,61 @@ public final class WikiStoreModel {
                 byteSize: transcript.markdown.utf8.count,
                 kind: .videoTranscript)
         }
-        // No transcript available — embed only (current behavior).
+        // No transcript available — fall back to a metadata-only synthetic
+        // markdown page so the reader + File Provider `.md` sibling + Tantivy
+        // still see real content for this embed (issue #646). Pre-#646 behavior
+        // left the source with no readable content at all.
+        writeSyntheticBytelessMarkdown(
+            sourceID: summary.id, url: match.planURL, metadata: metadata,
+            fallbackTitle: tabTitle, transcript: nil,
+            technique: Self.bytelessMetadataTechnique)
         openTab(.source(summary.id), title: tabTitle)
         return URLFetchService.FetchOutcome(
             filename: match.filename, byteSize: 0, kind: .videoEmbed)
     }
 
-    /// Off-main oEmbed title fetch for a byteless media match. The GET itself
-    /// runs in a detached `Task` so it can't stall the `@MainActor` model; a
-    /// `nil` leaves the synthetic name in place. Shared by the YouTube and the
-    /// generic provider paths so the title fetch is one code path. Issue #572.
-    private func fetchMediaTitle(
+    /// Off-main oEmbed metadata fetch for a byteless media match. The GET
+    /// itself runs in a detached `Task` so it can't stall the `@MainActor`
+    /// model; a `nil` leaves the synthetic name + minimal synthetic markdown
+    /// in place. Shared by the YouTube and the generic provider paths so the
+    /// oEmbed fetch is one code path. Issue #572; extended by #646 to surface
+    /// the full metadata blob (author / provider / description / duration).
+    private func fetchMediaMetadata(
         for match: MediaEmbedMatch,
         urlFetcher: any URLFetchService.URLResourceFetcher
-    ) async -> String? {
+    ) async -> MediaTitleFetcher.MediaOEmbedMetadata? {
         let matchCopy = match
         let fetcherCopy = urlFetcher
         return await Task.detached(priority: .userInitiated) {
-            await MediaTitleFetcher.title(for: matchCopy, fetcher: fetcherCopy)
+            await MediaTitleFetcher.metadata(for: matchCopy, fetcher: fetcherCopy)
         }.value
+    }
+
+    /// Best-effort synthetic markdown write for a byteless source. Renders via
+    /// `MediaMarkdownSynthesizer` and stores through `appendProcessedMarkdown`
+    /// so the reader + File Provider `.md` sibling + Tantivy all see it. Never
+    /// throws — the embed has already landed; a markdown failure is a partial-
+    /// failure log, not a throw (#475 discipline). Issue #646.
+    private func writeSyntheticBytelessMarkdown(
+        sourceID: PageID,
+        url: String,
+        metadata: MediaTitleFetcher.MediaOEmbedMetadata?,
+        fallbackTitle: String,
+        transcript: String?,
+        technique: String
+    ) {
+        let markdown = MediaMarkdownSynthesizer.synthesize(
+            url: url, metadata: metadata,
+            fallbackTitle: fallbackTitle, transcript: transcript)
+        do {
+            try store.appendProcessedMarkdown(
+                sourceID: sourceID, content: markdown,
+                origin: .transcript, note: nil, technique: technique)
+        } catch {
+            // #475: never silently swallow — log to Console.app so a partial
+            // failure is traceable. The source itself was already saved.
+            DebugLog.store("synthetic byteless markdown write failed (source=\(sourceID.rawValue), technique=\(technique)): \(error)")
+        }
     }
 
     /// The web-fetch ingest path (HTML→md / PDF / text / binary), shared by both

--- a/Tests/WikiFSTests/BytelessEmbedIntegrationTests.swift
+++ b/Tests/WikiFSTests/BytelessEmbedIntegrationTests.swift
@@ -187,6 +187,122 @@ struct BytelessEmbedIntegrationTests {
         #expect(outcome.kind == .htmlConverted)
     }
 
+    // MARK: - #646: synthetic markdown for byteless sources
+
+    /// Serves a rich Vimeo-shaped oEmbed payload so the synthesizer can render
+    /// a readable page from real metadata (title + author + provider + duration
+    /// + description).
+    struct VimeoMetadataFetcher: URLFetchService.URLResourceFetcher {
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse {
+            // Only oEmbed URLs are expected; explode for anything else.
+            let absolute = url.absoluteString
+            guard absolute.contains("/oembed") || absolute.contains("api/oembed") else {
+                throw URLFetchService.FetchError.network("not an oEmbed URL")
+            }
+            let body = """
+            {"title":"Orientation","author_name":"Vimeo Staff",
+             "author_url":"https://vimeo.com/staff","provider_name":"Vimeo",
+             "thumbnail_url":"https://i.vimeocdn.com/x.jpg",
+             "description":"A short orientation","duration":42}
+            """
+            return URLFetchService.FetchResponse(
+                data: Data(body.utf8), contentType: "application/json", finalURL: url)
+        }
+    }
+
+    /// Serves an empty 200 OK for oEmbed — simulates a reachable-but-empty
+    /// provider response. The fetcher's `data.isEmpty` guard rejects this; the
+    /// title-fetcher returns nil metadata, and the synthesizer falls back to
+    /// a URL + filename-only page.
+    struct EmptyOEmbedFetcher: URLFetchService.URLResourceFetcher {
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse {
+            URLFetchService.FetchResponse(
+                data: Data(), contentType: "application/json", finalURL: url)
+        }
+    }
+
+    @Test func vimeoURLWritesSyntheticMarkdownFromFullMetadata() async throws {
+        let store = try tempStore()
+        store.eventBus = WikiEventBus(wikiID: "test")
+        let model = WikiStoreModel(store: store)
+        let outcome = try await model.addURL(
+            "https://vimeo.com/76979871", fetcher: VimeoMetadataFetcher())
+        #expect(outcome.kind == .videoEmbed)
+        let source = try #require(try store.listSources().first)
+        // The display name is the oEmbed title (not the synthetic `vimeo-<id>`).
+        #expect(source.effectiveName == "Orientation")
+        let md = try #require(try store.processedMarkdownHead(sourceID: source.id))
+        #expect(md.origin == .transcript)
+        #expect(md.technique == "byteless-oembed-synthetic")
+        #expect(md.content.hasPrefix("# Orientation\n"))
+        #expect(md.content.contains("[https://vimeo.com/76979871](https://vimeo.com/76979871)"))
+        #expect(md.content.contains("**Provider:** Vimeo"))
+        #expect(md.content.contains("**Author:** [Vimeo Staff](https://vimeo.com/staff)"))
+        #expect(md.content.contains("**Duration:** 0:42"))
+        #expect(md.content.contains("A short orientation"))
+        #expect(!md.content.contains("## Transcript"))
+    }
+
+    @Test func spotifyURLWritesSyntheticMarkdownEvenWithPartialMetadata() async throws {
+        let store = try tempStore()
+        store.eventBus = WikiEventBus(wikiID: "test")
+        let model = WikiStoreModel(store: store)
+        // ExplodingFetcher serves title + author only (Spotify-shape: no
+        // description / duration).
+        let outcome = try await model.addURL(
+            "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC",
+            fetcher: ExplodingFetcher())
+        #expect(outcome.kind == .audioEmbed)
+        let source = try #require(try store.listSources().first)
+        let md = try #require(try store.processedMarkdownHead(sourceID: source.id))
+        #expect(md.technique == "byteless-oembed-synthetic")
+        // Title from oEmbed (ExplodingFetcher serves "Exploding Fixture Title")
+        #expect(md.content.hasPrefix("# Exploding Fixture Title\n"))
+        #expect(md.content.contains("[https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC]"))
+        #expect(md.content.contains("**Author:** x"))
+        // No description / duration block for Spotify-shape metadata.
+        #expect(!md.content.contains("**Duration:**"))
+        #expect(!md.content.contains("## Transcript"))
+    }
+
+    @Test func remoteMediaWritesMinimalSyntheticMarkdownWhenNoOEmbed() async throws {
+        let store = try tempStore()
+        store.eventBus = WikiEventBus(wikiID: "test")
+        let model = WikiStoreModel(store: store)
+        // remote-media has no oEmbed endpoint → MediaTitleFetcher.oembedURL
+        // returns nil → fetchMediaMetadata returns nil → synthesizer renders
+        // a title-from-filename + URL-only page.
+        let outcome = try await model.addURL(
+            "https://radio.example.com/live.mp3", fetcher: ExplodingFetcher())
+        #expect(outcome.kind == .remoteMedia)
+        let source = try #require(try store.listSources().first)
+        let md = try #require(try store.processedMarkdownHead(sourceID: source.id))
+        #expect(md.technique == "byteless-oembed-synthetic")
+        // Title falls back to the effective name (filename "live.mp3").
+        #expect(md.content.hasPrefix("# live.mp3\n"))
+        #expect(md.content.contains("[https://radio.example.com/live.mp3]"))
+        // No metadata block (no oEmbed).
+        #expect(!md.content.contains("**Provider:**"))
+        #expect(!md.content.contains("**Author:**"))
+        #expect(!md.content.contains("**Duration:**"))
+    }
+
+    @Test func bytelessSyntheticMarkdownIsEmptyOEmbedFallback() async throws {
+        let store = try tempStore()
+        store.eventBus = WikiEventBus(wikiID: "test")
+        let model = WikiStoreModel(store: store)
+        // An empty oEmbed body ⇒ metadata = nil (best-effort) ⇒ minimal page.
+        let outcome = try await model.addURL(
+            "https://vimeo.com/1", fetcher: EmptyOEmbedFetcher())
+        #expect(outcome.kind == .videoEmbed)
+        let source = try #require(try store.listSources().first)
+        let md = try #require(try store.processedMarkdownHead(sourceID: source.id))
+        // No title in metadata → fallback to the synthetic filename.
+        #expect(md.content.hasPrefix("# vimeo-1\n"))
+        #expect(md.content.contains("[https://vimeo.com/1](https://vimeo.com/1)"))
+        #expect(!md.content.contains("**Provider:**"))
+    }
+
     // MARK: - #564: YouTube transcript extraction
 
     /// A fake YouTube fetcher that serves canned watch-page HTML + caption XML.
@@ -258,7 +374,7 @@ struct BytelessEmbedIntegrationTests {
         #expect(md.technique == "youtube-captions")
     }
 
-    @Test func youtubeURLWithNoCaptionsFallsBackToEmbedOnly() async throws {
+    @Test func youtubeURLWithNoCaptionsFallsBackToSyntheticMarkdown() async throws {
         let store = try tempStore()
         store.eventBus = WikiEventBus(wikiID: "test")
         let model = WikiStoreModel(store: store)
@@ -274,14 +390,22 @@ struct BytelessEmbedIntegrationTests {
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             fetcher: emptyFetcher)
         #endif
-        // No captions → embed only (current behavior), transcript failure swallowed.
+        // No captions → embed outcome (kind unchanged), transcript failure swallowed,
+        // BUT #646: a synthetic metadata-only markdown page is written so the reader
+        // still has something to show (the no-oEmbed path — this fixture doesn't
+        // serve the oEmbed endpoint, so the synthesizer renders URL + filename only).
         #expect(outcome.kind == .videoEmbed)
         let sources = try store.listSources()
         #expect(sources.count == 1)
         let source = try #require(sources.first)
-        #expect(source.byteSize == 0)  // byteless embed, no transcript stored
-        // No processed markdown version was created.
-        #expect(try store.processedMarkdownHead(sourceID: source.id) == nil)
+        #expect(source.byteSize == 0)  // byteless embed
+        // The synthetic markdown head exists (was nil pre-#646) and carries the URL.
+        let md = try #require(try store.processedMarkdownHead(sourceID: source.id))
+        #expect(md.origin == .transcript)
+        #expect(md.technique == "byteless-oembed-synthetic")
+        #expect(md.content.contains("https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+        // No transcript cues present (captions weren't available).
+        #expect(!md.content.contains("Hello world"))
     }
 
     /// Serves a watch page that has no caption tracks → `.noCaptions`.

--- a/Tests/WikiFSTests/MediaEmbedPlayerTests.swift
+++ b/Tests/WikiFSTests/MediaEmbedPlayerTests.swift
@@ -105,6 +105,130 @@ struct MediaEmbedPlayerTests {
         #expect(MediaTitleFetcher.parseTitle(from: Data("not json".utf8)) == nil)
     }
 
+    // MARK: - MediaTitleFetcher.parseMetadata (#646)
+
+    @Test func parseMetadataDecodesFullBlob() throws {
+        // Vimeo-shaped: title + author + description + duration + thumbnail.
+        let json = """
+        {"title":"Orientation","author_name":"Vimeo Staff","author_url":"https://vimeo.com/staff",
+         "provider_name":"Vimeo","thumbnail_url":"https://i.vimeocdn.com/x.jpg",
+         "description":"A short orientation","duration":42}
+        """
+        let m = try #require(MediaTitleFetcher.parseMetadata(from: Data(json.utf8)))
+        #expect(m.title == "Orientation")
+        #expect(m.authorName == "Vimeo Staff")
+        #expect(m.authorURL == "https://vimeo.com/staff")
+        #expect(m.providerName == "Vimeo")
+        #expect(m.thumbnailURL == "https://i.vimeocdn.com/x.jpg")
+        #expect(m.descriptionText == "A short orientation")
+        #expect(m.durationSeconds == 42)
+    }
+
+    @Test func parseMetadataTolerantOfMissingFields() {
+        // YouTube-shape: title + author + provider + thumbnail, NO description/duration.
+        let json = #"{"title":"Wave","author_name":"Channel","provider_name":"YouTube"}"#
+        let m = MediaTitleFetcher.parseMetadata(from: Data(json.utf8))
+        #expect(m?.title == "Wave")
+        #expect(m?.authorName == "Channel")
+        #expect(m?.providerName == "YouTube")
+        #expect(m?.descriptionText == nil)
+        #expect(m?.durationSeconds == nil)
+    }
+
+    @Test func parseMetadataTrimsAndRejectsWhitespaceOnly() {
+        let json = #"{"title":"  Padded  ","description":"\n  \t"}"#
+        let m = MediaTitleFetcher.parseMetadata(from: Data(json.utf8))
+        #expect(m?.title == "Padded")
+        #expect(m?.descriptionText == nil)  // whitespace-only ⇒ nil
+    }
+
+    @Test func parseMetadataNilForNonJSON() {
+        #expect(MediaTitleFetcher.parseMetadata(from: Data("not json".utf8)) == nil)
+    }
+
+    @Test func parseMetadataDurationAcceptsNumericString() {
+        let json = #"{"title":"x","duration":"90"}"#
+        let m = MediaTitleFetcher.parseMetadata(from: Data(json.utf8))
+        #expect(m?.durationSeconds == 90)
+    }
+
+    // MARK: - MediaMarkdownSynthesizer (#646)
+
+    @Test func synthesizeIncludesAllMetadataFieldsWhenPresent() {
+        let m = MediaTitleFetcher.MediaOEmbedMetadata(
+            title: "Orientation", authorName: "Vimeo Staff",
+            authorURL: "https://vimeo.com/staff", providerName: "Vimeo",
+            thumbnailURL: "https://i.vimeocdn.com/x.jpg",
+            descriptionText: "A short orientation", durationSeconds: 3661)
+        let md = MediaMarkdownSynthesizer.synthesize(
+            url: "https://vimeo.com/1", metadata: m, fallbackTitle: "fallback")
+        #expect(md.hasPrefix("# Orientation\n"))
+        #expect(md.contains("[https://vimeo.com/1](https://vimeo.com/1)"))
+        #expect(md.contains("**Provider:** Vimeo"))
+        #expect(md.contains("**Author:** [Vimeo Staff](https://vimeo.com/staff)"))
+        #expect(md.contains("**Duration:** 1:01:01"))
+        #expect(md.contains("A short orientation"))
+        // No transcript section when none provided.
+        #expect(!md.contains("## Transcript"))
+    }
+
+    @Test func synthesizeFallsBackToTitleWhenMetadataNil() {
+        let md = MediaMarkdownSynthesizer.synthesize(
+            url: "https://example.com/a.mp3", metadata: nil,
+            fallbackTitle: "remote-example.com")
+        #expect(md.hasPrefix("# remote-example.com\n"))
+        #expect(md.contains("[https://example.com/a.mp3](https://example.com/a.mp3)"))
+        #expect(!md.contains("**Provider:**"))
+        #expect(!md.contains("**Author:**"))
+        #expect(!md.contains("**Duration:**"))
+        #expect(!md.contains("## Transcript"))
+    }
+
+    @Test func synthesizeUsesMetadataTitleOverFallback() {
+        let m = MediaTitleFetcher.MediaOEmbedMetadata(
+            title: "Real Title", authorName: nil, authorURL: nil,
+            providerName: nil, thumbnailURL: nil,
+            descriptionText: nil, durationSeconds: nil)
+        let md = MediaMarkdownSynthesizer.synthesize(
+            url: "https://x", metadata: m, fallbackTitle: "fallback-name")
+        #expect(md.hasPrefix("# Real Title\n"))
+    }
+
+    @Test func synthesizeAppendsTranscriptSectionWhenTranscriptProvided() {
+        let md = MediaMarkdownSynthesizer.synthesize(
+            url: "https://x", metadata: nil, fallbackTitle: "fallback",
+            transcript: "Hello world\nSecond cue")
+        #expect(md.contains("---"))
+        #expect(md.contains("## Transcript"))
+        #expect(md.contains("Hello world"))
+        #expect(md.contains("Second cue"))
+    }
+
+    @Test func synthesizeOmitsTranscriptSectionForEmptyTranscript() {
+        let md = MediaMarkdownSynthesizer.synthesize(
+            url: "https://x", metadata: nil, fallbackTitle: "fallback",
+            transcript: "")
+        #expect(!md.contains("## Transcript"))
+    }
+
+    @Test func synthesizeAuthorWithoutURLRendersPlain() {
+        let m = MediaTitleFetcher.MediaOEmbedMetadata(
+            title: "T", authorName: "Channel", authorURL: nil,
+            providerName: nil, thumbnailURL: nil,
+            descriptionText: nil, durationSeconds: nil)
+        let md = MediaMarkdownSynthesizer.synthesize(
+            url: "https://x", metadata: m, fallbackTitle: "fallback")
+        #expect(md.contains("**Author:** Channel"))
+        #expect(!md.contains("[Channel]"))
+    }
+
+    @Test func formatDurationHandlesMinutesAndHours() {
+        #expect(MediaMarkdownSynthesizer.formatDuration(0) == "0:00")
+        #expect(MediaMarkdownSynthesizer.formatDuration(59) == "0:59")
+        #expect(MediaMarkdownSynthesizer.formatDuration(90) == "1:30")
+        #expect(MediaMarkdownSynthesizer.formatDuration(3661) == "1:01:01")
+    }
+
     // MARK: - MediaEmbedPlayerHTML (iframe element + document)
 
     @Test func youTubeIframeEagerLoadsAndForwardsReferrer() throws {


### PR DESCRIPTION
Closes #646

## Problem

For byteless sources (YouTube, podcasts, Vimeo, Spotify, Soundcloud), there were no file bytes and no markdown content — the user saw a metadata chip but nothing to **read**. Storage already worked (`appendProcessedMarkdown` writes `source_markdown_versions`; the File Provider auto-projects a `.md` sibling for any source with markdown + non-`text/*` mime), the gap was that nothing was calling it for byteless sources:

- YouTube with captions: already wrote the transcript via `appendProcessedMarkdown(origin: .transcript)`.
- YouTube **without** captions: logged and returned with **NO markdown**.
- Generic byteless path (Vimeo / Spotify / SoundCloud / remote-media): created the source + fetched oEmbed title for the display name but **never called `appendProcessedMarkdown`**.

## Fix

Generate synthetic markdown from oEmbed metadata + URL (+ transcript when available) so byteless sources have readable content the moment they're added.

### Step 1 — Extend `MediaTitleFetcher` (`Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift`)

Added a `MediaOEmbedMetadata` struct (title, authorName, authorURL, providerName, thumbnailURL, descriptionText, durationSeconds) and `metadata(for:fetcher:)` returning it. `parseMetadata` tolerates missing fields (providers vary in what they return) and trims whitespace-only strings to nil. `title(for:fetcher:)` is preserved as a thin wrapper so existing callers + tests are unchanged.

Verified oEmbed field availability:
- YouTube: title, author_name, author_url, provider_name, thumbnail_url (no description/duration)
- Vimeo: title, author, description, duration, thumbnail (rich — full synthesizer output)
- Spotify: title, thumbnail only
- SoundCloud: title, author, description, thumbnail

### Step 2 — Pure synthesizer (`Sources/WikiFSCore/Integrations/MediaMarkdownSynthesizer.swift`)

A pure function that takes URL + optional metadata + optional transcript and returns markdown:

```markdown
# {title}

[{url}]({url})

**Provider:** {providerName}
**Author:** [{authorName}]({authorUrl})
**Duration:** {H:MM:SS}

{description}

---

## Transcript

{transcript text if available}
```

Each block is omitted when its data is absent — keeps the output clean for partial-metadata providers (Spotify has no description, YouTube has no duration, remote-media has no oEmbed at all). Pure (no I/O, no actor hops, no error paths) so it's fixture-testable like `MediaEmbedURL`.

### Step 3 — Wire into `bytelessMediaOutcome` (`WikiStoreModel.swift:2071`)

After `setSourceDisplayName`, fetch full oEmbed metadata (not just title), then `appendProcessedMarkdown(content: synthesized, origin: .transcript, technique: "byteless-oembed-synthetic")`. The File Provider's existing `sourceNodes` logic auto-projects the `.md` sibling because the synthetic mimes (`video/youtube`, `audio/spotify`, …) are non-`text/*`. Tantivy FTS refresh runs inside `appendProcessedMarkdown` so the synthetic page is immediately searchable.

### Step 4 — Fix YouTube no-captions fallback (`youtubeEmbedAndTranscriptOutcome`)

When `YouTubeTranscriptService` returns no captions (or the network fails, or the fetcher is nil), write a synthetic metadata-only markdown page instead of returning with **no** content. The with-captions path is unchanged (still writes `transcript.markdown` via the `youtube-captions` technique with its `# title` + `[Watch on YouTube]` header — no risk to existing transcript tests).

### Step 5 — Skipped (optional)

The issue body marked extending `YouTubeTranscriptService.PlayerResponse.VideoDetails` to decode `shortDescription` + `lengthSeconds` + `author` as **optional** — free data from the existing watch-page fetch. Skipped to keep the scope tight and avoid changing the `YouTubeTranscriptFetching` protocol + all test fixtures. The oEmbed `author_name` + `provider_name` already cover the metadata block for YouTube.

## House rules (CLAUDE.md)

- **Feature branch only** — `feature/synthetic-markdown-byteless`, never touched `main`.
- **No bare `try?`** — `writeSyntheticBytelessMarkdown` uses `do { try … } catch { DebugLog.store(…) }` (the #475 discipline; the embed itself already landed, so a markdown failure is a partial-failure log, not a throw).
- **No `print`** — all diagnostics go through `DebugLog.store` / `DebugLog.ingest` (os_log, subsystem `com.selfdrivingwiki.debug`).
- **Swift Testing over XCTest** — all new tests use Swift Testing (`@Test`, `#expect`, `#require`).

## Tests

`MediaEmbedPlayerTests` (+6 pure tests):
- `parseMetadataDecodesFullBlob` — Vimeo-shape: title/author/description/duration/thumbnail all decoded.
- `parseMetadataTolerantOfMissingFields` — YouTube-shape: missing description/duration stay nil.
- `parseMetadataTrimsAndRejectsWhitespaceOnly` — `"  Padded  "` → `"Padded"`; `"\n  \t"` → nil.
- `parseMetadataNilForNonJSON`, `parseMetadataDurationAcceptsNumericString`.

`MediaEmbedPlayerTests` (+7 synthesizer tests):
- `synthesizeIncludesAllMetadataFieldsWhenPresent` — title, URL link, Provider, Author with link, Duration as `1:01:01`, description.
- `synthesizeFallsBackToTitleWhenMetadataNil`, `synthesizeUsesMetadataTitleOverFallback`.
- `synthesizeAppendsTranscriptSectionWhenTranscriptProvided`, `synthesizeOmitsTranscriptSectionForEmptyTranscript`.
- `synthesizeAuthorWithoutURLRendersPlain`, `formatDurationHandlesMinutesAndHours`.

`BytelessEmbedIntegrationTests` (+4 integration tests):
- `vimeoURLWritesSyntheticMarkdownFromFullMetadata` — display name = oEmbed title, markdown has all fields, technique `byteless-oembed-synthetic`.
- `spotifyURLWritesSyntheticMarkdownEvenWithPartialMetadata` — title + Author only, no Duration block.
- `remoteMediaWritesMinimalSyntheticMarkdownWhenNoOEmbed` — no oEmbed call (renderer has none), minimal URL + filename page.
- `bytelessSyntheticMarkdownIsEmptyOEmbedFallback` — empty oEmbed body → metadata nil → URL + filename only.

Renamed `youtubeURLWithNoCaptionsFallsBackToEmbedOnly` → `youtubeURLWithNoCaptionsFallsBackToSyntheticMarkdown` and updated assertions (pre-#646 asserted `processedMarkdownHead == nil`; now asserts the synthetic page exists with origin `.transcript`, technique `byteless-oembed-synthetic`, and the URL — without transcript cues).

## Verification

```
make version prompts
swift build                                     # ✓ Build complete
swift test --filter 'MediaEmbedPlayerTests|BytelessEmbedIntegrationTests'   # ✓ 43/43 pass
swift test --skip '<fast-tier skip list>'        # ✓ 2742/2742 pass
```

(2742 tests in 233 suites — the full fast-tier from `.github/workflows/ci.yml` — green.)
