### PR TITLE
Fix source detail buttons not working for mermaid sources (#656)

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -600,13 +600,18 @@ struct SourceDetailView: View {
                         // (like openSource) so the filename is human-readable
                         // and the URL is guaranteed to resolve.
                         Button("Show in List", systemImage: "sidebar.left") {
+                            DebugLog.tabs("SourceDetailView: Show in List tapped — id=\(file.id.rawValue)")
                             store.requestSidebarReveal(.source(file.id))
                         }
                         .help("Reveal this source in the sidebar")
                         if fileProvider.path != nil {
                             Button("Share", systemImage: "square.and.arrow.up") {
+                                DebugLog.fileprovider("SourceDetailView: Share tapped — id=\(file.id.rawValue)")
                                 Task {
-                                    guard let url = await fileProvider.resolveSourceByNameURL(id: file.id) else { return }
+                                    guard let url = await fileProvider.resolveSourceByNameURL(id: file.id) else {
+                                        DebugLog.fileprovider("Share source detail: resolveSourceByNameURL returned nil — id=\(file.id.rawValue)")
+                                        return
+                                    }
                                     DebugLog.fileprovider("Share source detail: \(url.lastPathComponent)")
                                     let picker = NSSharingServicePicker(items: [url])
                                     let mouseScreen = NSEvent.mouseLocation
@@ -622,6 +627,7 @@ struct SourceDetailView: View {
                             }
                             .help("Share this source file")
                             Button("Reveal in Finder", systemImage: "folder") {
+                                DebugLog.fileprovider("SourceDetailView: Reveal in Finder tapped — id=\(file.id.rawValue)")
                                 Task { await fileProvider.revealSourceInFinder(id: file.id) }
                             }
                             .help("Reveal this source file in Finder")
@@ -792,10 +798,23 @@ struct SourceDetailView: View {
 
     /// The content area plus the optional outline sidebar. Extracted from
     /// `body` so the type-checker can resolve each subtree independently.
+    ///
+    /// The explicit `.frame(maxWidth: .infinity, maxHeight: .infinity,
+    /// alignment: .topLeading)` on `contentArea` is load-bearing and mirrors
+    /// `PageDetailView`'s `contentAndOutline` shape. Without it, the inner
+    /// `WikiReaderView` (an `NSViewRepresentable` wrapping a `WKWebView`)
+    /// reports no intrinsic content size and SwiftUI leaves the layout
+    /// indeterminate — for pure Mermaid sources, where PR #648's
+    /// `isOutlineApplicable` guard also removed the always-present
+    /// `PageOutlineView` sibling that previously helped pin the `HStack`'s
+    /// vertical extent, the indeterminate layout leaks into the header area.
+    /// The header's Show in List / Share / Reveal in Finder buttons render
+    /// above, but no longer receive their click. Issue #656.
     @ViewBuilder
     private var contentAndOutline: some View {
         HStack(spacing: 0) {
             contentArea
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             // `isOutlineApplicable` excludes pure Mermaid sources (`.mmd` /
             // `text/mermaid`) — the outline parses markdown headings, which a
             // diagram source has none of. Without this guard the pane leaks


### PR DESCRIPTION
## Closes #656

In the Mermaid source detail view, the "Show in List", "Share", and "Reveal in Finder" buttons
were visible but did not respond to clicks. This was a regression that surfaced after PR #648
(hide outline sidebar for standalone Mermaid sources).

## Root cause

`SourceDetailView.contentAndOutline` built the content's `HStack` **without** the explicit
`.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)` modifier on
`contentArea`. `PageDetailView.contentAndOutline` has always wrapped its content in a
`Group { ... }.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)`, so
its `WikiReaderView` (an `NSViewRepresentable` wrapping a `WKWebView`) was always given a
defined, fill-the-available-space frame by its parent.

In `SourceDetailView`, that frame was missing. Without it, the inner `WikiReaderView`'s
`NSViewRepresentable` reports **no intrinsic content size** to SwiftUI, leaving the layout
of the `contentAndOutline` `HStack` indeterminate. Previously the always-present
`PageOutlineView` sibling (even when collapsed, even for `.mmd` sources where it parsed zero
headings) helped pin the `HStack`'s vertical extent, masking the latent sizing defect. PR #648
added `isOutlineApplicable` (correctly) to remove that always-present sibling for pure
Mermaid sources — exposing the latent indeterminacy and letting the `WKWebView`'s layout
leak upward into the header region where it intercepted button taps.

The fix ships in PR #648 itself is correct ("hide useless empty outline for diagrams");
the regression was the missing frame constraint that #648 accidently surfaced.

## Fix

Mirror `PageDetailView`'s `contentAndOutline` shape: add the explicit
`.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)` modifier on
`contentArea`. This pins the WebView's frame to the available content area, restoring a
deterministic layout and keeping the `WKWebView` strictly below the header regardless of
source type / outline applicability.

One-line structural fix. No behavior change for non-Mermaid sources (their layout already
worked because `isOutlineApplicable` is `true` so the always-present outline pane was holding
the layout together — but the explicit frame is correct for them too).

## Diagnostic instrumentation

Each button tap is now logged via `DebugLog` (existing channels — no new infrastructure):
- "Show in List" → `DebugLog.tabs` (sidebar reveal is the same family as tab open/reveal events)
- "Share" → `DebugLog.fileprovider` + a new nil-resolution log on the `resolveSourceByNameURL`
  guard branch (previously the silent `return` swallowed the nil case)
- "Reveal in Finder" → `DebugLog.fileprovider`

This makes the failure mode structurally impossible to silently regress in the future: a quick
`log show --predicate 'subsystem == "com.selfdrivingwiki.debug"'` confirms whether each
handler fires (so if the layout leaks again on some view, the absence of the tap log narrows
the cause immediately).

## Verification

- `make version prompts` ✓
- `swift build` ✓
- `swift test --skip '<CI fast-tier skip list>'` — all 2726 tests in 233 suites pass.
- Visual repro of the live bug (per the `reproducing-live-ui-bugs` skill) requires operator
  click inspection — the new `DebugLog` instrumentation gives the operator a concrete
  verification path: after the fix, tapping each of the three buttons in a Mermaid source
  detail should produce a `DebugLog.tabs` / `DebugLog.fileprovider` line in Console.app and
  execute its intended action.

## Out of scope

- Not adding a hosted SwiftUI test that constructs a full `SourceDetailView`. The view has
  many app-layer dependencies (queue engine, launcher, file provider, extraction coordinator)
  that don't have lightweight fakes; the existing hosted-view tests
  (`QuoteHighlightWebViewTests`, `YouTubeEmbedWebViewTests`) reach the same `WikiReaderView`
  seam directly without going through `SourceDetailView`, so a hosted regression test would
  duplicate that scaffolding without testing the actual button wiring beyond what's covered
  here. The structural fix mirrors an existing, working pattern in `PageDetailView`.
