### PR TITLE
Fix #738: env-var editor hints, validation, tightened layout

### DIFF
--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -835,36 +835,7 @@ private struct ProviderEditorView: View {
                 }
 
                 DisclosureGroup(isExpanded: $showAdvanced) {
-                    Section {
-                        ForEach($envRows) { $row in
-                            HStack {
-                                TextField("KEY", text: $row.key)
-                                    .fontDesign(.monospaced)
-                                    .frame(maxWidth: 160)
-                                TextField("value", text: $row.value)
-                                    .fontDesign(.monospaced)
-                                Button {
-                                    envRows.removeAll { $0.id == row.id }
-                                } label: {
-                                    Image(systemName: "minus.circle")
-                                }
-                                .buttonStyle(.borderless)
-                            }
-                        }
-                        Button {
-                            envRows.append(EnvRow(key: "", value: ""))
-                        } label: {
-                            Label("Add Variable", systemImage: "plus")
-                        }
-                        .buttonStyle(.borderless)
-                    } header: {
-                        Text("Environment")
-                    } footer: {
-                        Text("Non-secret configuration only — API keys and other secrets belong in the field below, never here (this list is stored in plain JSON).")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
+                    envVarsSection
                     Section {
                         SecureField("API Key", text: $apiKey, prompt: Text("optional"))
                     } header: {
@@ -904,7 +875,7 @@ private struct ProviderEditorView: View {
                     // (`SpawnModelGuard`). The "Provider default" picker option
                     // (tag "") counts as no selection: it leaves the provider
                     // with no selectedModelId.
-                    .disabled(label.trimmingCharacters(in: .whitespaces).isEmpty || selectedModelId.isEmpty)
+                    .disabled(!canSave)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 10)
@@ -938,6 +909,156 @@ private struct ProviderEditorView: View {
                 isAvailable = if case .found = result { true } else { false }
             }
         }
+    }
+
+    // MARK: - Env-var editor (#738)
+
+    /// The env-var Section with tightened layout, inline validation hints, and
+    /// suggested-keys guidance. Replaces the old bare KEY/value `HStack` list
+    /// with aligned columns, per-row red error text, and a muted common-keys
+    /// hint line surfaced from `EnvVarHints`.
+    @ViewBuilder
+    private var envVarsSection: some View {
+        Section {
+            ForEach($envRows) { $row in
+                envRowView(for: $row)
+            }
+            Button {
+                envRows.append(EnvRow(key: "", value: ""))
+            } label: {
+                Label("Add Variable", systemImage: "plus")
+            }
+            .buttonStyle(.borderless)
+        } header: {
+            HStack(spacing: 4) {
+                Text("Environment")
+                if let hintError = envSectionError {
+                    Spacer()
+                    Text(hintError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+        } footer: {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Non-secret configuration only — API keys and other secrets belong in the field below, never here (this list is stored in plain JSON).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let hints = EnvVarHints.hints(forProviderID: originalID),
+                   !hints.isEmpty {
+                    suggestedKeysView(hints)
+                }
+            }
+        }
+    }
+
+    /// One env-var row: aligned KEY/value columns + remove button + a red
+    /// per-row error hint when the key is empty-with-value or duplicated.
+    @ViewBuilder
+    private func envRowView(for row: Binding<EnvRow>) -> some View {
+        let trimmedKey = row.wrappedValue.key.trimmingCharacters(in: .whitespaces)
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                TextField("KEY", text: row.key)
+                    .fontDesign(.monospaced)
+                    .frame(maxWidth: 160)
+                TextField("value", text: row.value)
+                    .fontDesign(.monospaced)
+                Button {
+                    envRows.removeAll { $0.id == row.wrappedValue.id }
+                } label: {
+                    Image(systemName: "minus.circle")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.borderless)
+                .help("Remove variable")
+            }
+            // Per-row inline error: empty key with a non-empty value, or a
+            // duplicated key. By design we do NOT flag a fully-empty row
+            // (both key+value blank) — it gets dropped on save, matching the
+            // pre-existing `save()` behavior.
+            if let rowError = envRowError(for: trimmedKey, rawRow: row.wrappedValue) {
+                Text(rowError)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    /// Muted "Common variables" hint line listing the suggested keys for the
+    /// current provider, so users don't have to guess exact names when
+    /// following troubleshooting guidance (#733 / #737).
+    @ViewBuilder
+    private func suggestedKeysView(_ hints: [EnvVarHints.Hint]) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Common variables for this provider:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ForEach(hints, id: \.key) { hint in
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(hint.key)
+                        .font(.caption)
+                        .fontDesign(.monospaced)
+                    Text("— \(hint.description)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: Env-var validation
+
+    /// Set of key strings (trimmed) that appear more than once across the
+    /// env rows. Empty when no duplicates. Computed on every render but cheap
+    /// (env lists are short — at most a handful of rows).
+    private var duplicateKeys: Set<String> {
+        var counts: [String: Int] = [:]
+        for row in envRows {
+            let key = row.key.trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { continue }
+            counts[key, default: 0] += 1
+        }
+        return Set(counts.filter { $0.value > 1 }.keys)
+    }
+
+    /// A per-row error message for the given trimmed key, or `nil` when the
+    /// row is valid. A fully-empty row (empty key + empty value) is NOT an
+    /// error — it gets dropped on save.
+    private func envRowError(for trimmedKey: String, rawRow: EnvRow) -> String? {
+        if trimmedKey.isEmpty {
+            // Only flag when the value is non-empty — a fully blank row is a
+            // not-yet-filled row, which is fine (dropped on save).
+            return rawRow.value.isEmpty ? nil : "Key is required"
+        }
+        if duplicateKeys.contains(trimmedKey) {
+            return "Duplicate key"
+        }
+        return nil
+    }
+
+    /// A section-level error summary (shown in the header) when there are any
+    /// duplicate or empty-key-with-value rows. `nil` when env rows are clean.
+    private var envSectionError: String? {
+        if !duplicateKeys.isEmpty {
+            return "Resolve duplicate keys"
+        }
+        for row in envRows {
+            let key = row.key.trimmingCharacters(in: .whitespaces)
+            if key.isEmpty && !row.value.isEmpty {
+                return "Resolve empty keys"
+            }
+        }
+        return nil
+    }
+
+    /// Whether the editor can be saved. Combines the pre-existing model/label
+    /// guards (#663) with the #738 env-var validation (no duplicate or
+    /// empty-with-value keys).
+    private var canSave: Bool {
+        let labelClean = label.trimmingCharacters(in: .whitespaces)
+        guard !labelClean.isEmpty, !selectedModelId.isEmpty else { return false }
+        return envSectionError == nil
     }
 
     /// #640: drive the ACP model-discovery probe for THIS provider. Mirrors

--- a/Sources/WikiFS/Settings/EnvVarHints.swift
+++ b/Sources/WikiFS/Settings/EnvVarHints.swift
@@ -1,0 +1,73 @@
+import WikiFSCore
+
+/// #738: per-provider "common env vars" hints surfaced under the env-var editor
+/// so users configuring env-based fixes (e.g. `CLAUDE_CODE_EXECUTABLE` per #733,
+/// `CODEX_PATH` per #737) don't have to guess exact key names.
+///
+/// A muted-hint approach (not autocomplete) — the issue explicitly calls a
+/// simple muted list acceptable when autocomplete would be too heavy. The list
+/// is deliberately short and provider-specific; generic browser-style env vars
+/// (PATH, HOME) are NOT listed because the app already injects/manages those
+/// (`ACPBackend.buildAgentEnv` owns WIKI_DB / WIKICTL / PATH).
+///
+/// PURE + Sendable so it is unit-testable without rendering.
+struct EnvVarHints {
+
+    /// A single suggested key + a short one-line description of what it does.
+    struct Hint: Sendable, Equatable {
+        let key: String
+        let description: String
+    }
+
+    /// Returns the suggested env-var hints for the given provider id, or `nil`
+    /// when there are no known hints (the editor renders no hint line). The
+    /// provider id follows `AgentProvider.id` / `KnownACPAgent.id` — e.g.
+    /// "claude-acp", "gemini", "hermes", "codex", "custom".
+    static func hints(forProviderID id: String) -> [Hint]? {
+        switch id {
+        case "claude-acp":
+            return [
+                .init(key: "CLAUDE_CODE_EXECUTABLE",
+                      description: "Path to the `claude` binary when it is not on PATH."),
+                .init(key: "ANTHROPIC_API_KEY",
+                      description: "Anthropic API key (prefer the API Key field below for Keychain storage)."),
+            ]
+        case "gemini":
+            return [
+                .init(key: "GEMINI_API_KEY",
+                      description: "Google AI API key (prefer the API Key field below for Keychain storage)."),
+                .init(key: "GOOGLE_GENAI_USE_VERTEXAI",
+                      description: "Set to \"1\" to use Vertex AI instead of the Gemini API."),
+            ]
+        case "codex":
+            return [
+                .init(key: "CODEX_PATH",
+                      description: "Path to the `codex` binary when it is not on PATH."),
+                .init(key: "OPENAI_API_KEY",
+                      description: "OpenAI API key (prefer the API Key field below for Keychain storage)."),
+            ]
+        case "opencode":
+            return [
+                .init(key: "OPENAI_API_KEY",
+                      description: "OpenAI API key (prefer the API Key field below for Keychain storage)."),
+                .init(key: "ANTHROPIC_API_KEY",
+                      description: "Anthropic API key (prefer the API Key field below for Keychain storage)."),
+            ]
+        case "goose":
+            return [
+                .init(key: "GOOSE_PROVIDER",
+                      description: "The model provider Goose should use (e.g. \"anthropic\", \"openai\")."),
+                .init(key: "GOOSE_MODEL",
+                      description: "The model id Goose should use."),
+            ]
+        case "hermes", "copilot", "kimi", "cursor", "kiro", "grok",
+             "codewhale", "kilo":
+            // Known catalogs with no app-specific env hints yet — return nil so
+            // the editor shows the generic guidance line instead.
+            return nil
+        default:
+            // Custom / unknown provider ids: no provider-specific hints.
+            return nil
+        }
+    }
+}

--- a/Tests/WikiFSTests/EnvVarHintsTests.swift
+++ b/Tests/WikiFSTests/EnvVarHintsTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import Foundation
+@testable import WikiFS
+
+/// #738: tests for the per-provider env-var hints catalog surfaced under the
+/// env-var editor. The hints are pure data — no SwiftUI rendering needed —
+/// so these tests call `EnvVarHints.hints(forProviderID:)` directly.
+///
+/// The validation computed properties (`duplicateKeys`, `envSectionError`,
+/// `canSave`) are private to `ProviderEditorView` and are exercised indirectly
+/// via the build + manual validation in `make run`; the catalog coverage here
+/// pins the key→hint mapping so a future regression can't silently drop the
+/// `CLAUDE_CODE_EXECUTABLE` / `CODEX_PATH` guidance that #733/#737 rely on.
+@Suite("EnvVarHints")
+struct EnvVarHintsTests {
+
+    // MARK: - Providers with known hints
+
+    @Test func claudeAcpSurfacesClaudeCodeExecutable() {
+        // #733: the Claude ACP provider must surface CLAUDE_CODE_EXECUTABLE so
+        // users following the "set CLAUDE_CODE_EXECUTABLE" guidance can find
+        // the exact key name without guessing.
+        let hints = EnvVarHints.hints(forProviderID: "claude-acp")
+        #expect(hints != nil)
+        #expect(hints?.contains(where: { $0.key == "CLAUDE_CODE_EXECUTABLE" }) == true)
+    }
+
+    @Test func codexProviderSurfacesCodexPath() {
+        // #737: a Codex provider (id "codex") must surface CODEX_PATH.
+        let hints = EnvVarHints.hints(forProviderID: "codex")
+        #expect(hints != nil)
+        #expect(hints?.contains(where: { $0.key == "CODEX_PATH" }) == true)
+    }
+
+    @Test func geminiSurfacesGeminiApiKey() {
+        let hints = EnvVarHints.hints(forProviderID: "gemini")
+        #expect(hints != nil)
+        #expect(hints?.contains(where: { $0.key == "GEMINI_API_KEY" }) == true)
+    }
+
+    @Test func gooseSurfacesGooseProvider() {
+        let hints = EnvVarHints.hints(forProviderID: "goose")
+        #expect(hints != nil)
+        #expect(hints?.contains(where: { $0.key == "GOOSE_PROVIDER" }) == true)
+    }
+
+    // MARK: - Providers with no known hints
+
+    @Test func hermesHasNoHints() {
+        // Hermes has no app-specific env hints yet — nil so the editor shows
+        // no hint line (rather than an empty "Common variables" block).
+        #expect(EnvVarHints.hints(forProviderID: "hermes") == nil)
+    }
+
+    @Test func copilotHasNoHints() {
+        #expect(EnvVarHints.hints(forProviderID: "copilot") == nil)
+    }
+
+    // MARK: - Custom / unknown providers
+
+    @Test func customProviderHasNoHints() {
+        #expect(EnvVarHints.hints(forProviderID: "custom") == nil)
+    }
+
+    @Test func unknownProviderHasNoHints() {
+        #expect(EnvVarHints.hints(forProviderID: "totally-unknown") == nil)
+    }
+
+    // MARK: - Hint shape
+
+    @Test func hintsAreNonEmptyAndHaveDescriptions() {
+        // Every hint across every provider that returns non-nil must have a
+        // non-empty key + description — an empty hint would render as a blank
+        // line in the editor footer.
+        let providerIDs = ["claude-acp", "gemini", "codex", "opencode", "goose"]
+        for id in providerIDs {
+            guard let hints = EnvVarHints.hints(forProviderID: id) else {
+                Issue.record("Expected hints for provider \(id)")
+                continue
+            }
+            #expect(!hints.isEmpty, "Hints for \(id) should not be empty")
+            for hint in hints {
+                #expect(!hint.key.isEmpty, "Hint key should not be empty for \(id)")
+                #expect(!hint.description.isEmpty, "Description should not be empty for \(id)/\(hint.key)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #738

## Summary

The env-var editor in the provider settings sheet was a blank freeform list with no validation and no hints. This PR tightens the layout, adds duplicate/empty-key validation, and surfaces per-provider common env-var hints.

## Changes

### 1. Layout tightening
- Extracted the env Section into `envVarsSection` + `envRowView(for:)` with aligned KEY/value columns, consistent spacing (`spacing: 8`), and the `.frame(maxWidth: 160)` key-field treatment applied uniformly.
- Added `.help("Remove variable")` tooltip on the minus button.
- Each row is wrapped in a `VStack` that can show an inline error below the fields.

### 2. Validation (duplicate / empty keys)
- Added `duplicateKeys`, `envRowError(for:rawRow:)`, `envSectionError`, and `canSave` computed properties.
- **Save button** is now disabled when env rows have duplicate keys or empty keys with a non-empty value.
- **Per-row red hints**: "Key is required" (empty key + non-empty value) / "Duplicate key".
- **Section header summary**: "Resolve duplicate keys" / "Resolve empty keys".
- A fully-empty row (blank key+value) is NOT an error — it's dropped on save (pre-existing `save()` behavior preserved).

### 3. Suggested keys hint
- New `EnvVarHints` catalog (`Sources/WikiFS/Settings/EnvVarHints.swift`) — per-provider common env-var keys surfaced as a muted hint in the env footer:
  - `claude-acp` → `CLAUDE_CODE_EXECUTABLE` (#733), `ANTHROPIC_API_KEY`
  - `codex` → `CODEX_PATH` (#737), `OPENAI_API_KEY`
  - `gemini` → `GEMINI_API_KEY`, `GOOGLE_GENAI_USE_VERTEXAI`
  - `goose` → `GOOSE_PROVIDER`, `GOOSE_MODEL`
  - `opencode` → `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`
- Providers with no known hints (hermes, copilot, custom, etc.) show no hint line.

## Files
- `Sources/WikiFS/Settings/EnvVarHints.swift` (new)
- `Sources/WikiFS/Settings/AgentsSettingsView.swift` (env Section rewrite + validation)
- `Tests/WikiFSTests/EnvVarHintsTests.swift` (new, 9 tests)
- `PROGRESS.md`

## Verification
- `swift build` — passes
- `swift test` — 3266 tests pass (9 new)
- Manual: `make run` → Agents settings → Edit provider → Advanced → env-var editor: aligned columns, red hints on duplicate/empty keys, Save disabled when invalid, common keys listed in footer.
