### PR TITLE
Omnibox cleanup: move WikiSwitcher from toolbar into sidebar header

### DIFF
--- a/Sources/WikiFS/Editor/AddressBarView.swift
+++ b/Sources/WikiFS/Editor/AddressBarView.swift
@@ -18,10 +18,6 @@ import WikiFSCore
 struct AddressBarView: View {
     @Bindable var store: WikiStoreModel
     @Binding var isFocused: Bool
-    /// The active wiki's display name, shown in the trailing switcher. A longer
-    /// name widens that switcher, so the omnibox reserves extra room for it and
-    /// shrinks — keeping the switcher on-screen instead of overflowing.
-    var wikiName: String
     /// The width of the detail column (the region the toolbar spans), measured by a
     /// `GeometryReader` in `ContentView`. This shrinks when the left sidebar opens
     /// and is unaffected by the right transcript panel — exactly the omnibox's
@@ -287,41 +283,31 @@ struct AddressBarView: View {
         .transition(.opacity)
     }
 
-    /// The omnibox field's width, from the measured detail-region width, the sidebar
-    /// state, and the wiki name. The arithmetic (stretch, shrink, overflow-expand)
-    /// lives in `OmniboxLayout` so it can be unit-tested; here we only supply the
-    /// measurements. `switcherExtra` is how much wider the current wiki name renders
-    /// than the baseline name — the switcher's fixed icon/chevron overhead cancels
-    /// out, so only text width matters.
+    /// The omnibox field's width, from the measured detail-region width and the
+    /// sidebar state. The arithmetic (stretch, shrink, overflow-expand) lives in
+    /// `OmniboxLayout` so it can be unit-tested; here we only supply the
+    /// measurements. The wiki switcher has moved out of the toolbar into the
+    /// sidebar header, so there's no name-driven width delta to pass —
+    /// `switcherExtra` is always zero (the only trailing toolbar item now is the
+    /// Change Log toggle, whose width is captured in
+    /// `OmniboxLayout.Metrics.trailingWithSwitcher`).
     private var fieldWidth: CGFloat {
-        let switcherExtra = headlineTextWidth(wikiName)
-            - headlineTextWidth(AddressBarMetrics.baselineSwitcherName)
-        return OmniboxLayout.fieldWidth(
+        OmniboxLayout.fieldWidth(
             detailWidth: detailWidth,
             sidebarVisible: sidebarVisible,
             homeButtonShown: homePageID != nil,
-            switcherExtra: switcherExtra)
+            switcherExtra: 0)
     }
 
     /// Extra width appended after the field in `omniboxGroup` once `fieldWidth`
-    /// has hit its cap — keeps the trailing switcher/toggle flush against the
-    /// window edge instead of stalling short of it. Zero everywhere below the cap.
+    /// has hit its cap — keeps the trailing toggle flush against the window edge
+    /// instead of stalling short of it. Zero everywhere below the cap.
     private var overflowSpacerWidth: CGFloat {
-        let switcherExtra = headlineTextWidth(wikiName)
-            - headlineTextWidth(AddressBarMetrics.baselineSwitcherName)
-        return OmniboxLayout.overflowSpacerWidth(
+        OmniboxLayout.overflowSpacerWidth(
             detailWidth: detailWidth,
             sidebarVisible: sidebarVisible,
             homeButtonShown: homePageID != nil,
-            switcherExtra: switcherExtra)
-    }
-
-    /// Rendered width of `text` in the switcher's font (`.headline`). Only the
-    /// *difference* from the baseline name is used, so the switcher's fixed
-    /// icon/chevron overhead cancels out and this need only be accurate for the text.
-    private func headlineTextWidth(_ text: String) -> CGFloat {
-        let font = NSFont.preferredFont(forTextStyle: .headline)
-        return (text as NSString).size(withAttributes: [.font: font]).width
+            switcherExtra: 0)
     }
 
     // MARK: - Actions
@@ -556,11 +542,6 @@ enum AddressBarMetrics {
     /// `OmniboxLayout.Metrics.openLeadingChrome`/`closedLeadingChrome`; changing it
     /// here requires updating those constants by the same delta.
     static let navToOmniboxGap: CGFloat = 14
-    /// The wiki-switcher name the trailing reservation is tuned against. A name
-    /// wider than this reserves the extra width (the omnibox yields it); a narrower
-    /// one lets the omnibox reclaim it. Only the width *difference* is used, so the
-    /// switcher's fixed icon/chevron overhead cancels out. See `OmniboxLayout`.
-    static let baselineSwitcherName = "My Wiki"
     /// Left padding from the pill's rounded edge to the Page Menu icon, so the
     /// icon sits inside the omnibox rather than hugging the edge.
     static let iconLeadingInset: CGFloat = 8

--- a/Sources/WikiFS/Editor/OmniboxLayout.swift
+++ b/Sources/WikiFS/Editor/OmniboxLayout.swift
@@ -12,9 +12,9 @@ import CoreGraphics
 /// `fieldWidth(detailWidth:sidebarVisible:switcherExtra:)`.
 enum OmniboxLayout {
     struct Metrics: Equatable {
-        /// Space reserved to the field's right for the trailing Change Log
-        /// toggle (the only toolbar item after the omnibox now that the wiki
-        /// switcher has moved into the sidebar header).
+        /// Space reserved to the field's right for trailing toolbar items. Zero
+        /// now — the wiki switcher moved into the sidebar header and the Change
+        /// Log toggle was removed, so the omnibox owns the full toolbar width.
         var trailingWithSwitcher: CGFloat
         /// Space reserved when the toggle has spilled into the `»` overflow —
         /// only the small overflow button remains, so the field fills nearly to
@@ -53,7 +53,7 @@ enum OmniboxLayout {
         var homeButtonExtra: CGFloat
 
         static let `default` = Metrics(
-            trailingWithSwitcher: 110,
+            trailingWithSwitcher: 0,
             trailingOverflow: 60,
             minWidth: 120,
             maxWidth: 1200,

--- a/Sources/WikiFS/Editor/OmniboxLayout.swift
+++ b/Sources/WikiFS/Editor/OmniboxLayout.swift
@@ -12,12 +12,13 @@ import CoreGraphics
 /// `fieldWidth(detailWidth:sidebarVisible:switcherExtra:)`.
 enum OmniboxLayout {
     struct Metrics: Equatable {
-        /// Space reserved to the field's right for the wiki switcher (at the
-        /// baseline name length) plus the transcript toggle, when they're shown.
+        /// Space reserved to the field's right for the trailing Change Log
+        /// toggle (the only toolbar item after the omnibox now that the wiki
+        /// switcher has moved into the sidebar header).
         var trailingWithSwitcher: CGFloat
-        /// Space reserved when the switcher + transcript have spilled into the `»`
-        /// overflow — only the small overflow button remains, so the field fills
-        /// nearly to the window edge.
+        /// Space reserved when the toggle has spilled into the `»` overflow —
+        /// only the small overflow button remains, so the field fills nearly to
+        /// the window edge.
         var trailingOverflow: CGFloat
         /// The field never shrinks below this (a couple of words); past this point
         /// the switcher is pushed into overflow rather than the field shrinking more.
@@ -52,7 +53,7 @@ enum OmniboxLayout {
         var homeButtonExtra: CGFloat
 
         static let `default` = Metrics(
-            trailingWithSwitcher: 180,
+            trailingWithSwitcher: 110,
             trailingOverflow: 60,
             minWidth: 120,
             maxWidth: 1200,
@@ -90,17 +91,17 @@ enum OmniboxLayout {
                    switcherExtra: switcherExtra, metrics: metrics)
     }
 
-    /// The field width if the switcher is kept on-screen: the field fills from its
-    /// leading edge to just short of the switcher. Can fall below `minWidth`,
-    /// which is the signal that the switcher no longer fits.
+    /// The field width if the trailing toggle is kept on-screen: the field fills
+    /// from its leading edge to just short of the toggle. Can fall below
+    /// `minWidth`, which is the signal that the toggle no longer fits.
     static func widthKeepingSwitcher(windowWidth: CGFloat, fieldLeadingX: CGFloat,
                                      switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
         windowWidth - metrics.trailingWithSwitcher - switcherExtra - fieldLeadingX
     }
 
-    /// Whether the wiki switcher fits on-screen beside a field no narrower than
-    /// `minWidth`. When false, NSToolbar drops the switcher into the `»` overflow
-    /// and the field reclaims that trailing space (see `fieldWidth`).
+    /// Whether the trailing Change Log toggle fits on-screen beside a field no
+    /// narrower than `minWidth`. When false, NSToolbar drops the toggle into the
+    /// `»` overflow and the field reclaims that trailing space (see `fieldWidth`).
     static func switcherFits(windowWidth: CGFloat, fieldLeadingX: CGFloat,
                              switcherExtra: CGFloat, metrics: Metrics = .default) -> Bool {
         widthKeepingSwitcher(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -195,14 +195,6 @@ struct ContentView: View {
             && KeychainZoteroCredentialStore().apiKey() != nil
     }
 
-    /// The active wiki's display name (as shown in the toolbar's `WikiSwitcher`),
-    /// passed to the omnibox so it can reserve room for a long switcher and shrink
-    /// instead of pushing the switcher into overflow. Mirrors `WikiSwitcher`'s
-    /// `activeDescriptor`.
-    private var activeWikiName: String {
-        session.descriptor.displayName
-    }
-
     /// The active wiki's configured home page, if any (issue #280). `nil` hides
     /// the omnibox home button.
     private var activeHomePageID: PageID? {
@@ -272,20 +264,13 @@ struct ContentView: View {
             // the sidebar opening.
             ToolbarItem(placement: .navigation) {
                 AddressBarView(store: store, isFocused: $addressBarFocused,
-                               wikiName: activeWikiName,
                                detailWidth: detailWidth,
                                sidebarVisible: columnVisibility != .detailOnly,
                                homePageID: activeHomePageID,
                                onAddToBookmarks: { omniboxBookmarkContext = $0 })
             }
 
-            // The wiki switcher moves out of the sidebar header into the toolbar,
-            // trailing the omnibox (like a browser account / profile control).
-            ToolbarItem(placement: .primaryAction) {
-                WikiSwitcher(registry: registry, currentWikiID: session.wikiID)
-            }
-
-            // Change-log sidebar toggle, trailing the switcher — the standard
+            // Change-log sidebar toggle, trailing the omnibox — the standard
             // inspector-toggle position (rightmost, like Notes/Freeform).
             ToolbarItem(placement: .primaryAction) {
                 Button {

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -270,17 +270,6 @@ struct ContentView: View {
                                onAddToBookmarks: { omniboxBookmarkContext = $0 })
             }
 
-            // Change-log sidebar toggle, trailing the omnibox — the standard
-            // inspector-toggle position (rightmost, like Notes/Freeform).
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    store.isChangeLogSidebarVisible.toggle()
-                } label: {
-                    Label("Change Log", systemImage: "sidebar.trailing")
-                }
-                .help(store.isChangeLogSidebarVisible
-                    ? "Hide Change Log" : "Show Change Log")
-            }
         }
         // Suppress the window title so the omnibox owns the toolbar. `.navigationTitle("")`
         // alone only empties the *text* — the toolbar still reserves ~160pt for the

--- a/Sources/WikiFS/Window/SidebarView.swift
+++ b/Sources/WikiFS/Window/SidebarView.swift
@@ -70,9 +70,14 @@ struct SidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // The wiki switcher moved into the window toolbar (Safari-style,
-            // trailing the omnibox); the sidebar now starts at the section
-            // selector.
+            // Wiki selector in the sidebar header — like the account header at
+            // the top of Notes/Mail's navigator. It collapses with the sidebar
+            // when the leading panel toggle hides it, so it leaves the toolbar
+            // (which now holds only the nav cluster + omnibox + Change Log toggle).
+            WikiSwitcher(registry: registry, currentWikiID: session.wikiID)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            Divider()
             sectionSelectorBar
                 .padding(.top, 8)
             Divider()

--- a/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
+++ b/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
@@ -54,7 +54,6 @@ struct AddressBarLayoutHostedTests {
         let view = AddressBarView(
             store: model,
             isFocused: .constant(false),
-            wikiName: "My Wiki",
             detailWidth: detailWidth,
             sidebarVisible: sidebarVisible,
             homePageID: homePageID,

--- a/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
+++ b/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
@@ -7,16 +7,18 @@ import Testing
 /// Sizing/overflow behavior of the toolbar omnibox. Uses a fixed `Metrics` so the
 /// thresholds are exact and independent of the real switcher/transcript widths.
 @Suite struct OmniboxLayoutTests {
-    // trailingWithSwitcher 110 (Change Log toggle only — the wiki switcher moved
-    // into the sidebar header), trailingOverflow 60, min 120, max 1200.
+    // trailingWithSwitcher 0 (no trailing toolbar items — the wiki switcher
+    // moved into the sidebar header and the Change Log toggle was removed, so
+    // the omnibox owns the full toolbar width), trailingOverflow 60, min 120,
+    // max 1200.
     let m = OmniboxLayout.Metrics.default
 
-    // MARK: Switcher visible
+    // MARK: Field fills to the window edge
 
-    @Test func fillsToTheSwitcherOnAWideWindow() {
-        // 1200 - 110 (toggle) - 0 (baseline name) - 200 (leading) = 890.
+    @Test func fillsToTheWindowEdgeOnAWideWindow() {
+        // 1200 - 0 (no trailing items) - 0 (baseline) - 200 (leading) = 1000.
         let w = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == 890)
+        #expect(w == 1000)
         #expect(OmniboxLayout.switcherFits(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0))
     }
 
@@ -24,7 +26,7 @@ import Testing
         let base = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
         let long = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 150)
         #expect(long == base - 150)
-        #expect(long == 740)
+        #expect(long == 850)
     }
 
     @Test func aShorterWikiNameLetsTheFieldGrow() {
@@ -41,41 +43,38 @@ import Testing
     }
 
     // MARK: Overflow threshold + expansion
+    //
+    // With `trailingWithSwitcher = 0` there are no trailing toolbar items, so
+    // the overflow path is degenerate — it only activates when the window is
+    // so narrow that even with zero trailing reservation the field can't reach
+    // `minWidth`. In that regime the overflow path yields *less* than `minWidth`
+    // (because `trailingOverflow > trailingWithSwitcher`), so the field clamps
+    // to `minWidth` either way. The tests below lock that degenerate behavior.
 
     @Test func switcherStaysUntilTheFieldReachesItsFloor() {
-        // 430 - 110 - 200 = 120 == floor: toggle still fits, exactly.
-        #expect(OmniboxLayout.switcherFits(windowWidth: 430, fieldLeadingX: 200, switcherExtra: 0))
-        #expect(OmniboxLayout.fieldWidth(windowWidth: 430, fieldLeadingX: 200, switcherExtra: 0) == 120)
+        // 320 - 0 - 200 = 120 == floor: no overflow needed, exactly.
+        #expect(OmniboxLayout.switcherFits(windowWidth: 320, fieldLeadingX: 200, switcherExtra: 0))
+        #expect(OmniboxLayout.fieldWidth(windowWidth: 320, fieldLeadingX: 200, switcherExtra: 0) == 120)
     }
 
     @Test func switcherOverflowsJustBelowTheFloor() {
-        // 420 - 110 - 200 = 110 < floor: toggle drops into » overflow.
-        #expect(!OmniboxLayout.switcherFits(windowWidth: 420, fieldLeadingX: 200, switcherExtra: 0))
+        // 319 - 0 - 200 = 119 < floor: would overflow if there were trailing items.
+        #expect(!OmniboxLayout.switcherFits(windowWidth: 319, fieldLeadingX: 200, switcherExtra: 0))
     }
 
-    @Test func fieldExpandsToFillFreedSpaceOnceSwitcherOverflows() {
-        // At 420 the toggle overflows; the field must expand past its floor to
-        // fill the freed trailing space (420 - 60 overflow - 200 leading = 160),
-        // not stay stranded at the 120 floor.
-        let w = OmniboxLayout.fieldWidth(windowWidth: 420, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == 160)
-        #expect(w > m.minWidth)
-    }
-
-    @Test func crossingTheThresholdJumpsWiderNotNarrower() {
-        // Just above the threshold the toggle shows (field at floor); just below,
-        // it overflows and the field jumps *wider* to reclaim the space.
-        let showing = OmniboxLayout.fieldWidth(windowWidth: 430, fieldLeadingX: 200, switcherExtra: 0)
-        let overflowed = OmniboxLayout.fieldWidth(windowWidth: 429, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(showing == 120)
-        #expect(overflowed > showing)
+    @Test func fieldClampsToFloorInOverflowRegime() {
+        // With no trailing items, the overflow path yields less than minWidth
+        // (319 - 60 overflow - 200 = 59 < 120), so the field clamps to floor
+        // rather than expanding.
+        let w = OmniboxLayout.fieldWidth(windowWidth: 319, fieldLeadingX: 200, switcherExtra: 0)
+        #expect(w == m.minWidth)
     }
 
     @Test func aLongWikiNameTriggersOverflowSooner() {
-        // Same window; a long name reserves more, so the toggle overflows at a
-        // width where a baseline name would still fit.
-        #expect(OmniboxLayout.switcherFits(windowWidth: 560, fieldLeadingX: 200, switcherExtra: 0))
-        #expect(!OmniboxLayout.switcherFits(windowWidth: 560, fieldLeadingX: 200, switcherExtra: 150))
+        // Same window; a long name reserves more, so the field drops below floor
+        // at a width where a baseline name would still fit.
+        #expect(OmniboxLayout.switcherFits(windowWidth: 350, fieldLeadingX: 200, switcherExtra: 0))
+        #expect(!OmniboxLayout.switcherFits(windowWidth: 350, fieldLeadingX: 200, switcherExtra: 150))
     }
 
     // MARK: Clamps
@@ -95,19 +94,21 @@ import Testing
     //
     // Once `fieldWidth` hits `maxWidth` it stops absorbing extra window width, so
     // `fieldLeadingX + fieldWidth + trailingWithSwitcher` no longer sums to
-    // `windowWidth` — the invariant that otherwise keeps the trailing switcher +
-    // transcript toggle flush against the true edge. `overflowSpacerWidth` reports
-    // exactly the shortfall so the toolbar item can absorb it itself.
+    // `windowWidth` — the invariant that would otherwise keep the trailing items
+    // flush against the true edge. `overflowSpacerWidth` reports exactly the
+    // shortfall so the toolbar item can absorb it itself. With no trailing items
+    // (`trailingWithSwitcher = 0`) the spacer still fills dead space past the cap,
+    // keeping the omnibox group's total width tracking the detail region 1:1.
 
     @Test func overflowSpacerIsZeroBelowTheCap() {
-        // 1200 window: field (820) is well under maxWidth, nothing to absorb.
+        // 1200 window: field (1000) is well under maxWidth, nothing to absorb.
         let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
         #expect(s == 0)
     }
 
     @Test func overflowSpacerIsZeroExactlyAtTheCap() {
-        // kept == maxWidth exactly: 200 + 1200 + 110 = 1510.
-        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1510, fieldLeadingX: 200, switcherExtra: 0)
+        // kept == maxWidth exactly: 200 + 1200 + 0 = 1400.
+        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1400, fieldLeadingX: 200, switcherExtra: 0)
         #expect(s == 0)
     }
 
@@ -117,7 +118,7 @@ import Testing
         let w = OmniboxLayout.fieldWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
         let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
         #expect(200 + w + s + m.trailingWithSwitcher == 2000)
-        #expect(s == 490)
+        #expect(s == 600)
     }
 
     @Test func overflowSpacerGrowsOneForOneWithWindowWidthPastTheCap() {
@@ -165,9 +166,7 @@ import Testing
     // A wiki with a configured home page (issue #280) adds a fourth nav button,
     // shifting the field's real leading edge right by `homeButtonExtra`. Omitting
     // this previously under-reserved the field's own width by that fixed amount —
-    // independent of window width — permanently encroaching into the trailing
-    // switcher/toggle's space for any such wiki (that wiki's Toggle Transcript
-    // button sat in the `»` overflow no matter how wide the window was resized).
+    // independent of window width.
 
     @Test func homeButtonAddsExtraLeadingChromeInBothSidebarStates() {
         #expect(OmniboxLayout.leadingChrome(sidebarVisible: true, homeButtonShown: true)
@@ -190,8 +189,8 @@ import Testing
         // The reported bug: unlike an overflow threshold (which clears once the
         // window is wide enough), a missing home-button reservation is a FIXED
         // offset — it never resolves no matter how wide the window gets. Confirm
-        // the fixed invariant holds (trailing edge stays correctly reserved) at
-        // both a narrow-ish and a very wide detailWidth, with the home button shown.
+        // the fixed invariant holds at both a narrow-ish and a very wide
+        // detailWidth, with the home button shown.
         for detailWidth: CGFloat in [700, 2200] {
             let field = OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: true,
                                                  homeButtonShown: true, switcherExtra: 73.5)
@@ -213,22 +212,19 @@ import Testing
 
     @Test func openSidebarLeavesMoreRoomForTheFieldAtAGivenDetailWidth() {
         // For the SAME detail width, the sidebar-shown case reserves less leading
-        // chrome, so the field is wider by exactly that difference. (In practice the
-        // detail width also shrinks when the sidebar opens; this isolates the chrome.)
+        // chrome, so the field is wider by exactly that difference.
         let closed = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: false, switcherExtra: 0)
         let open = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true, switcherExtra: 0)
         #expect(open - closed == m.closedLeadingChrome - m.openLeadingChrome)
     }
 
-    @Test func overflowExpansionStillWorksThroughTheDetailWidthDriver() {
-        // A detail region too narrow to keep the toggle: the field must expand past
-        // its floor to reclaim the freed trailing space (same behavior as the core,
-        // reached via the detail-width overload).
-        let w = OmniboxLayout.fieldWidth(detailWidth: 260, sidebarVisible: true, switcherExtra: 0)
-        // 260 - 70 chrome - 110 keepsSwitcher = 80 < 120 floor → overflow path:
-        // 260 - 70 - 60 overflow = 130.
-        #expect(w == 130)
-        #expect(w > m.minWidth)
+    @Test func overflowClampsToFloorThroughTheDetailWidthDriver() {
+        // A detail region too narrow to fit even minWidth (with zero trailing
+        // reservation): the field clamps to the floor rather than going negative.
+        let w = OmniboxLayout.fieldWidth(detailWidth: 180, sidebarVisible: true, switcherExtra: 0)
+        // 180 - 70 chrome - 0 trailing = 110 < 120 floor → overflow path:
+        // 180 - 70 - 60 overflow = 50 < 120 → clamped to 120.
+        #expect(w == m.minWidth)
     }
 
     @Test func returnsFloorBeforeTheDetailWidthIsMeasured() {

--- a/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
+++ b/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
@@ -7,15 +7,16 @@ import Testing
 /// Sizing/overflow behavior of the toolbar omnibox. Uses a fixed `Metrics` so the
 /// thresholds are exact and independent of the real switcher/transcript widths.
 @Suite struct OmniboxLayoutTests {
-    // trailingWithSwitcher 180, trailingOverflow 60, min 120, max 1200.
+    // trailingWithSwitcher 110 (Change Log toggle only — the wiki switcher moved
+    // into the sidebar header), trailingOverflow 60, min 120, max 1200.
     let m = OmniboxLayout.Metrics.default
 
     // MARK: Switcher visible
 
     @Test func fillsToTheSwitcherOnAWideWindow() {
-        // 1200 - 180 (switcher+transcript) - 0 (baseline name) - 200 (leading) = 820.
+        // 1200 - 110 (toggle) - 0 (baseline name) - 200 (leading) = 890.
         let w = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == 820)
+        #expect(w == 890)
         #expect(OmniboxLayout.switcherFits(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0))
     }
 
@@ -23,7 +24,7 @@ import Testing
         let base = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
         let long = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 150)
         #expect(long == base - 150)
-        #expect(long == 670)
+        #expect(long == 740)
     }
 
     @Test func aShorterWikiNameLetsTheFieldGrow() {
@@ -42,39 +43,39 @@ import Testing
     // MARK: Overflow threshold + expansion
 
     @Test func switcherStaysUntilTheFieldReachesItsFloor() {
-        // 500 - 180 - 200 = 120 == floor: switcher still fits, exactly.
-        #expect(OmniboxLayout.switcherFits(windowWidth: 500, fieldLeadingX: 200, switcherExtra: 0))
-        #expect(OmniboxLayout.fieldWidth(windowWidth: 500, fieldLeadingX: 200, switcherExtra: 0) == 120)
+        // 430 - 110 - 200 = 120 == floor: toggle still fits, exactly.
+        #expect(OmniboxLayout.switcherFits(windowWidth: 430, fieldLeadingX: 200, switcherExtra: 0))
+        #expect(OmniboxLayout.fieldWidth(windowWidth: 430, fieldLeadingX: 200, switcherExtra: 0) == 120)
     }
 
     @Test func switcherOverflowsJustBelowTheFloor() {
-        // 490 - 180 - 200 = 110 < floor: switcher drops into » overflow.
-        #expect(!OmniboxLayout.switcherFits(windowWidth: 490, fieldLeadingX: 200, switcherExtra: 0))
+        // 420 - 110 - 200 = 110 < floor: toggle drops into » overflow.
+        #expect(!OmniboxLayout.switcherFits(windowWidth: 420, fieldLeadingX: 200, switcherExtra: 0))
     }
 
     @Test func fieldExpandsToFillFreedSpaceOnceSwitcherOverflows() {
-        // At 490 the switcher overflows; the field must expand past its floor to
-        // fill the freed trailing space (490 - 60 overflow - 200 leading = 230),
+        // At 420 the toggle overflows; the field must expand past its floor to
+        // fill the freed trailing space (420 - 60 overflow - 200 leading = 160),
         // not stay stranded at the 120 floor.
-        let w = OmniboxLayout.fieldWidth(windowWidth: 490, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == 230)
+        let w = OmniboxLayout.fieldWidth(windowWidth: 420, fieldLeadingX: 200, switcherExtra: 0)
+        #expect(w == 160)
         #expect(w > m.minWidth)
     }
 
     @Test func crossingTheThresholdJumpsWiderNotNarrower() {
-        // Just above the threshold the switcher shows (field at floor); just below,
+        // Just above the threshold the toggle shows (field at floor); just below,
         // it overflows and the field jumps *wider* to reclaim the space.
-        let showing = OmniboxLayout.fieldWidth(windowWidth: 500, fieldLeadingX: 200, switcherExtra: 0)
-        let overflowed = OmniboxLayout.fieldWidth(windowWidth: 490, fieldLeadingX: 200, switcherExtra: 0)
+        let showing = OmniboxLayout.fieldWidth(windowWidth: 430, fieldLeadingX: 200, switcherExtra: 0)
+        let overflowed = OmniboxLayout.fieldWidth(windowWidth: 429, fieldLeadingX: 200, switcherExtra: 0)
         #expect(showing == 120)
         #expect(overflowed > showing)
     }
 
     @Test func aLongWikiNameTriggersOverflowSooner() {
-        // Same window; a long name reserves more, so the switcher overflows at a
+        // Same window; a long name reserves more, so the toggle overflows at a
         // width where a baseline name would still fit.
-        #expect(OmniboxLayout.switcherFits(windowWidth: 620, fieldLeadingX: 200, switcherExtra: 0))
-        #expect(!OmniboxLayout.switcherFits(windowWidth: 620, fieldLeadingX: 200, switcherExtra: 150))
+        #expect(OmniboxLayout.switcherFits(windowWidth: 560, fieldLeadingX: 200, switcherExtra: 0))
+        #expect(!OmniboxLayout.switcherFits(windowWidth: 560, fieldLeadingX: 200, switcherExtra: 150))
     }
 
     // MARK: Clamps
@@ -105,8 +106,8 @@ import Testing
     }
 
     @Test func overflowSpacerIsZeroExactlyAtTheCap() {
-        // kept == maxWidth exactly: 200 + 1200 + 180 = 1580.
-        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1580, fieldLeadingX: 200, switcherExtra: 0)
+        // kept == maxWidth exactly: 200 + 1200 + 110 = 1510.
+        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1510, fieldLeadingX: 200, switcherExtra: 0)
         #expect(s == 0)
     }
 
@@ -116,7 +117,7 @@ import Testing
         let w = OmniboxLayout.fieldWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
         let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
         #expect(200 + w + s + m.trailingWithSwitcher == 2000)
-        #expect(s == 420)
+        #expect(s == 490)
     }
 
     @Test func overflowSpacerGrowsOneForOneWithWindowWidthPastTheCap() {
@@ -220,13 +221,13 @@ import Testing
     }
 
     @Test func overflowExpansionStillWorksThroughTheDetailWidthDriver() {
-        // A detail region too narrow to keep the switcher: the field must expand past
+        // A detail region too narrow to keep the toggle: the field must expand past
         // its floor to reclaim the freed trailing space (same behavior as the core,
         // reached via the detail-width overload).
-        let w = OmniboxLayout.fieldWidth(detailWidth: 360, sidebarVisible: true, switcherExtra: 0)
-        // 360 - 70 chrome - 180 keepsSwitcher = 110 < 120 floor → overflow path:
-        // 360 - 70 - 60 overflow = 230.
-        #expect(w == 230)
+        let w = OmniboxLayout.fieldWidth(detailWidth: 260, sidebarVisible: true, switcherExtra: 0)
+        // 260 - 70 chrome - 110 keepsSwitcher = 80 < 120 floor → overflow path:
+        // 260 - 70 - 60 overflow = 130.
+        #expect(w == 130)
         #expect(w > m.minWidth)
     }
 

--- a/plans/omnibox-cleanup.md
+++ b/plans/omnibox-cleanup.md
@@ -1,0 +1,36 @@
+# Plan: Omnibox cleanup — Wiki Selector to sidebar
+
+## Goal
+Simplify the toolbar to a single clean omnibox:
+1. Move `WikiSwitcher` from the toolbar's trailing `.primaryAction` into the
+   **sidebar's title/header area** — so it collapses when the sidebar is hidden
+   (clicking the left panel toggle).
+2. Keep the Back/Forward/Home nav cluster in the toolbar.
+3. Leave only `[Back/Forward/Home] [Omnibox]` + `[ChangeLog toggle]` in the
+   toolbar.
+
+## Files changed
+| File | Change |
+|---|---|
+| `Sources/WikiFS/Window/SidebarView.swift` | Add `WikiSwitcher` at the top of the sidebar header |
+| `Sources/WikiFS/Window/ContentView.swift` | Remove the `WikiSwitcher` `ToolbarItem`; drop the now-unused `wikiName:` arg + `activeWikiName` |
+| `Sources/WikiFS/Editor/AddressBarView.swift` | Drop `wikiName` (switcher is gone); pass `switcherExtra: 0`; remove `headlineTextWidth` + `baselineSwitcherName` |
+| `Sources/WikiFSCore/Core/OmniboxLayout.swift` | Retune `trailingWithSwitcher` (180→110) — only the ChangeLog toggle remains in the toolbar |
+| `Tests/WikiFSAppTests/OmniboxLayoutTests.swift` | Recompute expected widths for the retuned trailing reservation |
+| `Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift` | Drop the `wikiName:` arg from the hosted constructor |
+
+## Acceptance criteria
+- [x] `WikiSwitcher` appears at the top of the sidebar (above the section selector).
+- [x] When the sidebar is collapsed, the `WikiSwitcher` disappears with it.
+- [x] Toolbar has only `[Back/Forward/Home] [Omnibox]` + `[ChangeLog toggle]`.
+- [x] Omnibox expands to fill the toolbar width (trailing switcher reservation removed).
+- [x] `make build && make test` passes.
+- [x] No `print`; no bare `try?`.
+
+## Notes
+- The Home button stays in `AddressBarView` (issue #280) — only the `WikiSwitcher`
+  leaves the toolbar.
+- `OmniboxLayout` keeps its API (`switcherExtra` is now always `0` from the view);
+  only `Metrics.default.trailingWithSwitcher` is retuned from 180 (switcher +
+  transcript) to 110 (the single ChangeLog toggle). Hosted tests assert *deltas*,
+  which are invariant to the reservation value.


### PR DESCRIPTION
## Summary

Simplifies the toolbar to a single clean omnibox by moving the `WikiSwitcher` into the sidebar header and removing the Change Log toggle. The toolbar now has only `[Back/Forward/Home] [Omnibox]` — no wiki switcher, no change log toggle.

## Changes

### 1. Move WikiSwitcher into the sidebar header (`SidebarView.swift`)

Added `WikiSwitcher` at the top of the sidebar (above `sectionSelectorBar`), with `.padding(.horizontal, 12)` / `.padding(.vertical, 8)` to match the sidebar's existing padding style. A `Divider()` separates it from the section selector below.

`SidebarView` already had `registry: WikiRegistryClient` and `session: WikiSession`, so it had everything needed — no new dependencies.

### 2. Remove WikiSwitcher from the toolbar (`ContentView.swift`)

Removed the `ToolbarItem(placement: .primaryAction)` containing `WikiSwitcher`. Also dropped the now-unused `wikiName:` arg from the `AddressBarView` call site and removed the `activeWikiName` computed property.

### 3. Remove ChangeLog toolbar toggle (`ContentView.swift`)

Removed the trailing Change Log `ToolbarItem`. The change log sidebar code (`ChangeLogDetailView`, `isChangeLogSidebarVisible`) stays in place but inactive — it defaults to `false` and there's no longer a UI toggle to show it.

### 4. Update OmniboxLayout metrics (`OmniboxLayout.swift`, `AddressBarView.swift`)

With no trailing toolbar items remaining, retuned `Metrics.default.trailingWithSwitcher` to `0` — the omnibox now owns the full toolbar width (up to `maxWidth`). Removed the `wikiName` field, `headlineTextWidth`, and `baselineSwitcherName` from `AddressBarView` — with no switcher in the toolbar there's no name-driven width delta, so `switcherExtra` is always `0`.

### 5. Update tests

- `OmniboxLayoutTests.swift`: rewrote for `trailingWithSwitcher=0` — the overflow path is now degenerate (no trailing items to overflow), so tests focus on the fill-to-edge behavior, clamps, and the overflow spacer past the cap (all 24 pass).
- `AddressBarLayoutHostedTests.swift`: dropped the `wikiName:` arg from the hosted constructor (all 4 pass).

## Acceptance criteria

- [x] The `WikiSwitcher` appears at the top of the sidebar (above the section selector).
- [x] When the sidebar is collapsed (left panel toggle), the `WikiSwitcher` disappears with it.
- [x] The toolbar has only `[Back/Forward/Home] [Omnibox]` — no WikiSwitcher, no ChangeLog toggle.
- [x] The omnibox expands to fill the full toolbar width.
- [x] `make build && make test` passes.
- [x] No `print`; no bare `try?`.

## Test results

`make build` passes. `make test` passes 3356/3358 tests. The 2 failures are pre-existing `DefuddleExtractionServiceTests` failures (`extractsSimpleArticle` and `extractsMarkdownAndMetadata`) — they depend on the real bundled bun + defuddle script and are unrelated to this change. Confirmed by stashing and re-running on the base branch (`6d4e936`): the same 2 failures occur without any of these changes.

## Notes

- The Home button stays in `AddressBarView` (issue #280) — only the `WikiSwitcher` and Change Log toggle moved/were removed.
- The `OmniboxLayout` API is unchanged (`switcherExtra` is now always `0` from the view); only the `trailingWithSwitcher` metric value changed.
- Plan doc: `plans/omnibox-cleanup.md`.
