### PR TITLE
Nudge users toward non-free ingest models (#612)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -243,8 +243,7 @@ let package = Package(
         .testTarget(
             name: "WikiFSCoreTests",
             dependencies: ["WikiFSCore", "WikiCtlCore", "WikiFSEngine",
-                           .product(name: "ACPModel", package: "swift-acp"),
-                           .product(name: "Markdown", package: "swift-markdown")],
+                           .product(name: "ACPModel", package: "swift-acp")],
             path: "Tests/WikiFSTests",
             swiftSettings: strictSwiftSettings
         ),

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -313,6 +313,19 @@ struct AgentsSettingsView: View {
             case .noneCaptured, .selected, .disabled:
                 EmptyView()
             }
+            // #612: info-tone nudge when the provider's selected model is a
+            // known free-tier model (e.g. opencode/big-pickle). NOT a
+            // prohibition — the user can still select it; this is a gentle
+            // steer toward a stronger model. Uses `.secondary` (muted info
+            // tone), NOT `.orange` (warning) — see macos-design caption idiom.
+            if let modelId = config.selectedModelId(forProvider: provider.id),
+               let nudge = FreeTierModelNudge.message(for: modelId) {
+                Text(nudge)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
+                    .frame(maxWidth: 180)
+            }
         }
     }
 

--- a/Sources/WikiFS/Settings/StageProviderModelPicker.swift
+++ b/Sources/WikiFS/Settings/StageProviderModelPicker.swift
@@ -77,7 +77,27 @@ struct StageProviderModelPicker: View {
             .help(resolvedModels.isEmpty
                   ? "Chat with this provider once to discover its models."
                   : "Pick a model for the \(label) stage. “Same as provider” uses the provider's selected model.")
+
+            // #612: info-tone nudge when the stage's resolved model (pinned or
+            // inherited from the provider) is a known free-tier model (e.g.
+            // opencode/big-pickle). NOT a prohibition — the user can still
+            // select it; this is a gentle steer toward a stronger model. Uses
+            // `.secondary` (muted info tone), NOT `.orange` (warning).
+            if let nudge = freeTierNudge {
+                Text(nudge)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
+    }
+
+    /// #612: the free-tier nudge message for this stage's resolved model, or
+    /// `nil` when the model is not a known free-tier model. Resolves through
+    /// `config.modelId(forStage:)` so it fires whether the user pinned a
+    /// specific model OR left "Same as provider" and the provider's own
+    /// `selectedModelId` is free-tier. PURE (reads only the config).
+    private var freeTierNudge: String? {
+        FreeTierModelNudge.message(for: config.modelId(forStage: stageKey))
     }
 
     /// Reads/writes `config.stageProviderIds[stageKey]`. On set, routes through

--- a/Sources/WikiFSCore/Core/FreeTierModelNudge.swift
+++ b/Sources/WikiFSCore/Core/FreeTierModelNudge.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// #612: detects known free-tier models that may not follow ingestion
+/// instructions reliably, so the Settings UI can show an **info-tone nudge**
+/// (NOT a warning/prohibition) steering the user toward a stronger model.
+///
+/// PR #605 closed the "no model" hole (`SpawnModelGuard` refuses to spawn
+/// without an explicit `selectedModelId`), but it doesn't steer users OFF
+/// free-tier models (e.g. `opencode/big-pickle`) that drift from instructions.
+/// This helper powers the gentle nudge caption shown in the Agents-settings
+/// pickers — it never blocks selection.
+///
+/// PURE + STATIC + `nonisolated` so it can be unit-tested without rendering
+/// and called from any actor. Mirrors the `SpawnModelGuard` shape (pure, no I/O)
+/// and the `modelWarning(for:in:)` pattern on `AgentsSettingsView` (static,
+/// testable, surfaced as a caption).
+public enum FreeTierModelNudge {
+
+    /// Known free-tier model id substrings. A model id is considered free-tier
+    /// when it contains any of these (case-insensitive). Extend this set as
+    /// new free-tier models are identified. Kept as `public` so tests can pin
+    /// the membership and future code can assert coverage.
+    public static let freeTierModelPatterns: [String] = [
+        "big-pickle",
+        "big_pickle",
+    ]
+
+    /// The info-tone nudge message shown beneath a picker whose selected model
+    /// is a known free-tier model. Surfaced as a `.secondary` (muted) caption —
+    /// NOT an orange warning or a red error — so it reads as advice, not alarm.
+    public static let nudgeMessage: String = (
+        "Free-tier models may not follow ingestion instructions reliably. "
+        + "Consider a stronger model."
+    )
+
+    /// Returns the nudge message when `modelId` matches a known free-tier
+    /// pattern; `nil` otherwise. PURE — no I/O, no actor. Case-insensitive
+    /// substring match so `opencode/big-pickle`, `BIG-PICKLE`, and
+    /// `big_pickle_v2` all fire.
+    ///
+    /// - Parameter modelId: The resolved model id (e.g. the stage's
+    ///   `config.modelId(forStage:)` result or a provider's
+    ///   `selectedModelId`). `nil`/empty → `nil` (no nudge).
+    /// - Returns: The nudge message string when the model is free-tier; `nil`
+    ///   when the model is unknown or free of free-tier patterns.
+    public static func message(for modelId: String?) -> String? {
+        guard let modelId, !modelId.isEmpty else { return nil }
+        let lower = modelId.lowercased()
+        guard freeTierModelPatterns.contains(where: { lower.contains($0) }) else {
+            return nil
+        }
+        return nudgeMessage
+    }
+}

--- a/Tests/WikiFSTests/FreeTierModelNudgeTests.swift
+++ b/Tests/WikiFSTests/FreeTierModelNudgeTests.swift
@@ -1,6 +1,5 @@
 import Testing
 import Foundation
-@testable import WikiFS
 import WikiFSCore
 
 /// Pure-logic tests for `FreeTierModelNudge` (#612).

--- a/Tests/WikiFSTests/FreeTierModelNudgeTests.swift
+++ b/Tests/WikiFSTests/FreeTierModelNudgeTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import Foundation
+@testable import WikiFS
+import WikiFSCore
+
+/// Pure-logic tests for `FreeTierModelNudge` (#612).
+///
+/// The helper powers the info-tone nudge caption shown in the Agents-settings
+/// pickers when the selected model is a known free-tier model (e.g.
+/// `opencode/big-pickle`). It never blocks selection — the caption is a gentle
+/// steer toward a stronger model. PURE + STATIC so these tests call it
+/// directly without a SwiftUI view tree.
+@Suite("FreeTierModelNudge")
+struct FreeTierModelNudgeTests {
+
+    // MARK: - Returns nil for non-free-tier models
+
+    @Test func returnsNilForNilModelId() {
+        #expect(FreeTierModelNudge.message(for: nil) == nil)
+    }
+
+    @Test func returnsNilForEmptyModelId() {
+        #expect(FreeTierModelNudge.message(for: "") == nil)
+    }
+
+    @Test func returnsNilForRegularModel() {
+        #expect(FreeTierModelNudge.message(for: "sonnet") == nil)
+        #expect(FreeTierModelNudge.message(for: "claude-sonnet-4.5") == nil)
+        #expect(FreeTierModelNudge.message(for: "glm-4.7") == nil)
+    }
+
+    // MARK: - Returns nudge for free-tier models
+
+    @Test func returnsNudgeForBigPickle() {
+        let msg = FreeTierModelNudge.message(for: "opencode/big-pickle")
+        #expect(msg != nil)
+        #expect(msg?.contains("Free-tier models") == true)
+        #expect(msg?.contains("stronger model") == true)
+    }
+
+    @Test func returnsNudgeForBigPickleUnderscoreVariant() {
+        let msg = FreeTierModelNudge.message(for: "opencode/big_pickle")
+        #expect(msg != nil)
+    }
+
+    @Test func returnsNudgeCaseInsensitive() {
+        #expect(FreeTierModelNudge.message(for: "BIG-PICKLE") != nil)
+        #expect(FreeTierModelNudge.message(for: "Big_Pickle") != nil)
+    }
+
+    @Test func returnsNudgeForModelIdContainingPattern() {
+        // The pattern is a substring match, so a versioned or prefixed id
+        // still fires.
+        #expect(FreeTierModelNudge.message(for: "opencode/big-pickle-v2") != nil)
+        #expect(FreeTierModelNudge.message(for: "free/big-pickle-mini") != nil)
+    }
+
+    @Test func returnsSameMessageForAllFreeTierModels() {
+        // The message is a constant, not model-specific — pin it so the UI
+        // caption is stable.
+        let a = FreeTierModelNudge.message(for: "opencode/big-pickle")
+        let b = FreeTierModelNudge.message(for: "other/big_pickle")
+        #expect(a == b)
+        #expect(a == FreeTierModelNudge.nudgeMessage)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #612.

PR #605 closed the "no model" hole — `SpawnModelGuard` now refuses to spawn without an explicit `selectedModelId`. But it doesn't steer users off **free-tier models** (e.g. `opencode/big-pickle`) that drift from ingestion instructions. Users could still pick a free-tier model and get silently degraded ingestion quality.

This PR adds an **info-tone nudge caption** (muted `.secondary`, not orange-warning) that appears beneath the model pickers when the selected model is a known free-tier model. It is advisory — it never blocks selection.

## Changes

### New: `FreeTierModelNudge` (pure helper)
- `Sources/WikiFSCore/Core/FreeTierModelNudge.swift`
- Pure, static, `nonisolated` — unit-testable without rendering.
- Case-insensitive substring match against known free-tier model id patterns: `big-pickle`, `big_pickle`.
- Returns the nudge message string or `nil`.

### `AgentsSettingsView.providerControls`
- Below the per-provider model picker, shows the nudge caption when the provider's `selectedModelId` is a known free-tier model.
- Follows the existing `modelWarning` caption pattern but with `.foregroundStyle(.secondary)` (muted info tone) instead of `.orange` (warning).

### `StageProviderModelPicker.body`
- Below the per-stage model picker, shows the nudge caption when the stage's **resolved** model (`config.modelId(forStage:)`) is a known free-tier model.
- Resolves through `modelId(forStage:)` so it fires whether the user pinned a specific model OR left "Same as provider" and the provider's own `selectedModelId` is free-tier.

### Tests
- `Tests/WikiFSTests/FreeTierModelNudgeTests.swift` — 8 tests covering nil/empty, regular models, `big-pickle` variants, case-insensitivity, substring matching, and message stability.

## Guardrails
- Does NOT block free-tier model selection — it's a nudge, not a prohibition.
- Uses `.secondary` foreground (muted info tone), not `.orange` or `.red` — reads as advice, not alarm (per macos-design caption idiom).
- No `print` (DebugLog only). No bare `try?`.

## Build / Test
- `swift build` — ✅ 
- `swift test --filter FreeTierModelNudgeTests` — ✅ 8 passed
- `swift test --filter "AgentsSettingsViewWarningTests|AgentsSettingsViewModelStatusTests"` — ✅ 13 passed (no regressions)
