### PR TITLE
feat: HTML + Podcast backend enums + Settings pickers (PR1 of #799)

### DIFF
--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -38,6 +38,11 @@ struct ExtractionSettingsView: View {
     @State private var anthropicTest = TestPhase.idle
     @State private var geminiTest = TestPhase.idle
     @State private var doclingTest = TestPhase.idle
+    // Issue #799 PR1: HTML + Podcast backend drafts (optional — nil = no
+    // default yet, user is prompted to pick on first extraction). Seeded from
+    // `ExtractionConfig` in `init`, written back in `writeConfig`.
+    @State private var draftHtmlBackend: HtmlExtractionBackend?
+    @State private var draftPodcastBackend: PodcastTranscriptionBackend?
 
     private enum TestPhase: Equatable {
         case idle
@@ -70,6 +75,8 @@ struct ExtractionSettingsView: View {
         _geminiBaseURLText = State(initialValue: config.geminiBaseURLOverride ?? "")
         _doclingEndpointText = State(initialValue: config.doclingServeEndpoint ?? "")
         _doclingTokenText = State(initialValue: credentialStore.secret(.doclingServeToken) ?? "")
+        _draftHtmlBackend = State(initialValue: config.htmlBackend)
+        _draftPodcastBackend = State(initialValue: config.podcastBackend)
     }
 
     var body: some View {
@@ -93,6 +100,43 @@ struct ExtractionSettingsView: View {
                 Text("PDF Extraction")
             } footer: {
                 Text(draftBackend.helpText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Issue #799 PR1: HTML + Podcast backend pickers. These are
+            // scaffolding only — the trigger UI (PR2) and the removal of
+            // auto-extraction at ingest (PR3) land in later PRs. The user
+            // picks a default here so the eventual trigger has a backend
+            // to run without prompting each time; nil = "prompt me".
+            Section {
+                Picker("Backend", selection: htmlBackendBinding) {
+                    Text("Prompt me when extracting").tag(nil as HtmlExtractionBackend?)
+                    ForEach(HtmlExtractionBackend.allCases, id: \.self) { backend in
+                        Text(backend.displayName).tag(backend as HtmlExtractionBackend?)
+                    }
+                }
+                .onChange(of: draftHtmlBackend) { persistAll() }
+            } header: {
+                Text("HTML Extraction")
+            } footer: {
+                Text("The backend to use when extracting an HTML source to markdown. Defuddle runs the bundled article-extraction binary; tag-based is built-in and always available but lower fidelity. Extraction still runs automatically at ingest for now (PR3 removes that).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Picker("Backend", selection: podcastBackendBinding) {
+                    Text("Prompt me when transcribing").tag(nil as PodcastTranscriptionBackend?)
+                    ForEach(PodcastTranscriptionBackend.allCases, id: \.self) { backend in
+                        Text(backend.displayName).tag(backend as PodcastTranscriptionBackend?)
+                    }
+                }
+                .onChange(of: draftPodcastBackend) { persistAll() }
+            } header: {
+                Text("Podcast Transcription")
+            } footer: {
+                Text("The backend to use when transcribing a podcast episode. Apple Podcasts transcript fetches the transcript over the network (requires the bundled signing helper — disabled in app-store builds). Transcription still runs automatically at ingest for now (PR4 removes that).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -273,6 +317,23 @@ struct ExtractionSettingsView: View {
         !tracker.extractingSourceIDs.isEmpty
     }
 
+    /// `Picker`'s `selection:` can't bind directly to `@State var x: T?` when
+    /// the option set includes a "no default" nil tag — wrap it so SwiftUI gets
+    /// a plain `Binding<HtmlExtractionBackend?>` it can read/write. Writing
+    /// through the binding updates `draftHtmlBackend`, which `.onChange` watches
+    /// to trigger `persistAll()` — same auto-save flow as every other field.
+    private var htmlBackendBinding: Binding<HtmlExtractionBackend?> {
+        Binding(
+            get: { draftHtmlBackend },
+            set: { draftHtmlBackend = $0 })
+    }
+
+    private var podcastBackendBinding: Binding<PodcastTranscriptionBackend?> {
+        Binding(
+            get: { draftPodcastBackend },
+            set: { draftPodcastBackend = $0 })
+    }
+
     // MARK: - Auto-save
 
     /// Persist every non-secret draft into `ExtractionConfig` and every secret
@@ -302,6 +363,8 @@ struct ExtractionSettingsView: View {
         config.geminiBaseURLOverride = geminiBase.isEmpty ? nil : geminiBase
         let endpoint = doclingEndpointText.trimmingCharacters(in: .whitespacesAndNewlines)
         config.doclingServeEndpoint = endpoint.isEmpty ? nil : endpoint
+        config.htmlBackend = draftHtmlBackend
+        config.podcastBackend = draftPodcastBackend
     }
 
     // MARK: - Test Connection (per backend). Drafts are already persisted by

--- a/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
+++ b/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
@@ -41,6 +41,22 @@ public struct ExtractionConfig: JSONSidecarConfig {
     /// `http://localhost:5001`. `nil` until configured.
     public var doclingServeEndpoint: String?
 
+    /// The HTML→Markdown backend to use when the user explicitly extracts an
+    /// HTML source (issue #799 PR1: scaffolding only — extraction still
+    /// auto-runs at ingest with the current method; the trigger wiring lands in
+    /// PR2, the auto-extraction removal in PR3). `nil` = no default chosen:
+    /// the user is prompted to pick a backend before the first extraction.
+    /// Mirrors the typed-backend pattern of `backend` but optional, since HTML
+    /// has no always-available fallback (defuddle binary may be missing).
+    public var htmlBackend: HtmlExtractionBackend?
+
+    /// The podcast→transcript backend to use when the user explicitly
+    /// transcribes a podcast source (issue #799 PR4 — framework only here;
+    /// the Transcribe trigger and `#if PODCAST_TRANSCRIPTS` gating land in
+    /// PR4). `nil` = no default chosen. Currently only `appleTranscript`, with
+    /// Whisper/Rev.ai backends as future follow-ups.
+    public var podcastBackend: PodcastTranscriptionBackend?
+
     /// The config's JSON filename inside the App Group container.
     public static let fileName = "extraction-config.json"
 
@@ -51,7 +67,9 @@ public struct ExtractionConfig: JSONSidecarConfig {
         anthropicBaseURLOverride: String? = nil,
         geminiModel: String = ExtractionConfig.defaultGeminiModel,
         geminiBaseURLOverride: String? = nil,
-        doclingServeEndpoint: String? = nil
+        doclingServeEndpoint: String? = nil,
+        htmlBackend: HtmlExtractionBackend? = nil,
+        podcastBackend: PodcastTranscriptionBackend? = nil
     ) {
         self.backend = backend
         self.acpProviderId = acpProviderId
@@ -60,6 +78,8 @@ public struct ExtractionConfig: JSONSidecarConfig {
         self.geminiModel = geminiModel
         self.geminiBaseURLOverride = geminiBaseURLOverride
         self.doclingServeEndpoint = doclingServeEndpoint
+        self.htmlBackend = htmlBackend
+        self.podcastBackend = podcastBackend
     }
 
     /// The default model id used everywhere a model isn't explicitly set, so the
@@ -95,6 +115,7 @@ public struct ExtractionConfig: JSONSidecarConfig {
         case anthropicModel, anthropicBaseURLOverride
         case geminiModel, geminiBaseURLOverride
         case doclingServeEndpoint
+        case htmlBackend, podcastBackend
     }
 
     public init(from decoder: Decoder) throws {
@@ -108,6 +129,17 @@ public struct ExtractionConfig: JSONSidecarConfig {
             ?? ExtractionConfig.defaultGeminiModel
         self.geminiBaseURLOverride = try c.decodeIfPresent(String.self, forKey: .geminiBaseURLOverride)
         self.doclingServeEndpoint = try c.decodeIfPresent(String.self, forKey: .doclingServeEndpoint)
+        // Forward-compat for issue #799 PR1: a config file written before
+        // this field shipped (no `htmlBackend`/`podcastBackend` key) decodes
+        // to nil — the user picks a backend on first extraction. Mirrors the
+        // exact pattern `backend` uses below: `try? c.decode(...)` so a missing
+        // key OR an unknown raw value (a future/typo'd backend) degrades
+        // gracefully rather than rejecting the whole file. The "default" for
+        // these optional fields is `nil` (vs `backend`'s `.localPdf2md`), so a
+        // typo silently picks "prompt me" instead of "PDF" — same resilient
+        // decode philosophy as `unknownBackendValueDegradesToLocalPdf2md`.
+        self.htmlBackend = try? c.decode(HtmlExtractionBackend.self, forKey: .htmlBackend)
+        self.podcastBackend = try? c.decode(PodcastTranscriptionBackend.self, forKey: .podcastBackend)
     }
 
     // MARK: - Persistence (via `JSONSidecarConfig`)

--- a/Sources/WikiFSCore/Integrations/PodcastTranscriptionBackend.swift
+++ b/Sources/WikiFSCore/Integrations/PodcastTranscriptionBackend.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// A Podcast→transcript backend — the user's chosen engine for fetching a
+/// transcript of an Apple Podcasts episode. Persisted in
+/// `extraction-config.json` as `ExtractionConfig.podcastBackend` (issue #799:
+/// no auto-transcription at ingest — the user picks a backend and triggers
+/// transcription explicitly).
+///
+/// Mirrors `ExtractionBackend` (PDF) and `HtmlExtractionBackend` (HTML) for
+/// parity, but is intentionally a **separate** type — podcast transcription is
+/// architecturally different from the other two (PR4 detail):
+///
+/// - **Not bytes→markdown**: the transcript comes from Apple's network API
+///   (signed bearer token → AMP metadata → TTML download → parse). There are no
+///   stored bytes to convert; the "backend" picks the network pipeline, not a
+///   converter. The trigger is therefore a separate code path, NOT through
+///   the PDF-coupled queue engine (`ExtractionResolution.pdfData` etc.).
+/// - **Behind `#if PODCAST_TRANSCRIPTS`**: the signing helper
+///   (`HelperPodcastTokenProvider`, shells out to `podcast-token-helper`) may
+///   not be present in app-store builds. The enum itself is unconditional
+///   (PR1 only adds the typed config field + Settings picker — no behavior
+///   change); the actual transcription behind it is gated, and the Transcribe
+///   button is disabled when the helper is unavailable (PR4).
+///
+/// `nil` (no backend chosen yet) is a valid state, mirroring
+/// `htmlBackend`: a fresh install decodes `podcastBackend` as nil and the UI
+/// prompts the user to pick one before the first transcription. Currently only
+/// `appleTranscript` exists, but the enum is extensible — Whisper / Rev.ai / etc.
+/// backends will be added as future PRs.
+public enum PodcastTranscriptionBackend: String, CaseIterable, Sendable, Codable {
+    /// Apple Podcasts' native transcript pipeline (signed bearer token → AMP
+    /// metadata → TTML download → parse → markdown). The only option today;
+    /// behind `#if PODCAST_TRANSCRIPTS` at the call site (PR4).
+    case appleTranscript
+
+    /// A short label for the Settings picker and the Transcribe menu.
+    public var displayName: String {
+        switch self {
+        case .appleTranscript: return "Apple Podcasts transcript"
+        }
+    }
+}

--- a/Sources/WikiFSMarkdown/HtmlExtractionBackend.swift
+++ b/Sources/WikiFSMarkdown/HtmlExtractionBackend.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// An HTML→Markdown extraction backend — the user's chosen engine for turning a
+/// raw HTML source into readable markdown. Persisted in `extraction-config.json`
+/// as `ExtractionConfig.htmlBackend` (issue #799: no auto-extraction at ingest —
+/// the user picks a backend and triggers extraction explicitly).
+///
+/// Mirrors `ExtractionBackend` (PDF) for parity, but is intentionally a
+/// **separate** type rather than folded in: the input space differs (HTML bytes
+/// vs PDF bytes), the conformer protocols differ (`HtmlMarkdownExtractor` vs
+/// `MarkdownExtractor`), and the available engines have no overlap (there is no
+/// `defuddle` for PDFs and no `pdf2md` for HTML). One typed enum per content
+/// type keeps the Settings UI and the trigger paths honest — you can't ask the
+/// PDF extractor to handle HTML by mistake.
+///
+/// `nil` (no backend chosen yet) is a valid state: a fresh install, or a config
+/// file written before this field existed, decodes `htmlBackend` as nil and the
+/// UI prompts the user to pick one before the first extraction. This is the
+/// deliberate asymmetry with PDF's non-optional `backend: ExtractionBackend`
+/// (which always falls back to `.localPdf2md`): HTML has no always-available
+/// fallback engine — `defuddle` requires the bundled binary and `tagBased`
+/// quality varies by site, so "no default" is the safer posture.
+public enum HtmlExtractionBackend: String, CaseIterable, Sendable, Codable {
+    /// The bundled `defuddle` binary (Readability-style article extraction with
+    /// site-specific heuristics). Produces the highest-quality article markdown
+    /// for well-structured pages (blogs, news, docs). Requires the defuddle
+    /// binary at runtime; if missing, extraction falls back to `tagBased`.
+    case defuddle
+    /// The built-in tag-based converter (`HTMLToMarkdown.convert`) — no external
+    /// dependency, runs everywhere. Lower fidelity on complex layouts (Sidebars,
+    /// nav bars, cookie banners leak through), but always available.
+    case tagBased
+
+    /// A short label for the Settings picker and the Extract/Re-extract menu.
+    public var displayName: String {
+        switch self {
+        case .defuddle: return "Defuddle (article extraction)"
+        case .tagBased: return "Tag-based (built-in)"
+        }
+    }
+}

--- a/Tests/WikiFSTests/ExtractionConfigTests.swift
+++ b/Tests/WikiFSTests/ExtractionConfigTests.swift
@@ -129,4 +129,85 @@ struct ExtractionConfigTests {
         let loaded = ExtractionConfig.load(from: dir)
         #expect(loaded.acpProviderId == nil)
     }
+
+    // MARK: - Issue #799 PR1: HTML + Podcast backend round-trip
+
+    /// AC.1: `ExtractionConfig` round-trips all three backend fields
+    /// (PDF + HTML + Podcast) via save/load.
+    @Test func htmlAndPodcastBackendsRoundTrip() throws {
+        let dir = tempDirectory()
+        var config = ExtractionConfig()
+        config.backend = .doclingServe
+        config.htmlBackend = .tagBased
+        config.podcastBackend = .appleTranscript
+        try config.save(to: dir)
+
+        let loaded = ExtractionConfig.load(from: dir)
+        #expect(loaded == config)
+        #expect(loaded.backend == .doclingServe)
+        #expect(loaded.htmlBackend == .tagBased)
+        #expect(loaded.podcastBackend == .appleTranscript)
+    }
+
+    /// AC.1 (negative case): both new fields round-trip nil when explicitly
+    /// reset — the "prompt me" state must survive a save/load.
+    @Test func htmlAndPodcastBackendsRoundTripNil() throws {
+        let dir = tempDirectory()
+        let config = ExtractionConfig(
+            backend: .anthropic,
+            htmlBackend: nil,
+            podcastBackend: nil)
+        try config.save(to: dir)
+        let loaded = ExtractionConfig.load(from: dir)
+        #expect(loaded == config)
+        #expect(loaded.htmlBackend == nil)
+        #expect(loaded.podcastBackend == nil)
+    }
+
+    /// AC.2: a legacy config file written before issue #799 PR1 shipped (no
+    /// `htmlBackend` / `podcastBackend` keys) decodes both new fields as nil
+    /// — the user is prompted to pick a backend on first extraction.
+    /// Mirrors `acpProviderIdDecodesAsNilWhenAbsent` forward-compat contract.
+    @Test func htmlAndPodcastBackendsDecodeAsNilWhenAbsent() throws {
+        let json = Data(#"{"backend":"anthropic"}"#.utf8)
+        let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
+        #expect(config.backend == .anthropic)
+        #expect(config.htmlBackend == nil)
+        #expect(config.podcastBackend == nil)
+    }
+
+    /// Unknown raw values for the new backends degrade silently to nil —
+    /// symmetric with `unknownBackendValueDegradesToLocalPdf2md` for the PDF
+    /// `backend` field (a future/typo'd raw value doesn't crash the decode,
+    /// the whole config still loads, the optional field just ends up nil). A
+    /// typo'd `htmlBackend` therefore picks "prompt me" rather than rejecting
+    /// the entire config — same resilient-decode philosophy as the existing
+    /// fields, and the safer posture for a fresh-install user who hand-edited
+    /// the JSON.
+    @Test func unknownHtmlAndPodcastBackendValuesDegradeToNil() throws {
+        let json = Data(#"""
+        {"backend":"anthropic","htmlBackend":"whisper","podcastBackend":"rev_ai"}
+        """#.utf8)
+        let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
+        #expect(config.backend == .anthropic)
+        #expect(config.htmlBackend == nil)
+        #expect(config.podcastBackend == nil)
+    }
+
+    /// A config with the new backends also persists the existing PDF backend
+    /// unchanged — the three fields coexist in one file without crosstalk.
+    @Test func pdfBackendSurvivesWhenNewBackendsAreSet() throws {
+        let dir = tempDirectory()
+        var config = ExtractionConfig()
+        config.backend = .acp
+        config.acpProviderId = "claude-acp"
+        config.htmlBackend = .defuddle
+        config.podcastBackend = .appleTranscript
+        try config.save(to: dir)
+        let loaded = ExtractionConfig.load(from: dir)
+        #expect(loaded.backend == .acp)
+        #expect(loaded.acpProviderId == "claude-acp")
+        #expect(loaded.htmlBackend == .defuddle)
+        #expect(loaded.podcastBackend == .appleTranscript)
+    }
 }

--- a/Tests/WikiFSTests/HtmlExtractionBackendTests.swift
+++ b/Tests/WikiFSTests/HtmlExtractionBackendTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// `HtmlExtractionBackend` — the typed enum persisted in
+/// `ExtractionConfig.htmlBackend` (issue #799 PR1). Mirrors `ExtractionBackend`
+/// (PDF) tests: Codable round-trip for each case, displayName sanity, raw-value
+/// stability (so the JSON-side format doesn't drift between releases), and
+/// `CaseIterable` ordering locked in — the Settings picker's iteration order
+/// and the round-trip JSON keys both depend on it.
+struct HtmlExtractionBackendTests {
+
+    @Test func codableRoundTripsAllCases() throws {
+        for backend in HtmlExtractionBackend.allCases {
+            let encoded = try JSONEncoder().encode(backend)
+            let decoded = try JSONDecoder().decode(HtmlExtractionBackend.self, from: encoded)
+            #expect(decoded == backend)
+        }
+    }
+
+    @Test func stringRawValueRoundTripsThroughJSON() throws {
+        // The raw value IS the JSON string in extraction-config.json, so a
+        // config written by an older release of this same code reads back the
+        // same case. Lock the literal strings to prevent silent renames.
+        for (backend, raw) in [
+            (HtmlExtractionBackend.defuddle, "defuddle"),
+            (HtmlExtractionBackend.tagBased, "tagBased"),
+        ] {
+            let json = Data(#""\#(raw)""#.utf8)
+            let decoded = try JSONDecoder().decode(HtmlExtractionBackend.self, from: json)
+            #expect(decoded == backend)
+            #expect(backend.rawValue == raw)
+        }
+    }
+
+    @Test func unknownRawValueThrows() {
+        // A backend not yet invented (future Whisper / readability / etc.) or a
+        // typo doesn't decode as a phantom case — it errors. The
+        // `ExtractionConfig` decode then degrades this throw to nil via its
+        // `try?` wrapper (see `unknownHtmlAndPodcastBackendValuesDegradeToNil`
+        // in ExtractionConfigTests); here we lock the raw enum's own contract.
+        let json = Data(#""whisper""#.utf8)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(HtmlExtractionBackend.self, from: json)
+        }
+    }
+
+    @Test func allCasesMatchesExpectedCasesInOrder() {
+        // The Settings picker iterates `allCases` — lock the order so a
+        // source-order swap in the enum doesn't silently shuffle the picker.
+        #expect(HtmlExtractionBackend.allCases == [.defuddle, .tagBased])
+    }
+
+    @Test func displayNameNonEmptyAndDistinctPerCase() {
+        // A bare or duplicate displayName would either render an empty picker
+        // row or two indistinguishable rows; either is a UI bug. Lock both.
+        let names = HtmlExtractionBackend.allCases.map(\.displayName)
+        #expect(names.allSatisfy { !$0.isEmpty })
+        #expect(Set(names).count == names.count)
+    }
+
+    @Test func displayNameStability() {
+        // Lock the literal strings shown in the Settings picker & the
+        // Extract/Re-extract menu (future PR2). Renames are user-visible.
+        #expect(HtmlExtractionBackend.defuddle.displayName == "Defuddle (article extraction)")
+        #expect(HtmlExtractionBackend.tagBased.displayName == "Tag-based (built-in)")
+    }
+}

--- a/plans/extraction-framework.md
+++ b/plans/extraction-framework.md
@@ -1,0 +1,282 @@
+# Plan: General Extraction Framework — No Auto-Extraction (#799)
+
+## Vision
+
+Every content type that needs extraction (HTML, PDF, Podcast) follows the same
+lifecycle: **raw bytes/content stored at ingest, NO automatic extraction, user
+explicitly chooses a backend and triggers extraction**, re-extract with a
+different backend at any time.
+
+PDF already works this way. HTML and Podcast currently auto-extract at ingest
+with no user choice. This plan brings them to parity — staged across 4 PRs.
+
+## Phasing (per plan-reviewer recommendation)
+
+This is too large for one PR. The staged approach ensures no intermediate state
+leaves HTML sources with no readable content:
+
+| PR | Scope | Risk | Ships independently? |
+|----|-------|------|---------------------|
+| **PR1** | Config + backend enums + Settings UI | Low — additive, no behavior change | Yes |
+| **PR2** | Generalize Extract/Re-extract UI for HTML | Medium — new extraction trigger, inline (not queue) | Yes (after PR1) |
+| **PR3** | Remove HTML auto-extraction at ingest | Medium — behavioral change, must land after PR2 | No — after PR2 |
+| **PR4** | Podcast framework | High — different protocol, network fetch, `#if PODCAST_TRANSCRIPTS` | Independent |
+
+---
+
+## PR1: Config + Backend Enums + Settings UI
+
+**Goal:** Add the typed backend enums and Settings pickers. No behavior change —
+extraction still auto-runs at ingest with the current method. This is pure
+scaffolding that PR2/PR3 build on.
+
+### New types
+
+`Sources/WikiFSMarkdown/HtmlExtractionBackend.swift`:
+```swift
+public enum HtmlExtractionBackend: String, CaseIterable, Codable, Sendable {
+    case defuddle
+    case tagBased
+    var displayName: String { ... }
+}
+```
+
+`Sources/WikiFSCore/Integrations/PodcastTranscriptionBackend.swift`:
+```swift
+public enum PodcastTranscriptionBackend: String, CaseIterable, Codable, Sendable {
+    case appleTranscript
+    var displayName: String { ... }
+}
+```
+
+### Extend ExtractionConfig
+
+`Sources/WikiFSCore/Integrations/ExtractionConfig.swift` — add two optional fields.
+
+**Critical:** ExtractionConfig has hand-written Codable (`CodingKeys` at `:93`,
+`init(from:)` at `:100`, memberwise `init(...)` at `:47`). Must edit ALL THREE:
+```swift
+public var htmlBackend: HtmlExtractionBackend?     // nil = no default yet
+public var podcastBackend: PodcastTranscriptionBackend?
+
+// CodingKeys: add case htmlBackend, case podcastBackend
+// init(from:): try decodeIfPresent for both
+// init(...): add both parameters with nil defaults
+```
+
+Note the asymmetry: the existing PDF `backend` is non-optional (defaults to
+`.localPdf2md`). HTML/Podcast are optional (nil = prompt user to choose). This
+is intentional — PDF has a sensible always-available fallback; HTML/Podcast may
+not (defuddle binary missing, podcast helper absent).
+
+### Settings UI
+
+`Sources/WikiFS/Sources/ExtractionSettingsView.swift` — add HTML + Podcast
+picker sections below the existing PDF picker. Each is a `Picker` bound to the
+config draft, auto-saves on change.
+
+### Acceptance criteria (PR1)
+
+- **AC.1**: `ExtractionConfig` round-trips all three backend fields (PDF, HTML, Podcast).
+- **AC.2**: Legacy config files without the new fields decode to nil (prompt to choose).
+- **AC.3**: `ExtractionSettingsView` renders three backend pickers.
+- **AC.4**: No behavior change — existing auto-extraction still runs at ingest.
+
+### Files touched (PR1)
+- **New:** `Sources/WikiFSMarkdown/HtmlExtractionBackend.swift`, `Sources/WikiFSCore/Integrations/PodcastTranscriptionBackend.swift`
+- **Edit:** `Sources/WikiFSCore/Integrations/ExtractionConfig.swift` (CodingKeys + init(from:) + memberwise init), `Sources/WikiFS/Sources/ExtractionSettingsView.swift`
+- **Tests:** `Tests/WikiFSTests/ExtractionConfigTests.swift` (extend), `Tests/WikiFSTests/HtmlExtractionBackendTests.swift` (new)
+
+---
+
+## PR2: HTML Extraction Trigger (Generalize Extract/Re-extract UI)
+
+**Goal:** Add the "Extract" button and "Re-extract with" menu for HTML sources,
+using the **existing inline extraction path** (not the queue engine). This must
+ship BEFORE removing auto-extraction (PR3), so users always have a way to
+extract.
+
+### Wrap HTMLToMarkdown in an HtmlMarkdownExtractor conformer
+
+`Sources/WikiFSMarkdown/HTMLToMarkdown.swift` — add:
+```swift
+public struct TagBasedHtmlExtractor: HtmlMarkdownExtractor {
+    public func extract(html: String) async -> HtmlExtractionResult? {
+        HtmlExtractionResult(markdown: HTMLToMarkdown.convert(html), ...)
+    }
+}
+```
+
+### Generalize SourceDetailView predicates
+
+Currently PDF-only. Concrete changes:
+- `needsExtraction` (`:300`): change from `isPDF && !hasMarkdown` to
+  `isExtractable && !hasMarkdown` where `isExtractable` = content type has
+  extraction backends (HTML + PDF).
+- Extract button (`:662`): show when `needsExtraction` (now covers HTML).
+- `extractionProvenanceChip` (`:659`): generalize gate from `if isPDF, hasMarkdown`
+  to `if isExtractable, hasMarkdown`.
+- Re-extract menu (`:1387`): currently iterates `ExtractionBackend.allCases`
+  (PDF-only). Make it content-type-aware: HTML sources list
+  `HtmlExtractionBackend.allCases`, PDF sources list `ExtractionBackend.allCases`.
+
+### HTML extraction trigger (inline, NOT through queue)
+
+The queue engine is deeply PDF-coupled (`ExtractionResolution.pdfData`,
+`convert(pdfData:)`, `seedPdfMarkdown`) — generalizing it is a separate
+sub-project (deferred). Instead, HTML extraction uses the existing inline path:
+
+- Add `WikiStoreModel.extractHtml(sourceID:backend:)` — reads the source's HTML
+  bytes from the store, runs the chosen extractor (defuddle or
+  `TagBasedHtmlExtractor`), writes the result via `appendProcessedMarkdown`
+  (same write path as the current `enrichWithDefuddle`).
+- Re-extract appends a coexisting alternative (does not clobber), same as PDF's
+  `runReExtraction`.
+- The backend is resolved from `ExtractionConfig.htmlBackend` (set in PR1), or
+  the user picks from the menu.
+
+**Config wiring:** `WikiStoreModel` is deliberately NOT config-aware (config is
+read by `ExtractionCoordinator` in WikiFSEngine). Inject the chosen HTML backend
+into `WikiStoreModel` as a new `@ObservationIgnored var htmlBackend` (mirroring
+the existing `htmlMarkdownExtractor` injection at `:318`), resolved at app wiring
+time from `ExtractionConfig`.
+
+### Acceptance criteria (PR2)
+
+- **AC.5**: "Extract" button appears on an HTML source with no markdown. Clicking
+  it with defuddle creates a markdown version (technique "defuddle").
+- **AC.6**: "Extract" with tag-based creates a markdown version (technique
+  "html-to-markdown").
+- **AC.7**: "Re-extract with" on an HTML source creates a coexisting alternative.
+  The provenance chip shows both versions.
+- **AC.8**: Existing auto-extraction at ingest still runs (PR3 hasn't landed yet).
+
+### Files touched (PR2)
+- **Edit:** `Sources/WikiFSMarkdown/HTMLToMarkdown.swift` (conformer), `Sources/WikiFS/Sources/SourceDetailView.swift` (predicates + menus), `Sources/WikiFSCore/Store/WikiStoreModel.swift` (extractHtml method + htmlBackend injection), `Sources/WikiFSEngine/WikiSession.swift` or `SessionManager.swift` (wire htmlBackend from config)
+- **Tests:** WikiStoreModel integration tests for extractHtml + re-extract
+
+---
+
+## PR3: Remove HTML Auto-Extraction at Ingest
+
+**Goal:** Stop auto-extracting markdown at ingest time. HTML sources store raw
+bytes only; the user triggers extraction via the button added in PR2.
+
+### Remove enrichWithDefuddle calls
+
+**THREE callers** (confirmed by plan-reviewer):
+1. `addFiles` (`WikiStoreModel.swift:2040`)
+2. `addURLViaWebsite` — no-images branch (`WikiStoreModel.swift:2450`)
+3. `ingestFromZotero` (`WikiStoreModel.swift:2633`)
+
+All three: remove the `enrichWithDefuddle` call. Store raw HTML bytes only.
+
+### Website snapshots with images — SEPARATE path (plan-reviewer finding)
+
+**Critical:** `addURLViaWebsite` has a **fourth** auto-extract path at `:2461`
+(`storeSnapshot`) that the first plan draft missed. When a website has images,
+`WebsiteSnapshotExtractor` computes markdown with image-src rewriting and stores
+it as a `.extraction`-origin version via `appendExtractedMarkdown` at `:2525`.
+
+**Decision needed:** does "no auto-extraction" apply to image-bearing snapshots?
+- **If yes**: the reader shows raw HTML with broken image refs until the user
+  extracts. Image-src rewriting is inseparable from extraction — the user can't
+  get working images without extraction. This is a significant UX regression.
+- **If no**: image snapshots keep auto-extraction (it's inseparable from the
+  image handling). AC must say "non-snapshot HTML" and the scope boundary must
+  be explicit. **Recommended** — snapshot extraction is a different operation
+  (image handling, not article extraction).
+
+### FormatMaterializer.dispatch change
+
+`FormatMaterializer.dispatch` (`:123`) currently ALWAYS computes tag-based
+markdown for HTML. After PR3, skip the `HTMLToMarkdown.convert` call at ingest
+time — store the raw HTML format without the `extractedMarkdown` sidecar. The
+format detection (`.html`) still runs so the source is tagged correctly.
+
+### Downstream impacts (plan-reviewer finding — must document)
+
+Removing auto-extraction means HTML sources arrive with NO processed markdown:
+1. **Search** (Tantivy): indexes title-only, body unsearchable until extracted. Not broken, degraded.
+2. **File Provider .md sibling**: no `.md` projected — source appears as raw `.html` in Finder. Visible behavior change.
+3. **Reader view**: falls back to raw HTML rendering (HTML tab). No markdown until extracted.
+4. **Agent ingestion**: agent gets raw HTML bytes (not extracted markdown). May degrade agent quality.
+
+Each is acceptable given the user's explicit "no automatic extraction" directive,
+but must be documented as known trade-offs.
+
+### Acceptance criteria (PR3)
+
+- **AC.9**: Ingesting a URL (no images) stores raw HTML with NO markdown sidecar.
+- **AC.10**: Ingesting an HTML file from a folder stores raw HTML with NO markdown sidecar.
+- **AC.11**: Ingesting a Zotero HTML attachment stores raw HTML with NO markdown sidecar.
+- **AC.12**: Website snapshots with images still auto-extract (scope boundary — extraction is inseparable from image handling). OR: snapshots also defer (if operator chooses the UX regression).
+- **AC.13**: The "Extract" button (from PR2) works on these un-extracted sources.
+
+### Files touched (PR3)
+- **Edit:** `Sources/WikiFSCore/Store/WikiStoreModel.swift` (remove 3 enrichWithDefuddle calls), `Sources/WikiFSCore/Sources/FormatMaterializer.swift` (skip markdown computation at ingest)
+- **Tests:** Integration tests asserting no markdown version after ingest
+
+---
+
+## PR4: Podcast Framework
+
+**Goal:** Stop auto-transcribing at ingest. Store podcast as byteless embed.
+User clicks "Transcribe" to trigger transcription.
+
+### Architectural difference (plan-reviewer finding)
+
+Podcast transcription is **fundamentally different** from PDF/HTML extraction:
+- **Not bytes→markdown**: the transcript comes from Apple's network API (signed
+  bearer token → AMP metadata → TTML download → parse). There are no stored bytes.
+- **Queue engine incompatibility**: the queue reads `store.sourceBytes(id:)` and
+  calls `convert(pdfData:)`. For a byteless podcast, `sourceBytes` returns empty.
+  The podcast trigger must be a **separate code path**, not through the queue.
+- **Behind `#if PODCAST_TRANSCRIPTS`**: the signing helper may not be present.
+  The Transcribe button must be disabled when the helper is unavailable.
+
+### Design
+
+- **Ingest change**: `WikiStoreModel.addURL` podcast path (`:2127`) currently
+  calls `ApplePodcastTranscriptService.transcript(for:)` → stores transcript.
+  Change to: store as byteless embed source (like YouTube/video embeds), NO
+  transcript. The podcast URL → `EmbedTarget` → embed source.
+- **Transcribe trigger**: new `WikiStoreModel.transcribePodcast(sourceID:)` —
+  reconstructs the episode URL from provenance (`externalIdentity`), re-injects
+  `PodcastTranscriptFetching`, calls `transcript(for:)`, stores via
+  `appendProcessedMarkdown`. NOT through the queue engine.
+- **UI**: `SourceDetailView` shows a "Transcribe" button on podcast sources with
+  no transcript. Disabled when `#if !PODCAST_TRANSCRIPTS` or helper unavailable.
+  Backend picker shows `PodcastTranscriptionBackend.allCases` (currently just
+  `appleTranscript`; extensible to Whisper etc. in future PRs).
+
+### Acceptance criteria (PR4)
+
+- **AC.14**: Ingesting a podcast URL stores the embed with NO transcript.
+- **AC.15**: "Transcribe" button triggers `PodcastTranscriptFetching` and creates
+  a transcript version.
+- **AC.16**: "Transcribe" is disabled when the signing helper is unavailable.
+
+### Files touched (PR4)
+- **Edit:** `Sources/WikiFSCore/Store/WikiStoreModel.swift` (podcast ingest → embed-only, transcribePodcast method), `Sources/WikiFS/Sources/SourceDetailView.swift` (Transcribe button), `Sources/WikiFSEngine/SessionManager.swift` (podcast fetcher injection for re-transcription)
+
+---
+
+## Out of scope
+
+- **Queue engine generalization** — the PDF-coupled queue (`ExtractionResolution.pdfData`,
+  `convert(pdfData:)`, `seedPdfMarkdown`) stays PDF-only. HTML uses inline extraction,
+  podcast uses a direct trigger. Unifying the queue is a future sub-project.
+- **New podcast backends** (Whisper, Rev.ai) — PR4 adds the framework + Apple backend.
+  New backends are follow-ups.
+- **Unifying the three extraction protocols** (`MarkdownExtractor`, `HtmlMarkdownExtractor`,
+  `PodcastTranscriptFetching`) — they have fundamentally different input types.
+- **Migrating existing auto-extracted sources** — their markdown versions persist.
+  Only new ingests change.
+
+## Build & test
+
+```bash
+make prompts && swift build
+swift test
+```


### PR DESCRIPTION
## Summary

PR1 of 4 for the **General Extraction Framework — No Auto-Extraction** plan (#799). Pure scaffolding — typed backend enums + Settings UI. **No behavior change**: extraction still auto-runs at ingest with the current method.

See [`plans/extraction-framework.md`](plans/extraction-framework.md) for the full 4-PR plan. This PR implements PR1 only; PR2 (HTML extraction trigger UI), PR3 (remove HTML auto-extraction at ingest), and PR4 (podcast transcription framework) are follow-ups.

## What this PR adds

### New types

- `HtmlExtractionBackend { defuddle, tagBased }` — `Sources/WikiFSMarkdown/HtmlExtractionBackend.swift`. The typed user choice for HTML→Markdown extraction. Mirrors `ExtractionBackend` (PDF) but is a separate type — HTML and PDF have no shared converters and folding them into one enum would let the caller pick an HTML backend for a PDF by mistake.
- `PodcastTranscriptionBackend { appleTranscript }` — `Sources/WikiFSCore/Integrations/PodcastTranscriptionBackend.swift`. The typed user choice for podcast transcription. Currently one case; extensible to Whisper / Rev.ai in future PRs. The enum itself is unconditional (`#if PODCAST_TRANSCRIPTS` doesn't gate types — only the call site, which is PR4).

Both are `String`-raw-valued `CaseIterable`, `Codable`, `Sendable` enums with a `displayName` for the Settings picker. Both support `nil` as a "no default yet — prompt me" state.

### `ExtractionConfig` extension

`Sources/WikiFSCore/Integrations/ExtractionConfig.swift` — adds two optional fields:

```swift
public var htmlBackend: HtmlExtractionBackend?      // nil = no default yet
public var podcastBackend: PodcastTranscriptionBackend?
```

**Critical**: ExtractionConfig has hand-written Codable — `CodingKeys`, `init(from:)`, AND the memberwise `init(...)` all needed updating to include the new fields. The decode uses `try? c.decode(...)` (mirrors the existing `backend` field's resilient pattern): a missing key OR an unknown raw value degrades to nil rather than rejecting the whole config. This is symmetric with how `backend` degrades to `.localPdf2md` on unknown raw values — same philosophy, just `nil` is the "default" for optional fields.

The asymmetry (`backend` non-optional, `htmlBackend`/`podcastBackend` optional) is intentional: PDF has an always-available safe fallback (`localPdf2md`); HTML/Podcast don't (defuddle binary may be missing, podcast signing helper is gated behind `#if PODCAST_TRANSCRIPTS`). So a fresh install prompts the user to pick a backend on first extraction rather than silently picking a default that might not work.

### Settings UI

`Sources/WikiFS/Sources/ExtractionSettingsView.swift` — adds two `Picker` sections below the existing PDF picker:

- **HTML Extraction**: lists `HtmlExtractionBackend.allCases` plus a "Prompt me when extracting" nil option.
- **Podcast Transcription**: lists `PodcastTranscriptionBackend.allCases` plus a "Prompt me when transcribing" nil option.

Both use the same auto-save-on-change pattern as the existing PDF Picker (`@State` draft + `.onChange` → `persistAll()` → `writeConfig` writes to `ExtractionConfig`). Each section has a footer explaining the backends + that the trigger UI / auto-extraction-removal lands in later PRs.

## Acceptance criteria (PR1)

| AC | Status | How verified |
|----|--------|--------------|
| **AC.1** `ExtractionConfig` round-trips all three backend fields (PDF, HTML, Podcast) | ✅ | `ExtractionConfigTests.htmlAndPodcastBackendsRoundTrip` + `pdfBackendSurvivesWhenNewBackendsAreSet` |
| **AC.2** Legacy config files without the new fields decode to nil (prompt to choose) | ✅ | `ExtractionConfigTests.htmlAndPodcastBackendsDecodeAsNilWhenAbsent` |
| **AC.3** `ExtractionSettingsView` renders three backend pickers | ✅ | Manual code review; `swift build` clean (no compile errors in the view target) |
| **AC.4** No behavior change — existing auto-extraction still runs at ingest | ✅ | No changes to ingestion/extraction code paths; full `swift test` (3351 tests in 280 suites) green |

## Build & test

```
make version prompts && swift build   # GeneratedVersion.swift + GeneratedPrompts.swift regenerated
swift test                              # 3351 tests, 280 suites, 0 failures
```

## Files

**New** (3):
- `Sources/WikiFSMarkdown/HtmlExtractionBackend.swift`
- `Sources/WikiFSCore/Integrations/PodcastTranscriptionBackend.swift`
- `Tests/WikiFSTests/HtmlExtractionBackendTests.swift`

**Edit** (3):
- `Sources/WikiFSCore/Integrations/ExtractionConfig.swift`
- `Sources/WikiFS/Sources/ExtractionSettingsView.swift`
- `Tests/WikiFSTests/ExtractionConfigTests.swift`

## Test coverage added

- `ExtractionConfigTests.htmlAndPodcastBackendsRoundTrip` — AC.1
- `ExtractionConfigTests.htmlAndPodcastBackendsRoundTripNil` — explicit-nil round-trip ("Prompt me" survives save/load)
- `ExtractionConfigTests.htmlAndPodcastBackendsDecodeAsNilWhenAbsent` — AC.2 (forward-compat with legacy configs)
- `ExtractionConfigTests.unknownHtmlAndPodcastBackendValuesDegradeToNil` — typo'd raw value doesn't reject the file
- `ExtractionConfigTests.pdfBackendSurvivesWhenNewBackendsAreSet` — fields coexist without crosstalk
- `HtmlExtractionBackendTests.codableRoundTripsAllCases` — enum-level round-trip
- `HtmlExtractionBackendTests.stringRawValueRoundTripsThroughJSON` — raw-value stability (literals locked)
- `HtmlExtractionBackendTests.unknownRawValueThrows` — enum-level contract (config layer degrades to nil)
- `HtmlExtractionBackendTests.allCasesMatchesExpectedCasesInOrder` — picker ordering locked
- `HtmlExtractionBackendTests.displayNameNonEmptyAndDistinctPerCase` — picker sanity
- `HtmlExtractionBackendTests.displayNameStability` — literal strings locked (user-visible)

Closes #799 (PR1 of 4).

---

## Out of scope for this PR

- **PR2** HTML extraction trigger UI (generalize Extract/Re-extract menus in `SourceDetailView`).
- **PR3** Remove HTML auto-extraction at ingest (`addFiles` / `addURLViaWebsite` / `ingestFromZotero` callers of `enrichWithDefuddle`).
- **PR4** Podcast transcription framework (`WikiStoreModel.transcribePodcast` + `SourceDetailView` Transcribe button + `#if PODCAST_TRANSCRIPTS` gating).
- **Queue engine generalization** — the PDF-coupled queue stays PDF-only; HTML uses inline extraction, podcast uses a direct trigger.
- **New podcast backends** (Whisper, Rev.ai) — this PR adds the framework with the Apple backend only.
