### PR TITLE
Split Permissions into its own Settings tab

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6492,3 +6492,43 @@ test assertions are prompt-text replacements only.
 **Result:** 258 suites / 3031 tests pass. `swift build` clean.
 
 **Build:** `make version prompts && swift build && swift test`.
+
+## Split Permissions into its own Settings tab
+
+**Why:** The Agents tab (`AgentsSettingsView`) held both `providersSection`
+and `permissionSection` in one `Form`. With >~3 providers, the inner `List`
+on a `.frame(maxHeight: 220)` plus the permission `Picker`s exceeded the
+window height, the `Form` did not scroll, and the permission section was
+clipped out of view — invisible to the operator.
+
+**What changed:**
+
+- **`Sources/WikiFS/Settings/PermissionsSettingsView.swift`** (new) — host
+  for the three permission-mode `Picker`s (Chat / Ingest / Lint). Plain
+  `Form { Section { ... } header: "Permissions" footer: ... }
+  .formStyle(.grouped)`, mirroring `GeneralSettingsView`. Same three
+  `@AppStorage(AgentLauncher.PermissionModeKey.<x>)` bindings as before —
+  the keys are view-independent (`UserDefaults`), so moving the bindings
+  into a new view is a pure refactor, not a migration.
+- **`Sources/WikiFS/Window/WikiFSApp.swift`** — added `case permissions` to
+  `SettingsTab` and a new `TabView` entry:
+  `PermissionsSettingsView().tag(.permissions)
+  .tabItem { Label("Permissions", systemImage: "lock.shield") }`.
+- **`Sources/WikiFS/Settings/AgentsSettingsView.swift`** — removed the
+  `permissionSection` computed property, removed its three now-unused
+  `@AppStorage` vars (`chatModeRaw` / `ingestModeRaw` / `lintModeRaw`),
+  and dropped `permissionSection` from the body. Also dropped the
+  `.maxHeight: 220` cap from the providers `List`'s `.frame(...)` so the
+  list can grow with content (the outer `Form` with `.formStyle(.grouped)`
+  scrolls natively when the section exceeds the window). `$selectedProviderID`
+  selection on the `List` is preserved (the Add/Delete/Make Default/Edit
+  toolbar relies on it).
+
+**No test changes** — the existing `AgentsSettingsViewModelStatusTests` /
+`AgentsSettingsViewWarningTests` only exercise the `nonisolated static`
+`modelStatus(for:in:)` / `modelWarning(for:in:)` classifiers, neither of
+which was touched. No test previously rendered `permissionSection`.
+
+**Result:** 260 suites / 3064 tests pass. `swift build` clean.
+
+**Build:** `make version prompts && swift build && swift test`.

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -43,10 +43,6 @@ struct AgentsSettingsView: View {
     /// chevron) avoids a friction click on every visit.
     @State private var isExpanded = true
 
-    @AppStorage(AgentLauncher.PermissionModeKey.chat)   private var chatModeRaw   = PermissionPolicy.bypass.rawValue
-    @AppStorage(AgentLauncher.PermissionModeKey.ingest) private var ingestModeRaw = PermissionPolicy.bypass.rawValue
-    @AppStorage(AgentLauncher.PermissionModeKey.lint)   private var lintModeRaw   = PermissionPolicy.bypass.rawValue
-
     let containerDirectory: URL
     private let credentialStore: any ACPCredentialStore
 
@@ -75,7 +71,6 @@ struct AgentsSettingsView: View {
         ) {
             Form {
                 providersSection
-                permissionSection
             }
             .formStyle(.grouped)
             .frame(minWidth: 560, minHeight: 520)
@@ -147,7 +142,7 @@ struct AgentsSettingsView: View {
                             editingProvider = provider
                         }
                 }
-                .frame(minHeight: 160, maxHeight: 220)
+                .frame(minHeight: 160)
                 .listStyle(.inset)
 
                 HStack {
@@ -405,41 +400,6 @@ struct AgentsSettingsView: View {
             selectedProviderID = config.providers.first?.id
         }
         providerPendingDeletion = nil
-    }
-
-    // MARK: - Permission mode (moved from the old Agent tab)
-
-    /// #607: per-operation permission pickers. Pre-split, a single shared
-    /// `agentPermissionMode` key fed chat + ingest + lint — a user who chose
-    /// `alwaysAsk` for chat got the same gating applied to an unattended
-    /// ingest/lint, guaranteeing a stall on the first prompt needing a
-    /// permission (#606). Now three independent pickers. Extraction is
-    /// intentionally omitted — see `plans/acp-permissions.md` §5.1 (extraction
-    /// keeps its `.bypass` default on `ACPExtractionClient`).
-    private var permissionSection: some View {
-        Section {
-            Picker("Chat Permission Mode", selection: $chatModeRaw) {
-                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
-                    Text(mode.label).tag(mode.rawValue)
-                }
-            }
-            Picker("Ingest Permission Mode", selection: $ingestModeRaw) {
-                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
-                    Text(mode.label).tag(mode.rawValue)
-                }
-            }
-            Picker("Lint Permission Mode", selection: $lintModeRaw) {
-                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
-                    Text(mode.label).tag(mode.rawValue)
-                }
-            }
-        } header: {
-            Text("Permissions")
-        } footer: {
-            Text("These control how the app responds to the agent's permission requests for each operation. Ingest and Lint run unattended — Bypass is recommended (the sandbox already confines writes; an unattended pipeline can't use Always Ask productively, and a stuck permission would auto-reject after 60s).")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
     }
 
     // MARK: - Persistence

--- a/Sources/WikiFS/Settings/PermissionsSettingsView.swift
+++ b/Sources/WikiFS/Settings/PermissionsSettingsView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import WikiFSEngine
+
+/// Settings → **Permissions** tab.
+///
+/// Previously lived as `permissionSection` inside `AgentsSettingsView`; split
+/// into its own tab so the Agents tab (provider list) no longer pushes the
+/// permission pickers below the fold when there are more than ~3 providers
+/// (the Form clipped without scrolling, hiding the permissions entirely).
+///
+/// The `@AppStorage` keys (`AgentLauncher.PermissionModeKey.chat/ingest/lint`)
+/// are independent of the view, so the same bindings work here as they did
+/// inline in `AgentsSettingsView`. See `plans/acp-permissions.md` §5.1 for
+/// the rationale behind three independent per-operation pickers (pre-split, a
+/// single shared key fed chat + ingest + lint — a user who chose `alwaysAsk`
+/// for chat got the same gating on unattended ingest/lint, guaranteeing a
+/// stall on the first prompt needing a permission).
+///
+/// Extraction is intentionally NOT a kind here — it keeps its `.bypass`
+/// default on `ACPExtractionClient`.
+struct PermissionsSettingsView: View {
+    @AppStorage(AgentLauncher.PermissionModeKey.chat)   private var chatModeRaw   = PermissionPolicy.bypass.rawValue
+    @AppStorage(AgentLauncher.PermissionModeKey.ingest) private var ingestModeRaw = PermissionPolicy.bypass.rawValue
+    @AppStorage(AgentLauncher.PermissionModeKey.lint)   private var lintModeRaw   = PermissionPolicy.bypass.rawValue
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Chat Permission Mode", selection: $chatModeRaw) {
+                    ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                        Text(mode.label).tag(mode.rawValue)
+                    }
+                }
+                Picker("Ingest Permission Mode", selection: $ingestModeRaw) {
+                    ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                        Text(mode.label).tag(mode.rawValue)
+                    }
+                }
+                Picker("Lint Permission Mode", selection: $lintModeRaw) {
+                    ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                        Text(mode.label).tag(mode.rawValue)
+                    }
+                }
+            } header: {
+                Text("Permissions")
+            } footer: {
+                Text("These control how the app responds to the agent's permission requests for each operation. Ingest and Lint run unattended — Bypass is recommended (the sandbox already confines writes; an unattended pipeline can't use Always Ask productively, and a stuck permission would auto-reject after 60s).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+#Preview {
+    PermissionsSettingsView()
+        .frame(width: 460, height: 460)
+}

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -513,6 +513,15 @@ struct WikiFSApp: App {
                 AgentsSettingsView(containerDirectory: containerDirectory)
                     .tag(SettingsTab.agents)
                     .tabItem { Label("Agents", systemImage: "cpu") }
+                // Split out from the Agents tab so the provider list no
+                // longer pushes the permission pickers out of view when
+                // there are more than ~3 providers (the Form clipped at
+                // the window height without scrolling). The `@AppStorage`
+                // keys are view-independent so they work unchanged in a
+                // separate view.
+                PermissionsSettingsView()
+                    .tag(SettingsTab.permissions)
+                    .tabItem { Label("Permissions", systemImage: "lock.shield") }
             }
             .appEnvironment(tracker: activityTracker)
             .frame(minWidth: 560, minHeight: 520)
@@ -526,6 +535,7 @@ struct WikiFSApp: App {
         case zotero
         case extraction
         case agents
+        case permissions
     }
 
     /// Binding that bridges `@AppStorage(String)` → `SettingsTab` for the


### PR DESCRIPTION
## Why

`AgentsSettingsView` had both `providersSection` and `permissionSection` in one Form. With more than ~3 providers, the inner List (`.frame(maxHeight: 220)`) plus the permission Pickers exceeded the window height, the Form did not scroll, and the permission section was clipped off-screen — invisible to the operator.

## What changed

- **`Sources/WikiFS/Settings/PermissionsSettingsView.swift`** (new) — host for the three permission-mode Pickers (Chat / Ingest / Lint). Plain `Form { Section { ... } header: "Permissions" footer: ... }.formStyle(.grouped)`, mirroring `GeneralSettingsView`. Same three `@AppStorage(AgentLauncher.PermissionModeKey.<x>)` bindings as before — the keys are view-independent (`UserDefaults`), so moving the bindings into a new view is a pure refactor, not a migration.
- **`Sources/WikiFS/Window/WikiFSApp.swift`** — added `case permissions` to `SettingsTab` and a new TabView entry: `PermissionsSettingsView().tag(.permissions).tabItem { Label("Permissions", systemImage: "lock.shield") }`.
- **`Sources/WikiFS/Settings/AgentsSettingsView.swift`** — removed the `permissionSection` computed property, removed its three now-unused `@AppStorage` vars (`chatModeRaw` / `ingestModeRaw` / `lintModeRaw`), and dropped `permissionSection` from the body. Also dropped the `.maxHeight: 220` cap from the providers List's `.frame(...)` so the list can grow with content; the outer `Form` with `.formStyle(.grouped)` scrolls natively when the section exceeds the window. `$selectedProviderID` selection on the List is preserved (the Add/Delete/Make Default/Edit toolbar relies on it).

## No test changes

Existing `AgentsSettingsViewModelStatusTests` / `AgentsSettingsViewWarningTests` only exercise the `nonisolated static` `modelStatus(for:in:)` / `modelWarning(for:in:)` classifiers, neither of which was touched. No test previously rendered `permissionSection`.

## Verification

`make version prompts && swift build && swift test` — `swift build` clean; 260 suites / 3064 tests pass.
