### PR TITLE
Add collapsible title bar to Agents settings view

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -591,6 +591,12 @@ struct ChatView: View {
                     }
                     .help("Open the complete debug trace folder (ACP messages, permissions, usage)")
                 }
+                // Pin action buttons at the leading edge and the outline
+                // toggle at the trailing edge so the row's layout is
+                // independent of the parent's proposed width (which changes
+                // when the outline pane or the header expands/collapses —
+                // keeps "Show in List" and friends in a fixed position).
+                Spacer()
                 Button {
                     DebugLog.tabs("ChatView: Toggle Outline tapped")
                     chatOutlineExpanded.toggle()

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -76,6 +76,13 @@ struct PageDetailView: View {
                         }
                         .keyboardShortcut(.escape, modifiers: [])
 
+                        // Pin action buttons at the leading edge and the
+                        // outline toggle at the trailing edge so the row's
+                        // layout is independent of the parent's proposed width
+                        // (which changes when the outline pane or the header
+                        // expands/collapses — keeps "Show in List" and friends
+                        // in a fixed position).
+                        Spacer()
                         Button {
                             DebugLog.tabs("PageDetailView: Toggle Outline tapped (editing)")
                             isOutlineExpanded.toggle()
@@ -128,6 +135,10 @@ struct PageDetailView: View {
                             }
                             .help("Reveal this page file in Finder")
                         }
+                        // Pin action buttons at the leading edge and the outline
+                        // toggle at the trailing edge (see the matching comment
+                        // in the editing branch above).
+                        Spacer()
                         Button {
                             DebugLog.tabs("PageDetailView: Toggle Outline tapped")
                             isOutlineExpanded.toggle()

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -37,6 +37,11 @@ struct AgentsSettingsView: View {
     /// hardcoded seed buttons (Add Claude / Add Hermes / Add OpenCode) with
     /// a non-destructive, catalog-driven sheet. Cancel = no change (AC.2).
     @State private var showAddSheet = false
+    /// Per-view collapse state for the `CollapsibleDetailHeader`. Starts
+    /// expanded — a Settings panel is something the user opened to interact
+    /// with, so showing the form by default (rather than hiding it behind a
+    /// chevron) avoids a friction click on every visit.
+    @State private var isExpanded = true
 
     @AppStorage(AgentLauncher.PermissionModeKey.chat)   private var chatModeRaw   = PermissionPolicy.bypass.rawValue
     @AppStorage(AgentLauncher.PermissionModeKey.ingest) private var ingestModeRaw = PermissionPolicy.bypass.rawValue
@@ -57,57 +62,69 @@ struct AgentsSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            providersSection
-            permissionSection
-        }
-        .formStyle(.grouped)
-        .frame(minWidth: 560, minHeight: 520)
-        // #663: the Add Provider sheet. Non-destructive (nothing is written
-        // until an Add button is pressed — AC.2). The handoff to the editor
-        // uses `DispatchQueue.main.async` (see correction §5): letting this
-        // sheet finish dismissing before the editor presents avoids the
-        // SwiftUI hazard where the second sheet silently fails when the
-        // first is mid-dismissal.
-        .sheet(isPresented: $showAddSheet) {
-            AddProviderSheet(
-                existingIDs: Set(config.providers.map(\.id)),
-                onAdd: { provider in appendProvider(provider) },
-                onAddNeedsEditor: { provider in
-                    showAddSheet = false
-                    DispatchQueue.main.async { editingProvider = provider }
-                })
-        }
-        .sheet(item: $editingProvider) { provider in
-            ProviderEditorView(
-                provider: provider,
-                cachedModels: config.cachedModels(forProvider: provider.id),
-                selectedModelId: config.selectedModelId(forProvider: provider.id) ?? "",
-                credentialStore: credentialStore,
-                onSave: { updated, selectedModelId in
-                    applyEdit(updated, selectedModelId: selectedModelId)
-                },
-                onRefreshModels: { provider, models in
-                    // #640: durable-persist path for probe-discovered models.
-                    // Runs on the parent (which owns `containerDirectory` +
-                    // `@State config`). Uses `settingCachedModels` directly so
-                    // ALL existing fields carry over (maxConcurrent in
-                    // particular — the parent's `save(_:)` helper drops it,
-                    // pre-existing bug at AgentsSettingsView.swift:250-255,
-                    // :360-362). `@Sendable` so the sheet's `Task` can call
-                    // it across actors.
-                    await persistDiscoveredModels(models, forProvider: provider.id)
-                })
-        }
-        .confirmationDialog(
-            "Delete \(providerPendingDeletion?.label ?? "provider")?",
-            isPresented: isShowingDeleteConfirmation,
-            titleVisibility: .visible
+        // Collapsible title bar matching `PageDetailView` / `SourceDetailView`
+        // / `ChatView`. Collapsed shows just the "Agents" title row; expanded
+        // reveals the Form below. The title is non-editable (a fixed label
+        // for the whole settings tab), so `isTitleDisabled` pins it.
+        CollapsibleDetailHeader(
+            systemImage: "cpu",
+            title: "Agents",
+            isTitleDisabled: true,
+            isExpanded: $isExpanded,
+            onTitleCommit: { _ in }
         ) {
-            Button("Delete", role: .destructive) { confirmDelete() }
-            Button("Cancel", role: .cancel) { providerPendingDeletion = nil }
-        } message: {
-            Text("This removes its command and environment. Its API key stays in the Keychain until overwritten.")
+            Form {
+                providersSection
+                permissionSection
+            }
+            .formStyle(.grouped)
+            .frame(minWidth: 560, minHeight: 520)
+            // #663: the Add Provider sheet. Non-destructive (nothing is written
+            // until an Add button is pressed — AC.2). The handoff to the editor
+            // uses `DispatchQueue.main.async` (see correction §5): letting this
+            // sheet finish dismissing before the editor presents avoids the
+            // SwiftUI hazard where the second sheet silently fails when the
+            // first is mid-dismissal.
+            .sheet(isPresented: $showAddSheet) {
+                AddProviderSheet(
+                    existingIDs: Set(config.providers.map(\.id)),
+                    onAdd: { provider in appendProvider(provider) },
+                    onAddNeedsEditor: { provider in
+                        showAddSheet = false
+                        DispatchQueue.main.async { editingProvider = provider }
+                    })
+            }
+            .sheet(item: $editingProvider) { provider in
+                ProviderEditorView(
+                    provider: provider,
+                    cachedModels: config.cachedModels(forProvider: provider.id),
+                    selectedModelId: config.selectedModelId(forProvider: provider.id) ?? "",
+                    credentialStore: credentialStore,
+                    onSave: { updated, selectedModelId in
+                        applyEdit(updated, selectedModelId: selectedModelId)
+                    },
+                    onRefreshModels: { provider, models in
+                        // #640: durable-persist path for probe-discovered models.
+                        // Runs on the parent (which owns `containerDirectory` +
+                        // `@State config`). Uses `settingCachedModels` directly so
+                        // ALL existing fields carry over (maxConcurrent in
+                        // particular — the parent's `save(_:)` helper drops it,
+                        // pre-existing bug at AgentsSettingsView.swift:250-255,
+                        // :360-362). `@Sendable` so the sheet's `Task` can call
+                        // it across actors.
+                        await persistDiscoveredModels(models, forProvider: provider.id)
+                    })
+            }
+            .confirmationDialog(
+                "Delete \(providerPendingDeletion?.label ?? "provider")?",
+                isPresented: isShowingDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) { confirmDelete() }
+                Button("Cancel", role: .cancel) { providerPendingDeletion = nil }
+            } message: {
+                Text("This removes its command and environment. Its API key stays in the Keychain until overwritten.")
+            }
         }
     }
 

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -531,6 +531,12 @@ struct SourceDetailView: View {
                         .keyboardShortcut(.escape, modifiers: [])
 
                         if isOutlineApplicable {
+                            // Pin save/cancel at the leading edge and the
+                            // outline toggle at the trailing edge so the row's
+                            // layout is independent of the parent's proposed
+                            // width (which changes when the outline pane or
+                            // the header expands/collapses).
+                            Spacer()
                             Button {
                                 DebugLog.tabs("SourceDetailView: Toggle Outline tapped (editing)")
                                 isOutlineExpanded.toggle()
@@ -645,6 +651,10 @@ struct SourceDetailView: View {
                             .help("Reveal this source file in Finder")
                         }
                         if isOutlineApplicable {
+                            // Pin action buttons at the leading edge and the
+                            // outline toggle at the trailing edge (see the
+                            // matching comment in the editing branch above).
+                            Spacer()
                             Button {
                                 DebugLog.tabs("SourceDetailView: Toggle Outline tapped")
                                 isOutlineExpanded.toggle()


### PR DESCRIPTION
## What

- Wrap `AgentsSettingsView.body` in `CollapsibleDetailHeader`, matching `PageDetailView` / `SourceDetailView` / `ChatView`.
- Fix a pre-existing toolbar-button position drift in those three detail views (surfaced while testing the wrap).

## Changes

### 1. `Sources/WikiFS/Settings/AgentsSettingsView.swift`

- Added `@State private var isExpanded = true` (starts expanded — a settings panel is something the user opened to interact with, so showing the form by default avoids a friction click on every visit; the other detail views start collapsed because they present a resource the user is browsing, not configuring).
- Wrapped the existing `Form { providersSection ; permissionSection }` (plus its `.formStyle(.grouped)`, `.frame(minWidth:560, minHeight:520)`, `.sheet(isPresented: $showAddSheet)`, `.sheet(item: $editingProvider)`, and `.confirmationDialog(...)`) inside `CollapsibleDetailHeader`'s `expandedContent` closure. Title `"Agents"`, `systemImage: "cpu"` (matches the tab item in `WikiFSApp.swift:515`), `isTitleDisabled: true` (the label is fixed — it represents the whole settings tab, not an editable resource name).
- All existing functionality is preserved unchanged: the AddProviderSheet, provider selection / enable toggle / delete, provider editor sheet, permission mode pickers, durable model-cache persist path. Nothing rerouted — the form just moved one level of nesting deeper.

### 2. Layout fix: `PageDetailView.swift`, `ChatView.swift`, `SourceDetailView.swift`

While testing the wrap the operator noticed the leading action buttons (e.g. **Show in List**, Share, Reveal in Finder) could shift horizontally between expanded / collapsed states. Root cause: the action-button `HStack` in each detail view's expanded content had no `Spacer`, so the HStack's children redistributed depending on the parent's proposed width (which changes when the outline pane toggles, when the header collapses, or when the window resizes).

Added a `Spacer()` immediately before the trailing **Toggle Outline** (`sidebar.right`) button in each action HStack — five spots total:

- `PageDetailView.swift` editing branch (Save / Cancel / Toggle Outline)
- `PageDetailView.swift` viewing branch (Edit / Lint / Show in List / Share / Reveal in Finder / Toggle Outline)
- `ChatView.swift` (Show in List / Share / Reveal in Finder / Reveal Debug Folder / Toggle Outline)
- `SourceDetailView.swift` editing branch (Save / Cancel / Toggle Outline)
- `SourceDetailView.swift` Row 2 viewing branch (Edit / Show in List / Share / Reveal in Finder / Toggle Outline)

Now the action cluster is pinned to the leading edge and the outline toggle is pinned to the trailing edge, so positions stay fixed regardless of the parent's proposed width.

## Verification

```
make version prompts && swift build   # Build complete!
swift test                            # 3011 tests in 257 suites, all pass
```

## Notes

- House rules followed: no bare `try?` (the existing one in `save(_:)` predates this change and is out of scope), no `print`, scratch artifacts in `tmp/`.
- Did not merge — PR opens against `main` for review.
