### PR TITLE
Remove redundant 'Reveal Log' menu items

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -228,11 +228,6 @@ struct ChatView: View {
                     if let status = launcher.exitStatus {
                         Label(status == 0 ? "Ended" : "Exited \(status)", systemImage: status == 0 ? "checkmark.circle" : "xmark.circle")
                     }
-                    if let logURL = launcher.logFileURL {
-                        Button("Reveal Log", systemImage: "doc.text.magnifyingglass") {
-                            NSWorkspace.shared.activateFileViewerSelecting([logURL])
-                        }
-                    }
                     if let debugURL = launcher.debugFolderURL {
                         Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
                             NSWorkspace.shared.activateFileViewerSelecting([debugURL])

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -314,19 +314,11 @@ struct ActivityWindowView: View {
                 copyTranscript(for: item)
             }
         }
-        let logURL = activityTracker.logURL(for: item.id)
         let debugURL = activityTracker.debugURL(for: item.id)
-        if logURL != nil || debugURL != nil {
+        if let debugURL {
             Divider()
-            if let logURL {
-                Button("Reveal Log", systemImage: "doc.text.magnifyingglass") {
-                    NSWorkspace.shared.activateFileViewerSelecting([logURL])
-                }
-            }
-            if let debugURL {
-                Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
-                    NSWorkspace.shared.activateFileViewerSelecting([debugURL])
-                }
+            Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
+                NSWorkspace.shared.activateFileViewerSelecting([debugURL])
             }
         }
         switch item.state {
@@ -713,36 +705,24 @@ struct ActivityWindowView: View {
         openWindowBridge?.openWiki?(wikiID)
     }
 
-    // MARK: - Reveal log / debug folder
+    // MARK: - Reveal debug folder
 
-    /// A compact menu offering "Reveal Log" and "Reveal Debug Folder" for the
-    /// selected item. Only shown when at least one path is available — items
-    /// that never spawned an agent (preflight failure, cancelled before run)
-    /// won't have either. Mirrors the ChatView's activity menu.
+    /// A compact button revealing the run's debug folder in Finder. Only
+    /// shown when a debug folder is available — items that never spawned an
+    /// agent (preflight failure, cancelled before run) won't have one. The
+    /// debug folder contains the complete trace (ACP messages, permissions,
+    /// usage, stderr.log), which supersedes the per-run `run.jsonl` log that
+    /// used to be exposed separately. Mirrors the ChatView's debug button.
     @ViewBuilder
     private func revealMenu(for item: QueueItem) -> some View {
-        let logURL = activityTracker.logURL(for: item.id)
-        let debugURL = activityTracker.debugURL(for: item.id)
-        if logURL != nil || debugURL != nil {
-            Menu {
-                if let logURL {
-                    Button("Reveal Log", systemImage: "doc.text.magnifyingglass") {
-                        NSWorkspace.shared.activateFileViewerSelecting([logURL])
-                    }
-                    .help("Reveal the lightweight run.jsonl log in Finder")
-                }
-                if let debugURL {
-                    Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
-                        NSWorkspace.shared.activateFileViewerSelecting([debugURL])
-                    }
-                    .help("Open the complete debug trace folder (ACP messages, permissions, usage)")
-                }
+        if let debugURL = activityTracker.debugURL(for: item.id) {
+            Button {
+                NSWorkspace.shared.activateFileViewerSelecting([debugURL])
             } label: {
-                Label("Reveal", systemImage: "ellipsis.circle")
+                Label("Reveal Debug Folder", systemImage: "folder.badge.gearshape")
             }
             .labelStyle(.iconOnly)
-            .menuStyle(.borderlessButton)
-            .help("Reveal log files in Finder")
+            .help("Open the complete debug trace folder (ACP messages, permissions, usage)")
         }
     }
 

--- a/docs/user-guide/chat.md
+++ b/docs/user-guide/chat.md
@@ -149,7 +149,8 @@ After each agent response completes:
   - **Show internals** — reveals the raw event feed (tool calls, diagnostics).
   - **Hide tool calls** — filters tool-call rows.
   - **Exit status** — shows "Ended" or "Exited N" when the process finishes.
-  - **Reveal Log** — opens the raw log file in Finder.
+  - **Reveal Debug Folder** — opens the run's debug trace folder in Finder
+    (ACP messages, permissions, usage, stderr.log).
 
 ---
 


### PR DESCRIPTION
## Summary

Removes the redundant "Reveal Log" UI affordance from three surfaces. The button
opened `run.jsonl`, which the operator confirms never contains a valid log.
"Reveal Debug Folder" reveals the complete debug trace folder (ACP messages,
permissions, usage, `stderr.log`) — a strict superset — so the standalone log
reveal adds nothing.

## Changes

**`Sources/WikiFS/Queue/ActivityWindowView.swift`**
- `revealMenu(for:)` — was a `Menu` with two items ("Reveal Log" + "Reveal
  Debug Folder"); now a direct `Button` revealing the debug folder (only one
  item remained, so the dropdown added a click for no reason). Doc comment
  updated to match.
- `contextMenu(for:)` — removed the Reveal Log item; the `Divider` now only
  precedes Reveal Debug Folder when a debug URL exists for the item. The
  context menu still has its other entries (Copy Transcript / Cancel / Retry /
  Copy Error), so it stays a context menu.

**`Sources/WikiFS/Chats/ChatView.swift`**
- `controls` — removed the Reveal Log `Button` from the Activity `⋯` menu.
  The menu itself is kept (it still hosts Show internals / Hide tool calls /
  Exit status / Reveal Debug Folder).
- `logFileURL` on `AgentLauncher` is unchanged — still available for internal
  use, just no longer surfaced to the operator.

**`docs/user-guide/chat.md`**
- Swapped the user-facing "Reveal Log" bullet for "Reveal Debug Folder" so the
  docs match the screen.

## What's left alone

- `AgentLauncher.logFileURL` — kept for internal/debugging use, per task spec.
- `QueueActivityTracker.logURL(for:)` — same; the field stays, only the UI is
  dropped.
- `ChatView.debugFolderButtonHelpText` and `ChatViewDebugFolderButtonTests`
  — untouched (they only test the still-existing Reveal Debug Folder button).
- No DB / store / engine changes.

## Verification

```
make version prompts && swift build && swift test
```

- `swift build` — clean (Build complete! in ~132 s).
- `swift test` — **3069 tests in 261 suites passed** in ~31 s. No regressions.

## Notes

The task spec listed two locations (the `revealMenu(for:)` function and
ChatView's debug cluster). A third "Reveal Log" Button existed in
`ActivityWindowView.contextMenu(for:)` (right-click menu on a queue item),
doing the same thing for the same reason — removed it for consistency. Flagging
explicitly in case you wanted that one kept.
