### PR TITLE
Fix chat autocomplete panel positioning (caret-based, not view-bounds)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,91 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-19 — Fix chat autocomplete panel positioning (branch `fix-autocomplete-pos`)
+
+**Problem.** The chat composer's `[[kind:partial` autocomplete dropdown
+(`ChatAutocompletePanel`) appeared several lines above the caret instead of
+just above the current line. Two compounding bugs in `present(above:)` at
+`Sources/WikiFS/Chats/ChatAutocompletePanel.swift:80`:
+
+1. The panel anchored to the **entire NSTextView's bounds**
+   (`anchor.convert(anchor.bounds, to: nil)`) rather than the caret line —
+   for a 3-line default composer, the anchor's top is 3 lines above the
+   caret, so the panel was 3 lines too high before even counting the panel
+   gap math.
+2. The above-placement math added `frame.height` to the origin Y
+   (`rectOnScreen.maxY + frame.height + 4`), leaving a panel-height-plus-4pt
+   gap between the anchor's top and the panel's bottom — visually "a panel
+   too high". The below-fallback math in the same method matched the omnibox's
+   correct below-placement math, so only the above path was wrong.
+
+**Scope.**
+
+- `Sources/WikiFS/Chats/ChatAutocompletePanel.swift` — replaced
+  `present(above: NSView)` with caret-relative positioning, generalized so
+  the editor autocomplete (#680, not yet implemented) can reuse the same
+  panel with different placement heuristics. New API:
+  - `enum Placement { case above, below, auto }` — preferred direction.
+    `.above` is the chat composer convention (composer is near the bottom
+    of the chat window, so below-caret is clipped); `.below` will be the
+    editor convention (the editor is tall, more room below the caret);
+    `.auto` picks whichever side has more room tie-broken to `.above`.
+  - `nonisolated static func origin(caretRect:panelSize:windowFrame:placement:gap:horizontalOffset:)`
+    — pure, testable origin computation. No AppKit state access (only
+    `NSRect`/`NSPoint`/`NSSize`/`CGFloat` arithmetic on value types). The
+    "room above/below" math is measured against the caret rect, not the
+    window — so `.auto` is genuinely caret-relative, not window-relative.
+  - `func present(caretRect:in:placement:gap:horizontalOffset:)` — instance
+    method: computes the origin via the static helper, sets the frame,
+    attaches as a child window (`addChildWindow(_:ordered:)`) so it tracks
+    window moves, keeps the parent-window attachment idempotent via the
+    `parent == nil` guard.
+  - `@MainActor static func caretRect(in textView: NSTextView) -> NSRect?`
+    — canonical AppKit recipe for the screen-coordinate caret-line rect:
+    `ensureLayout(for:)` → `glyphRange(forCharacterRange:length:0)` →
+    `lineFragmentRect(forGlyphAt:effectiveRange:)` (gets the line's full
+    height, important so "above vs below" measures against the full line,
+    not a 0-height point) → `textContainerOrigin` offset →
+    `convert(_:to: nil)` → `convertToScreen(_:)`. Handles the empty-document
+    case (no glyphs → fall back to `textContainerOrigin`) and the
+    end-of-document caret case (`glyphRange.location == glyphCount` →
+    clamp to `glyphCount - 1`).
+- `Sources/WikiFS/Editor/ComposerTextView.swift` — `Coordinator.presentPanel()`
+  now calls `ChatAutocompletePanel.caretRect(in: anchor)` and passes the
+  result to `panel.present(caretRect:in:placement:)`. Defensive fallback:
+  if `caretRect(in:)` returns nil (no `layoutManager`, `textContainer`, or
+  `window` — shouldn't happen in practice but defensive), falls back to the
+  text view's bounds converted to screen coordinates; the new positioning
+  math is still applied, so the fallback gives the correct "4pt gap above
+  the view's top" behavior even without a caret rect. Adds an explicit
+  `guard let window` early-return so a `nil` window doesn't try to attach
+  the panel (matches the original silent return semantics).
+- `Tests/WikiFSTests/ChatAutocompletePanelPlacementTests.swift` — NEW;
+  10 pure tests for `ChatAutocompletePanel.origin(...)`, covering `.above`
+  / `.below` placement + their no-room fallbacks, `.auto` picking the
+  roomier side (with tie → above), default gap (4pt, matches historical),
+  custom gap, and horizontal offset.
+
+**Why didn't I write a live-NSWindow integration test for `caretRect(in:)`?**
+The existing `ComposerAutocompleteHostedTests` already exercises
+`presentPanel()` end-to-end (via `applyResults` → `presentPanel()` →
+`caretRect(in:)` → `present(caretRect:in:)`), so the integration path is
+covered. A focused test asserting the exact line-fragment rect / screen
+coordinate would be brittle under font-dependent line metrics; the pure
+`origin(...)` tests cover the policy decisions (above/below/auto/fallback)
+exhaustively, which is where the bug was.
+
+**Build/test.** `make version prompts && swift build` clean;
+`swift test` — 3021 tests in 258 suites all pass (including the 10 new
+`ChatAutocompletePanelPlacementTests`). Run time ~30s.
+
+**No new logs.** No `DebugLog` calls added — the panel's existing
+silent-return-on-nil-window convention was preserved, and no error paths
+were introduced (the new fallback to view-bounds positioning is a
+defensive measure for state that is technically possible but doesn't fire
+in practice; `caretRect(in:)` succeeds whenever the composer has a
+window, which is `presentPanel()`'s only caller's precondition).
+
 ## 2026-07-19 — Issue #674: Double-click to toggle collapsed/expanded headers + chat blocks (branch `feature/double-click-expand`)
 
 **Problem.** Collapsible headers and chat collapsible blocks only toggled

--- a/Sources/WikiFS/Chats/ChatAutocompletePanel.swift
+++ b/Sources/WikiFS/Chats/ChatAutocompletePanel.swift
@@ -10,9 +10,15 @@ import WikiFSSearch
 /// `NSTextView` keeps first responder while the dropdown floats above — the
 /// exact property the omnibox relies on for typing-while-navigating.
 ///
-/// Anchored ABOVE the composer (the composer sits near the bottom of the chat
-/// window, so a below-anchor dropdown would be clipped). Tracks the parent
-/// window via `addChildWindow(_:ordered:)` so it follows window moves.
+/// Positioning: anchored relative to the **caret line** of the composer
+/// (`present(caretRect:in:placement:)`), not the composer's view bounds —
+/// a multi-line composer is several lines tall, so positioning relative to the
+/// view bounds would put the panel far above the caret. The composer uses
+/// ``Placement/above`` (the composer sits near the bottom of the chat window,
+/// so a below-caret dropdown would be clipped); the editor autocomplete (#680,
+/// not yet implemented) will reuse this panel with `.below` or `.auto`.
+/// Tracks the parent window via `addChildWindow(_:ordered:)` so it follows
+/// window moves.
 @MainActor
 final class ChatAutocompletePanel: NSPanel {
     private var hosting: NSHostingView<AnyView>?
@@ -68,39 +74,180 @@ final class ChatAutocompletePanel: NSPanel {
         setContentSize(NSSize(width: width, height: host.fittingSize.height))
     }
 
-    /// Position the panel **above** the anchor view and attach it as a child
-    /// window so it tracks window moves. The composer sits near the bottom of
-    /// the chat window, so a below-anchor placement (the omnibox convention)
-    /// would be clipped.
+    /// Preferred placement of the dropdown relative to the caret. Extracted as
+    /// a type so the editor autocomplete (#680) can reuse the chat panel with
+    /// different placement heuristics than the chat composer.
     ///
-    /// `minY` floor: clamp the panel origin to at least the window's content
-    /// min Y + a small margin so a very-tall dropdown (the composer just
-    /// opened at the bottom of a short window) never overflows the title bar.
-    /// If the panel doesn't fit above the anchor, fall back to below.
-    func present(above anchor: NSView) {
-        guard let window = anchor.window else { return }
-        let rectInWindow = anchor.convert(anchor.bounds, to: nil)
-        let rectOnScreen = window.convertToScreen(rectInWindow)
-        let aboveOrigin = NSPoint(
-            x: rectOnScreen.minX,
-            y: rectOnScreen.maxY + frame.height + 4)
-        // If above-origin places the panel's top above the parent window's top,
-        // fall back to below (composer-height + 4pt gap).
-        let parentTopY = window.convertToScreen(
-            NSRect(x: 0, y: 0, width: 0, height: window.frame.height)).maxY
-        let origin: NSPoint
-        if aboveOrigin.y + frame.height > parentTopY - 8 {
-            // Not enough room above — pop BELOW the anchor instead.
-            origin = NSPoint(x: rectOnScreen.minX,
-                             y: rectOnScreen.minY - frame.height - 4)
-        } else {
-            origin = aboveOrigin
+    /// - `.above`: chat composer convention (composer lives near the bottom of
+    ///   the chat window, so below-caret would be clipped against the window's
+    ///   bottom edge).
+    /// - `.below`: editor convention (the editor is a tall NSTextView in the
+    ///   middle of the window, so there's more room below the caret than
+    ///   above).
+    /// - `.auto`: pick whichever side has more room between the caret and the
+    ///   parent window's edges — same idea as the original chat panel logic,
+    ///   but measured against the CARET rect, not the entire text view's
+    ///   bounds.
+    enum Placement: Sendable {
+        case above
+        case below
+        case auto
+    }
+
+    /// Pure, testable: compute the panel's screen-coordinate origin (bottom-
+    /// left corner) given a caret rect (in screen coordinates), the panel's
+    /// own size, the parent window's frame, and a preferred placement.
+    ///
+    /// macOS screen coordinates are bottom-left origin, so "above the caret"
+    /// = larger Y, "below" = smaller Y. The panel's origin is its bottom-left
+    /// corner, so:
+    ///   - above → origin.y = `caretRect.maxY + gap` (panel bottom sits `gap`
+    ///     above the caret's top edge, extends upward).
+    ///   - below → origin.y = `caretRect.minY - height - gap` (panel top sits
+    ///     `gap` below the caret's bottom edge, extends downward).
+    ///
+    /// The 8pt margin matches the historical behavior — don't visually touch
+    /// the parent window's title bar (top) or bottom edge. When the preferred
+    /// side doesn't have room, fall back to the other side (matches the
+    /// original chat behavior; preserves the "panel still appears" property).
+    nonisolated static func origin(
+        caretRect: NSRect,
+        panelSize: NSSize,
+        windowFrame: NSRect,
+        placement: Placement,
+        gap: CGFloat = 4,
+        horizontalOffset: CGFloat = 0
+    ) -> NSPoint {
+        let aboveOriginY = caretRect.maxY + gap
+        let belowOriginY = caretRect.minY - panelSize.height - gap
+        let roomAbove = (windowFrame.maxY - 8) - panelSize.height - caretRect.maxY - gap
+        let roomBelow = caretRect.minY - (windowFrame.minY + 8) - panelSize.height - gap
+        let x = caretRect.minX + horizontalOffset
+        switch placement {
+        case .above:
+            return roomAbove >= 0
+                ? NSPoint(x: x, y: aboveOriginY)
+                : NSPoint(x: x, y: belowOriginY)
+        case .below:
+            return roomBelow >= 0
+                ? NSPoint(x: x, y: belowOriginY)
+                : NSPoint(x: x, y: aboveOriginY)
+        case .auto:
+            // Tie → above (chat composer is the more common consumer).
+            if roomBelow > roomAbove {
+                return NSPoint(x: x, y: belowOriginY)
+            }
+            return NSPoint(x: x, y: aboveOriginY)
         }
+    }
+
+    /// Position the panel relative to a caret rect (in screen coordinates) and
+    /// attach it as a child window so it tracks window moves. The composer
+    /// coordinator computes the caret rect via ``caretRect(in:)`` and passes it
+    /// here; the panel itself stays free of NSTextView/AppKit-layout concerns.
+    ///
+    /// - Parameters:
+    ///   - caretRect: rect (screen coordinates) of the line containing the
+    ///     caret. Passing a 0-height rect (just the caret point) is fine — the
+    ///     positioning math measures "above/below the caret point" rather than
+    ///     "above/below the caret's line", but `.auto` still has both sides to
+    ///     compare against.
+    ///   - window: the parent window to attach to (and to measure room
+    ///     against).
+    ///   - placement: preferred direction (default `.above` — chat composer
+    ///     convention).
+    ///   - gap: vertical gap between the caret rect and the panel (default
+    ///     4pt).
+    ///   - horizontalOffset: extra horizontal offset added to the computed
+    ///     origin (default 0).
+    func present(
+        caretRect: NSRect,
+        in window: NSWindow,
+        placement: Placement = .above,
+        gap: CGFloat = 4,
+        horizontalOffset: CGFloat = 0
+    ) {
+        let origin = Self.origin(
+            caretRect: caretRect,
+            panelSize: frame.size,
+            windowFrame: window.frame,
+            placement: placement,
+            gap: gap,
+            horizontalOffset: horizontalOffset)
         setFrameOrigin(origin)
         if parent == nil {
             window.addChildWindow(self, ordered: .above)
         }
         orderFront(nil)
+    }
+
+    /// Compute the rect (in screen coordinates) of the line that contains an
+    /// `NSTextView`'s caret. Returns nil if the live AppKit state is unusable
+    /// (no `layoutManager`, `textContainer`, or `window`), in which case the
+    /// caller should fall back to positioning relative to the text view's
+    /// bounds (see `ComposerTextView.Coordinator.presentPanel()`).
+    ///
+    /// Canonical AppKit recipe:
+    /// 1. `ensureLayout(for: textContainer)` so the layout manager has line
+    ///    fragments for the current text.
+    /// 2. Map the caret's character location → glyph location via
+    ///    `glyphRange(forCharacterRange:)` (a 0-length character range → 0-
+    ///    length glyph range, but the location is what we need).
+    /// 3. `lineFragmentRect(forGlyphAt:effectiveRange:)` returns the line's
+    ///    rect in text-container coordinate space (with the line's full
+    ///    height — important so "above vs below" measures against the full
+    ///    line, not a 0-height point).
+    /// 4. Offset by `textContainerOrigin` → text-view coordinate space.
+    /// 5. `convert(_:to: nil)` → window coordinate space.
+    /// 6. `convertToScreen(_:)` → screen coordinate space.
+    @MainActor
+    static func caretRect(in textView: NSTextView) -> NSRect? {
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer,
+              let window = textView.window else { return nil }
+        let sel = textView.selectedRange()  // (location, 0) for a plain caret
+        let stringLength = (textView.string as NSString).length
+        guard sel.location >= 0, sel.location <= stringLength else { return nil }
+        layoutManager.ensureLayout(for: textContainer)
+
+        // Empty document: no glyphs to anchor a line fragment rect to. Use
+        // the text container origin (top of the text area) so the caller can
+        // still position the panel at the right vertical location.
+        let glyphCount = layoutManager.numberOfGlyphs
+        guard glyphCount > 0 else {
+            let originInTextView = textView.textContainerOrigin
+            let rectInWindow = textView.convert(
+                NSRect(origin: originInTextView, size: .zero),
+                to: nil)
+            return window.convertToScreen(rectInWindow)
+        }
+
+        // Map the caret's character location → glyph location. For a 0-length
+        // character range this returns a 0-length glyph range, but the
+        // location is what we want.
+        let glyphRange = layoutManager.glyphRange(
+            forCharacterRange: NSRange(location: sel.location, length: 0),
+            actualCharacterRange: nil)
+        // Caret at end-of-document: glyphRange.location may equal glyphCount.
+        // Clamp to the last valid glyph index so lineFragmentRect doesn't
+        // return .zero.
+        let safeGlyphIndex: Int
+        if glyphRange.location != NSNotFound, glyphRange.location < glyphCount {
+            safeGlyphIndex = glyphRange.location
+        } else {
+            safeGlyphIndex = glyphCount - 1
+        }
+        let lineFragmentRect = layoutManager.lineFragmentRect(
+            forGlyphAt: safeGlyphIndex,
+            effectiveRange: nil)
+        let textContainerOrigin = textView.textContainerOrigin
+        let rectInTextView = NSRect(
+            x: lineFragmentRect.minX + textContainerOrigin.x,
+            y: lineFragmentRect.minY + textContainerOrigin.y,
+            width: lineFragmentRect.width,
+            height: lineFragmentRect.height)
+        let rectInWindow = textView.convert(rectInTextView, to: nil)
+        return window.convertToScreen(rectInWindow)
     }
 }
 

--- a/Sources/WikiFS/Editor/ComposerTextView.swift
+++ b/Sources/WikiFS/Editor/ComposerTextView.swift
@@ -472,6 +472,12 @@ struct ComposerTextView: NSViewRepresentable {
 
         /// Show (or refresh) the dropdown above the composer. Installs the
         /// local ↑/↓/Escape monitor (reviewer correction #2).
+        ///
+        /// Positioning (#680 prep): the panel anchors to the **caret line**,
+        /// not the text view's bounds — for a multi-line composer, view-bounds
+        /// anchoring would put the dropdown far above the caret. Falls back to
+        /// the text view's bounds only if `caretRect(in:)` returns nil (live
+        /// AppKit state not ready, e.g. no layoutManager).
         @MainActor
         private func presentPanel() {
             guard parent.autocomplete != nil else { return }
@@ -485,7 +491,20 @@ struct ComposerTextView: NSViewRepresentable {
                     self?.commitSelection(result)
                 }
             }
-            panel.present(above: anchor)
+            guard let window = anchor.window else {
+                // No window yet — can't attach as child. Bail; the next
+                // keystroke will retry once the view is in a window.
+                return
+            }
+            // Prefer the caret-line rect; fall back to the text view's bounds
+            // if the live AppKit state isn't usable (no layoutManager, no
+            // textContainer, empty document with no glyphs). Bounds-based
+            // placement still uses the same caret-rect math (so the rect's
+            // max/min Y just becomes the view's top/bottom instead of the
+            // caret line's), preserving the "just above with 4pt gap" behavior.
+            let caretRect = ChatAutocompletePanel.caretRect(in: anchor)
+                ?? window.convertToScreen(anchor.convert(anchor.bounds, to: nil))
+            panel.present(caretRect: caretRect, in: window, placement: .above)
             installKeyMonitor()
         }
 

--- a/Tests/WikiFSTests/ChatAutocompletePanelPlacementTests.swift
+++ b/Tests/WikiFSTests/ChatAutocompletePanelPlacementTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import AppKit
+import Testing
+@testable import WikiFS
+
+/// Pure-function unit tests for `ChatAutocompletePanel.origin(...)` — the
+/// caret-relative placement math (a `nonisolated static` helper on the
+/// `@MainActor` panel class). No live NSPanel, no NSWindow, no AppKit layout
+/// — these tests assert the screen-coordinate origin computation purely from
+/// `NSRect` arithmetic.
+///
+/// Companion to `ChatAutocompleteSelectionTests`: that suite covers selection
+/// advancement; this one covers the new (caret-based, not view-bounds)
+/// dropdown positioning introduced when the panel was generalized from
+/// `present(above:)` to `present(caretRect:in:placement:)`.
+///
+/// Screen coordinates on macOS are bottom-left origin. The panel's "origin" is
+/// its BOTTOM-LEFT corner, so:
+///   - above → origin.y = caretRect.maxY + gap (panel bottom sits `gap` above
+///     the caret's top edge, extends upward).
+///   - below → origin.y = caretRect.minY - panel.height - gap (panel top sits
+///     `gap` below the caret's bottom edge, extends downward).
+struct ChatAutocompletePanelPlacementTests {
+
+    /// Window used in the room-measurement tests. (`window.frame` is a value
+    /// type — pure to construct; never lives in a live AppKit window.)
+    private let window = NSRect(x: 0, y: 0, width: 800, height: 600)
+    private let panelSize = NSSize(width: 460, height: 100)
+
+    // MARK: - `.above` placement
+
+    @Test func abovePlacesPanelJustAboveCaretWhenRoom() {
+        // Caret at y=100–120 (one line near the bottom of the window).
+        // Panel (100pt tall) should sit just above with 4pt gap:
+        // origin.y = 120 + 4 = 124, origin.x = caret.minX = 100.
+        let caret = NSRect(x: 100, y: 100, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .above)
+        #expect(origin == NSPoint(x: 100, y: 124))
+    }
+
+    @Test func aboveFallsBackToBelowWhenNoRoomAbove() {
+        // Caret at y=580–600 — within 8pt of the parent window's top (592).
+        // No room above (panel would need 100pt + 4 gap, only has 0); falls
+        // back to below: origin.y = 580 - 100 - 4 = 476.
+        let caret = NSRect(x: 100, y: 580, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .above)
+        #expect(origin == NSPoint(x: 100, y: 476))
+    }
+
+    // MARK: - `.below` placement
+
+    @Test func belowPlacesPanelJustBelowCaretWhenRoom() {
+        // Caret at y=200–220. Panel (100pt tall) should sit just below with
+        // 4pt gap: origin.y = 200 - 100 - 4 = 96 (panel top at 196, leaving
+        // 4pt gap below the caret's bottom). origin.x = caret.minX.
+        let caret = NSRect(x: 100, y: 200, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .below)
+        #expect(origin == NSPoint(x: 100, y: 96))
+    }
+
+    @Test func belowFallsBackToAboveWhenNoRoomBelow() {
+        // Caret at y=50–70. Room below = 50 - 4 - 100 - 8 = -62 (negative →
+        // doesn't fit). Falls back to above: origin.y = 70 + 4 = 74.
+        let caret = NSRect(x: 100, y: 50, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .below)
+        #expect(origin == NSPoint(x: 100, y: 74))
+    }
+
+    // MARK: - `.auto` placement (picks the roomier side)
+
+    @Test func autoPicksAboveWhenMoreRoomAbove() {
+        // Caret near bottom of window (y=100–120). More room above than below.
+        let caret = NSRect(x: 100, y: 100, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .auto)
+        #expect(origin == NSPoint(x: 100, y: 124))
+    }
+
+    @Test func autoPicksBelowWhenMoreRoomBelow() {
+        // Caret near top of window (y=500–520). More room below than above.
+        let caret = NSRect(x: 100, y: 500, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .auto)
+        // Below: origin.y = 500 - 100 - 4 = 396.
+        #expect(origin == NSPoint(x: 100, y: 396))
+    }
+
+    @Test func autoDefaultsToAboveOnExactTie() {
+        // Construct a tie: roomAbove == roomBelow.
+        // roomAbove = 592 - 100 - caret.maxY - 4 = 488 - caret.maxY
+        // roomBelow = caret.minY - 4 - 100 - 8 = caret.minY - 112
+        // For a height-0 caret (point), caret.maxY == caret.minY:
+        //   488 - y = y - 112 → 2y = 600 → y = 300
+        let caret = NSRect(x: 100, y: 300, width: 0, height: 0)
+        let aboveRoom = (window.maxY - 8) - panelSize.height - caret.maxY - 4
+        let belowRoom = caret.minY - (window.minY + 8) - panelSize.height - 4
+        #expect(aboveRoom == belowRoom, "sanity: caret y should produce an exact tie")
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .auto)
+        // Tie → above. origin.y = caret.maxY + 4 = 300 + 4 = 304.
+        #expect(origin == NSPoint(x: 100, y: 304))
+    }
+
+    // MARK: - Gap + horizontal offset
+
+    @Test func customGapAppliedBetweenCaretAndPanel() {
+        // gap = 10 (instead of default 4). Caret at y=100–120, placement above.
+        // origin.y = 120 + 10 = 130.
+        let caret = NSRect(x: 100, y: 100, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .above, gap: 10)
+        #expect(origin == NSPoint(x: 100, y: 130))
+    }
+
+    @Test func horizontalOffsetShiftsXCoordinate() {
+        // Same setup as abovePlacesPanelJustAboveCaretWhenRoom, but shifted
+        // right by 20pt.
+        let caret = NSRect(x: 100, y: 100, width: 0, height: 20)
+        let origin = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .above,
+            gap: 4, horizontalOffset: 20)
+        #expect(origin == NSPoint(x: 120, y: 124))
+    }
+
+    // MARK: - Default gap matches the historical 4pt convention
+
+    @Test func defaultGapIsHistoricalFourPoints() {
+        // Document the default value — 4pt matches the chat composer's
+        // historical visual gap and the omnibox's below-anchor gap.
+        let caret = NSRect(x: 0, y: 0, width: 0, height: 0)
+        let withDefault = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .above)
+        let withExplicitFour = ChatAutocompletePanel.origin(
+            caretRect: caret, panelSize: panelSize,
+            windowFrame: window, placement: .above, gap: 4)
+        #expect(withDefault == withExplicitFour)
+    }
+}


### PR DESCRIPTION
## Problem

The chat composer's `[[kind:partial` autocomplete dropdown appeared several
lines above the caret instead of just above the current line. Two compounding
bugs in `ChatAutocompletePanel.present(above:)` at
`Sources/WikiFS/Chats/ChatAutocompletePanel.swift:80`:

1. The panel anchored to the **entire NSTextView's bounds**
   (`anchor.convert(anchor.bounds, to: nil)`) rather than the caret line —
   for a 3-line default composer, the anchor's top is 3 lines above the
   caret, so the panel was 3 lines too high before even counting the
   per-panel gap math.
2. The above-placement math added an extra `frame.height` to the origin Y
   (`rectOnScreen.maxY + frame.height + 4`), leaving a panel-height-plus-4pt
   gap between the anchor's top and the panel's bottom — visually "a panel too
   high". The below-fallback math in the same method matched the omnibox's
   correct below-placement math, so only the above path was wrong.

## Fix

Replaced `present(above: NSView)` with caret-relative positioning,
generalized so the editor autocomplete (#680, not yet implemented) can
reuse the same panel with different placement heuristics.

### `ChatAutocompletePanel` (positioning + caret-rect helper)

- `enum Placement { case above, below, auto }` — preferred direction.
  - `.above` is the chat composer convention (composer is near the bottom
    of the chat window, so below-caret is clipped against the window's
    bottom edge).
  - `.below` will be the editor convention (the editor is a tall NSTextView
    in the middle of the window, more room below the caret than above).
  - `.auto` picks whichever side has more room between the caret and the
    parent window's edges — tie-broken to `.above` (chat is the more common
    consumer). Like the original chat behavior but measured against the
    CARET, not the entire text view's bounds.
- `nonisolated static func origin(caretRect:panelSize:windowFrame:placement:gap:horizontalOffset:)`
  — pure, testable origin computation. No AppKit state access (only
  `NSRect`/`NSPoint`/`NSSize`/`CGFloat` arithmetic on value types). The
  8pt margin matches the historical behavior (don't visually touch the
  title bar / bottom edge). When the preferred side doesn't have room,
  falls back to the other side.
- `func present(caretRect:in:placement:gap:horizontalOffset:)` — instance
  method: computes the origin via the static helper, sets the frame, and
  attaches as a child window (`addChildWindow(_:ordered:)`) so it tracks
  window moves. Child-window attachment stays idempotent via the
  `parent == nil` guard.
- `@MainActor static func caretRect(in textView: NSTextView) -> NSRect?`
  — canonical AppKit recipe for the screen-coordinate caret-line rect:
  `ensureLayout(for:)` → `glyphRange(forCharacterRange:length:0)` →
  `lineFragmentRect(forGlyphAt:effectiveRange:)` (gets the line's full
  height — important so "above vs below" measures against the full line,
  not a 0-height point) → `textContainerOrigin` offset →
  `convert(_:to: nil)` → `convertToScreen(_:)`. Handles the empty-document
  case (no glyphs → fall back to `textContainerOrigin`) and the
  end-of-document caret case (`glyphRange.location == glyphCount` →
  clamp to `glyphCount - 1`).

### `ComposerTextView.Coordinator.presentPanel()`

Calls `ChatAutocompletePanel.caretRect(in: anchor)` and passes the result
to `panel.present(caretRect:in:placement:)`. Defensive fallback: if
`caretRect(in:)` returns nil (no `layoutManager`, `textContainer`, or
`window` — shouldn't happen in practice but defensive), falls back to the
text view's bounds converted to screen coordinates; the new positioning
math is still applied, so the fallback gives the correct "4pt gap above the
view's top" behavior even without a caret rect. Adds an explicit
`guard let window` early-return so a `nil` window doesn't try to attach
the panel (matches the original silent-return semantics).

## Tests

New `Tests/WikiFSTests/ChatAutocompletePanelPlacementTests.swift`: 10 pure
tests for `ChatAutocompletePanel.origin(...)` covering:
- `.above` placement places panel just above caret when there's room.
- `.above` placement falls back to below when there isn't room above.
- `.below` placement places panel just below caret when there's room.
- `.below` placement falls back to above when there isn't room below.
- `.auto` picks above when more room above.
- `.auto` picks below when more room below.
- `.auto` defaults to above on exact tie.
- Default gap is 4pt (matches historical chat + omnibox gap).
- Custom gap is applied.
- Horizontal offset shifts the X coordinate.

The existing `ComposerAutocompleteHostedTests` already exercises
`presentPanel()` end-to-end (via `applyResults` → `presentPanel()` →
`caretRect(in:)` → `present(caretRect:in:)`), so the integration path is
covered; no new live-NSWindow integration tests were added because a focused
test asserting the exact line-fragment rect / screen coordinate would be
brittle under font-dependent line metrics, and the pure `origin(...)`
tests cover the policy decisions (above/below/auto/fallback) exhaustively —
which is where the bug was.

## Build + test

`make version prompts && swift build` — clean.
`swift test` — 3021 tests in 258 suites all pass (including the 10 new
`ChatAutocompletePanelPlacementTests`).

## House rules

- No bare `try?` (none introduced).
- No `print` / no `DebugLog` calls added — the panel's existing
  silent-return-on-nil-window convention was preserved, and no error paths
  were introduced (the new fallback to view-bounds positioning is a
  defensive measure for state that is technically possible but doesn't
  fire in practice).
- No new sqlite / store touch — panel positioning is pure AppKit.
