### PR TITLE
Add debug logging to trace chat summary pipeline

### DIFF
--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -629,6 +629,11 @@ struct ChatDetailView: View {
                 if let q = pendingQuestion {
                     let cached = i < cachedSummaries.count ? cachedSummaries[i] : nil
                     let summary = cached ?? ChatSummary.summaryExtract(from: text, maxLength: 200)
+                    if cached != nil {
+                        DebugLog.debug("chatOutlineEntries: seq=\(i) using cached summary (kind=\(visiblePersistedMessages[i].summaryKind?.rawValue ?? "unknown"))")
+                    } else {
+                        DebugLog.debug("chatOutlineEntries: seq=\(i) no cache, using truncation fallback")
+                    }
                     entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
                                                     questionTimestamp: pendingQuestionTS, responseTimestamp: ts))
                     pendingQuestion = nil
@@ -638,6 +643,11 @@ struct ChatDetailView: View {
                 if let q = pendingQuestion {
                     let cached = i < cachedSummaries.count ? cachedSummaries[i] : nil
                     let summary = cached ?? ChatSummary.summaryExtract(from: text, maxLength: 200)
+                    if cached != nil {
+                        DebugLog.debug("chatOutlineEntries: seq=\(i) using cached summary (kind=\(visiblePersistedMessages[i].summaryKind?.rawValue ?? "unknown"))")
+                    } else {
+                        DebugLog.debug("chatOutlineEntries: seq=\(i) no cache, using truncation fallback")
+                    }
                     entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
                                                     questionTimestamp: pendingQuestionTS, responseTimestamp: ts))
                     pendingQuestion = nil

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -3237,7 +3237,11 @@ public final class AgentLauncher {
     /// owns the mode dispatch + the off-main Task for model mode; this method
     /// just hands it the chat id.
     private func fireMessageSummarySink() {
-        guard let chatID = activeChatID else { return }
+        guard let chatID = activeChatID else {
+            DebugLog.ingest("fireMessageSummarySink: no activeChatID, skipping")
+            return
+        }
+        DebugLog.ingest("fireMessageSummarySink: activeChatID=\(chatID)")
         messageSummarySink?(PageID(rawValue: chatID))
     }
 

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -505,31 +505,38 @@ public enum AgentOperationRunner {
     private static func summarizePendingMessages(
         chatID: PageID, store: WikiStoreModel?, launcher: AgentLauncher
     ) {
-        guard let store else { return }
+        guard let store else {
+            DebugLog.ingest("summarizePendingMessages: store torn down, skipping")
+            return
+        }
         let config = AgentProvidersConfig.loadOrSeed(from: launcher.resolveProvidersContainerDirectory())
         let mode = MessageSummarizer.mode(for: config)
+        let summarizerPin = config.stageProviderIds["summarizer"] ?? "none"
 
-        // Query the persisted messages + filter to unsummarized assistant-text
-        // rows. This is the compute-once guard (AC.6): already-summarized rows
-        // are skipped.
         let messages = store.chatMessages(chatID: chatID)
         let pending = messages.filter { msg in
             msg.summary == nil
                 && (MessageSummarizer.textToSummarize(from: msg.event)?.isEmpty == false)
         }
-        guard !pending.isEmpty else { return }
+        DebugLog.ingest("summarizePendingMessages: chatID=\(chatID.rawValue) mode=\(mode) pin=\(summarizerPin) pending=\(pending.count)")
+
+        guard !pending.isEmpty else {
+            DebugLog.ingest("summarizePendingMessages: no pending messages after dedup")
+            return
+        }
 
         switch mode {
         case .defaultTruncation:
             // Pure + cheap — run inline on the main actor.
-            for msg in pending {
-                guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
-                let summary = MessageSummarizer.defaultSummary(for: text)
-                guard !summary.isEmpty else { continue }
-                store.updateMessageSummary(
-                    chatID: chatID, messageID: msg.id,
-                    summary: summary, kind: .defaultTruncation)
-            }
+        for msg in pending {
+            guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
+            let summary = MessageSummarizer.defaultSummary(for: text)
+            guard !summary.isEmpty else { continue }
+            store.updateMessageSummary(
+                chatID: chatID, messageID: msg.id,
+                summary: summary, kind: .defaultTruncation)
+            DebugLog.ingest("summarizePendingMessages: wrote summary for id=\(msg.id.rawValue.prefix(8)) kind=defaultTruncation")
+        }
         case .model:
             // Off-main via a detached Task. The config + pending messages are
             // captured by value (Sendable) so the Task can cross the actor
@@ -568,16 +575,15 @@ public enum AgentOperationRunner {
         let backend = AgentBackendFactory.makeBackend(policy: .bypass)
         for msg in pending {
             guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
-            // Off-main: the backend session runs on its own actor / process.
-            // The await suspends the MainActor without blocking it.
             guard let summary = await MessageSummarizer.modelSummary(
-                text: text, backend: backend, profile: profile) else { continue }
-            // Marshal the DB write back to @MainActor (we're already here —
-            // this method is @MainActor). `updateMessageSummary` routes through
-            // `mutate()` + emits `.chat .updated` (#129).
+                text: text, backend: backend, profile: profile) else {
+                DebugLog.ingest("summarizePendingMessages: summarizer returned nil for message id=\(msg.id.rawValue.prefix(8))")
+                continue
+            }
             store.updateMessageSummary(
                 chatID: chatID, messageID: msg.id,
                 summary: summary, kind: .model)
+            DebugLog.ingest("summarizePendingMessages: wrote summary for id=\(msg.id.rawValue.prefix(8)) kind=model")
         }
     }
 }

--- a/Sources/WikiFSEngine/MessageSummarizer.swift
+++ b/Sources/WikiFSEngine/MessageSummarizer.swift
@@ -102,7 +102,8 @@ public enum MessageSummarizer {
         let cleanText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleanText.isEmpty else { return nil }
 
-        // Start the one-shot session.
+        DebugLog.ingest("MessageSummarizer: starting model mode for seq=\(cleanText.prefix(40))...")
+
         let session: SessionHandle
         do {
             session = try await backend.start(
@@ -146,7 +147,11 @@ public enum MessageSummarizer {
         }
 
         let trimmed = collected.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
+        guard !trimmed.isEmpty else {
+            DebugLog.ingest("MessageSummarizer: model returned empty output for seq=\(cleanText.prefix(40))...")
+            return nil
+        }
+        DebugLog.ingest("MessageSummarizer: model summary for seq=\(cleanText.prefix(40))... length=\(trimmed.count)")
         return trimmed
     }
 

--- a/plans/summary-debug-logging.md
+++ b/plans/summary-debug-logging.md
@@ -1,0 +1,47 @@
+# Chat Summary Pipeline Debug Logging
+
+## Problem
+User sees raw sentences instead of LLM summaries in chat outline.
+
+## Pipeline Flow
+AgentLauncher.sendInteractiveMessage (turn end, :3059) -> flushTranscript (:3065) -> fireMessageSummarySink (:3239) -> AgentOperationRunner.summarizePendingMessages (:505) -> MessageSummarizer -> WikiStoreModel.updateMessageSummary (:4049) -> GRDBWikiStore UPDATE (:6099)
+
+View reads it in ChatDetailView.chatOutlineEntries (:605) where cached ?? ChatSummary.summaryExtract(...) — cache wins, truncation is fallback.
+
+## Two Modes
+- **Default (empty pin)**: pure first-sentence truncation, NO LLM. 'Raw sentences' is expected output.
+- **Model (non-empty pin)**: real one-shot ACP LLM session with inline prompt.
+
+Gated on config.stageProviderIds['summarizer']
+
+## Debug Log Locations
+
+### 1. AgentOperationRunner.summarizePendingMessages (~line 505-531)
+- TOP of method: mode, pin, pending count
+- Store torn down skip
+- No pending messages skip
+
+### 2. AgentOperationRunner.runModelSummarization (~line 558-580)
+- Profile resolve fail (already logged)
+- MessageSummarizer returns nil
+- Summary success
+
+### 3. MessageSummarizer.modelSummary (~line 97-151)
+- Start model mode
+- ACP start fail (already logged)
+- Turn fail (already logged)
+- **Model output empty** (currently unlogged)
+- Success
+
+### 4. AgentLauncher.fireMessageSummarySink (~line 3239-3242)
+- Called with chatID
+- Skipped when no activeChatID
+
+### 5. ChatDetailView.chatOutlineEntries (~line 605-655)
+- Cache hit vs fallback
+
+## Changes
+- All logs use DebugLog.ingest or DebugLog.chat
+- No logic changes
+- Build verification: `make prompts && swift build`
+- Test verification: `swift test`


### PR DESCRIPTION
Add debug logging to trace the chat summary pipeline and diagnose why users see raw sentences instead of LLM summaries.

## Problem
Users are seeing raw sentences in the chat outline instead of LLM-generated summaries, but we don't have visibility into where the pipeline fails.

## Solution
Added comprehensive `DebugLog` statements at key points in the chat summary pipeline:

### 1. AgentOperationRunner.swift (summarizePendingMessages ~505-586)
- **Mode detection**: Logs chatID, mode (default/model), pin (summarizer provider ID), pending count
- **Skip conditions**: Store torn down, no pending messages after dedup
- **Success tracking**: Logs when summaries are written (defaultTruncation and model modes)
- **Failure tracking**: Logs when model summarizer returns nil

### 2. MessageSummarizer.swift (modelSummary ~97-156)
- **Model start**: Logs when model mode begins with text preview
- **Empty output detection**: Logs when model returns empty output (previously unlogged - key diagnostic)
- **Success tracking**: Logs model success with text preview and length

### 3. AgentLauncher.swift (fireMessageSummarySink ~3239-3246)
- **Sink firing**: Logs when called with activeChatID
- **Skip condition**: Logs when skipped (no activeChatID)

### 4. ChatDetailView.swift (chatOutlineEntries ~629-651, 643-655)
- **Cache vs fallback**: Logs when cached summary is used (with kind) vs truncation fallback

## DebugLog channels
- `DebugLog.ingest` - Summarization-related logs
- `DebugLog.debug` - View-level cache hit/fallback logs
- `DebugLog.agent` - Agent-level errors (already present)

## Testing
- Build: `swift build` ✓ (12.01s)
- Tests: `swift test` ✓ (3433 tests, 287 suites passed)

## Viewing logs
```bash
log show --predicate 'subsystem == "com.selfdrivingwiki.debug"' \
         --style compact --info --debug --last 30m
```

See `plans/summary-debug-logging.md` for detailed pipeline documentation.