### PR TITLE
Fix SwiftUI "Modifying state during view update" in WikiReaderView

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,30 @@ agents, NOT Polytoken):
   `mutate(`). Adding a new public mutator? Route it through `mutate()` or the
   guard fails. See `plans/event-bus.md`.
 
+* **Never write SwiftUI state synchronously from an `NSViewRepresentable`'s
+  `makeNSView`/`updateNSView`, or from anything reachable from them.** Both run
+  inside SwiftUI's update pass, so a `@State`/`@Binding` write there is
+  "Modifying state during view update, this will cause undefined behavior."
+  `WikiReaderView.Coordinator.startLoad` wrote `isLoading.wrappedValue = true`
+  from `makeNSView` and warned on *every* reader mount.
+  - **The trap is indirection.** AppKit setters post delegate notifications
+    **synchronously**, so the write is often several frames deep and not visible
+    at the call site: `textView.string = …` → `textViewDidChangeSelection` →
+    `onCaretChange` → `@State`. Assigning `.string`, `setSelectedRange`,
+    `selectRowIndexes`, and friends all do this. Wiring `delegate` *before*
+    seeding content in `makeNSView` is the classic way to trip it.
+  - **The rule:** in a Coordinator, either **defer** the write
+    (`Task { @MainActor in … }` — see `ComposerTextView.Coordinator.recomputeHeight`)
+    or **suppress** it while you are the one mutating the view (an
+    `isApplyingProgrammaticChange` flag bracketing the mutation, with the
+    write-back path gated on it — see `ScrollableTextEditor`). Programmatic
+    mutation is not user input; don't report it back into SwiftUI.
+  - **These are runtime issues, not compile warnings.** They appear in no build
+    log, and `swift test` does not display them, so a clean build and a green
+    CLI test run are *not* evidence they're absent. Capture and bisect procedure:
+    [`docs/skills/reproducing-live-ui-bugs/SKILL.md`](docs/skills/reproducing-live-ui-bugs/SKILL.md)
+    §"SwiftUI runtime issues".
+
 * Never use `print` for diagnostics — route all logging through `DebugLog`
   (`os_log` → Console.app, subsystem `com.selfdrivingwiki.debug`) so it's visible
   no matter how the app launched. The only exception is real CLI stdout (e.g.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7601,4 +7601,11 @@ more. Verify UI fixes under xcodebuild.
 `swift test` (3358 tests / 279 suites) also 0. Bisected by stubbing
 `PageDetailView`'s body; `PageDetailView.swift` itself is unchanged.
 
+**Codified:** the invariant (never write SwiftUI state synchronously from a
+representable's `makeNSView`/`updateNSView`, plus the defer/suppress fix
+patterns) is now a rule in AGENTS.md; the detection + bisect procedure is a new
+"SwiftUI runtime issues" section in
+`docs/skills/reproducing-live-ui-bugs/SKILL.md`, whose `description` now also
+advertises the runtime-issue case so it gets discovered.
+
 **Build:** `swift build && swift test`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7549,3 +7549,56 @@ No `print`. DebugLog only.
 
 **Build:** `swift build && swift test`.
 
+
+## SwiftUI "Modifying state during view update" in the reader (#791 follow-up)
+
+**Why:** Running the test suite in Xcode surfaced repeated runtime issues:
+`Modifying state during view update, this will cause undefined behavior.`
+Xcode attributed them to `PageDetailView.editorContent`, which was a red
+herring — the write was three layers away, in `WikiReaderView`.
+
+**Root cause:** `WikiReaderView.Coordinator.startLoad(markdown:isLoading:)`
+did `isLoading.wrappedValue = true` synchronously. `startLoad` is called from
+both `makeNSView` and `updateNSView`, i.e. from inside SwiftUI's update pass,
+so every mount of the reader wrote `@State` mid-update. Because the reader is
+embedded widely (and `PageDetailView` seeds `isEditing` in `.onAppear`, so the
+reader branch renders on first paint even for a page opened in edit mode), one
+defect produced warnings that looked scattered across unrelated suites.
+
+**What changed:**
+
+- **`Sources/WikiFS/Reader/WikiReaderView.swift`** — `startLoad` no longer
+  writes the binding synchronously. It skips the write entirely when already
+  loading (the first-mount case, where `isLoading` starts `true`) and otherwise
+  hops to the next main-actor turn. Mirrors the existing precedent in
+  `ComposerTextView.Coordinator.recomputeHeight` (#436), which already carried
+  the comment "must never write synchronously, since this also runs from inside
+  `updateNSView`" — the lesson had been learned once and not generalized.
+
+- **`Sources/WikiFS/Editor/ScrollableTextEditor.swift`** — unrelated hardening
+  for the same bug class, found while investigating (no test currently mounts
+  the path, so it was not the reported warning). `makeNSView` now seeds
+  `textView.string` before wiring the delegate; `updateNSView` brackets its
+  programmatic `.string` sync and `setSelectedRange` with a new
+  `isApplyingProgrammaticChange` flag that suppresses caret/text write-back.
+  A heading jump still updates the outline highlight via a deferred report, so
+  behavior is preserved.
+
+**Detection method (worth keeping):** these are runtime issues, not compile
+warnings — they never appear in a build log, and `swift test` does not display
+them. They are `os_log` faults and can be captured from the CLI:
+
+    /usr/bin/log stream --predicate \
+      'subsystem == "com.apple.runtime-issues" and category == "SwiftUI"' \
+      --style compact
+
+Run that alongside the tests to get the same purple diamonds Xcode shows.
+Note that `swift test` mounts hosted views without a window server, so some
+suites never lay out and stay silent; xcodebuild renders for real and exposes
+more. Verify UI fixes under xcodebuild.
+
+**Result:** full xcodebuild test run went from 8 occurrences to 0; full
+`swift test` (3358 tests / 279 suites) also 0. Bisected by stubbing
+`PageDetailView`'s body; `PageDetailView.swift` itself is unchanged.
+
+**Build:** `swift build && swift test`.

--- a/Sources/WikiFS/Editor/ScrollableTextEditor.swift
+++ b/Sources/WikiFS/Editor/ScrollableTextEditor.swift
@@ -108,8 +108,14 @@ struct ScrollableTextEditor: NSViewRepresentable {
         scrollView.drawsBackground = false
 
         let textView = Self.makeConfiguredTextView(font: font)
-        textView.delegate = context.coordinator
+        // Seed the text BEFORE wiring the delegate. Assigning `.string` resets
+        // the selection and posts `NSTextViewDidChangeSelectionNotification`
+        // synchronously; with the delegate already attached that would call
+        // `onCaretChange` — a SwiftUI `@State` write — while `makeNSView` is
+        // still running inside SwiftUI's update pass ("Modifying state during
+        // view update").
         textView.string = text
+        textView.delegate = context.coordinator
         if let dropTV = textView as? DropLinkTextView {
             dropTV.sidebarDropBuilder = sidebarDropBuilder
         }
@@ -125,8 +131,15 @@ struct ScrollableTextEditor: NSViewRepresentable {
         // Sync text only when it changed externally (avoids clobbering the
         // user's in-flight edit). Setting `.string` resets undo + selection,
         // so we must skip it when the text view is already in sync.
+        //
+        // The selection reset fires `textViewDidChangeSelection` synchronously,
+        // which would report a caret move back into SwiftUI `@State` from
+        // inside the update pass. Flag the window so `reportCaret` ignores it:
+        // a programmatic text sync is not a user caret move.
         if textView.string != text {
+            context.coordinator.isApplyingProgrammaticChange = true
             textView.string = text
+            context.coordinator.isApplyingProgrammaticChange = false
         }
         if textView.font?.fontName != font.fontName
             || textView.font?.pointSize != font.pointSize {
@@ -146,15 +159,24 @@ struct ScrollableTextEditor: NSViewRepresentable {
         }
 
         // Consume a pending scroll request.
+        //
+        // `setSelectedRange` also posts the selection notification synchronously,
+        // so it needs the same suppression as the text sync above. Unlike a text
+        // sync, though, the caret genuinely did move (the user jumped to a
+        // heading) and the outline highlight should follow — so re-report it on
+        // a hop, once SwiftUI's update pass has finished.
         if let request = scrollRequest,
            context.coordinator.appliedScrollVersion != request.version {
             context.coordinator.appliedScrollVersion = request.version
             let length = (textView.string as NSString).length
             let clamped = min(max(0, request.charOffset), length)
             let range = NSRange(location: clamped, length: 0)
+            context.coordinator.isApplyingProgrammaticChange = true
             textView.setSelectedRange(range)
             textView.scrollRangeToVisible(range)
             textView.window?.makeFirstResponder(textView)
+            context.coordinator.isApplyingProgrammaticChange = false
+            context.coordinator.reportCaretAfterUpdate(in: textView)
         }
     }
 
@@ -216,6 +238,12 @@ struct ScrollableTextEditor: NSViewRepresentable {
         /// Avoids redundant SwiftUI updates: only reports the caret when its
         /// index actually changed.
         private var lastReportedCaret: Int?
+        /// True while `updateNSView` is mutating the text view itself (syncing
+        /// `.string`, applying a scroll request). AppKit posts the resulting
+        /// change/selection notifications synchronously, so any delegate
+        /// callback that writes back into SwiftUI would land in the middle of
+        /// the view update. Every such write is gated on this being false.
+        var isApplyingProgrammaticChange = false
 
         // MARK: - Autocomplete (#680)
 
@@ -232,6 +260,12 @@ struct ScrollableTextEditor: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            // Assigning `.string` does not post this notification, but editing
+            // APIs that pair `replaceCharacters` with `didChangeText()` do. If
+            // one ever runs from `updateNSView`, the binding write below would
+            // mutate `store.draftBody` mid-update — and the value would be
+            // whatever we just pushed in, so there is nothing to report back.
+            guard !isApplyingProgrammaticChange else { return }
             if parent.text != textView.string {
                 parent.text = textView.string
             }
@@ -317,7 +351,18 @@ struct ScrollableTextEditor: NSViewRepresentable {
             autocompleteController = nil
         }
 
+        /// Reports the caret once the current SwiftUI update pass has finished.
+        /// Used for programmatic caret moves that the outline *should* follow
+        /// (a heading jump) but that cannot be published synchronously.
+        func reportCaretAfterUpdate(in textView: NSTextView) {
+            Task { @MainActor [weak textView] in
+                guard let textView else { return }
+                self.reportCaret(in: textView)
+            }
+        }
+
         private func reportCaret(in textView: NSTextView) {
+            guard !isApplyingProgrammaticChange else { return }
             let caret = textView.selectedRange().location
             guard caret != lastReportedCaret else { return }
             lastReportedCaret = caret

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -996,7 +996,16 @@ internal struct WikiReaderRep: NSViewRepresentable {
             loadedMarkdown = markdown
             pageLoaded = false
             isLoadingBinding = isLoading
-            isLoading.wrappedValue = true
+            // Never write this binding synchronously: `startLoad` is called from
+            // `makeNSView` / `updateNSView`, i.e. from inside SwiftUI's update
+            // pass, and a direct write there is "Modifying state during view
+            // update". Skip entirely when already loading (the common case on
+            // first mount, where `isLoading` starts `true`) and otherwise hop to
+            // the next main-actor turn. Mirrors
+            // `ComposerTextView.Coordinator.recomputeHeight` (#436).
+            if !isLoading.wrappedValue {
+                Task { @MainActor in isLoading.wrappedValue = true }
+            }
             loadStart = DispatchTime.now()
             // Measure the synchronous click→startLoad window: openTab →
             // loadDrafts (getPage + stripped) → SwiftUI re-render → this

--- a/docs/skills/reproducing-live-ui-bugs/SKILL.md
+++ b/docs/skills/reproducing-live-ui-bugs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Steps for debugging a live UI bug that passes all unit tests but fails in the running app, when you cannot see the screen.
+description: Steps for debugging a live UI bug that passes all unit tests but fails in the running app, when you cannot see the screen. Also covers SwiftUI runtime issues that only Xcode displays — "Modifying state during view update", purple runtime warnings, Hang Risk — including how to capture them from the CLI via `log stream` and bisect a view body to find the real source.
 ---
 
 # Debugging a live UI bug that passes tests
@@ -132,6 +132,55 @@ Two wiring failures this playbook has actually surfaced:
 - Assert after polling — `apply`-style calls are fire-and-forget
   `evaluateJavaScript`, so the effect lands asynchronously.
 
+## SwiftUI runtime issues ("Modifying state during view update")
+
+A separate invisible-failure class: SwiftUI emits **runtime issues**, not compile
+warnings. They appear in **no build log**, and `swift test` does not display
+them — a clean build plus a green CLI test run is *not* evidence they're absent.
+Xcode shows them; everything else looks fine.
+
+**Capture them from the CLI.** They are `os_log` faults to a system subsystem:
+
+```sh
+/usr/bin/log stream --predicate \
+  'subsystem == "com.apple.runtime-issues" and category == "SwiftUI"' \
+  --style compact
+```
+
+Run that alongside the tests (start the stream, `sleep 2`, run, `sleep 3`, kill)
+and count `Modifying state`. That turns an Xcode-only symptom into a scriptable
+pass/fail you can bisect against. Drop the `category` clause to also see
+`Hang Risk` (priority inversions) and other categories.
+
+**Choose the runner deliberately.** `swift test` mounts hosted views *without a
+window server*, so some suites never lay out and stay silent; `xcodebuild`
+renders for real and exposes strictly more. One real case: xcodebuild surfaced 8
+occurrences where `swift test` showed 2. **Verify UI fixes under xcodebuild.**
+
+**Distrust the reported location.** The warning names whichever view body was
+mid-evaluation when the graph committed — *not* the code that wrote the state.
+A real case pointed at `PageDetailView.editorContent`; the write was in
+`WikiReaderView`, a different file two layers down, and `PageDetailView` needed
+no change at all. Treat the location as a starting point, never a conclusion.
+
+**Bisect the body — don't theorize.** With the capture loop above as the oracle:
+
+1. Establish a baseline count on the smallest failing test (aim for a sub-second
+   incremental run).
+2. Wrap subtrees of the suspect `body` in `if false { … }`, re-run, re-count.
+3. Narrow until the count drops to 0; the last subtree removed owns the write.
+4. Read the representable that subtree mounts, and check its Coordinator for
+   `@State`/`@Binding` writes reachable from `makeNSView`/`updateNSView`.
+5. `diff` the file against a backup afterwards to prove the scaffolding is gone.
+
+Watch for a branch rendering that you didn't expect: state seeded in `.onAppear`
+means the *other* branch renders on first paint, so a view can warn from code the
+test looks like it never exercises. That detail is usually what makes the counts
+across tests look inexplicable.
+
+The underlying invariant, and the defer/suppress fix patterns, are in AGENTS.md
+("Never write SwiftUI state synchronously from an `NSViewRepresentable`…").
+
 ## Anti-patterns to avoid
 
 - Theorizing about content without reading the real DB row.
@@ -142,3 +191,8 @@ Two wiring failures this playbook has actually surfaced:
   host the **real** container so the lifecycle is exercised.
 - `print`-based logging that vanishes when the app isn't launched from a
   terminal.
+- Treating "the build is clean" or "`swift test` passed" as proof a SwiftUI
+  runtime issue is fixed — neither runner reports them. Re-measure with the
+  `log stream` capture above, under `xcodebuild`, and show the count going to 0.
+- Trusting the file/method the runtime issue names without confirming a state
+  write actually lives there.


### PR DESCRIPTION
## Problem

Running the test suite in Xcode surfaced repeated SwiftUI runtime issues:

> Modifying state during view update, this will cause undefined behavior.

Xcode attributed them to `PageDetailView.editorContent`. That was a red herring — the offending write is three layers away, in `WikiReaderView`, and `PageDetailView.swift` is unchanged by this PR.

## Root cause

`WikiReaderView.Coordinator.startLoad(markdown:isLoading:)` wrote the binding synchronously:

```swift
isLoading.wrappedValue = true
```

`startLoad` is called from both `makeNSView` and `updateNSView` — i.e. from inside SwiftUI's update pass — so every mount of the reader modified `@State` mid-update.

Because the reader is embedded widely, and `PageDetailView` seeds `isEditing` in `.onAppear` (so the reader branch renders on first paint even for a page opened in edit mode), this single defect produced warnings that looked scattered across unrelated suites.

## Fix

`startLoad` no longer writes the binding synchronously. It skips the write entirely when already loading — the first-mount case, where `isLoading` starts `true` — and otherwise hops to the next main-actor turn. The deferral is invisible in practice: `didFinish` clears the flag on a WebKit callback orders of magnitude later.

This mirrors the existing precedent in `ComposerTextView.Coordinator.recomputeHeight` (#436), which already carried the comment *"must never write synchronously, since this also runs from inside `updateNSView`"* — the lesson had been learned once and not generalized.

## Also included: `ScrollableTextEditor` hardening

Unrelated to the reported warning, found while investigating. **No test currently mounts this path**, so it was not the cause — but `setSelectedRange` inside `updateNSView` is a genuine latent instance of the same bug class.

- `makeNSView` seeds `textView.string` **before** wiring the delegate (assigning `.string` posts the selection notification synchronously).
- `updateNSView` brackets its programmatic `.string` sync and `setSelectedRange` with a new `isApplyingProgrammaticChange` flag that suppresses caret/text write-back.
- A heading jump still updates the outline highlight, via a deferred report — behavior preserved.

Happy to split this into its own PR if you'd rather keep this one to the single-line reader fix.

## Verification

These are runtime issues, not compile warnings: they appear in **no build log**, and `swift test` does not display them. They are `os_log` faults and can be captured from the CLI:

```
/usr/bin/log stream --predicate \
  'subsystem == "com.apple.runtime-issues" and category == "SwiftUI"' \
  --style compact
```

| Run | Reader fix | Occurrences |
|---|---|---|
| xcodebuild full suite | before | **8** |
| xcodebuild full suite | after | **0** |
| `swift test` (3358 tests / 279 suites) | after | **0** |

Localized by bisecting `PageDetailView`'s body (stub subtrees, re-run, count warnings), then reading the representable the surviving subtree mounts.

Note: `swift test` mounts hosted views without a window server, so some suites never lay out and stay silent. xcodebuild renders for real and exposes more — verify UI fixes there.

## Codified so this doesn't recur

The failure mode here was subtle in two directions — the warning pointed at the wrong file, and the usual "it builds clean, tests pass" evidence was structurally incapable of detecting it. Both halves are now written down:

- **AGENTS.md** — the invariant as a house rule: never write SwiftUI state synchronously from an `NSViewRepresentable`'s `makeNSView`/`updateNSView` or anything reachable from them, why the indirection through AppKit delegate notifications hides it, and the two fix patterns (defer via `Task { @MainActor }`, or suppress via an `isApplyingProgrammaticChange` flag).
- **`docs/skills/reproducing-live-ui-bugs/SKILL.md`** — a new "SwiftUI runtime issues" section with the `log stream` capture recipe, the `swift test` vs `xcodebuild` visibility difference, why the reported location is untrustworthy, and the body-bisection procedure. Its `description` frontmatter now advertises the runtime-issue case so the skill is actually discovered for it. Two anti-patterns added: treating a clean build or a green `swift test` as proof, and trusting the named file without confirming a state write lives there.

## Pre-existing, not from this PR

The xcodebuild run reports 17 failures that `swift test` does not, all named `…MatchesFile()` (`chatMatchesFile`, `lintTaskMatchesFile`, `digesterPromptMatchesFile`, …). They compare prompt resources against on-disk files and fail only under xcodebuild, which resolves resource bundles differently than SwiftPM. This PR touches two view files and nothing resource-related. I have not verified this against a clean checkout, so treat it as inference — but it may be worth a look if CI runs through xcodebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
