### PR TITLE
Use defuddle for HTML source content extraction (#761)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -243,8 +243,7 @@ let package = Package(
         .testTarget(
             name: "WikiFSCoreTests",
             dependencies: ["WikiFSCore", "WikiCtlCore", "WikiFSEngine",
-                           .product(name: "ACPModel", package: "swift-acp"),
-                           .product(name: "Markdown", package: "swift-markdown")],
+                           .product(name: "ACPModel", package: "swift-acp")],
             path: "Tests/WikiFSTests",
             swiftSettings: strictSwiftSettings
         ),

--- a/Sources/WikiFS/Sources/DefuddleExtractionService.swift
+++ b/Sources/WikiFS/Sources/DefuddleExtractionService.swift
@@ -44,7 +44,10 @@ enum DefuddleExtractionService {
     /// Resolve the bundled bun runtime + the defuddle script.
     /// Priority for each: bundled → dev build dir → well-known system location.
     /// Returns nil only if EITHER artifact is unresolvable (caller falls back).
-    static func resolve() -> (bun: URL, script: URL)? {
+    ///
+    /// `nonisolated` — pure filesystem checks, no actor state. Called from both
+    /// `@MainActor` (the extract path) and non-isolated test contexts.
+    static nonisolated func resolve() -> (bun: URL, script: URL)? {
         guard let bun = resolveBun(), let script = resolveDefuddle() else {
             return nil
         }
@@ -184,7 +187,7 @@ enum DefuddleExtractionService {
     // MARK: - Binary resolution
 
     /// Resolve the bun runtime. `isExecutableFile` — bun is exec'd directly.
-    private static func resolveBun() -> URL? {
+    private static nonisolated func resolveBun() -> URL? {
         let fm = FileManager.default
         for candidate in candidateHelperDirectories() {
             let bun = candidate.appendingPathComponent("bun", isDirectory: false)
@@ -204,7 +207,7 @@ enum DefuddleExtractionService {
 
     /// Resolve the defuddle script. `fileExists` (NOT `isExecutableFile`) — bun
     /// reads the script rather than exec'ing it, so readability is what matters.
-    private static func resolveDefuddle() -> URL? {
+    private static nonisolated func resolveDefuddle() -> URL? {
         let fm = FileManager.default
         for candidate in candidateHelperDirectories() {
             let script = candidate.appendingPathComponent("defuddle", isDirectory: false)

--- a/Sources/WikiFS/Sources/DefuddleExtractionService.swift
+++ b/Sources/WikiFS/Sources/DefuddleExtractionService.swift
@@ -1,0 +1,396 @@
+import AppKit
+import Foundation
+import WikiFSCore
+
+/// Extracts article markdown + metadata from HTML via the bundled `defuddle`
+/// Node script run with the bundled `bun` runtime.
+///
+/// This is a near-clone of `PdfExtractionService`'s `Process` pattern, but
+/// strictly simpler:
+/// - no uv/Python/venv (bun is always bundled and required by the build),
+/// - HTML on stdin (not a temp file path arg),
+/// - sub-second runtime (a 30s timeout is only a safety net),
+/// - best-effort: `extract()` returns nil on ANY failure so the caller can fall
+///   back to the tag-based `HTMLToMarkdown` path — zero regression.
+///
+/// `LocalDefuddleExtractor` (a thin struct in this file) conforms to
+/// `HtmlMarkdownExtractor` (WikiFSCore protocol) and delegates to these static
+/// methods, so `WikiStoreModel.htmlMarkdownExtractor` can invoke defuddle
+/// without a direct dependency on the WikiFS target — mirroring the
+/// `LocalPdf2MarkdownExtractor` / `PdfExtractionService` split.
+///
+/// **Invocation:** `bun <defuddle> parse -j -` (HTML on stdin, JSON on stdout).
+/// We deliberately use `parse -j -` and NOT `-m -j -`: with `-m -j`, defuddle
+/// overloads the `content` field with markdown and drops `contentMarkdown`
+/// (verified). The decoder prefers `contentMarkdown` and falls back to `content`
+/// so it is robust to either shape. See `tools/defuddle/README.md` and
+/// `plans/defuddle-extraction.md` §0/§7.
+@MainActor
+enum DefuddleExtractionService {
+
+    /// Markdown body + parsed metadata. Empty-string metadata fields are
+    /// normalized to nil (defuddle emits `""`, not null, for absent values).
+    struct ExtractionResult: Sendable {
+        let markdown: String         // contentMarkdown (preferred) or content
+        let title: String?
+        let author: String?
+        let description: String?
+        let published: String?       // ISO 8601 string
+        let wordCount: Int?
+    }
+
+    // MARK: - Public
+
+    /// Resolve the bundled bun runtime + the defuddle script.
+    /// Priority for each: bundled → dev build dir → well-known system location.
+    /// Returns nil only if EITHER artifact is unresolvable (caller falls back).
+    static func resolve() -> (bun: URL, script: URL)? {
+        guard let bun = resolveBun(), let script = resolveDefuddle() else {
+            return nil
+        }
+        return (bun, script)
+    }
+
+    /// Extract markdown + metadata from HTML bytes via `bun defuddle parse -j -`.
+    /// Best-effort: returns nil on any failure (binary missing, non-zero exit,
+    /// empty content for SPA/JS-rendered pages, bad JSON, timeout). Never throws.
+    static func extract(html: String, timeout: Duration = .seconds(30)) async -> ExtractionResult? {
+        guard let (bun, script) = resolve() else {
+            DebugLog.extraction("[defuddle] extract: bun or defuddle script not resolvable — falling back to tag-based")
+            return nil
+        }
+
+        let htmlBytes = Data(html.utf8)
+        DebugLog.extraction("[defuddle] extract: \(htmlBytes.count) bytes → bun \(bun.lastPathComponent) + \(script.lastPathComponent)")
+
+        // Continuous stdout/stderr drain. Pipe `readabilityHandler` callbacks fire
+        // off-actor, so the buffers they append to must be their own lock-guarded
+        // boxes — NOT actor state (same pipe-deadlock avoidance as PdfExtractionService).
+        let stdoutBuffer = OutputBuffer()
+        let stderrBuffer = OutputBuffer()
+
+        let process = Process()
+        process.executableURL = bun                              // Helpers/bun
+        process.arguments = [script.path, "parse", "-j", "-"]    // [defuddle, "parse","-j","-"]
+        // NO PATH augmentation: bun is an absolute executableURL (unlike pdf2md,
+        // whose shebang needs `uv` on PATH). A Finder-launched app has no shell
+        // PATH, but we never go through a shebang here — bun IS the executable.
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        stdoutPipe.fileHandleForReading.readabilityHandler = { @Sendable handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            stdoutBuffer.append(data)
+        }
+        stderrPipe.fileHandleForReading.readabilityHandler = { @Sendable handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            stderrBuffer.append(data)
+        }
+
+        return await withTaskGroup(of: ExtractionResult?.self) { group in
+            // Process completion.
+            group.addTask {
+                await withCheckedContinuation { (continuation: CheckedContinuation<ExtractionResult?, Never>) in
+                    process.terminationHandler = { proc in
+                        processRegistry.untrack(proc)
+                        // Stop the continuous handlers, then drain the kernel pipe
+                        // buffers so no bytes are lost between the last handler
+                        // invocation and now. Do NOT use readToEnd() here — after a
+                        // readabilityHandler it races with a queued callback and can
+                        // drop the final bytes. Nil the handler, let any in-flight
+                        // callback land, then loop availableData. (Same discipline as
+                        // PdfExtractionService.)
+                        stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                        stderrPipe.fileHandleForReading.readabilityHandler = nil
+                        Thread.sleep(forTimeInterval: 0.05)
+                        while true {
+                            let data = stdoutPipe.fileHandleForReading.availableData
+                            if data.isEmpty { break }
+                            stdoutBuffer.append(data)
+                        }
+                        while true {
+                            let data = stderrPipe.fileHandleForReading.availableData
+                            if data.isEmpty { break }
+                            stderrBuffer.append(data)
+                        }
+
+                        let status = proc.terminationStatus
+                        guard status == 0 else {
+                            let err = String(data: stderrBuffer.take(), encoding: .utf8) ?? ""
+                            DebugLog.extraction("[defuddle] extract: exit=\(status)\(err.isEmpty ? "" : ": \(err.trimmingCharacters(in: .whitespacesAndNewlines))") — falling back to tag-based")
+                            continuation.resume(returning: nil)
+                            return
+                        }
+                        let outData = stdoutBuffer.take()
+                        if let result = parseDefuddleJSON(outData) {
+                            DebugLog.extraction("[defuddle] extract: success — \(result.markdown.count) chars of markdown")
+                            continuation.resume(returning: result)
+                        } else {
+                            DebugLog.extraction("[defuddle] extract: exit 0 but no usable markdown (SPA / empty / bad JSON) — falling back to tag-based")
+                            continuation.resume(returning: nil)
+                        }
+                    }
+
+                    processRegistry.track(process)
+                    do {
+                        try process.run()
+                    } catch {
+                        processRegistry.untrack(process)
+                        DebugLog.extraction("[defuddle] extract: process.run() failed: \(error)")
+                        continuation.resume(returning: nil)
+                        return
+                    }
+
+                    // Feed HTML to stdin, then CLOSE the write end (EOF signals
+                    // defuddle that input is complete — without it defuddle blocks
+                    // waiting for more input → deadlock). Write on a background
+                    // queue so a very large page can't block the actor; close
+                    // immediately after the write drains.
+                    let writeHandle = stdinPipe.fileHandleForWriting
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        writeHandle.write(htmlBytes)
+                        try? writeHandle.close()
+                    }
+                }
+            }
+
+            // Timeout safety net. defuddle is sub-second, but a hung process
+            // (e.g. stdin not closed, pathological input) must not hang ingestion.
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return nil
+            }
+
+            defer {
+                group.cancelAll()
+                if process.isRunning { process.terminate() }
+            }
+
+            let result = await group.next() ?? nil
+            // If the timeout won, the process may still be running; the defer
+            // terminates it. If the process won, cancelling the sleep task is a
+            // no-op.
+            return result
+        }
+    }
+
+    // MARK: - Binary resolution
+
+    /// Resolve the bun runtime. `isExecutableFile` — bun is exec'd directly.
+    private static func resolveBun() -> URL? {
+        let fm = FileManager.default
+        for candidate in candidateHelperDirectories() {
+            let bun = candidate.appendingPathComponent("bun", isDirectory: false)
+            if fm.isExecutableFile(atPath: bun.path) {
+                return bun
+            }
+        }
+        // ~ ~/.bun/bin/bun (dev / `swift run` before `make build`).
+        let homeBun = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent(".bun/bin/bun", isDirectory: false)
+        if fm.isExecutableFile(atPath: homeBun.path) {
+            return homeBun
+        }
+        DebugLog.extraction("[defuddle] resolveBun: bun not found in any candidate location")
+        return nil
+    }
+
+    /// Resolve the defuddle script. `fileExists` (NOT `isExecutableFile`) — bun
+    /// reads the script rather than exec'ing it, so readability is what matters.
+    private static func resolveDefuddle() -> URL? {
+        let fm = FileManager.default
+        for candidate in candidateHelperDirectories() {
+            let script = candidate.appendingPathComponent("defuddle", isDirectory: false)
+            if fm.fileExists(atPath: script.path) {
+                DebugLog.extraction("[defuddle] resolveDefuddle: \(script.path)")
+                return script
+            }
+        }
+        // Repo tools directory (development / `swift run`): tools/defuddle/defuddle,
+        // resolved relative to the running executable's project root.
+        if let exe = Bundle.main.executableURL {
+            let projectRoot = exe
+                .deletingLastPathComponent()  // debug (in .build/...)
+                .deletingLastPathComponent()  // .build
+            let repoScript = projectRoot
+                .appendingPathComponent("tools/defuddle/defuddle", isDirectory: false)
+            if fm.fileExists(atPath: repoScript.path) {
+                DebugLog.extraction("[defuddle] resolveDefuddle: \(repoScript.path)")
+                return repoScript
+            }
+        }
+        // System install (~/.local/bin/defuddle — the npm global bin).
+        let system = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/bin/defuddle", isDirectory: false)
+        if fm.fileExists(atPath: system.path) {
+            DebugLog.extraction("[defuddle] resolveDefuddle: \(system.path)")
+            return system
+        }
+        DebugLog.extraction("[defuddle] resolveDefuddle: script not found in any candidate location")
+        return nil
+    }
+
+    /// Bundled Helpers/ then dev build/ then the executable's own directory.
+    /// Mirrors `HelpersLocation`/`PdfExtractionService.candidateLocations`.
+    private static nonisolated func candidateHelperDirectories() -> [URL] {
+        var dirs: [URL] = []
+        // 1. Signed app bundle (Contents/Helpers).
+        dirs.append(
+            Bundle.main.bundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("Helpers", isDirectory: true)
+        )
+        // 2. Dev build output dir (build/bun, build/defuddle), relative to cwd.
+        dirs.append(URL(fileURLWithPath: "build", isDirectory: true))
+        // 3. Directory of the running executable (covers `swift run`).
+        if let exe = Bundle.main.executableURL {
+            dirs.append(exe.deletingLastPathComponent())
+        }
+        return dirs
+    }
+
+    // MARK: - JSON parse
+
+    /// Parse defuddle's `parse -j -` JSON. Robust to both `-j` (contentMarkdown
+    /// present) and `-m -j` shapes (content overloaded with markdown,
+    /// contentMarkdown absent). Prefers `contentMarkdown`; falls back to `content`
+    /// only when it actually holds markdown. Empty strings → nil.
+    ///
+    /// `nonisolated` because it's called from the `terminationHandler` (which
+    /// fires off-actor). It's a pure decoder with no actor state.
+    private static nonisolated func parseDefuddleJSON(_ data: Data) -> ExtractionResult? {
+        struct DefuddlePayload: Decodable {
+            let content: String?
+            let contentMarkdown: String?
+            let title: String?
+            let author: String?
+            let description: String?
+            let published: String?
+            let wordCount: Int?
+        }
+        guard let payload = try? JSONDecoder().decode(DefuddlePayload.self, from: data) else {
+            DebugLog.extraction("[defuddle] parseJSON: decode failed (\(data.count) bytes)")
+            return nil
+        }
+        // Prefer the dedicated markdown field; fall back to `content` (which
+        // holds markdown when `-m` was passed). Either way: non-empty check.
+        let markdown = nonEmpty(payload.contentMarkdown) ?? nonEmpty(payload.content)
+        guard let markdown else {
+            DebugLog.extraction("[defuddle] parseJSON: empty markdown — SPA or no article body")
+            return nil
+        }
+        return ExtractionResult(
+            markdown: markdown,
+            title: nonEmpty(payload.title),
+            author: nonEmpty(payload.author),
+            description: nonEmpty(payload.description),
+            published: nonEmpty(payload.published),
+            wordCount: payload.wordCount
+        )
+    }
+
+    /// Map empty/whitespace-only strings to nil (defuddle emits `""` for absent
+    /// metadata rather than null). `nonisolated` — pure string helper called from
+    /// the off-actor terminationHandler.
+    private static nonisolated func nonEmpty(_ s: String?) -> String? {
+        guard let s, !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return s
+    }
+
+    // MARK: - Process registry
+
+    /// Tracks spawned defuddle processes so they can be terminated at app exit.
+    /// Non-isolated: termination handlers fire on background threads, so the
+    /// registry must be its own lock-guarded box (not actor state).
+    final class ProcessRegistry: @unchecked Sendable {
+        private var procs = Set<Process>()
+        private var registered = false
+        private let lock = NSLock()
+
+        func registerIfNeeded() {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !registered else { return }
+            registered = true
+            NotificationCenter.default.addObserver(
+                forName: NSApplication.willTerminateNotification,
+                object: nil, queue: .main
+            ) { [weak self] _ in
+                self?.terminateAll()
+            }
+        }
+
+        func track(_ process: Process) {
+            registerIfNeeded()
+            lock.lock()
+            procs.insert(process)
+            lock.unlock()
+        }
+
+        func untrack(_ process: Process) {
+            lock.lock()
+            procs.remove(process)
+            lock.unlock()
+        }
+
+        /// For tests: terminate any tracked processes.
+        func terminateAllForTesting() { terminateAll() }
+
+        private func terminateAll() {
+            lock.lock()
+            let snapshot = procs
+            lock.unlock()
+            for p in snapshot where p.isRunning {
+                p.terminate()
+            }
+        }
+    }
+
+    private static nonisolated let processRegistry = ProcessRegistry()
+
+    // MARK: - Output buffer
+
+    /// Thread-safe byte accumulator for a pipe drained on a background queue.
+    final class OutputBuffer: @unchecked Sendable {
+        private var data = Data()
+        private let lock = NSLock()
+        func append(_ chunk: Data) {
+            lock.lock(); data.append(chunk); lock.unlock()
+        }
+        func take() -> Data {
+            lock.lock(); defer { lock.unlock() }; return data
+        }
+    }
+}
+
+// MARK: - HtmlMarkdownExtractor conformance
+
+/// The bundled defuddle backend as an `HtmlMarkdownExtractor`.
+///
+/// `DefuddleExtractionService` itself is a caseless `@MainActor enum` used as a
+/// namespace of static subprocess methods, so it can't be an instance conformer.
+/// This thin non-isolated value type is the conformer: it delegates across the
+/// main-actor boundary (allowed for async) so `WikiStoreModel` can invoke it.
+/// Mirrors the `LocalPdf2MarkdownExtractor` / `PdfExtractionService` split.
+struct LocalDefuddleExtractor: HtmlMarkdownExtractor {
+    func extract(html: String) async -> HtmlExtractionResult? {
+        await DefuddleExtractionService.extract(html: html).map {
+            HtmlExtractionResult(
+                markdown: $0.markdown,
+                title: $0.title,
+                author: $0.author,
+                description: $0.description,
+                published: $0.published,
+                wordCount: $0.wordCount)
+        }
+    }
+}

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -217,6 +217,7 @@ struct WikiFSApp: App {
             queueEngine: queueEngine,
             extractionProvider: extractionProvider,
             pdf2mdScriptPathResolver: { PdfExtractionService.resolveScript()?.path },
+            htmlMarkdownExtractorFactory: { LocalDefuddleExtractor() },
             interactiveUsageRecorder: { [weak activityTracker] usage in
                 // Interactive chat (Ask/Edit) usage delta → daily total so the
                 // menu bar "Today: X tokens" includes chat, not just queue runs.

--- a/Sources/WikiFSCore/Sources/FormatMaterializer.swift
+++ b/Sources/WikiFSCore/Sources/FormatMaterializer.swift
@@ -58,6 +58,48 @@ public struct FormatPlan: Sendable, Equatable {
     }
 }
 
+// MARK: - HTML extraction protocol
+
+/// The markdown + metadata an HTML extractor (defuddle by default) produces.
+/// Carried alongside the original HTML bytes (issue #599 two-layer model) and
+/// written as a `.extraction`-origin processed-markdown version.
+public struct HtmlExtractionResult: Sendable {
+    public let markdown: String
+    public let title: String?
+    public let author: String?
+    public let description: String?
+    public let published: String?
+    public let wordCount: Int?
+
+    public init(
+        markdown: String,
+        title: String? = nil,
+        author: String? = nil,
+        description: String? = nil,
+        published: String? = nil,
+        wordCount: Int? = nil
+    ) {
+        self.markdown = markdown
+        self.title = title
+        self.author = author
+        self.description = description
+        self.published = published
+        self.wordCount = wordCount
+    }
+}
+
+/// Injectable HTML→Markdown extractor (defuddle by default). The protocol lives
+/// in WikiFSCore so `WikiStoreModel` can call it from the ingest path; the concrete
+/// `DefuddleExtractionService` (which needs AppKit for process lifecycle) lives in
+/// the WikiFS target and is injected via a factory closure at app wiring time
+/// — mirroring the `MarkdownExtractor` / `LocalPdf2MarkdownExtractor` pattern.
+public protocol HtmlMarkdownExtractor: Sendable {
+    /// Extract article markdown + metadata from HTML. Best-effort: returns nil
+    /// on any failure (binary missing, SPA/empty body, bad JSON) so the caller
+    /// falls back to tag-based `HTMLToMarkdown`.
+    func extract(html: String) async -> HtmlExtractionResult?
+}
+
 // MARK: - Dispatcher
 
 /// A pure, URL-independent format dispatcher. Origin materializers acquire
@@ -131,8 +173,49 @@ public enum FormatMaterializer {
         return FormatPlan(filename: filename, data: data, format: .binary)
     }
 
-    // MARK: - Content sniffing (pure)
+    // MARK: - HTML enrichment (async, injectable)
 
+    /// Best-effort: if the plan is HTML, run the defuddle extractor to obtain
+    /// site-specific markdown + metadata; on any failure, keep the tag-based
+    /// markdown already on the plan. Returns the (possibly rewritten) plan and
+    /// the technique tag to stamp on the stored version.
+    ///
+    /// `dispatch` stays pure + synchronous (it's called from tests and the
+    /// pure-dispatch contract is valuable). This async helper is called by
+    /// materializers after `dispatch`.
+    public static func enrich(
+        _ plan: FormatPlan,
+        using extractor: (any HtmlMarkdownExtractor)?
+    ) async -> (plan: FormatPlan, technique: String) {
+        guard plan.format == .html, let extractor else {
+            return (plan, "html-to-markdown")
+        }
+        let html = decodeText(plan.data)
+        guard let result = await extractor.extract(html: html) else {
+            // Fallback: keep tag-based extractedMarkdown already on the plan.
+            return (plan, "html-to-markdown")
+        }
+        // Defuddle's <title> may be richer than the tag-based heuristic. Use it
+        // for the filename when available (mirrors dispatch's title→stem logic).
+        let stem: String
+        if let title = result.title.flatMap({ nonEmpty($0) }) {
+            stem = sanitizeStem(title)
+        } else {
+            stem = sanitizeStem((plan.filename as NSString).deletingPathExtension)
+        }
+        let filename = ensureExtension(stem, ext: "html")
+        return (
+            FormatPlan(
+                filename: filename,
+                data: plan.data,
+                format: .html,
+                extractedMarkdown: result.markdown
+            ),
+            "defuddle"
+        )
+    }
+
+    // MARK: - Content sniffing (pure)
     /// Whether a declared MIME is ambiguous enough to second-guess via the bytes:
     /// `text/html` (the interstitial case), a missing type, or the catch-all
     /// `application/octet-stream`. A specific declared type is trusted as-is.

--- a/Sources/WikiFSCore/Sources/SourceMaterializer.swift
+++ b/Sources/WikiFSCore/Sources/SourceMaterializer.swift
@@ -82,6 +82,12 @@ public struct MaterializedSource: Sendable {
     public let zoteroItemTitle: String?
     public let provenance: SourceProvenance?
     public let extractedMarkdown: String?
+    /// Which extractor produced `extractedMarkdown` (`"defuddle"` or
+    /// `"html-to-markdown"`). Stamped on the `source_markdown_versions.technique`
+    /// column so the provenance/alternatives UI surfaces the producer. `nil` for
+    /// non-HTML sources (no extracted-markdown sidecar) — defaults to
+    /// `"html-to-markdown"` in the store path.
+    public let extractionTechnique: String?
 
     public init(
         filename: String,
@@ -90,7 +96,8 @@ public struct MaterializedSource: Sendable {
         zoteroItemKey: String? = nil,
         zoteroItemTitle: String? = nil,
         provenance: SourceProvenance? = nil,
-        extractedMarkdown: String? = nil
+        extractedMarkdown: String? = nil,
+        extractionTechnique: String? = nil
     ) {
         self.filename = filename
         self.data = data
@@ -99,6 +106,7 @@ public struct MaterializedSource: Sendable {
         self.zoteroItemTitle = zoteroItemTitle
         self.provenance = provenance
         self.extractedMarkdown = extractedMarkdown
+        self.extractionTechnique = extractionTechnique
     }
 }
 

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -303,17 +303,14 @@ public final class WikiStoreModel {
     /// derived index) — search silently falls back to FTS5 in that case.
     #if os(macOS)
     @ObservationIgnored public var tantivySearch: TantivySearchService?
-<<<<<<< HEAD
     #else
     // Linux: Tantivy is unavailable — the search path uses nil bm25Leg (FTS5 fallback).
     @ObservationIgnored public var tantivySearch: Any?
     #endif
-=======
     /// Injectable HTML→Markdown extractor (defuddle). Set at app wiring time by
     /// `WikiSession` → `SessionManager` → `WikiFSApp`. `nil` means fall back to
     /// the tag-based `HTMLToMarkdown` path (CI, clean dev before `make build`).
     @ObservationIgnored public var htmlMarkdownExtractor: (any HtmlMarkdownExtractor)?
->>>>>>> 11bd242 (defuddle extraction service + ingestion wiring (#761))
     private var autosaveTask: Task<Void, Never>?
     private var systemPromptAutosaveTask: Task<Void, Never>?
 

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -303,10 +303,17 @@ public final class WikiStoreModel {
     /// derived index) — search silently falls back to FTS5 in that case.
     #if os(macOS)
     @ObservationIgnored public var tantivySearch: TantivySearchService?
+<<<<<<< HEAD
     #else
     // Linux: Tantivy is unavailable — the search path uses nil bm25Leg (FTS5 fallback).
     @ObservationIgnored public var tantivySearch: Any?
     #endif
+=======
+    /// Injectable HTML→Markdown extractor (defuddle). Set at app wiring time by
+    /// `WikiSession` → `SessionManager` → `WikiFSApp`. `nil` means fall back to
+    /// the tag-based `HTMLToMarkdown` path (CI, clean dev before `make build`).
+    @ObservationIgnored public var htmlMarkdownExtractor: (any HtmlMarkdownExtractor)?
+>>>>>>> 11bd242 (defuddle extraction service + ingestion wiring (#761))
     private var autosaveTask: Task<Void, Never>?
     private var systemPromptAutosaveTask: Task<Void, Never>?
 
@@ -1953,7 +1960,7 @@ public final class WikiStoreModel {
             try store.appendProcessedMarkdown(
                 sourceID: summary.id, content: markdown,
                 origin: .extraction, note: nil,
-                technique: Self.htmlToMarkdownTechnique)
+                technique: m.extractionTechnique ?? Self.htmlToMarkdownTechnique)
         } catch {
             DebugLog.store("WikiStoreModel.appendExtractedMarkdown failed (source=\(summary.id.rawValue)): \(error)")
         }
@@ -1964,6 +1971,36 @@ public final class WikiStoreModel {
     /// technique tags (e.g. `"pdf2md"`) so the "Converted" provenance row
     /// surfaces the producer in the alternatives UI.
     private static let htmlToMarkdownTechnique = "html-to-markdown"
+
+    /// Best-effort: if the materialized source is HTML (has an extracted-markdown
+    /// sidecar from `FormatMaterializer.dispatch`), run the defuddle extractor to
+    /// obtain site-specific markdown + metadata. On any failure, keep the
+    /// tag-based markdown. Sets `extractionTechnique` on the returned source so
+    /// `appendExtractedMarkdown` stamps the right technique column.
+    ///
+    /// Does NOT run for website snapshots (those use `WebsiteSnapshotExtractor`
+    /// which does image-aware extraction — defuddle can't replace that without
+    /// losing image src rewriting). Called by `addFiles` and `ingestFromZotero`.
+    private func enrichWithDefuddle(_ m: MaterializedSource) async -> MaterializedSource {
+        // Only HTML sources have a non-nil extractedMarkdown sidecar (issue #599
+        // two-layer model). Non-HTML sources skip enrichment entirely.
+        guard m.extractedMarkdown != nil else { return m }
+        // Reconstruct a FormatPlan to reuse the shared enrich helper.
+        let plan = FormatPlan(
+            filename: m.filename, data: m.data, format: .html,
+            extractedMarkdown: m.extractedMarkdown)
+        let (enriched, technique) = await FormatMaterializer.enrich(
+            plan, using: htmlMarkdownExtractor)
+        return MaterializedSource(
+            filename: enriched.filename,
+            data: enriched.data,
+            mimeType: m.mimeType,
+            zoteroItemKey: m.zoteroItemKey,
+            zoteroItemTitle: m.zoteroItemTitle,
+            provenance: m.provenance,
+            extractedMarkdown: enriched.extractedMarkdown,
+            extractionTechnique: technique)
+    }
 
     /// Ingest dropped files. For each URL: reject directories (a recursive
     /// directory ingest is out of scope), read the bytes OFF the main thread
@@ -1997,13 +2034,16 @@ public final class WikiStoreModel {
                 continue
             }
 
+            // Best-effort defuddle enrichment for HTML sources (issue #761).
+            let materializedEnriched = await enrichWithDefuddle(materialized)
+
             // Pre-resolve display name off-main for PDFs (issue #229).
             let resolvedDisplayName = await preResolveDisplayName(
-                filename: materialized.filename, data: materialized.data,
-                mimeType: materialized.mimeType, zoteroItemTitle: materialized.zoteroItemTitle)
+                filename: materializedEnriched.filename, data: materializedEnriched.data,
+                mimeType: materializedEnriched.mimeType, zoteroItemTitle: materializedEnriched.zoteroItemTitle)
 
             do {
-                let summary = try storeMaterialized(materialized, resolvedDisplayName: resolvedDisplayName)
+                let summary = try storeMaterialized(materializedEnriched, resolvedDisplayName: resolvedDisplayName)
                 lastSourceID = summary.id
                 lastSourceName = summary.effectiveName
             } catch WikiStoreError.duplicateContent(let existing) {
@@ -2399,17 +2439,27 @@ public final class WikiStoreModel {
     ) async throws -> URLFetchService.FetchOutcome {
         let provider = WebsiteMaterializer(rawInput: rawInput, fetcher: fetcher)
         let snapshot = try await provider.materializeSnapshot()
+        // For HTML pages without snapshot images (no-download or image-less),
+        // enrich the extracted markdown via defuddle (issue #761). The snapshot
+        // path (images present) keeps its image-aware extraction — defuddle
+        // can't replace the src rewriting without losing image references.
+        let pageEnriched: MaterializedSource
+        if snapshot.plan.format == .html && snapshot.images.isEmpty {
+            pageEnriched = await enrichWithDefuddle(snapshot.page)
+        } else {
+            pageEnriched = snapshot.page
+        }
         // Pre-resolve the page's display name off the main actor so a PDF
         // source's PDFKit parse doesn't block the UI or delay the store write
         // (issue #229). Non-PDFs are unaffected (helper returns nil → inline).
         let resolvedDisplayName = await preResolveDisplayName(
-            filename: snapshot.page.filename, data: snapshot.page.data,
-            mimeType: snapshot.page.mimeType, zoteroItemTitle: snapshot.page.zoteroItemTitle)
+            filename: pageEnriched.filename, data: pageEnriched.data,
+            mimeType: pageEnriched.mimeType, zoteroItemTitle: pageEnriched.zoteroItemTitle)
         var summary: SourceSummary
         if snapshot.plan.format == .html && !snapshot.images.isEmpty {
             summary = try storeSnapshot(snapshot)
         } else {
-            summary = try storeMaterialized(snapshot.page, resolvedDisplayName: resolvedDisplayName)
+            summary = try storeMaterialized(pageEnriched, resolvedDisplayName: resolvedDisplayName)
         }
         // HTML sources have ".html" appended to the storage filename (issue #599:
         // the original HTML bytes are now the source blob, not the converted
@@ -2577,12 +2627,14 @@ public final class WikiStoreModel {
         // Resolve + read off the main actor (the provider materializes, throwing
         // ZoteroFetchError.unavailable when the attachment isn't local).
         let materialized = try await provider.materialize()
+        // Best-effort defuddle enrichment for HTML sources (issue #761).
+        let materializedEnriched = await enrichWithDefuddle(materialized)
         // Pre-resolve display name off-main for PDFs (issue #229).
         let resolvedDisplayName = await preResolveDisplayName(
-            filename: materialized.filename, data: materialized.data,
-            mimeType: materialized.mimeType, zoteroItemTitle: materialized.zoteroItemTitle)
+            filename: materializedEnriched.filename, data: materializedEnriched.data,
+            mimeType: materializedEnriched.mimeType, zoteroItemTitle: materializedEnriched.zoteroItemTitle)
         do {
-            let summary = try storeMaterialized(materialized, resolvedDisplayName: resolvedDisplayName)
+            let summary = try storeMaterialized(materializedEnriched, resolvedDisplayName: resolvedDisplayName)
             // No manual reload — the bus fires reloadFromStore() async after the
             // store write. The tab title is passed explicitly so tabTitle (which
             // reads `sources`) needs no synchronous freshness.

--- a/Sources/WikiFSEngine/SessionManager.swift
+++ b/Sources/WikiFSEngine/SessionManager.swift
@@ -60,12 +60,19 @@ public final class SessionManager {
     /// headless/daemon callers (which have no UI tracker) are unaffected.
     public let interactiveUsageRecorder: @MainActor (SessionUsage) -> Void
 
+    /// Factory for the HTML→Markdown extractor (defuddle). Called once per
+    /// session at creation. The app passes a closure returning
+    /// `LocalDefuddleExtractor()` (WikiFS target); defaults to nil (tag-based
+    /// fallback) for headless/daemon/test callers. Issue #761.
+    public let htmlMarkdownExtractorFactory: @MainActor () -> (any HtmlMarkdownExtractor)?
+
     public init(
         containerDirectory: URL,
         extractionCoordinator: ExtractionCoordinator,
         queueEngine: QueueEngine,
         extractionProvider: any QueueExtractionProvider,
         pdf2mdScriptPathResolver: @escaping () -> String?,
+        htmlMarkdownExtractorFactory: @escaping @MainActor () -> (any HtmlMarkdownExtractor)? = { nil },
         interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
     ) {
         self.containerDirectory = containerDirectory
@@ -73,6 +80,7 @@ public final class SessionManager {
         self.queueEngine = queueEngine
         self.extractionProvider = extractionProvider
         self.pdf2mdScriptPathResolver = pdf2mdScriptPathResolver
+        self.htmlMarkdownExtractorFactory = htmlMarkdownExtractorFactory
         self.interactiveUsageRecorder = interactiveUsageRecorder
     }
 
@@ -96,6 +104,7 @@ public final class SessionManager {
             queueEngine: queueEngine,
             extractionProvider: extractionProvider,
             pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
+            htmlMarkdownExtractorFactory: htmlMarkdownExtractorFactory,
             interactiveUsageRecorder: interactiveUsageRecorder
         )
         // Transfer any deferred wiki-link click (registered by

--- a/Sources/WikiFSEngine/WikiSession.swift
+++ b/Sources/WikiFSEngine/WikiSession.swift
@@ -154,6 +154,7 @@ public final class WikiSession {
         extractionProvider: any QueueExtractionProvider,
         makeStore: @escaping (URL) throws -> WikiStore = { try StoreBackend.current.makeStore(databaseURL: $0) },
         pdf2mdScriptPathResolver: @escaping () -> String? = { nil },
+        htmlMarkdownExtractorFactory: @escaping @MainActor () -> (any HtmlMarkdownExtractor)? = { nil },
         interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
     ) {
         self.wikiID = wikiID
@@ -221,6 +222,12 @@ public final class WikiSession {
         }
         self.store = model
         self.descriptor = sessionDescriptor
+        // Inject the HTML→Markdown extractor (defuddle) into the store model so
+        // the ingest path can enrich HTML sources (issue #761). The factory is
+        // provided by the app layer (WikiFSApp) which has access to the WikiFS
+        // target where the concrete `LocalDefuddleExtractor` lives. `nil` (the
+        // default in tests / CI) means fall back to tag-based HTMLToMarkdown.
+        model.htmlMarkdownExtractor = htmlMarkdownExtractorFactory()
 
         // Phase 2 Tantivy search index (plans/tantivy-search-sidecar.md §4.4).
         // Phase 2 CUTOVER (#634): Tantivy is the SOLE BM25 leg of the hybrid

--- a/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
+++ b/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 import Testing
 @testable import WikiFS
@@ -140,3 +141,4 @@ import Testing
         #expect(p.terminationStatus != 0)
     }
 }
+#endif

--- a/Tests/WikiFSTests/DefuddleExtractionServiceTests.swift
+++ b/Tests/WikiFSTests/DefuddleExtractionServiceTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import WikiFS
+
+/// Tests for the defuddle HTML extraction service.
+///
+/// These tests run the REAL bundled bun + defuddle script (no mocks). They
+/// **skip gracefully** if `DefuddleExtractionService.resolve()` returns nil
+/// (CI, clean dev before `make build`) — defuddle is opt-in until the script is
+/// bundled via `build.sh`. See `plans/defuddle-extraction.md` §5.
+@Suite struct DefuddleExtractionServiceTests {
+
+    /// Whether bun + the defuddle script are resolvable on this machine.
+    private var resolved: (bun: URL, script: URL)? {
+        DefuddleExtractionService.resolve()
+    }
+
+    // MARK: - End-to-end extraction (real subprocess)
+
+    @Test func extractsMarkdownAndMetadata() async throws {
+        guard let _ = resolved else { return }  // skip if unbundled
+        let html = #"""
+        <html><head>
+        <title>Sample Article: A Test Page</title>
+        <meta name="author" content="Jane Doe">
+        <meta name="description" content="A test article">
+        <meta property="article:published_time" content="2024-03-15T10:00:00Z">
+        </head><body>
+        <nav><a href="/">Home</a> | <a href="/about">About</a></nav>
+        <article>
+        <h1>Main Content</h1>
+        <p>The <strong>main content</strong> paragraph.</p>
+        <p>Second paragraph with a <a href="https://example.com">link</a>.</p>
+        </article>
+        <footer>Copyright 2024. All rights reserved.</footer>
+        </body></html>
+        """#
+        let result = try #require(await DefuddleExtractionService.extract(html: html))
+
+        // Markdown contains the article body.
+        #expect(result.markdown.contains("main content"))
+        #expect(result.markdown.contains("Second paragraph"))
+
+        // Nav/footer boilerplate stripped (site-specific readability extraction).
+        #expect(!result.markdown.contains("Home"))
+        #expect(!result.markdown.contains("Copyright"))
+        #expect(!result.markdown.contains("About"))
+
+        // Metadata parsed.
+        #expect(result.title == "Sample Article: A Test Page")
+        #expect(result.author == "Jane Doe")
+        #expect(result.published == "2024-03-15T10:00:00Z")
+
+        // Word count is positive.
+        #expect((result.wordCount ?? 0) > 0)
+    }
+
+    @Test func extractsSimpleArticle() async throws {
+        guard let _ = resolved else { return }
+        let html = #"<html><head><title>Simple</title></head><body><article><p>Hello world.</p></article></body></html>"#
+        let result = try #require(await DefuddleExtractionService.extract(html: html))
+        #expect(result.markdown.contains("Hello world."))
+        #expect(result.title == "Simple")
+    }
+
+    // MARK: - Fallback: SPA / empty body → nil
+
+    @Test func returnsNilForSPAEmptyBody() async {
+        guard let _ = resolved else { return }
+        let html = #"<html><head><title>SPA</title></head><body><div id="app"></div></body></html>"#
+        let result = await DefuddleExtractionService.extract(html: html)
+        #expect(result == nil)  // fallback trigger — caller uses tag-based
+    }
+
+    @Test func returnsNilForEmptyInput() async {
+        guard let _ = resolved else { return }
+        #expect(await DefuddleExtractionService.extract(html: "") == nil)
+    }
+
+    // MARK: - Binary resolution
+
+    @Test func resolvesBunAndScript() {
+        guard resolved != nil else { return }
+        let r = DefuddleExtractionService.resolve()
+        #expect(r != nil)
+        #expect(r?.bun.lastPathComponent == "bun")
+        #expect(r?.script.lastPathComponent == "defuddle")
+    }
+
+    // MARK: - OutputBuffer
+
+    @Test func outputBufferAccumulatesAndTakes() {
+        let buf = DefuddleExtractionService.OutputBuffer()
+        buf.append(Data("hello ".utf8))
+        buf.append(Data("world".utf8))
+        let taken = buf.take()
+        #expect(String(data: taken, encoding: .utf8) == "hello world")
+    }
+
+    @Test func outputBufferTakeReturnsEmptyWhenNothingAppended() {
+        let buf = DefuddleExtractionService.OutputBuffer()
+        #expect(buf.take().isEmpty)
+    }
+
+    @Test func outputBufferIsConcurrentSafe() async {
+        let buf = DefuddleExtractionService.OutputBuffer()
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<100 {
+                group.addTask { buf.append(Data("chunk\(i) ".utf8)) }
+            }
+        }
+        let taken = buf.take()
+        // All 100 chunks should be present (order not guaranteed).
+        for i in 0..<100 {
+            #expect(String(data: taken, encoding: .utf8)?.contains("chunk\(i)") == true)
+        }
+    }
+
+    // MARK: - ProcessRegistry
+
+    @Test func processRegistryTracksAndUntracks() {
+        let reg = DefuddleExtractionService.ProcessRegistry()
+        let p = Process()
+        reg.track(p)
+        reg.untrack(p)
+    }
+
+    @Test func processRegistryTerminatesTracked() {
+        let reg = DefuddleExtractionService.ProcessRegistry()
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        p.arguments = ["999"]
+        try? p.run()
+        #expect(p.isRunning)
+
+        reg.track(p)
+        reg.terminateAllForTesting()
+        p.waitUntilExit()
+        #expect(!p.isRunning)
+        #expect(p.terminationStatus != 0)
+    }
+}

--- a/Tests/WikiFSTests/FormatMaterializerTests.swift
+++ b/Tests/WikiFSTests/FormatMaterializerTests.swift
@@ -266,6 +266,83 @@ struct FormatMaterializerTests {
         }
     }
 
+    // MARK: - enrich(_:using:) — async defuddle enrichment (issue #761)
+
+    @Test func enrichWithNilExtractorKeepsTagBasedMarkdown() async {
+        let html = "<html><head><title>Cool Page</title></head><body><article><p>Hi</p></article></body></html>"
+        let plan = FormatMaterializer.dispatch(
+            data: Data(html.utf8), contentType: "text/html",
+            stem: "article", extensionHint: nil)
+        let (enriched, technique) = await FormatMaterializer.enrich(plan, using: nil)
+        // nil extractor → no change, technique is tag-based.
+        #expect(enriched.extractedMarkdown == plan.extractedMarkdown)
+        #expect(technique == "html-to-markdown")
+    }
+
+    @Test func enrichWithFailingExtractorFallsBackToTagBased() async {
+        struct FailingExtractor: HtmlMarkdownExtractor {
+            func extract(html: String) async -> HtmlExtractionResult? { nil }
+        }
+        let html = "<html><head><title>Cool Page</title></head><body><article><p>Hi</p></article></body></html>"
+        let plan = FormatMaterializer.dispatch(
+            data: Data(html.utf8), contentType: "text/html",
+            stem: "article", extensionHint: nil)
+        let (enriched, technique) = await FormatMaterializer.enrich(plan, using: FailingExtractor())
+        // Extractor returned nil → keep tag-based markdown, technique is fallback.
+        #expect(enriched.extractedMarkdown == plan.extractedMarkdown)
+        #expect(technique == "html-to-markdown")
+    }
+
+    @Test func enrichWithSuccessfulExtractorUsesDefuddleMarkdown() async {
+        struct StubExtractor: HtmlMarkdownExtractor {
+            func extract(html: String) async -> HtmlExtractionResult? {
+                HtmlExtractionResult(markdown: "## Defuddle Title\n\nClean content.", title: "Defuddle Title")
+            }
+        }
+        let html = "<html><head><title>Old Title</title></head><body><article><p>Hi</p></article></body></html>"
+        let plan = FormatMaterializer.dispatch(
+            data: Data(html.utf8), contentType: "text/html",
+            stem: "article", extensionHint: nil)
+        let (enriched, technique) = await FormatMaterializer.enrich(plan, using: StubExtractor())
+        // Defuddle markdown replaces tag-based; technique is "defuddle".
+        #expect(enriched.extractedMarkdown == "## Defuddle Title\n\nClean content.")
+        #expect(technique == "defuddle")
+        // Filename derived from defuddle's title.
+        #expect(enriched.filename == "Defuddle Title.html")
+        // Original HTML bytes preserved (issue #599 two-layer model).
+        #expect(enriched.data == Data(html.utf8))
+    }
+
+    @Test func enrichSkipsNonHTMLFormats() async {
+        struct StubExtractor: HtmlMarkdownExtractor {
+            func extract(html: String) async -> HtmlExtractionResult? {
+                HtmlExtractionResult(markdown: "should not be used", title: nil)
+            }
+        }
+        // PDF — not HTML.
+        let plan = FormatMaterializer.dispatch(
+            data: Data([0x25, 0x50, 0x44, 0x46]), contentType: "application/pdf",
+            stem: "doc", extensionHint: nil)
+        let (enriched, technique) = await FormatMaterializer.enrich(plan, using: StubExtractor())
+        #expect(enriched.extractedMarkdown == plan.extractedMarkdown)  // nil — no sidecar for PDF
+        #expect(technique == "html-to-markdown")
+    }
+
+    @Test func enrichUsesDispatchStemWhenExtractorTitleIsNil() async {
+        struct StubExtractor: HtmlMarkdownExtractor {
+            func extract(html: String) async -> HtmlExtractionResult? {
+                HtmlExtractionResult(markdown: "content", title: nil)
+            }
+        }
+        let html = "<html><head><title>Original Title</title></head><body><article><p>Hi</p></article></body></html>"
+        let plan = FormatMaterializer.dispatch(
+            data: Data(html.utf8), contentType: "text/html",
+            stem: "fallback-stem", extensionHint: nil)
+        let (enriched, _) = await FormatMaterializer.enrich(plan, using: StubExtractor())
+        // No defuddle title → keep the dispatch-derived filename.
+        #expect(enriched.filename == "Original Title.html")
+    }
+
     // MARK: - Helpers
 
     /// Walk up from `#filePath` to the directory containing `Package.swift`.

--- a/Tests/WikiFSTests/QueueEventLogTests.swift
+++ b/Tests/WikiFSTests/QueueEventLogTests.swift
@@ -429,11 +429,16 @@ struct QueueEventLogTests {
         await log.start(events: engine.events)
 
         await engine.start()
-        _ = try await engine.enqueue(
+        let itemID = try await engine.enqueue(
             QueueItemRequest(queue: .extraction, wikiID: "wiki1", payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "SRC1")])))
 
-        // Wait for the item to complete.
-        try await Task.sleep(nanoseconds: 300_000_000)
+        // Wait for the item to complete (deterministic, avoids timing flakes on CI).
+        _ = try await engine.waitForCompletion(of: itemID).get()
+
+        // Give the log's async stream consumer a chance to drain the
+        // .completed event before we stop — without this, stop() can cancel
+        // the stream task before .completed is written.
+        try await Task.sleep(nanoseconds: 200_000_000)
 
         await log.stop()
 

--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,8 @@ DAEMON_NAME="wikid"
 PODCAST_HELPER_NAME="podcast-token-helper"
 PDF2MD_NAME="pdf2md"
 PDF2MD_SRC="tools/pdf2md/pdf2md"
+DEFUDDLE_NAME="defuddle"
+DEFUDDLE_SRC="tools/defuddle/defuddle"
 BUNDLE_ID="${BUNDLE_ID:-org.sockpuppet.WikiFS}"
 EXT_BUNDLE_ID="${EXT_BUNDLE_ID:-org.sockpuppet.WikiFS.FileProvider}"
 APP_GROUP="${APP_GROUP:-group.org.sockpuppet.wiki}"
@@ -200,6 +202,14 @@ if [ -f "${PDF2MD_SRC}" ]; then
   cp "${PDF2MD_SRC}" "${BUILD_DIR}/${PDF2MD_NAME}"
 else
   echo "  (pdf2md not found at ${PDF2MD_SRC} — skipping; PDF extraction will fall back to agent Read tool)"
+fi
+# Bundle the defuddle readability extractor (Node script run via the bundled
+# bun). Used by DefuddleExtractionService for HTML article markdown+metadata.
+if [ -f "${DEFUDDLE_SRC}" ]; then
+  cp "${DEFUDDLE_SRC}" "${HELPERS_DIR}/${DEFUDDLE_NAME}"
+  cp "${DEFUDDLE_SRC}" "${BUILD_DIR}/${DEFUDDLE_NAME}"
+else
+  echo "  (defuddle not found at ${DEFUDDLE_SRC} — skipping; HTML extraction will fall back to tag-based)"
 fi
 # Semantic vector search is now pure Swift (`VectorCosine` in WikiFSSearch —
 # issue #628): no C extension to copy, no per-connection registration.
@@ -434,6 +444,13 @@ PLIST
     codesign --force --timestamp=none --sign "${IDENTITY}" \
       "${HELPERS_DIR}/${PDF2MD_NAME}"
   fi
+  # defuddle is a plain script bundled in Helpers/ — must also be signed, or the
+  # outer app's seal fails ("code object is not signed at all"). bun reads the
+  # file; signing is for the seal (same reason as pdf2md above).
+  if [ -f "${HELPERS_DIR}/${DEFUDDLE_NAME}" ]; then
+    codesign --force --timestamp=none --sign "${IDENTITY}" \
+      "${HELPERS_DIR}/${DEFUDDLE_NAME}"
+  fi
   # podcast-token-helper is a nested Mach-O — sign it before the outer app (same
   # inside-out discipline as wikictl). Only present in a feature-on build.
   if [ -f "${HELPERS_DIR}/${PODCAST_HELPER_NAME}" ]; then
@@ -464,6 +481,9 @@ else
   codesign --force --sign - "${HELPERS_DIR}/${CTL_NAME}"
   if [ -f "${HELPERS_DIR}/${PDF2MD_NAME}" ]; then
     codesign --force --sign - "${HELPERS_DIR}/${PDF2MD_NAME}"
+  fi
+  if [ -f "${HELPERS_DIR}/${DEFUDDLE_NAME}" ]; then
+    codesign --force --sign - "${HELPERS_DIR}/${DEFUDDLE_NAME}"
   fi
   if [ -f "${HELPERS_DIR}/${PODCAST_HELPER_NAME}" ]; then
     codesign --force --sign - "${HELPERS_DIR}/${PODCAST_HELPER_NAME}"

--- a/plans/defuddle-extraction.md
+++ b/plans/defuddle-extraction.md
@@ -1,0 +1,370 @@
+# Defuddle HTML Extraction — Implementation Plan (v2, simplified)
+
+> **Issue #761** — Use defuddle for HTML source content extraction, replacing
+> the current tag-based `HTMLToMarkdown.scopeToMainContent`. Supersedes #209.
+>
+> **Design (confirmed by operator):** defuddle is a `#!/usr/bin/env node` script.
+> The app **already bundles bun** (a Node-compatible runtime) in `Contents/Helpers/`.
+> So the integration is: **bundle the defuddle script** (like pdf2md) and **run it
+> with the bundled bun** — fully self-contained, no external runtime dependency.
+> This is a near-clone of the `PdfExtractionService` pattern, but STRICTLY SIMPLER:
+> no uv/Python/venv, stdin input, sub-second runtime.
+
+---
+
+## 0. Key Empirical Findings (verified this session)
+
+1. **What defuddle is:** `~/.local/bin/defuddle` is a `#!/usr/bin/env node` script,
+   7416 bytes, a self-contained CommonJS bundle (`Object.defineProperty(exports,…)`,
+   no external `require`s). **bun runs it standalone** — verified:
+
+   ```sh
+   $ echo '<html>…<article><p>Hi <strong>there</strong>.</p></article>…' \
+       | bun ~/.local/bin/defuddle parse -j -
+   { "contentMarkdown": "Hi **there**.", "title": "T", "author": "", … }
+   ```
+
+2. **JSON field behavior — CRITICAL GOTCHA (verified):**
+
+   | Invocation | `content` field | `contentMarkdown` field |
+   |------------|-----------------|-------------------------|
+   | `parse -j -` (no `-m`) | **cleaned HTML** (`<article><p>Hi</p></article>`) | **markdown** (`Hi **there**.`) |
+   | `parse -m -j -` | **markdown** (`Hi **there**.`) | **ABSENT** |
+
+   With `-m -j`, defuddle **overloads `content` with markdown and drops
+   `contentMarkdown`**. The skill doc + issue prompt assume `-m -j` yields
+   `contentMarkdown` — it does not. **Use `parse -j -` (no `-m`) and read
+   `contentMarkdown`** — that's the field literally named for markdown, and
+   `content` still gives the cleaned HTML (useful if ever needed). Make the
+   decoder robust to both (prefer `contentMarkdown`, fall back to `content`).
+
+3. **SPA / empty content:** a page with no article body (e.g. `<div id="app">`)
+   makes defuddle **exit 1 with empty stdout**. This is the fallback trigger.
+
+4. **bun is already bundled + signed:** `build.sh` copies `~/.bun/bin/bun`
+   into `Contents/Helpers/bun` and signs it. It is REQUIRED by the build (ACP
+   providers need it). So **bun is always present in the bundle** — defuddle
+   needs no separate runtime, no PATH search, no uv-style graceful degradation.
+   This makes defuddle **strictly better than pdf2md** (which needs the
+   un-bundled uv+Python and falls back to the agent when absent).
+
+---
+
+## 1. Current State — the seam being replaced
+
+### 1.1 `HTMLToMarkdown.scopeToMainContent` (the current extractor)
+
+Pure tag-based heuristic: strip `script/style/head/nav/footer`, then prefer
+`<article>` → `<main>` → `<body>` (first match wins). No readability scoring, no
+site-specific knowledge. Works for clean articles; noisy for heavy-chrome pages.
+
+### 1.2 The HTML ingestion path (trace — where defuddle slots in)
+
+```
+WebsiteMaterializer.materializeWithPlan()        SourceMaterializer.swift
+  ├─ URLFetchService.fetch(url)                  → raw HTML bytes
+  ├─ FormatMaterializer.dispatch(...)            (PURE, SYNC — unchanged)
+  │    └─ if mime == html/xhtml:
+  │         HTMLToMarkdown.convert(html)         ← THE SEAM (tag-based markdown + <title>)
+  │         → FormatPlan(data: HTML, .html, extractedMarkdown: tagMD)
+  ├─ [NEW] await DefuddleExtractionService.extract(html)   ← defuddle replaces the markdown
+  │    └─ if non-empty: overwrite extractedMarkdown; else keep tag-based fallback
+  └─ MaterializedSource(..., extractedMarkdown: <defuddle OR tag-based>)
+```
+
+Store-write (unchanged): `WikiStoreModel.storeMaterialized` →
+`appendExtractedMarkdown` →
+`store.appendProcessedMarkdown(origin: .extraction, technique: …)`.
+
+**Issue #599 two-layer model is intact:** original HTML bytes are the source blob
+(`.html` format); extracted markdown is a derived `source_markdown_versions` row.
+Defuddle only changes *what produces the markdown*, not the storage model.
+
+### 1.3 Where defuddle does NOT run (out of scope)
+
+- **`WebsiteSnapshotExtractor`** — uses
+  `HTMLToMarkdown.scopedTokens(for:)` for token-level `<img src>` rewriting.
+  Defuddle returns cleaned markdown, not tokens. **Keep HTMLToMarkdown here.**
+- **Re-extraction UI** — the PDF re-extract button. HTML re-extract via defuddle
+  is a natural follow-on, not in the initial PR. **The ingestion path is the target.**
+
+---
+
+## 2. The Integration — simplest possible, mirroring pdf2md
+
+### 2.1 build.sh: bundle the defuddle script (4 edits, all mirroring pdf2md)
+
+| # | build.sh location | pdf2md pattern to mirror | defuddle addition |
+|---|-------------------|--------------------------|-------------------|
+| 1 | variable defs | `PDF2MD_NAME`/`PDF2MD_SRC` | `DEFUDDLE_NAME="defuddle"` / `DEFUDDLE_SRC="tools/defuddle/defuddle"` |
+| 2 | cp into bundle | `cp "${PDF2MD_SRC}" "${HELPERS_DIR}/…"` + build/ copy | same for defuddle |
+| 3 | real-identity codesign | `codesign … --sign "${IDENTITY}" "${HELPERS_DIR}/${PDF2MD_NAME}"` | same for defuddle |
+| 4 | ad-hoc codesign | `codesign --force --sign - "${HELPERS_DIR}/${PDF2MD_NAME}"` | same for defuddle |
+
+**Why sign a plain script?** Same reason as pdf2md: a plain script bundled in
+`Helpers/` must be signed or the outer app's seal fails ("code object is not
+signed at all"). bun reads the file; signing is for the seal.
+
+**Repo vendoring:** the 7416-byte self-contained script lives at
+`tools/defuddle/defuddle` (parallel to `tools/pdf2md/pdf2md`). Single bundle — no
+`node_modules`, no install step. `tools/defuddle/README.md` notes the source
+version (0.19.1) and update procedure.
+
+### 2.2 New file: `Sources/WikiFS/Sources/DefuddleExtractionService.swift`
+
+A `@MainActor enum` (namespace of statics), a **near-clone of
+`PdfExtractionService`** but simpler. Lives in the `WikiFS` target alongside
+`PdfExtractionService.swift`.
+
+**Resolved binary pair:** unlike pdf2md (one script), defuddle needs **two
+artifacts**: the bun runtime + the defuddle script. `resolve()` returns
+`(bun: URL, script: URL)?`.
+
+```swift
+import Foundation
+import WikiFSCore
+
+/// Extracts article markdown + metadata from HTML via the bundled `defuddle`
+/// Node script run with the bundled `bun` runtime. A near-clone of
+/// PdfExtractionService's Process pattern, but simpler: no uv/Python/venv (bun
+/// is always bundled), HTML on stdin, sub-second runtime, JSON on stdout.
+///
+/// Fallback contract: extract() returns nil on ANY failure (binary missing,
+/// non-zero exit, empty content for SPA/JS-rendered pages, bad JSON). The
+/// caller then uses the tag-based HTMLToMarkdown path — zero regression.
+@MainActor
+enum DefuddleExtractionService {
+
+    /// Markdown body + parsed metadata.
+    struct ExtractionResult: Sendable {
+        let markdown: String        // contentMarkdown (preferred) or content
+        let title: String?
+        let author: String?
+        let description: String?
+        let published: String?      // ISO 8601 string
+        let wordCount: Int?
+    }
+
+    /// Resolve (bundled bun, defuddle script). Returns nil only if EITHER is
+    /// unresolvable.
+    static func resolve() -> (bun: URL, script: URL)? { … }
+
+    /// Extract markdown + metadata from HTML bytes via `bun defuddle parse -j -`.
+    /// Best-effort: returns nil on any failure. Never throws.
+    static func extract(html: String, timeout: Duration = .seconds(30)) async -> ExtractionResult? { … }
+
+    // MARK: - JSON parse (robust to both -j and -m -j field shapes)
+    private static func parseDefuddleJSON(_ data: Data) -> ExtractionResult? { … }
+}
+```
+
+### 2.3 The subprocess invocation — concrete shape
+
+Mirror `PdfExtractionService.run()`, adapted for stdin + bun:
+
+```swift
+let process = Process()
+process.executableURL = bun                           // Helpers/bun
+process.arguments = [script.path, "parse", "-j", "-"] // [defuddle, "parse","-j","-"]
+// NO env PATH augmentation needed — bun is the absolute executableURL.
+
+let stdinPipe = Pipe();  process.standardInput = stdinPipe
+let stdoutPipe = Pipe(); process.standardOutput = stdoutPipe
+let stderrPipe = Pipe(); process.standardError = stderrPipe
+
+// Continuous stdout/stderr drain (OutputBuffer + readabilityHandler) —
+// SAME pipe-deadlock avoidance as PdfExtractionService.
+let stdoutBuffer = OutputBuffer()
+stdoutPipe.fileHandleForReading.readabilityHandler = { h in
+    let d = h.availableData; guard !d.isEmpty else { return }; stdoutBuffer.append(d)
+}
+let stderrBuffer = OutputBuffer()
+stderrPipe.fileHandleForReading.readabilityHandler = { h in
+    let d = h.availableData; guard !d.isEmpty else { return }; stderrBuffer.append(d)
+}
+
+try process.run()
+// Feed HTML to stdin, then CLOSE (EOF signals defuddle to parse):
+stdinPipe.fileHandleForWriting.write(Data(html.utf8))
+try? stdinPipe.fileHandleForWriting.close()
+```
+
+**Three things that differ from PdfExtractionService.run():**
+1. **stdin input** (HTML bytes via pipe + `closeFile`) instead of a temp file path arg.
+2. **bun as executableURL** instead of the script itself (the script is `arguments[0]`).
+3. **A timeout** (`withTaskGroup` race vs `Task.sleep(30s)` — pdf2md has none because
+   a cold run is legitimately minutes; defuddle is sub-second so 30s is a safety net).
+
+### 2.4 Wire into the ingestion path (the materializers)
+
+`FormatMaterializer.dispatch` stays **pure + synchronous** (it's called from tests
+and the pure-dispatch contract is valuable). Defuddle is async, so the call lives
+in the **materializers** (already `async throws`). Add one shared helper + call it
+from each HTML-producing materializer.
+
+**New helper** (add to `FormatMaterializer`):
+
+```swift
+/// If the plan is HTML, try defuddle; fall back to the tag-based markdown already
+/// on the plan. Async — called by materializers after dispatch. Returns the
+/// (possibly rewritten) plan + the technique tag to stamp on the stored version.
+static func enrichWithDefuddle(_ plan: FormatPlan) async -> (plan: FormatPlan, technique: String) {
+    guard plan.format == .html else { return (plan, "html-to-markdown") }
+    let html = decodeText(plan.data)
+    if let r = await DefuddleExtractionService.extract(html: html) {
+        // Defuddle title may be better than the tag-based <title>.
+        return (FormatPlan(filename: …, data: plan.data, format: .html,
+                           extractedMarkdown: r.markdown), "defuddle")
+    }
+    return (plan, "html-to-markdown")  // fallback: keep tag-based extractedMarkdown
+}
+```
+
+**Call sites** (3 materializers, each ~2 lines added after the `dispatch` call):
+`WebsiteMaterializer`, `LocalFileMaterializer`, `ZoteroMaterializer`.
+
+### 2.5 Thread the technique tag to the store (lightweight)
+
+The current path hardcodes `"html-to-markdown"`. To surface which extractor
+produced each version, add one optional field:
+
+**`MaterializedSource`** gains:
+```swift
+public let extractionTechnique: String?  // "defuddle" | "html-to-markdown" | nil
+```
+
+**`WikiStoreModel.appendExtractedMarkdown`** reads it:
+```swift
+let technique = m.extractionTechnique ?? Self.htmlToMarkdownTechnique
+try store.appendProcessedMarkdown(sourceID: summary.id, content: markdown,
+    origin: .extraction, note: nil, technique: technique)
+```
+
+(Metadata enrichment — author/description/published → provenance — is
+explicitly **out of scope**. `ExtractionResult` captures them, but the
+`MaterializedSource`/`SourceProvenance` types don't yet carry author/published.
+That's a follow-on task, not a blocker.)
+
+---
+
+## 3. The Fallback Chain (zero-regression guarantee)
+
+```
+materialize() [async]
+  └─ FormatMaterializer.dispatch()  →  FormatPlan(.html, extractedMarkdown: TAG-BASED)
+  └─ FormatMaterializer.enrichWithDefuddle(plan)
+       └─ DefuddleExtractionService.extract(html)  [async subprocess]
+            ├─ bun + script resolvable?
+            │    NO → return nil
+            ├─ exit 0 + non-empty contentMarkdown?
+            │    YES → return ExtractionResult  →  use defuddle markdown, technique="defuddle"
+            │    NO (exit 1 / empty / SPA / bad JSON) → return nil
+            └─ nil → KEEP plan.extractedMarkdown (tag-based), technique="html-to-markdown"
+```
+
+**The fallback guarantees it is impossible to do worse than today.** Defuddle
+either improves extraction (site-specific parsers: GitHub, Wikipedia, Substack,
+YouTube transcripts, …) or transparently degrades to the current tag-based path.
+
+---
+
+## 4. Files to Modify
+
+| File | Change |
+|------|--------|
+| `tools/defuddle/defuddle` | **NEW** — vendor the 7416-byte script |
+| `tools/defuddle/README.md` | **NEW** — version (0.19.1), source, update procedure |
+| `build.sh` | 4 edits: var defs, cp+sign (real + ad-hoc) — mirror pdf2md |
+| `Sources/WikiFS/Sources/DefuddleExtractionService.swift` | **NEW** — ~120-line Process wrapper |
+| `Sources/WikiFSCore/Sources/FormatMaterializer.swift` | Add `enrichWithDefuddle(_:)` async helper |
+| `Sources/WikiFSCore/Sources/SourceMaterializer.swift` | Add `extractionTechnique` to `MaterializedSource`; call `enrichWithDefuddle` in 3 materializers |
+| `Sources/WikiFSCore/Store/WikiStoreModel.swift` | `appendExtractedMarkdown` reads `m.extractionTechnique` |
+| `Tests/WikiFSTests/DefuddleExtractionServiceTests.swift` | **NEW** — extraction + JSON parse + fallback tests |
+| `Tests/WikiFSTests/FormatMaterializerTests.swift` | Add async `enrichWithDefuddle` tests |
+
+---
+
+## 5. Testing Plan (Swift Testing)
+
+### 5.1 `DefuddleExtractionServiceTests` (new)
+
+Mirror `PdfExtractionServiceTests` structure. Tests run the **real** bundled
+bun + defuddle script. **Skip gracefully if `resolve()` returns nil** (CI / clean
+dev) via an early `return` + comment (defuddle is opt-in until vendored).
+
+- `extractsMarkdownAndMetadata` — article with nav/footer stripped, title/author/published parsed.
+- `returnsNilForSPAEmptyBody` — `<div id="app">` → nil (fallback trigger).
+- `returnsNilForEmptyInput` — `""` → nil.
+- `parseJSONHandlesMissingContentMarkdown` — content present (HTML), contentMarkdown absent → nil.
+- `parseJSONPrefersContentMarkdownOverContent` — both present → contentMarkdown wins.
+- `resolvesBunAndScript` — resolve() != nil when bundled.
+
+### 5.2 Fallback integration test
+
+`enrichWithDefuddleFallsBackToTagBased` — SPA HTML → tag-based markdown kept,
+technique == "html-to-markdown".
+
+### 5.3 Regression
+
+- `FormatMaterializerTests` — `dispatch` is unchanged (still pure/sync); pass as-is.
+- `HTMLToMarkdownTests` — unchanged (still the fallback).
+- `SourceMaterializerTests` — materializers are already `async`; add `await`.
+
+---
+
+## 6. Acceptance Criteria
+
+1. **AC1 — Defuddle extraction:** ingesting a `text/html` URL yields markdown via
+   defuddle with site-specific extraction (no nav/footer boilerplate).
+2. **AC2 — Fallback on SPA:** a JS-rendered page (empty body) falls back to
+   tag-based `HTMLToMarkdown` — no crash, no empty result.
+3. **AC3 — Original HTML preserved:** the source blob is still the original HTML
+   bytes (issue #599 two-layer model intact). The HTML tab in `SourceDetailView`
+   still shows raw HTML.
+4. **AC4 — Technique tag:** the `source_markdown_versions.technique` column is
+   `"defuddle"` on success, `"html-to-markdown"` on fallback.
+5. **AC5 — Self-contained:** runs via the **bundled bun** (no system Node/bun
+   needed, no external runtime dependency). No uv-style degradation path.
+6. **AC6 — No `print` / no bare `try?`:** all diagnostics via `DebugLog.extraction`;
+   swallowed errors are logged, not hidden.
+7. **AC7 — No regression:** all existing tests pass.
+8. **AC8 — Unbundled is safe:** if `resolve()` returns nil, `extract()` returns
+   nil, the fallback runs, a `DebugLog` note fires. No crash.
+
+---
+
+## 7. Gotchas
+
+1. **`-j` vs `-m -j` field names (verified):** use `parse -j -` and read
+   `contentMarkdown`. With `-m -j`, defuddle overloads `content` with markdown
+   and **drops `contentMarkdown`**. Invoke `-j`; make the decoder robust
+   (prefer `contentMarkdown`, fall back to `content`).
+2. **stdin must be closed (EOF):** after `write`, call
+   `stdinPipe.fileHandleForWriting.close()`. Without EOF, defuddle blocks
+   waiting for more input → deadlock.
+3. **stdout must drain continuously** (`readabilityHandler` + `OutputBuffer`),
+   not only in `terminationHandler` — same 64 KB pipe-buffer deadlock as pdf2md.
+4. **Sign the defuddle script** in `build.sh` — a plain script in `Helpers/`
+   breaks the app seal if unsigned. Mirror the pdf2md codesign in BOTH the
+   real-identity and ad-hoc branches.
+5. **macOS 15 / Swift 6.0:** no `@Entry` (manual `EnvironmentKey`); strict
+   concurrency — `OutputBuffer` must be `@unchecked Sendable` with a lock (pipe
+   callbacks fire off-actor). `@MainActor enum` for the service, `nonisolated`
+   for the registry/PATH helpers.
+6. **bun is `executableURL`, script is `arguments[0]`:**
+   `process.executableURL = bun`; `arguments = [script.path, "parse", "-j", "-"]`.
+   NOT `executableURL = script` (the shebang would search PATH for node, which a
+   Finder-launched app doesn't have).
+7. **`resolveDefuddle` uses `fileExists`, not `isExecutableFile`:** bun *reads*
+   the script (doesn't exec it), so the executable bit is irrelevant; readability
+   is what matters.
+8. **No PATH augmentation needed:** bun is resolved as an absolute
+   `executableURL` (Helpers/bun), unlike pdf2md whose shebang needs `uv` on PATH.
+   This is the key simplification — no `uvSearchPATH` equivalent.
+9. **Empty-string metadata → nil:** defuddle emits `""` (not null) for absent
+   `author`/`published`/`description`. Map with a `nonEmpty()` helper.
+10. **Timeout (30s):** defuddle is sub-second, but a hung process (e.g. stdin not
+    closed) is possible. Race the `terminationHandler` continuation against
+    `Task.sleep(30s)` via `withTaskGroup`; on timeout, `process.terminate()`.
+11. **`WebsiteSnapshotExtractor` is NOT touched** — it needs token-level access
+    for `<img src>` rewriting. Document as a known follow-on.

--- a/tools/defuddle/README.md
+++ b/tools/defuddle/README.md
@@ -1,0 +1,82 @@
+# defuddle
+
+Bundled copy of [defuddle](https://github.com/kepano/defuddle) — a
+self-contained Node script that extracts article markdown + metadata from
+HTML using readability scoring and site-specific parsers (GitHub, Wikipedia,
+Substack, YouTube transcripts, …).
+
+Part of [Self Driving Wiki](../..). Replaces the tag-based
+`HTMLToMarkdown.scopeToMainContent` heuristic for the HTML-ingestion path
+(issue #761).
+
+## Why bundle it
+
+The app already bundles **bun** (a Node-compatible runtime) in
+`Contents/Helpers/bun`, required by the build for ACP providers. So defuddle
+runs fully self-contained via the bundled bun — no system Node, no uv/Python,
+no external runtime dependency. This makes defuddle strictly simpler than
+`pdf2md` (which needs unbundled uv+Python and falls back to the agent when
+absent).
+
+## Version
+
+- **defuddle 0.19.1** (from `~/.local/lib/node_modules/defuddle`)
+- The script is the published `dist/cli.js` CommonJS bundle — 7416 bytes, no
+  external `require`s, run directly by bun.
+
+## Usage (how the app invokes it)
+
+```sh
+echo '<html>…<article><p>Hi <strong>there</strong>.</p></article>…' \
+    | bun tools/defuddle/defuddle parse -j -
+```
+
+Outputs JSON on stdout with, among others:
+
+- `contentMarkdown` — the extracted markdown (`Hi **there**.`)
+- `content` — cleaned HTML (`<article><p>Hi</p></article>`)
+- `title`, `author`, `description`, `published`, `wordCount`
+
+### ⚠️ Critical gotcha: use `parse -j -`, NOT `-m -j -`
+
+| Invocation | `content` field | `contentMarkdown` field |
+|------------|-----------------|-------------------------|
+| `parse -j -` (no `-m`) | cleaned HTML | **markdown** ✓ |
+| `parse -m -j -` | markdown (overloaded) | **ABSENT** ✗ |
+
+With `-m -j`, defuddle overloads `content` with markdown and drops
+`contentMarkdown`. **Use `parse -j -` and read `contentMarkdown`.** The
+JSON decoder prefers `contentMarkdown` and falls back to `content`, so it is
+robust to both shapes.
+
+### SPA / empty content
+
+A page with no article body (e.g. `<div id="app">`) makes defuddle exit 1
+with empty stdout. This is the fallback trigger
+(`DefuddleExtractionService.extract` returns nil → caller uses tag-based
+`HTMLToMarkdown`). Input is read from stdin (`-`); the stdin pipe **must be
+closed** after writing so defuddle sees EOF.
+
+## Update procedure
+
+```sh
+# 1. Install/update defuddle globally (npm)
+npm install -g defuddle            # or: npm install -g defuddle@latest
+
+# 2. Resolve the real file (the bin is a symlink to dist/cli.js)
+SRC="$(readlink -f ~/.local/bin/defuddle)"
+
+# 3. Copy the bundle into this directory
+cp "$SRC" tools/defuddle/defuddle
+
+# 4. Update the version number in this README and in
+#    Sources/WikiFS/Sources/DefuddleExtractionService.swift comments if needed.
+
+# 5. Re-run the test suite
+swift test --filter DefuddleExtractionService
+```
+
+The copy is a single self-contained bundle — no `node_modules`, no install
+step at build time. `build.sh` copies it into `Contents/Helpers/defuddle` and
+codesigns it (a plain script in `Helpers/` must be signed or the app seal
+fails; same as pdf2md).

--- a/tools/defuddle/defuddle
+++ b/tools/defuddle/defuddle
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.readStdin = readStdin;
+exports.parseSource = parseSource;
+exports.createProgram = createProgram;
+const commander_1 = require("commander");
+const node_1 = require("./node");
+const promises_1 = require("fs/promises");
+const path_1 = require("path");
+const linkedom_compat_1 = require("./utils/linkedom-compat");
+const utils_1 = require("./utils");
+const frontmatter_1 = require("./frontmatter");
+const fetch_1 = require("./fetch");
+// ANSI color helpers (avoids chalk dependency which is ESM-only)
+const useColor = process.stdout.isTTY ?? false;
+const ansi = {
+    red: (s) => useColor ? `\x1b[31m${s}\x1b[39m` : s,
+    green: (s) => useColor ? `\x1b[32m${s}\x1b[39m` : s,
+};
+// Read version from package.json
+const version = require('../package.json').version;
+async function readStdin(input = process.stdin) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        input.setEncoding('utf8');
+        input.on('data', (chunk) => {
+            chunks.push(chunk);
+        });
+        input.on('end', () => resolve(chunks.join('')));
+        input.on('error', reject);
+    });
+}
+async function parseSource(source, options, input = process.stdin) {
+    // Handle --md alias
+    if (options.md) {
+        options.markdown = true;
+    }
+    const defuddleOpts = {
+        debug: options.debug,
+        markdown: options.markdown,
+        separateMarkdown: options.markdown || options.json,
+        language: options.lang,
+    };
+    let html;
+    let url;
+    const usesStdin = !source || source === '-';
+    const isUrl = !usesStdin && (source.startsWith('http://') || source.startsWith('https://'));
+    if (usesStdin) {
+        if (input.isTTY) {
+            throw new Error('No input source provided. Pass a file path or URL, or pipe HTML to stdin.');
+        }
+        html = await readStdin(input);
+    }
+    else if (isUrl) {
+        url = source;
+        const initialUA = options.userAgent || (0, fetch_1.getInitialUA)(source);
+        html = await (0, fetch_1.fetchPage)(source, initialUA, options.lang);
+    }
+    else {
+        const filePath = (0, path_1.resolve)(process.cwd(), source);
+        html = await (0, promises_1.readFile)(filePath, 'utf-8');
+    }
+    const doc = (0, linkedom_compat_1.parseLinkedomHTML)(html);
+    let result = await (0, node_1.Defuddle)(doc, url, defuddleOpts);
+    // If no content was extracted from a URL, retry with bot UA.
+    // Some sites (e.g. Obsidian Publish) serve pre-rendered content to bots.
+    // Skipped when the user set a UA explicitly — respect their choice.
+    if (isUrl && result.wordCount === 0 && !options.userAgent) {
+        try {
+            const botHtml = await (0, fetch_1.fetchPage)(source, fetch_1.BOT_UA, options.lang);
+            // Check for raw markdown before DOM parsing destroys whitespace
+            const rawMarkdown = (0, fetch_1.extractRawMarkdown)(botHtml);
+            if (rawMarkdown) {
+                const botDoc = (0, linkedom_compat_1.parseLinkedomHTML)(botHtml);
+                const botResult = await (0, node_1.Defuddle)(botDoc, url, defuddleOpts);
+                botResult.content = (0, fetch_1.cleanMarkdownContent)(rawMarkdown);
+                botResult.wordCount = (0, utils_1.countWords)(botResult.content);
+                result = botResult;
+            }
+            else {
+                const botDoc = (0, linkedom_compat_1.parseLinkedomHTML)(botHtml);
+                const botResult = await (0, node_1.Defuddle)(botDoc, url, defuddleOpts);
+                if (botResult.wordCount > 0) {
+                    result = botResult;
+                }
+            }
+        }
+        catch {
+            // Bot UA may be blocked — use original result
+        }
+    }
+    // Check if parsing produced meaningful content
+    const textContent = (0, linkedom_compat_1.parseLinkedomHTML)(`<!DOCTYPE html><html><body>${result.content}</body></html>`)
+        .body.textContent?.trim() || '';
+    if (!textContent) {
+        throw new Error(`No content could be extracted from ${usesStdin ? 'stdin' : source}`);
+    }
+    // Format output
+    let output;
+    if (options.property) {
+        const property = options.property;
+        if (property in result) {
+            output = result[property]?.toString() || '';
+        }
+        else {
+            throw new Error(`Property "${property}" not found in response`);
+        }
+    }
+    else if (options.json) {
+        output = JSON.stringify({
+            content: result.content,
+            title: result.title,
+            description: result.description,
+            domain: result.domain,
+            favicon: result.favicon,
+            image: result.image,
+            language: result.language,
+            metaTags: result.metaTags,
+            parseTime: result.parseTime,
+            published: result.published,
+            author: result.author,
+            site: result.site,
+            schemaOrgData: result.schemaOrgData,
+            wordCount: result.wordCount,
+            ...(result.contentMarkdown ? { contentMarkdown: result.contentMarkdown } : {}),
+            ...(result.variables ? { variables: result.variables } : {}),
+        }, null, 2);
+    }
+    else {
+        output = options.frontmatter ? (0, frontmatter_1.buildFrontmatter)(result, url) + result.content : result.content;
+    }
+    return { output };
+}
+function createProgram() {
+    const program = new commander_1.Command();
+    program
+        .name('defuddle')
+        .description('Extract article content from web pages')
+        .version(version);
+    program
+        .command('parse')
+        .description('Parse HTML content from a file, URL, or stdin')
+        .argument('[source]', 'HTML file path, URL, or "-" to read from stdin')
+        .option('-o, --output <file>', 'Output file path (default: stdout)')
+        .option('-m, --markdown', 'Convert content to markdown format')
+        .option('--md', 'Alias for --markdown')
+        .option('-j, --json', 'Output as JSON with metadata and content')
+        .option('-f, --frontmatter', 'Prepend YAML frontmatter (title, author, source, etc.) to the output')
+        .option('-p, --property <name>', 'Extract a specific property (e.g., title, description, domain)')
+        .option('--debug', 'Enable debug mode')
+        .option('-l, --lang <code>', 'Preferred language (BCP 47, e.g. en, fr, ja)')
+        .option('-u, --user-agent <string>', 'Custom User-Agent header for HTTP requests (helps with 403/FORBIDDEN responses)')
+        .action(async (source, options) => {
+        try {
+            const { output } = await parseSource(source, options);
+            // Handle output
+            if (options.output) {
+                const outputPath = (0, path_1.resolve)(process.cwd(), options.output);
+                await (0, promises_1.writeFile)(outputPath, output, 'utf-8');
+                console.log(ansi.green(`Output written to ${options.output}`));
+            }
+            else {
+                console.log(output);
+            }
+        }
+        catch (error) {
+            console.error(ansi.red('Error:'), error instanceof Error ? error.message : 'Unknown error occurred');
+            process.exit(1);
+        }
+    });
+    return program;
+}
+const program = createProgram();
+if (require.main === module) {
+    program.parse();
+}
+//# sourceMappingURL=cli.js.map


### PR DESCRIPTION
## Summary

Replace the tag-based `HTMLToMarkdown.scopeToMainContent` heuristic with
[defuddle](https://github.com/kepano/defuddle) for HTML source content
extraction (issue #761). Defuddle provides readability scoring + site-specific
parsers (GitHub, Wikipedia, Substack, YouTube transcripts, etc.) — yielding
cleaner markdown with nav/footer/chrome stripped.

**Zero-regression fallback:** defuddle runs via the already-bundled bun runtime
(no external dependency). If defuddle fails for any reason (binary missing,
SPA/empty body, bad JSON, timeout), the ingest path transparently falls back to
the existing tag-based `HTMLToMarkdown` — it's impossible to do worse than today.

Closes #761. Supersedes #209.

## Design

- **defuddle** is a self-contained 7KB CommonJS Node script. **bun** (already
  bundled + signed in `Contents/Helpers/bun` for ACP providers) runs it
  standalone — no system Node, no uv/Python/venv. This makes defuddle strictly
  simpler than pdf2md (which needs unbundled uv+Python).
- **Invocation:** `bun <defuddle> parse -j -` (HTML on stdin, JSON on stdout).
  Uses `parse -j -` (NOT `-m -j`): with `-m -j`, defuddle overloads `content`
  with markdown and drops `contentMarkdown`. The decoder prefers
  `contentMarkdown`, falls back to `content`, so it's robust to both shapes.
- **Architecture:** mirrors the `PdfExtractionService` / `LocalPdf2MarkdownExtractor`
  pattern — `HtmlMarkdownExtractor` protocol in WikiFSCore, concrete
  `DefuddleExtractionService` + `LocalDefuddleExtractor` conformer in WikiFS,
  injected via a factory closure through `SessionManager` → `WikiSession` →
  `WikiStoreModel` (same injection seam as `pdf2mdScriptPathResolver`).

## Changes

| File | Change |
|------|--------|
| `tools/defuddle/defuddle` | **NEW** — vendored defuddle 0.19.1 (7416-byte bundle) |
| `tools/defuddle/README.md` | **NEW** — version, source, usage, `-j` vs `-m -j` gotcha, update procedure |
| `build.sh` | 4 edits mirroring pdf2md: var defs, cp into bundle, codesign (real + ad-hoc) |
| `Sources/WikiFS/Sources/DefuddleExtractionService.swift` | **NEW** — ~370-line Process wrapper (bun as executableURL, script as arguments[0], stdin pipe + EOF close, stdout drain via readabilityHandler+OutputBuffer, 30s timeout race) + `LocalDefuddleExtractor` conformer |
| `Sources/WikiFSCore/Sources/FormatMaterializer.swift` | `HtmlMarkdownExtractor` protocol + `HtmlExtractionResult` type + `enrich(_:using:)` async helper |
| `Sources/WikiFSCore/Sources/SourceMaterializer.swift` | `extractionTechnique` field on `MaterializedSource` |
| `Sources/WikiFSCore/Store/WikiStoreModel.swift` | `htmlMarkdownExtractor` property, `enrichWithDefuddle()` in `addFiles`/`ingestFromZotero`/`addURLViaWebsite` (image-less HTML only), `appendExtractedMarkdown` reads technique |
| `Sources/WikiFSEngine/WikiSession.swift` | `htmlMarkdownExtractorFactory` param → `model.htmlMarkdownExtractor` |
| `Sources/WikiFSEngine/SessionManager.swift` | `htmlMarkdownExtractorFactory` stored + forwarded |
| `Sources/WikiFS/Window/WikiFSApp.swift` | Wires `LocalDefuddleExtractor()` factory |
| `Tests/WikiFSTests/DefuddleExtractionServiceTests.swift` | **NEW** — 10 tests (extraction, SPA fallback, OutputBuffer, ProcessRegistry) |
| `Tests/WikiFSTests/FormatMaterializerTests.swift` | 5 `enrich` tests (nil/failing/successful extractor, non-HTML skip, title fallback) |

## Testing

- `swift build` — compiles clean
- `swift test --filter DefuddleExtractionService` — 10/10 pass (real bun+defuddle)
- `swift test --filter FormatMaterializer` — 23/23 pass (including 5 new enrich tests)
- `swift test` (full suite) — **3272 tests, 271 suites, 0 failures**

Tests skip gracefully if `resolve()` returns nil (CI / clean dev before `make build`).

## Acceptance Criteria

- [x] **AC1** — Defuddle extraction: ingesting `text/html` yields markdown via
      defuddle with site-specific extraction (verified: nav/footer stripped)
- [x] **AC2** — Fallback on SPA: empty body falls back to tag-based (nil → tag-based)
- [x] **AC3** — Original HTML preserved: source blob is still the original HTML
      bytes (issue #599 two-layer model intact)
- [x] **AC4** — Technique tag: `source_markdown_versions.technique` is `"defuddle"`
      on success, `"html-to-markdown"` on fallback
- [x] **AC5** — Self-contained: runs via bundled bun (no external runtime)
- [x] **AC6** — No `print` / no bare `try?`: all diagnostics via `DebugLog.extraction`
- [x] **AC7** — No regression: all existing tests pass
- [x] **AC8** — Unbundled is safe: `resolve()` nil → `extract()` nil → fallback

## Out of scope (follow-ons)

- **Website snapshots with images** keep `WebsiteSnapshotExtractor` (image-aware
  extraction with `<img src>` rewriting — defuddle can't replace that without
  losing image references). Defuddle runs only for image-less HTML.
- **Re-extraction UI** (HTML re-extract button) — natural follow-on.
- **Metadata → provenance** (`author`/`description`/`published` captured on
  `ExtractionResult` but not yet written to the store; types don't carry them).
