### PR TITLE
Fix: editor sidebar drops silently did nothing (#616 regression)

### DIFF
--- a/Sources/WikiFS/Editor/DropLinkTextView.swift
+++ b/Sources/WikiFS/Editor/DropLinkTextView.swift
@@ -65,6 +65,33 @@ final class DropLinkTextView: NSTextView {
         super.registerForDraggedTypes(combined)
     }
 
+    /// Eagerly register the sidebar drag type as soon as the view is placed in a
+    /// window.
+    ///
+    /// ROOT CAUSE of #616-regression: `NSTextView` registers its drag types
+    /// *lazily* — and in this SwiftUI-hosted, `drawsBackground = false`
+    /// configuration it never calls `registerForDraggedTypes` at all until the
+    /// user actually begins dragging *selected text out* of the editor. So a
+    /// freshly-opened editor had ZERO registered dragged types, AppKit never
+    /// routed a sidebar drag to it (no `draggingEntered`/`performDragOperation`
+    /// ever fired), and the drop silently did nothing. Relying on the
+    /// `registerForDraggedTypes` override to piggyback on NSTextView's own
+    /// registration (see the override above) never worked because that call was
+    /// never made.
+    ///
+    /// Registering here makes the editor a live drop target the moment it
+    /// appears, independent of first-responder / text-selection state. The
+    /// `registerForDraggedTypes` override still runs (it adds the sidebar type
+    /// ALONGSIDE whatever text types NSTextView later registers when the user
+    /// drags selected text), so drag-selected-text-to-move within the editor and
+    /// text drops from other apps keep working — this just guarantees the
+    /// sidebar type is present up front rather than never.
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        registerForDraggedTypes([NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)])
+    }
+
     // MARK: - Drag destination
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
@@ -83,6 +110,20 @@ final class DropLinkTextView: NSTextView {
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
         if hasSidebarPayloads(sender.draggingPasteboard) { return .copy }
         return super.draggingUpdated(sender)
+    }
+
+    /// AppKit's drop handshake is `draggingEntered` → `prepareForDragOperation`
+    /// → `performDragOperation`. `NSView`'s default `prepareForDragOperation`
+    /// returns `true`, but `NSTextView` OVERRIDES it to accept only pasteboards
+    /// it can read as native text — and a `wikiSidebarItem` payload conforms to
+    /// `public.item` (NOT a text type), so NSTextView's override VETOES the drop
+    /// and `performDragOperation` is never called (the drag glyph shows `.copy`
+    /// from `draggingEntered`, but the release silently does nothing). Override
+    /// to accept sidebar drops explicitly; fall through to `super` for everything
+    /// else so NSTextView's own text-drop gating is unchanged.
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        if hasSidebarPayloads(sender.draggingPasteboard) { return true }
+        return super.prepareForDragOperation(sender)
     }
 
     /// `true` only when the sidebar payloads were decoded AND the builder
@@ -108,7 +149,23 @@ final class DropLinkTextView: NSTextView {
         let dropPoint = convert(sender.draggingLocation, from: nil)
         let dropChar = characterIndexForInsertion(at: dropPoint)
         let range = NSRange(location: dropChar, length: 0)
-        replaceCharacters(in: range, with: text)   // fires textDidChange → @Binding
+
+        // Route the programmatic insert through the `shouldChangeText` /
+        // `didChangeText` bracket — NOT a bare `textStorage.replaceCharacters`.
+        // A raw text-storage mutation does NOT post `NSTextDidChangeNotification`,
+        // so the `NSTextViewDelegate.textDidChange` never fires, `parent.text`
+        // (the SwiftUI `@Binding` → `store.draftBody`) is never updated, and the
+        // very next `updateNSView` sees `textView.string != text` and REVERTS
+        // the insert back to the stale binding value (the drop appears to do
+        // nothing). `didChangeText()` posts the notification (→ binding sync) and
+        // `shouldChangeText` registers the edit for undo — the same path a typed
+        // edit takes.
+        guard shouldChangeText(in: range, replacementString: text) else {
+            DebugLog.editor("[drop] editor sidebar drop vetoed by shouldChangeText; nothing inserted")
+            return false
+        }
+        textStorage?.replaceCharacters(in: range, with: text)
+        didChangeText()
 
         // Move the caret to just AFTER the inserted text and reveal it. This is
         // the same outcome as typing the link by hand: caret ends up ready for

--- a/Tests/WikiFSTests/DropLinkTextViewDropTests.swift
+++ b/Tests/WikiFSTests/DropLinkTextViewDropTests.swift
@@ -116,6 +116,41 @@ struct DropLinkTextViewDropTests {
         #expect(registered.contains(sidebarType))
         #expect(registered.contains(customType))
     }
+
+    // MARK: - Eager registration when hosted in a window (#616 live-drop fix)
+
+    /// THE regression test for the #616-in-the-app fix. `NSTextView` registers
+    /// its drag types *lazily* (only once the user begins dragging selected text
+    /// out of it), so a freshly-opened editor that the user never dragged FROM
+    /// had ZERO registered dragged types — AppKit never routed a sidebar drag to
+    /// it and the drop silently did nothing. `DropLinkTextView.viewDidMoveToWindow`
+    /// eagerly registers the sidebar type so the editor is a live drop target the
+    /// moment it appears. Pin that: put the view in a window WITHOUT ever making
+    /// it first responder or calling `registerForDraggedTypes` by hand, and the
+    /// sidebar type must already be registered.
+    @Test func viewDidMoveToWindow_eagerlyRegistersSidebarType() {
+        let tv = ScrollableTextEditor.makeConfiguredTextView(
+            font: .monospacedSystemFont(ofSize: 13, weight: .regular))
+        let sidebarType = NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)
+
+        // Before entering a window, NSTextView has not lazily registered its
+        // drag types — the sidebar type is NOT yet present. (If a future SDK
+        // starts eager-registering, this pre-condition may change; the
+        // post-condition below is the load-bearing assertion.)
+        #expect(!tv.registeredDraggedTypes.contains(sidebarType))
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled], backing: .buffered, defer: false)
+        let scrollView = NSScrollView(frame: window.contentLayoutRect)
+        scrollView.documentView = tv
+        window.contentView = scrollView
+
+        // Placing the view in a window fires `viewDidMoveToWindow`, which must
+        // have eagerly registered the sidebar type — WITHOUT the view ever
+        // becoming first responder or us calling `registerForDraggedTypes`.
+        #expect(tv.registeredDraggedTypes.contains(sidebarType))
+    }
 }
 
 /// Tests for the store-side builder (`SidebarDropBuilder.insertionText`) — the


### PR DESCRIPTION
## Problem

Dragging a sidebar item (source / page / chat) into the page or source **editor** did nothing. This is the drag-wikilinks feature from #616. Before #683 the drag was (wrongly) caught by a SwiftUI `.dropDestination` on `WikiDetailView` and opened a new tab; #683 correctly removed that while editing — which exposed that the `DropLinkTextView` (`NSTextView` subclass) drop path never actually worked in the running app.

## Root cause

Found by instrumenting `registeredDraggedTypes` + the AppKit drag callbacks and reproducing the drag in the running app (screenshots + `log show`). **Three** independent AppKit bugs, each of which alone breaks the drop:

1. **The editor was never a drop target.** `NSTextView` registers its drag types *lazily* — only when the user starts dragging selected text *out* of it. A freshly-opened editor had **zero** registered dragged types (`viewDidMoveToWindow` logged `types=[]`), so AppKit never routed the sidebar drag to it and `draggingEntered` never fired. The existing `registerForDraggedTypes` override was designed to "piggyback" on NSTextView's own registration call — but that call was never made.

2. **NSTextView vetoed the drop.** Its `prepareForDragOperation` override accepts only pasteboards it can read as native text. A `wikiSidebarItem` payload conforms to `public.item` (not a text type), so the drop was vetoed and `performDragOperation` was never called — even after `draggingEntered` returned `.copy` (cursor showed the `+` glyph, release did nothing).

3. **The insert was reverted.** `replaceCharacters(in:with:)` is a raw text-storage mutation that does **not** post `NSTextDidChangeNotification`, so the SwiftUI `@Binding` (`store.draftBody`) never updated and the next `updateNSView` clobbered the insert back to the stale value.

## Fix (`DropLinkTextView`)

1. `viewDidMoveToWindow` eagerly registers the `wikiSidebarItem` type, making the editor a live drop target the moment it appears (independent of first-responder / text-selection state). The `registerForDraggedTypes` override still layers the sidebar type alongside NSTextView's text types when they later register, so drag-selected-text-to-move within the editor and text drops from other apps keep working.
2. Override `prepareForDragOperation` to accept sidebar payloads (fall through to `super` otherwise — NSTextView's text-drop gating is unchanged).
3. Route the insert through the `shouldChangeText` / `didChangeText` bracket (posts the change notification → binding syncs; also registers undo — the same path a typed edit takes).

## Verification

- Reproduced live: dragging the sidebar row into the editor now inserts `[[page:<ULID>|Home]]` at the drop point and it **persists** (confirmed via the text view's accessibility value + screenshot).
- `swift test`: **3049 tests pass**. Adds `viewDidMoveToWindow_eagerlyRegistersSidebarType` pinning the primary root cause (view hosted in a window registers the sidebar type without ever becoming first responder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)