### PR TITLE
Composer toolbar: de-grey model/bypass/plus controls + add hover

### DIFF
--- a/Sources/WikiFS/Editor/AddContextPicker.swift
+++ b/Sources/WikiFS/Editor/AddContextPicker.swift
@@ -20,6 +20,7 @@ struct AddContextPicker: View {
     @State private var isPresented = false
     @State private var searchText = ""
     @State private var hoveredID: String?
+    @State private var isHovered = false
 
     /// Cap the unfiltered list so a large wiki doesn't render thousands of rows
     /// before the user has typed anything to narrow it.
@@ -31,10 +32,18 @@ struct AddContextPicker: View {
         } label: {
             Image(systemName: "plus")
                 .font(.callout.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.primary)
                 .frame(width: 22, height: 22)
                 .contentShape(Rectangle())
         }
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
+                .padding(.horizontal, -2)
+                .padding(.vertical, -2)
+        )
+        .onHover { isHovered = $0 }
+        .animation(.easeInOut(duration: 0.15), value: isHovered)
         .buttonStyle(.borderless)
         .popover(isPresented: $isPresented, arrowEdge: .top) {
             popoverContent

--- a/Sources/WikiFS/Settings/PermissionModeSelector.swift
+++ b/Sources/WikiFS/Settings/PermissionModeSelector.swift
@@ -17,6 +17,7 @@ struct PermissionModeSelector: View {
     @State private var isPresented = false
     @State private var searchText = ""
     @State private var hovered: PermissionPolicy?
+    @State private var isHovered = false
 
     /// The selected policy (falls back to bypass — the persisted default — if
     /// the raw value is somehow unknown).
@@ -40,20 +41,29 @@ struct PermissionModeSelector: View {
     // MARK: - Trigger chip
 
     /// The compact chip: glyph + label + chevron. Styled to match
-    /// `ProviderSelector`'s trigger (`.caption` + secondary fill) so the two
-    /// read as sibling chips in the composer toolbar.
+    /// `ProviderSelector`'s trigger (`.callout` + primary fill) so the two
+    /// read as sibling chips in the composer toolbar. A subtle hover bubble
+    /// (matching the popover-row idiom) signals clickability.
     private var trigger: some View {
         HStack(spacing: 4) {
             Image(systemName: current.glyph)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.primary)
             Text(current.label)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.primary)
             Image(systemName: "chevron.up.chevron.down")
                 .imageScale(.small)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.primary)
         }
         .font(.callout)
         .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
+                .padding(.horizontal, -4)
+                .padding(.vertical, -2)
+        )
+        .onHover { isHovered = $0 }
+        .animation(.easeInOut(duration: 0.15), value: isHovered)
     }
 
     // MARK: - Popover (search + flat list)

--- a/Sources/WikiFS/Settings/ProviderSelector.swift
+++ b/Sources/WikiFS/Settings/ProviderSelector.swift
@@ -48,6 +48,9 @@ struct ProviderSelector: View {
     /// The row currently under the pointer (for the hover highlight).
     @State private var hoveredRowID: String?
 
+    /// Whether the trigger chip is currently under the pointer.
+    @State private var isHovered = false
+
     @Environment(\.openSettings) private var openSettings
 
     init(launcher: AgentLauncher) {
@@ -320,22 +323,31 @@ struct ProviderSelector: View {
 
     // MARK: - Trigger
 
-    /// The compact trigger: glyph + "Provider · model" + chevron. `.caption`
-    /// type + secondary fill so it reads as an auxiliary affordance under the
-    /// composer, not a primary control. The model segment reflects the
-    /// per-provider selection, or "default" when none is set.
+    /// The compact trigger: glyph + "Provider · model" + chevron. `.callout`
+    /// type + primary fill so it reads as a real affordance under the
+    /// composer. The model segment reflects the per-provider selection, or
+    /// "default" when none is set. A subtle hover bubble (matching the
+    /// popover-row idiom) signals clickability.
     private var trigger: some View {
         HStack(spacing: 4) {
             Image(systemName: glyph(for: current))
                 .foregroundStyle(Color.blue)
             Text(triggerLabel)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.primary)
             Image(systemName: "chevron.up.chevron.down")
                 .imageScale(.small)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.primary)
         }
         .font(.callout)
         .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
+                .padding(.horizontal, -4)
+                .padding(.vertical, -2)
+        )
+        .onHover { isHovered = $0 }
+        .animation(.easeInOut(duration: 0.15), value: isHovered)
     }
 
     /// "Provider · model". For ACP providers the model is the user's selection

--- a/plans/composer-styling.md
+++ b/plans/composer-styling.md
@@ -1,0 +1,94 @@
+# Composer Styling Plan
+
+## Goal
+
+De-grey the chat composer controls and add hover affordances so the model selector, bypass control, and plus button are more visible and interactive.
+
+**Changes:**
+1. Model selection (ProviderSelector) → normal-strength text (`.primary`) + hover background
+2. Bypass control (PermissionModeSelector) → normal-strength text (`.primary`) + hover background
+3. Plus button (AddContextPicker) → normal-strength icon (`.primary`) + hover background
+
+**Scope:** Minimal styling changes only — no behavior changes, no re-layout, no new controls.
+
+---
+
+## Location
+
+The composer is in `Sources/WikiFS/Chats/ChatView.swift`:
+- **Main composer view:** `composer(enabled:)`
+- **Toolbar row:** `composerToolbar(sendActive:)`
+
+The toolbar hosts three controls in an `HStack`:
+1. **Plus button:** `AddContextPicker(store:store) { … }`
+2. **Model selector:** `ProviderSelector(launcher: launcher)`
+3. **Bypass control:** `PermissionModeSelector(rawValue: $permissionModeRaw)`
+
+---
+
+## Control 1: Model Selection (ProviderSelector)
+
+**File:** `Sources/WikiFS/Settings/ProviderSelector.swift`
+**Location:** `trigger` view
+
+**Fix:**
+- Change `.foregroundStyle(.secondary)` on the label → `.foregroundStyle(.primary)`
+- Change `.foregroundStyle(.tertiary)` on the chevron → `.foregroundStyle(.primary)`
+- Add `@State private var isHovered = false`
+- Add hover background with `Color.primary.opacity(0.08)` RoundedRectangle(cornerRadius: 6)
+- Add `.onHover { isHovered = $0 }` and `.animation(.easeInOut(duration: 0.15), value: isHovered)`
+
+## Control 2: Bypass Control (PermissionModeSelector)
+
+**File:** `Sources/WikiFS/Settings/PermissionModeSelector.swift`
+**Location:** `trigger` view
+
+**Fix:** Same approach — change `.secondary`/`.tertiary` → `.primary` on glyph, label, chevron; add hover background.
+
+## Control 3: Plus Button (AddContextPicker)
+
+**File:** `Sources/WikiFS/Editor/AddContextPicker.swift`
+**Location:** Button label in `body`
+
+**Fix:** Change Image `.foregroundStyle(.secondary)` → `.foregroundStyle(.primary)`; add hover background.
+
+---
+
+## Existing Hover Idiom
+
+The app uses a consistent hover pattern for list rows:
+- `Color.primary.opacity(0.08)` background
+- `RoundedRectangle(cornerRadius: 6)`
+- Examples in `ProviderSelector.rowView`, `PermissionModeSelector.row`, `AddContextPicker.row`
+
+We match this idiom on the trigger chips, with `.easeInOut(duration: 0.15)` animation.
+
+---
+
+## Testing
+
+Manual UI validation: launch app, open chat composer, verify in light + dark mode that:
+- Text/icons render at full-strength primary color (not greyed)
+- Hover shows the bubble background on each control
+- Popovers still open correctly
+- Toolbar layout unchanged
+
+```bash
+make build && make test
+```
+
+## Acceptance Criteria
+
+- [ ] Model selector text is full-strength (white in dark / dark in light)
+- [ ] Bypass control text is full-strength
+- [ ] Plus button icon is full-strength
+- [ ] All three controls show hover bubble
+- [ ] Popover row hover unchanged
+- [ ] Toolbar layout unchanged
+- [ ] Build + tests pass
+
+## Gotchas
+
+- Use `.primary` (adapts to light/dark) — never hardcode `Color.white`/`Color.black`.
+- PR #716 (agent-settings-tabs) merged and shifted line numbers in `ProviderSelector.swift` — locate the trigger view by content (`private var trigger: some View`).
+- No `print()` (use `DebugLog`), no bare `try?`.


### PR DESCRIPTION
## Goal

De-grey the three composer toolbar controls and add a hover affordance so they read as the real, clickable affordances they are — matching the hover idiom already used on the popover rows in the same files.

## Changes

Three controls in `ChatView`'s composer toolbar:

1. **Model selector** (`ProviderSelector.swift` `trigger`) — text + chevron: `.secondary`/`.tertiary` → `.primary`; added hover bubble.
2. **Bypass control** (`PermissionModeSelector.swift` `trigger`) — glyph + text + chevron: `.secondary`/`.tertiary` → `.primary`; added hover bubble.
3. **Plus button** (`AddContextPicker.swift` `body`) — `Image(systemName: "plus")`: `.secondary` → `.primary`; added hover bubble.

The hover uses the existing app-wide idiom (already present on the popover rows in all three files):

```swift
.background(
    RoundedRectangle(cornerRadius: 6)
        .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
        .padding(.horizontal, -4)
        .padding(.vertical, -2)
)
.onHover { isHovered = $0 }
.animation(.easeInOut(duration: 0.15), value: isHovered)
```

`.primary` adapts to light/dark automatically — no hardcoded colors.

## Scope

Pure styling. No behavior changes (popovers, selection, attachment unchanged), no layout changes (toolbar order, spacing, structure unchanged), no new controls. Popover row hover is untouched.

## Validation

- `make check` — compiles clean (debug)
- `make test` — all 3167 tests pass (266 suites)
- `make build` — app bundle builds (for live UI review)

**Live UI review needed** (colors/hover aren't unit-testable): launch the built app, open a chat, and confirm in both light + dark mode that:
- Model selector / bypass control / plus button render at full-strength primary (not greyed)
- Each shows the 8% hover bubble on mouse-over
- Popovers still open correctly; toolbar layout is unchanged

Plan: `plans/composer-styling.md`.

## Files

- `Sources/WikiFS/Settings/ProviderSelector.swift`
- `Sources/WikiFS/Settings/PermissionModeSelector.swift`
- `Sources/WikiFS/Editor/AddContextPicker.swift`
- `plans/composer-styling.md` (new)
