### PR TITLE
Show debug log folder button for all chats, not just live session (#671)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -573,6 +573,24 @@ struct ChatView: View {
                     }
                     .help("Reveal this chat file in Finder")
                 }
+                // #671: persistent "Reveal Debug Folder" — reads from the
+                // launcher's in-memory chatID→path map (populated at spawn
+                // commit in `startInteractiveQuery`), falling back to the live
+                // session's `debugFolderURL` so an in-progress run reveals before
+                // the map entry is finalized. Visible for any chat that ran in
+                // this app session (live or reopened from history); absent for
+                // chats that never ran here or whose run failed preflight (no
+                // scratch dir → no debug folder). Mirrors ingestion's
+                // `ActivityWindowView.revealMenu(for:)`.
+                if let chatID,
+                   let debugURL = launcher.debugFolderURL(forChat: chatID.rawValue)
+                        ?? (isLiveChat ? launcher.debugFolderURL : nil) {
+                    Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
+                        DebugLog.agent("ChatView: Reveal Debug Folder tapped — id=\(chatID.rawValue)")
+                        NSWorkspace.shared.activateFileViewerSelecting([debugURL])
+                    }
+                    .help("Open the complete debug trace folder (ACP messages, permissions, usage)")
+                }
                 Button {
                     DebugLog.tabs("ChatView: Toggle Outline tapped")
                     chatOutlineExpanded.toggle()

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -162,6 +162,15 @@ public final class AgentLauncher {
     /// when no run has started or the folder couldn't be created. Survives
     /// `finish()` so the UI can reveal it after the run completes.
     public private(set) var debugFolderURL: URL?
+    /// Per-chat in-memory map of `(logFileURL, debugFolderURL)` captured at
+    /// spawn commit in `startInteractiveQuery`. Lets the chat detail toolbar
+    /// reveal a chat's debug folder after the live session ends or the chat is
+    /// reopened from history (same app session only — cleared on restart,
+    /// mirroring ingestion's `QueueActivityTracker` lifetime). Keyed by chatID
+    /// string (the `PageID.rawValue` passed to `startInteractiveQuery`).
+    /// No file-provider emission — paths are read-only metadata, not store
+    /// mutations (the #129 `mutate()` rule does not apply to `AgentLauncher`).
+    public private(set) var chatLogPaths: [String: (log: URL?, debug: URL?)] = [:]
     /// The wall-clock start time of the current/last run, captured at spawn
     /// commit so `summary.json`'s duration is accurate even if `runStartedAt`
     /// (set inside `setGenerating(true)`) is reset.nil when no run has started.
@@ -276,6 +285,21 @@ public final class AgentLauncher {
     /// closure delegating to `PdfExtractionService.resolveScript()` at wiring
     /// time; tests/the daemon default to nil (no deny rule emitted).
     @ObservationIgnored public var pdf2mdScriptPathResolver: () -> String? = { nil }
+
+    /// Returns the persisted debug-folder URL for a chat that ran during this
+    /// app session, or nil if the chat never ran (or ran before this launch).
+    /// Reads from `chatLogPaths`, the in-memory map populated at spawn commit
+    /// in `startInteractiveQuery`. Mirrors `QueueActivityTracker.debugURL(for:)`.
+    public func debugFolderURL(forChat id: String) -> URL? {
+        chatLogPaths[id]?.debug
+    }
+
+    /// Returns the persisted run-log URL for a chat that ran during this app
+    /// session, or nil if the chat never ran. Companion to
+    /// `debugFolderURL(forChat:)`.
+    public func logFileURL(forChat id: String) -> URL? {
+        chatLogPaths[id]?.log
+    }
 
     /// Read the persisted provider config (loads + seeds on first run). The
     /// composer's provider selector binds to this for the providers list + the
@@ -2289,6 +2313,15 @@ public final class AgentLauncher {
         // persisted store. Set here (after resetRunArtifacts cleared any prior
         // value) so the flip is live from the first streamed token.
         activeChatID = chatID
+        // #671: capture (logFileURL, debugFolderURL) under chatID so the chat
+        // detail toolbar can reveal a chat's debug folder after the live session
+        // ends or the chat is reopened from history (same app session only —
+        // mirroring ingestion's `QueueActivityTracker` in-memory lifetime).
+        // Placed right after `activeChatID = chatID` and after `openLogFiles`
+        // (line above) so the binding + paths land atomically with the live flip.
+        if let chatID {
+            chatLogPaths[chatID] = (logFileURL, debugFolderURL)
+        }
         // Pre-display the user's message so it appears instantly — don't make
         // the user wait ~4s for backend.start (spawn + initialize + newSession)
         // before seeing their own text. `sendInteractiveMessage` will skip its


### PR DESCRIPTION
Closes #671.

## Problem

Chat sessions already have "Reveal Log" / "Reveal Debug Folder" buttons, but they're buried in the live-session-only Activity menu and disappear the moment generation stops (and never appear for a persisted chat reopened later in the same app session). The debug folder is keyed by a random `UUID()` created at spawn time (`AgentLauncher.startInteractiveQuery`), so it is **not derivable from `chatID` — a mapping must be stored somewhere.

## Fix

Mirror how ingestion already handles this (its `QueueActivityTracker` keeps an in-memory `itemLogURLs` / `itemDebugURLs` map, surfaced via `ActivityWindowView.revealMenu(for:)` calling `NSWorkspace.shared.activateFileViewerSelecting([url])`):

1. **`AgentLauncher`** — capture a per-chat in-memory map `chatLogPaths: [String: (log: URL?, debug: URL?)]` at spawn commit in `startInteractiveQuery` (right after `activeChatID = chatID`, which itself runs after `openLogFiles` so the URLs are already set). Exposed via `debugFolderURL(forChat:)` / `logFileURL(forChat:)`.
2. **`ChatView`** — add a persistent "Reveal Debug Folder" button to the chat detail toolbar (next to "Reveal in Finder") that resolves the URL as `launcher.debugFolderURL(forChat: chatID.rawValue) ?? (isLiveChat ? launcher.debugFolderURL : nil)`, wrapped in `if let` so the button is hidden when no path exists (e.g. preflight failure, or a chat that never ran this session). Opens via `NSWorkspace.shared.activateFileViewerSelecting([debugURL])` — same call as ingestion and the existing live-session Activity menu button.

## In-memory only — no schema change

Matches ingestion: the map is in-memory and does not survive an app restart. No columns are added to the `chats` table, and `ChatSummary` is unchanged. (A DB-backed variant for cross-restart reveal is sketched as a follow-up in the plan.)

## Discipline notes

- `#129 mutate()` rule does **not** apply — this is `AgentLauncher`, not `SQLiteWikiStore`. The paths are read-only metadata, not store mutations, so no `ResourceChangeEvent` / File-Provider signaling is introduced.
- No bare `try?` — no error paths are touched.
- No `print` — the new button uses `DebugLog.agent(...)` (consistent with the surrounding `DebugLog.fileprovider(...)` calls in the same toolbar).
- The existing live-session Activity menu buttons (`ChatView.swift:231-241`) are left unchanged for parity; the new toolbar button supersedes them for the common case.

## Acceptance

- [x] Live generating chat: button visible in toolbar, opens the correct `…/<uuid>/debug/` folder.
- [x] After generation stops: button remains, opens the same folder.
- [x] Persisted chat reopened in the same app session (that ran earlier): button present, opens its folder.
- [x] Chat that never ran this session: button absent, no crash.
- [x] Preflight failure (no scratch dir): button absent.

## Testing

- `make version prompts && swift build` — clean.
- `swift test` — **3042 tests in 260 suites, 0 failures** (including `StoreEmissionExhaustivenessTests` confirming the #129 EMIT/READ/NO-EMIT partition is unaffected, and `QueueActivityTrackerRunPathsTests` confirming the ingestion path is untouched).

## Files

- `Sources/WikiFSEngine/AgentLauncher.swift` — `chatLogPaths` map + `debugFolderURL(forChat:)` / `logFileURL(forChat:)` accessors; record `(logFileURL, debugFolderURL)` under `chatID` at spawn commit.
- `Sources/WikiFS/Chats/ChatView.swift` — persistent "Reveal Debug Folder" toolbar button.
