### PR TITLE
Embed mermaid diagrams inline in pages (#670)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,106 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-19 — Issue #670: Embed mermaid diagrams inline in pages (branch `diagram-embeds`)
+
+**Problem.** A wiki page that wanted to inline a Mermaid diagram from a `.mmd`
+source (`![[source:flow.mmd]]`) fell through to a cite link — the existing
+embed pipeline only knew how to render byteful media blobs (image / audio /
+video / PDF) and byteless external media (provider iframes / direct-remote /
+Apple Podcasts). Diagram sources (`.mmd` / `text/mermaid`) are byteful but
+none of those kinds, so they rendered as nothing useful.
+
+**Fix.** Add a fourth `EmbedTarget.Kind` — `.diagram` — that carries the raw
+Mermaid source text in a new `content: String?` field on `EmbedTarget`. The
+page renderer emits `<div class='mermaid'>ESCAPED_CONTENT</div>`, and the
+already-bundled `mermaid.min.js` (v11) renders it inline as SVG — no
+per-embed JS, no new vendored library.
+
+**Resolution chain (3 layers, one PR):**
+
+1. **`EmbedTarget` (`Sources/WikiFSTypes/EmbedTarget.swift`)** — `Kind` gains
+   `case diagram`; `EmbedTarget` gains `public let content: String?` (nil for
+   the three media kinds, the diagram source text for `.diagram`). `init`
+   defaults `content` to nil so existing call sites stay clean.
+
+2. **`WikiRenderContext.build(from:)` (`Sources/WikiFSCore/Core/WikiRenderContext.swift`)**
+   — the per-source embed-map loop now tries the Mermaid resolution path
+   first, before the byteless-external descriptor path. Uses
+   `MermaidSourceDetector.isMermaidSource(mimeType:filename:content:nil)`
+   (the cheap mime + filename arms — no content scan, since reading every
+   source's bytes during render-context build would be wasteful) and, when
+   true, reads `store.sourceBytes(id:)` and decodes UTF-8. The result:
+   `EmbedTarget(kind: .diagram, url: source.id.rawValue, content: text)`.
+   Falls through to the descriptor path on non-mermaid sources or on
+   un-decodable bytes (no half-rendered empty div).
+   - **Why `WikiRenderContext` and not `ExternalEmbed`:** `ExternalEmbed`
+     operates on `SourceEmbedDescriptor`, which the `embedDescriptors()`
+     query filters to byteless sources only (`WHERE sv.blob_hash IS NULL`).
+     A `.mmd` source is byteful, so it never reaches `ExternalEmbed`.
+     The render-context loop iterates all `store.sources` and is the right
+     seam for byteful-as-embed (matches how MediaEmbedPlayerView reads
+     source bytes via the same store handle).
+
+3. **`WikiLinkMarkdown.embedHTML` (`Sources/WikiFSLinks/WikiLinkMarkdown.swift`)**
+   — the switch on `target.kind` gains `case .diagram`, emitting
+   `<div class="mermaid">ESCAPED_CONTENT</div>`. Content is HTML-escaped via
+   the existing `embedEscape` helper (the same set used for alt text:
+   `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`) so the parser
+   can't misread a `<` inside a Mermaid label as the start of a tag. The
+   reader's existing `mermaidBootstrapJS` reads `div.textContent` (which
+   un-escapes back to the raw diagram source) before rendering — that's
+   the same mechanism the ` ```mermaid ` code-block path uses, so the
+   reader doesn't need a new bootstrap.
+
+**Reader change (one line):** `WikiReaderView.documentHTML`'s mermaid-lib
+injection condition now triggers on either `class="language-mermaid"` (the
+existing ` ```mermaid ` code-block form) OR `class="mermaid"` (the new div
+form emitted by `.diagram` embeds). The bootstrap script does
+`mermaid.run({ querySelector: '.mermaid' })` regardless of how the div got
+there, so the rest is unchanged.
+
+**Scope.**
+
+- `Sources/WikiFSTypes/EmbedTarget.swift` — added `case diagram` to `Kind`
+  and `public let content: String?` field; default-nil `init` param for
+  backward compat with media-kind constructors.
+- `Sources/WikiFSCore/Core/WikiRenderContext.swift` — per-source embed-map
+  loop now tries Mermaid resolution first (cheap detection + lazy byte read)
+  before falling through to the byteless-external descriptor path.
+- `Sources/WikiFSLinks/WikiLinkMarkdown.swift` — `embedHTML` switch gains
+  `case .diagram` returning `<div class="mermaid">ESCAPED</div>`; doc on
+  `SourceEmbedInfo` updated to mention diagrams.
+- `Sources/WikiFS/Reader/WikiReaderView.swift` — lib-injection condition
+  extended to also match the div form (one extra `||` clause).
+- `Sources/WikiFS/Sources/MediaEmbedPlayerView.swift` — `element(for:)`
+  switch gains `case .diagram` returning empty string (defensive — diagrams
+  never reach this media-player view; `SourceDetailView` shows no Media tab
+  for `.mmd` sources so no embed target is constructed that way).
+- `Tests/WikiFSTests/DiagramEmbedTests.swift` — NEW (11 tests):
+  - `EmbedTarget.Kind.diagram` + `content` field (#670 §1): existence,
+    backward-compat nil default, kind-equality.
+  - `WikiRenderContext.build(from:)` (#670 §2): `.mmd` source → `.diagram`
+    target carrying the raw text (resolved by filename, ext-stripped, and
+    canonical id); `text/mermaid` mime source → same; non-mermaid `.md`
+    source → `target == nil` (falls through to blob/cite); un-decodable
+    bytes → `target == nil` (no garbled div).
+  - `WikiLinkMarkdown.embedHTML` (#670 §3): `.diagram` target →
+    `<div class="mermaid">…</div>` containing the (HTML-escaped) source;
+    dangerous chars (`<` `>` `&`) escaped; missing target → cite link
+    fallback (no half-rendered div); media embeds (iframe / audio / video)
+    still render through the same switch now that `.diagram` is a fourth
+    arm (#670 non-regression guard).
+
+**Verification.**
+
+- `make version prompts && swift build` — clean, 0 errors / 0 warnings.
+- `swift test --filter DiagramEmbedTests` — 11/11 pass (~0.05 s).
+- `swift test` (full suite) — **3026 tests / 258 suites pass** (~32 s).
+  No regressions.
+
+**Closes #670.** NOT merged — branch `diagram-embeds` left open for review;
+PR title: "Embed mermaid diagrams inline in pages (#670)".
+
 ## 2026-07-19 — Issue #669: Replace merval with mermaid.min.js for v11 syntax validation (branch `feature/mermaid-validator-v11`)
 
 **Problem.** `MermaidValidator` validated mermaid blocks via the vendored

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -192,12 +192,15 @@ struct WikiReaderView: View {
         let width = Int(PageEditorMetrics.readableContentWidth)
         let inset = Int(PageEditorMetrics.contentInset)
         // Embed the vendored Mermaid library + bootstrap only when the page
-        // actually contains a mermaid code block (the exact class visitCodeBlock
-        // emits) and the library is bundled. Otherwise the block stays a normal
-        // <pre><code> — graceful degradation for swift test / dev runs with no
-        // bundle, and no ~3 MB parse cost for diagram-free pages.
+        // actually contains a mermaid block (the exact class visitCodeBlock
+        // emits, OR a `<div class="mermaid">` emitted directly by a diagram
+        // embed — #670) and the library is bundled. Otherwise the block stays
+        // a normal `<pre><code>` — graceful degradation for swift test / dev
+        // runs with no bundle, and no ~3 MB parse cost for diagram-free pages.
         var mermaidScripts = ""
-        if body.contains("class=\"language-mermaid\""), let lib = mermaidLib {
+        if (body.contains("class=\"language-mermaid\"")
+                || body.contains("class=\"mermaid\"")),
+           let lib = mermaidLib {
             mermaidScripts = "<script>\(lib)</script>\n<script>\(mermaidBootstrapJS)</script>"
         }
         return """

--- a/Sources/WikiFS/Sources/MediaEmbedPlayerView.swift
+++ b/Sources/WikiFS/Sources/MediaEmbedPlayerView.swift
@@ -127,6 +127,12 @@ enum MediaEmbedPlayerHTML {
             return "<audio src=\"\(esc(target.url))\" controls class=\"wiki-embed\"></audio>"
         case .video:
             return "<video src=\"\(esc(target.url))\" controls class=\"wiki-embed\"></video>"
+        case .diagram:
+            // #670 — diagrams render inline through `WikiLinkMarkdown.embedHTML`
+            // in the page reader; this media-player view is never used for a
+            // diagram (no Source Detail Media tab is shown for `.mmd` sources).
+            // Defensive empty fallback for exhaustiveness.
+            return ""
         }
     }
 

--- a/Sources/WikiFSCore/Core/WikiRenderContext.swift
+++ b/Sources/WikiFSCore/Core/WikiRenderContext.swift
@@ -162,11 +162,41 @@ public struct WikiRenderContext: Sendable {
         let uniqueLooseKeys = index.uniqueSourceLooseKeys
 
         // --- Embed map (reader lines ~848–873; WRC-specific — per-source) ---
+        //
+        // Two resolution paths compose here, in priority order:
+        //   1. **Mermaid diagram** (#670): a source carrying `.mmd` /
+        //      `text/mermaid` / `text/x-mermaid` (cheap detector arms —
+        //      mime + filename only, no content scan) resolves to a `.diagram`
+        //      EmbedTarget carrying the raw source text. The renderer emits
+        //      `<div class='mermaid'>…</div>`; the bundled mermaid.min.js (v11)
+        //      picks it up and inlines an SVG. Diagram takes precedence over
+        //      the descriptor path because a `.mmd` source is byteful (it
+        //      carries real text bytes) and therefore absent from
+        //      `embedDescriptors()` (which is `WHERE sv.blob_hash IS NULL`) —
+        //      a diagram source would otherwise fall through to the byteful
+        //      blob branch and emit nothing (no image/audio/video/pdf).
+        //   2. **Byteless external media** (Phase 4b): synthetic provider mimes
+        //      + Apple Podcasts + direct-remote media, dispatched through
+        //      `ExternalEmbed.target(for:)` as before.
         let embedDescriptorMap = store.embedDescriptors()
         var embedMap: [String: WikiLinkMarkdown.SourceEmbedInfo] = [:]
         for source in store.sources {
-            let target = embedDescriptorMap[source.id]
-                .flatMap { ExternalEmbed.target(for: $0) }
+            let target: EmbedTarget? = {
+                // 1. Mermaid diagram — #670.
+                if MermaidSourceDetector.isMermaidSource(
+                    mimeType: source.mimeType,
+                    filename: source.filename,
+                    content: nil),
+                   let bytes = store.sourceBytes(id: source.id),
+                   let text = String(data: bytes, encoding: .utf8) {
+                    return EmbedTarget(
+                        kind: .diagram, url: source.id.rawValue, content: text)
+                }
+                // 2. Byteless external media (provider iframes, direct-remote,
+                //    Apple Podcasts).
+                return embedDescriptorMap[source.id]
+                    .flatMap { ExternalEmbed.target(for: $0) }
+            }()
             let info = WikiLinkMarkdown.SourceEmbedInfo(
                 id: source.id, mimeType: source.mimeType, target: target)
             let names = [source.displayName, source.filename].compactMap({ $0 })

--- a/Sources/WikiFSLinks/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSLinks/WikiLinkMarkdown.swift
@@ -26,9 +26,10 @@ public enum WikiLinkMarkdown {
     /// The render decision for one `![[source:…]]` embed: the source id + its
     /// MIME type (for the byteful `wiki-blob://` dispatch) and an optional
     /// external `EmbedTarget` (for byteless external media — provider iframes,
-    /// direct-remote `<audio>`/`<video>`, Apple Podcasts player). When `target`
-    /// is non-nil the renderer emits the external element; otherwise it falls
-    /// back to the byteful blob dispatch (Phase 4a), then to a cite link.
+    /// direct-remote `<audio>`/`<video>`, Apple Podcasts player — or an inline
+    /// Mermaid diagram, #670). When `target` is non-nil the renderer emits the
+    /// element for the target's `kind`; otherwise it falls back to the byteful
+    /// blob dispatch (Phase 4a), then to a cite link.
     public struct SourceEmbedInfo: Sendable, Equatable {
         public let id: PageID
         public let mimeType: String?
@@ -392,7 +393,8 @@ public enum WikiLinkMarkdown {
     /// `<video src="wiki-blob://…">` against empty bytes). The `wiki-blob://` URL
     /// is served by `BlobSchemeHandler` (Phase 4a).
     private static func embedHTML(display: String, id: PageID, mimeType: String?, target: EmbedTarget?) -> String? {
-        // 1. Byteless external media: provider iframe or direct-remote native tag.
+        // 1. Byteless external media or inline diagram: provider iframe,
+        // direct-remote native tag, or a Mermaid diagram div.
         if let target {
             switch target.kind {
             case .iframe:
@@ -411,6 +413,21 @@ public enum WikiLinkMarkdown {
                 return "<audio src=\"\(embedEscape(target.url))\" controls class=\"wiki-embed\"></audio>"
             case .video:
                 return "<video src=\"\(embedEscape(target.url))\" controls class=\"wiki-embed\"></video>"
+            case .diagram:
+                // #670 — inline Mermaid diagram. Emit a `<div class='mermaid'>`
+                // carrying the HTML-escaped source text; the reader's bundled
+                // `mermaid.min.js` (v11) scans the DOM for `.mermaid` divs,
+                // reads `div.textContent` (which un-escapes the entities below
+                // back to the raw diagram source), and renders an inline SVG.
+                // No per-embed JS — the reader's `mermaidBootstrapJS` is what
+                // initializes the library and calls `mermaid.run`.
+                //
+                // Escape the same set `embedEscape` uses for alt text so `<`,
+                // `>`, `&`, and `"` survive the HTML parser intact (a mermaid
+                // arrow `A --> B` is literal text, but `A < B` would otherwise
+                // start a tag and break the surrounding markup).
+                let escaped = embedEscape(target.content ?? "")
+                return "<div class=\"mermaid\">\(escaped)</div>"
             }
         }
         // 2. Byteful blob dispatch (Phase 4a) — unchanged.

--- a/Sources/WikiFSTypes/EmbedTarget.swift
+++ b/Sources/WikiFSTypes/EmbedTarget.swift
@@ -17,13 +17,26 @@ public struct EmbedTarget: Sendable, Equatable {
         case audio
         /// A native `<video>` pointed at a direct-remote media URL.
         case video
+        /// A Mermaid diagram rendered inline as a `<div class='mermaid'>`. The
+        /// diagram source text travels in `content`; `url` carries the source
+        /// id (informational — the renderer dispatches on `kind`, not `url`).
+        /// The bundled `mermaid.min.js` (v11) scans the document for
+        /// `.mermaid` divs and renders them as inline SVG — no per-embed JS.
+        /// Issue #670.
+        case diagram
     }
 
     public let kind: Kind
     public let url: String
+    /// For `.diagram` targets, the raw Mermaid source text that the renderer
+    /// emits inside `<div class='mermaid'>…</div>`. `nil` for all media
+    /// embeds (`.iframe` / `.audio` / `.video`) — those dispatch on `url`
+    /// alone. Issue #670.
+    public let content: String?
 
-    public init(kind: Kind, url: String) {
+    public init(kind: Kind, url: String, content: String? = nil) {
         self.kind = kind
         self.url = url
+        self.content = content
     }
 }

--- a/Tests/WikiFSTests/DiagramEmbedTests.swift
+++ b/Tests/WikiFSTests/DiagramEmbedTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Issue #670 — Mermaid diagram source embeds (`![[source:diagram.mmd]]`).
+///
+/// A `.mmd` source (or any `text/mermaid` source) embedded in a page renders
+/// inline as a `<div class='mermaid'>…</div>` element, picked up by the
+/// bundled `mermaid.min.js` (v11) and rendered as an inline SVG — no per-embed
+/// JS. The diagram source text travels through the embed target itself
+/// (`EmbedTarget.content`) so the renderer stays pure / store-free.
+///
+/// Three layers tested here:
+///   1. `EmbedTarget.Kind.diagram` + the `content` field (#670 §1).
+///   2. `WikiRenderContext` resolves a `.mmd` source to a `.diagram` target
+///      carrying the source text (#670 §2) — the same text the source-detail
+///      Reader tab would show.
+///   3. `WikiLinkMarkdown.embedHTML` emits the mermaid div with HTML-escaped
+///      content so the page parser can't break on `<`/`>`/`&` inside the
+///      diagram source (#670 §3).
+@MainActor
+struct DiagramEmbedTests {
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("diagram-embed-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    // MARK: - EmbedTarget API surface (#670 §1)
+
+    @Test func diagramKindExistsAndCarriesContent() throws {
+        // The new `.diagram` kind + `content` field are the public surface the
+        // renderer dispatches on. `url` is informational for diagrams.
+        let target = EmbedTarget(
+            kind: .diagram, url: "01HDIAGRAM0000000000000001",
+            content: "flowchart LR\n  A --> B")
+        #expect(target.kind == .diagram)
+        #expect(target.content == "flowchart LR\n  A --> B")
+        #expect(target.url == "01HDIAGRAM0000000000000001")
+    }
+
+    @Test func mediaTargetsKeepNilContentByDefault() throws {
+        // Existing media embed constructors (provider iframe, direct-remote
+        // audio/video) carry no content — backward compat: `content` defaults to
+        // nil so unchanged call sites stay clean.
+        let iframe = EmbedTarget(kind: .iframe, url: "https://player/1")
+        let audio = EmbedTarget(kind: .audio, url: "https://x/ep.mp3")
+        let video = EmbedTarget(kind: .video, url: "https://x/clip.mp4")
+        #expect(iframe.content == nil)
+        #expect(audio.content == nil)
+        #expect(video.content == nil)
+    }
+
+    @Test func allKindsDistinguishInEquality() throws {
+        // `.diagram` must be its own case — not blend into an existing one.
+        // Equality on `Kind` is what switch statements compile down to.
+        #expect(EmbedTarget.Kind.diagram != .iframe)
+        #expect(EmbedTarget.Kind.diagram != .audio)
+        #expect(EmbedTarget.Kind.diagram != .video)
+    }
+
+    // MARK: - WikiRenderContext resolution (#670 §2)
+
+    @Test func renderContextResolvesMmdSourceToDiagramTarget() throws {
+        // A `.mmd` source — the byteful case `embedDescriptors()` skips
+        // (`WHERE sv.blob_hash IS NULL`), so the diagram-resolution path
+        // in `WikiRenderContext.build(from:)` is what fills its embed entry.
+        let store = try GRDBWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+        let diagram = "flowchart LR\n  A --> B\n  B --> C"
+        // .mmd extension → `text/mermaid` mime (via `MimeType.mime(forExtension:)`,
+        // the #620 fallback for extensions UTType can't resolve).
+        let src = try store.addSource(
+            filename: "Flow.mmd", data: Data(diagram.utf8))
+        model.reloadFromStore()
+
+        let ctx = WikiRenderContext.build(from: model)
+
+        // The source is a `.diagram` target carrying the raw mermaid text —
+        // resolved by filename (lowercased "flow.mmd"), by id, and by
+        // ext-stripped ("flow").
+        let byName = try #require(ctx.embedInfo("flow.mmd"))
+        #expect(byName.id == src.id)
+        let target = try #require(byName.target)
+        #expect(target.kind == .diagram)
+        #expect(target.content == diagram)
+        #expect(target.url == src.id.rawValue)  // informational
+        // By ext-stripped name.
+        let byStripped = try #require(ctx.embedInfo("flow"))
+        #expect(byStripped.id == src.id)
+        // By canonical id (lowercased).
+        let byID = try #require(ctx.embedInfo(src.id.rawValue.lowercased()))
+        #expect(byID.id == src.id)
+    }
+
+    @Test func renderContextResolvesTextMermaidMimeSource() throws {
+        // A source with the explicit `text/mermaid` mime (no `.mmd` extension)
+        // also resolves to a `.diagram` target — the detector's MIME arm fires.
+        let store = try GRDBWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+        let diagram = "sequenceDiagram\n  Alice->>Bob: Hi"
+        let src = try store.addSource(
+            filename: "sequence.txt", data: Data(diagram.utf8),
+            mimeType: "text/mermaid")
+        model.reloadFromStore()
+
+        let ctx = WikiRenderContext.build(from: model)
+        let info = try #require(ctx.embedInfo("sequence.txt"))
+        let target = try #require(info.target)
+        #expect(target.kind == .diagram)
+        #expect(target.content == diagram)
+        #expect(info.id == src.id)
+    }
+
+    @Test func renderContextDoesNotResolveNonMermaidTextSource() throws {
+        // A generic `.md` source with no fenced ```mermaid block does NOT
+        // produce a `.diagram` target — the cheap detector (mime + filename
+        // only, `content: nil`) returns false, so the source falls through to
+        // the byteful blob / cite-link path unchanged.
+        let store = try GRDBWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+        _ = try store.addSource(
+            filename: "notes.md", data: Data("# Notes\nHello world".utf8))
+        model.reloadFromStore()
+
+        let ctx = WikiRenderContext.build(from: model)
+        let info = try #require(ctx.embedInfo("notes.md"))
+        // No diagram target — the source's mime (text/markdown) does not match
+        // and the filename isn't `.mmd`.
+        #expect(info.target == nil)
+    }
+
+    @Test func renderContextEmptyOrUnencodableBytesFallsBackToNoTarget() throws {
+        // A `.mmd` source whose bytes couldn't be decoded as UTF-8 does NOT
+        // produce a `.diagram` target with garbage content — we refuse to emit
+        // a `<div class='mermaid'>…</div>` against text we can't read. Falls
+        // back to nil (the renderer emits a cite link).
+        let store = try GRDBWikiStore(databaseURL: tempDatabaseURL())
+        let model = WikiStoreModel(store: store)
+        // Invalid UTF-8 — `String(data:encoding:.utf8)` returns nil.
+        let badBytes = Data([0xFF, 0xFE, 0xFD])
+        _ = try store.addSource(
+            filename: "broken.mmd", data: badBytes)
+        model.reloadFromStore()
+
+        let ctx = WikiRenderContext.build(from: model)
+        let info = try #require(ctx.embedInfo("broken.mmd"))
+        // bytes present but un-decodable as UTF-8 → no diagram target.
+        #expect(info.target == nil)
+    }
+
+    // MARK: - embedHTML emits the mermaid div (#670 §3)
+
+    @Test func embedDiagramTargetRendersMermaidDiv() throws {
+        let id = PageID(rawValue: "01HDIAGRAM000000000000000A")
+        let target = EmbedTarget(
+            kind: .diagram, url: id.rawValue,
+            content: "flowchart LR\n  A --> B")
+        let out = WikiLinkMarkdown.linkified(
+            "![[source:Flow]]",
+            isResolved: { _, _ in true },
+            embedInfo: { _ in
+                WikiLinkMarkdown.SourceEmbedInfo(
+                    id: id, mimeType: "text/mermaid", target: target)
+            }
+        )
+        // The mermaid div with the diagram text — the bundled mermaid.min.js
+        // (v11) scans the document for `.mermaid` divs and reads
+        // `div.textContent` (which un-escapes `&gt;` back to `>`) before
+        // rendering, mirroring the reader's ` ```mermaid ` code-block path
+        // (`WikiReaderView.mermaidBootstrapJS`).
+        #expect(out.contains("<div class=\"mermaid\">"))
+        #expect(out.contains("flowchart LR"))
+        // The `-->` arrow is HTML-escaped to `--&gt;` so the parser stays
+        // safe; `div.textContent` (read by mermaid) un-escapes it back.
+        #expect(out.contains("A --&gt; B"))
+        #expect(out.contains("</div>"))
+        // The diagram is NOT a wiki-blob (no bytes fetched) and NOT a cite link.
+        #expect(!out.contains("wiki-blob://"))
+        #expect(!out.contains("wiki://source"))
+    }
+
+    @Test func embedDiagramHTMLEscapesAngleBracketsAndAmpersand() throws {
+        // The HTML parser would otherwise treat `<`/`>`/`&` in the diagram text
+        // as markup. We escape them so the DOM survives intact; the mermaid
+        // library reads `div.textContent`, which un-escapes back to the raw
+        // diagram source — verified by the reader's existing bootstrap
+        // (`WikiReaderView.mermaidBootstrapJS` does the same with
+        // `code.textContent` for ` ```mermaid ` code blocks).
+        let id = PageID(rawValue: "01HDIAGRAM000000000000000B")
+        // A diagram with `<`, `>`, `&` in the body (e.g. a node label).
+        let diagram = "flowchart LR\n  A[\"x < y & z > w\"] --> B"
+        let target = EmbedTarget(
+            kind: .diagram, url: id.rawValue, content: diagram)
+        let out = WikiLinkMarkdown.linkified(
+            "![[source:Inequality]]",
+            isResolved: { _, _ in true },
+            embedInfo: { _ in
+                WikiLinkMarkdown.SourceEmbedInfo(
+                    id: id, mimeType: "text/mermaid", target: target)
+            }
+        )
+        // The dangerous chars are HTML-escaped inside the div.
+        #expect(out.contains("&lt;"))
+        #expect(out.contains("&gt;"))
+        #expect(out.contains("&amp;"))
+        // The escaped forms do NOT leak the raw bracket chars as bare markup —
+        // the div opens and closes around the escaped text.
+        #expect(out.contains("<div class=\"mermaid\">"))
+        #expect(out.contains("</div>"))
+    }
+
+    @Test func embedDiagramWithoutTargetFallsBackToCiteLink() throws {
+        // A `.mmd` source name the embedInfo resolver returns nil for → the
+        // renderer falls back to the cite-link path (no half-rendered div).
+        let out = WikiLinkMarkdown.linkified(
+            "![[source:missing-diagram.mmd]]",
+            isResolved: { _, _ in true },
+            embedInfo: { _ in nil }
+        )
+        #expect(out.contains("wiki://source"))
+        #expect(!out.contains("<div class=\"mermaid\">"))
+    }
+
+    // MARK: - No regression: media embeds still resolve
+
+    @Test func mediaEmbedsStillRenderViaEmbedHTML() throws {
+        // Spot-check that the existing media embed paths (iframe, audio, video)
+        // still render through the same `embedHTML` switch now that `.diagram`
+        // is a fourth arm. (Existing `WikiLinkMarkdownTests` cover this in
+        // depth; this is the #670 non-regression guard.)
+        let ytID = PageID(rawValue: "01HTESTYT00000000000000YA")
+        let yt = EmbedTarget(kind: .iframe,
+            url: "https://www.youtube-nocookie.com/embed/x")
+        let audioID = PageID(rawValue: "01HTESTMP300000000000YA")
+        let audio = EmbedTarget(kind: .audio, url: "https://x/live.mp3")
+        let videoID = PageID(rawValue: "01HTESTMP40000000000YA")
+        let video = EmbedTarget(kind: .video, url: "https://x/clip.mp4")
+
+        let ytOut = WikiLinkMarkdown.linkified("![[source:yt]]",
+            isResolved: { _, _ in true },
+            embedInfo: { _ in WikiLinkMarkdown.SourceEmbedInfo(
+                id: ytID, mimeType: "video/youtube", target: yt) })
+        #expect(ytOut.contains("<iframe"))
+        #expect(!ytOut.contains("<div class=\"mermaid\">"))
+
+        let audioOut = WikiLinkMarkdown.linkified("![[source:stream]]",
+            isResolved: { _, _ in true },
+            embedInfo: { _ in WikiLinkMarkdown.SourceEmbedInfo(
+                id: audioID, mimeType: "audio/mpeg", target: audio) })
+        #expect(audioOut.contains("<audio"))
+        #expect(!audioOut.contains("<div class=\"mermaid\">"))
+
+        let videoOut = WikiLinkMarkdown.linkified("![[source:clip]]",
+            isResolved: { _, _ in true },
+            embedInfo: { _ in WikiLinkMarkdown.SourceEmbedInfo(
+                id: videoID, mimeType: "video/mp4", target: video) })
+        #expect(videoOut.contains("<video"))
+        #expect(!videoOut.contains("<div class=\"mermaid\">"))
+    }
+}


### PR DESCRIPTION
## What

Add a fourth `EmbedTarget.Kind` — `.diagram` — that carries the raw Mermaid
source text in a new `content: String?` field. A wiki page that embeds a
`.mmd` source via `![[source:flow.mmd]]` now renders the diagram inline as
SVG, picked up by the already-bundled `mermaid.min.js` (v11). No per-embed
JS, no new vendored library.

Closes #670.

## Why

Before this change, embedding a `.mmd` source in a page fell through to a
cite link. The existing embed pipeline only knew how to render byteful
media blobs (image / audio / video / PDF) and byteless external media
(provider iframes / direct-remote / Apple Podcasts). Diagram sources
(`.mmd` / `text/mermaid`) are byteful but none of those kinds, so they
rendered as nothing useful.

## How (resolution chain)

Three layers, one PR:

1. **`EmbedTarget`** (`Sources/WikiFSTypes/EmbedTarget.swift`) — `Kind`
   gains `case diagram`; `EmbedTarget` gains `public let content: String?`
   (nil for the three media kinds, the diagram source text for `.diagram`).
   `init` defaults `content` to nil so existing call sites stay clean.

2. **`WikiRenderContext.build(from:)`**
   (`Sources/WikiFSCore/Core/WikiRenderContext.swift`) — the per-source
   embed-map loop now tries the Mermaid resolution path first, before
   the byteless-external descriptor path. Uses
   `MermaidSourceDetector.isMermaidSource(mimeType:filename:content:nil)`
   (the cheap mime + filename arms — no content scan, since reading every
   source's bytes during render-context build would be wasteful) and,
   when true, reads `store.sourceBytes(id:)` and decodes UTF-8. The result:
   `EmbedTarget(kind: .diagram, url: source.id.rawValue, content: text)`.
   Falls through to the descriptor path on non-mermaid sources or on
   un-decodable bytes (no half-rendered empty div).

   **Why `WikiRenderContext` and not `ExternalEmbed`:** `ExternalEmbed`
   operates on `SourceEmbedDescriptor`, which the `embedDescriptors()`
   query filters to byteless sources only (`WHERE sv.blob_hash IS NULL`).
   A `.mmd` source is byteful, so it never reaches `ExternalEmbed`. The
   render-context loop iterates all `store.sources` and is the right
   seam for byteful-as-embed.

3. **`WikiLinkMarkdown.embedHTML`** (`Sources/WikiFSLinks/WikiLinkMarkdown.swift`)
   — the switch on `target.kind` gains `case .diagram`, emitting
   `<div class="mermaid">ESCAPED_CONTENT</div>`. Content is HTML-escaped via
   the existing `embedEscape` helper (the same set used for alt text:
   `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`) so the parser
   can't misread a `<` inside a Mermaid label as the start of a tag. The
   reader's existing `mermaidBootstrapJS` reads `div.textContent` (which
   un-escapes back to the raw diagram source) before rendering — the same
   mechanism the ` ```mermaid ` code-block path uses, so the reader
   doesn't need a new bootstrap.

**Reader change (one line):** `WikiReaderView.documentHTML`'s mermaid-lib
injection condition now triggers on either `class="language-mermaid"` (the
existing ` ```mermaid ` code-block form) OR `class="mermaid"` (the new div
form emitted by `.diagram` embeds). The bootstrap script does
`mermaid.run({ querySelector: '.mermaid' })` regardless of how the div got
there, so the rest is unchanged.

## Scope

| File | Change |
| --- | --- |
| `Sources/WikiFSTypes/EmbedTarget.swift` | Added `case diagram` to `Kind`; added `content: String?` field; default-nil `init` param |
| `Sources/WikiFSCore/Core/WikiRenderContext.swift` | Per-source embed-map loop tries Mermaid resolution first (cheap detection + lazy byte read); falls through to descriptor path otherwise |
| `Sources/WikiFSLinks/WikiLinkMarkdown.swift` | `embedHTML` switch gains `case .diagram` returning the mermaid div; updated `SourceEmbedInfo` doc |
| `Sources/WikiFS/Reader/WikiReaderView.swift` | Lib-injection condition extended to also match the div form (one extra `\|\|` clause) |
| `Sources/WikiFS/Sources/MediaEmbedPlayerView.swift` | `element(for:)` switch gains defensive `case .diagram` (returns empty — never reached) |
| `Tests/WikiFSTests/DiagramEmbedTests.swift` | NEW (11 tests across all three layers + the #670 non-regression guard) |
| `PROGRESS.md` | New entry documenting the work |

## Behavior

- `![[source:Flow.mmd]]` in a page body → `<div class="mermaid">…</div>`
  in the reader DOM → mermaid.min.js renders an inline SVG.
- `![[source:Sequence.txt]]` with `text/mermaid` mime also embeds inline
  (the detector's MIME arm fires).
- Non-mermaid sources (`.md` with no mermaid blocks, `.pdf`, etc.) are
  unaffected — they fall through to their existing embed path.
- Media embeds (YouTube iframe, direct-remote audio/video, Apple Podcasts)
  are unchanged — the `embedHTML` switch just has one more arm.
- Diagrams that can't be decoded as UTF-8 refuse to emit a div (no
  garbled half-rendered embed) — the renderer falls back to a cite link.

## Tests

`Tests/WikiFSTests/DiagramEmbedTests.swift` (11 tests):

**`EmbedTarget` surface (#670 §1)** — `diagramKindExistsAndCarriesContent`,
`mediaTargetsKeepNilContentByDefault`, `allKindsDistinguishInEquality`.

**`WikiRenderContext` resolution (#670 §2)** —
`renderContextResolvesMmdSourceToDiagramTarget`,
`renderContextResolvesTextMermaidMimeSource`,
`renderContextDoesNotResolveNonMermaidTextSource`,
`renderContextEmptyOrUnencodableBytesFallsBackToNoTarget`.

**`embedHTML` HTML emission (#670 §3)** —
`embedDiagramTargetRendersMermaidDiv`,
`embedDiagramHTMLEscapesAngleBracketsAndAmpersand`,
`embedDiagramWithoutTargetFallsBackToCiteLink`,
`mediaEmbedsStillRenderViaEmbedHTML` (non-regression).

## Verification

- `make version prompts && swift build` — clean, 0 errors / 0 warnings.
- `swift test --filter DiagramEmbedTests` — 11/11 pass (~0.05 s).
- `swift test` (full suite) — 3026 tests / 258 suites pass (~32 s).
  No regressions.

## Out of scope

- Diagram embeds inside **chat transcripts** (`ChatWebView`) — chats don't
  load the Mermaid library at all today (`ChatWebView` has no mermaid
  bootstrap). Chats that reference `.mmd` sources would render the escaped
  text inside the div but not render an SVG. This matches the existing
  chat-vs-reader split for ` ```mermaid ` code blocks, and is out of scope
  for #670 (the task targets page rendering).
- Markdown sources with embedded ` ```mermaid ` fences (`Some Doc.md`)
  embedded via `![[source:Some Doc.md]]` — the cheap detector
  (`content: nil`) doesn't catch these; the content-scan arm would require
  reading every source's bytes during render-context build. The primary
  #670 use case is standalone `.mmd` files. Future work: pre-compute a
  `has_mermaid_block` flag on `source_markdown_versions` and consult that
  from the cheap detector.
