### PR TITLE
Page provenance: each wiki page records the agent + activity that created/edited it

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,167 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-19 — Page provenance: wiki page records the agent + activity that created/edited it (branch `page-provenance`)
+
+**Problem.** Each wiki page recorded only a flat `last_edited_by` TEXT string
+(#131/#397) — the `chat:<id>` / `agent:<kind>` / `user` / model-id of the
+last writer. On the CAS path only it also appended a `page_versions` row
+whose `activity_id` pointed at a **shared anonymous `legacy-import` agent**,
+and the CAS-off path (`wikictl` default, no `--expect-head`) recorded NO
+history at all. There was no read-side accessor for the PROV graph and no
+UI surface. The plan (`plans/page-provenance.md`) is the design doc; this
+entry is the Phase A + B implementation.
+
+**Approach.** Reuse the existing PROV-DM substrate (`agents` +
+`activities` + `page_versions`, the same graph sources use) — NOT a new
+table. The fix is the writer swap (`legacyImportAgentID →
+ensurePageAuthorAgent`) + the CAS-off path routing through a shared
+`appendPageVersionLocked(on db:)` helper + two new read accessors.
+
+### `Sources/WikiFSCore/Core/PageOrigin.swift` (NEW)
+
+- `PageOrigin` struct — `versionID` / `title` / `blobHash` / `agentName` /
+  `agentKind` / `activityKind` / `plan` / `externalRef` / `savedAt`. The
+  read-side mirror of `SourceOrigin` for sources (Phase 3a).
+
+### `Sources/WikiFSCore/Store/WikiStore.swift` (protocol surface)
+
+- Two new protocol requirements (NO default-impl extension — mirrors
+  `sourceOrigin` and `pageVersionHistory`):
+  - `pageOrigin(pageID:) throws -> PageOrigin?` — joins
+    `refs → page_versions → activities → agents` for the HEAD.
+  - `pageEditHistory(pageID:) throws -> [PageOrigin]` — full version chain
+    joined to activity + agent, oldest-first.
+- `GRDBWikiStore` is the sole conformer (single site) — no test mock
+  breaks.
+
+### `Sources/WikiFSCore/Store/GRDBWikiStore.swift` (the writer swap)
+
+- **Schema bumped v38 → v39.** New explicit `if version < 39 … PRAGMA
+  user_version = 39 …` step inserted BEFORE the catch-all fallback at the
+  end of `migrate(from:in:)` — the fallback's guard is keyed on
+  `currentSchemaVersion` and short-circuits past any new step once that
+  constant is bumped. Forward-only: no backfill — pre-v39 rows degrade to
+  `legacy-import` agent (same as today).
+- **Authored `authorKind(_:)`** (NEW, not in the prior art) — `chat:…` →
+  `"chat"`, `agent:…` → `"agent"`, `"user"` → `"human"`, anything else →
+  `"model"`, `nil`/empty → `"software"` (the legacy-import kind).
+- **`ensurePageAuthorAgent(_:on:)`** — the writer-side swap. Get-or-creates
+  a REAL named agent on `(name, kind)` via `ensureAgent` when the author
+  string carries a chat/agent/user/model identity; falls back to
+  `legacyImportAgentID` when nil/empty (degraded, no data loss).
+- **`createPage` + `appendPageVersion` + `updatePage`** all route their
+  activity's agent through `ensurePageAuthorAgent` instead of
+  `legacyImportAgentID`. Single edit site (`ensurePageAuthorAgent`).
+- **Extracted `appendPageVersionLocked(on db:)`** (NEW private helper — the
+  HIGH-hazard fix). Holds the body shared by `appendPageVersion` (CAS path)
+  + `updatePage` (CAS-off path). NOT a `mutate` wrapper — does NOT emit;
+  the public callers wrap their own `mutate` body and emit `.page .updated`
+  ONCE there (Approach-A composition pattern per `mutate`'s doc; a public
+  mutator that re-calls `mutate` would deadlock). `updatePage` deliberately
+  calls this helper, NOT public `appendPageVersion` (would double-emit AND
+  re-enter).
+  - Includes a no-op guard: identical body hash + identical title =
+    pure content no-op → skip the version-append (just bumps `updated_at`
+    + `last_edited_by` on the mirror). The plan's risk-table mention of
+    "`wikictl` re-write bloat" — this is the gate.
+  - The `tryAmendPageVersion` autosave coalescer ALSO runs on the CAS-off
+    path now (per §5.3 LOW note) — a rapid same-author save within the 5s
+    window amends the head version in place instead of appending. AC.3
+    uses a DISTINCT author to keep the amend short-circuit from
+    suppressing the new version row.
+- **`updatePage` existence check** — added `guard exists … else { throw
+  WikiStoreError.notFound(id) }` at the start. The pre-refactor contract
+  threw `.notFound` when the page was gone via `guard db.changesCount > 0
+  else { throw notFound }` AFTER the UPDATE; the refactor INSERTs into
+  `page_versions` before the UPDATE so the existence check moved first
+  (otherwise a FK violation from `page_versions.page_id` would surface as
+  a raw `DatabaseError`, breaking `StoreEmissionReentrancyTests
+  .throwingMutationEmitsNothing`).
+
+### `Sources/WikiFSCore/Store/WikiStoreModel.swift` (read accessors)
+
+- `pageOrigin(for:)` / `pageEditHistory(for:)` — `try?` wrappers around
+  the protocol methods. Used by `PageDetailView`.
+
+### `Sources/WikiFS/Pages/PageDetailView.swift` (UI surface)
+
+- New collapsible "Provenance" `DisclosureGroup` in the header expansion,
+  between the date row and the action buttons. Defaults collapsed — the
+  origin + edit-history reads are gated on expansion (per the plan's risk
+  table — keep the provenance read out of the hot `body` re-render).
+- `ProvenancePanel` (new view struct) renders the HEAD origin row + the
+  edit history list. `chat:<id>` agents render with the chat bubble icon
+  (the `chat:<id>` provenance value shape from #397); `agent:<kind>` with
+  the cpu icon; `user` with the person icon; `legacy-import` with the tray
+  icon (pre-v39 rows degrade distinctly).
+- `@State provenanceOrigin` / `provenanceHistory` cleared on
+  `store.selection` change (in-tab navigation), so a stale panel from the
+  previous page doesn't flicker before the `.task(id:)` reloads. The `.task
+  (id: ProvenanceTaskKey(pageID:expanded:))` fires both on selection change
+  AND on expansion so the read only runs when there's something to show.
+
+### `Sources/WikiCtlCore/PageCommand.swift` + `ArgumentParser.swift` (CLI surface)
+
+- New `page info (--title X | --id Y)` subcommand — mirrors `source info`
+  (Phase 3a). Prints identity (id/title/slug/created/updated/version_count)
+  + HEAD origin (activity/agent/agent_kind/plan/external_ref/saved_at/
+  blob_hash) + editable history (oldest-first; seq/activity/agent/
+  agent_kind/date/title/version_id/blob_hash/parent).
+
+### Tests
+
+- NEW `Tests/WikiFSTests/PageVersionTests.swift` additions — 8 tests:
+  - `pageOriginReflectsChatAuthorOnCreate` (AC.1) — `chat:<id>` create
+    surfaces in `pageOrigin` as `agentName == chat:<id>`,
+    `agentKind == "chat"`, `activityKind == "import"`.
+  - `pageOriginReflectsAgentKindOnCreate` (AC.1 variant) — `agent:<kind>`.
+  - `pageOriginDegradesToLegacyImportWhenNoAuthor` (AC.1 degraded) — nil
+    author degrades to `legacy-import` / `"software"`.
+  - `pageEditHistoryCountsCreateAndEdit` (AC.2) — exactly 2 entries on
+    fresh create+edit (DISTINCT authors so the amend coalescer can't
+    suppress the new row); entry[1] pinned to chat agent + edited body.
+  - `updatePageCASOffAppendsVersionAndActivity` (AC.3) — row-count before/
+    after the CAS-off update.
+  - `pageEditActivityPointsAtRealNamedAgent` (AC.4) — HEAD activity's
+    `agent_id` joins to `chat:<id>` agent row, NOT `legacy-import`.
+  - `pageEditNilAuthorDegradesToLegacyImport` (AC.4 degraded).
+  - `v39SchemaVersionAfterMigration` (AC.8) — schema version reports 39.
+- EXTENDED `Tests/WikiFSTests/StoreEmissionTests.swift`:
+  - `test_updatePage_after_versioning_refactor_emits_single_page_updated`
+    (NEW, AC.6) — asserts EXACTLY ONE `.page .updated` event after
+    `updatePage`, catching the double-emit regression from naive
+    delegation to public `appendPageVersion`.
+- NEW `Tests/WikiFSTests/StoreEmissionReentrancyTests.swift`:
+  - `updatePageAfterVersioningRefactorEmitsOnceNoDeadlock` (AC.7) — mirrors
+    `withTransactionMutationEmitsOnceNoDeadlock`; asserts single-emit +
+    no deadlock now that `updatePage` composes via `appendPageVersionLocked`.
+- NEW `Tests/WikiFSTests/WikiCtlCommandTests.swift` additions — 5 tests:
+  - `pageInfoPrintsChatOrigin` — round-trip create-with-author → `page info`
+    prints identity + HEAD origin.
+  - `pageInfoAfterEditShowsEditOrigin` — post-edit HEAD reflects the chat
+    agent + 'edit' activity.
+  - `parsesPageInfoByID` / `parsesPageInfoByTitle` — argparser coverage.
+  - `pageInfoOnMissingPageThrows`.
+
+### Verification
+
+- `make check` ✓ (compiles debug, 0 errors / 0 warnings)
+- `make test` ✓ — **3120 tests / 263 suites pass** (~30 s; in-memory SQLite
+  fixtures since #658). One earlier run had a flaky snapshot-test failure
+  (unrelated); re-ran clean.
+
+### Out of scope (deferred per §10 phasing)
+
+- **Phase C** (optional): backfill historical `activity.agent_id` from
+  `last_edited_by` behind a `wiki_metadata` flag (irreversible — guarded
+  rollout). + thread `WIKI_RUN_REF` → `activities.external_ref` for
+  structured run identity.
+- **Phase D** (hygiene): build a real reflection-based
+  `WikiStoreEmissionExhaustivenessTests` (the phantom test the loaded
+  context references); delete the stale phantom references in
+  `ChangeTokenContributorTests.swift:18` and `GRDBWikiStore.swift:2614`.
+
 ## 2026-07-19 — Per-operation provider overrides (chat / ingest / lint) (branch `per-op-provider`, PR #704)
 
 **Problem.** A single shared `defaultProvider` was used for all three ACP

--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -99,6 +99,8 @@ public enum ArgumentParser {
       page history (--title X | --id Y)       show version history (W0)
       page revert (--title X | --id Y) --version V
                                               revert a page to version V (W0)
+      page info (--title X | --id Y)          print page identity + origin provenance
+                                              (HEAD's agent/activity + full edit history)
       log append --kind ingest|query|lint --title X [--note N] [--source <file-id>]
                                               append one dated row to log.md;
                                               --source stamps that file "Processed"
@@ -277,6 +279,9 @@ public enum ArgumentParser {
                 throw Failure.usage("page revert: --version is required")
             }
             return .page(.revert(try options.requireSelector(), versionID: versionID))
+
+        case "info":
+            return .page(.info(try options.requireSelector()))
 
         default:
             throw Failure.usage("page: unknown subcommand \(sub.debugDescription)")

--- a/Sources/WikiCtlCore/PageCommand.swift
+++ b/Sources/WikiCtlCore/PageCommand.swift
@@ -48,6 +48,11 @@ public enum PageCommand {
         /// Revert a page to a specific version (W0, PR #312). Repoints the
         /// page-content ref to `versionID` and updates the body mirror.
         case revert(Selector, versionID: String)
+        /// Print identity (id, title, slug, created/updated, version count) +
+        /// origin provenance (HEAD's agent + activity, edit history) for a
+        /// page. Mirrors `source info` (`SourceCommand.info`) — a read-side
+        /// diagnostic for agents + debugging. Read-only.
+        case info(Selector)
     }
 
     public enum Failure: Error, CustomStringConvertible {
@@ -97,6 +102,8 @@ public enum PageCommand {
             return try history(selector, in: store)
         case .revert(let selector, let versionID):
             return try revert(selector, versionID: versionID, in: store)
+        case .info(let selector):
+            return try info(selector, in: store)
         }
     }
 
@@ -344,6 +351,67 @@ public enum PageCommand {
         let id = try resolve(selector, in: store)
         try store.revertPage(pageID: id, to: versionID)
         return Result(output: "reverted \(id.rawValue) to \(versionID)", didCommit: true)
+    }
+
+    // MARK: - info (page provenance, #page-provenance)
+
+    /// Print identity (id, title, slug, head version id, version count,
+    /// created/updated) + origin provenance for the page's HEAD + every prior
+    /// version. Mirrors `SourceCommand.info`. Read-only. The HEAD's
+    /// `agentName` reflects the writer — for a chat edit, `"chat:<id>"`;
+    /// for an ingestion executor, `"agent:<kind>"`; for a manual app edit,
+    /// `"user"`; for pre-v39 rows, `"legacy-import"`.
+    private static func info(_ selector: Selector, in store: WikiStore) throws -> Result {
+        let id = try resolve(selector, in: store)
+        let page = try store.getPage(id: id)
+        let headVersionID = try store.pageHeadVersionID(pageID: id)
+        let history = try store.pageVersionHistory(pageID: id)
+
+        var lines: [String] = []
+        lines.append("id\t\(page.id.rawValue)")
+        lines.append("title\t\(page.title)")
+        lines.append("slug\t\(page.slug)")
+        if let createdBy = page.createdBy { lines.append("created_by\t\(createdBy)") }
+        if let lastEditedBy = page.lastEditedBy { lines.append("last_edited_by\t\(lastEditedBy)") }
+        lines.append("version\t\(page.version)")
+        let created = ISO8601DateFormatter().string(from: page.createdAt)
+        let updated = ISO8601DateFormatter().string(from: page.updatedAt)
+        lines.append("created_at\t\(created)")
+        lines.append("updated_at\t\(updated)")
+        lines.append("version_count\t\(history.count)")
+        if let headVersionID {
+            lines.append("head_version_id\t\(headVersionID)")
+        }
+
+        // HEAD origin (the active page-content ref → version → activity → agent).
+        if let origin = try store.pageOrigin(pageID: id) {
+            lines.append("")
+            lines.append("# origin (HEAD)")
+            lines.append("activity\t\(origin.activityKind)")
+            lines.append("agent\t\(origin.agentName)")
+            lines.append("agent_kind\t\(origin.agentKind)")
+            if let plan = origin.plan { lines.append("plan\t\(plan)") }
+            if let extRef = origin.externalRef { lines.append("external_ref\t\(extRef)") }
+            let savedAt = ISO8601DateFormatter().string(from: origin.savedAt)
+            lines.append("saved_at\t\(savedAt)")
+            if let hash = origin.blobHash { lines.append("blob_hash\t\(hash)") }
+        }
+
+        // Full edit history (every page_versions row joined to activity + agent).
+        let editHistory = try store.pageEditHistory(pageID: id)
+        if !editHistory.isEmpty {
+            lines.append("")
+            lines.append("# edit history (oldest-first)")
+            for (i, entry) in editHistory.enumerated() {
+                let savedAt = ISO8601DateFormatter().string(from: entry.savedAt)
+                // seq<TAB>activity<TAB>agent<TAB>agent_kind<TAB>date<TAB>title<TAB>version_id<TAB>blob_hash
+                let hash = entry.blobHash?.prefix(12) ?? "—"
+                let parent = history[i].parentID?.prefix(12) ?? "—"
+                lines.append("\(i)\t\(entry.activityKind)\t\(entry.agentName)\t\(entry.agentKind)\t\(savedAt)\t\(entry.title)\t\(entry.versionID.prefix(12))\t\(hash)\t\(parent)")
+            }
+        }
+
+        return Result(output: lines.joined(separator: "\n"), didCommit: false)
     }
 
     // MARK: - Selector resolution

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -28,6 +28,18 @@ struct PageDetailView: View {
     /// Per-view collapse state for the header. Starts collapsed; persists
     /// across same-type tab switches (SwiftUI keeps the view alive).
     @State private var isHeaderExpanded = false
+    /// Per-view collapse state for the Provenance panel (page-provenance
+    /// #page-provenance). Defaults collapsed; the heavy-ish origin/history
+    /// reads are gated on expansion so the hot `body` re-render stays cheap
+    /// (per the plan §7 risk table — keep the provenance read in a `@State`
+    /// loaded on expand, not inline in the view body).
+    @State private var isProvenanceExpanded = false
+    /// The HEAD origin (once loaded, when the panel is expanded). `nil`
+    /// indicates "not yet loaded" or "no version rows for this page".
+    @State private var provenanceOrigin: PageOrigin?
+    /// The full edit history (every `page_versions` row joined to its
+    /// activity + agent, oldest-first). Loaded alongside `provenanceOrigin`.
+    @State private var provenanceHistory: [PageOrigin] = []
 
     // Find bar state. The model is shared (hoisted to `ContentView` and injected
     // via environment) so the address bar's "Find on Page…" menu item can drive
@@ -60,6 +72,8 @@ struct PageDetailView: View {
                 }
                 .font(.callout)
                 .foregroundStyle(.secondary)
+
+                provenanceSection
 
                 HStack(spacing: 10) {
                     if isEditing {
@@ -180,6 +194,11 @@ struct PageDetailView: View {
             if store.activeTabID == lastKnownActiveTabID {
                 isEditing = false
             }
+            // Reset provenance state when the selection changes so a stale
+            // origin/history from the previous page doesn't flicker into the
+            // expanded panel before the `.task(id:)` reloads.
+            provenanceOrigin = nil
+            provenanceHistory = []
         }
         .onChange(of: store.activeTabID) { _, newID in
             lastKnownActiveTabID = newID
@@ -378,6 +397,44 @@ struct PageDetailView: View {
         guard let selection = store.selection,
               case .page(let id) = selection else { return nil }
         return store.summaries.first(where: { $0.id == id })?.updatedAt
+    }
+
+    // MARK: - Provenance (page origin / edit history, #page-provenance)
+
+    /// The id of the page currently shown in this detail view (the read-side
+    /// key the `WikiStoreModel` provenance accessors take).
+    private var currentPageID: PageID? {
+        guard case .page(let id) = store.selection else { return nil }
+        return id
+    }
+
+    /// Collapsible "Provenance" panel — created-by / last-edited-by / edit
+    /// history from the page-PROV graph (`agents` + `activities` +
+    /// `page_versions`). Defaults collapsed so the hot `_ = body` re-render
+    /// doesn't pay for a 4-table join per keystatechange; the `.task(id:)`
+    /// only fires when the panel expands or the page changes. Loaded via
+    /// `WikiStoreModel.pageOrigin(for:)` / `pageEditHistory(for:)` (through
+    /// the public `WikiStore` protocol, no downcast).
+    @ViewBuilder private var provenanceSection: some View {
+        if let pageID = currentPageID {
+            DisclosureGroup(isExpanded: $isProvenanceExpanded) {
+                ProvenancePanel(
+                    pageID: pageID,
+                    origin: provenanceOrigin,
+                    history: provenanceHistory)
+                .padding(.top, 4)
+            } label: {
+                Label("Provenance", systemImage: "clock.arrow.circlepath")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .task(id: ProvenanceTaskKey(pageID: pageID, expanded: isProvenanceExpanded)) {
+                // Only load when expanded; a collapsed panel needs no read.
+                guard isProvenanceExpanded else { return }
+                provenanceOrigin = store.pageOrigin(for: pageID)
+                provenanceHistory = store.pageEditHistory(for: pageID)
+            }
+        }
     }
 
     // MARK: - Subviews
@@ -662,6 +719,124 @@ struct PageOutlineView: View {
         result = result.replacingOccurrences(of: "**", with: "")
         result = result.replacingOccurrences(of: "__", with: "")
         return result
+    }
+}
+
+// MARK: - Provenance panel (#page-provenance)
+
+/// Hashable key for `PageDetailView.provenanceSection`'s `.task(id:)` — fires
+/// both on selection change AND on the disclosure expanding, so the provenance
+/// read runs only when there's something to show.
+private struct ProvenanceTaskKey: Hashable {
+    let pageID: PageID
+    let expanded: Bool
+}
+
+/// The expanded contents of the "Provenance" `DisclosureGroup` in
+/// `PageDetailView`. Pure-render over its inputs (no I/O); the parent
+/// `PageDetailView` loads `.origin` + `.history` via its `.task(id:)` and
+/// passes them in here. Kept self-contained so the type checker resolves the
+/// `body` subtree independently (the parent body is large already).
+struct ProvenancePanel: View {
+    let pageID: PageID
+    let origin: PageOrigin?
+    let history: [PageOrigin]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let origin {
+                originRow(origin)
+            } else {
+                Text("No provenance yet")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
+            if !history.isEmpty {
+                Divider().opacity(0.5)
+                Text("Edit history")
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(Array(history.enumerated()), id: \.element.versionID) { idx, entry in
+                    historyRow(idx, entry)
+                }
+            }
+        }
+        .font(.callout)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder private func originRow(_ origin: PageOrigin) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            // Created-by / last-edited-by row.
+            HStack(spacing: 6) {
+                Text("Last saved by")
+                    .foregroundStyle(.secondary)
+                agentLabel(name: origin.agentName, kind: origin.agentKind)
+                Text("·")
+                    .foregroundStyle(.secondary)
+                Text(origin.activityKind)
+                    .font(.callout.weight(.semibold))
+                Text("·")
+                    .foregroundStyle(.secondary)
+                Text(origin.savedAt, style: .relative)
+                    .foregroundStyle(.secondary)
+                Text("ago")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder private func historyRow(_ idx: Int, _ entry: PageOrigin) -> some View {
+        HStack(spacing: 6) {
+            Text("\(idx)")
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+            Text(entry.activityKind)
+                .font(.callout.weight(.semibold))
+            agentLabel(name: entry.agentName, kind: entry.agentKind)
+            Text("·")
+                .foregroundStyle(.secondary)
+            Text(entry.savedAt, style: .date)
+                .foregroundStyle(.secondary)
+            if entry.title.isEmpty == false {
+                Text("·")
+                    .foregroundStyle(.secondary)
+                Text(entry.title)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+    }
+
+    /// Render the agent identity. For `chat:<id>` agents, render the chatID
+    /// as a `[[chat:…]]`-style link (per #page-provenance §5.5 — consistent
+    /// with how `chat:<id>` provenance values surface elsewhere). For other
+    /// kinds, the agent name is shown verbatim with its kind label.
+    @ViewBuilder
+    private func agentLabel(name: String, kind: String) -> some View {
+        if name.hasPrefix("chat:") {
+            // Drop the `chat:` prefix to render the chat id cleanly with the
+            // chat icon. The full `chat:<id>` is preserved in the tooltip.
+            let chatID = String(name.dropFirst("chat:".count))
+            Label(chatID, systemImage: "bubble.left.and.bubble.right")
+                .help(name)
+                .foregroundStyle(.secondary)
+        } else if name.hasPrefix("agent:") {
+            Label(name, systemImage: "cpu")
+                .help("\(kind) agent")
+                .foregroundStyle(.secondary)
+        } else if name == "user" {
+            Label(name, systemImage: "person")
+                .foregroundStyle(.secondary)
+        } else if name == "legacy-import" {
+            Label("Imported (legacy)", systemImage: "tray.and.arrow.down")
+                .foregroundStyle(.secondary)
+        } else {
+            Text(name)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 

--- a/Sources/WikiFSCore/Core/PageOrigin.swift
+++ b/Sources/WikiFSCore/Core/PageOrigin.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// The read-side projection of a page's origin provenance — the inverse of the
+/// write-path that stamps an `agents` + `activities` + `page_versions` triple
+/// on every save (the PROV-DM graph reuse, ``GRDBWikiStore``).
+///
+/// ``pageOrigin(pageID:)`` returns the active (HEAD) row; ``pageEditHistory
+/// (pageID:)`` walks the whole `page_versions` chain for the page, oldest-first.
+/// Mirrors ``SourceOrigin`` for sources (Phase 3a): the same
+/// `refs → *_versions → activities → agents` join, decoded into a
+/// pure-data struct that NULL-degrades gracefully (no row, no activity, or no
+/// agent each fall through to nil/empty without throwing).
+///
+/// `agentKind` is exposed alongside `agentName` so the UI can render
+/// `chat:<id>` / `agent:<kind>` / `human` / `model` distinctly (the writer
+/// stamps it via ``GRDBWikiStore/authorKind(_:)`` — the structured upgrade of
+/// the #131 flat `created_by`/`last_edited_by` strings). Pre-v39 rows and
+/// unknown authors degrade to `"software"` (the legacy-import agent).
+public struct PageOrigin: Sendable, Equatable {
+    /// The page-version row id (the ULID of the `page_versions` row).
+    public let versionID: String
+    /// The version's title snapshotted at save time.
+    public let title: String
+    /// SHA-256 hex of the version's body blob (the CAS key). Useful for
+    /// detecting no-op rewrites and tying history entries to blob rows.
+    public let blobHash: String?
+    /// The agent's display name — `chat:<chatID>` / `agent:<kind>` / `user` /
+    /// a model id — i.e. exactly the value `last_edited_by` carries (and that
+    /// the writer threads into `ensureAgent`). Degrades to `"unknown"` when
+    /// the activity has no agent (NULL FK).
+    public let agentName: String
+    /// The agent's structured kind (`chat` / `agent` / `human` / `model` /
+    /// `software`). Degrades to `"software"` for the legacy-import shared
+    /// agent so the UI can label pre-v39 rows distinctly.
+    public let agentKind: String
+    /// The activity's kind: `'import'` (page create) or `'edit'` (page update).
+    /// Degrades to `"import"` when NULL.
+    public let activityKind: String
+    /// Optional activity `plan` (executor phase / run label). Not yet
+    /// populated by the write path (Phase 2 will thread a `WIKI_RUN_REF`).
+    public let plan: String?
+    /// Optional activity `external_ref` (run dir or chatID). Not yet
+    /// populated by the write path (Phase 2).
+    public let externalRef: String?
+    /// When the save committed (the activity's `started_at`/`ended_at`,
+    /// which match `page_versions.saved_at`).
+    public let savedAt: Date
+
+    public init(
+        versionID: String,
+        title: String,
+        blobHash: String?,
+        agentName: String,
+        agentKind: String,
+        activityKind: String,
+        plan: String?,
+        externalRef: String?,
+        savedAt: Date
+    ) {
+        self.versionID = versionID
+        self.title = title
+        self.blobHash = blobHash
+        self.agentName = agentName
+        self.agentKind = agentKind
+        self.activityKind = activityKind
+        self.plan = plan
+        self.externalRef = externalRef
+        self.savedAt = savedAt
+    }
+}

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -58,7 +58,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// databases produced by that store carry `PRAGMA user_version` up to 37, and
     /// this store must recognize them as already-current so the ladder is a no-op
     /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 38
+    private static let currentSchemaVersion = 39
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -409,7 +409,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     ///   for a store that's already migrated) is a no-op; genuine upgrades run
     ///   only the steps they owe.
     ///
-    /// Both paths end at `user_version = currentSchemaVersion` (37), so the
+    /// Both paths end at `user_version = currentSchemaVersion` (39), so the
     /// File Provider's read-only handle to the same WAL file never sees a
     /// half-migrated schema.
     ///
@@ -1141,6 +1141,47 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         // `DROP TRIGGER IF EXISTS` so a fresh-DB forced through the ladder (which
         // never created them at v13/v28) is a no-op. Mirrors the SQLiteWikiStore
         // ladder's v37→v38 step.
+        if version < 38 {
+            try Self.dropFTS5TablesAndTriggers(in: db)
+            try db.execute(sql: "PRAGMA user_version = 38;")
+            version = 38
+        }
+
+        // Step 38 → 39 (page provenance — #page-provenance): forward-only
+        // bump. The write-path change (route `updatePage` CAS-off through
+        // `appendPageVersionLocked`, swap `legacyImportAgentID → ensureAgent`)
+        // is what guarantees correctness for NEW saves; this step is the
+        // explicit `user_version` bump so existing v38 DBs re-open as v39 and
+        // a fresh DB lands at v39. NO backfill — pre-v39 page activities stay
+        // on the shared `legacy-import` agent (degraded, same as today); the
+        // `pageOrigin(pageID:)` read accessor degrades `agentName` to
+        // `"unknown"` and `agentKind` to `"software"` for those rows. A
+        // future, guarded, irreversible backfill can repoint historical
+        // `activity.agent_id` from `last_edited_by` behind a `wiki_metadata`
+        // flag (#page-provenance §5.2 — Phase C, deferred).
+        //
+        // ⚠ LOAD-BEARING ordering: this step MUST precede the catch-all
+        // fallback immediately below. The fallback's guard is keyed on
+        // `currentSchemaVersion` (39 now), so once this constant is bumped it
+        // short-circuits: it re-runs `dropFTS5TablesAndTriggers` (harmless —
+        // `DROP … IF EXISTS`) and stamps `user_version = 39`, executing NONE
+        // of any new step above it. Any new v39 migration work belongs INSIDE
+        // this block (before the fallback), not as a sibling after it.
+        if version < 39 {
+            try db.execute(sql: "PRAGMA user_version = 39;")
+            version = 39
+        }
+
+        // Catch-all fallback: any DB older than `currentSchemaVersion` whose
+        // per-step work has not been added above (the steady-state guard for a
+        // genuine currentSchemaVersion bump). Drops FTS5 + stamps
+        // `user_version` so the read-only File Provider handle never sees a
+        // half-migrated schema. Idempotent (`DROP … IF EXISTS`). Mirrors the
+        // historical SQLiteWikiStore ladder terminator. The version-specific
+        // step above is the one that runs on a real upgrade; this only fires
+        // if a future contributor bumps `currentSchemaVersion` without adding
+        // an explicit step (defensive — emits a loud reminder in the form of
+        // a redundant `PRAGMA user_version = N`).
         if version < Self.currentSchemaVersion {
             try Self.dropFTS5TablesAndTriggers(in: db)
             try db.execute(sql: "PRAGMA user_version = \(Self.currentSchemaVersion);")
@@ -2123,9 +2164,9 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         return nil
     }
 
-    /// Build the complete current schema (v37 end-state) on a fresh `Database`.
+    /// Build the complete current schema (v39 end-state) on a fresh `Database`.
     /// Mirrors `SQLiteWikiStore.createFreshSchemaV20()` + the additive tables
-    /// from v23–v37. All DDL is `IF NOT EXISTS`-guarded so re-running on an
+    /// from v23–v39. All DDL is `IF NOT EXISTS`-guarded so re-running on an
     /// already-current DB is a no-op (idempotent for GRDB's migrator).
     private static func createFreshSchema(on db: Database) throws {
         let now = Date().timeIntervalSince1970
@@ -2515,7 +2556,12 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     }
 
     /// Get-or-create the `legacy-import` agent row, returning its id.
-    /// Mirrors `SQLiteWikiStore.legacyImportAgentID`.
+    /// Mirrors `SQLiteWikiStore.legacyImportAgentID`. Used as the fallback
+    /// when a page mutation has no author identity (nil/empty `created_by` /
+    /// `last_edited_by` — pre-v39 rows, legacy callers). Page-PROV (#page-
+    /// provenance) routes authored saves through `ensureAgent(name:kind:)`
+    /// so the activity carries the REAL `chat:<id>` / `agent:<kind>` /
+    /// `user` / model-id identity; this stays as the degraded path.
     private func legacyImportAgentID(on db: Database) throws -> String {
         if let id = try String.fetchOne(
             db,
@@ -2528,6 +2574,43 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         INSERT INTO agents (id, kind, name) VALUES (?, 'software', 'legacy-import');
         """, arguments: [id])
         return id
+    }
+
+    /// Map a provenance author string (#131 / #397) to an `agents.kind`
+    /// value, mirroring the writer shapes documented in
+    /// `plans/wikictl-author-provenance.md`. The write seam threads the SAME
+    /// `chat:<id>` / `agent:<kind>` / `user` / model-id string that
+    /// `created_by`/`last_edited_by` carry into `ensureAgent(name:kind:)`,
+    /// so page activities point at REAL named agents (not the shared
+    /// `legacy-import`). `nil`/empty falls back to `"software"` (the
+    /// `legacyImportAgentID` path degrades the same as today — no data loss).
+    ///
+    /// `chat:<id>` and `agent:<kind>` are ULID-suffixed by construction
+    /// (`AgentLauncher.startInteractiveQuery` / `WIKI_AUTHOR` env), so they
+    /// cannot collide with a stray page titled `chat:…` on `ensureAgent`'s
+    /// `(name, kind)` dedup.
+    private func authorKind(_ author: String?) -> String {
+        guard let author, !author.isEmpty else { return "software" }
+        if author.hasPrefix("chat:")  { return "chat" }
+        if author.hasPrefix("agent:") { return "agent" }
+        if author == "user"           { return "human" }
+        return "model"
+    }
+
+    /// Resolve the agent for a page mutation's activity: if `author` carries a
+    /// `chat:`/`agent:`/`user`/model-id identity, dedup a REAL named agent on
+    /// `(name, kind)` via `ensureAgent`; otherwise degrade to the shared
+    /// `legacy-import` (pre-v39 behaviour). `db:`-taking so it composes inside
+    /// `mutate(event:_:)` bodies (the page-provenance write seam — see
+    /// `appendPageVersionLocked` + `createPage`).
+    private func ensurePageAuthorAgent(
+        _ author: String?, on db: Database
+    ) throws -> String {
+        guard let author, !author.isEmpty else {
+            return try legacyImportAgentID(on: db)
+        }
+        return try ensureAgent(
+            name: author, kind: authorKind(author), on: db)
     }
 
     // MARK: - changeToken (File Provider sync anchor)
@@ -2786,12 +2869,17 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             INSERT OR IGNORE INTO blobs (hash, byte_size, content) VALUES (?, ?, ?);
             """, arguments: [hash, Int64(0), bodyData])
 
-            let legacyAgentID = try self.legacyImportAgentID(on: db)
+            // Page provenance (#page-provenance): route the root activity's
+            // agent through `ensureAgent(name:kind:)` so a chat / agent / user
+            // author identity lands as a REAL named agent row (not the shared
+            // `legacy-import`). Degrades to the shared legacy agent when
+            // `createdBy` is nil/empty (pre-v39 behaviour, no data loss).
+            let agentID = try self.ensurePageAuthorAgent(createdBy, on: db)
             let activityID = ULID.generate()
             try db.execute(sql: """
             INSERT INTO activities (id, kind, agent_id, started_at, ended_at)
             VALUES (?, 'import', ?, ?, ?);
-            """, arguments: [activityID, legacyAgentID, nowTS, nowTS])
+            """, arguments: [activityID, agentID, nowTS, nowTS])
 
             let versionID = ULID.generate()
             try db.execute(sql: """
@@ -2823,20 +2911,63 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         try mutate(event: { _ in
             self.localEvent(.page, id: id.rawValue, change: .updated)
         }) { db in
+            // Existence check — match the pre-refactor contract that threw
+            // `.notFound` when the id is gone (the legacy `guard
+            // db.changesCount > 0` ran AFTER the UPDATE; this runs FIRST
+            // because the refactored body INSERTs into `page_versions` —
+            // whose FK on pages(id) would otherwise throw a raw SQLite
+            // `FOREIGN KEY constraint failed` instead of the user-friendly
+            // `.notFound`). The savepoint rolls back; `mutate` discards the
+            // buffered event (no emit on failure) — see
+            // `StoreEmissionReentrancyTests.throwingMutationEmitsNothing`.
+            let exists = try Int.fetchOne(
+                db,
+                sql: "SELECT 1 FROM pages WHERE id = ?;",
+                arguments: [id.rawValue]
+            ) ?? 0
+            guard exists == 1 else { throw WikiStoreError.notFound(id) }
+
             let title = WikiNameRules.sanitized(title)
             let slug = try self.uniqueSlug(from: title, id: id, on: db)
-            try db.execute(sql: """
-            UPDATE pages
-            SET title = ?, slug = ?, body_markdown = ?,
-                updated_at = ?, version = version + 1, last_edited_by = ?
-            WHERE id = ?;
-            """, arguments: [title, slug, body,
-                            Date().timeIntervalSince1970, lastEditedBy,
-                            id.rawValue])
-            // Match SQLiteWikiStore: a 0-row UPDATE means the id is gone, so
-            // throw .notFound inside `mutate`'s body. The savepoint rolls back
-            // and `mutate` discards the buffered event (no emit on failure).
-            guard db.changesCount > 0 else { throw WikiStoreError.notFound(id) }
+            let bodyData = Data(body.utf8)
+            let hash = SHA256.hash(data: bodyData)
+                .map { String(format: "%02x", $0) }.joined()
+            let now = Date()
+            let nowTS = now.timeIntervalSince1970
+
+            // Page provenance (#page-provenance): the CAS-off path (no
+            // `expectedHeadVersionID`, the `wikictl` default — see
+            // `PageUpsert.writePage`) now appends a `page_versions` +
+            // `activities` row just like the CAS path, closing the "records
+            // nothing" hole (pre-v39, only the flat `last_edited_by` string
+            // survived). Routes through `appendPageVersionLocked` — NOT public
+            // `appendPageVersion` — because (a) `mutate`'s doc warns
+            // `dbWriter.write` is NOT reentrant (a public mutator that
+            // re-calls `mutate` deadlocks), and (b) `appendPageVersion` is
+            // itself a `mutate` wrapper that emits `.page .updated`, so a
+            // naive delegation would double-emit (the HIGH hazard in §5.3).
+            // This method's own `mutate` wrapper is the single emit site; the
+            // shared helper emits nothing.
+            //
+            // The amend-coalescing check (`tryAmendPageVersion`) at line ~6461
+            // IS run on this path too — a rapid same-author save within the
+            // 5s window amend-coalesces into the head instead of appending a
+            // new row (autosave semantics). The plan's AC.3 row-count test
+            // accounts for this by using a DISTINCT author from the create so
+            // the amend short-circuit does not suppress the new version row.
+            let head = try Self.pageHeadVersionIDLocked(pageID: id, on: db)
+            if let amendVersionID = try self.tryAmendPageVersion(
+                db: db, pageID: id, head: head, title: title, slug: slug,
+                body: body, bodyData: bodyData, hash: hash,
+                lastEditedBy: lastEditedBy, now: now, nowTS: nowTS)
+            {
+                _ = amendVersionID   // amend already touched the mirror.
+                return
+            }
+            _ = try self.appendPageVersionLocked(
+                db: db, pageID: id, head: head, title: title, slug: slug,
+                body: body, bodyData: bodyData, hash: hash,
+                lastEditedBy: lastEditedBy, now: now, nowTS: nowTS)
         }
     }
 
@@ -4087,47 +4218,120 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 return amendVersionID
             }
 
-            // 2. Blob (identical body = one row, ever).
-            try db.execute(sql: """
-            INSERT OR IGNORE INTO blobs (hash, byte_size, content) VALUES (?, ?, ?);
-            """, arguments: [hash, Int64(bodyData.count), bodyData])
-
-            // 3. Legacy-import agent + activity.
-            let agentID = try self.legacyImportAgentID(on: db)
-            let activityID = ULID.generate()
-            try db.execute(sql: """
-            INSERT INTO activities (id, kind, agent_id, started_at, ended_at)
-            VALUES (?, 'edit', ?, ?, ?);
-            """, arguments: [activityID, agentID, nowTS, nowTS])
-
-            // 4. New version (parent = current head).
-            let versionID = ULID.generate()
-            try db.execute(sql: """
-            INSERT INTO page_versions (id, page_id, parent_id, merge_parent_id, blob_hash, title, activity_id, saved_at)
-            VALUES (?, ?, ?, NULL, ?, ?, ?, ?);
-            """, arguments: [versionID, pageID.rawValue, head, hash, title, activityID, nowTS])
-
-            // 5. Update the denormalized pages mirror.
-            try db.execute(sql: """
-            UPDATE pages
-            SET title = ?, slug = ?, body_markdown = ?,
-                updated_at = ?, version = version + 1, last_edited_by = ?
-            WHERE id = ?;
-            """, arguments: [title, slug, body, nowTS, lastEditedBy, pageID.rawValue])
-            guard db.changesCount > 0 else { throw WikiStoreError.notFound(pageID) }
-
-            // 6. Write the page-content ref.
-            try db.execute(sql: """
-            INSERT INTO refs (kind, owner_id, version_id, generation, updated_at)
-            VALUES ('page-content', ?, ?, 1, ?)
-            ON CONFLICT(kind, owner_id) DO UPDATE SET
-                version_id = excluded.version_id,
-                generation = generation + 1,
-                updated_at = excluded.updated_at;
-            """, arguments: [pageID.rawValue, versionID, nowTS])
-
-            return versionID
+            // 2–6. Append the new version row (blob + activity + version +
+            //      mirror + ref). Extracted to `appendPageVersionLocked` so
+            //      `updatePage` (CAS-off) can share the same write seam
+            //      WITHOUT re-entering `mutate(event:)` (the HIGH hazard
+            //      called out in `plans/page-provenance.md` §5.3 — public
+            //      mutators that compose must pass the `Database` to internal
+            //      helpers, not re-call `mutate`). This helper does NOT emit;
+            //      this method's `mutate` wrapper is the single emit site.
+            return try self.appendPageVersionLocked(
+                db: db, pageID: pageID, head: head, title: title, slug: slug,
+                body: body, bodyData: bodyData, hash: hash,
+                lastEditedBy: lastEditedBy, now: now, nowTS: nowTS)
         }
+    }
+
+    /// Shared version-append logic for `appendPageVersion` (CAS path) and
+    /// `updatePage` (CAS-off path). Performs the six-step write:
+    /// (1) skip the no-op case when the new body's hash matches the head blob
+    ///     (avoids bloat from `wikictl` re-writes that touched nothing), but
+    ///     ONLY when both titles also match — a pure title rename still
+    ///     appends (the mirror needs the new slug);
+    /// (2) `INSERT OR IGNORE` the new blob (CAS — identical bodies dedup);
+    /// (3) get-or-create the activity's `agents` row via `ensurePageAuthorAgent`
+    ///     so the author chain points at the REAL `chat:<id>` / `agent:<kind>`
+    ///     / `user` / model-id (the structured #page-provenance upgrade —
+    ///     previously the shared `legacy-import` agent for every page edit);
+    /// (4) insert an `activities` row of kind `'edit'`;
+    /// (5) insert a `page_versions` row (parent = `head`);
+    /// (6) update the `pages` denormalized mirror + UPSERT the `page-content`
+    ///     ref's `version_id` (bumping `generation`).
+    ///
+    /// NOT a `mutate(event:)` wrapper — does NOT emit. Each public caller
+    /// (`appendPageVersion`, `updatePage`) wraps its own `mutate` body around
+    /// this and emits `.page .updated` ONCE there (the Approach-A composition
+    /// pattern — `mutate`'s doc at the top of this file warns `dbWriter.write`
+    /// is NOT reentrant; a public mutator that re-calls `mutate` deadlocks).
+    /// `updatePage` MUST NOT call public `appendPageVersion` (would double-emit
+    /// AND re-enter); both call THIS instead.
+    private func appendPageVersionLocked(
+        db: Database, pageID: PageID, head: String?,
+        title: String, slug: String,
+        body: String, bodyData: Data, hash: String,
+        lastEditedBy: String?, now: Date, nowTS: Double
+    ) throws -> String {
+        // No-op guard: identical body AND title = no real change. Skip the
+        // version-append and the `pages` UPDATE (the ref's generation is
+        // unchanged too). The mirror already reflects the head. `wikictl`'s
+        // idempotent re-writes are the common case here — saves a row + a
+        // `pages` UPDATE per no-op save. Returns the existing head's id so the
+        // public caller's return value stays consistent with "the active
+        // version after this save".
+        if let head,
+           let headRow = try Row.fetchOne(db, sql: """
+                SELECT pv.blob_hash, pv.title
+                FROM page_versions pv WHERE pv.id = ?;
+                """, arguments: [head])
+        {
+            let headHash: String? = headRow["blob_hash"]
+            let headTitle: String? = headRow["title"]
+            if headHash == hash && headTitle == title {
+                // Still bump the mirror's `updated_at` so callers observing
+                // `updated_at` see refreshed activity without polluting the
+                // version chain (a `wikictl` re-write is a real "save attempt"
+                // — just a content-no-op). No `version` bump.
+                try db.execute(sql: """
+                UPDATE pages SET updated_at = ?, last_edited_by = ? WHERE id = ?;
+                """, arguments: [nowTS, lastEditedBy, pageID.rawValue])
+                return head
+            }
+        }
+
+        // 2. Blob (identical body = one row, ever).
+        try db.execute(sql: """
+        INSERT OR IGNORE INTO blobs (hash, byte_size, content) VALUES (?, ?, ?);
+        """, arguments: [hash, Int64(bodyData.count), bodyData])
+
+        // 3. Real named agent (page provenance #page-provenance) + an
+        //    'edit' activity. Degrades to legacy-import for nil/empty authors.
+        let agentID = try self.ensurePageAuthorAgent(lastEditedBy, on: db)
+        let activityID = ULID.generate()
+        try db.execute(sql: """
+        INSERT INTO activities (id, kind, agent_id, started_at, ended_at)
+        VALUES (?, 'edit', ?, ?, ?);
+        """, arguments: [activityID, agentID, nowTS, nowTS])
+
+        // 4. New version (parent = current head, or NULL for a brand-new page
+        //    with no prior versions — `head == nil` should not happen after v34
+        //    migration but is defensive).
+        let versionID = ULID.generate()
+        try db.execute(sql: """
+        INSERT INTO page_versions (id, page_id, parent_id, merge_parent_id, blob_hash, title, activity_id, saved_at)
+        VALUES (?, ?, ?, NULL, ?, ?, ?, ?);
+        """, arguments: [versionID, pageID.rawValue, head, hash, title, activityID, nowTS])
+
+        // 5. Update the denormalized pages mirror.
+        try db.execute(sql: """
+        UPDATE pages
+        SET title = ?, slug = ?, body_markdown = ?,
+            updated_at = ?, version = version + 1, last_edited_by = ?
+        WHERE id = ?;
+        """, arguments: [title, slug, body, nowTS, lastEditedBy, pageID.rawValue])
+        guard db.changesCount > 0 else { throw WikiStoreError.notFound(pageID) }
+
+        // 6. Write the page-content ref.
+        try db.execute(sql: """
+        INSERT INTO refs (kind, owner_id, version_id, generation, updated_at)
+        VALUES ('page-content', ?, ?, 1, ?)
+        ON CONFLICT(kind, owner_id) DO UPDATE SET
+            version_id = excluded.version_id,
+            generation = generation + 1,
+            updated_at = excluded.updated_at;
+        """, arguments: [pageID.rawValue, versionID, nowTS])
+
+        return versionID
     }
 
 
@@ -4170,6 +4374,125 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 )
             }
         }
+    }
+
+    /// The origin provenance of a page's active (HEAD) version: joins
+    /// `refs → page_versions → activities → agents` (the read mirror of the
+    /// page-PROV graph substrate sources already use). Falls back to the
+    /// default-active rule (`MAX(id)` version) when no `page-content` ref
+    /// exists (should not happen after v34 migration, but defensive). Returns
+    /// `nil` when the page has no version rows (unknown id).
+    ///
+    /// NULL activity/agent columns degrade gracefully:
+    /// - no activity → `activityKind` falls back to `"import"`, `plan`/`externalRef` to `nil`;
+    /// - no agent → `agentName` falls back to `"unknown"`, `agentKind` to `"software"`
+    ///   (the kind of the shared `legacy-import` agent that pre-v39 rows point at).
+    ///
+    /// Read-only: routes through `dbWriter.read` so this is safe off-main via
+    /// `WikiReadPool` (a pooled store is `GRDBWikiStore(readOnlyURL:)`, no
+    /// migrations). READ-ONLY → emits no `ResourceChangeEvent`.
+    public func pageOrigin(pageID: PageID) throws -> PageOrigin? {
+        try dbWriter.read { db in
+            let cols = """
+            pv.id, pv.title, pv.blob_hash,
+            a.name, a.kind,
+            act.kind, act.plan, act.external_ref,
+            pv.saved_at
+            """
+            // 1. Prefer the active ref (matches pageHeadVersionIDLocked).
+            if let row = try Row.fetchOne(
+                db,
+                sql: """
+                SELECT \(cols)
+                FROM refs r
+                JOIN page_versions pv ON pv.id = r.version_id
+                LEFT JOIN activities act ON act.id = pv.activity_id
+                LEFT JOIN agents a ON a.id = act.agent_id
+                WHERE r.kind = 'page-content' AND r.owner_id = ?;
+                """,
+                arguments: [pageID.rawValue]
+            ) {
+                return Self.pageOriginFrom(row: row)
+            }
+            // 2. Fall back to the default-active rule: MAX(id) version.
+            guard let row = try Row.fetchOne(
+                db,
+                sql: """
+                SELECT \(cols)
+                FROM page_versions pv
+                LEFT JOIN activities act ON act.id = pv.activity_id
+                LEFT JOIN agents a ON a.id = act.agent_id
+                WHERE pv.page_id = ? ORDER BY pv.id DESC LIMIT 1;
+                """,
+                arguments: [pageID.rawValue]
+            ) else { return nil }
+            return Self.pageOriginFrom(row: row)
+        }
+    }
+
+    /// The full edit history for a page — every `page_versions` row joined to
+    /// its `activities` → `agents` (extends `pageVersionHistory` with the
+    /// PROV join). Ordered OLDEST-FIRST (matches `pageVersionHistory` so
+    /// `entry.last` is the HEAD). An empty page (`createPage`'s empty root)
+    /// is included as one entry (kind 'import'); a fresh-then-edited page
+    /// therefore returns exactly 2 entries (the empty root + the first real
+    /// edit) — unless the same author edited within the 5s amend-coalescing
+    /// window, in which case the second save amends the root in place and no
+    /// new version row is appended (autosave semantics — see
+    /// `tryAmendPageVersion`). Read-only: emits nothing.
+    public func pageEditHistory(pageID: PageID) throws -> [PageOrigin] {
+        try dbWriter.read { db in
+            let cols = """
+            pv.id, pv.title, pv.blob_hash,
+            a.name, a.kind,
+            act.kind, act.plan, act.external_ref,
+            pv.saved_at
+            """
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                SELECT \(cols)
+                FROM page_versions pv
+                LEFT JOIN activities act ON act.id = pv.activity_id
+                LEFT JOIN agents a ON a.id = act.agent_id
+                WHERE pv.page_id = ?
+                ORDER BY pv.id ASC;
+                """,
+                arguments: [pageID.rawValue]
+            )
+            return rows.map { Self.pageOriginFrom(row: $0) }
+        }
+    }
+
+    /// Decode a `PageOrigin` from a joined row. NULL activity/agent columns
+    /// degrade gracefully (matches `originFrom(row:)` for sources).
+    private static func pageOriginFrom(row: Row) -> PageOrigin {
+        // Position 0..8 mirrors the SELECT column order in `pageOrigin`/
+        // `pageEditHistory`. `pv.id`/`pv.title`/`pv.blob_hash`/`pv.saved_at`
+        // are NOT NULL per the `page_versions` schema; the LEFT-joined
+        // `agents` + `activities` columns can be NULL (a pre-v39 page whose
+        // activity's agent was deleted, or a root version whose activity_id is
+        // somehow null). `String?` decodes both cases; `?? default` degrades.
+        let versionID: String = (row[0] as String?) ?? ""
+        let title: String = (row[1] as String?) ?? ""
+        let blobHash: String? = row[2]
+        let agentName: String? = row[3]
+        let agentKind: String? = row[4]
+        let activityKind: String? = row[5]
+        let plan: String? = row[6]
+        let externalRef: String? = row[7]
+        let savedAt: Double = (row[8] as Double?) ?? 0
+        return PageOrigin(
+            versionID: versionID,
+            title: title,
+            blobHash: blobHash,
+            agentName: agentName ?? "unknown",
+            agentKind: agentKind ?? "software",
+            activityKind: activityKind ?? "import",
+            plan: plan,
+            externalRef: externalRef,
+            savedAt: Date(timeIntervalSince1970: savedAt)
+        )
     }
 
 

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -398,6 +398,31 @@ public protocol WikiStore: Sendable {
     /// The full version chain for a page, ordered by ULID (chain order).
     func pageVersionHistory(pageID: PageID) throws -> [PageVersionSummary]
 
+    /// The origin provenance of a page's active (HEAD) version: joins
+    /// `refs → page_versions → activities → agents` (the PROV-DM read
+    /// mirror of `sourceOrigin(sourceID:)`). Returns `nil` when the page has
+    /// no version rows (unknown id). `agentName` is `chat:<id>` /
+    /// `agent:<kind>` / `user` / a model id (the structured upgrade of the
+    /// #131 flat `last_edited_by` string); `agentKind` is its PROV kind
+    /// (chat / agent / human / model / software). Pre-v39 rows and unknown
+    /// authors degrade to the shared `"legacy-import"` agent (no crash). On
+    /// the protocol (not only the concrete read helper) so callers — notably
+    /// `PageDetailView` and `wikictl page info` — can route through it via
+    /// `any WikiStore`. No default implementation (mirrors `sourceOrigin`):
+    /// `GRDBWikiStore` is the sole conformer; a future mock/test double must
+    /// stub `nil`.
+    func pageOrigin(pageID: PageID) throws -> PageOrigin?
+
+    /// The full edit history for a page — every `page_versions` row joined to
+    /// its `activities` → `agents` (extending `pageVersionHistory` with the
+    /// agent/activity join). Ordered OLDEST-FIRST (matches `pageVersionHistory`
+    /// so `entry.last` is the HEAD). An empty page (`createPage`'s empty root)
+    /// is included as one entry (kind 'import'); a fresh-then-edited page
+    /// therefore returns exactly 2 entries (the empty root + the first real
+    /// edit). NULL activity/agent columns degrade gracefully. New protocol
+    /// requirement (no default — mirrors `pageOrigin`/`sourceOrigin`).
+    func pageEditHistory(pageID: PageID) throws -> [PageOrigin]
+
     /// Revert a page to a specific version: repoint the `page-content` ref to
     /// `versionID` and update the denormalized `pages.body_markdown` from the
     /// version's blob. Emits a `.page .updated` change event.

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2711,6 +2711,26 @@ public final class WikiStoreModel {
         try? store.sourceOrigin(sourceID: id)
     }
 
+    /// The origin provenance of a page's HEAD — the agent + activity that last
+    /// created/edited it (page provenance, #page-provenance). `nil` when the
+    /// read fails (unknown id, no version rows). Drives the "Provenance" row
+    /// in `PageDetailView`. Off-main-safe when the read pool is configured
+    /// (the call routes through `WikiStore.pageOrigin`'s `dbWriter.read`); on
+    /// the main actor for the simple in-memory case. Threads via the public
+    /// `WikiStore` protocol so the model's `store: WikiStore` indirection
+    /// doesn't need a downcast.
+    public func pageOrigin(for id: PageID) -> PageOrigin? {
+        try? store.pageOrigin(pageID: id)
+    }
+
+    /// The full edit history for a page — every `page_versions` row joined to
+    /// its activity + agent, oldest-first. `nil`/empty when the read fails or
+    /// the page has no versions. Drives the expandable "Edit history" list in
+    /// `PageDetailView`.
+    public func pageEditHistory(for id: PageID) -> [PageOrigin] {
+        (try? store.pageEditHistory(pageID: id)) ?? []
+    }
+
     /// `true` iff `refreshSource(_:)` would actually succeed for this source —
     /// the single source of truth the detail view gates the Refresh button on.
     /// Mirrors `SourceRefreshService.materialize` + the `performRefresh` snapshot

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -375,4 +375,207 @@ struct PageVersionTests {
         let history = try store.pageVersionHistory(pageID: page.id)
         #expect(history.count == 3, "two appends + root")
     }
+
+    // MARK: - Page provenance (#page-provenance): AC.1, AC.2, AC.3, AC.4
+
+    /// AC.1 — after a "chat" creates a page (the simulation of an ingestion
+    /// executor creating a page via `wikictl page upsert --author chat:<id>`),
+    /// `pageOrigin(pageID:)` returns a non-nil `PageOrigin` whose `agentName`
+    /// is `chat:<id>`, `agentKind` is `"chat"`, `activityKind` is `"import"`,
+    /// and `savedAt` is approximately now. The agent row was deduped via
+    /// `ensureAgent(name:kind:)` — NOT the shared `legacy-import` — so the
+    /// activity's `agent_id` points at the real chat identity.
+    @Test func pageOriginReflectsChatAuthorOnCreate() throws {
+        let store = try tempStore()
+        let chatID = "chat:01JTESTCHAT00000000"
+        let page = try store.createPage(title: "Chat-Created", createdBy: chatID)
+
+        guard let origin = try store.pageOrigin(pageID: page.id) else {
+            Issue.record("pageOrigin returned nil for a freshly created page")
+            return
+        }
+        #expect(origin.agentName == chatID, "agentName should be \(chatID) (got \(origin.agentName))")
+        #expect(origin.agentKind == "chat", "agentKind for chat:<id> is 'chat'")
+        #expect(origin.activityKind == "import", "root activity is 'import'")
+        #expect(origin.title == "Chat-Created")
+        // savedAt is "now" (within 5s — the test runs fast).
+        let drift = abs(origin.savedAt.timeIntervalSinceNow)
+        #expect(drift < 5.0, "savedAt should be ~now (drift \(drift)s)")
+    }
+
+    /// AC.1 (variant) — when the createPage author is `agent:<kind>`
+    /// (e.g. an ingestion executor), `agentKind` is `"agent"` and `agentName`
+    /// is `agent:<kind>`.
+    @Test func pageOriginReflectsAgentKindOnCreate() throws {
+        let store = try tempStore()
+        let agentLabel = "agent:ingest"
+        let page = try store.createPage(title: "Ingest Page", createdBy: agentLabel)
+
+        let origin = try store.pageOrigin(pageID: page.id)
+        #expect(origin?.agentName == agentLabel)
+        #expect(origin?.agentKind == "agent")
+        #expect(origin?.activityKind == "import")
+    }
+
+    /// AC.1 (degraded path) — a `createPage` with no author (nil) falls back
+    /// to the shared `legacy-import` agent. `pageOrigin` reports `agentName
+    /// == "legacy-import"` and `agentKind == "software"`. No crash, no data
+    /// loss. (Pre-v39 rows look the same — they degraded identically.)
+    @Test func pageOriginDegradesToLegacyImportWhenNoAuthor() throws {
+        let store = try tempStore()
+        let page = try store.createPage(title: "No-Author Page", createdBy: nil)
+
+        let origin = try store.pageOrigin(pageID: page.id)
+        #expect(origin?.agentName == "legacy-import")
+        #expect(origin?.agentKind == "software")
+        #expect(origin?.activityKind == "import")
+    }
+
+    /// AC.2 — a freshly-created-then-edited page (with a DISTINCT author on
+    /// the edit so `tryAmendPageVersion` cannot coalesce). `pageEditHistory`
+    /// returns EXACTLY 2 entries (the empty-root `'import'` + the `'edit'`),
+    /// and `entry.last` pins the chat author + edited body — so it cannot
+    /// pass trivially off the create-double-row artifact.
+    @Test func pageEditHistoryCountsCreateAndEdit() throws {
+        let store = try tempStore()
+        // Create with one author (an ingestion agent)…
+        let createAuthor = "agent:ingest"
+        let page = try store.createPage(title: "Edit Chain", createdBy: createAuthor)
+        // …then edit with a DISTINCT author (a chat) so the amend-coalescer
+        // returns nil (different actor) and the version-append actually runs.
+        let editAuthor = "chat:01JTESTCHAT00000001"
+        try store.updatePage(
+            id: page.id, title: "Edit Chain", body: "edited body",
+            lastEditedBy: editAuthor)
+
+        let history = try store.pageEditHistory(pageID: page.id)
+        #expect(history.count == 2, "fresh create+edit yields 2 origin entries (got \(history.count))")
+
+        // entry[0] = root (the create's empty-root 'import' activity).
+        #expect(history[0].activityKind == "import")
+        #expect(history[0].agentName == createAuthor)
+        #expect(history[0].agentKind == "agent")
+
+        // entry[1] = the edit — pinned to the chat author + the edited body.
+        #expect(history[1].activityKind == "edit")
+        #expect(history[1].agentName == editAuthor)
+        #expect(history[1].agentKind == "chat")
+        // The title is the version's stored title (which equals what
+        // updatePage wrote).
+        #expect(history[1].title == "Edit Chain")
+
+        // pageOrigin(pageID:) reflects the HEAD = entry[1] (the chat edit).
+        let head = try store.pageOrigin(pageID: page.id)
+        #expect(head?.agentName == editAuthor)
+        #expect(head?.agentKind == "chat")
+        #expect(head?.activityKind == "edit")
+    }
+
+    /// AC.3 — the CAS-OFF path (`updatePage` with no `expectedHeadVersionID`,
+    /// the `wikictl` default) now appends a `page_versions` + `activities`
+    /// row, closing the pre-v39 "records nothing" hole. Verified by row count
+    /// before/after. Uses DISTINCT authors (per §5.3 LOW note) so the amend
+    /// short-circuit does not suppress the new version row.
+    @Test func updatePageCASOffAppendsVersionAndActivity() throws {
+        let store = try tempStore()
+        let createAuthor = "agent:create"
+        let page = try store.createPage(title: "CAS-Off", createdBy: createAuthor)
+
+        // Before: 1 page_versions row (the empty root), 1 activity (create's
+        // 'import').
+        let versionsBefore = try store.pageVersionHistory(pageID: page.id)
+        #expect(versionsBefore.count == 1)
+        let activitiesBefore = store.scalarText(
+            "SELECT COUNT(*) FROM activities;"
+        )
+        let beforeCount = Int(activitiesBefore) ?? -1
+        #expect(beforeCount == 1, "createPage seeds one 'import' activity")
+
+        // CAS-off update with a DISTINCT author (so amend can't coalesce).
+        try store.updatePage(
+            id: page.id, title: "CAS-Off", body: "first edit",
+            lastEditedBy: "chat:01JTESTCHAT00000002")
+
+        let versionsAfter = try store.pageVersionHistory(pageID: page.id)
+        #expect(versionsAfter.count == 2, "CAS-off update appends a version row (got \(versionsAfter.count))")
+
+        let activitiesAfterRaw = store.scalarText(
+            "SELECT COUNT(*) FROM activities;"
+        )
+        let afterCount = Int(activitiesAfterRaw) ?? -1
+        #expect(afterCount == beforeCount + 1, "CAS-off update adds one activity row")
+    }
+
+    /// AC.4 — page activities' `agent_id` resolves via `ensureAgent` to a REAL
+    /// named agent (not the shared `legacy-import`) when `lastEditedBy` is
+    /// non-null. Verified by querying the activity's agent row directly.
+    @Test func pageEditActivityPointsAtRealNamedAgent() throws {
+        let store = try tempStore()
+        let page = try store.createPage(title: "Real Agent", createdBy: "agent:ingest")
+        try store.updatePage(
+            id: page.id, title: "Real Agent", body: "edited",
+            lastEditedBy: "chat:01JTESTCHAT00000003")
+
+        // The HEAD activity (on the just-appended version) should point at a
+        // real `chat:<id>` agent, NOT the shared `legacy-import`. Verified by
+        // joining the HEAD version's activity to agents.name.
+        guard let head = try store.pageHeadVersionID(pageID: page.id) else {
+            Issue.record("expected a HEAD version after the update")
+            return
+        }
+        let agentName = store.scalarText("""
+        SELECT a.name FROM page_versions pv
+        JOIN activities act ON act.id = pv.activity_id
+        JOIN agents a ON a.id = act.agent_id
+        WHERE pv.id = '\(head)';
+        """)
+        #expect(agentName == "chat:01JTESTCHAT00000003",
+                "HEAD activity agent should be the chat (got \(agentName))")
+
+        let agentKind = store.scalarText("""
+        SELECT a.kind FROM page_versions pv
+        JOIN activities act ON act.id = pv.activity_id
+        JOIN agents a ON a.id = act.agent_id
+        WHERE pv.id = '\(head)';
+        """)
+        #expect(agentKind == "chat", "HEAD activity agent kind is 'chat'")
+    }
+
+    /// AC.4 (degraded) — when `lastEditedBy` is nil/empty, the activity's
+    /// `agent_id` falls back to the legacy-import shared agent. No crash, no
+    /// data loss.
+    @Test func pageEditNilAuthorDegradesToLegacyImport() throws {
+        let store = try tempStore()
+        // Create with a chat author so the root activity has a real agent.
+        let page = try store.createPage(title: "Degrade", createdBy: "chat:01JDEGRADE000000001")
+        // UpdatePage with lastEditedBy=nil — the append (CAS-off, no
+        // amend-can-fire because pages.last_edited_by="chat:…" ≠ nil) lands a
+        // new activity pointing at legacy-import.
+        try store.updatePage(
+            id: page.id, title: "Degrade", body: "v2", lastEditedBy: nil)
+
+        guard let head = try store.pageHeadVersionID(pageID: page.id) else {
+            Issue.record("expected a HEAD version")
+            return
+        }
+        let agentName = store.scalarText("""
+        SELECT a.name FROM page_versions pv
+        JOIN activities act ON act.id = pv.activity_id
+        JOIN agents a ON a.id = act.agent_id
+        WHERE pv.id = '\(head)';
+        """)
+        #expect(agentName == "legacy-import",
+                "nil author degrades to legacy-import (got \(agentName))")
+    }
+
+    /// AC.8 (migration ladder sanity) — a v38 DB reopened at v39 must report
+    /// `user_version = 39`. The migration step is a no-op `PRAGMA user_version
+    /// = 39` (no schema change; the write-path change is the real fix).
+    @Test func v39SchemaVersionAfterMigration() throws {
+        #expect(GRDBWikiStore.schemaVersion == 39,
+                "schemaVersion must report 39 after the page-provenance bump")
+        let store = try tempStore()
+        let v = store.pragmaValue("user_version")
+        #expect(v == "39", "fresh DB stamps user_version = 39 (got \(v))")
+    }
 }

--- a/Tests/WikiFSTests/StoreEmissionReentrancyTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionReentrancyTests.swift
@@ -60,6 +60,34 @@ struct StoreEmissionReentrancyTests {
         #expect(rec.snapshot.last?.change == .deleted)
     }
 
+    /// AC.7 — `updatePage` now composes the version-append logic via
+    /// `appendPageVersionLocked` (an internal `db:`-taking helper, NOT a
+    /// `mutate` wrapper).
+    /// The HIGH hazard called out in `plans/page-provenance.md` §5.3 is
+    /// double-emit + re-entrant `mutate` deadlock when a public mutator
+    /// delegates to another public mutator. The structural fix is one emit
+    /// per public wrapper; this test asserts both invariants: exactly one
+    /// event, no deadlock.
+    /// Mirrors `withTransactionMutationEmitsOnceNoDeadlock`'s shape. Uses a
+    /// DISTINCT author (per §5.3 LOW note) so `tryAmendPageVersion` cannot
+    /// short-circuit and `appendPageVersionLocked` actually runs.
+    @Test func updatePageAfterVersioningRefactorEmitsOnceNoDeadlock() async throws {
+        let (store, _, rec) = try makeHarness()
+        let page = try store.createPage(title: "Provenance Composer")
+        // createPage emitted one event; isolate updatePage.
+        try await awaitCount(rec, 1)
+        let beforeUpdate = rec.count
+        try store.updatePage(
+            id: page.id, title: "Provenance Composer (v2)", body: "edited",
+            lastEditedBy: "agent-edit")
+        try await awaitCount(rec, beforeUpdate + 1)
+        // Exactly one new event — no double-emit (the regression AC.6 also
+        // asserts, but this test enforces the structural reentrance property).
+        #expect(rec.count == beforeUpdate + 1)
+        #expect(rec.snapshot.last?.kind == .page)
+        #expect(rec.snapshot.last?.change == .updated)
+    }
+
     /// (b) A subscriber that re-enters the store to READ observes the COMMITTED
     /// value (the event fires post-commit, after the lock is released). This
     /// catches a misplaced/inner flush that would let a reader see uncommitted

--- a/Tests/WikiFSTests/StoreEmissionTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionTests.swift
@@ -80,6 +80,36 @@ struct StoreEmissionTests {
         #expect(events.last?.id == page.id.rawValue)
     }
 
+    /// AC.6 — `updatePage` after the page-provenance refactor composes the
+    /// version-append logic via `appendPageVersionLocked` (a private `db:`-
+    /// taking helper that does NOT emit). This MUST emit EXACTLY one
+    /// `.page .updated` event per call — the refactor's HIGH hazard
+    /// (`plans/page-provenance.md` §5.3) is that delegating to public
+    /// `appendPageVersion` would double-emit AND re-enter `mutate`. The
+    /// structural fix is one emit per public wrapper; this test catches a
+    /// regression by counting events.
+    ///
+    /// Uses a DISTINCT author (`lastEditedBy: "agent-edit"`) from the create
+    /// page (which had `createdBy: nil` → `last_edited_by = nil`) so the
+    /// `tryAmendPageVersion` same-actor coalescer cannot short-circuit and
+    /// `appendPageVersionLocked` actually runs. (Per AC.3 / §5.3 LOW note.)
+    @Test func test_updatePage_after_versioning_refactor_emits_single_page_updated() async throws {
+        let (store, _, rec) = try makeHarness()
+        let page = try store.createPage(title: "Provenance")
+        try await drain(rec)
+        let beforeUpdate = rec.count
+        try store.updatePage(
+            id: page.id, title: "Provenance (edited)", body: "edited body",
+            lastEditedBy: "agent-edit")
+        // Exactly ONE new event for the update — no double-emit, no deadlock.
+        let events = try await awaitEvents(rec, expected: beforeUpdate + 1)
+        let newEvents = Array(events.dropFirst(beforeUpdate))
+        #expect(newEvents.count == 1, "updatePage must emit exactly one event (got \(newEvents.count))")
+        #expect(newEvents.first?.kind == .page)
+        #expect(newEvents.first?.change == .updated)
+        #expect(newEvents.first?.id == page.id.rawValue)
+    }
+
     @Test func deletePageEmitsPageDeleted() async throws {
         let (store, _, rec) = try makeHarness()
         let page = try store.createPage(title: "Hello")

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -281,6 +281,80 @@ struct WikiCtlCommandTests {
         #expect(try store.listPages(sortBy: .lastUpdated).isEmpty)
     }
 
+    // MARK: - page info (page provenance, #page-provenance)
+
+    /// `wikictl page info --title X` round-trip: creates a page with a chat
+    /// author via `add --author`, then `page info` prints the identity +
+    /// origin provenance for the HEAD. Mirrors `source info`'s smoke test.
+    @Test func pageInfoPrintsChatOrigin() throws {
+        let store = try tempStore()
+        let created = try PageCommand.run(
+            .add(id: nil, title: "Provenance Doc", body: .inline("hello"),
+                 author: "chat:01JTESTCHAT00000004"),
+            in: store)
+        let id = PageID(rawValue: created.output)
+        let result = try PageCommand.run(.info(.id(id)), in: store)
+        #expect(!result.didCommit, "page info is a read; must not commit")
+        // Identity header.
+        #expect(result.output.contains("id\t\(id.rawValue)"))
+        #expect(result.output.contains("title\tProvenance Doc"))
+        // HEAD origin = the imported create's activity, agent = chat:<id>.
+        #expect(result.output.contains("# origin (HEAD)"))
+        #expect(result.output.contains("activity\timport"))
+        #expect(result.output.contains("agent\tchat:01JTESTCHAT00000004"))
+        #expect(result.output.contains("agent_kind\tchat"))
+        // Edit history section present (just the root version).
+        #expect(result.output.contains("# edit history (oldest-first)"))
+        #expect(result.output.contains("0\timport\tchat:01JTESTCHAT00000004\tchat\t"))
+    }
+
+    /// `page info --title X` after a chat edit shows the edit activity on the
+    /// HEAD, with the chat agent. Mirrors `pageEditHistoryCountsCreateAndEdit`
+    /// (PageVersionTests) but via the CLI surface.
+    @Test func pageInfoAfterEditShowsEditOrigin() throws {
+        let store = try tempStore()
+        let created = try PageCommand.run(
+            .add(id: nil, title: "Edit Doc", body: .inline("v1"),
+                 author: "agent:ingest"),
+            in: store)
+        let id = PageID(rawValue: created.output)
+        // Chat edit (different author — amend won't fire).
+        _ = try PageCommand.run(
+            .add(id: id, title: "Edit Doc", body: .inline("v2"),
+                 author: "chat:01JTESTCHAT00000005"),
+            in: store)
+        let result = try PageCommand.run(.info(.title("Edit Doc")), in: store)
+        #expect(!result.didCommit)
+        #expect(result.output.contains("# origin (HEAD)"))
+        #expect(result.output.contains("activity\tedit"))
+        #expect(result.output.contains("agent\tchat:01JTESTCHAT00000005"))
+        #expect(result.output.contains("agent_kind\tchat"))
+        // The edit history has both entries (import + edit).
+        let historyLines = result.output
+            .split(separator: "\n")
+            .filter { $0.hasPrefix("0\t") || $0.hasPrefix("1\t") }
+        #expect(historyLines.count == 2, "create + edit yields 2 history rows")
+    }
+
+    @Test func parsesPageInfoByID() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "info", "--id", "01ABC"], env: noEnv)
+        #expect(invocation.command == .page(.info(.id(PageID(rawValue: "01ABC")))))
+    }
+
+    @Test func parsesPageInfoByTitle() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "info", "--title", "X"], env: noEnv)
+        #expect(invocation.command == .page(.info(.title("X"))))
+    }
+
+    @Test func pageInfoOnMissingPageThrows() throws {
+        let store = try tempStore()
+        #expect(throws: PageCommand.Failure.self) {
+            try PageCommand.run(.info(.title("Nope")), in: store)
+        }
+    }
+
     // MARK: - Search dispatch
     //
     // Post-#634: `PageCommand.run(.search)` needs a `bm25Leg` to produce

--- a/plans/page-provenance.md
+++ b/plans/page-provenance.md
@@ -1,0 +1,638 @@
+# Page Provenance — Scope + Plan
+
+> Status: **investigation + design only.** No repo file is modified; this lives
+> under `tmp/` (gitignored). All citations are `file:line` against the working
+> tree at the time of writing (store schema v38, `GRDBWikiStore`).
+>
+> Related: issue #261, PR #310 (design — *not on disk*), PR #486, issues #131 /
+> #397 (shipped page-author provenance), `plans/phase-3a-providers-and-provenance.md`
+> (shipped source provenance).
+
+---
+
+## 1. What the operator asked for
+
+Each wiki page should carry **provenance metadata** linking it to the ingestion
+job(s)/run(s) and chat(s) that **created or edited** it — IDs + timestamps — so a
+page's creation/edit history is queryable and surfaceable in the UI.
+
+## 2. Prior-art summary (don't redesign from zero)
+
+There is already substantial provenance machinery in the codebase. The page
+feature is a **gap-fill**, not a greenfield.
+
+### 2.1 Issue #261 — *source providers*, not page provenance
+#261 (`gh issue view 261`) is titled "New source providers: git@SHA, Tavily,
+Slack, archives (graph-model Phase 7)". It is about new `SourceProvider`
+leaves, and its "Gate" mentions "frozen, **provenance-carrying** source". It is
+**not** about page provenance. Useful only as context for the connections vs.
+provenance split (#310).
+
+### 2.2 PR #310 — the snapshot invariant (design doc; NOT merged/on-disk)
+#310 adds `plans/connections.md` (452 lines). It establishes the architectural
+rule this plan inherits verbatim:
+
+> **Connections are mutable configuration; provenance is immutable history that
+> snapshots connection identity at ingest — no foreign key, so deleting a
+> connection never touches provenance.**
+
+Its schema sketch puts nullable `connection_id` / `connection_label` on the
+`activities` table (snapshotted at ingest). `plans/connections.md` is **not on
+disk** (`ls plans/connections.md` → No such file) — the PR is OPEN/unmerged.
+So #310 is *direction*, not implemented substrate. This plan is forward-
+compatible with it: page activities already live in the same `activities`
+table #310 proposes to extend.
+
+### 2.3 PR #486 — per-wiki `connections` table (OPEN)
+#486 moves connections into each wiki's SQLite DB as a new `connections` table
+(schema v38), with store methods all routed through `mutate()` + emitting
+`ResourceChangeEvent`. This is the **connections substrate**. Page provenance
+is orthogonal (it records *who wrote the page*, not *where bytes came from*),
+but both share the `activities` table and the snapshot-invariant philosophy.
+
+### 2.4 What IS shipped (on-disk) — the existing provenance substrate
+- **Source provenance (Phase 3a, shipped 2026-07-05)** — `plans/phase-3a-providers-and-provenance.md`:
+  a `SourceProvider` protocol + `SourceProvenance` descriptor threaded into
+  `addSource`, seeding real named `agents` + `activities` (carrying
+  `plan`/`external_ref`) and binding `external_identity` on `source_versions`.
+  Read-side: `sourceOrigin(sourceID:)` joins
+  `refs → source_versions → activities → agents`.
+- **Page author provenance (#131 / #397, shipped)** — `plans/wikictl-author-provenance.md`:
+  `pages.created_by` / `pages.last_edited_by` TEXT columns (#131, migration
+  v32→v33), stamped via a `WIKI_AUTHOR` env var injected at spawn time
+  (`agent:<kind>` or `chat:<chatID>`) and threaded through
+  `wikictl page upsert --author` → `PageUpsert.upsert(author:)`.
+
+### 2.5 The PROV-DM substrate (graph-model Phase 0/1)
+Three tables form a W3C-PROV-style graph (DDL at `GRDBWikiStore.swift:2330-2368`):
+
+```
+agents      (id, kind, name, version, external_ref)
+activities  (id, kind, agent_id→agents, plan, external_ref, started_at, ended_at)
+page_versions (id, page_id→pages, parent_id, merge_parent_id,
+               blob_hash→blobs, title, activity_id→activities, saved_at)
+source_versions (...) — same shape, for sources
+refs (kind, owner_id, version_id, generation, updated_at)  -- active-version pointer
+```
+
+`page_versions.activity_id` is a **FK into `activities`** — so the graph already
+links every versioned page save to an activity + agent. **Pages already have a
+provenance chain; it is just under-populated and unread.**
+
+## 3. Current page schema + write paths (verified, `file:line`)
+
+**Production store = `GRDBWikiStore`** (the app, `wikictl`, `wikid` daemon, and
+File Provider all instantiate it — `WikiFSEngine/WikiSession.swift:201`,
+`wikictl/main.swift:83`, `wikid/WikiDaemon.swift:134`, `StoreBackend.swift:24`).
+`SQLiteWikiStore.swift` is **deleted** from disk; the loaded-context references
+to it are stale. Schema is at **v38** (`GRDBWikiStore.swift:61`). The
+`sqlite-concurrency` SKILL invariants still hold, but the *mechanism* changed:
+GRDB `DatabasePool` serializes via its own dispatch queue (no
+`NSRecursiveLock`); `mutate(event:_:)` is a savepoint-wrapped write that emits
+post-commit (`GRDBWikiStore.swift:356-386`).
+
+### 3.1 The `pages` table (`GRDBWikiStore.swift:2135-2145`)
+```sql
+CREATE TABLE pages (
+    id TEXT PRIMARY KEY, title TEXT NOT NULL, slug TEXT NOT NULL,
+    body_markdown TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL, updated_at REAL NOT NULL,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_by TEXT,          -- #131: agent/model name or "chat:<id>" / "agent:<kind>"
+    last_edited_by TEXT       -- #131: same
+);
+```
+**This is the only page-level provenance today** — two nullable TEXT columns
+holding a *string* (e.g. `"chat:01J…"`). They carry the chat/agent identity but
+**not** the run/job timestamp, source IDs, or executor phase, and they are
+last-write-wins (no history).
+
+### 3.2 The single write seam: `PageUpsert.upsert` (`Sources/WikiFSCore/Core/PageUpsert.swift:48-123`)
+Both the **in-app editor** (`WikiStoreModel`) and **`wikictl page upsert`**
+(the path ingestion executors + chats use) call the *same* `PageUpsert.upsert`.
+Its private `writePage` (lines 89-123) branches:
+
+| Case | Method called | Stamps activity/page_versions? | `created_by`/`last_edited_by`? |
+|---|---|---|---|
+| **Create** (new title) | `createPage(title:createdBy:)` (:120) | ✅ seeds root `page_versions` + an `activities` row (kind `'import'`) | ✅ `created_by`=author |
+| **Update, CAS on** (`expectedHeadVersionID` given) | `appendPageVersion(...lastEditedBy:)` (:102,:112) | ✅ appends `page_versions` + `activities` (kind `'edit'`) | ✅ `last_edited_by`=author |
+| **Update, CAS off** (`expectedHeadVersionID == nil`) | `updatePage(id:title:body:lastEditedBy:)` (:106,:116) | ❌ **stamps nothing** — flat UPDATE only | ✅ `last_edited_by`=author |
+
+The critical gap: **the CAS-off path — which is `wikictl`'s default (it does
+not pass `--expect-head`) — records no version/activity at all.** Only the flat
+string survives.
+
+### 3.3 The two store mutators
+- `createPage(title:createdBy:)` (`GRDBWikiStore.swift:2762-2813`): INSERTs
+  `pages`, then seeds a blob + an `activities` row (kind `'import'`,
+  **agent = `legacyImportAgentID`**) + a root `page_versions` row + a
+  `page-content` ref. Routed through `mutate(event:)` → emits `.page/.created`.
+- `appendPageVersion(...)` (`:4057-4131`): CAS check → optional amend
+  (autosave coalescing) → blob → `activities` (kind `'edit'`,
+  **agent = `legacyImportAgentID`**) → `page_versions` → UPDATE `pages` mirror
+  → `page-content` ref. Routed through `mutate(event:)` → emits `.page/.updated`.
+- `updatePage(...)` (`:2822-2841`): **flat UPDATE only**, no version/activity.
+  Routed through `mutate(event:)` → emits `.page/.updated`. (So the *event*
+  fires, but no history row is written.)
+
+### 3.4 The agent asymmetry (the core defect)
+Page activities are stamped with `legacyImportAgentID` (`:2519-2531`) — a
+**single shared agent** named `"legacy-import"`, created once and reused for
+every page create/edit. So even on the CAS path, the activity's `agent_id`
+points at an anonymous shared row, **not** the real `chat:<id>` /
+`agent:<kind>` identity already living in `last_edited_by`.
+
+By contrast, sources use `ensureAgent(name:kind:version:externalRef:on:)`
+(`:5905-5923`) which **dedups a real named agent** on `(name, kind)` — so two
+website ingests share one `"website"` agent but distinct activities. Pages
+should use the same seam.
+
+### 3.5 Read side (the missing mirror)
+`sourceOrigin(sourceID:)` (`:3268-3302`) is the read-side template: it joins
+`refs → source_versions → activities → agents` and decodes a `SourceOrigin`
+(`agentName`, `activityKind`, `plan`, `externalRef`, `externalIdentity`,
+`fetchedAt`). **There is no `pageOrigin(pageID:)` equivalent.**
+`pageVersionHistory(pageID:)` (`:4152+`) returns the version chain but does
+not join activities/agents.
+
+### 3.6 Frontmatter projection
+`PageMarkdownFormat.fileContent(for:)` (`Sources/WikiFSCore/Markdown/PageMarkdownFormat.swift`)
+generates the `---` frontmatter served by the File Provider, conditionally
+emitting `created_by:` / `last_edited_by:` when present. This is the
+file-visible provenance today.
+
+### 3.7 Identifiers available at the write seams
+- **chat ID** — already captured as `"chat:<chatID>"` in `last_edited_by`
+  (`AgentLauncher.startInteractiveQuery` injects `WIKI_AUTHOR=chat:<chatID>`,
+  per `plans/wikictl-author-provenance.md:36-37`). The raw chatID is a ULID in
+  the `chats` table (`GRDBWikiStore.swift:2382`).
+- **run/job identity** — ingestion runs are identified by **chatULID + run
+  timestamp** (the run dir `<Caches>/Self Driving Wiki-agent/<chatULID>/runs/<timestamp>/`,
+  `Sources/WikiFSEngine/AgentLauncher.swift:294-299`). There is no first-class
+  `run_id`/`job_id` column anywhere today; the run timestamp is the natural
+  key, and `activities.started_at` already records it.
+- **source IDs** — ULIDs in `sources`; a page cites sources via `source_links`
+  (`from_page_id → to_source_id`, `:2219-2232`). So "which sources fed this
+  page" is *already queryable* via `source_links` — provenance need not
+  duplicate it.
+- **executor phase** — the `WIKI_AUTHOR=agent:<kind>` string (`agent:ingest` /
+  `agent:lint` / `agent:query`) already encodes it.
+
+## 4. The gap (one paragraph)
+
+Pages record *who last touched them* as a single denormalized string
+(`created_by`/`last_edited_by`, #131/#397) and, on the CAS path only, append a
+`page_versions` row — but that row's `activity_id` points at a **shared
+anonymous "legacy-import" agent**, the **CAS-off path records no history at
+all**, and there is **no read-side accessor** to surface any of it. So a page's
+"which job/run/chat created or edited me, and when" is only partially captured,
+unqueryable as history, and invisible in the UI beyond two frontmatter lines.
+The fix is to (a) make page activities point at **real named agents** (reuse
+`ensureAgent`), (b) stamp a `page_versions` + activity row on **every** save
+(not just CAS), carrying run/chat identity + timestamp, and (c) add a
+`pageOrigin(pageID:)` read accessor + UI surface — reusing the exact PROV
+substrate sources already use.
+
+## 5. Recommended design
+
+**One sentence:** extend the existing `activities`/`agents`/`page_versions`
+PROV graph to pages (it already half-exists), stamp it on **every** write via
+the single `PageUpsert` seam, and surface it with a `pageOrigin(pageID:)`
+accessor + an inspector row — no new top-level table, minimal schema change.
+
+### 5.1 WHAT to store per page
+- **Agent** (reuse `agents`): one row per distinct author identity, deduped on
+  `(name, kind)`. `name` = the existing author string
+  (`"chat:<chatID>"` / `"agent:<kind>"` / `"user"` / a model id);
+  `kind` = `"chat"` / `"agent"` / `"human"` / `"model"`. This is the structured
+  upgrade of the flat `created_by` string — same identity, now first-class.
+- **Activity** (reuse `activities`): one row per create/edit, carrying
+  `kind` (`'import'` on create, `'edit'` on update), `started_at`/`ended_at`
+  (== the save timestamp), and optionally `plan` (executor phase / run label)
+  + `external_ref` (run dir or chatID). `agent_id` → the real agent above.
+- **Version** (reuse `page_versions`): one append-only row per save, FK
+  `activity_id` → the activity. The body lives in `blobs` (CAS) — already the
+  design.
+- **Keep** `created_by`/`last_edited_by` as denormalized fast-path columns
+  (unchanged) — they remain the cheap "last actor" mirror; the PROV graph is
+  the authoritative history. No data loss, no migration of existing rows
+  required (they keep their strings; the graph is populated going forward).
+- **sourceLinks are already queryable** via `source_links`; do NOT duplicate
+  sourceIDs into provenance. (If a future "this edit was sourced from X"
+  link is wanted, that's a `source_links` enhancement, separate scope.)
+
+**Rationale for reusing the graph over a new `page_provenance` table:**
+the `page_versions.activity_id → activities → agents` chain already exists and
+is the exact PROV-DM model sources use. A parallel table would duplicate the
+agent/activity lifecycle, fork the GC/query paths, and contradict #310's
+"provenance is the activities graph" framing. The only *new* persistence is
+making the existing columns non-NULL-populated with real data.
+
+### 5.2 WHERE — schema change (one migration step, v38 → v39)
+**No new table.** `page_versions.activity_id` is already `REFERENCES
+activities(id)` and nullable (`GRDBWikiStore.swift:2434`); no column add is
+needed. The only DDL delta is the version bump, optionally paired with a data
+backfill.
+
+**⚠ Ladder ordering is load-bearing (verified `GRDBWikiStore.swift:1132-1148`).**
+The stepwise `migrate(from:in:)` ladder ends with a **catch-all fallback** at
+`:1144`:
+
+```swift
+if version < Self.currentSchemaVersion {                 // :1144
+    try Self.dropFTS5TablesAndTriggers(in: db)           // :1145
+    try db.execute(sql: "PRAGMA user_version = \(Self.currentSchemaVersion);")  // :1146
+    version = Self.currentSchemaVersion
+}
+```
+
+The moment `currentSchemaVersion` (`:61`) is bumped 38 → 39, that fallback's
+guard becomes true for a v38 DB and it **short-circuits**: it re-runs the FTS5
+drop (harmless — `DROP … IF EXISTS`) and stamps `user_version = 39`, executing
+**none** of any new provenance backfill. So a new explicit step MUST be
+inserted **before** `:1144`, mirroring the v37→v38 step that sits immediately
+above it (`:1132-1148`):
+
+```swift
+// Step 38 → 39 (page provenance): [backfill, if any — see below].
+// MUST precede the catch-all fallback at :1144.
+if version < 39 {
+    // try Self.migrateV38ToV39(in: db)   // data backfill only — see "Backfill" note
+    try db.execute(sql: "PRAGMA user_version = 39;")
+    version = 39
+}
+```
+
+```sql
+-- v38 → v39 backfill (OPTIONAL — only if historical attribution is wanted now):
+--   (a) seed a real named agent for every distinct non-null created_by/last_edited_by value
+--       (dedup on (name, kind) exactly like ensureAgent, :5905-5923), and
+--   (b) for pages whose root page_versions.activity_id points at the legacy-import agent
+--       (:2519-2531), repoint its activity.agent_id to the real agent derived from created_by.
+-- Rows with NULL created_by stay on legacy-import (truly unknown) — degraded gracefully.
+```
+
+**Recommendation: forward-only first.** Ship the version bump as a no-op
+`PRAGMA user_version = 39` (the explicit `if version < 39` step above, with the
+backfill call commented out). The **write-path** change (§5.3) alone guarantees
+correctness for all new saves; pre-existing rows degrade to "unknown", exactly
+as today. Defer the backfill (and a `wiki_metadata` guard flag, `:1122-1129`)
+to Phase C unless the operator wants historical attribution immediately — it is
+irreversible and benefits from a guarded rollout.
+
+Add to `createFreshSchema` (no-op for a fresh DB — it already builds v38 = the
+target shape) and `migrate(from:)` per the existing ladder convention
+(`:1081-1085` shows the v32→v33 step pattern). `currentSchemaVersion` bumps
+38 → 39 (`:61`).
+
+> **LOW fix (housekeeping):** while editing this region, the stale doc comment
+> at `GRDBWikiStore.swift:412` — `"Both paths end at user_version =
+> currentSchemaVersion (37)"` — should be corrected to `(39)` (it already
+> drifted from 37→38; don't let it drift again).
+
+### 5.3 HOW stamped — the write seams
+**Single principle: every page mutation routes its activity through
+`ensureAgent`, and the non-CAS update path must also append a version.**
+
+#### Pre-req: `authorKind(_:)` is NEW code (not reuse)
+§5.3 below calls `authorKind(createdBy)`. **That helper does not exist today**
+(`rg 'authorKind' Sources` → no hits). It must be **authored** as a small
+private helper on `GRDBWikiStore`, e.g.:
+
+```swift
+/// Map a provenance author string (#397) to an `agents.kind` value.
+/// `chat:<id>` → "chat"; `agent:<kind>` → "agent"; the literal "user" → "human";
+/// anything else (a model id like "claude-sonnet-4-5…") → "model".
+private func authorKind(_ author: String?) -> String {
+    guard let author, !author.isEmpty else { return "software" }   // unknown
+    if author.hasPrefix("chat:")  { return "chat" }
+    if author.hasPrefix("agent:") { return "agent" }
+    if author == "user"           { return "human" }
+    return "model"
+}
+```
+The `kind` feeds `ensureAgent(name:kind:on:)` (`:5905-5923`), which dedups on
+`(name, kind)` — so `"chat:01J…"` and a stray page titled `chat:01J…` cannot
+collapse (distinct `name`s). `nil`/empty authors fall back to the existing
+`legacyImportAgentID` path (degraded, same as today).
+
+#### The refactor — extract `appendPageVersionLocked(on db:)` (fixes the HIGH hazard)
+Both `updatePage` (`:2823`) and `appendPageVersion` (`:4062`) wrap their bodies
+in `mutate(event:)` → emit `.page/.updated`. The `mutate` doc (`:349-355`)
+warns `dbWriter.write` is **NOT reentrant** — public methods that compose must
+**pass the `Database` handle to an internal helper, never re-enter `mutate`.**
+So `updatePage` MUST NOT call the public `appendPageVersion` (that would
+double-emit AND re-enter). The fix:
+
+1. **Extract** the version-append logic (steps 2-6 of `appendPageVersion`
+   today: blob → `ensureAgent` → `activities` INSERT → `page_versions` INSERT
+   → `pages` mirror UPDATE → `page-content` ref) into a private
+   `appendPageVersionLocked(pageID:title:body:head:expectedHeadVersionID:
+   lastEditedBy:author:now:nowTS: on db:)`. **No `mutate` wrapper, no emit**
+   — it takes the open `Database` and performs pure SQL, returning the new
+   version id.
+2. **`appendPageVersion(...)`** (`:4057`) keeps its `mutate(event:)` wrapper,
+   does the CAS head-resolve + amend check inside, then calls
+   `appendPageVersionLocked(... on: db)`. Emits `.page/.updated` once.
+3. **`updatePage(id:title:body:lastEditedBy:)`** (`:2822`) keeps its own
+   `mutate(event:)` wrapper, resolves the head + amendment inside, then calls
+   `appendPageVersionLocked(... expectedHeadVersionID: nil, on: db)` — the
+   **CAS-off path** = "no CAS check, just append". Emits `.page/.updated`
+   **once** (its own wrapper; `appendPageVersionLocked` does not emit).
+
+This is the documented Approach-A composition pattern (`:349-355`): one emit per
+public method, the shared work factored into a `db:`-taking helper. The
+`ensureAgent` swap (item below) happens **inside** `appendPageVersionLocked`,
+so both public paths benefit from one edit.
+
+> *Performance note:* appending a blob + version per save is the existing
+> CAS-path cost; the amend-coalescing in `tryAmendPageVersion` (`:4082`)
+> already collapses same-actor rapid saves, so the cost is bounded. Gate the
+> append on "body hash ≠ head blob hash" (compare SHA to head) to skip
+> no-op `wikictl` re-writes.
+
+#### `createPage` + `appendPageVersion` — the `ensureAgent` swap
+- **`createPage(title:createdBy:)`** (`:2762`): replace
+  `legacyImportAgentID(on:)` (`:2519`) with `ensureAgent(name: createdBy ??
+  "unknown", kind: authorKind(createdBy), on:)` for its root `activities` row.
+  Optionally bind `plan`/`external_ref` (Phase 2 threading). Keep emitting
+  `.page/.created`.
+- The shared `appendPageVersionLocked` (above) does the same swap for the edit
+  path, so `appendPageVersion` and `updatePage` are covered in one place.
+
+#### ⚠ Create-then-update → TWO version rows on a brand-new page (MEDIUM)
+`PageUpsert.writePage` (`PageUpsert.swift:120-122`) on the **create** branch
+calls `createPage(...)` **then** `updatePage(...)`. Today that yields **one**
+`page_versions` row (create seeds the root; `updatePage` was a flat UPDATE that
+wrote none). After this refactor, `updatePage` ALSO appends a version → every
+brand-new page gets **TWO** `page_versions` rows (empty root + first real
+edit) and **TWO** `activities` rows (`'import'` + `'edit'`).
+
+This is **benign** (the chain is still correct; `pageOrigin` returns the most
+recent; `pageEditHistory` shows both), but it must be accounted for in AC.2:
+
+- **AC.2 expected counts** (the create+edit case): `pageEditHistory` returns
+  **exactly 2** entries for a fresh page edited once — entry[0] = `kind
+  'import'`, empty body; entry[1] = `kind 'edit'`, the real body. The test
+  asserts `count == 2` (not `>= 2`) and that the *second* entry's agent +
+  body match the chat edit, so it cannot pass trivially off the empty-root
+  artifact.
+- **Alternative (cleaner, deferred):** give `createPage` an optional `body:`
+  parameter so `writePage`'s create branch writes the body in one shot and
+  skips the second `updatePage`. This is a larger change to the protocol +
+  the root-version seeding; **leave for a follow-up** unless the double-row
+  is objectionable. Document the decision either way.
+
+#### Threading richer identity (optional Phase 2)
+Today only the `author` string reaches the store. To record the **run dir** /
+**executor phase** as structured `activities.plan`, extend the `WIKI_AUTHOR`
+injection (`AgentLauncher`) to also set a `WIKI_RUN_REF` env var (the run dir
+or `<chatULID>/<timestamp>`, per `AgentLauncher.swift:294-299`), and thread it
+as a new optional `runRef: String?` through `PageUpsert.upsert` →
+`createPage`/`appendPageVersionLocked` → `activities.external_ref`. Additive; if
+omitted, provenance still carries chat/agent identity + timestamp (the core
+ask).
+
+### 5.4 HOW read — `pageOrigin`/`pageEditHistory` are new `WikiStore` protocol requirements
+`sourceOrigin(sourceID:)` (`WikiStore.swift:240`), `pageVersionHistory(pageID:)`
+(`:399`), `appendPageVersion(...)` (`:387`), and `createPage`/`updatePage`
+(`:136-138`) are all **protocol requirements with no default implementation** —
+`GRDBWikiStore` is the sole concrete conformer (`rg ': WikiStore' Sources` →
+only `GRDBWikiStore`; `WikiStoreModel` wraps a store, it does not conform).
+Tests use `GRDBWikiStore` in-memory via `TestStoreFactory.inMemory()`, not a
+mock conformance.
+
+Add **both** new requirements to the `WikiStore` protocol, exactly as
+`sourceOrigin` was added (Phase 3a — bare protocol func, no default, concrete
+impl in `GRDBWikiStore`):
+
+```swift
+// WikiStore.swift — alongside sourceOrigin (:240) and pageVersionHistory (:399)
+func pageOrigin(pageID: PageID) throws -> PageOrigin?
+func pageEditHistory(pageID: PageID) throws -> [PageOrigin]
+```
+
+- **`pageOrigin(pageID:)`** — joins `refs → page_versions → activities →
+  agents` (copy `sourceOrigin`'s shape at `:3268-3302`; swap
+  `source_versions`→`page_versions`, `external_identity`/`fetched_at`→
+  `saved_at`). Returns a `PageOrigin` struct (`agentName`, `agentKind`,
+  `activityKind`, `plan`, `externalRef`, `savedAt`). Uses `dbWriter.read { }`
+  (read-only, off-main-safe via `WikiReadPool`). NULLs degrade gracefully.
+- **`pageEditHistory(pageID:)`** — walks the whole `page_versions` chain for
+  the page joined to `activities`→`agents` (extends `pageVersionHistory`
+  `:4152` with the join), newest-first or oldest-first (pick one; document).
+
+**Conformance impact:** because these are new protocol requirements with no
+default, the build will fail at every conformer until implemented. Since
+`GRDBWikiStore` is the only conformer, that's a single site. If a mock/test
+double conforming to `WikiStore` is ever introduced, it must stub both (return
+`nil` / `[]`) — note this in the protocol doc comment. **Do not** add a
+default-impl protocol extension here: `sourceOrigin` deliberately has none
+(the protocol comment at `:240` documents that it's "On the protocol (not only
+the concrete read helper) so callers … can route through it"), and matching
+that keeps the two read surfaces consistent.
+
+### 5.5 HOW surfaced — UI
+- **`PageDetailView`** (`Sources/WikiFS/Pages/PageDetailView.swift:9`): add a
+  collapsible "Provenance" / inspector section (a `DisclosureGroup` or an
+  `.inspector`-style panel) showing: Created by `<agentName>`
+  (`<agentKind>`) on `<createdAt>`; Last edited by `<…>` on `<updatedAt>`;
+  and an expandable "Edit history" list (timestamp + actor + activity kind)
+  from `pageEditHistory`. For `chat:<id>` agents, render the chatID as a
+  `[[chat:…]]`-style link (consistent with the existing `chat:<id>` provenance
+  value shape from #397).
+- **Frontmatter** (`PageMarkdownFormat`): already emits `created_by`/
+  `last_edited_by`; optionally extend with a `provenance:` block or leave as-is
+  (the two existing lines already satisfy "file-visible provenance").
+- **`wikictl page info`**: add a subcommand (mirror the shipped `source info`
+  from Phase 3a) printing `pageOrigin` + edit history — useful for agents/debug.
+
+## 6. Constraints respected
+
+### 6.1 SQLite concurrency (`docs/skills/sqlite-concurrency/SKILL.md`)
+- The store is **method-atomic**; in `GRDBWikiStore` that's GRDB's serial
+  `DatabasePool` queue, not an `NSRecursiveLock`. New/changed methods keep the
+  `mutate(event:_:)` wrapper (`:356`) — the savepoint-nesting, post-commit-emit
+  shape. **Do not introduce raw `BEGIN`/`COMMIT`.**
+- **Statement lifetime:** GRDB materializes rows (`Row.fetchAll`) — no manual
+  `sqlite3_stmt` reset needed (the SKILL's `defer { stmt.reset() }` rule is a
+  `SQLiteWikiStore` concern; GRDB handles it). But never let a raw handle cross
+  a boundary.
+- **No inference/network inside a transaction** — the write commits, then any
+  post-commit side effects (embeddings, search) run (see `renameSource` pattern
+  at `:3308-3332`). The provenance writes are pure SQL inside the existing
+  `mutate` body — fine.
+- **Reads off-main:** `pageOrigin`/`pageEditHistory` use `dbWriter.read` →
+  safe through `WikiReadPool` (each pooled store is `GRDBWikiStore(readOnlyURL:)`,
+  no migrations). Keep the main-store fallback branch.
+
+### 6.2 Change signaling (#129 slice 2a) — and the gap the loaded context overstates
+> The invariant *as written* in the project's AGENTS.md / loaded-context note
+> claims "`StoreEmissionExhaustivenessTests` enforces the 'every mutator must
+> emit' invariant." **That test does not exist.** It is a phantom — the only
+> references to "exhaustiveness" are **stale comments**
+> (`ChangeTokenContributorTests.swift:18`, `GRDBWikiStore.swift:2614`). The
+> invariant is today **unforced except by per-method spies someone hand-wrote.**
+
+**Verified:** the emission test surface is three files —
+- `Tests/WikiFSTests/StoreEmissionTests.swift` — **per-method `@Test` spies**
+  (`createPageEmitsPageCreated` `:63`, `updatePageEmitsPageUpdated` `:72`,
+  `deletePageEmitsPageDeleted` `:83`, …). Each fires one call and asserts
+  `events.last?.kind/.change/.id`. There is **no `Mirror`/`reflect`**, no
+  enumeration of public mutators, no EMIT/READ/NO-EMIT partition table. It
+  catches a *specific* regression in a *specific* method, not the class.
+- `Tests/WikiFSTests/StoreEmissionReentrancyTests.swift` and
+  `GRDBEmissionReentrancyTests.swift` — assert **single-emit + no deadlock**
+  for composed mutations (e.g. `withTransactionMutationEmitsOnceNoDeadlock`).
+  These are the realistic enforcement for the *reentrance/double-emit* hazard.
+
+So this plan must **not** rely on an exhaustiveness guard as a safety net. The
+plan's mitigation is concrete instead:
+
+1. **No emission-contract change.** `createPage`/`updatePage`/`appendPageVersion`/
+   `deletePage` already route through `mutate(event:)` and emit
+   (`.page/.created|updated|deleted`). This plan **modifies their bodies, not
+   their wrappers** — the per-method spies keep passing.
+2. **The real hazard is double-emit** from the §5.3 refactor (`updatePage`
+   sharing logic with `appendPageVersion`). That is closed *structurally* —
+   `appendPageVersionLocked` takes the `Database` and does NOT wrap `mutate`
+   (`:349-355` reentrance rule) — and asserted by a **new named test**
+   (AC.6, see §8).
+3. **If a NEW public mutator is added** (e.g. a `repointPageProvenance`
+   backfill), it MUST call `mutate(...)` + `localEvent(...)` or carry a
+   `// NO-EMIT:` comment with a reason. Because there is no exhaustiveness
+   test, this is **review-enforced**, not CI-enforced — add it to the PR
+   checklist.
+4. The provenance read accessors (`pageOrigin`, `pageEditHistory`) are
+   READ-only → no emit.
+
+**Tests to touch (all real):**
+- **`StoreEmissionTests.swift`** — extend `updatePageEmitsPageUpdated` (`:72`)
+  to assert **exactly one** event after the refactor (`events.count` == the
+  recorder's pre-update count + 1; not just `events.last`), and confirm
+  `createPageEmitsPageCreated` (`:63`) still single-emits. (See AC.6.)
+- **`StoreEmissionReentrancyTests.swift`** — add a case asserting `updatePage`
+  emits exactly once after it starts composing via `appendPageVersionLocked`
+  (it now resembles `appendPageVersion`'s composition shape). This is the
+  realistic double-emit guard. (See AC.7.)
+
+> **Risk to flag:** because no test enumerates `WikiStore`'s public mutators,
+> a *future* contributor adding a non-emitting mutator will NOT trip CI — the
+> File Provider would silently go stale. Option (a) below closes that gap
+> permanently; option (b) is the pragmatic minimum for *this* plan.
+>
+> **(a) Build the missing exhaustiveness test (recommended follow-up, out of
+> scope here but tracked):** a reflection-based `WikiStoreEmissionExhaustiveness
+> Tests` that enumerates `WikiStore`'s public mutating `func`s via `Mirror`,
+> asserts each is classified EMIT / READ / NO-EMIT in a table, and that every
+> EMIT member's body contains a `mutate(` call. Own AC + fixtures. This is the
+> test the loaded context *thinks* already exists. (Also: delete the stale
+> `StoreEmissionExhaustivenessTests` comment at `ChangeTokenContributorTests
+> .swift:18` and the `contributor-exhaustiveness` wording at
+> `GRDBWikiStore.swift:2614` — or repoint them at the new real test.)
+
+### 6.3 GRDB, not SQLiteWikiStore
+All file:line citations and edits target `GRDBWikiStore.swift`. The
+`SQLiteWikiStore` references in the loaded context / SKILL are historical; that
+file is gone. The schema-version constant lives only at
+`GRDBWikiStore.swift:61`.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| **(CRITICAL gap)** No exhaustiveness test guards "every mutator emits" — a future non-emitting mutator silently stale the File Provider. Loaded context overstates this as enforced. | Plan does NOT rely on it. The §5.3 refactor closes *this* plan's hazard structurally (`appendPageVersionLocked` doesn't emit; one emit per public wrapper). Track building the missing `WikiStoreEmissionExhaustivenessTests` (§6.2 option a) as a follow-up; meanwhile review-enforce. |
+| **(HIGH)** `updatePage` sharing logic with `appendPageVersion` → double-emit + re-entrant `mutate` deadlock. | Resolved structurally in §5.3: extract `appendPageVersionLocked(on db:)` (no `mutate` wrapper); both public methods call it *inside their own* `mutate` body. `updatePage` MUST NOT call the public `appendPageVersion`. Asserted by AC.6 (`updatePageEmitsPageUpdated` extended to exactly-one) + AC.7 (reentrancy test). |
+| **(MEDIUM)** Create-then-update (`PageUpsert.writePage:120-122`) yields TWO `page_versions`/`activities` rows on every brand-new page (empty root + first edit). | Documented in §5.3; AC.2 asserts `count == 2` (not `>= 2`) and pins entry[1]'s agent/body so it can't pass off the artifact. Optional follow-up: `createPage(body:)` to write in one shot. |
+| `updatePage` now appends a version on every `wikictl` edit → version-table bloat / slower saves | Gate append on "body hash ≠ head blob hash"; rely on `tryAmendPageVersion` coalescing (`:4082`). Measure with `PageVersionTests`. |
+| **(MEDIUM)** v38→v39 step silently skipped by the catch-all fallback if inserted after `:1144`. | §5.2 spells it out: insert the explicit `if version < 39` step **before** `:1144`; the fallback's guard is keyed to `currentSchemaVersion` and short-circuits past it once bumped. |
+| **(MEDIUM)** New protocol requirements `pageOrigin`/`pageEditHistory` break every `WikiStore` conformer until implemented. | §5.4: `GRDBWikiStore` is the sole conformer (single site); no default-impl extension (matches `sourceOrigin`). Document in the protocol comment; any future mock must stub `nil`/`[]`. |
+| Backfill (5.2) repoints historical `activity.agent_id` — irreversible if wrong | Forward-only first (no-op v39 bump); defer backfill to Phase C behind a `wiki_metadata` flag (`:1122-1129`); keep `created_by` strings as source of truth. |
+| `ensureAgent` dedup on `(name,kind)` could collide if two chats share a name-shaped string | Names are already ULID-suffixed (`chat:<ULID>`, `agent:<kind>`) — collision-free by construction. |
+| Forward-compat with #310 (`connection_id`/`connection_label` on `activities`) | Additive — those columns don't exist yet; when #310 lands it ALTERs `activities`, independent of this. Page activities coexist. |
+| `PageDetailView` is a hot view — a new inspector section could add re-render cost | Use the `swiftui-performance-audit` skill; keep the provenance read in a `@State` loaded on appear / via the read pool, not inline in the view body. |
+
+## 8. Acceptance criteria
+
+1. After an **ingestion executor** creates a page via `wikictl page upsert`,
+   `pageOrigin(pageID:)` returns a non-nil `PageOrigin` whose `agentName` ==
+   `"agent:<kind>"` (or `"chat:<id>"`), `activityKind` == `"import"`,
+   `savedAt` ≈ now.
+2. After a **chat** edits a page, `pageOrigin` reflects the chat agent +
+   `activityKind == "edit"`. `pageEditHistory` returns **exactly 2** entries
+   for a freshly-created-then-edited page (the empty-root `'import'` +
+   the `'edit'`), and the test **pins entry[1]** (the edit) to the chat agent
+   + the edited body — so it cannot pass trivially off the create-double-row
+   artifact (§5.3). *(If `createPage(body:)` is adopted to avoid the
+   double-row, adjust to `count == 1` for create-with-body.)*
+3. The **CAS-off** path (`updatePage` with no `expectedHeadVersionID`) now
+   appends a `page_versions` + `activities` row (verified by row count before/
+   after) — closing the "records nothing" hole. Asserted by a row-count check
+   in `PageVersionTests`.
+4. Page activities' `agent_id` resolves via `ensureAgent` to a **real named
+   agent** (not the shared `legacy-import`) when `created_by`/`last_edited_by`
+   is non-null; NULL authors degrade to `legacy-import`/`"unknown"` (no crash,
+   no data loss).
+5. `PageDetailView` shows created-by / last-edited-by / edit history; a
+   `chat:<id>` value renders as a chat link.
+6. **(double-emit guard)** New test
+   `test_updatePage_after_versioning_refactor_emits_single_page_updated` in
+   `StoreEmissionTests.swift`: call `updatePage` once on an existing page,
+   assert `Recorder.count == before + 1` and the event == `(.page, id,
+   .updated)`. Extend the existing `updatePageEmitsPageUpdated` (`:72`) to
+   assert **exactly one** event (not just `events.last`), and confirm
+   `createPageEmitsPageCreated` (`:63`) still single-emits. *This test would
+   FAIL today if `updatePage` naively delegated to public `appendPageVersion`
+   (double-emit) — that's the regression it catches.*
+7. **(reentrance guard)** `StoreEmissionReentrancyTests` gains a case:
+   `updatePage` (now composing via `appendPageVersionLocked`) emits exactly
+   once with no deadlock — mirrors the existing
+   `withTransactionMutationEmitsOnceNoDeadlock`. This is the realistic
+   enforcement for the composition hazard (the phantom "exhaustiveness" test
+   does not exist — see §6.2).
+8. Migration v38→v39: the explicit `if version < 39` step is inserted
+   **before** the catch-all fallback at `GRDBWikiStore.swift:1144`; a v38 DB
+   runs it (not the fallback); re-opening a v39 DB is a no-op; a fresh DB
+   gets the v39 shape via `createFreshSchema`. The stale `(37)` doc comment
+   at `:412` is corrected.
+
+## 9. Build / test commands
+
+> Do **NOT** use bare `swift build` — it fails in fresh worktrees because
+> `GeneratedPrompts.swift` / `GeneratedVersion.swift` are gitignored derived
+> artifacts. Use the `make` targets that regenerate them first.
+
+```bash
+make version prompts    # regenerate git/build derived sources (CI runs this)
+make build              # == make version prompts && swift build
+make check              # build + lint/quick checks
+make test               # full suite (~1.5 min, in-memory SQLite fixtures since #658)
+
+# Targeted:
+swift test --filter StoreEmissionTests          # AC.6: updatePage single-emit
+swift test --filter StoreEmissionReentrancyTests # AC.7: composition/no-deadlock
+swift test --filter PageVersionTests             # AC.3: CAS-off appends a version
+swift test --filter SourceProviderTests          # the pattern this mirrors
+swift test --filter StoreConcurrencyTests
+```
+
+## 10. Suggested phasing
+
+- **Phase A (core, no backfill):** author `authorKind(_:)`; extract
+  `appendPageVersionLocked(on db:)`; swap `legacyImportAgentID` → `ensureAgent`
+  in `createPage` + the locked helper; route `updatePage` (CAS-off) through the
+  helper; add `pageOrigin`/`pageEditHistory` protocol reqs + `GRDBWikiStore`
+  impls; bump to v39 (no-op structural, explicit step before `:1144`); fix the
+  stale `(37)` comment at `:412`. Tests: AC.3, AC.6, AC.7, AC.8.
+- **Phase B (UI):** `PageDetailView` provenance section; `wikictl page info`.
+- **Phase C (optional):** thread `WIKI_RUN_REF` → `activities.external_ref`;
+  historical backfill behind a `wiki_metadata` flag (guarded, irreversible).
+- **Phase D (hygiene + forward-compat):** build the missing reflection-based
+  `WikiStoreEmissionExhaustivenessTests` (§6.2 option a) and delete the stale
+  phantom refs at `ChangeTokenContributorTests.swift:18` /
+  `GRDBWikiStore.swift:2614`; when #310 lands, ensure page activities snapshot
+  `connection_id`/`connection_label` if a connection sourced the page.
+
+---
+
+*Plan path: `tmp/sdw-plans/page-provenance.md` (gitignored scratch).*


### PR DESCRIPTION
## Summary

Implements the page-provenance workstream (Phase A + B) from `plans/page-provenance.md`. Each wiki page now records the agent + activity that created or edited it via the existing PROV-DM substrate (`agents` + `activities` + `page_versions`) — **no new table**. The same graph sources already use. Read-side: a new `pageOrigin(pageID:)` + `pageEditHistory(pageID:)` accessor surfaces created-by / last-edited-by / edit history in `PageDetailView` and a new `wikictl page info` command.

## Changes

- **`Sources/WikiFSCore/Core/PageOrigin.swift`** (new) — `PageOrigin` struct (read-side mirror of `SourceOrigin`).
- **`Sources/WikiFSCore/Store/WikiStore.swift`** — adds `pageOrigin(pageID:)` + `pageEditHistory(pageID:)` protocol requirements (no default impl, mirrors `sourceOrigin`).
- **`Sources/WikiFSCore/Store/GRDBWikiStore.swift`**
  - Bumps schema v38 → v39; inserts the explicit `if version < 39` step **before** the catch-all fallback at the end of `migrate(from:in:)` (the fallback short-circuits past any new step once `currentSchemaVersion` is bumped — §5.2). Forward-only, no backfill — pre-v39 rows degrade to `legacy-import` agent (same as today).
  - **NEW `authorKind(_:)`** helper: maps `chat:…` → `"chat"`, `agent:…` → `"agent"`, `"user"` → `"human"`, anything else → `"model"`, `nil`/empty → `"software"`.
  - **NEW `ensurePageAuthorAgent(_:on:)`** — swap for `legacyImportAgentID`. Routes the activity's agent through `ensureAgent(name:kind:)` so page activities point at real named agents (`chat:<id>` / `agent:<kind>` / `user` / model-id). Single edit site.
  - **NEW `appendPageVersionLocked(on db:)`** — extracted from `appendPageVersion` so `updatePage` (CAS-off) can share the write seam WITHOUT re-entering `mutate(event:)` (the HIGH double-emit + reentrant-mutate hazard from §5.3). Helper does NOT emit; both public callers wrap their own `mutate` and emit `.page .updated` ONCE. Includes a no-op guard (identical body hash + identical title → skip the version append, just bump `updated_at` on the mirror).
  - `createPage` + `appendPageVersion` + `updatePage` route via `ensurePageAuthorAgent` for their activity's agent (was `legacyImportAgentID`).
  - `updatePage` CAS-off path now appends a `page_versions` + `activities` row on every save (was a flat `UPDATE` — "records nothing" hole). Added an existence check at the start to preserve the `.notFound` contract for unknown ids (otherwise the INSERT into `page_versions` would surface a raw FK error and break `StoreEmissionReentrancyTests.throwingMutationEmitsNothing`).
  - Fixes stale doc comment at the `migrateIfNeeded` header (`(37)` → `(39)`).
- **`Sources/WikiFSCore/Store/WikiStoreModel.swift`** — `pageOrigin(for:)` / `pageEditHistory(for:)` `try?` wrappers.
- **`Sources/WikiFS/Pages/PageDetailView.swift`** — collapsible **Provenance** `DisclosureGroup` between the date row and the action buttons. Defaults collapsed; the origin + edit-history reads are gated on expansion (per §7 risk table — keep the read out of the hot `body` re-render). New `ProvenancePanel` view renders HEAD origin + edit history; `chat:<id>` agents render with the chat-bubble icon (the `chat:<id>` provenance value shape from #397), `agent:<kind>` with the cpu icon, `user` with the person icon, `legacy-import` with the tray icon (pre-v39 rows degrade distinctly).
- **`Sources/WikiCtlCore/PageCommand.swift`** + **`Sources/WikiCtlCore/ArgumentParser.swift`** — new `page info (--title X | --id Y)` subcommand mirroring `source info` (Phase 3a). Prints identity + HEAD origin + edit history.
- **`Tests/WikiFSTests/PageVersionTests.swift`** — 8 new tests (AC.1, AC.2, AC.3, AC.4, AC.8).
- **`Tests/WikiFSTests/StoreEmissionTests.swift`** — AC.6 `test_updatePage_after_versioning_refactor_emits_single_page_updated` asserts exactly ONE `.page .updated` event after `updatePage` (catches double-emit regression from naive delegation to public `appendPageVersion`).
- **`Tests/WikiFSTests/StoreEmissionReentrancyTests.swift`** — AC.7 `updatePageAfterVersioningRefactorEmitsOnceNoDeadlock` mirrors `withTransactionMutationEmitsOnceNoDeadlock`, asserting single-emit + no deadlock now that `updatePage` composes via the locked helper.
- **`Tests/WikiFSTests/WikiCtlCommandTests.swift`** — 5 new tests for `page info`: round-trip create-with-author → info; post-edit HEAD; argparser coverage; missing-page throws.
- **`PROGRESS.md`** — full entry documenting the work + out-of-scope deferrals (Phase C backfill, Phase D phantom-exhaustiveness-test housekeeping).

## Acceptance criteria

- ✅ **AC.1** — after a chat creates a page, `pageOrigin(pageID:)` returns the chat agent + `activityKind == "import"`.
- ✅ **AC.2** — `pageEditHistory` returns exactly 2 entries for a fresh create+edit (DISTINCT authors so the amend coalescer can't suppress the new row); entry[1] pinned to chat agent + edited body.
- ✅ **AC.3** — `updatePage` CAS-off appends a `page_versions` + `activities` row (verified by row count before/after).
- ✅ **AC.4** — page activities' `agent_id` resolves via `ensureAgent` to a real named agent (not `legacy-import`) when `last_edited_by` is non-null; nil authors degrade to `legacy-import`/`"software"`.
- ✅ **AC.5** — `PageDetailView` shows created-by / last-edited-by / edit history; `chat:<id>` renders with a chat-bubble icon.
- ✅ **AC.6** — `test_updatePage_after_versioning_refactor_emits_single_page_updated` asserts exactly ONE event.
- ✅ **AC.7** — `updatePageAfterVersioningRefactorEmitsOnceNoDeadlock` asserts single-emit + no deadlock.
- ✅ **AC.8** — `if version < 39` step inserted before the catch-all fallback; fresh DB stamps `user_version = 39`; stale `(37)` comment at line 412 corrected.

## Verification

- `make check` ✓ (compiles debug, 0 errors / 0 warnings)
- `make test` ✓ — **3120 tests / 263 suites pass** (~30 s; in-memory SQLite fixtures since #658).

## Notes

- **`StoreEmissionExhaustivenessTests` does NOT exist** despite stale comments in `ChangeTokenContributorTests.swift:18` / `GRDBWikiStore.swift:2614`. The emission invariant is enforced by per-method `StoreEmissionTests` spies + `StoreEmissionReentrancyTests` + this PR's new `AC.6`/`AC.7` tests. The §6.2 option (a) — building a real reflection-based exhaustiveness test — is deferred to Phase D.
- **§5.3 LOW note**: the `tryAmendPageVersion` coalescer now also runs on `updatePage`'s CAS-off path — a rapid same-author save within the 5s window amends the head in place instead of appending a new version row. AC.2/AC.3 account for this by using a DISTINCT author from the create.
- **`createPage(body:)` deferred** (§5.3 cleaner alternative) — a fresh page edited once through `PageUpsert.writePage`'s create-then-update flow now produces 2 entries when the authors differ, OR 1 amended entry when the authors match (autosave semantics).

Does not merge to `main` (per the working agreement — branch pushed, PR open for review).
