### PR TITLE
Fix quit dialog not coming to front

### DIFF
--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -790,7 +790,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Activate the app so the alert appears frontmost. On macOS 14+, the
         // new activate() API replaces the deprecated activate(ignoringOtherApps:).
-        NSApp.activate()
+        NSApp.activate(ignoringOtherApps: true)
 
         // Present as a sheet on the current key window when possible; fall back
         // to a modal dialog when no window is available (e.g. all windows
@@ -798,6 +798,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let window = sender.windows.first(
             where: { $0.isVisible && $0.canBecomeKey }
         ) {
+            window.makeKeyAndOrderFront(nil)
             alert.beginSheetModal(for: window) { response in
                 if response == .alertFirstButtonReturn, let cancel = self.cancelInFlightForQuit {
                     // Cancel in-flight items BEFORE replying to terminate so


### PR DESCRIPTION
Fixes the issue where the quit confirmation dialog would not appear frontmost when running in .accessory activation policy.

## Changes Made

1. **Strong activation (line 793):** Changed NSApp.activate() to NSApp.activate(ignoringOtherApps: true) - the weak cooperative macOS 14+ variant doesn't force the app to frontmost. This matches the pattern used elsewhere (MenuBarItemController at lines 301, 326, 361, 370).

2. **Window ordering (line 801):** Added window.makeKeyAndOrderFront(nil) before alert.beginSheetModal(for: window) - without raising the window first, the sheet attaches to a background window and never appears.

## Root Cause

The app runs in .accessory activation policy (set at line 729), where the weak activate() is especially ineffective. Without raising the window before attaching the sheet, the dialog stays in the background.