### PR TITLE
fix(bookmarks): folder drag onto another folder moves instead of copy-by-contents (#743)

### DIFF
--- a/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
@@ -401,6 +401,43 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
         return list
     }
 
+    /// The private `com.selfdrivingwiki.bookmark-node-id` pasteboard type that
+    /// identifies a drag as originating from THIS bookmarks outline (intra-tree
+    /// reorder / move). Only `SidebarDragPasteboardItem` for a bookmark row
+    /// carries it; external sidebar drags (omnibox icon, SwiftUI `.draggable`
+    /// rows) and wiki-link drags do not.
+    private static let bookmarkNodeType =
+        NSPasteboard.PasteboardType("com.selfdrivingwiki.bookmark-node-id")
+
+    /// True when the drag originated from this outline — i.e. the pasteboard
+    /// carries the private `bookmark-node-id` type. This is the signal that
+    /// distinguishes an intra-outline folder move (issue #743) from an external
+    /// `SidebarDragPayloadList` drop that should create bookmarks (the #150
+    /// welcome-screen feature). A folder's pasteboard writer always carries
+    /// BOTH representations, so we must check this BEFORE
+    /// `firstSidebarPayload` — otherwise a folder dragged within the outline
+    /// is misread as a sidebar-payload drop and copy-by-contents the leaves.
+    private static func isOutlineInternalDrag(_ pb: NSPasteboard) -> Bool {
+        (pb.pasteboardItems ?? []).contains { $0.string(forType: bookmarkNodeType) != nil }
+    }
+
+    /// Reads the bookmark node ids off an intra-outline drag's pasteboard
+    /// (one per dragged row — multi-selection is allowed). Empty for external
+    /// / wiki-link drags.
+    private static func draggedBookmarkNodeIDs(from pb: NSPasteboard) -> [String] {
+        (pb.pasteboardItems ?? [])
+            .compactMap { $0.string(forType: bookmarkNodeType) }
+    }
+
+    /// True when `ancestorID` is `id` or lies anywhere on `id`'s descendant
+    /// chain — used to refuse moving a folder into itself or one of its own
+    /// descendants (would create a cycle). Walks the in-memory children map
+    /// (already built for the outline), so it reflects the visible tree.
+    private func isDescendant(_ ancestorID: String, of id: String) -> Bool {
+        if ancestorID == id { return true }
+        return children(of: id).contains { isDescendant(ancestorID, of: $0.id) }
+    }
+
     /// Resolve a dropped sidebar-item payload and insert a bookmark node for
     /// each target (page/source/chat) at the drop position. Mirrors the
     /// wiki-link drop's parent/position resolution.
@@ -518,6 +555,35 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             if item is BookmarkNode { return .copy }              // leaf → sibling
             return []
         }
+        // Intra-outline move/reorder: the drag originated from THIS outline
+        // (pasteboard carries the private `bookmark-node-id` type). This MUST
+        // be checked BEFORE the sidebar-payload branch: a folder's writer
+        // carries BOTH the node id and a `SidebarDragPayloadList` (the latter
+        // for the #150 welcome-screen drop), so checking the payload first
+        // misreads an intra-outline folder drag as a "create bookmarks for the
+        // leaves" copy — issue #743. Only external sidebar drags (omnibox
+        // icon, SwiftUI `.draggable` rows, which have no bookmark-node-id type)
+        // fall through to the sidebar-payload branch.
+        if Self.isOutlineInternalDrag(info.draggingPasteboard) {
+            guard info.draggingSourceOperationMask.contains(.move) else { return [] }
+            // Refuse to move a folder into itself or one of its own
+            // descendants (cycle). The store guards this too, but advertising
+            // [] here gives the right no-drop cursor affordance.
+            if let folder = item as? BookmarkNode, folder.kind == .folder {
+                for id in Self.draggedBookmarkNodeIDs(from: info.draggingPasteboard) {
+                    if isDescendant(folder.id, of: id) { return [] }
+                }
+                return .move
+            }
+            if item == nil {
+                return .move
+            }
+            // Allow reorder between siblings.
+            if item is BookmarkNode {
+                return .move
+            }
+            return []
+        }
         // Sidebar-item drop: a page/source/chat dragged from the omnibox icon
         // or a sidebar row via SwiftUI .draggable. Accept as `.copy` so
         // `acceptDrop` creates a bookmark node for the payload's target.
@@ -526,18 +592,6 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             if (item as? BookmarkNode)?.kind == .folder { return .copy }
             if item is BookmarkNode { return .copy }              // leaf → sibling
             return []
-        }
-        guard info.draggingSourceOperationMask.contains(.move) else { return [] }
-        // Allow drop onto folders or between rows.
-        if let folder = item as? BookmarkNode, folder.kind == .folder {
-            return .move
-        }
-        if item == nil {
-            return .move
-        }
-        // Allow reorder between siblings.
-        if item is BookmarkNode {
-            return .move
         }
         return []
     }
@@ -556,40 +610,57 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             return acceptWikiLinkDrop(url: url, onto: item, atIndex: index, store: store)
         }
 
+        // Intra-outline move/reorder (issue #743): when the drag originated
+        // from THIS outline — pasteboard carries the private `bookmark-node-id`
+        // type — take the move path BEFORE the sidebar-payload branch. A
+        // folder's writer carries BOTH the node id and a
+        // `SidebarDragPayloadList` (the latter for the #150 welcome-screen
+        // drop); checking the payload first would misread an intra-outline
+        // folder drag as a "create bookmarks for every leaf" copy. Only
+        // external sidebar drags (no bookmark-node-id type) fall through to
+        // the sidebar-payload branch below.
+        if Self.isOutlineInternalDrag(info.draggingPasteboard) {
+            let draggedIDs = Self.draggedBookmarkNodeIDs(from: info.draggingPasteboard)
+            guard !draggedIDs.isEmpty else { return false }
+
+            func moveAll(toParentID parentID: String?, startingAt position: Int) -> Bool {
+                var position = position
+                var succeeded = true
+                for id in draggedIDs {
+                    succeeded = store.moveBookmarkNode(id: id, toParentID: parentID, position: position) && succeeded
+                    position += 1
+                }
+                return succeeded
+            }
+
+            if let folder = item as? BookmarkNode, folder.kind == .folder {
+                // Refuse moving a folder into itself or one of its own
+                // descendants (cycle). validateDrop advertises [] for this,
+                // but guard here too in case acceptDrop is reached anyway.
+                for id in draggedIDs where isDescendant(folder.id, of: id) {
+                    DebugLog.tabs("[drop] bookmark move refused: \(id) → \(folder.id) (descendant)")
+                    return false
+                }
+                return moveAll(toParentID: folder.id, startingAt: children(of: folder.id).count)
+            }
+
+            if let leaf = item as? BookmarkNode {
+                // Reorder within the same parent.
+                return moveAll(toParentID: leaf.parentID, startingAt: index >= 0 ? index : leaf.position)
+            }
+
+            // Root append
+            return moveAll(toParentID: nil, startingAt: children(of: nil).count)
+        }
+
         // Sidebar-item drop → create a bookmark for each page/source/chat in
-        // the payload (omnibox icon drag, or a SwiftUI .draggable sidebar row).
+        // the payload (omnibox icon drag, or a SwiftUI .draggable sidebar row,
+        // or a bookmark folder dragged onto the welcome screen — #150).
         if let payloadList = Self.firstSidebarPayload(from: info.draggingPasteboard) {
             return acceptSidebarPayloadDrop(payloadList, onto: item, atIndex: index, store: store)
         }
 
-        // Multi-selection is allowed, so a reorder drag can carry more than one
-        // node id — one pasteboard item per dragged row.
-        let bookmarkNodeType = NSPasteboard.PasteboardType("com.selfdrivingwiki.bookmark-node-id")
-        let draggedIDs = (info.draggingPasteboard.pasteboardItems ?? [])
-            .compactMap { $0.string(forType: bookmarkNodeType) }
-        guard !draggedIDs.isEmpty else { return false }
-
-        func moveAll(toParentID parentID: String?, startingAt position: Int) -> Bool {
-            var position = position
-            var succeeded = true
-            for id in draggedIDs {
-                succeeded = store.moveBookmarkNode(id: id, toParentID: parentID, position: position) && succeeded
-                position += 1
-            }
-            return succeeded
-        }
-
-        if let folder = item as? BookmarkNode, folder.kind == .folder {
-            return moveAll(toParentID: folder.id, startingAt: children(of: folder.id).count)
-        }
-
-        if let leaf = item as? BookmarkNode {
-            // Reorder within the same parent.
-            return moveAll(toParentID: leaf.parentID, startingAt: index >= 0 ? index : leaf.position)
-        }
-
-        // Root append
-        return moveAll(toParentID: nil, startingAt: children(of: nil).count)
+        return false
     }
 }
 

--- a/plans/bookmark-drag-move.md
+++ b/plans/bookmark-drag-move.md
@@ -1,0 +1,94 @@
+# Plan: Dragging a bookmark folder into another folder moves it, doesn't copy (#743)
+
+## Goal
+Dragging a bookmark **folder** onto another folder in the bookmarks outline
+should **move** the folder (the folder node itself becomes a child of the
+target). Today it instead recreates every leaf (page/source/chat ref) under
+the folder as new bookmarks in the target — leaving the original folder in
+place — effectively a copy-by-contents.
+
+## Root cause (from issue #743)
+In `Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift`:
+
+- `pasteboardWriterForItem` (L335-350) writes **two** representations for a
+  folder drag: the private `com.selfdrivingwiki.bookmark-node-id` type (for
+  intra-tree move/reorder) AND a `SidebarDragPayloadList` of every leaf
+  reachable under the folder, via `leafPayloads(under:)` (L346, L354-361). The
+  payload list is a deliberate feature for dropping a folder onto the
+  **welcome screen** to open its contents as tabs (#150).
+- `validateDrop` (L506-543) and `acceptDrop` (L545-593) both check
+  `firstSidebarPayload(from:)` **before** falling through to the private
+  bookmark-node-id move/reorder path. Because a folder's pasteboard item
+  always carries a `SidebarDragPayloadList`, `firstSidebarPayload` returns
+  non-nil for a folder drag onto ANY target — including another bookmark folder
+  in the same outline — so it takes the "sidebar-item drop → create a bookmark
+  for each payload" branch (`acceptSidebarPayloadDrop`) and never reaches
+  `moveAll(toParentID:startingAt:)` / `store.moveBookmarkNode(...)`.
+
+The correct intra-tree move path (`moveAll`, L572-580, which handles "drop node
+onto folder" at L582-583) is only reached for leaf refs, never for folders,
+because folders never pass the sidebar-payload check.
+
+## Fix (the ordering fix the issue proposes)
+`validateDrop`/`acceptDrop` must distinguish:
+
+- **Drop onto the bookmarks outline itself** (same outline) → prefer the
+  **intra-tree bookmark-node-id move** path when the drag originated from the
+  outline; never interpret a folder drag within the outline as a
+  sidebar-payload drop.
+- **Drop onto an external target** (e.g. the welcome screen) → the
+  `SidebarDragPayloadList` is the right interpretation (keep this working —
+  it's the #150 feature).
+
+Concretely: when the drop target is the bookmarks outline AND the drag's
+pasteboard carries the private `bookmarkNodeID` type (i.e. the drag originated
+from this outline), check `bookmarkNodeID`/use the move path **first**, and
+only fall back to `firstSidebarPayload` when the drag is external (no
+`bookmarkNodeID` type, or `draggingSource` is not the outline).
+
+Signals verified in the code:
+
+- The `bookmarkNodeID` pasteboard type presence is the cleanest "drag
+  originated from this outline" signal (`SidebarDragPasteboardItem` only sets
+  it for bookmark rows, and it's the `com.selfdrivingwiki.bookmark-node-id`
+  private UTType).
+
+## Implementation notes
+
+- The store's `moveBookmarkNode`
+  (`Sources/WikiFSCore/Store/GRDBWikiStore.swift:5621`) already rejects moving
+  a node into itself or any of its descendants (cycle prevention at L5635-
+  5647), so a folder-into-own-descendant drop is a safe no-op at the store
+  level. We additionally guard in `validateDrop` to advertise `[]` for that
+  case so the cursor gives no drop affordance.
+
+## Guardrails / non-regressions
+- **Do NOT break the welcome-screen drop (#150):** dropping a folder onto the
+  welcome screen must still open its leaf contents as tabs. That target is NOT
+  the outline, so the "external target → sidebar payload" branch must still
+  fire. Verify with the #150 behavior in the running app.
+- Do NOT change `pasteboardWriterForItem` / `leafPayloads` — the pasteboard
+  writer is correct (both representations are needed for the two distinct drop
+  targets). The bug is purely in `validateDrop`/`acceptDrop` ordering.
+- Keep leaf (page/source) drags working exactly as today (they already hit
+  the move path correctly).
+- No `print` — `DebugLog` only; no bare `try?`.
+
+## Files
+- `Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift` — reorder the
+  `validateDrop` (L506-543) and `acceptDrop` (L545-593) checks so an
+  intra-outline drag (pasteboard carries `bookmarkNodeID`) takes the move path
+  before the sidebar-payload path.
+
+## Build/test
+`make build && make test`. This is a drag-drop/outline behavior — NOT unit-
+testable; validate in the running app (`make run`):
+
+1. Drag a folder onto another folder → folder **moves** (original gone from
+   old parent, now under the target).
+2. Drag a leaf bookmark onto a folder → still moves (regression-safe).
+3. Drag a folder onto the welcome screen → still opens its contents as tabs
+   (regression-safe #150).
+4. Drag a folder into one of its own descendants → no-op (no corruption).
+
+Push the branch, open a PR with `Closes #743`. **Do NOT merge to main.**


### PR DESCRIPTION
## Summary

Fixes #743 — dragging a bookmark **folder** onto another folder in the bookmarks outline now **moves** the folder (it becomes a child of the target) instead of copy-by-contents (recreating every leaf as new bookmarks and leaving the original folder in place).

## Root cause

`pasteboardWriterForItem` deliberately writes **two** representations for a folder drag:
- the private `com.selfdrivingwiki.bookmark-node-id` type (intra-tree move/reorder), and
- a `SidebarDragPayloadList` of every leaf under the folder (the #150 welcome-screen "drop folder → open tabs" feature).

`validateDrop` / `acceptDrop` checked `firstSidebarPayload` **before** the bookmark-node-id move path. Because a folder always carries the payload list, `firstSidebarPayload` returned non-nil for a folder drag onto *any* target — including another folder in the same outline — so the sidebar-payload branch fired and recreated the leaves, never reaching `moveBookmarkNode`.

## Fix

Reorder both `validateDrop` and `acceptDrop` so an **intra-outline drag** (pasteboard carries the private `bookmark-node-id` type — signals the drag originated from this outline) takes the move path **before** the sidebar-payload branch. External sidebar drags (omnibox icon, SwiftUI `.draggable` rows, and — importantly — a bookmark folder dropped onto the **welcome screen**) carry no `bookmark-node-id` type, so they still fall through to `acceptSidebarPayloadDrop`, preserving #150.

Adds a descendant-cycle guard: dropping a folder into itself or one of its own descendants advertises `[]` in `validateDrop` (no drop affordance) and is a no-op in `acceptDrop`, alongside the store's existing cycle prevention in `moveBookmarkNode`.

`pasteboardWriterForItem` / `leafPayloads` are unchanged — the writer is correct; the bug was purely in the drop-handler ordering.

## Validation

- `make build` ✓
- `make test` — 3253 tests pass ✓

Manual (drag-drop is not unit-testable) — to verify in `make run`:
1. Drag a folder onto another folder → folder **moves** (original gone, now under target).
2. Drag a leaf bookmark onto a folder → still moves (regression-safe).
3. Drag a folder onto the welcome screen → still opens its contents as tabs (regression-safe #150).
4. Drag a folder into one of its own descendants → no-op (no corruption).

Closes #743
