### PR TITLE
Reorganize page history — date-first, operation badges, newest-first

### DIFF
--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -820,8 +820,8 @@ struct ProvenancePanel: View {
                 Text("Edit history")
                     .font(.callout.weight(.semibold))
                     .foregroundStyle(.secondary)
-                ForEach(Array(history.enumerated()), id: \.element.versionID) { idx, entry in
-                    historyRow(idx, entry)
+                ForEach(history, id: \.versionID) { entry in
+                    historyRow(entry)
                 }
             }
         }
@@ -832,42 +832,40 @@ struct ProvenancePanel: View {
 
     @ViewBuilder private func originRow(_ origin: PageOrigin) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            // Created-by / last-edited-by row.
+            // Created-by / last-edited-by-row, date-first to match the
+            // history rows below.
             HStack(spacing: 6) {
-                Text("Last saved by")
+                Text(origin.savedAt,
+                     format: .dateTime.month().day().year().hour().minute())
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                operationBadge(origin.activityKind)
+                Text("by")
                     .foregroundStyle(.secondary)
                 agentLabel(origin)
-                Text("·")
-                    .foregroundStyle(.secondary)
-                Text(origin.activityKind)
-                    .font(.callout.weight(.semibold))
-                Text("·")
-                    .foregroundStyle(.secondary)
-                Text(origin.savedAt, style: .relative)
-                    .foregroundStyle(.secondary)
-                Text("ago")
-                    .foregroundStyle(.secondary)
             }
         }
     }
 
-    @ViewBuilder private func historyRow(_ idx: Int, _ entry: PageOrigin) -> some View {
-        HStack(spacing: 6) {
-            Text("\(idx)")
+    @ViewBuilder private func historyRow(_ entry: PageOrigin) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            // Date — leading, fixed-width for column alignment.
+            Text(entry.savedAt,
+                 format: .dateTime.month().day().year().hour().minute())
+                .font(.callout.monospacedDigit())
                 .foregroundStyle(.secondary)
-                .monospacedDigit()
-            Text(entry.activityKind)
-                .font(.callout.weight(.semibold))
+                .frame(width: 140, alignment: .leading)
+
+            operationBadge(entry.activityKind)
+
             agentLabel(entry)
-            Text("·")
-                .foregroundStyle(.secondary)
-            Text(entry.savedAt, style: .date)
-                .foregroundStyle(.secondary)
+
+            Spacer()
+
             if entry.title.isEmpty == false {
-                Text("·")
-                    .foregroundStyle(.secondary)
                 Text(entry.title)
-                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                    .foregroundStyle(.tertiary)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -875,6 +873,24 @@ struct ProvenancePanel: View {
         .contentShape(Rectangle())
         .hoverRowBackground()
         .onTapGesture { handleProvenanceTap(entry) }
+    }
+
+    /// A compact colored badge for the provenance activity kind
+    /// (`import` → blue, `edit` → green, others → gray). Makes the
+    /// operation scannable in the history list.
+    @ViewBuilder
+    private func operationBadge(_ kind: String) -> some View {
+        let color: Color = switch kind {
+        case "import": .blue
+        case "edit":   .green
+        default:       .secondary
+        }
+        Text(kind.capitalized)
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
+            .foregroundStyle(color)
     }
 
     /// Navigate to the provenance entry's origin (#745):

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -4518,7 +4518,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 LEFT JOIN activities act ON act.id = pv.activity_id
                 LEFT JOIN agents a ON a.id = act.agent_id
                 WHERE pv.page_id = ?
-                ORDER BY pv.id ASC;
+                ORDER BY pv.id DESC;
                 """,
                 arguments: [pageID.rawValue]
             )

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -528,20 +528,20 @@ struct PageVersionTests {
         let history = try store.pageEditHistory(pageID: page.id)
         #expect(history.count == 2, "fresh create+edit yields 2 origin entries (got \(history.count))")
 
-        // entry[0] = root (the create's empty-root 'import' activity).
-        #expect(history[0].activityKind == "import")
-        #expect(history[0].agentName == createAuthor)
-        #expect(history[0].agentKind == "agent")
-
-        // entry[1] = the edit — pinned to the chat author + the edited body.
-        #expect(history[1].activityKind == "edit")
-        #expect(history[1].agentName == editAuthor)
-        #expect(history[1].agentKind == "chat")
+        // Newest-first (DESC): entry[0] = the edit (most recent),
+        // entry[1] = the root 'import' (oldest).
+        #expect(history[0].activityKind == "edit")
+        #expect(history[0].agentName == editAuthor)
+        #expect(history[0].agentKind == "chat")
         // The title is the version's stored title (which equals what
         // updatePage wrote).
-        #expect(history[1].title == "Edit Chain")
+        #expect(history[0].title == "Edit Chain")
 
-        // pageOrigin(pageID:) reflects the HEAD = entry[1] (the chat edit).
+        #expect(history[1].activityKind == "import")
+        #expect(history[1].agentName == createAuthor)
+        #expect(history[1].agentKind == "agent")
+
+        // pageOrigin(pageID:) reflects the HEAD = entry[0] (the chat edit).
         let head = try store.pageOrigin(pageID: page.id)
         #expect(head?.agentName == editAuthor)
         #expect(head?.agentKind == "chat")

--- a/plans/history-reorganize.md
+++ b/plans/history-reorganize.md
@@ -1,0 +1,148 @@
+# Plan: Reorganize page history — date-first, better operation/agent labels
+
+## Problem
+The page version history (in the inspector's History tab) lists entries with a flat index number (`0`, `1`, `2`...) instead of a date, and the layout is: `index · activityKind · agentLabel · date · title`. The user wants:
+1. **Date first** — each row should lead with the date, not an index.
+2. **Better organized operation + agent** — the operation (import/edit) and who did it should be clearly labeled and grouped.
+
+## Current state
+
+### The query (`GRDBWikiStore.swift:4520`)
+```sql
+ORDER BY pv.id ASC;
+```
+Returns oldest-first (ULID ordering). The UI renders in this order.
+
+### The rendering (`PageDetailView.swift:799-880`)
+```swift
+// originRow — the "Last saved by" header
+HStack {
+    "Last saved by" · agentLabel · "·" · activityKind · "·" · savedAt(relative) · "ago"
+}
+
+// historyRow — each entry
+HStack {
+    Text("\(idx)")           // ← flat index, not a date
+    Text(entry.activityKind)  // "import" / "edit" — raw
+    agentLabel(entry)
+    "·"
+    Text(entry.savedAt, style: .date)  // date, but THIRD
+    if title not empty { "·" title }
+}
+```
+
+### PageOrigin fields available (`PageOrigin.swift:19-78`)
+- `versionID: String` (ULID)
+- `title: String` (title at save time)
+- `agentName: String` (`chat:<id>` / `agent:<kind>` / `user` / model id)
+- `agentKind: String` (`chat` / `agent` / `human` / `model` / `software`)
+- `activityKind: String` (`import` / `edit`)
+- `runTitle: String?` (chat title for chat-backed saves)
+- `savedAt: Date`
+
+## Design
+
+### 1. Change query to newest-first (`GRDBWikiStore.swift:4520`)
+```sql
+ORDER BY pv.id DESC;
+```
+Most recent version at the top — standard version history UX (like git log).
+
+### 2. Redesign `historyRow` layout — date-first
+
+Each row should read like a version timeline entry:
+
+```
+Jul 21, 2026 3:45 PM    [Edit]  Agent Name
+Jul 21, 2026 2:12 PM    [Import]  Agent Name
+Jul 20, 2026 9:00 AM    [Edit]  Chat: "Some Chat Title"
+```
+
+New layout:
+```swift
+HStack(alignment: .firstTextBaseline, spacing: 8) {
+    // Date — leading, fixed-width for alignment
+    Text(entry.savedAt, format: .dateTime.month().day().year().hour().minute())
+        .font(.callout.monospacedDigit())
+        .foregroundStyle(.secondary)
+        .frame(width: 140, alignment: .leading)
+
+    // Operation badge
+    operationBadge(entry.activityKind)
+
+    // Agent label (existing agentLabel helper)
+    agentLabel(entry)
+
+    Spacer()
+
+    // Title at save time (if different from current title)
+    if entry.title.isEmpty == false {
+        Text(entry.title)
+            .foregroundStyle(.tertiary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+}
+```
+
+### 3. Operation badge (`PageDetailView.swift`)
+A small colored badge for the activity kind, making it scannable:
+
+```swift
+@ViewBuilder private func operationBadge(_ kind: String) -> some View {
+    let label = kind.capitalized  // "Import" / "Edit"
+    let color: Color = kind == "import" ? .blue : .green
+    Text(label)
+        .font(.caption.weight(.medium))
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(color.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
+        .foregroundStyle(color)
+}
+```
+
+### 4. Remove the flat index number
+The index (`0`, `1`, `2`...) is meaningless to the user. The date replaces it as the leading column.
+
+### 5. Keep the origin header but simplify
+The `originRow` (last saved by) is fine as a summary header above the list. Keep it but make it match the new date-first style:
+
+```swift
+HStack {
+    Text("Last saved")
+        .foregroundStyle(.secondary)
+    Text(origin.savedAt, format: .dateTime.month().day().year().hour().minute())
+        .foregroundStyle(.secondary)
+    operationBadge(origin.activityKind)
+    agentLabel(origin)
+}
+```
+
+### 6. Make rows clickable (preserve #745 behavior)
+The `handleProvenanceTap` is already wired. Keep it.
+
+## Files to modify
+| File | Change |
+|---|---|
+| `Sources/WikiFSCore/Store/GRDBWikiStore.swift` | Change `ORDER BY pv.id ASC` → `DESC` (newest-first) |
+| `Sources/WikiFS/Pages/PageDetailView.swift` | Redesign `historyRow` + `originRow` in ProvenancePanel; add `operationBadge` helper |
+
+## Acceptance criteria
+- [ ] History entries are **date-first** (date is the leading column).
+- [ ] History is **newest-first** (most recent at top).
+- [ ] Each row shows the operation (Import/Edit) as a clear badge.
+- [ ] Each row shows the agent (chat title / agent kind / user) clearly.
+- [ ] The flat index number is removed.
+- [ ] The title-at-save-time is shown (secondary/tertiary) when different from current.
+- [ ] Rows are still clickable (#745 — navigate to chat/activity).
+- [ ] `make build && make test` passes.
+- [ ] No `print`; no bare `try?`.
+
+## Gotchas
+1. **`ORDER BY pv.id DESC`** — ULIDs are time-ordered, so DESC = newest-first. This is correct.
+2. **Date formatting** — use `.dateTime.month().day().year().hour().minute()` for a compact but readable format. Use `.monospacedDigit()` for alignment.
+3. **Fixed-width date column** — use `.frame(width: 140, alignment: .leading)` so dates align in a column. Adjust width if needed.
+4. **The `idx` parameter** is no longer needed in `historyRow` — remove it from the `ForEach` call too.
+5. **macos-design skill** — consult `docs/skills/macos-design/SKILL.md` for the badge style. Keep it simple — a rounded rect background with the operation color.
+6. **swiftui-pro skill** — consult `docs/skills/swiftui-pro/SKILL.md` for the HStack alignment (`.firstTextBaseline`) and `.frame` usage.
+7. **No file overlap** — #780 (linux-ci) touches ci.yml; #784 (inspector panel) is merged. This PR only touches PageDetailView.swift + GRDBWikiStore.swift.


### PR DESCRIPTION
## Summary

Reorganizes the page version history (inspector's History tab) to lead with the date instead of a flat index number, with a colored operation badge and newest-first ordering — standard version-history UX.

## Changes

- **`GRDBWikiStore.swift`**: `pageEditHistory` query changed from `ORDER BY pv.id ASC` → `DESC` (newest-first, like git log)
- **`PageDetailView.swift`**: Redesigned `historyRow` — date is the leading column (fixed-width 140pt, monospaced digits), operation shown as a color-coded badge, agent label, and title at save time; removed the flat index number
- **`PageDetailView.swift`**: Simplified `originRow` ("Last saved" header) to match the date-first style
- **`PageDetailView.swift`**: Added `operationBadge` helper — `import` → blue, `edit` → green, rounded-rect badge
- **`PageVersionTests.swift`**: Updated `pageEditHistoryCountsCreateAndEdit` test for the new DESC ordering (edit is now entry[0], import is entry[1])

## Before / After

**Before:**
```
0  import  chat:01J…  ·  Jul 21, 2026  · Edit Chain
1  edit    chat:01J…  ·  Jul 21, 2026  · Edit Chain
```

**After:**
```
Jul 21, 2026 3:45 PM  [Edit]    💬 Edit Chain  ............  Edit Chain
Jul 21, 2026 2:12 PM  [Import]  🤖 Ingestion  .............  Edit Chain
```

## Test plan

- [x] `make build` passes
- [x] `swift test --filter PageVersionTests` passes (27/27)
- [x] All 3359 tests pass except 2 pre-existing `DefuddleExtractionServiceTests` failures (confirmed on clean baseline — defuddle is opt-in/not bundled)
- [ ] Manual: open History tab, verify date-first layout + newest-first order + badge colors + row click still navigates to chat/activity (#745)
