### PR TITLE
Fix chat references with pipe-in-source-name not navigating (#619 render path)

### DIFF
--- a/Sources/WikiFSLinks/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSLinks/WikiLinkMarkdown.swift
@@ -223,12 +223,68 @@ public enum WikiLinkMarkdown {
             // link to ULID form and the canonical branch above emits the pin.
             let raw = fragment.map { "\(bareTarget)#\($0)" } ?? bareTarget
             let split = WikiLinkResolver.resolvedSplit(of: raw) { isResolved($0, kind) }
-            let resolved = split != nil
-            let linkTarget = split?.base ?? bareTarget
-            let linkFragment = split.map(\.fragment) ?? fragment
+
+            // Issue #619 (render path): when the bare target didn't resolve
+            // AND the regex found a `|` (alias present), the `|` may have
+            // been part of the real display name (common with YouTube titles
+            // the app ingests, or doc-set names like "Flex Tier - Documentation
+            // | Neuralwatt Cloud") rather than a true alias separator.
+            // Reconstruct `bareTarget | alias` (plus any `#`-fragment that
+            // landed in the alias portion) and run THAT through resolvedSplit.
+            // Mirrors the canonicalize-seam fix in WikiLinkRewriter (lines
+            // 71–126), so uncanonicalized bodies — chat transcripts in
+            // particular — render pipe-containing source links as resolvable
+            // `wiki://source` links instead of inert `wiki://missing`.
+            //
+            // Only runs as a FALLBACK when the bare target failed, so a
+            // genuine alias link (`[[Foo|bar]]` where Foo exists) already
+            // resolved via `split` above and is unaffected.
+            var resolvedViaReconstruction = false
+            let reconSplit: WikiLinkResolver.Split?
+            if split == nil, let alias = fixed.alias {
+                let normalizedAlias = collapseWhitespace(alias)
+                if normalizedAlias.isEmpty {
+                    reconSplit = nil
+                } else {
+                    let reconstructedRaw = fragment.map { "\(bareTarget) | \(normalizedAlias)#\($0)" }
+                        ?? "\(bareTarget) | \(normalizedAlias)"
+                    reconSplit = WikiLinkResolver.resolvedSplit(
+                        of: reconstructedRaw,
+                        isKnown: { isResolved($0, kind) }
+                    )
+                    resolvedViaReconstruction = reconSplit != nil
+                }
+            } else {
+                reconSplit = nil
+            }
+
+            let resolved = split != nil || reconSplit != nil
+            // Resolve (target, fragment) explicitly: `split?.fragment ?? ...`
+            // would conflate "split hit but fragment nil" (the whole-target
+            // case, e.g. "C# Guide" resolving whole) with "split missed", so
+            // branch on which source of truth won.
+            let linkTarget: String
+            let linkFragment: String?
+            if let split {
+                linkTarget = split.base
+                linkFragment = split.fragment
+            } else if let reconSplit {
+                linkTarget = reconSplit.base
+                linkFragment = reconSplit.fragment
+            } else {
+                linkTarget = bareTarget
+                linkFragment = fragment
+            }
 
             let display: String
-            if let alias = fixed.alias {
+            if resolvedViaReconstruction, let recon = reconSplit {
+                // The `|` was part of the name, not a real alias separator:
+                // display the FULL resolved name (e.g. "Flex Tier -
+                // Documentation | Neuralwatt Cloud"), NOT the alias fragment
+                // ("Neuralwatt Cloud#"quote""). Mirrors WikiLinkRewriter's
+                // `resolvedName` auto-alias at the canonicalize seam.
+                display = recon.base
+            } else if let alias = fixed.alias {
                 let collapsedAlias = collapseWhitespace(alias)
                 display = collapsedAlias.isEmpty ? linkTarget : collapsedAlias
             } else {

--- a/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
+++ b/Tests/WikiFSTests/WikiLinkMarkdownTests.swift
@@ -362,6 +362,91 @@ struct WikiLinkMarkdownTests {
         #expect(url.fragment == nil)
     }
 
+    // MARK: - Pipe inside the NAME (issue #619 render-path mirror)
+    //
+    // The regex splits `[[target|alias]]` at the first `|`, but a display
+    // name can legitimately contain a literal `|` (YouTube titles the app
+    // ingests, doc-set names like "Flex Tier - Documentation | Neuralwatt
+    // Cloud"). On the render path used by chat (which never canonicalizes),
+    // the split target is truncated and would render as inert
+    // `wiki://missing`. The reconstruction below mirrors the canonicalize-seam
+    // fix (WikiLinkRewriter.swift:71-126): try `bareTarget | alias` whole
+    // through resolvedSplit, emit a navigable link when it resolves.
+
+    @Test func pipeInSourceNameResolvesViaAliasReconstruction() {
+        // A source whose display name contains a literal `|`. The regex
+        // splits at `|`, but the reconstructed whole name resolves.
+        let out = WikiLinkMarkdown.linkified(
+            "[[source:Flex Tier - Documentation | Neuralwatt Cloud]]"
+        ) { name, kind in
+            name == "Flex Tier - Documentation | Neuralwatt Cloud" && kind == .source
+        }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "Flex Tier - Documentation | Neuralwatt Cloud")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .source)
+    }
+
+    @Test func pipeInSourceNameWithQuoteFragmentResolves() {
+        // The chat footnote case: pipe-containing name + #"quote" anchor.
+        // The fragment lands in the alias portion after the `|` split; the
+        // reconstruction carries it through resolvedSplit.
+        let out = WikiLinkMarkdown.linkified(
+            "[[source:Flex Tier - Documentation | Neuralwatt Cloud#\"a quoted passage\"]]"
+        ) { name, kind in
+            name == "Flex Tier - Documentation | Neuralwatt Cloud" && kind == .source
+        }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "Flex Tier - Documentation | Neuralwatt Cloud")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .source)
+        #expect(WikiLinkMarkdown.fragment(from: url) == "\"a quoted passage\"")
+    }
+
+    @Test func pipeInPageNameResolvesViaAliasReconstruction() {
+        // Page-side equivalent: a page title containing `|`.
+        let out = WikiLinkMarkdown.linkified(
+            "[[But what is cross-entropy? | Compression is Intelligence Part 2]]"
+        ) { name, kind in
+            name == "But what is cross-entropy? | Compression is Intelligence Part 2" && kind == .page
+        }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url)
+                == "But what is cross-entropy? | Compression is Intelligence Part 2")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .page)
+    }
+
+    @Test func pipeInChatNameResolvesViaAliasReconstruction() {
+        // Chat-side equivalent: a chat title containing `|`.
+        let out = WikiLinkMarkdown.linkified(
+            "[[chat:Standup - 2026-01-15 | Project Alpha]]"
+        ) { name, kind in
+            name == "Standup - 2026-01-15 | Project Alpha" && kind == .chat
+        }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "Standup - 2026-01-15 | Project Alpha")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .chat)
+    }
+
+    @Test func genuineAliasUnaffectedByPipeReconstruction() {
+        // `[[Alpha|B]]` where Alpha exists and "Alpha | B" does NOT: the
+        // reconstruction fails, falls through to the normal path, resolves Alpha.
+        let out = WikiLinkMarkdown.linkified("[[Alpha|B]]") { name, _ in
+            name == "Alpha"
+        }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "Alpha")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .page)
+    }
+
+    @Test func pipeReconstructionFallsThroughToMissingWhenUnresolved() {
+        // Neither the truncated target nor the reconstructed whole resolves:
+        // falls through to today's behavior — `wiki://missing`, no navigation.
+        let out = WikiLinkMarkdown.linkified("[[source:Ghost | Pipeline]]") { _, _ in false }
+        let url = URL(string: extractURL(out))!
+        #expect(WikiLinkMarkdown.target(from: url) == "Ghost")
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == nil)
+        #expect(out.contains("wiki://missing"))
+    }
+
     // MARK: - Code-span protection for source links
 
     @Test func sourceLinkInsideCodeSpanIsLiteral() {

--- a/plans/chat-references-fix.md
+++ b/plans/chat-references-fix.md
@@ -1,0 +1,182 @@
+# Chat References Don't Navigate — Fix Plan
+
+## Goal
+
+Clicking a "reference" (footnote definition at the bottom of a chat
+response) should navigate to the referenced page/source. Currently it does
+nothing ("takes me nowhere").
+
+## Root Cause
+
+**Source display names containing a pipe `|` get mis-split by the
+`[[…]]` regex, truncating the link target so it never resolves and renders
+as an inert `wiki://missing` link.**
+
+### The exact chain
+
+1. The agent emits footnote definitions per the system prompt
+   (`prompts/footnote-conclusions-rule.md`):
+   ```
+   [^retries]: [[source:Flex Tier - Documentation | Neuralwatt Cloud#"Flex is best-effort…"]]
+   ```
+   The source's real display name is `Flex Tier - Documentation | Neuralwatt Cloud`
+   (it contains a pipe).
+
+2. The `[[…]]` regex (`Sources/WikiFSLinks/WikiLinkSpan.swift:20`) treats `|`
+   as the alias separator:
+   ```
+   \[\[((?:[^\]\|"]|"[^"]*")+)(?:\|([^\]]+))?\]\]
+   ```
+   So the match splits as:
+   - **target** = `source:Flex Tier - Documentation ` ← truncated
+   - **alias**  = ` Neuralwatt Cloud#"Flex is best-effort…"`
+
+3. `WikiLinkMarkdown.linkified` (`Sources/WikiFSLinks/WikiLinkMarkdown.swift:85`)
+   — the render path used by chat (via `ChatWebView.renderedMarkdown` →
+   `ReaderMarkdown.prepared` → `MarkdownHTMLRenderer.render`) — resolves the
+   truncated target against `isResolved`. The full name
+   `Flex Tier - Documentation | Neuralwatt Cloud` IS in the store's
+   `sourceNames` set, but the truncated `Flex Tier - Documentation` is NOT.
+   → `isResolved` returns `false`.
+
+4. The link renders as `wiki://missing?title=Flex%20Tier%20-%20Documentation`
+   (host `missing` = unresolved/inert). The HTML is
+   `<a href="wiki://missing?…">…</a>`.
+
+5. `ChatWebView.decidePolicyFor` (`Sources/WikiFS/Chats/ChatWebView.swift:314`)
+   fires `onWikiLink?(url, openInNewTab)` →
+   `WikiReaderView.onWikiLinkHandler` (`Sources/WikiFS/Reader/WikiReaderView.swift:125`)
+   → `linkRoute(for: url)` returns `.inert` (host `missing`) → `break`.
+   **Nothing happens.**
+
+### Why it works for pages but not chat
+
+Pages get canonicalized on save: `WikiLinkRewriter.canonicalize`
+(`Sources/WikiFSLinks/WikiLinkRewriter.swift:40`) runs the **pipe-in-name
+fix** (issue #619, lines 71–126) that reconstructs `bareTarget | alias` and
+resolves the whole name, promoting the link to canonical
+`[[source:ULID|DisplayName]]` form. Chat messages are stored as raw agent
+output and **never canonicalized**, so they keep the broken name-form link
+and hit the render path's unresolved branch.
+
+`WikiLinkMarkdown.linkified` (the shared render path) has NO pipe
+reconstruction — only `WikiLinkRewriter` (the canonicalize path) does.
+
+## Exact Fix
+
+**Add pipe-in-name reconstruction to `WikiLinkMarkdown.linkified`, in the
+non-canonical name-based resolution branch** (mirroring the `WikiLinkRewriter`
+logic at lines 71–126).
+
+### File: `Sources/WikiFSLinks/WikiLinkMarkdown.swift`
+
+Insert pipe-reconstruction before the `resolvedSplit` call (around line 224).
+When `fixed.alias` is present (i.e. the regex split target|alias), reconstruct
+the whole name (`bareTarget | normalizedAlias`, plus any `#`-fragment), run
+that through `WikiLinkResolver.resolvedSplit`, and if it resolves emit a
+navigable `wiki://source`/`page`/`chat` link with the FULL resolved name as
+both the URL target and the display text. Otherwise fall through to the
+existing path unchanged.
+
+**Key properties of the fix:**
+- Reconstructs `bareTarget | normalizedAlias` (+ `#fragment` if present) and
+  runs it through `WikiLinkResolver.resolvedSplit` (which handles `#` splits
+  and loose matching). `resolvedSplit` returns `nil` if the reconstructed
+  name doesn't resolve → falls through to the unchanged existing path.
+- Only triggers when `fixed.alias != nil` (i.e. there WAS a `|` in the span),
+  so zero-cost for non-pipe links.
+- Resolved pipe-links render with the FULL resolved name as display text
+  (mirroring `WikiLinkRewriter`'s `resolvedName` auto-alias) and carry the
+  FULL resolved base name in the `wiki://source?title=<full name>` URL.
+- The `resolved: true` + correct `target` means `linkRoute` returns
+  `.source(title:…, id:nil, fragment:…)` and `selectSource(byDisplayName:)`
+  resolves it.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `Sources/WikiFSLinks/WikiLinkMarkdown.swift` | Add pipe-reconstruction block (lines ~213–228) |
+| `Tests/WikiFSTests/WikiLinkMarkdownTests.swift` | Add tests: pipe-containing source/page/chat names resolve |
+
+## Testing Plan
+
+### Swift Testing (pure — no UI)
+
+Add to `Tests/WikiFSTests/WikiLinkMarkdownTests.swift`:
+
+- A `[[source:Name | Alias]]` where the real source name contains `|`
+  resolves and renders a navigable `wiki://source` link (not `wiki://missing`).
+- Cover source/page/chat.
+- The chat footnote case: pipe-containing name + `#"quote"` anchor — the
+  fragment lands in the alias portion after the `|` split; the reconstruction
+  carries it through `resolvedSplit`.
+- A genuine alias (`[[Alpha|B]]` where Alpha exists and "Alpha | B" does NOT)
+  still resolves to Alpha — the reconstruction fails and falls through.
+- A genuinely-missing name still falls through to `wiki://missing`.
+
+Run:
+```bash
+swift test --filter WikiLinkMarkdownTests
+```
+
+### Full suite
+
+```bash
+swift test   # ~1.5 min; ensures no regressions in reader/canonicalize
+```
+
+### Live UI manual validation
+
+1. Build: `make build`
+2. Open the Self Driving Wiki app, open the chat that has the failing run
+   (Neuralwatt Flex Tier Q&A).
+3. Scroll to the footnote definitions at the bottom of the assistant
+   response.
+4. Click a reference link (e.g. the `Flex Tier - Documentation | Neuralwatt
+   Cloud` source link in a footnote).
+5. **Expected:** the source detail view opens (and scrolls to the quoted
+   passage if the `#"quote"` anchor matched).
+6. Also verify: footnote reference superscripts (the `¹`, `²` in the body)
+   still scroll to the definition at the bottom (these are fragment-only
+   `#wiki-fn-…` links — unchanged by this fix).
+
+## Acceptance Criteria
+
+- [ ] Clicking a footnote-definition source link in a chat navigates to the
+      source detail view (when the source exists).
+- [ ] Sources with `|` in their display name resolve and navigate.
+- [ ] Sources WITHOUT `|` continue to resolve (no regression).
+- [ ] Genuine alias links (`[[Foo|bar]]` where Foo exists) are unaffected.
+- [ ] Footnote reference superscripts still scroll within the transcript.
+- [ ] `swift test` passes (including the new tests).
+- [ ] The reader (page/source view) is unaffected — it canonicalizes on save,
+      so the render-path fix is additive robustness there.
+
+## Gotchas
+
+1. **Don't canonicalize chat messages.** Chat is raw agent output stored as
+   text; canonicalizing it would require a write-back path and risks
+   clobbering agent output on re-render. The render-path fix is the right
+   layer — it heals at display time without touching bytes.
+
+2. **The fix is in the render path (`linkified`), shared by reader + chat.**
+   This is intentional: it makes BOTH more robust (the reader's
+   canonicalize fix only runs on save; a freshly-typed-but-unsaved
+   `[[source:Name|With Pipe]]` benefits too). It mirrors the exact
+   reconstruction strategy already proven in `WikiLinkRewriter`.
+
+3. **`resolvedSplit` does the heavy lifting.** The reconstruction just feeds
+   `bareTarget | alias` (+ fragment) into the existing `#`-split + loose-match
+   machinery. Don't reimplement fragment splitting.
+
+4. **Display text uses the FULL resolved name** (`reconSplit.base`), matching
+   `WikiLinkRewriter`'s `resolvedName` auto-alias. The `|` was part of the
+   name, not a real alias separator, so showing just the post-`|` fragment
+   would misrepresent the citation.
+
+5. **macOS 15 / Swift 6.0.** The fix is pure String manipulation — no
+   concurrency, no actor boundaries, no version-gated APIs.
+
+6. **Scope to `fixed.alias != nil`.** The reconstruction only runs when the
+   regex found a `|`. A non-pipe link has no alias, so zero overhead.


### PR DESCRIPTION
## Summary

Chat footnote references to sources whose display name contains a literal `|`
(e.g. `Flex Tier - Documentation | Neuralwatt Cloud`) rendered as inert
`wiki://missing` links — clicking did nothing. This adds pipe-in-name
reconstruction to the **render path** (`WikiLinkMarkdown.linkified`) so
uncanonicalized bodies — chat transcripts in particular — resolve the same way
pages already do at save time.

## Root cause

The `[[…]]` regex (`WikiLinkSpan`) splits at the first `|` as alias separator.
For a source literally named `A | B`, the target becomes `A` (truncated) and
the alias becomes `B`. The truncated target never resolves, so
`WikiLinkMarkdown.linkified` emits `wiki://missing`. Pages work because
`WikiLinkRewriter.canonicalize` runs at save time and has a pipe-in-name
reconstruction (issue #619) — but **chat messages are never canonicalized**
(raw agent output), so they stay broken through the render path, which had no
pipe reconstruction of its own.

## Fix

`Sources/WikiFSLinks/WikiLinkMarkdown.swift` — in the name-based resolution
branch, after the bare-target `resolvedSplit` fails AND an alias is present,
reconstruct `bareTarget | alias` (+ any `#`-fragment that landed in the alias
portion) and feed that through `resolvedSplit`. If it resolves, emit a
navigable `wiki://source`/`page`/`chat` link carrying the FULL resolved name;
otherwise fall through to today's behavior unchanged.

Mirrors the proven canonicalize-seam logic in `WikiLinkRewriter.swift:71-126`
(#619). Reconstruction runs only as a fallback (bare target must have failed),
so a genuine alias like `[[Foo|bar]]` (where Foo exists) is unaffected. The
display text is the full resolved name — the `|` was part of the name, not a
real alias separator — matching `WikiLinkRewriter`'s `resolvedName` auto-alias.

## Tests

New cases in `Tests/WikiFSTests/WikiLinkMarkdownTests.swift`:

- `pipeInSourceNameResolvesViaAliasReconstruction` — the chat footnote repro
- `pipeInSourceNameWithQuoteFragmentResolves` — `#"quote"` anchor after `|`
- `pipeInPageNameResolvesViaAliasReconstruction` — page-name variant
- `pipeInChatNameResolvesViaAliasReconstruction` — chat-name variant
- `genuineAliasUnaffectedByPipeReconstruction` — `[[Alpha|B]]` (Alpha exists)
  still resolves to Alpha
- `pipeReconstructionFallsThroughToMissingWhenUnresolved` — neither name
  resolves → still `wiki://missing`

## Verification

- `swift test --filter WikiLinkMarkdownTests` — 83/83 pass
- `swift test --filter "WikiLink|Canonicaliz|ReaderMarkdown|MarkdownHTML"` — 307/307 pass
- `make test-fast` — 3042/3042 pass

## Acceptance criteria

- [x] Sources with `|` in their display name resolve and navigate
- [x] Sources WITHOUT `|` continue to resolve (no regression)
- [x] Genuine alias links (`[[Foo|bar]]` where Foo exists) are unaffected
- [x] Genuinely-missing names still fall through to `wiki://missing`
- [x] The reader (page/source view) is unaffected — additive robustness
- [x] `swift test` passes (including the 6 new tests)

## Scope

Single-file change to the render path + tests. No changes to the regex
(`WikiLinkSpan`), the canonicalize path (`WikiLinkRewriter`), or any storage.
Pure String manipulation — no concurrency, no actor boundaries.

## Live validation (manual)

Build with `make build`, open a chat with a pipe-containing source footnote
reference (e.g. the Neuralwatt Flex Tier Q&A), click the reference link at the
bottom of the assistant response. Expected: source detail view opens (and
scrolls to the quoted passage when the `#"quote"` anchor matches).
