### PR TITLE
Delete key deletes selected bookmark row/folder (#744)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,24 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-20 — Delete key deletes selected bookmark row/folder (branch `bookmark-delete-key`, #744)
+
+**Problem.** Selecting a bookmark row/folder in the bookmarks outline and
+pressing Delete/Backspace did nothing — deletion required right-click →
+context menu → Delete. There was no `keyDown` / `deleteBackward` /
+`deleteForward` handling on the outline view or its controller.
+
+**Fix.** Added `deleteBackward(_:)` and `deleteForward(_:)` overrides on
+`BookmarksNSOutlineView` (the existing `NSOutlineView` subclass) that
+forward to a `deleteSelection()` method on `BookmarksOutlineViewController`
+when a row is selected. `deleteSelection` builds the effective node list
+from the outline's current selection and routes through the **same**
+`deleteAction(_:)` / `onDelete` callback the context-menu "Delete" item
+uses — no separate deletion path. When a text field is editing (rename), it
+is the first responder and consumes `deleteBackward` itself, so Backspace
+edits the name instead of deleting the bookmark. See
+`plans/bookmark-delete-key.md`.
+
 ## 2026-07-20 — "Add Page" opens in the editor with the title pane expanded (branch `add-page-editor-default`)
 
 **Problem.** Clicking "Add Page" (welcome screen button or sidebar `+`) opened

--- a/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
@@ -836,7 +836,26 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
 
     @objc private func deleteAction(_ sender: NSMenuItem) {
         guard let payload = sender.representedObject as? BookmarksMenuPayload else { return }
-        callbacks?.onDelete(payload.effectiveNodes.map(\.id))
+        deleteNodes(payload.effectiveNodes.map(\.id))
+    }
+
+    /// Keyboard-delete entry point (Backspace / forward-Delete on selected
+    /// rows). Builds the effective node list from the outline's current
+    /// selection and routes through the same `onDelete` callback the
+    /// context-menu "Delete" item uses — no separate deletion path (#744).
+    @objc func deleteSelection() {
+        let nodes = outlineView.selectedRowIndexes.compactMap {
+            outlineView.item(atRow: $0) as? BookmarkNode
+        }
+        guard !nodes.isEmpty else { return }
+        deleteNodes(nodes.map(\.id))
+    }
+
+    /// Shared deletion seam for both the context-menu "Delete" action and the
+    /// keyboard Delete/Backspace path (`deleteSelection`).
+    private func deleteNodes(_ ids: [String]) {
+        guard !ids.isEmpty else { return }
+        callbacks?.onDelete(ids)
     }
 }
 
@@ -849,5 +868,28 @@ final class BookmarksNSOutlineView: NSOutlineView {
         guard row >= 0 else { return nil }
         let item = self.item(atRow: row)
         return (self.delegate as? BookmarksOutlineViewController)?.outlineView(self, menuFor: item ?? "")
+    }
+
+    // Keyboard-delete (#744): when the outline view is first responder (no
+    // text field editing) and at least one row is selected, forward Delete /
+    // Backspace to the controller's deletion seam — the same `onDelete`
+    // callback the context-menu "Delete" item uses. A text field that is
+    // editing is the first responder and consumes `deleteBackward` /
+    // `deleteForward` itself, so this override only fires when no editor is
+    // active — renames/edit fields keep Backspace for text editing.
+    override func deleteBackward(_ sender: Any?) {
+        guard selectedRow != -1 else {
+            super.deleteBackward(sender)
+            return
+        }
+        (delegate as? BookmarksOutlineViewController)?.deleteSelection()
+    }
+
+    override func deleteForward(_ sender: Any?) {
+        guard selectedRow != -1 else {
+            super.deleteForward(sender)
+            return
+        }
+        (delegate as? BookmarksOutlineViewController)?.deleteSelection()
     }
 }

--- a/plans/bookmark-delete-key.md
+++ b/plans/bookmark-delete-key.md
@@ -1,0 +1,28 @@
+# Plan: Delete key on selected bookmark deletes it (#744)
+
+## Goal
+Selecting a bookmark row/folder in the bookmarks outline and pressing **Delete** or **Backspace** should delete it — the standard macOS convention for deleting a selected item in a list/outline. Today it does nothing; deletion requires a right-click → context menu → Delete.
+
+## Current state
+- `Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift:834-836` — `deleteAction(_:)` is the existing `@objc` action wired to the context menu's "Delete" item and a `onDelete` callback. It already does the right thing (deletes the current selection). Reuse it — do NOT write a new deletion code path.
+- There is **no** `keyDown(with:)` / `deleteBackward(_:)` / `deleteForward(_:)` handling on the outline view or its controller, so the Delete/Backspace keys are unhandled.
+
+## Fix
+Add keyboard handling that invokes the existing `deleteAction(_:)` (or the `onDelete` callback it calls) when Delete/Backspace is pressed on the current selection. Idiomatic AppKit options (pick the one that fits the existing structure — read the view/controller setup first):
+- Override `keyDown(with:)` on the `NSOutlineView` subclass (if there is one) or the hosting `NSViewController`, and when `event.specialKey == .delete` (or `event.charactersIgnoringModifiers` is `"\u{7f}"` / `"\u{08}"`), forward to `deleteAction(_:)` gated on a non-empty `selectedRowIndexes` / `selectedRow != -1`.
+- OR override `deleteBackward(_:)` (the responder-chain action for the Backspace key in lists) and call `deleteAction(_:)`; that's the more "macOS-native" path (binding the Delete command) and avoids raw key-event parsing.
+- Prefer `deleteBackward(_:)` if the outline view is a responder and the existing pattern is action-based (no key-event parsing); fall back to `keyDown` if the responder chain isn't set up.
+
+## Guardrails
+- **Only invoke the existing `deleteAction(_:)`** — do not reimplement deletion. The bug is "no key binding," not "delete is broken."
+- Only fire on a non-empty selection; if `selectedRow == -1`, do nothing (fall through to default).
+- Must not fire on a text-edit field (there's a bookmark rename/edit text field — Backspace should edit there, not delete). If a text field is the first responder, the event must reach it first (responder-chain `deleteBackward` naturally handles this, which is another reason to prefer it).
+- No `print` — use `DebugLog` if any diagnostic is needed (house rule).
+- No bare `try?` (house rule).
+- This is a keyboard/responder behavior — NOT unit-testable. Validate in the running app (`make run`): select a bookmark → Delete → it's gone; select a folder → Delete → folder + children gone; rename a bookmark → Backspace edits the name (does NOT delete).
+
+## Files
+- `Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift` — add the `deleteBackward(_:)` (or `keyDown`) override calling `deleteAction(_:)`, gated on selection. (If there's an outline-view subclass already, add it there; else on the hosting controller.)
+
+## Build/test
+`make build && make test`. Push the branch, open a PR with `Closes #744`. **Do NOT merge to main.** Scratch in `tmp/` inside your own worktree.


### PR DESCRIPTION
## Summary

Selecting a bookmark row/folder in the bookmarks outline and pressing **Delete** or **Backspace** now deletes it — the standard macOS convention for deleting a selected item in a list/outline. Previously the keystroke did nothing; deletion required right-click → context menu → Delete.

Closes #744.

## Approach

Added `deleteBackward(_:)` and `deleteForward(_:)` overrides on the existing `BookmarksNSOutlineView` subclass (the `NSOutlineView` that backs the bookmarks tree). When a row is selected and the outline view is first responder, these forward to a new `deleteSelection()` method on `BookmarksOutlineViewController`, which builds the effective node list from the outline's current selection and routes through the **same** `deleteAction(_:)` / `onDelete` callback the context-menu "Delete" item already uses — no separate deletion code path.

### Why `deleteBackward` / `deleteForward`

These are the responder-chain actions AppKit sends for the Backspace and forward-Delete keys in lists. The responder chain naturally handles the text-field guard: when a bookmark rename/edit field is the first responder, it consumes `deleteBackward` itself, so Backspace edits the name rather than deleting the bookmark. No raw `keyDown` parsing or first-responder introspection needed.

## Guardrails honored

- **Only invokes the existing `deleteAction(_:)` seam** — does not reimplement deletion.
- Only fires on a non-empty selection (`selectedRow != -1`); otherwise falls through to `super`.
- Text-field editing (rename) unaffected — the editing field is first responder and consumes the key.
- No `print` (uses `DebugLog` if diagnostics are ever needed). No bare `try?`.
- This is keyboard/responder behavior — not unit-testable. Validation is manual (`make run`).

## Validation checklist (`make run`)

- [ ] Select a bookmark → **Delete** → bookmark is gone.
- [ ] Select a bookmark → **Backspace** → bookmark is gone.
- [ ] Select a folder → **Delete** → folder + children gone.
- [ ] Select a folder → **Backspace** → folder + children gone.
- [ ] Multi-select bookmarks → **Delete** → all selected gone.
- [ ] Rename a bookmark → **Backspace** edits the name (does NOT delete).
- [ ] No selection → **Delete** is a no-op.

## Build / test

`make build` ✅
`make test` ✅ (3253 tests pass)

## Files

- `Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift` — added `deleteBackward`/`deleteForward` on `BookmarksNSOutlineView`; added `deleteSelection()` + refactored `deleteAction` to share a `deleteNodes(_:)` seam.
- `plans/bookmark-delete-key.md` — plan doc.
- `PROGRESS.md` — progress entry.
