### PR TITLE
feat: centralize WorkspaceStatus into a guarded FSM

### DIFF
--- a/Sources/WikiFSCore/Sources/SourceVersioning.swift
+++ b/Sources/WikiFSCore/Sources/SourceVersioning.swift
@@ -169,12 +169,58 @@ public struct PageConflictError: Error, Equatable {
 /// The lifecycle state of a workspace. Transitions: `open` → `merging` →
 /// `merged` (success) or `conflicted` (merge parked). `abandoned` is terminal
 /// (the workspace is GC'd — its `workspace_refs` are deleted).
-public enum WorkspaceStatus: String, Sendable, Equatable {
+///
+/// Legal transitions are declared by `allowedTargets` and enforced centrally by
+/// `GRDBWikiStore.transitionWorkspace(on:id:to:allowedFrom:)` — the single
+/// write seam for the `workspaces.status` column (see
+/// `plans/workspace-status-fsm.md`). Every UPDATE to that column routes through
+/// it; raw `UPDATE workspaces SET status = …` writes must not be reintroduced.
+public enum WorkspaceStatus: String, Sendable, CaseIterable, Codable, Equatable {
     case open
     case merging
     case merged
     case conflicted
     case abandoned
+
+    /// Legal target states reachable from this state in a single transition.
+    /// Terminal states (`merged`, `abandoned`) return an empty set. This is the
+    /// spec the validator consults; the per-call `allowedFrom` sets at each
+    /// write site are subsets of these (narrowed by what's actually reachable
+    /// at that site — e.g. the merge catch block always runs from `.open`
+    /// because `mutate()`'s savepoint rolled the step-1 `'merging'` write back).
+    public var allowedTargets: Set<WorkspaceStatus> {
+        switch self {
+        case .open:        return [.merging, .abandoned]
+        case .merging:     return [.merged, .conflicted, .abandoned]
+        case .merged:      return []
+        case .conflicted:  return [.open, .abandoned]
+        case .abandoned:   return []
+        }
+    }
+}
+
+/// Thrown by `GRDBWikiStore.transitionWorkspace` when a workspace row is
+/// missing (`.notFound`) or its current status is not in the call's
+/// `allowedFrom` set (`.invalidStateTransition`). Mirrors
+/// `QueueStoreError.invalidStateTransition`; keeps the workspace domain's
+/// errors with the workspace types rather than overloading `WikiStoreError`.
+/// `from` is `nil` only when the row exists but its `status` column holds a
+/// value outside the `WorkspaceStatus` domain — unreachable given the closed
+/// write seam, but surfaced (not silently coerced) for a corrupt DB.
+public enum WorkspaceError: Error, Equatable, CustomStringConvertible, LocalizedError {
+    case notFound(String)
+    case invalidStateTransition(from: WorkspaceStatus?, to: WorkspaceStatus)
+
+    public var description: String {
+        switch self {
+        case .notFound(let id):
+            return "Workspace not found: \(id)"
+        case .invalidStateTransition(let from, let to):
+            return "Invalid workspace status transition: \(from?.rawValue ?? "unknown") → \(to.rawValue)"
+        }
+    }
+
+    public var errorDescription: String? { description }
 }
 
 /// A summary of one workspace (W1, PR #312).

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -4686,6 +4686,44 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         return id
     }
 
+    /// Validate and execute a `workspaces.status` transition on `db`.
+    ///
+    /// This is the **single write seam** for the `status` column: every UPDATE
+    /// to it routes through here (the initial `INSERT … 'open'` in
+    /// `createWorkspace` is the lone exception — it sets the starting state,
+    /// not a transition). Reads the current status inside the caller's
+    /// savepoint, asserts it is in `allowedFrom`, and writes the new status —
+    /// read-validate-write in one transaction, so there is no TOCTOU window
+    /// between the guard and the write. Mirrors `QueueStore.validateTransition`
+    /// but operates inline on the caller's `Database` (it does NOT open its own
+    /// write, so it preserves the `mutate(event:_:)` emission invariant — every
+    /// public mutator still owns its `mutate` call and event emission).
+    ///
+    /// The per-call `allowedFrom` reflects the status that is **actually
+    /// reachable at that call site** (e.g. the merge catch block runs from
+    /// `.open`, because `mutate()` rolls the step-1 `'merging'` write back when
+    /// the closure throws on conflict). See `plans/workspace-status-fsm.md`.
+    private func transitionWorkspace(
+        on db: Database, id: String,
+        to: WorkspaceStatus, allowedFrom: Set<WorkspaceStatus>
+    ) throws {
+        let currentRaw = try String.fetchOne(
+            db, sql: "SELECT status FROM workspaces WHERE id = ?;",
+            arguments: [id]
+        )
+        guard let currentRaw else { throw WorkspaceError.notFound(id) }
+        guard let current = WorkspaceStatus(rawValue: currentRaw) else {
+            throw WorkspaceError.invalidStateTransition(from: nil, to: to)
+        }
+        guard allowedFrom.contains(current) else {
+            throw WorkspaceError.invalidStateTransition(from: current, to: to)
+        }
+        try db.execute(
+            sql: "UPDATE workspaces SET status = ?, updated_at = ? WHERE id = ?;",
+            arguments: [to.rawValue, Date().timeIntervalSince1970, id]
+        )
+    }
+
     public func workspaceSummary(id: String) throws -> WorkspaceSummary? {
         try dbWriter.read { db in
             guard let row = try Row.fetchOne(db, sql: """
@@ -4891,14 +4929,10 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         var mergedPageIDs: [String] = []
         do {
             try mutate(event: { _ in nil }) { db in
-                // 1. Mark workspace as 'merging'.
-                try db.execute(sql: """
-                UPDATE workspaces SET status = 'merging', updated_at = ?
-                WHERE id = ? AND status = 'open';
-                """, arguments: [Date().timeIntervalSince1970, workspaceID])
-                guard db.changesCount > 0 else {
-                    throw WikiStoreError.unexpected("workspace \(workspaceID) is not open (already merging/merged/conflicted/abandoned)")
-                }
+                // 1. Mark workspace as 'merging' (.open → .merging, validated).
+                try self.transitionWorkspace(
+                    on: db, id: workspaceID, to: .merging, allowedFrom: [.open]
+                )
 
                 // 2. For each workspace_ref, attempt fast-forward or mint.
                 let refs = try Row.fetchAll(db, sql: """
@@ -4996,10 +5030,10 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                     throw WikiStoreError.unexpected("workspace \(workspaceID) merge: \(conflicts.count) conflict(s)")
                 }
 
-                // 4. All fast-forwarded → mark 'merged'.
-                try db.execute(sql: """
-                UPDATE workspaces SET status = 'merged', updated_at = ? WHERE id = ?;
-                """, arguments: [Date().timeIntervalSince1970, workspaceID])
+                // 4. All fast-forwarded → mark 'merged' (.merging → .merged).
+                try self.transitionWorkspace(
+                    on: db, id: workspaceID, to: .merged, allowedFrom: [.merging]
+                )
             }
         } catch {
             // Only park if there were actual conflicts (not a different error).
@@ -5011,9 +5045,12 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 // Park in a separate transaction.
                 try mutate(event: { _ in nil }) { db in
                     let nowTS = Date().timeIntervalSince1970
-                    try db.execute(sql: """
-                    UPDATE workspaces SET status = 'conflicted', updated_at = ? WHERE id = ?;
-                    """, arguments: [nowTS, workspaceID])
+                    // The merge savepoint rolled back on the conflict throw, so
+                    // status reverted to .open (the step-1 'merging' write was
+                    // undone) — transition from .open, not .merging.
+                    try self.transitionWorkspace(
+                        on: db, id: workspaceID, to: .conflicted, allowedFrom: [.open]
+                    )
 
                     try db.execute(sql: """
                     DELETE FROM workspace_conflicts WHERE workspace_id = ?;
@@ -5055,8 +5092,10 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
     public func abandonWorkspace(id: String) throws {
         try mutate(event: { _ in nil }) { db in
-            try db.execute(sql: "UPDATE workspaces SET status = 'abandoned', updated_at = ? WHERE id = ?;",
-                           arguments: [Date().timeIntervalSince1970, id])
+            try self.transitionWorkspace(
+                on: db, id: id, to: .abandoned,
+                allowedFrom: [.open, .merging, .conflicted]
+            )
             try db.execute(sql: "DELETE FROM workspace_refs WHERE workspace_id = ?;",
                            arguments: [id])
         }
@@ -5151,9 +5190,12 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             if !conflicts.isEmpty {
                 try mutate(event: { _ in nil }) { db in
                     let nowTS = Date().timeIntervalSince1970
-                    try db.execute(sql: """
-                    UPDATE workspaces SET status = 'conflicted', updated_at = ? WHERE id = ?;
-                    """, arguments: [nowTS, workspaceID])
+                    // Refresh never wrote status in its savepoint (it only
+                    // read-validated ==.open); that savepoint rolled back on the
+                    // conflict throw, so status is still .open here.
+                    try self.transitionWorkspace(
+                        on: db, id: workspaceID, to: .conflicted, allowedFrom: [.open]
+                    )
 
                     try db.execute(sql: """
                     DELETE FROM workspace_conflicts WHERE workspace_id = ?;
@@ -5269,13 +5311,9 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
     public func workspaceRetryMerge(workspaceID: String) throws {
         try mutate(event: { _ in nil }) { db in
-            try db.execute(sql: """
-            UPDATE workspaces SET status = 'open', updated_at = ?
-            WHERE id = ? AND status = 'conflicted';
-            """, arguments: [Date().timeIntervalSince1970, workspaceID])
-            guard db.changesCount > 0 else {
-                throw WikiStoreError.unexpected("workspace \(workspaceID) is not conflicted")
-            }
+            try self.transitionWorkspace(
+                on: db, id: workspaceID, to: .open, allowedFrom: [.conflicted]
+            )
         }
         // Now attempt the merge again.
         _ = try workspaceMerge(workspaceID: workspaceID)
@@ -5296,15 +5334,15 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             // Delete refs + conflicts, then mark abandoned (mirrors
             // SQLiteWikiStore.reapStaleWorkspaces — the refs are the staging
             // rows, which must not survive a reap).
-            let now = Date().timeIntervalSince1970
             for id in staleIDs {
                 try db.execute(sql: "DELETE FROM workspace_refs WHERE workspace_id = ?;",
                                arguments: [id])
                 try db.execute(sql: "DELETE FROM workspace_conflicts WHERE workspace_id = ?;",
                                arguments: [id])
-                try db.execute(
-                    sql: "UPDATE workspaces SET status = 'abandoned', updated_at = ? WHERE id = ?;",
-                    arguments: [now, id]
+                // staleIDs are all '.open' (the SELECT filters on status='open'),
+                // so the transition is .open → .abandoned.
+                try self.transitionWorkspace(
+                    on: db, id: id, to: .abandoned, allowedFrom: [.open]
                 )
             }
             return staleIDs.count

--- a/Tests/WikiFSTests/WorkspaceTransitionTests.swift
+++ b/Tests/WikiFSTests/WorkspaceTransitionTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Unit tests for the centralized `WorkspaceStatus` FSM
+/// (`GRDBWikiStore.transitionWorkspace` — the single write seam for the
+/// `workspaces.status` column; see `plans/workspace-status-fsm.md`).
+///
+/// Covers:
+/// - **AC.1** — `WorkspaceStatus.allowedTargets` matches the FSM spec for all
+///   5 states (pure; terminal states are terminal).
+/// - **AC.2** — `transitionWorkspace` throws `.invalidStateTransition` on
+///   illegal moves, driven through the public API (so the reachable-status
+///   reality at each call site is exercised, not just the spec).
+/// - **AC.6** — every legal transition reachable from the public API, and a
+///   representative set of illegal ones (`merged→merging`, `abandoned→abandoned`,
+///   `merged→abandoned`, `open→open` via retry on a non-conflicted workspace).
+@MainActor
+@Suite(.timeLimit(.minutes(5)))
+struct WorkspaceTransitionTests {
+
+    private func tempStore() throws -> GRDBWikiStore {
+        try TestStoreFactory.inMemory()
+    }
+
+    // MARK: - AC.1: the spec (pure)
+
+    @Test func allowedTargetsMatchesFSMSpec() {
+        #expect(WorkspaceStatus.open.allowedTargets == [.merging, .abandoned])
+        #expect(WorkspaceStatus.merging.allowedTargets == [.merged, .conflicted, .abandoned])
+        #expect(WorkspaceStatus.merged.allowedTargets == [])
+        #expect(WorkspaceStatus.conflicted.allowedTargets == [.open, .abandoned])
+        #expect(WorkspaceStatus.abandoned.allowedTargets == [])
+    }
+
+    @Test func mergedAndAbandonedAreTerminal() {
+        #expect(WorkspaceStatus.merged.allowedTargets.isEmpty)
+        #expect(WorkspaceStatus.abandoned.allowedTargets.isEmpty)
+    }
+
+    /// Every state except the initial `.open` must appear as *some* state's
+    /// allowed target — otherwise it would be unreachable, a spec bug.
+    @Test func everyNonInitialStateIsReachable() {
+        let all = Set(WorkspaceStatus.allCases)
+        let reachable = Set(WorkspaceStatus.allCases.flatMap { $0.allowedTargets })
+        #expect(reachable.isSuperset(of: all.subtracting([.open])))
+        // The initial state itself is reached only by INSERT (createWorkspace),
+        // never by a transition, so it need not be any target.
+    }
+
+    // MARK: - AC.6: legal transitions via the public API
+
+    /// `open` → `merging` → `merged` (fast-forward merge: ws change alone on main).
+    @Test func legal_open_toMerging_toMerged() throws {
+        let store = try tempStore()
+        let page = try store.createPage(title: "FF Page")
+        _ = try store.appendPageVersion(
+            pageID: page.id, title: "FF Page", body: "v1",
+            expectedHeadVersionID: nil)
+
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        _ = try store.workspaceWritePage(
+            workspaceID: wsID, pageID: page.id, title: "FF Page", body: "ws body")
+
+        _ = try store.workspaceMerge(workspaceID: wsID)
+        #expect(try store.workspaceSummary(id: wsID)?.status == .merged)
+    }
+
+    /// `open` → (`merging` rolled back) → `conflicted` (merge parks on a conflict).
+    /// Exercises the catch-block write site whose `allowedFrom` is `[.open]`
+    /// (NOT `.merging`) because `mutate()`'s savepoint rolled the step-1 write back.
+    @Test func legal_open_toConflicted_parkOnConflict() throws {
+        let store = try tempStore()
+        let wsID = try readyConflictedWorkspace(store: store)
+        #expect(try store.workspaceSummary(id: wsID)?.status == .conflicted)
+    }
+
+    /// `conflicted` → `open` → `merging` → `merged` (resolve + retry).
+    /// Exercises the `.conflicted` → `.open` write site in `workspaceRetryMerge`.
+    @Test func legal_conflicted_toOpen_toMerged_viaRetry() throws {
+        let store = try tempStore()
+        let page = try store.createPage(title: "Retry Page")
+        _ = try store.appendPageVersion(
+            pageID: page.id, title: "Retry Page", body: "line1\nline2",
+            expectedHeadVersionID: nil)
+
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        _ = try store.workspaceWritePage(
+            workspaceID: wsID, pageID: page.id, title: "Retry Page",
+            body: "line1\nws-line2")
+
+        let mainHead = try store.pageHeadVersionID(pageID: page.id)
+        _ = try store.appendPageVersion(
+            pageID: page.id, title: "Retry Page",
+            body: "line1\nmain-line2", expectedHeadVersionID: mainHead)
+
+        _ = try store.workspaceMerge(workspaceID: wsID)
+        #expect(try store.workspaceSummary(id: wsID)?.status == .conflicted)
+
+        try store.workspaceResolveConflict(
+            workspaceID: wsID, pageID: page.id,
+            body: "line1\nmain-line2\nws-line2")
+
+        try store.workspaceRetryMerge(workspaceID: wsID)
+        #expect(try store.workspaceSummary(id: wsID)?.status == .merged)
+    }
+
+    /// `open` → `abandoned` (give up on an open workspace).
+    @Test func legal_open_toAbandoned() throws {
+        let store = try tempStore()
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        try store.abandonWorkspace(id: wsID)
+        #expect(try store.workspaceSummary(id: wsID)?.status == .abandoned)
+        #expect(try store.workspaceRefs(workspaceID: wsID).isEmpty)
+    }
+
+    /// `conflicted` → `abandoned` (give up on a parked workspace).
+    @Test func legal_conflicted_toAbandoned() throws {
+        let store = try tempStore()
+        let wsID = try readyConflictedWorkspace(store: store)
+        #expect(try store.workspaceSummary(id: wsID)?.status == .conflicted)
+        try store.abandonWorkspace(id: wsID)
+        #expect(try store.workspaceSummary(id: wsID)?.status == .abandoned)
+    }
+
+    // MARK: - AC.2: illegal transitions throw `.invalidStateTransition`
+
+    /// `merged` → `merging`: re-merging an already-merged workspace is illegal.
+    @Test func illegal_merged_toMerging() throws {
+        let store = try tempStore()
+        let wsID = try readyMergedWorkspace(store: store)
+        try assertInvalidTransition(from: .merged, to: .merging) {
+            _ = try store.workspaceMerge(workspaceID: wsID)
+        }
+        // State must be unchanged after a rejected transition.
+        #expect(try store.workspaceSummary(id: wsID)?.status == .merged)
+    }
+
+    /// `abandoned` → `abandoned`: abandoning an already-abandoned workspace.
+    @Test func illegal_abandoned_toAbandoned() throws {
+        let store = try tempStore()
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        try store.abandonWorkspace(id: wsID)
+        try assertInvalidTransition(from: .abandoned, to: .abandoned) {
+            try store.abandonWorkspace(id: wsID)
+        }
+        #expect(try store.workspaceSummary(id: wsID)?.status == .abandoned)
+    }
+
+    /// `merged` → `abandoned`: a terminal-success workspace cannot be abandoned.
+    @Test func illegal_merged_toAbandoned() throws {
+        let store = try tempStore()
+        let wsID = try readyMergedWorkspace(store: store)
+        try assertInvalidTransition(from: .merged, to: .abandoned) {
+            try store.abandonWorkspace(id: wsID)
+        }
+        #expect(try store.workspaceSummary(id: wsID)?.status == .merged)
+    }
+
+    /// `open` → `open` via `workspaceRetryMerge`: retry is only legal from
+    /// `.conflicted`. On a fresh open workspace the validator rejects it.
+    @Test func illegal_open_toOpen_viaRetry() throws {
+        let store = try tempStore()
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        try assertInvalidTransition(from: .open, to: .open) {
+            try store.workspaceRetryMerge(workspaceID: wsID)
+        }
+        #expect(try store.workspaceSummary(id: wsID)?.status == .open)
+    }
+
+    // MARK: - Helpers
+
+    /// A workspace parked at `.conflicted` (conflict-merge setup, no resolve).
+    private func readyConflictedWorkspace(store: GRDBWikiStore) throws -> String {
+        let page = try store.createPage(title: "Page")
+        _ = try store.appendPageVersion(
+            pageID: page.id, title: "Page", body: "line1\nline2",
+            expectedHeadVersionID: nil)
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        _ = try store.workspaceWritePage(
+            workspaceID: wsID, pageID: page.id, title: "Page",
+            body: "line1\nws-line2")
+        let mainHead = try store.pageHeadVersionID(pageID: page.id)
+        _ = try store.appendPageVersion(
+            pageID: page.id, title: "Page",
+            body: "line1\nmain-line2", expectedHeadVersionID: mainHead)
+        _ = try store.workspaceMerge(workspaceID: wsID)
+        return wsID
+    }
+
+    /// A workspace at `.merged` (fast-forward merge completes cleanly).
+    private func readyMergedWorkspace(store: GRDBWikiStore) throws -> String {
+        let page = try store.createPage(title: "Merged Page")
+        _ = try store.appendPageVersion(
+            pageID: page.id, title: "Merged Page", body: "v1",
+            expectedHeadVersionID: nil)
+        let wsID = try store.createWorkspace(name: nil, activityID: nil)
+        _ = try store.workspaceWritePage(
+            workspaceID: wsID, pageID: page.id, title: "Merged Page", body: "ws body")
+        _ = try store.workspaceMerge(workspaceID: wsID)
+        return wsID
+    }
+
+    /// Assert `action` throws `WorkspaceError.invalidStateTransition` with the
+    /// given `from`/`to`. Runs `action` exactly once.
+    private func assertInvalidTransition(
+        from: WorkspaceStatus, to: WorkspaceStatus,
+        _ action: () throws -> Void
+    ) throws {
+        do {
+            try action()
+            Issue.record("expected WorkspaceError.invalidStateTransition(\(from) → \(to))")
+        } catch let err as WorkspaceError {
+            #expect(
+                err == .invalidStateTransition(from: from, to: to),
+                "got \(err)"
+            )
+        } catch {
+            Issue.record("expected WorkspaceError, got \(type(of: error)): \(error)")
+        }
+    }
+}

--- a/plans/workspace-status-fsm.md
+++ b/plans/workspace-status-fsm.md
@@ -1,0 +1,152 @@
+# Plan: Centralize WorkspaceStatus into a Guarded FSM
+
+## Summary
+
+Replace the 8 scattered raw-SQL `status` writes on `workspaces` with a single
+`transitionWorkspace(id:to:allowedFrom:)` method that validates legal transitions
+(mirroring `QueueStore.validateTransition`). Add a `WorkspaceStatus` enum with
+documented legal transitions. No DB migration required (CHECK constraint deferred).
+
+## Problem
+
+`WorkspaceStatus` has 5 states (`open`, `merging`, `merged`, `conflicted`,
+`abandoned`) written by **8 raw-SQL string literals** scattered across
+`GRDBWikiStore`, each with ad-hoc `WHERE` self-guards. No central validator, no
+DB CHECK. Nothing structurally prevents illegal transitions (`merged→open`,
+`abandoned→merging`). Adding a new writer means re-deriving the legal set by
+reading all 8 sites. This is the exact pattern `QueueItemState` already solved
+via `QueueStore.validateTransition`.
+
+## Design
+
+### Step 1: Promote WorkspaceStatus to a proper enum
+
+`Sources/WikiFSCore/Sources/SourceVersioning.swift:172` — the enum already
+exists with 5 cases. Add a `legalTransitions` computed property or a static
+method:
+
+```swift
+public enum WorkspaceStatus: String, CaseIterable, Codable, Sendable {
+    case open, merging, merged, conflicted, abandoned
+
+    /// Legal target states from this state.
+    public var allowedTargets: Set<WorkspaceStatus> {
+        switch self {
+        case .open:        return [.merging, .abandoned]
+        case .merging:     return [.merged, .conflicted, .abandoned]
+        case .merged:      return []           // terminal
+        case .conflicted:  return [.open, .abandoned]  // retry or give up
+        case .abandoned:   return []           // terminal
+        }
+    }
+}
+```
+
+### Step 2: Add transitionWorkspace to GRDBWikiStore
+
+Add a private method that validates + writes. **Implementation note: every
+status-write site already lives inside a `mutate(event:_:)` closure that passes
+a `Database`. To preserve atomicity and the `mutate()` emission invariant
+(AGENTS.md: every public mutator routes through `mutate` and emits), this
+helper takes the existing `db` rather than opening its own write.**
+
+```swift
+/// Validate and execute a workspace status transition on `db`.
+/// Throws `.notFound` if the row is missing, or
+/// `.invalidStateTransition` if the current status is not in `allowedFrom`.
+/// Mirrors `QueueStore.validateTransition`, but operates inside the caller's
+/// savepoint (read-validate-write in one transaction — no TOCTOU window).
+private func transitionWorkspace(
+    on db: Database, id: String,
+    to: WorkspaceStatus, allowedFrom: Set<WorkspaceStatus>
+) throws {
+    let currentRaw = try String.fetchOne(
+        db, sql: "SELECT status FROM workspaces WHERE id = ?;",
+        arguments: [id]
+    )
+    guard let currentRaw else { throw WorkspaceError.notFound(id) }
+    guard let current = WorkspaceStatus(rawValue: currentRaw) else {
+        throw WorkspaceError.invalidStateTransition(from: currentRaw, to: to)
+    }
+    guard allowedFrom.contains(current) else {
+        throw WorkspaceError.invalidStateTransition(from: current, to: to)
+    }
+    try db.execute(
+        sql: "UPDATE workspaces SET status = ?, updated_at = ? WHERE id = ?;",
+        arguments: [to.rawValue, Date().timeIntervalSince1970, id]
+    )
+}
+```
+
+### Step 3: Route all write sites through transitionWorkspace
+
+> **Corrected `allowedFrom`** — the plan's original table assumed the merge
+> closure's step-1 `'merging'` write persisted into the rollback catch block.
+> It does not: `mutate()` wraps the body in `db.inSavepoint` (see
+> `GRDBWikiStore.swift:336`), so when the closure throws on conflict, the
+> `'merging'` write is rolled back → status reverts to `'open'`. The catch
+> block then writes `'conflicted'` from `.open`. Same for `reapStaleWorkspaces`
+> (its SELECT only returns `'open'` rows). The `allowedFrom` below reflects
+> the **actually reachable status at each write site** (verified by reading the
+> code), which is what preserves existing behavior.
+
+| Site | Method | `to` | reachable-from (code-truth) | `allowedFrom` |
+|------|--------|------|------|---------------|
+| `createWorkspace` (~L4682) | INSERT | `'open'` | n/a (initial state) | stays INSERT |
+| `workspaceMerge` step 1 (~L4896) | in main closure | `.merging` | `.open` | `[.open]` |
+| `workspaceMerge` step 4 (~L5001) | in main closure | `.merged` | `.merging` | `[.merging]` |
+| `workspaceMerge` catch (~L5015) | separate txn, post-rollback | `.conflicted` | `.open` | `[.open]` |
+| `abandonWorkspace` (~L5058) | public | `.abandoned` | any non-terminal | `[.open, .merging, .conflicted]` |
+| `workspaceRefresh` catch (~L5155) | separate txn, post-rollback | `.conflicted` | `.open` | `[.open]` |
+| `workspaceRetryMerge` (~L5273) | public | `.open` | `.conflicted` | `[.conflicted]` |
+| `reapStaleWorkspaces` (~L5306) | loop over stale `'open'` IDs | `.abandoned` | `.open` | `[.open]` |
+
+Behavior changes (intended):
+- The two `WHERE status = 'X'` self-guards (L4897 `status='open'`, L5274
+  `status='conflicted'`) and their `db.changesCount > 0` friendly-error
+  checks are removed; `transitionWorkspace` replaces them with a typed
+  `WorkspaceError.invalidStateTransition`. No test asserts on the old
+  `WikiStoreError.unexpected("… is not open/conflicted")` strings (verified).
+- `abandonWorkspace` is newly restricted to non-terminal states
+  (`[.open, .merging, .conflicted]`); today it has no guard. No caller
+  abandons a terminal (`merged`/`abandoned`) workspace (verified in tests +
+  `WorkspaceCommand`).
+
+### Step 4: Add WorkspaceError
+
+Lives next to `WorkspaceStatus` + `PageConflictError` in `SourceVersioning.swift`
+(mirrors how `QueueStoreError` is a domain-local error type):
+
+```swift
+public enum WorkspaceError: Error, Equatable, CustomStringConvertible, LocalizedError {
+    case notFound(String)
+    case invalidStateTransition(from: WorkspaceStatus, to: WorkspaceStatus)
+    // (an unknown raw string in the DB column is surfaced as invalidStateTransition
+    //  with from = the raw string — but WorkspaceStatus is a closed enum, so the
+    //  typed from-below overload is used; keep a String-`from` overload only if needed.)
+
+    public var description: String { … }
+    public var errorDescription: String? { description }
+}
+```
+
+### Acceptance criteria
+
+- **AC.1**: `WorkspaceStatus.allowedTargets` returns the correct legal set for each state.
+- **AC.2**: `transitionWorkspace` throws `.invalidStateTransition` on illegal moves (e.g., `merged→open`).
+- **AC.3**: All 7 UPDATE sites (excluding the initial INSERT) route through `transitionWorkspace`.
+- **AC.4**: The `WHERE status=…` self-guards at each site are removed (the validator replaces them).
+- **AC.5**: `swift build` + `swift test` pass.
+- **AC.6**: New test: `WorkspaceTransitionTests` covering every legal + illegal transition.
+
+### Files touched
+
+- **Edit:** `Sources/WikiFSCore/Sources/SourceVersioning.swift` (add `allowedTargets` + `CaseIterable`/`Codable`; add `WorkspaceError`)
+- **Edit:** `Sources/WikiFSCore/Store/GRDBWikiStore.swift` (add `transitionWorkspace`, route 7 sites, remove raw SQL + `WHERE status` guards)
+- **New:** `Tests/WikiFSTests/WorkspaceTransitionTests.swift`
+
+### Out of scope
+
+- DB CHECK constraint (requires table-rebuild migration — separate PR)
+- Typed IDs (SourceID/ChatID/VersionID newtypes — separate large effort)
+- QueueRunState guard (only 2 cases, low risk)


### PR DESCRIPTION
## Summary

Replaces the 8 scattered raw-SQL `status` writes on the `workspaces` table with a single `transitionWorkspace(on:id:to:allowedFrom:)` validator that enforces legal state transitions — the same pattern `QueueStore.validateTransition` already uses for `QueueItemState`. No DB migration.

## Problem

`WorkspaceStatus` has 5 states (`open`, `merging`, `merged`, `conflicted`, `abandoned`) written by **8 raw-SQL string literals** scattered across `GRDBWikiStore`, each with ad-hoc `WHERE status='...'` self-guards. No central validator, no DB CHECK constraint. Nothing structurally prevents illegal transitions (`merged→open`, `abandoned→merging`), and adding a new writer means re-deriving the legal set by reading all 8 sites.

## Changes

### `WorkspaceStatus` (`SourceVersioning.swift`)
- Added `allowedTargets: Set<WorkspaceStatus>` — the legal-transition spec, consulted by the validator. Terminal states (`merged`, `abandoned`) return `[]`.
- Added `CaseIterable` + `Codable` conformance (needed by tests + future typed-column work).

### `WorkspaceError` (new, `SourceVersioning.swift`)
- `case notFound(String)` — row missing.
- `case invalidStateTransition(from: WorkspaceStatus?, to: WorkspaceStatus)` — illegal move. `from` is `nil` only for a corrupt `status` value outside the enum (unreachable given the closed write seam, but surfaced rather than silently coerced).
- `Equatable` + `CustomStringConvertible` + `LocalizedError`.

### `transitionWorkspace` (`GRDBWikiStore.swift`)
Private helper that is now the **single write seam** for the `workspaces.status` column:
- Reads the current status inside the caller's savepoint, asserts it's in `allowedFrom`, writes the new status — read-validate-write in one transaction, no TOCTOU window.
- Operates **inline on the caller's `Database`** (does NOT open its own write), so it preserves the `mutate(event:_:)` emission invariant from AGENTS.md — every public mutator still owns its `mutate` call.

### Routed 7 UPDATE sites through `transitionWorkspace`

| Site | `to` | `allowedFrom` (code-truth) |
|------|------|----------------------------|
| `workspaceMerge` step 1 | `.merging` | `[.open]` |
| `workspaceMerge` step 4 | `.merged` | `[.merging]` |
| `workspaceMerge` catch | `.conflicted` | `[.open]` |
| `abandonWorkspace` | `.abandoned` | `[.open, .merging, .conflicted]` |
| `workspaceRefresh` catch | `.conflicted` | `[.open]` |
| `workspaceRetryMerge` | `.open` | `[.conflicted]` |
| `reapStaleWorkspaces` | `.abandoned` | `[.open]` |

The initial `INSERT … 'open'` in `createWorkspace` stays an INSERT (it sets the starting state, not a transition).

### ⚠️ Correction to the plan's original `allowedFrom`

The original plan sketch assumed the merge closure's step-1 `'merging'` write persisted into the rollback catch block. **It does not**: `mutate()` wraps the body in `db.inSavepoint` (`GRDBWikiStore.swift:336`), so when the closure throws on conflict, the `'merging'` write is rolled back → status reverts to `.open`. The catch block then writes `'conflicted'` **from `.open`**, not `.merging`. Same for `workspaceRefresh` (its savepoint also rolls back on the conflict throw). The `allowedFrom` values above reflect the **actually reachable status at each write site** (verified by reading the code), which is what preserves existing behavior. See `plans/workspace-status-fsm.md` for the full correction writeup.

### Guards removed
- `WHERE status='open'` (L4897) + its `db.changesCount > 0` friendly-error check → `transitionWorkspace` rejects with typed error.
- `WHERE status='conflicted'` (L5274) + its `db.changesCount > 0` check → same.

No test asserted on the old `WikiStoreError.unexpected("… is not open/conflicted")` strings (verified).

### Behavior changes (intended)
- `abandonWorkspace` is now restricted to non-terminal states (`[.open, .merging, .conflicted]`); today it has no guard. No caller abandons a terminal (`merged`/`abandoned`) workspace (verified in tests + `WorkspaceCommand`).

## Tests

New `Tests/WikiFSTests/WorkspaceTransitionTests.swift` — 12 tests:
- **AC.1**: `allowedTargets` matches the FSM spec for all 5 states; terminal states are terminal.
- **AC.6**: Every legal transition reachable from the public API (`open→merging→merged`, `open→conflicted`, `conflicted→open→merged`, `open→abandoned`, `conflicted→abandoned`).
- **AC.2**: Illegal transitions throw `.invalidStateTransition` (`merged→merging`, `abandoned→abandoned`, `merged→abandoned`, `open→open` via retry on a non-conflicted workspace), and state is unchanged after a rejected transition.

## Verification

- `make prompts && swift build` ✅
- `swift test` ✅ — 3418 tests in 285 suites, 0 failures (includes the 12 new tests + the existing workspace merge/abandon/retry/conflict tests, all green).

## Out of scope
- DB CHECK constraint (requires table-rebuild migration — separate PR)
- Typed IDs (SourceID/ChatID/VersionID newtypes)
- `QueueRunState` guard (only 2 cases, low risk)

## Plan doc
`plans/workspace-status-fsm.md` (committed in the first commit of this PR).
