### PR TITLE
Fix: editor drag-wikilinks hijacked by tab-opening drop handler

### DIFF
--- a/Sources/WikiFS/Window/WikiDetailView.swift
+++ b/Sources/WikiFS/Window/WikiDetailView.swift
@@ -28,25 +28,52 @@ struct WikiDetailView: View {
 
     var body: some View {
         detailContent
-            // Accept an internal sidebar drag anywhere in the detail column —
-            // dropping a page/source/bookmark onto the welcome screen OR onto any
-            // open detail tab opens it as a tab and focuses it (openTab reuses an
-            // existing tab if one is already open). Innermost drop target, so
-            // URL/file drops still fall through to the window-level ingest
-            // destination in ContentView.
-            .dropDestination(for: SidebarDragPayloadList.self) { lists, _ in
-                let payloads = lists.flatMap(\.items)
-                guard !payloads.isEmpty else {
-                    DebugLog.tabs("[drop] detail action fired with NO payload")
-                    return false
+            // The `.dropDestination` lives in a `Color.clear` background so it
+            // shares the detail column's bounds without wrapping `detailContent`
+            // structurally. The conditional lives inside the `.background` — the
+            // only thing it toggles is the stateless `Color.clear`, so
+            // `detailContent` keeps a single structural identity across the
+            // edit-mode toggle (per swiftui-pro/perf: avoid `_ConditionalContent`
+            // around state-bearing content). Otherwise `PageDetailView` /
+            // `SourceDetailView` would be torn down + recreated on each toggle
+            // and lose their `@State isEditing`, throwing the user out of the
+            // editor they just opened.
+            //
+            // WHILE EDITING (`store.isActiveTabEditing == true`): no
+            // `.dropDestination` is installed at all. A sidebar drag over the
+            // editor surface is claimed by the `DropLinkTextView` (an `NSTextView`
+            // subclass that registers `wikiSidebarItem` at the AppKit level and
+            // inserts a `[[wikilink]]` at the drop point — issue #616). The
+            // previous implementation wrapped the whole column with
+            // `.dropDestination`, which intercepted the drag at drag-tracking
+            // time (before the `NSTextView` saw `draggingEntered`) and opened a
+            // new tab instead — the regression this gate fixes.
+            //
+            // WHILE NOT EDITING: `.dropDestination` is installed behind the
+            // content. Drops on the welcome screen, page/source chrome, and
+            // reader surfaces (where the underlying `WikiReaderView` is the
+            // frontmost registered `NSView` and claims sidebar drags itself via
+            // its own `performDragOperation`) open the dragged item as a tab —
+            // matching the original behavior.
+            .background {
+                if !store.isActiveTabEditing {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .dropDestination(for: SidebarDragPayloadList.self) { lists, _ in
+                            let payloads = lists.flatMap(\.items)
+                            guard !payloads.isEmpty else {
+                                DebugLog.tabs("[drop] detail action fired with NO payload")
+                                return false
+                            }
+                            for payload in payloads {
+                                DebugLog.tabs("[drop] detail action fired: kind=\(payload.kind) id=\(payload.id)")
+                                store.openTab(payload.selection)
+                            }
+                            return true
+                        } isTargeted: { targeted in
+                            isSidebarDropTargeted = targeted
+                        }
                 }
-                for payload in payloads {
-                    DebugLog.tabs("[drop] detail action fired: kind=\(payload.kind) id=\(payload.id)")
-                    store.openTab(payload.selection)
-                }
-                return true
-            } isTargeted: { targeted in
-                isSidebarDropTargeted = targeted
             }
     }
 

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -152,6 +152,23 @@ public final class WikiStoreModel {
         tabs.first { $0.id == activeTabID }
     }
 
+    /// `true` when the active tab is showing the markdown editor — a
+    /// `PageDetailView` or `SourceDetailView` in edit mode (the two surfaces
+    /// backed by `DropLinkTextView`; see `Sources/WikiFS/Editor/DropLinkTextView.swift`).
+    /// Both views sync their local `@State isEditing` into `EditorTab.isEditing`
+    /// via `setTabEditing(tabID:isEditing:)`, so reading the tab here is the
+    /// single source of truth.
+    ///
+    /// Used by `WikiDetailView.body` to gate its parent-level `.dropDestination`
+    /// on `wikiSidebarItem`: while editing, the destination is removed so a
+    /// sidebar drag inserts a `[[wikilink]]` at the editor's drop point (issue #616)
+    /// instead of opening a new tab. Other surfaces (`SystemPromptDetailView`,
+    /// `ChatView`, welcome screen, reader mode) never set `isEditing`, so they
+    /// keep the tab-opening drop behavior — matching the original semantics.
+    public var isActiveTabEditing: Bool {
+        activeTab?.isEditing ?? false
+    }
+
     /// The removable list of ingested files (Phase 5). Like `summaries`, this is
     /// ALWAYS rebuilt from `store.listSources()` after a change, never
     /// incrementally patched (§3.1). Most-recent-first.

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -870,4 +870,99 @@ struct EditorTabTests {
         #expect(model.tabs.first?.selection == .page(a.id))
         #expect(model.activeTabID == model.tabs.first?.id)
     }
+
+    // MARK: - isActiveTabEditing (drop-wikilinks gate, issue #616)
+
+    // `isActiveTabEditing` is the seam `WikiDetailView.body` uses to gate its
+    // parent-level `.dropDestination` on `wikiSidebarItem`. While true, the
+    // destination is removed so a sidebar drag inserts a `[[wikilink]]` at the
+    // `DropLinkTextView`'s drop point instead of opening a new tab. The state is
+    // synced from `PageDetailView`/`SourceDetailView` via `setTabEditing` — pin
+    // the model-level contract here so the SwiftUI gate stays correct.
+
+    @Test func isActiveTabEditing_falseWhenNoTabs() throws {
+        let (model, _) = try tempModel()
+        #expect(model.tabs.isEmpty)
+        #expect(model.activeTabID == nil)
+        #expect(model.isActiveTabEditing == false)
+    }
+
+    @Test func isActiveTabEditing_falseWhenActiveTabNotEditing() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+        model.openTab(.page(a.id))
+        // Default tab state is `isEditing == false`.
+        #expect(model.activeTab?.isEditing == false)
+        #expect(model.isActiveTabEditing == false)
+    }
+
+    @Test func isActiveTabEditing_trueWhenActiveTabIsEditing() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+        model.openTab(.page(a.id))
+        guard let id = model.activeTabID else {
+            Issue.record("expected active tab after openTab")
+            return
+        }
+        model.setTabEditing(tabID: id, isEditing: true)
+        #expect(model.activeTab?.isEditing == true)
+        #expect(model.isActiveTabEditing == true)
+    }
+
+    @Test func isActiveTabEditing_falseAfterEditingTurnedOff() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        model.reloadFromStore()
+        model.openTab(.page(a.id))
+        guard let id = model.activeTabID else {
+            Issue.record("expected active tab after openTab")
+            return
+        }
+        model.setTabEditing(tabID: id, isEditing: true)
+        #expect(model.isActiveTabEditing == true)
+        model.setTabEditing(tabID: id, isEditing: false)
+        #expect(model.isActiveTabEditing == false)
+    }
+
+    @Test func isActiveTabEditing_tracksActiveTabSwitch() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+        model.openTab(.page(a.id))
+        model.openTab(.page(b.id))
+        // Active is B; mark A as editing (a non-active tab's state is preserved
+        // by the view layer via setTabEditing on tab switch-back).
+        let tabA = model.tabs.first { $0.selection == .page(a.id) }?.id
+        guard let tabA else {
+            Issue.record("expected tab A in tabs")
+            return
+        }
+        model.setTabEditing(tabID: tabA, isEditing: true)
+        // Active tab (B) is not editing.
+        #expect(model.isActiveTabEditing == false)
+        // Switching to A — now A is active AND editing.
+        model.selectTab(id: tabA)
+        #expect(model.activeTabID == tabA)
+        #expect(model.isActiveTabEditing == true)
+    }
+
+    @Test func isActiveTabEditing_ignoresNonActiveEditingTab() throws {
+        let (model, store) = try tempModel()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        model.reloadFromStore()
+        model.openTab(.page(a.id))
+        model.openTab(.page(b.id))
+        // Mark A (non-active) as editing. Active tab (B) is not.
+        let tabA = model.tabs.first { $0.selection == .page(a.id) }?.id
+        guard let tabA else {
+            Issue.record("expected tab A in tabs")
+            return
+        }
+        model.setTabEditing(tabID: tabA, isEditing: true)
+        #expect(model.isActiveTabEditing == false)
+    }
 }


### PR DESCRIPTION
## What

Fixes the drag-wikilinks regression (#616) where dragging a sidebar item
(page / source / bookmark / chat) over the markdown editor in edit mode
opened a new tab instead of inserting a `[[wikilink]]` at the drop point.

## Root cause

`WikiDetailView.body` wrapped the entire detail column with
`.dropDestination(for: SidebarDragPayloadList.self)` that called
`store.openTab(payload.selection)`. SwiftUI's `.dropDestination` overlay
intercepts the drag at drag-tracking time (during `draggingEntered` /
`draggingUpdated`) — before the `DropLinkTextView`'s AppKit-level
`draggingEntered` / `performDragOperation` (in
`Sources/WikiFS/Editor/DropLinkTextView.swift:70-100`) ever sees it. So
the editor never got a chance to insert the wikilink; the SwiftUI
overlay's action fired and opened a new tab instead.

## Fix

**Approach: gate the `.dropDestination` on edit mode (option 1 from the
bug report), but structurally isolate the conditional so the
detail content's `@State` is preserved across the toggle.**

- New seam: `WikiStoreModel.isActiveTabEditing: Bool`
  (`Sources/WikiFSCore/Store/WikiStoreModel.swift`) reads
  `activeTab?.isEditing ?? false`. This is already kept in sync by
  `PageDetailView` and `SourceDetailView` via
  `store.setTabEditing(tabID:isEditing:)` (the same mechanism that
  restores edit mode on tab switch-back). Only those two surfaces use
  `ScrollableTextEditor` → `DropLinkTextView`, so gating on this flag
  exactly targets the buggy case without affecting `SystemPromptDetailView`
  (SwiftUI `TextEditor`), `ChatView`, the welcome screen, or reader mode.

- `WikiDetailView.body`: the `.dropDestination` is now installed inside a
  `.background { Color.clear.contentShape(...).dropDestination(...) }`
  that's conditionally present only when `!store.isActiveTabEditing`.
  - **When editing:** no `.dropDestination` overlay is installed at all.
    The `DropLinkTextView` is the frontmost `NSView` registered for
    `wikiSidebarItem`, so AppKit routes the drag to it and a wikilink is
    inserted at the drop point (issue #616, fixed).
  - **When not editing:** `.dropDestination` is installed behind the
    content. Drops on the welcome screen, page/source chrome, and reader
    surfaces still open the dragged item as a tab — matching the
    original behavior. (`WikiReaderView` remains the frontmost registered
    `NSView` over its own body and continues to handle its own
    `performDragOperation`.)

### Why `.background` instead of `if/else` around `detailContent`

A direct `if store.isActiveTabEditing { detailContent } else {
detailContent.dropDestination(...) }` would create `_ConditionalContent`
around `detailContent`, which (per the swiftui-pro/perf reference) breaks
structural identity. On every edit-mode toggle, `PageDetailView` /
`SourceDetailView` would be torn down and recreated with fresh `@State`
(`isEditing = false`), throwing the user out of the editor they just
opened — even though the store's `tab.isEditing` is still `true`.

Moving the conditional inside `.background { ... }` keeps the
`_ConditionalContent` scoped to the stateless `Color.clear` child —
`detailContent`'s structural identity (and the inner views' `@State`) is
preserved across the toggle.

### Why option 2 (return `false` from the action) wasn't enough

The bug report flagged that returning `false` from the `.dropDestination`
action "may NOT work." The reason: SwiftUI's overlay claims the drag at
drag-tracking time (during `draggingEntered`), independent of what the
action closure later returns. Returning `false` only signals that the
*drop* was rejected — the overlay has still intercepted the drag, so the
`DropLinkTextView` never receives `draggingEntered` /
`performDragOperation`. Structurally removing the `.dropDestination`
while editing is required.

## Tests

- New unit tests on `WikiStoreModel.isActiveTabEditing`
  (`Tests/WikiFSTests/EditorTabTests.swift`):
  - `isActiveTabEditing_falseWhenNoTabs`
  - `isActiveTabEditing_falseWhenActiveTabNotEditing`
  - `isActiveTabEditing_trueWhenActiveTabIsEditing`
  - `isActiveTabEditing_falseAfterEditingTurnedOff`
  - `isActiveTabEditing_tracksActiveTabSwitch` (non-active editing tab →
    false; switch to it → true)
  - `isActiveTabEditing_ignoresNonActiveEditingTab`

- Existing `DropLinkTextViewDropTests` /
  `SidebarDropBuilderIntegrationTests` /
  `SidebarDragPasteboardBridgeTests` continue to pass — the
  `DropLinkTextView` wiring and the `SidebarDropBuilder` closure are
  unchanged.

- Full suite: `swift test` — **3048 tests pass** (~32s).

## House rules

- No `print` — only `DebugLog.tabs` (unchanged from the original
  `.dropDestination` action).
- No bare `try?` — no error handling was needed in this change.
- Scratch written to `tmp/` (not `/tmp`); the PR body itself is in
  `tmp/pr-drag-editor-body.md`.
- Branch pushed; not merging.

## Manual smoke (not unit-tested — GUI drag)

The unit tests can't reproduce SwiftUI's drag-routing overlay behavior
(per the existing `DropLinkTextViewDropTests` header comment, "the
load-bearing pasteboard-decode path is already pinned," and the
drag-tracking behavior is AppKit/SwiftUI-internal). Recommended manual
verification:

1. Open a page, click **Edit**.
2. Drag a sidebar page onto the editor → expect a `[[page:<ULID>|<Title>]]`
   inserted at the drop point. (Before this PR: a new tab opens.)
3. Drag a sidebar source → `[[source:<ULID>|<Name>]]`.
4. Drag a bookmark folder → flat depth-0 markdown list of `[[kind:<ULID>|<name>]]`
   lines.
5. Cancel / Save → editor exits; drag a sidebar item onto the rendered
   reader body → expect a new tab (unchanged behavior, owned by
   `WikiReaderView`'s own `performDragOperation`).
6. Drag a sidebar item onto the welcome screen → expect a new tab
   (unchanged behavior, owned by the gated `.dropDestination`).
