### PR TITLE
Fix provider detection false positives + misleading removal warning

### DIFF
--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -118,7 +118,7 @@ struct AgentsSettingsView: View {
                 Button("Delete", role: .destructive) { confirmDelete() }
                 Button("Cancel", role: .cancel) { providerPendingDeletion = nil }
             } message: {
-                Text("This removes its command and environment. Its API key stays in the Keychain until overwritten.")
+                Text("This removes the provider from the app. You can add it again later.")
             }
         }
     }

--- a/Sources/WikiFSCore/Integrations/ACPProviderCatalog.swift
+++ b/Sources/WikiFSCore/Integrations/ACPProviderCatalog.swift
@@ -23,13 +23,29 @@ public struct KnownACPAgent: Sendable, Equatable, Identifiable {
     public let summary: String
     public let detectExecutable: String   // PATH binary whose presence = "installed"
     public let command: [String]          // ACP spawn argv (command[0] == detectExecutable by convention)
+    /// Whether `discover()` should auto-detect this agent by its `detectExecutable`
+    /// on PATH. `false` for entries whose `detectExecutable` is a generic JS/Python
+    /// **runtime** (`bun`, `npx`, `node`, `uvx`) — finding the runtime on PATH does
+    /// NOT mean the agent package is installed, so these false-positive if
+    /// auto-detected. The user adds them manually via the Add Provider sheet and
+    /// refreshes models via the probe button. Standalone-binary agents (gemini,
+    /// hermes, copilot, …) default to `true`.
+    public let autoDetectable: Bool
 
-    public init(id: String, label: String, summary: String, detectExecutable: String, command: [String]) {
+    public init(
+        id: String,
+        label: String,
+        summary: String,
+        detectExecutable: String,
+        command: [String],
+        autoDetectable: Bool = true
+    ) {
         self.id = id
         self.label = label
         self.summary = summary
         self.detectExecutable = detectExecutable
         self.command = command
+        self.autoDetectable = autoDetectable
     }
 }
 
@@ -49,7 +65,12 @@ public enum ACPProviderCatalog {
             label: "Claude",
             summary: "Claude Code via the official ACP wrapper (bunx @agentclientprotocol/claude-agent-acp).",
             detectExecutable: "bun",
-            command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"]),
+            command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"],
+            // `bun` is a generic JS runtime — finding it on PATH does NOT mean
+            // the `@agentclientprotocol/claude-agent-acp` package is installed.
+            // Don't auto-detect; the user adds this provider manually and
+            // discovers models via the refresh-probe button.
+            autoDetectable: false),
         KnownACPAgent(
             id: "gemini",
             label: "Gemini CLI",

--- a/Sources/WikiFSCore/Integrations/ACPProviderDiscovery.swift
+++ b/Sources/WikiFSCore/Integrations/ACPProviderDiscovery.swift
@@ -13,6 +13,12 @@ import Foundation
 /// Discovery checks the BINARY exists — it does NOT verify the agent actually
 /// speaks ACP (that's validated when `ACPBackend` launches it). A found agent is
 /// a candidate, not a guarantee.
+///
+/// Entries where `KnownACPAgent.autoDetectable == false` are SKIPPED. Those
+/// entries' `detectExecutable` is a generic JS/Python runtime (`bun`, `npx`,
+/// `uvx`, `node`) — finding the runtime on PATH doesn't mean the agent package
+/// is installed (false positive). The user adds those manually via the Add
+/// Provider sheet and discovers models via the refresh-probe button.
 public struct DiscoveredACPAgent: Sendable, Equatable {
     public let agent: KnownACPAgent
     public let resolvedPath: String   // absolute path the binary was found at
@@ -29,11 +35,18 @@ public enum ACPProviderDiscovery {
     /// catalog). `resolve` maps an executable name to a `PathPreflight.Result`;
     /// the default resolves on the login-shell PATH. Returns the catalog agents
     /// whose binary was found, each with its resolved path.
+    ///
+    /// Non-autoDetectable entries (runtime-launched agents like `claude-acp`
+    /// via `bun`, or npx/uvx packages) are skipped — see
+    /// `KnownACPAgent.autoDetectable`.
     public static func discover(
         in catalog: [KnownACPAgent] = ACPProviderCatalog.agents,
         resolve: (String) -> PathPreflight.Result = PathPreflight.resolveOnLoginShell
     ) -> [DiscoveredACPAgent] {
         catalog.compactMap { agent in
+            // Skip runtime-launched agents — finding the runtime on PATH does
+            // NOT mean the agent package is installed.
+            guard agent.autoDetectable else { return nil }
             switch resolve(agent.detectExecutable) {
             case .found(let path):
                 return DiscoveredACPAgent(agent: agent, resolvedPath: path)

--- a/Sources/WikiFSCore/Integrations/ACPRegistry.swift
+++ b/Sources/WikiFSCore/Integrations/ACPRegistry.swift
@@ -324,7 +324,12 @@ struct ACPRegistryClient: Sendable {
                 label: agent.name,
                 summary: agent.description ?? "",
                 detectExecutable: spawn.detect,
-                command: spawn.command
+                command: spawn.command,
+                // `npx` / `uvx` distributions use the runtime as `detectExecutable`
+                // — finding the runtime on PATH does NOT mean the agent package
+                // is installed, so don't auto-detect. Standalone-binary entries
+                // (the `.binary` case) keep the default `true`.
+                autoDetectable: spawn.autoDetectable
             )
         }
     }
@@ -341,18 +346,22 @@ struct ACPRegistryClient: Sendable {
     ///   to `darwin-x86_64` if the aarch64 entry is absent (the binary will
     ///   run under Rosetta on an Apple-Silicon Mac).
     /// - `uvx` → `command = ["uvx", package] + args`, `detectExecutable = "uvx"`.
+    ///
+    /// `autoDetectable` is `false` for `npx`/`uvx` (the runtime being on PATH
+    /// doesn't mean the package is installed) and `true` for `binary` (the
+    /// standalone executable IS the agent).
     private static func spawn(
         for distribution: ACPRegistryDistribution
-    ) -> (detect: String, command: [String])? {
+    ) -> (detect: String, command: [String], autoDetectable: Bool)? {
         switch distribution {
         case .npx(let npx):
             var command = ["npx", npx.package]
             if let args = npx.args { command.append(contentsOf: args) }
-            return ("npx", command)
+            return ("npx", command, false)
         case .uvx(let uvx):
             var command = ["uvx", uvx.package]
             if let args = uvx.args { command.append(contentsOf: args) }
-            return ("uvx", command)
+            return ("uvx", command, false)
         case .binary(let platforms):
             // Prefer the native arch; fall back to x86_64 (Rosetta).
             let platform = platforms["darwin-aarch64"] ?? platforms["darwin-x86_64"]
@@ -360,7 +369,7 @@ struct ACPRegistryClient: Sendable {
             let detect = bin.cmd.hasPrefix("./") ? String(bin.cmd.dropFirst(2)) : bin.cmd
             var command = [detect]
             if let args = bin.args { command.append(contentsOf: args) }
-            return (detect, command)
+            return (detect, command, true)
         }
     }
 }

--- a/Tests/WikiFSTests/ACPProviderDiscoveryTests.swift
+++ b/Tests/WikiFSTests/ACPProviderDiscoveryTests.swift
@@ -53,18 +53,50 @@ struct ACPProviderDiscoveryTests {
         }
     }
 
+    @Test func claudeAcpIsNotAutoDetectable() {
+        // Claude via ACP runs through `bun` — a generic JS runtime. Finding `bun`
+        // on PATH does NOT mean `@agentclientprotocol/claude-agent-acp` is
+        // installed, so the catalog entry must be marked `autoDetectable: false`.
+        let claude = ACPProviderCatalog.agents.first(where: { $0.id == "claude-acp" })
+        #expect(claude != nil)
+        #expect(claude?.autoDetectable == false)
+    }
+
+    @Test func skipsNonAutoDetectableEvenWhenBinaryIsFound() {
+        // A runtime-launched agent (detectExecutable == "bun" here) must NOT
+        // appear in `discover()` output, even when its runtime is on PATH —
+        // otherwise users see "Claude detected" just because they have bun.
+        let catalog = [
+            KnownACPAgent(id: "claude-acp", label: "Claude", summary: "",
+                         detectExecutable: "bun", command: ["bun", "x", "pkg"],
+                         autoDetectable: false),
+            KnownACPAgent(id: "gemini", label: "Gemini", summary: "",
+                         detectExecutable: "gemini", command: ["gemini", "--acp"]),
+        ]
+        let resolve: (String) -> PathPreflight.Result = { exe in
+            // Both binaries "found" — but only the autoDetectable one should surface.
+            .found(path: "/usr/local/bin/\(exe)")
+        }
+        let found = ACPProviderDiscovery.discover(in: catalog, resolve: resolve)
+        #expect(found.map(\.agent.id) == ["gemini"])
+    }
+
     // MARK: - Live (this machine's PATH)
 
     @Test
     func liveDiscoveryMatchesFilesystem() {
-        // Machine-agnostic: for each catalog agent, discovery must report it
-        // installed iff its binary is actually on the login-shell PATH. No
-        // hard-coded agent names — so this passes on a CI runner that has none
-        // installed (all missing → none reported) and still validates the real
-        // login-shell resolver end-to-end on a machine that has some.
+        // Machine-agnostic: for each *auto-detectable* catalog agent, discovery
+        // must report it installed iff its binary is actually on the login-shell
+        // PATH. Non-autoDetectable agents (e.g. claude-acp via `bun`) are
+        // NEVER reported, regardless of whether their runtime is on PATH — so
+        // they're excluded from this equivalence check (and asserted absent
+        // separately below). No hard-coded agent names — so this passes on a
+        // CI runner that has none installed (all missing → none reported) and
+        // still validates the real login-shell resolver end-to-end on a machine
+        // that has some.
         let discovered = ACPProviderDiscovery.discover()
         let discoveredIDs = Set(discovered.map(\.agent.id))
-        for agent in ACPProviderCatalog.agents {
+        for agent in ACPProviderCatalog.agents where agent.autoDetectable {
             switch PathPreflight.resolveOnLoginShell(executable: agent.detectExecutable) {
             case .found:
                 #expect(discoveredIDs.contains(agent.id),
@@ -73,6 +105,12 @@ struct ACPProviderDiscoveryTests {
                 #expect(!discoveredIDs.contains(agent.id),
                         "discovery reported a non-installed agent \(agent.id)")
             }
+        }
+        // Non-autoDetectable agents are never discovered, even if their runtime
+        // happens to be on PATH (e.g. `bun` for claude-acp).
+        for agent in ACPProviderCatalog.agents where !agent.autoDetectable {
+            #expect(!discoveredIDs.contains(agent.id),
+                    "discovery reported a non-autoDetectable agent \(agent.id)")
         }
         // Resolved paths are absolute for whatever was found.
         for d in discovered {

--- a/Tests/WikiFSTests/ACPRegistryTests.swift
+++ b/Tests/WikiFSTests/ACPRegistryTests.swift
@@ -140,6 +140,9 @@ struct ACPRegistryTests {
         #expect(agent.command == ["npx", "@agentclientprotocol/claude-agent-acp@0.59.0", "--acp"])
         // Convention: command[0] == detectExecutable.
         #expect(agent.command.first == agent.detectExecutable)
+        // `npx` is a generic JS runtime — finding it on PATH does NOT mean the
+        // agent package is installed, so auto-detect would false-positive.
+        #expect(agent.autoDetectable == false)
     }
 
     @Test func mapsNpxWithoutArgs() throws {
@@ -165,6 +168,8 @@ struct ACPRegistryTests {
         #expect(agent.detectExecutable == "uvx")
         #expect(agent.command == ["uvx", "fast-agent-acp==0.9.16", "-x"])
         #expect(agent.command.first == agent.detectExecutable)
+        // `uvx` is a generic Python runtime — same false-positive risk as `npx`.
+        #expect(agent.autoDetectable == false)
     }
 
     @Test func mapsBinaryStripsLeadingDotSlash() throws {
@@ -180,6 +185,9 @@ struct ACPRegistryTests {
         #expect(agent.detectExecutable == "amp-acp")
         #expect(agent.command == ["amp-acp", "serve"])
         #expect(agent.command.first == agent.detectExecutable)
+        // `binary` distributions ship a standalone executable — the binary IS
+        // the agent, so finding it on PATH means the agent is installed.
+        #expect(agent.autoDetectable == true)
     }
 
     @Test func mapsBinaryWithoutLeadingDotSlash() throws {


### PR DESCRIPTION
## Summary

Two provider-management bug fixes.

### Bug 1 — Misleading removal warning
`AgentsSettingsView.swift`'s remove-provider confirmation dialog unconditionally
mentioned an API key staying in the Keychain, but the user may never have set
one. Removed that sentence — the dialog now reads:

> This removes the provider from the app. You can add it again later.

### Bug 2 — Provider detection false positives
`ACPProviderDiscovery.discover()` flagged agents as "installed" whenever their
`detectExecutable` was found on PATH. For runtime-launched agents (Claude via
`bun`, anything via `npx`/`uvx`), `detectExecutable` is a generic JS/Python
**runtime** — finding it on PATH does **not** mean the agent package is
installed. Users with `bun`/`npx` would see Claude (and any npx-launched agent)
as "detected/installed" incorrectly.

Added a new `KnownACPAgent.autoDetectable: Bool` (default `true`) and set it
`false` for:
- `claude-acp` in the hardcoded `fallbackCatalog` (detectExecutable == `bun`)
- `.npx` and `.uvx` distributions in `ACPRegistryClient.mapRegistryToCatalog`
  (detectExecutable == `npx` / `uvx`)

`.binary` distributions (standalone executables — gemini, hermes, copilot,
etc.) keep `autoDetectable == true`.

`ACPProviderDiscovery.discover()` now skips entries where
`autoDetectable == false`. Those providers still appear in the Add Provider
catalog — the user adds them manually and discovers models via the refresh-probe
button.

The user's option B was chosen (simplest, least invasive): a single new flag on
`KnownACPAgent`, default true so existing callers continue to compile.

## Tests
- Full suite: `swift test` — 3072 tests pass.
- New/focused tests:
  - `ACPProviderDiscoveryTests.claudeAcpIsNotAutoDetectable`
  - `ACPProviderDiscoveryTests.skipsNonAutoDetectableEvenWhenBinaryIsFound`
  - `ACPProviderDiscoveryTests.liveDiscoveryMatchesFilesystem` (updated to
    filter out non-autoDetectable entries + assert they're never discovered)
  - `ACPRegistryTests.mapsNpxToNpxCommandAndDetect` (asserts `autoDetectable == false`)
  - `ACPRegistryTests.mapsUvxToUvxCommandAndDetect` (asserts `autoDetectable == false`)
  - `ACPRegistryTests.mapsBinaryStripsLeadingDotSlash` (asserts `autoDetectable == true`)

## Risk
- Any catalog entry currently auto-detected through `npx`/`uvx`/`bun` will no
  longer be. That's the desired behavior — those were false positives. The user
  adds such providers manually via Add Provider (which they had to do anyway in
  practice — discovery's "installed" claim didn't actually verify the package).
- The fallback catalog (used when no bundled snapshot / cache / live registry
  is available) keeps all its entries; only claude-acp's autoDetect flag changes.
