### PR TITLE
Fix FileProvider EXC_BREAKPOINT crash on nil getUserVisibleURL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,41 @@ agents, NOT Polytoken):
   read the stack at the moment of death. Reach for this *before* rebuild-and-
   guess when there's no `.ips`.
 
+* **Swift async bridging of nullable Objective-C object returns can trap
+  (`EXC_BREAKPOINT`/`SIGTRAP`) instead of throwing (#756).** When an Obj-C
+  method's completion handler is `(NSURL?, NSError?)` (or any nullable object
+  pointer: `URL?`, `Array?`, `Dictionary?`), Swift's `async` bridge imports it
+  as a **non-optional** `async throws -> URL` and routes nil through
+  `<Type>._unconditionallyBridgeFromObjectiveC(_:)`, which **traps before the
+  `throws`/`try` machinery can intervene** — an uncatchable runtime death, not
+  a catchable error. `try await`, `CheckedContinuation` wrappers, and timeouts
+  give **no protection**; the trap is before they run.
+  - **The rule:** before `await`ing an Apple `async` API whose bridged return is
+    a non-optional `URL`/`NSURL` (or non-optional `Array`/`Dictionary` where the
+    underlying completion is nullable), check Apple's docs for nil as a
+    documented return. If nil is possible, **use the completion-handler overload
+    directly** and branch on the `URL?`:
+    ```swift
+    // BAD — traps on nil:
+    let url = try await manager.getUserVisibleURL(for: id)
+    // GOOD — nil becomes a recoverable error:
+    manager.getUserVisibleURL(for: id) { url, error in
+        if let url { resume(.success(url)) }
+        else { resume(.failure(error ?? MyError.urlNil)) }
+    }
+    ```
+  - **Known-affected families to watch for:** `NSFileProviderManager.getUserVisibleURL(for:)`
+    (fixed at `FileProviderFacade.userVisibleURL`), `FileManager.url(for:in:appropriateFor:create:)`,
+    `NSItemProvider.loadObject(ofClass:)`/`loadItem(forTypeIdentifier:)`, and any
+    future `NSFileProviderManager`/`NSFileCoordinator` API returning a nullable URL.
+    `Void`-returning bridges (`add(domain)`, `remove(domain)`) are safe; `[NSFileProviderDomain]`
+    array bridges fail-soft to `[]` in this codebase (already wrapped in `try?` + `?? []`).
+    `FileProviderExtension` overrides are server-side callbacks *we implement* with the
+    completion-handler signature — no async bridge, no trap surface.
+  - Audit recipe if a new unexplained `EXC_BREAKPOINT`/`SIGTRAP` appears: `rg -n 'try await .*(getUserVisibleURL|urlForItem|url\(for:|loadObject|loadItem)' Sources/`
+    and look for any non-optional `URL` await where the Obj-C completion is `(NSURL?, …)`.
+    See `plans/fileprovider-crash-fix.md` for the full root-cause writeup.
+
 * **SQLite concurrency (graph-model Phase 0): the store is method-atomic —
   every `SQLiteWikiStore` entry point holds an internal recursive lock; writes
   still flow through the `@MainActor` model; off-main reads go through

--- a/Sources/WikiFS/Window/FileProviderFacade.swift
+++ b/Sources/WikiFS/Window/FileProviderFacade.swift
@@ -258,36 +258,60 @@ final class FileProviderFacade: ChangeSignaler {
         isResolvingPath = true
         defer { isResolvingPath = false }
 
+        // Gate: only ask the daemon for a visible URL if the domain is already
+        // registered. At launch `registerAllDomains` (WikiFSApp) and
+        // `activate`→here race with no ordering; `NSFileProviderManager(for:)`
+        // returns a manager for any identifier whether registered or not, so
+        // without this gate we can reach `getUserVisibleURL(for: .rootContainer)`
+        // against a domain the daemon hasn't mounted yet → nil URL. The
+        // completion-handler overload in `userVisibleURL` already makes that nil
+        // a recoverable error instead of a trap; this gate additionally skips the
+        // doomed 5s call on an unregistered domain and goes straight to
+        // (re)registration so the wiki self-heals instead of stalling. See #756.
+        let alreadyRegistered = await isDomainRegistered(id: id)
+
         let domain = domain(id: id, displayName: displayName)
         guard let manager = NSFileProviderManager(for: domain) else {
             status = "No manager for domain"
             return
         }
-        do {
-            let url = try await userVisibleURL(
-                manager: manager,
-                itemIdentifier: .rootContainer,
-                timeout: .seconds(5))
-            path = url.path
-            status = "Mounted"
-        } catch {
-            status = "Resolving mount timed out; retrying domain registration…"
-            if await registerDomain(id: id, displayName: displayName) {
-                await nudgeInitialEnumeration(forWikiID: id)
-                do {
-                    let url = try await userVisibleURL(
-                        manager: manager,
-                        itemIdentifier: .rootContainer,
-                        timeout: .seconds(5))
-                    path = url.path
-                    status = "Mounted"
-                    return
-                } catch {
-                    status = "Mount unavailable: \(error.localizedDescription)"
-                }
-            } else {
+
+        if alreadyRegistered {
+            do {
+                let url = try await userVisibleURL(
+                    manager: manager,
+                    itemIdentifier: .rootContainer,
+                    timeout: .seconds(5))
+                path = url.path
+                status = "Mounted"
+                return
+            } catch {
+                DebugLog.reader("resolvePath: first userVisibleURL failed for \(id); error=\(error.localizedDescription)")
+            }
+        } else {
+            DebugLog.reader("resolvePath: domain \(id) not registered yet (still mounting); registering before resolving mount path")
+        }
+
+        // (Re)register and retry — covers BOTH the not-registered launch race and a
+        // transient first-attempt failure. `registerDomain` is idempotent (adds
+        // only if absent), safe while `registerAllDomains` is racing.
+        status = alreadyRegistered
+            ? "Resolving mount timed out; retrying domain registration…"
+            : "Wiki is still mounting; registering domain…"
+        if await registerDomain(id: id, displayName: displayName) {
+            await nudgeInitialEnumeration(forWikiID: id)
+            do {
+                let url = try await userVisibleURL(
+                    manager: manager,
+                    itemIdentifier: .rootContainer,
+                    timeout: .seconds(5))
+                path = url.path
+                status = "Mounted"
+            } catch {
                 status = "Mount unavailable: \(error.localizedDescription)"
             }
+        } else {
+            status = "Mount unavailable: domain not registered"
         }
     }
 
@@ -618,12 +642,26 @@ final class FileProviderFacade: ChangeSignaler {
     ) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
             let resolution = MountURLResolution(continuation: continuation)
-            Task { @MainActor in
-                do {
-                    let url = try await manager.getUserVisibleURL(for: itemIdentifier)
-                    resolution.succeed(url)
-                } catch {
-                    resolution.fail(error)
+            // Use the completion-handler overload rather than
+            // `try await manager.getUserVisibleURL(for:)`. The async overload is
+            // imported as `async throws -> URL` (non-optional), bridged from the
+            // Obj-C completion handler `(NSURL?, NSError?)`. Apple documents the URL
+            // as "or nil if an error occurs" — nil is a valid return — but the async
+            // bridging runs `URL._unconditionallyBridgeFromObjectiveC(_:)`, which
+            // traps (`brk 1`, EXC_BREAKPOINT/SIGTRAP) on a nil NSURL. That trap fires
+            // BEFORE the `throws`/`try` machinery can intervene; the 5s timeout and
+            // CheckedContinuation give no protection. Using the completion-handler form
+            // hands us the raw `URL?` so nil becomes a recoverable error (via
+            // `DebugLog.reader` + `MountURLResolution.fail`) instead of an uncatchable
+            // runtime trap. This is the only `getUserVisibleURL` call site (#756).
+            manager.getUserVisibleURL(for: itemIdentifier) { url, error in
+                Task { @MainActor in
+                    if let url {
+                        resolution.succeed(url)
+                    } else {
+                        DebugLog.reader("getUserVisibleURL returned nil URL for itemIdentifier=\(itemIdentifier.rawValue); error=\(error?.localizedDescription ?? "none")")
+                        resolution.fail(error ?? MountResolutionError.urlNil)
+                    }
                 }
             }
             Task {
@@ -637,11 +675,14 @@ final class FileProviderFacade: ChangeSignaler {
 
     private enum MountResolutionError: LocalizedError {
         case timedOut
+        case urlNil
 
         var errorDescription: String? {
             switch self {
             case .timedOut:
                 "File Provider did not return a mount URL in time"
+            case .urlNil:
+                "File Provider returned no URL for this item — the domain may not be fully mounted yet"
             }
         }
     }

--- a/plans/fileprovider-crash-fix.md
+++ b/plans/fileprovider-crash-fix.md
@@ -1,0 +1,88 @@
+# Plan: Fix FileProvider EXC_BREAKPOINT crash (#756)
+
+## Root cause (CONFIRMED)
+`Sources/WikiFS/Window/FileProviderFacade.swift:623`:
+```swift
+let url = try await manager.getUserVisibleURL(for: itemIdentifier)
+```
+`NSFileProviderManager.getUserVisibleURL(for:)` is imported as `async throws -> URL`
+(non-optional), bridged from an Obj-C completion handler `(NSURL?, NSError?)`. Apple's
+docs say the URL is returned "or nil if an error occurs" — nil is a **documented, valid**
+return. The async bridging calls `URL._unconditionallyBridgeFromObjectiveC(_:)`, which
+traps (`brk 1`, EXC_BREAKPOINT/SIGTRAP) when the NSURL is nil. This is an **uncatchable
+Swift runtime trap** — it fires before the `try`/`throws` machinery can intervene. The
+5-second timeout and `CheckedContinuation` wrapper give no protection.
+
+**The race (confirmed):** At launch, two fire-and-forget Tasks compete with no ordering:
+Task A registers domains (`WikiFSApp.swift:334`, `registerAllDomains`); Task B resolves
+the mount path (`RootScene.swift:196`, `activate` → `resolvePath`). `resolvePath` does
+NOT gate on `isDomainRegistered` — its only gate is `NSFileProviderManager(for: domain)`,
+which returns a manager for any identifier whether registered or not. So
+`getUserVisibleURL(for: .rootContainer)` can be asked of a domain Task A hasn't finished
+mounting yet → nil URL → trap.
+
+**macOS 26 specificity:** The trap is latent on macOS 15 too (no `#available` guards; the
+contract permits nil on all versions). But macOS Tahoe's well-documented `fileproviderd`
+instability makes the daemon return nil URLs far more often during the launch window,
+which is why it manifests on Tahoe. Not Tahoe-only; Tahoe makes it reproducible.
+
+## Fix
+
+### Primary: switch to the completion-handler overload (the single chokepoint)
+`Sources/WikiFS/Window/FileProviderFacade.swift`, `userVisibleURL(manager:itemIdentifier:timeout:)`
+(L614-636). Replace L623's `try await manager.getUserVisibleURL(for:)` with the
+completion-handler form that returns `URL?` directly:
+
+```swift
+// BEFORE (L623 — traps on nil):
+let url = try await manager.getUserVisibleURL(for: itemIdentifier)
+
+// AFTER — use the completion-handler overload, branch on nil:
+manager.getUserVisibleURL(for: itemIdentifier) { url, error in
+    if let url {
+        resolution.succeed(url)
+    } else {
+        resolution.fail(error ?? MountResolutionError.urlNil)
+    }
+}
+```
+Add a `MountResolutionError.urlNil` case with a descriptive `errorDescription` (e.g.
+"File Provider returned no URL for this item — the domain may not be fully mounted yet").
+Do NOT use bare `try?` — surface via `DebugLog.reader` + the `MountURLResolution.fail`
+path. This is the ONLY `getUserVisibleURL` call site in the codebase (grep-confirmed),
+so it makes ALL callers nil-safe with no caller-side changes: `resolvePath`, `openSource`,
+`resolvePageByTitleURL`, `resolveChatByNameURL`, `resolveSourceByNameURL`.
+
+### Secondary: gate resolvePath on domain registration
+`Sources/WikiFS/Window/FileProviderFacade.swift`, `resolvePath(id:displayName:)` (~L256).
+Before calling `userVisibleURL`, add `guard await isDomainRegistered(id: id)` — reusing
+the existing `isDomainRegistered(id:)` (L190-204). If the domain isn't registered yet,
+either wait (poll with a short delay) or fail gracefully with a `DebugLog.reader` line
+and a user-facing "wiki is still mounting" message. This kills the race at its source.
+
+### Rejected (do NOT do)
+- `#available(macOS 26, *)` branching — nil is contractually valid on both macOS 15 and 26;
+  version-gating would leave macOS 15 latent.
+- `FileProviderExtension.fetchContents` (`:40`) as an "alternative API" — it's the extension's
+  server-side byte-fetch callback, correctly typed `(URL?, NSFileProviderItem?, Error?)`, NOT a
+  client-side path-resolution API the app can call.
+
+## Files
+- `Sources/WikiFS/Window/FileProviderFacade.swift` — L614-636 (the chokepoint: switch to
+  completion-handler overload + add `MountResolutionError.urlNil`); L256 (gate `resolvePath`
+  on `isDomainRegistered`).
+
+## Acceptance
+- The app does NOT `EXC_BREAKPOINT`/`SIGTRAP` on macOS 26.5.2 during launch / mount
+  resolution / opening a page/source/chat.
+- `getUserVisibleURL` nil → a recoverable error (visible in `DebugLog.reader` + a
+  user-facing message), NOT a trap.
+- `resolvePath` only calls `userVisibleURL` after the domain is confirmed registered.
+- No bare `try?`; no `print`; route through `DebugLog`.
+- `make build && make test` green.
+- Manual validation in the running app (`make run`): cold launch on macOS 26 → no crash;
+  open a page → opens correctly; the mount path resolves.
+
+## Build/test
+`make build && make test`. Push the branch, open a PR with `Closes #756`. **Do NOT merge
+to main.** Scratch in `tmp/` inside your own worktree.


### PR DESCRIPTION
Closes #756

## Root cause (confirmed)

`NSFileProviderManager.getUserVisibleURL(for:)` is imported as `async throws -> URL` (non-optional), bridged from the Obj-C completion handler `(NSURL?, NSError?)`. Apple documents the URL as "or nil if an error occurs" — nil is a **documented, valid** return. The async bridging calls `URL._unconditionallyBridgeFromObjectiveC(_:)`, which **traps** (`brk 1`, `EXC_BREAKPOINT`/`SIGTRAP`) when the `NSURL` is nil. This fires **before** the `throws`/`try` machinery can intervene — an uncatchable Swift runtime trap. The 5-second timeout and `CheckedContinuation` wrapper gave no protection.

**The race:** at launch, two fire-and-forget Tasks compete with no ordering — Task A registers domains (`registerAllDomains`, `WikiFSApp.swift`), Task B resolves the mount path (`RootScene` `activate` → `resolvePath`). `resolvePath` did not gate on `isDomainRegistered` — its only gate was `NSFileProviderManager(for: domain)`, which returns a manager for any identifier whether registered or not. So `getUserVisibleURL(for: .rootContainer)` could be asked of a domain the daemon hadn't finished mounting yet → nil URL → trap.

**macOS 26 specificity:** the trap is latent on macOS 15 too (nil is contractually valid on all versions; no `#available` guards), but macOS Tahoe's `fileproviderd` instability makes the daemon return nil URLs far more often during the launch window, which is why it manifests there.

## Fix

### Primary — switch to the completion-handler overload (the single chokepoint)

`FileProviderFacade.userVisibleURL(manager:itemIdentifier:timeout:)`. Replaced `try await manager.getUserVisibleURL(for:)` with the completion-handler form that returns `URL?` directly:

```swift
manager.getUserVisibleURL(for: itemIdentifier) { url, error in
    Task { @MainActor in
        if let url {
            resolution.succeed(url)
        } else {
            DebugLog.reader("getUserVisibleURL returned nil URL …")
            resolution.fail(error ?? MountResolutionError.urlNil)
        }
    }
}
```

Added `MountResolutionError.urlNil` with a descriptive `errorDescription`. This is the **only** `getUserVisibleURL` call site in the codebase, so it nil-safes every caller (`resolvePath`, `openSource`, `resolvePageByTitleURL`, `resolveChatByNameURL`, `resolveSourceByNameURL`) with no caller-side changes. Nil is now a recoverable error visible in `DebugLog.reader`, not a trap.

### Secondary — gate `resolvePath` on domain registration

`resolvePath` now checks `await isDomainRegistered(id:)` before asking for a visible URL. When the domain isn't registered yet (the launch race), it skips the doomed 5s call and goes straight to (re)registration so the wiki **self-heals** instead of stalling on "still mounting". Preserves the existing register-and-retry recovery for the transient-failure case. `registerDomain` is idempotent (adds only if absent), safe to call while `registerAllDomains` is racing.

### Rejected

- `#available(macOS 26, *)` branching — nil is contractually valid on **both** macOS 15 and 26; version-gating would leave macOS 15 latent.
- `FileProviderExtension.fetchContents` as an "alternative API" — it's the extension's server-side byte-fetch callback, correctly typed `(URL?, NSFileProviderItem?, Error?)`, not a client-side path-resolution API the app can call.

## Acceptance

- `make build` ✓
- `make test` ✓ — 3257 tests in 270 suites, including `FileProviderFacadeMountPathTests.resolvePathCompletesWithoutBlocking`
- Manual (`make run`): cold launch on macOS 26 → no `EXC_BREAKPOINT`/`SIGTRAP`; open a page → opens correctly; mount path resolves ✓
- No bare `try?`; no `print`; routing through `DebugLog`

## Files

- `Sources/WikiFS/Window/FileProviderFacade.swift` — `userVisibleURL` (chokepoint) + `MountResolutionError.urlNil`; `resolvePath` (registration gate)
- `plans/fileprovider-crash-fix.md` — plan document
