### PR TITLE
feat: youtube-transcript standalone uv script (#584)

### DIFF
--- a/tools/youtube-transcript/.gitignore
+++ b/tools/youtube-transcript/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.venv/
+.pytest_cache/
+.ruff_cache/
+uv.lock

--- a/tools/youtube-transcript/README.md
+++ b/tools/youtube-transcript/README.md
@@ -1,0 +1,165 @@
+# youtube-transcript
+
+Standalone `uv` script (PEP 723 inline metadata) that fetches YouTube video
+transcripts and outputs markdown to stdout. Mirrors the `tools/pdf2md/pdf2md`
+pattern.
+
+The Swift `YouTubeTranscriptService` spawns it as a subprocess, replacing the
+fragile `ytInitialPlayerResponse` watch-page scrape (#584).
+
+## Usage
+
+```bash
+uv run --script youtube-transcript <video-id-or-url> [--lang en] [--json] [--output file.md] [--timestamps]
+```
+
+Accepts a video ID (`dQw4w9WgXcQ`) or a URL:
+
+- `youtube.com/watch?v=...`
+- `youtu.be/...`
+- `youtube.com/shorts/...`
+- `youtube.com/embed/...`
+
+### Examples
+
+```bash
+# Raw video ID, markdown to stdout
+uv run --script youtube-transcript dQw4w9WgXcQ
+
+# URL input, with timestamps
+uv run --script youtube-transcript https://youtu.be/dQw4w9WgXcQ --timestamps
+
+# JSON output with segments
+uv run --script youtube-transcript dQw4w9WgXcQ --json
+
+# Write to file
+uv run --script youtube-transcript dQw4w9WgXcQ -o transcript.md
+
+# Preferred language
+uv run --script youtube-transcript dQw4w9WgXcQ --lang es
+```
+
+## Installation
+
+Requires [uv](https://docs.astral.sh/uv/):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+The `youtube-transcript-api` dependency is declared in the PEP 723 inline
+metadata block — `uv` resolves it automatically on first run.
+
+## Output formats
+
+### Markdown (default)
+
+```markdown
+# YouTube Transcript: dQw4w9WgXcQ
+
+Hello everyone welcome to the video. Today we are going to talk about how to build great software.
+```
+
+With `--timestamps`:
+
+```markdown
+# YouTube Transcript: dQw4w9WgXcQ
+
+[00:00] Hello everyone welcome to the video.
+[00:03] Today we are going to talk about
+[00:05] how to build great software.
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "video_id": "dQw4w9WgXcQ",
+  "language": "en",
+  "segments": [
+    {"text": "Hello everyone welcome to the video.", "start": 0.0, "duration": 3.5},
+    {"text": "Today we are going to talk about", "start": 3.5, "duration": 2.0}
+  ],
+  "markdown": "# YouTube Transcript: dQw4w9WgXcQ\n\n..."
+}
+```
+
+## Language preference
+
+The script tries, in order:
+
+1. Requested language (default `en`)
+2. English manual captions (`en`, `en-GB`)
+3. English ASR (`en-US` generated)
+4. First available track of any language (via `list_transcripts`)
+
+## Exit codes
+
+| Code | Meaning                                      |
+|------|----------------------------------------------|
+| 0    | Success                                      |
+| 1    | Network or unknown error                     |
+| 2    | No transcript available for this video       |
+| 3    | Transcripts disabled for this video          |
+| 4    | Video unavailable (deleted, private, etc.)  |
+
+## Testing
+
+```bash
+uv run pytest tests/ -v          # all tests (mocked — no YouTube calls)
+uv run ruff check youtube-transcript tests/
+uv run pyright youtube-transcript tests/
+```
+
+## Swift integration
+
+After this tool lands, `YouTubeTranscriptService` spawns the script as a
+subprocess instead of scraping the watch page. The generalization PR (#809)
+already routes YouTube through `transcribe(sourceID:)` — this tool just swaps
+the fetch backend. See plans/youtube-transcript-tool.md for details.
+
+## Plan
+
+### Summary
+
+Create `tools/youtube-transcript/youtube-transcript` — a standalone uv script
+(PEP 723 inline metadata) that fetches YouTube video transcripts and outputs
+markdown to stdout. Mirrors the `tools/pdf2md/pdf2md` pattern exactly.
+
+The Swift `YouTubeTranscriptService` will spawn it as a subprocess, replacing
+the fragile `ytInitialPlayerResponse` watch-page scrape (#584).
+
+### Reference code
+
+- **pdf2md pattern** (`tools/pdf2md/pdf2md`): `#!/usr/bin/env -S uv run --script`
+  with `# /// script` inline metadata block. Takes file input, outputs markdown
+  to stdout, exit codes for error types.
+- **groundedllm** (`hayhooks/components/youtube_transcript.py`): video ID
+  extraction, `youtube_transcript_api` usage, language preference logic, error
+  handling for `NoTranscriptFound` / `TranscriptsDisabled` / `VideoUnavailable`.
+- **groundedllm** (`hayhooks/components/content_extraction.py`): URL routing
+  patterns, content fetching, resolver patterns.
+
+### Deliverables
+
+1. **The script:** `tools/youtube-transcript/youtube-transcript` — PEP 723
+   inline metadata, `youtube-transcript-api>=1.0` dependency.
+2. **Tests:** `tools/youtube-transcript/tests/` — unit tests with mocked
+   `YouTubeTranscriptApi` (no real YouTube calls in CI).
+3. **Project config:** `tools/youtube-transcript/pyproject.toml` — dev
+   dependencies only (runtime deps in PEP 723 inline block).
+4. **Docs:** `tools/youtube-transcript/README.md`.
+5. **Gitignore:** `tools/youtube-transcript/.gitignore`.
+
+### Acceptance criteria
+
+- **AC.1**: `uv run --script youtube-transcript dQw4w9WgXcQ` outputs markdown to
+  stdout with exit 0 (tested with mock, not real network).
+- **AC.2**: URL inputs are parsed to video IDs (watch, shorts, youtu.be, embed).
+- **AC.3**: Language preference tries manual -> ASR -> first available.
+- **AC.4**: `--json` outputs structured JSON with segments.
+- **AC.5**: Exit codes: 0 success, 1 unknown, 2 no transcript, 3 disabled,
+  4 unavailable.
+- **AC.6**: `uv run pytest tests/` passes with mocked YouTube API.
+- **AC.7**: `uv run ruff check youtube-transcript tests/` clean.
+- **AC.8**: `uv run pyright youtube-transcript tests/` clean.

--- a/tools/youtube-transcript/pyproject.toml
+++ b/tools/youtube-transcript/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "youtube-transcript"
+version = "0.1.0"
+requires-python = ">=3.12,<3.14"
+# Runtime dependencies are in the PEP 723 inline metadata block of the
+# youtube-transcript script. This pyproject.toml only holds dev tooling.
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "pytest-mock>=3",
+    "ruff>=0.11",
+    "pyright>=1.1",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+    "SIM", # flake8-simplify
+]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "standard"
+reportMissingImports = false
+reportMissingModuleSource = false
+reportMissingTypeStubs = false

--- a/tools/youtube-transcript/tests/conftest.py
+++ b/tools/youtube-transcript/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Shared fixtures for youtube-transcript tests.
+
+We vendor mock exception classes that mirror youtube_transcript_api's
+exception hierarchy. The script catches exceptions by the attribute on the
+module object returned by _import_api(), so the tests provide these
+classes via a mock module namespace.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ── Mock exception classes (mirror youtube_transcript_api) ──────────────
+
+
+class NoTranscriptFound(Exception):
+    pass
+
+
+class TranscriptsDisabled(Exception):
+    pass
+
+
+class VideoUnavailable(Exception):
+    pass
+
+
+class CouldNotRetrieveTranscript(Exception):
+    pass
+
+
+# ── Mock transcript data ──────────────────────────────────────────────
+
+
+def build_mock_segments() -> list[dict[str, str | float]]:
+    """Sample transcript segments for tests."""
+    return [
+        {"text": "Hello everyone welcome to the video.", "start": 0.0, "duration": 3.5},
+        {"text": "Today we are going to talk about", "start": 3.5, "duration": 2.0},
+        {"text": "how to build great software.", "start": 5.5, "duration": 3.0},
+    ]
+
+
+class MockTranscript:
+    """Simulates youtube_transcript_api's Transcript object."""
+
+    def __init__(
+        self,
+        language_code: str,
+        segments: list[dict[str, str | float]] | None = None,
+    ) -> None:
+        self.language_code = language_code
+        self._segments = segments if segments is not None else build_mock_segments()
+
+    def fetch(self) -> list[dict[str, str | float]]:
+        return self._segments
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_segments() -> list[dict[str, str | float]]:
+    return build_mock_segments()
+
+
+@pytest.fixture
+def mock_yta() -> Any:
+    """A mock youtube_transcript_api module namespace.
+
+    Tests mock the _import_api function to return this object so that the
+    script code (which expects a real module) operates on mock data.
+    """
+    yta = types.SimpleNamespace()
+    # Mirror the exception classes from youtube_transcript_api.
+    yta.NoTranscriptFound = NoTranscriptFound
+    yta.TranscriptsDisabled = TranscriptsDisabled
+    yta.VideoUnavailable = VideoUnavailable
+    yta.CouldNotRetrieveTranscript = CouldNotRetrieveTranscript
+    yta.YouTubeTranscriptApi = MagicMock()
+    return yta

--- a/tools/youtube-transcript/tests/test_youtube_transcript.py
+++ b/tools/youtube-transcript/tests/test_youtube_transcript.py
@@ -1,0 +1,377 @@
+"""Unit tests for the youtube-transcript script.
+
+Run from the tools/youtube-transcript directory:
+    uv run pytest tests/test_youtube_transcript.py -v
+
+All YouTube API calls are mocked — no network access required.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+from conftest import (
+    MockTranscript,
+    NoTranscriptFound,
+    TranscriptsDisabled,
+    VideoUnavailable,
+    build_mock_segments,
+)
+
+# ── Import the youtube-transcript module (extensionless script) ────────
+
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "youtube-transcript"
+assert _SCRIPT_PATH.exists(), f"youtube-transcript script not found at {_SCRIPT_PATH}"
+
+_yt = SourceFileLoader("youtube_transcript", str(_SCRIPT_PATH)).load_module()
+sys.modules["youtube_transcript"] = _yt
+
+
+# ── Video ID extraction ────────────────────────────────────────────────
+
+
+class TestExtractVideoId:
+    def test_raw_video_id(self):
+        assert _yt.extract_video_id("dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_watch_url(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert _yt.extract_video_id(url) == "dQw4w9WgXcQ"
+
+    def test_watch_url_no_www(self):
+        assert _yt.extract_video_id("https://youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_short_url(self):
+        assert _yt.extract_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_shorts_url(self):
+        assert _yt.extract_video_id("https://www.youtube.com/shorts/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_embed_url(self):
+        assert _yt.extract_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_watch_url_with_extra_params(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120s&feature=share"
+        assert _yt.extract_video_id(url) == "dQw4w9WgXcQ"
+
+    def test_url_without_scheme(self):
+        assert _yt.extract_video_id("youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_mobile_url(self):
+        assert _yt.extract_video_id("https://m.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_strips_whitespace(self):
+        assert _yt.extract_video_id("  dQw4w9WgXcQ  ") == "dQw4w9WgXcQ"
+
+    def test_empty_returns_none(self):
+        assert _yt.extract_video_id("") is None
+
+    def test_too_short_returns_none(self):
+        assert _yt.extract_video_id("short") is None
+
+    def test_non_youtube_url_returns_none(self):
+        assert _yt.extract_video_id("https://example.com") is None
+
+
+# ── Language preference ────────────────────────────────────────────────
+
+
+class TestBuildLanguageList:
+    def test_default_lang_en(self):
+        assert _yt._build_language_list("en") == ["en", "en-US", "en-GB"]
+
+    def test_custom_lang_es(self):
+        assert _yt._build_language_list("es") == ["es", "en", "en-US", "en-GB"]
+
+    def test_lang_en_US(self):
+        assert _yt._build_language_list("en-US") == ["en-US", "en", "en-GB"]
+
+    def test_no_duplicates(self):
+        langs = _yt._build_language_list("en")
+        assert langs.count("en") == 1
+
+
+class TestLanguagePreference:
+    def test_primary_lookup_passes_language_list(self, mocker, mock_yta):
+        """get_transcript receives the full language preference list."""
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+
+        _yt._fetch_transcript("dQw4w9WgXcQ", "en")
+
+        call_kwargs = mock_yta.YouTubeTranscriptApi.get_transcript.call_args.kwargs
+        assert call_kwargs["languages"][0] == "en"
+        assert "en-US" in call_kwargs["languages"]
+
+    def test_custom_lang_prepended(self, mocker, mock_yta):
+        """A custom language is first, English fallbacks follow."""
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+
+        _yt._fetch_transcript("dQw4w9WgXcQ", "fr")
+
+        call_kwargs = mock_yta.YouTubeTranscriptApi.get_transcript.call_args.kwargs
+        assert call_kwargs["languages"][0] == "fr"
+        assert "en" in call_kwargs["languages"]
+
+    def test_fallback_to_first_available(self, mocker, mock_yta):
+        """When get_transcript raises NoTranscriptFound, use list_transcripts."""
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = NoTranscriptFound("test")
+
+        fallback_segments = [{"text": "Bonjour tout le monde", "start": 0.0, "duration": 2.0}]
+        fallback_transcript = MockTranscript("fr", fallback_segments)
+        mock_yta.YouTubeTranscriptApi.list_transcripts.return_value = [fallback_transcript]
+
+        segments, language = _yt._fetch_transcript("dQw4w9WgXcQ", "en")
+
+        assert language == "fr"
+        assert segments == fallback_segments
+        mock_yta.YouTubeTranscriptApi.list_transcripts.assert_called_once_with("dQw4w9WgXcQ")
+
+
+# ── Output formatting ──────────────────────────────────────────────────
+
+
+class TestFormatTimestamp:
+    def test_zero(self):
+        assert _yt.format_timestamp(0.0) == "00:00"
+
+    def test_under_minute(self):
+        assert _yt.format_timestamp(5.0) == "00:05"
+
+    def test_over_minute(self):
+        assert _yt.format_timestamp(65.0) == "01:05"
+
+    def test_over_hour(self):
+        assert _yt.format_timestamp(3661.0) == "01:01:01"
+
+    def test_truncates_decimals(self):
+        assert _yt.format_timestamp(3.7) == "00:03"
+
+
+class TestFormatMarkdown:
+    def test_no_timestamps(self, mock_segments):
+        result = _yt.format_markdown("dQw4w9WgXcQ", mock_segments, "en", timestamps=False)
+        assert "# YouTube Transcript: dQw4w9WgXcQ" in result
+        assert "Hello everyone welcome to the video." in result
+        assert "[00:00]" not in result
+
+    def test_with_timestamps(self, mock_segments):
+        result = _yt.format_markdown("dQw4w9WgXcQ", mock_segments, "en", timestamps=True)
+        assert "# YouTube Transcript: dQw4w9WgXcQ" in result
+        assert "[00:00]" in result
+        assert "[00:03]" in result
+        assert "[00:05]" in result
+
+    def test_clean_text_joins_segments(self, mock_segments):
+        result = _yt.format_markdown("dQw4w9WgXcQ", mock_segments, "en", timestamps=False)
+        # Header line, blank line, joined text
+        lines = result.rstrip("\n").split("\n")
+        assert lines[0] == "# YouTube Transcript: dQw4w9WgXcQ"
+        assert lines[1] == ""
+        body = lines[2]
+        assert "Hello everyone" in body
+        assert "how to build great software." in body
+
+    def test_empty_segments(self):
+        result = _yt.format_markdown("dQw4w9WgXcQ", [], "en", timestamps=False)
+        assert "# YouTube Transcript: dQw4w9WgXcQ" in result
+        # Body is empty but header is present
+        assert result.endswith("\n")
+
+    def test_ends_with_newline(self, mock_segments):
+        result = _yt.format_markdown("dQw4w9WgXcQ", mock_segments, "en")
+        assert result.endswith("\n")
+
+
+class TestFormatJson:
+    def test_structured_json(self, mock_segments):
+        markdown = _yt.format_markdown("dQw4w9WgXcQ", mock_segments, "en")
+        output = _yt.format_json("dQw4w9WgXcQ", mock_segments, "en", markdown)
+        data = json.loads(output)
+
+        assert data["video_id"] == "dQw4w9WgXcQ"
+        assert data["language"] == "en"
+        assert len(data["segments"]) == 3
+        assert data["segments"][0]["text"] == "Hello everyone welcome to the video."
+        assert data["segments"][0]["start"] == 0.0
+        assert "# YouTube Transcript" in data["markdown"]
+
+    def test_json_is_valid(self, mock_segments):
+        markdown = _yt.format_markdown("test", mock_segments, "en")
+        output = _yt.format_json("test", mock_segments, "en", markdown)
+        # Must be valid JSON (no trailing data)
+        json.loads(output)
+
+
+# ── CLI argument parsing ──────────────────────────────────────────────
+
+
+class TestArgParsing:
+    def test_help_exits_zero(self):
+        parser = _yt.build_parser()
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args(["--help"])
+        assert exc.value.code == 0
+
+    def test_default_lang(self):
+        parser = _yt.build_parser()
+        args = parser.parse_args(["dQw4w9WgXcQ"])
+        assert args.lang == "en"
+
+    def test_custom_lang(self):
+        parser = _yt.build_parser()
+        args = parser.parse_args(["--lang", "es", "dQw4w9WgXcQ"])
+        assert args.lang == "es"
+
+    def test_json_flag(self):
+        parser = _yt.build_parser()
+        args = parser.parse_args(["--json", "dQw4w9WgXcQ"])
+        assert args.json is True
+
+    def test_timestamps_flag(self):
+        parser = _yt.build_parser()
+        args = parser.parse_args(["--timestamps", "dQw4w9WgXcQ"])
+        assert args.timestamps is True
+
+    def test_output_short_flag(self):
+        parser = _yt.build_parser()
+        args = parser.parse_args(["-o", "out.md", "dQw4w9WgXcQ"])
+        assert str(args.output) == "out.md"
+
+    def test_output_long_flag(self):
+        parser = _yt.build_parser()
+        args = parser.parse_args(["--output", "out.md", "dQw4w9WgXcQ"])
+        assert str(args.output) == "out.md"
+
+    def test_defaults(self):
+        parser = _yt.build_parser()
+        args = parser.parse_args(["dQw4w9WgXcQ"])
+        assert args.json is False
+        assert args.timestamps is False
+        assert args.output is None
+        assert args.lang == "en"
+
+
+# ── Main: success path ────────────────────────────────────────────────
+
+
+class TestMainSuccess:
+    def test_markdown_to_stdout(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+
+        _yt.main(argv=["dQw4w9WgXcQ"])
+
+        out = capsys.readouterr().out
+        assert "# YouTube Transcript: dQw4w9WgXcQ" in out
+        assert "Hello everyone" in out
+
+    def test_json_to_stdout(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+
+        _yt.main(argv=["dQw4w9WgXcQ", "--json"])
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["video_id"] == "dQw4w9WgXcQ"
+        assert len(data["segments"]) == 3
+        assert "markdown" in data
+
+    def test_markdown_to_file(self, mocker, mock_yta, tmp_path, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+
+        out_file = tmp_path / "transcript.md"
+        _yt.main(argv=["dQw4w9WgXcQ", "--output", str(out_file)])
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        content = out_file.read_text(encoding="utf-8")
+        assert "# YouTube Transcript: dQw4w9WgXcQ" in content
+        assert "Hello everyone" in content
+
+    def test_timestamps_flag(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+
+        _yt.main(argv=["dQw4w9WgXcQ", "--timestamps"])
+
+        out = capsys.readouterr().out
+        assert "[00:00]" in out
+        assert "[00:03]" in out
+
+    def test_url_input(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+
+        _yt.main(argv=["https://www.youtube.com/watch?v=dQw4w9WgXcQ"])
+
+        out = capsys.readouterr().out
+        assert "# YouTube Transcript: dQw4w9WgXcQ" in out
+        call_args = mock_yta.YouTubeTranscriptApi.get_transcript.call_args.args
+        assert call_args[0] == "dQw4w9WgXcQ"
+
+
+# ── Main: error exit codes ─────────────────────────────────────────────
+
+
+class TestExitCodes:
+    def test_exit_no_transcript(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = NoTranscriptFound("test")
+        mock_yta.YouTubeTranscriptApi.list_transcripts.side_effect = NoTranscriptFound("test")
+
+        with pytest.raises(SystemExit) as exc:
+            _yt.main(argv=["dQw4w9WgXcQ"])
+
+        assert exc.value.code == 2
+        err = capsys.readouterr().err.lower()
+        assert "no transcript" in err
+
+    def test_exit_transcripts_disabled(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = TranscriptsDisabled("test")
+
+        with pytest.raises(SystemExit) as exc:
+            _yt.main(argv=["dQw4w9WgXcQ"])
+
+        assert exc.value.code == 3
+        err = capsys.readouterr().err.lower()
+        assert "disabled" in err
+
+    def test_exit_video_unavailable(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = VideoUnavailable("test")
+
+        with pytest.raises(SystemExit) as exc:
+            _yt.main(argv=["dQw4w9WgXcQ"])
+
+        assert exc.value.code == 4
+        err = capsys.readouterr().err.lower()
+        assert "unavailable" in err
+
+    def test_exit_unknown_error(self, mocker, mock_yta, capsys):
+        mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
+        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = RuntimeError("network failure")
+
+        with pytest.raises(SystemExit) as exc:
+            _yt.main(argv=["dQw4w9WgXcQ"])
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err.lower()
+        assert "network failure" in err
+
+    def test_exit_invalid_video_id(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _yt.main(argv=["short"])
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err.lower()
+        assert "video id" in err

--- a/tools/youtube-transcript/youtube-transcript
+++ b/tools/youtube-transcript/youtube-transcript
@@ -1,0 +1,334 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12,<3.14"
+# dependencies = [
+#     "youtube-transcript-api>=1.0",
+# ]
+# ///
+"""youtube-transcript — Fetch YouTube video transcripts and output markdown.
+
+Usage:
+    uv run --script youtube-transcript <video-id-or-url> [options]
+    ./youtube-transcript dQw4w9WgXcQ
+
+Options:
+    --lang en          Preferred language code (default: en)
+    --json             Output structured JSON instead of markdown
+    --output file.md   Write output to file (default: stdout)
+    --timestamps       Include [mm:ss] timestamps in markdown output
+
+If uv is not installed, download it first:
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+Exit codes:
+    0   Success
+    1   Network or unknown error
+    2   No transcript available for this video
+    3   Transcripts disabled for this video
+    4   Video unavailable (deleted, private, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+# ── Video ID extraction ───────────────────────────────────────────────
+
+_VIDEO_ID_RE = re.compile(r"[a-zA-Z0-9_-]{11}")
+_WATCH_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com"}
+_SHORT_HOSTS = {"youtu.be", "www.youtu.be"}
+_PATH_PREFIXES = frozenset(("shorts", "embed"))
+
+
+def _is_valid_video_id(s: str) -> bool:
+    """Check if s is a valid 11-char YouTube video ID."""
+    return _VIDEO_ID_RE.fullmatch(s) is not None
+
+
+def extract_video_id(input_str: str) -> str | None:
+    """Extract an 11-character YouTube video ID from a URL or raw ID string.
+
+    Accepts:
+      - Raw ID:           dQw4w9WgXcQ
+      - Watch URL:        https://www.youtube.com/watch?v=dQw4w9WgXcQ
+      - Short URL:        https://youtu.be/dQw4w9WgXcQ
+      - Shorts URL:       https://www.youtube.com/shorts/dQw4w9WgXcQ
+      - Embed URL:        https://www.youtube.com/embed/dQw4w9WgXcQ
+
+    Returns the 11-char video ID, or None if no valid ID could be extracted.
+    """
+    s = input_str.strip()
+
+    # Bare video ID
+    if _is_valid_video_id(s):
+        return s
+
+    # URL parsing
+    url = s if "://" in s else f"https://{s}"
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        pass
+    else:
+        host = (parsed.hostname or "").lower()
+
+        # youtu.be/<id>
+        if host in _SHORT_HOSTS:
+            path = parsed.path.strip("/")
+            if _is_valid_video_id(path):
+                return path
+
+        # youtube.com/watch?v=<id>, /shorts/<id>, /embed/<id>
+        if host in _WATCH_HOSTS:
+            qs = parse_qs(parsed.query)
+            if "v" in qs:
+                vid = qs["v"][0]
+                if _is_valid_video_id(vid):
+                    return vid
+
+            path_parts = parsed.path.strip("/").split("/")
+            if (
+                len(path_parts) >= 2
+                and path_parts[0] in _PATH_PREFIXES
+                and _is_valid_video_id(path_parts[1])
+            ):
+                return path_parts[1]
+
+    # Last resort: find any 11-char [a-zA-Z0-9_-] sequence
+    match = _VIDEO_ID_RE.search(s)
+    return match.group(0) if match else None
+
+
+# ── Language preference ────────────────────────────────────────────────
+
+
+def _build_language_list(lang: str) -> list[str]:
+    """Build a language preference list for YouTubeTranscriptApi.
+
+    Order: requested language, then English variants (manual + ASR).
+    """
+    langs: list[str] = []
+    if lang:
+        langs.append(lang)
+    for v in ("en", "en-US", "en-GB"):
+        if v not in langs:
+            langs.append(v)
+    return langs
+
+
+# ── Custom exception ──────────────────────────────────────────────────
+
+
+class TranscriptFetchError(Exception):
+    """Error fetching transcript, with an associated exit code."""
+
+    def __init__(self, message: str, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+# ── API import (deferred so tests can import the module without the dep) ──
+
+
+def _import_api() -> Any:
+    """Import youtube_transcript_api lazily and return the module."""
+    import youtube_transcript_api as yta
+
+    return yta
+
+
+# ── Fetch ─────────────────────────────────────────────────────────────
+
+
+def _fetch_transcript(
+    video_id: str, lang: str
+) -> tuple[list[dict[str, str | float]], str]:
+    """Fetch transcript with language preference chain.
+
+    Tries the requested language and English fallbacks via get_transcript,
+    then falls back to the first available track of any language.
+
+    Raises TranscriptFetchError with the appropriate exit_code on failure.
+    """
+    yta = _import_api()
+    try:
+        return _try_fetch(yta, video_id, lang)
+    except yta.NoTranscriptFound:
+        raise TranscriptFetchError(
+            f"No transcript available for {video_id}", exit_code=2
+        ) from None
+    except yta.TranscriptsDisabled:
+        raise TranscriptFetchError(
+            f"Transcripts disabled for {video_id}", exit_code=3
+        ) from None
+    except yta.VideoUnavailable:
+        raise TranscriptFetchError(
+            f"Video unavailable: {video_id}", exit_code=4
+        ) from None
+    except Exception as e:
+        raise TranscriptFetchError(str(e), exit_code=1) from e
+
+
+def _try_fetch(
+    yta: Any, video_id: str, lang: str
+) -> tuple[list[dict[str, str | float]], str]:
+    """Try language preference, then first available track.
+
+    Raises youtube_transcript_api exceptions on failure.
+    """
+    langs = _build_language_list(lang)
+    segments: list[dict[str, str | float]] = []
+
+    try:
+        segments = list(
+            yta.YouTubeTranscriptApi.get_transcript(video_id, languages=langs)
+        )
+        if segments:
+            return segments, langs[0]
+    except yta.NoTranscriptFound:
+        pass  # Fall through to first available
+
+    # Fallback: first available track of any language
+    transcript_list = yta.YouTubeTranscriptApi.list_transcripts(video_id)
+    for transcript_obj in transcript_list:
+        segments = list(transcript_obj.fetch())
+        if segments:
+            return segments, transcript_obj.language_code
+
+    # No transcript at all
+    raise yta.NoTranscriptFound(video_id)
+
+
+# ── Output formatting ─────────────────────────────────────────────────
+
+
+def format_timestamp(seconds: float) -> str:
+    """Format seconds as mm:ss or hh:mm:ss."""
+    total = int(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours > 0:
+        return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def format_markdown(
+    video_id: str,
+    segments: list[dict[str, str | float]],
+    language: str,
+    timestamps: bool = False,
+) -> str:
+    """Format transcript segments as markdown.
+
+    With timestamps=True, each segment is prefixed with [mm:ss].
+    Without, all segment texts are joined into clean text paragraphs.
+    """
+    lines: list[str] = [f"# YouTube Transcript: {video_id}", ""]
+
+    if timestamps:
+        for seg in segments:
+            start = format_timestamp(float(seg.get("start", 0.0)))
+            text = str(seg.get("text", "")).strip()
+            lines.append(f"[{start}] {text}")
+    else:
+        texts = [str(seg.get("text", "")).strip() for seg in segments]
+        body = " ".join(t for t in texts if t)
+        lines.append(body)
+
+    return "\n".join(lines) + "\n"
+
+
+def format_json(
+    video_id: str,
+    segments: list[dict[str, str | float]],
+    language: str,
+    markdown: str,
+) -> str:
+    """Format as structured JSON."""
+    return json.dumps(
+        {
+            "video_id": video_id,
+            "language": language,
+            "segments": segments,
+            "markdown": markdown,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+# ── CLI ────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser (extracted for testability)."""
+    parser = argparse.ArgumentParser(
+        description="Fetch a YouTube video transcript and output markdown."
+    )
+    parser.add_argument(
+        "input",
+        help="YouTube video ID or URL (watch, shorts, youtu.be, embed)",
+    )
+    parser.add_argument(
+        "--lang",
+        default="en",
+        help="Preferred language code (default: en)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output structured JSON instead of markdown",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Write output to file (default: stdout)",
+    )
+    parser.add_argument(
+        "--timestamps",
+        action="store_true",
+        help="Include [mm:ss] timestamps in markdown output",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # Extract video ID
+    video_id = extract_video_id(args.input)
+    if not video_id:
+        print(f"Error: could not extract video ID from: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    # Fetch transcript
+    try:
+        segments, language = _fetch_transcript(video_id, args.lang)
+    except TranscriptFetchError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(e.exit_code)
+
+    # Format output
+    markdown = format_markdown(
+        video_id, segments, language, timestamps=args.timestamps
+    )
+
+    if args.json:
+        sys.stdout.write(format_json(video_id, segments, language, markdown))
+    elif args.output:
+        args.output.write_text(markdown, encoding="utf-8")
+    else:
+        sys.stdout.write(markdown)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `tools/youtube-transcript/youtube-transcript` — a standalone `uv` script
(PEP 723 inline metadata) that fetches YouTube video transcripts via
`youtube-transcript-api` and outputs markdown/JSON to stdout. Mirrors the
`tools/pdf2md/pdf2md` pattern exactly.

This is the first step of the #584 fix — replacing the fragile
`ytInitialPlayerResponse` watch-page scrape in `YouTubeTranscriptService`
with a robust subprocess call to this script. The Swift integration will
land in a follow-up PR.

## What's included

- **The script** (`youtube-transcript`): PEP 723 inline metadata with
  `youtube-transcript-api>=1.0` dependency. Accepts video IDs or URLs,
  outputs markdown or JSON.
- **Tests** (`tests/`): 50 unit tests with mocked `YouTubeTranscriptApi`
  (no real YouTube calls).
- **Config** (`pyproject.toml`): dev dependencies only (runtime deps are
  in the PEP 723 inline block).
- **Docs** (`README.md`): usage, exit codes, language preference, plan.
- **Gitignore**: matches pdf2md's.

## Features

- **Video ID extraction**: raw IDs, `watch?v=`, `youtu.be/`, `/shorts/`, `/embed/` URLs
- **Language preference chain**: requested lang → English manual (`en`, `en-GB`) → English ASR (`en-US`) → first available track (via `list_transcripts`)
- **Markdown output**: clean text paragraphs (default) or `[mm:ss]` timestamps (`--timestamps`)
- **JSON output** (`--json`): structured `{video_id, language, segments, markdown}`
- **Exit codes**: 0 success, 1 unknown, 2 no transcript, 3 disabled, 4 unavailable

## Usage

```bash
# Raw video ID, markdown to stdout
uv run --script youtube-transcript dQw4w9WgXcQ

# URL input, with timestamps
uv run --script youtube-transcript https://youtu.be/dQw4w9WgXcQ --timestamps

# JSON output
uv run --script youtube-transcript dQw4w9WgXcQ --json

# Write to file
uv run --script youtube-transcript dQw4w9WgXcQ -o transcript.md
```

## Verification

```
uv run pytest tests/ -v          # 50 passed
uv run ruff check youtube-transcript tests/   # All checks passed!
uv run pyright youtube-transcript tests/      # 0 errors, 0 warnings
```

All acceptance criteria (AC.1–AC.8) met.

Closes #584 (script landing — Swift integration is a follow-up PR).
