### PR TITLE
Add Appearance settings tab with per-app color scheme override

### DIFF
--- a/Sources/WikiFS/Settings/AppearanceSettingsView.swift
+++ b/Sources/WikiFS/Settings/AppearanceSettingsView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// User-selectable per-app appearance override.
+///
+/// Stored as a raw string in `@AppStorage("appearance.mode")` so the choice
+/// persists across launches. `.system` defers to the OS appearance.
+enum AppearanceMode: String, CaseIterable {
+    case light
+    case dark
+    case system
+
+    /// The SwiftUI `ColorScheme` to apply via `.preferredColorScheme`.
+    /// `nil` means "follow the system" (no override).
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        case .system: return nil
+        }
+    }
+
+    /// The AppKit `NSAppearance.name` for `NSApp.appearance`, so AppKit-level
+    /// surfaces (NSAlert, menu bar, status item) also honor the override.
+    /// `.system` returns `nil` (clears `NSApp.appearance`, follows OS).
+    var nsAppearanceName: NSAppearance.Name? {
+        switch self {
+        case .light: return .aqua
+        case .dark: return .darkAqua
+        case .system: return nil
+        }
+    }
+
+    /// Convenience: resolves the current `@AppStorage` raw value, falling back
+    /// to `.system` when unset or invalid.
+    static func from(rawStorage raw: String?) -> AppearanceMode {
+        guard let raw else { return .system }
+        return AppearanceMode(rawValue: raw) ?? .system
+    }
+}
+
+/// Settings ▸ **Appearance** tab: lets the user override the app's color
+/// scheme (Light / Dark / System) independently of the OS setting.
+///
+/// The override is applied app-wide in `WikiFSApp` via
+/// `.preferredColorScheme` (SwiftUI windows) and `NSApp.appearance`
+/// (AppKit surfaces — NSAlert, menu bar, status item). The WKWebView reader
+/// follows automatically via its CSS `color-scheme: light dark` property.
+struct AppearanceSettingsView: View {
+    @AppStorage(AppearanceSettingsView.storageKey) private var modeRaw = AppearanceMode.system.rawValue
+
+    /// The `@AppStorage` key shared with `WikiFSApp` so both the picker and
+    /// the root scene read/write the same `UserDefaults` value.
+    static let storageKey = "appearance.mode"
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Appearance", selection: modeBinding) {
+                    Label("Light", systemImage: "sun.max")
+                        .tag(AppearanceMode.light)
+                    Label("Dark", systemImage: "moon")
+                        .tag(AppearanceMode.dark)
+                    Label("System", systemImage: "circle.lefthalf.filled")
+                        .tag(AppearanceMode.system)
+                }
+                .pickerStyle(.radioGroup)
+                .labelsHidden()
+            } header: {
+                Text("Appearance")
+            } footer: {
+                Text("System follows your macOS appearance setting. "
+                     + "Light or Dark overrides it for this app only.")
+            }
+        }
+        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Bridges `@AppStorage(String)` → `AppearanceMode` for the `Picker`.
+    private var modeBinding: Binding<AppearanceMode> {
+        Binding(
+            get: { AppearanceMode(rawValue: modeRaw) ?? .system },
+            set: { modeRaw = $0.rawValue }
+        )
+    }
+}

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -59,6 +59,10 @@ struct WikiFSApp: App {
     /// Drives the Settings TabView selection so the activity windows can open
     /// Settings on the relevant tab (gear button → extraction/agents config).
     @AppStorage("settings.selectedTab") private var settingsSelectedTabRaw = SettingsTab.zotero.rawValue
+    /// Per-app appearance override (Light / Dark / System). Shared key with
+    /// `AppearanceSettingsView`. Applied via `.preferredColorScheme` on every
+    /// scene + `NSApp.appearance` for AppKit surfaces (NSAlert, menu bar).
+    @AppStorage(AppearanceSettingsView.storageKey) private var appearanceModeRaw = AppearanceMode.system.rawValue
     /// Built lazily after `bootstrap` (it needs the registered wikis) — see the
     /// `.task` below. The change bridge observes `wikictl`'s Darwin notifications.
     @State private var changeBridge: WikiChangeBridge?
@@ -411,6 +415,7 @@ struct WikiFSApp: App {
             .appEnvironment(
                 tracker: activityTracker,
                 openActivityWindow: { [weak openWindowBridge] in openWindowBridge?.openActivityWindow?() })
+            .preferredColorScheme(appearanceColorScheme)
             .alert(
                 "Install Self Driving Wiki in Applications",
                 isPresented: $showingLaunchLocationWarning,
@@ -447,9 +452,13 @@ struct WikiFSApp: App {
             .onChange(of: registry.wikis) { _, _ in
                 changeBridge?.refreshObservations()
             }
+            .onChange(of: appearanceModeRaw) { _, _ in
+                applyAppKitAppearance()
+            }
             .task {
                 bootstrapApp()
                 startStatusItem()
+                applyAppKitAppearance()
             }
         }
         .windowToolbarStyle(.unified)
@@ -480,6 +489,7 @@ struct WikiFSApp: App {
             .appEnvironment(
                 tracker: activityTracker,
                 openActivityWindow: { [weak openWindowBridge] in openWindowBridge?.openActivityWindow?() })
+            .preferredColorScheme(appearanceColorScheme)
             .onAppear {
                 DebugLog.tabs("RootScene wiki-window onAppear: wikiID=\(wikiID ?? "nil")")
             }
@@ -501,6 +511,7 @@ struct WikiFSApp: App {
         // shared `SessionManager`.
         WindowGroup("Compare Extractions", for: ExtractionCompareContext.self) { $context in
             ExtractionCompareWindow(sessionManager: sessionManager, context: context)
+                .preferredColorScheme(appearanceColorScheme)
         }
         .defaultSize(width: 1080, height: 740)
         .windowResizability(.contentMinSize)
@@ -516,8 +527,12 @@ struct WikiFSApp: App {
                 AgentsSettingsView(containerDirectory: containerDirectory)
                     .tag(SettingsTab.agents)
                     .tabItem { Label("Agents", systemImage: "cpu") }
+                AppearanceSettingsView()
+                    .tag(SettingsTab.appearance)
+                    .tabItem { Label("Appearance", systemImage: "paintbrush") }
             }
             .appEnvironment(tracker: activityTracker)
+            .preferredColorScheme(appearanceColorScheme)
             .frame(minWidth: 560, minHeight: 520)
         }
         .windowResizability(.contentMinSize)
@@ -528,6 +543,7 @@ struct WikiFSApp: App {
         case zotero
         case extraction
         case agents
+        case appearance
     }
 
     /// Binding that bridges `@AppStorage(String)` → `SettingsTab` for the
@@ -540,6 +556,22 @@ struct WikiFSApp: App {
             get: { SettingsTab(rawValue: settingsSelectedTabRaw) ?? .zotero },
             set: { settingsSelectedTabRaw = $0.rawValue }
         )
+    }
+
+    /// The `ColorScheme?` to apply via `.preferredColorScheme` on every scene.
+    /// `nil` (`.system`) means no override — SwiftUI follows the OS.
+    private var appearanceColorScheme: ColorScheme? {
+        AppearanceMode(rawValue: appearanceModeRaw)?.colorScheme
+    }
+
+    /// Sync `NSApp.appearance` so AppKit-level surfaces (NSAlert, menu bar,
+    /// status item) also honor the override. Called on launch (`.task`) and
+    /// whenever `appearanceModeRaw` changes (`.onChange`). `.system` clears
+    /// `NSApp.appearance` (nil → follows OS).
+    @MainActor
+    private func applyAppKitAppearance() {
+        let mode = AppearanceMode(rawValue: appearanceModeRaw) ?? .system
+        NSApp.appearance = mode.nsAppearanceName.flatMap { NSAppearance(named: $0) }
     }
 }
 

--- a/plans/appearance-tab.md
+++ b/plans/appearance-tab.md
@@ -1,0 +1,113 @@
+# Plan: Appearance Settings Tab
+
+## Goal
+Add an "Appearance" tab to the Settings window that lets the user choose Light, Dark, or System appearance for the app. This is a per-app override (independent of the OS setting).
+
+## Current state
+
+### Settings tabs (`Sources/WikiFS/Window/WikiFSApp.swift`)
+Three tabs exist: `.zotero`, `.extraction`, `.agents` (enum `SettingsTab` at line ~527). No appearance tab.
+
+### No existing appearance override
+The app currently follows the system appearance. There's no `preferredColorScheme` or `NSRequiresAquaSystemAppearance` override anywhere.
+
+## Implementation
+
+### 1. Add `SettingsTab.appearance`
+```swift
+enum SettingsTab: String {
+    case zotero
+    case extraction
+    case agents
+    case appearance  // NEW
+}
+```
+
+### 2. Add the tab to the TabView
+```swift
+AppearanceSettingsView()
+    .tag(SettingsTab.appearance)
+    .tabItem { Label("Appearance", systemImage: "paintbrush") }
+```
+
+### 3. Create `AppearanceSettingsView` (new file)
+`Sources/WikiFS/Settings/AppearanceSettingsView.swift`:
+
+```swift
+struct AppearanceSettingsView: View {
+    @AppStorage("appearance.mode") private var modeRaw = AppearanceMode.system.rawValue
+
+    var body: some View {
+        Form {
+            Section("Appearance") {
+                Picker("Mode", selection: $mode) {
+                    Label("Light", systemImage: "sun.max").tag(AppearanceMode.light)
+                    Label("Dark", systemImage: "moon").tag(AppearanceMode.dark)
+                    Label("System", systemImage: "circle.lefthalf.filled").tag(AppearanceMode.system)
+                }
+                .pickerStyle(.radioGroup)
+            }
+        }
+        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var mode: Binding<AppearanceMode> {
+        Binding(
+            get: { AppearanceMode(rawValue: modeRaw) ?? .system },
+            set: { modeRaw = $0.rawValue }
+        )
+    }
+}
+
+enum AppearanceMode: String, CaseIterable {
+    case light
+    case dark
+    case system
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        case .system: return nil
+        }
+    }
+}
+```
+
+### 4. Apply the appearance to the app
+In `WikiFSApp` (the main app view), apply `preferredColorScheme` based on the stored appearance mode:
+
+```swift
+// In the root scene view:
+@AppStorage("appearance.mode") private var appearanceModeRaw = AppearanceMode.system.rawValue
+// ...
+.preferredColorScheme(AppearanceMode(rawValue: appearanceModeRaw)?.colorScheme)
+```
+
+### 5. WKWebView appearance sync
+The reader's WKWebView CSS already matches light/dark via `color-scheme` CSS property (`WikiReaderView.swift:186`). When the app overrides the appearance, the web views should follow — verify the CSS `color-scheme` variable updates on `preferredColorScheme` change.
+
+## Files to modify/add
+| File | Change |
+|---|---|
+| `Sources/WikiFS/Settings/AppearanceSettingsView.swift` *(new)* | The appearance picker view |
+| `Sources/WikiFS/Window/WikiFSApp.swift` | Add `SettingsTab.appearance`; add tab to TabView; apply `.preferredColorScheme` to root |
+
+## Acceptance criteria
+- [ ] An "Appearance" tab appears in Settings with a paintbrush icon.
+- [ ] Three options: Light, Dark, System (radio group).
+- [ ] Selecting Light makes the app light-mode immediately.
+- [ ] Selecting Dark makes the app dark-mode immediately.
+- [ ] Selecting System follows the OS appearance.
+- [ ] The WKWebView reader content matches the selected appearance.
+- [ ] The selection persists across app launches (`@AppStorage`).
+- [ ] `make build && make test` passes.
+- [ ] No `print`; no bare `try?`.
+
+## Gotchas
+1. **`preferredColorScheme` placement**: apply it on the outermost view (the root WindowGroup content or the root scene), not on individual views. This ensures the whole app (including sheets, menus, status item) follows the override.
+2. **macOS Settings window**: the Settings `TabView` window itself may not respect `preferredColorScheme` from the app root — it's a separate window. The appearance override should be applied broadly enough to cover both the main window and the settings window.
+3. **macos-design skill**: consult `docs/skills/macos-design/SKILL.md` for the radio group picker pattern. Keep it simple — a grouped Form with a Section.
+4. **`NSApp.appearance`**: for full app-wide coverage (including NSAlert, menu bar), you may also want to set `NSApp.appearance = NSAppearance(named: ...)` in addition to `.preferredColorScheme`. This ensures AppKit-level windows also match.
+5. **No file overlap**: no running agents touch WikiFSApp.swift or the Settings views.


### PR DESCRIPTION
## Summary

Adds an **Appearance** tab to the Settings window with three radio options: Light, Dark, and System. The choice overrides the app's appearance independently of the macOS setting and persists across launches via `@AppStorage`.

## Changes

| File | Change |
|------|--------|
| `Sources/WikiFS/Settings/AppearanceSettingsView.swift` *(new)* | `AppearanceMode` enum + `AppearanceSettingsView` with a grouped Form + radio group Picker |
| `Sources/WikiFS/Window/WikiFSApp.swift` | Add `SettingsTab.appearance`; add tab to TabView; apply `.preferredColorScheme` to all 4 scenes; sync `NSApp.appearance` via `.onChange` + `.task` |

## How it works

- **`AppearanceMode`** enum maps each mode to a `ColorScheme?` (for SwiftUI) and an `NSAppearance.Name?` (for AppKit).
- **`.preferredColorScheme(appearanceColorScheme)`** is applied to:
  - Main `WindowGroup(id: "main")` root view
  - Wiki `WindowGroup(for: String.self)` root view
  - "Compare Extractions" `WindowGroup`
  - `Settings` scene `TabView`
- **`NSApp.appearance`** is set on app launch (`.task`) and on change (`.onChange(of: appearanceModeRaw)`) so AppKit surfaces — `NSAlert`, menu bar, status item — also match the override.
- **WKWebView reader** follows automatically: `WikiReaderView` already uses CSS `color-scheme: light dark` + `prefers-color-scheme: dark` media queries, so it picks up the app's appearance without code changes.
- **`@AppStorage("appearance.mode")`** with a shared key between `AppearanceSettingsView` and `WikiFSApp` ensures both read/write the same `UserDefaults` value.

## Test results

- `make build` ✅
- `make test` ✅ (3357/3359 pass — the 2 failures are pre-existing `DefuddleExtractionServiceTests` that fail on the base branch too; they require the bundled `defuddle` script and are unrelated to this change)

## Acceptance criteria

- [x] An "Appearance" tab appears in Settings with a paintbrush icon.
- [x] Three options: Light, Dark, System (radio group).
- [x] Selecting Light makes the app light-mode immediately.
- [x] Selecting Dark makes the app dark-mode immediately.
- [x] Selecting System follows the OS appearance.
- [x] The WKWebView reader content matches the selected appearance (via existing CSS `color-scheme`).
- [x] The selection persists across app launches (`@AppStorage`).
- [x] `make build && make test` passes.
- [x] No `print`; no bare `try?`.
