### PR TITLE
Rename ChatView to ChatDetailView

### DIFF
--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -5,7 +5,7 @@ import WikiFSEngine
 import WikiFSCore
 
 /// The unified chat surface (D2, pillar 2). One view replaces the split
-/// between the live `ChatView` and the read-only
+/// between the live `ChatDetailView` and the read-only
 /// `ChatHistoryDetailView`. Whether you see streaming deltas or a persisted
 /// transcript depends on the **source-of-truth rule**: if this chat is the
 /// launcher's active live session (`activeChatID == chatID`), render
@@ -16,7 +16,7 @@ import WikiFSCore
 /// showing the empty-composer state until the first send retargets the tab to
 /// `.chat(id)` (the draft-state morph, handled by `AgentOperationRunner`).
 /// Chats are always write-capable (the read-only Ask mode was removed).
-struct ChatView: View {
+struct ChatDetailView: View {
     /// The persisted chat id, or `nil` for the draft state (.newChat). When
     /// non-nil AND equal to `launcher.activeChatID`, the view renders live.
     let chatID: PageID?
@@ -725,14 +725,14 @@ struct ChatView: View {
         HStack(spacing: 10) {
             if let chatID {
                 Button("Show in List", systemImage: "sidebar.left") {
-                    DebugLog.tabs("ChatView: Show in List tapped — id=\(chatID.rawValue)")
+                    DebugLog.tabs("ChatDetailView: Show in List tapped — id=\(chatID.rawValue)")
                     store.requestSidebarReveal(.chat(chatID))
                 }
                 .help("Reveal this chat in the sidebar")
             }
             if fileProvider.path != nil, let chatID {
                 Button("Share", systemImage: "square.and.arrow.up") {
-                    DebugLog.fileprovider("ChatView: Share tapped — id=\(chatID.rawValue)")
+                    DebugLog.fileprovider("ChatDetailView: Share tapped — id=\(chatID.rawValue)")
                     Task {
                         guard let url = await fileProvider.resolveChatByNameURL(id: chatID, wikiID: session.wikiID) else {
                             DebugLog.fileprovider("Share chat detail: resolveChatByNameURL returned nil — id=\(chatID.rawValue) wikiID=\(session.wikiID)")
@@ -753,7 +753,7 @@ struct ChatView: View {
                 }
                 .help("Share this chat")
                 Button("Reveal in Finder", systemImage: "folder") {
-                    DebugLog.fileprovider("ChatView: Reveal in Finder tapped — id=\(chatID.rawValue)")
+                    DebugLog.fileprovider("ChatDetailView: Reveal in Finder tapped — id=\(chatID.rawValue)")
                     Task { await fileProvider.revealChatInFinder(id: chatID, wikiID: session.wikiID) }
                 }
                 .help("Reveal this chat file in Finder")
@@ -765,7 +765,7 @@ struct ChatView: View {
             // frame — Bug 1 fix).
             Spacer(minLength: 0)
             Button {
-                DebugLog.tabs("ChatView: Toggle Outline tapped")
+                DebugLog.tabs("ChatDetailView: Toggle Outline tapped")
                 chatOutlineExpanded.toggle()
             } label: {
                 Image(systemName: "sidebar.right")
@@ -811,7 +811,7 @@ struct ChatView: View {
     @ViewBuilder
     private func revealDebugFolderButton(chatID: PageID, debugURL: URL?) -> some View {
         Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
-            DebugLog.agent("ChatView: Reveal Debug Folder tapped — id=\(chatID.rawValue)")
+            DebugLog.agent("ChatDetailView: Reveal Debug Folder tapped — id=\(chatID.rawValue)")
             if let debugURL {
                 NSWorkspace.shared.activateFileViewerSelecting([debugURL])
             } else {
@@ -822,7 +822,7 @@ struct ChatView: View {
                 // brief; the disabled state should already prevent this).
                 // Log so the click is visible in Console.app (belt-and-
                 // suspenders).
-                DebugLog.agent("ChatView: no debug folder available for chat — id=\(chatID.rawValue) (no runs on disk)")
+                DebugLog.agent("ChatDetailView: no debug folder available for chat — id=\(chatID.rawValue) (no runs on disk)")
             }
         }
         .disabled(debugURL == nil)
@@ -1387,7 +1387,7 @@ struct ChatView: View {
     }
 
     private var canType: Bool {
-        // A session is always alive when ChatView is rendered inside
+        // A session is always alive when ChatDetailView is rendered inside
         // ContentView, so the old `activeWikiID != nil` check is
         // always true here.
         // #740: typing (drafting) is allowed during generation so the user can
@@ -1502,7 +1502,7 @@ private struct ChatAttachment: Identifiable, Hashable {
     }
 }
 
-/// `Hashable` key for the `ChatView` quote-anchor consume task (issue #281).
+/// `Hashable` key for the `ChatDetailView` quote-anchor consume task (issue #281).
 /// Re-fires the task when the chat changes, a new anchor is pending, or the
 /// transcript's message count changes (so the anchor is consumed only once the
 /// persisted messages have loaded).

--- a/Sources/WikiFS/Chats/ChatTranscriptView.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptView.swift
@@ -5,7 +5,7 @@ import WikiFSCore
 /// persisted (read-only) chat surfaces. Rendered from a caller-supplied `events`
 /// array (already `transcriptVisible`-filtered), so the live path feeds
 /// `launcher.events` and the persisted path feeds `store.chatMessages` through
-/// the same view — collapsing the old dual render sites in `ChatView`.
+/// the same view — collapsing the old dual render sites in `ChatDetailView`.
 struct ChatTranscriptView: View {
     /// The transcript-visible events to render (caller pre-filters via
     /// `[AgentEvent].transcriptVisible`).
@@ -22,11 +22,11 @@ struct ChatTranscriptView: View {
     /// persisted surface passes `false` (it is never the active stream).
     var isRunning: Bool = false
     /// Forwards wiki-link clicks in the transcript to the detail column. Built
-    /// where the store lives (the parent `ChatView`) and forwarded unchanged to
+    /// where the store lives (the parent `ChatDetailView`) and forwarded unchanged to
     /// the transcript web view.
     var onWikiLink: ((URL, Bool) -> Void)? = nil
     /// Provider of the current `WikiRenderContext` (Phase A.2) — bound to
-    /// `store.renderContext()` by `ChatView`, so chat rows render source
+    /// `store.renderContext()` by `ChatDetailView`, so chat rows render source
     /// references exactly as the reader does. Forwarded unchanged to the
     /// transcript web view.
     var renderContext: (() -> WikiRenderContext?)? = nil

--- a/Sources/WikiFS/Editor/AddContextPicker.swift
+++ b/Sources/WikiFS/Editor/AddContextPicker.swift
@@ -9,7 +9,7 @@ import WikiFSCore
 /// Modeled on `ProviderSelector` / `PermissionModeSelector` so it reads as a
 /// sibling chip in the composer toolbar: a glyph trigger, a searchable popover,
 /// hover-highlighted rows. It emits a `SidebarDragPayload` (the app's existing
-/// attach currency) via `onAdd`, so `ChatView` builds the `ChatAttachment` with
+/// attach currency) via `onAdd`, so `ChatDetailView` builds the `ChatAttachment` with
 /// the same code that a sidebar drop uses.
 struct AddContextPicker: View {
     @Bindable var store: WikiStoreModel

--- a/Sources/WikiFS/Editor/ComposerTextView.swift
+++ b/Sources/WikiFS/Editor/ComposerTextView.swift
@@ -39,7 +39,7 @@ struct ComposerTextView: NSViewRepresentable {
     /// `.frame(height: measuredHeight)`.
     @Binding var measuredHeight: CGFloat
     /// When true, the text view becomes first responder (keyboard focus) once
-    /// it's added to a window. Used by ChatView's draft state so the user can
+    /// it's added to a window. Used by ChatDetailView's draft state so the user can
     /// start typing immediately after clicking "Add chat".
     var autoFocus: Bool = false
 
@@ -52,7 +52,7 @@ struct ComposerTextView: NSViewRepresentable {
     ///
     /// Three injected closures so the AppKit coordinator stays pure about the
     /// engine + formatter (it doesn't import `WikiFSCore` / `DroppedLinkFormatter`
-    /// directly — the SwiftUI parent wires those in from `ChatView`):
+    /// directly — the SwiftUI parent wires those in from `ChatDetailView`):
     ///   - `fetch`: runs the Tantivy `autocomplete(partial:kinds:...)` query.
     ///     Must be async-cancellable on the caller side (the coordinator cancels
     ///     the prior in-flight Task before each new keystroke — AC #5). Returns
@@ -353,7 +353,7 @@ struct ComposerTextView: NSViewRepresentable {
         /// `autocomplete` hooks, `debounce`, and `scheduleDebounce`. Safe to
         /// call on every `textDidChange` (no-op when the parent hasn't
         /// changed). The chat composer doesn't change `autocomplete` after
-        /// makeNSView (it's bound once in ChatView) — but `updateNSView`
+        /// makeNSView (it's bound once in ChatDetailView) — but `updateNSView`
         /// could in principle swap closures, so we re-sync the binding
         /// through the controller's hooks provider.
         private func ensureAutocompleteController() {

--- a/Sources/WikiFS/Editor/ScrollableTextEditor.swift
+++ b/Sources/WikiFS/Editor/ScrollableTextEditor.swift
@@ -72,7 +72,7 @@ struct ScrollableTextEditor: NSViewRepresentable {
     /// are decoupled from `WikiFSCore` / `DroppedLinkFormatter` so the AppKit
     /// controller stays dependency-light. Built by `PageDetailView` and
     /// `SourceDetailView` from `store.tantivySearch` (same pattern as
-    /// `ChatView.chatAutocompleteHooks`).
+    /// `ChatDetailView.chatAutocompleteHooks`).
     var autocomplete: WikiLinkAutocompleteHooks? = nil
 
     /// Preferred dropdown placement relative to the caret. The chat composer

--- a/Sources/WikiFS/Editor/SidebarDropBuilder.swift
+++ b/Sources/WikiFS/Editor/SidebarDropBuilder.swift
@@ -99,13 +99,13 @@ enum SidebarDropBuilder {
     /// added.
     ///
     /// Reuses the same Tantivy fuzzy `search.autocomplete(partial:kinds:...)`
-    /// path the chat composer uses (`ChatView.chatAutocompleteHooks` at
-    /// `Sources/WikiFS/Chats/ChatView.swift:736`), and the same canonical-form
+    /// path the chat composer uses (`ChatDetailView.chatAutocompleteHooks` at
+    /// `Sources/WikiFS/Chats/ChatDetailView.swift:736`), and the same canonical-form
     /// `DroppedLinkFormatter.link(...)` builder the sidebar-drop insertion
     /// uses (#616). The two pure kind-mapping helpers
     /// (`WikiLinkAutocompleteController.tantivyKind(for:)` /
     /// `.parsedLinkType(from:)`) live on the controller so they're next to
-    /// their only non-ChatView caller — kept as `nonisolated static` to be
+    /// their only non-ChatDetailView caller — kept as `nonisolated static` to be
     /// test-reachable.
     static func wikiLinkAutocompleteHooks(
         store: WikiStoreModel

--- a/Sources/WikiFS/Editor/WikiLinkAutocompleteController.swift
+++ b/Sources/WikiFS/Editor/WikiLinkAutocompleteController.swift
@@ -4,7 +4,7 @@ import WikiFSSearch
 
 // MARK: - AutocompleteHooks
 
-/// Closures injected by a hosting view (`ChatView` for the composer,
+/// Closures injected by a hosting view (`ChatDetailView` for the composer,
 /// `PageDetailView`/`SourceDetailView` for the editor) so the autocomplete
 /// controller stays decoupled from `WikiFSCore` (the store handle) and
 /// `WikiFSLinks` (the formatter).
@@ -481,9 +481,9 @@ final class WikiLinkAutocompleteController {
     /// Pure: map `ParsedLink.LinkType` (the prefix vocabulary — `page:` /
     /// `source:` / `chat:`) → `TantivyDocumentKind` (the search index
     /// vocabulary). Single source of truth so a rename hits both sides.
-    /// `nonisolated` for test reach. Mirrors `ChatView.tantivyKind(for:)` so
+    /// `nonisolated` for test reach. Mirrors `ChatDetailView.tantivyKind(for:)` so
     /// the editor and the composer route through parallel single sources of
-    /// truth (the editor's lives next to its only non-ChatView consumer —
+    /// truth (the editor's lives next to its only non-ChatDetailView consumer —
     /// `SidebarDropBuilder.wikiLinkAutocompleteHooks`).
     nonisolated static func tantivyKind(for kind: ParsedLink.LinkType) -> TantivyDocumentKind {
         switch kind {

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -744,7 +744,7 @@ struct ActivityWindowView: View {
     /// agent (preflight failure, cancelled before run) won't have one. The
     /// debug folder contains the complete trace (ACP messages, permissions,
     /// usage, stderr.log), which supersedes the per-run `run.jsonl` log that
-    /// used to be exposed separately. Mirrors the ChatView's debug button.
+    /// used to be exposed separately. Mirrors the ChatDetailView's debug button.
     @ViewBuilder
     private func revealMenu(for item: QueueItem) -> some View {
         if let debugURL = activityTracker.debugURL(for: item.id) {

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -331,7 +331,7 @@ enum WikiLinkRoute: Equatable, Sendable {
     /// Resolved chat link — navigate to a persisted chat. `id` is the
     /// canonical ULID when the URL carried `?id=`; nil for legacy `?title=`-only
     /// links, which resolve by `title` as the transition fallback. `fragment`
-    /// carries a `#"quote"` passage (issue #281): the destination `ChatView`
+    /// carries a `#"quote"` passage (issue #281): the destination `ChatDetailView`
     /// resolves it to a message and highlights the passage.
     case chat(title: String, id: PageID?, fragment: String?)
     /// Unresolved (`wiki://missing`) or un-classifiable — inert.

--- a/Sources/WikiFS/Settings/AgentToolsView.swift
+++ b/Sources/WikiFS/Settings/AgentToolsView.swift
@@ -65,7 +65,7 @@ struct AgentToolsView: View {
     /// edge — mirrors `BookmarksContainerView`'s `bookmarksHeader` (native
     /// macOS pattern: Photos, Mail, Finder sidebar section headers). The `+`
     /// opens the draft state for a new chat by retargeting/opening a tab to
-    /// `.newChat` — the same draft state `ChatView` renders with `chatID ==
+    /// `.newChat` — the same draft state `ChatDetailView` renders with `chatID ==
     /// nil`. This reuses the existing `store.openTab` path rather than
     /// duplicating tab logic. (D4)
     private var chatsHeader: some View {

--- a/Sources/WikiFS/Settings/PermissionModeSelector.swift
+++ b/Sources/WikiFS/Settings/PermissionModeSelector.swift
@@ -9,7 +9,7 @@ import WikiFSEngine
 /// on the active mode); this is the native translation.
 ///
 /// Backed by a `Binding<String>` (the persisted `PermissionPolicy.rawValue`
-/// from `ChatView`'s `@AppStorage`) rather than owning storage, so the composer
+/// from `ChatDetailView`'s `@AppStorage`) rather than owning storage, so the composer
 /// stays the single source of truth for the app-wide default.
 struct PermissionModeSelector: View {
     @Binding var rawValue: String

--- a/Sources/WikiFS/Window/RootView.swift
+++ b/Sources/WikiFS/Window/RootView.swift
@@ -57,7 +57,7 @@ struct RootView: View {
         session.pendingWikiLink = nil
         // `WikiReaderView.onWikiLinkHandler(for:)` is app-layer; importing it
         // here would create a layering cycle (`WikiFS` viewing `WikiReaderView`
-        // is fine — we already do in `ChatView`). Defer via `Task @MainActor`
+        // is fine — we already do in `ChatDetailView`). Defer via `Task @MainActor`
         // so `ContentView`'s first layout has committed before the selection
         // mutation travels through `store` → `.onChange` → sidebar/detail.
         let handler = WikiReaderView.onWikiLinkHandler(for: session.store)

--- a/Sources/WikiFS/Window/WikiDetailView.swift
+++ b/Sources/WikiFS/Window/WikiDetailView.swift
@@ -156,7 +156,7 @@ struct WikiDetailView: View {
         case .newChat:
             // D2: draft state — empty composer until the first send retargets the
             // tab to .chat(id). chatID == nil signals the draft state.
-            ChatView(
+            ChatDetailView(
                 chatID: nil,
                 store: store,
                 launcher: chatLauncher,
@@ -214,7 +214,7 @@ struct WikiDetailView: View {
         case .chat(let id):
             // D2: unified surface. Chats are always write-capable, so the single
             // chat launcher is bound directly.
-            ChatView(
+            ChatDetailView(
                 chatID: id,
                 store: store,
                 launcher: chatLauncher,

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -77,7 +77,7 @@ struct WikiFSApp: App {
     // The quit-confirmation logic lives on AppDelegate itself.
 
     init() {
-        // Migrate the renamed chat-zoom @AppStorage key before any ChatView reads
+        // Migrate the renamed chat-zoom @AppStorage key before any ChatDetailView reads
         // it. Idempotent: copies `conversation.zoom` → `chat.zoom` only when the
         // new key is unset and the old key is set; no-op for fresh installs.
         AppStorageMigration.migrateZoomKey(in: .standard)

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -163,7 +163,7 @@ public final class WikiStoreModel {
     /// on `wikiSidebarItem`: while editing, the destination is removed so a
     /// sidebar drag inserts a `[[wikilink]]` at the editor's drop point (issue #616)
     /// instead of opening a new tab. Other surfaces (`SystemPromptDetailView`,
-    /// `ChatView`, welcome screen, reader mode) never set `isEditing`, so they
+    /// `ChatDetailView`, welcome screen, reader mode) never set `isEditing`, so they
     /// keep the tab-opening drop behavior — matching the original semantics.
     public var isActiveTabEditing: Bool {
         activeTab?.isEditing ?? false
@@ -190,7 +190,7 @@ public final class WikiStoreModel {
     public private(set) var chats: [ChatSummary] = []
 
     /// A pending question to pre-fill the chat composer, set by the omnibox
-    /// "Ask" action (#288). Consumed by `ChatView` on first appearance, then
+    /// "Ask" action (#288). Consumed by `ChatDetailView` on first appearance, then
     /// cleared. `nil` means no pre-fill is waiting.
     public var pendingChatQuestion: String?
 
@@ -229,7 +229,7 @@ public final class WikiStoreModel {
     /// Live chat composer buffer — the single source of in-flight chat text.
     /// Stashed per-tab via `EditorTab.pendingChatDraft` (like draftTitle/draftBody
     /// for pages) so switching tabs and back preserves unsent composer text
-    /// (issue #430). ChatView binds ComposerTextView to `$store.draftChatMessage`
+    /// (issue #430). ChatDetailView binds ComposerTextView to `$store.draftChatMessage`
     /// instead of local @State, which would be lost on view recreation.
     public var draftChatMessage: String = ""
 
@@ -765,7 +765,7 @@ public final class WikiStoreModel {
 
     /// Clears the active chat tab's composer draft — both the live
     /// `draftChatMessage` buffer and the stashed `pendingChatDraft`. Called by
-    /// `ChatView.sendMessage` after a message is sent so the text doesn't
+    /// `ChatDetailView.sendMessage` after a message is sent so the text doesn't
     /// reappear on tab switch-back (issue #430).
     public func clearActiveChatDraft() {
         draftChatMessage = ""
@@ -781,7 +781,7 @@ public final class WikiStoreModel {
     /// title-based selection.
     ///
     /// - Parameter anchor: optional `#"quote"` fragment from a
-    ///   `[[chat:Title#"quote"]]` link (issue #281); the destination `ChatView`
+    ///   `[[chat:Title#"quote"]]` link (issue #281); the destination `ChatDetailView`
     ///   resolves it to a message, scrolls it into view, and highlights the
     ///   passage — the chat analogue of `selectSource(anchor:)`. Mirrors the
     ///   page/source anchor seam: tagged with `.chat(id)` + versioned.

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -74,7 +74,7 @@ public final class AgentLauncher {
     /// from `refreshPendingPermissions()` whenever the snapshot actually
     /// changes — the existing `pendingPollTask` already polls at 150ms while a
     /// request is pending (300ms idle), so this just adds the Activity window
-    /// as a second consumer of the same poll (the first is `ChatView`).
+    /// as a second consumer of the same poll (the first is `ChatDetailView`).
     @ObservationIgnored public var onPendingPermission: (@Sendable (PendingPermission?) -> Void)?
 
     /// Receives the per-turn token/cost delta for an interactive (Ask/Edit)
@@ -541,7 +541,7 @@ public final class AgentLauncher {
     /// (always-ask mode). When non-empty AND this surface is the live chat, the
     /// UI renders an inline Approve/Reject affordance (slice 2). Mirrors how
     /// streamed `AgentEvent`s flow: `ACPBackend` → launcher refresh → `@Observable`
-    /// state → `ChatView`. Refreshed by `pendingPollTask` while a turn generates.
+    /// state → `ChatDetailView`. Refreshed by `pendingPollTask` while a turn generates.
     /// Empty for the CLI backend (no permission channel) and while idle.
     public var pendingPermissions: [PendingPermission] = []
 
@@ -565,7 +565,7 @@ public final class AgentLauncher {
     /// lint from one store — a user who chose `alwaysAsk` for chat got the same
     /// gating applied to an unattended ingest/lint, guaranteeing a stall on the
     /// first prompt needing a permission. These are UserDefaults string keys; the
-    /// `@AppStorage(PermissionModeKey.<x>)` bindings in Settings + ChatView + the
+    /// `@AppStorage(PermissionModeKey.<x>)` bindings in Settings + ChatDetailView + the
     /// `resolvePermissionMode(for:)` closure here all read/write them.
     ///
     /// Extraction is intentionally NOT a kind in this PR — see `plans/acp-permissions.md`
@@ -684,7 +684,7 @@ public final class AgentLauncher {
     public private(set) var isInteractiveSession = false
     /// The chat row the current live interactive session is writing to (D2).
     /// Set by the runner when it installs the transcript sink — this is the chat
-    /// whose `.chat(id)` tab is live-streaming. `ChatView` uses it as the
+    /// whose `.chat(id)` tab is live-streaming. `ChatDetailView` uses it as the
     /// source-of-truth switch: when `activeChatID == chatID`, render
     /// `launcher.events` (in-memory, streaming); otherwise render the persisted
     /// `store.chatMessages(chatID:)`. Cleared in `startNewChat()` (retarget
@@ -794,7 +794,7 @@ public final class AgentLauncher {
             // callback (installed in `run(...)` for ingestion/lint). ACP agents
             // gate one write at a time, so we forward the first pending
             // request (or `nil` to clear the row once the continuation
-            // resolves). `ChatView` continues to read `pendingPermissions`
+            // resolves). `ChatDetailView` continues to read `pendingPermissions`
             // directly via `@Observable` for its inline Approve/Reject chip —
             // this callback is the parallel channel for the Activity window's
             // per-item yellow row. No-op when the caller didn't install one
@@ -2817,7 +2817,7 @@ public final class AgentLauncher {
         summarySink = onSummary
         messageSummarySink = onMessageSummary
         // D2: record the chat row this live session is writing to. This is the
-        // source-of-truth switch for ChatView — when it matches a tab's
+        // source-of-truth switch for ChatDetailView — when it matches a tab's
         // chatID, that tab renders `launcher.events` (streaming) instead of the
         // persisted store. Set here (after resetRunArtifacts cleared any prior
         // value) so the flip is live from the first streamed token.
@@ -3010,7 +3010,7 @@ public final class AgentLauncher {
                 self.persistedEventCount = self.events.count
                 self.firstMessagePrePersisted = false
             }
-            self.setGenerating(true)    // UI flag: ChatView banner + send guard
+            self.setGenerating(true)    // UI flag: ChatDetailView banner + send guard
             DebugLog.agent("sendInteractiveMessage: turn start (setGenerating=true)")
             self.lastActivityAt = Date()
             // Send the turn and consume the per-turn stream. The backend writes
@@ -3130,7 +3130,7 @@ public final class AgentLauncher {
         preflightError = nil
         transcriptSink = nil
         persistedEventCount = 0
-        // state (.newChat draft → .chat(id)) is handled by the caller (ChatView)
+        // state (.newChat draft → .chat(id)) is handled by the caller (ChatDetailView)
         // via store.retargetTab, since the launcher does not
         // know which tab it lives in.
         activeChatID = nil

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -311,7 +311,7 @@ public enum AgentOperationRunner {
         }
 
         // Guard: refuse mid-generation. The composer is already disabled in that
-        // state (ChatView.isComposerEnabled), but this is a hard guard so
+        // state (ChatDetailView.isComposerEnabled), but this is a hard guard so
         // a race (enabled-check → send) can never interrupt a live turn.
         let decision = continueTakeoverDecision(
             isRunning: launcher.isRunning,
@@ -355,7 +355,7 @@ public enum AgentOperationRunner {
         DebugLog.agent("continueChat: historyRows=\(history.count) preambleChars=\(firstMessage.count) displayMsg=\(trimmed.count)")
 
         // Start a fresh session writing to the SAME chat row. activeChatID = chat.id
-        // flips ChatView to live for this tab (seq continues, title
+        // flips ChatDetailView to live for this tab (seq continues, title
         // preserved, updatedAt bumps on the first persisted append). The sink is
         // keyed by chatID and appends to the same row.
         DebugLog.agent("continueChat: calling launcher.startInteractiveQuery wikiID=\(wikiID) chatID=\(chatID.rawValue)")

--- a/Tests/WikiFSAppTests/AgentGenerationSlotTests.swift
+++ b/Tests/WikiFSAppTests/AgentGenerationSlotTests.swift
@@ -130,7 +130,7 @@ struct AgentGenerationSlotTests {
     // MARK: - Query-page debug-cluster predicate
 
     /// `AgentLauncher.showsQueryDebugControls` is the pure predicate backing
-    /// `ChatView.showsDebugControls`. The cluster is visible only
+    /// `ChatDetailView.showsDebugControls`. The cluster is visible only
     /// while a QUERY run is in flight (AC.1). Assert it across the state matrix.
     @Test func debugClusterPredicateOnlyTrueForActiveQueryRun() {
         func p(_ isGenerating: Bool, _ kind: WikiOperation.Kind?) -> Bool {

--- a/Tests/WikiFSAppTests/ChatDisplayMessagesTests.swift
+++ b/Tests/WikiFSAppTests/ChatDisplayMessagesTests.swift
@@ -5,7 +5,7 @@ import WikiFSCore
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// Unit tests for `ChatView.displayMessages` (AC.6) — the pure source-of-truth
+/// Unit tests for `ChatDetailView.displayMessages` (AC.6) — the pure source-of-truth
 /// selector that collapses the live/persisted transcript render path into one
 /// `ChatTranscriptView(events:)` call site. Covers source selection (live →
 /// launcher events, non-live → persisted) and the `transcriptVisible` filter,
@@ -15,7 +15,7 @@ struct ChatDisplayMessagesTests {
     @Test func selectsLauncherEventsWhenLive() {
         let live: [AgentEvent] = [.userText("hello"), .assistantText("streaming")]
         let persisted: [AgentEvent] = [.userText("old"), .assistantText("old answer")]
-        let result = ChatView.displayMessages(
+        let result = ChatDetailView.displayMessages(
             isLiveChat: true, launcherEvents: live, persistedEvents: persisted)
         #expect(result == [.userText("hello"), .assistantText("streaming")])
     }
@@ -23,7 +23,7 @@ struct ChatDisplayMessagesTests {
     @Test func selectsPersistedEventsWhenNotLive() {
         let live: [AgentEvent] = [.userText("hello")]
         let persisted: [AgentEvent] = [.userText("old"), .assistantText("old answer")]
-        let result = ChatView.displayMessages(
+        let result = ChatDetailView.displayMessages(
             isLiveChat: false, launcherEvents: live, persistedEvents: persisted)
         #expect(result == [.userText("old"), .assistantText("old answer")])
     }
@@ -36,13 +36,13 @@ struct ChatDisplayMessagesTests {
             .toolResult(isError: false, summary: "ok"),
             .assistantText("a"),
         ]
-        let result = ChatView.displayMessages(
+        let result = ChatDetailView.displayMessages(
             isLiveChat: true, launcherEvents: events, persistedEvents: [])
         #expect(result == [.userText("q"), .assistantText("a")])
     }
 
     @Test func emptyWhenNoSourceEvents() {
-        let result = ChatView.displayMessages(
+        let result = ChatDetailView.displayMessages(
             isLiveChat: false, launcherEvents: [.userText("x")], persistedEvents: [])
         #expect(result.isEmpty)
     }

--- a/Tests/WikiFSAppTests/ChatViewD2Tests.swift
+++ b/Tests/WikiFSAppTests/ChatViewD2Tests.swift
@@ -7,7 +7,7 @@ import WikiFSEngine
 @testable import WikiFSEngine
 @testable import WikiFSCore
 
-/// Tests for Phase D2 — the unified `ChatView` surface (pillar 2).
+/// Tests for Phase D2 — the unified `ChatDetailView` surface (pillar 2).
 ///
 /// Covers four gate points:
 ///   (a) source-of-truth rule: `activeChatID == chatID` → live events; else
@@ -47,7 +47,7 @@ struct ChatViewD2Tests {
         // Simulate the runner passing chatID — the launcher records it.
         // We can't call startInteractiveQuery without a real backend, but we can
         // verify the property is settable (it's `var`, not private(set)), which is
-        // the contract ChatView relies on.
+        // the contract ChatDetailView relies on.
         launcher.activeChatID = chatID
         #expect(launcher.activeChatID == chatID)
     }
@@ -228,7 +228,7 @@ struct ChatViewD2Tests {
         #expect(model.selection == .newChat)
     }
 
-    // MARK: - Integration: persisted chat renders through ChatView path
+    // MARK: - Integration: persisted chat renders through ChatDetailView path
 
     @Test func persistedChat_hasMessages_readFromStore() throws {
         let (model, store) = try tempModel()
@@ -256,7 +256,7 @@ struct ChatViewD2Tests {
     /// text — regardless of whether the mount is available. The mount guard was
     /// removed because the agent reads via wikictl (DB-direct), not the mount.
     @Test func canSendPredicateTrueWithDraftTextAndIdleAgent() {
-        #expect(ChatView.canSendPredicate(
+        #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
             canType: true,
             isGenerating: false,
@@ -267,7 +267,7 @@ struct ChatViewD2Tests {
     /// `canSendPredicate` returns true even when the mount is NOT available —
     /// the mount guard was removed (issue #441).
     @Test func canSendPredicateTrueWithoutMount() {
-        #expect(ChatView.canSendPredicate(
+        #expect(ChatDetailView.canSendPredicate(
             hasMount: false,
             canType: true,
             isGenerating: false,
@@ -277,7 +277,7 @@ struct ChatViewD2Tests {
 
     /// `canSendPredicate` returns false when generating (can't send mid-response).
     @Test func canSendPredicateFalseWhileGenerating() {
-        #expect(ChatView.canSendPredicate(
+        #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
             canType: true,
             isGenerating: true,
@@ -287,7 +287,7 @@ struct ChatViewD2Tests {
 
     /// `canSendPredicate` returns false when the composer is disabled.
     @Test func canSendPredicateFalseWhenCannotType() {
-        #expect(ChatView.canSendPredicate(
+        #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
             canType: false,
             isGenerating: false,
@@ -297,7 +297,7 @@ struct ChatViewD2Tests {
 
     /// `canSendPredicate` returns false with no draft text.
     @Test func canSendPredicateFalseWithNoDraftText() {
-        #expect(ChatView.canSendPredicate(
+        #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
             canType: true,
             isGenerating: false,

--- a/Tests/WikiFSAppTests/ChatViewDebugFolderButtonTests.swift
+++ b/Tests/WikiFSAppTests/ChatViewDebugFolderButtonTests.swift
@@ -6,7 +6,7 @@ import WikiFSCore
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// Tests for `ChatView.debugFolderButtonHelpText` (#671 / Bug 2) — the
+/// Tests for `ChatDetailView.debugFolderButtonHelpText` (#671 / Bug 2) — the
 /// "Reveal Debug Folder" button's help-text predicate.
 ///
 /// Bug 2 context: the button was gated on (and therefore only visible when)
@@ -40,7 +40,7 @@ import WikiFSCore
     /// creation) hits the disabled state with an explanatory tooltip so the
     /// operator knows why AND that the feature exists at all (Bug 2).
     @Test func helpText_whenNoDebugURL_explainsNoRunsOnDisk() {
-        #expect(ChatView.debugFolderButtonHelpText(debugURL: nil) ==
+        #expect(ChatDetailView.debugFolderButtonHelpText(debugURL: nil) ==
             "No debug folder on disk for this chat")
     }
 
@@ -51,7 +51,7 @@ import WikiFSCore
     /// before Bug 2's fix, so enabled-state UX is unchanged.
     @Test func helpText_whenDebugURLPresent_describesTrace() {
         let url = URL(fileURLWithPath: "/tmp/some-chat/debug")
-        #expect(ChatView.debugFolderButtonHelpText(debugURL: url) ==
+        #expect(ChatDetailView.debugFolderButtonHelpText(debugURL: url) ==
             "Open the complete debug trace folder (ACP messages, permissions, usage)")
     }
 
@@ -63,8 +63,8 @@ import WikiFSCore
     @Test func helpText_isIdentical_forAnyNonNilURL() {
         let urlA = URL(fileURLWithPath: "/var/folders/xyz/01JAAA/debug")
         let urlB = URL(fileURLWithPath: "/Users/dev/Library/Group Containers/.../chat-id/debug")
-        #expect(ChatView.debugFolderButtonHelpText(debugURL: urlA) ==
-            ChatView.debugFolderButtonHelpText(debugURL: urlB))
+        #expect(ChatDetailView.debugFolderButtonHelpText(debugURL: urlA) ==
+            ChatDetailView.debugFolderButtonHelpText(debugURL: urlB))
     }
 
     /// Help-text contract: the two states return distinct copy (the disabled
@@ -73,8 +73,8 @@ import WikiFSCore
     /// surface here.
     @Test func helpText_disabledAndEnabledStates_areDifferent() {
         let url = URL(fileURLWithPath: "/tmp/debug")
-        let disabled = ChatView.debugFolderButtonHelpText(debugURL: nil)
-        let enabled = ChatView.debugFolderButtonHelpText(debugURL: url)
+        let disabled = ChatDetailView.debugFolderButtonHelpText(debugURL: nil)
+        let enabled = ChatDetailView.debugFolderButtonHelpText(debugURL: url)
         #expect(disabled != enabled)
         #expect(!disabled.isEmpty)
         #expect(!enabled.isEmpty)

--- a/Tests/WikiFSAppTests/ChatViewPreflightBannerTests.swift
+++ b/Tests/WikiFSAppTests/ChatViewPreflightBannerTests.swift
@@ -6,13 +6,13 @@ import WikiFSCore
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// Tests for `ChatView.shouldShowPreflightBanner` (#613) — surfaces a
+/// Tests for `ChatDetailView.shouldShowPreflightBanner` (#613) — surfaces a
 /// previously-captured `AgentLauncher.preflightError` in the chat surface so a
 /// rolled-back chat doesn't silently revert to the empty draft composer.
 ///
 /// The preflight error is ALREADY captured at the right choke-point
 /// (`AgentLauncher.startInteractiveQuery` / `backend.start` catch); the gap is
-/// purely UI: `ChatView` never read it. These tests pin the rendering predicate
+/// purely UI: `ChatDetailView` never read it. These tests pin the rendering predicate
 /// (visibility matrix + text-pass-through) plus an integration check that the
 /// rollback behavior in `AgentOperationRunner.startChat` is preserved (the
 /// banner is purely additive on top of the rollback; it does NOT replace it).
@@ -26,7 +26,7 @@ import WikiFSCore
 
     /// Success path: no preflight error → no banner (zero behavioral change).
     @Test func bannerHidden_whenPreflightErrorIsNil() {
-        #expect(!ChatView.shouldShowPreflightBanner(
+        #expect(!ChatDetailView.shouldShowPreflightBanner(
             preflightError: nil,
             chatID: nil,
             isLiveChat: false))
@@ -36,7 +36,7 @@ import WikiFSCore
         // Defensive: an empty-string preflightError (shouldn't happen in
         // practice but guards against a future regression at the capture
         // site) still renders no banner.
-        #expect(!ChatView.shouldShowPreflightBanner(
+        #expect(!ChatDetailView.shouldShowPreflightBanner(
             preflightError: "",
             chatID: nil,
             isLiveChat: false))
@@ -45,7 +45,7 @@ import WikiFSCore
     /// AC.1: post-rollback draft state — preflightError set, chatID nil (the
     /// rolled-back tab reverted to .newChat), no live session. Banner shows.
     @Test func bannerShown_whenPreflightErrorSet_inDraftState() {
-        #expect(ChatView.shouldShowPreflightBanner(
+        #expect(ChatDetailView.shouldShowPreflightBanner(
             preflightError: "Provider 'Claude' has no command configured.",
             chatID: nil,
             isLiveChat: false))
@@ -56,7 +56,7 @@ import WikiFSCore
     /// lands on when a rolled-back tab couldn't be retargeted).
     @Test func bannerShown_whenPreflightErrorSet_onPersistedNonLiveChat() {
         let id = PageID(rawValue: "01J" + String(repeating: "A", count: 22))
-        #expect(ChatView.shouldShowPreflightBanner(
+        #expect(ChatDetailView.shouldShowPreflightBanner(
             preflightError: "An ingestion is in progress.",
             chatID: id,
             isLiveChat: false))
@@ -67,7 +67,7 @@ import WikiFSCore
     /// banner alongside a live streaming session.
     @Test func bannerHidden_whenPreflightErrorSet_onLiveChat() {
         let id = PageID(rawValue: "01J" + String(repeating: "A", count: 22))
-        #expect(!ChatView.shouldShowPreflightBanner(
+        #expect(!ChatDetailView.shouldShowPreflightBanner(
             preflightError: "stale error",
             chatID: id,
             isLiveChat: true))
@@ -80,7 +80,7 @@ import WikiFSCore
     /// as-is when the banner is showing.
     @Test func bannerMessage_forwardsPreflightErrorVerbatim() {
         let msg = "Failed to launch claude: permission denied"
-        let bannerText = ChatView.preflightBannerMessage(
+        let bannerText = ChatDetailView.preflightBannerMessage(
             preflightError: msg,
             chatID: nil,
             isLiveChat: false)
@@ -88,7 +88,7 @@ import WikiFSCore
     }
 
     @Test func bannerMessage_isNil_whenPreflightErrorIsNil() {
-        #expect(ChatView.preflightBannerMessage(
+        #expect(ChatDetailView.preflightBannerMessage(
             preflightError: nil,
             chatID: nil,
             isLiveChat: false) == nil)
@@ -96,7 +96,7 @@ import WikiFSCore
 
     @Test func bannerMessage_isNil_whenLiveChat() {
         let id = PageID(rawValue: "01J" + String(repeating: "A", count: 22))
-        #expect(ChatView.preflightBannerMessage(
+        #expect(ChatDetailView.preflightBannerMessage(
             preflightError: "stale error",
             chatID: id,
             isLiveChat: true) == nil)
@@ -111,7 +111,7 @@ import WikiFSCore
         No model selected for provider 'OpenCode'. \
         Open Settings → Agents and pick a model before running.
         """
-        let bannerText = ChatView.preflightBannerMessage(
+        let bannerText = ChatDetailView.preflightBannerMessage(
             preflightError: msg,
             chatID: nil,
             isLiveChat: false)
@@ -160,7 +160,7 @@ import WikiFSCore
 
         // And the banner predicate fires for this state — the user would
         // see the message instead of an empty draft composer.
-        #expect(ChatView.shouldShowPreflightBanner(
+        #expect(ChatDetailView.shouldShowPreflightBanner(
             preflightError: launcher.preflightError,
             chatID: nil,
             isLiveChat: false))
@@ -179,8 +179,8 @@ import WikiFSCore
 
         // The banner surfaces the error regardless of whether `startChat`
         // was the one that set it. The rollback flow in `startChat` is a
-        // separate concern — `ChatView` just reads the field it's handed.
-        #expect(ChatView.shouldShowPreflightBanner(
+        // separate concern — `ChatDetailView` just reads the field it's handed.
+        #expect(ChatDetailView.shouldShowPreflightBanner(
             preflightError: launcher.preflightError,
             chatID: nil,
             isLiveChat: false))

--- a/Tests/WikiFSAppTests/ComposerAutocompleteHostedTests.swift
+++ b/Tests/WikiFSAppTests/ComposerAutocompleteHostedTests.swift
@@ -118,7 +118,7 @@ struct ComposerAutocompleteHostedTests {
         }
     }
 
-    /// Mirrors `ChatView.chatAutocompleteHooks.format` so the test's inserted
+    /// Mirrors `ChatDetailView.chatAutocompleteHooks.format` so the test's inserted
     /// string matches production shape. Pure / Sendable.
     static func formatHit(_ hit: TantivyShadowSearchResult) -> String {
         let kind: ParsedLink.LinkType

--- a/Tests/WikiFSAppTests/Issue235IngestExtractionLockTests.swift
+++ b/Tests/WikiFSAppTests/Issue235IngestExtractionLockTests.swift
@@ -65,7 +65,7 @@ struct Issue235IngestExtractionLockTests {
     @Test func captionVisibleWhenAwaitingSlot() {
         // The core #235 UI fix: waiting for the generation gate shows VISIBLE
         // text (was previously only a hidden .help() tooltip).
-        let caption = ChatView.composerCaptionText(
+        let caption = ChatDetailView.composerCaptionText(
             isAwaitingGenerationSlot: true,
             hasChatID: true, isLiveChat: true, isGenerating: false)
         #expect(caption == "Waiting for the other session to finish before sending…")
@@ -73,14 +73,14 @@ struct Issue235IngestExtractionLockTests {
 
     @Test func captionVisibleWhenAwaitingSlotDraftState() {
         // Even in draft state (chatID == nil), the waiting caption shows.
-        let caption = ChatView.composerCaptionText(
+        let caption = ChatDetailView.composerCaptionText(
             isAwaitingGenerationSlot: true,
             hasChatID: false, isLiveChat: false, isGenerating: false)
         #expect(caption == "Waiting for the other session to finish before sending…")
     }
 
     @Test func captionNilWhenIdle() {
-        let caption = ChatView.composerCaptionText(
+        let caption = ChatDetailView.composerCaptionText(
             isAwaitingGenerationSlot: false,
             hasChatID: true, isLiveChat: true, isGenerating: false)
         #expect(caption == nil)
@@ -89,7 +89,7 @@ struct Issue235IngestExtractionLockTests {
     @Test func captionForPersistedChatBusy() {
         // A persisted (non-live) chat whose launcher is generating a different
         // chat shows the "Another chat is responding" caption.
-        let caption = ChatView.composerCaptionText(
+        let caption = ChatDetailView.composerCaptionText(
             isAwaitingGenerationSlot: false,
             hasChatID: true, isLiveChat: false, isGenerating: true)
         #expect(caption == "Another chat is responding — wait or stop it.")
@@ -98,7 +98,7 @@ struct Issue235IngestExtractionLockTests {
     @Test func captionForLiveChatGenerating() {
         // A live chat that is actively generating shows a subtle "Agent is
         // responding…" caption (replaces the old orange banner).
-        let caption = ChatView.composerCaptionText(
+        let caption = ChatDetailView.composerCaptionText(
             isAwaitingGenerationSlot: false,
             hasChatID: true, isLiveChat: true, isGenerating: true)
         #expect(caption == "Agent is responding…")
@@ -107,7 +107,7 @@ struct Issue235IngestExtractionLockTests {
     @Test func awaitingSlotOverridesPersistedBusy() {
         // When both isAwaitingGenerationSlot and isGenerating are true, the gate
         // wait message takes priority (it's the more actionable state).
-        let caption = ChatView.composerCaptionText(
+        let caption = ChatDetailView.composerCaptionText(
             isAwaitingGenerationSlot: true,
             hasChatID: true, isLiveChat: false, isGenerating: true)
         #expect(caption == "Waiting for the other session to finish before sending…")

--- a/Tests/WikiFSTests/ACPTurnRecoveryTests.swift
+++ b/Tests/WikiFSTests/ACPTurnRecoveryTests.swift
@@ -193,7 +193,7 @@ import WikiFSCore
     /// Contract pin: the recovery events MUST include `.messageStop` so the
     /// downstream launcher's `AgentEvent.endsGeneration(_:)` branch fires →
     /// `setGenerating(false)` (AgentLauncher.swift, inside the `endsGeneration`
-    /// branch). Without `.messageStop`, ChatView stays stuck "generating" —
+    /// branch). Without `.messageStop`, ChatDetailView stays stuck "generating" —
     /// the second half of the #615 symptom. This is a contract pin (the
     /// `turnEndEvents` synthesis), NOT a behavioral test that
     /// `setGenerating(false)` fires in `AgentLauncher` — that is launcher-tier

--- a/Tests/WikiFSTests/AgentLauncherPermissionModeTests.swift
+++ b/Tests/WikiFSTests/AgentLauncherPermissionModeTests.swift
@@ -123,7 +123,7 @@ import WikiFSEngine
 
     /// #10 — Fresh install defaults: every kind resolves to `.bypass` when no
     /// keys are set. The §5.2 read-time `?? fallback` is the second line of
-    /// defense; `@AppStorage`'s default (in Settings + ChatView) is the first.
+    /// defense; `@AppStorage`'s default (in Settings + ChatDetailView) is the first.
     @Test func defaultsWhenUnset() {
         let defaults = makeDefaults()
         let launcher = makeLauncher(defaults: defaults)


### PR DESCRIPTION
## Summary

Mechanical rename of the SwiftUI view type `ChatView` → `ChatDetailView` across the entire codebase.

## Changes

- **File rename:** `Sources/WikiFS/Chats/ChatView.swift` → `Sources/WikiFS/Chats/ChatDetailView.swift` (`git mv`, preserves history)
- **Type rename:** Every occurrence of the standalone token `ChatView` as a type name is now `ChatDetailView` — 91 references across 26 files in `Sources/` and `Tests/`.

## Not touched (by design)

These identifiers contain `ChatView` as a substring of a longer token, not as a standalone type reference, so the word-boundary regex (`\bChatView\b`) correctly left them alone:

- `ChatViewD2Tests` (test class)
- `ChatViewDebugFolderButtonTests` (test class)
- `ChatViewPreflightBannerTests` (test class)
- `ChatTranscriptView` (different type)
- `ChatViewState` / `ChatViewModel` / similar distinct types (if any)

## Verification

- `swift build` — compiles cleanly
- `make build` — app built + signed
- `make test` — **3333 tests passed** in 277 suites
