### PR TITLE
Fix chat detail buttons not responding to clicks (#672)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -540,14 +540,20 @@ struct ChatView: View {
             HStack(spacing: 10) {
                 if let chatID {
                     Button("Show in List", systemImage: "sidebar.left") {
+                        DebugLog.tabs("ChatView: Show in List tapped — id=\(chatID.rawValue)")
                         store.requestSidebarReveal(.chat(chatID))
                     }
                     .help("Reveal this chat in the sidebar")
                 }
                 if fileProvider.path != nil, let chatID {
                     Button("Share", systemImage: "square.and.arrow.up") {
+                        DebugLog.fileprovider("ChatView: Share tapped — id=\(chatID.rawValue)")
                         Task {
-                            guard let url = await fileProvider.resolveChatByNameURL(id: chatID) else { return }
+                            guard let url = await fileProvider.resolveChatByNameURL(id: chatID, wikiID: session.wikiID) else {
+                                DebugLog.fileprovider("Share chat detail: resolveChatByNameURL returned nil — id=\(chatID.rawValue) wikiID=\(session.wikiID)")
+                                return
+                            }
+                            DebugLog.fileprovider("Share chat detail: \(url.lastPathComponent)")
                             let picker = NSSharingServicePicker(items: [url])
                             let mouseScreen = NSEvent.mouseLocation
                             guard let window = NSApplication.shared.keyWindow,
@@ -562,11 +568,13 @@ struct ChatView: View {
                     }
                     .help("Share this chat")
                     Button("Reveal in Finder", systemImage: "folder") {
-                        Task { await fileProvider.revealChatInFinder(id: chatID) }
+                        DebugLog.fileprovider("ChatView: Reveal in Finder tapped — id=\(chatID.rawValue)")
+                        Task { await fileProvider.revealChatInFinder(id: chatID, wikiID: session.wikiID) }
                     }
                     .help("Reveal this chat file in Finder")
                 }
                 Button {
+                    DebugLog.tabs("ChatView: Toggle Outline tapped")
                     chatOutlineExpanded.toggle()
                 } label: {
                     Image(systemName: "sidebar.right")

--- a/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
+++ b/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WikiFSCore
 
 /// A detail-view header with a collapsible disclosure area. The title row
 /// (disclosure chevron + resource icon + editable title) is always visible;
@@ -41,6 +42,7 @@ struct CollapsibleDetailHeader<Expanded: View>: View {
     private var titleRow: some View {
         HStack(alignment: .center, spacing: 6) {
             Button {
+                DebugLog.tabs("CollapsibleDetailHeader: chevron tapped — wasExpanded=\(isExpanded)")
                 withAnimation(.easeInOut(duration: 0.2)) {
                     isExpanded.toggle()
                 }

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -64,17 +64,20 @@ struct PageDetailView: View {
                 HStack(spacing: 10) {
                     if isEditing {
                         Button("Save Changes", systemImage: "checkmark.circle") {
+                            DebugLog.tabs("PageDetailView: Save Changes tapped")
                             commitEdit()
                         }
                         .keyboardShortcut("s", modifiers: .command)
                         .disabled(store.draftBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
                         Button("Cancel", systemImage: "xmark.circle") {
+                            DebugLog.tabs("PageDetailView: Cancel tapped")
                             cancelEdit()
                         }
                         .keyboardShortcut(.escape, modifiers: [])
 
                         Button {
+                            DebugLog.tabs("PageDetailView: Toggle Outline tapped (editing)")
                             isOutlineExpanded.toggle()
                         } label: {
                             Image(systemName: "sidebar.right")
@@ -82,21 +85,30 @@ struct PageDetailView: View {
                         .help("Toggle Outline")
                     } else {
                         Button("Edit",
-                               systemImage: "pencil") { isEditing = true }
+                               systemImage: "pencil") {
+                            DebugLog.tabs("PageDetailView: Edit tapped")
+                            isEditing = true
+                        }
                             .help("Edit this page manually")
                         if case .page = store.selection {
                             lintButton
                         }
                         if case .page(let pageID) = store.selection {
                             Button("Show in List", systemImage: "sidebar.left") {
+                                DebugLog.tabs("PageDetailView: Show in List tapped — id=\(pageID.rawValue)")
                                 store.requestSidebarReveal(.page(pageID))
                             }
                             .help("Reveal this page in the sidebar")
                         }
                         if fileProvider.path != nil, case .page(let pageID) = store.selection {
                             Button("Share", systemImage: "square.and.arrow.up") {
+                                DebugLog.fileprovider("PageDetailView: Share tapped — id=\(pageID.rawValue)")
                                 Task {
-                                    guard let url = await fileProvider.resolvePageByTitleURL(id: pageID) else { return }
+                                    guard let url = await fileProvider.resolvePageByTitleURL(id: pageID, wikiID: session.wikiID) else {
+                                        DebugLog.fileprovider("Share page detail: resolvePageByTitleURL returned nil — id=\(pageID.rawValue) wikiID=\(session.wikiID)")
+                                        return
+                                    }
+                                    DebugLog.fileprovider("Share page detail: \(url.lastPathComponent)")
                                     let picker = NSSharingServicePicker(items: [url])
                                     let mouseScreen = NSEvent.mouseLocation
                                     guard let window = NSApplication.shared.keyWindow,
@@ -111,11 +123,13 @@ struct PageDetailView: View {
                             }
                             .help("Share this page")
                             Button("Reveal in Finder", systemImage: "folder") {
-                                Task { await fileProvider.revealPageInFinder(id: pageID) }
+                                DebugLog.fileprovider("PageDetailView: Reveal in Finder tapped — id=\(pageID.rawValue)")
+                                Task { await fileProvider.revealPageInFinder(id: pageID, wikiID: session.wikiID) }
                             }
                             .help("Reveal this page file in Finder")
                         }
                         Button {
+                            DebugLog.tabs("PageDetailView: Toggle Outline tapped")
                             isOutlineExpanded.toggle()
                         } label: {
                             Image(systemName: "sidebar.right")

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -26,6 +26,12 @@ struct SourceDetailView: View {
     /// (i.e., the query agent with "Allow wiki edits" checked). Disables the
     /// Ingest button so the user sees it's unavailable before clicking.
     let isEditLockedExternally: Bool
+    /// The wiki this source belongs to. Used as the FP domain selector for
+    /// Share / Reveal in Finder, which route through `FileProviderFacade`'s
+    /// `getUserVisibleURL`. Multi-window means the shared `activeWikiID` is
+    /// last-activate-wins, so passing the session's explicit `wikiID` here is
+    /// required to reach the correct FP extension (issue #672).
+    let wikiID: String
     let runIngest: (PageID) -> Void
     /// Shared launcher — used by the standalone `runExtraction` to take the
     /// extraction slot (so a standalone extract and an ingest-path extract serialize
@@ -511,6 +517,7 @@ struct SourceDetailView: View {
                 if isEditing {
                     HStack(spacing: 10) {
                         Button("Save Changes", systemImage: "checkmark.circle") {
+                            DebugLog.tabs("SourceDetailView: Save Changes tapped")
                             commitEdit()
                         }
                         .keyboardShortcut("s", modifiers: .command)
@@ -518,12 +525,14 @@ struct SourceDetailView: View {
                                   || (headVersion?.content == editBuffer))
 
                         Button("Cancel", systemImage: "xmark.circle") {
+                            DebugLog.tabs("SourceDetailView: Cancel tapped")
                             isEditing = false
                         }
                         .keyboardShortcut(.escape, modifiers: [])
 
                         if isOutlineApplicable {
                             Button {
+                                DebugLog.tabs("SourceDetailView: Toggle Outline tapped (editing)")
                                 isOutlineExpanded.toggle()
                             } label: {
                                 Image(systemName: "sidebar.right")
@@ -546,6 +555,7 @@ struct SourceDetailView: View {
                             // secondary until there's markdown worth ingesting.
                             Button(isExtracting ? "Extracting…" : "Extract",
                                    systemImage: "doc.plaintext") {
+                                DebugLog.extraction("SourceDetailView: Extract tapped — id=\(file.id.rawValue)")
                                 Task {
                                     await runExtraction()
                                 }
@@ -566,6 +576,7 @@ struct SourceDetailView: View {
                         // re-fetch and append a new version.
                         if isRefreshable, !needsExtraction {
                             Button("Refresh", systemImage: "arrow.clockwise") {
+                                DebugLog.extraction("SourceDetailView: Refresh tapped — id=\(file.id.rawValue)")
                                 Task { await runRefresh() }
                             }
                             .disabled(isRefreshing)
@@ -577,6 +588,7 @@ struct SourceDetailView: View {
                     HStack(spacing: 10) {
                         if isMarkdownEditable {
                             Button("Edit", systemImage: "pencil") {
+                                DebugLog.tabs("SourceDetailView: Edit tapped — id=\(file.id.rawValue)")
                                 // Source the buffer from the resolved content so
                                 // a native `.mmd` (no processed-markdown head)
                                 // edits its raw diagram source, not an empty
@@ -608,8 +620,8 @@ struct SourceDetailView: View {
                             Button("Share", systemImage: "square.and.arrow.up") {
                                 DebugLog.fileprovider("SourceDetailView: Share tapped — id=\(file.id.rawValue)")
                                 Task {
-                                    guard let url = await fileProvider.resolveSourceByNameURL(id: file.id) else {
-                                        DebugLog.fileprovider("Share source detail: resolveSourceByNameURL returned nil — id=\(file.id.rawValue)")
+                                    guard let url = await fileProvider.resolveSourceByNameURL(id: file.id, wikiID: wikiID) else {
+                                        DebugLog.fileprovider("Share source detail: resolveSourceByNameURL returned nil — id=\(file.id.rawValue) wikiID=\(wikiID)")
                                         return
                                     }
                                     DebugLog.fileprovider("Share source detail: \(url.lastPathComponent)")
@@ -628,12 +640,13 @@ struct SourceDetailView: View {
                             .help("Share this source file")
                             Button("Reveal in Finder", systemImage: "folder") {
                                 DebugLog.fileprovider("SourceDetailView: Reveal in Finder tapped — id=\(file.id.rawValue)")
-                                Task { await fileProvider.revealSourceInFinder(id: file.id) }
+                                Task { await fileProvider.revealSourceInFinder(id: file.id, wikiID: wikiID) }
                             }
                             .help("Reveal this source file in Finder")
                         }
                         if isOutlineApplicable {
                             Button {
+                                DebugLog.tabs("SourceDetailView: Toggle Outline tapped")
                                 isOutlineExpanded.toggle()
                             } label: {
                                 Image(systemName: "sidebar.right")

--- a/Sources/WikiFS/Window/FileProviderFacade.swift
+++ b/Sources/WikiFS/Window/FileProviderFacade.swift
@@ -324,16 +324,16 @@ final class FileProviderFacade: ChangeSignaler {
         }
     }
 
-    func revealPageInFinder(id: PageID) async {
-        guard let url = await resolvePageByTitleURL(id: id) else { return }
+    func revealPageInFinder(id: PageID, wikiID: String? = nil) async {
+        guard let url = await resolvePageByTitleURL(id: id, wikiID: wikiID) else { return }
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
     /// Reveal a chat transcript file in Finder via its `chat-by-name` leaf
     /// identifier. Mirrors `revealPageInFinder`. Best-effort: silently no-ops if
     /// the domain isn't active or the daemon can't resolve the item.
-    func revealChatInFinder(id: PageID) async {
-        guard let url = await resolveChatByNameURL(id: id) else { return }
+    func revealChatInFinder(id: PageID, wikiID: String? = nil) async {
+        guard let url = await resolveChatByNameURL(id: id, wikiID: wikiID) else { return }
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
@@ -342,9 +342,18 @@ final class FileProviderFacade: ChangeSignaler {
     /// `page-by-title` identifier (the same resolution `share`/`reveal` use) and
     /// hands it to `NSWorkspace`. URL asked at click time. Pass `appURL` to
     /// launch a specific app instead of the default handler.
-    func openPage(id: PageID, with appURL: URL? = nil) async {
-        guard let url = await resolvePageByTitleURL(id: id) else {
-            DebugLog.agent("openPage: FAILED resolving URL for id=\(id.rawValue)")
+    ///
+    /// Pass an explicit `wikiID` (instead of relying on the shared
+    /// `activeWikiID`) when the caller has session context — multi-window means
+    /// the shared `activeWikiID` is last-activate-wins, so a page from wiki A
+    /// viewed while wiki B's window was last activated would otherwise resolve
+    /// against wiki B's domain (issue #672: detail-view "Share" / "Reveal in
+    /// Finder" buttons routing to the wrong wiki's extension → "file doesn't
+    /// exist"). Detail views pass `session.wikiID`; legacy call sites without
+    /// session context leave the default (`activeWikiID`).
+    func openPage(id: PageID, with appURL: URL? = nil, wikiID: String? = nil) async {
+        guard let url = await resolvePageByTitleURL(id: id, wikiID: wikiID) else {
+            DebugLog.agent("openPage: FAILED resolving URL for id=\(id.rawValue) wikiID=\(wikiID ?? "nil(active=\(activeWikiID ?? "nil"))")")
             status = "Couldn’t resolve page for open."
             return
         }
@@ -357,9 +366,9 @@ final class FileProviderFacade: ChangeSignaler {
     /// (the same resolution `revealChatInFinder` uses) and hands it to
     /// `NSWorkspace`. Pass `appURL` to launch a specific app instead of the
     /// default handler. Mirrors `openPage`.
-    func openChat(id: PageID, with appURL: URL? = nil) async {
-        guard let url = await resolveChatByNameURL(id: id) else {
-            DebugLog.agent("openChat: FAILED resolving URL for id=\(id.rawValue)")
+    func openChat(id: PageID, with appURL: URL? = nil, wikiID: String? = nil) async {
+        guard let url = await resolveChatByNameURL(id: id, wikiID: wikiID) else {
+            DebugLog.agent("openChat: FAILED resolving URL for id=\(id.rawValue) wikiID=\(wikiID ?? "nil(active=\(activeWikiID ?? "nil"))")")
             status = "Couldn’t resolve chat for open."
             return
         }
@@ -391,8 +400,8 @@ final class FileProviderFacade: ChangeSignaler {
         }
     }
 
-    func revealSourceInFinder(id: PageID) async {
-        guard let url = await resolveSourceByNameURL(id: id) else { return }
+    func revealSourceInFinder(id: PageID, wikiID: String? = nil) async {
+        guard let url = await resolveSourceByNameURL(id: id, wikiID: wikiID) else { return }
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
@@ -402,9 +411,22 @@ final class FileProviderFacade: ChangeSignaler {
     /// is human-readable (display name + short-id + extension), exactly what
     /// `sourceNode` projects under `sources/by-name/`.  Returns `nil` if the
     /// domain isn't active or the daemon can't resolve the item.
-    func resolveSourceByNameURL(id: PageID) async -> URL? {
-        guard let wikiID = activeWikiID else { return nil }
-        let domain = domain(id: wikiID, displayName: wikiID)
+    ///
+    /// `wikiID` selects the File Provider domain (one per wiki). Without an
+    /// explicit value it falls back to `activeWikiID` — but in multi-window
+    /// scenarios where two wiki windows are open at once, `activeWikiID` is
+    /// last-activate-wins, so callers with `WikiSession` context MUST pass
+    /// `session.wikiID` to avoid the request being routed to the wrong wiki's
+    /// FP extension (issue #672). The returned "file doesn't exist" error from
+    /// `getUserVisibleURL` is the symptom of routing to the wrong domain — the
+    /// extension reads the wrong wiki's DB and naturally doesn't find the item.
+    func resolveSourceByNameURL(id: PageID, wikiID: String? = nil) async -> URL? {
+        let resolvedWikiID = wikiID ?? activeWikiID
+        guard let wiki = resolvedWikiID else {
+            DebugLog.fileprovider("resolveSourceByNameURL: no wikiID (explicit=nil, active=nil) — id=\(id.rawValue)")
+            return nil
+        }
+        let domain = domain(id: wiki, displayName: wiki)
         guard let manager = NSFileProviderManager(for: domain) else { return nil }
         let identifier = NSFileProviderItemIdentifier(WikiFSContainerID.sourceByName(id.rawValue))
         do {
@@ -412,10 +434,10 @@ final class FileProviderFacade: ChangeSignaler {
                 manager: manager,
                 itemIdentifier: identifier,
                 timeout: .seconds(5))
-            DebugLog.fileprovider("resolveSourceByNameURL: resolved \(url.lastPathComponent)")
+            DebugLog.fileprovider("resolveSourceByNameURL: resolved \(url.lastPathComponent) wikiID=\(wiki)")
             return url
         } catch {
-            DebugLog.fileprovider("resolveSourceByNameURL: failed — \(error.localizedDescription)")
+            DebugLog.fileprovider("resolveSourceByNameURL: failed wikiID=\(wiki) explicitWikiIDArg=\(wikiID ?? "nil") activeWikiID=\(activeWikiID ?? "nil") — \(error.localizedDescription)")
             return nil
         }
     }
@@ -424,18 +446,26 @@ final class FileProviderFacade: ChangeSignaler {
     /// identifier.  Mirrors `resolveSourceByNameURL` but for pages — the daemon
     /// returns the canonical URL so the filename is human-readable and guaranteed
     /// to resolve.  Returns `nil` if the domain isn't active.
-    func resolvePageByTitleURL(id: PageID) async -> URL? {
-        guard let wikiID = activeWikiID else { return nil }
-        let domain = domain(id: wikiID, displayName: wikiID)
+    ///
+    /// See `resolveSourceByNameURL` for the `wikiID` parameter's role (issue #672).
+    func resolvePageByTitleURL(id: PageID, wikiID: String? = nil) async -> URL? {
+        let resolvedWikiID = wikiID ?? activeWikiID
+        guard let wiki = resolvedWikiID else {
+            DebugLog.fileprovider("resolvePageByTitleURL: no wikiID (explicit=nil, active=nil) — id=\(id.rawValue)")
+            return nil
+        }
+        let domain = domain(id: wiki, displayName: wiki)
         guard let manager = NSFileProviderManager(for: domain) else { return nil }
         let identifier = NSFileProviderItemIdentifier("page-by-title:\(id.rawValue)")
         do {
-            return try await userVisibleURL(
+            let url = try await userVisibleURL(
                 manager: manager,
                 itemIdentifier: identifier,
                 timeout: .seconds(5))
+            DebugLog.fileprovider("resolvePageByTitleURL: resolved \(url.lastPathComponent) wikiID=\(wiki)")
+            return url
         } catch {
-            DebugLog.fileprovider("resolvePageByTitleURL: failed — \(error.localizedDescription)")
+            DebugLog.fileprovider("resolvePageByTitleURL: failed wikiID=\(wiki) explicitWikiIDArg=\(wikiID ?? "nil") activeWikiID=\(activeWikiID ?? "nil") — \(error.localizedDescription)")
             return nil
         }
     }
@@ -445,9 +475,15 @@ final class FileProviderFacade: ChangeSignaler {
     /// — the daemon returns the canonical URL directly, so no path construction
     /// and no cold-cache race. Returns `nil` if the domain isn't active or the
     /// daemon can't resolve the item.
-    func resolveChatByNameURL(id: PageID) async -> URL? {
-        guard let wikiID = activeWikiID else { return nil }
-        let domain = domain(id: wikiID, displayName: wikiID)
+    ///
+    /// See `resolveSourceByNameURL` for the `wikiID` parameter's role (issue #672).
+    func resolveChatByNameURL(id: PageID, wikiID: String? = nil) async -> URL? {
+        let resolvedWikiID = wikiID ?? activeWikiID
+        guard let wiki = resolvedWikiID else {
+            DebugLog.fileprovider("resolveChatByNameURL: no wikiID (explicit=nil, active=nil) — id=\(id.rawValue)")
+            return nil
+        }
+        let domain = domain(id: wiki, displayName: wiki)
         guard let manager = NSFileProviderManager(for: domain) else { return nil }
         let identifier = NSFileProviderItemIdentifier(WikiFSContainerID.chatByName(id.rawValue))
         do {
@@ -455,10 +491,10 @@ final class FileProviderFacade: ChangeSignaler {
                 manager: manager,
                 itemIdentifier: identifier,
                 timeout: .seconds(5))
-            DebugLog.fileprovider("resolveChatByNameURL: resolved \(url.lastPathComponent)")
+            DebugLog.fileprovider("resolveChatByNameURL: resolved \(url.lastPathComponent) wikiID=\(wiki)")
             return url
         } catch {
-            DebugLog.fileprovider("resolveChatByNameURL: failed — \(error.localizedDescription)")
+            DebugLog.fileprovider("resolveChatByNameURL: failed wikiID=\(wiki) explicitWikiIDArg=\(wikiID ?? "nil") activeWikiID=\(activeWikiID ?? "nil") — \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/WikiFS/Window/WikiDetailView.swift
+++ b/Sources/WikiFS/Window/WikiDetailView.swift
@@ -162,6 +162,7 @@ struct WikiDetailView: View {
                     isThisFileExtracting: tracker.extractingSourceIDs.contains(file.id),
                     // No edit lock — CAS prevents data races. Only extraction locks editing.
                     isEditLockedExternally: false,
+                    wikiID: session.wikiID,
                     runIngest: runIngest,
                     launcher: launcher,
                     extractionCoordinator: extractionCoordinator,


### PR DESCRIPTION
## Summary

Closes #672. The **Share** and **Reveal in Finder** buttons in `ChatView`, `PageDetailView`, and `SourceDetailView` rendered but had no effect — clicking them produced no error and no action. This fix also adds `DebugLog` instrumentation across every button handler in all three detail views + the `CollapsibleDetailHeader` chevron so future regressions trace cleanly.

## Root cause

`FileProviderFacade.activeWikiID` is an app-scoped `@State` shared across every window. Every `RootScene` calls `fileProvider.activate(id:)` on session resolve, so with two wiki windows open `activeWikiID` is **last-activate-wins**.

When the user opens `Share` or `Reveal in Finder` on a page/source/chat in wiki A's window while wiki B's window was the last to resolve its session, the FP resolution flow:

1. `resolvePageByTitleURL(id:)` constructs a domain for `activeWikiID` (B).
2. `NSFileProviderManager.getUserVisibleURL(...)` routes the request to the FP extension bound to wiki B.
3. Wiki B's extension opens its own SQLite DB, looks up `page-by-title:<id>`, and returns "The file doesn't exist." (the page is in wiki A's DB, not B's).

The os_log trace (`debug.log:107-220`) captured this end-to-end:

```
PageDetailView: Reveal in Finder tapped — id=01KXTRXGW8744X0HP19MPNG6YV
WikiFSFileProvider[1874] ReadScope wikiID=01KX1367BPBE2161MMGMPGWQAD   ← wrong wiki's extension
resolvePageByTitleURL: failed — The file doesn't exist.
```

The page is in wiki `01KXTRXG...` (per `LintActivity: started page-level lint for 1 page(s) in wiki 01KXTRXG`), but the FP system routed the request to the `01KX1367...` extension (last-activated wiki).

### Why only Share / Reveal in Finder

The state-only buttons (`Edit`, `Save Changes`, `Cancel`, `Lint`, `Show in List`, `Toggle Outline`) work because they mutate `store` directly — they don't depend on `fileProvider` and don't route through `NSFileProviderManager`. The trace confirms all six log on every tap. Only `Share`, `Reveal in Finder`, and `Reveal Log` (in `controls`) go through `fileProvider.resolveXxxByNameURL`, which is the only path through the shared `activeWikiID`.

### PR #659 wasn't the cause

PR #659's `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)` on SourceDetailView's content area (addressing #656) is already in place — the layout-overlap theory doesn't apply here. The buttons fire; the bug is downstream in FP resolution.

## Fix

Thread an explicit `wikiID:` parameter through the resolve/reveal/open methods on `FileProviderFacade`:

| Method | Change |
| - | - |
| `resolveSourceByNameURL(id:wikiID:)` | Uses explicit `wikiID` (or `activeWikiID` fallback) |
| `resolvePageByTitleURL(id:wikiID:)` | Same |
| `resolveChatByNameURL(id:wikiID:)` | Same |
| `revealSourceInFinder(id:wikiID:)` | Forwards to resolve |
| `revealPageInFinder(id:wikiID:)` | Forwards to resolve |
| `revealChatInFinder(id:wikiID:)` | Forwards to resolve |
| `openPage(id:with:wikiID:)` | Forwards to resolve |
| `openChat(id:with:wikiID:)` | Forwards to resolve |

The detail views already have a `WikiSession`, so they pass `session.wikiID`:

- `ChatView.swift:552` — Share → `resolveChatByNameURL(id: chatID, wikiID: session.wikiID)`
- `ChatView.swift:572` — Reveal in Finder → `revealChatInFinder(id: chatID, wikiID: session.wikiID)`
- `PageDetailView.swift:107` — Share → `resolvePageByTitleURL(id: pageID, wikiID: session.wikiID)`
- `PageDetailView.swift:127` — Reveal in Finder → `revealPageInFinder(id: pageID, wikiID: session.wikiID)`

`SourceDetailView` had no `session`, so it now takes a `wikiID: String` parameter (passed by `WikiDetailView` from `session.wikiID`):

- `SourceDetailView.swift:617` — Share → `resolveSourceByNameURL(id: file.id, wikiID: wikiID)`
- `SourceDetailView.swift:637` — Reveal in Finder → `revealSourceInFinder(id: file.id, wikiID: wikiID)`

### Out of scope (left unchanged, kept `activeWikiID` fallback)

These call sites are reachable from contexts that may not have session context and aren't part of the #672 report; they retain the previous behavior under single-window (which is correct there):

- `BookmarksOutlineView.swift:808,810,812` — `openPage` / `openSource` / `openChat`
- `PagesContainerView.swift:143,152,162` — `openPage` / `resolvePageByTitleURL` / `revealPageInFinder`
- `SourcesContainerView.swift:197,206,216` — `openSource` / `resolveSourceByNameURL` / `revealSourceInFinder`
- `WikiReaderView.swift:530,535,623,627` — `resolvePageByTitleURL` / `resolveSourceByNameURL`

If a similar bug surfaces for those, the fix shape is the same (thread session.wikiID).

## DebugLog instrumentation

While diagnosing, every button handler in all three detail views + the `CollapsibleDetailHeader` chevron toggle got a `DebugLog.tabs/fileprovider(...)` call so the runtime trace could localize the issue. The instrumented build was how the operator confirmed "everything works except Share/Reveal in Finder":

```
log show --predicate 'subsystem == "com.selfdrivingwiki.debug"' \
         --style compact --info --debug --last 10m
```

The `FileProviderFacade` resolve failure logs now include both the resolved `wikiID` AND the argument vs. the active value, so a future wrong-wiki route would be obvious at a glance:

```
resolvePageByTitleURL: failed wikiID=01KX1367... explicitWikiIDArg=nil activeWikiID=01KX1367... — The file doesn't exist.
```

## Verification

```
swift package clean
make version prompts
swift build
swift test                       # All 3025 tests pass in 259 suites
```

Operator re-test on the instrumented build is requested (but not blocking — the root cause is unambiguous from the trace): with two wiki windows open, Share / Reveal in Finder on a page in the non-frontmost wiki should now succeed instead of failing with "file doesn't exist."

## Files

- `Sources/WikiFS/Window/FileProviderFacade.swift` — added `wikiID:` parameter (default `nil`, falls back to `activeWikiID`) on 8 resolve/reveal/open methods; richer failure logs.
- `Sources/WikiFS/Pages/PageDetailView.swift` — pass `session.wikiID` to Share + Reveal in Finder; DebugLog on all button handlers.
- `Sources/WikiFS/Sources/SourceDetailView.swift` — added `wikiID: String` stored property; pass to Share + Reveal in Finder; DebugLog on all button handlers (Save / Cancel / Edit / Refresh / Extract / Ingest / Toggle Outline).
- `Sources/WikiFS/Chats/ChatView.swift` — pass `session.wikiID` to Share + Reveal in Finder; DebugLog on the chat detail button handlers.
- `Sources/WikiFS/Window/WikiDetailView.swift` — pass `session.wikiID` when constructing `SourceDetailView`.
- `Sources/WikiFS/Editor/CollapsibleDetailHeader.swift` — DebugLog on the chevron toggle.

Closes #672. Do NOT merge.
