### PR TITLE
feat: typed SourceProvider enum for source origin taxonomy

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -562,9 +562,13 @@ struct SourceDetailView: View {
                         } else {
                             Label(zoteroLabel, systemImage: "books.vertical")
                         }
-                    } else if let origin, origin.agentName != "legacy-import" {
+                    } else if let origin, origin.provider != .legacyImport {
                         // Phase 3a provider origin: website → clickable link to the
                         // origin URL; local-file → "File"; markdown-folder → "Folder".
+                        // `provider != .legacyImport` filters the shared
+                        // `legacy-import` agent (the pre-v39 degraded fallback —
+                        // nil satisfies it too, since `SourceProvider(rawValue:nil)`
+                        // is nil).
                         metadataSeparator
                         providerOriginTag(origin)
                     }
@@ -816,112 +820,72 @@ struct SourceDetailView: View {
     /// "File / {content type}" (e.g. "File / Mermaid", "File / PDF") since a
     /// drag-drop can carry anything. URL/media providers and markdown folders
     /// imply their content type, so their labels stay single-dimensional.
+    ///
+    /// The per-provider label/icon/helpVerb are sourced from
+    /// `SourceProvider.displayLabel` / `.systemImage` / `.helpVerb` so the
+    /// DetailView and `SourceOrigin.displayLabel` can't drift (#source-
+    /// provider-enum). `mediaProviderInfo`'s former switch table is now
+    /// enum-carried and lives on `SourceProvider` itself.
     @ViewBuilder
     private func providerOriginTag(_ origin: SourceOrigin) -> some View {
-        switch origin.agentName {
-        case "website":
-            let websiteLabel = SourceProvenanceLabel.combine(
-                provider: "Website", ext: file.ext, mimeType: file.mimeType)
+        switch origin.provider {
+        case .website, .applePodcast, .youtube, .vimeo, .spotify, .soundcloud, .remoteMedia:
+            // URL providers (web pages, podcasts, byteless media embeds) — all
+            // open in the default browser via NSWorkspace.shared.open. They share
+            // one action shape; only the label / icon / help text differ, and
+            // those come from the enum. Force-unwrap is safe — this arm only
+            // matched when `origin.provider` is `.some(…)` (non-nil).
+            let provider = origin.provider!
+            let providerLabel = SourceProvenanceLabel.combine(
+                provider: provider.displayLabel, ext: file.ext, mimeType: file.mimeType)
             let urlString = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
             if let url = URL(string: urlString), url.scheme != nil {
                 Button {
                     NSWorkspace.shared.open(url)
                 } label: {
-                    Label(websiteLabel, systemImage: "globe")
+                    Label(providerLabel, systemImage: provider.systemImage)
                 }
                 .buttonStyle(.link)
-                .help("Open original: \(urlString)")
+                .help("\(provider.helpVerb): \(urlString)")
             } else {
-                Label(websiteLabel, systemImage: "globe")
+                Label(providerLabel, systemImage: provider.systemImage)
             }
-        case "markdown-folder":
-            // Two-dimensional label (#644): "Folder / Markdown" when the content
-            // type is derivable, or just "Folder" when it's unknown.
-            let folderLabel = SourceProvenanceLabel.combine(
-                provider: "Folder", ext: file.ext, mimeType: file.mimeType)
-            let folderPath = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
-            if !folderPath.isEmpty {
+        case .localFile, .markdownFolder, .zotero, .legacyImport, nil:
+            // Local-path reveal (Finder). `.localFile` shows "File" + "doc";
+            // `.markdownFolder` shows "Folder" + "folder" — both via their
+            // own enum values. `.legacyImport` is filtered out at the caller
+            // (the `origin.provider != .legacyImport` gate above), and
+            // `nil` covers any future/unknown provider; both fall back to
+            // `SourceProvider.localFile`'s values ("File" / "doc" /
+            // "Reveal original file"), matching the pre-enum default arm.
+            //
+            // `.zotero` is also handled inline ABOVE the caller's gate (a
+            // dedicated `zotero://select?itemKey=…` button row); reaching
+            // providerOriginTag with a zotero origin is unreachable in
+            // practice but listed here so the switch is exhaustive. The
+            // pre-enum `default:` arm rendered it as "File" — preserved here
+            // via the `.localFile` fallback below.
+            //
+            // Single ternary expression (not a conditional statement) so the
+            // surrounding @ViewBuilder doesn't try to fold this into a view.
+            let effective: SourceProvider = (origin.provider == .localFile || origin.provider == .markdownFolder)
+                ? origin.provider!
+                : .localFile
+            let providerLabel = SourceProvenanceLabel.combine(
+                provider: effective.displayLabel, ext: file.ext, mimeType: file.mimeType)
+            let path = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
+            if !path.isEmpty {
                 Button {
                     NSWorkspace.shared.activateFileViewerSelecting(
-                        [URL(fileURLWithPath: folderPath)])
+                        [URL(fileURLWithPath: path)])
                 } label: {
-                    Label(folderLabel, systemImage: "folder")
+                    Label(providerLabel, systemImage: effective.systemImage)
                 }
                 .buttonStyle(.link)
-                .help("Reveal original folder: \(folderPath)")
+                .help("\(effective.helpVerb): \(path)")
             } else {
-                Label(folderLabel, systemImage: "folder")
+                Label(providerLabel, systemImage: effective.systemImage)
             }
-        case "apple-podcast":
-            // Byteless source (a transcript) — link to the episode page, like the
-            // website tag. Never "File": a podcast source carries no file bytes.
-            let podcastLabel = SourceProvenanceLabel.combine(
-                provider: "Apple Podcast", ext: file.ext, mimeType: file.mimeType)
-            let urlString = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
-            if let url = URL(string: urlString), url.scheme != nil {
-                Button {
-                    NSWorkspace.shared.open(url)
-                } label: {
-                    Label(podcastLabel, systemImage: "waveform")
-                }
-                .buttonStyle(.link)
-                .help("Open episode: \(urlString)")
-            } else {
-                Label(podcastLabel, systemImage: "waveform")
-            }
-        case "youtube", "vimeo", "spotify", "soundcloud", "remote-media":
-            // Phase 4b byteless media providers. The watch/listen URL lives on
-            // `origin.plan` (the pasted link, normalized); never "File" — these
-            // sources carry no file bytes. (Issue #618.)
-            let info = mediaProviderInfo(origin.agentName)
-            let mediaLabel = SourceProvenanceLabel.combine(
-                provider: info.label, ext: file.ext, mimeType: file.mimeType)
-            let urlString = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
-            if let url = URL(string: urlString), url.scheme != nil {
-                Button {
-                    NSWorkspace.shared.open(url)
-                } label: {
-                    Label(mediaLabel, systemImage: info.systemImage)
-                }
-                .buttonStyle(.link)
-                .help("\(info.helpVerb): \(urlString)")
-            } else {
-                Label(mediaLabel, systemImage: info.systemImage)
-            }
-        default:
-            // Local-file (and any unrecognized import provider). Two-dimensional
-            // label (#644): "File / Mermaid", "File / PDF", "File / Markdown",
-            // or just "File" when the content type is unknown. A drag-drop can
-            // carry anything, so the suffix is meaningful here.
-            let fileLabel = SourceProvenanceLabel.combine(
-                provider: "File", ext: file.ext, mimeType: file.mimeType)
-            let filePath = origin.plan ?? origin.externalRef ?? origin.externalIdentity ?? ""
-            if !filePath.isEmpty {
-                Button {
-                    NSWorkspace.shared.activateFileViewerSelecting(
-                        [URL(fileURLWithPath: filePath)])
-                } label: {
-                    Label(fileLabel, systemImage: "doc")
-                }
-                .buttonStyle(.link)
-                .help("Reveal original file: \(filePath)")
-            } else {
-                Label(fileLabel, systemImage: "doc")
-            }
-        }
-    }
-
-    /// Provider-correct display text, SF Symbol, and tooltip verb for the
-    /// Phase 4b byteless media providers (`youtube`/`vimeo`/`spotify`/
-    /// `soundcloud`/`remote-media`). Used by `providerOriginTag(_:)`.
-    private func mediaProviderInfo(_ agentName: String) -> (label: String, systemImage: String, helpVerb: String) {
-        switch agentName {
-        case "youtube":      return ("YouTube", "play.rectangle", "Open video")
-        case "vimeo":        return ("Vimeo", "play.rectangle", "Open video")
-        case "spotify":      return ("Spotify", "music.note", "Open track")
-        case "soundcloud":   return ("SoundCloud", "waveform", "Open track")
-        case "remote-media": return ("Media", "music.note", "Open media")
-        default:             return ("Media", "music.note", "Open media")
         }
     }
 
@@ -1040,8 +1004,8 @@ struct SourceDetailView: View {
 
     /// The placeholder copy when a byteless embed has no transcript yet.
     private var embedEmptyLabel: String {
-        switch origin?.agentName {
-        case "youtube": return "No Transcript Available"
+        switch origin?.provider {
+        case .youtube?: return "No Transcript Available"
         default: return "No Transcript"
         }
     }
@@ -1049,7 +1013,7 @@ struct SourceDetailView: View {
     /// The placeholder description; explains why there's no text and that the
     /// player above is the source's content.
     private var embedEmptyDescription: String {
-        if origin?.agentName == "youtube" {
+        if origin?.provider == .youtube {
             return "This video has no captions, so no transcript was extracted. The player above is the source."
         }
         return "This media source has no extracted text yet. The player above is the source."

--- a/Sources/WikiFSCore/Integrations/ExternalEmbed.swift
+++ b/Sources/WikiFSCore/Integrations/ExternalEmbed.swift
@@ -46,6 +46,13 @@ public struct SourceEmbedDescriptor: Sendable, Equatable {
         self.agentName = agentName
         self.planURL = planURL
     }
+
+    /// The typed provider parsed from `agentName` (`SourceProvider(rawValue:)`),
+    /// or `nil` when `agentName` is `nil`/empty/unknown. Switch sites consult
+    /// this so the compiler can enforce exhaustiveness.
+    public var provider: SourceProvider? {
+        SourceProvider(rawValue: agentName)
+    }
 }
 
 // MARK: - WikiReaderOrigin
@@ -147,7 +154,7 @@ public enum ExternalEmbed {
         // Keyed on agentName (not a synthetic mime) because the podcast source
         // carries a real-ish mime from the transcript pipeline. Idempotent: a
         // planURL already on embed.podcasts.apple.com resolves unchanged.
-        if d.agentName == "apple-podcast", let embedURL = applePodcastEmbedURL(from: d.planURL) {
+        if d.provider == .applePodcast, let embedURL = applePodcastEmbedURL(from: d.planURL) {
             return EmbedTarget(kind: .iframe, url: embedURL)
         }
 
@@ -186,7 +193,7 @@ public enum ExternalEmbed {
         let mime = d.mimeType ?? ""
         if mime.hasPrefix("audio/") { return "Audio" }
         if mime.hasPrefix("video/") { return "Video" }
-        if d.agentName == "apple-podcast" { return "Audio" }
+        if d.provider == .applePodcast { return "Audio" }
         return "Media"
     }
 

--- a/Sources/WikiFSCore/Integrations/MediaEmbedURL.swift
+++ b/Sources/WikiFSCore/Integrations/MediaEmbedURL.swift
@@ -42,6 +42,13 @@ public struct MediaEmbedMatch: Sendable, Equatable {
         self.planURL = planURL
         self.activityKind = activityKind
     }
+
+    /// The typed provider parsed from `agentName` (`SourceProvider(rawValue:)`),
+    /// or `nil` for unknown/empty values. Switch sites consult this so the
+    /// compiler can enforce exhaustiveness over the known-provider arms.
+    public var provider: SourceProvider? {
+        SourceProvider(rawValue: agentName)
+    }
 }
 
 public enum MediaEmbedURL {
@@ -80,7 +87,7 @@ public enum MediaEmbedURL {
         guard isValidYouTubeID(id) else { return nil }
         let absolute = url.absoluteString
         return MediaEmbedMatch(
-            agentName: "youtube",
+            agentName: SourceProvider.youtube.rawValue,
             mimeType: "video/youtube",
             externalIdentity: id,
             filename: "youtube-\(id)",
@@ -101,7 +108,7 @@ public enum MediaEmbedURL {
         guard let id, !id.isEmpty else { return nil }
         let absolute = url.absoluteString
         return MediaEmbedMatch(
-            agentName: "vimeo",
+            agentName: SourceProvider.vimeo.rawValue,
             mimeType: "video/vimeo",
             externalIdentity: id,
             filename: "vimeo-\(id)",
@@ -124,7 +131,7 @@ public enum MediaEmbedURL {
         guard !id.isEmpty else { return nil }
         let absolute = url.absoluteString
         return MediaEmbedMatch(
-            agentName: "spotify",
+            agentName: SourceProvider.spotify.rawValue,
             mimeType: "audio/spotify",
             externalIdentity: "\(type)/\(id)",
             filename: "spotify-\(type)-\(id)",
@@ -145,7 +152,7 @@ public enum MediaEmbedURL {
         let trackSlug = segs.last ?? segs[1]
         let absolute = url.absoluteString
         return MediaEmbedMatch(
-            agentName: "soundcloud",
+            agentName: SourceProvider.soundcloud.rawValue,
             mimeType: "audio/soundcloud",
             externalIdentity: absolute,
             filename: "soundcloud-\(trackSlug)",
@@ -167,7 +174,7 @@ public enum MediaEmbedURL {
         let last = (url.path as NSString).lastPathComponent
         let filename = last.isEmpty ? "remote-\(url.host ?? "media")" : last
         return MediaEmbedMatch(
-            agentName: "remote-media",
+            agentName: SourceProvider.remoteMedia.rawValue,
             mimeType: mime,
             externalIdentity: absolute,
             filename: filename,

--- a/Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift
+++ b/Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift
@@ -97,16 +97,22 @@ public enum MediaTitleFetcher {
         allowed.remove(charactersIn: ":/?&=#")
         guard let encoded = match.planURL.addingPercentEncoding(
             withAllowedCharacters: allowed) else { return nil }
-        switch match.agentName {
-        case "youtube":
+        // Switch on `match.provider` (Optional<SourceProvider>) — the arms for
+        // `.youtube` etc. auto-promote to `.some(.youtube)` so the compiler
+        // can flag a missing provider when the enum grows. The `default` arm
+        // covers `nil` (unknown provider) AND `.remoteMedia`/`.applePodcast`
+        // (no oEmbed endpoint) — matching the pre-enum fallthrough.
+        switch match.provider {
+        case .youtube:
             return URL(string: "https://www.youtube.com/oembed?url=\(encoded)&format=json")
-        case "vimeo":
+        case .vimeo:
             return URL(string: "https://vimeo.com/api/oembed.json?url=\(encoded)")
-        case "spotify":
+        case .spotify:
             return URL(string: "https://open.spotify.com/oembed?url=\(encoded)")
-        case "soundcloud":
+        case .soundcloud:
             return URL(string: "https://soundcloud.com/oembed?format=json&url=\(encoded)")
-        default:
+        case .localFile, .website, .zotero, .markdownFolder, .applePodcast,
+             .remoteMedia, .legacyImport, nil:
             return nil
         }
     }

--- a/Sources/WikiFSCore/Sources/SourceMaterializer.swift
+++ b/Sources/WikiFSCore/Sources/SourceMaterializer.swift
@@ -171,17 +171,21 @@ public struct SourceOrigin: Sendable, Equatable {
         self.fetchedAt = fetchedAt
     }
 
-    /// A short human label for the origin, for UI/CLI display.
+    /// The typed provider parsed from `agentName` (`SourceProvider(rawValue:)`),
+    /// or `nil` for unknown/empty values. Switch sites consult this so the
+    /// compiler can enforce exhaustiveness over the known-provider arm while
+    /// nil/unknown degrades to a default branch. See
+    /// `plans/source-provider-enum.md` §Type changes.
+    public var provider: SourceProvider? {
+        SourceProvider(rawValue: agentName)
+    }
+
+    /// A short human label for the origin, for UI/CLI display. Canonical —
+    /// delegates to `SourceProvider.displayLabel` so every provider has ONE
+    /// label (e.g. `markdown-folder` → "Folder", not "Markdown folder").
+    /// Unknown values fall back to `agentName.capitalized`.
     public var displayLabel: String {
-        switch agentName {
-        case "website": return "Website"
-        case "zotero": return "Zotero"
-        case "markdown-folder": return "Markdown folder"
-        case "local-file": return "File"
-        case "legacy-import": return "Imported"
-        case "apple-podcast": return "Apple Podcast"
-        default: return agentName.capitalized
-        }
+        provider?.displayLabel ?? agentName.capitalized
     }
 }
 
@@ -191,7 +195,7 @@ public struct SourceOrigin: Sendable, Equatable {
 /// the MIME type, and records `agentName = "local-file"` with an `import`
 /// activity (no external identity).
 public struct LocalFileMaterializer: SourceMaterializer {
-    public let agentName = "local-file"
+    public let agentName = SourceProvider.localFile.rawValue
     public let fileURL: URL
 
     public init(fileURL: URL) {
@@ -243,7 +247,7 @@ public struct LocalFileMaterializer: SourceMaterializer {
 /// (kind/size) without a second fetch. A pure struct — `materialize()` is the
 /// protocol-conformant projection that discards the plan.
 public struct WebsiteMaterializer: SourceMaterializer {
-    public let agentName = "website"
+    public let agentName = SourceProvider.website.rawValue
     public let rawInput: String
     public let fetcher: any URLFetchService.URLResourceFetcher
 
@@ -399,7 +403,7 @@ public struct WebsiteSnapshot: Sendable {
 /// the AMP endpoint wants, but the URL is what the user pasted and what the Origin
 /// row should surface.
 public struct ApplePodcastMaterializer: SourceMaterializer {
-    public let agentName = "apple-podcast"
+    public let agentName = SourceProvider.applePodcast.rawValue
     public let episode: PodcastEpisodeURL.EpisodeRef
     public let pageURL: URL
     public let fetcher: any PodcastTranscriptFetching
@@ -446,7 +450,7 @@ public struct ApplePodcastMaterializer: SourceMaterializer {
 /// `externalIdentity` = the parent item key. Also populates the retained legacy
 /// `zoteroItemKey`/`zoteroItemTitle` columns (§4.2).
 public struct ZoteroMaterializer: SourceMaterializer {
-    public let agentName = "zotero"
+    public let agentName = SourceProvider.zotero.rawValue
     public let attachment: ZoteroAttachment
     public let parentItem: ZoteroItem
     public let zoteroDir: URL
@@ -503,7 +507,7 @@ public struct ZoteroMaterializer: SourceMaterializer {
 /// join). Takes the pre-read `(filename, data)` from the walk to avoid a
 /// double-read.
 public struct MarkdownFolderMaterializer: SourceMaterializer {
-    public let agentName = "markdown-folder"
+    public let agentName = SourceProvider.markdownFolder.rawValue
     public let filename: String
     public let data: Data
     public let mimeType: String?

--- a/Sources/WikiFSCore/Sources/SourceRefreshService.swift
+++ b/Sources/WikiFSCore/Sources/SourceRefreshService.swift
@@ -81,12 +81,18 @@ public struct SourceRefreshService: Sendable {
     /// for import-only sources and `.missingPlan` when a refreshable source's
     /// origin has no URL.
     public func materialize(origin: SourceOrigin) async throws -> RefreshMaterial {
-        switch origin.agentName {
-        case "website":
+        // nil/unknown provider (forward-compat: a newer build wrote an unknown
+        // `agents.name`) → not refreshable. The known-provider arms mirror the
+        // `provider.supportsRefresh` baseline, but stay explicit so the refresh
+        // path's branching is self-documenting (and the compiler's
+        // exhaustiveness check fails if a new provider is added).
+        switch origin.provider {
+        case .website:
             return try await materializeWebsite(origin: origin)
-        case "apple-podcast":
+        case .applePodcast:
             return try await materializePodcast(origin: origin)
-        default:
+        case .localFile, .zotero, .markdownFolder, .youtube, .vimeo, .spotify,
+             .soundcloud, .remoteMedia, .legacyImport, nil:
             throw RefreshError.notRefreshable(origin.agentName)
         }
     }

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2846,16 +2846,27 @@ public final class WikiStoreModel {
     ///   is import-only and not refreshable.
     public func isSourceRefreshable(for id: PageID) -> Bool {
         guard let origin = sourceOrigin(for: id), origin.plan != nil else { return false }
-        switch origin.agentName {
-        case "website":
+        // Delegate the baseline to `provider.supportsRefresh`, then layer the
+        // runtime guards on top (snapshot image siblings for websites; the
+        // bundled signing helper for podcasts). See `plans/source-provider-enum.md`
+        // §supportsRefresh — this is the full predicate; the enum property is
+        // baseline-only.
+        guard let provider = origin.provider, provider.supportsRefresh else { return false }
+        switch provider {
+        case .website:
             return !((try? store.hasImageSiblings(sourceID: id)) ?? false)
-        case "apple-podcast":
+        case .applePodcast:
             #if PODCAST_TRANSCRIPTS
             return ApplePodcastTranscriptService.bundled() != nil
             #else
             return false
             #endif
-        default:
+        // Exhaustive over the non-refreshable providers — `supportsRefresh`
+        // returned false above, so these are unreachable; the compiler still
+        // enforces exhaustiveness if a new provider is ever added (it has to
+        // be added here, to `supportsRefresh`, or the build fails).
+        case .localFile, .zotero, .markdownFolder,
+             .youtube, .vimeo, .spotify, .soundcloud, .remoteMedia, .legacyImport:
             return false
         }
     }

--- a/Sources/WikiFSTypes/SourceProvider.swift
+++ b/Sources/WikiFSTypes/SourceProvider.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Typed taxonomy for source origin — the `agents.name` value stamped by each
+/// materializer and projected from the PROV graph. Single source of truth for
+/// the convention strings: every construction site (the 5 materializers + the
+/// 5 byteless-media recognizers) routes through `SourceProvider.X.rawValue`,
+/// and every parse/display site routes through `SourceProvider(rawValue:)`.
+///
+/// The convention itself is unchanged from the pre-typing discipline
+/// (`plans/source-provider-enum.md`): the bytes stored in `agents.name` are
+/// byte-identical before and after this enum lands, so no DB migration is
+/// required. This mirrors the `PageAuthor` pattern (#797 Phase 1).
+///
+/// Lives in `WikiFSTypes` (the shared leaf target) so the write seam
+/// (`WikiFSCore`'s `SourceMaterializer` / `MediaEmbedURL`), the refresh service
+/// (`WikiFSCore`'s `SourceRefreshService`), and the read-side UI (`WikiFS`'s
+/// `SourceDetailView`) all share one definition with no new module edge.
+public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable {
+
+    /// A drag-dropped / picked local file. Stored as `"local-file"`.
+    case localFile       = "local-file"
+    /// A fetched website (HTML→Markdown / PDF / text / binary). Stored as `"website"`.
+    case website         = "website"
+    /// A Zotero attachment import. Stored as `"zotero"`.
+    case zotero          = "zotero"
+    /// One `.md`/`.markdown` file from a folder import. Stored as `"markdown-folder"`.
+    case markdownFolder  = "markdown-folder"
+    /// An Apple Podcasts episode transcript (byteless). Stored as `"apple-podcast"`.
+    case applePodcast    = "apple-podcast"
+    /// A byteless YouTube embed (synthetic `video/youtube` mime). Stored as `"youtube"`.
+    case youtube         = "youtube"
+    /// A byteless Vimeo embed. Stored as `"vimeo"`.
+    case vimeo           = "vimeo"
+    /// A byteless Spotify embed. Stored as `"spotify"`.
+    case spotify         = "spotify"
+    /// A byteless SoundCloud embed. Stored as `"soundcloud"`.
+    case soundcloud      = "soundcloud"
+    /// Direct-remote media (mp3/mp4/HLS); real mime, no provider iframe. Stored as `"remote-media"`.
+    case remoteMedia     = "remote-media"
+    /// The shared pre-v39 / nil-origin fallback. Stored as `"legacy-import"`.
+    case legacyImport    = "legacy-import"
+
+    /// Parse a stored `agents.name` value. `nil`/empty/unknown → `nil`.
+    /// Unlike `PageAuthor` (which falls back to `.legacyImport`), unknown values
+    /// here return `nil` so each switch site can choose its own default-arm
+    /// behaviour (the SourceDetailView chip shows "File"; the refresh service
+    /// throws `.notRefreshable`). This intentional nil-vs-fallback split is
+    /// documented in `plans/source-provider-enum.md` §Type changes.
+    public init?(rawValue: String?) {
+        guard let rawValue, !rawValue.isEmpty else { return nil }
+        self.init(rawValue: rawValue)
+    }
+
+    /// Display label for the origin chip — canonical across all UI sites.
+    /// Replaces the prior disagreements where `SourceOrigin.displayLabel`
+    /// returned "Markdown folder" but `SourceDetailView` rendered "Folder".
+    public var displayLabel: String {
+        switch self {
+        case .localFile:       return "File"
+        case .website:         return "Website"
+        case .zotero:          return "Zotero"
+        case .markdownFolder:  return "Folder"
+        case .applePodcast:    return "Apple Podcast"
+        case .youtube:         return "YouTube"
+        case .vimeo:           return "Vimeo"
+        case .spotify:         return "Spotify"
+        case .soundcloud:      return "SoundCloud"
+        case .remoteMedia:     return "Media"
+        case .legacyImport:    return "Imported"
+        }
+    }
+
+    /// SF Symbol for the origin chip. The symbol mirrors what each
+    /// provider's content *is* (globe for website, folder for folder, doc for
+    /// file, play rectangle for video providers, music note for audio, etc.).
+    public var systemImage: String {
+        switch self {
+        case .localFile:       return "doc"
+        case .website:         return "globe"
+        case .zotero:          return "books.vertical"
+        case .markdownFolder:  return "folder"
+        case .applePodcast:    return "waveform"
+        case .youtube:         return "play.rectangle"
+        case .vimeo:           return "play.rectangle"
+        case .spotify:         return "music.note"
+        case .soundcloud:      return "waveform"
+        case .remoteMedia:     return "music.note"
+        case .legacyImport:    return "tray.and.arrow.down"
+        }
+    }
+
+    /// Help-text verb for the origin chip's tooltip/click action. Composed at
+    /// the call site as `"\(helpVerb): \(urlString)"` (or used verbatim). The
+    /// verb distinguishes "Open" (URL providers) from "Reveal" (local paths).
+    public var helpVerb: String {
+        switch self {
+        case .localFile:       return "Reveal original file"
+        case .website:         return "Open original"
+        case .zotero:          return "View in Zotero"
+        case .markdownFolder:  return "Reveal original folder"
+        case .applePodcast:    return "Open episode"
+        case .youtube:         return "Open video"
+        case .vimeo:           return "Open video"
+        case .spotify:         return "Open track"
+        case .soundcloud:      return "Open track"
+        case .remoteMedia:     return "Open media"
+        case .legacyImport:    return "View provenance"
+        }
+    }
+
+    /// **Baseline** refresh capability — `true` for providers that *in
+    /// principle* support re-fetching a newer content version. NOT the full
+    /// refreshability predicate.
+    ///
+    /// Runtime guards layered on top at `WikiStoreModel.isSourceRefreshable`:
+    /// - `website`: `false` when the source is a snapshot with image siblings
+    ///   (single-source refresh would orphan them — D3 guard).
+    /// - `applePodcast`: `false` when this build doesn't compile podcast
+    ///   support OR the `podcast-token-helper` binary isn't present at runtime.
+    ///
+    /// Every other provider (local-file / Zotero / folder / YouTube / Vimeo /
+    /// Spotify / SoundCloud / remote-media / legacy-import / unknown) is
+    /// import-only or byteless-embed-only — there's no URL to re-fetch.
+    public var supportsRefresh: Bool {
+        switch self {
+        case .website, .applePodcast:
+            return true
+        case .localFile, .zotero, .markdownFolder,
+             .youtube, .vimeo, .spotify, .soundcloud, .remoteMedia,
+             .legacyImport:
+            return false
+        }
+    }
+}

--- a/Tests/WikiFSTests/SourceProviderTests.swift
+++ b/Tests/WikiFSTests/SourceProviderTests.swift
@@ -1,0 +1,282 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// `SourceProvider` enum — typed taxonomy for source origin. Exercises
+/// rawValue round-trip identity, the parse-with-fallback for unknown/nil
+/// values, the enum-carried display properties (displayLabel / systemImage /
+/// helpVerb / supportsRefresh), and the `SourceOrigin.provider` /
+/// `MediaEmbedMatch.provider` / `SourceEmbedDescriptor.provider` computed
+/// properties' resolution for known + unknown agent names.
+///
+/// #source-provider-enum — see `plans/source-provider-enum.md`. The stored
+/// `agents.name` bytes are byte-identical to the pre-enum strings, so existing
+/// suite tests still exercise the construction + parse paths.
+@Suite struct SourceProviderTests {
+
+    // MARK: - AC.1: round-trip identity
+
+    /// `SourceProvider(rawValue: p.rawValue) == p` for every case. Also
+    /// exercises CaseIterable coverage so a future case is automatically
+    /// caught by this test (the parameter list will need updating).
+    @Test("SourceProvider round-trips every case through rawValue",
+          arguments: SourceProvider.allCases)
+    func roundTripIdentity(_ provider: SourceProvider) {
+        let parsed = SourceProvider(rawValue: provider.rawValue)
+        #expect(parsed == provider,
+                "\(provider.rawValue) should round-trip (got \(parsed.map(String.init(describing:)) ?? "nil"))")
+    }
+
+    // MARK: - AC.2: init(rawValue:) edge cases
+
+    @Test("init(rawValue:) returns nil for empty + nil input")
+    func parsesNilAndEmptyAsNil() {
+        #expect(SourceProvider(rawValue: nil as String?) == nil)
+        #expect(SourceProvider(rawValue: "") == nil)
+    }
+
+    @Test("init(rawValue:) returns nil for unknown values (forward compat)")
+    func parsesUnknownAsNil() {
+        // A future code path that writes an unmigrated provider's `agents.name`
+        // (or a test value) parses as nil — the switch sites degrade to their
+        // default arm. This is the intentional "graceful fallback" rule from
+        // `plans/source-provider-enum.md` §Type changes (verifying nil here
+        // documents the contract: unknown ≠ .legacyImport, unlike PageAuthor).
+        #expect(SourceProvider(rawValue: "test") == nil)
+        #expect(SourceProvider(rawValue: "unknown-provider") == nil)
+        #expect(SourceProvider(rawValue: "Website") == nil, // case-sensitive
+                "rawValue matching is case-sensitive (stored values are lowercase)")
+    }
+
+    // MARK: - AC.3: enum-carried display values
+
+    @Test("rawValue matches the canonical stored string for each case")
+    func rawValueLiterals() {
+        // Pins the rawValues so a future rename to the enum case name doesn't
+        // silently shift the stored bytes (no DB migration). The stored
+        // values use kebab-case; the Swift case names use camelCase.
+        #expect(SourceProvider.localFile.rawValue == "local-file")
+        #expect(SourceProvider.website.rawValue == "website")
+        #expect(SourceProvider.zotero.rawValue == "zotero")
+        #expect(SourceProvider.markdownFolder.rawValue == "markdown-folder")
+        #expect(SourceProvider.applePodcast.rawValue == "apple-podcast")
+        #expect(SourceProvider.youtube.rawValue == "youtube")
+        #expect(SourceProvider.vimeo.rawValue == "vimeo")
+        #expect(SourceProvider.spotify.rawValue == "spotify")
+        #expect(SourceProvider.soundcloud.rawValue == "soundcloud")
+        #expect(SourceProvider.remoteMedia.rawValue == "remote-media")
+        #expect(SourceProvider.legacyImport.rawValue == "legacy-import")
+    }
+
+    @Test("displayLabel returns the canonical UI label for each case")
+    func displayLabelMapping() {
+        // AC.6: collapses disagreements across the 4 switch sites. The enum
+        // carries ONE canonical label per provider.
+        #expect(SourceProvider.localFile.displayLabel == "File")
+        #expect(SourceProvider.website.displayLabel == "Website")
+        #expect(SourceProvider.zotero.displayLabel == "Zotero")
+        #expect(SourceProvider.markdownFolder.displayLabel == "Folder",
+                "markdown-folder displays as 'Folder' (not 'Markdown folder') — matches DetailView UI")
+        #expect(SourceProvider.applePodcast.displayLabel == "Apple Podcast")
+        #expect(SourceProvider.youtube.displayLabel == "YouTube",
+                "YouTube brand casing (not 'Youtube')")
+        #expect(SourceProvider.vimeo.displayLabel == "Vimeo")
+        #expect(SourceProvider.spotify.displayLabel == "Spotify")
+        #expect(SourceProvider.soundcloud.displayLabel == "SoundCloud",
+                "SoundCloud brand casing (not 'Soundcloud')")
+        #expect(SourceProvider.remoteMedia.displayLabel == "Media")
+        #expect(SourceProvider.legacyImport.displayLabel == "Imported")
+    }
+
+    @Test("systemImage returns a non-empty SF Symbol name for each case",
+          arguments: SourceProvider.allCases)
+    func systemImageNonEmpty(_ provider: SourceProvider) {
+        let symbol = provider.systemImage
+        #expect(!symbol.isEmpty,
+                "systemImage must be non-empty for \(provider.rawValue)")
+    }
+
+    @Test("helpVerb returns a non-empty help text for each case",
+          arguments: SourceProvider.allCases)
+    func helpVerbNonEmpty(_ provider: SourceProvider) {
+        let verb = provider.helpVerb
+        #expect(!verb.isEmpty,
+                "helpVerb must be non-empty for \(provider.rawValue)")
+    }
+
+    @Test("helpVerb covers Reveal vs Open semantics")
+    func helpVerbSemantics() {
+        // Local paths (file/folder) "Reveal" in Finder; URL providers "Open"
+        // (or subclasses like "Open episode" for podcasts). The verb lets
+        // the UI chip phrase its tooltip consistently.
+        #expect(SourceProvider.localFile.helpVerb.hasPrefix("Reveal"))
+        #expect(SourceProvider.markdownFolder.helpVerb.hasPrefix("Reveal"))
+        #expect(SourceProvider.website.helpVerb.hasPrefix("Open"))
+        #expect(SourceProvider.applePodcast.helpVerb.hasPrefix("Open"))
+        #expect(SourceProvider.youtube.helpVerb.hasPrefix("Open"))
+        #expect(SourceProvider.remoteMedia.helpVerb.hasPrefix("Open"))
+    }
+
+    // MARK: - AC.7: supportsRefresh baseline
+
+    @Test("supportsRefresh is true only for website + applePodcast (baseline)")
+    func supportsRefreshBaseline() {
+        // AC.7: `supportsRefresh` collapses the refreshability switch into one
+        // enum property. This is BASELINE ONLY — `WikiStoreModel.isSourceRefreshable`
+        // layers runtime guards (hasImageSiblings for websites; the bundled
+        // signing helper for podcasts) on top of this predicate.
+        #expect(SourceProvider.website.supportsRefresh == true)
+        #expect(SourceProvider.applePodcast.supportsRefresh == true)
+        // Everything else is import-only or byteless-embed-only — no URL to
+        // re-fetch. (Direct-remote media could in principle be re-fetched, but
+        // the refresh service doesn't implement it today.)
+        #expect(SourceProvider.localFile.supportsRefresh == false)
+        #expect(SourceProvider.zotero.supportsRefresh == false)
+        #expect(SourceProvider.markdownFolder.supportsRefresh == false)
+        #expect(SourceProvider.youtube.supportsRefresh == false)
+        #expect(SourceProvider.vimeo.supportsRefresh == false)
+        #expect(SourceProvider.spotify.supportsRefresh == false)
+        #expect(SourceProvider.soundcloud.supportsRefresh == false)
+        #expect(SourceProvider.remoteMedia.supportsRefresh == false)
+        #expect(SourceProvider.legacyImport.supportsRefresh == false)
+    }
+
+    // MARK: - AC.4: SourceOrigin.provider
+
+    /// Build a minimal `SourceOrigin` for testing the `provider` computed
+    /// property — only `agentName` matters; the other columns are filler.
+    private func origin(agentName: String) -> SourceOrigin {
+        SourceOrigin(
+            versionID: "01JTESTVERSION000000",
+            agentName: agentName,
+            agentKind: "software",
+            activityKind: "import",
+            plan: nil, externalRef: nil, externalIdentity: nil,
+            runTitle: nil,
+            fetchedAt: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test("SourceOrigin.provider resolves each known provider")
+    func sourceOriginProviderKnown() {
+        // Round-trip: each known rawValue parses to its case via SourceOrigin.provider.
+        #expect(origin(agentName: "local-file").provider == .localFile)
+        #expect(origin(agentName: "website").provider == .website)
+        #expect(origin(agentName: "zotero").provider == .zotero)
+        #expect(origin(agentName: "markdown-folder").provider == .markdownFolder)
+        #expect(origin(agentName: "apple-podcast").provider == .applePodcast)
+        #expect(origin(agentName: "youtube").provider == .youtube)
+        #expect(origin(agentName: "vimeo").provider == .vimeo)
+        #expect(origin(agentName: "spotify").provider == .spotify)
+        #expect(origin(agentName: "soundcloud").provider == .soundcloud)
+        #expect(origin(agentName: "remote-media").provider == .remoteMedia)
+        #expect(origin(agentName: "legacy-import").provider == .legacyImport)
+    }
+
+    @Test("SourceOrigin.provider returns nil for unknown agentName")
+    func sourceOriginProviderUnknown() {
+        #expect(origin(agentName: "").provider == nil)
+        #expect(origin(agentName: "unknown").provider == nil)
+        #expect(origin(agentName: "test").provider == nil)
+        #expect(origin(agentName: "Website").provider == nil,
+                "case-sensitive parse — 'Website' (capital W) is NOT 'website'")
+    }
+
+    // MARK: - AC.4 + AC.6: SourceOrigin.displayLabel delegates to provider
+
+    @Test("SourceOrigin.displayLabel delegates to provider.displayLabel")
+    func sourceOriginDisplayLabelDelegates() {
+        // The label disagreements are resolved: SourceOrigin.displayLabel
+        // returns the enum's canonical label (Folder, YouTube, SoundCloud).
+        #expect(origin(agentName: "markdown-folder").displayLabel == "Folder")
+        #expect(origin(agentName: "youtube").displayLabel == "YouTube")
+        #expect(origin(agentName: "soundcloud").displayLabel == "SoundCloud")
+        #expect(origin(agentName: "local-file").displayLabel == "File")
+        #expect(origin(agentName: "legacy-import").displayLabel == "Imported")
+    }
+
+    @Test("SourceOrigin.displayLabel falls back to agentName.capitalized for unknown")
+    func sourceOriginDisplayLabelUnknownFallback() {
+        // Unknown agents use the pre-enum fallback: agentName.capitalized.
+        // Swift's .capitalized capitalizes the first char of EACH word AND
+        // lowercases the rest; word breaks happen at punctuation (e.g. `-`).
+        #expect(origin(agentName: "custom-bot").displayLabel == "Custom-Bot")
+        #expect(origin(agentName: "futureProvider").displayLabel == "Futureprovider")
+        #expect(origin(agentName: "").displayLabel == "")
+    }
+
+    // MARK: - AC.4 extension: MediaEmbedMatch.provider + SourceEmbedDescriptor.provider
+
+    @Test("MediaEmbedMatch.provider resolves byteless providers")
+    func mediaEmbedMatchProvider() {
+        // MediaEmbedMatch's agentName is always set by MediaEmbedURL's
+        // recognizers (SourceProvider.X.rawValue), so provider is non-nil for
+        // any real match — but the property degrades safely for unknown.
+        let youtube = MediaEmbedMatch(
+            agentName: "youtube", mimeType: "video/youtube",
+            externalIdentity: "abc", filename: "youtube-abc",
+            planURL: "https://youtu.be/abc", activityKind: "fetch")
+        #expect(youtube.provider == .youtube)
+
+        let remoteMedia = MediaEmbedMatch(
+            agentName: "remote-media", mimeType: "audio/mpeg",
+            externalIdentity: "https://example.com/x.mp3", filename: "x.mp3",
+            planURL: "https://example.com/x.mp3", activityKind: "import")
+        #expect(remoteMedia.provider == .remoteMedia)
+
+        let unknown = MediaEmbedMatch(
+            agentName: "future-provider", mimeType: "video/future",
+            externalIdentity: "x", filename: "future-x",
+            planURL: "https://example.com/x", activityKind: "fetch")
+        #expect(unknown.provider == nil)
+    }
+
+    @Test("SourceEmbedDescriptor.provider resolves byteless provider descriptors")
+    func sourceEmbedDescriptorProvider() {
+        // agentName is an Optional<String> on SourceEmbedDescriptor, so provider
+        // is nil for any of {nil, "", "unknown"}.
+        let podcastDescriptor = SourceEmbedDescriptor(
+            id: PageID(rawValue: "01JTESTDESC00000000"),
+            mimeType: "text/markdown",
+            externalIdentity: nil,
+            agentName: "apple-podcast",
+            planURL: "https://podcasts.apple.com/podcast/episode?id=123")
+        #expect(podcastDescriptor.provider == .applePodcast)
+
+        let nilAgent = SourceEmbedDescriptor(
+            id: PageID(rawValue: "01JTESTDESC00000001"),
+            mimeType: "audio/mpeg",
+            externalIdentity: "https://example.com/x.mp3",
+            agentName: nil,
+            planURL: nil)
+        #expect(nilAgent.provider == nil)
+
+        let emptyAgent = SourceEmbedDescriptor(
+            id: PageID(rawValue: "01JTESTDESC00000002"),
+            mimeType: "audio/mpeg",
+            externalIdentity: "https://example.com/y.mp3",
+            agentName: "",
+            planURL: "https://example.com/y.mp3")
+        #expect(emptyAgent.provider == nil,
+                "agentName = '' parses to nil (SourceProvider's init rejects empty)")
+    }
+
+    // MARK: - CaseIterable coverage
+
+    @Test("SourceProvider.allCases covers 11 cases")
+    func allCasesCount() {
+        #expect(SourceProvider.allCases.count == 11)
+        // Spot-check membership so adding a case without updating the count
+        // assertion doesn't silently regress coverage.
+        #expect(SourceProvider.allCases.contains(.localFile))
+        #expect(SourceProvider.allCases.contains(.website))
+        #expect(SourceProvider.allCases.contains(.zotero))
+        #expect(SourceProvider.allCases.contains(.markdownFolder))
+        #expect(SourceProvider.allCases.contains(.applePodcast))
+        #expect(SourceProvider.allCases.contains(.youtube))
+        #expect(SourceProvider.allCases.contains(.vimeo))
+        #expect(SourceProvider.allCases.contains(.spotify))
+        #expect(SourceProvider.allCases.contains(.soundcloud))
+        #expect(SourceProvider.allCases.contains(.remoteMedia))
+        #expect(SourceProvider.allCases.contains(.legacyImport))
+    }
+}

--- a/plans/source-provider-enum.md
+++ b/plans/source-provider-enum.md
@@ -1,0 +1,176 @@
+# Plan: SourceProvider Enum — Typed Source Origin Taxonomy
+
+## Summary
+
+Replace the raw convention strings ("website", "zotero", "local-file",
+"markdown-folder", "apple-podcast", "youtube", etc.) used as `agentName` values
+for source provenance with a typed `SourceProvider` enum. Centralize display
+labels, SF Symbols, refreshability, and help text as enum-carried properties.
+Collapse label disagreements across switch sites.
+
+**No DB migration** — `agents.name` values are byte-identical; the enum's
+`rawValue` matches today's strings exactly.
+
+## Problem
+
+The source-provider string convention is enforced by string discipline in 5
+materializers + 2 byteless-media sites, and parsed by 4 hardcoded switch
+statements + 2 equality checks across 3 files. Nothing prevents drift. Two
+switch sites **disagree** on labels ("Folder" vs "Markdown folder", "Youtube" vs
+"YouTube", "Soundcloud" vs "SoundCloud"). This is the same pattern PageAuthor
+fixed for page-version authors (PR #798).
+
+## Design
+
+### New: `Sources/WikiFSTypes/SourceProvider.swift`
+
+```swift
+/// Typed taxonomy for source origin — the `agents.name` value stamped by each
+/// materializer and projected from the PROV graph. Single source of truth for
+/// the convention strings. rawValue matches today's literals for DB back-compat.
+public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable {
+    case localFile       = "local-file"
+    case website         = "website"
+    case zotero          = "zotero"
+    case markdownFolder  = "markdown-folder"
+    case applePodcast    = "apple-podcast"
+    case youtube         = "youtube"
+    case vimeo           = "vimeo"
+    case spotify         = "spotify"
+    case soundcloud      = "soundcloud"
+    case remoteMedia     = "remote-media"
+    case legacyImport    = "legacy-import"
+
+    /// Parse a stored `agents.name` value. Unknown/test values → nil.
+    public init?(rawValue: String?) {
+        guard let rawValue, !rawValue.isEmpty else { return nil }
+        self.init(rawValue: rawValue)
+    }
+
+    /// Display label for the origin chip. Canonical — replaces disagreements.
+    public var displayLabel: String { ... }     // "File", "Website", "Folder", etc.
+
+    /// SF Symbol for the origin chip.
+    public var systemImage: String { ... }       // "doc", "globe", "folder", etc.
+
+    /// Help-text verb for the origin chip's tooltip/click action.
+    public var helpVerb: String { ... }          // "Reveal original file", "Open original", etc.
+
+    /// Baseline refresh capability (website + applePodcast support re-fetch in
+    /// principle). This is NOT the full refreshability predicate — runtime checks
+    /// (hasImageSiblings for websites, bundled helper for podcasts) gate on top.
+    public var supportsRefresh: Bool { ... }      // true for website, applePodcast
+}
+```
+
+**Label disagreements resolved** (enum carries ONE canonical value):
+
+| Provider | displayLabel | systemImage | Resolution |
+|----------|-------------|-------------|------------|
+| `markdownFolder` | "Folder" | `folder` | Use "Folder" (matches DetailView UI; "Markdown folder" too verbose for chip) |
+| `youtube` | "YouTube" | `play.rectangle` | Proper brand casing |
+| `soundcloud` | "SoundCloud" | `waveform` | Proper brand casing |
+
+### Route construction sites (write path)
+
+| Site | File | Change |
+|------|------|--------|
+| `LocalFileMaterializer.agentName` | `SourceMaterializer.swift:194` | `SourceProvider.localFile.rawValue` |
+| `WebsiteMaterializer.agentName` | `SourceMaterializer.swift:246` | `SourceProvider.website.rawValue` |
+| `ApplePodcastMaterializer.agentName` | `SourceMaterializer.swift:402` | `SourceProvider.applePodcast.rawValue` |
+| `ZoteroMaterializer.agentName` | `SourceMaterializer.swift:449` | `SourceProvider.zotero.rawValue` |
+| `MarkdownFolderMaterializer.agentName` | `SourceMaterializer.swift:506` | `SourceProvider.markdownFolder.rawValue` |
+| `bytelessMediaOutcome` | `WikiStoreModel.swift:2229` | `match.provider.rawValue` |
+| YouTube-with-transcript | `WikiStoreModel.swift:2296` | `match.provider.rawValue` |
+| `MediaEmbedMatch` literals | `MediaEmbedURL.swift:83,104,127,148,170` | `SourceProvider.youtube.rawValue` etc. |
+
+The materializer protocol `var agentName: String` (`SourceMaterializer.swift:120`)
+stays `String` (the rawValue) — or optionally becomes `var provider: SourceProvider`.
+Recommend keeping `String` to minimize the diff; the materializer just returns
+the enum's rawValue.
+
+### Route parse/display sites (read path)
+
+| Site | File | Change |
+|------|------|--------|
+| `SourceOrigin.displayLabel` switch | `SourceMaterializer.swift:175` | `provider.displayLabel` — delete the switch |
+| `SourceRefreshService` switch | `SourceRefreshService.swift:84` | `switch provider` — exhaustive, no default |
+| `WikiStoreModel.isSourceRefreshable` switch | `WikiStoreModel.swift:2834` | `provider.isRefreshable` + podcast helper check |
+| `SourceDetailView.providerOriginTag` switch | `SourceDetailView.swift:821` | `switch provider` — exhaustive, use `provider.displayLabel` / `.systemImage` / `.helpVerb` |
+| `SourceDetailView.mediaProviderInfo` switch | `SourceDetailView.swift:917` | Merge into providerOriginTag via `provider.displayLabel` / `.systemImage` / `.helpVerb` |
+| `SourceDetailView.embedEmptyLabel` switch | `SourceDetailView.swift:1043` | `switch provider` |
+| `MediaTitleFetcher` oEmbed switch | `MediaTitleFetcher.swift:100` | `switch provider` — exhaustive per-provider URL templates |
+| `SourceDetailView:565` equality check | `SourceDetailView.swift:565` | `provider != .legacyImport` |
+| `SourceDetailView:1052` equality check | `SourceDetailView.swift:1052` | `provider == .youtube` |
+| `ExternalEmbed:150,189` | `ExternalEmbed.swift` | `provider == .applePodcast` |
+
+### Type changes
+
+**`SourceProvenance.agentName`** (`SourceMaterializer.swift:31`):
+- Keep as `String` (it's the write-side descriptor that flows to `ensureAgent(name:)`).
+  The materializers set it to `SourceProvider.X.rawValue`. This minimizes the diff
+  and keeps the GRDBWikiStore write seams untouched.
+
+**`SourceOrigin.agentName`** (`SourceMaterializer.swift:137`):
+- Add a computed property `var provider: SourceProvider?` that wraps
+  `SourceProvider(rawValue: agentName)`. Keep `agentName: String` as-is (the DB
+  read path populates it from `a.name`). The switch sites use `provider` instead
+  of raw string matching. This handles unknown values gracefully (nil → default).
+
+### DB write seams (no change needed)
+
+The three `ensureAgent(name: prov.agentName, ...)` calls (`GRDBWikiStore.swift:3217,3338,3638`)
+already receive the string. Since the materializers set `agentName =
+SourceProvider.X.rawValue`, the stored value is identical. No change.
+
+`legacyImportAgentID` (`:2607`) writes `"legacy-import"` as a literal — it stays
+as-is (it's the DB fallback, not a materializer). `SourceProvider.legacyImport`
+exists for the read/display side.
+
+### Acceptance criteria
+
+- **AC.1**: `SourceProvider(rawValue:)` round-trips every case.
+- **AC.2**: Unknown string ("test", "unknown") → nil (graceful fallback).
+- **AC.3**: `displayLabel` / `systemImage` / `helpVerb` return canonical values for every case.
+- **AC.4**: `SourceOrigin.provider` resolves correctly for all known providers + nil for unknown.
+- **AC.5**: All 4 switch sites + 2 equality checks use the enum, not raw strings.
+- **AC.6**: Label disagreements resolved — "Folder" (not "Markdown folder"), "YouTube" (not "Youtube"), "SoundCloud" (not "Soundcloud").
+- **AC.7**: `isRefreshable` collapses the refreshability logic from 2 switch sites into one enum property.
+- **AC.8**: `swift build` + `swift test` pass (existing test assertions still work — rawValues are unchanged).
+
+### Test strategy
+
+| AC | Test | Location |
+|----|------|----------|
+| AC.1 | Round-trip every case | `Tests/WikiFSTests/SourceProviderTests.swift` (new) |
+| AC.2 | Unknown/string/nil → nil | Same |
+| AC.3 | displayLabel/systemImage/helpVerb for each case | Same |
+| AC.4 | SourceOrigin.provider for known + unknown | Same |
+| AC.5-7 | Existing tests pass (rawValues unchanged) | Existing suite |
+| AC.8 | Full suite green | Existing suite |
+
+### Files touched
+
+**New:**
+- `Sources/WikiFSTypes/SourceProvider.swift`
+- `Tests/WikiFSTests/SourceProviderTests.swift`
+
+**Edit (construction):**
+- `Sources/WikiFSCore/Sources/SourceMaterializer.swift` — 5 materializer agentName constants
+- `Sources/WikiFSCore/Store/WikiStoreModel.swift:2229,2296` — byteless-media provenance
+- `Sources/WikiFSCore/Integrations/MediaEmbedURL.swift:83,104,127,148,170` — MediaEmbedMatch literals
+
+**Edit (parse/display):**
+- `Sources/WikiFSCore/Sources/SourceMaterializer.swift:175` — SourceOrigin.displayLabel + add `provider` computed property
+- `Sources/WikiFSCore/Sources/SourceRefreshService.swift:84` — switch on provider
+- `Sources/WikiFSCore/Store/WikiStoreModel.swift:2834` — isSourceRefreshable via provider
+- `Sources/WikiFS/Sources/SourceDetailView.swift:821,917,1043,1052,565` — switch/equality on provider
+- `Sources/WikiFSCore/Integrations/ExternalEmbed.swift:150,189` — provider comparison
+
+## Out of scope
+
+- Typing `SourceProvenance.agentKind` (separate concern — overlaps with AgentKind).
+- Typing `SourceProvenance.activityKind` ("fetch" vs "import" — separate enum).
+- DB CHECK constraints on `agents.name` (migration v42+).
+- Changing the materializer protocol signature (`var agentName: String` stays).
+- Unifying `SourceEmbedDescriptor.agentName` with `SourceProvider` (tightly coupled to media-player pipeline — separate decision).


### PR DESCRIPTION
# SourceProvider Enum — Typed Source Origin Taxonomy

Replace the raw convention strings (`"website"`, `"zotero"`, `"local-file"`,
`"markdown-folder"`, `"apple-podcast"`, `"youtube"`, `vimeo`, `spotify`,
`soundcloud`, `remote-media`, `legacy-import`) used as `agents.name` values
for source provenance with a typed `SourceProvider` enum. Centralizes
`displayLabel`, `systemImage`, `helpVerb`, and `supportsRefresh` as
enum-carried properties. Switches on `Optional<SourceProvider>` at the read
sites so the compiler enforces exhaustiveness while gracefully degrading to
`nil` for unknown/forward-compat DB values.

**No DB migration** — `rawValue` matches today's literal strings exactly
(`SourceProvider.localFile = "local-file"`, …). The three `ensureAgent` write
seams + the `legacyImportAgentID` SQL fallback in `GRDBWikiStore` are
untouched: the materializers now source `agentName` from
`SourceProvider.X.rawValue`, but the written bytes are byte-identical.

Mirrors the `PageAuthor` pattern from #798 PR1. See `plans/source-provider-enum.md`
for the full design.

## Label disagreements resolved

The enum carries ONE canonical value per provider:

| Provider          | displayLabel | systemImage       | Old disagreement |
|-------------------|--------------|--------------------|------------------|
| `markdownFolder`  | `Folder`     | `folder`           | `SourceOrigin` returned "Markdown folder"; `DetailView` rendered "Folder" |
| `youtube`         | `YouTube`    | `play.rectangle`   | `mediaProviderInfo` returned "YouTube"; one site compared "Youtube" elsewhere |
| `soundcloud`      | `SoundCloud` | `waveform`         | `mediaProviderInfo` returned "SoundCloud"; one site compared "Soundcloud" elsewhere |

## Construction sites converted

| Site                                    | File                                  | Change |
|-----------------------------------------|---------------------------------------|--------|
| `LocalFileMaterializer.agentName`       | `SourceMaterializer.swift:194`        | `SourceProvider.localFile.rawValue` |
| `WebsiteMaterializer.agentName`         | `SourceMaterializer.swift:246`        | `SourceProvider.website.rawValue` |
| `ApplePodcastMaterializer.agentName`    | `SourceMaterializer.swift:402`        | `SourceProvider.applePodcast.rawValue` |
| `ZoteroMaterializer.agentName`          | `SourceMaterializer.swift:449`        | `SourceProvider.zotero.rawValue` |
| `MarkdownFolderMaterializer.agentName`  | `SourceMaterializer.swift:506`        | `SourceProvider.markdownFolder.rawValue` |
| `MediaEmbedMatch` literals              | `MediaEmbedURL.swift:83,104,127,148,170` | `SourceProvider.youtube.rawValue` etc. |

The materializer protocol `var agentName: String` stays `String` (the
rawValue) — minimizes the diff and keeps the GRDBWikiStore write seams
untouched.

## Parse / display sites converted

| Site                                          | File                                  | Change |
|-----------------------------------------------|---------------------------------------|--------|
| `SourceOrigin.displayLabel`                   | `SourceMaterializer.swift:175`        | `provider?.displayLabel ?? agentName.capitalized` — switch deleted |
| `SourceRefreshService.materialize(origin:)`   | `SourceRefreshService.swift:84`       | exhaustive switch on `origin.provider` (no `default`; `nil` covers unknown) |
| `WikiStoreModel.isSourceRefreshable`          | `WikiStoreModel.swift:2834`           | `provider.supportsRefresh` baseline + runtime guards (`hasImageSiblings`; bundled helper) layered on top |
| `SourceDetailView.providerOriginTag`          | `SourceDetailView.swift:821`         | exhaustive switch on `origin.provider`, enum-carried label/icon/helpVerb; collapsed 5 arms → 2 (URL providers + local-path reveal) |
| `mediaProviderInfo`                          | `SourceDetailView.swift:917`         | **deleted** — its values now live on `SourceProvider` |
| `SourceDetailView` equality at `:565`         | `SourceDetailView.swift:565`          | `origin.provider != .legacyImport` (was `origin.agentName != "legacy-import"`) |
| `embedEmptyLabel` / `embedEmptyDescription`  | `SourceDetailView.swift:1043,1052`    | switch / equality on `origin?.provider` |
| `MediaTitleFetcher.oembedURL(for:)`           | `MediaTitleFetcher.swift:100`         | exhaustive switch on `match.provider` (no `default`) |
| `ExternalEmbed.target(for:)` + `mediaTabLabel`| `ExternalEmbed.swift:150,189`         | `d.provider == .applePodcast` |

## Type changes

**`SourceProvenance.agentName`**: stays `String` (the write-side descriptor
that flows to `ensureAgent(name:)`). Materializers now set it to
`SourceProvider.X.rawValue`; the type is unchanged to keep the write seam
untouched.

**`SourceOrigin.agentName`**: stays `String` (populated from `a.name` at the
DB read path). Added a computed `var provider: SourceProvider?` wrapping
`SourceProvider(rawValue: agentName)` — switch sites use `provider` instead
of raw string matching. Same pattern applied to `MediaEmbedMatch` and
`SourceEmbedDescriptor`.

## Acceptance criteria

- **AC.1**: `SourceProvider(rawValue: p.rawValue) == p` for every case ✓
- **AC.2**: Unknown (`"test"`, `"unknown"`) + nil + empty → `nil` (graceful fallback, intentional nil-vs-`.legacyImport` split) ✓
- **AC.3**: `displayLabel` / `systemImage` / `helpVerb` return canonical values for every case ✓
- **AC.4**: `SourceOrigin.provider`, `MediaEmbedMatch.provider`, `SourceEmbedDescriptor.provider` resolve correctly for all known providers + `nil` for unknown ✓
- **AC.5**: All 4 switch sites + 2 equality checks use the enum, not raw strings ✓
- **AC.6**: Label disagreements resolved — `"Folder"`, `"YouTube"`, `"SoundCloud"` ✓
- **AC.7**: `supportsRefresh` collapses the refreshability baseline into one enum property (`WikiStoreModel.isSourceRefreshable` layers runtime guards on top) ✓
- **AC.8**: `swift build` clean + `swift test` full suite green ✓

## Test coverage

`Tests/WikiFSTests/SourceProviderTests.swift` (16 tests, 33 parameterised
invocations) covers AC.1–AC.7:

- Round-trip identity for each case
- Unknown/nil/empty → `nil`
- Raw-value literals pinned (so a future rename to the Swift case name can't silently shift stored bytes)
- Canonical display label mapping (`Folder` / `YouTube` / `SoundCloud`)
- `systemImage` / `helpVerb` non-empty for each case
- `helpVerb` Reveal-vs-Open semantics
- `supportsRefresh` baseline (`website` + `applePodcast` only)
- `SourceOrigin.provider` for known + unknown
- `SourceOrigin.displayLabel` delegates to provider + agentName.capitalized fallback for unknown
- `MediaEmbedMatch.provider` + `SourceEmbedDescriptor.provider` resolution
- `allCases` covers all 11 cases

The full suite (3,382 tests across 282 suites) passes — the stored byte
values are unchanged.

## Out of scope (named follow-ons)

- Typing `SourceProvenance.agentKind` (overlaps with `AgentKind`)
- Typing `SourceProvenance.activityKind` (`"fetch"` vs `"import"`)
- DB `CHECK` constraints on `agents.name` (migration v42+)
- Changing the materializer protocol signature (`var agentName: String` stays)
- Unifying `SourceEmbedDescriptor.agentName` with `SourceProvider` (tightly coupled to media-player pipeline — separate decision)
