### PR TITLE
Fix: Split view left pane shows code view for mermaid sources

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -970,7 +970,11 @@ struct SourceDetailView: View {
     @ViewBuilder
     private var splitContent: some View {
         HSplitView {
-            markdownContent
+            if isMermaidSource {
+                diagramCodeContent
+            } else {
+                markdownContent
+            }
             if isBytelessEmbedWithPlayer {
                 videoPlayerContent
             } else if isMermaidSource {


### PR DESCRIPTION
## Bug

In `SourceDetailView.swift`, the Split view's left pane showed markdown rendering for **all** sources — including mermaid diagram sources that should show a monospace code view. The right pane correctly showed `renderedMermaidContent` for mermaid sources, but the left pane still used `markdownContent`, ignoring the `diagramCodeContent` view added in #686 for the Reader tab.

## Fix

Route the Split view's left pane through `diagramCodeContent` when `isMermaidSource` is true, mirroring what the Reader tab already does:

```swift
HSplitView {
    if isMermaidSource {
        diagramCodeContent
    } else {
        markdownContent
    }
    // right pane unchanged
    if isBytelessEmbedWithPlayer { videoPlayerContent }
    else if isMermaidSource { renderedMermaidContent }
    else { pdfView }
}
```

One-line conditional routing change. The right pane is untouched.

## Verification

- `make version prompts && swift build` — builds clean
- `swift test` — all 3048 tests pass (259 suites)
