### PR TITLE
Fix #759: queued chat messages render below composer + never auto-send

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7464,3 +7464,46 @@ which was touched. No test previously rendered `permissionSection`.
 **Result:** 260 suites / 3064 tests pass. `swift build` clean.
 
 **Build:** `make version prompts && swift build && swift test`.
+
+---
+
+## #759 — chat-queue rendering + auto-send fix
+
+**Regression of #740 (PR #751):** the feature shipped but two things were
+broken. `Sources/WikiFS/Chats/ChatView.swift` only.
+
+**LAYOUT** — the queued-message list rendered BELOW the composer (it was
+placed after `composer(enabled:)` in the `chatComposer` VStack). Moved it
+ABOVE the composer so stacked "up next" items read as a playlist feeding
+into the input (macos-design: muted, above the affordance they feed).
+
+**AUTO-SEND** — the turn-completion observer was wired to
+`.onChange(of: launcher.isRunning)`, but an interactive session keeps
+`isRunning == true` across turns (the claude process stays alive). The real
+per-turn "done, ready for next input" signal is `launcher.isGenerating`
+going false (set in `setGenerating(false)` at the `endsGeneration` event, or
+in `finish()` on process death). Added `.onChange(of: launcher.isGenerating)`
+that fires the first queued message one-per-turn via the same `submitMessage`
+path a manual Send uses. The original `isRunning` observer stays as the
+session-end-between-turns fallback; both are safe to co-fire because
+`firePendingQueuedMessage` drains exactly one item and then the queue is
+empty (the second observer's guard no-ops). #740 multi-queue was already an
+array (`[PendingQueuedMessage]`) with `removeFirst()` playlist semantics —
+no change needed there.
+
+**EDIT affordance** — added a per-row pencil button that pulls a specific
+queued message back into the composer draft for editing (removes it from its
+slot; remaining items shift down). Guarded by `.disabled(hasDraftText)` so a
+half-typed draft is never overwritten (write rules: never lose the user's
+in-flight text). The user re-queues the edited text via Send/Queue as normal.
+Cancel (✕) already existed.
+
+**No bare `try?`** in the queue/fire path — `submitMessage` uses
+`sendInteractiveMessage` (sync void) or spawns `Task { await ... }` for the
+async `continueChat`/`startChat` paths, which log via `DebugLog` internally.
+No `print`. DebugLog only.
+
+**Result:** `swift build` clean. 270 suites / 3257 tests pass.
+
+**Build:** `swift build && swift test`.
+

--- a/Sources/WikiFS/Chats/ChatView.swift
+++ b/Sources/WikiFS/Chats/ChatView.swift
@@ -161,17 +161,34 @@ struct ChatView: View {
             // later ingest/lint run doesn't inherit it and strand the view on
             // `AgentQueueView`. (AC.1)
             if !isRunning { showsInternals = false }
-            // #740: when a turn completes, deliver the FIRST queued message as
-            // the next turn's input (playlist: one per turn). The rest stay queued
-            // and each fires in order as subsequent turns complete. Only fires what
-            // was explicitly queued via the Queue button — a half-typed draft stays
-            // in the composer untouched (it isn't part of `queuedMessages`). The
-            // dispatch goes through the same `submitMessage` path used by a normal
-            // Send, so it reuses the interactive/continue/start routing without
-            // disturbing the draft.
+            // #759: covers the session-end-between-turns case — when the whole
+            // process exits with a queued message still pending, deliver it as the
+            // next turn via the same `submitMessage` path used by a normal Send.
+            // (Per-turn completion is handled by the `isGenerating` observer below;
+            // both observers are safe to co-fire because `firePendingQueuedMessage`
+            // drains exactly one item and then the queue is empty — the second
+            // observer's guard no-ops.)
             if !isRunning, !queuedMessages.isEmpty {
                 firePendingQueuedMessage()
             }
+        }
+        // #759: the per-turn completion signal. An interactive session keeps
+        // `isRunning == true` across turns (the claude process stays alive), so the
+        // observer above would never fire between turns — the queued message would
+        // sit forever until the session ended. The real "turn done, ready for next
+        // input" transition is `isGenerating` going false (set in `setGenerating(false)`
+        // at the `endsGeneration` event, or in `finish()` on process death). Fire the
+        // first queued message there, one per turn. Only fires what was explicitly
+        // queued via the Queue button / Return-during-generation — a half-typed draft
+        // stays in the composer untouched (it isn't part of `queuedMessages`).
+        .onChange(of: launcher.isGenerating) { _, isGenerating in
+            guard !isGenerating else { return }
+            // Skip the initial "not generating" state and any transition that isn't
+            // a turn boundary: only fire while the session is still alive. (When the
+            // process dies, `isRunning` goes false too and the observer above handles
+            // delivery — this guard avoids a redundant dispatch on that path.)
+            guard launcher.isRunning, !queuedMessages.isEmpty else { return }
+            firePendingQueuedMessage()
         }
         .task(id: chatID) {
             // Reload persisted messages whenever the chatID changes (or the store
@@ -433,12 +450,17 @@ struct ChatView: View {
     /// The composer, placed once as a VStack sibling below the transcript (the
     /// live placement). For a persisted (non-live) chat it also carries the
     /// "another chat is responding" caption when the kind's launcher is busy.
+    ///
+    /// #759: the queued-message list renders ABOVE the composer text field so
+    /// stacked "up next" items read as a playlist feeding into the input,
+    /// not as an afterthought dangling below it. (macos-design: muted,
+    /// above the affordance they feed, clearly secondary.)
     private var chatComposer: some View {
         VStack(spacing: 4) {
-            composer(enabled: isComposerEnabled)
             if !queuedMessages.isEmpty {
                 queuedMessagesList
             }
+            composer(enabled: isComposerEnabled)
             if let caption = composerCaption {
                 Text(caption)
                     .font(.caption)
@@ -488,6 +510,21 @@ struct ChatView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 0)
+            // #759: edit-before-fires affordance. Pulls this message back into
+            // the composer draft for editing, removing it from the queue. Only
+            // acts when the draft is empty — a half-typed draft is preserved
+            // (write rules: never lose the user's in-flight text). The user can
+            // finish/discard their draft first and then edit the queued item.
+            Button {
+                editQueuedMessage(at: index)
+            } label: {
+                Image(systemName: "pencil")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Edit this queued message")
+            .disabled(hasDraftText)
             Button {
                 queuedMessages.remove(at: index)
             } label: {
@@ -1217,6 +1254,18 @@ struct ChatView: View {
     /// are rebuilt from current attachments on the next queue/send).
     private func recallQueuedMessage() {
         guard let pending = queuedMessages.popLast() else { return }
+        store.draftChatMessage = pending.preview
+    }
+
+    /// #759: pull a specific queued message back into the composer draft for
+    /// editing, removing it from its slot in the queue. The remaining items
+    /// shift down (the first still fires next). Only acts when the draft is
+    /// empty (guarded by the row's `.disabled(hasDraftText)`) — a half-typed
+    /// draft is never overwritten. The user re-queues the edited text via
+    /// Send/Queue as normal.
+    private func editQueuedMessage(at index: Int) {
+        guard !hasDraftText, queuedMessages.indices.contains(index) else { return }
+        let pending = queuedMessages.remove(at: index)
         store.draftChatMessage = pending.preview
     }
 


### PR DESCRIPTION
Closes #759.

## What was broken

Regression of #740 (PR #751) — the chat-queue feature shipped but two things
were broken in `Sources/WikiFS/Chats/ChatView.swift`:

1. **Layout:** the queued-message list rendered *below* the composer (placed
   after `composer(enabled:)` in the `chatComposer` VStack), not above it.
2. **Auto-send:** the turn-completion observer was wired to
   `.onChange(of: launcher.isRunning)`, but an interactive session keeps
   `isRunning == true` across turns (the claude process stays alive between
   turns). So the queued message never auto-fired when a turn ended — it sat
   until the whole session exited.

## Fix

### Layout
Moved `queuedMessagesList` above `composer(enabled:)` in the `chatComposer`
VStack so stacked `up next` items read as a playlist feeding into the text
field (macos-design: muted, above the affordance they feed, clearly
secondary).

### Auto-send
Added `.onChange(of: launcher.isGenerating)` that fires when `isGenerating`
transitions to `false` — the real per-turn `done, ready for next input`
signal (set in `setGenerating(false)` at the `endsGeneration` event, or in
`finish()` on process death). If the queue is non-empty, it delivers the
**first** queued message as the next turn's input via the same
`submitMessage` path a manual Send uses (no parallel send path). One per
turn; the rest stay queued.

The original `isRunning` observer stays as the session-end-between-turns
fallback. Both observers are safe to co-fire: `firePendingQueuedMessage`
drains exactly one item, then the queue is empty and the second observer's
guard no-ops.

### Edit affordance
Added a per-row pencil button that pulls a specific queued message back into
the composer draft for editing (removes it from its slot; remaining items
shift down, the first still fires next). Guarded by
`.disabled(hasDraftText)` so a half-typed draft is never overwritten (write
rules: never lose the user's in-flight text). The user re-queues the edited
text via Send/Queue as normal. Cancel (✕) already existed.

### Multi-queue
Already an array (`[PendingQueuedMessage]`) with `removeFirst()`
playlist semantics from #740 — no change needed.

## Guardrails
- No bare `try?` in the queue/fire path. `submitMessage` uses
  `sendInteractiveMessage` (sync void) or spawns `Task { await ... }` for the
  async `continueChat`/`startChat` paths, which log via `DebugLog`
  internally.
- No `print` (DebugLog only).
- A half-typed draft is preserved — only queued-via-Send auto-fires; the
  draft stays as draft text.
- Loaded `macos-design` skill for the queued-message affordance guidance
  (muted, above the composer, clear).

## Build/test
- `swift build` — clean.
- `swift test` — 270 suites / 3257 tests pass.

## Validate in `make run`
Start a chat turn; type + Send during generation → queues above the
composer; type another + Send → stacks; when the turn ends → first queued
message auto-sends as the next turn; cancel / edit work.
