### PR TITLE
Fix: force model pick when adding a provider in Settings → Agents

### DIFF
--- a/Sources/WikiFS/Settings/AddProviderSheet.swift
+++ b/Sources/WikiFS/Settings/AddProviderSheet.swift
@@ -36,11 +36,13 @@ struct AddProviderSheet: View {
     /// provider (so the sheet itself touches no state outside its model).
     let onAdd: (AgentProvider) -> Void
 
-    /// Invoked alongside `onAdd` when the freshly-added provider should land
-    /// in the editor (custom command, or a non-detected catalog agent whose
-    /// PATH status the user may want to address). The parent throttles this
-    /// via `DispatchQueue.main.async` so the editor sheet doesn't pre-empt
-    /// this sheet's dismissal (a known SwiftUI hazard — see
+    /// Invoked alongside `onAdd` so the freshly-added provider lands in the
+    /// editor — EVERY newly-added provider opens the editor so the user MUST
+    /// pick a model before the provider is usable (otherwise the row would
+    /// sit in the list with a "No model captured yet" warning and the
+    /// launcher would refuse to spawn). The parent throttles this via
+    /// `DispatchQueue.main.async` so the editor sheet doesn't pre-empt this
+    /// sheet's dismissal (a known SwiftUI hazard — see
     /// `plans/663-combined-plan.md` correction §5).
     let onAddNeedsEditor: (AgentProvider) -> Void
 
@@ -253,17 +255,15 @@ struct AddProviderSheet: View {
     }
 
     private func handleAdd(_ provider: AgentProvider) {
-        // Persist via the parent (the parent owns `config` + the `containerDirectory`).
-        // The needsEditor heuristic (correction §4) drops the non-existent
-        // `catalogEntryRequiresKey` reference and keys off `model.detected`:
-        // a freshly-added detected agent skips the editor (fast path); a
-        // custom provider or a non-detected catalog agent lands in the editor
-        // for env/key/command follow-up.
-        let needsEditor = model.needsEditor(for: provider)
+        // Persist via the parent (the parent owns `config` + the
+        // `containerDirectory`). The editor ALWAYS opens after an Add — every
+        // freshly-added provider must have a model picked before it lands in
+        // the list as usable, otherwise the row shows a "No model captured
+        // yet" warning and the launcher refuses to spawn (`SpawnModelGuard`).
+        // Previously a `needsEditor` heuristic skipped the editor for
+        // cleanly-detected PATH agents, which left them with no model.
         onAdd(provider)
-        if needsEditor {
-            onAddNeedsEditor(provider)
-        }
+        onAddNeedsEditor(provider)
         dismiss()
     }
 }
@@ -392,16 +392,6 @@ final class AddProviderModel {
         let found = await Task.detached { ACPProviderDiscovery.discover() }.value
         detected = found
         isScanning = false
-    }
-
-    /// Heuristic (correction §4): the editor should auto-open for a freshly-
-    /// added provider when (a) the command is empty (custom add) or (b) the
-    /// agent wasn't detected on PATH (catalog add for an agent whose binary
-    /// is missing — the user may want to tweak the command/env/key). A cleanly
-    /// detected catalog agent skips the editor (the fast path).
-    func needsEditor(for provider: AgentProvider) -> Bool {
-        if provider.command?.isEmpty ?? true { return true }
-        return !detected.contains(where: { $0.agent.id == provider.id })
     }
 
     /// `custom` / `custom-2` / `custom-3` … — the existing collision-loop

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -37,6 +37,13 @@ struct AgentsSettingsView: View {
     /// hardcoded seed buttons (Add Claude / Add Hermes / Add OpenCode) with
     /// a non-destructive, catalog-driven sheet. Cancel = no change (AC.2).
     @State private var showAddSheet = false
+    /// #663: tracks whether the editor was opened from the Add flow (true)
+    /// or from Edit…/double-click on an EXISTING provider (false). When true,
+    /// the editor's Cancel button removes the freshly-added provider from
+    /// `config.providers` — a newly-added provider with no model MUST NOT
+    /// persist in the list (otherwise the row sits with a "No model captured
+    /// yet" warning and the launcher refuses to spawn).
+    @State private var isAddingNewProvider = false
     /// Per-view collapse state for the `CollapsibleDetailHeader`. Starts
     /// expanded — a Settings panel is something the user opened to interact
     /// with, so showing the form by default (rather than hiding it behind a
@@ -86,7 +93,14 @@ struct AgentsSettingsView: View {
                     onAdd: { provider in appendProvider(provider) },
                     onAddNeedsEditor: { provider in
                         showAddSheet = false
-                        DispatchQueue.main.async { editingProvider = provider }
+                        // #663: this provider was just appended by `onAdd`
+                        // above with no selected model. Mark it as a fresh add
+                        // so the editor's Cancel button removes it (see
+                        // `ProviderEditorView` Cancel handler).
+                        DispatchQueue.main.async {
+                            isAddingNewProvider = true
+                            editingProvider = provider
+                        }
                     })
             }
             .sheet(item: $editingProvider) { provider in
@@ -94,9 +108,21 @@ struct AgentsSettingsView: View {
                     provider: provider,
                     cachedModels: config.cachedModels(forProvider: provider.id),
                     selectedModelId: config.selectedModelId(forProvider: provider.id) ?? "",
+                    isAddingNew: isAddingNewProvider,
                     credentialStore: credentialStore,
                     onSave: { updated, selectedModelId in
                         applyEdit(updated, selectedModelId: selectedModelId)
+                        isAddingNewProvider = false
+                    },
+                    onDelete: {
+                        // Cancel on a freshly-added provider: remove it from
+                        // `config.providers` (no confirmation needed — it has
+                        // no model and was just appended; its API key, if any,
+                        // is left in the Keychain for a future add).
+                        if let pending = editingProvider {
+                            removeProvider(pending)
+                        }
+                        isAddingNewProvider = false
                     },
                     onRefreshModels: { provider, models in
                         // #640: durable-persist path for probe-discovered models.
@@ -139,6 +165,7 @@ struct AgentsSettingsView: View {
                         .contentShape(Rectangle())
                         .onTapGesture(count: 2) {
                             selectedProviderID = provider.id
+                            isAddingNewProvider = false
                             editingProvider = provider
                         }
                 }
@@ -173,6 +200,7 @@ struct AgentsSettingsView: View {
 
                     Button("Edit…") {
                         if let provider = selectedProvider {
+                            isAddingNewProvider = false
                             editingProvider = provider
                         }
                     }
@@ -356,9 +384,9 @@ struct AgentsSettingsView: View {
     /// #663: non-destructive append — replaces `addSeed(_:)` and the
     /// pre-persist tail of `addCustom()`. Called by `AddProviderSheet`'s
     /// `onAdd`. Persists the provider immediately (the row appears in the
-    /// list as soon as the sheet dismisses); the editor opens separately
-    /// via the `onAddNeedsEditor` callback when the heuristic in
-    /// `AddProviderModel.needsEditor(for:)` says so.
+    /// list as soon as the sheet dismisses); the editor ALWAYS opens
+    /// separately via the `onAddNeedsEditor` callback so the user is forced
+    /// to pick a model before the provider is usable.
     ///
     /// Dedup: a provider with the same id is NOT replaced — the call is a
     /// no-op (the `AddProviderSheet` already hides already-added agents
@@ -385,8 +413,13 @@ struct AgentsSettingsView: View {
             set: { if !$0 { providerPendingDeletion = nil } })
     }
 
-    private func confirmDelete() {
-        guard let provider = providerPendingDeletion else { return }
+    /// #663: removes a provider from `config.providers` and re-normalizes
+    /// (promotes a new default if the deleted one was default). Shared by
+    /// the delete-confirmation flow (`confirmDelete`) and the editor's
+    /// Cancel-on-new-provider path. No confirmation dialog — callers decide
+    /// whether to gate behind a confirmation (`providerPendingDeletion`).
+    private func removeProvider(_ provider: AgentProvider) {
+        guard config.providers.contains(where: { $0.id == provider.id }) else { return }
         var updated = config
         updated.providers.removeAll { $0.id == provider.id }
         // Re-running init() re-normalizes: promotes a new default if the
@@ -399,6 +432,11 @@ struct AgentsSettingsView: View {
         if selectedProviderID == provider.id {
             selectedProviderID = config.providers.first?.id
         }
+    }
+
+    private func confirmDelete() {
+        guard let provider = providerPendingDeletion else { return }
+        removeProvider(provider)
         providerPendingDeletion = nil
     }
 
@@ -478,12 +516,24 @@ private struct ProviderEditorView: View {
 
     let credentialStore: any ACPCredentialStore
     let onSave: (AgentProvider, String?) -> Void
+    /// #663: invoked when the user cancels the editor on a freshly-added
+    /// provider (only fired when `isAddingNew == true`). The parent removes
+    /// the provider from `config.providers` — a newly-added provider with no
+    /// model MUST NOT persist in the list.
+    let onDelete: (() -> Void)?
     /// #640: durable-persist callback for discovered models. The probe calls
     /// this on success so the discovered list lands in `agent-providers.json`
     /// immediately (survives the user never clicking Save — same behavior as
     /// the launcher's post-spawn `cacheDiscoveredModels`). nil when the parent
     /// does not support refresh (kept optional for the hosted-test seam).
     let onRefreshModels: (@Sendable (AgentProvider, [CachedModelInfo]) async -> Void)?
+
+    /// #663: true when this editor was opened from the Add flow (the provider
+    /// was just appended with no model). Drives the Cancel button: when true,
+    /// Cancel removes the provider from `config.providers` via `onDelete`;
+    /// when false (Edit…/double-click on an existing provider), Cancel keeps
+    /// the provider as-is.
+    let isAddingNew: Bool
 
     /// #640: the probe's lifecycle state. Equatable so SwiftUI skips body
     /// re-renders when the state hasn't changed (e.g. `.idle` → `.idle`).
@@ -504,8 +554,10 @@ private struct ProviderEditorView: View {
         provider: AgentProvider,
         cachedModels: [CachedModelInfo],
         selectedModelId: String,
+        isAddingNew: Bool = false,
         credentialStore: any ACPCredentialStore,
         onSave: @escaping (AgentProvider, String?) -> Void,
+        onDelete: (() -> Void)? = nil,
         onRefreshModels: (@Sendable (AgentProvider, [CachedModelInfo]) async -> Void)? = nil
     ) {
         self.originalID = provider.id
@@ -517,8 +569,10 @@ private struct ProviderEditorView: View {
         self._apiKey = State(initialValue: "")
         self._selectedModelId = State(initialValue: selectedModelId)
         self._cachedModels = State(initialValue: cachedModels)
+        self.isAddingNew = isAddingNew
         self.credentialStore = credentialStore
         self.onSave = onSave
+        self.onDelete = onDelete
         self.onRefreshModels = onRefreshModels
     }
 
@@ -645,11 +699,26 @@ private struct ProviderEditorView: View {
 
             HStack {
                 Spacer()
-                Button("Cancel") { dismiss() }
-                    .keyboardShortcut(.cancelAction)
+                Button("Cancel") {
+                    // #663: a freshly-added provider with no model MUST NOT
+                    // persist in the list — fire the parent's `onDelete`
+                    // callback so it's removed before the sheet dismisses.
+                    // Editing an EXISTING provider (Cancel) keeps it as-is.
+                    if isAddingNew {
+                        onDelete?()
+                    }
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
                 Button("Save") { save() }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(label.trimmingCharacters(in: .whitespaces).isEmpty)
+                    // #663: a provider cannot be saved without a selected model
+                    // — otherwise the row sits with a "No model captured yet"
+                    // warning and the launcher refuses to spawn
+                    // (`SpawnModelGuard`). The "Provider default" picker option
+                    // (tag "") counts as no selection: it leaves the provider
+                    // with no selectedModelId.
+                    .disabled(label.trimmingCharacters(in: .whitespaces).isEmpty || selectedModelId.isEmpty)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 10)

--- a/Tests/WikiFSTests/AddProviderSheetTests.swift
+++ b/Tests/WikiFSTests/AddProviderSheetTests.swift
@@ -10,9 +10,10 @@ import WikiFSCore
 /// - **AC.2**: `AddProviderSheet` writes nothing to config until an Add
 ///   button is pressed — cancel = no change.
 /// - **AC.6**: `seed()` returns only `[claudeAcpDefault]`.
-/// - **needsEditor heuristic** — a freshly-added catalog agent without a
-///   detected binary opens the editor; a cleanly-detected one skips it; a
-///   custom add with no command opens it.
+/// - **forced editor**: every newly-added provider opens the editor (the
+///   user MUST pick a model before the provider is usable). The old
+///   `needsEditor` heuristic that skipped the editor for cleanly-detected
+///   PATH agents was removed — it left providers with no model.
 ///
 /// The `AddProviderSheet` view body itself isn't rendered here — AC.2 is
 /// asserted at the protocol seam: constructing the sheet + invoking only
@@ -74,47 +75,6 @@ struct AddProviderSheetTests {
         let config = AgentProvidersConfig(providers: [])
         #expect(config.providers.map(\.id) == ["claude-acp"])
         #expect(config.defaultProvider.id == "claude-acp")
-    }
-
-    // MARK: - needsEditor heuristic (correction §4)
-
-    @Test func needsEditorTrueForCustomWithEmptyCommand() {
-        // The custom-add path lands the user in the editor for env/key
-        // follow-up. The heuristic's first branch (`provider.command` empty
-        // or nil) catches this.
-        let model = AddProviderModel(existingIDs: [])
-        let custom = AgentProvider(
-            id: "custom", label: "My Agent",
-            command: nil,
-            env: [:], enabled: true, isDefault: false)
-        #expect(model.needsEditor(for: custom) == true)
-    }
-
-    @Test func needsEditorFalseForDetectedCatalogAgent() {
-        // A cleanly-detected catalog agent skips the editor (fast path: 2
-        // clicks total). Construct a model whose `detected` list contains
-        // the agent — that's the post-scan state.
-        let agent = ACPProviderCatalog.agents.first(where: { $0.id == "claude-acp" })!
-        let discovered = DiscoveredACPAgent(agent: agent, resolvedPath: "/opt/homebrew/bin/bun")
-        let model = AddProviderModel(existingIDs: [])
-        model.detected = [discovered]
-        model.isScanning = false
-        let provider = AgentProvider.acp(from: agent)
-        #expect(model.needsEditor(for: provider) == false)
-    }
-
-    @Test func needsEditorTrueForNonDetectedCatalogAgent() {
-        // A catalog agent whose binary is NOT on PATH (added from the
-        // "Other known agents" section) opens the editor — the user may
-        // want to tweak the command/env/key (e.g. adding an API key for a
-        // provider whose binary will be installed later).
-        let agent = ACPProviderCatalog.agents.first(where: { $0.id == "gemini" })!
-        let model = AddProviderModel(existingIDs: [])
-        // Empty `detected` simulates "gemini not on PATH."
-        model.detected = []
-        model.isScanning = false
-        let provider = AgentProvider.acp(from: agent)
-        #expect(model.needsEditor(for: provider) == true)
     }
 
     // MARK: - freshCustomID — collision loop


### PR DESCRIPTION
## Problem

When adding a new provider in Settings → Agents, a "cleanly detected" provider
(binary found on PATH) skipped the editor entirely and landed in the list with
the orange "No model captured yet" warning. Result: providers persisted with
no selected model, and the launcher's `SpawnModelGuard` refused to spawn them.
The user had to remember to come back and Edit… → pick a model — but the UI
didn't signal that the editor was missing.

The `AddProviderModel.needsEditor(for:)` heuristic returned `false` for any
agent whose binary was on PATH, gating the editor open with that single signal.
A "cleanly detected" binary was treated as "the user doesn't need to do
anything".

## Fix

Three coordinated changes:

### 1. Always open the editor after adding (`AddProviderSheet.swift`)

`handleAdd` now always invokes `onAddNeedsEditor(provider)` after `onAdd`.
The `needsEditor(for:)` method on `AddProviderModel` was dead code and is
removed. The user is forced to land in the editor for every newly-added
provider — detected or not, catalog or custom.

### 2. Disable Save until a model is selected (`AgentsSettingsView.swift`)

The `ProviderEditorView` Save button now also checks
`selectedModelId.isEmpty`. The "Provider default" picker option (tag `""`)
counts as no selection — picking it leaves the provider with no
`selectedModelId`, so the user must pick a real model off the cached list
(Refresh Models first if empty) before Save is enabled.

### 3. Cancel removes a newly-added provider (`AgentsSettingsView.swift`)

`ProviderEditorView` now takes an `isAddingNew` flag and an `onDelete`
closure. When `isAddingNew == true` (opened from Add → editor flow), Cancel
fires `onDelete`, which removes the provider from `config.providers` before
the sheet dismisses. When `isAddingNew == false` (Edit… or double-click on an
existing provider), Cancel keeps the provider as-is.

The parent tracks `isAddingNewProvider` state — set to `true` in the
`AddProviderSheet.onAddNeedsEditor` callback, cleared to `false` in
`onSave`, `onDelete`, the Edit… button, and the double-click handler.

The deletion logic is factored out of `confirmDelete` into a new
`removeProvider(_:)` helper so both the confirmation-gated delete flow and
the no-confirmation cancel-on-new flow share the same re-normalization
(promotes a new default when the deleted one was the default).

### Tests

The three `needsEditor*` tests in `AddProviderSheetTests.swift` pinned the
buggy heuristic directly (one asserted `needsEditor == false` for
cleanly-detected agents — that's the bug). All three are removed; the suite
docstring is updated to document the "forced editor" contract instead.

## Verification

```
make version prompts && swift build && swift test
```

- `swift build`: clean (no warnings on touched files).
- `swift test`: **3067 tests passed in 261 suites** (35.4s) — including the
  existing `AgentsSettingsViewWarningTests`, `AgentsSettingsViewModelStatusTests`,
  and the trimmed `AddProviderSheetTests` suite.

## House rules check

- No bare `try?` added (the existing ones in touched files are pre-existing).
- No `print` — no new logging added.
- PR body written to `tmp/pr-body-force-model-pick.md` and passed via
  `--body-file` (no inline markdown through the shell).
- Branch `force-model-pick` pushed; PR opened against `main` (not merged).
