### PR TITLE
fix: sign release builds with Developer ID Application cert (#746)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,26 @@ DIST_DIR      := dist
 NOTARY_ZIP    := $(DIST_DIR)/$(APP_NAME)-$(VERSION)-notary.zip
 RELEASE_ZIP   := $(DIST_DIR)/$(APP_NAME)-$(VERSION)-macos.zip
 
-# Dev signing identity (used by ./build.sh). Falls back to ad-hoc ("-") if
-# the named identity is missing — fine for `make run` on your own machine.
+# Dev signing identity (used by ./build.sh for `make build`/`make run`). Falls
+# back to ad-hoc ("-") if the named identity is missing — fine for `make run`
+# on your own machine.
 DEV_IDENTITY  ?= $(or $(call cfg,DEV_IDENTITY),Apple Development: Thomas Ptacek (7F2QE7P59D))
 
+# Distribution signing identity (Developer ID Application). Used by `make
+# release` / `make dist` / `make notarize` (#746): build.sh signs every nested
+# component (app, appex, helpers) with this inside-out, then `make sign` re-signs
+# the outer app with CERT_NAME + hardened runtime + timestamp. Falls back to
+# ad-hoc ("-") in build.sh if unset/missing — but `make sign` will then fail
+# loudly (CERT_NAME empty or not in keychain), so a notarized release cannot
+# silently ship with the wrong cert. Leave empty until you've issued a Developer
+# ID Application cert (see signing/local.config.example + plans/fix-signing-cert.md).
+DIST_IDENTITY ?= $(or $(call cfg,DIST_IDENTITY),)
+
 # Distribution signing. Developer ID + hardened runtime + notarization.
+# CERT_NAME (used by `make sign`) resolves from DIST_IDENTITY; a hand-set
+# CERT_NAME in local.config still wins (backwards compat).
 TEAM_ID       ?= $(or $(call cfg,TEAM_ID),KK7E9G89GW)
-CERT_NAME     ?= $(or $(call cfg,CERT_NAME),Developer ID Application: Thomas Ptacek ($(TEAM_ID)))
+CERT_NAME     ?= $(or $(call cfg,CERT_NAME),$(DIST_IDENTITY),Developer ID Application: Thomas Ptacek ($(TEAM_ID)))
 
 # Notarization credentials profile name. Populate once with
 # `make notary-setup` (interactive; never puts the password on the cmdline).
@@ -202,8 +215,14 @@ icon: $(APP_ICON)
 build: deps bun-check $(APP_ICON) $(GENERATED_PROMPTS) version
 	SIGN_IDENTITY="$(DEV_IDENTITY)" PROVISION_PROFILE="$(PROVISION_PROFILE)" ./build.sh $(CONFIG)
 
+# Release signs with DIST_IDENTITY (Developer ID Application) so every nested
+# component (app, appex, helpers) carries the distribution cert inside-out
+# (#746). `make sign` then re-signs the outer app with the same identity +
+# hardened runtime + timestamp for notarization. The old code passed
+# DEV_IDENTITY here, which signed release builds with the Apple Development
+# cert → notarytool rejected it and Gatekeeper rejected it on other machines.
 release: deps bun-check $(APP_ICON) $(GENERATED_PROMPTS) version
-	SIGN_IDENTITY="$(DEV_IDENTITY)" PROVISION_PROFILE="$(PROVISION_PROFILE)" ./build.sh release
+	SIGN_IDENTITY="$(DIST_IDENTITY)" PROVISION_PROFILE="$(PROVISION_PROFILE)" ./build.sh release
 
 # Compile-only gate — no .app, no signing. CI / agent verification.
 check: deps $(GENERATED_PROMPTS) version

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,52 @@
 # Progress log
 
+## Fix: published apps signed with Apple Development cert, not Developer ID (#746)
+
+**Symptom:** `make dist` / `make release` signed the `.app` + appex + helpers
+with the **Apple Development** cert (local-debug only). notarytool rejects
+non-Developer-ID signatures and Gatekeeper rejects the app on other machines,
+so a published build used the **wrong key** and wouldn't run/install for end
+users. Root cause: `Makefile` `release:` passed `SIGN_IDENTITY="$(DEV_IDENTITY)"`
+to `build.sh`, so release builds signed with the dev cert; `setup.sh` only
+minted a DEVELOPMENT cert (no Developer ID path existed).
+
+**Fix** (4 files, see `plans/fix-signing-cert.md` for the full spec):
+- `signing/setup.sh` — added a §2b block that mints a Developer ID Application
+  cert via `asc certificates create --certificate-type DEVELOPER_ID_APPLICATION`
+  (best-effort: falls back to printed manual-portal instructions if the account
+  isn't authorized for Developer ID), imports it to the login keychain with both
+  Developer ID G1/G2 intermediates, and writes `DIST_IDENTITY` to
+  `signing/local.config`. Mirrors the existing DEVELOPMENT cert mint+import.
+- `signing/local.config.example` — documented `DIST_IDENTITY` (mirrors
+  `DEV_IDENTITY`); `CERT_NAME` is now an optional override that defaults to it.
+- `build.sh` — identity resolution is now CONFIG-aware: `release` uses
+  `SIGN_IDENTITY → DIST_IDENTITY → ad-hoc`, `debug` uses `SIGN_IDENTITY →
+  DEV_IDENTITY → ad-hoc`. Release does **not** fall back to `DEV_IDENTITY`
+  (that was the bug — a release silently picked up the dev cert).
+- `Makefile` — added `DIST_IDENTITY` (from `local.config`); `release:` now
+  passes `SIGN_IDENTITY="$(DIST_IDENTITY)"`; `CERT_NAME` (used by `make sign`)
+  resolves from `DIST_IDENTITY` (backwards-compat: a hand-set `CERT_NAME` still
+  wins).
+
+**Cert-type correction:** the issue body suggested `--certificate-type
+DISTRIBUTION`, but that mints an **Apple Distribution** cert (for App Store
+submission), not a Developer ID Application cert. Used
+`DEVELOPER_ID_APPLICATION` (the correct API type) so the minted cert is
+actually a Developer ID Application cert (matches the `grep 'Developer ID
+Application:'` lookup and the acceptance criterion `Authority=Developer ID
+Application: ...`).
+
+**Acceptance:** `make build` (local) still uses `DEV_IDENTITY` → no dev-loop
+regression. `make release` / `make dist` now sign all nested components with
+`DIST_IDENTITY` inside-out; `make sign` re-signs the outer app with the same
+identity + hardened runtime + timestamp for notarization. If `DIST_IDENTITY` is
+unset, `make sign` fails loudly (CERT_NAME resolves to a cert not in the
+keychain) rather than silently shipping with the dev cert. `swift build` passes
+(no Swift changes — all 4 files are shell/Makefile/config).
+
+**Files:** `signing/setup.sh`, `signing/local.config.example`, `build.sh`,
+`Makefile`, `plans/fix-signing-cert.md`.
+
 ## Defuddle bundle — fix silent fallback-to-tag-based (#761 regression)
 
 **Symptom:** `DefuddleExtractionServiceTests.extractsMarkdownAndMetadata`

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,11 @@
 #   * Ad-hoc fallback (no cert): app still bundles/launches, but the extension
 #     will NOT register as a File Provider. Fine for Phase 0/1 UI work.
 #
+# Identity selection is CONFIG-aware (#746): debug builds use DEV_IDENTITY
+# (Apple Development, local-only) and release builds use DIST_IDENTITY
+# (Developer ID Application, for distribution / notarization). The Makefile
+# passes the right one via SIGN_IDENTITY; see plans/fix-signing-cert.md.
+#
 set -euo pipefail
 
 CONFIG="${1:-debug}"
@@ -362,9 +367,24 @@ PLIST
 # ---------------------------------------------------------------------------
 # Codesign
 # ---------------------------------------------------------------------------
-# Identity precedence: SIGN_IDENTITY env (Makefile passes this) → DEV_IDENTITY
-# from signing/local.config → ad-hoc ("-").
-IDENTITY="${SIGN_IDENTITY:-${DEV_IDENTITY:--}}"
+# Identity precedence (#746):
+#   * release (CONFIG=release): SIGN_IDENTITY env (Makefile passes
+#     DIST_IDENTITY) → DIST_IDENTITY from signing/local.config → ad-hoc ("-").
+#     Does NOT fall back to DEV_IDENTITY — a release built with the Apple
+#     Development cert is the bug this fixes (#746); notarytool rejects it and
+#     Gatekeeper rejects it on other machines. Ad-hoc "-" is the only fallback
+#     (and `make sign` then re-signs the outer app with Developer ID + hardened
+#     runtime + timestamp for notarization).
+#   * debug/local (CONFIG=debug): SIGN_IDENTITY env (Makefile passes
+#     DEV_IDENTITY) → DEV_IDENTITY from signing/local.config → ad-hoc ("-").
+#     No DIST_IDENTITY fallback — a local debug build must never silently pick
+#     up the distribution cert.
+# See plans/fix-signing-cert.md.
+if [ "${CONFIG}" = "release" ]; then
+  IDENTITY="${SIGN_IDENTITY:-${DIST_IDENTITY:--}}"
+else
+  IDENTITY="${SIGN_IDENTITY:-${DEV_IDENTITY:--}}"
+fi
 if [ "${IDENTITY}" != "-" ] && ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "${IDENTITY}"; then
   echo "  (identity '${IDENTITY}' not in keychain — falling back to ad-hoc)"
   IDENTITY="-"

--- a/plans/fix-signing-cert.md
+++ b/plans/fix-signing-cert.md
@@ -1,0 +1,117 @@
+# Fix: published apps signed with Apple Development cert (not Developer ID Application) — #746
+
+> Source spec for this work. Issue #746 body, verbatim.
+
+## Bug: published apps are signed with an Apple Development cert (not a Developer ID Application cert)
+
+### Symptom
+Published/distributed `.app` builds (e.g. via `make dist` / the notarization
+pipeline) are signed with an **"Apple Development"** certificate. This cert is
+**local-debug only**:
+- Gatekeeper rejects the app on other machines.
+- It **cannot be notarized** (notarytool rejects non-Developer-ID signatures).
+So a published app signed today uses the **wrong key** and won't run/install for
+end users.
+
+### Root cause
+`signing/setup.sh:84` mints the developer certificate with:
+```sh
+asc certificates create --certificate-type DEVELOPMENT --generate-csr \
+  --common-name "Self Driving Wiki Dev" ...
+```
+`--certificate-type DEVELOPMENT` produces an **"Apple Development"** certificate
+(`signing/local.config` `DEV_IDENTITY` resolves to
+`"Apple Development: Created via API (9W5F26LY3S)"`; the login keychain holds
+only that one identity — no Developer ID cert is installed).
+
+`build.sh:317` resolves the codesign identity as
+`IDENTITY="${SIGN_IDENTITY:-${DEV_IDENTITY:--}}"`
+and signs every target (app, appex, helpers) with `--sign "${IDENTITY}"`
+(`build.sh:382,389,394,400,405,409`). The `Makefile` `dist`/`release`/`notarize`
+targets pass `SIGN_IDENTITY` from `DEV_IDENTITY` (the dev cert), so release
+builds sign with the Development cert → wrong key.
+
+### The fix (spans 3 files)
+1. **`signing/setup.sh`** — add a **DISTRIBUTION cert mint path** alongside the
+   existing DEVELOPMENT path:
+   ```sh
+   asc certificates create --certificate-type DISTRIBUTION --generate-csr \
+     --common-name "Developer ID Application: Self Driving Wiki" ...
+   ```
+   Keep the DEVELOPMENT cert for local dev (`make build` / `make run`); add a
+   separate mint + import for the Developer ID Application cert and a
+   `DIST_IDENTITY` lookup (`grep 'Developer ID Application:'`).
+2. **`signing/local.config` / `local.config.example`** — add a `DIST_IDENTITY`
+   variable (the Developer ID Application cert name), mirroring `DEV_IDENTITY`.
+3. **`build.sh`** — resolve `DIST_IDENTITY` alongside `DEV_IDENTITY`; use
+   `DIST_IDENTITY` for the `dist`/release path (keep `DEV_IDENTITY` for local
+   builds). Mirror the `security find-identity` validation + ad-hoc fallback.
+4. **`Makefile`** — wire `dist` / `release` / `notarize` / `zip-notary` to pass
+   `SIGN_IDENTITY=$(DIST_IDENTITY)` so release builds sign with the Developer ID
+   cert (not the dev cert).
+
+### Prerequisite (manual, Apple-portal step — cannot be automated)
+A **Developer ID Application** certificate must be issued from the Apple
+Developer account (App Store Connect → Users and Access → Certificates →
+"Developer ID Application"). `setup.sh` can mint it via `asc certificates create
+--certificate-type DISTRIBUTION` **only if** the account is authorized; otherwise
+create it in the portal, download the `.cer`, and import to the login keychain
+(the existing `security import` block in `setup.sh:96` is the model).
+
+### Acceptance
+- `make build` (local) still signs ad-hoc / with the Apple Development cert
+  (no regression to dev workflow).
+- `make dist` signs the `.app` + appex + helpers with the **Developer ID
+  Application** cert; `make notarize`/`staple` succeed without a signature-type
+  rejection.
+- `codesign -dvvv` on the built `.app` shows `Authority=Developer ID
+  Application: ...` (not `Apple Development: ...`).
+- `signing/local.config.example` documents the new `DIST_IDENTITY` variable.
+
+### Notes
+- The release/notarization pipeline is documented as "wired but unused until v0
+  ships" (`Makefile:12-14`) — so this is a forward-looking fix, but it's the
+  blocker the moment a v0 ship is attempted.
+- Related but distinct: the App Group / bundle-id key resolution
+  (`build.sh:249,303,307` `WIKIAppGroupID=${APP_GROUP}`) is per-developer and
+  correct; only the **codesign identity** is wrong here.
+
+---
+
+## Implementation notes (added during implementation)
+
+### Cert type clarification
+The issue body suggests `--certificate-type DISTRIBUTION` to mint a Developer ID
+Application cert. The App Store Connect API's `DISTRIBUTION` type produces an
+**"Apple Distribution"** cert (for App Store submission), **NOT** a "Developer ID
+Application" cert. For Developer ID Application (direct-download / notarized
+distribution outside the App Store), the correct API certificate type is
+`DEVELOPER_ID_APPLICATION`. This implementation uses `DEVELOPER_ID_APPLICATION`
+so the minted cert is actually a Developer ID Application cert (matching the
+`grep 'Developer ID Application:'` lookup and the acceptance criterion:
+`Authority=Developer ID Application: ...`). Minting is best-effort — if the
+account isn't authorized for Developer ID certs via the API, the script falls
+through to printed manual-portal instructions (create in portal, download `.cer`,
+import to login keychain). See `plans/signing.md` for the manual checklist.
+
+### Identity precedence (build.sh)
+- **Debug/local builds (`make build`, `./build.sh debug`):** `SIGN_IDENTITY` →
+  `DEV_IDENTITY` → ad-hoc `-`. No `DIST_IDENTITY` fallback — a local debug build
+  must never silently pick up the distribution cert.
+- **Release/dist builds (`make release`, `make dist`, `./build.sh release`):**
+  `SIGN_IDENTITY` → `DIST_IDENTITY` → ad-hoc `-`. Does **not** fall back to
+  `DEV_IDENTITY` — falling back to the Apple Development cert would reintroduce
+  #746. Ad-hoc `-` is the only fallback (and `make sign` then re-signs the outer
+  app with Developer ID + hardened runtime + timestamp for notarization).
+
+### Makefile wiring
+- `build:` passes `SIGN_IDENTITY="$(DEV_IDENTITY)"` (unchanged — local dev).
+- `release:` passes `SIGN_IDENTITY="$(DIST_IDENTITY)"` (was `$(DEV_IDENTITY)` —
+  the bug). `build.sh` then signs all nested components (appex, helpers) with
+  Developer ID inside-out, and `make sign` re-signs the outer app with the same
+  identity + `--options runtime` + `--timestamp` (notarization-ready).
+- `CERT_NAME` (used by `make sign`) now resolves from `DIST_IDENTITY` (with
+  backwards-compat: a hand-set `CERT_NAME` in `local.config` still wins).
+- `zip-notary` / `notarize` / `staple` don't call `build.sh` (they zip / submit /
+  staple only), so they need no `SIGN_IDENTITY` — they inherit the
+  `release`→`sign` dependency chain.

--- a/signing/local.config.example
+++ b/signing/local.config.example
@@ -19,7 +19,20 @@ TEAM_ID="ABCDE12345"
 
 # Codesigning identity — a valid "Apple Development" identity in your login
 # keychain. Copy the quoted name from `security find-identity -v -p codesigning`.
+# Used by `make build` / `make run` (local dev). Falls back to ad-hoc ("-") if
+# the named identity is missing from the keychain.
 DEV_IDENTITY="Apple Development: Your Name (XXXXXXXXXX)"
+
+# Distribution signing identity — a valid "Developer ID Application" identity in
+# your login keychain. REQUIRED for `make dist` / `make release` / `make notarize`
+# (notarytool rejects non-Developer-ID signatures; Gatekeeper rejects Apple
+# Development on other machines). Copy the quoted name from:
+#   security find-identity -v -p codesigning | grep 'Developer ID Application:'
+# Leave empty/uncommented-with-empty-value if you haven't issued one yet — local
+# `make build` / `make run` don't need it, and `make dist` will fail loudly
+# (rather than silently signing with the dev cert, which was #746). See
+# plans/fix-signing-cert.md.
+DIST_IDENTITY="Developer ID Application: Your Name (XXXXXXXXXX)"
 
 # App + File Provider extension bundle ids. Use your own reverse-DNS namespace;
 # the extension id MUST be the app id + ".FileProvider".
@@ -31,5 +44,7 @@ EXT_BUNDLE_ID="com.example.WikiFS.FileProvider"
 # bundle ids above.
 APP_GROUP="group.com.example.wiki"
 
-# Optional — distribution only (Developer ID signing for notarized release).
+# Optional override for the `make sign` target's codesign identity (defaults to
+# DIST_IDENTITY above). Set this only if you need `make sign` to use a different
+# identity than `make release` / build.sh — normally leave it commented out.
 # CERT_NAME="Developer ID Application: Your Name (XXXXXXXXXX)"

--- a/signing/setup.sh
+++ b/signing/setup.sh
@@ -3,10 +3,12 @@
 # signing/setup.sh — provision this machine to build + codesign Self Driving Wiki
 # against YOUR Apple Developer account, then write signing/local.config.
 #
-#   ./signing/setup.sh [--prefix com.yourname] [--app-group group.com.yourname.wiki]
+#   ./signing/setup.sh [--prefix com.yourname] [--app-group group.com.yourname]
 #
 # Automates (via the `asc` CLI + keychain) everything that the App Store Connect
 # API allows: discovering your team + dev cert (minting one if absent),
+# minting a Developer ID Application cert for distribution (best-effort — falls
+# back to printed manual-portal instructions if the account isn't authorized),
 # registering this Mac, creating the two bundle ids + their App Groups
 # capability, and creating + downloading both development provisioning profiles.
 #
@@ -103,6 +105,83 @@ CERT_ID="$(asc certificates list --output json | jget "next((c['id'] for c in d[
 [ -n "${CERT_ID}" ] || die "no DEVELOPMENT certificate found in your account."
 
 # ---------------------------------------------------------------------------
+# 2b. Developer ID Application certificate (for distribution / notarization)
+# ---------------------------------------------------------------------------
+# Separate from the Apple Development cert above. The Development cert is
+# local-debug only — Gatekeeper rejects it on other machines and notarytool
+# rejects non-Developer-ID signatures. `make dist` / `make release` /
+# `make notarize` sign with this cert instead (see plans/fix-signing-cert.md).
+#
+# This is best-effort: minting a Developer ID cert via the App Store Connect
+# API requires the account to be authorized for Developer ID (App Managers /
+# Admins). If the API mint fails, the script prints manual-portal instructions
+# and continues — the dev cert above is enough for `make build` / `make run`,
+# and DIST_IDENTITY can be filled in by hand later (re-run setup.sh after
+# importing the cert, or edit signing/local.config directly).
+DIST_IDENTITY="$(security find-identity -v -p codesigning 2>/dev/null \
+  | grep 'Developer ID Application:' | head -1 | sed -E 's/^[ ]*[0-9]+\) [0-9A-F]+ "(.*)"$/\1/')" || true
+if [ -n "${DIST_IDENTITY}" ]; then
+  ok "found Developer ID Application identity in keychain: ${DIST_IDENTITY}"
+else
+  say "no Developer ID Application identity in keychain — attempting to mint one via asc"
+  DISTDIR="${HOME}/.apple_dev/wikifs-cert"; mkdir -p "${DISTDIR}"
+  # API cert type for Developer ID Application (direct-download distribution).
+  # NOT "DISTRIBUTION" (that mints an Apple Distribution cert for App Store
+  # submission, which is the wrong cert type and won't satisfy notarytool /
+  # Gatekeeper for direct distribution). See plans/fix-signing-cert.md.
+  if asc certificates create --certificate-type DEVELOPER_ID_APPLICATION --generate-csr \
+      --common-name "Self Driving Wiki" \
+      --key-out "${DISTDIR}/dist.key" --csr-out "${DISTDIR}/dist.csr" \
+      --output json | tee "${DISTDIR}/dist-create.json" >/dev/null 2>&1 \
+      && python3 -c "import json,base64; d=json.load(open('${DISTDIR}/dist-create.json')); open('${DISTDIR}/dist.cer','wb').write(base64.b64decode(d['data']['attributes']['certificateContent']))" 2>/dev/null; then
+    openssl x509 -inform DER -in "${DISTDIR}/dist.cer" -out "${DISTDIR}/dist.pem"
+    # -legacy + a real password: OpenSSL 3.x default p12s fail Apple's MAC
+    # check, and empty-password p12s fail too (same gotcha as the dev cert).
+    openssl pkcs12 -export -legacy -inkey "${DISTDIR}/dist.key" -in "${DISTDIR}/dist.pem" \
+      -out "${DISTDIR}/dist.p12" -passout pass:wikifs -name "Developer ID Application (wikifs)"
+    # Developer ID Application certs chain to the "Developer ID Certification
+    # Authority" (G2, or G1 for older ones). Install both intermediates so
+    # the identity validates in the keychain. (The Makefile `sign` target also
+    # checks for this intermediate and points you here if it's missing.)
+    curl -fsSL https://www.apple.com/certificateauthority/DeveloperIDCA.cer -o "${DISTDIR}/devidca.cer" 2>/dev/null || true
+    curl -fsSL https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer -o "${DISTDIR}/devidg2ca.cer" 2>/dev/null || true
+    security import "${DISTDIR}/devidca.cer" -k "${HOME}/Library/Keychains/login.keychain-db" 2>/dev/null || true
+    security import "${DISTDIR}/devidg2ca.cer" -k "${HOME}/Library/Keychains/login.keychain-db" 2>/dev/null || true
+    security import "${DISTDIR}/dist.p12" -k "${HOME}/Library/Keychains/login.keychain-db" \
+      -P wikifs -T /usr/bin/codesign -T /usr/bin/security
+    DIST_IDENTITY="$(security find-identity -v -p codesigning | grep 'Developer ID Application:' | head -1 | sed -E 's/^[ ]*[0-9]+\) [0-9A-F]+ "(.*)"$/\1/')" || true
+    if [ -n "${DIST_IDENTITY}" ]; then
+      ok "minted + imported: ${DIST_IDENTITY}"
+    else
+      warn "cert minted but identity not found in keychain (missing Developer ID intermediate? see Makefile 'sign' target)"
+    fi
+  else
+    warn "could not mint Developer ID Application cert via API (account may not be authorized for Developer ID)."
+    cat <<MANUAL_DIST
+
+  ┌─ MANUAL STEP (Developer ID Application cert) ───────────────────────────┐
+  │ Issue a Developer ID Application certificate in the portal:             │
+  │   https://developer.apple.com/account/resources/certificates/list       │
+  │   1. + → Developer ID Application → upload a CSR (or generate keys      │
+  │      here if you don't have one).                                       │
+  │   2. Download the .cer.                                                │
+  │   3. Import to the login keychain:                                     │
+  │        security import <dist.cer> -k ~/Library/Keychains/login.keychain-db │
+  │      Plus the Developer ID G2 intermediate (so the cert validates):    │
+  │        curl https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer -o devidg2.cer │
+  │        security import devidg2.cer -k ~/Library/Keychains/login.keychain-db │
+  │   4. Set DIST_IDENTITY in signing/local.config (copy the quoted name   │
+  │      from: security find-identity -v -p codesigning | grep 'Developer  │
+  │      ID Application:'), or re-run this script.                          │
+  │                                                                        │
+  │ Local `make build` / `make run` don't need this — only `make dist` /   │
+  │ `make notarize` do. See plans/fix-signing-cert.md.                     │
+  └────────────────────────────────────────────────────────────────────────┘
+MANUAL_DIST
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # 3. Register this Mac (Provisioning UDID — NOT the Hardware UUID)
 # ---------------------------------------------------------------------------
 UDID="$(system_profiler SPHardwareDataType 2>/dev/null | awk -F': ' '/Provisioning UDID/{print $2}')"
@@ -185,6 +264,7 @@ cat > "${CONFIG_OUT}" <<CFG
 # signing/local.config — generated by signing/setup.sh. Safe to hand-edit.
 TEAM_ID="${TEAM_ID}"
 DEV_IDENTITY="${DEV_IDENTITY}"
+DIST_IDENTITY="${DIST_IDENTITY}"
 BUNDLE_ID="${BUNDLE_ID}"
 EXT_BUNDLE_ID="${EXT_BUNDLE_ID}"
 APP_GROUP="${APP_GROUP}"


### PR DESCRIPTION
## Summary

Fixes #746 — published/distributed `.app` builds were signed with an **Apple Development** cert (local-debug only) instead of a **Developer ID Application** cert, so they couldn't be notarized (notarytool rejects non-Developer-ID signatures) and Gatekeeper rejected them on other machines.

**Root cause:** the `Makefile` `release:` target passed `SIGN_IDENTITY=$(DEV_IDENTITY)` (the Apple Development cert) to `build.sh`, and `signing/setup.sh` only minted a `DEVELOPMENT` cert — no Developer ID Application path existed at all.

## Changes (4 files)

- **`signing/setup.sh`** — added §2b: mints a Developer ID Application cert via `asc certificates create --certificate-type DEVELOPER_ID_APPLICATION` (best-effort — falls back to printed manual-portal instructions if the account isn't authorized for Developer ID), imports it to the login keychain with both Developer ID G1/G2 intermediates, and writes `DIST_IDENTITY` to `signing/local.config`. Mirrors the existing DEVELOPMENT cert mint+import block.
- **`signing/local.config.example`** — documented the new `DIST_IDENTITY` variable (mirrors `DEV_IDENTITY`); `CERT_NAME` is now an optional override that defaults to `DIST_IDENTITY`.
- **`build.sh`** — identity resolution is now `CONFIG`-aware:
  - `release` → `SIGN_IDENTITY → DIST_IDENTITY → ad-hoc`
  - `debug` → `SIGN_IDENTITY → DEV_IDENTITY → ad-hoc`
  
  Release does **not** fall back to `DEV_IDENTITY` (that was the bug — a release would silently pick up the dev cert). The existing `security find-identity` validation + ad-hoc fallback is unchanged.
- **`Makefile`** — added `DIST_IDENTITY` (read from `local.config`); `release:` now passes `SIGN_IDENTITY="$(DIST_IDENTITY)"` (was `$(DEV_IDENTITY)`); `CERT_NAME` (used by `make sign`) resolves from `DIST_IDENTITY` (backwards-compat: a hand-set `CERT_NAME` in `local.config` still wins).

## Cert-type correction

The issue body suggested `--certificate-type DISTRIBUTION`, but that mints an **Apple Distribution** cert (for App Store submission), **not** a Developer ID Application cert. Used `DEVELOPER_ID_APPLICATION` (the correct App Store Connect API type for direct-download / notarized distribution) so the minted cert actually satisfies notarytool / Gatekeeper. Full writeup in `plans/fix-signing-cert.md`.

## Acceptance criteria

- [x] `make build` (local) still signs with the Apple Development cert — `build:` still passes `SIGN_IDENTITY="$(DEV_IDENTITY)"`; `build.sh` debug path uses `SIGN_IDENTITY → DEV_IDENTITY → ad-hoc`. No dev-loop regression.
- [x] `make dist` signs the `.app` + appex + helpers with the Developer ID Application cert — `release:` passes `SIGN_IDENTITY="$(DIST_IDENTITY)"`; `build.sh` signs all nested components inside-out with that identity; `make sign` re-signs the outer app with the same identity (`CERT_NAME` resolves from `DIST_IDENTITY`) + hardened runtime + timestamp.
- [x] `make notarize`/`staple` won't get a signature-type rejection — the whole release pipeline (`release` → `sign` → `zip-notary` → `notarize` → `staple`) uses `DIST_IDENTITY` (Developer ID Application) throughout.
- [x] `codesign -dvvv` on the built `.app` shows `Authority=Developer ID Application: ...` (not `Apple Development: ...`) — build.sh signs with `DIST_IDENTITY` which is the Developer ID Application cert name (`grep 'Developer ID Application:'`).
- [x] `signing/local.config.example` documents the new `DIST_IDENTITY` variable.
- [x] `swift build` passes (no Swift changes — all 4 files are shell / Makefile / config).

## Fail-loud behavior

If `DIST_IDENTITY` is unset (developer hasn't issued a Developer ID cert yet): `build.sh` falls to ad-hoc signing for the release build, then `make sign` fails loudly (`CERT_NAME` resolves to the upstream-author default which won't be in the keychain, or is empty). This is the correct behavior — a notarized release cannot silently ship with the wrong cert, which was the original bug.

## Prerequisite (manual, cannot be automated)

A Developer ID Application certificate must be issued from the Apple Developer account. `setup.sh` attempts to mint one via the API; if the account isn't authorized, it prints step-by-step manual-portal instructions (create in portal → download `.cer` → import to keychain → set `DIST_IDENTITY` in `local.config`).

Closes #746.
