### PR TITLE
Replace @Entry with manual EnvironmentKey; require SwiftPM-CLI buildability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
+* **All Swift code must compile via `swift build` / `swift test` from the
+  command line (SwiftPM only) — never rely on Xcode-only tooling or APIs.**
+  In practice this means: no macros or APIs that require an Xcode project
+  file, an Xcode-managed scheme, or Xcode's build system to resolve (e.g.
+  avoid `@Entry` for `EnvironmentValues`/`FocusedValues` — use the manual
+  `EnvironmentKey`/`FocusedValueKey` pattern instead). If a feature only
+  builds inside Xcode, it doesn't belong in this codebase.
+
 * For all coding tasks use your judgement to decide an appropriate lower
   power model and run that in a subagent.
 

--- a/Sources/WikiFS/Reader/WikiLinkMenuNSItems.swift
+++ b/Sources/WikiFS/Reader/WikiLinkMenuNSItems.swift
@@ -150,6 +150,14 @@ private final class ClosureMenuItemTarget: NSObject {
     @objc func invoke() { closure() }
 }
 
+private struct AddURLHandlerKey: EnvironmentKey {
+    static let defaultValue: ((String) -> Void)? = nil
+}
+
+private struct AddBookmarkHandlerKey: EnvironmentKey {
+    static let defaultValue: ((BookmarkTargetPickerContext) -> Void)? = nil
+}
+
 extension EnvironmentValues {
     /// Opens the "Add from URL" sheet, pre-filling the field with the given URL
     /// string (empty for the toolbar / empty-state buttons; the absolute URL for
@@ -160,11 +168,17 @@ extension EnvironmentValues {
     /// buttons) so external links can be ingested from any reader without
     /// threading a closure through every detail view. Mirrors how the reader
     /// already injects behavior via `\.openURL`.
-    @Entry var addURLHandler: ((String) -> Void)? = nil
+    var addURLHandler: ((String) -> Void)? {
+        get { self[AddURLHandlerKey.self] }
+        set { self[AddURLHandlerKey.self] = newValue }
+    }
 
     /// Presents `BookmarkTargetPickerSheet` for the given context — set once by
     /// `ContentView` and read deep in the reader tree via `WikiLinkMenuNSItems`,
     /// so a right-clicked internal wiki link can be filed into a bookmark folder
     /// without threading a closure through every detail view. Issue #188.
-    @Entry var addBookmarkHandler: ((BookmarkTargetPickerContext) -> Void)? = nil
+    var addBookmarkHandler: ((BookmarkTargetPickerContext) -> Void)? {
+        get { self[AddBookmarkHandlerKey.self] }
+        set { self[AddBookmarkHandlerKey.self] = newValue }
+    }
 }


### PR DESCRIPTION
## Summary
- Replaces the two `@Entry`-based `EnvironmentValues` properties in `WikiLinkMenuNSItems.swift` (`addURLHandler`, `addBookmarkHandler`) with the traditional manual `EnvironmentKey` struct pattern, removing an Xcode-macro dependency.
- Adds a requirement to `AGENTS.md` that all Swift code must compile via plain `swift build`/`swift test` (SwiftPM CLI only), calling out `@Entry` as an example to avoid.

## Test plan
- [x] `swiftc -parse` on the changed file (clean, no syntax errors)
- [ ] `swift build` / `swift test` (blocked in this sandbox — no network access to resolve SwiftPM dependencies; please verify locally)