### PR TITLE
Omnibox: Safari-style centered, expandable, no overflow

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,48 @@
 
 Newest first. To get up to speed: read `PLAN.md` then this file.
 
+## 2026-07-21 — Omnibox: Safari-style centered, expandable, no overflow (branch `fix/omnibox-centered-no-overflow`)
+
+**Problem.** The toolbar omnibox rendered full-width flush-left and
+*consistently* dropped into the `»` overflow. Root cause: `OmniboxLayout`
+tried to *predict* NSToolbar's internal layout with hand-tuned constants
+(`closedLeadingChrome` 214, `openLeadingChrome` 70, `trailingMargin` 30,
+`homeButtonExtra` 26, an overflow spacer) and sized the field to ~100% of the
+detail region. NSToolbar's overflow is all-or-nothing, so any error in those
+guesses dumped the whole group to `»`. Unit tests passed throughout because
+they exercised the arithmetic, not whether the constants matched NSToolbar.
+
+**Fix — cooperate with NSToolbar instead of predicting it.**
+- Split into two toolbar items: `OmniboxNavButtons` (Back/Forward/Home) in
+  `.navigation` (flush-left, Safari-style) and the field in `.principal`, which
+  NSToolbar centers for us. Deleted all the leading-chrome / overflow-spacer /
+  position-prediction math (~300 lines net removed).
+- The field is sized to the detail region minus a side margin on each side,
+  clamped to `[minWidth 240, maxWidth 820]`. It never approaches 100% of the
+  region, so the overflow trigger can't fire; NSToolbar centers the pill.
+- **Sidebar-aware margin** (`sideMarginOpen` 150 / `sideMarginClosed` 290): with
+  the sidebar hidden the field centers across the whole window and its left
+  margin must clear traffic-lights + toggle + nav (~250pt); with it shown, only
+  the ~102pt nav cluster is in the region. Symmetric centering can't give the
+  left more than the right, so both margins take the larger value when hidden.
+- **macOS 26 (Tahoe) glass bubble:** the auto-grouped nav capsule clipped the
+  wide `house` glyph against its edge — added `navBubbleInset` (10pt) so the
+  capsule leaves breathing room around the icons.
+
+**Changed files.** `Sources/WikiFS/Editor/OmniboxLayout.swift` (rewritten to a
+centered-pill width fn), `Sources/WikiFS/Editor/AddressBarView.swift` (field-only
+principal view + new `OmniboxNavButtons`), `Sources/WikiFS/Window/ContentView.swift`
+(two toolbar items), `Sources/WikiFS/Window/SidebarView.swift` (WikiSwitcher moved
+to the sidebar's bottom bar, freeing the toolbar), and both omnibox test files
+rewritten for the new model.
+
+**Verified live** (screenshots + accessibility frame reads): centered to <0.5pt in
+both sidebar states; no overflow on fresh launch or incremental drag-resize
+720↔1200; home icon clears the bubble. `swift build` clean, 11/11 omnibox tests
+pass.
+
+**Build:** `swift build && swift test`.
+
 ## 2026-07-20 — Fix swift CI: build+cache fixed; test hang addressed (branch `ci-speedup`, PR #732)
 
 **Outcome.** Build + cache + test steps all green in CI. The test hang that

--- a/Sources/WikiFS/Editor/AddressBarView.swift
+++ b/Sources/WikiFS/Editor/AddressBarView.swift
@@ -2,8 +2,8 @@ import AppKit
 import SwiftUI
 import WikiFSCore
 
-/// A Safari-style omnibox that lives in the window's **toolbar** (a principal
-/// toolbar item), replacing the window title. Serves two roles depending on
+/// A Safari-style omnibox that lives in the window's **toolbar** as a centered
+/// `.principal` item, replacing the window title. Serves two roles depending on
 /// focus state — no explicit mode switch required:
 ///
 /// 1. **Idle (not focused):** shows the active page's wikilink (`[[Page Title]]`)
@@ -15,23 +15,26 @@ import WikiFSCore
 /// The editable field is an AppKit `NSSearchField` (`OmniboxSearchField`) —
 /// SwiftUI `TextField` can't take first responder inside an `NSToolbar` item —
 /// and the suggestions live in a non-activating child panel.
+///
+/// The Back/Forward/Home nav cluster is a *separate* `.navigation` toolbar item
+/// (`OmniboxNavButtons`), flush-left like Safari's; this view is only the
+/// centered field. Its width comes from `OmniboxLayout.fieldWidth(detailWidth:)`
+/// — a fraction of the detail region with margins on each side — and NSToolbar
+/// centers it. Nothing here predicts NSToolbar's insets, so the field can no
+/// longer tip the toolbar into the `»` overflow.
 struct AddressBarView: View {
     @Bindable var store: WikiStoreModel
     @Binding var isFocused: Bool
     /// The width of the detail column (the region the toolbar spans), measured by a
     /// `GeometryReader` in `ContentView`. This shrinks when the left sidebar opens
     /// and is unaffected by the right transcript panel — exactly the omnibox's
-    /// usable toolbar span. Measuring the detail region (never in toolbar overflow)
-    /// instead of the field's own leading edge (which overflow strands) is what
-    /// keeps the width from getting stuck. See `OmniboxLayout`.
+    /// usable toolbar span. Drives the centered pill's width (see `OmniboxLayout`).
     var detailWidth: CGFloat
-    /// Whether the left sidebar is shown. Selects the fixed leading chrome ahead of
-    /// the field (`OmniboxLayout.leadingChrome`): with the sidebar hidden the detail
-    /// region spans the whole window and includes the traffic-light + toggle zone.
+    /// Whether the left sidebar is shown. Selects the side margin the centered pill
+    /// keeps: with the sidebar hidden the field centers across the whole window and
+    /// must reserve more room to clear the traffic-light + toggle chrome on its
+    /// left (see `OmniboxLayout.Metrics.sideMarginClosed`).
     var sidebarVisible: Bool
-    /// The active wiki's configured home page (issue #280). `nil` hides the home
-    /// button — there's nowhere to navigate to yet.
-    var homePageID: PageID?
 
     @State private var queryText = ""
     @State private var results: [OmniboxResult] = []
@@ -54,80 +57,26 @@ struct AddressBarView: View {
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
 
     var body: some View {
-        // Back / Forward (+ Home) + the omnibox are one `.navigation` group,
-        // flush-left in the detail region. The nav cluster sits tightly grouped on
-        // its own (Safari-style), separated from the omnibox pill by a wider gap so
-        // it doesn't read as fused to it. The nav buttons are fixed-width; the field
-        // is given an explicit width (`fieldWidth`) so it stretches from just after
-        // the gap to the trailing wiki switcher, shrinking as the window narrows /
-        // the wiki name grows and expanding once the switcher overflows (see
-        // `OmniboxLayout`). The gap's width is baked into `OmniboxLayout.Metrics`
-        // (`openLeadingChrome`/`closedLeadingChrome`) — changing the spacing here
-        // without updating those constants would reopen the flush-right bug fixed
-        // in issue #114, just at a different threshold.
-        HStack(spacing: AddressBarMetrics.navToOmniboxGap) {
-            navButtonGroup
-            omniboxGroup
-        }
-        // Cmd-L flips `isFocused`; turn that into a focus request for the field.
-        .onChange(of: isFocused) { _, focused in
-            if focused { focusToken &+= 1 }
-        }
-        // Empty state (no content loaded): focus the field so the user can type
-        // a search immediately — at launch and whenever the last tab closes.
-        .onAppear { focusIfEmpty() }
-        .onChange(of: hasContentLoaded) { _, loaded in
-            if !loaded { focusIfEmpty() }
-        }
+        // The omnibox is the toolbar's `.principal` item — NSToolbar centers it in
+        // the detail region. This view is *only* the field; the Back/Forward/Home
+        // cluster is a separate flush-left `.navigation` item (`OmniboxNavButtons`).
+        // The field's width comes from `OmniboxLayout.fieldWidth(detailWidth:)` — a
+        // fraction of the detail region with margins on each side — so it never
+        // fills the region edge-to-edge and can't tip the toolbar into overflow.
+        omniboxField
+            // Cmd-L flips `isFocused`; turn that into a focus request for the field.
+            .onChange(of: isFocused) { _, focused in
+                if focused { focusToken &+= 1 }
+            }
+            // Empty state (no content loaded): focus the field so the user can type
+            // a search immediately — at launch and whenever the last tab closes.
+            .onAppear { focusIfEmpty() }
+            .onChange(of: hasContentLoaded) { _, loaded in
+                if !loaded { focusIfEmpty() }
+            }
     }
 
-    /// Back / Forward (+ Home when the active wiki has one configured), grouped
-    /// tightly on their own so the cluster reads as a single control distinct from
-    /// the omnibox pill — the wider gap to `omniboxGroup` (`AddressBarMetrics.
-    /// navToOmniboxGap`, set on the parent `HStack`) does the actual separating.
-    private var navButtonGroup: some View {
-        HStack(spacing: AddressBarMetrics.navButtonSpacing) {
-            navButton("chevron.left", help: "Go back", enabled: store.canNavigateBack) {
-                store.navigateBack()
-            }
-            .keyboardShortcut("[", modifiers: .command)
-
-            navButton("chevron.right", help: "Go forward", enabled: store.canNavigateForward) {
-                store.navigateForward()
-            }
-            .keyboardShortcut("]", modifiers: .command)
-
-            if let homePageID {
-                navButton("house", help: "Go to home page", enabled: true) {
-                    _ = store.selectPage(byID: homePageID)
-                }
-            }
-        }
-    }
-
-    /// The omnibox field plus, once the field has hit its readability cap
-    /// (`OmniboxLayout.Metrics.maxWidth`), an invisible trailing spacer that
-    /// absorbs the rest of the space the field would otherwise have grown into.
-    /// Without this, the field stalls at `maxWidth` on wide windows while the
-    /// trailing wiki switcher and transcript toggle — separate, later toolbar
-    /// items — stay put, opening a gap between them and the true trailing edge
-    /// (issue #114). The spacer is zero-width below the cap, matching the old
-    /// behavior exactly.
-    private var omniboxGroup: some View {
-        HStack(spacing: 0) {
-            omniboxField
-            if overflowSpacerWidth > 0 {
-                // `Color.clear` is still hit-testable by default — without this it
-                // would swallow clicks/drags over what reads as empty toolbar space
-                // (including the window-drag region past the cap), even though
-                // nothing is drawn there.
-                Color.clear.frame(width: overflowSpacerWidth)
-                    .allowsHitTesting(false)
-            }
-        }
-    }
-
-    /// The search field itself, sized to fill from its leading edge to the switcher.
+    /// The search field itself, sized to a centered pill by `fieldWidth`.
     private var omniboxField: some View {
         OmniboxSearchField(
             text: $queryText,
@@ -175,23 +124,6 @@ struct AddressBarView: View {
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.12)) { isHovering = hovering }
         }
-    }
-
-    /// A toolbar-styled chevron button for Back / Forward, rendered inside the
-    /// principal group (so it needs its own borderless styling to read as a
-    /// toolbar control rather than a bordered push button).
-    private func navButton(_ symbol: String, help: String, enabled: Bool,
-                           action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: symbol)
-                .font(.system(size: 15, weight: .medium))
-                .frame(width: AddressBarMetrics.navButtonWidth, height: 28)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.borderless)
-        .foregroundStyle(enabled ? Color.primary : Color.secondary.opacity(0.35))
-        .disabled(!enabled)
-        .help(help)
     }
 
     // MARK: - Reader menu (Safari-style page controls)
@@ -283,31 +215,12 @@ struct AddressBarView: View {
         .transition(.opacity)
     }
 
-    /// The omnibox field's width, from the measured detail-region width and the
-    /// sidebar state. The arithmetic (stretch, shrink, overflow-expand) lives in
-    /// `OmniboxLayout` so it can be unit-tested; here we only supply the
-    /// measurements. The wiki switcher has moved out of the toolbar into the
-    /// sidebar header, so there's no name-driven width delta to pass —
-    /// `switcherExtra` is always zero (the only trailing toolbar item now is the
-    /// Change Log toggle, whose width is captured in
-    /// `OmniboxLayout.Metrics.trailingWithSwitcher`).
+    /// The omnibox field's width, from the measured detail-region width. The
+    /// centered-pill arithmetic lives in `OmniboxLayout` so it can be unit-tested;
+    /// here we only supply the measurement. NSToolbar centers the `.principal`
+    /// item, so there's no leading/trailing position math to do.
     private var fieldWidth: CGFloat {
-        OmniboxLayout.fieldWidth(
-            detailWidth: detailWidth,
-            sidebarVisible: sidebarVisible,
-            homeButtonShown: homePageID != nil,
-            switcherExtra: 0)
-    }
-
-    /// Extra width appended after the field in `omniboxGroup` once `fieldWidth`
-    /// has hit its cap — keeps the trailing toggle flush against the window edge
-    /// instead of stalling short of it. Zero everywhere below the cap.
-    private var overflowSpacerWidth: CGFloat {
-        OmniboxLayout.overflowSpacerWidth(
-            detailWidth: detailWidth,
-            sidebarVisible: sidebarVisible,
-            homeButtonShown: homePageID != nil,
-            switcherExtra: 0)
+        OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: sidebarVisible)
     }
 
     // MARK: - Actions
@@ -443,6 +356,63 @@ struct AddressBarView: View {
     }
 }
 
+// MARK: - Nav buttons
+
+/// The Back / Forward (+ Home when the active wiki has one configured) cluster,
+/// a *separate* flush-left `.navigation` toolbar item from the centered omnibox
+/// field (`AddressBarView`) — the Safari layout: nav pinned to the leading edge,
+/// URL field centered. Kept its own item (not folded into the field) so NSToolbar
+/// can center the principal field independently of this fixed-width cluster.
+struct OmniboxNavButtons: View {
+    @Bindable var store: WikiStoreModel
+    /// The active wiki's configured home page (issue #280). `nil` hides the Home
+    /// button — there's nowhere to navigate to yet.
+    var homePageID: PageID?
+
+    var body: some View {
+        HStack(spacing: AddressBarMetrics.navButtonSpacing) {
+            navButton("chevron.left", help: "Go back", enabled: store.canNavigateBack) {
+                store.navigateBack()
+            }
+            .keyboardShortcut("[", modifiers: .command)
+
+            navButton("chevron.right", help: "Go forward", enabled: store.canNavigateForward) {
+                store.navigateForward()
+            }
+            .keyboardShortcut("]", modifiers: .command)
+
+            if let homePageID {
+                navButton("house", help: "Go to home page", enabled: true) {
+                    _ = store.selectPage(byID: homePageID)
+                }
+            }
+        }
+        // macOS 26 (Tahoe) auto-wraps this cluster in a rounded "glass" toolbar
+        // bubble that hugs the content. The wide `house` glyph fills its 22pt
+        // frame edge-to-edge, so with no inset it renders jammed against — and
+        // clipped by — the bubble's rounded right edge. This horizontal padding
+        // grows the bubble just enough that every icon (especially Home) keeps a
+        // clear margin from the capsule.
+        .padding(.horizontal, AddressBarMetrics.navBubbleInset)
+    }
+
+    /// A toolbar-styled chevron button for Back / Forward / Home. Borderless so it
+    /// reads as a toolbar control rather than a bordered push button.
+    private func navButton(_ symbol: String, help: String, enabled: Bool,
+                           action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 15, weight: .medium))
+                .frame(width: AddressBarMetrics.navButtonWidth, height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(enabled ? Color.primary : Color.secondary.opacity(0.35))
+        .disabled(!enabled)
+        .help(help)
+    }
+}
+
 // MARK: - Suggestions list
 
 /// The ranked results list shown in the omnibox suggestions panel. Rows
@@ -528,20 +498,15 @@ struct AddressResultsList: View {
 // MARK: - Metrics
 
 enum AddressBarMetrics {
-    /// Fixed width of each Back/Forward/Home nav button. Shared with
-    /// `OmniboxLayout.Metrics.homeButtonExtra`'s derivation — when the Home
-    /// button shows, the field's leading edge shifts right by exactly this plus
-    /// one `navButtonSpacing`.
+    /// Fixed width of each Back/Forward/Home nav button in `OmniboxNavButtons`.
     static let navButtonWidth: CGFloat = 22
-    /// Spacing between Back/Forward/Home within `navButtonGroup` — tight, so the
+    /// Spacing between Back/Forward/Home within `OmniboxNavButtons` — tight, so the
     /// cluster reads as one control.
     static let navButtonSpacing: CGFloat = 4
-    /// Gap between `navButtonGroup` and the omnibox pill — wider than
-    /// `navButtonSpacing` so the nav cluster reads as visually distinct from the
-    /// omnibox rather than fused to it. This width is baked into
-    /// `OmniboxLayout.Metrics.openLeadingChrome`/`closedLeadingChrome`; changing it
-    /// here requires updating those constants by the same delta.
-    static let navToOmniboxGap: CGFloat = 14
+    /// Horizontal inset around the nav cluster so the macOS 26 toolbar "bubble"
+    /// (which hugs the content) leaves a margin around the icons — without it the
+    /// wide `house` glyph sits clipped against the capsule's right edge.
+    static let navBubbleInset: CGFloat = 10
     /// Left padding from the pill's rounded edge to the Page Menu icon, so the
     /// icon sits inside the omnibox rather than hugging the edge.
     static let iconLeadingInset: CGFloat = 8

--- a/Sources/WikiFS/Editor/OmniboxLayout.swift
+++ b/Sources/WikiFS/Editor/OmniboxLayout.swift
@@ -1,170 +1,80 @@
 import CoreGraphics
 
 /// Pure sizing math for the toolbar omnibox, factored out of `AddressBarView` so
-/// the stretch/overflow behavior can be unit-tested without a running window.
+/// the centered/expandable behavior can be unit-tested without a running window.
 ///
-/// The view hands this type two things it can measure *reliably*: the detail
-/// column's width (from a `GeometryReader` in the always-visible detail content —
-/// never pulled into toolbar overflow) and whether the left sidebar is shown.
-/// From those it derives the same `(windowWidth, fieldLeadingX)` the core math
-/// wants, without ever measuring the field's own leading edge — which the toolbar
-/// yanks out of the window when it overflows, stranding the old measurement. See
-/// `fieldWidth(detailWidth:sidebarVisible:switcherExtra:)`.
+/// **Design (Safari-style centered omnibox).** The field lives in a `.principal`
+/// toolbar item, which NSToolbar *centers* in the detail region for us — so this
+/// type no longer tries to predict NSToolbar's internal insets to hand-position
+/// the field (the old leading-chrome / trailing-margin / overflow-spacer math,
+/// which was a stack of hand-tuned constants that tipped the whole `.navigation`
+/// group into the `»` overflow whenever any guess was slightly off).
+///
+/// All that remains is the field's **width**: it grows with the detail region,
+/// keeping a comfortable margin on each side (so it reads as a centered pill, and
+/// crucially never approaches 100% of the region — the condition that used to
+/// trigger the all-or-nothing toolbar overflow), and it stops growing at a
+/// readable cap so it isn't one unbroken line on a very wide monitor. Centering
+/// is NSToolbar's job; this is only how wide the pill is at a given window size.
 enum OmniboxLayout {
     struct Metrics: Equatable {
-        /// Space reserved to the field's right for trailing toolbar items. Zero
-        /// now — the wiki switcher moved into the sidebar header and the Change
-        /// Log toggle was removed, so the omnibox owns the full toolbar width.
-        var trailingWithSwitcher: CGFloat
-        /// Space reserved when the toggle has spilled into the `»` overflow —
-        /// only the small overflow button remains, so the field fills nearly to
-        /// the window edge.
-        var trailingOverflow: CGFloat
-        /// The field never shrinks below this (a couple of words); past this point
-        /// the switcher is pushed into overflow rather than the field shrinking more.
+        /// Breathing room reserved on *each* side of the centered field when the
+        /// **sidebar is shown**. The field is a symmetrically-centered `.principal`
+        /// item, so in the growing regime its side margin equals this value — and
+        /// NSToolbar bails the whole group to the `»` overflow if centering would
+        /// crowd the flush-left leading chrome. With the sidebar shown the traffic
+        /// lights sit over the sidebar, so the only leading chrome inside the
+        /// detail region is the `OmniboxNavButtons` cluster (~102pt with its
+        /// bubble inset); this must clear it with room to spare.
+        var sideMarginOpen: CGFloat
+        /// Same, but when the **sidebar is hidden** — then the detail region spans
+        /// the whole window and the field centers across it, so its left margin
+        /// must clear the traffic lights + sidebar-toggle + nav cluster (~250pt),
+        /// not just the nav cluster. Symmetric centering can't give the left side
+        /// more than the right, so BOTH margins must be this large or the group
+        /// overflows on any window narrow enough that the margin drops below the
+        /// chrome. This is the single reason the omnibox needs to know the sidebar
+        /// state at all.
+        var sideMarginClosed: CGFloat
+        /// The field never shrinks below this (a couple of words) — on a very
+        /// narrow window the margins give instead.
         var minWidth: CGFloat
-        /// The field never grows beyond this, so it isn't an unreadable line on a
-        /// very wide monitor.
+        /// The field never grows beyond this, so it stays a readable pill rather
+        /// than one edge-to-edge line on a wide monitor; past this width the side
+        /// margins simply grow.
         var maxWidth: CGFloat
-        /// Fixed chrome to the field's left (Back/Forward, the tight gap between
-        /// them, and the wider gap to the omnibox pill — `AddressBarMetrics.
-        /// navButtonSpacing`/`navToOmniboxGap`) when the sidebar is *shown*. The
-        /// traffic-light + sidebar-toggle zone then sits over the sidebar, outside
-        /// the measured detail region, so only the nav cluster + gap remain between
-        /// the detail region's edge and the field.
-        var openLeadingChrome: CGFloat
-        /// Fixed chrome to the field's left when the sidebar is *hidden*. The detail
-        /// region now spans the whole window, so it includes the traffic lights +
-        /// sidebar toggle ahead of the nav cluster — a larger offset.
-        var closedLeadingChrome: CGFloat
-        /// Extra leading chrome added when the omnibox's Home button is shown (a
-        /// wiki with a configured home page, issue #280, adds a fourth nav
-        /// button). Equal to the button's own width (`AddressBarMetrics.
-        /// navButtonWidth`, 22) plus the one extra internal nav-cluster gap it
-        /// introduces (`AddressBarMetrics.navButtonSpacing`, 4). Previously
-        /// omitted entirely: the field's leading edge (and therefore its
-        /// trailing edge too, since width is computed from it) silently sat 26pt
-        /// further right than this math assumed for any wiki with a home page
-        /// configured — a WINDOW-WIDTH-INDEPENDENT encroachment into the
-        /// trailing switcher/toggle's reserved space, since it's a fixed offset
-        /// baked into every window size alike. That wiki's Toggle Transcript
-        /// button would sit in the `»` overflow permanently, not just past some
-        /// width threshold.
-        var homeButtonExtra: CGFloat
 
         static let `default` = Metrics(
-            trailingWithSwitcher: 0,
-            trailingOverflow: 60,
-            minWidth: 120,
-            maxWidth: 1200,
-            openLeadingChrome: 70,
-            closedLeadingChrome: 214,
-            homeButtonExtra: 26)
+            sideMarginOpen: 150,
+            sideMarginClosed: 290,
+            minWidth: 240,
+            maxWidth: 820)
     }
 
-    /// Fixed chrome to the field's left, measured from the detail region's leading
-    /// edge. It differs by sidebar state only because the traffic-light + toggle
-    /// zone sits over the detail region when the sidebar is hidden and over the
-    /// sidebar when it's shown (see the `Metrics` fields). `homeButtonShown` adds
-    /// `homeButtonExtra` for the wiki's optional fourth nav button (issue #280) —
-    /// omitting this when the button is shown was the root cause of the Toggle
-    /// Transcript button permanently sitting in the toolbar's `»` overflow for
-    /// any wiki with a configured home page, at any window width.
-    static func leadingChrome(sidebarVisible: Bool, homeButtonShown: Bool = false,
-                             metrics: Metrics = .default) -> CGFloat {
-        let base = sidebarVisible ? metrics.openLeadingChrome : metrics.closedLeadingChrome
-        return homeButtonShown ? base + metrics.homeButtonExtra : base
+    /// The side margin reserved on each side of the centered field, chosen by
+    /// sidebar state (see `sideMarginOpen`/`sideMarginClosed`).
+    static func sideMargin(sidebarVisible: Bool, metrics: Metrics = .default) -> CGFloat {
+        sidebarVisible ? metrics.sideMarginOpen : metrics.sideMarginClosed
     }
 
-    /// The omnibox field's width, driven by the reliably-measurable detail-region
-    /// width and sidebar state. Delegates to the core `fieldWidth(windowWidth:
-    /// fieldLeadingX:…)` — the detail width plays the role of the window width and
-    /// the fixed leading chrome the role of the field's leading edge, because the
-    /// core only ever uses their difference (the span right of the field's start).
-    /// This keeps the stretch/shrink/overflow-expand behavior identical while
-    /// sourcing it from a measurement the toolbar can't strand.
-    static func fieldWidth(detailWidth: CGFloat, sidebarVisible: Bool, homeButtonShown: Bool = false,
-                           switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
-        fieldWidth(windowWidth: detailWidth,
-                   fieldLeadingX: leadingChrome(sidebarVisible: sidebarVisible,
-                                               homeButtonShown: homeButtonShown, metrics: metrics),
-                   switcherExtra: switcherExtra, metrics: metrics)
-    }
-
-    /// The field width if the trailing toggle is kept on-screen: the field fills
-    /// from its leading edge to just short of the toggle. Can fall below
-    /// `minWidth`, which is the signal that the toggle no longer fits.
-    static func widthKeepingSwitcher(windowWidth: CGFloat, fieldLeadingX: CGFloat,
-                                     switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
-        windowWidth - metrics.trailingWithSwitcher - switcherExtra - fieldLeadingX
-    }
-
-    /// Whether the trailing Change Log toggle fits on-screen beside a field no
-    /// narrower than `minWidth`. When false, NSToolbar drops the toggle into the
-    /// `»` overflow and the field reclaims that trailing space (see `fieldWidth`).
-    static func switcherFits(windowWidth: CGFloat, fieldLeadingX: CGFloat,
-                             switcherExtra: CGFloat, metrics: Metrics = .default) -> Bool {
-        widthKeepingSwitcher(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
-                             switcherExtra: switcherExtra, metrics: metrics) >= metrics.minWidth
-    }
-
-    /// The field width before the `maxWidth` clamp — what the field would need to
-    /// be to stay exactly flush against the trailing switcher/overflow button.
-    /// Shared by `fieldWidth` (which clamps it for readability) and
-    /// `overflowSpacerWidth` (which reports how much of it got clamped away), so
-    /// the two always agree on where the true trailing edge is.
-    private static func rawFieldWidth(windowWidth: CGFloat, fieldLeadingX: CGFloat,
-                                      switcherExtra: CGFloat, metrics: Metrics) -> CGFloat {
-        let kept = widthKeepingSwitcher(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
-                                        switcherExtra: switcherExtra, metrics: metrics)
-        return kept >= metrics.minWidth
-            ? kept
-            : windowWidth - metrics.trailingOverflow - fieldLeadingX
-    }
-
-    /// The omnibox field's width. It stretches from its measured leading edge to
-    /// just short of the trailing items, shrinks as the window narrows or the wiki
-    /// name lengthens, and — once the switcher can no longer fit and drops into the
-    /// `»` overflow — expands to fill the freed trailing space.
+    /// The omnibox field's width for a given detail-region width and sidebar state.
+    /// It's the region minus a (sidebar-dependent) margin on each side — so the
+    /// centered pill keeps enough breathing room to clear the leading chrome and
+    /// never fills the region (the old overflow trigger) — clamped to
+    /// `[minWidth, maxWidth]`. Centering itself is handled by the `.principal`
+    /// toolbar placement; the margin only has to be wide enough that the centered
+    /// field doesn't crowd the flush-left chrome (which is larger when the sidebar
+    /// is hidden — see `sideMarginClosed`).
     ///
     /// - Parameters:
-    ///   - windowWidth: the host window's width.
-    ///   - fieldLeadingX: the field's x-origin in window coordinates (measured).
-    ///   - switcherExtra: how much wider the current wiki name renders than the
-    ///     baseline name (may be negative for a shorter name). The switcher's
-    ///     fixed icon/chevron overhead is baked into `trailingWithSwitcher`, so
-    ///     only the text-width difference is passed here.
-    static func fieldWidth(windowWidth: CGFloat, fieldLeadingX: CGFloat,
-                           switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
-        guard windowWidth > 0 else { return metrics.minWidth }
-        let raw = rawFieldWidth(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
-                                switcherExtra: switcherExtra, metrics: metrics)
-        return min(max(raw, metrics.minWidth), metrics.maxWidth)
-    }
-
-    /// Extra invisible width to place immediately after the (possibly capped)
-    /// field, inside the same toolbar item, so the trailing wiki switcher and
-    /// transcript toggle stay pinned to the window's true trailing edge even once
-    /// `fieldWidth` has hit `maxWidth` and stopped growing (issue #114). Below the
-    /// cap this is always zero — `fieldWidth` alone already sums exactly to the
-    /// trailing edge, same as before this existed.
-    static func overflowSpacerWidth(windowWidth: CGFloat, fieldLeadingX: CGFloat,
-                                    switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
-        guard windowWidth > 0 else { return 0 }
-        let raw = rawFieldWidth(windowWidth: windowWidth, fieldLeadingX: fieldLeadingX,
-                                switcherExtra: switcherExtra, metrics: metrics)
-        return max(0, raw - metrics.maxWidth)
-    }
-
-    /// `overflowSpacerWidth`, sourced from the same measurable `(detailWidth,
-    /// sidebarVisible)` pair `fieldWidth(detailWidth:sidebarVisible:switcherExtra:)`
-    /// uses, for the same reason: the field's own leading edge gets stranded when
-    /// the toolbar pushes it into overflow.
-    static func overflowSpacerWidth(detailWidth: CGFloat, sidebarVisible: Bool, homeButtonShown: Bool = false,
-                                    switcherExtra: CGFloat, metrics: Metrics = .default) -> CGFloat {
-        overflowSpacerWidth(windowWidth: detailWidth,
-                            fieldLeadingX: leadingChrome(sidebarVisible: sidebarVisible,
-                                                        homeButtonShown: homeButtonShown, metrics: metrics),
-                            switcherExtra: switcherExtra, metrics: metrics)
+    ///   - detailWidth: the width of the detail column the toolbar spans, measured
+    ///     by a `GeometryReader` in `ContentView`. `0` before first layout yields
+    ///     `minWidth` (never a negative or absurd width).
+    ///   - sidebarVisible: whether the left sidebar is shown; selects the margin.
+    static func fieldWidth(detailWidth: CGFloat, sidebarVisible: Bool,
+                           metrics: Metrics = .default) -> CGFloat {
+        guard detailWidth > 0 else { return metrics.minWidth }
+        let available = detailWidth - 2 * sideMargin(sidebarVisible: sidebarVisible, metrics: metrics)
+        return min(max(available, metrics.minWidth), metrics.maxWidth)
     }
 }

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -254,22 +254,24 @@ struct ContentView: View {
         // whole group into the `»` overflow. Declared here it centers within the
         // detail region, so it survives the sidebar opening.
         .toolbar {
-            // The omnibox group (Back / Forward + search field) is placed
-            // `.navigation` so it flows flush-left from the leading edge of the
-            // detail region (no centering gap). `AddressBarView` sizes the group
-            // to an explicit width that fills up to the trailing wiki switcher —
-            // the empty title space that would otherwise sit between them is
-            // reclaimed by hiding the window title (see `OmniboxSearchField`'s
-            // `viewDidMoveToWindow`). Declared on the detail column so it survives
-            // the sidebar opening.
+            // Safari layout: the Back/Forward/Home cluster is pinned flush-left
+            // (`.navigation`) and the omnibox field is centered (`.principal`).
+            // Splitting them into two items lets NSToolbar center the field
+            // independently of the fixed-width nav cluster. The field is sized to
+            // a fraction of the detail region (`OmniboxLayout.fieldWidth`) with
+            // margins on each side, so it never fills the region edge-to-edge —
+            // the condition that used to tip the whole group into the `»`
+            // overflow. The empty title space is reclaimed by hiding the window
+            // title (`.toolbar(removing: .title)` below).
             ToolbarItem(placement: .navigation) {
+                OmniboxNavButtons(store: store, homePageID: activeHomePageID)
+            }
+            ToolbarItem(placement: .principal) {
                 AddressBarView(store: store, isFocused: $addressBarFocused,
                                detailWidth: detailWidth,
                                sidebarVisible: columnVisibility != .detailOnly,
-                               homePageID: activeHomePageID,
                                onAddToBookmarks: { omniboxBookmarkContext = $0 })
             }
-
         }
         // Suppress the window title so the omnibox owns the toolbar. `.navigationTitle("")`
         // alone only empties the *text* — the toolbar still reserves ~160pt for the

--- a/Sources/WikiFS/Window/SidebarView.swift
+++ b/Sources/WikiFS/Window/SidebarView.swift
@@ -70,18 +70,21 @@ struct SidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Wiki selector in the sidebar header — like the account header at
-            // the top of Notes/Mail's navigator. It collapses with the sidebar
-            // when the leading panel toggle hides it, so it leaves the toolbar
-            // (which now holds only the nav cluster + omnibox + Change Log toggle).
-            WikiSwitcher(registry: registry, currentWikiID: session.wikiID)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-            Divider()
             sectionSelectorBar
                 .padding(.top, 8)
             Divider()
             bookmarksOrList
+        }
+        // Wiki switcher pinned to the sidebar's bottom bar — like Xcode's
+        // navigator footer or Finder's status bar. It collapses with the
+        // sidebar when the leading panel toggle hides it, leaving the toolbar
+        // to hold only the nav cluster + omnibox.
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            Divider()
+            WikiSwitcher(registry: registry, currentWikiID: session.wikiID)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.bar)
         }
         .navigationTitle(activeWikiName)
         .navigationSplitViewColumnWidth(min: PageEditorMetrics.sidebarMinWidth,

--- a/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
+++ b/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
@@ -6,24 +6,16 @@ import Testing
 @testable import WikiFSEngine
 @testable import WikiFSCore
 
-/// Hosted-view checks that the SwiftUI wiring behind the omnibox toolbar item
-/// actually renders the width `OmniboxLayout` computes. `OmniboxLayoutTests`
-/// only proves the pure math is right; it can't catch a `Color.clear` spacer
-/// wired into the wrong `HStack`, an extra implicit spacing eating into it, or
-/// the field itself silently growing past its cap — all invisible to the pure
-/// function but exactly the class of bug issue #114 was about (a real widget
-/// stalling short of the true trailing edge). Render the actual view and read
-/// its layout back.
+/// Hosted-view checks that the SwiftUI wiring behind the centered omnibox actually
+/// renders the width `OmniboxLayout` computes. `OmniboxLayoutTests` only proves the
+/// pure math is right; it can't catch the field silently growing past its cap or an
+/// implicit spacing eating into the frame. Render the actual `AddressBarView` (which
+/// is now *only* the field — the nav cluster is a separate `.navigation` item) and
+/// read its rendered width back.
 ///
-/// A `NSHostingController.view.fittingSize` is used rather than a real
-/// `NSToolbar` (which needs a window on screen with a toolbar attached and adds
-/// its own empirically-observed padding — see `OmniboxLayout.Metrics`'s
-/// `openLeadingChrome`/`closedLeadingChrome` doc comments). Absolute widths
-/// aren't comparable to those constants outside a real toolbar, so these tests
-/// assert *deltas*: how much the rendered width moves when `detailWidth` moves.
-/// That's exactly what the fix is about — the group's total rendered width must
-/// track `detailWidth` 1:1 everywhere, including past the field's cap — and it's
-/// invariant to whatever padding a real `NSToolbar` adds on top.
+/// `NSHostingController.view.fittingSize` is used rather than a real `NSToolbar`
+/// (which needs an on-screen window with a toolbar). Since the field carries an
+/// explicit `.frame(width:)`, its fitting width is the computed `fieldWidth`.
 @MainActor
 struct AddressBarLayoutHostedTests {
     /// An `NSHostingController` in a `swift test` CLI has no host app, so give
@@ -42,12 +34,8 @@ struct AddressBarLayoutHostedTests {
     }
 
     /// Hosts the real `AddressBarView` at a fixed `detailWidth` and returns its
-    /// natural (unconstrained) width — the same sizing an `NSToolbar` reads to
-    /// place the trailing items after it. `homePageID` mirrors the real trigger
-    /// for the Home nav button (issue #280): non-`nil` renders a fourth nav
-    /// button, exactly like a wiki with a configured home page.
-    private func renderedWidth(detailWidth: CGFloat, sidebarVisible: Bool,
-                               homePageID: PageID? = nil) async throws -> CGFloat {
+    /// rendered width — the width NSToolbar would center as the `.principal` item.
+    private func renderedWidth(detailWidth: CGFloat, sidebarVisible: Bool = true) async throws -> CGFloat {
         _ = Self.app
         let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let model = WikiStoreModel(store: store)
@@ -56,7 +44,6 @@ struct AddressBarLayoutHostedTests {
             isFocused: .constant(false),
             detailWidth: detailWidth,
             sidebarVisible: sidebarVisible,
-            homePageID: homePageID,
             onAddToBookmarks: { _ in })
             .environment(FindModel())
         let hosting = NSHostingController(rootView: view)
@@ -68,59 +55,32 @@ struct AddressBarLayoutHostedTests {
         return hosting.view.fittingSize.width
     }
 
-    /// Below the cap: the field alone absorbs window growth, 1-for-1, same as
-    /// before the spacer existed — this proves the fix didn't disturb the
-    /// unclamped case.
+    /// Below the cap: the field absorbs region growth 1-for-1, exactly as
+    /// `OmniboxLayout.fieldWidth` says it should.
     @Test func renderedWidthTracksDetailWidthOneForOneBelowTheCap() async throws {
-        let narrow = try await renderedWidth(detailWidth: 700, sidebarVisible: true)
-        let wider = try await renderedWidth(detailWidth: 800, sidebarVisible: true)
+        let narrow = try await renderedWidth(detailWidth: 700)
+        let wider = try await renderedWidth(detailWidth: 800)
         #expect(abs((wider - narrow) - 100) < 1)
     }
 
-    /// The regression this issue is about: past the field's `maxWidth` cap, a
-    /// widening window used to produce NO change in the group's rendered width
-    /// (the field was stuck at the cap and nothing else absorbed the rest) — that
-    /// frozen total is exactly the growing trailing-edge gap the user reported.
-    /// With the spacer wired in, the rendered width must keep tracking
-    /// `detailWidth` 1-for-1 even past the cap.
-    @Test func renderedWidthKeepsTrackingDetailWidthPastTheCap() async throws {
+    /// The rendered width matches the pure computation — no implicit padding or
+    /// stray spacing has crept into the frame.
+    @Test func renderedWidthMatchesTheComputedFieldWidth() async throws {
+        let rendered = try await renderedWidth(detailWidth: 700)
+        #expect(abs(rendered - OmniboxLayout.fieldWidth(detailWidth: 700, sidebarVisible: true)) < 1)
+    }
+
+    /// Past the readability cap the pill freezes: a wider window adds side margin,
+    /// not field width, so the rendered width stops moving.
+    @Test func renderedWidthFreezesAtTheCap() async throws {
         let m = OmniboxLayout.Metrics.default
-        let field2000 = OmniboxLayout.fieldWidth(detailWidth: 2000, sidebarVisible: true, switcherExtra: 0)
-        let field2200 = OmniboxLayout.fieldWidth(detailWidth: 2200, sidebarVisible: true, switcherExtra: 0)
-        // Sanity: both points really are past the cap (field itself is frozen).
-        #expect(field2000 == m.maxWidth)
-        #expect(field2200 == m.maxWidth)
+        // Both points are past the cap (region - margins exceeds maxWidth).
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 1400, sidebarVisible: true) == m.maxWidth)
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 1800, sidebarVisible: true) == m.maxWidth)
 
-        let atCap = try await renderedWidth(detailWidth: 2000, sidebarVisible: true)
-        let pastCap = try await renderedWidth(detailWidth: 2200, sidebarVisible: true)
-        #expect(abs((pastCap - atCap) - 200) < 1)
-    }
-
-    /// Same check with the sidebar hidden (the other `leadingChrome` branch),
-    /// since the fix touches both.
-    @Test func renderedWidthKeepsTrackingDetailWidthPastTheCapWithSidebarHidden() async throws {
-        let atCap = try await renderedWidth(detailWidth: 2200, sidebarVisible: false)
-        let pastCap = try await renderedWidth(detailWidth: 2400, sidebarVisible: false)
-        #expect(abs((pastCap - atCap) - 200) < 1)
-    }
-
-    /// The home-button regression: a wiki with a configured home page (issue
-    /// #280) renders a fourth nav button. If `OmniboxLayout` doesn't know about
-    /// it (`homeButtonShown`), the field doesn't shrink to compensate, so the
-    /// WHOLE group (nav cluster + gap + field) renders WIDER than with no home
-    /// button — encroaching into the trailing switcher/toggle's reserved space
-    /// by exactly the button's footprint. That's what permanently pushed the
-    /// Toggle Transcript button into the toolbar's `»` overflow for any such
-    /// wiki, at any window width (a fixed offset, not a threshold — widening the
-    /// window never fixed it). With the fix, the field shrinks by exactly the
-    /// button's own footprint, so the total rendered width is UNCHANGED whether
-    /// or not the home button shows — the trailing items land in the same place
-    /// either way.
-    @Test func homeButtonDoesNotChangeTotalRenderedWidthBecauseTheFieldCompensates() async throws {
-        let withoutHome = try await renderedWidth(detailWidth: 900, sidebarVisible: true, homePageID: nil)
-        let withHome = try await renderedWidth(detailWidth: 900, sidebarVisible: true,
-                                               homePageID: PageID(rawValue: "test-home-page"))
-        #expect(abs(withoutHome - withHome) < 1)
+        let atCap = try await renderedWidth(detailWidth: 1400)
+        let pastCap = try await renderedWidth(detailWidth: 1800)
+        #expect(abs(pastCap - atCap) < 1)
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
+++ b/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
@@ -4,233 +4,86 @@ import Testing
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// Sizing/overflow behavior of the toolbar omnibox. Uses a fixed `Metrics` so the
-/// thresholds are exact and independent of the real switcher/transcript widths.
+/// Sizing behavior of the centered toolbar omnibox. Uses a fixed `Metrics` so the
+/// thresholds are exact and independent of any future retuning. Centering itself
+/// is NSToolbar's job (the field is a `.principal` item); these tests cover only
+/// the pill's *width* as the detail region grows, and that the width leaves a
+/// large enough margin to clear the leading chrome in each sidebar state.
 @Suite struct OmniboxLayoutTests {
-    // trailingWithSwitcher 0 (no trailing toolbar items — the wiki switcher
-    // moved into the sidebar header and the Change Log toggle was removed, so
-    // the omnibox owns the full toolbar width), trailingOverflow 60, min 120,
-    // max 1200.
+    // sideMarginOpen 150, sideMarginClosed 290, min 240, max 820.
     let m = OmniboxLayout.Metrics.default
 
-    // MARK: Field fills to the window edge
+    // MARK: Grows with the region, keeping side margins
 
-    @Test func fillsToTheWindowEdgeOnAWideWindow() {
-        // 1200 - 0 (no trailing items) - 0 (baseline) - 200 (leading) = 1000.
-        let w = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == 1000)
-        #expect(OmniboxLayout.switcherFits(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0))
+    @Test func fieldTakesTheRegionMinusAMarginOnEachSide() {
+        // Sidebar shown: 900 - 2*150 = 600.
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 900, sidebarVisible: true) == 600)
+        // Sidebar hidden: 900 - 2*290 = 320 (a larger margin clears the traffic
+        // lights + toggle that now sit in the field's left margin).
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 900, sidebarVisible: false) == 320)
     }
 
-    @Test func aLongerWikiNameShrinksTheField() {
-        let base = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
-        let long = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 150)
-        #expect(long == base - 150)
-        #expect(long == 850)
+    @Test func widerRegionGrowsTheFieldOneForOneBelowTheCap() {
+        for sidebar in [true, false] {
+            let narrow = OmniboxLayout.fieldWidth(detailWidth: 900, sidebarVisible: sidebar)
+            let wider = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: sidebar)
+            #expect(wider - narrow == 100)
+        }
     }
 
-    @Test func aShorterWikiNameLetsTheFieldGrow() {
-        let base = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
-        let short = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: -40)
-        #expect(short == base + 40)
+    @Test func hiddenSidebarReservesMoreMarginSoTheFieldIsNarrower() {
+        // Same region, but hiding the sidebar puts more chrome in the left margin,
+        // so the field must be narrower by exactly twice the margin difference.
+        let open = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true)
+        let closed = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: false)
+        #expect(open - closed == 2 * (m.sideMarginClosed - m.sideMarginOpen))
     }
 
-    @Test func openSidebarPushesTheLeadingEdgeAndShrinksTheField() {
-        // A larger leading edge (sidebar open) yields a narrower field, 1-for-1.
-        let closed = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
-        let open = OmniboxLayout.fieldWidth(windowWidth: 1200, fieldLeadingX: 380, switcherExtra: 0)
-        #expect(open == closed - 180)
-    }
-
-    // MARK: Overflow threshold + expansion
-    //
-    // With `trailingWithSwitcher = 0` there are no trailing toolbar items, so
-    // the overflow path is degenerate — it only activates when the window is
-    // so narrow that even with zero trailing reservation the field can't reach
-    // `minWidth`. In that regime the overflow path yields *less* than `minWidth`
-    // (because `trailingOverflow > trailingWithSwitcher`), so the field clamps
-    // to `minWidth` either way. The tests below lock that degenerate behavior.
-
-    @Test func switcherStaysUntilTheFieldReachesItsFloor() {
-        // 320 - 0 - 200 = 120 == floor: no overflow needed, exactly.
-        #expect(OmniboxLayout.switcherFits(windowWidth: 320, fieldLeadingX: 200, switcherExtra: 0))
-        #expect(OmniboxLayout.fieldWidth(windowWidth: 320, fieldLeadingX: 200, switcherExtra: 0) == 120)
-    }
-
-    @Test func switcherOverflowsJustBelowTheFloor() {
-        // 319 - 0 - 200 = 119 < floor: would overflow if there were trailing items.
-        #expect(!OmniboxLayout.switcherFits(windowWidth: 319, fieldLeadingX: 200, switcherExtra: 0))
-    }
-
-    @Test func fieldClampsToFloorInOverflowRegime() {
-        // With no trailing items, the overflow path yields less than minWidth
-        // (319 - 60 overflow - 200 = 59 < 120), so the field clamps to floor
-        // rather than expanding.
-        let w = OmniboxLayout.fieldWidth(windowWidth: 319, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == m.minWidth)
-    }
-
-    @Test func aLongWikiNameTriggersOverflowSooner() {
-        // Same window; a long name reserves more, so the field drops below floor
-        // at a width where a baseline name would still fit.
-        #expect(OmniboxLayout.switcherFits(windowWidth: 350, fieldLeadingX: 200, switcherExtra: 0))
-        #expect(!OmniboxLayout.switcherFits(windowWidth: 350, fieldLeadingX: 200, switcherExtra: 150))
+    @Test func sideMarginIsPreservedBelowTheCap() {
+        // (region - field) / 2 == the state's side margin, so the centered pill
+        // can never touch the region edges (the old overflow trigger). Widths
+        // chosen to sit in each state's growing regime.
+        for detailWidth: CGFloat in [700, 900, 1100] {
+            let open = OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: true)
+            #expect((detailWidth - open) / 2 == m.sideMarginOpen)
+        }
+        for detailWidth: CGFloat in [900, 1100, 1300] {
+            let closed = OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: false)
+            #expect((detailWidth - closed) / 2 == m.sideMarginClosed)
+        }
     }
 
     // MARK: Clamps
 
     @Test func neverShrinksBelowTheFloor() {
-        // Tiny window, everything overflows: still clamped to the floor.
-        let w = OmniboxLayout.fieldWidth(windowWidth: 300, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == m.minWidth)
+        // Very narrow region: region - margins would go below the floor, so the
+        // floor holds and the margins give instead (never a negative width).
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 500, sidebarVisible: true) == m.minWidth)
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 700, sidebarVisible: false) == m.minWidth)
     }
 
     @Test func neverGrowsPastTheCap() {
-        let w = OmniboxLayout.fieldWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(w == m.maxWidth)
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 2000, sidebarVisible: true) == m.maxWidth)
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 2000, sidebarVisible: false) == m.maxWidth)
     }
 
-    // MARK: Overflow spacer (issue #114)
-    //
-    // Once `fieldWidth` hits `maxWidth` it stops absorbing extra window width, so
-    // `fieldLeadingX + fieldWidth + trailingWithSwitcher` no longer sums to
-    // `windowWidth` — the invariant that would otherwise keep the trailing items
-    // flush against the true edge. `overflowSpacerWidth` reports exactly the
-    // shortfall so the toolbar item can absorb it itself. With no trailing items
-    // (`trailingWithSwitcher = 0`) the spacer still fills dead space past the cap,
-    // keeping the omnibox group's total width tracking the detail region 1:1.
-
-    @Test func overflowSpacerIsZeroBelowTheCap() {
-        // 1200 window: field (1000) is well under maxWidth, nothing to absorb.
-        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1200, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(s == 0)
+    @Test func marginsGrowPastTheCap() {
+        // Once the field is capped, extra window width becomes margin — the pill
+        // stays a fixed readable width and floats centered with more air around it.
+        let wide = OmniboxLayout.fieldWidth(detailWidth: 1600, sidebarVisible: true)
+        let wider = OmniboxLayout.fieldWidth(detailWidth: 2000, sidebarVisible: true)
+        #expect(wide == m.maxWidth)
+        #expect(wider == m.maxWidth)
+        #expect((1600 - wide) / 2 == 390)
+        #expect((2000 - wider) / 2 == 590)
     }
 
-    @Test func overflowSpacerIsZeroExactlyAtTheCap() {
-        // kept == maxWidth exactly: 200 + 1200 + 0 = 1400.
-        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 1400, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(s == 0)
-    }
-
-    @Test func overflowSpacerAbsorbsExactlyWhatTheCapClampedAway() {
-        // 2000 window: field clamps to maxWidth (1200); the spacer must make up
-        // the rest so fieldLeadingX + fieldWidth + spacer + trailing == windowWidth.
-        let w = OmniboxLayout.fieldWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
-        let s = OmniboxLayout.overflowSpacerWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(200 + w + s + m.trailingWithSwitcher == 2000)
-        #expect(s == 600)
-    }
-
-    @Test func overflowSpacerGrowsOneForOneWithWindowWidthPastTheCap() {
-        let base = OmniboxLayout.overflowSpacerWidth(windowWidth: 2000, fieldLeadingX: 200, switcherExtra: 0)
-        let wider = OmniboxLayout.overflowSpacerWidth(windowWidth: 2100, fieldLeadingX: 200, switcherExtra: 0)
-        #expect(wider == base + 100)
-    }
-
-    @Test func overflowSpacerMatchesTheIssueThreshold() {
-        // Sidebar open: issue #114's gap starts once detailWidth exceeds
-        // maxWidth + trailingWithSwitcher + openLeadingChrome (derived from default
-        // metrics rather than hardcoded, so this doesn't fight future retuning).
-        // Below/at it the spacer is zero; just past it the gap starts opening.
-        let threshold = m.maxWidth + m.trailingWithSwitcher + m.openLeadingChrome
-        let atThreshold = OmniboxLayout.overflowSpacerWidth(detailWidth: threshold, sidebarVisible: true, switcherExtra: 0)
-        let pastThreshold = OmniboxLayout.overflowSpacerWidth(detailWidth: threshold + 1, sidebarVisible: true, switcherExtra: 0)
-        #expect(atThreshold == 0)
-        #expect(pastThreshold == 1)
-    }
+    // MARK: Unmeasured region
 
     @Test func returnsFloorBeforeGeometryIsKnown() {
-        // windowWidth 0 → not yet measured → floor, never a negative width.
-        #expect(OmniboxLayout.fieldWidth(windowWidth: 0, fieldLeadingX: 0, switcherExtra: 0) == m.minWidth)
-    }
-
-    // MARK: Detail-width driver (sidebar-aware)
-    //
-    // The view can't reliably measure the field's own leading edge — the toolbar
-    // yanks it out of the window on overflow, stranding the reading. Instead it
-    // measures the detail region's width (never in overflow) and the sidebar state,
-    // and `fieldWidth(detailWidth:sidebarVisible:…)` derives the field width from
-    // them. These lock that derivation and the leading-chrome branch.
-
-    @Test func leadingChromeDiffersBySidebarState() {
-        // Sidebar shown: only the nav buttons sit left of the field (traffic lights
-        // + toggle are over the sidebar). Sidebar hidden: the detail region spans
-        // the whole window, so it also includes that traffic-light + toggle zone.
-        #expect(OmniboxLayout.leadingChrome(sidebarVisible: true) == m.openLeadingChrome)
-        #expect(OmniboxLayout.leadingChrome(sidebarVisible: false) == m.closedLeadingChrome)
-        #expect(m.openLeadingChrome < m.closedLeadingChrome)
-    }
-
-    // MARK: Home button leading chrome
-    //
-    // A wiki with a configured home page (issue #280) adds a fourth nav button,
-    // shifting the field's real leading edge right by `homeButtonExtra`. Omitting
-    // this previously under-reserved the field's own width by that fixed amount —
-    // independent of window width.
-
-    @Test func homeButtonAddsExtraLeadingChromeInBothSidebarStates() {
-        #expect(OmniboxLayout.leadingChrome(sidebarVisible: true, homeButtonShown: true)
-                == m.openLeadingChrome + m.homeButtonExtra)
-        #expect(OmniboxLayout.leadingChrome(sidebarVisible: false, homeButtonShown: true)
-                == m.closedLeadingChrome + m.homeButtonExtra)
-    }
-
-    @Test func homeButtonShrinksTheFieldByExactlyItsOwnWidth() {
-        // Isolates the home-button effect: same detailWidth/sidebar state, only
-        // `homeButtonShown` differs, so the field must shrink by exactly
-        // `homeButtonExtra` — the button's own width plus its one nav-cluster gap.
-        let withoutHome = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true, switcherExtra: 0)
-        let withHome = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true,
-                                                homeButtonShown: true, switcherExtra: 0)
-        #expect(withoutHome - withHome == m.homeButtonExtra)
-    }
-
-    @Test func homeButtonEncroachmentIsIndependentOfWindowWidth() {
-        // The reported bug: unlike an overflow threshold (which clears once the
-        // window is wide enough), a missing home-button reservation is a FIXED
-        // offset — it never resolves no matter how wide the window gets. Confirm
-        // the fixed invariant holds at both a narrow-ish and a very wide
-        // detailWidth, with the home button shown.
-        for detailWidth: CGFloat in [700, 2200] {
-            let field = OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: true,
-                                                 homeButtonShown: true, switcherExtra: 73.5)
-            let spacer = OmniboxLayout.overflowSpacerWidth(detailWidth: detailWidth, sidebarVisible: true,
-                                                           homeButtonShown: true, switcherExtra: 73.5)
-            let leading = OmniboxLayout.leadingChrome(sidebarVisible: true, homeButtonShown: true)
-            #expect(leading + field + spacer + m.trailingWithSwitcher + 73.5 == detailWidth)
-        }
-    }
-
-    @Test func detailWidthDriverDelegatesToTheCore() {
-        // The detail-width overload is exactly the core math with detailWidth as the
-        // window width and the fixed leading chrome as the field's leading edge.
-        let closed = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: false, switcherExtra: 0)
-        #expect(closed == OmniboxLayout.fieldWidth(windowWidth: 1000, fieldLeadingX: m.closedLeadingChrome, switcherExtra: 0))
-        let open = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true, switcherExtra: 0)
-        #expect(open == OmniboxLayout.fieldWidth(windowWidth: 1000, fieldLeadingX: m.openLeadingChrome, switcherExtra: 0))
-    }
-
-    @Test func openSidebarLeavesMoreRoomForTheFieldAtAGivenDetailWidth() {
-        // For the SAME detail width, the sidebar-shown case reserves less leading
-        // chrome, so the field is wider by exactly that difference.
-        let closed = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: false, switcherExtra: 0)
-        let open = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true, switcherExtra: 0)
-        #expect(open - closed == m.closedLeadingChrome - m.openLeadingChrome)
-    }
-
-    @Test func overflowClampsToFloorThroughTheDetailWidthDriver() {
-        // A detail region too narrow to fit even minWidth (with zero trailing
-        // reservation): the field clamps to the floor rather than going negative.
-        let w = OmniboxLayout.fieldWidth(detailWidth: 180, sidebarVisible: true, switcherExtra: 0)
-        // 180 - 70 chrome - 0 trailing = 110 < 120 floor → overflow path:
-        // 180 - 70 - 60 overflow = 50 < 120 → clamped to 120.
-        #expect(w == m.minWidth)
-    }
-
-    @Test func returnsFloorBeforeTheDetailWidthIsMeasured() {
         // GeometryReader reports 0 until first layout; never a negative width.
-        #expect(OmniboxLayout.fieldWidth(detailWidth: 0, sidebarVisible: true, switcherExtra: 0) == m.minWidth)
-        #expect(OmniboxLayout.fieldWidth(detailWidth: 0, sidebarVisible: false, switcherExtra: 0) == m.minWidth)
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 0, sidebarVisible: true) == m.minWidth)
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 0, sidebarVisible: false) == m.minWidth)
     }
 }
 #endif


### PR DESCRIPTION
The toolbar omnibox rendered full-width flush-left and consistently dropped
into the `»` overflow. `OmniboxLayout` tried to predict NSToolbar's internal
layout with hand-tuned constants and sized the field to ~100% of the detail
region; NSToolbar's all-or-nothing overflow then dumped the whole group to `»`
whenever any guess was slightly off.

Cooperate with NSToolbar instead of predicting it:
- Split into two toolbar items: OmniboxNavButtons (Back/Forward/Home) in
  `.navigation` (flush-left) and the field in `.principal`, which NSToolbar
  centers. Removes the leading-chrome / overflow-spacer / position math.
- Size the field to the detail region minus a side margin per side, clamped to
  [240, 820], so it never fills the region and can't trigger overflow.
- Sidebar-aware margin (open 150 / closed 290): with the sidebar hidden the
  field centers across the whole window and its left margin must clear traffic
  lights + toggle + nav, not just the nav cluster.
- Add navBubbleInset so the macOS 26 glass toolbar bubble doesn't clip the wide
  house glyph.

Also moves the WikiSwitcher into the sidebar's bottom bar, freeing the toolbar
for the omnibox. Both omnibox test suites rewritten for the new model.

Verified live (screenshots + accessibility frames): centered in both sidebar
states, no overflow on fresh launch or drag-resize 720<->1200. 11/11 tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
