### PR TITLE
Fix: fire per-message summary sink on turn end, not just finish()

### DIFF
--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -3025,6 +3025,18 @@ public final class AgentLauncher {
                     self.setGenerating(false)
                     self.flushTranscript()
                     self.generateChatSummary()
+                    // Fire per-message summarization on the turn boundary — not
+                    // just in finish(). Interactive chats stay alive across many
+                    // turns without ever reaching finish(), so the sink must run
+                    // here or summarizePendingMessages never fires for them
+                    // (DB evidence: 0 of 285 chat_messages had summary columns
+                    // set). Safe because: flushTranscript() already persisted
+                    // the turn's events to the DB above; the sink's compute-once
+                    // guard (summary == nil) skips already-summarized rows; and
+                    // model mode dispatches the actual LLM call off-main via
+                    // Task.detached, so it doesn't block this turn. The finish()
+                    // call remains as a safety net for the one-shot run() path.
+                    self.fireMessageSummarySink()
                     // Capture the per-turn usage delta and forward it to the
                     // menu bar tracker (if wired). Reads the backend's
                     // cumulative session snapshot and emits the delta vs the


### PR DESCRIPTION
## Fix: per-message summarization never runs for interactive chats

### Root cause
`fireMessageSummarySink()` was called ONLY in `finish()` (session teardown at `AgentLauncher.swift:3363`), NOT on the interactive per-turn boundary. The turn-boundary handler called `flushTranscript()` + `generateChatSummary()` but omitted `fireMessageSummarySink()`, so `summarizePendingMessages` never ran for interactive chats that stay alive across many turns.

DB evidence: 0 of 285 `chat_messages` across all wikis had `summary`/`summary_kind`/`summary_at` set.

### The fix
Added `fireMessageSummarySink()` to the `endsGeneration` turn-boundary handler in `sendInteractiveMessage`, right after `generateChatSummary()`:

```swift
self.flushTranscript()
self.generateChatSummary()
self.fireMessageSummarySink()    // ← added
```

### Why this is safe
- **`flushTranscript()` runs first** (synchronous, `@MainActor`) — persists the turn's events to the DB BEFORE the sink queries them.
- **Compute-once guard** (`summary == nil`) — already-summarized messages are never re-summarized.
- **Model mode is off-main** — the actual LLM call is dispatched via `Task.detached`, so it doesn't block the turn.
- **`finish()` call retained** as a safety net for the one-shot `run()` path.

### Testing
- `swift build` — ✅ compiles
- `swift test` — ✅ 3359 tests, 279 suites, all pass
