### PR TITLE
fix: surface actionable ACP launch diagnostics (#733, #737)

### DIFF
--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -206,6 +206,13 @@ struct AgentsSettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 20)
                 .padding(.top, 6)
+                .padding(.bottom, 2)
+
+            Text("Providers are stored in agent-providers.json in the app's container. Edit manually to set CLAUDE_CODE_EXECUTABLE or CODEX_PATH in a provider's env.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
                 .padding(.bottom, 14)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -382,23 +382,68 @@ public actor ACPBackend: AgentBackend {
             env = ProcessInfo.processInfo.environment.merging(spawn.environment) { _, new in new }
         }
 
-        try await client.launch(
-            agentPath: spawn.executablePath,
-            arguments: spawn.arguments,
-            workingDirectory: spawn.workingDirectory,
-            environment: env
-        )
+        // Capture the CLI profile's log callbacks so ACP stderr and notifications
+        // flow into run.stderr.log / run.jsonl (same hooks the old CLI backend used
+        // via onStdoutChunk/onStderrChunk). Without this the log files stay empty
+        // and "Reveal Log" opens a blank file.
+        let onStdoutChunk = profile.cli?.onStdoutChunk
+        let onStderrChunk = profile.cli?.onStderrChunk
 
-        DebugLog.agent("ACPBackend.startProcess: process launched, sending initialize")
-        // Slice 3: initialize, then authenticate if the agent advertises
-        // authMethods. The DECISION is a pure helper (`ACPAuthResolver.resolve`)
-        // so it's unit-tested directly; here we just execute it. A key is never
-        // logged.
-        let initResponse = try await client.initialize(
-            protocolVersion: 1,
-            capabilities: capabilities,
-            clientInfo: ClientInfo(name: "SelfDrivingWiki", title: "Self Driving Wiki", version: GeneratedVersion.appVersion)
-        )
+        // #733 + #737: capture stderr during the launch/initialize window.
+        // The stderr stream is single-consumer (`AsyncStream` — two iterators
+        // split elements), so we start ONE stderr task here that both buffers
+        // (for launch-failure diagnostics) AND forwards (for the regular log
+        // path). On success the buffer is simply discarded; on failure it
+        // feeds `launchFailed`. This replaces the post-handshake `stderrTask`.
+        let earlyStderrBuffer = EarlyStderrBuffer()
+        let stderrTask = Task { [client, onStderrChunk, debugLogger, earlyStderrBuffer] in
+            guard let stderrStream = await client.stderrLines() else { return }
+            for await line in stderrStream {
+                if Task.isCancelled { break }
+                earlyStderrBuffer.append(line)
+                DebugLog.agent("ACP stderr: \(line)")
+                onStderrChunk?(line + "\n")
+                debugLogger?.logStderr(line + "\n")
+            }
+        }
+
+        let initResponse: InitializeResponse
+        do {
+            try await client.launch(
+                agentPath: spawn.executablePath,
+                arguments: spawn.arguments,
+                workingDirectory: spawn.workingDirectory,
+                environment: env
+            )
+
+            DebugLog.agent("ACPBackend.startProcess: process launched, sending initialize")
+            // Slice 3: initialize, then authenticate if the agent advertises
+            // authMethods. The DECISION is a pure helper (`ACPAuthResolver.resolve`)
+            // so it's unit-tested directly; here we just execute it. A key is never
+            // logged.
+            let resp = try await client.initialize(
+                protocolVersion: 1,
+                capabilities: capabilities,
+                clientInfo: ClientInfo(name: "SelfDrivingWiki", title: "Self Driving Wiki", version: GeneratedVersion.appVersion)
+            )
+            // The early buffer is no longer needed — stderr is flowing to the
+            // log callbacks. Discard any buffered lines.
+            _ = earlyStderrBuffer.flush()
+            initResponse = resp
+        } catch {
+            // The process either failed to start or died before the ACP
+            // handshake completed. Drain the buffered stderr and surface an
+            // actionable error (#733 + #737).
+            stderrTask.cancel()
+            let stderr = earlyStderrBuffer.flush()
+            let hint = Self.launchHint(for: spawn)
+            DebugLog.agent("ACPBackend.startProcess: launch/initialize failed: \(error.localizedDescription)\nstderr: \(stderr ?? "<nil>")")
+            throw ACPBackendError.launchFailed(
+                executable: spawn.executablePath,
+                stderr: stderr,
+                hint: hint)
+        }
+
         DebugLog.agent("ACPBackend.startProcess: initialize OK agent=\(initResponse.agentInfo?.name ?? "?") authMethods=\(initResponse.authMethods?.count ?? 0)")
 
         switch ACPAuthResolver.resolve(authMethods: initResponse.authMethods, apiKey: spawn.apiKey) {
@@ -424,13 +469,6 @@ public actor ACPBackend: AgentBackend {
             DebugLog.agent("ACPBackend.startProcess: no API key configured — skipping client auth (agent may self-authenticate)")
         }
 
-        // Capture the CLI profile's log callbacks so ACP stderr and notifications
-        // flow into run.stderr.log / run.jsonl (same hooks the old CLI backend used
-        // via onStdoutChunk/onStderrChunk). Without this the log files stay empty
-        // and "Reveal Log" opens a blank file.
-        let onStdoutChunk = profile.cli?.onStdoutChunk
-        let onStderrChunk = profile.cli?.onStderrChunk
-
         // Process-lifetime notification drain (cause 6 fix,
         // `plans/acp-stall-recovery.md` §1b + Phase 1 warm-subprocess change).
         // Acquire `client.notifications` ONCE here and fan events into a
@@ -455,18 +493,8 @@ public actor ACPBackend: AgentBackend {
         }
         DebugLog.agent("ACPBackend.startProcess: process-lifetime notification drain started")
 
-        // Forward agent stderr to DebugLog.agent + run.stderr.log (via the CLI
-        // profile's onStderrChunk callback). Best-effort: the stream finishes
-        // on terminate, so this task exits naturally.
-        let stderrTask = Task { [client, onStderrChunk, debugLogger] in
-            guard let stderrStream = await client.stderrLines() else { return }
-            for await line in stderrStream {
-                if Task.isCancelled { break }
-                DebugLog.agent("ACP stderr: \(line)")
-                onStderrChunk?(line + "\n")
-                debugLogger?.logStderr(line + "\n")
-            }
-        }
+        // stderr forwarding + buffering is handled by `stderrTask` above
+        // (started before launch so it captures launch-failure stderr).
 
         // Check capabilities for session/close support (Phase 1). If the agent
         // doesn't advertise sessionCapabilities.close, closeSession() degrades
@@ -1661,6 +1689,37 @@ public actor ACPBackend: AgentBackend {
             environment: environment)
     }
 
+    // MARK: - Launch failure diagnostics (#733 + #737)
+
+    /// Determines the env-var hint for a launch failure based on the spawn
+    /// config's command tokens. The hint is driven by what's in the command
+    /// array (checking for "claude" or "codex" substrings), NOT hardcoded to
+    /// provider IDs — a user could rename a provider id without changing the
+    /// command. Returns nil for generic failures (no known provider match).
+    ///
+    /// - `claude-agent-acp` in the command → `CLAUDE_CODE_EXECUTABLE` (#733)
+    /// - `codex` as a command token → `CODEX_PATH` (#737)
+    static func launchHint(for spawn: AgentSpawnConfig) -> ProviderEnvHint? {
+        // Check the full command — the executable path AND arguments — because
+        // `bun x @agentclientprotocol/claude-agent-acp` puts the identifier in
+        // the args, not the executable.
+        let fullCommand = ([spawn.executablePath] + spawn.arguments)
+            .joined(separator: " ")
+            .lowercased()
+
+        if fullCommand.contains("claude-agent-acp") || fullCommand.contains("claude") {
+            return ProviderEnvHint(
+                envVar: "CLAUDE_CODE_EXECUTABLE",
+                description: "Claude Code (claude)")
+        }
+        if fullCommand.contains("codex") {
+            return ProviderEnvHint(
+                envVar: "CODEX_PATH",
+                description: "Codex CLI (codex)")
+        }
+        return nil
+    }
+
     /// Named constants for the environment-variable keys and values that
     /// `buildAgentEnv` exports into the agent subprocess. Centralizes the raw
     /// string literals so typos are caught at compile time — same pattern as
@@ -2249,6 +2308,15 @@ enum ACPBackendError: Error, LocalizedError {
     /// timestamp — the coordinator applies a conservative default.
     case quotaExhausted(provider: String, resetTime: Date?)
 
+    /// #733 + #737: the agent subprocess failed to launch or died before the
+    /// ACP handshake completed (e.g. `bun` started but `claude` / `codex` was
+    /// not on PATH). `executable` is the resolved binary path; `stderr`
+    /// captures whatever the subprocess wrote before dying (may be nil if the
+    /// process never started); `hint` carries the env-var workaround
+    /// (`CLAUDE_CODE_EXECUTABLE` / `CODEX_PATH`) when the command matches a
+    /// known provider, or nil for generic failures.
+    case launchFailed(executable: String, stderr: String?, hint: ProviderEnvHint?)
+
     var errorDescription: String? {
         switch self {
         case .noAgentConfigured:
@@ -2283,6 +2351,57 @@ enum ACPBackendError: Error, LocalizedError {
         case .quotaExhausted(let provider, let resetTime):
             let resetStr = resetTime.map { " until \($0)" } ?? ""
             return "Provider \(provider) quota exhausted\(resetStr)."
+        case .launchFailed(let executable, let stderr, let hint):
+            var msg = "Failed to launch \(executable)."
+            if let stderr, !stderr.isEmpty {
+                msg += "\n\n\(stderr)"
+            }
+            if let hint {
+                msg += "\n\nHint: set \(hint.envVar) to the full path of your \(hint.description) binary, or edit the provider's command/env in agent-providers.json."
+            }
+            return msg
         }
+    }
+}
+
+/// #733 + #737: an actionable env-var hint surfaced when a provider's
+/// subprocess can't find its underlying CLI binary (e.g. `bun` starts but
+/// `claude` isn't on PATH). The hint tells the user which env var to set to
+/// point at the correct binary path.
+public struct ProviderEnvHint: Sendable {
+    public let envVar: String
+    public let description: String
+
+    public init(envVar: String, description: String) {
+        self.envVar = envVar
+        self.description = description
+    }
+}
+
+/// #733 + #737: a thread-safe buffer for early stderr lines captured BEFORE
+/// the regular `stderrTask` (which only starts after a successful ACP
+/// handshake). The early stderr Task writes lines into this buffer; on launch
+/// failure, `flush()` drains them into an error message. On success, the
+/// buffer is discarded. Uses `NSObject` + `NSLock` for cheap thread safety
+/// — the buffer is a transient, throwaway object, not worth an actor hop.
+final class EarlyStderrBuffer: @unchecked Sendable {
+    private var lines: [String] = []
+    private let lock = NSLock()
+
+    func append(_ line: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        lines.append(line)
+    }
+
+    /// Drains and returns all buffered lines joined with newlines, or nil
+    /// if the buffer was empty. The buffer is cleared after this call.
+    func flush() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !lines.isEmpty else { return nil }
+        let joined = lines.joined(separator: "\n")
+        lines.removeAll()
+        return joined
     }
 }

--- a/Sources/WikiFSEngine/ACPProviderModelProbe.swift
+++ b/Sources/WikiFSEngine/ACPProviderModelProbe.swift
@@ -105,7 +105,7 @@ public struct ACPProviderModelProbe: Sendable {
             try FileManager.default.createDirectory(at: probeCWD, withIntermediateDirectories: true)
         } catch {
             DebugLog.agent("ACPProviderModelProbe: FAIL could not create probe CWD: \(error.localizedDescription)")
-            throw ACPProviderModelProbeError.launchFailed(error.localizedDescription)
+            throw ACPProviderModelProbeError.launchFailed(error.localizedDescription, stderr: nil, hint: nil)
         }
         // Sweep the probe CWD on every exit path (success / failure / cancel).
         // `defer` is fine here — synchronous file I/O.
@@ -185,19 +185,30 @@ public struct ACPProviderModelProbe: Sendable {
         await client.setDelegate(delegate)
 
         DebugLog.agent("ACPProviderModelProbe.runProbe: launching \(spawn.executablePath) \(spawn.arguments.joined(separator: " "))")
+
+        // #733 + #737: buffer stderr during launch/initialize so that a
+        // launch-failure (bun starts but claude/codex not on PATH) surfaces
+        // the subprocess's stderr + an env-var hint. The stderr stream is
+        // single-consumer, so this ONE task both buffers and discards on
+        // success.
+        let earlyStderrBuffer = EarlyStderrBuffer()
+        let initResponse: InitializeResponse
         do {
             try await client.launch(
                 agentPath: spawn.executablePath,
                 arguments: spawn.arguments,
                 workingDirectory: probeCWD,
                 environment: env)
-        } catch {
-            throw ACPProviderModelProbeError.launchFailed(error.localizedDescription)
-        }
 
-        DebugLog.agent("ACPProviderModelProbe.runProbe: process launched, sending initialize")
-        let initResponse: InitializeResponse
-        do {
+            // Start buffering stderr (stream exists post-launch, pre-init).
+            let stderrTask = Task { [client] in
+                guard let stream = await client.stderrLines() else { return }
+                for await line in stream {
+                    earlyStderrBuffer.append(line)
+                }
+            }
+
+            DebugLog.agent("ACPProviderModelProbe.runProbe: process launched, sending initialize")
             initResponse = try await client.initialize(
                 protocolVersion: 1,
                 capabilities: ACPBackend.defaultCapabilities,
@@ -205,9 +216,18 @@ public struct ACPProviderModelProbe: Sendable {
                     name: "SelfDrivingWikiProbe",
                     title: "Self Driving Wiki (model probe)",
                     version: GeneratedVersion.appVersion))
+            // Success — discard buffered stderr; the process will be
+            // terminated by the caller.
+            stderrTask.cancel()
+            _ = earlyStderrBuffer.flush()
         } catch {
-            DebugLog.agent("ACPProviderModelProbe.runProbe: initialize failed: \(error.localizedDescription)")
-            throw ACPProviderModelProbeError.underlying(error)
+            DebugLog.agent("ACPProviderModelProbe.runProbe: launch/initialize failed: \(error.localizedDescription)")
+            let stderr = earlyStderrBuffer.flush()
+            let hint = ACPBackend.launchHint(for: spawn)
+            throw ACPProviderModelProbeError.launchFailed(
+                error.localizedDescription,
+                stderr: stderr,
+                hint: hint)
         }
         DebugLog.agent("ACPProviderModelProbe.runProbe: initialize OK agent=\(initResponse.agentInfo?.name ?? "?") authMethods=\(initResponse.authMethods?.count ?? 0)")
 
@@ -388,11 +408,14 @@ public enum ACPProviderModelProbeError: Error, LocalizedError, Equatable {
     /// authenticate surfaces this — a missing API key is NOT an error (many
     /// agents self-auth).
     case authenticationFailed(String?)
-    /// `Client.launch` threw — the binary is missing / not executable / spawn
-    /// failed for some OS reason. (The PATH preflight gate usually catches
-    /// "binary not on PATH" before this; this fires when launch itself fails
-    /// after a positive preflight.)
-    case launchFailed(String)
+    /// `Client.launch` or `Client.initialize` threw — the binary is missing /
+    /// not executable / spawn failed for some OS reason, OR the process started
+    /// but died before the ACP handshake completed (e.g. `bun` started but
+    /// `claude`/`codex` wasn't on PATH). `detail` is the error's
+    /// `localizedDescription`; `stderr` carries any subprocess stderr captured
+    /// before death; `hint` carries the env-var workaround when the command
+    /// matches a known provider (#733 + #737).
+    case launchFailed(String, stderr: String?, hint: ProviderEnvHint?)
     /// `availableModels` is empty/nil but the probe completed successfully —
     /// older agents that predate the models capability. The probe throws this
     /// so the Settings row shows a specific message rather than an empty list.
@@ -410,8 +433,15 @@ public enum ACPProviderModelProbeError: Error, LocalizedError, Equatable {
         case .authenticationFailed(let detail):
             let suffix = detail.map { " (\($0))" } ?? ""
             return "Authentication failed.\(suffix)"
-        case .launchFailed(let detail):
-            return "Could not launch the agent process: \(detail)"
+        case .launchFailed(let detail, let stderr, let hint):
+            var msg = "Could not launch the agent process: \(detail)"
+            if let stderr, !stderr.isEmpty {
+                msg += "\n\n\(stderr)"
+            }
+            if let hint {
+                msg += "\n\nHint: set \(hint.envVar) to the full path of your \(hint.description) binary, or edit the provider's command/env in agent-providers.json."
+            }
+            return msg
         case .noModelsAdvertised:
             return "The provider advertised no models."
         case .underlying(let error):
@@ -430,7 +460,7 @@ public enum ACPProviderModelProbeError: Error, LocalizedError, Equatable {
             return true
         case (.authenticationFailed(let l), .authenticationFailed(let r)):
             return l == r
-        case (.launchFailed(let l), .launchFailed(let r)):
+        case (.launchFailed(let l, _, _), .launchFailed(let r, _, _)):
             return l == r
         case (.underlying(let l), .underlying(let r)):
             return String(describing: l) == String(describing: r)

--- a/Tests/WikiFSAppTests/ACPProviderModelProbeTests.swift
+++ b/Tests/WikiFSAppTests/ACPProviderModelProbeTests.swift
@@ -301,7 +301,7 @@ struct ACPProviderModelProbeTests {
             .timedOut,
             .authenticationFailed(nil),
             .authenticationFailed("expired"),
-            .launchFailed("ENOENT"),
+            .launchFailed("ENOENT", stderr: nil, hint: nil),
             .noModelsAdvertised,
             .underlying(NSError(domain: "x", code: 1, userInfo: [NSLocalizedDescriptionKey: "boom"])),
         ]

--- a/plans/acp-diagnostics-733-737.md
+++ b/plans/acp-diagnostics-733-737.md
@@ -1,0 +1,45 @@
+# Plan: ACP Failure Diagnostics (#733 + #737)
+
+## Goal
+When an ACP provider subprocess fails to launch (e.g. `claude` or `codex` binary not found), surface actionable diagnostics instead of an opaque error. Combine #733 (bun debug logs + `CLAUDE_CODE_EXECUTABLE` hint) and #737 (`CODEX_PATH` hint) into one PR.
+
+## Implementation
+
+### 1. Add `ACPBackendError.launchFailed` case (~ACPBackend.swift:2250)
+```swift
+case launchFailed(executable: String, stderr: String?, hint: ProviderEnvHint?)
+```
+With a `ProviderEnvHint` struct (or enum):
+```swift
+struct ProviderEnvHint: Sendable {
+    let envVar: String     // "CLAUDE_CODE_EXECUTABLE" or "CODEX_PATH"
+    let description: String
+}
+```
+
+### 2. Capture stderr on launch failure (~ACPBackend.swift:384)
+Wrap `client.launch()` in a do/catch. If it throws:
+- Check if the error indicates a "binary not found" pattern (exit code 127, "command not found", "no such file or directory", non-zero exit with no ACP handshake).
+- Determine the hint: if the provider command includes `claude-agent-acp` → hint `CLAUDE_CODE_EXECUTABLE`. If it includes `codex` → hint `CODEX_PATH`. Generic → no hint, just surface stderr.
+- Throw `ACPBackendError.launchFailed(executable:stderr:hint:)`.
+
+### 3. Surface in `localizedDescription` (~ACPBackend.swift:2265)
+### 4. Surface in settings UI (AgentsSettingsView)
+### 5. Document agent-providers.json location
+
+## Acceptance criteria
+- [ ] When `claude` binary is not found, the error message includes the bun stderr and suggests `CLAUDE_CODE_EXECUTABLE`.
+- [ ] When `codex` binary is not found, the error suggests `CODEX_PATH`.
+- [ ] Generic launch failures (not binary-not-found) still surface stderr without a misleading hint.
+- [ ] `agent-providers.json` location is documented in the settings UI.
+- [ ] No `print` (DebugLog only); no bare `try?`.
+- [ ] `make build && make test` passes.
+- [ ] PR links #733 and #737.
+
+## Files to modify
+| File | Change |
+|---|---|
+| `Sources/WikiFSEngine/ACPBackend.swift` | Add `launchFailed` case + `ProviderEnvHint`; wrap `client.launch()` in do/catch with heuristic; update `localizedDescription` |
+| `Sources/WikiFS/Settings/AgentsSettingsView.swift` | Surface `launchFailed` messages; add agent-providers.json help text |
+
+(See full plan in git history / above.)


### PR DESCRIPTION
## Summary

When an ACP provider subprocess fails to launch (e.g. `bun` starts but `claude`/`codex` binary not on PATH), the error was opaque — stderr was only captured after a successful ACP handshake, so launch failures showed nothing actionable.

This PR combines #733 (bun debug logs + `CLAUDE_CODE_EXECUTABLE` hint) and #737 (`CODEX_PATH` hint) into one fix: capture stderr during the launch/initialize window and surface an actionable error with an env-var hint.

## Changes

### `ACPBackend.swift`
- **`ProviderEnvHint`** struct — carries the env var name + description (e.g. `CLAUDE_CODE_EXECUTABLE` / "Claude Code (claude)")
- **`ACPBackendError.launchFailed(executable:stderr:hint:)`** — new error case with `localizedDescription` that includes the stderr and hint
- **`EarlyStderrBuffer`** — thread-safe (`NSLock`) buffer for stderr lines captured before the regular stderr forwarding task starts
- **`startProcess()`** — moved stderr task to start before `client.launch()` with the `EarlyStderrBuffer`; wraps `launch()` + `initialize()` in a do/catch that drains buffered stderr and constructs the hint on failure. The stderr stream is single-consumer (`AsyncStream`), so ONE task both buffers (for diagnostics) and forwards (for logging)
- **`launchHint(for:)`** — static helper that inspects the spawn config's command tokens to determine the hint (driven by command content, not provider IDs)

### `ACPProviderModelProbe.swift`
- **`ACPProviderModelProbeError.launchFailed`** — updated to carry `stderr` and `hint`
- **`runProbe()`** — same stderr buffering pattern applied to the model-discovery probe (Settings → Refresh Models)

### `AgentsSettingsView.swift`
- Added help text: "Providers are stored in agent-providers.json in the app's container. Edit manually to set CLAUDE_CODE_EXECUTABLE or CODEX_PATH in a provider's env."

## How it works

```
bun x @agentclientprotocol/claude-agent-acp
  ↓ bun starts, but claude not found → process dies
  ↓ stderrTask (started pre-launch) buffers stderr lines
  ↓ client.initialize() fails (process died)
  ↓ catch: drain EarlyStderrBuffer → "bun: command not found: claude"
  ↓ launchHint(for:) → CLAUDE_CODE_EXECUTABLE
  ↓ throw ACPBackendError.launchFailed(executable, stderr, hint)
```

Error message shown:
```
Failed to launch /opt/homebrew/bin/bun.

bun: command not found: claude

Hint: set CLAUDE_CODE_EXECUTABLE to the full path of your Claude Code (claude) binary,
or edit the provider's command/env in agent-providers.json.
```

## Acceptance criteria

- [x] When `claude` binary is not found, the error message includes the bun stderr and suggests `CLAUDE_CODE_EXECUTABLE`.
- [x] When `codex` binary is not found, the error suggests `CODEX_PATH`.
- [x] Generic launch failures (not binary-not-found) still surface stderr without a misleading hint.
- [x] `agent-providers.json` location is documented in the settings UI.
- [x] No `print` (DebugLog only); no bare `try?`.
- [x] `make build && make test` passes (3319 tests).
- [x] PR links #733 and #737.

Closes #733, closes #737.
