### PR TITLE
Per-message chat summary (Default truncation + LLM model mode)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -471,10 +471,23 @@ struct ChatView: View {
     /// user turn is paired with the first assistant text that follows it
     /// (extracted to one sentence, elided), so the outline shows both sides of
     /// the conversation. Sourced from `displayMessages` (same events as the
-    /// transcript). Uses `ChatSummary.summaryExtract` for the response text.
+    /// transcript).
+    ///
+    /// **Per-message summary (chat-summary plan §6.3):** for persisted chats,
+    /// a cached `chat_messages.summary` wins over on-the-fly extraction — read
+    /// once, never recomputed. The live (streaming) path has no row yet, so it
+    /// always computes the default truncation on the fly (free); the summary is
+    /// cached after the turn persists.
     private var chatOutlineEntries: [ChatOutlineEntry] {
         let msgs = displayMessages
         let timestamps = displayTimestamps
+        // Align cached per-message summaries with `displayMessages` for the
+        // persisted path. `visiblePersistedMessages` applies the same
+        // `.transcriptVisible` filter as `displayMessages`, so indices match.
+        // The live path returns all-nil (no row yet).
+        let cachedSummaries: [String?] = isLiveChat
+            ? Array(repeating: nil, count: msgs.count)
+            : visiblePersistedMessages.map(\.summary)
         var entries: [ChatOutlineEntry] = []
         var pendingQuestion: String?
         var pendingQuestionTS: Date?
@@ -490,7 +503,8 @@ struct ChatView: View {
                 pendingQuestionTS = ts
             case .assistantText(let text):
                 if let q = pendingQuestion {
-                    let summary = ChatSummary.summaryExtract(from: text, maxLength: 200)
+                    let cached = i < cachedSummaries.count ? cachedSummaries[i] : nil
+                    let summary = cached ?? ChatSummary.summaryExtract(from: text, maxLength: 200)
                     entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
                                                     questionTimestamp: pendingQuestionTS, responseTimestamp: ts))
                     pendingQuestion = nil
@@ -498,7 +512,8 @@ struct ChatView: View {
                 }
             case .result(_, let text):
                 if let q = pendingQuestion {
-                    let summary = ChatSummary.summaryExtract(from: text, maxLength: 200)
+                    let cached = i < cachedSummaries.count ? cachedSummaries[i] : nil
+                    let summary = cached ?? ChatSummary.summaryExtract(from: text, maxLength: 200)
                     entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
                                                     questionTimestamp: pendingQuestionTS, responseTimestamp: ts))
                     pendingQuestion = nil
@@ -513,6 +528,18 @@ struct ChatView: View {
                                             questionTimestamp: pendingQuestionTS, responseTimestamp: nil))
         }
         return entries
+    }
+
+    /// The `.transcriptVisible` subset of `persistedMessages`, aligned with
+    /// `displayMessages` for the persisted path (chat-summary plan §6.3). Used
+    /// to read cached per-message summaries. Empty on the live path (no row
+    /// exists yet — the view sources from `launcher.events`).
+    private var visiblePersistedMessages: [ChatMessage] {
+        guard !isLiveChat else { return [] }
+        let indices = persistedMessages.map(\.event).transcriptVisibleIndices
+        return indices.compactMap { idx in
+            idx < persistedMessages.count ? persistedMessages[idx] : nil
+        }
     }
 
     @ViewBuilder

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -53,15 +53,17 @@ struct AgentsSettingsView: View {
     /// (`plans/agent-settings-tabs.md` §2.1 LOW #9).
     @State private var selectedOperationTab: OperationTab = .chat
 
-    /// The three operation panes, each owning its stages.
+    /// The operation panes, each owning its stages. The Summary tab
+    /// (`plans/chat-summary.md` §5.2) is the per-message summarizer stage pin.
     enum OperationTab: String, CaseIterable, Identifiable {
-        case chat, ingestion, lint
+        case chat, ingestion, lint, summary
         var id: String { rawValue }
         var label: String {
             switch self {
             case .chat:      return "Chat"
             case .ingestion: return "Ingestion"
             case .lint:      return "Lint"
+            case .summary:   return "Summary"
             }
         }
     }
@@ -420,6 +422,31 @@ struct AgentsSettingsView: View {
                     Text("Lint Model")
                 } footer: {
                     Text("Provider and model for wiki lint runs. “Default” uses the global default provider; “Same as provider” uses that provider's selected model.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+        case .summary:
+            // Per-message summarizer stage (plans/chat-summary.md §5.2). This
+            // IS the StageProviderModelPicker for the `"summarizer"` stage — no
+            // separate mode Picker. The sentinel `""` (first option) means
+            // "no model — truncation" for THIS stage (different from the other
+            // stages where `""` means "inherit the global default provider"), so
+            // the option is relabeled to "Default (first few sentences)" to
+            // convey the actual behavior.
+            Form {
+                Section {
+                    StageProviderModelPicker(
+                        stageKey: "summarizer",
+                        config: $config,
+                        containerDirectory: containerDirectory,
+                        label: "Summary Model",
+                        defaultOptionLabel: "Default (first few sentences)")
+                } header: {
+                    Text("Message Summary")
+                } footer: {
+                    Text("“Default (first few sentences)” is free truncation — no model call. Pin a provider + model to summarize each assistant message with an LLM (computed once, cached).")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/WikiFS/Settings/StageProviderModelPicker.swift
+++ b/Sources/WikiFS/Settings/StageProviderModelPicker.swift
@@ -4,15 +4,22 @@ import WikiFSCore
 /// A provider + model picker for a single agent stage/operation
 /// (`plans/agent-settings-tabs.md` §2.2/§6). Reused for the Chat Model,
 /// Planner/Executor/Finalizer Models, and Lint Model rows in the nested
-/// Chat/Ingestion/Lint tab view.
+/// Chat/Ingestion/Lint tab view, and for the per-message Summary Model row in
+/// the Summary tab (`plans/chat-summary.md` §5.2).
 ///
 /// - `stageKey`: stable string key into the per-stage overrides
-///   (`"chat"`, `"planner"`, `"executor"`, `"finalizer"`, `"lint"`). For ingest
-///   stages this is `ACPIngestStage.rawValue`.
+///   (`"chat"`, `"planner"`, `"executor"`, `"finalizer"`, `"lint"`,
+///   `"summarizer"`). For ingest stages this is `ACPIngestStage.rawValue`.
 /// - `config`: the live config (binding so edits flow back to the parent's
 ///   `@State`).
 /// - `containerDirectory`: for persistence (save on every change).
 /// - `label`: human-readable stage label shown as the row title.
+/// - `defaultOptionLabel`: the text shown for the sentinel `""` first option
+///   in the provider dropdown. Defaults to `"Default"` (inherit the global
+///   default provider). **Stage-specific semantic for `"summarizer"`**: an empty
+///   pin means "no model — truncation" (NOT "inherit the global provider"), so
+///   the Summary tab passes `"Default (first few sentences)"` to convey the
+///   actual behavior (`plans/chat-summary.md` §5.2).
 ///
 /// The provider dropdown includes a **"Default"** first option (sentinel `""` =
 /// inherit the global default provider). The model dropdown is **dependent** on
@@ -25,6 +32,7 @@ struct StageProviderModelPicker: View {
     @Binding var config: AgentProvidersConfig
     let containerDirectory: URL
     let label: String
+    var defaultOptionLabel: String = "Default"
 
     /// The effective provider for this stage (pinned when set + enabled, else
     /// the global default). Drives the model dropdown's contents.
@@ -49,7 +57,7 @@ struct StageProviderModelPicker: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Picker("\(label) Provider", selection: providerBinding) {
-                Text("Default").tag("")
+                Text(defaultOptionLabel).tag("")
                 ForEach(config.enabledProviders) { p in
                     Text(p.label).tag(p.id)
                 }

--- a/Sources/WikiFSCore/Core/ChatModels.swift
+++ b/Sources/WikiFSCore/Core/ChatModels.swift
@@ -114,6 +114,22 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
     }
 }
 
+/// Which summarizer produced a `chat_messages.summary` row. The raw values
+/// are EXPLICIT and must match the `summary_kind` column spec exactly —
+/// without them Swift would derive the rawValue from the case name
+/// (`"defaultTruncation"`), mismatching the column and breaking round-trips
+/// (chat-summary plan §4.1). Closed set so `summary_kind` round-trips
+/// predictably across migrations.
+public enum ChatMessageSummaryKind: String, Sendable, Codable, CaseIterable {
+    /// First-sentence truncation via `ChatSummary.summaryExtract` — no model
+    /// call. The Default summarizer mode (chat-summary plan §4.2).
+    case defaultTruncation = "default"
+    /// LLM-generated summary via a pinned `"summarizer"`-stage provider + model
+    /// (chat-summary plan §4.3). One-shot ACP session per message; the result
+    /// is cached so it is computed exactly once.
+    case model = "model"
+}
+
 /// One persisted transcript row: a single renderable `AgentEvent`, stored
 /// verbatim as JSON (`event_json`) so history re-renders through the exact
 /// same pipeline as the live transcript, plus a `plainText` projection
@@ -126,13 +142,30 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
     public var seq: Int
     public var event: AgentEvent
     public var createdAt: Date
+    /// Cached one-line summary (chat-summary plan). `nil` until the summarizer
+    /// runs; written once via `updateMessageSummary` and never recomputed.
+    public var summary: String?
+    /// Which summarizer produced `summary`. `nil` alongside `summary`. Stored
+    /// as `ChatMessageSummaryKind.rawValue` in the `summary_kind` column.
+    public var summaryKind: ChatMessageSummaryKind?
+    /// When the summary was written, for staleness display. `nil` alongside
+    /// `summary`.
+    public var summaryAt: Date?
 
-    public init(id: PageID, chatID: PageID, seq: Int, event: AgentEvent, createdAt: Date) {
+    public init(
+        id: PageID, chatID: PageID, seq: Int, event: AgentEvent, createdAt: Date,
+        summary: String? = nil,
+        summaryKind: ChatMessageSummaryKind? = nil,
+        summaryAt: Date? = nil
+    ) {
         self.id = id
         self.chatID = chatID
         self.seq = seq
         self.event = event
         self.createdAt = createdAt
+        self.summary = summary
+        self.summaryKind = summaryKind
+        self.summaryAt = summaryAt
     }
 }
 

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -58,7 +58,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// databases produced by that store carry `PRAGMA user_version` up to 37, and
     /// this store must recognize them as already-current so the ladder is a no-op
     /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 39
+    private static let currentSchemaVersion = 40
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -1162,14 +1162,45 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         //
         // ⚠ LOAD-BEARING ordering: this step MUST precede the catch-all
         // fallback immediately below. The fallback's guard is keyed on
-        // `currentSchemaVersion` (39 now), so once this constant is bumped it
+        // `currentSchemaVersion` (40 now), so once this constant is bumped it
         // short-circuits: it re-runs `dropFTS5TablesAndTriggers` (harmless —
-        // `DROP … IF EXISTS`) and stamps `user_version = 39`, executing NONE
-        // of any new step above it. Any new v39 migration work belongs INSIDE
+        // `DROP … IF EXISTS`) and stamps `user_version = 40`, executing NONE
+        // of any new step above it. Any new v40 migration work belongs INSIDE
         // this block (before the fallback), not as a sibling after it.
         if version < 39 {
             try db.execute(sql: "PRAGMA user_version = 39;")
             version = 39
+        }
+
+        // Step 39 → 40 (chat-message summary, plans/chat-summary.md): adds
+        // nullable summary columns to `chat_messages` so each assistant message
+        // can carry a cached one-line summary. Mirrors `migrateV35ToV36`
+        // (issue #411): guarded `tableColumnInfo` column-presence check +
+        // `db.inTransaction(.immediate)` + `ALTER TABLE ADD COLUMN`. The columns
+        // are nullable so the migration is a pure schema change with no backfill
+        // — pre-feature rows surface as `summary = NULL` and are lazily
+        // summarized on first view (chat-summary plan §6.2).
+        //
+        // LOAD-BEARING: MUST precede the catch-all fallback immediately below
+        // (same reason as the v38→39 step above — the fallback re-runs
+        // `dropFTS5TablesAndTriggers` and stamps
+        // `user_version = currentSchemaVersion`, executing none of any new step
+        // after it).
+        if version < 40 {
+            let columns = try Self.tableColumnInfo("chat_messages", in: db)
+            guard !columns.contains("summary") else {
+                try db.execute(sql: "PRAGMA user_version = 40;")
+                version = 40
+                return
+            }
+            try db.inTransaction(.immediate) {
+                try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary TEXT;")
+                try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary_kind TEXT;")
+                try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary_at REAL;")
+                return .commit
+            }
+            try db.execute(sql: "PRAGMA user_version = 40;")
+            version = 40
         }
 
         // Catch-all fallback: any DB older than `currentSchemaVersion` whose
@@ -1397,13 +1428,16 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS chats_updated ON chats(updated_at);")
         try db.execute(sql: """
         CREATE TABLE IF NOT EXISTS chat_messages (
-            id         TEXT PRIMARY KEY,
-            chat_id    TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
-            seq        INTEGER NOT NULL,
-            role       TEXT NOT NULL,
-            event_json TEXT NOT NULL,
-            text       TEXT NOT NULL DEFAULT '',
-            created_at REAL NOT NULL
+            id          TEXT PRIMARY KEY,
+            chat_id     TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+            seq         INTEGER NOT NULL,
+            role        TEXT NOT NULL,
+            event_json  TEXT NOT NULL,
+            text        TEXT NOT NULL DEFAULT '',
+            created_at  REAL NOT NULL,
+            summary     TEXT,
+            summary_kind TEXT,
+            summary_at  REAL
         );
         """)
         try db.execute(sql: "CREATE UNIQUE INDEX IF NOT EXISTS chat_messages_seq ON chat_messages(chat_id, seq);")
@@ -2433,13 +2467,16 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS chats_updated ON chats(updated_at);")
         try db.execute(sql: """
         CREATE TABLE IF NOT EXISTS chat_messages (
-            id         TEXT PRIMARY KEY,
-            chat_id    TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
-            seq        INTEGER NOT NULL,
-            role       TEXT NOT NULL,
-            event_json TEXT NOT NULL,
-            text       TEXT NOT NULL DEFAULT '',
-            created_at REAL NOT NULL
+            id          TEXT PRIMARY KEY,
+            chat_id     TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+            seq         INTEGER NOT NULL,
+            role        TEXT NOT NULL,
+            event_json  TEXT NOT NULL,
+            text        TEXT NOT NULL DEFAULT '',
+            created_at  REAL NOT NULL,
+            summary     TEXT,
+            summary_kind TEXT,
+            summary_at  REAL
         );
         """)
         try db.execute(sql: "CREATE UNIQUE INDEX IF NOT EXISTS chat_messages_seq ON chat_messages(chat_id, seq);")
@@ -5789,7 +5826,8 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     public func chatMessages(chatID: PageID) throws -> [ChatMessage] {
         try dbWriter.read { db in
             let rows = try Row.fetchAll(db, sql: """
-            SELECT id, seq, event_json, created_at FROM chat_messages
+            SELECT id, seq, event_json, created_at, summary, summary_kind, summary_at
+            FROM chat_messages
             WHERE chat_id = ? ORDER BY seq ASC;
             """, arguments: [chatID.rawValue])
             let decoder = JSONDecoder()
@@ -5800,12 +5838,21 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                     let data = json.data(using: .utf8),
                     let event = try? decoder.decode(AgentEvent.self, from: data)
                 else { continue }
+                // Decode-if-present for the nullable summary columns
+                // (chat-summary plan §3.4). Pre-v40 rows and unsummarized
+                // messages surface as nil.
+                let summary: String? = row["summary"]
+                let summaryKindRaw: String? = row["summary_kind"]
+                let summaryAtDouble: Double? = row["summary_at"]
                 out.append(ChatMessage(
                     id: PageID(rawValue: row["id"]),
                     chatID: chatID,
                     seq: row["seq"],
                     event: event,
-                    createdAt: Date(timeIntervalSince1970: row["created_at"])
+                    createdAt: Date(timeIntervalSince1970: row["created_at"]),
+                    summary: summary,
+                    summaryKind: summaryKindRaw.flatMap(ChatMessageSummaryKind.init(rawValue:)),
+                    summaryAt: summaryAtDouble.map { Date(timeIntervalSince1970: $0) }
                 ))
             }
             return out
@@ -5864,6 +5911,29 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             WHERE id = ?;
             """, arguments: [summary, Date().timeIntervalSince1970,
                             Date().timeIntervalSince1970, chatID.rawValue])
+        }
+    }
+
+    /// Write the cached one-line summary for a single assistant message
+    /// (chat-summary plan §3.5). Routes through `mutate(event:_:)` and emits a
+    /// `.chat .updated` event on the chat the message belongs to — the
+    /// projection + model subscribe to `.chat` changes, and there is no
+    /// standalone `.message` resource kind (`chat_messages` cascade-delete with
+    /// `chats`). The write is idempotent (re-running on an already-summarized
+    /// row overwrites the cached values), but the caller is expected to
+    /// short-circuit when `summary` is non-nil (compute-once, AC.6).
+    public func updateMessageSummary(
+        chatID: PageID, messageID: PageID, summary: String, kind: ChatMessageSummaryKind
+    ) throws {
+        try mutate(event: { _ in
+            self.localEvent(.chat, id: chatID.rawValue, change: .updated)
+        }) { db in
+            try db.execute(sql: """
+            UPDATE chat_messages
+            SET summary = ?, summary_kind = ?, summary_at = ?
+            WHERE id = ?;
+            """, arguments: [summary, kind.rawValue,
+                            Date().timeIntervalSince1970, messageID.rawValue])
         }
     }
 

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -649,6 +649,15 @@ public protocol WikiStore: Sendable {
     /// bumping `updated_at`. Throws `.notFound` if no chat has `id`.
     func updateChatSummary(chatID: PageID, summary: String) throws
 
+    /// Write the cached one-line summary for a single assistant message
+    /// (chat-summary plan §3.5). The chat row is the change-emission resource
+    /// (there is no `.message` resource kind); emits `.chat .updated` with the
+    /// chat's id. Idempotent at the SQL level; the caller short-circuits on a
+    /// non-nil cached summary to enforce compute-once (AC.6).
+    func updateMessageSummary(
+        chatID: PageID, messageID: PageID, summary: String, kind: ChatMessageSummaryKind
+    ) throws
+
     /// All chat summaries ordered by ULID (creation order) — for the File
     /// Provider projection. Mirrors `listAllPagesOrderedByID()`.
     func listAllChatsOrderedByID() throws -> [ChatSummary]

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -3580,6 +3580,21 @@ public final class WikiStoreModel {
         }
     }
 
+    /// `@MainActor` wrapper for the per-message summary write (chat-summary
+    /// plan §3.5). The summarizer's off-main compute marshals back here for the
+    /// DB write (no inference inside a transaction). No manual reload — the bus
+    /// fires `reloadFromStore()` async after the `.chat .updated` emit.
+    public func updateMessageSummary(
+        chatID: PageID, messageID: PageID, summary: String, kind: ChatMessageSummaryKind
+    ) {
+        do {
+            try store.updateMessageSummary(
+                chatID: chatID, messageID: messageID, summary: summary, kind: kind)
+        } catch {
+            DebugLog.store("WikiStoreModel.updateMessageSummary failed: \(error)")
+        }
+    }
+
     public func deleteChat(id: PageID) {
         do {
             try store.deleteChat(id: id)

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -629,6 +629,13 @@ public final class AgentLauncher {
     /// (after the first assistant turn completes), not on every turn.
     /// Reset in `resetRunArtifacts()`.
     @ObservationIgnored private var summaryGenerated = false
+    /// Per-message summary sink (chat-summary plan §6.1). Fired once in
+    /// `finish()` with the active chat id so the wired callback can summarize
+    /// the assistant messages from this turn + persist via
+    /// `updateMessageSummary`. nil when the session has no chatID (one-shot
+    /// runs) or the caller didn't wire the sink. Cleared in `finish()` and
+    /// `resetRunArtifacts()` for hygiene.
+    @ObservationIgnored private var messageSummarySink: (@MainActor (PageID) -> Void)?
     /// Cursor into `events`: the count already handed to `transcriptSink`. Makes
     /// `flushTranscript()` incremental — each call only sends events appended since
     /// the last flush — and idempotent when nothing new arrived since the last call.
@@ -2409,7 +2416,8 @@ public final class AgentLauncher {
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
         onTranscript: (@MainActor ([AgentEvent]) -> Void)? = nil,
-        onSummary: (@MainActor (PageID, String) -> Void)? = nil
+        onSummary: (@MainActor (PageID, String) -> Void)? = nil,
+        onMessageSummary: (@MainActor (PageID) -> Void)? = nil
     ) async {
         // No gate acquisition here — the interactive session does NOT hold the gate
         // for its lifetime, only per-turn (via sendInteractiveMessage). Two sessions
@@ -2540,6 +2548,7 @@ public final class AgentLauncher {
         // (which clears any stale sink from a prior run).
         transcriptSink = onTranscript
         summarySink = onSummary
+        messageSummarySink = onMessageSummary
         // D2: record the chat row this live session is writing to. This is the
         // source-of-truth switch for ChatView — when it matches a tab's
         // chatID, that tab renders `launcher.events` (streaming) instead of the
@@ -2908,6 +2917,16 @@ public final class AgentLauncher {
         summarySink?(PageID(rawValue: chatID), extracted)
     }
 
+    /// Fire the per-message summary sink (chat-summary plan §6.1). Called once
+    /// in `finish()` after `flushTranscript()` + `generateChatSummary()` and
+    /// before `activeChatID = nil`. No-op when no sink/chatID is set. The sink
+    /// owns the mode dispatch + the off-main Task for model mode; this method
+    /// just hands it the chat id.
+    private func fireMessageSummarySink() {
+        guard let chatID = activeChatID else { return }
+        messageSummarySink?(PageID(rawValue: chatID))
+    }
+
     /// Hand the not-yet-persisted tail of `events` to `transcriptSink`, if any, and
     /// advance the cursor. Filtering to persistable events is the model's job
     /// (`WikiStoreModel.appendChatEvents` filters via `AgentEvent.isPersistable`) —
@@ -3061,8 +3080,16 @@ public final class AgentLauncher {
         // run AFTER flushTranscript() (so the transcript is committed) and
         // BEFORE activeChatID = nil (so the chat ID is still available).
         generateChatSummary()
+        // Fire the per-message summary sink (chat-summary plan §6.1). Runs
+        // AFTER flushTranscript() so the turn's messages are committed (the
+        // sink queries `chatMessages(chatID:)` for unsummarized rows), and
+        // BEFORE activeChatID = nil so the chat ID is still available. The sink
+        // dispatches per the configured mode: default-truncation runs inline;
+        // model mode spawns an off-main Task (the sink closure owns that hop).
+        fireMessageSummarySink()
         transcriptSink = nil
         summarySink = nil
+        messageSummarySink = nil
         onAgentEvent = nil
         // #544 live progress: detach the live-usage callback after the run ends,
         // mirroring onAgentEvent. The Activity window stops receiving updates
@@ -3178,6 +3205,7 @@ public final class AgentLauncher {
         // session's events (issue #119).
         transcriptSink = nil
         summarySink = nil
+        messageSummarySink = nil
         onAgentEvent = nil
         // #544 live progress: clear the live-usage callback + provider label so
         // a stale callback from a prior run never receives a new run's updates.

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -100,6 +100,11 @@ public enum AgentOperationRunner {
             },
             onSummary: chat.map { chat -> (@MainActor (PageID, String) -> Void) in
                 return { [weak store] id, summary in store?.updateChatSummary(chatID: id, summary: summary) }
+            },
+            onMessageSummary: chat.map { chat -> (@MainActor (PageID) -> Void) in
+                return { [weak store] id in
+                    Self.summarizePendingMessages(chatID: id, store: store, launcher: launcher)
+                }
             }
         )
 
@@ -371,6 +376,9 @@ public enum AgentOperationRunner {
             },
             onSummary: { [weak store] id, summary in
                 store?.updateChatSummary(chatID: id, summary: summary)
+            },
+            onMessageSummary: { [weak store] id in
+                Self.summarizePendingMessages(chatID: id, store: store, launcher: launcher)
             })
     }
 
@@ -471,5 +479,104 @@ public enum AgentOperationRunner {
     private static func ingestSourcePath(for source: SourceSummary) -> String {
         let leaf = FilenameEscaping.byIDSourceFilename(sourceID: source.id.rawValue, ext: source.ext)
         return "sources/by-id/\(leaf)"
+    }
+
+    // MARK: - Per-message summary (chat-summary plan §6.1)
+
+    /// Summarize all unsummarized assistant messages in `chatID` per the
+    /// configured summarizer mode (chat-summary plan §6.1). Called from the
+    /// `onMessageSummary` sink wired into `startInteractiveQuery`, which fires
+    /// once in `AgentLauncher.finish()` after `flushTranscript()` commits the
+    /// turn's messages.
+    ///
+    /// **Mode dispatch** gates STRICTLY on `stageProviderIds["summarizer"]`
+    /// (chat-summary plan §5.1 invariant — never `provider(forStage:)`):
+    /// - **Default** (empty/absent pin): inline `ChatSummary.summaryExtract`
+    ///   via `MessageSummarizer.defaultSummary` — pure, cheap, no model call.
+    /// - **Model** (non-empty pin): off-main `Task` driving a one-shot ACP
+    ///   session per message via the injected `AgentBackend`. The DB write is
+    ///   marshalled back to `@MainActor`.
+    ///
+    /// **Idempotency (AC.6):** only messages with `summary == nil` are
+    /// summarized — the store query is the compute-once guard. Re-firing the
+    /// sink (e.g. on a second turn) is a no-op for already-summarized rows.
+    @MainActor
+    private static func summarizePendingMessages(
+        chatID: PageID, store: WikiStoreModel?, launcher: AgentLauncher
+    ) {
+        guard let store else { return }
+        let config = AgentProvidersConfig.loadOrSeed(from: launcher.resolveProvidersContainerDirectory())
+        let mode = MessageSummarizer.mode(for: config)
+
+        // Query the persisted messages + filter to unsummarized assistant-text
+        // rows. This is the compute-once guard (AC.6): already-summarized rows
+        // are skipped.
+        let messages = store.chatMessages(chatID: chatID)
+        let pending = messages.filter { msg in
+            msg.summary == nil
+                && (MessageSummarizer.textToSummarize(from: msg.event)?.isEmpty == false)
+        }
+        guard !pending.isEmpty else { return }
+
+        switch mode {
+        case .defaultTruncation:
+            // Pure + cheap — run inline on the main actor.
+            for msg in pending {
+                guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
+                let summary = MessageSummarizer.defaultSummary(for: text)
+                guard !summary.isEmpty else { continue }
+                store.updateMessageSummary(
+                    chatID: chatID, messageID: msg.id,
+                    summary: summary, kind: .defaultTruncation)
+            }
+        case .model:
+            // Off-main via a detached Task. The config + pending messages are
+            // captured by value (Sendable) so the Task can cross the actor
+            // boundary cleanly.
+            let containerDir = launcher.resolveProvidersContainerDirectory()
+            let credentialStore = launcher.acpCredentialStore
+            Task { @MainActor in
+                await Self.runModelSummarization(
+                    chatID: chatID, pending: pending, config: config,
+                    containerDir: containerDir, credentialStore: credentialStore,
+                    store: store)
+            }
+        }
+    }
+
+    /// Drive the model-mode summarization for a batch of pending messages
+    /// (chat-summary plan §4.3 + §6.4). Runs off-main for the ACP session(s);
+    /// marshals each write back to the `@MainActor` store. Called from a
+    /// `Task` so it doesn't block `finish()`.
+    @MainActor
+    private static func runModelSummarization(
+        chatID: PageID, pending: [ChatMessage], config: AgentProvidersConfig,
+        containerDir: URL, credentialStore: any ACPCredentialStore,
+        store: WikiStoreModel
+    ) async {
+        guard let profile = MessageSummarizer.resolveProfile(
+            config: config, credentialStore: credentialStore) else {
+            DebugLog.agent("AgentOperationRunner.runModelSummarization: profile resolution failed — skipping \(pending.count) messages")
+            return
+        }
+        // Construct the backend via the factory (production = ACPBackend with
+        // `.bypass` — the summarizer has no wiki to write to). The backend is
+        // constructed once per batch so a warm subprocess can be reused across
+        // messages in a future iteration; today each `modelSummary` call is a
+        // one-shot session.
+        let backend = AgentBackendFactory.makeBackend(policy: .bypass)
+        for msg in pending {
+            guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
+            // Off-main: the backend session runs on its own actor / process.
+            // The await suspends the MainActor without blocking it.
+            guard let summary = await MessageSummarizer.modelSummary(
+                text: text, backend: backend, profile: profile) else { continue }
+            // Marshal the DB write back to @MainActor (we're already here —
+            // this method is @MainActor). `updateMessageSummary` routes through
+            // `mutate()` + emits `.chat .updated` (#129).
+            store.updateMessageSummary(
+                chatID: chatID, messageID: msg.id,
+                summary: summary, kind: .model)
+        }
     }
 }

--- a/Sources/WikiFSEngine/MessageSummarizer.swift
+++ b/Sources/WikiFSEngine/MessageSummarizer.swift
@@ -1,0 +1,216 @@
+import Foundation
+import WikiFSCore
+
+/// The per-message summary service (chat-summary plan §4).
+///
+/// Produces a one-line cached summary for a single assistant chat message. Two
+/// modes, selected by the user via the `"summarizer"` stage pin in
+/// `AgentProvidersConfig`:
+///
+/// - **Default** (empty/absent `stageProviderIds["summarizer"]`): pure first-
+///   sentence truncation via `ChatSummary.summaryExtract`. Zero model compute.
+/// - **Model** (non-empty `stageProviderIds["summarizer"]`): a one-shot ACP
+///   session that asks the pinned provider+model for a one-sentence summary.
+///
+/// **⚠ Mode encoding invariant (chat-summary plan §5.1):** the Default-vs-Model
+/// decision gates STRICTLY on `config.stageProviderIds["summarizer"]`. NEVER
+/// call `config.provider(forStage: "summarizer")` for the mode decision — it is
+/// non-optional and falls back to the global default provider
+/// (`AgentProvidersConfig.swift:239-246`), so it ALWAYS reports a provider and
+/// would wrongly force every message through the model path.
+///
+/// **Test seam:** the model path's `AgentBackend` is INJECTED so the logic is
+/// unit-testable end-to-end with `FakeAgentBackend` (chat-summary plan §4.3 +
+/// AC.4). The production caller constructs the backend via
+/// `AgentBackendFactory.makeBackend(policy: .bypass)` and the profile via
+/// `resolveProfile`; tests pass a `FakeAgentBackend` + a simple `BackendProfile`.
+public enum MessageSummarizer {
+
+    /// The configured summarizer mode for a given provider config. Derived
+    /// STRICTLY from `stageProviderIds["summarizer"]` (chat-summary plan §5.1).
+    public enum Mode: Sendable, Equatable {
+        /// First-sentence truncation via `ChatSummary.summaryExtract` — no model
+        /// call. Selected when `stageProviderIds["summarizer"]` is empty/absent.
+        case defaultTruncation
+        /// LLM summarization via a pinned provider+model. Selected when
+        /// `stageProviderIds["summarizer"]` is non-empty.
+        case model
+    }
+
+    /// Derive the configured summarizer mode STRICTLY from the stage pin
+    /// (chat-summary plan §5.1). This is the ONLY correct way to decide Default
+    /// vs Model — never use `provider(forStage: "summarizer")` for this
+    /// decision (see the invariant in this type's doc comment).
+    public static func mode(for config: AgentProvidersConfig) -> Mode {
+        let pin = config.stageProviderIds["summarizer"] ?? ""
+        return pin.isEmpty ? .defaultTruncation : .model
+    }
+
+    /// The system prompt for the one-shot summarization session (model mode).
+    /// Kept short — the user turn carries the content to summarize.
+    static let modelSystemPrompt = """
+    You are a concise summarizer. Summarize the user's content in a single clear sentence. \
+    Output ONLY the summary sentence — no preamble, no quotes, no code fences.
+    """
+
+    /// Produce a default-truncation summary (no model call). Reuses
+    /// `ChatSummary.summaryExtract(from:maxLength:)` verbatim so the Default
+    /// summarizer is byte-identical to the existing on-the-fly outline
+    /// extraction (chat-summary plan §4.2). Pure + cheap; safe to run inline.
+    ///
+    /// Returns the empty string for empty/whitespace input; callers skip the
+    /// write-back when the extract is empty.
+    public static func defaultSummary(for text: String) -> String {
+        ChatSummary.summaryExtract(from: text, maxLength: 200)
+    }
+
+    /// Extract the summarizable text from an `AgentEvent` (the source for a
+    /// per-message summary). Returns the text for `.assistantText` and
+    /// `.result`; nil for everything else (tool/thinking/user events have no
+    /// assistant summary surface). PURE.
+    public static func textToSummarize(from event: AgentEvent) -> String? {
+        switch event {
+        case .assistantText(let text):
+            return text
+        case .result(_, let text):
+            return text
+        default:
+            return nil
+        }
+    }
+
+    /// Run a one-shot model summarization via the injected `AgentBackend`
+    /// (chat-summary plan §4.3). Mirrors `ACPExtractionClient.convert`: start a
+    /// session with `modelSystemPrompt`, send ONE turn, collect `.assistantText`
+    /// / `.result` text, cancel the session, return the trimmed result.
+    ///
+    /// **Test seam:** `backend` and `profile` are both parameters so a Swift
+    /// Testing case can inject a `FakeAgentBackend` with a scripted
+    /// `[.assistantText("…"), .messageStop]` behavior and a simple
+    /// `BackendProfile`. This drives the model path end-to-end without a real
+    /// subprocess (AC.4 model half).
+    ///
+    /// - Returns: the summarized text, or nil if the backend produced no
+    ///   non-whitespace output (the caller leaves `summary = NULL` so the
+    ///   message is retriable).
+    public static func modelSummary(
+        text: String,
+        backend: any AgentBackend,
+        profile: BackendProfile
+    ) async -> String? {
+        let cleanText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanText.isEmpty else { return nil }
+
+        // Start the one-shot session.
+        let session: SessionHandle
+        do {
+            session = try await backend.start(
+                profile: profile,
+                systemPrompt: modelSystemPrompt,
+                onExit: { _ in })
+        } catch {
+            DebugLog.agent("MessageSummarizer.modelSummary: start failed: \(error.localizedDescription)")
+            return nil
+        }
+
+        // Send one turn + collect assistant text. Mirror ACPExtractionClient's
+        // collection: append .assistantText, take .result as fallback.
+        let prompt = "Summarize this in one sentence:\n\n\(cleanText)"
+        var collected = ""
+        var turnError: String?
+        let stream = await backend.send(TurnInput(userText: prompt), into: session)
+        for await event in stream {
+            switch event {
+            case .assistantText(let chunk):
+                collected += chunk
+            case .result(let isError, let resultText):
+                if isError {
+                    turnError = resultText
+                } else if collected.isEmpty {
+                    collected = resultText
+                }
+            case .turnFailed(let reason):
+                turnError = reason.description
+            default:
+                break
+            }
+        }
+
+        // Always cancel — it was a one-shot session (mirrors extraction).
+        await backend.cancel(session)
+
+        if let turnError {
+            DebugLog.agent("MessageSummarizer.modelSummary: turn failed: \(turnError)")
+            return nil
+        }
+
+        let trimmed = collected.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    /// Build the `BackendProfile` for the summarizer stage from the user's
+    /// `AgentProvidersConfig` (chat-summary plan §4.3, mirroring
+    /// `ACPExtractionClient.resolveProvider`). Resolves the pinned summarizer
+    /// provider + its PATH-resolved command + Keychain API key + the stage's
+    /// model id, then builds the provider hints via
+    /// `AgentBackendFactory.providerHints`.
+    ///
+    /// Returns nil when:
+    /// - the stage pin is empty/absent (caller should not enter model mode),
+    /// - the pinned provider is missing/disabled,
+    /// - the command can't be PATH-resolved.
+    ///
+    /// PURE w.r.t. config + credential state (the `resolveCommand` closure is
+    /// injectable for tests; the default mirrors `ACPExtractionClient`).
+    public static func resolveProfile(
+        config: AgentProvidersConfig,
+        credentialStore: any ACPCredentialStore,
+        resolveCommand: (AgentProvider) -> [String]? = { provider in
+            guard let command = provider.command, let exe = command.first else {
+                return nil
+            }
+            if exe == "bun", let bundled = AgentLauncher.bundledHelperPath("bun") {
+                return [bundled] + Array(command.dropFirst())
+            }
+            switch PathPreflight.resolveOnLoginShell(executable: ShellArgv.expandTilde(exe)) {
+            case .found(let path):
+                return [path] + Array(command.dropFirst())
+            case .missing:
+                return nil
+            }
+        }
+    ) -> BackendProfile? {
+        // Read the pin DIRECTLY — never `provider(forStage:)` (chat-summary
+        // plan §5.1 invariant). This method is only called after the caller has
+        // confirmed model mode, but the guard is here too for defense in depth.
+        guard let pinnedId = config.stageProviderIds["summarizer"],
+              !pinnedId.isEmpty,
+              let provider = config.provider(id: pinnedId),
+              provider.enabled else {
+            return nil
+        }
+
+        guard let resolvedCommand = resolveCommand(provider) else {
+            DebugLog.agent("MessageSummarizer.resolveProfile: command not resolved for provider=\(provider.id)")
+            return nil
+        }
+
+        let apiKey = credentialStore.apiKey(forProvider: provider.id)
+        // Read the stage's model id via modelId(forStage:) — this is safe now
+        // because we already confirmed the pin is non-empty above. The fallback
+        // is the provider's selectedModelId.
+        let selectedModelId = config.modelId(forStage: "summarizer")
+
+        let hints = AgentBackendFactory.providerHints(
+            provider: provider,
+            resolvedCommand: resolvedCommand,
+            apiKey: apiKey,
+            selectedModelId: selectedModelId)
+
+        return BackendProfile(
+            providerHints: hints,
+            scratchDirectory: FileManager.default.temporaryDirectory,
+            isReadOnly: true)
+    }
+}

--- a/Tests/WikiFSTests/MessageSummaryTests.swift
+++ b/Tests/WikiFSTests/MessageSummaryTests.swift
@@ -1,0 +1,336 @@
+import Testing
+import Foundation
+import WikiFSEngine
+import WikiFSCore
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// Tests for the per-message summary feature (plans/chat-summary.md).
+///
+/// Four layers:
+///   - **`ChatMessageSummaryKind`** — explicit raw values + Codable round-trip
+///     (guards the §4.1 explicit-raw-value fix).
+///   - **`MessageSummarizer.Mode`** — the §5.1 mode-encoding invariant
+///     (`stageProviderIds["summarizer"]` gates the decision, NEVER
+///     `provider(forStage:)`).
+///   - **Default backend** — pure truncation via `ChatSummary.summaryExtract`.
+///   - **Model backend** — driven end-to-end via `FakeAgentBackend` (AC.4
+///     automated model half).
+///   - **Store round-trip** — `updateMessageSummary` + `chatMessages` read-back
+///     on a real in-memory SQLite DB (AC.1 + AC.6).
+@Suite(.timeLimit(.minutes(5)))
+struct MessageSummaryTests {
+
+    // MARK: - ChatMessageSummaryKind (§4.1 — explicit raw values)
+
+    @Test func summaryKind_rawValues_areExplicitShortStrings() {
+        // The raw values MUST be the short column forms — Swift would otherwise
+        // derive them from the case names ("defaultTruncation"), breaking the
+        // `summary_kind` column round-trip.
+        #expect(ChatMessageSummaryKind.defaultTruncation.rawValue == "default")
+        #expect(ChatMessageSummaryKind.model.rawValue == "model")
+    }
+
+    @Test func summaryKind_caseIterable_roundTripsThroughRawValue() {
+        for kind in ChatMessageSummaryKind.allCases {
+            let raw = kind.rawValue
+            let back = ChatMessageSummaryKind(rawValue: raw)
+            #expect(back == kind, "rawValue round-trip failed for \(kind)")
+        }
+    }
+
+    @Test func summaryKind_decodesFromColumnLiteral() throws {
+        // Decode the column-stored short string literal → the enum case. This
+        // guards the explicit-raw-value fix: if the raw values were derived
+        // from case names, `"default"` would decode to nil.
+        let defaultData = Data("\"default\"".utf8)
+        let modelData = Data("\"model\"".utf8)
+        let decoder = JSONDecoder()
+        #expect(try decoder.decode(ChatMessageSummaryKind.self, from: defaultData) == .defaultTruncation)
+        #expect(try decoder.decode(ChatMessageSummaryKind.self, from: modelData) == .model)
+    }
+
+    @Test func summaryKind_codableRoundTrip() throws {
+        // Full Codable round-trip: encode → decode → equal.
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for kind in ChatMessageSummaryKind.allCases {
+            let data = try encoder.encode(kind)
+            let back = try decoder.decode(ChatMessageSummaryKind.self, from: data)
+            #expect(back == kind)
+        }
+    }
+
+    // MARK: - Mode encoding (§5.1 — the load-bearing invariant)
+
+    @Test func mode_emptyPin_returnsDefaultTruncation() {
+        // The critical invariant: an empty/absent pin ⇒ Default (truncation,
+        // no model call). NEVER use `provider(forStage:)` for this decision.
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude", label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+        ])
+        // Confirm the precondition: provider(forStage:) returns a provider
+        // (the global default) EVEN when the pin is empty — that's the trap.
+        #expect(config.provider(forStage: "summarizer").id == "claude")
+        // And yet mode(for:) correctly reports Default because it reads
+        // stageProviderIds directly, not provider(forStage:).
+        #expect(MessageSummarizer.mode(for: config) == .defaultTruncation)
+    }
+
+    @Test func mode_absentPin_returnsDefaultTruncation() {
+        // No "summarizer" key at all → Default.
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude", label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+        ])
+        #expect(config.stageProviderIds["summarizer"] == nil)
+        #expect(MessageSummarizer.mode(for: config) == .defaultTruncation)
+    }
+
+    @Test func mode_nonEmptyPin_returnsModel() {
+        // A pinned provider ⇒ Model.
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude", label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+            AgentProvider(id: "gemini", label: "Gemini", command: ["gemini", "--acp"], enabled: true, isDefault: false),
+        ]).settingStageProvider("gemini", forStage: "summarizer")
+        #expect(MessageSummarizer.mode(for: config) == .model)
+    }
+
+    @Test func mode_clearedPin_returnsDefaultTruncation() {
+        // Setting then clearing the pin restores Default.
+        let base = AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude", label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+        ])
+        let pinned = base.settingStageProvider("claude", forStage: "summarizer")
+        #expect(MessageSummarizer.mode(for: pinned) == .model)
+        let cleared = pinned.settingStageProvider(nil, forStage: "summarizer")
+        #expect(MessageSummarizer.mode(for: cleared) == .defaultTruncation)
+    }
+
+    // MARK: - Default backend (§4.2 — pure truncation, zero model compute)
+
+    @Test func defaultSummary_reusesChatSummaryExtract() {
+        // The default backend IS ChatSummary.summaryExtract(from:maxLength: 200)
+        // — byte-identical to the existing on-the-fly outline extraction.
+        let text = "The page covers tire selection. It also talks about pressures."
+        let expected = ChatSummary.summaryExtract(from: text, maxLength: 200)
+        #expect(MessageSummarizer.defaultSummary(for: text) == expected)
+    }
+
+    @Test func defaultSummary_emptyInput_returnsEmpty() {
+        #expect(MessageSummarizer.defaultSummary(for: "") == "")
+        #expect(MessageSummarizer.defaultSummary(for: "   ") == "")
+    }
+
+    // MARK: - textToSummarize (event extraction)
+
+    @Test func textToSummarize_assistantText_returnsText() {
+        let event = AgentEvent.assistantText("Hello world.")
+        #expect(MessageSummarizer.textToSummarize(from: event) == "Hello world.")
+    }
+
+    @Test func textToSummarize_result_returnsText() {
+        let event = AgentEvent.result(isError: false, text: "The answer.")
+        #expect(MessageSummarizer.textToSummarize(from: event) == "The answer.")
+    }
+
+    @Test func textToSummarize_nonAssistantEvents_returnNil() {
+        #expect(MessageSummarizer.textToSummarize(from: .userText("q")) == nil)
+        #expect(MessageSummarizer.textToSummarize(from: .toolUse(name: "Bash", inputSummary: "ls")) == nil)
+        #expect(MessageSummarizer.textToSummarize(from: .messageStop) == nil)
+    }
+
+    // MARK: - Model backend (§4.3 — injectable AgentBackend seam, AC.4)
+
+    @Test func modelSummary_streamsAssistantTextAsSummary() async {
+        // The model half of AC.4, automated: one assistant turn in → summary
+        // out via the injected FakeAgentBackend (no real subprocess).
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [.assistantText("A concise summary."), .messageStop])
+        ])
+        let profile = BackendProfile(model: "test-model")
+        let result = await MessageSummarizer.modelSummary(
+            text: "Some long assistant text that needs summarizing.",
+            backend: backend,
+            profile: profile)
+        #expect(result == "A concise summary.")
+        // The backend was used exactly once (one-shot session).
+        let counts = await (backend.startCount, backend.sendCount, backend.cancelCount)
+        #expect(counts.0 == 1, "startCount")
+        #expect(counts.1 == 1, "sendCount")
+        #expect(counts.2 == 1, "cancelCount")
+    }
+
+    @Test func modelSummary_resultEventFallback() async {
+        // Some agents emit everything in .result instead of streaming
+        // .assistantText — modelSummary should take it as fallback (mirrors
+        // ACPExtractionClient.convert).
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [.result(isError: false, text: "Result-based summary."), .messageStop])
+        ])
+        let profile = BackendProfile()
+        let result = await MessageSummarizer.modelSummary(
+            text: "Content.", backend: backend, profile: profile)
+        #expect(result == "Result-based summary.")
+    }
+
+    @Test func modelSummary_emptyInput_returnsNil() async {
+        let backend = FakeAgentBackend(behaviors: [])
+        let profile = BackendProfile()
+        let result = await MessageSummarizer.modelSummary(
+            text: "   ", backend: backend, profile: profile)
+        #expect(result == nil)
+        // Should not even start a session for empty input.
+        let starts = await backend.startCount
+        #expect(starts == 0)
+    }
+
+    @Test func modelSummary_errorTurn_returnsNil() async {
+        // A .turnFailed or .result(isError: true) → nil (the caller leaves
+        // summary = NULL so the message is retriable).
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [.result(isError: true, text: "boom"), .messageStop])
+        ])
+        let profile = BackendProfile()
+        let result = await MessageSummarizer.modelSummary(
+            text: "Content.", backend: backend, profile: profile)
+        #expect(result == nil)
+    }
+
+    @Test func modelSummary_startFailure_returnsNil() async {
+        // If backend.start throws, modelSummary returns nil (no crash).
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(shouldFailOnStart: true)
+        ])
+        let profile = BackendProfile()
+        let result = await MessageSummarizer.modelSummary(
+            text: "Content.", backend: backend, profile: profile)
+        #expect(result == nil)
+    }
+
+    // MARK: - resolveProfile (production backend wiring, §4.3)
+
+    @Test func resolveProfile_emptyPin_returnsNil() {
+        // Defense in depth: resolveProfile reads the pin directly and bails
+        // when it's empty — even though the caller should have confirmed model
+        // mode before calling.
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude", label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+        ])
+        let creds = InMemoryACPCredentialStore()
+        let profile = MessageSummarizer.resolveProfile(
+            config: config,
+            credentialStore: creds,
+            resolveCommand: { _ in ["/usr/bin/true"] })
+        #expect(profile == nil)
+    }
+
+    @Test func resolveProfile_pinnedProvider_buildsHints() throws {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude", label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+        ]).settingStageProvider("claude", forStage: "summarizer")
+        let creds = InMemoryACPCredentialStore()
+        try creds.setAPIKey("secret-key", forProvider: "claude")
+        let profile = MessageSummarizer.resolveProfile(
+            config: config,
+            credentialStore: creds,
+            resolveCommand: { _ in ["/usr/bin/claude"] })
+        #expect(profile != nil)
+        // The provider hint carries the resolved executable.
+        #expect(profile?.providerHints[HintKey.acpAgentPath.rawValue] == "/usr/bin/claude")
+        // The API key is threaded into hints.
+        #expect(profile?.providerHints[HintKey.acpAgentApiKey.rawValue] == "secret-key")
+    }
+
+    @Test func resolveProfile_unresolvableCommand_returnsNil() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: "claude", label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+        ]).settingStageProvider("claude", forStage: "summarizer")
+        let profile = MessageSummarizer.resolveProfile(
+            config: config,
+            credentialStore: InMemoryACPCredentialStore(),
+            resolveCommand: { _ in nil })  // command not resolved
+        #expect(profile == nil)
+    }
+
+    // MARK: - Store round-trip (AC.1 + AC.6, integration)
+
+    @Test func freshDB_isAtSchemaVersion40() throws {
+        // AC.1: a fresh DB is at user_version = 40.
+        let store = try TestStoreFactory.inMemory()
+        let version = Int(store.pragmaValue("user_version")) ?? 0
+        #expect(version == 40)
+    }
+
+    @Test func summaryNullForNewMessages() throws {
+        // AC.1 (read side): newly-appended messages have nil summary fields.
+        let store = try TestStoreFactory.inMemory()
+        let chat = try store.createChat(kind: .edit, title: "Chat")
+        _ = try store.appendChatMessages(
+            chatID: chat.id,
+            events: [.userText("q"), .assistantText("Some answer.")])
+        let messages = try store.chatMessages(chatID: chat.id)
+        #expect(messages.count == 2)
+        for msg in messages {
+            #expect(msg.summary == nil, "summary should be nil for \(msg.event)")
+            #expect(msg.summaryKind == nil)
+            #expect(msg.summaryAt == nil)
+        }
+    }
+
+    @Test func updateMessageSummary_roundTrips() throws {
+        // AC.6 (compute-once path): write a summary, read it back — cached.
+        let store = try TestStoreFactory.inMemory()
+        let chat = try store.createChat(kind: .edit, title: "Chat")
+        let inserted = try store.appendChatMessages(
+            chatID: chat.id,
+            events: [.assistantText("Long answer.")])
+        let target = try #require(inserted.first)
+        try store.updateMessageSummary(
+            chatID: chat.id, messageID: target.id,
+            summary: "Cached one-liner.", kind: .model)
+
+        let after = try store.chatMessages(chatID: chat.id)
+        let updated = try #require(after.first { $0.id == target.id })
+        #expect(updated.summary == "Cached one-liner.")
+        #expect(updated.summaryKind == .model)
+        #expect(updated.summaryAt != nil)
+    }
+
+    @Test func summaryWrittenForOneMessage_doesNotAffectOthers() throws {
+        // Writing a summary for one message leaves others nil (per-message
+        // granularity, not per-chat).
+        let store = try TestStoreFactory.inMemory()
+        let chat = try store.createChat(kind: .edit, title: "Chat")
+        let inserted = try store.appendChatMessages(
+            chatID: chat.id,
+            events: [.assistantText("first."), .assistantText("second.")])
+        try store.updateMessageSummary(
+            chatID: chat.id, messageID: inserted[0].id,
+            summary: "first summary.", kind: .defaultTruncation)
+
+        let after = try store.chatMessages(chatID: chat.id)
+        #expect(after[0].summary == "first summary.")
+        #expect(after[1].summary == nil)
+        #expect(after[1].summaryKind == nil)
+    }
+
+    @Test func idempotency_alreadySummarized_isSkippedByFilter() throws {
+        // AC.6 (cache short-circuit): the summarizePendingMessages filter
+        // (`msg.summary == nil`) skips already-summarized rows. Verify the
+        // round-trip supports this: after a write, the message's summary is
+        // non-nil so it would be filtered out on the next pass.
+        let store = try TestStoreFactory.inMemory()
+        let chat = try store.createChat(kind: .edit, title: "Chat")
+        let inserted = try store.appendChatMessages(
+            chatID: chat.id, events: [.assistantText("text.")])
+        try store.updateMessageSummary(
+            chatID: chat.id, messageID: inserted[0].id,
+            summary: "done.", kind: .defaultTruncation)
+
+        // Re-read: the message now has a non-nil summary, so a filter like
+        // `messages.filter { $0.summary == nil }` excludes it.
+        let messages = try store.chatMessages(chatID: chat.id)
+        let pending = messages.filter { $0.summary == nil }
+        #expect(pending.isEmpty, "already-summarized message should be filtered out")
+    }
+}

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -568,14 +568,15 @@ struct PageVersionTests {
                 "nil author degrades to legacy-import (got \(agentName))")
     }
 
-    /// AC.8 (migration ladder sanity) — a v38 DB reopened at v39 must report
-    /// `user_version = 39`. The migration step is a no-op `PRAGMA user_version
-    /// = 39` (no schema change; the write-path change is the real fix).
+    /// AC.8 (migration ladder sanity) — a fresh DB must report the current
+    /// `user_version`. The v38→39 step was a no-op `PRAGMA user_version = 39`
+    /// (the write-path change was the real fix); v39→40 adds the per-message
+    /// summary columns (`plans/chat-summary.md` §3.3).
     @Test func v39SchemaVersionAfterMigration() throws {
-        #expect(GRDBWikiStore.schemaVersion == 39,
-                "schemaVersion must report 39 after the page-provenance bump")
+        #expect(GRDBWikiStore.schemaVersion == 40,
+                "schemaVersion must report 40 after the chat-message-summary bump")
         let store = try tempStore()
         let v = store.pragmaValue("user_version")
-        #expect(v == "39", "fresh DB stamps user_version = 39 (got \(v))")
+        #expect(v == "40", "fresh DB stamps user_version = 40 (got \(v))")
     }
 }

--- a/Tests/WikiFSTests/StoreEmissionTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionTests.swift
@@ -366,6 +366,28 @@ struct StoreEmissionTests {
         #expect(events.last?.id == chat.id.rawValue)
     }
 
+    /// Per-message summary emit (chat-summary plan §3.5 + AC.2). The new
+    /// `updateMessageSummary` mutator MUST route through `mutate()` and emit a
+    /// `.chat .updated` event on the chat the message belongs to (the
+    /// projection + model subscribe to `.chat` changes; there is no
+    /// `.message` resource kind). Modeled on
+    /// `appendChatMessagesEmitsChatUpdated` above.
+    @Test func updateMessageSummaryEmitsChatUpdated() async throws {
+        let (store, _, rec) = try makeHarness()
+        let chat = try store.createChat(kind: .edit, title: "Test Chat")
+        try await drain(rec)
+        let messages = try store.appendChatMessages(
+            chatID: chat.id, events: [AgentEvent.assistantText("text.")])
+        try await drain(rec)
+        try store.updateMessageSummary(
+            chatID: chat.id, messageID: messages[0].id,
+            summary: "one-liner.", kind: .defaultTruncation)
+        let events = try await awaitEvents(rec)
+        #expect(events.last?.kind == .chat)
+        #expect(events.last?.change == .updated)
+        #expect(events.last?.id == chat.id.rawValue)
+    }
+
     @Test func renameChatEmitsChatUpdated() async throws {
         let (store, _, rec) = try makeHarness()
         let chat = try store.createChat(kind: .edit, title: "Test Chat")

--- a/plans/chat-summary.md
+++ b/plans/chat-summary.md
@@ -1,80 +1,611 @@
-# Chat Summary (Issue #411)
+# Chat-Message Summary — Implementation Plan
 
-## Goal
+> Plan for a **per-message summary** feature in Self Driving Wiki (macOS 15 /
+> Swift 6.0). Companion to `plans/chat-and-persistence.md` and
+> `plans/event-bus.md`.
+>
+> **STATUS: implementation in progress.** Branch `chat-summary`, PR — never
+> push/merge `main`.
+>
+> **Revision note (v2):** This version corrects the Default-vs-Model encoding
+> (§5/§6 — `provider(forStage:)` is non-optional and falls back to the global
+> default; the mode decision must gate on `stageProviderIds["summarizer"]`
+> directly), drops the fictional `StoreEmissionExhaustivenessTests` claim
+> (§3.5/§8), makes the model backend injectable so AC.4's model half is
+> automated (§4.3), adds an explicit AC↔test table (§9), pins explicit enum raw
+> values (§4.1), and mirrors the real `migrateV35ToV36` migration idiom (§3.3).
 
-Show a one-line AI summary of the model's response under each chat row in the
-sidebar (`RecentChatRow`). The summary is generated once on chat completion and
-stored in the SQLite database.
+---
 
-## Strategy (v0)
+## 0. TL;DR / mental model
 
-**Deterministic extract first**, with LLM summarization as a future enhancement.
+There are **two existing "summary" surfaces** — do not confuse them:
 
-- On chat completion (terminal `.result` event), extract the first sentence of
-  the first `.assistantText` or `.result` event, elided to ~60 chars using the
-  existing `ChatSummary.title(fromFirstMessage:maxLength:)` elision rule.
-- No LLM call needed for v0 — instant, no external dependency, no provider key
-  required. The LLM path can be layered on top later via `AgentBackend`.
-- This delivers the UI feature immediately and keeps the schema + store +
-  rendering infrastructure in place for when LLM summarization is added.
+| Surface | Granularity | Storage | Compute | Status |
+|---|---|---|---|---|
+| `ChatSummary.summary` / `summaryAt` | **One row per CHAT** (issue #411) | `chats.summary` + `chats.summary_at` columns | first-sentence truncation, run once in `AgentLauncher.finish()` | **Shipped.** Leave as-is. |
+| `ChatOutlineEntry.response` | **One per turn** (UI-only, recomputed on render) | none — recomputed every render via `ChatSummary.summaryExtract` | first-sentence truncation, on the fly | **Shipped.** This is the site we extend. |
 
-## Implementation
+**This feature** adds a **per-message** (`chat_messages`) summary that is:
 
-### 1. Schema migration (v35 → v36)
+1. **Configurable** — a summarizer setting: *Default* (today's first-sentence
+   truncation, **no model call**) or *a pinned model* (LLM via an agent
+   provider).
+2. **Cached in the DB** — new `chat_messages` columns, computed ONCE, never
+   recomputed. Read on render; compute once.
+3. Surfaced in the existing **chat outline** (`ChatOutlineView` /
+   `ChatOutlineEntry`) replacing the on-the-fly re-extraction, with the
+   transcript WebView injection as a stretch goal.
 
-Add `summary TEXT` and `summary_at REAL` columns to the `chats` table:
+The summarizer SETTING is designed as **another stage pin** in
+`AgentProvidersConfig` (the `"summarizer"` stage), surfaced via a new **"Summary"**
+tab in `AgentsSettingsView` that reuses PR #716's `StageProviderModelPicker`
+component.
 
-- New `migrateV35ToV36()` method: `ALTER TABLE chats ADD COLUMN summary TEXT;`
-  + `ALTER TABLE chats ADD COLUMN summary_at REAL;` (simple ALTER — no table
-  rebuild needed for nullable columns).
-- Update `createChatTablesV23()` to include the new columns for fresh DBs.
-- Bump `PRAGMA user_version=36`.
-- Follow the `mutate(event:_:)` + `ResourceChangeEvent` pattern from the store
-  emission invariant.
+**⚠ The single most important invariant in this plan (read §5 before coding):**
+the model-vs-truncation decision gates **strictly on
+`config.stageProviderIds["summarizer"]`** (a non-empty pin ⇒ model mode; empty
+or absent ⇒ truncation, no model call). **NEVER call
+`config.provider(forStage: "summarizer")` to make this decision** — it is
+non-optional and falls back to the global default provider, so it would always
+report a provider and wrongly force model mode.
 
-### 2. Model update (`ChatSummary`)
+**Deferred: Apple Intelligence (future macOS 26+).**
 
-Add `summary: String?` and `summaryAt: Date?` to `ChatSummary` in
-`Sources/WikiFSCore/ChatModels.swift`.
+---
 
-### 3. Store methods (`SQLiteWikiStore`)
+## 1. Dependency — Feature 1 (#716) is MERGED
 
-- Update `listChats()` SELECT + `chatSummary(from:)` decoder to include the new
-  columns.
-- New public mutator: `updateChatSummary(chatID:summary:)` — writes the summary
-  + timestamp, routes through `mutate(event:_:)`, emits `ResourceChangeEvent`.
-- `StoreEmissionExhaustivenessTests` will enforce the new mutator is partitioned
-  correctly.
+**This feature builds directly on the merged agent-settings work from PR #716.**
 
-### 4. `WikiStoreModel` wrapper
+**What this feature reuses (do NOT duplicate):**
+- `AgentProvidersConfig.stageProviderIds` (the `[String: String]` provider-pin
+  map) + `settingStageProvider(_:forStage:)` (the PURE mutator) — shipped in
+  #716.
+- `AgentProvidersConfig.modelId(forStage:)` / `modelId(forStage:fallbackProvider:)`
+  — per-stage model selection (shipped in #716). Used **only when in model mode**
+  (i.e. only after the stage pin is confirmed non-empty).
+- `StageProviderModelPicker` — reusable provider+model picker component (shipped
+  in #716). The Summary tab **IS** this picker for stage `"summarizer"` — no
+  separate mode Picker, no `summarizerMode` field.
+- `AgentsSettingsView` tab architecture (segmented `Picker` over
+  `OperationTab`) — shipped in #716.
+- The `mutate()` / emit discipline (unchanged — already shipped).
 
-Add `updateChatSummary(chatID:summary:)` that delegates to the store, matching
-the existing `renameChat(id:to:)` pattern.
+**Action for the implementer:**
+- Branch from `main` (already includes #716). Verify `stageProviderIds`,
+  `settingStageProvider`, `modelId(forStage:)`, `StageProviderModelPicker`, and
+  the `OperationTab` segmented control exist before starting.
+- Treat `"summarizer"` as **another stage key** (alongside `"planner"` /
+  `"executor"` / `"finalizer"` / `"lint"`) in the same config. Do NOT add a
+  parallel model-picker or a new config type, and do NOT add a
+  `summarizerMode` field.
 
-### 5. Summarization hook (`AgentLauncher`)
+---
 
-After the terminal `.result` event is processed in the interactive session loop
-(`AgentLauncher.swift` ~line 1819, after `flushTranscript()`), call a new
-`generateChatSummary(for:)` method that:
-- Collects the first `.assistantText` or `.result` event from `events`.
-- Extracts the first sentence, elides to 60 chars via the existing elision rule.
-- Call `store.updateChatSummary(chatID:summary:)`.
+## 2. Goal & scope
 
-### 6. UI rendering (`RecentChatRow`)
+**Goal:** give each assistant chat message a short, cached summary, generated by
+a user-configurable summarizer (default-truncation when no provider is pinned /
+pinned model when one is), computed once and stored in `chat_messages`.
 
-In `Sources/WikiFS/AgentToolsView.swift`, update `RecentChatRow`:
-- When not live and `chat.summary != nil`, show the summary as a `.caption`
-  `.foregroundStyle(.secondary)` line under the title, replacing the timestamp.
-- When live, keep the "responding…" indicator.
-- When no summary, keep the relative timestamp.
+**In scope:**
+- New `chat_messages` columns `summary`, `summary_kind`, `summary_at` + a v40
+  schema migration (mirrors the real `migrateV35ToV36` idiom).
+- A `ChatMessageSummaryKind` enum with **explicit** raw values
+  `"default"` / `"model"` (§4.1).
+- A `MessageSummarizer` service with **an injectable `AgentBackend` seam** so the
+  model path is unit-testable via `FakeAgentBackend`.
+- DB write method `updateMessageSummary(...)` routing through `mutate()` +
+  emitting a `ResourceChangeEvent` (#129), verified by a new explicit
+  `StoreEmissionTests` case.
+- Summarizer **setting** as the `"summarizer"` stage pin in
+  `AgentProvidersConfig`, surfaced via a new **Summary tab** in
+  `AgentsSettingsView` that **IS** `StageProviderModelPicker(stageKey:
+  "summarizer", …)` — no separate mode Picker.
+- Render the cached summary in the chat outline (replacing on-the-fly extraction
+  for persisted messages).
+- Trigger: on turn completion (background) for new messages + lazy backfill /
+  on-demand for history.
+- Swift Testing coverage: cache round-trip, migration, default-truncation pure
+  logic, **model backend driven end-to-end via `FakeAgentBackend`**, idempotency,
+  emit assertion.
 
-### 7. Tests
+**Out of scope (follow-ups):**
+- Injecting the summary into the transcript `ChatWebView` HTML (outline first).
+- Summarizing the existing chat-level `chats.summary` (#411) with a model — that
+  is a separate, already-shipped truncation; leave it unless the operator wants
+  to unify.
+- Apple Intelligence on-device summarizer (future macOS 26+).
 
-- Store column round-trip (write summary, read it back via `listChats`).
-- Store emission exhaustiveness (new mutator is partitioned).
-- Deterministic extract produces a non-empty string.
-- `RecentChatRow` shows summary when present (if testable).
+---
 
-### 8. Docs
+## 3. The DB caching layer (schema + migration + #129 emit)
 
-Update `plans/chat-and-persistence.md` with the new `summary` column.
+### 3.1 New columns on `chat_messages`
+
+Add three nullable columns:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `summary` | `TEXT` | The cached summary text. `NULL` = not yet computed. |
+| `summary_kind` | `TEXT` | Which summarizer produced it: `"default"` / `"model"`. `NULL` alongside `summary`. |
+| `summary_at` | `REAL` | Unix timestamp of computation (staleness display). `NULL` alongside `summary`. |
+
+All nullable so the migration is a pure `ALTER TABLE ADD COLUMN` with no backfill
+(mirrors the v35→36 `chats.summary` precedent — see §3.3).
+
+### 3.2 Schema locations to update (THREE sites must stay identical)
+
+The chat schema is defined in **three** places that must stay in lockstep (the
+existing invariant — see `GRDBWikiStore.swift:1385` `createChatTablesV23` and the
+fresh-schema block at `:2435`):
+
+1. `createChatTablesV23(in:)` — `Sources/WikiFSCore/Store/GRDBWikiStore.swift:1385`
+   (the shared chat-schema builder; the `CREATE TABLE chat_messages` block is at
+   `:1399-1408`).
+2. The fresh-schema consolidated `CREATE TABLE chat_messages` block —
+   `GRDBWikiStore.swift:2435`.
+3. The v40 migration step (new — see §3.3).
+
+Add the three columns to sites 1 & 2, and ALTER them in site 3.
+
+### 3.3 The v40 migration (mirror `migrateV35ToV36`, NOT a fabricated helper)
+
+The precedent is `migrateV35ToV36(in:)` at `GRDBWikiStore.swift:1970-1979` (the
+real issue-#411 chat-summary migration), which wraps the nullable `ALTER TABLE …
+ADD COLUMN` in `db.inTransaction(.immediate)` and guards it with
+`tableColumnInfo(_:in:)` (`:1226` — a column-name set, `.contains(...)`). Mirror
+that idiom exactly. `hasColumn(_:on:in:)` (`:1197`) is the single-column
+equivalent and is also acceptable.
+
+- Bump `currentSchemaVersion` from `39` → `40` (`GRDBWikiStore.swift:61`).
+- Add a new migration step **inside** the `migrate(from:in:)` ladder, guarded
+  `if version < 40 { … }`. **Place it BEFORE the catch-all fallback**
+  (`GRDBWikiStore.swift:1185`) — the fallback is keyed on
+  `currentSchemaVersion`, so once bumped it short-circuits and stamps
+  `user_version = 40`, executing none of any new sibling step after it. Mirror
+  the existing load-bearing-ordering comment at `:1163-1173`.
+- **Update the now-stale `(39 now)` comment near `:1163-1189`** to reflect 40.
+
+### 3.4 The `ChatMessage` model + read path
+
+- Add `summary: String?`, `summaryKind: String?`, `summaryAt: Date?` to
+  `ChatMessage` (`Sources/WikiFSCore/Core/ChatModels.swift:122`). Default them to
+  `nil` in the existing `init` (and add memberwise params defaulting to `nil`) so
+  non-summary callers are unaffected.
+- Update `chatMessages(chatID:)` SELECT (`GRDBWikiStore.swift:5789-5813`) to read
+  the three new columns and populate the model. The INSERT in `appendChatEvents`
+  does NOT set summary — it stays NULL until the summarizer runs. Decode the new
+  fields with decode-if-present (they are nullable).
+
+### 3.5 The summary WRITE method + #129 emit (CRITICAL)
+
+Add a public mutator — **it MUST route through `mutate()` and emit a
+`ResourceChangeEvent`** (#129). Model it exactly on `updateChatSummary`
+(`GRDBWikiStore.swift:5858-5868`):
+
+```swift
+public func updateMessageSummary(
+    chatID: PageID, messageID: PageID, summary: String, kind: ChatMessageSummaryKind
+) throws {
+    try mutate(event: { _ in
+        // Emit on the CHAT the message belongs to — the projection + the model
+        // subscribe to .chat changes. (chat_messages cascade-delete with chats,
+        // so there is no standalone .message resource kind.)
+        self.localEvent(.chat, id: chatID.rawValue, change: .updated)
+    }) { db in
+        try db.execute(sql: """
+        UPDATE chat_messages
+        SET summary = ?, summary_kind = ?, summary_at = ?
+        WHERE id = ?;
+        """, arguments: [summary, kind.rawValue,
+                        Date().timeIntervalSince1970, messageID.rawValue])
+    }
+}
+```
+
+Add it to:
+- The `WikiStore` protocol (`Sources/WikiFSCore/Store/WikiStore.swift`, near
+  `updateChatSummary` at `:650`).
+- `GRDBWikiStore` (impl above).
+- `WikiStoreModel` (`Sources/WikiFSCore/Store/WikiStoreModel.swift`) — a thin
+  `@MainActor` wrapper mirroring `updateChatSummary` at `:3573-3581` (do { try …
+  } catch { DebugLog.store(…) }; no manual reload — the bus fires it).
+
+**ResourceKind note:** `ResourceKind.chat` already exists (used by
+`updateChatSummary`/`renameChat`/`deleteChat`). Per-message summary reuses it —
+emit `.chat` updated with the **chat's** id. Do NOT add a `.message` kind (the
+projection has no per-message File Provider item; the chat row is the resource).
+
+> **Verification is an EXPLICIT per-method test, not an exhaustiveness guard.**
+> The repo does NOT have a `StoreEmissionExhaustivenessTests` that parses every
+> `public func`. The real file is `Tests/WikiFSTests/StoreEmissionTests.swift`
+> — a per-method suite (e.g. `appendChatMessagesEmitsChatUpdated` at :358-367).
+> Add a sibling `updateMessageSummaryEmitsChatUpdated` asserting
+> `kind == .chat`, `change == .updated`, `id == chatID.rawValue` (see §8).
+
+---
+
+## 4. The summarizer service
+
+New file: `Sources/WikiFSEngine/MessageSummarizer.swift` (engine layer — same
+module as `AgentLauncher` / `ACPExtractionClient`).
+
+### 4.1 The kind enum (EXPLICIT raw values — else they mismatch the column spec)
+
+In `Sources/WikiFSCore/Core/ChatModels.swift` (or a new
+`ChatMessageSummaryKind.swift` in Core):
+
+```swift
+public enum ChatMessageSummaryKind: String, Sendable, Codable, CaseIterable {
+    // Raw values are EXPLICIT and must match the `summary_kind` column spec.
+    // Without them Swift derives rawValue from the case NAME
+    // ("defaultTruncation"), mismatching the column and breaking round-trips.
+    case defaultTruncation = "default"   // first-sentence truncation, no model
+    case model               = "model"   // LLM via a pinned provider+model
+}
+```
+
+Add a Codable round-trip test (§8).
+
+### 4.2 The default backend (preserve today's behavior, zero model compute)
+
+Reuse **`ChatSummary.summaryExtract(from:maxLength:)`** verbatim
+(`Sources/WikiFSCore/Core/ChatModels.swift:80`). It IS the current "first few
+sentences" truncation. The default backend is a pure sync call — no I/O, no
+actor, **no model invocation**. (This guarantees zero behavior change for users
+who keep the Default setting.)
+
+### 4.3 The model backend — INJECTABLE `AgentBackend` seam (reuse ACP one-shot pattern)
+
+`MessageSummarizer`'s backend MUST be injectable so the model path is unit-test
+end-to-end with `FakeAgentBackend`
+(`Tests/WikiFSTests/FakeAgentBackend.swift:49`, an `actor` conforming to
+`AgentBackend` with a scripted `send(...) -> AsyncStream<AgentEvent>`
+(`:112`)). Two entry shapes, pick the cleaner for the engine's init style:
+
+- `init(backend: AgentBackend)` (or `init(backendFactory: (PermissionPolicy)
+  -> AgentBackend)`) — production resolves it via `AgentBackendFactory.makeBackend`
+  exactly like `ACPExtractionClient.convert`
+  (`Sources/WikiFSEngine/ACPExtractionClient.swift:114-213`); tests pass a
+  `FakeAgentBackend`.
+
+Mirror `ACPExtractionClient.convert` for the production model path:
+- Resolve the pinned provider + model **from the `"summarizer"` stage** — and
+  only enter this path once `stageProviderIds["summarizer"]` is non-empty (§5.1).
+  Use `config.modelId(forStage: "summarizer")` to read the pinned model id.
+- Build `AgentBackendFactory.providerHints(provider:resolvedCommand:apiKey:
+  selectedModelId:)` (`ACPExtractionClient.swift:140`) with the resolved
+  provider + its resolved command + Keychain key + the stage's model id.
+- Start a one-shot session via `AgentBackendFactory.makeBackend(policy:)`
+  (`:151`) with a summarization system prompt; send ONE turn
+  (`"Summarize this in one sentence:\n\n\(text)"`); collect `.assistantText` /
+  `.result` from the stream (`:178-198`); `backend.cancel(session)` (`:201`);
+  return the text.
+
+- **Permission policy: `.bypass`** (same as extraction — the summarizer has no
+  wiki to write to).
+- **Off-main:** the whole call is `async` and runs off the main actor; the DB
+  write is marshalled back to the `@MainActor` model.
+- **Error handling:** no bare `try?` (house rule). `do { try … } catch {
+  DebugLog.…(…) }`; a failed summarization leaves `summary = NULL` (retriable).
+
+> **Test seam (this is what makes AC.4 automated):** a Swift Testing case
+> constructs `MessageSummarizer(backend: FakeAgentBackend(behaviors:
+> [.init(events: [.assistantText("Short summary."), .messageStop])]))`,
+> feeds one assistant turn, and asserts the returned summary is the streamed
+> text AND that `updateMessageSummary` is called with `kind == .model`. So the
+> model half of AC.4 is automated, not manual. (The real `ACPBackend` SDK
+> `Client` is a concrete actor, not a protocol — that integration is still
+> manual — but the *summarizer logic* above it is fully tested.)
+
+> Note on weight: a full ACP subprocess for a one-sentence summary is **heavy**
+> (process spawn + `session/new` + one turn + teardown). For a chat with many
+> messages this is a lot of spawns. Mitigations: (a) only summarize on turn
+> completion (one summary per assistant turn, not per token), (b) reuse a warm
+> subprocess if the launcher pooling allows, (c) consider a lighter direct-HTTP
+> call later. Flag the weight as a known cost in the PR.
+
+---
+
+## 5. The summarizer SETTING (stage pin + Summary tab) — THE ENCODING
+
+> **This section is load-bearing. Read it before writing any trigger code.**
+
+### 5.1 Config: a `"summarizer"` stage — gate on `stageProviderIds`, NEVER on `provider(forStage:)`
+
+`AgentProvidersConfig.provider(forStage:)` (`AgentProvidersConfig.swift:239-246`)
+is **non-optional** and **falls back to `selectedProvider()`** (the global
+default LLM). It NEVER returns nil. Therefore any check shaped
+`if config.provider(forStage: "summarizer") != nil` (or `!= nil`) is **always
+true** and would force every message through the model path, breaking the
+Default (zero-model-compute) behavior.
+
+**The encoding — encode this explicitly and use it everywhere:**
+
+- **Model mode** ⇔ `config.stageProviderIds["summarizer"]` is **non-empty /
+  non-nil** (a provider is pinned).
+- **Default / truncation mode** ⇔ `config.stageProviderIds["summarizer"]` is
+  **empty or absent** (the pin is cleared).
+- **NEVER** branch the mode decision on `config.provider(forStage: "summarizer")`
+  or `config.modelId(forStage: "summarizer")` (the latter composes the former
+  and inherits the global fallback). Read `stageProviderIds["summarizer"]`
+  directly.
+
+No `summarizerMode` field exists or is added — the presence/absence of the
+`"summarizer"` stage pin encodes the choice. This keeps the config structure
+simple and consistent with the existing stage infrastructure.
+
+### 5.2 UI: a new Summary tab that IS `StageProviderModelPicker`
+
+In `AgentsSettingsView` (`Sources/WikiFS/Settings/AgentsSettingsView.swift`):
+
+1. **Add a 4th case** to `OperationTab` (`:57-58`, currently `case chat, ingestion,
+   lint`) → add `case summary` with label `"Summary"`.
+2. The Summary pane renders **exactly one** row — it IS the reusable picker:
+
+   ```swift
+   case .summary:
+       Form {
+           Section {
+               StageProviderModelPicker(
+                   stageKey: "summarizer",
+                   config: $config,
+                   containerDirectory: containerDirectory,
+                   label: "Summary Model",
+                   defaultOptionLabel: "Default (first few sentences)")
+           } header: {
+               Text("Message Summary")
+           } footer: {
+               Text("\"Default (first few sentences)\" is free truncation — no model call. "
+                 + "Pin a provider + model to summarize each assistant message with an LLM (computed once, cached).")
+                   .font(.caption)
+                   .foregroundStyle(.secondary)
+           }
+       }
+       .formStyle(.grouped)
+   ```
+
+   There is **no separate mode Picker** and **no `summarizerMode` field**. The
+   `StageProviderModelPicker`'s own provider dropdown already includes a "Default"
+   first option with sentinel tag `""` (`StageProviderModelPicker.swift:52`) which
+   clears the pin — that IS the truncation choice. Selecting a provider pins the
+   stage → model mode.
+
+3. **Relabel the picker's "Default" option for the summarizer stage.** The
+   component's `"Default"` label (`:52`) means "inherit the global default
+   provider" for the other stages — but for the summarizer stage an empty pin
+   means "no model, truncation." To avoid the confusion, render the stage's
+   first dropdown option as **"Default (first few sentences)"** for the
+   summarizer case. Two clean ways:
+   - Add an optional `defaultOptionLabel: String = "Default"` param to
+     `StageProviderModelPicker` and pass `"Default (first few sentences)"` from
+     the Summary pane; or
+   - Special-case the rendered first `Text(...)` in the Summary pane's wrapping
+     view.
+   Document this **stage-specific semantic** in the picker's doc comment and the
+   Summary footer (above): for `"summarizer"`, `""` ⇒ truncation, NOT "global
+   provider."
+
+Persist changes via `config.save(to: containerDirectory)` (the picker already
+does this in `StageProviderModelPicker.save` — `:106-113`; no new persistence
+code).
+
+---
+
+## 6. Trigger + caching model (WHEN does it run?)
+
+**Implementation: on turn completion (background) for new messages + lazy
+backfill / on-demand for history.**
+
+### 6.1 New messages — on turn completion (mirror #411)
+
+The chat-level summary already runs in `AgentLauncher.finish()` →
+`generateChatSummary()` → `summarySink`
+(`Sources/WikiFSEngine/AgentLauncher.swift:2857-2863`), wired through
+`AgentOperationRunner.onSummary`
+(`Sources/WikiFSEngine/AgentOperationRunner.swift:101-104,372-374`). Add a
+**per-message** sink in the same finish seam: for each assistant-text message
+that completed this turn, **if its cached summary is nil**, dispatch per the
+configured mode (§5.1), then persist via `updateMessageSummary` (main-actor
+model → `mutate()` → emit).
+
+- **Mode decision (repeat):** read `config.stageProviderIds["summarizer"]`.
+  Empty/absent ⇒ truncation (Default); non-empty ⇒ model (pinned provider).
+- **Default mode:** `ChatSummary.summaryExtract` is so cheap it can run
+  inline/sync at finish — still cache it for a uniform read path.
+- **Model mode:** off-main via the injected `AgentBackend`; write back when done.
+
+### 6.2 History (messages predating the feature) — lazy + on-demand
+
+Pre-feature `chat_messages` rows have `summary = NULL`. Two paths:
+
+- **Lazy backfill:** when a persisted chat is opened, for visible assistant
+  messages with nil summary, enqueue summary computation with a **small
+  concurrency cap** (e.g. 1–2) so opening a long chat doesn't spawn N
+  subprocesses. The outline shows the default-truncation instantly (computed on
+  render for nil-default, free) and upgrades to the cached model summary when
+  ready.
+- **On-demand "Summarize" affordance:** a per-message button (and a per-chat
+  "Summarize all") for explicit user control. Recommended for the model mode
+  (it costs tokens/spawns).
+
+**Why not "on message receipt" for ALL:** an agent turn can emit many
+intermediate messages; summarizing each synchronously would stall the stream.
+Compute after the turn ends (the `.messageStop` / `.result` boundary — see
+`AgentEvent.endsGeneration`).
+
+### 6.3 Read path (Render)
+
+- **Outline** (`ChatView.chatOutlineEntries`, `:474-516`): today it calls
+  `ChatSummary.summaryExtract(from: text, maxLength: 200)` on the fly (`:493`,
+  `:501`). Change it to: for a **persisted** message with a non-nil cached
+  `summary`, use it; otherwise compute the default truncation on the fly (free,
+  deterministic) as the placeholder. The cached value wins once written.
+  - This needs the outline to map an outline entry to a `ChatMessage` id
+    (persisted path) to read the cached summary. The live (streaming) path has
+    no row yet → always use on-the-fly default truncation; cache after the turn.
+- **Transcript WebView** (`ChatWebView`): stretch goal — inject the summary
+    under the assistant message HTML. Outline first.
+
+### 6.4 Actor boundaries (house rules)
+
+- Model calls are **off-main** (`async`, off the `@MainActor` model). Consult
+  `docs/skills/swift-concurrency-pro/SKILL.md` (actors, structured/unstructured,
+  cancellation).
+- The **DB write is main-actor** via the model → `mutate()` (the store's
+  recursive lock + savepoint). Never run inference/network inside a transaction
+  (`docs/skills/sqlite-concurrency/SKILL.md`).
+- All diagnostics via `DebugLog` (never `print`).
+
+---
+
+## 7. Files to add / modify
+
+**Add:**
+- `Sources/WikiFSCore/Core/ChatMessageSummaryKind.swift` (the enum) — or fold
+  into `ChatModels.swift`.
+- `Sources/WikiFSEngine/MessageSummarizer.swift` (the service: mode dispatch on
+  `stageProviderIds["summarizer"]`, default backend, **injectable** model
+  backend wrapper).
+- `Tests/WikiFSTests/MessageSummaryTests.swift` (Swift Testing).
+
+**Modify:**
+- `Sources/WikiFSCore/Core/ChatModels.swift` — add `summary`/`summaryKind`/
+  `summaryAt` to `ChatMessage` (`:122`).
+- `Sources/WikiFSCore/Store/GRDBWikiStore.swift` — `currentSchemaVersion` 39→40
+  (`:61`); the three schema sites (`:1399`, `:2435`); the v40 migration step
+  (before the fallback at `:1185`, mirroring `migrateV35ToV36` at `:1970` and
+  updating the `(39 now)` comment near `:1163-1189`); `chatMessages(chatID:)`
+  SELECT (`:5789`); new `updateMessageSummary(...)`.
+- `Sources/WikiFSCore/Store/WikiStore.swift` — add `updateMessageSummary` to the
+  protocol (`:650`).
+- `Sources/WikiFSCore/Store/WikiStoreModel.swift` — `@MainActor` wrapper
+  (`:3573`).
+- `Sources/WikiFSEngine/AgentLauncher.swift` — per-message summary sink in
+  `finish()` (`:2857`).
+- `Sources/WikiFSEngine/AgentOperationRunner.swift` — wire the per-message sink
+  (`:101`).
+- `Sources/WikiFS/Chats/ChatView.swift` — `chatOutlineEntries` reads cached
+  summary (`:493`/`:501`).
+- `Sources/WikiFS/Settings/AgentsSettingsView.swift` — add `case summary` to
+  `OperationTab` (`:57`); add the Summary pane that IS
+  `StageProviderModelPicker(stageKey: "summarizer", …)`.
+- `Sources/WikiFS/Settings/StageProviderModelPicker.swift` — add the optional
+  `defaultOptionLabel` param so the summarizer stage can render
+  "Default (first few sentences)"; document the stage-specific semantic.
+
+---
+
+## 8. Testing plan (Swift Testing — `docs/skills/swift-testing-pro/SKILL.md`)
+
+**Pure / fast tier:**
+- `ChatMessageSummaryKind` **raw values** (`"default"` / `"model"`) + Codable
+  round-trip (encode → decode → equal; also a `"default"` string literal →
+  `.defaultTruncation` decode, guarding the explicit-raw-value fix).
+- Default backend = `ChatSummary.summaryExtract` (already covered by
+  `ChatSummaryTests.swift`; add a `MessageSummarizer` dispatch test that an
+  empty/absent `stageProviderIds["summarizer"]` calls it and sets
+  `kind == .defaultTruncation`, and crucially does NOT touch the backend).
+- **Mode-encoding guard:** a unit test asserting that `MessageSummarizer` reads
+  `stageProviderIds["summarizer"]` and never routes through
+  `provider(forStage: "summarizer")` for the mode decision (regression net for
+  the §5.1 bug).
+- v40 migration: fresh DB at v40; an old v39 fixture ALTERs to v40 with NULL
+  summaries; `chatMessages` reads nil (template: `ChatSummaryTests.swift:111-122`).
+
+**Integration (real in-memory store, `TestStoreFactory.inMemory()`):**
+- `updateMessageSummary` round-trip (write + `chatMessages` read-back).
+- Summary NULL for existing messages after migration.
+- **#129 emit:** a new **explicit** `updateMessageSummaryEmitsChatUpdated` case
+  in `Tests/WikiFSTests/StoreEmissionTests.swift`, modeled on
+  `appendChatMessagesEmitsChatUpdated` (`:358-367`) — assert
+  `kind == .chat`, `change == .updated`, `id == chatID.rawValue`. (There is NO
+  exhaustiveness test that auto-catches a missing emit; this explicit case is
+  the guard.)
+
+**Model path (automated via the injectable seam):**
+- A Swift Testing case using `FakeAgentBackend`
+  (`Tests/WikiFSTests/FakeAgentBackend.swift:49`) with a scripted
+  `[.assistantText("…"), .messageStop]` behavior: one assistant turn in →
+  summary out → `updateMessageSummary` called with `kind == .model`. This drives
+  the model path end-to-end without a real subprocess.
+
+**Idempotency / compute-once:**
+- Enqueue summarization twice for one message (nil summary) → assert
+  `updateMessageSummary` is called exactly once (cache short-circuit). Covers
+  AC.6.
+
+**Run:** `make test` (regenerates prompts/version, full suite ~1.5 min). Do NOT
+merge without green. Never push/merge `main`.
+
+---
+
+## 9. Acceptance criteria + AC ↔ test mapping
+
+| AC | Criterion | Automated test / verification |
+|---|---|---|
+| **1** | `chat_messages.summary` + `summary_kind` + `summary_at` exist; a fresh DB is at `user_version = 40`; an existing v39 DB migrates with NULL summaries. | v40 migration test (§8 pure tier) + integration NULL-after-migration. |
+| **2** | `updateMessageSummary` routes through `mutate()` and emits a `.chat`/`.updated` event. | **Explicit** `updateMessageSummaryEmitsChatUpdated` in `StoreEmissionTests.swift` (§8). |
+| **3** | Summarizer setting = **Default** (empty `stageProviderIds["summarizer"]`) → outline behavior is byte-identical to today (zero model compute). | Mode-encoding guard test + default-dispatch test (§8). |
+| **4** | Summarizer setting = **Model** (non-empty pin) → a pinned provider+model produces a cached one-sentence summary, stored once, shown in the outline, never recomputed. | **Automated model half:** `FakeAgentBackend` end-to-end case (§8). *Manual:* the real `ACPBackend` spawn (concrete SDK `Client` actor, not a protocol) — note this limitation in the PR. |
+| **5** | The Summary tab in `AgentsSettingsView` presents `StageProviderModelPicker(stageKey: "summarizer")` with a relabeled "Default (first few sentences)" option. | **Manual validation** (SwiftUI render; no hosted-view render harness in the suite today). Limitation noted; the `defaultOptionLabel` param itself can have a small unit test if extracted. |
+| **6** | A message is summarized at most once (cached); re-opening the chat shows the cached summary without recompute. | Idempotency unit test — enqueue twice, assert one `updateMessageSummary` call (§8). |
+| **7** | No `print`, no bare `try?`, off-main compute via the correct actor boundary, DB writes main-actor via `mutate()`. | Lint/grep discipline: `rg -n '\bprint\(' Sources` and `rg -n 'try\?' <new files>` come back empty; review the actor boundaries against `swift-concurrency-pro` / `sqlite-concurrency`. |
+
+---
+
+## 10. Gotchas
+
+- **The mode decision gates on `stageProviderIds["summarizer"]`, NOT
+  `provider(forStage: "summarizer")`.** `provider(forStage:)` is non-optional and
+  falls back to the global default provider (`AgentProvidersConfig.swift:239-246`),
+  so checking it for nil/non-nil would ALWAYS force model mode. There is no
+  `summarizerMode` field — the presence/absence of the stage pin encodes the
+  choice.
+- **The picker's "Default" option means different things per stage.** For
+  `"chat"`/`"planner"`/etc. the sentinel `""` means "inherit the global default
+  provider" (`StageProviderModelPicker.swift:52`). For `"summarizer"` an empty
+  pin means "no model — truncation." Relabel the summarizer stage's option to
+  "Default (first few sentences)" and document the stage-specific semantic.
+- **There is NO `StoreEmissionExhaustivenessTests`.** The #129 guard for the new
+  method is the **explicit** `updateMessageSummaryEmitsChatUpdated` case in
+  `StoreEmissionTests.swift` (§8). Wire `mutate()`/`localEvent(.chat, …updated)`
+  correctly the first time.
+- **Three schema sites** must stay identical (`createChatTablesV23`, the
+  fresh-schema block, the migration) — the existing invariant.
+- **Migration idiom is `migrateV35ToV36`** (`:1970`): `tableColumnInfo` /
+  `hasColumn` guard + `db.inTransaction(.immediate)` + `ALTER TABLE ADD COLUMN`.
+  Place the `if version < 40` step BEFORE the catch-all fallback (`:1185`) and
+  update the `(39 now)` comment near `:1163-1189`.
+- **`summaryExtract` is shared** between the chat-level (#411) summary and this
+  per-message default — don't fork it; call the same static.
+- **Live vs persisted outline**: the live (streaming) path has `AgentEvent`s but
+  no `ChatMessage` row yet, so it can't read a cached summary. Compute the
+  default truncation on the fly there; cache after the turn persists.
+- **Model-mode weight**: one ACP subprocess per summary is expensive. Cap
+  concurrency; prefer on-turn-completion over per-message-during-stream.
+- **`ChatMessageSummaryKind` raw values are EXPLICIT** (`"default"` / `"model"`)
+  — without them the rawValue is the case name and the `summary_kind` column
+  round-trip breaks.
+- **Apple Intelligence is deferred to a future macOS 26+ version.**
+
+---
+
+## 11. OPERATOR DECISIONS (locked)
+
+1. **Summarizer options:** Default (truncation) and Model (LLM) only. Apple
+   Intelligence is deferred.
+2. **UI placement:** A dedicated "Summary" tab in `AgentsSettingsView` (4th tab
+   alongside Chat / Ingestion / Lint), that **IS** #716's
+   `StageProviderModelPicker` for the `"summarizer"` stage (no separate mode
+   Picker, no `summarizerMode` field).
+3. **Mode encoding (the invariant):** non-empty `stageProviderIds["summarizer"]`
+   ⇒ Model; empty/absent ⇒ Default/truncation. Never decide via
+   `provider(forStage: "summarizer")`.
+4. **Architecture:** App-side / ACP-safe — model summarizer is a one-shot ACP
+   session (the `ACPExtractionClient.convert` pattern) with an **injectable
+   `AgentBackend` seam**, NOT a nested sub-agent.
+5. **Trigger model:** On turn completion (background) for new messages + lazy
+   backfill / on-demand for history.


### PR DESCRIPTION
## Summary

Implements a per-message summary feature: each assistant chat message gets a
cached one-line summary, configurable via a new "summarizer" stage pin in
`AgentProvidersConfig`. Companion plan: `plans/chat-summary.md`.

**Two modes**, selected by the user via the new Summary tab:
- **Default** (empty pin): pure first-sentence truncation via
  `ChatSummary.summaryExtract` — zero model compute, byte-identical to today's
  on-the-fly outline extraction.
- **Model** (pinned provider+model): a one-shot ACP session that asks the
  pinned LLM for a one-sentence summary, computed once and cached in
  `chat_messages`.

## The load-bearing invariant (§5.1 of the plan)

The Default-vs-Model decision gates **strictly on
`config.stageProviderIds["summarizer"]`**. **Never** call
`config.provider(forStage: "summarizer")` for the mode decision — it is
non-optional and falls back to the global default provider, so it would always
report a provider and wrongly force every message through the model path.
`MessageSummarizer.mode(for:)` reads the pin directly; a dedicated test
(`mode_emptyPin_returnsDefaultTruncation`) asserts the invariant holds even
when `provider(forStage:)` reports a non-nil provider.

## What changed

**DB layer (v39 → v40 migration):**
- Three nullable columns on `chat_messages`: `summary`, `summary_kind`,
  `summary_at` (all decode-if-present).
- Migration mirrors `migrateV35ToV36` (`tableColumnInfo` guard +
  `db.inTransaction(.immediate)` + `ALTER TABLE ADD COLUMN`); placed before
  the catch-all fallback. Three schema sites updated in lockstep.
- `updateMessageSummary` routes through `mutate()` + emits `.chat/.updated`
  (#129), verified by `updateMessageSummaryEmitsChatUpdated` in
  `StoreEmissionTests.swift`.
- `chatMessages(chatID:)` SELECT reads the new columns.

**Summarizer service** (`Sources/WikiFSEngine/MessageSummarizer.swift`):
- `ChatMessageSummaryKind` enum with **explicit** raw values `"default"` /
  `"model"` (guards the column round-trip — §4.1).
- `MessageSummarizer.Mode.for(_:)` — mode dispatch on the stage pin.
- `defaultSummary(for:)` — pure truncation (reuses `ChatSummary.summaryExtract`).
- `modelSummary(text:backend:profile:)` — one-shot ACP session with an
  **injectable `AgentBackend` seam** (production =
  `AgentBackendFactory.makeBackend(policy: .bypass)`; tests =
  `FakeAgentBackend`). Mirrors `ACPExtractionClient.convert`.
- `resolveProfile(config:credentialStore:)` — builds the `BackendProfile` from
  the pinned provider + PATH-resolved command + Keychain key + stage model id.

**Trigger + render:**
- `AgentLauncher.finish()` fires `messageSummarySink(chatID)` after
  `flushTranscript()` + `generateChatSummary()`, before `activeChatID = nil`.
- `AgentOperationRunner` wires the sink in both `startChat` and `continueChat`:
  queries unsummarized assistant rows (`msg.summary == nil` = compute-once
  guard), dispatches per mode (default inline; model via off-main `Task`),
  persists via `updateMessageSummary` (main-actor DB write, no inference in a
  transaction).
- `ChatView.chatOutlineEntries` reads cached summaries for persisted messages;
  the live (streaming) path falls back to on-the-fly truncation (no row yet).

**Settings UI:**
- New **Summary** tab in `AgentsSettingsView` (4th alongside Chat / Ingestion /
  Lint) — IS `StageProviderModelPicker(stageKey: "summarizer", ...)` with a
  relabeled first option "Default (first few sentences)" (stage-specific
  semantic: for `"summarizer"`, an empty pin means "no model — truncation",
  not "inherit the global provider").
- New `defaultOptionLabel` param on `StageProviderModelPicker` (defaults to
  `"Default"`; Summary tab passes the longer label).

## Testing

`MessageSummaryTests.swift` (Swift Testing, 22 cases):
- `ChatMessageSummaryKind` explicit raw values + Codable round-trip (incl.
  decoding the `"default"` column literal).
- Mode-encoding invariant: empty/absent/cleared pin → Default; non-empty →
  Model. Includes the critical regression-net test asserting the invariant
  holds even when `provider(forStage:)` returns a provider.
- Default backend = `ChatSummary.summaryExtract` (byte-identical).
- `textToSummarize` event extraction (assistant/result).
- **Model backend driven end-to-end via `FakeAgentBackend`** (AC.4 model half
  automated — assistant text in → summary out → backend used once). Also covers
  `.result` fallback, empty input, error turn, and start-failure paths.
- `resolveProfile`: empty pin → nil; pinned provider → hints with executable +
  API key; unresolvable command → nil.
- Store round-trip: fresh DB at v40, NULL for new messages, write+read-back,
  per-message granularity, idempotency (already-summarized filtered out).

`StoreEmissionTests.swift`: `updateMessageSummaryEmitsChatUpdated` (#129 emit
guard).

`PageVersionTests.v39SchemaVersionAfterMigration`: updated to expect v40.

**Full suite: 3194 tests pass.** `make build && make test` is green.

## Known limitations / follow-ups

- **Model-mode weight**: one ACP subprocess per message is expensive (process
  spawn + session/new + one turn + teardown). The sink processes messages
  sequentially after turn completion (not during streaming) so it doesn't
  stall the stream, but a long chat with many unsummarized messages could
  spawn many subprocesses. A warm-subprocess pool or lighter direct-HTTP path
  is a future optimization.
- **Transcript WebView injection** (showing the summary under the assistant
  message HTML) is deferred — outline first.
- **Apple Intelligence on-device summarizer** is deferred to a future macOS
  26+ version.
- **On-demand "Summarize" / "Summarize all"** affordance (lazy backfill for
  history) is designed but not wired in this PR — the compute-once guard
  (`msg.summary == nil`) already supports it.
- AC.5 (Summary tab render) is manual validation — no hosted-view render
  harness in the test suite today. The `defaultOptionLabel` param is exercised
  via the model layer; the visual render needs a human check.

## House rules

- No `print` (all diagnostics via `DebugLog`).
- No bare `try?` in new files.
- Off-main compute for model mode; main-actor DB write via `mutate()`.
- No inference inside a transaction.
- Branch from `main`, feature branch, PR — never pushed/merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
