### PR TITLE
Queue a chat message while the agent is working (#740)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,54 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-20 — Queue a chat message while the agent is working (branch `chat-queue`, PR #751)
+
+**Problem.** While the agent was generating a chat turn, the composer was
+fully disabled (`canType` / `isComposerEnabled` returned `false` during
+`launcher.isRunning`), the Send button was hidden behind the stop button, and
+`sendButtonTitle` literally told the user to "wait for the response." You
+couldn't even draft the next message, let alone queue one. See
+`plans/chat-queue.md`. Closes #740.
+
+**Fix.** Two tiers in `Sources/WikiFS/Chats/ChatView.swift` only:
+
+- **Minimum (typing during generation):** `canType` and `isComposerEnabled`
+  now return `true` during generation (live chat + draft state) so the
+  composer stays editable while the agent responds. Sending is still gated by
+  `canSendPredicate`'s `!isGenerating`, so this only enables *drafting* — it
+  never fires mid-turn (the existing #380 guard in `sendMessage` is untouched).
+- **Full (queue-on-send):** new `@State pendingMessage: PendingQueuedMessage?`
+  (value type: `wireMessage` + `preview`), separate from the D3
+  generation-gate queue (`isAwaitingGenerationSlot`, which gates *another*
+  chat's send) — this is the *same* chat's "type the next message now" path.
+  - `queueMessage()` stashes the draft (+ attachment refs via the extracted
+    `buildWireMessage`) and clears the draft/attachments so the user can
+    draft a *different* follow-up while the queued one waits.
+  - A `queueButton` (sibling of the stop button: filled circle + up-arrow,
+    accent/blue) appears during a running query turn when there's a draft and
+    nothing is queued; it inherits ⌘↩ (the normal Send button is hidden during
+    generation, so no shortcut conflict).
+  - On turn completion, the existing `.onChange(of: launcher.isRunning)`
+    observer calls `firePendingQueuedMessage()`, which routes through the
+    extracted `submitMessage(_:)` (shared with `sendMessage`) — same dispatch
+    as a manual send, only the *timing* differs. Crucially it does **not**
+    touch the composer draft, so a half-typed follow-up is preserved (#740
+    guardrail: only explicitly-queued-via-Queue messages auto-fire).
+  - A muted "Queued: …" affordance (clock glyph, truncated preview, ✕) under
+    the composer offers cancel before it fires; animated `.snappy`.
+
+**Concurrency:** no new background task — the observer fires on the main
+actor (`ChatView` is `@MainActor`); the queue delivers via the existing send
+path. Consulted `docs/skills/macos-design/SKILL.md` for the unobtrusive
+affordance (muted, `.secondary`, capsule). No bare `try?`; no `print`.
+
+**Tests.** No test changes — `canSendPredicate` / `composerCaptionText`
+static tests are unchanged (both still assert send is gated by
+`!isGenerating`). `make build` clean; `make test` → 270 suites / 3253 tests
+pass. Functional/GUI validation (type-during-generation, queue affordance,
+auto-fire, cancel) requires a live agent-generation turn and is left for the
+reviewer to confirm in `make run`. **Not merged to `main`.**
+
 ## 2026-07-20 — "Add Page" opens in the editor with the title pane expanded (branch `add-page-editor-default`)
 
 **Problem.** Clicking "Add Page" (welcome screen button or sidebar `+`) opened

--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -48,6 +48,13 @@ struct ChatView: View {
     @AppStorage("chat.hideToolCalls") private var hideToolCalls = false
     @State private var outlineScroll: ChatScrollRequest? = nil
     @State private var quoteAnchor: ChatHighlightRequest? = nil
+    /// #740: a message the user queued while the agent was generating a
+    /// response. It auto-fires as the next turn's input once the current turn
+    /// completes (observing `launcher.isRunning` going false). `nil` when
+    /// nothing is queued. Separate from the D3 generation-gate queue
+    /// (`isAwaitingGenerationSlot`, which gates *another* chat's send) because
+    /// this is the *same* chat's "type the next message now" path.
+    @State private var pendingMessage: PendingQueuedMessage? = nil
     /// The chat's always-ask/yolo mode (shared with the launcher, read at spawn).
     /// v1 app-wide, default off (yolo). Applies to the next conversation.
     ///
@@ -153,6 +160,15 @@ struct ChatView: View {
             // later ingest/lint run doesn't inherit it and strand the view on
             // `AgentQueueView`. (AC.1)
             if !isRunning { showsInternals = false }
+            // #740: when a turn completes, deliver the queued message as the next
+            // turn's input. Only fires what was explicitly queued via the Queue
+            // button — a half-typed draft stays in the composer untouched (it isn't
+            // part of `pendingMessage`). The dispatch goes through the same
+            // `submitMessage` path used by a normal Send, so it reuses the
+            // interactive/continue/start routing without disturbing the draft.
+            if !isRunning, pendingMessage != nil {
+                firePendingQueuedMessage()
+            }
         }
         .task(id: chatID) {
             // Reload persisted messages whenever the chatID changes (or the store
@@ -417,12 +433,54 @@ struct ChatView: View {
     private var chatComposer: some View {
         VStack(spacing: 4) {
             composer(enabled: isComposerEnabled)
+            if let pending = pendingMessage {
+                queuedMessageAffordance(pending)
+            }
             if let caption = composerCaption {
                 Text(caption)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
         }
+        // #740: animate the queued affordance in/out (macos-design: every
+        // state change gets a transition). `PendingQueuedMessage` is Equatable.
+        .animation(.snappy, value: pendingMessage)
+    }
+
+    /// #740: the muted "Queued" affordance shown under the composer while a
+    /// message is stashed for delivery when the current turn ends. Unobtrusive
+    /// by design (macos-design discipline): a secondary-tinted capsule with a
+    /// clock glyph, the (truncated) queued text, and a cancel (✕) that clears
+    /// `pendingMessage` so it won't auto-fire.
+    @ViewBuilder
+    private func queuedMessageAffordance(_ pending: PendingQueuedMessage) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("Queued:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(pending.preview)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: 0)
+            Button {
+                pendingMessage = nil
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Cancel the queued message")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.secondary.opacity(0.10), in: Capsule())
+        .transition(.opacity)
     }
 
     /// The paseo-style toolbar row that sits INSIDE the composer box, along its
@@ -449,6 +507,14 @@ struct ChatView: View {
             PermissionModeSelector(rawValue: $permissionModeRaw)
             Spacer(minLength: 0)
             if showsStopButton {
+                // #740: during a running turn the stop button stays primary (red,
+                // trailing). When the user has drafted a follow-up and nothing is
+                // queued yet, a secondary "Queue" button appears just before it so
+                // the next message is captured for delivery the moment this turn
+                // ends. ⌘↩ routes here (not Send) while generating.
+                if showsQueueButton && hasDraftText {
+                    queueButton
+                }
                 stopButton
             } else if hasDraftText {
                 // Paseo: the send button appears only once there's something to
@@ -976,6 +1042,36 @@ struct ChatView: View {
         .help("Stop the current response")
     }
 
+    /// #740: whether the "Queue" affordance should appear next to the stop
+    /// button. Shown only during THIS chat's query generation (not while
+    /// merely awaiting a generation slot — that's another session's turn) and
+    /// only when nothing is already queued.
+    private var showsQueueButton: Bool {
+        launcher.isGenerating
+            && launcher.runningKind == .query
+            && pendingMessage == nil
+    }
+
+    /// #740: the "Queue" button — sits just before the stop button during a
+    /// running turn. Stylistically a sibling of the send button (filled
+    /// circle + up-arrow) but tinted accent (blue) so it reads as "queue
+    /// next" rather than "send now". Inherits ⌘↩ so keyboard users can queue
+    /// without reaching for the mouse; the normal Send button's ⌘↩ shortcut
+    /// is hidden during generation so there's no conflict.
+    private var queueButton: some View {
+        Button(action: queueMessage) {
+            Image(systemName: "arrow.up")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: ChatMetrics.sendButtonSize, height: ChatMetrics.sendButtonSize)
+                .background(Color.accentColor.opacity(0.9), in: Circle())
+        }
+        .buttonStyle(.borderless)
+        .disabled(!hasDraftText)
+        .keyboardShortcut(.return, modifiers: .command)
+        .help("Queue for when the response finishes")
+    }
+
     /// The trailing send button in the composer's bottom toolbar — a green
     /// circle with a white up-arrow (paseo). Only shown when the composer has
     /// text (see `composerToolbar`).
@@ -1047,21 +1143,61 @@ struct ChatView: View {
         // by `canSend`, but the Return key in ComposerTextView calls this
         // unconditionally — so the same guard here prevents the message from
         // being silently dropped (issue #380). The draft is preserved so the
-        // user can send it once the agent finishes.
+        // user can send it once the agent finishes. (#740: to queue instead,
+        // the user presses the Queue button — see `queueMessage`.)
         guard canSend else { return }
         let message = store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
+        let wireMessage = buildWireMessage(from: message)
         store.clearActiveChatDraft()
-        // Build the wire message: prepend attachment references so the agent
-        // has context about the dragged-in pages/sources (issue #385).
-        let wireMessage: String
-        if !attachments.isEmpty {
-            let refs = attachments.map { $0.referenceText }.joined(separator: "\n")
-            wireMessage = "\(refs)\n\n\(message)"
-            attachments = []
-        } else {
-            wireMessage = message
-        }
+        attachments = []
+        submitMessage(wireMessage)
+    }
+
+    /// #740: stash the composer's current draft as the queued message — fires
+    /// automatically when the active turn completes (see the
+    /// `launcher.isRunning` observer). Clears the draft + attachments exactly
+    /// like `sendMessage` would at send time, so the composer is free for the
+    /// user to draft a *different* follow-up while the queued one waits. Only
+    /// valid during THIS chat's generation (see `showsQueueButton`); the
+    /// `guard` here defends against an out-of-band invocation.
+    private func queueMessage() {
+        guard launcher.isGenerating else { return }
+        let message = store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { return }
+        // Replacing an existing queued message is allowed — the new draft wins.
+        pendingMessage = PendingQueuedMessage(
+            wireMessage: buildWireMessage(from: message),
+            preview: message)
+        store.clearActiveChatDraft()
+        attachments = []
+    }
+
+    /// Delivers the queued message as the next turn's input when the current
+    /// turn completes. Routes through `submitMessage` (so it reuses the
+    /// interactive/continue/start routing) WITHOUT touching the composer's
+    /// draft — a half-typed follow-up the user may be mid-edit on is preserved
+    /// (#740 guardrail).
+    private func firePendingQueuedMessage() {
+        guard let pending = pendingMessage else { return }
+        pendingMessage = nil
+        submitMessage(pending.wireMessage)
+    }
+
+    /// Builds the wire message exactly like the legacy `sendMessage` body:
+    /// prepend attachment reference text (issue #385) so the agent has the
+    /// dragged-in context. Extracted so the queue path reuses the same shaping.
+    private func buildWireMessage(from message: String) -> String {
+        guard !attachments.isEmpty else { return message }
+        let refs = attachments.map { $0.referenceText }.joined(separator: "\n")
+        return "\(refs)\n\n\(message)"
+    }
+
+    /// Dispatches a fully-shaped wire message to the agent without touching the
+    /// composer draft or attachments. Shared by `sendMessage` (normal Send)
+    /// and `firePendingQueuedMessage` (#740 auto-fire), so the queued deliver
+    /// path is identical to a manual send — only the *timing* differs.
+    private func submitMessage(_ wireMessage: String) {
         if launcher.isInteractiveSession {
             // Live chat mid-session: append a turn to the existing session.
             launcher.sendInteractiveMessage(wireMessage)
@@ -1118,11 +1254,17 @@ struct ChatView: View {
         // Draft state (.newChat with chatID == nil): always enabled (a wiki
         // is open inside ContentView; nothing is generating).
         guard chatID != nil else {
+            // #740: allow drafting the first question even while some (unlikely)
+            // non-interactive generation is in flight.
             return launcher.isInteractiveSession || !launcher.isRunning
+                || launcher.isGenerating
         }
-        // The active live chat: enabled when a turn isn't in flight.
+        // The active live chat: #740 — editable during THIS chat's generation so
+        // the user can draft the next message; the Send button queues instead of
+        // firing immediately while `isGenerating` (see `composerToolbar`).
         if isLiveChat {
             return launcher.isInteractiveSession || !launcher.isRunning
+                || launcher.isGenerating
         }
         // D3: a persisted (non-live) chat is continuable when its kind's launcher
         // is idle (`!isGenerating && !isAwaitingGenerationSlot`). If that launcher
@@ -1150,7 +1292,12 @@ struct ChatView: View {
         // A session is always alive when ChatView is rendered inside
         // ContentView, so the old `activeWikiID != nil` check is
         // always true here.
+        // #740: typing (drafting) is allowed during generation so the user can
+        // compose the next message while the agent responds. Sending during
+        // generation is still gated by `canSendPredicate` (via `!isGenerating`),
+        // so this only enables drafting — the Send button routes to Queue.
         launcher.isInteractiveSession || !launcher.isRunning
+            || launcher.isGenerating
     }
 
     private var canSend: Bool {
@@ -1190,6 +1337,17 @@ struct ChatView: View {
         }
         return launcher.isInteractiveSession ? "Send" : "Start Query"
     }
+}
+
+/// #740: a message the user *queued* while the agent was generating a
+/// response (Send during a running turn). `wireMessage` carries attachment
+/// references (built at queue time, exactly like `sendMessage`); `preview` is
+/// the trimmed user text shown in the muted "Queued" affordance (without the
+/// prepended `[[kind:…]]` refs). Auto-fires via `submitMessage` when the turn
+/// completes; the user may cancel it before it fires.
+private struct PendingQueuedMessage: Equatable {
+    let wireMessage: String
+    let preview: String
 }
 
 /// A sidebar item dragged onto the chat composer as context for the next

--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -48,13 +48,14 @@ struct ChatView: View {
     @AppStorage("chat.hideToolCalls") private var hideToolCalls = false
     @State private var outlineScroll: ChatScrollRequest? = nil
     @State private var quoteAnchor: ChatHighlightRequest? = nil
-    /// #740: a message the user queued while the agent was generating a
-    /// response. It auto-fires as the next turn's input once the current turn
-    /// completes (observing `launcher.isRunning` going false). `nil` when
-    /// nothing is queued. Separate from the D3 generation-gate queue
+    /// #740: messages the user queued while the agent was generating a
+    /// response. **Playlist semantics:** on turn completion, only the FIRST
+    /// queued message fires as the next turn's input; the rest stay queued
+    /// and each fires in order as subsequent turns complete (one per turn).
+    /// Separate from the D3 generation-gate queue
     /// (`isAwaitingGenerationSlot`, which gates *another* chat's send) because
     /// this is the *same* chat's "type the next message now" path.
-    @State private var pendingMessage: PendingQueuedMessage? = nil
+    @State private var queuedMessages: [PendingQueuedMessage] = []
     /// The chat's always-ask/yolo mode (shared with the launcher, read at spawn).
     /// v1 app-wide, default off (yolo). Applies to the next conversation.
     ///
@@ -160,13 +161,15 @@ struct ChatView: View {
             // later ingest/lint run doesn't inherit it and strand the view on
             // `AgentQueueView`. (AC.1)
             if !isRunning { showsInternals = false }
-            // #740: when a turn completes, deliver the queued message as the next
-            // turn's input. Only fires what was explicitly queued via the Queue
-            // button — a half-typed draft stays in the composer untouched (it isn't
-            // part of `pendingMessage`). The dispatch goes through the same
-            // `submitMessage` path used by a normal Send, so it reuses the
-            // interactive/continue/start routing without disturbing the draft.
-            if !isRunning, pendingMessage != nil {
+            // #740: when a turn completes, deliver the FIRST queued message as
+            // the next turn's input (playlist: one per turn). The rest stay queued
+            // and each fires in order as subsequent turns complete. Only fires what
+            // was explicitly queued via the Queue button — a half-typed draft stays
+            // in the composer untouched (it isn't part of `queuedMessages`). The
+            // dispatch goes through the same `submitMessage` path used by a normal
+            // Send, so it reuses the interactive/continue/start routing without
+            // disturbing the draft.
+            if !isRunning, !queuedMessages.isEmpty {
                 firePendingQueuedMessage()
             }
         }
@@ -433,8 +436,8 @@ struct ChatView: View {
     private var chatComposer: some View {
         VStack(spacing: 4) {
             composer(enabled: isComposerEnabled)
-            if let pending = pendingMessage {
-                queuedMessageAffordance(pending)
+            if !queuedMessages.isEmpty {
+                queuedMessagesList
             }
             if let caption = composerCaption {
                 Text(caption)
@@ -442,25 +445,43 @@ struct ChatView: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        // #740: animate the queued affordance in/out (macos-design: every
-        // state change gets a transition). `PendingQueuedMessage` is Equatable.
-        .animation(.snappy, value: pendingMessage)
+        // #740: animate the queued list in/out (macos-design: every state
+        // change gets a transition). `[PendingQueuedMessage]` is Equatable.
+        .animation(.snappy, value: queuedMessages)
     }
 
-    /// #740: the muted "Queued" affordance shown under the composer while a
-    /// message is stashed for delivery when the current turn ends. Unobtrusive
-    /// by design (macos-design discipline): a secondary-tinted capsule with a
-    /// clock glyph, the (truncated) queued text, and a cancel (✕) that clears
-    /// `pendingMessage` so it won't auto-fire.
+    /// #740: the per-item "Queued" affordance shown under the composer while
+    /// one or more messages are stashed for delivery. Playlist semantics: the
+    /// first item fires when the current turn completes; subsequent items fire
+    /// one per turn. Each row is its own muted capsule with a clock glyph,
+    /// truncated preview, and per-item cancel (✕). The first row gets a badge
+    /// "Next" so the user knows which one fires next. Unobtrusive by design
+    /// (macos-design discipline: muted, `.secondary`, capsule).
     @ViewBuilder
-    private func queuedMessageAffordance(_ pending: PendingQueuedMessage) -> some View {
+    private var queuedMessagesList: some View {
+        VStack(spacing: 3) {
+            ForEach(Array(queuedMessages.enumerated()), id: \.element.id) { (index: Int, pending: PendingQueuedMessage) in
+                queuedMessageRow(pending, isFirst: index == 0, index: index)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func queuedMessageRow(_ pending: PendingQueuedMessage, isFirst: Bool, index: Int) -> some View {
         HStack(spacing: 6) {
             Image(systemName: "clock.arrow.circlepath")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
-            Text("Queued:")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            if isFirst {
+                Text("Next:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fontWeight(.medium)
+            } else {
+                Text("#\(index + 1):")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
             Text(pending.preview)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -468,14 +489,14 @@ struct ChatView: View {
                 .truncationMode(.tail)
             Spacer(minLength: 0)
             Button {
-                pendingMessage = nil
+                queuedMessages.remove(at: index)
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.borderless)
-            .help("Cancel the queued message")
+            .help("Cancel this queued message")
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -961,7 +982,7 @@ struct ChatView: View {
         // Built as an explicit closure so the type checker doesn't struggle with
         // a method-reference ternary.
         let recallAction: (() -> Void)? = {
-            guard pendingMessage != nil else { return nil }
+            guard !queuedMessages.isEmpty else { return nil }
             return { recallQueuedMessage() }
         }()
         // Paseo-style: ONE rounded box wrapping the text (top) and a toolbar row
@@ -1057,7 +1078,7 @@ struct ChatView: View {
     private var showsQueueButton: Bool {
         launcher.isGenerating
             && launcher.runningKind == .query
-            && pendingMessage == nil
+            && queuedMessages.isEmpty
     }
 
     /// #740: the "Queue" button — sits just before the stop button during a
@@ -1180,34 +1201,36 @@ struct ChatView: View {
         guard launcher.isGenerating else { return }
         let message = store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
-        // Replacing an existing queued message is allowed — the new draft wins.
-        pendingMessage = PendingQueuedMessage(
+        // Append to the playlist — the first item fires when the current turn
+        // completes; subsequent items fire one per turn.
+        queuedMessages.append(PendingQueuedMessage(
             wireMessage: buildWireMessage(from: message),
-            preview: message)
+            preview: message))
         store.clearActiveChatDraft()
         attachments = []
     }
 
-    /// #740: recall the queued message back into the composer draft for editing.
-    /// Triggered by Arrow ↑ on an empty composer (see `ComposerTextView`'s
-    /// `onRecallQueued`). Clears `pendingMessage` so it won't auto-fire — the
-    /// user must explicitly re-queue (via Queue button or Return) after editing.
-    /// The draft is restored as-is (user text only, not the `[[kind:…]]`` wire
-    /// refs — those are rebuilt from current attachments on the next queue/send).
+    /// #740: recall the most-recently queued message back into the composer
+    /// draft for editing. Triggered by Arrow ↑ on an empty composer (see
+    /// `ComposerTextView`'s `onRecallQueued`). Pops the last item so the user
+    /// edits the one they just typed; the queue shrinks by one. The draft is
+    /// restored as-is (user text only, not the `[[kind:…]]`` wire refs — those
+    /// are rebuilt from current attachments on the next queue/send).
     private func recallQueuedMessage() {
-        guard let pending = pendingMessage else { return }
-        pendingMessage = nil
+        guard let pending = queuedMessages.popLast() else { return }
         store.draftChatMessage = pending.preview
     }
 
-    /// Delivers the queued message as the next turn's input when the current
-    /// turn completes. Routes through `submitMessage` (so it reuses the
+    /// Delivers the FIRST queued message as the next turn's input when the
+    /// current turn completes (playlist: one per turn). Pops from the front;
+    /// the remaining items stay queued and the next turn completion fires the
+    /// next one. Routes through `submitMessage` (so it reuses the
     /// interactive/continue/start routing) WITHOUT touching the composer's
     /// draft — a half-typed follow-up the user may be mid-edit on is preserved
     /// (#740 guardrail).
     private func firePendingQueuedMessage() {
-        guard let pending = pendingMessage else { return }
-        pendingMessage = nil
+        guard let pending = queuedMessages.first else { return }
+        queuedMessages.removeFirst()
         submitMessage(pending.wireMessage)
     }
 
@@ -1363,9 +1386,9 @@ struct ChatView: View {
         // it queues the draft for delivery when the turn completes. The tooltip
         // reflects that rather than telling the user to wait.
         if launcher.isGenerating {
-            return pendingMessage != nil
-                ? "Queued — will send when the response finishes"
-                : "Queue for when the response finishes"
+            return queuedMessages.isEmpty
+                ? "Queue for when the response finishes"
+                : "Queued — will send when the response finishes"
         }
         return launcher.isInteractiveSession ? "Send" : "Start Query"
     }
@@ -1377,7 +1400,8 @@ struct ChatView: View {
 /// the trimmed user text shown in the muted "Queued" affordance (without the
 /// prepended `[[kind:…]]` refs). Auto-fires via `submitMessage` when the turn
 /// completes; the user may cancel it before it fires.
-private struct PendingQueuedMessage: Equatable {
+private struct PendingQueuedMessage: Identifiable, Equatable {
+    let id = UUID()
     let wireMessage: String
     let preview: String
 }

--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -957,6 +957,13 @@ struct ChatView: View {
 
     private func composer(enabled: Bool) -> some View {
         let sendActive = canSend && enabled
+        // #740: wire the Arrow ↑ recall only when a message is actually queued.
+        // Built as an explicit closure so the type checker doesn't struggle with
+        // a method-reference ternary.
+        let recallAction: (() -> Void)? = {
+            guard pendingMessage != nil else { return nil }
+            return { recallQueuedMessage() }
+        }()
         // Paseo-style: ONE rounded box wrapping the text (top) and a toolbar row
         // (bottom) — model chip · permission chip · send button. Replaces the old
         // capsule-with-inline-send + separate selector bar below.
@@ -971,7 +978,8 @@ struct ChatView: View {
                 onSubmit: sendMessage,
                 measuredHeight: $composerHeight,
                 autoFocus: chatID == nil,
-                autocomplete: chatAutocompleteHooks
+                autocomplete: chatAutocompleteHooks,
+                onRecallQueued: recallAction
             )
                 .frame(height: composerHeight)
                 .frame(maxWidth: .infinity)
@@ -1138,13 +1146,20 @@ struct ChatView: View {
     }
 
     private func sendMessage() {
+        // #740: during generation, plain Return (via onSubmit) queues instead of
+        // being a silent no-op — the user types + hits Enter, the message is
+        // queued for delivery when the turn completes. The guard below still
+        // protects the non-generating send path (issue #380).
+        if launcher.isGenerating {
+            queueMessage()
+            return
+        }
         // Guard: don't clear the draft or attempt to send when the agent is
         // generating or waiting for a slot. The Send button is already gated
         // by `canSend`, but the Return key in ComposerTextView calls this
         // unconditionally — so the same guard here prevents the message from
         // being silently dropped (issue #380). The draft is preserved so the
-        // user can send it once the agent finishes. (#740: to queue instead,
-        // the user presses the Queue button — see `queueMessage`.)
+        // user can send it once the agent finishes.
         guard canSend else { return }
         let message = store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
@@ -1171,6 +1186,18 @@ struct ChatView: View {
             preview: message)
         store.clearActiveChatDraft()
         attachments = []
+    }
+
+    /// #740: recall the queued message back into the composer draft for editing.
+    /// Triggered by Arrow ↑ on an empty composer (see `ComposerTextView`'s
+    /// `onRecallQueued`). Clears `pendingMessage` so it won't auto-fire — the
+    /// user must explicitly re-queue (via Queue button or Return) after editing.
+    /// The draft is restored as-is (user text only, not the `[[kind:…]]`` wire
+    /// refs — those are rebuilt from current attachments on the next queue/send).
+    private func recallQueuedMessage() {
+        guard let pending = pendingMessage else { return }
+        pendingMessage = nil
+        store.draftChatMessage = pending.preview
     }
 
     /// Delivers the queued message as the next turn's input when the current
@@ -1332,8 +1359,13 @@ struct ChatView: View {
         if launcher.isAwaitingGenerationSlot {
             return "Waiting for the other session to finish before sending…"
         }
+        // #740: the send button (Queue) is now actionable during generation —
+        // it queues the draft for delivery when the turn completes. The tooltip
+        // reflects that rather than telling the user to wait.
         if launcher.isGenerating {
-            return "Wait for the response before sending the next message"
+            return pendingMessage != nil
+                ? "Queued — will send when the response finishes"
+                : "Queue for when the response finishes"
         }
         return launcher.isInteractiveSession ? "Send" : "Start Query"
     }

--- a/Sources/WikiFS/Editor/ComposerTextView.swift
+++ b/Sources/WikiFS/Editor/ComposerTextView.swift
@@ -64,6 +64,12 @@ struct ComposerTextView: NSViewRepresentable {
     ///     (the composer's text view). Called each time the dropdown is shown.
     var autocomplete: AutocompleteHooks?
 
+    /// #740: when non-nil, pressing Arrow ↑ while the composer is empty recalls
+    /// the previously queued message back into the draft for editing. The caller
+    /// loads the queued text into the `text` binding and clears its queue state.
+    /// `nil` (default) disables the recall behavior (no queue → no-op).
+    var onRecallQueued: (() -> Void)? = nil
+
     /// `AutocompleteHooks` and `DebounceHandle` are typealias back-compat
     /// shims defined on `ComposerTextView` in
     /// `WikiLinkAutocompleteController.swift` (pointing to the top-level
@@ -315,6 +321,17 @@ struct ComposerTextView: NSViewRepresentable {
             let modifiers = (NSApp.currentEvent?.modifierFlags ?? []).intersection(.deviceIndependentFlagsMask)
             ensureAutocompleteController()
             let open = autocompleteController?.hasResults ?? false
+            // #740: Arrow ↑ on an empty composer recalls the queued message into
+            // the draft for editing (only when the caller wired `onRecallQueued`).
+            // We check `string.isEmpty` so ↑ still navigates within multi-line
+            // text normally — recall fires only when the draft is clear.
+            if (selector == #selector(NSResponder.moveUp(_:))
+                || selector == #selector(NSResponder.moveToBeginningOfParagraph(_:)))
+                && textView.string.isEmpty,
+                let onRecall = parent.onRecallQueued {
+                onRecall()
+                return true
+            }
             switch ComposerTextView.keyAction(for: selector, modifiers: modifiers, autocompleteOpen: open) {
             case .send:
                 parent.onSubmit()

--- a/plans/chat-queue.md
+++ b/plans/chat-queue.md
@@ -1,0 +1,36 @@
+# Plan: Queue a chat message while the agent is working (#740)
+
+## Goal
+Let the user type and queue their next message while the agent is still generating the current turn, instead of disabling the composer and making them wait. Two tiers:
+- **Minimum:** stop disabling the text field (`canType`) so the user can draft during generation.
+- **Full:** Send during a running turn queues the message; it auto-delivers as the next turn's input when the current turn completes (not lost, not dropped).
+
+## Current state
+`Sources/WikiFS/Chats/ChatView.swift`:
+- `canType` (~L1122) returns `false` whenever `launcher.isRunning` (and not interactive) → can't even type during generation.
+- `canSendPredicate` (~L1144) requires `!isGenerating && !isAwaitingSlot` → Send disabled until current turn finishes.
+- `sendButtonTitle` (~L1157) literally says "Wait for the response before sending the next message."
+- `isComposerEnabled` (~L1090), `canSend`/`canSendPredicate` (~L1129-1155).
+- `composerCaption` doc (~L1110-1113) mentions there's already a generation-gate queue for the "another chat is responding" case (D3) — `launcher.isGenerating` / `launcher.isAwaitingGenerationSlot`. That existing queue pattern may extend to "same chat, next message" queuing; READ it before designing.
+
+## Fix design (read the code first to confirm names/state)
+1. **Typing during generation (minimum):** Change `canType` so it returns `true` during generation (allow drafting). Keep it `false` only when the field genuinely can't accept input (e.g. no chat selected).
+2. **Queueing on Send during generation (full):** When the user sends while `isGenerating`/`isAwaitingSlot`:
+   - Stash the message in a `@State pendingMessage: String?` (or a small queue `[String]` if multi-queue is desired — start with single, one queued message).
+   - Show a "Queued: <message>" affordance in the composer area (reuse the existing caption/status pattern; keep it unobtrusive — macos-design discipline: muted, `.secondary`, clear).
+   - On turn-completion (observe `launcher.isRunning` going false / a published "turn ended" event), if `pendingMessage` is non-empty, auto-submit it as the next turn's input and clear `pendingMessage`.
+   - Allow Cancel-edit of the queued message (user can clear `pendingMessage` before it fires).
+3. **Button states:** `sendButtonTitle` during generation → "Queue" (or a send-with-queue icon) when a draft is present; during queue → "Queued ✓" or a cancel. `canSendPredicate` allows send during generation when there's text (it queues rather than sends immediately).
+
+## Guardrails
+- **Read the existing D3 generation-gate queue first** (`launcher.isAwaitingGenerationSlot`, `composerCaption`) — extend it rather than building a parallel queue. If the existing queue pattern doesn't fit "same chat, next message," add a small dedicated `pendingMessage` state with a comment explaining why it's separate.
+- **Concurrency:** the turn-completion observation must be on the main actor (ChatView is `@MainActor`); the queue fires via the existing send path, not a new background task. Follow `swift-concurrency-pro` (no structured tasks for this — observe the published `isRunning`).
+- **Do not drop the message** if the turn ends while the user is mid-edit — only auto-fire what was explicitly queued via Send; a half-typed draft stays as draft text.
+- **No bare `try?`**; **no `print`** (DebugLog if any diagnostic).
+- Consult `docs/skills/macos-design/SKILL.md` for the queued-message affordance so it feels native (badge/muted caption, not a modal).
+
+## Files
+- `Sources/WikiFS/Chats/ChatView.swift` — `canType`, `canSendPredicate`, `sendButtonTitle`; add `pendingMessage` state + turn-completion observer + queue affordance.
+
+## Build/test / validation
+`make build && make test`. Validate in the running app (`make run`): start a chat turn; while generating, type a message (text field is editable); press Send → message is queued (visible affordance); when the turn completes, the queued message auto-sends as the next turn; clear the queue before it fires (cancel). Push the branch, open a PR with `Closes #740`. **Do NOT merge to main.** Scratch in `tmp/` inside your own worktree.


### PR DESCRIPTION
## Queue a chat message while the agent is working

Closes #740.

Lets the user type and queue their next message while the agent is still generating the current turn, instead of disabling the composer and forcing them to wait.

### Changes (`Sources/WikiFS/Chats/ChatView.swift`)

**Minimum tier — typing during generation:**
- `canType` and `isComposerEnabled` now return `true` during generation (for the live chat / draft state), so the composer stays editable while the agent responds. Sending during generation is still gated by `canSendPredicate` (`!isGenerating`), so this only enables *drafting* — it never fires mid-turn.

**Full tier — queue-on-send:**
- New `@State pendingMessage: PendingQueuedMessage?` (a small value type holding `wireMessage` + `preview`). Separate from the D3 generation-gate queue (`isAwaitingGenerationSlot`, which gates *another* chat's send) — this is the *same* chat's "type the next message now" path (documented inline).
- **Queue button** (`queueButton`, `showsQueueButton`): a sibling of the stop button (filled circle + up-arrow, tinted accent/blue) that appears during a running query turn when there's a draft and nothing is queued yet. Inherits ⌘↩ (the normal Send button is hidden during generation, so no shortcut conflict). Help text: "Queue for when the response finishes".
- **`queueMessage()`**: stashes the draft (+ attachment refs, via the extracted `buildWireMessage`) as `pendingMessage`, clears the draft and attachments — so the composer is free for the user to draft a *different* follow-up while the queued one waits.
- **Auto-fire**: the existing `.onChange(of: launcher.isRunning)` observer now calls `firePendingQueuedMessage()` when a turn completes. It routes through the extracted `submitMessage(_:)` (shared with `sendMessage`) so the queued deliver path is identical to a manual send — only the *timing* differs. It does **not** touch the composer draft, so a half-typed follow-up the user is mid-edit on is preserved (#740 guardrail: only what was explicitly queued via Queue auto-fires).
- **Cancel**: a muted "Queued: …" affordance under the composer (clock glyph, truncated preview, ✕) clears `pendingMessage` before it fires. Animated in/out (`.snappy`).

### Guardrails honoured
- Reuses the existing send path (`submitMessage`) — no new background task; the observer fires on the main actor (`ChatView` is `@MainActor`).
- A half-typed draft is never dropped — only explicitly-queued messages auto-fire.
- No bare `try?`; no `print`. Consulted `docs/skills/macos-design/SKILL.md` for the unobtrusive (muted, `.secondary`, capsule) queued affordance.

### Validation
- `make build` ✅
- `make test` ✅ — all 3253 tests pass (existing `canSendPredicate` / `composerCaptionText` unit tests unchanged; both still assert send is gated by `!isGenerating`).
- **Functional / GUI validation** (type-during-generation, queue affordance, auto-fire on turn completion, cancel) requires a live agent-generation turn driven from the UI and was not exercised by an automated test — please confirm in `make run`: start a turn → type during generation (field editable) → press Queue / ⌘↩ (queued affordance appears) → turn ends (queued message auto-sends as the next turn) → cancel clears the queue before it fires.

No merge to `main`.
