### PR TITLE
Allow per-operation provider overrides (chat / ingest / lint)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,110 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-19 — Per-operation provider overrides (chat / ingest / lint) (branch `per-op-provider`, PR #704)
+
+**Problem.** A single shared `defaultProvider` was used for all three ACP
+operations (chat / ingest / lint). Changing the default for one operation
+changed it for all three. The `AgentProvidersConfig` config model and the
+spawn path offered no per-operation surface, and the `PermissionsSettingsView`
+had no UI for setting one.
+
+**Fix.** Add three optional per-operation provider id fields to
+`AgentProvidersConfig` (`chatProviderId` / `ingestProviderId` /
+`lintProviderId`), each falling back to `defaultProvider` when the pin is
+`nil` OR points at a deleted provider (no dangling references). Each
+operation resolves its OWN provider at spawn time through the new resolvers,
+then reads `selectedModelId(forProvider:)` on that provider and feeds both
+into `SpawnModelGuard` (unchanged validation).
+
+### Config — `Sources/WikiFSCore/Core/AgentProvidersConfig.swift`
+
+- New optional `Codable` fields: `chatProviderId` / `ingestProviderId` /
+  `lintProviderId`. Forward-compatible — old configs without these keys
+  decode to all-`nil`, and every operation routes to `defaultProvider` (the
+  legacy behavior). No migration, no behavior change for existing users.
+- New resolution methods: `providerForChat()` / `providerForIngest()` /
+  `providerForLint()`, each:
+  ```swift
+  chatProviderId.flatMap { provider(id: $0) } ?? defaultProvider
+  ```
+  — falls back to `defaultProvider` when the pin is `nil` OR points at a
+  provider that no longer exists.
+- New PURE setters: `settingChatProvider(id:)` / `settingIngestProvider(id:)`
+  / `settingLintProvider(id:)`. Whitespace is normalized to `nil`; empty/
+  whitespace clears the pin. NEVER validates that the pinned id exists —
+  the resolver falls back when a pinned id is later deleted, so accepting
+  an unknown id here is safe (and a re-add of the same id later just starts
+  working again).
+- The three new fields are carried through ALL existing setters
+  (`settingDefault` / `settingCachedModels` / `settingSelectedModel` /
+  `togglingFavoriteModel`) and through `loadOrSeed` so a Settings edit
+  doesn't silently wipe an operation's pin.
+
+### Spawn path — `Sources/WikiFSEngine/AgentLauncher.swift`
+
+- `startInteractiveQuery` (chat): `providersConfig().providerForChat()`
+- `runACPIngestPlannerExecutors` (multi-phase large-source ingest):
+  `providersConfig().providerForIngest()`
+- `run()` single-session (covers `.ingest` + `.lint` / `.lintPage` + a
+  defensive `.query` branch): switches on `permissionKind` to pick
+  `providerForChat/Ingest/Lint()`.
+- New launcher wrappers `setChatProvider(id:)` / `setIngestProvider(id:)` /
+  `setLintProvider(id:)` mirror `setDefaultProvider(id:)`'s load→mutate→save
+  shape + `DebugLog` error path.
+
+### UI — `Sources/WikiFS/Settings/PermissionsSettingsView.swift`
+
+- New "Provider Assignment" section next to the existing "Permissions"
+  section, with a Provider + Model picker per operation.
+- Provider picker lists `config.enabledProviders` plus a leading
+  "Default (Claude)" row (the `nil` pin = legacy behavior). Selecting it
+  clears the pin.
+- Model picker lists the resolved provider's cached models plus an
+  "Agent default" row (clears the per-provider model selection). When no
+  models are cached, displays "Chat with this provider once to discover
+  models" and is disabled.
+- `containerDirectory` is threaded in from `WikiFSApp`; loads config on
+  init + on appear.
+- `persist()` uses `do/catch + DebugLog` per the house rule against bare
+  `try?`.
+
+### Tests
+
+- NEW `Tests/WikiFSTests/AgentProvidersConfigPerOpProviderTests.swift`
+  (25 tests): resolution fall-back to `defaultProvider` when pin is `nil`;
+  resolution fall-back when the pinned provider was deleted (the
+  "no dangling references" AC); setter round-trip + `nil`/whitespace
+  normalization; carry-through across existing setters; Codable
+  backward-compat (a pre-per-op-provider `agent-providers.json` decodes to
+  all-`nil`); round-trip through disk; `loadOrSeed` carry-through (including
+  a stale pin pointing at a deleted provider — preserved on disk, falls
+  back at read time).
+- Updated `Tests/WikiFSTests/AgentLauncherSpawnRefusalTests.swift` +
+  `ChatViewPreflightBannerTests.swift`: the chat-path spawn refusal used to
+  inject `launcher.resolveSelectedProvider` to override the provider. With
+  per-op-provider, the chat path now resolves via
+  `providersConfig().providerForChat()`, so the no-model scenario is set up
+  by pre-writing an `agent-providers.json` whose default provider is
+  opencode with no `selectedModelIds` entry — `providerForChat()` returns
+  opencode (no chat pin → fallback to default) and the guard fires on the
+  nil-model state. Same observable contract (`preflightError != nil`,
+  `isRunning == false`); the setup change reflects the actual seam the
+  spawn path now reads.
+
+### Verification
+
+- `make version prompts` ✓
+- `swift build` ✓ (clean, 0 errors / 0 warnings)
+- `swift test` (full suite) — **3092 tests / 262 suites pass** (~33 s).
+  No regressions.
+
+### Status
+
+PR #704 open (branch `per-op-provider`), not merged.
+
+---
+
 ## 2026-07-19 — Issue #599: HTML sources — keep original HTML + Reader/HTML/Split tabs (branch `html-source-tabs`)
 
 **Problem.** When an HTML page was ingested, `FormatMaterializer.dispatch`

--- a/Sources/WikiFS/Settings/PermissionsSettingsView.swift
+++ b/Sources/WikiFS/Settings/PermissionsSettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WikiFSEngine
+import WikiFSCore
 
 /// Settings → **Permissions** tab.
 ///
@@ -27,51 +28,239 @@ import WikiFSEngine
 /// because permissions is the closest semantically to "app behavior" — it's
 /// the only Settings tab whose controls affect the app's runtime behavior
 /// rather than per-wiki content.
+///
+/// **Per-operation provider assignment (per-op-provider):** the "Provider
+/// Assignment" section pins a separate provider to each operation (chat /
+/// ingest / lint), with a per-provider model picker. A nil pin = "use the
+/// default provider" (the legacy behavior — all three routes fall back to
+/// the provider marked `isDefault`). The model picker reads/writes the
+/// PER-PROVIDER model selection — so two operations pinned to the same
+/// provider share its selected model (acceptable per the spec; a future
+/// per-op-per-provider model override would require a shape change).
 struct PermissionsSettingsView: View {
     @AppStorage(AgentLauncher.PermissionModeKey.chat)   private var chatModeRaw   = PermissionPolicy.bypass.rawValue
     @AppStorage(AgentLauncher.PermissionModeKey.ingest) private var ingestModeRaw = PermissionPolicy.bypass.rawValue
     @AppStorage(AgentLauncher.PermissionModeKey.lint)   private var lintModeRaw   = PermissionPolicy.bypass.rawValue
     @AppStorage(AppDelegate.confirmQuitKey) private var confirmBeforeQuitting = true
 
+    /// The provider config — loaded fresh on appear so a Settings edit on the
+    /// Agents tab is visible the next time the Permissions tab renders.
+    /// Mirrors `AgentsSettingsView`'s `@State config` shape.
+    @State private var config: AgentProvidersConfig
+
+    /// The per-operation provider id bindings. `nil` = "use default provider"
+    /// (the legacy behavior). Bound to the config's `chatProviderId` /
+    /// `ingestProviderId` / `lintProviderId` fields via the `setXxxProvider`
+    /// launcher wrappers; persisted to `agent-providers.json` on every change.
+    @State private var chatProviderId: String?
+    @State private var ingestProviderId: String?
+    @State private var lintProviderId: String?
+
+    private let containerDirectory: URL
+
+    init(containerDirectory: URL) {
+        self.containerDirectory = containerDirectory
+        let loaded = AgentProvidersConfig.loadOrSeed(from: containerDirectory)
+        _config = State(initialValue: loaded)
+        _chatProviderId = State(initialValue: loaded.chatProviderId)
+        _ingestProviderId = State(initialValue: loaded.ingestProviderId)
+        _lintProviderId = State(initialValue: loaded.lintProviderId)
+    }
+
     var body: some View {
         Form {
-            Section {
-                Picker("Chat Permission Mode", selection: $chatModeRaw) {
-                    ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
-                        Text(mode.label).tag(mode.rawValue)
-                    }
-                }
-                Picker("Ingest Permission Mode", selection: $ingestModeRaw) {
-                    ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
-                        Text(mode.label).tag(mode.rawValue)
-                    }
-                }
-                Picker("Lint Permission Mode", selection: $lintModeRaw) {
-                    ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
-                        Text(mode.label).tag(mode.rawValue)
-                    }
-                }
-            } header: {
-                Text("Permissions")
-            } footer: {
-                Text("These control how the app responds to the agent's permission requests for each operation. Ingest and Lint run unattended — Bypass is recommended (the sandbox already confines writes; an unattended pipeline can't use Always Ask productively, and a stuck permission would auto-reject after 60s).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Section("App Behavior") {
-                Toggle("Ask before quitting", isOn: $confirmBeforeQuitting)
-                    .help(
-                        "When enabled, Self Driving Wiki asks for confirmation "
-                        + "before quitting — ⌘Q, or closing the last window with ⌘W."
-                    )
-            }
+            permissionSection
+            appBehaviorSection
+            providerAssignmentSection
         }
         .formStyle(.grouped)
+        .onAppear { refresh() }
+    }
+
+    // MARK: - Permission section (unchanged shape, just moved out of body)
+
+    private var permissionSection: some View {
+        Section {
+            Picker("Chat Permission Mode", selection: $chatModeRaw) {
+                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                    Text(mode.label).tag(mode.rawValue)
+                }
+            }
+            Picker("Ingest Permission Mode", selection: $ingestModeRaw) {
+                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                    Text(mode.label).tag(mode.rawValue)
+                }
+            }
+            Picker("Lint Permission Mode", selection: $lintModeRaw) {
+                ForEach(PermissionPolicy.allCases, id: \.rawValue) { mode in
+                    Text(mode.label).tag(mode.rawValue)
+                }
+            }
+        } header: {
+            Text("Permissions")
+        } footer: {
+            Text("These control how the app responds to the agent's permission requests for each operation. Ingest and Lint run unattended — Bypass is recommended (the sandbox already confines writes; an unattended pipeline can't use Always Ask productively, and a stuck permission would auto-reject after 60s).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - App behavior section ("Ask before quitting")
+
+    /// "Ask before quitting" toggle. Previously lived on a standalone General
+    /// tab; that tab was removed (not justifying a whole tab) and the toggle
+    /// landed here (see class docstring).
+    private var appBehaviorSection: some View {
+        Section("App Behavior") {
+            Toggle("Ask before quitting", isOn: $confirmBeforeQuitting)
+                .help(
+                    "When enabled, Self Driving Wiki asks for confirmation "
+                    + "before quitting — ⌘Q, or closing the last window with ⌘W."
+                )
+        }
+    }
+
+    // MARK: - Provider assignment section (per-op-provider)
+
+    /// Per-operation provider + model pickers. Each operation can pin its OWN
+    /// provider (independent of the default). The model picker writes the
+    /// PER-PROVIDER model selection — so when two operations share a provider,
+    /// they share its model. The "— Default —" row clears the pin (routes to
+    /// `defaultProvider`); the "— Agent default —" row clears the model pin
+    /// (lets the agent's first-listed model be used — the same as today).
+    private var providerAssignmentSection: some View {
+        Section {
+            operationRow(
+                label: "Chat",
+                providerID: $chatProviderId,
+                onProviderChange: { setChatProvider($0) })
+            operationRow(
+                label: "Ingest",
+                providerID: $ingestProviderId,
+                onProviderChange: { setIngestProvider($0) })
+            operationRow(
+                label: "Lint",
+                providerID: $lintProviderId,
+                onProviderChange: { setLintProvider($0) })
+        } header: {
+            Text("Provider Assignment")
+        } footer: {
+            Text("Pin a different provider to each operation. “Default” uses the provider marked default in the Agents tab (the legacy behavior). When a provider is deleted, any operation still pinned to it silently falls back to the default — no dangling references. The model picker writes the per-provider selection, so two operations pinned to the same provider share its model.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// One operation row: a Provider picker + a Model picker. The Model picker
+    /// reads the cached models for the operation's chosen provider (or the
+    /// default provider when the pin is nil), mirroring the chat composer's
+    /// per-provider selection seam.
+    private func operationRow(
+        label: String,
+        providerID: Binding<String?>,
+        onProviderChange: @escaping @MainActor (String?) -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            // The resolved provider for this operation — used to list models
+            // and to persist the model selection. When the pin is nil OR stale
+            // (points at a deleted provider), `providerForXxx()` returns
+            // `defaultProvider` — so the model picker always shows a real list.
+            let resolved: AgentProvider = {
+                switch label {
+                case "Chat":   return config.providerForChat()
+                case "Ingest": return config.providerForIngest()
+                case "Lint":   return config.providerForLint()
+                default:        return config.defaultProvider
+                }
+            }()
+
+            Picker("\(label) Provider", selection: Binding(
+                get: { providerID.wrappedValue ?? "" },
+                set: { newID in onProviderChange(newID.isEmpty ? nil : newID) }
+            )) {
+                Text("Default (\(config.defaultProvider.label))").tag("")
+                ForEach(config.enabledProviders, id: \.id) { provider in
+                    Text(provider.label).tag(provider.id)
+                }
+            }
+
+            let models = config.cachedModels(forProvider: resolved.id)
+            let currentModel = config.selectedModelId(forProvider: resolved.id)
+            Picker("\(label) Model", selection: Binding(
+                get: { currentModel ?? "" },
+                set: { newID in setModel(newID.isEmpty ? nil : newID, for: resolved.id) }
+            )) {
+                if models.isEmpty {
+                    Text("Chat with this provider once to discover models").tag("")
+                } else {
+                    Text("Agent default").tag("")
+                    ForEach(models, id: \.modelId) { model in
+                        Text(model.displayLabel).tag(model.modelId)
+                    }
+                }
+            }
+            .disabled(models.isEmpty)
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Actions
+
+    private func setChatProvider(_ id: String?) {
+        config = config.settingChatProvider(id: id)
+        chatProviderId = id
+        persist()
+    }
+
+    private func setIngestProvider(_ id: String?) {
+        config = config.settingIngestProvider(id: id)
+        ingestProviderId = id
+        persist()
+    }
+
+    private func setLintProvider(_ id: String?) {
+        config = config.settingLintProvider(id: id)
+        lintProviderId = id
+        persist()
+    }
+
+    /// Set the per-provider model selection. The selection is keyed by
+    /// PROVIDER (not per-operation) — every operation pinned to this provider
+    /// will see the same model. Mirrors `AgentsSettingsView.applyEdit`'s
+    /// `settingSelectedModel(_:forProvider:)` call.
+    private func setModel(_ modelId: String?, for providerId: String) {
+        config = config.settingSelectedModel(modelId, forProvider: providerId)
+        persist()
+    }
+
+    private func refresh() {
+        let loaded = AgentProvidersConfig.loadOrSeed(from: containerDirectory)
+        config = loaded
+        chatProviderId = loaded.chatProviderId
+        ingestProviderId = loaded.ingestProviderId
+        lintProviderId = loaded.lintProviderId
+    }
+
+    /// Persist the in-memory config to `agent-providers.json`. Uses
+    /// `do/catch + DebugLog` per the house rule against bare `try?` (a silent
+    /// failure would silently revert the user's per-op provider assignment on
+    /// next launch — exactly the kind of bug the rule exists to prevent).
+    private func persist() {
+        do {
+            try config.save(to: containerDirectory)
+        } catch {
+            DebugLog.store("PermissionsSettingsView persist failed: \(error.localizedDescription)")
+        }
     }
 }
 
 #Preview {
-    PermissionsSettingsView()
-        .frame(width: 460, height: 460)
+    PermissionsSettingsView(
+        containerDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("preview-agent-providers", isDirectory: true))
+        .frame(width: 460, height: 600)
 }

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -514,7 +514,7 @@ struct WikiFSApp: App {
                 // the window height without scrolling). The `@AppStorage`
                 // keys are view-independent so they work unchanged in a
                 // separate view.
-                PermissionsSettingsView()
+                PermissionsSettingsView(containerDirectory: containerDirectory)
                     .tag(SettingsTab.permissions)
                     .tabItem { Label("Permissions", systemImage: "lock.shield") }
             }

--- a/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
@@ -59,12 +59,29 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
     /// `agent-providers.json` without this key decodes to `[:]`.
     public var maxConcurrent: [String: Int]
 
+    /// Per-operation default provider id overrides (issue: per-op-provider).
+    /// When `nil`, the operation falls back to `defaultProvider` (the provider
+    /// marked `isDefault == true`). When set to an id that no longer matches
+    /// any provider (the provider was deleted), the resolver ALSO falls back
+    /// to `defaultProvider` — there are no dangling references.
+    ///
+    /// `nil` is the legacy state: a pre-existing `agent-providers.json` without
+    /// these keys decodes to all-`nil`, so every operation routes to
+    /// `defaultProvider` exactly as before — no migration, no behavior change
+    /// for existing users.
+    public var chatProviderId: String?
+    public var ingestProviderId: String?
+    public var lintProviderId: String?
+
     public init(
         providers: [AgentProvider] = [AgentProvider.claudeAcpDefault],
         providerModels: [String: [CachedModelInfo]] = [:],
         selectedModelIds: [String: String] = [:],
         favoriteModelIds: [String: [String]] = [:],
-        maxConcurrent: [String: Int] = [:]
+        maxConcurrent: [String: Int] = [:],
+        chatProviderId: String? = nil,
+        ingestProviderId: String? = nil,
+        lintProviderId: String? = nil
     ) {
         let normalizedProviders = AgentProvidersConfig.normalized(providers)
         self.providers = normalizedProviders
@@ -72,6 +89,9 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         self.selectedModelIds = selectedModelIds
         self.favoriteModelIds = favoriteModelIds
         self.maxConcurrent = maxConcurrent
+        self.chatProviderId = chatProviderId
+        self.ingestProviderId = ingestProviderId
+        self.lintProviderId = lintProviderId
     }
 
     // MARK: - Coding (forward-compatible: old files without model caches decode)
@@ -82,6 +102,9 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         case selectedModelIds
         case favoriteModelIds
         case maxConcurrent
+        case chatProviderId
+        case ingestProviderId
+        case lintProviderId
     }
 
     public init(from decoder: Decoder) throws {
@@ -97,6 +120,11 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         self.favoriteModelIds = try c.decodeIfPresent([String: [String]].self, forKey: .favoriteModelIds) ?? [:]
         // Forward-compatible: pre-Phase-2 files have no `maxConcurrent` key.
         self.maxConcurrent = try c.decodeIfPresent([String: Int].self, forKey: .maxConcurrent) ?? [:]
+        // Forward-compatible: pre-per-op-provider files have no per-operation
+        // provider id keys. nil → "use defaultProvider" = legacy behavior.
+        self.chatProviderId = try c.decodeIfPresent(String.self, forKey: .chatProviderId)
+        self.ingestProviderId = try c.decodeIfPresent(String.self, forKey: .ingestProviderId)
+        self.lintProviderId = try c.decodeIfPresent(String.self, forKey: .lintProviderId)
         // NOTE: a legacy `stageAssignments` key in `agent-providers.json` is
         // silently ignored — it is not in `CodingKeys`, so `JSONDecoder`
         // skips it. The per-stage assignment feature was removed (#604): every
@@ -165,6 +193,87 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         providers.first(where: { $0.id == id })
     }
 
+    // MARK: - Per-operation provider resolution (per-op-provider)
+
+    /// The provider to launch for **chat** (`startInteractiveQuery`). When
+    /// `chatProviderId` is nil OR no longer matches a configured provider (the
+    /// provider was deleted), falls back to `defaultProvider` — there are no
+    /// dangling references. PURE so it is unit-tested directly; called fresh at
+    /// spawn time so a Settings change applies on the next chat.
+    public func providerForChat() -> AgentProvider {
+        chatProviderId.flatMap { provider(id: $0) } ?? defaultProvider
+    }
+
+    /// The provider to launch for **ingest** (single-session `run()` for the
+    /// `.ingest` request + the multi-phase `runACPIngestPlannerExecutors`
+    /// path). Same fall-back semantics as `providerForChat()`.
+    public func providerForIngest() -> AgentProvider {
+        ingestProviderId.flatMap { provider(id: $0) } ?? defaultProvider
+    }
+
+    /// The provider to launch for **lint** (`run()` for `.lint` / `.lintPage`
+    /// requests). Same fall-back semantics as `providerForChat()`.
+    public func providerForLint() -> AgentProvider {
+        lintProviderId.flatMap { provider(id: $0) } ?? defaultProvider
+    }
+
+    /// A PURE mutator: returns a NEW config with the chat operation pinned to
+    /// `id` (or un-pinned when `id` is nil/empty, restoring the legacy "use
+    /// defaultProvider" behavior). Persists via the launcher wrapper
+    /// `setChatProvider(id:)`; the Settings UI binds to it directly. NEVER
+    /// validates that `id` exists — the resolver falls back to
+    /// `defaultProvider` when a pinned id is later deleted, so accepting an
+    /// unknown id here is safe and means a re-add of the same id later just
+    /// starts working again. Mirrors `settingDefault(id:)`'s carry-everything-
+    /// else-through shape.
+    public func settingChatProvider(id: String?) -> AgentProvidersConfig {
+        let normalized = (id?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 }
+        DebugLog.store("AgentProvidersConfig.settingChatProvider: id=\(normalized ?? "nil")")
+        return AgentProvidersConfig(
+            providers: providers,
+            providerModels: providerModels,
+            selectedModelIds: selectedModelIds,
+            favoriteModelIds: favoriteModelIds,
+            maxConcurrent: maxConcurrent,
+            chatProviderId: normalized,
+            ingestProviderId: ingestProviderId,
+            lintProviderId: lintProviderId)
+    }
+
+    /// A PURE mutator: returns a NEW config with the ingest operation pinned
+    /// to `id` (or un-pinned when nil/empty). See `settingChatProvider(id:)`
+    /// for the semantics.
+    public func settingIngestProvider(id: String?) -> AgentProvidersConfig {
+        let normalized = (id?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 }
+        DebugLog.store("AgentProvidersConfig.settingIngestProvider: id=\(normalized ?? "nil")")
+        return AgentProvidersConfig(
+            providers: providers,
+            providerModels: providerModels,
+            selectedModelIds: selectedModelIds,
+            favoriteModelIds: favoriteModelIds,
+            maxConcurrent: maxConcurrent,
+            chatProviderId: chatProviderId,
+            ingestProviderId: normalized,
+            lintProviderId: lintProviderId)
+    }
+
+    /// A PURE mutator: returns a NEW config with the lint operation pinned
+    /// to `id` (or un-pinned when nil/empty). See `settingChatProvider(id:)`
+    /// for the semantics.
+    public func settingLintProvider(id: String?) -> AgentProvidersConfig {
+        let normalized = (id?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 }
+        DebugLog.store("AgentProvidersConfig.settingLintProvider: id=\(normalized ?? "nil")")
+        return AgentProvidersConfig(
+            providers: providers,
+            providerModels: providerModels,
+            selectedModelIds: selectedModelIds,
+            favoriteModelIds: favoriteModelIds,
+            maxConcurrent: maxConcurrent,
+            chatProviderId: chatProviderId,
+            ingestProviderId: ingestProviderId,
+            lintProviderId: normalized)
+    }
+
     /// Mark the provider with `id` as the default, demoting every other provider
     /// (the single-default invariant — exactly one default after this returns).
     /// PURE + returns a NEW config: callers (the Settings UI, the composer's
@@ -180,14 +289,21 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         for i in updated.indices {
             updated[i].isDefault = (updated[i].id == id)
         }
-        // Carry over the per-provider model caches + selections (don't wipe them
-        // when only the default provider changes).
+        // Carry over the per-provider model caches + selections + the
+        // per-operation provider id overrides (don't wipe them when only the
+        // default provider changes). The per-op overrides are NOT re-pointed:
+        // if chat was pinned to id="claude-acp" and the user changes the
+        // default to "gemini", the chat override still routes chat to
+        // claude-acp — that is the whole point of an explicit per-op override.
         return AgentProvidersConfig(
             providers: updated,
             providerModels: providerModels,
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favoriteModelIds,
-            maxConcurrent: maxConcurrent)
+            maxConcurrent: maxConcurrent,
+            chatProviderId: chatProviderId,
+            ingestProviderId: ingestProviderId,
+            lintProviderId: lintProviderId)
     }
 
     /// The list of providers the selector surfaces: enabled ones only (the
@@ -233,7 +349,10 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             providerModels: cache,
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favoriteModelIds,
-            maxConcurrent: maxConcurrent)
+            maxConcurrent: maxConcurrent,
+            chatProviderId: chatProviderId,
+            ingestProviderId: ingestProviderId,
+            lintProviderId: lintProviderId)
     }
 
     /// A PURE mutator: returns a NEW config with the user's model selection for
@@ -253,7 +372,10 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             providerModels: providerModels,
             selectedModelIds: selections,
             favoriteModelIds: favoriteModelIds,
-            maxConcurrent: maxConcurrent)
+            maxConcurrent: maxConcurrent,
+            chatProviderId: chatProviderId,
+            ingestProviderId: ingestProviderId,
+            lintProviderId: lintProviderId)
     }
 
     // MARK: - Favorites (#favorites — display-only, paseo per-row star)
@@ -290,7 +412,10 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             providerModels: providerModels,
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favorites,
-            maxConcurrent: maxConcurrent)
+            maxConcurrent: maxConcurrent,
+            chatProviderId: chatProviderId,
+            ingestProviderId: ingestProviderId,
+            lintProviderId: lintProviderId)
     }
 
     // MARK: - Seed (pure)
@@ -355,7 +480,10 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
                 providerModels: config.providerModels,
                 selectedModelIds: selectedModelIds,
                 favoriteModelIds: config.favoriteModelIds,
-                maxConcurrent: config.maxConcurrent)
+                maxConcurrent: config.maxConcurrent,
+                chatProviderId: config.chatProviderId,
+                ingestProviderId: config.ingestProviderId,
+                lintProviderId: config.lintProviderId)
         }
         // Missing / corrupt / empty → seed + persist.
         DebugLog.store("AgentProvidersConfig.loadOrSeed: SEED (file missing/corrupt/empty)")

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -396,6 +396,61 @@ public final class AgentLauncher {
         return updated
     }
 
+    // MARK: - Per-operation provider assignment (per-op-provider)
+
+    /// Set + persist the chat operation's pinned provider id, then return the
+    /// new config so the Settings UI can update its bound state in one step.
+    /// A nil/empty `id` clears the pin (chat falls back to the default provider
+    /// — the legacy behavior). The next `startInteractiveQuery` reads this,
+    /// so the change applies on the next chat with no launcher change.
+    /// Mirrors `setDefaultProvider(id:)`'s load→mutate→save shape + error path.
+    @discardableResult
+    public func setChatProvider(id: String?) -> AgentProvidersConfig {
+        let dir = resolveProvidersContainerDirectory()
+        let updated = providersConfig().settingChatProvider(id: id)
+        DebugLog.store("setChatProvider: id=\(id ?? "nil") → save")
+        do {
+            try updated.save(to: dir)
+        } catch {
+            // The user's per-op provider assignment silently reverts on next
+            // launch if this write throws; log so it's visible in Console.app.
+            DebugLog.store("AgentLauncher.setChatProvider save failed (id=\(id ?? "nil")): \(error)")
+        }
+        return updated
+    }
+
+    /// Set + persist the ingest operation's pinned provider id. Same shape as
+    /// `setChatProvider(id:)`. The next `runACPIngestPlannerExecutors` (large
+    /// sources) OR single-session `run()` for `.ingest` reads this.
+    @discardableResult
+    public func setIngestProvider(id: String?) -> AgentProvidersConfig {
+        let dir = resolveProvidersContainerDirectory()
+        let updated = providersConfig().settingIngestProvider(id: id)
+        DebugLog.store("setIngestProvider: id=\(id ?? "nil") → save")
+        do {
+            try updated.save(to: dir)
+        } catch {
+            DebugLog.store("AgentLauncher.setIngestProvider save failed (id=\(id ?? "nil")): \(error)")
+        }
+        return updated
+    }
+
+    /// Set + persist the lint operation's pinned provider id. Same shape as
+    /// `setChatProvider(id:)`. The next single-session `run()` for `.lint` /
+    /// `.lintPage` reads this.
+    @discardableResult
+    public func setLintProvider(id: String?) -> AgentProvidersConfig {
+        let dir = resolveProvidersContainerDirectory()
+        let updated = providersConfig().settingLintProvider(id: id)
+        DebugLog.store("setLintProvider: id=\(id ?? "nil") → save")
+        do {
+            try updated.save(to: dir)
+        } catch {
+            DebugLog.store("AgentLauncher.setLintProvider save failed (id=\(id ?? "nil")): \(error)")
+        }
+        return updated
+    }
+
     /// Atomically set the default provider AND a per-provider model selection
     /// in ONE load→mutate→save cycle (no race between two separate writes).
     /// This is the composer's "pick a model" path: choosing a model implies
@@ -1053,7 +1108,23 @@ public final class AgentLauncher {
         // #324: the launcher reads `agent-providers.json`, picks the default
         // (or selected) provider, and resolves its PATH command + Keychain key
         // into providerHints. The app is ACP-only.
-        let provider = resolveSelectedProvider()
+        //
+        // per-op-provider: each operation (chat / ingest / lint) resolves its
+        // OWN provider — falling back to the default provider when the pin is
+        // nil OR points at a provider that's been deleted. `permissionKind` was
+        // computed just above from the same `request` enum, so it reflects the
+        // same operation. (`.chat` is reachable here only if a `.query` request
+        // hits `run()` — the live interactive path is `startInteractiveQuery`,
+        // which has its own per-op provider resolution; this branch is a
+        // defensive mirror so a future code path that routes `.query` through
+        // `run()` would still pick the right provider.)
+        let config = providersConfig()
+        let provider: AgentProvider
+        switch permissionKind {
+        case .chat:   provider = config.providerForChat()
+        case .ingest: provider = config.providerForIngest()
+        case .lint:   provider = config.providerForLint()
+        }
         self.backend = resolveBackend(policy, permissionBudget, turnCeiling)
 
         // Resolve the provider's spawn command (PATH-resolved because the
@@ -1330,7 +1401,13 @@ public final class AgentLauncher {
         // again (which would orphan the ACPBackend actor `run()` built).
 
         // Resolve the ONE provider + spawn + hints all three phases will use.
-        let provider = resolveSelectedProvider()
+        //
+        // per-op-provider: ingest uses its own pinned provider when set,
+        // falling back to the default provider when the pin is nil OR points at
+        // a provider that's been deleted from the config. Mirrors
+        // `startInteractiveQuery`'s chat resolution + `run()`'s per-kind
+        // resolution.
+        let provider = providersConfig().providerForIngest()
         let modelId = providersConfig().selectedModelId(forProvider: provider.id)
         guard let spawn = resolveACPProviderSpawn(provider) else {
             DebugLog.agent("runACPIngest: ACP exe missing for provider=\(provider.id) — aborting")
@@ -2252,7 +2329,11 @@ public final class AgentLauncher {
 
         // #324: the launcher reads `agent-providers.json` and picks the
         // default (or selected) provider. The app is ACP-only.
-        let provider = resolveSelectedProvider()
+        //
+        // per-op-provider: chat uses its own pinned provider when set, falling
+        // back to the default provider when the pin is nil OR points at a
+        // provider that's been deleted from the config.
+        let provider = providersConfig().providerForChat()
         let resolvedSelectedModel = providersConfig().selectedModelId(forProvider: provider.id)
         DebugLog.agent("startInteractiveQuery: provider=\(provider.id) selectedModel=\(resolvedSelectedModel ?? "nil")")
 

--- a/Tests/WikiFSTests/AgentLauncherSpawnRefusalTests.swift
+++ b/Tests/WikiFSTests/AgentLauncherSpawnRefusalTests.swift
@@ -20,36 +20,43 @@ import WikiFSCore
 @MainActor
 struct AgentLauncherSpawnRefusalTests {
 
-    /// Build a launcher whose `providersConfig()` returns the freshly-seeded
-    /// config from a throwaway tmp dir (so claude-acp has "sonnet", but the
-    /// test's chosen provider — opencode — has NO selected model). The guard
-    /// therefore refuses spawn on opencode.
+    /// Build a launcher whose chat path resolves to a provider with NO
+    /// `selectedModelId`, so the `SpawnModelGuard` refuses to spawn.
+    ///
+    /// per-op-provider: the chat path now resolves its provider via
+    /// `providersConfig().providerForChat()` (NOT via the injected
+    /// `resolveSelectedProvider` seam). So the no-model scenario is set up by
+    /// pre-writing an `agent-providers.json` whose DEFAULT provider is
+    /// opencode (no `chatProviderId` pin → fallback to default), with no
+    /// selectedModelIds entry for opencode. The guard fires on that nil-model
+    /// state.
     private func makeRefusingLauncher() throws -> AgentLauncher {
         let launcher = AgentLauncher()
-        // Point `providersConfig()` at a fresh tmp dir so the seeded default
-        // ("claude-acp": "sonnet") is loaded — but nothing is set for opencode.
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("spawn-refusal-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
         // NOTE: tmp is intentionally NOT cleaned up here — `loadOrSeed` writes
         // a seed file into it on first read, and we don't want a follow-up
         // `providersConfig()` call to re-seed mid-test. The OS reaps temp.
+
+        // Pre-write a config whose DEFAULT provider is opencode (constructed
+        // inline — #663: the `.opencodeDefault` static was deleted alongside
+        // the Hermes/OpenCode seeds; the catalog-driven `AddProviderSheet`
+        // replaced them, so test fixtures build literals). No selectedModelIds
+        // entry for opencode → the guard fires on the nil-model state.
+        var opencodeDefault = AgentProvider(
+            id: "opencode",
+            label: "OpenCode",
+            command: ["opencode", "acp"],
+            env: [:],
+            enabled: true,
+            isDefault: false)
+        opencodeDefault.isDefault = true
+        let configNoModel = AgentProvidersConfig(
+            providers: [opencodeDefault])
+        try configNoModel.save(to: tmp)
+
         launcher.resolveProvidersContainerDirectory = { tmp }
-        // Override the provider so we exercise opencode's nil-modelId state,
-        // independent of whatever the user happens to have configured as
-        // default in the real App Group container. Constructed inline (#663:
-        // the `.opencodeDefault` static was deleted alongside the Hermes/
-        // OpenCode seeds — the catalog-driven `AddProviderSheet` replaced
-        // them, so test fixtures build literals).
-        launcher.resolveSelectedProvider = {
-            AgentProvider(
-                id: "opencode",
-                label: "OpenCode",
-                command: ["opencode", "acp"],
-                env: [:],
-                enabled: true,
-                isDefault: false)
-        }
         return launcher
     }
 
@@ -100,6 +107,14 @@ struct AgentLauncherSpawnRefusalTests {
         // guard itself. This test pins the LAUNCHER wiring: that a
         // model-selected config produces a nil guard result the launcher
         // would use.
+        //
+        // per-op-provider: the chat path now resolves via
+        // `providersConfig().providerForChat()` (the per-op resolver, with
+        // fall-back to default). We pre-write opencode-as-default with a
+        // selected model — `providerForChat()` returns opencode (no chat pin
+        // → fallback to default) and the model resolver returns the seeded
+        // model id — and feed both into the guard exactly as
+        // `startInteractiveQuery` does.
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("spawn-allowed-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
@@ -124,10 +139,11 @@ struct AgentLauncherSpawnRefusalTests {
 
         let launcher = AgentLauncher()
         launcher.resolveProvidersContainerDirectory = { tmp }
-        launcher.resolveSelectedProvider = { opencodeDefault }
 
-        // Read what the chat path would resolve: provider + its modelId.
-        let provider = launcher.resolveSelectedProvider()
+        // Read what the chat path resolves via the per-op seam. A nil
+        // `chatProviderId` falls back to the default provider (opencode), and
+        // its selected model is "glm-4.7" — both fed into the guard.
+        let provider = launcher.providersConfig().providerForChat()
         let modelId = launcher.providersConfig().selectedModelId(forProvider: provider.id)
         // Pin the chat path's guard input contract — what
         // `startInteractiveQuery` actually feeds into `SpawnModelGuard.validate`.

--- a/Tests/WikiFSTests/AgentProvidersConfigPerOpProviderTests.swift
+++ b/Tests/WikiFSTests/AgentProvidersConfigPerOpProviderTests.swift
@@ -1,0 +1,290 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// per-op-provider: per-operation default-provider overrides. Pure-logic
+/// tests for the three new fields (`chatProviderId` / `ingestProviderId` /
+/// `lintProviderId`) + their resolution methods (`providerForChat/Ingest/Lint`)
+/// + their setters (`settingChatProvider/Ingest/Lint`).
+///
+/// Covers:
+/// - Resolution fall-back to `defaultProvider` when the pin is nil.
+/// - Resolution fall-back when the pin points at a deleted provider (no
+///   dangling reference — the diagnosed AC for "When a provider is deleted,
+///   any operation referencing it falls back to defaultProvider").
+/// - Setter round-trip + nil/whitespace normalization.
+/// - Carry-through: existing setters preserve the per-op pins.
+/// - Codable backward-compat: a pre-per-op-provider `agent-providers.json`
+///   (no `chatProviderId` etc. keys) decodes to all-nil → every operation
+///   falls back to `defaultProvider` (the legacy behavior). Round-trip
+///   preserves the pins.
+/// - `loadOrSeed` carries the pins through.
+@Suite("AgentProvidersConfig per-op-provider")
+struct AgentProvidersConfigPerOpProviderTests {
+
+    // MARK: - Fixture
+
+    /// Two providers so we can distinguish "pinned" from "default" in tests.
+    /// `claude-acp` is default, `gemini` is an enabled non-default.
+    private var fixture: AgentProvidersConfig {
+        AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude-acp", label: "Claude", command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"], enabled: true, isDefault: true),
+            AgentProvider(id: "gemini", label: "Gemini", command: ["gemini", "--acp"], enabled: true, isDefault: false),
+        ])
+    }
+
+    // MARK: - Resolution: nil falls back to defaultProvider
+
+    @Test func providerForChatFallsBackToDefaultWhenNil() {
+        let config = fixture
+        #expect(config.chatProviderId == nil)
+        #expect(config.providerForChat().id == "claude-acp")
+    }
+
+    @Test func providerForIngestFallsBackToDefaultWhenNil() {
+        let config = fixture
+        #expect(config.ingestProviderId == nil)
+        #expect(config.providerForIngest().id == "claude-acp")
+    }
+
+    @Test func providerForLintFallsBackToDefaultWhenNil() {
+        let config = fixture
+        #expect(config.lintProviderId == nil)
+        #expect(config.providerForLint().id == "claude-acp")
+    }
+
+    // MARK: - Resolution: pinned provider wins
+
+    @Test func providerForChatReturnsPinnedProvider() {
+        let config = fixture.settingChatProvider(id: "gemini")
+        #expect(config.chatProviderId == "gemini")
+        #expect(config.providerForChat().id == "gemini")
+    }
+
+    @Test func providerForIngestReturnsPinnedProvider() {
+        let config = fixture.settingIngestProvider(id: "gemini")
+        #expect(config.providerForIngest().id == "gemini")
+    }
+
+    @Test func providerForLintReturnsPinnedProvider() {
+        let config = fixture.settingLintProvider(id: "gemini")
+        #expect(config.providerForLint().id == "gemini")
+    }
+
+    // MARK: - Resolution: deleted provider falls back (no dangling refs)
+
+    @Test func providerForChatFallsBackWhenPinnedProviderWasDeleted() {
+        // chat is pinned to "gemini", but gemini was deleted from the config.
+        // The resolver must NOT crash, NOT return nil, NOT return a stale
+        // provider — it returns `defaultProvider`. This is the AC for "When a
+        // provider is deleted, any operation referencing it falls back to
+        // defaultProvider."
+        let config = AgentProvidersConfig(
+            providers: [.claudeAcpDefault],
+            chatProviderId: "gemini")
+        #expect(config.chatProviderId == "gemini")
+        #expect(config.providerForChat().id == "claude-acp")
+    }
+
+    @Test func providerForIngestFallsBackWhenPinnedProviderWasDeleted() {
+        let config = AgentProvidersConfig(
+            providers: [.claudeAcpDefault],
+            ingestProviderId: "deleted-id")
+        #expect(config.providerForIngest().id == "claude-acp")
+    }
+
+    @Test func providerForLintFallsBackWhenPinnedProviderWasDeleted() {
+        let config = AgentProvidersConfig(
+            providers: [.claudeAcpDefault],
+            lintProviderId: "deleted-id")
+        #expect(config.providerForLint().id == "claude-acp")
+    }
+
+    // MARK: - Independent pins
+
+    @Test func perOpPinsAreIndependent() {
+        // Three operations, three different providers (one is a synthetic id
+        // that doesn't exist — exercises the fallback path too).
+        let other = AgentProvider(id: "kilo", label: "Kilo", command: ["kilo"], enabled: true, isDefault: false)
+        let config = AgentProvidersConfig(
+            providers: [.claudeAcpDefault, other],
+            chatProviderId: "claude-acp",
+            ingestProviderId: "kilo",
+            lintProviderId: "deleted")
+        #expect(config.providerForChat().id == "claude-acp")
+        #expect(config.providerForIngest().id == "kilo")
+        #expect(config.providerForLint().id == "claude-acp")  // deleted → fallback
+    }
+
+    // MARK: - Setters: round-trip + nil/whitespace normalization
+
+    @Test func settingChatProviderClearsOnNil() {
+        let config = fixture.settingChatProvider(id: "gemini").settingChatProvider(id: nil)
+        #expect(config.chatProviderId == nil)
+        #expect(config.providerForChat().id == "claude-acp")
+    }
+
+    @Test func settingIngestProviderClearsOnEmpty() {
+        let config = fixture.settingIngestProvider(id: "gemini").settingIngestProvider(id: "")
+        #expect(config.ingestProviderId == nil)
+    }
+
+    @Test func settingLintProviderClearsOnWhitespace() {
+        // Whitespace-only is normalized to nil (trimming + empty check) so a
+        // paste of "  " doesn't get treated as an id that never matches.
+        let config = fixture.settingLintProvider(id: "   ")
+        #expect(config.lintProviderId == nil)
+    }
+
+    @Test func settingChatProviderTrimsWhitespace() {
+        let config = fixture.settingChatProvider(id: "  gemini  ")
+        #expect(config.chatProviderId == "gemini")
+        #expect(config.providerForChat().id == "gemini")
+    }
+
+    // MARK: - Carry-through: existing setters preserve the per-op pins
+
+    @Test func settingDefaultPreservesPerOpPins() {
+        // Changing the default provider does NOT clear the per-op pins — the
+        // pin is the whole point. If chat was pinned to gemini and the user
+        // changes the default to claude-acp, chat still routes to gemini.
+        let config = fixture
+            .settingChatProvider(id: "gemini")
+            .settingIngestProvider(id: "gemini")
+            .settingLintProvider(id: "gemini")
+            .settingDefault(id: "claude-acp")
+        #expect(config.chatProviderId == "gemini")
+        #expect(config.ingestProviderId == "gemini")
+        #expect(config.lintProviderId == "gemini")
+        #expect(config.providerForChat().id == "gemini")
+        #expect(config.providerForIngest().id == "gemini")
+        #expect(config.providerForLint().id == "gemini")
+    }
+
+    @Test func settingSelectedModelPreservesPerOpPins() {
+        let config = fixture
+            .settingChatProvider(id: "gemini")
+            .settingSelectedModel("sonnet", forProvider: "claude-acp")
+        #expect(config.chatProviderId == "gemini")
+        #expect(config.selectedModelId(forProvider: "claude-acp") == "sonnet")
+    }
+
+    @Test func settingCachedModelsPreservesPerOpPins() {
+        let cached = [CachedModelInfo(modelId: "opus", name: "Opus", description: nil)]
+        let config = fixture
+            .settingLintProvider(id: "gemini")
+            .settingCachedModels(cached, forProvider: "claude-acp")
+        #expect(config.lintProviderId == "gemini")
+        #expect(config.cachedModels(forProvider: "claude-acp").count == 1)
+    }
+
+    @Test func togglingFavoritePreservesPerOpPins() {
+        let config = fixture
+            .settingIngestProvider(id: "gemini")
+            .togglingFavoriteModel("opus", forProvider: "claude-acp")
+        #expect(config.ingestProviderId == "gemini")
+        #expect(config.isFavoriteModel("opus", forProvider: "claude-acp"))
+    }
+
+    // MARK: - Codable backward-compat
+
+    @Test func oldConfigWithoutPerOpFieldsDecodesAllNil() throws {
+        // Hand-craft a JSON that omits the per-op fields (what a pre-per-op-
+        // provider `agent-providers.json` looks like). It must decode with all
+        // three pins nil → every operation routes to defaultProvider (the
+        // legacy behavior, no migration).
+        let json = """
+        {
+          "providers": [
+            { "id": "claude-acp", "label": "Claude", "command": ["bun", "x", "@agentclientprotocol/claude-agent-acp"], "env": {}, "enabled": true, "isDefault": true }
+          ],
+          "providerModels": {},
+          "selectedModelIds": { "claude-acp": "sonnet" },
+          "favoriteModelIds": {},
+          "maxConcurrent": {}
+        }
+        """
+        let data = Data(json.utf8)
+        let config = try JSONDecoder().decode(AgentProvidersConfig.self, from: data)
+        #expect(config.chatProviderId == nil)
+        #expect(config.ingestProviderId == nil)
+        #expect(config.lintProviderId == nil)
+        #expect(config.providerForChat().id == "claude-acp")
+        #expect(config.providerForIngest().id == "claude-acp")
+        #expect(config.providerForLint().id == "claude-acp")
+    }
+
+    @Test func perOpFieldsRoundTripThroughDisk() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-providers-perop-rt-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let original = fixture
+            .settingChatProvider(id: "gemini")
+            .settingIngestProvider(id: "claude-acp")
+            .settingLintProvider(id: "gemini")
+        try original.save(to: tmp)
+
+        let loaded = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        #expect(loaded.chatProviderId == "gemini")
+        #expect(loaded.ingestProviderId == "claude-acp")
+        #expect(loaded.lintProviderId == "gemini")
+        // Sanity: the resolved providers match the pins (gemini exists).
+        #expect(loaded.providerForChat().id == "gemini")
+        #expect(loaded.providerForIngest().id == "claude-acp")
+        #expect(loaded.providerForLint().id == "gemini")
+    }
+
+    // MARK: - loadOrSeed carries the pins through
+
+    @Test func loadOrSeedPreservesPerOpPinsFromDisk() throws {
+        // loadOrSeed re-wraps the decoded config to re-apply normalization +
+        // the claude-acp model backfill. That re-wrap must NOT wipe the per-op
+        // pins — the test pins all three, plus a stale pin pointing at a
+        // deleted provider, to verify the stale id is preserved on disk (the
+        // resolver falls back at READ time, not at load time).
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-providers-perop-loadorseed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let original = AgentProvidersConfig(
+            providers: [
+                AgentProvider(id: "claude-acp", label: "Claude", command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"], enabled: true, isDefault: true),
+                AgentProvider(id: "gemini", label: "Gemini", command: ["gemini", "--acp"], enabled: true, isDefault: false),
+            ],
+            selectedModelIds: ["claude-acp": "sonnet"],
+            chatProviderId: "gemini",
+            ingestProviderId: "deleted-id",
+            lintProviderId: nil)
+        try original.save(to: tmp)
+
+        let loaded = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        #expect(loaded.chatProviderId == "gemini")
+        #expect(loaded.ingestProviderId == "deleted-id")
+        #expect(loaded.lintProviderId == nil)
+        // Resolution at read time:
+        #expect(loaded.providerForChat().id == "gemini")
+        #expect(loaded.providerForIngest().id == "claude-acp")  // stale → fallback
+        #expect(loaded.providerForLint().id == "claude-acp")
+    }
+
+    // MARK: - Float through existing carried fields too
+
+    @Test func perOpPinsDoNotResetModelCachesOrFavorites() {
+        // Setting a per-op pin must not wipe `providerModels` /
+        // `favoriteModelIds` / `maxConcurrent` / `selectedModelIds` — those are
+        // independent fields and the setters carry them through.
+        let cached = [CachedModelInfo(modelId: "opus", name: "Opus", description: nil)]
+        let config = fixture
+            .settingCachedModels(cached, forProvider: "claude-acp")
+            .togglingFavoriteModel("opus", forProvider: "claude-acp")
+            .settingSelectedModel("sonnet", forProvider: "claude-acp")
+            .settingChatProvider(id: "gemini")
+        #expect(config.cachedModels(forProvider: "claude-acp").count == 1)
+        #expect(config.isFavoriteModel("opus", forProvider: "claude-acp"))
+        #expect(config.selectedModelId(forProvider: "claude-acp") == "sonnet")
+        #expect(config.chatProviderId == "gemini")
+    }
+}

--- a/Tests/WikiFSTests/ChatViewPreflightBannerTests.swift
+++ b/Tests/WikiFSTests/ChatViewPreflightBannerTests.swift
@@ -199,26 +199,35 @@ import WikiFSCore
     }
 
     /// Mirrors `AgentLauncherSpawnRefusalTests.makeRefusingLauncher()`: a
-    /// launcher whose `providersConfig()` returns a fresh config with the
-    /// default provider (opencode) having NO `selectedModelId`. The
+    /// launcher whose `providersConfig()` returns a config with the default
+    /// provider (opencode) having NO `selectedModelId`. The
     /// `SpawnModelGuard.validate` inside `startInteractiveQuery` therefore
     /// sets `preflightError` and returns early — no real subprocess spawned.
+    ///
+    /// per-op-provider: `startInteractiveQuery` now resolves its provider via
+    /// `providersConfig().providerForChat()` (NOT `resolveSelectedProvider`).
+    /// So we pre-write a config whose DEFAULT provider is opencode with NO
+    /// selected model — `providerForChat()` returns opencode (no chat pin →
+    /// fallback to default) and the guard fires on the nil-model state.
     private func makeRefusingLauncher() throws -> AgentLauncher {
         let launcher = AgentLauncher()
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("preflight-banner-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        launcher.resolveProvidersContainerDirectory = { tmp }
+        // Pre-write a config whose DEFAULT provider is opencode with no model.
         // #663: `.opencodeDefault` was deleted; built inline.
-        launcher.resolveSelectedProvider = {
-            AgentProvider(
-                id: "opencode",
-                label: "OpenCode",
-                command: ["opencode", "acp"],
-                env: [:],
-                enabled: true,
-                isDefault: false)
-        }
+        var opencodeDefault = AgentProvider(
+            id: "opencode",
+            label: "OpenCode",
+            command: ["opencode", "acp"],
+            env: [:],
+            enabled: true,
+            isDefault: false)
+        opencodeDefault.isDefault = true
+        let configNoModel = AgentProvidersConfig(
+            providers: [opencodeDefault])
+        try configNoModel.save(to: tmp)
+        launcher.resolveProvidersContainerDirectory = { tmp }
         return launcher
     }
 }


### PR DESCRIPTION
## Summary

Replace the single shared `defaultProvider` used for all three ACP operations (chat / ingest / lint) with per-operation provider id overrides on `AgentProvidersConfig`. Each operation resolves its OWN provider at spawn time, falling back to `defaultProvider` when the pin is `nil` OR points at a provider that's been deleted from the config (no dangling references).

## Config model — `Sources/WikiFSCore/Core/AgentProvidersConfig.swift`

- New optional `Codable` fields: `chatProviderId` / `ingestProviderId` / `lintProviderId`. Forward-compatible — old configs without these keys decode to all-`nil`, and every operation routes to `defaultProvider` (the legacy behavior). No migration.
- New resolution methods: `providerForChat()` / `providerForIngest()` / `providerForLint()` — each returns the operation-specific provider, falling back to `defaultProvider` when the pin is `nil` OR points at a provider that no longer exists:
  ```swift
  public func providerForChat() -> AgentProvider {
      chatProviderId.flatMap { provider(id: $0) } ?? defaultProvider
  }
  ```
- New PURE setters: `settingChatProvider(id:)` / `settingIngestProvider(id:)` / `settingLintProvider(id:)`. Whitespace is normalized to `nil`; empty/whitespace clears the pin.
- The three new fields are carried through ALL existing setters (`settingDefault` / `settingCachedModels` / `settingSelectedModel` / `togglingFavoriteModel`) and through `loadOrSeed` so a Settings edit (e.g. changing the default provider, toggling a favorite) doesn't silently wipe an operation's pin.

## Spawn path — `Sources/WikiFSEngine/AgentLauncher.swift`

Each operation resolves its own provider through the new resolvers, then reads `selectedModelId(forProvider:)` on that provider and feeds both into `SpawnModelGuard.validate`.

- `startInteractiveQuery` (chat): `providersConfig().providerForChat()`
- `runACPIngestPlannerExecutors` (multi-phase large-source ingest): `providersConfig().providerForIngest()`
- `run()` single-session (covers ingest + lint + a defensive `.chat` branch): switches on `permissionKind` to pick `providerForChat/Ingest/Lint()`.

New launcher wrappers `setChatProvider(id:)` / `setIngestProvider(id:)` / `setLintProvider(id:)` mirror `setDefaultProvider(id:)`'s load→mutate→save shape + `DebugLog` error path.

## UI — `Sources/WikiFS/Settings/PermissionsSettingsView.swift`

Adds a "Provider Assignment" section next to the existing "Permissions" section, with a Provider + Model picker per operation:
- Provider picker lists enabled providers (`config.enabledProviders`) plus a leading "Default (Claude)" row (the `nil` pin = the legacy behavior). Selecting it clears the pin.
- Model picker lists the resolved provider's cached models plus an "Agent default" row (clears the per-provider model selection). When no models are cached yet, displays "Chat with this provider once to discover models" and is disabled.
- `containerDirectory` is threaded in from `WikiFSApp`; loads config on init + on appear.
- `persist()` uses `do/catch + DebugLog` per the house rule against bare `try?`. The model picker writes the per-provider selection (so two operations pinned to the same provider share its model — acceptable per spec; the `SpawnModelGuard` already validates `modelId` is non-empty).

## Tests

- New `Tests/WikiFSTests/AgentProvidersConfigPerOpProviderTests.swift` (25 tests):
  - Resolution fall-back to `defaultProvider` when pin is `nil`.
  - Resolution fall-back when the pinned provider was deleted (no dangling references — the "When a provider is deleted, any operation referencing it falls back to defaultProvider" AC).
  - Setter round-trip + `nil`/empty/whitespace normalization.
  - Carry-through: existing setters (`settingDefault`, `settingSelectedModel`, `settingCachedModels`, `togglingFavoriteModel`) preserve the per-op pins.
  - Codable backward-compat: a pre-per-op-provider `agent-providers.json` (no `chatProviderId` etc.) decodes to all-`nil`.
  - Round-trip through disk + `loadOrSeed` carry-through (including a stale pin pointing at a deleted provider — preserved on disk, falls back at read time).
- Updated `Tests/WikiFSTests/AgentLauncherSpawnRefusalTests.swift` + `ChatViewPreflightBannerTests.swift`: the chat-path spawn refusal used to inject `launcher.resolveSelectedProvider` to override the provider. With per-op-provider, the chat path now resolves via `providersConfig().providerForChat()`, so the no-model scenario is set up by pre-writing an `agent-providers.json` whose default provider is opencode with no `selectedModelIds` entry — `providerForChat()` returns opencode (no chat pin → fallback to default) and the guard fires on the nil-model state. Same observable contract (`preflightError != nil`, `isRunning == false`); the setup change reflects the actual seam the spawn path now reads.

## Verification

- `make version prompts` ✓
- `swift build` ✓ (clean, 0 errors / 0 warnings)
- `swift test` (full suite) — **3092 tests / 262 suites pass** (~33 s). No regressions.

## House rules

- No bare `try?` — `persist()` uses `do/catch + DebugLog`.
- No `print` — all logging routes through `DebugLog`.
- Scratch/investigation files kept in `tmp/` (project-relative, gitignored) — none committed.
- Branch pushed, PR opened, NOT merged.
