### PR TITLE
Double-click to toggle collapsed/expanded headers + chat blocks (#674)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,39 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-19 — Issue #674: Double-click to toggle collapsed/expanded headers + chat blocks (branch `feature/double-click-expand`)
+
+**Problem.** Collapsible headers and chat collapsible blocks only toggled
+on a single click of the disclosure chevron / `<summary>`. There was no
+double-click affordance, so users expecting macOS-typical double-click to
+toggle had no shortcut.
+
+**Scope.**
+
+- `Sources/WikiFS/Editor/CollapsibleDetailHeader.swift` — added
+  `.onTapGesture(count: 2)` on the `titleRow` HStack that flips `isExpanded`
+  with the same `.easeInOut(duration: 0.2)` animation as the chevron
+  Button. SwiftUI's gesture arbitrator preserves the chevron Button's
+  single-click (its own gesture wins single taps) and EditableTitle's
+  rename `onTapGesture(count: 2)` (innermost wins inside the title bounds);
+  double-taps on the rest of the header (icon, padding) now toggle. Used
+  by `PageDetailView`, `SourceDetailView`, `ChatView` — three sites, one
+  fix.
+- `Sources/WikiFS/Chats/ChatWebView.swift` — added a `dblclick` listener
+  to the `document` in `shellHTML`'s `<script>` that finds the closest
+  `<summary>` ancestor and flips its parent `<details>` `open` attribute.
+  Covers every `<details>` in the transcript (thinking blocks via
+  `.row-thinking.collapsible`, feed tool blocks via
+  `.row-tool.collapsible`, chat tool blocks via `.chat-tool`). The
+  browser's native single-click toggle continues to fire for each click
+  of the pair; the trailing `dblclick` flips `open` once more so a
+  double-click nets to a single flip from the starting state.
+
+**No new tests.** Both surfaces are gesture/JS-handler additions to
+view-layer code; the project has no SwiftUI gesture test harness and the
+JS runs inside `WKWebView` (no JS test infra). `swift test` (~1.5 min)
+run cleanly on `feature/double-click-expand`.
+
 ## 2026-07-19 — Issue #665: Fetch official ACP registry for provider catalog (branch `feature/acp-registry`)
 
 **Problem.** The provider catalog (`ACPProviderCatalog.agents`) was a

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -975,6 +975,13 @@ struct ChatWebView: NSViewRepresentable {
               btn.classList.remove('copied');
             }, 1500);
           });
+          document.addEventListener('dblclick', function(e) {
+            var summary = e.target.closest && e.target.closest('summary');
+            if (!summary) return;
+            var details = summary.closest('details');
+            if (!details) return;
+            details.open = !details.open;
+          });
         </script>
         </body></html>
         """

--- a/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
+++ b/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
@@ -69,5 +69,11 @@ struct CollapsibleDetailHeader<Expanded: View>: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .onTapGesture(count: 2) {
+            DebugLog.tabs("CollapsibleDetailHeader: header double-tapped — wasExpanded=\(isExpanded)")
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded.toggle()
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #674.

## Summary

Double-click now toggles expand/collapse on the two surfaces users expect:

1. **`CollapsibleDetailHeader`** (used by `PageDetailView`, `SourceDetailView`, `ChatView`) — a new `.onTapGesture(count: 2)` on the `titleRow` HStack flips `isExpanded` with the same `.easeInOut(duration: 0.2)` animation the chevron Button already uses.
2. **Chat collapsible blocks** in `ChatWebView` — every `<details>`/`<summary>` pair (thinking blocks, feed tool blocks, chat tool blocks) gets a `dblclick` listener that flips the parent `<details>` `open` attribute.

## Files

- `Sources/WikiFS/Editor/CollapsibleDetailHeader.swift` — +6 lines. The new double-tap gesture sits at the titleRow level so it fires on icon/padding but falls through to `EditableTitle`'s rename gesture inside the title bounds (SwiftUI's innermost-gesture-wins rule) and to the chevron `Button`'s own single-tap on the chevron (the `Button` keeps its single-click affordance intact, including the existing help tooltip).
- `Sources/WikiFS/Chats/ChatWebView.swift` — +7 lines. A delegated `dblclick` listener in the `shellHTML` script. Native single-click `<summary>` toggling still fires for each of the two clicks in the pair; the trailing `dblclick` flips `open` once more so a double-click nets to a single flip from the starting state.
- `PROGRESS.md` — entry per the AGENTS.md house rule.

## Verification

```
make version prompts
swift build            # Build complete! in 73.23s
swift test             # 3042 tests passed in 30.6s
```

No new tests: both surfaces are gesture/JS-handler additions to view-layer code with no SwiftUI gesture test harness and no JS test infra in the project. The full Swift Testing suite (in-memory fixtures since #658, ~1.5 min) is green on `feature/double-click-expand`.

## House rules

- Feature branch only — no merge to `main`.
- Routing all diagnostics through `DebugLog` (no `print`).
- No bare `try?` introduced.
