### PR TITLE
Restructure Agents settings into Chat/Ingestion/Lint operation tabs

### DIFF
--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -45,6 +45,27 @@ struct AgentsSettingsView: View {
     /// yet" warning and the launcher refuses to spawn).
     @State private var isAddingNewProvider = false
 
+    /// The selected operation sub-tab (Chat / Ingestion / Lint) below the
+    /// Providers section. A segmented `Picker` (NOT a nested `TabView`) — a
+    /// nested `TabView` would inherit the Settings toolbar-tab style and
+    /// render a double bar. The segmented control is the cleaner inline
+    /// macOS idiom and satisfies the "tabs per operation" requirement
+    /// (`plans/agent-settings-tabs.md` §2.1 LOW #9).
+    @State private var selectedOperationTab: OperationTab = .chat
+
+    /// The three operation panes, each owning its stages.
+    enum OperationTab: String, CaseIterable, Identifiable {
+        case chat, ingestion, lint
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .chat:      return "Chat"
+            case .ingestion: return "Ingestion"
+            case .lint:      return "Lint"
+            }
+        }
+    }
+
     let containerDirectory: URL
     private let credentialStore: any ACPCredentialStore
 
@@ -170,16 +191,14 @@ struct AgentsSettingsView: View {
 
                 providerActionBar
 
-                // Per-stage MODEL picker for the resolved default provider
-                // (moved from the deleted PermissionsSettingsView — see
-                // plans/inline-models-and-remove-permissions-tab-v2.md §4d).
-                // Per-stage selects a model VARIANT within the provider's
-                // catalog, NOT a per-stage provider, so it does NOT belong
-                // on a per-provider row.
-                ingestStageSection
+                // Operation tabs (Chat / Ingestion / Lint): per-stage PROVIDER +
+                // MODEL pickers. Each stage can pin a provider (or "Default" =
+                // the global default) and a model from that provider's catalog.
+                // See `plans/agent-settings-tabs.md`.
+                operationTabsSection
             }
 
-            Text("Models you pick on each row apply when that provider runs. Use Edit… for command, environment, API key, and Refresh Models. Ingest Stage Models below apply to whichever provider is currently default.")
+            Text("Models you pick on each row apply when that provider runs. Use Edit… for command, environment, API key, and Refresh Models. The Chat / Ingestion / Lint tabs below pin the provider + model each operation runs with.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -326,53 +345,87 @@ struct AgentsSettingsView: View {
             })
     }
 
-    /// Per-ingest-stage model picker section (moved from the deleted
-    /// `PermissionsSettingsView`). Each ingest phase (planner / executor /
-    /// finalizer) can pick a different MODEL from the resolved default
-    /// provider's cached catalog — same provider across all three (per-stage
-    /// selects a model variant, NOT a provider). "Same as provider" (empty)
-    /// is the default → that stage uses the provider's `selectedModelId`
-    /// (the #604 collapsed behavior — no behavior change for existing users).
-    ///
-    /// Rendered as a nested `Form { Section { … } }.formStyle(.grouped)` so
-    /// the section keeps the same visual style it had in the Permissions tab
-    /// despite the parent being a plain VStack (not a Form). Kept as a
-    /// SIBLING of the providers List + action bar so it stays visible at the
-    /// bottom of the pane.
-    private var ingestStageSection: some View {
-        let provider = config.selectedProvider()
-        let models = config.cachedModels(forProvider: provider.id)
-        let fallbackLabel = config.selectedModelId(forProvider: provider.id) ?? "default"
-        return Form {
-            Section {
-                ForEach(ACPIngestStage.allCases, id: \.rawValue) { stage in
-                    Picker("\(stage.label) Model", selection: Binding(
-                        get: { config.ingestStageModelIds[stage.rawValue] ?? "" },
-                        set: { newID in setStageModel(stage, newID.isEmpty ? nil : newID) }
-                    )) {
-                        Text("Same as provider (\(fallbackLabel))").tag("")
-                        ForEach(models, id: \.modelId) { model in
-                            Text(model.displayLabel).tag(model.modelId)
-                        }
-                    }
-                    .disabled(models.isEmpty)
-                    .help(models.isEmpty
-                          ? "Chat with this provider once to discover its models."
-                          : "Pick a different model for the \(stage.label) phase. Empty uses the provider's selected model.")
+    /// Operation tabs (Chat / Ingestion / Lint): a segmented `Picker` over the
+    /// three operation panes, each rendering one or more
+    /// `StageProviderModelPicker` rows. The segmented control (NOT a nested
+    /// `TabView`) avoids the double-toolbar-bar a nested `TabView` would
+    /// create inside the Settings pane (§2.1 LOW #9). Each pane wraps its
+    /// pickers in a `Form { Section }.formStyle(.grouped)` so the rows keep
+    /// the inset-grouped visual style of the former ingest-stage section.
+    private var operationTabsSection: some View {
+        VStack(spacing: 0) {
+            Picker("Operation", selection: $selectedOperationTab) {
+                ForEach(OperationTab.allCases) { tab in
+                    Text(tab.label).tag(tab)
                 }
-            } header: {
-                Text("Ingest Stage Models (\(provider.label))")
-            } footer: {
-                Text("Pick a different model for each ingest phase — e.g. a small model for Executors and a large model for the Planner. “Same as provider” uses the provider's selected model (the legacy behavior).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 20)
+            .padding(.top, 14)
+            .padding(.bottom, 4)
+
+            operationTabContent
         }
-        .formStyle(.grouped)
     }
 
-    private func setStageModel(_ stage: ACPIngestStage, _ modelId: String?) {
-        save(config.settingIngestStageModel(modelId, forStage: stage.rawValue))
+    @ViewBuilder
+    private var operationTabContent: some View {
+        switch selectedOperationTab {
+        case .chat:
+            Form {
+                Section {
+                    StageProviderModelPicker(
+                        stageKey: "chat",
+                        config: $config,
+                        containerDirectory: containerDirectory,
+                        label: "Chat Model")
+                } header: {
+                    Text("Chat Model")
+                } footer: {
+                    Text("Provider and model for new chat sessions. “Default” uses the global default provider; “Same as provider” uses that provider's selected model.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+        case .ingestion:
+            Form {
+                Section {
+                    ForEach(ACPIngestStage.allCases, id: \.rawValue) { stage in
+                        StageProviderModelPicker(
+                            stageKey: stage.rawValue,
+                            config: $config,
+                            containerDirectory: containerDirectory,
+                            label: "\(stage.label) Model")
+                    }
+                } header: {
+                    Text("Ingest Stage Models")
+                } footer: {
+                    Text("Pin a provider + model for each ingest phase (Planner / Executor / Finalizer). “Default” uses the global default provider. A warm subprocess is shared across phases when stages resolve to the same provider.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+        case .lint:
+            Form {
+                Section {
+                    StageProviderModelPicker(
+                        stageKey: "lint",
+                        config: $config,
+                        containerDirectory: containerDirectory,
+                        label: "Lint Model")
+                } header: {
+                    Text("Lint Model")
+                } footer: {
+                    Text("Provider and model for wiki lint runs. “Default” uses the global default provider; “Same as provider” uses that provider's selected model.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+        }
     }
 
     /// Returns a warning string when `provider` is enabled, has no selected
@@ -544,7 +597,13 @@ struct AgentsSettingsView: View {
 
     private func save(_ updated: AgentProvidersConfig) {
         config = updated
-        try? config.save(to: containerDirectory)
+        do {
+            try updated.save(to: containerDirectory)
+        } catch {
+            // House rule: never bare `try?`. The write may fail (read-only
+            // mount, permission) — log so it's visible in Console.app.
+            DebugLog.store("Failed to save agent-providers config: \(error.localizedDescription)")
+        }
     }
 
     /// #640: persist probe-discovered models durably. Uses

--- a/Sources/WikiFS/Settings/ProviderSelector.swift
+++ b/Sources/WikiFS/Settings/ProviderSelector.swift
@@ -65,8 +65,17 @@ struct ProviderSelector: View {
         config.enabledProviders
     }
 
+    /// The effective provider for chat: the chat stage's pinned provider when
+    /// set + enabled, else the global default. **Decision A**
+    /// (`plans/agent-settings-tabs.md` §6.5): the composer chip must reflect
+    /// the provider chat will ACTUALLY use, so when the chat stage is pinned
+    /// the chip shows the pinned provider — no silent mismatch. Selecting a
+    /// row in the popover still sets the GLOBAL default via
+    /// `setSelectedModelAndDefault(...)` (unchanged behavior); picking in the
+    /// composer affects everything that follows "Default", just not a pinned
+    /// chat stage.
     private var current: AgentProvider {
-        config.selectedProvider()
+        config.provider(forStage: "chat")
     }
 
     var body: some View {

--- a/Sources/WikiFS/Settings/StageProviderModelPicker.swift
+++ b/Sources/WikiFS/Settings/StageProviderModelPicker.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import WikiFSCore
+
+/// A provider + model picker for a single agent stage/operation
+/// (`plans/agent-settings-tabs.md` §2.2/§6). Reused for the Chat Model,
+/// Planner/Executor/Finalizer Models, and Lint Model rows in the nested
+/// Chat/Ingestion/Lint tab view.
+///
+/// - `stageKey`: stable string key into the per-stage overrides
+///   (`"chat"`, `"planner"`, `"executor"`, `"finalizer"`, `"lint"`). For ingest
+///   stages this is `ACPIngestStage.rawValue`.
+/// - `config`: the live config (binding so edits flow back to the parent's
+///   `@State`).
+/// - `containerDirectory`: for persistence (save on every change).
+/// - `label`: human-readable stage label shown as the row title.
+///
+/// The provider dropdown includes a **"Default"** first option (sentinel `""` =
+/// inherit the global default provider). The model dropdown is **dependent** on
+/// the resolved provider's cached model list, and includes a **"Same as
+/// provider"** first option (sentinel `""` = the resolved provider's
+/// `selectedModelId`). Changing the provider pin clears the stage's stale model
+/// override (handled in `AgentProvidersConfig.settingStageProvider(_:forStage:)`).
+struct StageProviderModelPicker: View {
+    let stageKey: String
+    @Binding var config: AgentProvidersConfig
+    let containerDirectory: URL
+    let label: String
+
+    /// The effective provider for this stage (pinned when set + enabled, else
+    /// the global default). Drives the model dropdown's contents.
+    private var resolvedProvider: AgentProvider {
+        config.provider(forStage: stageKey)
+    }
+
+    /// The cached models advertised by the resolved provider. Empty when none
+    /// have been captured yet → the model picker is disabled with a guidance
+    /// placeholder.
+    private var resolvedModels: [CachedModelInfo] {
+        config.cachedModels(forProvider: resolvedProvider.id)
+    }
+
+    /// Friendly name for the "Same as provider" option — shows the concrete
+    /// model id the stage will actually use, so the user can see the effective
+    /// resolution at a glance.
+    private var fallbackLabel: String {
+        config.selectedModelId(forProvider: resolvedProvider.id) ?? "default"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Picker("\(label) Provider", selection: providerBinding) {
+                Text("Default").tag("")
+                ForEach(config.enabledProviders) { p in
+                    Text(p.label).tag(p.id)
+                }
+            }
+
+            Picker("\(label) Model", selection: modelBinding) {
+                if resolvedModels.isEmpty {
+                    Text("Chat with this provider to discover models").tag("")
+                } else {
+                    Text("Same as provider (\(fallbackLabel))").tag("")
+                    ForEach(resolvedModels, id: \.modelId) { model in
+                        Text(model.displayLabel).tag(model.modelId)
+                    }
+                }
+            }
+            .disabled(resolvedModels.isEmpty)
+            .help(resolvedModels.isEmpty
+                  ? "Chat with this provider once to discover its models."
+                  : "Pick a model for the \(label) stage. “Same as provider” uses the provider's selected model.")
+        }
+    }
+
+    /// Reads/writes `config.stageProviderIds[stageKey]`. On set, routes through
+    /// `settingStageProvider(_:forStage:)` (which ALSO clears the stage's stale
+    /// model override when the provider changes — §2.2.3), then persists.
+    private var providerBinding: Binding<String> {
+        Binding(
+            get: { config.stageProviderIds[stageKey] ?? "" },
+            set: { newID in
+                let updated = config.settingStageProvider(
+                    newID.isEmpty ? nil : newID,
+                    forStage: stageKey)
+                save(updated)
+            })
+    }
+
+    /// Reads/writes `config.ingestStageModelIds[stageKey]`. On set, routes
+    /// through `settingIngestStageModel(_:forStage:)`, then persists.
+    private var modelBinding: Binding<String> {
+        Binding(
+            get: { config.ingestStageModelIds[stageKey] ?? "" },
+            set: { newID in
+                let updated = config.settingIngestStageModel(
+                    newID.isEmpty ? nil : newID,
+                    forStage: stageKey)
+                save(updated)
+            })
+    }
+
+    /// Persist the updated config: write back to the parent's `@State` binding
+    /// AND save the sidecar. House rule: never bare `try?` — the write may fail
+    /// (read-only mount, permission) and the failure must be visible in
+    /// Console.app.
+    private func save(_ updated: AgentProvidersConfig) {
+        config = updated
+        do {
+            try updated.save(to: containerDirectory)
+        } catch {
+            DebugLog.store("StageProviderModelPicker save failed (stage=\(stageKey)): \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
@@ -59,16 +59,31 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
     /// `agent-providers.json` without this key decodes to `[:]`.
     public var maxConcurrent: [String: Int]
 
-    /// Per-ingest-stage model overrides. Keyed by stage name (`"planner"`,
-    /// `"executor"`, `"finalizer"` — see `ACPIngestStage`). Each value is a
-    /// model id FOR THE SAME PROVIDER the run resolves via
-    /// `selectedProvider()` (per-stage selects a MODEL variant, not a
-    /// provider). A missing or empty value falls back to
-    /// `selectedModelId(forProvider:)` — identical to today's behavior.
-    /// Forward-compatible: a pre-per-stage `agent-providers.json` without this
-    /// key decodes to `[:]` → every stage uses the provider's
-    /// `selectedModelId`. See `plans/per-stage-model-selection.md`.
+    /// Per-stage MODEL overrides. Keyed by stage name — the ingest stages
+    /// (`"planner"`, `"executor"`, `"finalizer"` — see `ACPIngestStage`) PLUS
+    /// the operation-level stages (`"chat"`, `"lint"`) introduced by the
+    /// agent-settings-tabs plan. Each value is a model id FOR THE STAGE'S
+    /// RESOLVED PROVIDER (see `provider(forStage:)`). A missing or empty value
+    /// falls back to that provider's `selectedModelId(forProvider:)`. The map
+    /// name retains the historical `ingest` prefix for backward-compat (the
+    /// persisted JSON key is unchanged); the chat/lint keys ride the same
+    /// string-keyed map. Do NOT "clean up" the non-ingest keys — they are
+    /// load-bearing (`plans/agent-settings-tabs.md`). Forward-compatible: a
+    /// pre-per-stage `agent-providers.json` without this key decodes to `[:]`
+    /// → every stage uses the provider's `selectedModelId`. See
+    /// `plans/per-stage-model-selection.md`.
     public var ingestStageModelIds: [String: String]
+
+    /// Per-stage PROVIDER overrides. Keyed by stage name (`"chat"`,
+    /// `"planner"`, `"executor"`, `"finalizer"`, `"lint"`). Value = provider
+    /// id. Missing/empty (`""`) = "use the global default provider"
+    /// (`selectedProvider()`). This lets the user pin a different PROVIDER per
+    /// operation/stage (Chat / Ingestion / Lint tabs in Settings), on top of
+    /// the per-stage MODEL overrides in `ingestStageModelIds`. Forward-
+    /// compatible: a pre-this-change `agent-providers.json` without this key
+    /// decodes to `[:]` → every stage uses the global default. See
+    /// `plans/agent-settings-tabs.md`.
+    public var stageProviderIds: [String: String]
 
     public init(
         providers: [AgentProvider] = [AgentProvider.claudeAcpDefault],
@@ -76,7 +91,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         selectedModelIds: [String: String] = [:],
         favoriteModelIds: [String: [String]] = [:],
         maxConcurrent: [String: Int] = [:],
-        ingestStageModelIds: [String: String] = [:]
+        ingestStageModelIds: [String: String] = [:],
+        stageProviderIds: [String: String] = [:]
     ) {
         let normalizedProviders = AgentProvidersConfig.normalized(providers)
         self.providers = normalizedProviders
@@ -85,6 +101,7 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         self.favoriteModelIds = favoriteModelIds
         self.maxConcurrent = maxConcurrent
         self.ingestStageModelIds = ingestStageModelIds
+        self.stageProviderIds = stageProviderIds
     }
 
     // MARK: - Coding (forward-compatible: old files without model caches decode)
@@ -96,6 +113,7 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         case favoriteModelIds
         case maxConcurrent
         case ingestStageModelIds
+        case stageProviderIds
     }
 
     public init(from decoder: Decoder) throws {
@@ -116,6 +134,10 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
         // (the legacy #604 collapsed behavior — no migration, no behavior
         // change for existing users).
         self.ingestStageModelIds = try c.decodeIfPresent([String: String].self, forKey: .ingestStageModelIds) ?? [:]
+        // Forward-compatible: pre-agent-settings-tabs files have no
+        // `stageProviderIds` key. `[:]` → every stage uses the global default
+        // provider (the legacy behavior — no migration, no behavior change).
+        self.stageProviderIds = try c.decodeIfPresent([String: String].self, forKey: .stageProviderIds) ?? [:]
         // NOTE: a legacy `stageAssignments` key in `agent-providers.json` is
         // silently ignored — it is not in `CodingKeys`, so `JSONDecoder`
         // skips it. The original per-stage assignment feature was removed
@@ -181,7 +203,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favoriteModelIds,
             maxConcurrent: maxConcurrent,
-            ingestStageModelIds: ingestStageModelIds)
+            ingestStageModelIds: ingestStageModelIds,
+            stageProviderIds: stageProviderIds)
     }
 
     /// The default provider (the launcher's fallback when the user hasn't picked
@@ -203,6 +226,35 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
     /// Look up a provider by id.
     public func provider(id: String) -> AgentProvider? {
         providers.first(where: { $0.id == id })
+    }
+
+    // MARK: - Per-stage provider + model resolution (agent-settings-tabs plan)
+
+    /// Resolve the concrete provider for a stage: the stage's pinned provider
+    /// when set + enabled, else the global `selectedProvider()`. The stage
+    /// key is one of `"chat"`, `"planner"`, `"executor"`, `"finalizer"`,
+    /// `"lint"`. PURE so it is unit-tested without a subprocess. A disabled
+    /// pin falls back to the default (the launcher never selects a disabled
+    /// provider). See `plans/agent-settings-tabs.md` §3.
+    public func provider(forStage stage: String) -> AgentProvider {
+        if let pinnedId = stageProviderIds[stage],
+           !pinnedId.isEmpty,
+           let p = provider(id: pinnedId), p.enabled {
+            return p
+        }
+        return selectedProvider()
+    }
+
+    /// Resolve the concrete model id for a stage using the stage-resolved
+    /// provider (`provider(forStage:)`). Returns the stage's pinned model id
+    /// when set + non-empty; otherwise falls back to that provider's
+    /// `selectedModelId`. PURE. This is the convenience wrapper that composes
+    /// `provider(forStage:)` + `modelId(forStage:fallbackProvider:)` — the
+    /// launcher's chat/lint/ingest sites call it so both the provider pin and
+    /// the model override resolve through one seam.
+    public func modelId(forStage stage: String) -> String? {
+        let p = provider(forStage: stage)
+        return modelId(forStage: stage, fallbackProvider: p.id)
     }
 
     // MARK: - Per-stage model selection (per-stage-model-selection plan)
@@ -245,7 +297,47 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favoriteModelIds,
             maxConcurrent: maxConcurrent,
-            ingestStageModelIds: stages)
+            ingestStageModelIds: stages,
+            stageProviderIds: stageProviderIds)
+    }
+
+    /// A PURE mutator: returns a NEW config with the per-stage PROVIDER pin for
+    /// `stage` set (or cleared when `providerId` is nil/empty, restoring the
+    /// "use the global default provider" behavior). Called by the Settings UI's
+    /// per-stage provider picker; persisted by the view. Stale-model safety
+    /// (agent-settings-tabs §2.2.3): when the provider pin CHANGES to a
+    /// non-empty value, the stage's MODEL override (`ingestStageModelIds[stage]`)
+    /// is CLEARED — a model id from the previous provider's catalog must never
+    /// be sent to the new provider. The user then re-picks (or leaves "Same as
+    /// provider"). Mirrors the carry-everything-else-through shape of the other
+    /// setters.
+    public func settingStageProvider(_ providerId: String?, forStage stage: String) -> AgentProvidersConfig {
+        let normalized = (providerId?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 }
+        var pins = stageProviderIds
+        let didChange: Bool
+        if let normalized {
+            didChange = (pins[stage] != normalized)
+            pins[stage] = normalized
+        } else {
+            didChange = (pins[stage] != nil)
+            pins.removeValue(forKey: stage)
+        }
+        // Clear the stale model override when the provider pin changes, so a
+        // model id from the old provider's catalog is never routed to the new
+        // provider's subprocess.
+        var stages = ingestStageModelIds
+        if didChange {
+            stages.removeValue(forKey: stage)
+        }
+        DebugLog.store("AgentProvidersConfig.settingStageProvider: stage=\(stage) providerId=\(normalized ?? "nil") clearedModel=\(didChange)")
+        return AgentProvidersConfig(
+            providers: providers,
+            providerModels: providerModels,
+            selectedModelIds: selectedModelIds,
+            favoriteModelIds: favoriteModelIds,
+            maxConcurrent: maxConcurrent,
+            ingestStageModelIds: stages,
+            stageProviderIds: pins)
     }
 
     /// Mark the provider with `id` as the default, demoting every other provider
@@ -272,7 +364,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favoriteModelIds,
             maxConcurrent: maxConcurrent,
-            ingestStageModelIds: ingestStageModelIds)
+            ingestStageModelIds: ingestStageModelIds,
+            stageProviderIds: stageProviderIds)
     }
 
     /// The list of providers the selector surfaces: enabled ones only (the
@@ -319,7 +412,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favoriteModelIds,
             maxConcurrent: maxConcurrent,
-            ingestStageModelIds: ingestStageModelIds)
+            ingestStageModelIds: ingestStageModelIds,
+            stageProviderIds: stageProviderIds)
     }
 
     /// A PURE mutator: returns a NEW config with the user's model selection for
@@ -340,7 +434,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             selectedModelIds: selections,
             favoriteModelIds: favoriteModelIds,
             maxConcurrent: maxConcurrent,
-            ingestStageModelIds: ingestStageModelIds)
+            ingestStageModelIds: ingestStageModelIds,
+            stageProviderIds: stageProviderIds)
     }
 
     // MARK: - Favorites (#favorites — display-only, paseo per-row star)
@@ -378,7 +473,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             selectedModelIds: selectedModelIds,
             favoriteModelIds: favorites,
             maxConcurrent: maxConcurrent,
-            ingestStageModelIds: ingestStageModelIds)
+            ingestStageModelIds: ingestStageModelIds,
+            stageProviderIds: stageProviderIds)
     }
 
     // MARK: - Seed (pure)
@@ -444,7 +540,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
                 selectedModelIds: selectedModelIds,
                 favoriteModelIds: config.favoriteModelIds,
                 maxConcurrent: config.maxConcurrent,
-                ingestStageModelIds: config.ingestStageModelIds)
+                ingestStageModelIds: config.ingestStageModelIds,
+                stageProviderIds: config.stageProviderIds)
         }
         // Missing / corrupt / empty → seed + persist.
         DebugLog.store("AgentProvidersConfig.loadOrSeed: SEED (file missing/corrupt/empty)")

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -1040,6 +1040,15 @@ public final class AgentLauncher {
             case .query: return .chat
             }
         }()
+        // agent-settings-tabs §3: derive the per-stage key from the operation
+        // kind. `run()` is the SHARED one-shot entry for `.ingest` / `.query` /
+        // `.lint`/`.lintPage`. The stageKey drives BOTH the provider
+        // (`provider(forStage:)`) and the model (`modelId(forStage:)`) below —
+        // do NOT hardcode `"lint"` here: that mis-routes small-source ingest
+        // and one-shot query to the lint stage's pinned provider. Large-source
+        // ingest returns early at the `isLargeSource` branch below and gets its
+        // own per-phase resolution in `runACPIngestPlannerExecutors`.
+        let stageKey = Self.stageKey(for: request)
         let policy: PermissionPolicy = resolvePermissionMode(permissionKind)
         // #606: chat is interactive (unbounded — the UI chip is the release
         // valve); ingest/lint are unattended and MUST auto-reject so a stuck
@@ -1052,21 +1061,35 @@ public final class AgentLauncher {
         // planner/executor/finalizer phases run under.
         let turnCeiling = TurnLivenessPolicy.ceiling(for: permissionKind)
 
-        // #324: the launcher reads `agent-providers.json`, picks the default
-        // (or selected) provider, and resolves its PATH command + Keychain key
-        // into providerHints. The app is ACP-only.
-        //
-        // per-stage-model-selection (#704 removed): there is no per-operation
-        // provider pin anymore — every operation (chat / ingest / lint)
-        // resolves ONE provider via `selectedProvider()`. Per-stage MODEL
-        // selection (planner / executor / finalizer) varies the model id
-        // within that ONE provider's catalog; see
-        // `runACPIngestPlannerExecutors` and `AgentProvidersConfig.modelId(
-        // forStage:fallbackProvider:)`. `permissionKind` is still computed
-        // above to drive permission policy + turn ceiling choices, NOT to
-        // pick a provider.
+        // #324 + agent-settings-tabs: the launcher reads `agent-providers.json`
+        // and resolves the provider + model for THIS operation's stage via
+        // `provider(forStage:)` (pinned provider when set + enabled, else the
+        // global default). The app is ACP-only. Per-stage PROVIDER pinning +
+        // per-stage MODEL selection (chat / planner / executor / finalizer /
+        // lint) resolve through one seam; see
+        // `AgentProvidersConfig.provider(forStage:)` /
+        // `modelId(forStage:fallbackProvider:)`. `permissionKind` is still
+        // computed above to drive permission policy + turn ceiling, NOT to
+        // pick a provider (it happens to map to the same stageKey here, but
+        // the provider comes from the config stage map).
         let config = providersConfig()
-        let provider = config.selectedProvider()
+        let provider = config.provider(forStage: stageKey)
+        let resolvedStageModelId = config.modelId(forStage: stageKey, fallbackProvider: provider.id)
+        // SpawnModelGuard for the shared one-shot path (small-source ingest,
+        // one-shot query, lint). Previously only the large-source ingest
+        // orchestrator + interactive chat had this guard — a lint run with no
+        // model picked would silently fall through to the ACP subprocess's
+        // first-listed model. The guard validates the stage-resolved model
+        // against the stage-resolved provider. See `plans/agent-settings-tabs.md`
+        // §3 (SpawnModelGuard scope). `stageName` is nil here — the kind-specific
+        // stage name is only surfaced by the ingest orchestrator's per-phase
+        // loop; for lint/query a generic refusal suffices.
+        if let msg = SpawnModelGuard.validate(provider: provider, modelId: resolvedStageModelId) {
+            preflightError = msg
+            isRunning = false
+            releaseGenerationSlot()
+            return
+        }
         self.backend = resolveBackend(policy, permissionBudget, turnCeiling)
 
         // Resolve the provider's spawn command (PATH-resolved because the
@@ -1129,7 +1152,7 @@ public final class AgentLauncher {
             operationKind: operation.kind.rawValue,
             providerId: provider.id,
             providerLabel: provider.label,
-            selectedModelId: config.selectedModelId(forProvider: provider.id),
+            selectedModelId: resolvedStageModelId,
             thinkingEffort: thinkingOption,
             sourceFiles: sourceFiles,
             sourceIDs: sourceIDs)
@@ -1182,7 +1205,7 @@ public final class AgentLauncher {
                 provider: provider,
                 resolvedCommand: resolvedACPCommand,
                 apiKey: acpAPIKey,
-                selectedModelId: providersConfig().selectedModelId(forProvider: provider.id))
+                selectedModelId: resolvedStageModelId)
         if let wsID = workspaceID {
             providerHints[HintKey.env("WIKI_WORKSPACE")] = wsID
         }
@@ -1360,20 +1383,26 @@ public final class AgentLauncher {
         // at :1022 — we REUSE `self.backend`, never call `resolveBackend`
         // again (which would orphan the ACPBackend actor `run()` built).
 
-        // Resolve the ONE provider + spawn all three phases will share.
+        // Resolve the provider + per-stage models for the three phases.
         //
-        // per-stage-model-selection (#704 removed): there is no per-operation
-        // provider pin anymore — ingest resolves ONE provider via
-        // `selectedProvider()`, and per-stage MODEL selection varies the model
-        // id within that provider's catalog (planner / executor / finalizer
-        // can pick `glm-5.2` / `glm-5.2-fast` / `glm-5.2-short`). The stage
-        // model ids are resolved + applied per-phase below; this top-level
-        // resolution stays ONE provider so the warm subprocess is reused
-        // across planner/executor/finalizer.
-        let provider = providersConfig().selectedProvider()
-        let plannerModel = providersConfig().modelId(forStage: ACPIngestStage.planner.rawValue, fallbackProvider: provider.id)
-        let executorModel = providersConfig().modelId(forStage: ACPIngestStage.executor.rawValue, fallbackProvider: provider.id)
-        let finalizerModel = providersConfig().modelId(forStage: ACPIngestStage.finalizer.rawValue, fallbackProvider: provider.id)
+        // agent-settings-tabs: the subprocess provider is the PLANNER stage's
+        // resolved provider (`provider(forStage: "planner")` — pinned when set,
+        // else the global default). This matches the provider `run()` already
+        // used to build `self.backend` (it derives `stageKey = "planner"` for
+        // `.ingest`). Per-stage MODEL ids resolve through EACH STAGE's own
+        // resolved provider via the `modelId(forStage:)` convenience wrapper,
+        // so a stage pinned to provider B falls back to B's `selectedModelId`.
+        // Architectural note: the warm subprocess is shared across phases
+        // (built from the planner provider) so fork-based context inheritance
+        // works. When all stages resolve to the SAME provider (the common
+        // case — all "Default" or all pinned alike) this is identical to the
+        // prior behavior. Pinning DIFFERENT providers per ingest stage is an
+        // explicit user choice; the per-stage model ids are routed to the
+        // shared subprocess as today.
+        let provider = providersConfig().provider(forStage: ACPIngestStage.planner.rawValue)
+        let plannerModel = providersConfig().modelId(forStage: ACPIngestStage.planner.rawValue)
+        let executorModel = providersConfig().modelId(forStage: ACPIngestStage.executor.rawValue)
+        let finalizerModel = providersConfig().modelId(forStage: ACPIngestStage.finalizer.rawValue)
         guard let spawn = resolveACPProviderSpawn(provider) else {
             DebugLog.agent("runACPIngest: ACP exe missing for provider=\(provider.id) — aborting")
             preflightError = "The agent executable for ‘\(provider.label)’ was not found on your PATH."
@@ -2322,6 +2351,23 @@ public final class AgentLauncher {
         return "agent:\(kind.rawValue)"
     }
 
+    /// Map a one-shot `OperationRequest` to the per-stage key the shared `run()`
+    /// path uses to resolve the provider + model (`agent-settings-tabs.md` §3).
+    /// PURE + static + `nonisolated` so the dispatch is unit-tested without a
+    /// subprocess or the main actor. The mapping is:
+    /// `.ingest → "planner"`, `.lint`/`.lintPage → "lint"`, `.query → "chat"`.
+    /// Do NOT hardcode a single key in `run()` — that would mis-route small-
+    /// source ingest and one-shot query to the lint stage's pinned provider.
+    /// Large-source ingest branches to its own orchestrator and resolves
+    /// per-phase.
+    nonisolated static func stageKey(for request: OperationRequest) -> String {
+        switch request {
+        case .ingest:          return ACPIngestStage.planner.rawValue
+        case .lint, .lintPage: return "lint"
+        case .query:           return "chat"
+        }
+    }
+
     /// Extract the `(sourceFiles, sourceIDs)` pair from a staged `WikiOperation`
     /// for the `models.json` record written at ingestion start. For `.ingest`
     /// this is `(sourcePaths, sourcePaths.map(WikiOperation.sourceID(fromPath:)))`;
@@ -2402,16 +2448,16 @@ public final class AgentLauncher {
         let turnCeiling = TurnLivenessPolicy.ceiling(for: .chat)
         DebugLog.agent("startInteractiveQuery: permissionPolicy=\(policy) budget=nil (interactive) ceiling=\(turnCeiling)s")
 
-        // #324: the launcher reads `agent-providers.json` and picks the
-        // default (or selected) provider. The app is ACP-only.
-        //
-        // per-stage-model-selection (#704 removed): there is no per-operation
-        // provider pin anymore — chat resolves ONE provider via
-        // `selectedProvider()`. Per-stage MODEL selection is an ingest-only
-        // concern (planner / executor / finalizer); chat is always a single
-        // session with one model.
-        let provider = providersConfig().selectedProvider()
-        let resolvedSelectedModel = providersConfig().selectedModelId(forProvider: provider.id)
+        // #324 + agent-settings-tabs: the launcher reads `agent-providers.json`
+        // and resolves the provider + model for the CHAT stage via
+        // `provider(forStage: "chat")` (pinned provider when set + enabled,
+        // else the global default). The app is ACP-only. Per-stage PROVIDER
+        // pinning lets the user route chat to a different provider than
+        // ingest/lint; the composer chip reflects this resolution (Decision A,
+        // `ProviderSelector.current`). The model resolves through the same
+        // stage seam so a chat-specific model override applies.
+        let provider = providersConfig().provider(forStage: "chat")
+        let resolvedSelectedModel = providersConfig().modelId(forStage: "chat")
         DebugLog.agent("startInteractiveQuery: provider=\(provider.id) selectedModel=\(resolvedSelectedModel ?? "nil")")
 
         // Refuse to spawn without an explicit `selectedModelId`. Mirrors the
@@ -2539,7 +2585,7 @@ public final class AgentLauncher {
                     provider: provider,
                     resolvedCommand: resolvedACPCommand,
                     apiKey: acpAPIKey,
-                    selectedModelId: providersConfig().selectedModelId(forProvider: provider.id))
+                    selectedModelId: resolvedSelectedModel)
                 // #397: chat-driven writes carry `chat:<chatID>` as their author
                 // provenance so created_by/last_edited_by points back to the
                 // originating conversation (resolvable via [[chat:…]]). An explicit

--- a/Tests/WikiFSTests/AgentLauncherStageKeyDispatchTests.swift
+++ b/Tests/WikiFSTests/AgentLauncherStageKeyDispatchTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// `plans/agent-settings-tabs.md` §3 (HIGH #2 — the shared `run()` dispatch):
+/// verifies `AgentLauncher.stageKey(for:)` maps each `OperationRequest` kind to
+/// the correct per-stage key. The shared `run()` one-shot entry serves
+/// `.ingest` / `.query` / `.lint` / `.lintPage`; deriving the WRONG key would
+/// mis-route operations to the wrong stage's pinned provider (e.g. a query
+/// silently using the lint provider). These tests pin the mapping without a
+/// subprocess — `stageKey(for:)` is pure + static.
+@Suite("AgentLauncher.stageKey dispatch (run() shared path)")
+struct AgentLauncherStageKeyDispatchTests {
+
+    private let emptyState = ""
+    private let emptySource = OperationRequest.StagedSource(
+        bytes: Data(), ext: "md", displayPath: "x.md", name: "x", sourceID: "ulid")
+
+    @Test func ingestMapsToPlanner() {
+        // Small-source OR large-source ingest (the large/small split is
+        // decided later inside run() after staging) — both derive "planner"
+        // here. Large-source ingest then branches to the orchestrator which
+        // resolves per-phase; small-source uses this key end-to-end.
+        let key = AgentLauncher.stageKey(for: .ingest(sources: [emptySource], stateMarkdown: emptyState))
+        #expect(key == "planner")
+    }
+
+    @Test func lintMapsToLint() {
+        #expect(AgentLauncher.stageKey(for: .lint(stateMarkdown: emptyState)) == "lint")
+    }
+
+    @Test func lintPageMapsToLint() {
+        #expect(AgentLauncher.stageKey(for: .lintPage(pageTitle: "P", brokenLinks: [], stateMarkdown: emptyState)) == "lint")
+    }
+
+    @Test func queryMapsToChat() {
+        // One-shot query (NOT interactive chat — that's startInteractiveQuery,
+        // which hardcodes the "chat" stage independently). A one-shot query
+        // routed through run() uses the chat stage key so it respects a
+        // chat-pinned provider.
+        #expect(AgentLauncher.stageKey(for: .query(question: "Q", stateMarkdown: emptyState)) == "chat")
+    }
+
+    // MARK: - Dispatch correctness vs. the lint stage (the reviewer's concern)
+
+    @Test func smallSourceIngestDoesNotRouteToLintStage() {
+        // The reviewer's explicit worry: hardcoding "lint" in run() would
+        // mis-route small-source ingest to the lint provider. The mapping
+        // MUST be "planner", so a lint-stage provider pin does NOT affect
+        // ingest. Configured with a lint pin, the planner stage (used by
+        // ingest) resolves to the global default, NOT the lint pin.
+        let config = AgentProvidersConfig(
+            providers: [
+                AgentProvider(id: "def", label: "Def", command: ["d"], enabled: true, isDefault: true),
+                AgentProvider(id: "linter", label: "Linter", command: ["l"], enabled: true, isDefault: false),
+            ],
+            stageProviderIds: ["lint": "linter"])
+        let ingestKey = AgentLauncher.stageKey(for: .ingest(sources: [emptySource], stateMarkdown: emptyState))
+        #expect(ingestKey == "planner")
+        // Ingest's resolved provider is the default (def), NOT the linter.
+        #expect(config.provider(forStage: ingestKey).id == "def")
+    }
+
+    @Test func queryDoesNotRouteToLintStage() {
+        // A one-shot query must NOT pick up the lint stage's pinned provider.
+        let config = AgentProvidersConfig(
+            providers: [
+                AgentProvider(id: "def", label: "Def", command: ["d"], enabled: true, isDefault: true),
+                AgentProvider(id: "linter", label: "Linter", command: ["l"], enabled: true, isDefault: false),
+            ],
+            stageProviderIds: ["lint": "linter"])
+        let queryKey = AgentLauncher.stageKey(for: .query(question: "Q", stateMarkdown: emptyState))
+        #expect(queryKey == "chat")
+        #expect(config.provider(forStage: queryKey).id == "def")
+    }
+
+    @Test func lintRoutesToLintStage() {
+        // Lint MUST use the lint stage's pinned provider when set.
+        let config = AgentProvidersConfig(
+            providers: [
+                AgentProvider(id: "def", label: "Def", command: ["d"], enabled: true, isDefault: true),
+                AgentProvider(id: "linter", label: "Linter", command: ["l"], enabled: true, isDefault: false),
+            ],
+            stageProviderIds: ["lint": "linter"])
+        let lintKey = AgentLauncher.stageKey(for: .lint(stateMarkdown: emptyState))
+        #expect(lintKey == "lint")
+        #expect(config.provider(forStage: lintKey).id == "linter")
+    }
+}

--- a/Tests/WikiFSTests/AgentProvidersConfigPerStageModelTests.swift
+++ b/Tests/WikiFSTests/AgentProvidersConfigPerStageModelTests.swift
@@ -355,6 +355,174 @@ struct AgentProvidersConfigPerStageModelTests {
         // read time since `neuralwatt` is no longer in the list).
         #expect(replaced.ingestStageModelIds["planner"] == "glm-5.2-flex")
     }
+
+    // MARK: - Per-stage PROVIDER pin (agent-settings-tabs plan)
+
+    /// Two providers so the pin has somewhere to go.
+    private var twoProviderFixture: AgentProvidersConfig {
+        AgentProvidersConfig(
+            providers: [
+                AgentProvider(
+                    id: "neuralwatt", label: "Neuralwatt",
+                    command: ["neuralwatt", "acp"], env: [:],
+                    enabled: true, isDefault: true),
+                AgentProvider(
+                    id: "acme", label: "Acme",
+                    command: ["acme", "acp"], env: [:],
+                    enabled: true, isDefault: false),
+            ],
+            providerModels: [
+                "neuralwatt": [CachedModelInfo(modelId: "glm-5.2", name: "GLM-5.2", description: nil)],
+                "acme": [CachedModelInfo(modelId: "acme-1", name: "Acme One", description: nil)],
+            ],
+            selectedModelIds: [
+                "neuralwatt": "glm-5.2",
+                "acme": "acme-1",
+            ])
+    }
+
+    @Test func providerForStageNoPinReturnsGlobalDefault() {
+        let config = twoProviderFixture
+        #expect(config.provider(forStage: "planner").id == "neuralwatt")
+        #expect(config.provider(forStage: "chat").id == "neuralwatt")
+        #expect(config.provider(forStage: "lint").id == "neuralwatt")
+    }
+
+    @Test func providerForStageEnabledPinReturnsPinned() {
+        let config = twoProviderFixture.settingStageProvider("acme", forStage: "chat")
+        #expect(config.provider(forStage: "chat").id == "acme")
+        // Other stages unaffected.
+        #expect(config.provider(forStage: "lint").id == "neuralwatt")
+    }
+
+    @Test func providerForStageDisabledPinFallsBackToDefault() {
+        var disabled = twoProviderFixture
+        disabled.providers[1].enabled = false  // disable acme
+        let config = disabled.settingStageProvider("acme", forStage: "chat")
+        // acme is disabled → the pin falls back to the global default.
+        #expect(config.provider(forStage: "chat").id == "neuralwatt")
+    }
+
+    @Test func modelIdForStageConvenienceUsesPerStageProvider() {
+        // modelId(forStage:) composes provider(forStage:) + model override.
+        // Pin chat to acme → the fallback is acme's selectedModelId.
+        let config = twoProviderFixture.settingStageProvider("acme", forStage: "chat")
+        #expect(config.modelId(forStage: "chat") == "acme-1")
+        // A chat stage model override wins.
+        let overridden = config.settingIngestStageModel("glm-5.2", forStage: "chat")
+        #expect(overridden.modelId(forStage: "chat") == "glm-5.2")
+    }
+
+    @Test func chatAndLintKeysResolveViaModelIdForStage() {
+        // The chat/lint keys ride the same ingestStageModelIds map (no schema
+        // change). modelId(forStage:) resolves them through provider(forStage:).
+        let config = twoProviderFixture
+            .settingIngestStageModel("glm-5.2", forStage: "chat")
+            .settingIngestStageModel("acme-1", forStage: "lint")
+        #expect(config.modelId(forStage: "chat") == "glm-5.2")
+        #expect(config.modelId(forStage: "lint") == "acme-1")
+    }
+
+    // MARK: - Stale-model clear on provider pin change (MEDIUM #6)
+
+    @Test func changingStageProviderClearsStaleModelOverride() {
+        // Set a model override under provider A, then change the stage's
+        // provider pin to B → the override MUST be cleared so a model id from
+        // A's catalog is never sent to B's subprocess.
+        let config = twoProviderFixture
+            .settingStageProvider("neuralwatt", forStage: "planner")
+            .settingIngestStageModel("glm-5.2", forStage: "planner")
+        #expect(config.ingestStageModelIds["planner"] == "glm-5.2")
+        let repinned = config.settingStageProvider("acme", forStage: "planner")
+        #expect(repinned.ingestStageModelIds["planner"] == nil)
+        // The provider pin itself changed.
+        #expect(repinned.stageProviderIds["planner"] == "acme")
+    }
+
+    @Test func clearingStageProviderPinDoesNotTouchOtherStages() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingStageProvider("acme", forStage: "lint")
+        let cleared = config.settingStageProvider(nil, forStage: "chat")
+        #expect(cleared.stageProviderIds["chat"] == nil)
+        #expect(cleared.stageProviderIds["lint"] == "acme")
+    }
+
+    @Test func settingSameStageProviderDoesNotClearModel() {
+        // Re-pinning the SAME provider is a no-op for the model override
+        // (didChange == false → no clear).
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingIngestStageModel("acme-1", forStage: "chat")
+        let samePin = config.settingStageProvider("acme", forStage: "chat")
+        #expect(samePin.ingestStageModelIds["chat"] == "acme-1")
+    }
+
+    // MARK: - settingStageProvider carry-through (other fields survive)
+
+    @Test func settingStageProviderPreservesOtherStagePinsAndModels() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingIngestStageModel("glm-5.2", forStage: "executor")
+        let repinned = config.settingStageProvider("acme", forStage: "lint")
+        #expect(repinned.stageProviderIds["chat"] == "acme")
+        #expect(repinned.ingestStageModelIds["executor"] == "glm-5.2")
+        #expect(repinned.selectedModelId(forProvider: "neuralwatt") == "glm-5.2")
+    }
+
+    @Test func settingStageProviderPreservesStageProviderIdsOfOtherStages() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingStageProvider("acme", forStage: "planner")
+        let repinned = config.settingStageProvider("neuralwatt", forStage: "lint")
+        #expect(repinned.stageProviderIds["chat"] == "acme")
+        #expect(repinned.stageProviderIds["planner"] == "acme")
+        #expect(repinned.stageProviderIds["lint"] == "neuralwatt")
+    }
+
+    // MARK: - stageProviderIds carry-through across existing mutators
+
+    @Test func settingDefaultPreservesStageProviderIds() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingDefault(id: "acme")
+        #expect(config.stageProviderIds["chat"] == "acme")
+    }
+
+    @Test func settingIngestStageModelPreservesStageProviderIds() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingIngestStageModel("acme-1", forStage: "chat")
+        #expect(config.stageProviderIds["chat"] == "acme")
+    }
+
+    @Test func settingCachedModelsPreservesStageProviderIds() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingCachedModels([], forProvider: "neuralwatt")
+        #expect(config.stageProviderIds["chat"] == "acme")
+    }
+
+    @Test func settingSelectedModelPreservesStageProviderIds() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .settingSelectedModel("acme-1", forProvider: "acme")
+        #expect(config.stageProviderIds["chat"] == "acme")
+    }
+
+    @Test func togglingFavoritePreservesStageProviderIds() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+            .togglingFavoriteModel("acme-1", forProvider: "acme")
+        #expect(config.stageProviderIds["chat"] == "acme")
+    }
+
+    @Test func replacingProvidersPreservesStageProviderIds() {
+        let config = twoProviderFixture
+            .settingStageProvider("acme", forStage: "chat")
+        let replaced = config.replacingProviders(config.providers)
+        #expect(replaced.stageProviderIds["chat"] == "acme")
+    }
 }
 
 /// per-stage-model-selection plan §7: pure-logic tests for the

--- a/Tests/WikiFSTests/AgentProvidersConfigSeedBackfillTests.swift
+++ b/Tests/WikiFSTests/AgentProvidersConfigSeedBackfillTests.swift
@@ -104,4 +104,79 @@ struct AgentProvidersConfigSeedBackfillTests {
         // (empty as written). The guard will refuse spawn on opencode here.
         #expect(loaded.selectedModelId(forProvider: "claude-acp") == nil)
     }
+
+    // MARK: - stageProviderIds (agent-settings-tabs HIGH #1)
+
+    @Test func oldConfigWithoutStageProviderIdsDecodesToEmpty() throws {
+        // A pre-agent-settings-tabs `agent-providers.json` (no
+        // `stageProviderIds` key) decodes to `[:]` → every stage uses the
+        // global default provider (no migration, no behavior change).
+        let json = """
+        {
+          "providers": [
+            { "id": "claude-acp", "label": "Claude", "command": ["bun"], "env": {}, "enabled": true, "isDefault": true }
+          ],
+          "providerModels": {},
+          "selectedModelIds": { "claude-acp": "sonnet" },
+          "favoriteModelIds": {},
+          "maxConcurrent": {},
+          "ingestStageModelIds": {}
+        }
+        """
+        let data = Data(json.utf8)
+        let config = try JSONDecoder().decode(AgentProvidersConfig.self, from: data)
+        #expect(config.stageProviderIds == [:])
+        #expect(config.provider(forStage: "chat").id == "claude-acp")
+    }
+
+    @Test func loadOrSeedRoundTripsStageProviderIds() throws {
+        // HIGH #1: `loadOrSeed` reconstructs the config via an explicit field
+        // list (its own comments warn it silently drops unlisted fields).
+        // `stageProviderIds` MUST be carried through that reconstruction or
+        // per-stage provider pins vanish on restart. This test writes pins,
+        // reloads via `loadOrSeed`, and asserts the pins SURVIVE.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-providers-stage-pin-rt-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let original = AgentProvidersConfig(
+            providers: [
+                AgentProvider(
+                    id: "claude-acp", label: "Claude",
+                    command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"],
+                    env: [:], enabled: true, isDefault: true),
+                AgentProvider(
+                    id: "acme", label: "Acme",
+                    command: ["acme", "acp"], env: [:],
+                    enabled: true, isDefault: false),
+            ],
+            selectedModelIds: ["claude-acp": "sonnet", "acme": "acme-1"],
+            stageProviderIds: [
+                "chat": "acme",
+                "lint": "claude-acp",
+                "planner": "acme",
+            ])
+        try original.save(to: tmp)
+
+        let loaded = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        // The pins survive the loadOrSeed reconstruction.
+        #expect(loaded.stageProviderIds["chat"] == "acme")
+        #expect(loaded.stageProviderIds["lint"] == "claude-acp")
+        #expect(loaded.stageProviderIds["planner"] == "acme")
+        // And they resolve correctly.
+        #expect(loaded.provider(forStage: "chat").id == "acme")
+        #expect(loaded.provider(forStage: "lint").id == "claude-acp")
+    }
+
+    @Test func stageProviderIdsEncodeAndDecodeThroughJSON() throws {
+        // The new field round-trips through Codable (encode → decode).
+        let original = AgentProvidersConfig(
+            providers: [.claudeAcpDefault],
+            selectedModelIds: ["claude-acp": "sonnet"],
+            stageProviderIds: ["chat": "claude-acp", "lint": "custom"])
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AgentProvidersConfig.self, from: encoded)
+        #expect(decoded.stageProviderIds == ["chat": "claude-acp", "lint": "custom"])
+    }
 }

--- a/Tests/WikiFSTests/StageProviderModelPickerTests.swift
+++ b/Tests/WikiFSTests/StageProviderModelPickerTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+@testable import WikiFSCore
+
+/// `plans/agent-settings-tabs.md` §7: pure-logic tests for the per-stage
+/// provider + model resolution that backs `StageProviderModelPicker`. The View
+/// itself can't be render-tested (no SwiftUI snapshot harness); these tests
+/// pin the resolvers (`provider(forStage:)`, `modelId(forStage:)`) the View
+/// reads so the dropdown behavior is covered. NO subprocess — pure config.
+@Suite("StageProviderModelPicker resolver logic")
+struct StageProviderModelPickerTests {
+
+    // MARK: - Fixture
+
+    /// Two enabled providers + one disabled, each with a cached model catalog,
+    /// and a selected model per provider. Lets every resolution branch fire.
+    private var fixture: AgentProvidersConfig {
+        AgentProvidersConfig(
+            providers: [
+                AgentProvider(
+                    id: "alpha", label: "Alpha",
+                    command: ["alpha", "acp"], env: [:],
+                    enabled: true, isDefault: true),
+                AgentProvider(
+                    id: "beta", label: "Beta",
+                    command: ["beta", "acp"], env: [:],
+                    enabled: true, isDefault: false),
+                AgentProvider(
+                    id: "gamma", label: "Gamma",
+                    command: ["gamma", "acp"], env: [:],
+                    enabled: false, isDefault: false),
+            ],
+            providerModels: [
+                "alpha": [
+                    CachedModelInfo(modelId: "a-1", name: "A One", description: nil),
+                    CachedModelInfo(modelId: "a-2", name: "A Two", description: nil),
+                ],
+                "beta": [
+                    CachedModelInfo(modelId: "b-1", name: "B One", description: nil),
+                ]
+            ],
+            selectedModelIds: [
+                "alpha": "a-1",
+                "beta": "b-1",
+            ])
+    }
+
+    // MARK: - Provider resolution: "" sentinel → global default
+
+    @Test func providerForStageWithEmptyPinReturnsGlobalDefault() {
+        let config = fixture
+        // No pin → the global default (alpha).
+        #expect(config.provider(forStage: "chat") == config.providers[0])
+        #expect(config.provider(forStage: "lint").id == "alpha")
+        #expect(config.provider(forStage: "planner").id == "alpha")
+    }
+
+    @Test func providerForStageWithMissingPinReturnsGlobalDefault() {
+        // A stage with NO entry at all behaves like the "" sentinel.
+        let config = fixture
+        #expect(config.stageProviderIds["chat"] == nil)
+        #expect(config.provider(forStage: "chat").id == "alpha")
+    }
+
+    // MARK: - Provider resolution: enabled pin → that provider
+
+    @Test func providerForStageWithEnabledPinReturnsPinned() {
+        let config = fixture.settingStageProvider("beta", forStage: "chat")
+        #expect(config.provider(forStage: "chat").id == "beta")
+    }
+
+    // MARK: - Provider resolution: disabled pin → fall back to default
+
+    @Test func providerForStageWithDisabledPinFallsBackToDefault() {
+        // gamma is disabled — a pin to it MUST fall back to the global default
+        // (the launcher never selects a disabled provider). This is the
+        // critical guard against routing to a provider that can't spawn.
+        let config = fixture.settingStageProvider("gamma", forStage: "lint")
+        #expect(config.provider(forStage: "lint").id == "alpha")
+    }
+
+    // MARK: - Model resolution: "" sentinel → provider's selectedModelId
+
+    @Test func modelForStageWithNoOverrideReturnsProvidersSelectedModel() {
+        let config = fixture
+        // No model override for chat → the chat stage's resolved provider's
+        // selectedModelId. Default provider is alpha → "a-1".
+        #expect(config.modelId(forStage: "chat") == "a-1")
+    }
+
+    @Test func modelForStageWithProviderPinUsesThatProvidersSelectedModel() {
+        // Pin chat to beta → the fallback is beta's selectedModelId ("b-1").
+        let config = fixture.settingStageProvider("beta", forStage: "chat")
+        #expect(config.modelId(forStage: "chat") == "b-1")
+    }
+
+    @Test func modelForStageOverrideWinsOverProviderFallback() {
+        // A stage model override takes precedence over the provider's
+        // selectedModelId.
+        let config = fixture
+            .settingStageProvider("beta", forStage: "chat")
+            .settingIngestStageModel("b-1", forStage: "chat")
+        #expect(config.modelId(forStage: "chat") == "b-1")
+    }
+
+    @Test func modelForStageReturnsNilWhenProviderHasNoSelection() {
+        // A provider with no selectedModelId and no stage override → nil (the
+        // agent's default model). Mirrors the legacy "no selection" behavior.
+        let config = AgentProvidersConfig(
+            providers: [AgentProvider(id: "p", label: "P", command: ["p"], enabled: true, isDefault: true)])
+        #expect(config.modelId(forStage: "chat") == nil)
+    }
+
+    // MARK: - Cached models follow the resolved provider
+
+    @Test func cachedModelsFollowResolvedProvider() {
+        // The model dropdown reads `cachedModels(forProvider: resolvedProvider.id)`.
+        // With no pin → alpha's catalog; pin chat to beta → beta's catalog.
+        let pinned = fixture.settingStageProvider("beta", forStage: "chat")
+        #expect(fixture.cachedModels(forProvider: fixture.provider(forStage: "chat").id).count == 2)
+        #expect(pinned.cachedModels(forProvider: pinned.provider(forStage: "chat").id).count == 1)
+    }
+
+    // MARK: - Stages are independent
+
+    @Test func stagesAreIndependent() {
+        // Chat pinned to beta, lint pinned to default, planner pinned to beta.
+        let config = fixture
+            .settingStageProvider("beta", forStage: "chat")
+            .settingStageProvider("beta", forStage: "planner")
+        #expect(config.provider(forStage: "chat").id == "beta")
+        #expect(config.provider(forStage: "lint").id == "alpha")
+        #expect(config.provider(forStage: "planner").id == "beta")
+    }
+}

--- a/plans/agent-settings-tabs.md
+++ b/plans/agent-settings-tabs.md
@@ -1,0 +1,515 @@
+# Agent Settings — Operation Tabs (Chat / Ingestion / Lint)
+
+> Plan doc (v2 — revised after plan-reviewer) for restructuring the **Agents**
+> settings tab into a 3-tab layout (Chat / Ingestion / Lint), each with a
+> per-stage provider dropdown (incl. "Default") + a dependent model dropdown.
+>
+> Target: macOS 15 / Swift 6.0.
+>
+> **v2 changelog** — incorporates all plan-reviewer findings:
+> - HIGH: `loadOrSeed` reconstruction now carries `stageProviderIds` (was dropped
+>   on every load → would break "persists across restart").
+> - HIGH: all `selectedProvider()` launch sites enumerated; extraction &
+>   queue-probe explicitly scoped out (was incorrectly "three sites").
+> - HIGH: lint `run()` model application rewired to the per-stage resolver (the
+>   lint model dropdown was cosmetic); SpawnModelGuard scope corrected.
+> - HIGH: composer vs chat-pin reconciled via **Decision A** (Chat tab
+>   authoritative; composer reflects the effective provider).
+> - MEDIUM: field name standardized to `stageProviderIds`; stale model override
+>   cleared on provider-pin change; AC→test mapping; `save()` bare-`try?` fixed.
+> - LOW: nested-TabView style committed; doc comment on the model-override map
+>   extended to cover chat/lint keys.
+
+---
+
+## 1. Goal & current-state summary
+
+### Goal
+
+Reorganize the **Agents** settings pane so each agent *operation* gets its own
+sub-tab:
+
+| Tab           | Stages it owns                                            |
+|---------------|-----------------------------------------------------------|
+| **Chat**      | Chat Model                                                 |
+| **Ingestion** | Planner Model, Executor Model, Finalizer Model            |
+| **Lint**      | Lint Model *(new — does not exist as a concept today)*    |
+
+Every stage gets a **provider dropdown** that includes a **"Default"** option,
+and a **model dropdown** whose options are **dependent on the chosen provider**
+(populated from that provider's cached model list).
+
+### Current state (file paths)
+
+| Concern                        | File / Type                                                                 |
+|--------------------------------|-----------------------------------------------------------------------------|
+| Settings container (TabView)   | `Sources/WikiFS/Window/WikiFSApp.swift:500-514` — `Settings { TabView }`    |
+| Agents settings view           | `Sources/WikiFS/Settings/AgentsSettingsView.swift` (~1010 lines)            |
+| Provider editor sheet          | `AgentsSettingsView.swift:583` `ProviderEditorView`                         |
+| Add-provider sheet             | `Sources/WikiFS/Settings/AddProviderSheet.swift`                            |
+| Composer provider+model picker | `Sources/WikiFS/Settings/ProviderSelector.swift`                            |
+| Persisted config (the model)   | `Sources/WikiFSCore/Core/AgentProvidersConfig.swift`                        |
+| Provider unit                  | `Sources/WikiFSCore/Core/AgentProvider.swift`                               |
+| Ingest stage enum              | `Sources/WikiFSCore/Sources/IngestPlan.swift:8` `ACPIngestStage`            |
+| Config persistence protocol    | `Sources/WikiFSCore/Core/JSONSidecarConfig.swift`                           |
+| Launcher (default resolution)  | `Sources/WikiFSEngine/AgentLauncher.swift`                                  |
+| Per-stage model resolution     | `AgentLauncher.swift:1373-1376` `modelId(forStage:fallbackProvider:)`       |
+| Chat resolution                | `AgentLauncher.swift:2413` `startInteractiveQuery`                          |
+| Lint/query one-shot            | `AgentLauncher.swift:1069` `run()` (provider) + `:1181-1185` (model)        |
+
+### Current AgentsSettingsView structure
+
+```
+AgentsSettingsView (body → providersSection)
+├── "Providers" header (Text)
+├── List(config.providers) { providerRow }            ← one row per provider
+│     providerRow: Toggle(enabled) + label + command + inline modelPicker(▾)
+│     (modelPicker: "Agent default" + cachedModels for THAT provider)
+├── providerActionBar                                  ← Add / Remove / Make Default / Edit…
+├── ingestStageSection                                 ← Form{Section} — per-stage MODEL picker
+│     ForEach(ACPIngestStage.allCases):
+│       Picker("\(stage.label) Model")                 ← planner/executor/finalizer
+│         "Same as provider (model)" .tag("")
+│         ForEach(cachedModels of the DEFAULT provider)
+├── footer caption
+└── save(_:) at :545-548  ← BARE try? (fixed in §6.6)
+```
+
+**Key observations:**
+- There is **no provider dropdown per stage** today. The whole view has ONE
+  shared default provider (`selectedProvider()`); the per-stage pickers only
+  vary the *model id* within that one provider's catalog.
+- `ACPIngestStage` = `.planner, .executor, .finalizer` only. There is **no chat
+  stage and no lint stage enum.**
+- The "Default" concept today = `AgentProvider.isDefault` (exactly one provider
+  is default; enforced by `normalized()`). "Default" is a *provider* property,
+  NOT a per-stage property.
+
+---
+
+## 2. Target design
+
+### 2.1 Top-level layout
+
+Keep the existing Settings `TabView` (Zotero / Extraction / Agents) in
+`WikiFSApp.swift` unchanged at the top level. Inside `AgentsSettingsView`,
+introduce a **nested `TabView`** (Chat / Ingestion / Lint) below the existing
+Providers section:
+
+```
+Settings TabView (unchanged)
+└── AgentsSettingsView
+    ├── [existing] Providers section (provider list + Add/Remove/Edit…)  ← KEEP AS-IS
+    └── OperationTabs  ← NEW nested TabView (Chat / Ingestion / Lint)
+        ├── Chat tab      → StageProviderModelPicker(stageKey: "chat", label: "Chat Model")
+        ├── Ingestion tab → ForEach(ACPIngestStage.allCases) { StageProviderModelPicker }
+        └── Lint tab      → StageProviderModelPicker(stageKey: "lint", label: "Lint Model")
+```
+
+**Tab control decision (LOW finding):** commit to a **nested `TabView`** with an
+explicit `.tabViewStyle(...)` chosen so it does not collide with the top-level
+toolbar-tab style. **Visual validation is an acceptance criterion** (§8). If the
+implementer finds the nested `TabView` renders an awkward double-bar inside the
+settings `Form`/`VStack`, fall back to a **`Picker(selection:).pickerStyle(.segmented)`**
+driving a `switch` over the three operation panes — this is the cleaner inline
+macOS idiom and satisfies the "tabs per operation" requirement.
+
+**Why keep the Providers section global:** providers (command/env/API key/cached
+models) are operation-agnostic subprocess configurations. The new tabs are about
+*which provider+model runs each operation/stage*, not editing provider details.
+
+### 2.2 The shared stage picker component
+
+Build a **new** reusable SwiftUI view: **`StageProviderModelPicker`**
+
+**Location:** `Sources/WikiFS/Settings/StageProviderModelPicker.swift` (new file)
+
+**Purpose:** One provider dropdown (incl. "Default") + one dependent model
+dropdown. Reused for Chat Model, Planner/Executor/Finalizer Models, and Lint Model.
+
+**Proposed API:**
+
+```swift
+/// A provider + model picker for a single agent stage/operation.
+///
+/// - `stageKey`: stable string key into the per-stage overrides
+///   (`"chat"`, `"planner"`, `"executor"`, `"finalizer"`, `"lint"`).
+///   For ingest stages this is `ACPIngestStage.rawValue`.
+/// - `config`: the live config (binding so edits flow back through `save()`).
+/// - `containerDirectory`: for persistence (save on change).
+/// - `label`: human-readable stage label shown as the row title.
+struct StageProviderModelPicker: View {
+    let stageKey: String
+    @Binding var config: AgentProvidersConfig
+    let containerDirectory: URL
+    let label: String
+}
+```
+
+**Behavior:**
+
+1. **Provider dropdown** (`Picker`):
+   - First option: **"Default"** (tag `""` = inherit the global default provider).
+   - Then one entry per `config.enabledProviders`.
+   - Selection reads/writes `config.stageProviderIds[stageKey]` (the NEW field, §4).
+2. **Model dropdown** (`Picker`, dependent):
+   - Options = the **resolved provider's** cached models.
+   - When the provider is "Default", resolve via `config.provider(forStage:)` →
+     `selectedProvider()`, then list ITS cached models.
+   - First model option: **"Same as provider"** (tag `""`) = the provider's
+     `selectedModelId` (legacy semantics, so existing overrides keep working).
+   - Reads/writes `config.ingestStageModelIds[stageKey]` (the existing field).
+   - Disabled + placeholder ("Chat with this provider to discover models") when
+     the resolved provider has no cached models.
+3. **Stale-model safety (MEDIUM finding):** when the user changes the **provider**
+   pin for a stage, **clear that stage's model override** (`ingestStageModelIds[stage]
+   = ""`) so a model id from the previous provider's catalog is never sent to the
+   new provider. The user then re-picks (or leaves "Same as provider").
+4. **On change:** persist via the **corrected** `save(_:)` helper (§6.6 — no bare
+   `try?`; `do/catch { DebugLog.store(...) }`).
+
+### 2.3 What goes in each tab
+
+| Tab | Stages rendered |
+|-----|-----------------|
+| **Chat** | One `StageProviderModelPicker(stageKey: "chat", label: "Chat Model")` |
+| **Ingestion** | `ForEach(ACPIngestStage.allCases)` → one `StageProviderModelPicker(stageKey: stage.rawValue, label: "\(stage.label) Model")` per planner/executor/finalizer |
+| **Lint** | One `StageProviderModelPicker(stageKey: "lint", label: "Lint Model")` |
+
+---
+
+## 3. "Default" sentinel handling & resolution
+
+### The existing "Default" concept
+
+- Today, "Default" is a property of a *provider*: `AgentProvider.isDefault`.
+  Exactly one provider is default (`normalized()` enforces this).
+- `config.selectedProvider()` = the default provider if enabled, else the first
+  enabled provider, else `claudeAcpDefault`.
+- There is **no per-stage "default provider"** today — every stage implicitly
+  uses `selectedProvider()`. The per-stage override only changes the *model id*.
+
+### New per-stage "Default" sentinel
+
+- **Provider sentinel:** empty string `""` in `stageProviderIds[stage]` means
+  "use the global default provider". This mirrors the existing model sentinel
+  (`""` = "Same as provider") for UX consistency. No collision risk: `""` is not
+  a valid provider id.
+- **Model sentinel:** empty string `""` in `ingestStageModelIds[stage]` means
+  "use the resolved provider's `selectedModelId`" (unchanged).
+
+### Resolution helpers to add (on `AgentProvidersConfig`, pure)
+
+```swift
+/// Resolve the concrete provider for a stage: the stage's pinned provider
+/// when set + enabled, else the global `selectedProvider()`.
+public func provider(forStage stage: String) -> AgentProvider {
+    if let pinnedId = stageProviderIds[stage],          // ← stageProviderIds (NOT ingestStageProviderIds)
+       !pinnedId.isEmpty,
+       let p = provider(id: pinnedId), p.enabled {
+        return p
+    }
+    return selectedProvider()
+}
+
+/// Resolve the concrete model id for a stage using the stage-resolved provider.
+public func modelId(forStage stage: String) -> String {
+    let p = provider(forStage: stage)
+    return modelId(forStage: stage, fallbackProvider: p.id)   // existing resolver
+}
+```
+
+And a pure mutator `settingStageProvider(_ providerId: String, forStage stage: String)`
+that returns a copy with `stageProviderIds[stage] = providerId` and (per §2.2.3)
+clears `ingestStageModelIds[stage]` to `""` when the provider pin changes.
+
+### Where "default" resolution happens — ALL launch sites (HIGH finding)
+
+The launcher is the single source of truth for turning "default" into a concrete
+provider+model. **Every** `selectedProvider()` call site that drives an actual
+agent subprocess must be enumerated. Confirmed sites:
+
+| Site | Path | Action in this change |
+|------|------|-----------------------|
+| Ingest planner/exec/finalizer | `AgentLauncher.runACPIngestPlannerExecutors` ~`:1373` | **WIRE** — resolve each stage's provider via `config.provider(forStage: <stage>)` instead of always `selectedProvider()`. Per-stage *model* via `modelId(forStage:)`. |
+| Chat | `AgentLauncher.startInteractiveQuery` ~`:2413` | **WIRE** — resolve via `config.provider(forStage: "chat")`. |
+| Lint / query / small-source ingest (shared `run()`) | `AgentLauncher.run()` ~`:1069` (provider) + `:1181-1185` (model) | **WIRE via operation-kind dispatch (v3 fix).** `run()` is the SHARED one-shot entry for `.ingest`/`.query`/`.lint` (kind switch at `:1036-1042`; large-source ingest returns early at `:1156`, so small-source ingest + all `.query` fall through to the `:1069` provider). Derive `stageKey` from the operation kind: `.lint`/`.lintPage → "lint"`, `.query → "chat"`, small-source `.ingest → "planner"`. Then BOTH `:1069` (`provider(forStage: stageKey)`) and `:1185` (`modelId(forStage: stageKey, fallbackProvider: provider.id)`) use that SAME key — do NOT hardcode `"lint"` (that mis-routes small-source ingest + query to the lint provider). Add tests: small-source ingest does NOT use the lint stage's pinned provider; query does NOT use the lint provider. |
+| Extraction subprocess | `ACPExtractionClient.make(...)` ~`:246-255` (`acpProviderId` else `selectedProvider()`) | **SCOPE OUT** — extraction is a distinct operation with its own `acpProviderId` override and is NOT one of Chat/Ingestion/Lint. Leave unchanged. |
+| Queue provider probe | `AppQueueIngestionProvider` ~`:55` | **SCOPE OUT** — detection-only (probes which provider can run); not a stage launch. Leave unchanged. |
+| Default-provider closure | `AgentLauncher.resolveSelectedProvider` ~`:259` (default closure) | **VERIFY** — confirm it is the fallback used by `selectedProvider()` and does not need a stage pin (it is the "Default" resolution target itself). Leave unchanged. |
+
+> The plan no longer claims "three sites". There are **three wired** (ingest /
+> chat / lint) and **two scoped out** (extraction, queue-probe) plus one verified
+> fallback closure.
+
+### SpawnModelGuard scope (HIGH finding #3, corrected)
+
+`SpawnModelGuard.validate(provider:modelId:)` is called at exactly **two** sites
+today — ingest (`:1397`) and chat (`:2434`) — **NOT** in `run()` (lint). The
+original gotcha "validate against the stage-resolved provider" applies to ingest
++ chat only. **Decision:** add `SpawnModelGuard` validation to the **lint**
+`run()` path as well, validating the lint stage's resolved model against the
+stage-resolved provider's cache, for consistency. (If the team prefers minimal
+surface, the fallback is to leave lint unguarded as today — but then the lint
+model dropdown's validity is unchecked; the plan recommends adding the guard.)
+
+---
+
+## 4. Persistence & config-model changes
+
+### This plan DOES require a config-model change
+
+The current `AgentProvidersConfig` stores per-stage **model** overrides only
+(`ingestStageModelIds: [String: String]`). There is **no per-stage provider**
+field, and **no chat model / lint model** concept.
+
+### NEW field on `AgentProvidersConfig`
+
+```swift
+/// Per-stage PROVIDER overrides. Keyed by stage name ("chat", "planner",
+/// "executor", "finalizer", "lint"). Value = provider id. Missing/empty ("")
+/// = "use the global default provider" (`selectedProvider()`).
+/// Backward-compatible: a pre-this-change file decodes to `[:]`.
+public var stageProviderIds: [String: String]
+```
+
+### EXISTING field — keep, extend doc comment (LOW finding #10)
+
+Keep `ingestStageModelIds` as the per-stage **model** override map (it already
+accepts arbitrary string keys, so `"chat"` / `"lint"` work with no schema change).
+**Extend its doc comment** to state it now holds model overrides for ALL stages
+(chat / planner / executor / finalizer / lint), not just ingest — so future
+readers don't "clean up" non-ingest keys. (A rename to `stageModelIds` is a
+possible future refactor but is NOT in scope here — it would touch more call
+sites and the persisted JSON key for no behavioral gain; backward compat is
+trivially preserved by keeping the name.)
+
+### Backward compatibility & loadOrSeed (HIGH finding #1) — CRITICAL
+
+Two construction paths must carry the new field, or it is silently dropped:
+
+1. **`init(from:)` decode:** add `stageProviderIds` to `CodingKeys` + decode with
+   `decodeIfPresent(...) ?? [:]` (same pattern every other new field uses).
+2. **`loadOrSeed` reconstruction (the trap):** `loadOrSeed` (~`:441-447`) is a
+   static factory that RECONSTRUCTS the config via the memberwise init with an
+   **explicit field list**. The file's own comments (`:173-174`) warn that this
+   reconstruction silently drops any defaulted field not listed. **`stageProviderIds`
+   MUST be passed through** the `loadOrSeed` reconstruction (`... stageProviderIds:
+   config.stageProviderIds ...`) or the just-decoded value is reset to `[:]` on
+   every load — breaking "survives restart".
+
+**Mutator carry-through:** carry `stageProviderIds` through EVERY existing pure
+mutator exactly as `ingestStageModelIds` is carried — the verified-complete list:
+`replacingProviders`, `settingDefault`, `settingIngestStageModel`,
+`settingCachedModels`, `settingSelectedModel`, `togglingFavoriteModel`. (And, per
+above, through `loadOrSeed`'s reconstruction.)
+
+### What NOT to change
+
+- `AgentProvider` (the provider unit is fine as-is).
+- `ACPIngestStage` (keep planner/executor/finalizer — chat/lint are string keys, not ingest stages).
+- `JSONSidecarConfig` protocol or the `save(to:)` / `load(from:)` / `loadOrSeed(from:)` shape.
+
+---
+
+## 5. Exact files to add / modify
+
+### NEW files
+
+| Path | Purpose |
+|------|---------|
+| `Sources/WikiFS/Settings/StageProviderModelPicker.swift` | Shared provider-dropdown + dependent-model-dropdown component (§2.2). |
+
+### MODIFIED files
+
+| Path | Change |
+|------|--------|
+| `Sources/WikiFSCore/Core/AgentProvidersConfig.swift` | Add `stageProviderIds` field + `CodingKeys` + `init(from:)` (decode-if-present). **Carry `stageProviderIds` through `loadOrSeed` reconstruction (`:441-447`) AND all 6 pure mutators.** Add `provider(forStage:)`, `modelId(forStage:)` (pure resolvers) + `settingStageProvider(_:forStage:)` (pure mutator that also clears the stage model override). Extend `ingestStageModelIds` doc comment. |
+| `Sources/WikiFS/Settings/AgentsSettingsView.swift` | Add nested `TabView` (Chat/Ingestion/Lint) below the Providers section; move `ingestStageSection`'s per-stage pickers into the Ingestion tab; add Chat + Lint tabs via `StageProviderModelPicker`. **Fix `save(_:)` (`:545-548`) bare-`try?` → `do/catch { DebugLog.store(...) }`** (§6.6). |
+| `Sources/WikiFS/Settings/ProviderSelector.swift` | **Decision A (HIGH finding #4):** the composer chip must reflect the *effective* chat provider. Read the displayed provider from `config.provider(forStage: "chat")` (not bare `selectedProvider()`) so when chat is pinned the chip shows the pinned provider — no silent mismatch. The composer picker KEEPS setting the global default via `setSelectedModelAndDefault(...)` (unchanged behavior); picking in the composer still affects everything that follows "Default", just not a pinned chat. |
+| `Sources/WikiFSEngine/AgentLauncher.swift` | Wire stage launches to `config.provider(forStage:)`: ingest `runACPIngestPlannerExecutors` (~`:1373`), chat `startInteractiveQuery` (~`:2413`). For the SHARED `run()` one-shot (`:1069` + `:1185`), derive `stageKey` from the operation kind (`:1036-1042`): `.lint→"lint"`, `.query→"chat"`, small-source `.ingest→"planner"`; use it for BOTH the provider (`:1069`) and the model builder (`:1185`). Add `SpawnModelGuard` to the lint path (§3). Leave extraction + queue-probe unchanged. |
+
+### NOT modified (explicitly scoped out — verified compatible)
+
+| Path | Why |
+|------|-----|
+| `Sources/WikiFSCore/Sources/IngestPlan.swift` (`ACPIngestStage`) | Stays planner/executor/finalizer. Chat/lint use string keys. |
+| `Sources/WikiFS/Window/WikiFSApp.swift` | Top-level Settings `TabView` unchanged. |
+| `Sources/WikiFS/Settings/AddProviderSheet.swift` | Provider CRUD is separate from per-stage pinning. |
+| `Sources/WikiFSEngine/ACPExtractionClient.swift` | Extraction is its own operation with its own `acpProviderId` override. |
+| `AppQueueIngestionProvider.swift` | Queue probe is detection-only. |
+
+---
+
+## 6. The shared picker component — detailed spec
+
+### 6.1 `StageProviderModelPicker`
+
+```swift
+struct StageProviderModelPicker: View {
+    let stageKey: String
+    @Binding var config: AgentProvidersConfig
+    let containerDirectory: URL
+    let label: String
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            // --- Provider dropdown ---
+            Picker("\(label) Provider", selection: providerBinding) {
+                Text("Default").tag("")            // sentinel = global default
+                ForEach(config.enabledProviders) { p in Text(p.label).tag(p.id) }
+            }
+            // --- Model dropdown (dependent on resolved provider) ---
+            Picker("\(label) Model", selection: modelBinding) {
+                Text("Same as provider").tag("")
+                ForEach(resolvedModels, id: \.modelId) { Text($0.displayLabel).tag($0.modelId) }
+            }
+            .disabled(resolvedModels.isEmpty)
+        }
+    }
+
+    private var resolvedProvider: AgentProvider { config.provider(forStage: stageKey) }
+    private var resolvedModels: [CachedModelInfo] { config.cachedModels(forProvider: resolvedProvider.id) }
+
+    // providerBinding reads/writes config.stageProviderIds[stageKey]
+    //   on set: config = config.settingStageProvider(newValue, forStage: stageKey)
+    //           (which ALSO clears ingestStageModelIds[stageKey] → "", §2.2.3)
+    //           then save(config)
+    // modelBinding reads/writes config.ingestStageModelIds[stageKey]
+    //   on set: config = config.settingIngestStageModel(newValue, forStage: stageKey)
+    //           then save(config)
+}
+```
+
+### 6.2 Sentinel rules
+- Provider = `""` (Default) → `provider(forStage:)` returns `selectedProvider()`.
+- Model = `""` (Same as provider) → `modelId(forStage:)` returns the resolved
+  provider's `selectedModelId`.
+
+### 6.3 Stale-model clear
+When `providerBinding` sets a non-empty provider pin, the mutator clears the
+stage's model override (§2.2.3). Covered by a test (§7).
+
+### 6.4 Field-name discipline (MEDIUM finding #5)
+Provider pin → `stageProviderIds` (new). Model override → `ingestStageModelIds`
+(existing, doc-comment-extended). The §3 snippets read `stageProviderIds` — not
+`ingestStageProviderIds` (that was the v1 typo).
+
+### 6.5 Composer reflection (Decision A)
+`ProviderSelector` displays `config.provider(forStage: "chat")` (effective
+provider). Keep `setSelectedModelAndDefault(...)` so the composer still sets the
+global default. Covered by an AC (§8).
+
+### 6.6 `save(_:)` fix (MEDIUM finding #8)
+```swift
+// BEFORE (AgentsSettingsView.swift:545-548) — violates house rule:
+private func save(_ updated: AgentProvidersConfig) {
+    config = updated
+    try? config.save(to: containerDirectory)        // bare try? — HIDDEN failure
+}
+// AFTER:
+private func save(_ updated: AgentProvidersConfig) {
+    config = updated
+    do { try config.save(to: containerDirectory) }
+    catch { DebugLog.store("Failed to save agent-providers config: \(error)") }
+}
+```
+`StageProviderModelPicker` routes persistence through this same corrected helper
+(via the binding's on-set), so it does not diverge from the established pattern.
+
+---
+
+## 7. Testing plan
+
+### NEW Swift Testing files
+
+| Path | What it tests |
+|------|---------------|
+| `Tests/WikiFSTests/StageProviderModelPickerTests.swift` | Pure resolver logic only: provider `""` → `selectedProvider()`; model `""` → provider's selected model; enabled-pin → that provider; disabled-pin → fallback. (Not the View.) |
+
+### MODIFIED Swift Testing files
+
+| Path | What to add |
+|------|-------------|
+| `Tests/WikiFSTests/AgentProvidersConfigPerStageModelTests.swift` | `provider(forStage:)`: no pin → default; enabled pin → that provider; disabled pin → falls back. `settingStageProvider` carry-through (other fields survive). `"chat"`/`"lint"` keys via `modelId(forStage:)`. **Stale-model clear:** set stage model under provider A, change stage provider to B → model override cleared. **Lint model application path** is exercised indirectly via the resolver. |
+| `Tests/WikiFSTests/AgentProvidersConfigSeedBackfillTests.swift` | Legacy `agent-providers.json` without `stageProviderIds` decodes to `[:]` (no crash, no behavior change). **NEW (HIGH #1):** a `loadOrSeed` round-trip test — write `stageProviderIds`, reload via `loadOrSeed`, assert the pins SURVIVE (catches the reconstruction drop). |
+
+### AC → test mapping (MEDIUM finding #7)
+
+| Acceptance criterion (§8) | Verification |
+|---|---|
+| Nested Chat/Ingestion/Lint tab bar renders | **Manual** (UI) |
+| Providers section unchanged & works | **Manual** (UI) |
+| Chat/Ingestion/Lint rows with provider+model dropdowns | **Manual** (UI) |
+| Provider dropdown includes "Default" first | **Manual** (UI) |
+| Selecting provider repopulates model dropdown | **Manual** (UI) |
+| Selecting "Default" resolves to global default's models | `StageProviderModelPickerTests` + `AgentProvidersConfigPerStageModelTests` (`provider(forStage:)` empty-pin) |
+| Composer chip reflects effective chat provider (pinned case) | **Manual** (UI) |
+| Changes persist across restart | `AgentProvidersConfigSeedBackfillTests` (loadOrSeed round-trip) |
+| Legacy file decodes; existing overrides still apply | `AgentProvidersConfigSeedBackfillTests` (legacy decode) |
+| Stale model cleared on provider switch | `AgentProvidersConfigPerStageModelTests` (stale-model) |
+| Lint model selection is actually applied at spawn | **Code review** (rewired `:1185`) — resolver covered by tests |
+| No `print`; no bare `try?` | **Code review** + grep guard |
+| New tests pass; full suite passes | `swift test` |
+
+**Test strategy:** there is no SwiftUI render/snapshot harness in the repo. UI
+ACs are therefore **explicitly downgraded to manual validation** (operator checks
+in the running app), with a limitation note. All pure-logic ACs map to named
+Swift Testing cases above.
+
+### Conventions
+- Swift Testing (`import Testing`, `@Suite`, `#expect`), NOT XCTest.
+- Pure-logic tests only (no subprocess / no View rendering).
+- Follow `docs/skills/swift-testing-pro/SKILL.md`.
+
+---
+
+## 8. Acceptance criteria
+
+- [ ] The Agents settings pane shows a nested tab bar with **Chat**, **Ingestion**, **Lint**.
+- [ ] The **Providers** section (list + Add/Remove/Make Default/Edit…) is unchanged and still works.
+- [ ] **Chat tab** shows a "Chat Model" row with a provider dropdown + model dropdown.
+- [ ] **Ingestion tab** shows Planner / Executor / Finalizer model rows, each with provider + model dropdowns.
+- [ ] **Lint tab** shows a "Lint Model" row with provider + model dropdowns.
+- [ ] Every provider dropdown includes a **"Default"** option as the first entry.
+- [ ] Selecting a provider repopulates the model dropdown with **that provider's** cached models.
+- [ ] Selecting "Default" resolves to the global default provider's models.
+- [ ] **Composer chip reflects the effective chat provider** (shows the pinned provider when chat is pinned — no silent mismatch). *(Decision A)*
+- [ ] **Lint model selection is actually applied** at spawn (rewired `:1185`, not cosmetic). *(HIGH #3)*
+- [ ] **`run()` routes by operation kind** — small-source ingest does NOT use the lint stage's pinned provider, and query does NOT use the lint provider (`stageKey` derived at `:1036-1042`, used at both `:1069` and `:1185`). *(plan-reviewer v3)*
+- [ ] Changes persist to `agent-providers.json` **and survive `loadOrSeed` restart** (round-trip test). *(HIGH #1)*
+- [ ] An existing `agent-providers.json` (pre-change) decodes without error; existing per-stage model overrides for planner/executor/finalizer still apply.
+- [ ] **Changing a stage's provider pin clears its stale model override.** *(MEDIUM #6)*
+- [ ] No `print` statements; all logging via `DebugLog`.
+- [ ] No bare `try?` — including the fixed `save(_:)` helper.
+- [ ] New tests pass: `swift test --filter AgentProvidersConfigPerStageModelTests` (+ seed-backfill + picker tests).
+- [ ] Full suite passes: `swift test` (or `make test`).
+- [ ] **Manual:** nested tab control renders cleanly (no awkward double-bar) on macOS 15. *(LOW #9)*
+
+---
+
+## 9. Constraints & house rules (from AGENTS.md)
+
+- **Never use `print`** — route diagnostics through `DebugLog` (`os_log`, subsystem `com.selfdrivingwiki.debug`).
+- **Never use bare `try?`** — `do { try … } catch { DebugLog.store(…) }`.
+- **Prefer Swift Testing** over XCTest.
+- **Never commit or push to `main`** — feature branch → PR. Do NOT merge to main.
+- **Build/test:** `make build` / `make test` (auto-regenerate `GeneratedPrompts.swift` + `GeneratedVersion.swift`); bare `swift build` does NOT — run `make prompts` first.
+- **Scratch files** go in `tmp/` (gitignored), not `/tmp`.
+- **Change signaling (#129):** not in play — this change touches `AgentProvidersConfig` (JSON sidecar), NOT `SQLiteWikiStore`.
+- **macOS 15 / Swift 6.0** — filter iOS 26 / Swift 6.2 guidance from skills.
+
+---
+
+## 10. Gotchas & risks (reviewer-corrected)
+
+1. **`loadOrSeed` silently drops new fields** (`:441-447`, warned at `:173-174`). `stageProviderIds` MUST be passed through the reconstruction or per-stage pins vanish on restart. *(HIGH #1 — now in §4.)*
+2. **More than three launch sites.** `selectedProvider()` is read at ingest/chat/lint (wire), extraction `ACPExtractionClient` (scope out — own `acpProviderId`), queue probe `AppQueueIngestionProvider` (scope out — detection), and the default closure `AgentLauncher:259` (verify). The lint path needs BOTH provider (`:1069`) and model (`:1185`) rewired. *(HIGH #2 & #3 — now in §3.)*
+3. **Composer vs chat pin** — reconciled via Decision A: composer reflects effective chat provider; keeps setting global default. *(HIGH #4 — now in §3/§5/§6.5.)*
+4. **Stale model after provider switch** — cleared in the mutator. *(MEDIUM #6 — now in §2.2.3/§6.3.)*
+5. **`save(_:)` bare `try?`** — fixed. The new picker routes through the corrected helper. *(MEDIUM #8 — now in §6.6.)*
+6. **`SpawnModelGuard`** covers ingest+chat only today; lint `run()` has none — this plan adds it for consistency. *(§3.)*
+7. **`claude-acp` backfill** (`loadOrSeed` injects `selectedModelIds["claude-acp"] = "sonnet"`) is keyed by provider id, not stage — still works; ensure chat/lint stage defaults don't shadow it.
+8. **`ProviderEditorView`** (Edit… sheet) has its own per-PROVIDER model picker — leave it alone (different concern).
+9. **Do NOT add chat/lint to `ACPIngestStage`** — they are string keys into `stageProviderIds` / `ingestStageModelIds`.
+10. **Nested `TabView` style** — commit + visually validate; fall back to segmented `Picker` if double-bar. *(LOW #9 — §2.1.)*


### PR DESCRIPTION
## Summary

Restructures the **Agents** settings pane into a 3-tab layout (Chat / Ingestion / Lint), each with a per-stage **provider** dropdown (incl. "Default") + a dependent **model** dropdown. Implements `plans/agent-settings-tabs.md`.

## What changed

**Config model (`AgentProvidersConfig`)**
- New `stageProviderIds: [String: String]` field — per-stage PROVIDER pins keyed by stage name (`"chat"`, `"planner"`, `"executor"`, `"finalizer"`, `"lint"`). Missing/empty = "use the global default provider".
- New pure resolvers: `provider(forStage:)` (pinned provider when set + enabled, else `selectedProvider()`), `modelId(forStage:)` (composes provider + model override).
- New pure mutator `settingStageProvider(_:forStage:)` — clears the stage's stale model override when the provider pin **changes** (so a model id from the old provider's catalog is never routed to the new provider).
- `stageProviderIds` carried through **both** construction paths (`init(from:)` decode-if-present AND the `loadOrSeed` reconstruction) and all 6 pure mutators — without this, per-stage pins silently vanish on restart.

**UI (`AgentsSettingsView` + new `StageProviderModelPicker`)**
- New nested **Chat / Ingestion / Lint** tab layout below the Providers section (segmented `Picker` — avoids the double-toolbar-bar a nested `TabView` would create).
- New reusable `StageProviderModelPicker`: provider dropdown (Default first) + dependent model dropdown (Same as provider first). Used for Chat Model, Planner/Executor/Finalizer Models, and Lint Model.
- Fixed `save(_:)` bare-`try?` → `do/catch { DebugLog.store(...) }`.

**Composer (`ProviderSelector`) — Decision A**
- The composer chip now reads `config.provider(forStage: "chat")` (the effective chat provider) instead of bare `selectedProvider()`, so when chat is pinned the chip shows the pinned provider — no silent mismatch. Selecting a row still sets the global default.

**Launcher (`AgentLauncher`)**
- `run()` (shared one-shot for ingest/query/lint): derives `stageKey` from the operation kind (`ingest→planner`, `query→chat`, `lint→lint`) and uses it for BOTH the provider (`provider(forStage:)`) and the model. The stageKey is a testable `nonisolated static func`.
- Large-source ingest orchestrator: resolves the subprocess provider via `provider(forStage: "planner")`; per-stage models via `modelId(forStage:)`.
- Interactive chat (`startInteractiveQuery`): resolves provider + model via the `"chat"` stage.
- Added `SpawnModelGuard` to the shared `run()` path (previously only large-source ingest + interactive chat had it — lint had no guard).

## The three things that were caught in plan review

1. **Persistence (HIGH):** `stageProviderIds` is carried through `init(from:)` AND the `loadOrSeed` reconstruction AND all 6 pure mutators. A `loadOrSeed` round-trip test (`AgentProvidersConfigSeedBackfillTests.loadOrSeedRoundTripsStageProviderIds`) asserts pins survive reload.
2. **The shared `run()` dispatch (HIGH):** `stageKey` is **derived** from the operation kind — never hardcoded `"lint"`. Tests assert small-source ingest does NOT use the lint provider, query does NOT use the lint provider, and lint DOES.
3. **Composer (Decision A):** `ProviderSelector.current` reads `provider(forStage: "chat")`; selecting still sets the global default.

## Tests

- `StageProviderModelPickerTests` (10) — resolver logic: empty pin → default, enabled pin → that provider, disabled pin → fallback, model sentinels.
- `AgentLauncherStageKeyDispatchTests` (7) — the run() dispatch: ingest→planner, query→chat, lint→lint, + the three "does NOT route to lint stage" assertions.
- `AgentProvidersConfigPerStageModelTests` (+24) — `provider(forStage:)`, `settingStageProvider` carry-through, stale-model clear, chat/lint keys.
- `AgentProvidersConfigSeedBackfillTests` (+3) — legacy decode without `stageProviderIds`, `loadOrSeed` round-trip, Codable round-trip.

Full suite: 3167 tests pass.

## Out of scope (explicitly)

- Extraction (`ACPExtractionClient`) — own `acpProviderId` override, left unchanged.
- Queue probe (`AppQueueIngestionProvider`) — detection-only, left unchanged.
- `ACPIngestStage` enum — stays planner/executor/finalizer; chat/lint are string keys.
- Nested `TabView` vs segmented `Picker`: used the segmented `Picker` (the sanctioned fallback) since a nested `TabView` inherits the Settings toolbar style and renders a double-bar. Visual validation is a manual step.

## Manual validation needed

- Nested Chat/Ingestion/Lint tab control renders cleanly.
- Selecting a provider repopulates the model dropdown.
- Composer chip reflects the pinned chat provider.
