### PR TITLE
feat: add History tab to SourceDetailView via shared DetailInspectorView + ProvenancePanel

### DIFF
--- a/Sources/WikiFS/Detail/DetailInspectorView.swift
+++ b/Sources/WikiFS/Detail/DetailInspectorView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import WikiFSCore
+
+// MARK: - InspectorTab
+
+/// The selected tab in the ``DetailInspectorView``. Persisted in `@AppStorage`
+/// (via a `@Binding` from the caller) so the user's last-used tab is restored
+/// on reopen.
+enum InspectorTab: String, CaseIterable {
+    case outline
+    case history
+}
+
+// MARK: - DetailInspectorView
+
+/// Xcode-style inspector panel for detail views. Shows a segmented tab bar
+/// at the top (Outline / History) and the selected tab's content below.
+///
+/// - **Outline tab**: renders the `@ViewBuilder` closure passed by the caller
+///   (the page's `PageOutlineView` or the source's outline view).
+/// - **History tab**: renders ``ProvenancePanel`` (origin + edit history).
+///
+/// Shared between `PageDetailView` and `SourceDetailView` so both have the
+/// same tabbed inspector. The resizable width divider lives at this level
+/// so both tabs share the same column width. Provenance is passed in by the
+/// caller (already loaded via a `.task(id:)` — this view does no I/O).
+///
+/// The `inspectorTab` and `outlineWidth` are `@Binding`s so each caller can
+/// persist them under its own `@AppStorage` key (page vs. source) without
+/// desync when switching views.
+struct DetailInspectorView<Outline: View>: View {
+    @Binding var inspectorTab: InspectorTab
+    @Binding var outlineWidth: Double
+    let origin: ProvenanceEntry?
+    let history: [ProvenanceEntry]
+    var store: WikiStoreModel?
+    @ViewBuilder let outline: () -> Outline
+
+    @State private var dragStartWidth: Double? = nil
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Draggable divider on the inspector's leading edge — shared by
+            // both tabs so the column width is always resizable.
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor))
+                .frame(width: 1)
+                .frame(maxHeight: .infinity)
+                .padding(.horizontal, 4)
+                .contentShape(Rectangle())
+                .onHover { isHovering in
+                    if isHovering {
+                        NSCursor.resizeLeftRight.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+                .gesture(
+                    DragGesture()
+                        .onChanged { value in
+                            if dragStartWidth == nil {
+                                dragStartWidth = outlineWidth
+                            }
+                            if let start = dragStartWidth {
+                                let newWidth = start - Double(value.translation.width)
+                                outlineWidth = max(180, min(500, newWidth))
+                            }
+                        }
+                        .onEnded { _ in
+                            dragStartWidth = nil
+                        }
+                )
+                .zIndex(1)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Picker("Inspector", selection: $inspectorTab) {
+                    Label("Outline", systemImage: "list.bullet.indent")
+                        .tag(InspectorTab.outline)
+                    Label("History", systemImage: "clock.arrow.circlepath")
+                        .tag(InspectorTab.history)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .padding(8)
+
+                Divider()
+
+                switch inspectorTab {
+                case .outline:
+                    outline()
+                case .history:
+                    ScrollView {
+                        ProvenancePanel(
+                            origin: origin,
+                            history: history,
+                            store: store)
+                        .padding()
+                    }
+                }
+            }
+            .frame(width: outlineWidth)
+            .background(Color(nsColor: .windowBackgroundColor))
+        }
+    }
+}

--- a/Sources/WikiFS/Detail/ProvenanceEntry+Origins.swift
+++ b/Sources/WikiFS/Detail/ProvenanceEntry+Origins.swift
@@ -1,0 +1,40 @@
+import Foundation
+import WikiFSCore
+
+// MARK: - ProvenanceEntry projections
+
+extension PageOrigin {
+    /// Project this page origin into the shared display model used by
+    /// ``ProvenancePanel`` (DRY with ``SourceOrigin``).
+    var provenanceEntry: ProvenanceEntry {
+        ProvenanceEntry(
+            versionID: versionID,
+            agentName: agentName,
+            agentKind: agentKind,
+            activityKind: activityKind,
+            plan: plan,
+            externalRef: externalRef,
+            runTitle: runTitle,
+            savedAt: savedAt
+        )
+    }
+}
+
+extension SourceOrigin {
+    /// Project this source origin into the shared display model used by
+    /// ``ProvenancePanel`` (DRY with ``PageOrigin``). Source origins use
+    /// `fetchedAt` as the display timestamp (the source-side equivalent of
+    /// `PageOrigin.savedAt`).
+    var provenanceEntry: ProvenanceEntry {
+        ProvenanceEntry(
+            versionID: versionID,
+            agentName: agentName,
+            agentKind: agentKind,
+            activityKind: activityKind,
+            plan: plan,
+            externalRef: externalRef,
+            runTitle: runTitle,
+            savedAt: fetchedAt
+        )
+    }
+}

--- a/Sources/WikiFS/Detail/ProvenanceEntry.swift
+++ b/Sources/WikiFS/Detail/ProvenanceEntry.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// A display-model projection of a single provenance entry — the shared
+/// representation used by ``ProvenancePanel`` to render both page and source
+/// history without depending on the concrete `PageOrigin` / `SourceOrigin`
+/// types. Both origins convert to this via their `.provenanceEntry` computed
+/// property.
+///
+/// Keeps the provenance UI DRY: the date-first layout, operation badge,
+/// agent label, and clickable-row behavior are identical for pages and
+/// sources — only the store accessors + origin types differ, and those are
+/// resolved by the caller before constructing a `ProvenanceEntry`.
+public struct ProvenanceEntry: Sendable, Equatable, Identifiable {
+    public let versionID: String
+    public let agentName: String
+    /// The agent's structured kind (`chat` / `agent` / `human` / `model` /
+    /// `software`). Used by the agent label to pick the right icon.
+    public let agentKind: String
+    public let activityKind: String
+    public let plan: String?
+    public let externalRef: String?
+    /// A human-readable run name resolved from the provenance payload (#745).
+    /// For `chat:<id>` agents this is the chat's display title; `nil` for
+    /// other agent kinds or when the chat has been deleted.
+    public let runTitle: String?
+    public let savedAt: Date
+
+    public var id: String { versionID }
+
+    public init(
+        versionID: String,
+        agentName: String,
+        agentKind: String,
+        activityKind: String,
+        plan: String?,
+        externalRef: String?,
+        runTitle: String?,
+        savedAt: Date
+    ) {
+        self.versionID = versionID
+        self.agentName = agentName
+        self.agentKind = agentKind
+        self.activityKind = activityKind
+        self.plan = plan
+        self.externalRef = externalRef
+        self.runTitle = runTitle
+        self.savedAt = savedAt
+    }
+}

--- a/Sources/WikiFS/Detail/ProvenancePanel.swift
+++ b/Sources/WikiFS/Detail/ProvenancePanel.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+import WikiFSCore
+
+/// The content of the inspector's "History" tab — origin + edit history
+/// from the PROV graph. Pure-render over its inputs (no I/O); the parent
+/// ``DetailInspectorView`` loads `origin` + `history` via its `.task(id:)` and
+/// passes them in here. Kept self-contained so the type checker resolves the
+/// `body` subtree independently.
+///
+/// Shared between `PageDetailView` and `SourceDetailView` via the
+/// ``ProvenanceEntry`` display model — both `PageOrigin` and `SourceOrigin`
+/// project to it, so the rendering code (date-first layout, operation badge,
+/// agent label, clickable rows) is identical for both.
+///
+/// #745: history rows are clickable. A `chat:<id>` provenance entry
+/// navigates to the chat tab (via `store.openTab(.chat(...))`); an
+/// `agent:<kind>` one-shot-run entry opens the Activity window (via the
+/// `\.openActivityWindow` environment closure). Neither applies → no-op.
+struct ProvenancePanel: View {
+    let origin: ProvenanceEntry?
+    let history: [ProvenanceEntry]
+    /// The wiki store — used to navigate to chat tabs on row click (#745).
+    /// Weak-ish: the parent detail view owns a `@Bindable` reference,
+    /// so this never outlives the view.
+    var store: WikiStoreModel?
+    @Environment(\.openActivityWindow) private var openActivityWindow
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let origin {
+                originRow(origin)
+            } else {
+                Text("No provenance yet")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
+            if !history.isEmpty {
+                Divider().opacity(0.5)
+                Text("Edit history")
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(history) { entry in
+                    historyRow(entry)
+                }
+            }
+        }
+        .font(.callout)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder private func originRow(_ origin: ProvenanceEntry) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            // Created-by / last-edited-by-row, date-first to match the
+            // history rows below.
+            HStack(spacing: 6) {
+                Text(origin.savedAt,
+                     format: .dateTime.month().day().year().hour().minute())
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                operationBadge(origin.activityKind)
+                Text("by")
+                    .foregroundStyle(.secondary)
+                agentLabel(origin)
+            }
+        }
+    }
+
+    @ViewBuilder private func historyRow(_ entry: ProvenanceEntry) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            // Date — leading, fixed-width for column alignment.
+            Text(entry.savedAt,
+                 format: .dateTime.month().day().year().hour().minute())
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(width: 140, alignment: .leading)
+
+            operationBadge(entry.activityKind)
+
+            agentLabel(entry)
+
+            Spacer()
+
+            if entry.runTitle?.isEmpty == false {
+                Text(entry.runTitle!)
+                    .font(.callout)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .contentShape(Rectangle())
+        .hoverRowBackground()
+        .onTapGesture { handleProvenanceTap(entry) }
+    }
+
+    /// A compact colored badge for the provenance activity kind
+    /// (`import` → blue, `edit` → green, others → gray). Makes the
+    /// operation scannable in the history list.
+    @ViewBuilder
+    private func operationBadge(_ kind: String) -> some View {
+        let color: Color = switch kind {
+        case "import": .blue
+        case "edit":   .green
+        default:       .secondary
+        }
+        Text(kind.capitalized)
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
+            .foregroundStyle(color)
+    }
+
+    /// Navigate to the provenance entry's origin (#745):
+    /// - `chat:<id>` → open the chat tab in the wiki's tab bar.
+    /// - `agent:<kind>` → open the Activity (queue) window.
+    /// - Otherwise → no-op (don't break).
+    private func handleProvenanceTap(_ entry: ProvenanceEntry) {
+        if entry.agentName.hasPrefix("chat:") {
+            let chatID = String(entry.agentName.dropFirst("chat:".count))
+            guard !chatID.isEmpty else { return }
+            let id = PageID(rawValue: chatID)
+            DebugLog.tabs("ProvenancePanel: navigating to chat \(id.rawValue.prefix(8))")
+            store?.openTab(.chat(id))
+        } else if entry.agentName.hasPrefix("agent:") {
+            DebugLog.tabs("ProvenancePanel: opening Activity window for \(entry.agentName)")
+            openActivityWindow?()
+        }
+    }
+
+    /// Render the agent identity (#745). For `chat:<id>` agents, prefer the
+    /// resolved `runTitle` (the chat's display title) over the raw ULID. When
+    /// the chat has been deleted (title is nil), fall back to a muted
+    /// "Deleted chat" label. For `agent:<kind>` one-shot runs, show a
+    /// friendly label derived from the kind (e.g. "Ingest" / "Lint") rather
+    /// than the raw `agent:ingest` string. Other kinds render verbatim.
+    @ViewBuilder
+    private func agentLabel(_ entry: ProvenanceEntry) -> some View {
+        let name = entry.agentName
+        if name.hasPrefix("chat:") {
+            if let runTitle = entry.runTitle, !runTitle.isEmpty {
+                Label(runTitle, systemImage: "bubble.left.and.bubble.right")
+                    .help(name)
+                    .foregroundStyle(.secondary)
+            } else {
+                // Chat was deleted or the title is unavailable — show a
+                // muted placeholder instead of the raw ULID.
+                Label("Deleted chat", systemImage: "bubble.left.and.bubble.right")
+                    .help(name)
+                    .foregroundStyle(.tertiary)
+            }
+        } else if name.hasPrefix("agent:") {
+            // One-shot run: resolve a friendly label from the kind suffix.
+            let kind = String(name.dropFirst("agent:".count))
+            let label = friendlyRunLabel(for: kind)
+            Label(label, systemImage: "cpu")
+                .help("\(kind) agent")
+                .foregroundStyle(.secondary)
+        } else if name == "user" {
+            Label(name, systemImage: "person")
+                .foregroundStyle(.secondary)
+        } else if name == "legacy-import" {
+            Label("Imported (legacy)", systemImage: "tray.and.arrow.down")
+                .foregroundStyle(.secondary)
+        } else {
+            Text(name)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Map an `agent:<kind>` suffix to a human-readable run label (#745).
+    /// `ingest` → "Ingestion", `lint` → "Lint", `query` → "Query".
+    /// Unknown kinds fall back to the capitalized kind.
+    private nonisolated func friendlyRunLabel(for kind: String) -> String {
+        switch kind {
+        case "ingest": return "Ingestion"
+        case "lint": return "Lint"
+        case "query": return "Query"
+        default: return kind.capitalized
+        }
+    }
+}

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -25,9 +25,15 @@ struct PageDetailView: View {
     @AppStorage("editor.zoom") private var editorZoom = Double(ZoomScale.defaultScale)
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
     @AppStorage("isOutlineExpanded") private var isOutlineExpanded = false
+    @AppStorage("pageInspectorTab") private var inspectorTab: InspectorTab = .outline
+    @AppStorage("pageOutlineWidth") private var outlineWidth: Double = 260
     /// Per-view collapse state for the header. Starts collapsed; persists
     /// across same-type tab switches (SwiftUI keeps the view alive).
     @State private var isHeaderExpanded = false
+    /// Provenance for the inspector's History tab. Loaded via `.task(id:)`
+    /// keyed on `currentPageID` so it re-fires on page navigation.
+    @State private var provenanceOrigin: PageOrigin?
+    @State private var provenanceHistory: [PageOrigin] = []
 
     // Find bar state. The model is shared (hoisted to `ContentView` and injected
     // via environment) so the address bar's "Find on Page…" menu item can drive
@@ -152,6 +158,15 @@ struct PageDetailView: View {
         .onChange(of: findModel.currentMatchIndex) { _, _ in
             guard findModel.currentMatchIndex > 0 else { return }
             findVersion &+= 1
+        }
+        .task(id: currentPageID) {
+            guard let pageID = currentPageID else {
+                provenanceOrigin = nil
+                provenanceHistory = []
+                return
+            }
+            provenanceOrigin = store.pageOrigin(for: pageID)
+            provenanceHistory = store.pageEditHistory(for: pageID)
         }
         .alert(
             "Title Already Exists",
@@ -324,16 +339,20 @@ struct PageDetailView: View {
 
             if isOutlineExpanded {
                 DetailInspectorView(
-                    pageID: currentPageID,
-                    markdown: store.draftBody,
-                    caretCharIndex: caretCharIndex,
-                    store: store) { heading in
-                    if isEditing {
-                        editorScrollRequest = EditorScrollRequest(
-                            charOffset: heading.charOffset,
-                            version: (editorScrollRequest?.version ?? 0) + 1)
-                    } else {
-                        store.jumpToAnchorInCurrentSelection(heading.id)
+                    inspectorTab: $inspectorTab,
+                    outlineWidth: $outlineWidth,
+                    origin: provenanceOrigin?.provenanceEntry,
+                    history: provenanceHistory.map(\.provenanceEntry),
+                    store: store) {
+                    PageOutlineView(markdown: store.draftBody,
+                                    caretCharIndex: caretCharIndex) { heading in
+                        if isEditing {
+                            editorScrollRequest = EditorScrollRequest(
+                                charOffset: heading.charOffset,
+                                version: (editorScrollRequest?.version ?? 0) + 1)
+                        } else {
+                            store.jumpToAnchorInCurrentSelection(heading.id)
+                        }
                     }
                 }
             }
@@ -671,295 +690,6 @@ struct PageOutlineView: View {
         result = result.replacingOccurrences(of: "**", with: "")
         result = result.replacingOccurrences(of: "__", with: "")
         return result
-    }
-}
-
-// MARK: - Inspector panel (Xcode-style tabbed right sidebar)
-
-/// The selected tab in the `DetailInspectorView`. Persisted in `@AppStorage`
-/// so the user's last-used tab is restored on reopen.
-enum InspectorTab: String, CaseIterable {
-    case outline
-    case history
-}
-
-/// Xcode-style inspector panel for `PageDetailView`. Shows a segmented tab
-/// bar at the top (Outline / History) and the selected tab's content below.
-///
-/// - **Outline tab**: renders `PageOutlineView` (heading list + caret tracking).
-/// - **History tab**: renders `ProvenancePanel` (page origin + edit history).
-///
-/// The resizable width divider lives at this level (not in `PageOutlineView`)
-/// so both tabs share the same column width. Provenance is loaded via a
-/// `.task(id:)` keyed on `pageID` — re-firing whenever the page changes.
-struct DetailInspectorView: View {
-    let pageID: PageID?
-    let markdown: String
-    var caretCharIndex: Int?
-    var store: WikiStoreModel?
-    let onSelectHeading: (HeadingItem) -> Void
-
-    @AppStorage("pageInspectorTab") private var inspectorTab: InspectorTab = .outline
-    @AppStorage("outlineWidth") private var outlineWidth: Double = 260
-    @State private var dragStartWidth: Double? = nil
-
-    @State private var provenanceOrigin: PageOrigin?
-    @State private var provenanceHistory: [PageOrigin] = []
-
-    var body: some View {
-        HStack(spacing: 0) {
-            // Draggable divider on the inspector's leading edge — shared by
-            // both tabs so the column width is always resizable.
-            Rectangle()
-                .fill(Color(nsColor: .separatorColor))
-                .frame(width: 1)
-                .frame(maxHeight: .infinity)
-                .padding(.horizontal, 4)
-                .contentShape(Rectangle())
-                .onHover { isHovering in
-                    if isHovering {
-                        NSCursor.resizeLeftRight.push()
-                    } else {
-                        NSCursor.pop()
-                    }
-                }
-                .gesture(
-                    DragGesture()
-                        .onChanged { value in
-                            if dragStartWidth == nil {
-                                dragStartWidth = outlineWidth
-                            }
-                            if let start = dragStartWidth {
-                                let newWidth = start - Double(value.translation.width)
-                                outlineWidth = max(180, min(500, newWidth))
-                            }
-                        }
-                        .onEnded { _ in
-                            dragStartWidth = nil
-                        }
-                )
-                .zIndex(1)
-
-            VStack(alignment: .leading, spacing: 0) {
-                Picker("Inspector", selection: $inspectorTab) {
-                    Label("Outline", systemImage: "list.bullet.indent")
-                        .tag(InspectorTab.outline)
-                    Label("History", systemImage: "clock.arrow.circlepath")
-                        .tag(InspectorTab.history)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .padding(8)
-
-                Divider()
-
-                switch inspectorTab {
-                case .outline:
-                    PageOutlineView(markdown: markdown,
-                                    caretCharIndex: caretCharIndex,
-                                    onSelect: onSelectHeading)
-                case .history:
-                    ScrollView {
-                        ProvenancePanel(
-                            pageID: pageID ?? PageID(rawValue: ""),
-                            origin: provenanceOrigin,
-                            history: provenanceHistory,
-                            store: store)
-                        .padding()
-                    }
-                }
-            }
-            .frame(width: outlineWidth)
-            .background(Color(nsColor: .windowBackgroundColor))
-        }
-        .task(id: pageID) {
-            guard let pageID else {
-                provenanceOrigin = nil
-                provenanceHistory = []
-                return
-            }
-            provenanceOrigin = store?.pageOrigin(for: pageID)
-            provenanceHistory = store?.pageEditHistory(for: pageID) ?? []
-        }
-    }
-}
-
-// MARK: - Provenance panel (#page-provenance)
-
-/// The content of the inspector's "History" tab — page origin + edit history
-/// from the page-PROV graph. Pure-render over its inputs (no I/O); the parent
-/// `DetailInspectorView` loads `.origin` + `.history` via its `.task(id:)` and
-/// passes them in here. Kept self-contained so the type checker resolves the
-/// `body` subtree independently (the parent body is large already).
-///
-/// #745: history rows are clickable. A `chat:<id>` provenance entry
-/// navigates to the chat tab (via `store.openTab(.chat(...))`); an
-/// `agent:<kind>` one-shot-run entry opens the Activity window (via the
-/// `\.openActivityWindow` environment closure). Neither applies → no-op.
-struct ProvenancePanel: View {
-    let pageID: PageID
-    let origin: PageOrigin?
-    let history: [PageOrigin]
-    /// The wiki store — used to navigate to chat tabs on row click (#745).
-    /// Weak-ish: the parent `PageDetailView` owns a `@Bindable` reference,
-    /// so this never outlives the view.
-    var store: WikiStoreModel?
-    @Environment(\.openActivityWindow) private var openActivityWindow
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            if let origin {
-                originRow(origin)
-            } else {
-                Text("No provenance yet")
-                    .foregroundStyle(.secondary)
-                    .font(.callout)
-            }
-            if !history.isEmpty {
-                Divider().opacity(0.5)
-                Text("Edit history")
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                ForEach(history, id: \.versionID) { entry in
-                    historyRow(entry)
-                }
-            }
-        }
-        .font(.callout)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 4)
-    }
-
-    @ViewBuilder private func originRow(_ origin: PageOrigin) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            // Created-by / last-edited-by-row, date-first to match the
-            // history rows below.
-            HStack(spacing: 6) {
-                Text(origin.savedAt,
-                     format: .dateTime.month().day().year().hour().minute())
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-                operationBadge(origin.activityKind)
-                Text("by")
-                    .foregroundStyle(.secondary)
-                agentLabel(origin)
-            }
-        }
-    }
-
-    @ViewBuilder private func historyRow(_ entry: PageOrigin) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            // Date — leading, fixed-width for column alignment.
-            Text(entry.savedAt,
-                 format: .dateTime.month().day().year().hour().minute())
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.secondary)
-                .frame(width: 140, alignment: .leading)
-
-            operationBadge(entry.activityKind)
-
-            agentLabel(entry)
-
-            Spacer()
-
-            if entry.title.isEmpty == false {
-                Text(entry.title)
-                    .font(.callout)
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-        }
-        .contentShape(Rectangle())
-        .hoverRowBackground()
-        .onTapGesture { handleProvenanceTap(entry) }
-    }
-
-    /// A compact colored badge for the provenance activity kind
-    /// (`import` → blue, `edit` → green, others → gray). Makes the
-    /// operation scannable in the history list.
-    @ViewBuilder
-    private func operationBadge(_ kind: String) -> some View {
-        let color: Color = switch kind {
-        case "import": .blue
-        case "edit":   .green
-        default:       .secondary
-        }
-        Text(kind.capitalized)
-            .font(.caption.weight(.medium))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(color.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
-            .foregroundStyle(color)
-    }
-
-    /// Navigate to the provenance entry's origin (#745):
-    /// - `chat:<id>` → open the chat tab in the wiki's tab bar.
-    /// - `agent:<kind>` → open the Activity (queue) window.
-    /// - Otherwise → no-op (don't break).
-    private func handleProvenanceTap(_ entry: PageOrigin) {
-        if entry.agentName.hasPrefix("chat:") {
-            let chatID = String(entry.agentName.dropFirst("chat:".count))
-            guard !chatID.isEmpty else { return }
-            let id = PageID(rawValue: chatID)
-            DebugLog.tabs("ProvenancePanel: navigating to chat \(id.rawValue.prefix(8))")
-            store?.openTab(.chat(id))
-        } else if entry.agentName.hasPrefix("agent:") {
-            DebugLog.tabs("ProvenancePanel: opening Activity window for \(entry.agentName)")
-            openActivityWindow?()
-        }
-    }
-
-    /// Render the agent identity (#745). For `chat:<id>` agents, prefer the
-    /// resolved `runTitle` (the chat's display title) over the raw ULID. When
-    /// the chat has been deleted (title is nil), fall back to a muted
-    /// "Deleted chat" label. For `agent:<kind>` one-shot runs, show a
-    /// friendly label derived from the kind (e.g. "Ingest" / "Lint") rather
-    /// than the raw `agent:ingest` string. Other kinds render verbatim.
-    @ViewBuilder
-    private func agentLabel(_ entry: PageOrigin) -> some View {
-        let name = entry.agentName
-        if name.hasPrefix("chat:") {
-            if let runTitle = entry.runTitle, !runTitle.isEmpty {
-                Label(runTitle, systemImage: "bubble.left.and.bubble.right")
-                    .help(name)
-                    .foregroundStyle(.secondary)
-            } else {
-                // Chat was deleted or the title is unavailable — show a
-                // muted placeholder instead of the raw ULID.
-                Label("Deleted chat", systemImage: "bubble.left.and.bubble.right")
-                    .help(name)
-                    .foregroundStyle(.tertiary)
-            }
-        } else if name.hasPrefix("agent:") {
-            // One-shot run: resolve a friendly label from the kind suffix.
-            let kind = String(name.dropFirst("agent:".count))
-            let label = friendlyRunLabel(for: kind)
-            Label(label, systemImage: "cpu")
-                .help("\(kind) agent")
-                .foregroundStyle(.secondary)
-        } else if name == "user" {
-            Label(name, systemImage: "person")
-                .foregroundStyle(.secondary)
-        } else if name == "legacy-import" {
-            Label("Imported (legacy)", systemImage: "tray.and.arrow.down")
-                .foregroundStyle(.secondary)
-        } else {
-            Text(name)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    /// Map an `agent:<kind>` suffix to a human-readable run label (#745).
-    /// `ingest` → "Ingestion", `lint` → "Lint", `query` → "Query".
-    /// Unknown kinds fall back to the capitalized kind.
-    private nonisolated func friendlyRunLabel(for kind: String) -> String {
-        switch kind {
-        case "ingest": return "Ingestion"
-        case "lint": return "Lint"
-        case "query": return "Query"
-        default: return kind.capitalized
-        }
     }
 }
 

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -48,12 +48,17 @@ struct SourceDetailView: View {
 
     @AppStorage("editor.zoom") private var editorZoom = Double(ZoomScale.defaultScale)
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
-    @AppStorage("isOutlineExpanded") private var isOutlineExpanded = false
+    @AppStorage("isSourceOutlineExpanded") private var isOutlineExpanded = false
+    @AppStorage("sourceInspectorTab") private var inspectorTab: InspectorTab = .outline
+    @AppStorage("sourceOutlineWidth") private var outlineWidth: Double = 260
     /// Per-view collapse state for the header. Starts collapsed; persists
     /// across same-type tab switches (SwiftUI keeps the view alive).
     @State private var isHeaderExpanded = false
     @State private var headVersion: SourceMarkdownVersion?
     @State private var origin: SourceOrigin?
+    /// Provenance edit history for the inspector's History tab. Loaded via
+    /// `.task(id:)` keyed on `file.id`.
+    @State private var editHistory: [SourceOrigin] = []
     @State private var isEditing = false
     @State private var editBuffer = ""
     /// Pending scroll-to-heading for the editor (outline click while editing).
@@ -321,7 +326,7 @@ struct SourceDetailView: View {
     /// markdown content AND it isn't a pure Mermaid diagram. Gates both the
     /// outline pane and its toggle button so a `.mmd` source never shows a
     /// useless empty outline (and never gets stuck with the pane open and no
-    /// way to close it — `isOutlineExpanded` is global `@AppStorage`, so
+    /// way to close it — `isOutlineExpanded` is persisted `@AppStorage`, so
     /// without this guard it leaks from a previous markdown source).
     /// Issue #642.
     private var isOutlineApplicable: Bool {
@@ -397,6 +402,7 @@ struct SourceDetailView: View {
         .onAppear {
             headVersion = store.processedMarkdownHead(for: file)
             origin = store.sourceOrigin(for: file.id)
+            editHistory = store.sourceEditHistory(for: file.id)
             isRefreshable = store.isSourceRefreshable(for: file.id)
             lastKnownActiveTabID = store.activeTabID
             consumePinnedExtraction()
@@ -416,6 +422,7 @@ struct SourceDetailView: View {
             showReingestConfirmation = false
             headVersion = nil
             origin = nil
+            editHistory = []
             isRefreshable = false
             selectedTab = .reader
             pdfQuote = nil
@@ -427,6 +434,7 @@ struct SourceDetailView: View {
         .task(id: file.id) {
             headVersion = store.processedMarkdownHead(for: file)
             origin = store.sourceOrigin(for: file.id)
+            editHistory = store.sourceEditHistory(for: file.id)
             isRefreshable = store.isSourceRefreshable(for: file.id)
         }
         .task(id: PDFTaskKey(sourceID: file.id, anchorVersion: store.pendingScrollAnchorVersion)) {
@@ -890,6 +898,11 @@ struct SourceDetailView: View {
     /// The content area plus the optional outline sidebar. Extracted from
     /// `body` so the type-checker can resolve each subtree independently.
     ///
+    /// Uses the shared `DetailInspectorView` (same as `PageDetailView`) so
+    /// sources get the same tabbed inspector (Outline / History). The outline
+    /// tab renders the source's `PageOutlineView`; the History tab renders
+    /// the shared `ProvenancePanel` with the source's provenance.
+    ///
     /// The explicit `.frame(maxWidth: .infinity, maxHeight: .infinity,
     /// alignment: .topLeading)` on `contentArea` is load-bearing and mirrors
     /// `PageDetailView`'s `contentAndOutline` shape. Without it, the inner
@@ -910,9 +923,16 @@ struct SourceDetailView: View {
             // `text/mermaid`) — the outline parses markdown headings, which a
             // diagram source has none of. Without this guard the pane leaks
             // open from a previous markdown source via the global
-            // `@AppStorage("isOutlineExpanded")` flag (issue #642).
+            // `@AppStorage("isSourceOutlineExpanded")` flag (issue #642).
             if isOutlineExpanded, isOutlineApplicable, let markdown = currentMarkdownContent {
-                outlineView(markdown: markdown)
+                DetailInspectorView(
+                    inspectorTab: $inspectorTab,
+                    outlineWidth: $outlineWidth,
+                    origin: origin?.provenanceEntry,
+                    history: editHistory.map(\.provenanceEntry),
+                    store: store) {
+                    outlineView(markdown: markdown)
+                }
             }
         }
     }

--- a/Sources/WikiFSCore/Sources/SourceMaterializer.swift
+++ b/Sources/WikiFSCore/Sources/SourceMaterializer.swift
@@ -130,26 +130,42 @@ public protocol SourceMaterializer: Sendable {
 /// (per-ingest, so two website sources with different URLs each return their
 /// own); `agentName` from the **agent** row.
 public struct SourceOrigin: Sendable, Equatable {
+    /// The source-version row id (the ULID of the `source_versions` row).
+    public let versionID: String
     public let agentName: String
+    /// The agent's structured kind (`chat` / `agent` / `human` / `model` /
+    /// `software`). Degrades to `"software"` for the legacy-import shared
+    /// agent so the UI can label pre-v39 rows distinctly.
+    public let agentKind: String
     public let activityKind: String
     public let plan: String?
     public let externalRef: String?
     public let externalIdentity: String?
+    /// A human-readable run name resolved from the provenance payload (#745).
+    /// For `chat:<id>` agents this is the chat's display title. `nil` for
+    /// other agent kinds or when the chat has been deleted.
+    public let runTitle: String?
     public let fetchedAt: Date
 
     public init(
+        versionID: String,
         agentName: String,
+        agentKind: String,
         activityKind: String,
         plan: String?,
         externalRef: String?,
         externalIdentity: String?,
+        runTitle: String? = nil,
         fetchedAt: Date
     ) {
+        self.versionID = versionID
         self.agentName = agentName
+        self.agentKind = agentKind
         self.activityKind = activityKind
         self.plan = plan
         self.externalRef = externalRef
         self.externalIdentity = externalIdentity
+        self.runTitle = runTitle
         self.fetchedAt = fetchedAt
     }
 

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -3439,9 +3439,14 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
     public func sourceOrigin(sourceID: PageID) throws -> SourceOrigin? {
         try dbWriter.read { db in
+            // Same `runTitle` subquery as `pageOrigin` (#745) — resolves the
+            // chat title for `chat:<id>` agents; NULL for other agent kinds.
             let cols = """
-            a.name, act.kind, act.plan, act.external_ref,
-            sv.external_identity, sv.fetched_at
+            sv.id,
+            a.name, a.kind,
+            act.kind, act.plan, act.external_ref,
+            sv.external_identity, sv.fetched_at,
+            (SELECT c.title FROM chats c WHERE c.id = substr(a.name, 6) AND a.name LIKE 'chat:%')
             """
             // 1. Prefer the active ref.
             if let row = try Row.fetchOne(
@@ -3471,6 +3476,37 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 arguments: [sourceID.rawValue]
             ) else { return nil }
             return Self.originFrom(row: row)
+        }
+    }
+
+    /// The full edit history for a source — every `source_versions` row joined
+    /// to its `activities` → `agents` (the source-side mirror of
+    /// `pageEditHistory`). Ordered NEWEST-FIRST (the provenance panel renders
+    /// newest at top). Read-only: routes through `dbWriter.read` so this is
+    /// safe off-main. READ-ONLY → emits no `ResourceChangeEvent`.
+    public func sourceEditHistory(sourceID: PageID) throws -> [SourceOrigin] {
+        try dbWriter.read { db in
+            // Same `runTitle` subquery as `sourceOrigin` (#745).
+            let cols = """
+            sv.id,
+            a.name, a.kind,
+            act.kind, act.plan, act.external_ref,
+            sv.external_identity, sv.fetched_at,
+            (SELECT c.title FROM chats c WHERE c.id = substr(a.name, 6) AND a.name LIKE 'chat:%')
+            """
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                SELECT \(cols)
+                FROM source_versions sv
+                LEFT JOIN activities act ON act.id = sv.activity_id
+                LEFT JOIN agents a ON a.id = act.agent_id
+                WHERE sv.source_id = ?
+                ORDER BY sv.id DESC;
+                """,
+                arguments: [sourceID.rawValue]
+            )
+            return rows.map { Self.originFrom(row: $0) }
         }
     }
 
@@ -6658,20 +6694,31 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     }
 
 
-    /// Decode an origin row. NULL activity/agent columns degrade gracefully.
+    /// Decode an origin row. NULL activity/agent columns degrade gracefully
+    /// (matches `pageOriginFrom(row:)` for pages). Position 0..7 mirrors the
+    /// SELECT column order in `sourceOrigin`/`sourceEditHistory`. `sv.id` and
+    /// `sv.fetched_at` are NOT NULL per the `source_versions` schema; the
+    /// LEFT-joined columns can be NULL. Position 7 is the `runTitle` subquery
+    /// (#745) — NULL for non-chat agents or when the chat has been deleted.
     private static func originFrom(row: Row) -> SourceOrigin {
-        let agentName: String? = row[0]
-        let activityKind: String? = row[1]
-        let plan: String? = row[2]
-        let externalRef: String? = row[3]
-        let externalIdentity: String? = row[4]
-        let fetchedAt: Double = row[5]
+        let versionID: String = (row[0] as String?) ?? ""
+        let agentName: String? = row[1]
+        let agentKind: String? = row[2]
+        let activityKind: String? = row[3]
+        let plan: String? = row[4]
+        let externalRef: String? = row[5]
+        let externalIdentity: String? = row[6]
+        let fetchedAt: Double = (row[7] as Double?) ?? 0
+        let runTitle: String? = row[8]
         return SourceOrigin(
+            versionID: versionID,
             agentName: agentName ?? "unknown",
+            agentKind: agentKind ?? "software",
             activityKind: activityKind ?? "import",
             plan: plan,
             externalRef: externalRef,
             externalIdentity: externalIdentity,
+            runTitle: runTitle,
             fetchedAt: Date(timeIntervalSince1970: fetchedAt)
         )
     }

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -239,6 +239,11 @@ public protocol WikiStore: Sendable {
     /// from the **agent** row.
     func sourceOrigin(sourceID: PageID) throws -> SourceOrigin?
 
+    /// The full edit history for a source — every `source_versions` row joined
+    /// to its `activities` → `agents` (the source-side mirror of
+    /// `pageEditHistory`). Ordered NEWEST-FIRST. Read-only: emits nothing.
+    func sourceEditHistory(sourceID: PageID) throws -> [SourceOrigin]
+
     /// The active content version for a source, resolved exactly like
     /// `sourceContent` (ref → version, else default-active `MAX(id)`). Returns
     /// nil when the source has no version rows at all. On the protocol (not only

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2780,6 +2780,15 @@ public final class WikiStoreModel {
         try? store.sourceOrigin(sourceID: id)
     }
 
+    /// The full edit history for a source — every `source_versions` row joined
+    /// to its activity + agent, newest-first. `nil`/empty when the read fails
+    /// or the source has no versions. Drives the History tab in
+    /// `SourceDetailView`'s inspector (the source-side mirror of
+    /// `pageEditHistory`).
+    public func sourceEditHistory(for id: PageID) -> [SourceOrigin] {
+        (try? store.sourceEditHistory(sourceID: id)) ?? []
+    }
+
     /// The origin provenance of a page's HEAD — the agent + activity that last
     /// created/edited it (page provenance, #page-provenance). `nil` when the
     /// read fails (unknown id, no version rows). Drives the "Provenance" row

--- a/Tests/WikiFSTests/SourceMaterializerTests.swift
+++ b/Tests/WikiFSTests/SourceMaterializerTests.swift
@@ -484,7 +484,8 @@ struct SourceMaterializerTests {
     /// not the `.capitalized` fallback ("Apple-podcast").
     @Test func applePodcastDisplayLabel() {
         let origin = SourceOrigin(
-            agentName: "apple-podcast", activityKind: "fetch",
+            versionID: "test", agentName: "apple-podcast", agentKind: "software",
+            activityKind: "fetch",
             plan: nil, externalRef: nil, externalIdentity: nil, fetchedAt: Date())
         #expect(origin.displayLabel == "Apple Podcast")
     }

--- a/plans/source-history-tab.md
+++ b/plans/source-history-tab.md
@@ -1,0 +1,129 @@
+# Plan: Source History Tab — DRY with PageDetail's Inspector + ProvenancePanel
+
+## Goal
+Add a History tab to `SourceDetailView`'s inspector panel (matching the one
+in `PageDetailView`). DRY the shared components so both detail views use the
+same `DetailInspectorView` and a generic `ProvenancePanel`.
+
+## Current state
+
+### PageDetailView (has the inspector)
+- `DetailInspectorView` (PageDetailView.swift:695) — the tabbed inspector.
+  Hardcodes `PageOutlineView` (Outline tab) + `ProvenancePanel` (History tab).
+- `InspectorTab` enum (PageDetailView.swift:681) — `.outline` / `.history`.
+- `ProvenancePanel` (PageDetailView.swift:799) — takes `pageID`,
+  `origin: PageOrigin?`, `history: [PageOrigin]`, `store: WikiStoreModel?`.
+- `PageOrigin` (Core/PageOrigin.swift:19) — the provenance struct. Fields:
+  versionID, title, blobHash, agentName, agentKind, activityKind, plan,
+  externalRef, runTitle, savedAt.
+- `pageOrigin(pageID:)` + `pageEditHistory(pageID:)` — store accessors
+  (GRDBWikiStore.swift:4447/4502).
+
+### SourceDetailView (doesn't have a history tab)
+- Has an outline pane (`contentAndOutline` at line 887) but NOT the tabbed
+  inspector.
+- `SourceOrigin` (SourceMaterializer.swift:132) — different struct. Fields:
+  agentName, activityKind, plan, externalRef, externalIdentity, fetchedAt.
+  Missing: versionID, agentKind, runTitle.
+- `sourceOrigin(sourceID:)` (GRDBWikiStore.swift:3440) — returns HEAD origin
+  only. **No `sourceEditHistory` exists.**
+- `source_versions` table exists (append-only ULID chain, same as
+  `page_versions`) — the data is there, just no read accessor.
+
+## Implementation
+
+### 1. Add `sourceEditHistory(sourceID:)` to the store
+Mirror `pageEditHistory(pageID:)` but for sources. In `GRDBWikiStore.swift`,
+after `sourceOrigin(sourceID:)`. Read-only (`dbWriter.read`), no `mutate()`.
+
+Add to `WikiStore.swift` protocol + `WikiStoreModel.swift` wrapper (same
+pattern as `pageEditHistory`).
+
+### 2. Extend `SourceOrigin` with fields needed for the history display
+Add: `versionID`, `agentKind`, `runTitle` so the generic ProvenancePanel can
+render it. Update `sourceOrigin(sourceID:)` query + `originFromSource(row:)`
+to select `a.kind` agent kind + `sv.id` versionID + the chat-title subquery
+(same as pageOrigin's).
+
+### 3. Create a generic `ProvenancePanel` via shared `ProvenanceEntry` struct
+```swift
+public struct ProvenanceEntry: Sendable, Equatable {
+    public let versionID: String
+    public let agentName: String
+    public let agentKind: String
+    public let activityKind: String
+    public let plan: String?
+    public let externalRef: String?
+    public let runTitle: String?
+    public let savedAt: Date
+}
+```
+Add `var provenanceEntry: ProvenanceEntry { ... }` to both `PageOrigin` and
+`SourceOrigin`. Rewrite `ProvenancePanel` to take
+`origin: ProvenanceEntry?` + `history: [ProvenanceEntry]`.
+
+### 4. Make `DetailInspectorView` generic
+Move `DetailInspectorView` + `InspectorTab` out of `PageDetailView.swift`
+into `Sources/WikiFS/Detail/DetailInspectorView.swift`. Accept:
+- `outlineView` as a `@ViewBuilder` closure
+- `origin`/`history` as `ProvenanceEntry` types + `store`
+
+```swift
+struct DetailInspectorView<Outline: View>: View {
+    @Binding var inspectorTab: InspectorTab
+    @ViewBuilder let outline: () -> Outline
+    let origin: ProvenanceEntry?
+    let history: [ProvenanceEntry]
+    var store: WikiStoreModel?
+}
+```
+
+### 5. Wire up SourceDetailView
+- `@State` for `sourceOrigin`/`sourceEditHistory` + a `.task(id:)` to load.
+- Replace `contentAndOutline` with the new `DetailInspectorView`.
+- Use source-specific `@AppStorage` keys (`sourceInspectorTab`,
+  `isSourceOutlineExpanded`, `sourceOutlineWidth`).
+
+### 6. Update PageDetailView to use the shared DetailInspectorView
+Replace the inline inspector with the shared component. The outline view
+closure passes `PageOutlineView(markdown:caretCharIndex:onSelect:)`.
+
+## Files to modify
+| File | Change |
+|---|---|
+| `Sources/WikiFS/Pages/PageDetailView.swift` | Extract `DetailInspectorView` + `InspectorTab` out; rewrite `ProvenancePanel` to use `ProvenanceEntry`; update to use shared components |
+| `Sources/WikiFS/Sources/SourceDetailView.swift` | Add provenance state + `.task`; replace `contentAndOutline` with `DetailInspectorView`; pass source outline |
+| `Sources/WikiFSCore/Sources/SourceMaterializer.swift` | Extend `SourceOrigin` with `versionID`, `agentKind`, `runTitle` |
+| `Sources/WikiFSCore/Store/GRDBWikiStore.swift` | Add `sourceEditHistory(sourceID:)`; update `sourceOrigin` query to include `agentKind`/`versionID`/`runTitle` |
+| `Sources/WikiFSCore/Store/WikiStore.swift` | Add `sourceEditHistory` to the protocol |
+| `Sources/WikiFSCore/Store/WikiStoreModel.swift` | Add `sourceEditHistory(for:)` wrapper |
+| `Sources/WikiFS/Detail/ProvenanceEntry.swift` *(new)* | Shared `ProvenanceEntry` struct |
+| `Sources/WikiFS/Detail/DetailInspectorView.swift` *(new)* | Shared inspector + `InspectorTab` enum |
+| `Sources/WikiFS/Detail/ProvenancePanel.swift` *(new)* | Shared provenance panel using `ProvenanceEntry` |
+
+## Acceptance criteria
+- [ ] `SourceDetailView` has a tabbed inspector with Outline + History tabs.
+- [ ] The History tab shows source version history (date-first, newest-first,
+      operation badges) — same as PageDetailView.
+- [ ] `ProvenancePanel` is shared (DRY) — used by both detail views.
+- [ ] `DetailInspectorView` is shared — used by both detail views.
+- [ ] Source history rows are clickable (#745 behavior).
+- [ ] `sourceEditHistory` is added to the store protocol + GRDBWikiStore +
+      WikiStoreModel.
+- [ ] `SourceOrigin` is extended with the fields needed for provenance.
+- [ ] PageDetailView's inspector still works exactly as before.
+- [ ] `make build && make test` passes.
+- [ ] No `print`; no bare `try?`.
+
+## Reviewer caveats (addressed)
+1. **@AppStorage key collisions**: SourceDetailView uses its own keys
+   (`sourceInspectorTab`, `isSourceOutlineExpanded`, `sourceOutlineWidth`).
+2. **SourceOrigin call sites**: only `originFrom(row:)` in GRDBWikiStore
+   constructs `SourceOrigin` — no test fixtures construct it directly.
+3. **sourceEditHistory query**: mirrors `sourceOrigin`'s join shape, walks
+   ALL `source_versions` rows (not just the active ref), `ORDER BY sv.id DESC`.
+4. **ProvenanceEntry**: plain struct, no protocols.
+5. **DetailInspectorView generic**: `@ViewBuilder` for outline closure; the
+   History tab is always `ProvenancePanel` (not generic).
+6. **File extraction**: `Sources/WikiFS/Detail/` directory for the shared
+   components.


### PR DESCRIPTION
## Summary

Add a History tab to `SourceDetailView`'s inspector panel (matching `PageDetailView`), and DRY the shared components so both detail views use the same `DetailInspectorView` and a generic `ProvenancePanel`.

## Changes

### Store layer
- **`sourceEditHistory(sourceID:)`** added to `WikiStore` protocol, `GRDBWikiStore`, and `WikiStoreModel` — mirrors `pageEditHistory(pageID:)`. Read-only (`dbWriter.read`), no `mutate()` needed, no `ResourceChangeEvent` emission.
- **`SourceOrigin` extended** with `versionID`, `agentKind`, `runTitle` fields so the generic `ProvenancePanel` can render it.
- **`sourceOrigin(sourceID:)` query + `originFrom(row:)` decoder** updated to select `sv.id`, `a.kind`, and the chat-title `runTitle` subquery (same pattern as `pageOrigin`).

### Shared UI components (new `Sources/WikiFS/Detail/` directory)
- **`ProvenanceEntry`** — display-model struct that both `PageOrigin` and `SourceOrigin` project to via `.provenanceEntry` (in `ProvenanceEntry+Origins.swift`). Plain struct, no protocols.
- **`ProvenancePanel`** — extracted from `PageDetailView`, rewritten to take `ProvenanceEntry` instead of `PageOrigin`. The date-first layout, operation badge, agent label, and clickable-row behavior are identical for pages and sources.
- **`DetailInspectorView<Outline: View>`** — extracted from `PageDetailView`, made generic with `@ViewBuilder` outline closure. The History tab is always `ProvenancePanel` (not generic). `inspectorTab` and `outlineWidth` are `@Binding`s so each caller persists its own `@AppStorage` key.
- **`InspectorTab`** enum moved to the shared file.

### Detail view wiring
- **`PageDetailView`**: uses the shared `DetailInspectorView` with `pageInspectorTab` / `pageOutlineWidth` `@AppStorage` keys. Provenance loaded via `.task(id: currentPageID)`.
- **`SourceDetailView`**: now has the tabbed inspector (Outline + History). Uses source-specific `@AppStorage` keys (`sourceInspectorTab`, `isSourceOutlineExpanded`, `sourceOutlineWidth`) to avoid desync with the page's keys. Provenance loaded via the existing `.task(id: file.id)`.

## Reviewer caveats addressed
1. **@AppStorage key collisions**: SourceDetailView uses its own keys — no shared page keys.
2. **`SourceOrigin` call sites**: only `originFrom(row:)` in `GRDBWikiStore` and one test fixture constructor — both updated.
3. **`sourceEditHistory` query**: mirrors `sourceOrigin`'s join shape, walks ALL `source_versions` rows (not just the active ref), `ORDER BY sv.id DESC`.
4. **`ProvenanceEntry`**: plain struct, no protocols.
5. **`DetailInspectorView`**: `@ViewBuilder` for outline closure; History tab is always `ProvenancePanel`.
6. **File extraction**: `Sources/WikiFS/Detail/` directory for shared components.

## Test results
- `make build` passes.
- `make test` passes all 3357 tests except 2 pre-existing `DefuddleExtractionServiceTests` failures (environment-dependent bun/defuddle subprocess — unrelated to this PR; the test doc says they "skip gracefully if `DefuddleExtractionService.resolve()` returns nil").
