### PR TITLE
Silence Swift Testing 'will always pass' warnings

### DIFF
--- a/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSTests/QuoteHighlightWebViewTests.swift
@@ -109,7 +109,7 @@ struct QuoteHighlightWebViewTests {
         print("DBG_WINDOW_FIND_TYPE=\(wfType ?? "nil")")
         print("DBG_ARTICLE_HTML=\(articleHTML ?? "nil")")
         print("DBG_PROBE=\(probe ?? "nil")")
-        #expect(true)
+        #expect(Bool(true))
     }
 
     @Test func highlightWrapsExactQuoteInMark() async throws {

--- a/Tests/WikiFSTests/WikiChangeBridgeTests.swift
+++ b/Tests/WikiFSTests/WikiChangeBridgeTests.swift
@@ -173,7 +173,7 @@ struct WikiChangeBridgeTests {
 
         // No crash is the main assertion — the bridge handled a non-matching
         // wiki id gracefully (FP was signaled, no bus was poked).
-        #expect(true)
+        #expect(Bool(true))
     }
 }
 

--- a/plans/silence-always-pass.md
+++ b/plans/silence-always-pass.md
@@ -1,0 +1,27 @@
+# Silence "will always pass" warnings
+
+Swift Testing warns on `#expect(true)` (literal `true` — always passes). The
+warning message itself says: "use `Bool(true)` to silence this warning". The
+codebase already uses this silencer at
+`Tests/WikiFSTests/NotificationFanoutTests.swift:76` (`#expect(Bool(true))`).
+
+## Fix (test-file only — no non-test source touched)
+
+1. `Tests/WikiFSTests/WikiChangeBridgeTests.swift:176` — `#expect(true)` →
+   `#expect(Bool(true))` (no-crash test for non-matching wikiID flush; comment
+   preserved).
+2. `Tests/WikiFSTests/QuoteHighlightWebViewTests.swift:112` — `#expect(true)` →
+   `#expect(Bool(true))` (diagnostic/probe test; surrounding probe code
+   preserved).
+
+Do NOT alter any `#expect(... == true)` expressions — those are real Bool
+comparisons, not tautological literals, and do not fire the warning.
+
+## Verify
+
+`make build && make test` — confirm the two warnings are gone.
+
+## Ship
+
+Push branch, open PR (no `Closes` issue — standalone warning cleanup). Do NOT
+merge to main.


### PR DESCRIPTION
Silence two Swift Testing "will always pass" warnings by replacing tautological `#expect(true)` literals with the documented silencer `#expect(Bool(true))`. Test-file-only change; no non-test source touched.

- `Tests/WikiFSTests/WikiChangeBridgeTests.swift:176` — no-crash test for non-matching wikiID flush (comment preserved)
- `Tests/WikiFSTests/QuoteHighlightWebViewTests.swift:112` — diagnostic/probe test (surrounding probe code preserved)

The codebase already uses this silencer at `Tests/WikiFSTests/NotificationFanoutTests.swift:76`. No `#expect(... == true)` expressions were altered — those are real Bool comparisons, not tautological literals, and do not fire the warning.

Verified: `make build && make test` passes (3253 tests, no "always pass" warnings).
