### PR TITLE
Persist chat debug-log paths to the DB (#681)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -573,17 +573,21 @@ struct ChatView: View {
                     }
                     .help("Reveal this chat file in Finder")
                 }
-                // #671: persistent "Reveal Debug Folder" — reads from the
-                // launcher's in-memory chatID→path map (populated at spawn
-                // commit in `startInteractiveQuery`), falling back to the live
-                // session's `debugFolderURL` so an in-progress run reveals before
-                // the map entry is finalized. Visible for any chat that ran in
-                // this app session (live or reopened from history); absent for
-                // chats that never ran here or whose run failed preflight (no
+                // #671 + #681: persistent "Reveal Debug Folder". Source of truth
+                // is the DB row (`ChatSummary.debugFolder`, persisted at spawn
+                // commit so paths survive app restarts). For a chat whose row
+                // hasn't been updated yet this launch (in-progress first run,
+                // DB write racing the toolbar render), fall back to the
+                // launcher's in-memory `chatLogPaths` map (same-session cache
+                // populated at spawn commit). The live session's
+                // `launcher.debugFolderURL` is the last-chance fallback — it
+                // resolves even before the map entry is finalized. Absent for
+                // chats that never ran here, or whose run failed preflight (no
                 // scratch dir → no debug folder). Mirrors ingestion's
                 // `ActivityWindowView.revealMenu(for:)`.
                 if let chatID,
-                   let debugURL = launcher.debugFolderURL(forChat: chatID.rawValue)
+                   let debugURL = chatSummary?.debugFolder.flatMap(URL.init(fileURLWithPath:))
+                        ?? launcher.debugFolderURL(forChat: chatID.rawValue)
                         ?? (isLiveChat ? launcher.debugFolderURL : nil) {
                     Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
                         DebugLog.agent("ChatView: Reveal Debug Folder tapped — id=\(chatID.rawValue)")

--- a/Sources/WikiFSCore/Core/ChatModels.swift
+++ b/Sources/WikiFSCore/Core/ChatModels.swift
@@ -35,11 +35,22 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
     /// When the summary was written, for staleness display. `nil` alongside
     /// `summary`.
     public var summaryAt: Date?
+    /// Absolute path to the chat's `DebugRunLogger` folder
+    /// (`~/Library/Caches/…/agent/<UUID>/debug/`), persisted at spawn commit
+    /// so a chat's debug logs survive app restarts (issue #681). `nil` when the
+    /// chat never ran here, ran before the v39 migration, or preflight failed
+    /// before a scratch directory was made.
+    public var debugFolder: String?
+    /// Absolute path to the chat's run-log file (the `DebugRunLogger` log file
+    /// inside `debugFolder`), persisted alongside `debugFolder` (issue #681).
+    /// `nil` alongside `debugFolder`.
+    public var logFile: String?
 
     public init(
         id: PageID, kind: ChatKind, title: String,
         createdAt: Date, updatedAt: Date, messageCount: Int,
-        summary: String? = nil, summaryAt: Date? = nil
+        summary: String? = nil, summaryAt: Date? = nil,
+        debugFolder: String? = nil, logFile: String? = nil
     ) {
         self.id = id
         self.kind = kind
@@ -49,6 +60,8 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
         self.messageCount = messageCount
         self.summary = summary
         self.summaryAt = summaryAt
+        self.debugFolder = debugFolder
+        self.logFile = logFile
     }
 
     /// Derive a chat title from the first user message: first line, trimmed,

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -55,10 +55,10 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// The latest schema version stamped by `createFreshSchema()` (for a fresh
     /// DB) and by `migrateIfNeeded(_:in:)` after running the ladder (for an
     /// existing DB). MUST match `SQLiteWikiStore.currentSchemaVersion`: existing
-    /// databases produced by that store carry `PRAGMA user_version` up to 37, and
-    /// this store must recognize them as already-current so the ladder is a no-op
-    /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 38
+    /// databases produced by that store carry `PRAGMA user_version` up to the
+    /// value below, and this store must recognize them as already-current so the
+    /// ladder is a no-op on re-open (the proven `if version < N`)
+    private static let currentSchemaVersion = 39
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -1141,8 +1141,25 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         // `DROP TRIGGER IF EXISTS` so a fresh-DB forced through the ladder (which
         // never created them at v13/v28) is a no-op. Mirrors the SQLiteWikiStore
         // ladder's v37→v38 step.
-        if version < Self.currentSchemaVersion {
+        if version < 38 {
             try Self.dropFTS5TablesAndTriggers(in: db)
+            try db.execute(sql: "PRAGMA user_version = 38;")
+            version = 38
+        }
+
+        // Step 38 → 39 (issue #681 — persist chat debug-log paths): adds
+        // `debug_folder` and `log_file` nullable TEXT columns to `chats` so a
+        // chat's `DebugRunLogger` folder survives app restarts. Previously the
+        // chatID→folder mapping lived only in `AgentLauncher.chatLogPaths` (an
+        // in-memory map populated at spawn commit, cleared on launch), so after
+        // a restart a chat's on-disk debug logs were unfindable — even though
+        // they still existed in `~/Library/Caches/…/agent/<UUID>/debug/`. The
+        // columns are absolute paths as TEXT (nil = the chat ran but preflight
+        // failed before a scratch dir was made, or never ran here). Simple
+        // ALTER — no table rebuild for nullable columns; pragmas idempotent so
+        // a DB rewound for testing stamps v39 without re-adding them.
+        if version < Self.currentSchemaVersion {
+            try Self.migrateV38ToV39(in: db)
             try db.execute(sql: "PRAGMA user_version = \(Self.currentSchemaVersion);")
             version = Self.currentSchemaVersion
         }
@@ -1344,13 +1361,15 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     private static func createChatTablesV23(in db: Database) throws {
         try db.execute(sql: """
         CREATE TABLE IF NOT EXISTS chats (
-            id         TEXT PRIMARY KEY,
-            kind       TEXT NOT NULL,
-            title      TEXT NOT NULL,
-            created_at REAL NOT NULL,
-            updated_at REAL NOT NULL,
-            summary    TEXT,
-            summary_at REAL
+            id           TEXT PRIMARY KEY,
+            kind         TEXT NOT NULL,
+            title        TEXT NOT NULL,
+            created_at   REAL NOT NULL,
+            updated_at   REAL NOT NULL,
+            summary      TEXT,
+            summary_at   REAL,
+            debug_folder TEXT,
+            log_file     TEXT
         );
         """)
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS chats_updated ON chats(updated_at);")
@@ -1432,6 +1451,28 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     }
 
     // MARK: - Data-migration helpers (v19 → v38)
+
+    /// The v38→v39 migration step (issue #681 — persist chat debug-log paths):
+    /// adds nullable TEXT `debug_folder` + `log_file` columns to `chats` so the
+    /// chatID→folder map (`AgentLauncher.chatLogPaths`, in-memory only) survives
+    /// app restarts. Both columns hold absolute paths (nil = the chat ran but
+    /// preflight failed before a scratch dir was made, or never ran here).
+    /// `pragma_table_info`-guarded so a rewound test DB stamps v39 without
+    /// re-adding the columns. Mirrors the v26→v27 `bookmark_nodes` column-add
+    /// pattern. No backfill: pre-v39 chats have no known debug folder (the
+    /// `DebugRunLogger` paths were never persisted for them), so existing rows
+    /// stay NULL — a future spawn for the same chatID will overwrite them.
+    /// Column defs match the fresh-path `CREATE TABLE chats` byte-for-byte.
+    private static func migrateV38ToV39(in db: Database) throws {
+        let hasDebugFolder = try Self.hasColumn("debug_folder", on: "chats", in: db)
+        if !hasDebugFolder {
+            try db.execute(sql: "ALTER TABLE chats ADD COLUMN debug_folder TEXT;")
+        }
+        let hasLogFile = try Self.hasColumn("log_file", on: "chats", in: db)
+        if !hasLogFile {
+            try db.execute(sql: "ALTER TABLE chats ADD COLUMN log_file TEXT;")
+        }
+    }
 
     /// The v19→20 migration step (graph-model Phase 1): move source content
     /// out of the mutable `sources.content` column into immutable,
@@ -2380,13 +2421,15 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         // v25: persisted chat history (chats + chat_messages).
         try db.execute(sql: """
         CREATE TABLE IF NOT EXISTS chats (
-            id         TEXT PRIMARY KEY,
-            kind       TEXT NOT NULL,
-            title      TEXT NOT NULL,
-            created_at REAL NOT NULL,
-            updated_at REAL NOT NULL,
-            summary    TEXT,
-            summary_at REAL
+            id           TEXT PRIMARY KEY,
+            kind         TEXT NOT NULL,
+            title        TEXT NOT NULL,
+            created_at   REAL NOT NULL,
+            updated_at   REAL NOT NULL,
+            summary      TEXT,
+            summary_at   REAL,
+            debug_folder TEXT,
+            log_file     TEXT
         );
         """)
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS chats_updated ON chats(updated_at);")
@@ -5446,17 +5489,21 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                   c.summary, c.summary_at
+                   c.summary, c.summary_at, c.debug_folder, c.log_file
             FROM chats c
             ORDER BY c.updated_at DESC, c.rowid DESC;
             """)
             return rows.map { row in
                 let summary: String? = row["summary"]
                 let summaryAt: Double? = row["summary_at"]
+                let debugFolder: String? = row["debug_folder"]
+                let logFile: String? = row["log_file"]
                 return Self.readChatSummary(
                     from: row,
                     summary: summary,
-                    summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) }
+                    summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) },
+                    debugFolder: debugFolder,
+                    logFile: logFile
                 )
             }
         }
@@ -5544,22 +5591,42 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// Persist a chat's debug-log folder + log-file absolute paths (issue #681).
+    /// NO-EMIT: debug paths are read-only metadata the File Provider never
+    /// indexes — the `nil` event skips the post-commit bus emit. Still routes
+    /// through `mutate()` for the atomic savepoint + WAL guard, like every
+    /// mutator. Does NOT bump `updated_at`: the chat's content didn't change.
+    public func updateChatDebugPaths(id: PageID, debugFolder: URL?, logFile: URL?) throws {
+        try mutate(event: { _ in nil }) { db in
+            try db.execute(sql: """
+            UPDATE chats SET debug_folder = ?, log_file = ?
+            WHERE id = ?;
+            """, arguments: [
+                debugFolder?.path, logFile?.path, id.rawValue
+            ])
+        }
+    }
+
     public func listAllChatsOrderedByID() throws -> [ChatSummary] {
         try dbWriter.read { db in
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                   c.summary, c.summary_at
+                   c.summary, c.summary_at, c.debug_folder, c.log_file
             FROM chats c
             ORDER BY c.id ASC;
             """)
             return rows.map { row in
                 let summary: String? = row["summary"]
                 let summaryAt: Double? = row["summary_at"]
+                let debugFolder: String? = row["debug_folder"]
+                let logFile: String? = row["log_file"]
                 return Self.readChatSummary(
                     from: row,
                     summary: summary,
-                    summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) }
+                    summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) },
+                    debugFolder: debugFolder,
+                    logFile: logFile
                 )
             }
         }
@@ -5868,13 +5935,15 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         (try? Row.fetchOne(db, sql: "SELECT vec_distance_cosine(x'00000000', x'00000000');")) != nil
     }
 
-    /// Read a ChatSummary from a GRDB Row. The `summary` and `summaryAt` columns
-    /// are passed in so this works for both the 6-column search variants (nil) and
-    /// the 8-column list variants. Mirrors SQLiteWikiStore.chatSummary(from:).
-    /// Columns (named): id, kind, title, created_at, updated_at, + an unnamed
-    /// message-count subquery at index 5.
+    /// Read a ChatSummary from a GRDB Row. The `summary`, `summaryAt`,
+    /// `debugFolder`, and `logFile` columns are passed in so this works for
+    /// both the 4-column search variants (all nil) and the full list variants.
+    /// Mirrors SQLiteWikiStore.chatSummary(from:). Columns (named): id, kind,
+    /// title, created_at, updated_at, + an unnamed message-count subquery at
+    /// index 5.
     private static func readChatSummary(
-        from row: Row, summary: String?, summaryAt: Date?
+        from row: Row, summary: String?, summaryAt: Date?,
+        debugFolder: String? = nil, logFile: String? = nil
     ) -> ChatSummary {
         ChatSummary(
             id: PageID(rawValue: row["id"]),
@@ -5884,7 +5953,9 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             updatedAt: Date(timeIntervalSince1970: row["updated_at"]),
             messageCount: row["msg_count"],
             summary: summary,
-            summaryAt: summaryAt
+            summaryAt: summaryAt,
+            debugFolder: debugFolder,
+            logFile: logFile
         )
     }
 
@@ -6771,17 +6842,21 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 sql: """
                 SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                        (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                       c.summary, c.summary_at
+                       c.summary, c.summary_at, c.debug_folder, c.log_file
                 FROM chats c WHERE c.id = ?;
                 """,
                 arguments: [id.rawValue]
             ) else { throw WikiStoreError.notFound(id) }
             let summary: String? = row["summary"]
             let summaryAt: Double? = row["summary_at"]
+            let debugFolder: String? = row["debug_folder"]
+            let logFile: String? = row["log_file"]
             return Self.readChatSummary(
                 from: row,
                 summary: summary,
-                summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) }
+                summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) },
+                debugFolder: debugFolder,
+                logFile: logFile
             )
         }
     }

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -624,6 +624,20 @@ public protocol WikiStore: Sendable {
     /// bumping `updated_at`. Throws `.notFound` if no chat has `id`.
     func updateChatSummary(chatID: PageID, summary: String) throws
 
+    /// Persist the chat's `DebugRunLogger` folder + log-file absolute paths so
+    /// they survive app restarts (issue #681). Called by `AgentLauncher` at
+    /// spawn commit, right after populating the in-memory `chatLogPaths` map.
+    /// Both arguments are absolute paths as TEXT; pass nil to clear (no
+    /// scratch dir was made — preflight failed before that point). No
+    /// `ResourceChangeEvent` emission: these are debug-log metadata only —
+    /// they're never read by the File Provider or any content surface
+    /// (`ResourceChangeEvent` exists to signal the projection/index layer,
+    /// which doesn't index debug paths). Routes through `mutate()` so the
+    /// change still applies atomically inside a savepoint, like every other
+    /// store mutator; the `nil` event simply skips the post-commit emit.
+    /// Does NOT bump `updated_at` (the chat's content didn't change).
+    func updateChatDebugPaths(id: PageID, debugFolder: URL?, logFile: URL?) throws
+
     /// All chat summaries ordered by ULID (creation order) — for the File
     /// Provider projection. Mirrors `listAllPagesOrderedByID()`.
     func listAllChatsOrderedByID() throws -> [ChatSummary]

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -3518,6 +3518,19 @@ public final class WikiStoreModel {
         }
     }
 
+    /// Persist `DebugRunLogger` folder + log-file paths for a chat so they
+    /// survive app restarts (issue #681). Called by `AgentLauncher` at spawn
+    /// commit, right after the in-memory `chatLogPaths` map is populated. A
+    /// failure is logged, never thrown — losing the debug path is a degraded
+    /// experience, not a reason to abort the chat.
+    public func updateChatDebugPaths(id: PageID, debugFolder: URL?, logFile: URL?) {
+        do {
+            try store.updateChatDebugPaths(id: id, debugFolder: debugFolder, logFile: logFile)
+        } catch {
+            DebugLog.store("WikiStoreModel.updateChatDebugPaths failed: \(error)")
+        }
+    }
+
     public func deleteChat(id: PageID) {
         do {
             try store.deleteChat(id: id)

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -2182,7 +2182,8 @@ public final class AgentLauncher {
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
         onTranscript: (@MainActor ([AgentEvent]) -> Void)? = nil,
-        onSummary: (@MainActor (PageID, String) -> Void)? = nil
+        onSummary: (@MainActor (PageID, String) -> Void)? = nil,
+        onPersistDebugPaths: (@MainActor (PageID, URL?, URL?) -> Void)? = nil
     ) async {
         // No gate acquisition here — the interactive session does NOT hold the gate
         // for its lifetime, only per-turn (via sendInteractiveMessage). Two sessions
@@ -2321,6 +2322,16 @@ public final class AgentLauncher {
         // (line above) so the binding + paths land atomically with the live flip.
         if let chatID {
             chatLogPaths[chatID] = (logFileURL, debugFolderURL)
+            // #681: persist the same paths to `chats.debug_folder` / `chats.log_file`
+            // so they survive app restarts. The in-memory map above is cleared on
+            // relaunch; the DB row is the source of truth across launches.
+            // Fire-and-forget best-effort — a store failure is logged inside
+            // `WikiStoreModel.updateChatDebugPaths`, not propagated (missing
+            // paths degrade the Reveal Debug Folder affordance, not the chat).
+            if let onPersistDebugPaths {
+                let pageID = PageID(rawValue: chatID)
+                onPersistDebugPaths(pageID, debugFolderURL, logFileURL)
+            }
         }
         // Pre-display the user's message so it appears instantly — don't make
         // the user wait ~4s for backend.start (spawn + initialize + newSession)

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -100,6 +100,16 @@ public enum AgentOperationRunner {
             },
             onSummary: chat.map { chat -> (@MainActor (PageID, String) -> Void) in
                 return { [weak store] id, summary in store?.updateChatSummary(chatID: id, summary: summary) }
+            },
+            // #681: persist the spawn's DebugRunLogger folder + log file paths
+            // so they survive app restarts. Same weak-store rule as above: a
+            // mid-session wiki switch degrades to a no-op, never a cross-wiki
+            // write. The callback fires inside the launcher right after its
+            // in-memory `chatLogPaths` map is populated (same spawn-commit step).
+            onPersistDebugPaths: chat.map { chat -> (@MainActor (PageID, URL?, URL?) -> Void) in
+                return { [weak store] id, debugFolder, logFile in
+                    store?.updateChatDebugPaths(id: id, debugFolder: debugFolder, logFile: logFile)
+                }
             }
         )
 
@@ -371,6 +381,13 @@ public enum AgentOperationRunner {
             },
             onSummary: { [weak store] id, summary in
                 store?.updateChatSummary(chatID: id, summary: summary)
+            },
+            // #681: continueChat reuses the chat's row, so re-persist the spawn's
+            // fresh DebugRunLogger paths into the SAME row — overwriting any
+            // prior value (a restarted chat gets a NEW debug folder under a new
+            // <UUID>/, so the old path is stale even if still on disk).
+            onPersistDebugPaths: { [weak store] id, debugFolder, logFile in
+                store?.updateChatDebugPaths(id: id, debugFolder: debugFolder, logFile: logFile)
             })
     }
 


### PR DESCRIPTION
## Problem

Every chat is an ACP session. `DebugRunLogger` writes logs for every one to `~/Library/Caches/Self Driving Wiki-agent/<UUID>/debug/`. But the chatID→folder mapping was in-memory only (`AgentLauncher.chatLogPaths`), wiped on restart — so after restarting the app there was no way to find a chat's debug logs even though they existed on disk.

## Fix: persist the paths to the `chats` table

### 1. Schema migration v38→v39 (`GRDBWikiStore.swift`)
- `currentSchemaVersion` bumped 38 → 39.
- New `migrateV38ToV39`: `ALTER TABLE chats ADD COLUMN debug_folder TEXT` + `ALTER TABLE chats ADD COLUMN log_file TEXT`, both `pragma_table_info`-guarded (idempotent).
- The same columns are mirrored in `createChatTablesV23` (used by the migration ladder's v23→v25 step) and `createFreshSchema` so a fresh DB at v39 and a rewound-then-migrated test DB end up byte-identical.
- No backfill: pre-v39 chats have no known debug folder (paths were never persisted for them), so existing rows stay NULL — a future spawn for the same chatID overwrites them.

> Note: the task description said "current schema version is 37, add migration v38", but the tree was already at v38 (v37→v38 was the already-shipped FTS5 drop). The new migration is therefore v38→v39.

### 2. Populate at spawn time (`AgentLauncher.swift` + `AgentOperationRunner.swift`)
- `startInteractiveQuery` gains an `onPersistDebugPaths: (@MainActor (PageID, URL?, URL?) -> Void)?` callback, fired right after the in-memory `chatLogPaths[chatID] = (logFileURL, debugFolderURL)` assignment at spawn commit.
- `AgentOperationRunner.startChat` and `continueChat` pass closures that back the store via the same `[weak store]` pattern already used by `onTranscript`/`onSummary` — so a mid-session wiki switch degrades to a no-op, never a cross-wiki write. `continueChat` overwrites the prior value (a restarted chat gets a NEW debug folder under a new `<UUID>/`).

### 3. `updateChatDebugPaths` on `WikiStore` + `GRDBWikiStore` + `WikiStoreModel`
- Protocol-level method writes both paths as absolute-path TEXT (nil clears).
- `GRDBWikiStore` implementation routes through `mutate(event: { _ in nil })` for the atomic savepoint + WAL guard. **NO-EMIT** with a comment explaining why: debug paths are derived metadata the File Provider never indexes (`ResourceChangeEvent` exists to signal the projection/index layer, which doesn't index debug paths). Does NOT bump `updated_at` — the chat's content didn't change.
- `WikiStoreModel.updateChatDebugPaths` wraps with `do/catch` + `DebugLog.store(...)`. Failures are logged, never thrown — losing the path degrades the Reveal Debug Folder affordance, not the chat.

### 4. Expose via `ChatSummary` (`ChatModels.swift`)
- New `debugFolder: String?` and `logFile: String?` fields with full doc comments.
- `readChatSummary` threads them through; `listChats`, `getChat`, `listAllChatsOrderedByID` SELECT and pass them. `searchSimilarChats` continues to pass nil (matching its existing summary/summaryAt=nil pattern) via the new params' default values.

### 5. `ChatView` resolves from `ChatSummary.debugFolder` first
The "Reveal Debug Folder" button now resolves in order:
1. `chatSummary?.debugFolder` (persisted DB row — survives restarts)
2. `launcher.debugFolderURL(forChat: chatID.rawValue)` (in-memory map — same-session fallback for the in-progress first run, where the DB write may be racing the toolbar render)
3. `isLiveChat ? launcher.debugFolderURL : nil` (live session's URL — last-chance fallback for a chat that just spawned)

## Build + test
```
make version prompts && swift build && swift test
```
**3064 tests in 260 suites, all pass.** In-memory fixtures (#658) keep the full suite at ~1.5 min.

## House rules checked
- ✅ No bare `try?` — `WikiStoreModel.updateChatDebugPaths` uses `do { try … } catch { DebugLog.store(…) }`.
- ✅ No `print` — only `DebugLog`.
- ✅ Scratch files in `tmp/` (only `tmp/pr-body-681.md` — project-relative, gitignored).
- ✅ Branch pushed, PR opened — **not merged**.

## Files changed
```
 Sources/WikiFS/Chats/ChatView.swift             |  20 ++--
 Sources/WikiFSCore/Core/ChatModels.swift        |  15 ++-
 Sources/WikiFSCore/Store/GRDBWikiStore.swift    | 139 ++++++++++++++++++------
 Sources/WikiFSCore/Store/WikiStore.swift        |  14 +++
 Sources/WikiFSCore/Store/WikiStoreModel.swift   |  13 +++
 Sources/WikiFSEngine/AgentLauncher.swift        |  13 ++-
 Sources/WikiFSEngine/AgentOperationRunner.swift |  17 +++
 7 files changed, 189 insertions(+), 42 deletions(-)
```

## Report
- **Schema migration version:** v38 → v39
- **Files changed:** 7 (see above)
- **swift test result:** 3064 tests in 260 suites — all pass
- **PR URL:** (see below)
