### PR TITLE
Write <scratch>/models.json at ingestion start

### DIFF
--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -1174,6 +1174,24 @@ public final class AgentLauncher {
         runCommitedAt = now
         runProviderLabel = provider.id
         openLogFiles(in: scratch)
+        // Write the resolved provider/model/thinking snapshot to
+        // `<scratch>/models.json` ONCE at ingestion start — a sibling of
+        // `run.jsonl`/`run.stderr.log` — so a run's model config is inspectable
+        // post-hoc. See `plans/log-ingestion-models.md` + the static helper on
+        // `DebugRunLogger` (the instance isn't built yet at this point — it lives
+        // in `ACPBackend.startProcess`, called below; hence the static helper).
+        let (sourceFiles, sourceIDs) = Self.sourceFilesAndIDs(for: operation)
+        let modelsRecord = DebugRunLogger.makeRecord(
+            chatULID: queueItemID,
+            startedAt: now,
+            operationKind: operation.kind.rawValue,
+            providerId: provider.id,
+            providerLabel: provider.label,
+            selectedModelId: config.selectedModelId(forProvider: provider.id),
+            thinkingEffort: thinkingOption,
+            sourceFiles: sourceFiles,
+            sourceIDs: sourceIDs)
+        DebugRunLogger.writeModelsConfig(modelsRecord, to: scratch)
         // A one-shot run is "generating" for its whole duration. The edit lock
         // for one-shot runs is owned by `onLock`/`onUnlock` around the spawn.
         setGenerating(true)
@@ -2259,6 +2277,20 @@ public final class AgentLauncher {
     static func authorForRun(kind: WikiOperation.Kind, chatID: String?) -> String {
         if let chatID { return "\(ResourceKind.chat.linkPrefix!)\(chatID)" }
         return "agent:\(kind.rawValue)"
+    }
+
+    /// Extract the `(sourceFiles, sourceIDs)` pair from a staged `WikiOperation`
+    /// for the `models.json` record written at ingestion start. For `.ingest`
+    /// this is `(sourcePaths, sourcePaths.map(WikiOperation.sourceID(fromPath:)))`;
+    /// for any other operation kind, both are `[]`. Pure — no I/O — so it can be
+    /// unit-tested directly from a nonisolated test context (`nonisolated` opts
+    /// out of the class default `@MainActor` isolation; it touches no instance
+    /// state, no UI, no processes).
+    nonisolated static func sourceFilesAndIDs(for operation: WikiOperation) -> (sourceFiles: [String], sourceIDs: [String]) {
+        if case .ingest(let sourcePaths, _, _, _) = operation {
+            return (sourcePaths, sourcePaths.map { WikiOperation.sourceID(fromPath: $0) })
+        }
+        return ([], [])
     }
 
     /// Start a stdin-backed query chat. The first user message is sent

--- a/Sources/WikiFSEngine/DebugRunLogger.swift
+++ b/Sources/WikiFSEngine/DebugRunLogger.swift
@@ -198,6 +198,74 @@ final class DebugRunLogger: @unchecked Sendable {
     /// UI affordance).
     var folderPath: URL { folderURL }
 
+    // MARK: - models.json (written at ingestion start, before the planner runs)
+
+    /// Write `record` to `<scratch>/models.json`. This is NOT a `debug/` artifact
+    /// — it lives at the run's scratch root as a sibling of `run.jsonl` and
+    /// `run.stderr.log`, written ONCE at ingestion start so a run's resolved
+    /// provider/model/thinking-effort can be inspected post-hoc without opening
+    /// the verbose ACP trace. Best-effort: any write failure is logged via
+    /// `DebugLog` and never thrown (house rule: no bare `try?`). `static` because
+    /// the `DebugRunLogger` *instance* is only constructed inside
+    /// `ACPBackend.startProcess` — AFTER `openLogFiles` runs; the launcher needs
+    /// to call this at the point where `run.jsonl` is created, before any
+    /// `DebugRunLogger` instance exists. See `plans/log-ingestion-models.md`.
+    static func writeModelsConfig(
+        _ record: ModelsConfigRecord,
+        to scratchURL: URL
+    ) {
+        let url = scratchURL.appendingPathComponent("models.json", isDirectory: false)
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(record)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            DebugLog.agent("DebugRunLogger.writeModelsConfig: failed \(url.path): \(error.localizedDescription)")
+        }
+    }
+
+    /// Build a `ModelsConfigRecord` from the data available at spawn time.
+    /// Pure — no I/O — so it's unit-tested directly. `thinkingEffort` is the
+    /// launcher's current `thinkingOption` at the moment of spawn: the user's
+    /// chosen level (may be `nil` when the agent hasn't advertised
+    /// `thought_level`, or before any session captured it). Captured here as a
+    /// best-effort snapshot of "what thinking level did this run use".
+    static func makeRecord(
+        chatULID: String?,
+        startedAt: Date,
+        operationKind: String,
+        providerId: String,
+        providerLabel: String?,
+        selectedModelId: String?,
+        thinkingEffort: ThinkingEffortOption?,
+        sourceFiles: [String],
+        sourceIDs: [String]
+    ) -> ModelsConfigRecord {
+        ModelsConfigRecord(
+            schemaVersion: 1,
+            chatULID: chatULID,
+            startedAt: ISO8601DateFormatter().string(from: startedAt),
+            operationKind: operationKind,
+            provider: ModelsConfigRecord.ProviderInfo(
+                id: providerId,
+                label: providerLabel),
+            selectedModelId: selectedModelId?.nilIfEmpty,
+            thinkingEffort: thinkingEffort.map {
+                ModelsConfigRecord.ThinkingEffortInfo(
+                    configId: $0.configId,
+                    currentValue: $0.currentValue.nilIfEmpty,
+                    choices: $0.choices.map {
+                        ModelsConfigRecord.ThinkingEffortInfo.Choice(
+                            value: $0.value,
+                            label: $0.label)
+                    })
+            },
+            sourceFiles: sourceFiles,
+            sourceIDs: sourceIDs,
+            phases: [])
+    }
+
     // MARK: - Private helpers
 
     private func nextSessionIndex() -> Int {
@@ -264,6 +332,81 @@ final class DebugRunLogger: @unchecked Sendable {
         } catch {
             DebugLog.agent("DebugRunLogger: append failed \(url.lastPathComponent): \(error.localizedDescription)")
         }
+    }
+}
+
+// MARK: - models.json record (written at ingestion start)
+
+/// Lightweight record of the resolved provider / model / thinking-effort for a
+/// run, written ONCE at ingestion start to `<scratch>/models.json`. A sibling
+/// of `run.jsonl` / `run.stderr.log` — NOT part of the verbose `debug/` trace.
+///
+/// **Forward-compatibility:** today the launcher resolves ONE provider+model+
+/// thinking triple and applies it across every phase of the run (the multi-phase
+/// planner/executor/finalizer path reuses the same triple). The `phases` array
+/// is `[]` today. When per-phase model selection lands, callers append
+/// `PhaseEntry`s (`{name, provider?, selectedModelId?, thinkingEffort?}`) to
+/// `phases` WITHOUT rewriting the schema. Readers MUST treat an absent/empty
+/// `phases` as "the top-level triple applies to every phase" — and a non-empty
+/// entry as an override for that phase only.
+struct ModelsConfigRecord: Codable, Sendable, Equatable {
+    /// Bumped on schema-breaking changes. Today: `1`.
+    var schemaVersion: Int
+    /// The run's chatULID (the `<queueItemID>` the launcher uses to build the
+    /// scratch path). `nil` only for legacy/test paths that omit it.
+    var chatULID: String?
+    /// ISO8601 timestamp the record was written (== ingestion start).
+    var startedAt: String
+    /// `"ingest"`, `"query"`, `"lint"` (the `WikiOperation.Kind.rawValue`).
+    var operationKind: String
+    /// The resolved provider.
+    var provider: ProviderInfo
+    /// The model selected for this run (per provider). `nil` when no model is
+    /// explicitly selected (the agent default applies).
+    var selectedModelId: String?
+    /// The thinking-effort config + current level. `nil` when the agent doesn't
+    /// advertise `thought_level` (capability detection) or it hasn't been
+    /// captured yet at spawn time.
+    var thinkingEffort: ThinkingEffortInfo?
+    /// Mount-relative source paths being ingested (`sourcePaths` from
+    /// `WikiOperation.ingest`). `[]` for non-ingest kinds.
+    var sourceFiles: [String]
+    /// Source IDs derived from `sourceFiles` (`WikiOperation.sourceID(fromPath:)`).
+    /// `[]` for non-ingest kinds.
+    var sourceIDs: [String]
+    /// Reserved for forward-compat: per-phase overrides (`planner`, `executor`,
+    /// `finalizer`). `[]` today — see the struct's doc comment.
+    var phases: [PhaseEntry]
+
+    struct ProviderInfo: Codable, Sendable, Equatable {
+        var id: String
+        var label: String?
+    }
+
+    struct ThinkingEffortInfo: Codable, Sendable, Equatable {
+        var configId: String
+        var currentValue: String?
+        var choices: [Choice]?
+
+        struct Choice: Codable, Sendable, Equatable {
+            var value: String
+            var label: String
+        }
+    }
+
+    struct PhaseEntry: Codable, Sendable, Equatable {
+        var name: String
+        var provider: ProviderInfo?
+        var selectedModelId: String?
+        var thinkingEffort: ThinkingEffortInfo?
+    }
+}
+
+private extension String {
+    /// Empty/whitespace-only string → nil (so `selectedModelId` /
+    /// `thinkingEffort.currentValue` normalize to "unset" in the JSON, not `""`).
+    var nilIfEmpty: String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
     }
 }
 

--- a/Tests/WikiFSTests/ModelsConfigRecordTests.swift
+++ b/Tests/WikiFSTests/ModelsConfigRecordTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import Testing
+import ACPModel
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// Swift Testing coverage for the `models.json` artifact written at ingestion
+/// start (see `plans/log-ingestion-models.md`). Asserts both the JSON shape
+/// written today and the forward-compatible `phases` array (which future
+/// per-phase model selection will populate without changing the schema).
+///
+/// Uses Swift Testing (not XCTest) per the project convention for new tests —
+/// see `docs/skills/swift-testing-pro/SKILL.md`. Structs, `init` over setUp, and
+/// `#expect`/`#require` over XCTAssert*. Per-test scratch dirs are UUID'd
+/// under the system temp dir and left for the OS to reap (no struct `deinit`).
+struct ModelsConfigRecordTests {
+
+    /// Per-test scratch dir, isolated via UUID so parallel runs don't collide.
+    /// Returned instead of stored as instance state (struct `deinit` isn't
+    /// available on Swift 6.0).
+    private func makeScratch() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelsConfigRecordTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - record shape
+
+    @Test func buildRecordPopulatesAllFields() {
+        let choice = ThinkingEffortOption.Choice(value: "high", label: "High")
+        let thinking = ThinkingEffortOption(
+            configId: "thought_level",
+            currentValue: "high",
+            choices: [choice, ThinkingEffortOption.Choice(value: "medium", label: "Medium")])
+        let startedAt = Date(timeIntervalSince1970: 1_753_000_000)
+
+        let record = DebugRunLogger.makeRecord(
+            chatULID: "01HXY8ATQRTESTCHAT000",
+            startedAt: startedAt,
+            operationKind: "ingest",
+            providerId: "claude",
+            providerLabel: "Claude",
+            selectedModelId: "claude-sonnet-4-5",
+            thinkingEffort: thinking,
+            sourceFiles: ["sources/by-id/01HXY8ATQR.md", "sources/by-id/01HXY8ATQZ.md"],
+            sourceIDs: ["01HXY8ATQR", "01HXY8ATQZ"])
+
+        #expect(record.schemaVersion == 1)
+        #expect(record.chatULID == "01HXY8ATQRTESTCHAT000")
+        #expect(record.operationKind == "ingest")
+        #expect(record.provider.id == "claude")
+        #expect(record.provider.label == "Claude")
+        #expect(record.selectedModelId == "claude-sonnet-4-5")
+        #expect(record.thinkingEffort?.configId == "thought_level")
+        #expect(record.thinkingEffort?.currentValue == "high")
+        #expect(record.thinkingEffort?.choices?.count == 2)
+        #expect(record.thinkingEffort?.choices?.first?.value == "high")
+        #expect(record.sourceFiles == ["sources/by-id/01HXY8ATQR.md", "sources/by-id/01HXY8ATQZ.md"])
+        #expect(record.sourceIDs == ["01HXY8ATQR", "01HXY8ATQZ"])
+        // Forward-compat slot: empty today, present so future per-phase population
+        // doesn't rewrite the schema.
+        #expect(record.phases.isEmpty)
+    }
+
+    @Test func emptySelectedModelIdNormalizesToNil() {
+        let record = DebugRunLogger.makeRecord(
+            chatULID: nil,
+            startedAt: Date(),
+            operationKind: "query",
+            providerId: "glm",
+            providerLabel: nil,
+            selectedModelId: "",
+            thinkingEffort: nil,
+            sourceFiles: [],
+            sourceIDs: [])
+        // An empty `selectedModelId` becomes `nil` (no model selected), not `""`.
+        #expect(record.selectedModelId == nil)
+        #expect(record.thinkingEffort == nil)
+        #expect(record.provider.label == nil)
+    }
+
+    // MARK: - file write
+
+    @Test func writeCreatesModelsJSONInScratchDir() throws {
+        let scratch = try makeScratch()
+        let thinking = ThinkingEffortOption(
+            configId: "thought_level",
+            currentValue: "high",
+            choices: [ThinkingEffortOption.Choice(value: "high", label: "High")])
+        let record = DebugRunLogger.makeRecord(
+            chatULID: "01HTESTCHAT",
+            startedAt: Date(timeIntervalSince1970: 1_753_000_000),
+            operationKind: "ingest",
+            providerId: "claude",
+            providerLabel: "Claude",
+            selectedModelId: "claude-sonnet-4-5",
+            thinkingEffort: thinking,
+            sourceFiles: ["sources/by-id/X.md"],
+            sourceIDs: ["X"])
+
+        DebugRunLogger.writeModelsConfig(record, to: scratch)
+
+        let url = scratch.appendingPathComponent("models.json", isDirectory: false)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+
+        // Round-trip the file through the Codable shape.
+        let data = try Data(contentsOf: url)
+        let decoded = try JSONDecoder().decode(ModelsConfigRecord.self, from: data)
+
+        #expect(decoded.schemaVersion == 1)
+        #expect(decoded.chatULID == "01HTESTCHAT")
+        #expect(decoded.operationKind == "ingest")
+        #expect(decoded.provider == ModelsConfigRecord.ProviderInfo(id: "claude", label: "Claude"))
+        #expect(decoded.selectedModelId == "claude-sonnet-4-5")
+        #expect(decoded.thinkingEffort?.configId == "thought_level")
+        #expect(decoded.thinkingEffort?.currentValue == "high")
+        #expect(decoded.thinkingEffort?.choices?.first?.value == "high")
+        #expect(decoded.thinkingEffort?.choices?.first?.label == "High")
+        #expect(decoded.sourceFiles == ["sources/by-id/X.md"])
+        #expect(decoded.sourceIDs == ["X"])
+        // The forward-compat slot round-trips as `[]`.
+        #expect(decoded.phases == [])
+    }
+
+    @Test func writeDoesNotThrowWhenScratchDirMissing() throws {
+        // A scratch dir that doesn't exist: write should log + return, not throw.
+        // (Read-back should find no file.)
+        let scratch = try makeScratch()
+        let bogus = scratch.appendingPathComponent("does-not-exist", isDirectory: true)
+        let record = DebugRunLogger.makeRecord(
+            chatULID: nil,
+            startedAt: Date(),
+            operationKind: "lint",
+            providerId: "glm",
+            providerLabel: nil,
+            selectedModelId: nil,
+            thinkingEffort: nil,
+            sourceFiles: [],
+            sourceIDs: [])
+        DebugRunLogger.writeModelsConfig(record, to: bogus)
+        let url = bogus.appendingPathComponent("models.json", isDirectory: false)
+        #expect(FileManager.default.fileExists(atPath: url.path) == false)
+    }
+
+    // MARK: - JSON passthrough shape (no Codable decode — assert raw keys)
+
+    @Test func writeProducesSortedPrettyJSONWithExpectedTopLevelKeys() throws {
+        let scratch = try makeScratch()
+        let record = DebugRunLogger.makeRecord(
+            chatULID: "C",
+            startedAt: Date(timeIntervalSince1970: 1_753_000_000),
+            operationKind: "ingest",
+            providerId: "p",
+            providerLabel: "P",
+            selectedModelId: "m",
+            thinkingEffort: nil,
+            sourceFiles: [],
+            sourceIDs: [])
+
+        DebugRunLogger.writeModelsConfig(record, to: scratch)
+        let url = scratch.appendingPathComponent("models.json", isDirectory: false)
+        let raw = try String(contentsOf: url, encoding: .utf8)
+
+        // Pretty-printed (multi-line).
+        #expect(raw.contains("\n"))
+        // Top-level required keys present (sorted alphabetically by encoder).
+        #expect(raw.contains("\"chatULID\""))
+        #expect(raw.contains("\"operationKind\""))
+        #expect(raw.contains("\"phases\""))
+        #expect(raw.contains("\"provider\""))
+        #expect(raw.contains("\"schemaVersion\""))
+        #expect(raw.contains("\"selectedModelId\""))
+        #expect(raw.contains("\"sourceFiles\""))
+        #expect(raw.contains("\"sourceIDs\""))
+        #expect(raw.contains("\"startedAt\""))
+        // `thinkingEffort` is `nil` here → key omitted (encodeIfPresent behavior
+        // is the synthesized default for optional Codable properties).
+        #expect(raw.contains("\"thinkingEffort\"") == false)
+    }
+
+    // MARK: - forward-compat phases (semantic contract)
+
+    @Test func phasesSlotAcceptsFuturePerPhaseEntries() throws {
+        // Simulate a future record where per-phase model selection has landed:
+        // a planner phase overrides the top-level model, the executor inherits.
+        // This MUST decode cleanly into today's `ModelsConfigRecord` (additive
+        // forward-compat — readers treat absent/empty phases as "the top-level
+        // triple applies to every phase", a non-empty entry as an override).
+        let futureJSON = """
+        {
+          "chatULID": "C",
+          "operationKind": "ingest",
+          "phases": [
+            { "name": "planner", "selectedModelId": "opus-4" },
+            { "name": "executor", "selectedModelId": "sonnet-4" }
+          ],
+          "provider": { "id": "claude", "label": "Claude" },
+          "schemaVersion": 1,
+          "sourceFiles": ["sources/by-id/X.md"],
+          "sourceIDs": ["X"],
+          "startedAt": "2026-07-19T12:34:56Z"
+        }
+        """
+        let data = try #require(futureJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(ModelsConfigRecord.self, from: data)
+        #expect(decoded.phases.count == 2)
+        #expect(decoded.phases[0].name == "planner")
+        #expect(decoded.phases[0].selectedModelId == "opus-4")
+        #expect(decoded.phases[1].name == "executor")
+        #expect(decoded.phases[1].selectedModelId == "sonnet-4")
+        // Top-level triple still present (the default applying to every phase
+        // absent an override).
+        #expect(decoded.provider.id == "claude")
+        // `selectedModelId` was absent at the top level here → nil (the agent
+        // default applies; per-phase entries override).
+        #expect(decoded.selectedModelId == nil)
+    }
+
+    // MARK: - AgentLauncher.sourceFilesAndIDs(for:)
+
+    @Test func sourceFilesAndIDsForIngest() {
+        let op = WikiOperation.ingest(
+            sourcePaths: ["sources/by-id/01HXY8ATQR.md", "sources/by-id/01HXY8ATQZ.md"],
+            stagedSourcePaths: ["/scratch/source-1.md", "/scratch/source-2.md"],
+            stateFilePath: "/scratch/WIKI_STATE.md",
+            plan: .singleOpus)
+        let (files, ids) = AgentLauncher.sourceFilesAndIDs(for: op)
+        #expect(files == ["sources/by-id/01HXY8ATQR.md", "sources/by-id/01HXY8ATQZ.md"])
+        // Source IDs are the leaf filename without extension (the same projection
+        // `WikiOperation.sourceID(fromPath:)` uses for the prompts).
+        #expect(ids == ["01HXY8ATQR", "01HXY8ATQZ"])
+    }
+
+    @Test func sourceFilesAndIDsForNonIngestAreEmpty() {
+        // `.query`, `.lint`, `.lintPage`, and `.queryChat` all carry no sources —
+        // `models.json` records `[]` for both arrays.
+        let query = WikiOperation.query(question: "what?", stateFilePath: "/x/WIKI_STATE.md")
+        #expect(AgentLauncher.sourceFilesAndIDs(for: query).sourceFiles.isEmpty)
+        #expect(AgentLauncher.sourceFilesAndIDs(for: query).sourceIDs.isEmpty)
+
+        let lint = WikiOperation.lint(stateFilePath: "/x/WIKI_STATE.md")
+        #expect(AgentLauncher.sourceFilesAndIDs(for: lint).sourceFiles.isEmpty)
+
+        let lintPage = WikiOperation.lintPage(
+            pageTitle: "X", brokenLinks: [], stateFilePath: "/x/WIKI_STATE.md")
+        #expect(AgentLauncher.sourceFilesAndIDs(for: lintPage).sourceIDs.isEmpty)
+
+        let chat = WikiOperation.queryChat(stateFilePath: "/x/WIKI_STATE.md")
+        #expect(AgentLauncher.sourceFilesAndIDs(for: chat).sourceFiles.isEmpty)
+    }
+}

--- a/plans/log-ingestion-models.md
+++ b/plans/log-ingestion-models.md
@@ -1,0 +1,102 @@
+# Plan: log resolved provider/models/thinking at ingestion start
+
+## Goal
+
+When an ingestion run starts, write a structured JSON record of the resolved
+**provider**, **model(s)**, and **thinking effort** into the run's directory on
+disk, so a run's model configuration can be inspected post-hoc (debugging "what
+model did this run use", audits, and later verifying per-phase model selection).
+
+## Verified insertion points (file:line)
+
+- The per-run dir is
+  `<Caches>/Self Driving Wiki-agent/<chatULID>/runs/<timestamp>/` (the `scratch`
+  dir). See `Sources/WikiFSEngine/AgentLauncher.swift:294-299` (run-dir
+  resolution) and `:3087-3092` (where `run.jsonl` + `run.stderr.log` are created
+  under `scratch`).
+- `Sources/WikiFSEngine/DebugRunLogger.swift` is the dedicated run-artifact
+  writer (its own comment says the lightweight `run.jsonl`/`run.stderr.log` are
+  *not* touched by it — those are siblings). This is the natural home for the
+  new file (a new lightweight sibling artifact, not part of the verbose
+  `debug/` trace).
+- Data available at ingest start:
+  - provider id (`runProviderLabel = provider.id`, `AgentLauncher.swift:1175`)
+  - `provider.label` (`AgentProvider.label`, `Sources/WikiFSCore/Core/AgentProvider.swift:25`)
+  - the selectedModelId (`providersConfig().selectedModelId(forProvider:)`,
+    `AgentLauncher.swift:481-482`)
+  - thinking effort (`ThinkingEffortOption`, declared in
+    `Sources/WikiFSEngine/ThinkingEffortOption.swift`; the current
+    `self.thinkingOption` value on the launcher).
+- The `DebugRunLogger` instance is built INSIDE `ACPBackend.startProcess`
+  (`ACPBackend.swift:339`) — AFTER `openLogFiles` runs. So the new write is a
+  **static** helper on `DebugRunLogger` (no instance needed), invoked from
+  `AgentLauncher.run()` immediately after `openLogFiles(in: scratch)`.
+
+## Fix
+
+1. **Add to `DebugRunLogger`** (in `Sources/WikiFSEngine/DebugRunLogger.swift`):
+   - A `Codable, Sendable` record type `ModelsConfigRecord` describing the JSON
+     shape, with comment explaining the forward-compatible `phases` array.
+   - A pure `static func makeRecord(...)` helper that builds a
+     `ModelsConfigRecord` from the data available at spawn time (provider id +
+     label, selectedModelId, `ThinkingEffortOption?`, chatULID, startedAt,
+     operationKind, sourceFiles, sourceIDs).
+   - A `static func writeModelsConfig(_:to:)` that writes the record as
+     pretty-printed JSON to `<scratch>/models.json`, best-effort (failures
+     logged via `DebugLog`, never thrown — house rule: **no bare `try?`**).
+2. **Call the write ONCE at ingestion start**, right after `openLogFiles(in:
+   scratch)` in `AgentLauncher.run()` (line ~1176). The `queueItemID` parameter
+   serves as the chatULID (it's what `makeScratchDirectory(id:)` uses to build
+   the `<Caches>/.../<id>/runs/<timestamp>/` path). For `.ingest` operations,
+   `sourceFiles`/`sourceIDs` come from the staged `WikiOperation.ingest`'s
+   `sourcePaths` (`WikiOperation.sourceID(fromPath:)` derives the id). For
+   non-ingest kinds, `sourceFiles`/`sourceIDs` are `[]`.
+3. Do **not** modify `run.jsonl` or `run.stderr.log` behavior — `models.json`
+   is a sibling file in `scratch/`, not in `debug/`.
+
+## JSON shape (forward-compatible)
+
+```json
+{
+  "schemaVersion": 1,
+  "chatULID": "<queueItemID>",
+  "startedAt": "2026-07-19T12:34:56.789Z",
+  "operationKind": "ingest",
+  "provider": { "id": "claude", "label": "Claude" },
+  "selectedModelId": "claude-sonnet-4-5",
+  "thinkingEffort": {
+    "configId": "thought_level",
+    "currentValue": "high",
+    "choices": [
+      { "value": "high", "label": "High" },
+      { "value": "medium", "label": "Medium" }
+    ]
+  },
+  "sourceFiles": ["sources/by-id/01HXY...md"],
+  "sourceIDs": ["01HXY..."],
+  "phases": []
+}
+```
+
+`phases` is `[]` today. Forward-compat intent: when per-phase model selection
+lands (planner/executor/finalizer), each phase gets an entry
+`{name, provider?, selectedModelId?, thinkingEffort?}` appended to `phases`
+without rewriting the schema. Readers MUST treat an absent/empty `phases` as
+"the top-level triple applies to every phase" and a non-empty entry as an
+override for that phase only.
+
+## Acceptance
+
+- `swift build` clean; `swift test` (full suite) green — no regressions.
+- Starting an ingestion writes `<run-dir>/models.json` with
+  provider/model/thinking. (Headless: verified by code + a focused unit test.
+  The operator confirms a real run writes the file.)
+- Focused unit test added in Swift Testing, asserting the JSON shape (including
+  the forward-compatible structure).
+
+## Workflow
+
+1. First commit: this plan in `plans/log-ingestion-models.md`.
+2. Implement.
+3. `swift build` + `swift test`.
+4. Push branch, open a PR. Do NOT merge to `main`.


### PR DESCRIPTION
## What

When an ingestion run starts, write a structured JSON record of the resolved **provider**, **selectedModelId**, and **thinking effort** into the run's scratch dir — a new `<scratch>/models.json` sibling of `run.jsonl` / `run.stderr.log`. So a run's model config can be inspected post-hoc (debugging "what model did this run use", audits, and later verifying per-phase model selection).

## Why

A run's resolved provider / model / thinking-effort was previously discoverable only by replaying the verbose ACP trace under `debug/`. That's too heavy for the common question "what model did this ingest run use?" — and impossible to read in CI logs. A single, lightweight artifact at the run's scratch root makes the metadata available in one `cat`.

The shape is also forward-compatible with per-phase model selection: today the launcher resolves one (provider, model, thinking) triple for the whole run; when per-phase model selection lands (planner/executor/finalizer), entries can be appended to the `phases` array without rewriting the schema.

Plan: `plans/log-ingestion-models.md`.

## How

- `DebugRunLogger` gains:
  - `ModelsConfigRecord: Codable, Sendable, Equatable` — schema-bumped (`schemaVersion: 1` today), with a `phases: [PhaseEntry]` array (`[]` now; future per-phase entries are additive).
  - `static func makeRecord(...)` — pure builder (no I/O) from spawn-time data.
  - `static func writeModelsConfig(_:to:)` — best-effort writer to `<scratch>/models.json`; failures log via `DebugLog`, never throw (house rule: no bare `try?`).
- `AgentLauncher.run()` builds the record and writes it right after `openLogFiles(in: scratch)`, before the planner runs. `chatULID` is the `queueItemID` (the same id `makeScratchDirectory` uses to namespace the run dir). For non-ingest operations `sourceFiles`/`sourceIDs` are `[]`.
- `AgentLauncher.sourceFilesAndIDs(for:)` — pure `nonisolated` helper that extracts `(sourcePaths, derived sourceIDs)` from staged `WikiOperation.ingest`, `[]` for other kinds.

The `DebugRunLogger` `instance` is only constructed later inside `ACPBackend.startProcess` — AFTER `openLogFiles` runs — so the helper is `static` so the launcher can call it at the point where `run.jsonl` is set up, before any `DebugRunLogger` instance exists. `run.jsonl` / `run.stderr.log` behavior is untouched.

## JSON shape

```json
{
  "schemaVersion": 1,
  "chatULID": "<queueItemID>",
  "startedAt": "2026-07-19T12:34:56.789Z",
  "operationKind": "ingest",
  "provider": { "id": "claude", "label": "Claude" },
  "selectedModelId": "claude-sonnet-4-5",
  "thinkingEffort": {
    "configId": "thought_level",
    "currentValue": "high",
    "choices": [
      { "value": "high", "label": "High" },
      { "value": "medium", "label": "Medium" }
    ]
  },
  "sourceFiles": ["sources/by-id/01HXY...md"],
  "sourceIDs": ["01HXY..."],
  "phases": []
}
```

`phases: []` today; future per-phase population appends `{name, provider?, selectedModelId?, thinkingEffort?}` entries without rewriting the schema. Readers treat absent/empty `phases` as "the top-level triple applies to every phase" and a non-empty entry as an override for that phase only.

## Tests

New Swift Testing suite `ModelsConfigRecordTests` (8 tests) covers:
- Record shape (all fields, normalized nil-on-empty).
- File write + Codable round-trip via `JSONDecoder`.
- Best-effort when scratch dir is missing (no throw, no file written).
- Raw JSON has expected top-level keys (sorted, pretty-printed); `thinkingEffort` omitted when nil.
- Forward-compat: a future-shape JSON with non-empty `phases` decodes cleanly into today's `ModelsConfigRecord` (additive).
- `AgentLauncher.sourceFilesAndIDs(for:)` across all operation kinds (`.ingest` populates; `.query` / `.lint` / `.lintPage` / `.queryChat` are `[]`).

## Verification

- `swift build` clean.
- `swift test` (full suite, 3099 tests) green on re-run. (One pre-existing flaky test, `PdfExtractionServiceTests/streamProcessCapturesStderrLines`, intermittently reports 0 captured stderr lines under parallel load — passes in isolation; race-prone `Task { await collector.add(line) }` in its capture closure. Unrelated to these changes.)
- Headless: I can't run a live ingest from here; the operator confirms a real run writes `<scratch>/models.json`.
