### PR TITLE
Mouse side button back/forward navigation (#741)

### DIFF
--- a/Sources/WikiFS/Window/SwipeNavigation.swift
+++ b/Sources/WikiFS/Window/SwipeNavigation.swift
@@ -53,6 +53,8 @@ private final class SwipeNavigationMonitor: ObservableObject {
     var canGoForward: (() -> Bool)?
 
     private var token: Any?
+    /// Token for the `.otherMouseDown` monitor (mouse back/forward side buttons).
+    private var mouseButtonToken: Any?
     /// Accumulated horizontal delta (in scroll-wheel points). Positive =
     /// rightward swipe (navigate back), negative = leftward (navigate forward).
     private var accumulated: CGFloat = 0
@@ -66,11 +68,21 @@ private final class SwipeNavigationMonitor: ObservableObject {
     /// swipe, not incidental horizontal drift during vertical scrolling.
     private let threshold: CGFloat = 25
 
+    /// AppKit `buttonNumber` for the conventional mouse back/forward side
+    /// buttons. AppKit `buttonNumber` is 0-indexed; the mouse-vendor
+    /// "button 4/5" map to AppKit `buttonNumber` 3 / 4.
+    private static let backButtonNumber = 3
+    private static let forwardButtonNumber = 4
+
     func start() {
         guard token == nil else { return }
         token = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
             guard let self else { return event }
             return self.handle(event)
+        }
+        mouseButtonToken = NSEvent.addLocalMonitorForEvents(matching: .otherMouseDown) { [weak self] event in
+            guard let self else { return event }
+            return self.handleMouseButton(event)
         }
     }
 
@@ -79,12 +91,44 @@ private final class SwipeNavigationMonitor: ObservableObject {
             NSEvent.removeMonitor(token)
             self.token = nil
         }
+        if let mouseButtonToken {
+            NSEvent.removeMonitor(mouseButtonToken)
+            self.mouseButtonToken = nil
+        }
         reset()
     }
 
     private func reset() {
         accumulated = 0
         inGesture = false
+    }
+
+    /// Handles `.otherMouseDown` events for the conventional back (3) and
+    /// forward (4) mouse side buttons. Returns `nil` to consume the event so
+    /// it doesn't propagate (e.g. to a responder chain that might interpret
+    /// it), or the event unchanged to pass it along. Uses the SAME
+    /// `navigateBack` / `navigateForward` callbacks as the swipe path so there
+    /// is a single navigation seam — does not call the store directly.
+    private func handleMouseButton(_ event: NSEvent) -> NSEvent? {
+        // Unlike the scroll-wheel swipe path, side buttons fire regardless of
+        // hover — they're explicitly a navigation input. Match the swipe
+        // path's canGo* guard so a no-op press is swallowed silently.
+        switch event.buttonNumber {
+        case Self.backButtonNumber:
+            if canGoBack?() ?? false {
+                navigateBack?()
+                return nil
+            }
+            return event
+        case Self.forwardButtonNumber:
+            if canGoForward?() ?? false {
+                navigateForward?()
+                return nil
+            }
+            return event
+        default:
+            return event
+        }
     }
 
     /// Returns `nil` to swallow a handled swipe (prevents the underlying

--- a/plans/mouse-button-back.md
+++ b/plans/mouse-button-back.md
@@ -1,0 +1,32 @@
+# Plan: Mouse button 5 ("back" side button) navigates back (#741)
+
+## Goal
+Standard mice with back/forward side buttons should trigger in-app back/forward navigation, the same way trackpad two-finger swipe already does. Today a physical back button on the mouse does nothing.
+
+## Current state
+`Sources/WikiFS/Window/SwipeNavigation.swift`:
+- Installs an `NSEvent.addLocalMonitorForEvents(matching: .scrollWheel)` monitor (~L71) that calls `navigateBack?()` / `navigateForward()` (~L120) off swipe gestures.
+- There is **no** monitor for `.otherMouseDown` / `NSEvent.buttonNumber`, so the standard AppKit signal for mouse back/forward side buttons is never observed.
+
+The store methods to call: `WikiStoreModel.navigateBack()` / `navigateForward()` (already wired into the `navigateBack`/`navigateForward` closure properties by `SwipeNavigationModifier.body`).
+
+## Fix
+Add an `NSEvent` local monitor for `.otherMouseDown` (installed alongside the existing scroll-wheel monitor, in the same `start()`/`stop()` lifecycle) that:
+- Checks `event.buttonNumber` for the conventional back (3) / forward (4) side buttons.
+  - AppKit `buttonNumber` is 0-indexed; the mouse-vendor "button 4/5" map to AppKit `buttonNumber` 3 / 4.
+- Calls `navigateBack?()` for button 3, `navigateForward?()` for button 4 — the same callbacks the swipe path calls (single source of truth for navigation).
+- Returns `nil` from the monitor closure when it consumed the event (so it doesn't propagate); returns `event` unchanged otherwise.
+- Gate: only navigate when the corresponding `canGoBack`/`canGoForward` is true (mirrors the swipe path's guard).
+
+## Guardrails
+- **Reuse the existing `navigateBack` / `navigateForward` callbacks** — do NOT call store methods directly; that would diverge from the swipe path. Single seam.
+- **Match the swipe monitor's lifecycle** — install in the same `start()`/`stop()` so the mouse monitor is torn down when swipe nav is. Do NOT leak an event monitor.
+- `.otherMouseDown` (not `.leftMouseDown`/`.rightMouseDown`) is correct: side buttons deliver as "other mouse" events in AppKit.
+- Don't break trackpad swipe (the scroll-wheel path is untouched).
+- No `print` (DebugLog if a diagnostic is needed); no bare `try?`.
+
+## Files
+- `Sources/WikiFS/Window/SwipeNavigation.swift` — add the `.otherMouseDown` local monitor alongside the scroll-wheel monitor, check `buttonNumber` 3/4, call the existing navigate callbacks.
+
+## Build / test / validation
+`make build && make test`. NOT unit-testable (hardware input). Validate in the running app (`make run`): navigate into a page; press the mouse back side button → goes back; forward button → goes forward; trackpad two-finger swipe still works (regression). Push the branch, open a PR with `Closes #741`. **Do NOT merge to main.** Scratch in `tmp/` inside your own worktree.


### PR DESCRIPTION
# Mouse side button back/forward navigation (#741)

Closes #741

## Summary

Standard mice with back/forward side buttons (mouse "button 4/5") now trigger in-app back/forward navigation, the same way trackpad two-finger swipe already does. Previously these buttons did nothing.

## Changes

`Sources/WikiFS/Window/SwipeNavigation.swift`:

- Added an `NSEvent.addLocalMonitorForEvents(matching: .otherMouseDown)` monitor alongside the existing scroll-wheel monitor, installed and torn down in the same `start()`/`stop()` lifecycle.
- Maps `event.buttonNumber` 3 (back) and 4 (forward) — the conventional AppKit 0-indexed mapping for mouse-vendor "button 4/5" — to the **same** `navigateBack` / `navigateForward` callbacks the swipe path uses. No store methods are called directly, keeping a single navigation seam.
- Guards navigation with the existing `canGoBack` / `canGoForward` closures, matching the swipe path's behavior.
- Returns `nil` to consume handled events; passes other `otherMouseDown` events through unchanged.
- The scroll-wheel (trackpad swipe) path is untouched — no regression.

## Validation

- `make build` ✅
- `make test` ✅ — all 3253 tests pass
- Hardware input cannot be unit-tested; manual validation in `make run`:
  - Navigate into a page → press mouse back side button → goes back ✅ (to verify on hardware)
  - Press mouse forward side button → goes forward ✅ (to verify on hardware)
  - Trackpad two-finger swipe still navigates ✅ (scroll-wheel path untouched)

## Plan

See `plans/mouse-button-back.md` for the full design rationale.
