### PR TITLE
Fix ChatWebView crash when a WebKit SPI key is dropped by the OS

### DIFF
--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -116,7 +116,14 @@ struct ChatWebView: NSViewRepresentable {
     /// See Bug #1 in `makeNSView` for why these keys are needed.
     @discardableResult
     private static func setSPI(_ key: String, _ value: Any, on webView: WKWebView) -> Bool {
-        guard webView.responds(to: NSSelectorFromString("setValue:forKey:")) else { return false }
+        // The obvious guard — `responds(to: setValue:forKey:)` — is useless: every
+        // NSObject responds to it, so it never blocked an unknown key. KVC then
+        // throws NSUnknownKeyException, an ObjC exception Swift cannot catch, which
+        // aborts the app (macOS 26 dropped one of these keys; regression from #708).
+        // Probe the key itself instead: both SPI keys are plain properties whose
+        // getter selector IS the key, so `responds(to:)` on the key is a real
+        // presence check that disappears the moment the OS removes the property.
+        guard webView.responds(to: NSSelectorFromString(key)) else { return false }
         webView.setValue(value, forKey: key)
         return true
     }


### PR DESCRIPTION
setSPI guarded with `responds(to: "setValue:forKey:")`, which is always
true for any NSObject — it never blocked an unknown key. On macOS 26.5.2
one of the `_clipsToVisibleRect` / `_automaticallyAdjustsContentInsets`
keys (added in #708) is no longer recognized, so KVC raised
NSUnknownKeyException. Swift can't catch ObjC exceptions, so it unwound
through the AppKit display cycle and aborted (SIGABRT in makeNSView).

Probe the key itself via `responds(to: NSSelectorFromString(key))`: both
keys are plain properties whose getter selector is the key name, so this
is a real presence check that safely skips when the OS removes the
property, degrading the scrollbar tweak instead of crashing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
