### PR TITLE
v40→v41 migration: replace  with bare wikictl in stored system prompts

### DIFF
--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -57,7 +57,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// databases produced by that store carry `PRAGMA user_version` up to 37, and
     /// this store must recognize them as already-current so the ladder is a no-op
     /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 40
+    private static let currentSchemaVersion = 41
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -1168,19 +1168,43 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         // after it).
         if version < 40 {
             let columns = try Self.tableColumnInfo("chat_messages", in: db)
-            guard !columns.contains("summary") else {
-                try db.execute(sql: "PRAGMA user_version = 40;")
-                version = 40
-                return
-            }
-            try db.inTransaction(.immediate) {
-                try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary TEXT;")
-                try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary_kind TEXT;")
-                try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary_at REAL;")
-                return .commit
+            if !columns.contains("summary") {
+                try db.inTransaction(.immediate) {
+                    try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary TEXT;")
+                    try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary_kind TEXT;")
+                    try db.execute(sql: "ALTER TABLE chat_messages ADD COLUMN summary_at REAL;")
+                    return .commit
+                }
             }
             try db.execute(sql: "PRAGMA user_version = 40;")
             version = 40
+        }
+
+        // v40→v41: migrate stored system prompts from `$WIKICTL` → bare
+        // `wikictl` (which is on PATH), and `wikictl page upsert` →
+        // `wikictl page add`. The default prompt was already updated, but
+        // existing wikis keep their seeded copy forever (`INSERT OR IGNORE`),
+        // and `$WIKICTL` doesn't always expand correctly in the agent's
+        // subprocess shell. Idempotent: a no-op on already-migrated prompts.
+        if version < 41 {
+            if let row = try Row.fetchOne(
+                db,
+                sql: "SELECT body_markdown FROM system_prompt WHERE id = 1;"
+            ),
+               let body = row["body_markdown"] as String?,
+               body.contains("$WIKICTL") {
+                let migrated = body
+                    .replacingOccurrences(of: "$WIKICTL", with: "wikictl")
+                    .replacingOccurrences(
+                        of: "wikictl page upsert", with: "wikictl page add"
+                    )
+                try db.execute(
+                    sql: "UPDATE system_prompt SET body_markdown = ?, updated_at = ? WHERE id = 1;",
+                    arguments: [migrated, Date.timeIntervalSinceReferenceDate]
+                )
+            }
+            try db.execute(sql: "PRAGMA user_version = 41;")
+            version = 41
         }
 
         // Catch-all fallback: any DB older than `currentSchemaVersion` whose

--- a/Tests/WikiFSTests/MessageSummaryTests.swift
+++ b/Tests/WikiFSTests/MessageSummaryTests.swift
@@ -254,11 +254,11 @@ struct MessageSummaryTests {
 
     // MARK: - Store round-trip (AC.1 + AC.6, integration)
 
-    @Test func freshDB_isAtSchemaVersion40() throws {
-        // AC.1: a fresh DB is at user_version = 40.
+    @Test func freshDB_isAtSchemaVersion41() throws {
+        // AC.1: a fresh DB is at user_version = 41.
         let store = try TestStoreFactory.inMemory()
         let version = Int(store.pragmaValue("user_version")) ?? 0
-        #expect(version == 40)
+        #expect(version == 41)
     }
 
     @Test func summaryNullForNewMessages() throws {

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -650,10 +650,10 @@ struct PageVersionTests {
     /// (the write-path change was the real fix); v39→40 adds the per-message
     /// summary columns (`plans/chat-summary.md` §3.3).
     @Test func v39SchemaVersionAfterMigration() throws {
-        #expect(GRDBWikiStore.schemaVersion == 40,
-                "schemaVersion must report 40 after the chat-message-summary bump")
+        #expect(GRDBWikiStore.schemaVersion == 41,
+                "schemaVersion must report 41 after the wikictl-prompt-migration bump")
         let store = try tempStore()
         let v = store.pragmaValue("user_version")
-        #expect(v == "40", "fresh DB stamps user_version = 40 (got \(v))")
+        #expect(v == "41", "fresh DB stamps user_version = 41 (got \(v))")
     }
 }

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -153,6 +153,115 @@ struct SystemPromptTests {
         #expect(prompt.body != SystemPrompt.defaultBody)
     }
 
+    // MARK: - v40→v41 migration: $WIKICTL → bare wikictl
+
+    /// The v40→v41 migration replaces `$WIKICTL` with bare `wikictl` and
+    /// `$WIKICTL page upsert` → `wikictl page add` in stored system prompts.
+    /// Existing wikis seeded under the old default still carry `$WIKICTL`
+    /// instructions; the migration fixes them on next open.
+    @Test func v40ToV41MigratesDollarWikictlToBare() throws {
+        let url = tempDatabaseURL()
+
+        // 1. Create a fresh DB at the current schema (v41). Then stamp it
+        //    back to v40 and inject an old $WIKICTL-era prompt body.
+        do {
+            let store = try GRDBWikiStore(databaseURL: url)
+            _ = try store.getSystemPrompt()
+        }
+
+        var raw: OpaquePointer?
+        #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        defer { sqlite3_close(raw) }
+        let oldBody = """
+        # System Prompt (v40-era)
+
+        Always invoke it as `$WIKICTL`.
+
+        ## Commands
+
+        - `$WIKICTL page list`
+        - `$WIKICTL page upsert`
+        - `$WIKICTL page get`
+        - `$WIKICTL page delete`
+
+        Read back what you just wrote.
+        """
+        let sql = """
+        UPDATE system_prompt SET body_markdown = '\(oldBody.replacingOccurrences(of: "'", with: "''"))' WHERE id = 1;
+        PRAGMA user_version = 40;
+        """
+        #expect(sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK)
+
+        // 2. Reopen — the v40→v41 migration should fire.
+        let store = try GRDBWikiStore(databaseURL: url)
+        let prompt = try store.getSystemPrompt()
+
+        // 3. $WIKICTL is gone; bare wikictl is in its place.
+        #expect(!prompt.body.contains("$WIKICTL"),
+               "migration must replace all $WIKICTL references; body still contains it")
+        #expect(prompt.body.contains("wikictl page list"))
+        // page upsert → page add.
+        #expect(!prompt.body.contains("page upsert"),
+               "migration must replace 'page upsert' with 'page add'")
+        #expect(prompt.body.contains("wikictl page add"))
+        // Non-command content rides through.
+        #expect(prompt.body.contains("Read back what you just wrote."))
+        // user_version advanced to 41.
+        #expect(Int(store.pragmaValue("user_version")) == 41)
+    }
+
+    /// The v40→v41 migration is idempotent: re-opening an already-migrated
+    /// DB is a no-op (the `$WIKICTL` guard prevents double-processing).
+    @Test func v40ToV41MigrationIsIdempotent() throws {
+        let url = tempDatabaseURL()
+
+        // Same setup: stamp to v40 with an old $WIKICTL body.
+        do {
+            let store = try GRDBWikiStore(databaseURL: url)
+            _ = try store.getSystemPrompt()
+        }
+        var raw: OpaquePointer?
+        #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        defer { sqlite3_close(raw) }
+        #expect(sqlite3_exec(raw, """
+        UPDATE system_prompt SET body_markdown = 'Use $WIKICTL page upsert' WHERE id = 1;
+        PRAGMA user_version = 40;
+        """, nil, nil, nil) == SQLITE_OK)
+
+        // First open runs the migration.
+        let store1 = try GRDBWikiStore(databaseURL: url)
+        let prompt1 = try store1.getSystemPrompt()
+        #expect(!prompt1.body.contains("$WIKICTL"))
+        #expect(prompt1.body.contains("wikictl page add"))
+
+        // Second open: already at v41, migration is a no-op. Body unchanged.
+        let store2 = try GRDBWikiStore(databaseURL: url)
+        let prompt2 = try store2.getSystemPrompt()
+        #expect(prompt2.body == prompt1.body)
+    }
+
+    /// A v40 DB whose prompt does NOT contain `$WIKICTL` (user edited away
+    /// from the default) is untouched by the migration.
+    @Test func v40ToV41MigrationSkipsPromptWithoutDollarWikictl() throws {
+        let url = tempDatabaseURL()
+        let customBody = "# My custom prompt\n\nNo wikictl references here.\n"
+
+        do {
+            let store = try GRDBWikiStore(databaseURL: url)
+            try store.updateSystemPrompt(body: customBody)
+        }
+        // Stamp back to v40; the body has no $WIKICTL.
+        var raw: OpaquePointer?
+        #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        defer { sqlite3_close(raw) }
+        #expect(sqlite3_exec(raw, "PRAGMA user_version = 40;", nil, nil, nil) == SQLITE_OK)
+
+        let store = try GRDBWikiStore(databaseURL: url)
+        let prompt = try store.getSystemPrompt()
+        #expect(prompt.body == customBody,
+               "migration must not touch a prompt that has no $WIKICTL")
+    }
+
     // MARK: - Change token advances on a prompt-only edit
 
     @Test func changeTokenAdvancesOnSystemPromptEdit() throws {

--- a/plans/wikictl-prompt-migration.md
+++ b/plans/wikictl-prompt-migration.md
@@ -1,0 +1,68 @@
+# Plan: Migrate stored system prompts to use bare `wikictl` instead of `$WIKICTL`
+
+## Problem
+The default system prompt (`prompts/system-prompt-default.md`) was already updated to say "Invoke it as a bare `wikictl`" and use `wikictl page add` (not `page upsert`). But existing wikis have an OLD version of the system prompt stored in their `system_prompt` table (seeded from the old default). The agent still sees `$WIKICTL` in its staged AGENTS.md, and `$WIKICTL` doesn't always resolve correctly in the agent's shell (it mentions "AGENTS.md hints not matching the actual executable").
+
+## Root cause
+- `system_prompt` table (`GRDBWikiStore.swift:2291`) stores the user-editable prompt, seeded from `SystemPrompt.defaultBody` on wiki creation.
+- `INSERT OR IGNORE` means existing wikis keep their old prompt forever — no migration updates it.
+- The old prompt says **"Always invoke it as `$WIKICTL`"** (line 199 of the staged AGENTS.md) and **"`$WIKICTL page upsert`"** — but the new default says **"Invoke it as a bare `wikictl`"** and **"wikictl page add"**.
+- The `WIKICTL` env var IS set (`ACPBackend.swift:1690`: `env[wikictl] = cli.wikictlDirectory + "/wikictl"`), and `wikictl` is on `PATH` (`:1692`). So `$WIKICTL` *should* work — but some agents/shells may not expand `$VAR` in certain contexts (e.g. subprocess without a login shell), making bare `wikictl` more reliable.
+
+## Fix: v40 → v41 migration
+
+Add a migration step in `GRDBWikiStore.migrate(from:in:)` that:
+1. Reads the stored `system_prompt` body.
+2. Replaces `$WIKICTL` → `wikictl` (regardless of context — the bare command is always correct since PATH includes the wikictl directory).
+3. Replaces `wikictl page upsert` → `wikictl page add` (after the $WIKICTL→wikictl replacement).
+4. Updates the stored body with the replaced text.
+5. Only runs if the body contains `$WIKICTL` (idempotent — skip already-migrated prompts).
+6. Bumps `user_version` to 41.
+
+### The migration code (in `Sources/WikiFSCore/Store/GRDBWikiStore.swift`)
+
+After the existing `if version < 40 { ... }` block, add:
+
+```swift
+if version < 41 {
+    // v40→v41: migrate stored system prompts from $WIKICTL → wikictl.
+    // The default prompt was updated to use bare `wikictl` (on PATH), but
+    // existing wikis still have the old $WIKICTL instructions from when
+    // they were seeded. $WIKICTL doesn't always expand correctly in the
+    // agent's subprocess shell.
+    let row = try Row.fetchOne(
+        db,
+        sql: "SELECT body_markdown FROM system_prompt WHERE id = 1;")
+    if let body = row?["body_markdown"] as String?,
+       body.contains("$WIKICTL") {
+        let migrated = body
+            .replacingOccurrences(of: "$WIKICTL", with: "wikictl")
+            .replacingOccurrences(of: "wikictl page upsert", with: "wikictl page add")
+        try db.execute(
+            sql: "UPDATE system_prompt SET body_markdown = ?, updated_at = ? WHERE id = 1;",
+            arguments: [migrated, Date.timeIntervalSinceReferenceDate])
+    }
+    try db.execute(sql: "PRAGMA user_version = 41;")
+    version = 41
+}
+```
+
+## Files to modify
+| File | Change |
+|---|---|
+| `Sources/WikiFSCore/Store/GRDBWikiStore.swift` | Add v40→v41 migration step; bump `currentSchemaVersion` from 40 to 41 |
+
+## Acceptance criteria
+- [ ] On opening an existing wiki with `$WIKICTL` in its stored system prompt, the prompt is migrated to use bare `wikictl`.
+- [ ] `page upsert` references in the stored prompt are changed to `page add`.
+- [ ] The migration is idempotent (running on an already-migrated prompt is a no-op).
+- [ ] New wikis are unaffected (they seed from the already-correct default).
+- [ ] `swift test` passes (including any DB migration tests).
+- [ ] `make build && make test` passes.
+
+## Gotchas
+1. **The `#129` emit rule** — this migration runs inside `migrate(from:in:)` which is NOT a public mutator. It runs during DB initialization, before the store is usable. No `ResourceChangeEvent` needed — the File Provider hasn't started observing yet. This is the same pattern as every other migration step.
+2. **SQLite concurrency** — the migration runs inside `migrateIfNeeded(_:)` which is called during `init(databaseURL:)`. This is within the store's own write path, so it's naturally serialized.
+3. **Don't touch the default prompt** — `prompts/system-prompt-default.md` is already correct. This migration only fixes *stored* prompts in existing DBs.
+4. **The `wiki_index` table** has the same pattern (seeded from default, user-editable). But it doesn't reference `$WIKICTL`, so no migration needed for it.
+5. **Don't break the `$WIKICTL` env var** — the env var is still SET by `ACPBackend.buildAgentEnv` (`:1690`). The bare `wikictl` works because it's on PATH. The migration only changes the *prompt text* that tells the agent which invocation to use — the underlying env var stays as a fallback.


### PR DESCRIPTION
## Summary

v40→v41 DB migration that fixes stored system prompts in existing wikis.

The default system prompt (`prompts/system-prompt-default.md`) was already updated to use bare `wikictl` and `wikictl page add` instead of `$WIKICTL` and `$WIKICTL page upsert`. But existing wikis still carry the old prompt in their `system_prompt` table — it was seeded via `INSERT OR IGNORE` and never updated.

`$WIKICTL` doesn't always expand correctly in the agent's subprocess shell (the .app path contains spaces, causing word-split failures like `/Applications/Self: No such file or directory`). Bare `wikictl` works because it's on `PATH`.

## Changes

### Migration (`GRDBWikiStore.swift`)

- **Bumped `currentSchemaVersion` from 40 to 41.**
- **Added v40→v41 migration step** in `migrate(from:in:)`:
  - Reads the stored `system_prompt` body.
  - If it contains `$WIKICTL`, replaces `$WIKICTL` → `wikictl` and `wikictl page upsert` → `wikictl page add`.
  - Writes the migrated body back with an updated `updated_at`.
  - Stamps `PRAGMA user_version = 41`.
  - **Idempotent**: the `body.contains("$WIKICTL")` guard means re-opening an already-migrated DB is a no-op.
- **Fixed v40 migration step's early `return`**: the `guard !columns.contains("summary") else { ...; return }` pattern returned from `migrate()` entirely when `chat_messages.summary` already existed, bypassing all subsequent migration steps (including v41). Replaced with an `if`-block that skips only the `ALTER TABLE` work, letting execution continue to v41.

### Tests

- Updated existing schema-version assertions (40 → 41) in `MessageSummaryTests` and `PageVersionTests`.
- Added 3 migration tests in `SystemPromptTests`:
  - `v40ToV41MigratesDollarWikictlToBare` — verifies `$WIKICTL` → `wikictl` and `page upsert` → `page add`.
  - `v40ToV41MigrationIsIdempotent` — re-opening an already-migrated DB is a no-op.
  - `v40ToV41MigrationSkipsPromptWithoutDollarWikictl` — a prompt without `$WIKICTL` is untouched.

## Acceptance criteria

- [x] On opening an existing wiki with `$WIKICTL` in its stored system prompt, the prompt is migrated to use bare `wikictl`.
- [x] `page upsert` references in the stored prompt are changed to `page add`.
- [x] The migration is idempotent (running on an already-migrated prompt is a no-op).
- [x] New wikis are unaffected (they seed from the already-correct default).
- [x] `make build && make test` passes (3336 tests, 0 failures).
