### PR TITLE
Bundle uv runtime so pdf2md extraction is self-contained

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -44,6 +44,7 @@ load-bearing for the app to function.
 | [`plans/query-conversation.md`](plans/query-conversation.md) | **Current Query direction:** a dedicated sidebar page with an interactive Claude session; output-first chat by default, hidden tool/internal rows behind a checkbox, and writes via `wikictl` only when the user asks to persist changes. |
 | [`plans/BRINGUP.md`](plans/BRINGUP.md) | The 4-phase bring-up plan from skeleton to v0 (groups INITIAL.md's M0–M6). Source of truth for *the order we build in*. |
 | [`plans/build-environment.md`](plans/build-environment.md) | How the app is built: SwiftPM + `build.sh` + `Makefile`, signing, icon generation, app-bundle layout. Source of truth for *how we build and run*. |
+| [`plans/bundle-uv.md`](plans/bundle-uv.md) | Bundle the `uv` runtime (single static binary, like `bun`) into `Contents/Helpers` so the `pdf2md` PEP 723 script is self-contained — no system uv needed. (#766) |
 | [`plans/file-provider.md`](plans/file-provider.md) | File Provider extension build + the 5 hard-won gotchas (entry-point recursion, entitlements⊆profile, user-enable toggle, /Applications, keychain). Proven by the 2026-06-15 spike. Read before Phase 2. |
 | [`plans/signing.md`](plans/signing.md) | The Apple cert / App Group / File Provider provisioning checklist (manual portal). Do this before Phase 2. Source of truth for *the Apple incantations*. |
 | [`plans/zotero-integration.md`](plans/zotero-integration.md) | browse a Zotero library from inside the app, ingest PDF/Markdown attachments through the existing ingest pipeline. |

--- a/Sources/WikiFS/Sources/PdfExtractionService.swift
+++ b/Sources/WikiFS/Sources/PdfExtractionService.swift
@@ -58,15 +58,22 @@ enum PdfExtractionService {
     private static nonisolated let processRegistry = ProcessRegistry()
 
     /// Directories prepended to a subprocess PATH so the `pdf2md` shebang
-    /// (`env -S uv run --script`) can find `uv`. A Finder-launched app inherits
-    /// the bare system PATH (`/usr/bin:/bin:…`), so cover every place uv
-    /// actually lands: `~/.local/bin` (the official installer),
-    /// `/opt/homebrew/bin` (Homebrew on Apple silicon), and `/usr/local/bin`
-    /// (Homebrew on Intel).
+    /// (`env -S uv run --script`) can find `uv`. The bundled uv binary lives
+    /// in the app's `Contents/Helpers` directory (placed there by build.sh,
+    /// same location as wikictl/bun) and is resolved at runtime via
+    /// `HelpersLocation.wikictlDirectory`, which finds the signed bundle's
+    /// Helpers dir in production and `build/` in a `swift run` dev launch.
+    /// It goes FIRST so the bundled uv wins over any system uv. The remaining
+    /// entries are a fallback if the bundled uv isn't there for some reason:
+    /// `~/.local/bin` (the official uv installer), `/opt/homebrew/bin`
+    /// (Homebrew on Apple silicon), and `/usr/local/bin` (Homebrew on Intel).
+    /// A Finder-launched app inherits the bare system PATH
+    /// (`/usr/bin:/bin:…`), so these cover every place uv actually lands.
     static nonisolated var uvSearchPATH: String {
+        let helpersDir = HelpersLocation.wikictlDirectory
         let localBin = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/bin", isDirectory: true).path
-        return "\(localBin):/opt/homebrew/bin:/usr/local/bin"
+        return "\(helpersDir):\(localBin):/opt/homebrew/bin:/usr/local/bin"
     }
 
     /// Thread-safe byte accumulator for a pipe drained on a background queue.

--- a/build.sh
+++ b/build.sh
@@ -158,6 +158,27 @@ else
   echo "    Or set BUN_INSTALL to point at your bun binary's directory." >&2
   exit 1
 fi
+
+# uv runtime — bundled so pdf2md (a PEP 723 inline script whose shebang is
+# `env -S uv run --script`) works without a system-wide uv install. Same
+# shape as bun: a single static binary (astral-sh/uv). PdfExtractionService
+# prepends this Helpers dir to the subprocess PATH so the bundled uv is found
+# first; the system-uv PATH fallbacks in uvSearchPATH remain as a safety net.
+# REQUIRED: if absent the build fails rather than shipping a broken app that
+# silently degrades PDF extraction to the agent Read tool. See #766.
+UV_SRC="${UV_INSTALL:-$HOME/.local/bin}/uv"
+if [ ! -x "${UV_SRC}" ]; then
+  UV_SRC="$(command -v uv 2>/dev/null || true)"
+fi
+if [ -x "${UV_SRC}" ]; then
+  cp "${UV_SRC}" "${HELPERS_DIR}/uv"
+  echo "  ✓ bundled uv ($(file -b "${UV_SRC}" | cut -d, -f1))"
+else
+  echo "  ✗ FATAL: uv not found" >&2
+  echo "    Install it:  curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+  echo "    Or set UV_INSTALL to point at your uv binary's directory." >&2
+  exit 1
+fi
 # wikictl is a plain CLI with no Info.plist, so it can't read the App Group id
 # the way the .app/.appex do. Drop a sidecar that WikiIdentifiers reads. It must
 # NOT live in Contents/Helpers (a code location — codesign rejects unsigned
@@ -424,6 +445,11 @@ PLIST
     codesign --force --timestamp=none --sign "${IDENTITY}" \
       "${HELPERS_DIR}/bun"
   fi
+  # uv runtime (nested Mach-O) — same inside-out signing as bun.
+  if [ -f "${HELPERS_DIR}/uv" ]; then
+    codesign --force --timestamp=none --sign "${IDENTITY}" \
+      "${HELPERS_DIR}/uv"
+  fi
   echo "→ codesign appex (${IDENTITY})"
   codesign --force --timestamp=none --sign "${IDENTITY}" \
     --entitlements "${EXT_ENTITLEMENTS}" \
@@ -441,6 +467,9 @@ else
   fi
   if [ -f "${HELPERS_DIR}/${PODCAST_HELPER_NAME}" ]; then
     codesign --force --sign - "${HELPERS_DIR}/${PODCAST_HELPER_NAME}"
+  fi
+  if [ -f "${HELPERS_DIR}/uv" ]; then
+    codesign --force --sign - "${HELPERS_DIR}/uv"
   fi
   codesign --force --sign - "${APPEX}"
   codesign --force --sign - "${APP_BUNDLE}"

--- a/plans/bundle-uv.md
+++ b/plans/bundle-uv.md
@@ -1,0 +1,49 @@
+# Bundle `uv` (like `bun`) so pdf2md extraction is self-contained
+
+Issue: #766
+
+## Problem
+The app bundles the `pdf2md` *script* (a PEP 723 inline script whose shebang is
+`#!/usr/bin/env -S uv run --script`) but NOT `uv` — the runtime it needs to
+bootstrap its own Python + dependencies. `PdfExtractionService` falls back to a
+PATH search (`~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) and, if uv
+isn't on the system, degrades to the agent Read tool (raw PDF, no extraction).
+
+## Solution
+Mirror the existing `bun` bundling pattern (single static binary copied into
+`Contents/Helpers/` and codesigned inside-out). `uv` (astral-sh/uv) is the same
+shape — a single self-contained binary.
+
+## Changes
+
+### 1. `build.sh` — bundle uv (mirror bun block at ~L147-160)
+Add a `UV_SRC` resolution + copy block placed right after the bun block:
+- Resolve `UV_SRC` from `UV_INSTALL` → `~/.local/bin/uv` → `command -v uv`.
+- `cp` to `${HELPERS_DIR}/uv`.
+- Fail with an install hint if absent (REQUIRED, matching bun's hard gate).
+- Do NOT touch the bun block — separate binary, separate block.
+
+### 2. `build.sh` — sign the bundled uv (~L391-426)
+Codesign `${HELPERS_DIR}/uv` inside-out (before the outer app), in BOTH the
+real-identity section and the ad-hoc fallback (`codesign --force --sign -`),
+mirroring how bun is signed.
+
+### 3. `Sources/WikiFS/Sources/PdfExtractionService.swift` (`uvSearchPATH`, L60-66)
+Prepend the bundled Helpers directory (resolved via `HelpersLocation.wikictlDirectory`,
+which already finds `Contents/Helpers` in the signed bundle and `build/` in dev)
+to `uvSearchPATH`, so the pdf2md shebang finds the bundled `uv` FIRST. Keep the
+existing system-uv fallback paths (`~/.local/bin`, `/opt/homebrew/bin`,
+`/usr/local/bin`) — they remain a fallback if the bundled uv is absent.
+
+## Guardrails
+- uv is a single static binary — no venv or Python to manage.
+- Do NOT change the pdf2md script itself.
+- Do NOT remove the existing system-uv fallback paths.
+- Bundled uv goes FIRST in the PATH.
+- Bun bundling must remain unaffected (separate binary, separate block).
+- No `print` (DebugLog only); no bare `try?`.
+
+## Build / test
+- `make build` — should bundle uv alongside bun; verify `Helpers/uv` exists.
+- `make test`.
+- Push branch, open PR with `Closes #766`. Do NOT merge to main.


### PR DESCRIPTION
## Summary

The app bundled the `pdf2md` *script* (a PEP 723 inline script whose shebang is `#!/usr/bin/env -S uv run --script`) but NOT `uv` — the runtime it needs to bootstrap its own Python + dependencies. If `uv` wasn't on the system, `PdfExtractionService` degraded to passing the raw PDF to the agent Read tool (no extraction, worse quality + higher token cost).

This mirrors the existing `bun` bundling pattern: `uv` (astral-sh/uv) is the same shape — a single static binary copied into `Contents/Helpers/` and codesigned inside-out.

## Changes

**1. `build.sh` — bundle uv (after the bun block, ~L162)**
Added a `UV_SRC` resolution + copy block right after the bun block.
- Resolution chain: `${UV_INSTALL}/uv` → `~/.local/bin/uv` → `command -v uv` (PATH).
- Copies to `${HELPERS_DIR}/uv`.
- REQUIRED — fails with an install hint (`curl -LsSf https://astral.sh/uv/install.sh | sh`) if absent (same hard gate as bun).
- Bun bundling is unaffected (separate binary, separate block).

**2. `build.sh` — codesign the bundled uv (~L448 / ~L471)**
Signs `${HELPERS_DIR}/uv` inside-out in BOTH the real-identity section and the ad-hoc fallback (`codesign --force --sign -`), same as bun.

**3. `Sources/WikiFS/Sources/PdfExtractionService.swift` — `uvSearchPATH` (L60-76)**
Prepends the bundled Helpers directory (resolved via `HelpersLocation.wikictlDirectory`, which finds `Contents/Helpers` in the signed bundle and `build/` in a `swift run` dev launch) so the pdf2md shebang finds the bundled `uv` FIRST. The existing system-uv fallback paths (`~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) are kept as a safety net.

## Guardrails honored
- uv is a single static binary — no venv or Python to manage.
- The pdf2md script itself is unchanged.
- The existing system-uv fallback paths in `uvSearchPATH` are kept.
- The bundled uv goes FIRST in the PATH.
- Bun bundling is unaffected (separate binary, separate block).
- No `print` (DebugLog only); no bare `try?`.

## Verification
- `make build` bundles `Helpers/uv` (41MB Mach-O arm64) alongside bun; both codesigned.
- Confirmed in the built `.app`: `Contents/Helpers/{uv,bun,pdf2md,wikictl}` all present and signed.
- `make test` passes (3257 tests in 270 suites).

Closes #766
