### PR TITLE
Fix model probe: fallback to configOptions when availableModels is empty (#654)

### DIFF
--- a/Sources/WikiFSEngine/ACPProviderModelProbe.swift
+++ b/Sources/WikiFSEngine/ACPProviderModelProbe.swift
@@ -244,7 +244,7 @@ public struct ACPProviderModelProbe: Sendable {
             throw ACPProviderModelProbeError.underlying(error)
         }
 
-        let models = Self.mapModelsToCache(session.models)
+        let models = Self.mapModelsToCache(session.models, configOptions: session.configOptions)
         DebugLog.agent("ACPProviderModelProbe.runProbe: discovered \(models.count) model(s) for provider=\(provider.id) ids=\(models.map(\.modelId))")
         return models
     }
@@ -252,13 +252,81 @@ public struct ACPProviderModelProbe: Sendable {
     // MARK: - PURE helpers (testable without a live Client actor)
 
     /// PURE. Map the SDK's `ModelsInfo?` (from `session/new`) to the app's
-    /// secrets-free `[CachedModelInfo]`. Returns `[]` when the agent advertised
-    /// nothing (older agents predate the models capability). Extracted so the
-    /// mapping is unit-tested without a subprocess.
-    public static func mapModelsToCache(_ models: ModelsInfo?) -> [CachedModelInfo] {
-        guard let models else { return [] }
-        return models.availableModels.map {
-            CachedModelInfo(modelId: $0.modelId, name: $0.name, description: $0.description)
+    /// secrets-free `[CachedModelInfo]`. Falls back to scanning
+    /// `configOptions` for a `model` select option when `availableModels` is
+    /// empty/nil — mirrors Paseo's `deriveModelDefinitionsFromACP` fallback
+    /// (`packages/server/src/server/agent/providers/acp-agent.ts:637-680`).
+    /// opencode (and possibly other agents) don't populate `availableModels`;
+    /// they advertise the model list as a `SessionConfigOption` select with
+    /// `category == "model"` (or `id.value == "model"`). Without this
+    /// fallback, the probe returns "The provider advertised no models" even
+    /// though the models ARE available (#654). Extracted so the mapping is
+    /// unit-tested without a subprocess.
+    ///
+    /// `configOptions` defaults to `nil` so the prior callers (which only
+    /// pass `session.models`) keep their existing behavior.
+    public static func mapModelsToCache(
+        _ models: ModelsInfo?,
+        configOptions: [SessionConfigOption]? = nil
+    ) -> [CachedModelInfo] {
+        // Primary path: the agent advertised `availableModels`. Paseo parity.
+        if let models, !models.availableModels.isEmpty {
+            return models.availableModels.map {
+                CachedModelInfo(modelId: $0.modelId, name: $0.name, description: $0.description)
+            }
+        }
+        // Fallback: derive from the configOptions model selector — the path
+        // opencode and other agents take when they don't populate
+        // `availableModels`.
+        guard let configOptions else { return [] }
+        return deriveModelsFromConfigOptions(configOptions)
+    }
+
+    /// PURE. Scan `configOptions` for a `model` select option (matched by
+    /// `id.value == "model"` OR `category == "model"` — the spec and the
+    /// daemon use different conventions, so accept both) and flatten its
+    /// choices to `[CachedModelInfo]`. Mirrors Paseo's
+    /// `deriveSelectorOptions(configOptions, "model")`. Returns `[]` when no
+    /// such option exists or it isn't a `.select`.
+    private static func deriveModelsFromConfigOptions(
+        _ configOptions: [SessionConfigOption]
+    ) -> [CachedModelInfo] {
+        guard let option = configOptions.first(where: { isModelSelector($0) }),
+              case .select(let select) = option.kind else {
+            return []
+        }
+        return flattenSelectOptions(select.options).map { choice in
+            // `choice.value` is `SessionConfigValueId` (a wrapped String) —
+            // `.value` is the model id sent to `session/set_model`. Matches
+            // the same unwrapping in `ThinkingEffortOption.flatChoices`.
+            CachedModelInfo(
+                modelId: choice.value.value,
+                name: choice.name,
+                description: choice.description)
+        }
+    }
+
+    /// Match heuristic: a model selector by id (opencode advertises
+    /// `id.value == "model"`) or by category (other agents use
+    /// `category == "model"`). Same dual-convention approach as
+    /// `ThinkingEffortOption.isThoughtLevel`.
+    private static func isModelSelector(_ option: SessionConfigOption) -> Bool {
+        option.id.value == "model" || option.category == "model"
+    }
+
+    /// PURE. Flatten the SDK's `ungrouped`/`grouped` select options into a
+    /// single `[SessionConfigSelectOption]` list. Grouped options preserve
+    /// the agent's ordering within each group but drop the group headings
+    /// (the model picker is a flat list). Mirrors
+    /// `ThinkingEffortOption.flatChoices`.
+    private static func flattenSelectOptions(
+        _ options: SessionConfigSelectOptions
+    ) -> [SessionConfigSelectOption] {
+        switch options {
+        case .ungrouped(let opts):
+            return opts
+        case .grouped(let groups):
+            return groups.flatMap { $0.options }
         }
     }
 

--- a/Tests/WikiFSTests/ACPProviderModelProbeTests.swift
+++ b/Tests/WikiFSTests/ACPProviderModelProbeTests.swift
@@ -66,6 +66,183 @@ struct ACPProviderModelProbeTests {
         #expect(cached.isEmpty)
     }
 
+    // MARK: - PURE: mapModelsToCache configOptions fallback (#654)
+
+    /// #654 exact repro: opencode doesn't populate `availableModels` — it
+    /// advertises the model list as a `configOptions` select whose
+    /// `id.value == "model"`. Pre-fix: probe returned [] ("advertised no
+    /// models"). Post-fix: probe extracts the choices from the select.
+    /// Mirrors Paseo's `deriveModelDefinitionsFromACP` fallback
+    /// (`acp-agent.ts:637-680`).
+    @Test func mapModelsToCacheFallsBackToConfigOptionsModelSelector() {
+        let configOptions = [
+            SessionConfigOption(
+                id: SessionConfigId("model"),
+                name: "Model",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("glm-4.7"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("glm-4.7"),
+                            name: "GLM-4.7",
+                            description: "Fast"),
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("glm-4-7"),
+                            name: "GLM 4.7 (legacy)"),
+                    ]))))
+        ]
+        let cached = ACPProviderModelProbe.mapModelsToCache(nil, configOptions: configOptions)
+        #expect(cached.count == 2)
+        #expect(cached.map(\.modelId) == ["glm-4.7", "glm-4-7"])
+        #expect(cached[0].name == "GLM-4.7")
+        #expect(cached[0].description == "Fast")
+        #expect(cached[1].description == nil)
+    }
+
+    /// #654 + grouped-options variant. Some agents group their model options
+    /// (e.g. "Fast" / "Smart"). The fallback must flatten the groups and
+    /// preserve the agent's in-group ordering (the picker is flat). Pinned so
+    /// a future refactor that drops `.grouped` handling is caught.
+    @Test func mapModelsToCacheFallsBackToConfigOptionsGrouped() {
+        let configOptions = [
+            SessionConfigOption(
+                id: SessionConfigId("model"),
+                name: "Model",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("sonnet"),
+                    options: .grouped([
+                        SessionConfigSelectGroup(
+                            group: SessionConfigGroupId("fast"),
+                            name: "Fast",
+                            options: [
+                                SessionConfigSelectOption(
+                                    value: SessionConfigValueId("haiku"),
+                                    name: "Claude Haiku"),
+                            ]),
+                        SessionConfigSelectGroup(
+                            group: SessionConfigGroupId("smart"),
+                            name: "Smart",
+                            options: [
+                                SessionConfigSelectOption(
+                                    value: SessionConfigValueId("sonnet"),
+                                    name: "Claude Sonnet"),
+                                SessionConfigSelectOption(
+                                    value: SessionConfigValueId("opus"),
+                                    name: "Claude Opus"),
+                            ]),
+                    ]))))
+        ]
+        let cached = ACPProviderModelProbe.mapModelsToCache(nil, configOptions: configOptions)
+        #expect(cached.count == 3)
+        #expect(cached.map(\.modelId) == ["haiku", "sonnet", "opus"])
+    }
+
+    /// #654 + `category == "model"` convention. The polytoken daemon
+    /// advertises the model selector by `category` rather than `id.value`.
+    /// The fallback accepts both (dual-convention parity with
+    /// `ThinkingEffortOption.isThoughtLevel`).
+    @Test func mapModelsToCacheFallsBackMatchesByCategory() {
+        let configOptions = [
+            SessionConfigOption(
+                id: SessionConfigId("model_picker"),
+                name: "Model Picker",
+                category: "model",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("gpt-5"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("gpt-5"),
+                            name: "GPT-5"),
+                    ]))))
+        ]
+        let cached = ACPProviderModelProbe.mapModelsToCache(nil, configOptions: configOptions)
+        #expect(cached.count == 1)
+        #expect(cached.first?.modelId == "gpt-5")
+    }
+
+    /// #654: the missing-model-list edge case. `availableModels` is EMPTY
+    /// (not nil) AND `configOptions` has a model selector. Pre-fix this was
+    /// treated as `.noModelsAdvertised`. Post-fix the fallback kicks in.
+    @Test func mapModelsToCacheFallsBackWhenAvailableModelsEmptyButConfigOptionsHasModels() {
+        let models = ModelsInfo(currentModelId: "", availableModels: [])
+        let configOptions = [
+            SessionConfigOption(
+                id: SessionConfigId("model"),
+                name: "Model",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("glm-4.7"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("glm-4.7"),
+                            name: "GLM-4.7"),
+                    ]))))
+        ]
+        let cached = ACPProviderModelProbe.mapModelsToCache(models, configOptions: configOptions)
+        #expect(cached.count == 1)
+        #expect(cached.first?.modelId == "glm-4.7")
+    }
+
+    /// Precedence: when BOTH `availableModels` and a `configOptions` model
+    /// selector are present, `availableModels` wins (Paseo parity). The
+    /// fallback is ONLY a fallback.
+    @Test func mapModelsToCachePrefersAvailableModelsOverConfigOptions() {
+        let models = ModelsInfo(
+            currentModelId: "sonnet",
+            availableModels: [
+                ModelInfo(modelId: "sonnet", name: "Claude Sonnet", description: nil),
+            ])
+        let configOptions = [
+            SessionConfigOption(
+                id: SessionConfigId("model"),
+                name: "Model",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("opus"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("opus"),
+                            name: "Claude Opus"),
+                    ]))))
+        ]
+        let cached = ACPProviderModelProbe.mapModelsToCache(models, configOptions: configOptions)
+        #expect(cached.count == 1)
+        #expect(cached.first?.modelId == "sonnet")
+    }
+
+    /// Fallback returns [] when `configOptions` is present but has NO model
+    /// selector — the agent advertised other options (e.g. `thought_level`)
+    /// but no model. The probe then surfaces `.noModelsAdvertised`.
+    @Test func mapModelsToCacheFallsBackEmptyWhenNoModelSelector() {
+        let configOptions = [
+            SessionConfigOption(
+                id: SessionConfigId("thought_level"),
+                name: "Thinking",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("high"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("high"),
+                            name: "High"),
+                    ]))))
+        ]
+        let cached = ACPProviderModelProbe.mapModelsToCache(nil, configOptions: configOptions)
+        #expect(cached.isEmpty)
+    }
+
+    /// Fallback returns [] when a `model` option exists but its `kind` is
+    /// `.boolean`, not `.select` — only `.select` carries a model list (a
+    /// `.boolean` doesn't make sense for a model picker). Defensive against
+    /// a malformed/edge-case agent.
+    @Test func mapModelsToCacheFallsBackEmptyWhenKindIsBoolean() {
+        let configOptions = [
+            SessionConfigOption(
+                id: SessionConfigId("model"),
+                name: "Model",
+                kind: .boolean(SessionConfigBoolean(currentValue: true)))
+        ]
+        let cached = ACPProviderModelProbe.mapModelsToCache(nil, configOptions: configOptions)
+        #expect(cached.isEmpty)
+    }
+
     // MARK: - PURE: shouldThrowNoModels
 
     @Test func shouldThrowNoModelsTrueForEmpty() {


### PR DESCRIPTION
## Fixes #654

### Problem

The ACP model discovery probe (`ACPProviderModelProbe`) only read
`session.models?.availableModels` to discover models. But opencode (and
possibly other agents) don't populate `availableModels` — they put the model
list in `session.configOptions` as a **model selector** (a
`SessionConfigOption` with `category == "model"` and `kind == .select`). The
probe returned "The provider advertised no models" even though the models
**were** available via `configOptions`, so users could not pick a model for
those providers and the `SpawnModelGuard` kept blocking chat starts (#640
deadlock resurfaced for opencode-style providers).

### Root cause

Paseo's reference implementation
(`~/work/paseo/packages/server/src/server/agent/providers/acp-agent.ts:637-680`)
has a **fallback**: when `availableModels` is empty, it derives the list from
`deriveSelectorOptions(configOptions, "model")`. SSW's
`mapModelsToCache` only did the first check and ignored
`session.configOptions` entirely.

### Fix

In `Sources/WikiFSEngine/ACPProviderModelProbe.swift`:

1. **`mapModelsToCache`** now takes an optional `configOptions` parameter.
   When `availableModels` is non-empty, it wins (Paseo precedence). When
   empty/nil, the helper falls through to scanning `configOptions` for a model
   selector. The parameter defaults to `nil`, so the prior call sites
   (and the existing tests) keep their behavior — the fallback is purely
   additive.

2. **`deriveModelsFromConfigOptions`** scans `configOptions` for a `.select`
   whose `id.value == "model"` OR `category == "model"` (dual-convention
   parity with `ThinkingEffortOption.isThoughtLevel`) and flattens its
   choices to `[CachedModelInfo]`. Each choice's `value.value` (a
   `SessionConfigValueId` wrapping the model id string) becomes
   `CachedModelInfo.modelId`.

3. **`flattenSelectOptions`** handles both SDK shapes: `.ungrouped` (flat
   list) and `.grouped` (groups flattened, agent ordering preserved, group
   headings dropped — the picker is a flat list). Mirrors
   `ThinkingEffortOption.flatChoices`.

4. **`runProbe` call site** now passes `session.configOptions` through to
   `mapModelsToCache`.

### Tests

8 new unit tests in `ACPProviderModelProbeTests.swift` (Swift Testing), all
under the existing `ACPProviderModelProbe` suite:

- `mapModelsToCacheFallsBackToConfigOptionsModelSelector` — the #654 exact
  repro (opencode shape: `id.value == "model"`, `.ungrouped`).
- `mapModelsToCacheFallsBackToConfigOptionsGrouped` — `.grouped` variant
  (preserves in-group ordering across groups).
- `mapModelsToCacheFallsBackMatchesByCategory` — `category == "model"`
  convention (polytoken daemon shape).
- `mapModelsToCacheFallsBackWhenAvailableModelsEmptyButConfigOptionsHasModels`
  — the bug edge case: empty (not nil) `availableModels` AND a configOptions
  model selector.
- `mapModelsToCachePrefersAvailableModelsOverConfigOptions` — precedence:
  `availableModels` wins when both are present.
- `mapModelsToCacheFallsBackEmptyWhenNoModelSelector` — configOptions with no
  model selector returns `[]` (probe then surfaces
  `.noModelsAdvertised`).
- `mapModelsToCacheFallsBackEmptyWhenKindIsBoolean` — a `model` option that's
  a `.boolean` (not `.select`) is ignored (defensive against malformed
  agents).

All 25 tests in the suite pass (17 pre-existing + 8 new).

### Verification

```
make version prompts
swift build                                  # Build complete! (117.54s)
swift test --filter ACPProviderModelProbe     # 25 tests passed in 2 suites
```

### Notes

- The fallback mirrors Paseo's `deriveModelDefinitionsFromACP`
  (`acp-agent.ts:637-680`) — same precedence (`availableModels` first) and
  same `model` selector match (by `id` or `category`).
- The `configOptions` parameter defaults to `nil`, preserving the existing
  call-site behavior. The fallback is purely additive.
- Unrelated to the `SpawnModelGuard` — that guard still rejects a nil
  `modelId` (its tests are unchanged). The probe breaks the deadlock by
  *discovering* the model list so the user can pick one, not by weakening
  the guard.

Closes #654.
