### PR TITLE
fix: title pane stretches full window width (DRY)

### DIFF
--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -633,9 +633,9 @@ struct ChatView: View {
     private func header(for chat: ChatSummary) -> some View {
         // The header is split into two rows:
         //
-        //   1. Title + date (inside `CollapsibleDetailHeader`'s expanded
-        //      content) — constrained to `readableContentWidth` so the
-        //      editable title and date stay readable.
+        //   1. Title row — full view width (the `.hoverRowBackground()` pill
+        //      stretches edge-to-edge). The expanded content (date) is capped
+        //      at `readableContentWidth` internally by `CollapsibleDetailHeader`.
         //
         //   2. The action toolbar row (Show in List / Share / Reveal in
         //      Finder / Reveal Debug Folder + outline toggle) — rendered as
@@ -665,7 +665,6 @@ struct ChatView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
-            .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
 
             if isHeaderExpanded {
                 chatActionBar

--- a/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
+++ b/Sources/WikiFS/Editor/CollapsibleDetailHeader.swift
@@ -32,6 +32,14 @@ struct CollapsibleDetailHeader<Expanded: View>: View {
             titleRow
             if isExpanded {
                 expandedContent()
+                    // The expanded body (metadata, action buttons, provenance)
+                    // is capped at readableContentWidth so long action rows
+                    // don't sprawl across a wide window. The title row above
+                    // is NOT capped — its `.hoverRowBackground()` pill stretches
+                    // edge-to-edge. Callers provide the horizontal inset via
+                    // `.padding(.horizontal, contentInset)` on the header.
+                    .frame(maxWidth: PageEditorMetrics.readableContentWidth,
+                           alignment: .leading)
                     .transition(.opacity)
             }
         }

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -165,7 +165,6 @@ struct PageDetailView: View {
                     .frame(maxWidth: .infinity)
                 }
             }
-            .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
             .padding(.horizontal, PageEditorMetrics.contentInset)
             .padding(.top, PageEditorMetrics.contentInset)
             .padding(.bottom, PageEditorMetrics.sectionSpacing)

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -744,7 +744,6 @@ struct SourceDetailView: View {
 
             }
         }
-        .frame(maxWidth: PageEditorMetrics.readableContentWidth, alignment: .leading)
         .padding(PageEditorMetrics.contentInset)
     }
 

--- a/plans/title-pane-fullwidth.md
+++ b/plans/title-pane-fullwidth.md
@@ -1,0 +1,40 @@
+# Title Pane Full-Width Fix (DRY)
+
+## Problem
+The `CollapsibleDetailHeader` (title pane) in detail views is capped at
+`readableContentWidth` (760pt), so the `.hoverRowBackground()` pill only
+stretches to ~736pt instead of the full window width. The 760pt cap should
+apply ONLY to the expanded body content (metadata, action buttons, provenance),
+not the title row.
+
+## Root Cause
+At each call site (`PageDetailView.swift` L168, `SourceDetailView.swift` L747,
+`ChatView.swift` L668), the entire `CollapsibleDetailHeader` was wrapped in
+`.frame(maxWidth: readableContentWidth)`, capping both the title row and the
+expanded content at 760pt.
+
+## Fix (DRY)
+Move the `readableContentWidth` cap INTO `CollapsibleDetailHeader` itself, so
+the layout contract is owned in one place:
+
+1. **`CollapsibleDetailHeader.swift`** — Apply
+   `.frame(maxWidth: readableContentWidth, alignment: .leading)` to the
+   `expandedContent()` call inside the body. The title row keeps
+   `.frame(maxWidth: .infinity)` so it stretches full width.
+
+2. **Call sites** (PageDetailView, SourceDetailView, ChatView) — Remove the
+   `.frame(maxWidth: readableContentWidth)` that was capping the whole header.
+   Keep `.padding(.horizontal, contentInset)` on the header for the title row's
+   12pt inset from the window edge.
+
+### Layout contract
+- **Title row**: full width of the padded container (window − 24pt), hover pill
+  stretches edge-to-edge.
+- **Expanded content**: capped at 760pt, aligned leading, same left edge as the
+  title text.
+- **Body** (editor/reader/provenance below the header): unchanged, still capped
+  at `readableContentWidth` + `contentInset` padding.
+
+## Guardrails
+- Do NOT change `readableContentWidth` (760) or `contentInset` (12) values.
+- No `print` (DebugLog only); no bare `try?`.


### PR DESCRIPTION
## Summary

The `CollapsibleDetailHeader` title pane (the hover pill row) now stretches the full window width instead of being capped at `readableContentWidth` (760pt). The 760pt readable-content cap is applied only to the expanded body (metadata, action buttons, provenance), not the title row.

## Root Cause

All three detail views (`PageDetailView`, `SourceDetailView`, `ChatView`) wrapped the entire `CollapsibleDetailHeader` in `.frame(maxWidth: readableContentWidth)`, capping both the title row and the expanded content at 760pt. The title row's `.hoverRowBackground()` pill therefore only reached ~736pt (760 − 2×12 padding).

## Fix (DRY)

Moved the `readableContentWidth` cap **into** `CollapsibleDetailHeader` itself:

- **`CollapsibleDetailHeader.swift`**: `.frame(maxWidth: readableContentWidth, alignment: .leading)` is now applied to `expandedContent()` only. The title row already had `.frame(maxWidth: .infinity)`, so it stretches full width.
- **`PageDetailView.swift`**: removed `.frame(maxWidth: readableContentWidth)` from the header container.
- **`SourceDetailView.swift`**: removed `.frame(maxWidth: readableContentWidth)` from `headerSection`.
- **`ChatView.swift`**: removed `.frame(maxWidth: readableContentWidth)` from `CollapsibleDetailHeader`; updated comment.

### Layout contract (owned in one place)
- **Title row**: full width of the padded container (window − 24pt). Hover pill goes edge-to-edge.
- **Expanded content**: capped at 760pt, aligned leading.
- **Body** (editor/reader/provenance below the header): unchanged.

## Validation

- `make build` ✓
- `make test` — all 3257 tests pass ✓

Closes the title-pane-fullwidth issue.
