### PR TITLE
Cache Swift build artifacts in CI to cut runner time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
           swift --version || xcrun swift --version
       - name: Generate codegen files (version + prompts)
         run: make version prompts
+      - name: Cache Swift build
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }}-${{ hashFiles('Sources/**/*.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }}-
+            ${{ runner.os }}-swift-
       - name: Build
         # Select the swift command that works on this runner and export it so
         # the Test step uses the SAME toolchain (a mismatch forces a full
@@ -46,6 +56,9 @@ jobs:
         # The full suite runs in ~1.5 min via in-memory SQLite fixtures (#658);
         # the previous fast/integration tier split + `.integration` tags are
         # retired (no slow disk I/O to skip). See AGENTS.md.
+        # timeout-minutes: 30 is a safety net for a cache-miss full rebuild
+        # (the suite itself is ~1.5 min; cold build+test should be well under 30).
+        timeout-minutes: 30
         run: $SWIFT test
 
   python:


### PR DESCRIPTION
## Problem

The `swift` CI job on GitHub's macOS runners takes **~84 minutes** for a suite that runs in **1.5 min locally**. Most of that time is spent recompiling the full dependency graph from scratch on every run — the runner starts with a clean `.build` directory every time, so incremental compilation never carries over between runs.

## Fix

Add an `actions/cache@v4` step to the `swift` job, placed immediately **before** the "Build" step so the build can reuse cached artifacts:

- **Cache paths:**
  - `.build` — compiled build artifacts
  - `~/Library/Caches/org.swift.swiftpm` — SwiftPM resolved-dependency download cache
- **Cache key:** `${{ runner.os }}-swift-<hash of Package.resolved>-<hash of Sources/**/*.swift>`. A dependency change (`Package.resolved`) *or* a source change busts the cache, so a stale build is never reused.
- **restore-keys:** two fallback prefixes (`...-<Package.resolved hash>-` then `...-swift-`) so a cache *miss* on the exact key still restores the best partial match when only source files have changed.

Also add `timeout-minutes: 30` to the Test step as a safety net — with a cache hit the suite finishes in a few minutes, and a cold build+test should finish well under 30 min. This prevents a repeat of the 84-min zombie-hang scenario without aborting legitimate runs.

## Expected speedup

| Scenario | Before | After (est.) |
| --- | --- | --- |
| Cache hit (deps + sources unchanged) | ~84 min | **~5–10 min** (restore + incremental test) |
| Cache miss / partial restore | ~84 min | **~20–30 min** (full rebuild, but dep download cached) |

The first run on this branch will be a cache miss (populating the cache); subsequent runs on `main` and PRs that don't touch `Package.resolved` or `Sources/**` will hit the cache.

## Validation

- `make version prompts` ✅
- `swift build` ✅ (1788 modules, Build complete in 148.56s)
- `swift test` ✅ (3042 tests in 260 suites passed in 31.28s)

No issue closure — standalone CI improvement.
