### PR TITLE
Fix #735: align Toggle Outline button to trailing edge in detail toolbar

### DIFF
--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -162,6 +162,7 @@ struct PageDetailView: View {
                         .help("Toggle Outline")
                     }
                     }
+                    .frame(maxWidth: .infinity)
                 }
             }
             .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)

--- a/plans/outline-toggle-align.md
+++ b/plans/outline-toggle-align.md
@@ -1,0 +1,37 @@
+# Plan: Fix #735 — Toggle Outline button alignment in detail view toolbar
+
+## Problem
+In `PageDetailView.swift`, the toolbar HStack (line 78) containing action
+buttons + `Spacer()` + outline toggle lacks `.frame(maxWidth: .infinity)`.
+
+It's nested inside two `VStack(alignment: .leading)` containers:
+1. The expanded content VStack (line 67)
+2. `CollapsibleDetailHeader`'s body VStack (line 31 of CollapsibleDetailHeader.swift)
+
+The parent `.frame(maxWidth: readableContentWidth, alignment: .leading)` (line 167)
+caps the header at 760pt but the HStack never explicitly requests full width.
+
+`CollapsibleDetailHeader.titleRow` already has `.frame(maxWidth: .infinity,
+alignment: .leading)` — the expanded content HStack needs the same treatment.
+
+Without it, the HStack sizes to its content. The `Spacer()` can't expand, so
+the outline toggle sits next to the action buttons instead of at the trailing
+edge.
+
+## Fix
+Add `.frame(maxWidth: .infinity)` to the action buttons HStack at line 78.
+
+This is the same idiom used by `CollapsibleDetailHeader.titleRow` (line 73) and
+is the standard SwiftUI pattern for a toolbar row with leading + trailing
+elements.
+
+## Scope
+- One line added: `.frame(maxWidth: .infinity)` after the HStack's closing brace
+- No behavior change — only layout
+- Applies to both editing and reading states (both branches are inside the
+  same HStack)
+
+## Validation
+- `make build && make test`
+- `make run`: verify in both editing and reading states that the outline toggle
+  is at the trailing edge and action buttons at the leading edge


### PR DESCRIPTION
## Fix #735

The "Toggle Outline" button in the detail view toolbar was not reaching the trailing edge — it sat next to the leading action buttons instead of being pushed right by the `Spacer()`.

### Root cause

The action-buttons `HStack` in `PageDetailView`'s expanded header content lacked `.frame(maxWidth: .infinity)`. It was nested inside two `VStack(alignment: .leading)` containers (the expanded content VStack and `CollapsibleDetailHeader`'s body VStack), and the parent `.frame(maxWidth: readableContentWidth, alignment: .leading)` capped the header at 760pt but the HStack never explicitly requested full width.

Without `.frame(maxWidth: .infinity)`, the HStack sized to its content, so the `Spacer()` between the leading action buttons and the trailing outline toggle couldn't expand — the toggle collapsed against the buttons.

`CollapsibleDetailHeader.titleRow` already uses `.frame(maxWidth: .infinity, alignment: .leading)` for the same reason; the expanded content row needed the same treatment.

### Fix

Added `.frame(maxWidth: .infinity)` to the action-buttons HStack. This is a one-line layout-only change — no button behavior is touched. It applies to both the editing and reading states since both branches live inside the same HStack.

### Validation

- `make build` ✓
- `make test` — all 3253 tests pass (including `PageDetailViewHostedTests`)

Closes #735
