### PR TITLE
Fix header double-click not expanding collapsed title pane

### DIFF
--- a/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
+++ b/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
@@ -69,6 +69,8 @@ struct CollapsibleDetailHeader<Expanded: View>: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
         .onTapGesture(count: 2) {
             DebugLog.tabs("CollapsibleDetailHeader: header double-tapped — wasExpanded=\(isExpanded)")
             withAnimation(.easeInOut(duration: 0.2)) {


### PR DESCRIPTION
## Problem

Double-clicking the collapsed title pane in `CollapsibleDetailHeader` did not expand it when the click landed in the empty space to the right of the title. The `titleRow` `HStack` only wrapped its visible content (chevron button + icon + title text), so the double-tap gesture attached to it only covered that narrow content region — the rest of the header row was inert.

## Fix

In `Sources/WikiFS/Editor/CollapsibleDetailHeader.swift`, add two modifiers **before** the existing `.onTapGesture(count: 2)` on `titleRow`:

```swift
.frame(maxWidth: .infinity, alignment: .leading)
.contentShape(Rectangle())
.onTapGesture(count: 2) { … }
```

- `.frame(maxWidth: .infinity, alignment: .leading)` makes the `HStack` fill the full header width instead of just wrapping its content.
- `.contentShape(Rectangle())` makes the now-empty area hittable so the double-tap gesture fires anywhere in the row.

## Verification

- `make version prompts && swift build` — clean
- `swift test` — all 3064 tests in 260 suites pass
