### PR TITLE
Fix: Refresh Models fails with 'file <exe> doesn't exist' (#640)

### DIFF
--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -739,43 +739,78 @@ private struct ProviderEditorView: View {
     /// parity: `provider-snapshot-manager.ts:773-786` overwrites status/error
     /// fields only).
     private func refreshModels() {
-        // Availability pre-check (Paseo parity, :748-756 — `client.isAvailable`).
-        // This is the SSW analogue: PathPreflight on the login-shell PATH.
-        // Done on-main with the `isAvailable` state already computed by
-        // `refreshAvailability()` — no spawn if the executable isn't found.
-        guard isAvailable else {
+        // PATH-resolve the executable BEFORE constructing the probe — the
+        // probe (and `AgentBackendFactory.providerHints` /
+        // `ACPBackend.resolveSpawnConfig` downstream) expects
+        // `resolvedCommand[0]` to be an ABSOLUTE PATH. The swift-acp SDK's
+        // `Process.launch()` does NOT do PATH lookup, and a GUI app's process
+        // PATH is the launchd-minimal one (usually lacks `/opt/homebrew/bin`),
+        // so passing the bare exe name reproduces the bug where the green
+        // "Executable found on PATH" chip stays lit but Refresh Models fails
+        // with "file <exe> doesn't exist". `AgentLauncher.
+        // resolveACPProviderSpawn` does this same PATH hop on the real spawn
+        // path; the probe must match (#640).
+        //
+        // NB: `AgentProvider.command` (what `save()` stores) is the BARE argv
+        // — resolution is a spawn-time concern, not a stored-config concern.
+        // The probe takes both: `provider` (bare, matching `save()`) and
+        // `resolvedCommand` (resolved, matching the spawn contract).
+        let words = ShellWords.split(commandText)
+        let exe = words.first ?? ""
+        guard !exe.isEmpty else {
+            isAvailable = false
             modelRefreshState = .error("Executable not found on PATH")
             return
         }
-        // Reviewer finding #4: build the provider from the editor's current
-        // state, mirroring `save()`'s construction verbatim — the probe needs
-        // the resolved command path (PATH resolution happens internally in
-        // `resolveSpawnConfig` via `providerHints`). `enabled`/`isDefault` are
-        // preserved by the parent on Save; the probe doesn't read them.
-        let words = ShellWords.split(commandText)
-        let env: [String: String] = envRows.reduce(into: [:]) { result, row in
-            let key = row.key.trimmingCharacters(in: .whitespaces)
-            guard !key.isEmpty else { return }
-            result[key] = row.value
-        }
-        let providerForProbe = AgentProvider(
-            id: originalID,
-            label: label.trimmingCharacters(in: .whitespaces),
-            command: words.isEmpty ? nil : words,
-            env: env,
-            enabled: true,
-            isDefault: false)
-        let apiKeyForProbe = apiKey.isEmpty ? nil : apiKey
-
         modelRefreshState = .loading
         DebugLog.agent("ProviderEditorView.refreshModels: starting probe provider=\(originalID)")
         Task {
+            // `PathPreflight.resolveOnLoginShell` spawns `/bin/zsh -lc
+            // 'echo $PATH'` (blocking I/O) — run it OFF the main actor,
+            // mirroring `refreshAvailability()`'s detached task. Re-resolve
+            // here instead of trusting the `onAppear`-time `isAvailable` state
+            // (the user's PATH could have changed in the meantime).
+            let resolved = await Task.detached {
+                PathPreflight.resolveOnLoginShell(executable: exe)
+            }.value
+            let resolvedWords: [String]
+            switch resolved {
+            case .found(let absolutePath):
+                resolvedWords = [absolutePath] + Array(words.dropFirst())
+                await MainActor.run { isAvailable = true }
+            case .missing(let reason):
+                await MainActor.run {
+                    isAvailable = false
+                    modelRefreshState = .error(reason)
+                }
+                return
+            }
+            // Reviewer finding #4: build the provider from the editor's
+            // current state, mirroring `save()`'s construction verbatim.
+            // `enabled`/`isDefault` are preserved by the parent on Save;
+            // the probe doesn't read them. `command` is the BARE argv (what
+            // `save()` stores); the resolved argv is passed separately as
+            // `resolvedCommand` below.
+            let env: [String: String] = envRows.reduce(into: [:]) { result, row in
+                let key = row.key.trimmingCharacters(in: .whitespaces)
+                guard !key.isEmpty else { return }
+                result[key] = row.value
+            }
+            let providerForProbe = AgentProvider(
+                id: originalID,
+                label: label.trimmingCharacters(in: .whitespaces),
+                command: words.isEmpty ? nil : words,
+                env: env,
+                enabled: true,
+                isDefault: false)
+            let apiKeyForProbe = apiKey.isEmpty ? nil : apiKey
+
             // The probe struct captures only Sendable config; the SDK Client
             // actor is the concurrency boundary. All subprocess I/O runs here,
             // off-main.
             let probe = ACPProviderModelProbe(
                 provider: providerForProbe,
-                resolvedCommand: words,
+                resolvedCommand: resolvedWords,
                 apiKey: apiKeyForProbe)
             let outcome: Result<[CachedModelInfo], Error>
             do {

--- a/Sources/WikiFSEngine/ACPProviderModelProbe.swift
+++ b/Sources/WikiFSEngine/ACPProviderModelProbe.swift
@@ -38,9 +38,16 @@ public struct ACPProviderModelProbe: Sendable {
     /// The provider whose agent subprocess the probe spawns. Captured by value
     /// (`AgentProvider` is `Sendable`).
     public let provider: AgentProvider
-    /// The PATH-resolved argv for the agent executable (first element is the
-    /// path; the rest are args). Same shape `ProviderEditorView.save()` builds
-    /// and `AgentBackendFactory.providerHints` consumes.
+    /// The PATH-resolved argv for the agent executable (first element MUST
+    /// be an absolute path; the rest are args). `AgentBackendFactory.
+    /// providerHints` consumes this verbatim as `acpAgentPath`/
+    /// `acpAgentArgs`. The swift-acp SDK's `Process.launch()` does NOT do
+    /// PATH lookup, so the caller MUST resolve against the login-shell PATH
+    /// before constructing the probe (mirror `AgentLauncher.
+    /// resolveACPProviderSpawn`). This is NOT the same shape
+    /// `ProviderEditorView.save()` stores — `save()` stores the BARE argv
+    /// (`AgentProvider.command`) and defers resolution to spawn time
+    /// (#640: passing bare here reproduces "file <exe> doesn't exist").
     public let resolvedCommand: [String]
     /// The Keychain-backed API key (nil when none is configured — many agents
     /// self-authenticate, e.g. Claude via OAuth, Hermes via ~/.hermes).


### PR DESCRIPTION
## Fix: Refresh Models fails with 'file <exe> doesn't exist' (#640)

### Bug
Clicking **Refresh Models** in `AgentsSettingsView` failed with `Could not launch the agent process. The file hermes doesn't exist.` even though the green **Executable found on PATH** chip was lit.

### Root cause
Two different PATH resolution paths diverged:

1. `refreshAvailability()` (`AgentsSettingsView.swift:713`) resolved the exe through the **login-shell PATH** via `PathPreflight.resolveOnLoginShell` — found `hermes`, lit the green chip.
2. `refreshModels()` constructed `ACPProviderModelProbe(resolvedCommand: ShellWords.split(commandText))` — passing the **BARE** exe name (`hermes`), not an absolute path.

The probe hands that bare name to `AgentBackendFactory.providerHints` → `acpAgentPath`, which the swift-acp SDK's `Process.launch()` tries to spawn directly. The SDK does **no PATH lookup**, and a GUI app's process PATH is the launchd-minimal one (usually lacks `/opt/homebrew/bin`), so the spawn failed.

Meanwhile `AgentLauncher.resolveACPProviderSpawn` (the real spawn path, `AgentLauncher.swift:2068`) **does** PATH-resolve — its comment explicitly calls out that "the swift-acp SDK `launch()` does NOT do PATH lookup." The probe skipped this step.

### Fix
In `refreshModels()`, PATH-resolve the exe **before** constructing the probe — the same `PathPreflight.resolveOnLoginShell` hop `refreshAvailability()` uses. Pass the resolved absolute path as the probe's `resolvedCommand[0]`. This mirrors `AgentLauncher.resolveACPProviderSpawn` exactly, so the probe and the real spawn see the same path.

```swift
let resolved = await Task.detached {
    PathPreflight.resolveOnLoginShell(executable: exe)
}.value
let resolvedWords: [String]
switch resolved {
case .found(let absolutePath):
    resolvedWords = [absolutePath] + Array(words.dropFirst())
    await MainActor.run { isAvailable = true }
case .missing(let reason):
    await MainActor.run {
        isAvailable = false
        modelRefreshState = .error(reason)
    }
    return
}
```

Side benefits:
- The `zsh -lc` hop runs off-main (`Task.detached`, mirroring `refreshAvailability`), so the UI doesn't block.
- `isAvailable` is updated to match the fresh resolution, so the green chip can't lie about a stale `onAppear`-time result if the user's PATH changed.
- `provider.command` (what `save()` stores) stays **BARE** — only the probe's `resolvedCommand` is absolute. This keeps storage semantics unchanged (PATH resolution is a spawn-time concern).

### Why fix at the call site, not inside `providerHints`?
The bug writeup floated fixing it inside `AgentBackendFactory.providerHints` itself. I considered both and chose the call site:

- `providerHints` is explicitly documented **PURE** and its parameter is named `resolvedCommand` (the contract is: callers resolve first). Adding `PathPreflight.resolveOnLoginShell` (which spawns `/bin/zsh`) breaks purity and would force an `async` signature cascade across 6+ call sites.
- Surveying all callers: `AgentLauncher.swift:1121`, `:1323`, `:2355` and `ACPExtractionClient.swift:140` **all** pre-resolve via `resolveACPProviderSpawn`. The probe was the **only** site skipping resolution. A downstream fix would address zero additional real bugs while expanding a documented contract.
- `providerHints` returns `[String: String]` with no error channel — silently resolving-and-dropping on failure would conflate "no command configured" with "exe not on PATH" (`refreshAvailability` already handles the latter).

### Doc fixes (same root cause)
The bug was obscured by two misleading comments that claimed PATH resolution happens downstream — both corrected:

- `ACPProviderModelProbe.resolvedCommand` docstring claimed "Same shape `ProviderEditorView.save()` builds". `save()` stores the **BARE** argv; the probe needs **resolved**. They are not the same shape.
- The comment in `refreshModels()` itself claimed "PATH resolution happens internally in `resolveSpawnConfig` via `providerHints`". It does not — `resolveSpawnConfig` just reads `acpAgentPath` from the hints dict; PATH resolution is `resolveACPProviderSpawn`'s job.

### Verification
```
make version prompts && swift build
swift test    # 3031 tests in 258 suites passed
swift test --filter ACPProviderModelProbeTests   # 25 tests passed
```

### House rules
- No `print` (uses `DebugLog`).
- No bare `try?` (none added; existing probe teardown pre-dates this fix).
- Scratch: none needed (surgical 2-file change).
- Branch pushed, PR opened, **not merged**.
