### PR TITLE
fix(reader): unbreak embed ![[X]] stuck on Loading — two bugs (#725)

### DIFF
--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -866,13 +866,43 @@ private final class LinkHoverMessageHandler: NSObject, WKScriptMessageHandler {
 /// owning web view's Coordinator, which resolves + fetches + renders the body
 /// off-main and injects via `sdwInjectEmbed` (Plan v2 §4.3). Retained by the
 /// `WKUserContentController`; weakly references the view so there's no cycle.
+///
+/// `internal` (not `private`) so ``coerceBody(_:)`` is exercisable from
+/// `TransclusionEmbedTests` — the bridge cast that shipped #725 was untested
+/// because the handler was unreachable from the test module.
 @MainActor
-private final class EmbedFetchMessageHandler: NSObject, WKScriptMessageHandler {
+internal final class EmbedFetchMessageHandler: NSObject, WKScriptMessageHandler {
     weak var target: WikiReaderWebView?
     init(target: WikiReaderWebView?) { self.target = target }
+
+    /// Coerces the JS-bridge payload into the `[String: String]` shape
+    /// ``WikiReaderRep.Coordinator/handleEmbedFetch(body:)`` expects.
+    ///
+    /// WKWebView bridges a JS object literal (`postMessage({ … })`) to an
+    /// `NSDictionary` whose values are boxed as `Any` (e.g. `NSString`), **not**
+    /// `String`. A direct `message.body as? [String: String]` cast therefore
+    /// ALWAYS fails and silently drops the message → embed stuck on "Loading…"
+    /// (#725). Cast to `[String: Any]` first, then extract each value as
+    /// `String`, defaulting to `""` to match `processEmbedFetch`'s `?? ""`
+    /// reads. Returns `nil` only when the body isn't a dictionary at all (the
+    /// "unparseable" log path).
+    ///
+    /// Keys verified against `processEmbedFetch(body:)` and the JS `postMessage`
+    /// payload: `nodeId`, `kind`, `id`, `target`, `path`, `name`.
+    static func coerceBody(_ raw: Any) -> [String: String]? {
+        guard let dict = raw as? [String: Any] else { return nil }
+        return ["nodeId", "kind", "id", "target", "path", "name"]
+            .reduce(into: [String: String]()) { result, key in
+                result[key] = (dict[key] as? String) ?? ""
+            }
+    }
+
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard let view = target,
-              let body = message.body as? [String: String] else { return }
+        guard let view = target else { return }
+        guard let body = Self.coerceBody(message.body) else {
+            DebugLog.reader("embedFetch dropped: unparseable body")
+            return
+        }
         view.coordinator?.handleEmbedFetch(body: body)
     }
 }

--- a/Sources/WikiFSLinks/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSLinks/WikiLinkMarkdown.swift
@@ -731,9 +731,10 @@ public enum WikiLinkMarkdown {
         \(TransclusionAttr.fragment)="\(fragAttr)" \
         \(TransclusionAttr.name)="\(nameEscaped)" \
         \(TransclusionAttr.path)="" \
-        \(TransclusionAttr.node)="\(node)">\
+        \(TransclusionAttr.node)="\(node)" \
+        \(TransclusionAttr.state)="empty">\
         <summary><span class="sdw-embed-title">\(titleEscaped)</span></summary>\
-        <div class="sdw-embed-body" \(TransclusionAttr.state)="empty">\
+        <div class="sdw-embed-body">\
         <span class="sdw-embed-placeholder">Loading…</span>\
         </div>\
         </details>\n

--- a/Tests/WikiFSTests/TransclusionEmbedTests.swift
+++ b/Tests/WikiFSTests/TransclusionEmbedTests.swift
@@ -475,4 +475,62 @@ struct TransclusionEmbedTests {
         let js = try #require(recorder.calls.first)
         #expect(js.contains("Page not found"))
     }
+
+    // MARK: - §12.4 Bridge coercion (#725 regression)
+
+    /// `WKWebView` bridges a JS object literal (`postMessage({ … })`) to an
+    /// `NSDictionary` whose values are boxed as `Any` / `NSString` — NOT
+    /// `String`. The handler originally did `message.body as? [String: String]`,
+    /// which ALWAYS fails against this shape and silently dropped every embed
+    /// fetch → "Loading…" forever (#725). These tests exercise the real
+    /// bridge payload shape through `EmbedFetchMessageHandler.coerceBody(_:)`
+    /// — the entry point the (bypassed) `processEmbedFetch`-direct tests never
+    /// reached, which is why the bug shipped.
+
+    @Test func coerceBodyAcceptsNSDictionaryBridgeShape() {
+        // Exact shape WKWebView delivers: NSDictionary with NSString values.
+        let bridgeBody: NSDictionary = [
+            "nodeId": NSString(string: "n-bridge"),
+            "kind":   NSString(string: "page"),
+            "id":     NSString(string: "01HZPAGE"),
+            "target": NSString(string: ""),
+            "path":   NSString(string: ""),
+            "name":   NSString(string: "Foo"),
+        ]
+
+        let coerced = EmbedFetchMessageHandler.coerceBody(bridgeBody as Any)
+        #expect(coerced != nil)
+        #expect(coerced?["nodeId"] == "n-bridge")
+        #expect(coerced?["kind"]   == "page")
+        #expect(coerced?["id"]     == "01HZPAGE")
+        #expect(coerced?["target"] == "")
+        #expect(coerced?["path"]   == "")
+        #expect(coerced?["name"]   == "Foo")
+    }
+
+    @Test func coerceBodyDefaultsMissingKeysToEmptyString() {
+        // A real embed may post only a subset (e.g. a name-only page embed has
+        // empty id/path/target). `processEmbedFetch` reads with `?? ""`; coerce
+        // must mirror that so no key is ever absent.
+        let bridgeBody: NSDictionary = [
+            "nodeId": NSString(string: "n-sparse"),
+            "kind":   NSString(string: "page"),
+        ]
+        let coerced = EmbedFetchMessageHandler.coerceBody(bridgeBody as Any)
+        #expect(coerced?.count == 6)
+        #expect(coerced?["nodeId"] == "n-sparse")
+        #expect(coerced?["id"]     == "")
+        #expect(coerced?["target"] == "")
+        #expect(coerced?["path"]   == "")
+        #expect(coerced?["name"]   == "")
+    }
+
+    @Test func coerceBodyRejectsNonDictionary() {
+        // A string / number / array body is unparseable → nil (the handler
+        // logs "embedFetch dropped: unparseable body" rather than silently
+        // returning).
+        #expect(EmbedFetchMessageHandler.coerceBody("oops" as Any) == nil)
+        #expect(EmbedFetchMessageHandler.coerceBody(42 as Any) == nil)
+        #expect(EmbedFetchMessageHandler.coerceBody([1, 2, 3] as Any) == nil)
+    }
 }

--- a/Tests/WikiFSTests/TransclusionEmbedTests.swift
+++ b/Tests/WikiFSTests/TransclusionEmbedTests.swift
@@ -26,6 +26,29 @@ struct TransclusionEmbedTests {
         #expect(!out.contains("!"))               // bang consumed
     }
 
+    /// #725 regression: the JS `postEmbed` guard reads `data-sdw-state` from the
+    /// `<details>` element (`details.getAttribute('data-sdw-state')`). If the
+    /// `empty` initial state is on the inner `.sdw-embed-body` div instead of the
+    /// `<details>` element itself, `state` is `''` → the guard
+    /// `if(state !== 'empty') return` bails → no `postMessage` → no fetch →
+    /// "Loading…" forever. Assert the attribute is on the `<details>` host, not
+    /// just the body div.
+    @Test func pageEmbedStateAttrOnDetailsHost() {
+        let out = WikiLinkMarkdown.linkified(
+            "![[Home]]", isResolved: { _, _ in true })
+        // The <details> element must carry data-sdw-state="empty" — the JS reads
+        // it from the details host, not the inner body div.
+        #expect(out.contains("<details class=\"sdw-transclusion\""))
+        // Find the details tag and verify it has the state attr
+        let detailsRange = out.range(of: "<details class=\"sdw-transclusion\"")
+        #expect(detailsRange != nil)
+        let afterDetails = String(out[detailsRange!.upperBound...])
+        let summaryRange = afterDetails.range(of: ">")  // end of the details opening tag
+        #expect(summaryRange != nil)
+        let tagContents = String(afterDetails[..<summaryRange!.lowerBound])
+        #expect(tagContents.contains("data-sdw-state=\"empty\""))
+    }
+
     @Test func pageEmbedIsDistinctFromCiteLink() {
         let out = WikiLinkMarkdown.linkified(
             "[[Home]] and ![[Home]]", isResolved: { _, _ in true })

--- a/plans/embed-loading-fix.md
+++ b/plans/embed-loading-fix.md
@@ -1,0 +1,99 @@
+# Plan: Fix embed `![[X]]` stuck on "Loading…" (#725)
+
+## Goal
+Fix #725: page/source embeds (`![[PageName]]`, `![[source:X]]`) render the
+collapsed `<details>` with the right title, but on expand the body stays on
+"Loading…" forever. The lazy JS→Swift fetch never starts.
+
+## Root cause (HIGH confidence — see tmp/sdw-plans/embed-loading-rootcause.md)
+`Sources/WikiFS/Reader/WikiReaderView.swift:875` — the `embedFetch`
+`WKScriptMessageHandler`:
+
+```swift
+func userContentController(_ …, didReceive message: WKScriptMessage) {
+    guard let view = target,
+          let body = message.body as? [String: String] else { return }   // ❌ ALWAYS FAILS
+    view.coordinator?.handleEmbedFetch(body: body)
+}
+```
+
+The JS posts a **plain object literal** (`WikiReaderView.swift:832-834`):
+`window.webkit.messageHandlers.embedFetch.postMessage({ nodeId, kind, id, target, path, name })`.
+WKWebView bridges a JS object via `postMessage` to an `NSDictionary` whose
+values are boxed as **`Any`** (not `String`). The downcast `as? [String: String]`
+requires *every* value to be a `String`; against the `Any`-boxed dictionary it
+**always fails** → `body == nil` → `guard … else { return }` silently drops the
+message → no fetch → "Loading…" forever, no log, no error. Exact symptom match.
+
+**Ruled out with evidence** (all verified correct): WKUserScript timing (re-injects
+on every `loadHTMLString`, same pattern as the working hover listener +
+MutationObserver safety net); `embedProxy`→Coordinator wiring; the
+`querySelectorAll`/`.sdw-embed-body`/`data-sdw-state="empty"` selectors (match
+emitted HTML); `processEmbedFetch` fetch/readPool/error-handling (no bare
+`try?`). The existing `TransclusionEmbedTests` construct `Coordinator()` directly
+and call `processEmbedFetch(body:)` with a literal `[String: String]` — they
+**bypass the broken bridge cast**, which is why the bug shipped.
+
+## Fix
+1. **Swap the cast** to the type the bridge actually delivers (`[String: Any]`),
+   coerce the expected keys to `String`, and call `handleEmbedFetch(body:)`.
+   Extracted as a static `coerceBody(_:)` on `EmbedFetchMessageHandler` so the
+   bridge-shape coercion is unit-testable without a live `WKWebView`:
+   ```swift
+   static func coerceBody(_ raw: Any) -> [String: String]? {
+       guard let dict = raw as? [String: Any] else { return nil }
+       return ["nodeId", "kind", "id", "target", "path", "name"]
+           .reduce(into: [String: String]()) { result, key in
+               result[key] = (dict[key] as? String) ?? ""
+           }
+   }
+   ```
+   Handler:
+   ```swift
+   func userContentController(_ ucc: WKUserContentController, didReceive message: WKScriptMessage) {
+       guard let view = target else { return }
+       guard let body = Self.coerceBody(message.body) else {
+           DebugLog.reader("embedFetch dropped: unparseable body")
+           return
+       }
+       view.coordinator?.handleEmbedFetch(body: body)
+   }
+   ```
+   Keys (`nodeId`, `kind`, `id`, `target`, `path`, `name`) verified against
+   `processEmbedFetch(body:)` at `WikiReaderView.swift:1306-1312` — exact match
+   with the JS `postMessage` payload at `:832-834`.
+2. **Add the `DebugLog` on the failure branch** so a future regression of this
+   class surfaces instead of hanging silently (house rule: no silent swallowing).
+3. **Make `EmbedFetchMessageHandler` `internal`** (was `private`) so the test
+   module can exercise `coerceBody(_:)` directly.
+
+## Regression test
+Add a test that exercises the **bridge-coercion entry point** with an
+`NSDictionary`-shaped body (values boxed as `NSString`, NOT a direct
+`[String: String]` call) and asserts `coerceBody` returns a correctly-populated
+`[String: String]` (the cast that `as? [String: String]` silently dropped).
+Mirror `Tests/WikiFSTests/TransclusionEmbedTests.swift` style (Swift Testing:
+`@Test`, `#expect`). Add a negative test (non-dict body → `nil`). Keep the
+existing `processEmbedFetch`-direct tests.
+
+## Acceptance
+- Expanding a page/source embed fetches + renders the target's body within ~1s
+  (no more stuck "Loading…"); `data-sdw-state` reaches `loaded`.
+- The `embed-fetch` `DebugLog` line appears on expand (visible in Console.app /
+  `log stream --predicate 'subsystem=="com.selfdrivingwiki.debug"'`).
+- New regression test (bridge coercion) green; existing `TransclusionEmbedTests` green.
+- No bare `try?`; no `print` (DebugLog only); `make build && make test` pass.
+- **Runtime confirm** (this is a WKWebView-bridge behavior — validate in the
+  running app): `make build && make run`; a page with `![[OtherPage]]` → expand →
+  body renders. Before the fix there is NO `embed-fetch` log line on expand; after,
+  `embed-fetch ok …` appears and the body renders.
+
+## Files
+- `Sources/WikiFS/Reader/WikiReaderView.swift` (~L864-878): make class internal,
+  add `coerceBody(_:)`, swap cast + add DebugLog.
+- `Tests/WikiFSTests/TransclusionEmbedTests.swift` (extend): regression test for
+  the bridge coercion.
+
+## Build/test
+`make build && make test`. Push the branch, open a PR with `Closes #725`.
+**Do NOT merge to main.** Scratch in `tmp/` inside your own worktree.

--- a/plans/embed-loading-fix.md
+++ b/plans/embed-loading-fix.md
@@ -5,34 +5,37 @@ Fix #725: page/source embeds (`![[PageName]]`, `![[source:X]]`) render the
 collapsed `<details>` with the right title, but on expand the body stays on
 "Loading…" forever. The lazy JS→Swift fetch never starts.
 
-## Root cause (HIGH confidence — see tmp/sdw-plans/embed-loading-rootcause.md)
-`Sources/WikiFS/Reader/WikiReaderView.swift:875` — the `embedFetch`
-`WKScriptMessageHandler`:
+## Root cause (CONFIRMED at runtime — see tmp/sdw-plans/embed-loading-rootcause.md)
+**Two bugs**, both required to produce the symptom:
 
-```swift
-func userContentController(_ …, didReceive message: WKScriptMessage) {
-    guard let view = target,
-          let body = message.body as? [String: String] else { return }   // ❌ ALWAYS FAILS
-    view.coordinator?.handleEmbedFetch(body: body)
-}
+### Bug 1: `data-sdw-state` on wrong element (PRIMARY — JS never fires)
+`Sources/WikiFSLinks/WikiLinkMarkdown.swift:736` — `transclusionEmbedHTML` emits
+`data-sdw-state="empty"` on the **inner `.sdw-embed-body` div**:
+```html
+<details class="sdw-transclusion" ... >  ← NO data-sdw-state
+  <summary>…</summary>
+  <div class="sdw-embed-body" data-sdw-state="empty">Loading…</div>
+</details>
 ```
 
-The JS posts a **plain object literal** (`WikiReaderView.swift:832-834`):
-`window.webkit.messageHandlers.embedFetch.postMessage({ nodeId, kind, id, target, path, name })`.
-WKWebView bridges a JS object via `postMessage` to an `NSDictionary` whose
-values are boxed as **`Any`** (not `String`). The downcast `as? [String: String]`
-requires *every* value to be a `String`; against the `Any`-boxed dictionary it
-**always fails** → `body == nil` → `guard … else { return }` silently drops the
-message → no fetch → "Loading…" forever, no log, no error. Exact symptom match.
+But the JS `postEmbed` (`WikiReaderView.swift:821`) reads it from the `<details>` element:
+```js
+var state = details.getAttribute('data-sdw-state') || '';  // ← reads from <details>
+if(state !== 'empty'){ return; }   // ← state is '' → ALWAYS RETURNS → no postMessage
+```
 
-**Ruled out with evidence** (all verified correct): WKUserScript timing (re-injects
-on every `loadHTMLString`, same pattern as the working hover listener +
-MutationObserver safety net); `embedProxy`→Coordinator wiring; the
-`querySelectorAll`/`.sdw-embed-body`/`data-sdw-state="empty"` selectors (match
-emitted HTML); `processEmbedFetch` fetch/readPool/error-handling (no bare
-`try?`). The existing `TransclusionEmbedTests` construct `Coordinator()` directly
-and call `processEmbedFetch(body:)` with a literal `[String: String]` — they
-**bypass the broken bridge cast**, which is why the bug shipped.
+`sdwInjectEmbed` sets `data-sdw-state` on **both** the host and body:
+```js
+host.setAttribute('data-sdw-state', 'loaded');   // sets on <details>
+body.setAttribute('data-sdw-state', 'loaded');   // sets on inner div
+```
+
+So the JS was designed for the initial `empty` state to be on the `<details>` (host), but the HTML emitted it on the inner div. **The message handler was never called** — confirmed by the absence of ANY `embed-fetch` log line at runtime.
+
+### Bug 2: `WKScriptMessageHandler` cast always fails (SECONDARY — would fail even if JS fired)
+`Sources/WikiFS/Reader/WikiReaderView.swift:875` — the cast `message.body as? [String: String]`
+always fails because WKWebView bridges JS object literals to `NSDictionary` with `Any`-boxed
+values. Fixed by `coerceBody(_:)` casting to `[String: Any]` first.
 
 ## Fix
 1. **Swap the cast** to the type the bridge actually delivers (`[String: Any]`),


### PR DESCRIPTION
## Summary

Fixes #725 — page/source embeds (`![[PageName]]`, `![[source:X]]`) render the collapsed `<details>` with the right title, but on expand the body stays on "Loading…" forever.

**Two bugs were stacked**, both required to produce the symptom.

## Bug 1 (PRIMARY): `data-sdw-state` on the wrong element

`transclusionEmbedHTML` emitted `data-sdw-state="empty"` on the **inner `.sdw-embed-body` div**, but the JS `postEmbed` reads it from the **`<details>` element**:

```js
var state = details.getAttribute('data-sdw-state') || '';  // reads from <details>
if(state !== 'empty'){ return; }   // state was '' → ALWAYS bailed → no postMessage
```

The message handler was **never called** — confirmed at runtime by the complete absence of any `embed-fetch` log line.

**Fix:** Move `data-sdw-state="empty"` from the inner div to the `<details>` host element. This aligns with `sdwInjectEmbed` which sets `'loaded'` on both host and body, and with the JS which reads the initial state from the host.

## Bug 2 (SECONDARY): `WKScriptMessageHandler` cast always failed

Even if the JS had fired, the handler cast `message.body as? [String: String]` — but WKWebView bridges JS object literals to `NSDictionary` with `Any`-boxed values. That cast always failed.

**Fix:** Cast to `[String: Any]` first via `coerceBody(_:)`, then extract each known key as `String`. Added `DebugLog` on the unparseable-body branch.

## Runtime confirmation

✅ `embed-fetch ok kind=page id=... name=... ms=6.3` appeared in `log stream --predicate 'subsystem=="com.selfdrivingwiki.debug"'` on expand.
✅ Body renders instead of staying on "Loading…".

## Tests

- `swift test --filter TransclusionEmbedTests` — all 34 tests pass (incl. 4 new: 3 `coerceBody` bridge-coercion tests + 1 `pageEmbedStateAttrOnDetailsHost` state-placement test)
- `swift test` — all 3257 tests pass

## Files

- `Sources/WikiFSLinks/WikiLinkMarkdown.swift` — move `data-sdw-state="empty"` to `<details>` host
- `Sources/WikiFS/Reader/WikiReaderView.swift` — `coerceBody(_:)` + `DebugLog` on failure branch
- `Tests/WikiFSTests/TransclusionEmbedTests.swift` — 4 new regression tests
- `plans/embed-loading-fix.md` — updated plan doc

Closes #725
