### PR TITLE
Generalize podcast transcription to any RSS feed

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,51 @@
 # Progress log
 
+## Generalize podcast transcription to any RSS feed
+
+**Goal:** Accept ANY podcast RSS feed URL (not just Apple Podcasts), keeping the
+Apple path intact. Tag-first via `<podcast:transcript>`, graceful fail when no
+tag. Builds on merged PR #824 (RSSPodcastTranscriptService + TranscriptSubprocess).
+
+**Plan:** `plans/podcast-generalize.md`
+
+**Changes:**
+- **Python script** (`tools/podcast-transcript/podcast-transcript`):
+  `_is_apple_podcasts_url` helper routes Apple vs direct-RSS; `fetch_transcript`
+  branches (Apple path unchanged; RSS path skips iTunes Lookup);
+  `find_episode_in_feed(episode_id=None)` returns most recent `<item>` by
+  `<pubDate>` (explicit early branch with pubDate-aware selection). 9 new Python
+  tests (55 total pass).
+- **De-guarding (C1 — critical):** New always-compiled
+  `PodcastTranscriptTypes.swift` moves `PodcastTranscript`,
+  `PodcastTranscriptFetching`, `RSSFeedTranscriptFetching`, `PodcastTranscriptError`,
+  `RSSPodcastTranscriptService` out of `#if PODCAST_TRANSCRIPTS`.
+  `PodcastEpisodeURL` unguarded (EpisodeRef always available).
+- **SourceProvider.podcast** (`"podcast"` rawValue): new case + all enum
+  property arms (displayLabel/systemImage/helpVerb/supportsRefresh/supportsTranscription).
+- **RSSPodcastTranscriptService** generalized: `init(sourceURL:)` (renamed) +
+  `transcript(forFeedURL:)` (H3 — feed-oriented entry, no EpisodeRef) +
+  `RSSFeedTranscriptFetching` protocol for test injection.
+- **transcribeRSSPodcast** helper (outside `#if`, injected fetcher per H2):
+  dispatch arm in both `#if`/`#else` transcribe blocks; technique
+  `"rss-podcast-transcript"`.
+- **RSSFeedEpisodeURL** recognizer (always compiled) + `addPodcastFeedURL(_:)`
+  intake entry point (M3 — explicit affordance, bypasses generic website fetch).
+- **All exhaustive switch sites updated:** SourceRefreshService.materialize,
+  isSourceRefreshable, SourceDetailView.isTranscribable + providerOriginTag (H1),
+  MediaTitleFetcher.oEmbedURL. materializePodcastFeed refresh path (always compiled).
+- **Tests:** `RSSPodcastTranscriptionTests.swift` (22 tests, UNGUARDED per M1) +
+  SourceProviderTests `.podcast` assertions.
+
+**Verification:**
+- `swift build` — compiles (PODCAST_TRANSCRIPTS on)
+- `WIKIFS_APP_STORE=1 swift build` — compiles (critical C1 gate — generic .podcast
+  path works when `#if PODCAST_TRANSCRIPTS` is off)
+- `swift test` — 3478 tests, 4 pre-existing ACP/quota failures (unrelated)
+- `uv run pytest tests/` — 55 pass
+- Apple-path regression (#824 RSSPodcastTranscriptTests) — 11 pass
+
+---
+
 ## refactor: remove system_prompt table (v42)
 
 **Goal:** Remove the user-editable `system_prompt` SQLite table entirely. The

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -208,6 +208,11 @@ struct SourceDetailView: View {
             // for `.applePodcast` outside `#if PODCAST_TRANSCRIPTS` or when
             // `ApplePodcastTranscriptService.bundled()` is nil.
             return store.isSourceRefreshable(for: file.id)
+        case .podcast:
+            // Generic RSS-feed podcast: always transcribable on every build —
+            // the `podcast-transcript` script needs only `uv` (no signing
+            // helper). Mirrors YouTube's "no runtime guard" shape.
+            return true
         case .youtube:
             // No signing helper needed — YouTube's pure-Swift scrape is always
             // available on every build. The model throws `.missingPlan` if
@@ -215,9 +220,9 @@ struct SourceDetailView: View {
             // surfaced by `runTranscription`, not gated here).
             return true
         // Unreachable: `supportsTranscription` returned false above (the
-        // property returns true only for `.applePodcast` + `.youtube`). The
-        // switch stays exhaustive so a future transcript-capable provider is
-        // automatically flagged by the compiler.
+        // property returns true only for `.applePodcast` + `.podcast` +
+        // `.youtube`). The switch stays exhaustive so a future transcript-
+        // capable provider is automatically flagged by the compiler.
         case .vimeo, .spotify, .soundcloud, .remoteMedia,
              .localFile, .website, .zotero, .markdownFolder, .legacyImport:
             return false
@@ -970,7 +975,7 @@ struct SourceDetailView: View {
     @ViewBuilder
     private func providerOriginTag(_ origin: SourceOrigin) -> some View {
         switch origin.provider {
-        case .website, .applePodcast, .youtube, .vimeo, .spotify, .soundcloud, .remoteMedia:
+        case .website, .applePodcast, .podcast, .youtube, .vimeo, .spotify, .soundcloud, .remoteMedia:
             // URL providers (web pages, podcasts, byteless media embeds) — all
             // open in the default browser via NSWorkspace.shared.open. They share
             // one action shape; only the label / icon / help text differ, and

--- a/Sources/WikiFSCore/Integrations/ApplePodcastTranscriptService.swift
+++ b/Sources/WikiFSCore/Integrations/ApplePodcastTranscriptService.swift
@@ -4,27 +4,6 @@ import Foundation
 import FoundationNetworking
 #endif
 
-/// The finished transcript for a recognized episode: episode ID, markdown text,
-/// and a suggested source filename.
-public struct PodcastTranscript: Equatable, Sendable {
-    public let episodeID: String
-    public let markdown: String
-    public let filename: String
-
-    public init(episodeID: String, markdown: String, filename: String) {
-        self.episodeID = episodeID
-        self.markdown = markdown
-        self.filename = filename
-    }
-}
-
-/// The one thing ingest calls: pasted URL → transcript. Injected so `URLIngestService`
-/// and `WikiStoreModel` can be unit-tested with a fake, and the app wires the real
-/// `ApplePodcastTranscriptService`.
-public protocol PodcastTranscriptFetching: Sendable {
-    func transcript(for episode: PodcastEpisodeURL.EpisodeRef) async throws -> PodcastTranscript
-}
-
 /// Produces the FairPlay-signed bearer token. The real one shells out to the
 /// `podcast-token-helper`; tests inject a canned token or error.
 public protocol PodcastTokenProviding: Sendable {
@@ -64,8 +43,8 @@ public struct ApplePodcastTranscriptService: PodcastTranscriptFetching {
             http: URLSessionPodcastHTTPClient())
     }
 
-    /// The production service if the `podcast-token-helper` binary is present next to
-    /// the app (`Contents/Helpers/`) or beside the built executable (dev/test), else
+    /// The production service if the `podcast-token-helper` binary is present next
+    /// to the app (`Contents/Helpers/`) or beside the built executable (dev/test), else
     /// nil — so a build without the helper simply doesn't offer podcast ingest rather
     /// than crashing. Mirrors how `wikictl` is resolved from the bundle.
     public static func bundled() -> ApplePodcastTranscriptService? {
@@ -109,126 +88,6 @@ public struct ApplePodcastTranscriptService: PodcastTranscriptFetching {
 
     /// The stored source's filename: `<slug>-<id>-transcript.md`, or
     /// `podcast-<id>-transcript.md` when the URL carried no slug.
-    static func filename(for episode: PodcastEpisodeURL.EpisodeRef) -> String {
-        let stem = episode.slug.map { "\($0)-\(episode.id)" } ?? "podcast-\(episode.id)"
-        return "\(FilenameEscaping.escapeTitle(stem))-transcript.md"
-    }
-}
-
-// MARK: - RSSPodcastTranscriptService
-
-/// Fetches a podcast transcript by spawning the `podcast-transcript` PEP 723
-/// script (`tools/podcast-transcript/podcast-transcript`), which fetches the
-/// RSS feed and looks for `<podcast:transcript>` tags — no FairPlay signing
-/// helper, no private frameworks. Mirrors `YouTubeTranscriptService` (subprocess
-/// pattern) and is a second `PodcastTranscriptFetching` conformer alongside
-/// `ApplePodcastTranscriptService` (the FairPlay path).
-///
-/// The script takes an Apple Podcasts episode URL as argv[1] and emits
-/// structured JSON with `--json`: `{show_id, episode_id, language, format, markdown}`.
-///
-/// Exit codes are mapped to `PodcastTranscriptError`:
-///   0 → success, 3 → podcast not found, 4 → episode not found,
-///   1/other → `.noTranscriptAvailable` (no RSS transcript / network error).
-///
-/// Issue #812.
-public struct RSSPodcastTranscriptService: PodcastTranscriptFetching {
-
-    /// The decoded JSON the `podcast-transcript --json` script emits.
-    struct ScriptOutput: Decodable {
-        let show_id: String?
-        let episode_id: String?
-        let language: String?
-        let format: String?
-        let markdown: String?
-    }
-
-    /// The full Apple Podcasts episode URL (e.g.
-    /// `https://podcasts.apple.com/us/podcast/slug/id123?i=456`). Stored at init
-    /// because `PodcastEpisodeURL.EpisodeRef` carries only the episode ID and
-    /// slug — not the show ID needed for the URL. The dispatch in
-    /// `WikiStoreModel.transcribePodcast` has `origin.plan` (the page URL).
-    private let episodeURL: URL
-
-    public init(episodeURL: URL) {
-        self.episodeURL = episodeURL
-    }
-
-    public func transcript(
-        for episode: PodcastEpisodeURL.EpisodeRef
-    ) async throws -> PodcastTranscript {
-        guard let script = Self.resolveScript() else {
-            DebugLog.extraction("[podcast-rss] transcript: script not found")
-            throw PodcastTranscriptError.signatureUnavailable(
-                "The podcast-transcript script isn't available in this build.")
-        }
-
-        DebugLog.extraction("[podcast-rss] transcript: spawning \(script.path) for \(episodeURL.absoluteString)")
-
-        do {
-            let result = try await TranscriptSubprocess.run(
-                script: script,
-                arguments: [episodeURL.absoluteString, "--json"]
-            )
-
-            return try Self.mapResult(result, episode: episode)
-        } catch let error as TranscriptSubprocessError {
-            DebugLog.extraction("[podcast-rss] transcript: subprocess error: \(error.localizedDescription)")
-            throw PodcastTranscriptError.signatureUnavailable(error.localizedDescription)
-        }
-    }
-
-    /// Map the subprocess result to a `PodcastTranscript` or throw the
-    /// appropriate `PodcastTranscriptError`. Pure — extracted for testability.
-    static func mapResult(
-        _ result: (stdout: String, stderr: String, status: Int32),
-        episode: PodcastEpisodeURL.EpisodeRef
-    ) throws -> PodcastTranscript {
-        switch result.status {
-        case 0:
-            break
-        case 3:
-            throw PodcastTranscriptError.noTranscriptAvailable
-        case 4:
-            throw PodcastTranscriptError.noTranscriptAvailable
-        default:
-            let msg = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            DebugLog.extraction("[podcast-rss] transcript: exit \(result.status): \(msg)")
-            throw PodcastTranscriptError.noTranscriptAvailable
-        }
-
-        let trimmed = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            throw PodcastTranscriptError.ttmlParseFailed
-        }
-
-        let output: ScriptOutput
-        do {
-            output = try JSONDecoder().decode(ScriptOutput.self, from: Data(trimmed.utf8))
-        } catch {
-            DebugLog.extraction("[podcast-rss] transcript: JSON decode failed: \(error)")
-            throw PodcastTranscriptError.ttmlParseFailed
-        }
-
-        let episodeID = output.episode_id ?? episode.id
-        let markdown = output.markdown ?? ""
-
-        return PodcastTranscript(
-            episodeID: episodeID,
-            markdown: markdown,
-            filename: Self.filename(for: episode))
-    }
-
-    /// Resolve the `podcast-transcript` script. Mirrors
-    /// `PdfExtractionService.resolveScript()`.
-    static func resolveScript() -> URL? {
-        TranscriptSubprocess.resolveScript(
-            named: "podcast-transcript",
-            repoSubdir: "tools/podcast-transcript")
-    }
-
-    /// Reuses `ApplePodcastTranscriptService.filename(for:)` so both backends
-    /// produce the same stored-source filename for the same episode.
     static func filename(for episode: PodcastEpisodeURL.EpisodeRef) -> String {
         let stem = episode.slug.map { "\($0)-\(episode.id)" } ?? "podcast-\(episode.id)"
         return "\(FilenameEscaping.escapeTitle(stem))-transcript.md"

--- a/Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift
+++ b/Sources/WikiFSCore/Integrations/MediaTitleFetcher.swift
@@ -112,7 +112,7 @@ public enum MediaTitleFetcher {
         case .soundcloud:
             return URL(string: "https://soundcloud.com/oembed?format=json&url=\(encoded)")
         case .localFile, .website, .zotero, .markdownFolder, .applePodcast,
-             .remoteMedia, .legacyImport, nil:
+             .podcast, .remoteMedia, .legacyImport, nil:
             return nil
         }
     }

--- a/Sources/WikiFSCore/Integrations/PodcastEpisodeURL.swift
+++ b/Sources/WikiFSCore/Integrations/PodcastEpisodeURL.swift
@@ -1,4 +1,3 @@
-#if PODCAST_TRANSCRIPTS  // Apple Podcasts transcript feature; off for WIKIFS_APP_STORE=1 builds.
 import Foundation
 
 /// Recognizes Apple Podcasts *episode* URLs pasted as sources — PURE, value-in /
@@ -11,6 +10,13 @@ import Foundation
 /// The `/podcast/<slug>/` path segment gives a human-readable stem for the stored
 /// transcript's filename. A show link without `i=` is NOT an episode — `parse`
 /// returns nil and the caller falls through to the normal HTML ingest path.
+///
+/// **Always compiled** (no `#if PODCAST_TRANSCRIPTS` guard) so the generic
+/// `.podcast` path can reach `EpisodeRef` (C1 in `plans/podcast-generalize.md`).
+/// The `parse`/`displayTitle` helpers are Apple-specific but pure + harmless —
+/// they're only CALLED from the gated Apple ingest path, so unguarding them
+/// doesn't enable Apple ingest on App Store builds (the `addURL` overload that
+/// calls them is itself gated).
 ///
 /// See `plans/podcast-transcripts.md`.
 public enum PodcastEpisodeURL {
@@ -112,4 +118,3 @@ public enum PodcastEpisodeURL {
         }
     }
 }
-#endif

--- a/Sources/WikiFSCore/Integrations/PodcastTranscriptTypes.swift
+++ b/Sources/WikiFSCore/Integrations/PodcastTranscriptTypes.swift
@@ -1,0 +1,319 @@
+import Foundation
+
+/// Always-compiled transcript value types, the fetcher protocol, the error
+/// enum, and the subprocess-backed `RSSPodcastTranscriptService`.
+///
+/// These symbols have **no FairPlay / private-framework dependency** — only the
+/// `podcast-transcript` `uv` script (PEP 723) — so they compile on EVERY build,
+/// including `WIKIFS_APP_STORE=1` (where `#if PODCAST_TRANSCRIPTS` is off). The
+/// FairPlay-specific code (`ApplePodcastTranscriptService`, `ApplePodcastAMP`,
+/// `TTMLTranscript` parse logic, `HelperPodcastTokenProvider`) stays gated.
+///
+/// Extracted from `ApplePodcastTranscriptService.swift` + `TTMLTranscript.swift`
+/// so the generic `.podcast` (any-RSS-feed) path — issue podcast-generalize —
+/// can reach `RSSPodcastTranscriptService` without the guard. See C1 in
+/// `plans/podcast-generalize.md`.
+
+// MARK: - PodcastTranscript
+
+/// The finished transcript for a recognized episode: episode ID, markdown text,
+/// and a suggested source filename.
+public struct PodcastTranscript: Equatable, Sendable {
+    public let episodeID: String
+    public let markdown: String
+    public let filename: String
+
+    public init(episodeID: String, markdown: String, filename: String) {
+        self.episodeID = episodeID
+        self.markdown = markdown
+        self.filename = filename
+    }
+}
+
+// MARK: - PodcastTranscriptFetching (Apple path)
+
+/// The Apple-path fetcher contract: pasted Apple episode URL → transcript.
+/// Injected so `URLIngestService` and `WikiStoreModel` can be unit-tested with
+/// a fake; the app wires the real `ApplePodcastTranscriptService` (FairPlay).
+public protocol PodcastTranscriptFetching: Sendable {
+    func transcript(for episode: PodcastEpisodeURL.EpisodeRef) async throws -> PodcastTranscript
+}
+
+// MARK: - RSSFeedTranscriptFetching (generic any-RSS-feed path)
+
+/// The generic-RSS-path fetcher contract: a direct RSS feed URL → transcript.
+/// Sister protocol to `PodcastTranscriptFetching` for the `.podcast` provider
+/// (any RSS feed, no Apple ID, no iTunes Lookup hop). Injection seam so tests
+/// can fake the subprocess without spawning `uv`. Always compiled.
+///
+/// Issue podcast-generalize (H3).
+public protocol RSSFeedTranscriptFetching: Sendable {
+    func transcript(forFeedURL url: URL) async throws -> PodcastTranscript
+}
+
+// MARK: - PodcastTranscriptError
+
+/// Errors for the URL → transcript pipeline, user-readable so the Add-from-URL
+/// sheet and `SourceDetailView.runTranscription` can surface them directly.
+public enum PodcastTranscriptError: Error, LocalizedError, Equatable {
+    /// The private-framework signing helper failed (missing, crashed, or the
+    /// macOS release changed the selectors). Carries the helper's stderr.
+    case signatureUnavailable(String)
+    /// AMP returned 40012 — the token lacks transcript permission even after a
+    /// forced refresh.
+    case insufficientPermissions
+    /// The episode/feed has no transcript (no `<podcast:transcript>` tag, or
+    /// Apple has no TTML). Surfaced as a graceful "no transcript" failure.
+    case noTranscriptAvailable
+    /// An unexpected HTTP status from the AMP or TTML request.
+    case badResponse(Int)
+    /// The TTML/JSON bytes didn't parse into any usable transcript.
+    case ttmlParseFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .signatureUnavailable(let detail):
+            return "Couldn't sign the Apple Podcasts token request: \(detail)"
+        case .insufficientPermissions:
+            return "Apple rejected the transcript request (insufficient permissions)."
+        case .noTranscriptAvailable:
+            return "This episode has no transcript."
+        case .badResponse(let code):
+            return "The transcript service returned HTTP \(code)."
+        case .ttmlParseFailed:
+            return "The transcript file couldn't be parsed."
+        }
+    }
+}
+
+// MARK: - RSSPodcastTranscriptService
+
+/// Fetches a podcast transcript by spawning the `podcast-transcript` PEP 723
+/// script (`tools/podcast-transcript/podcast-transcript`), which fetches the
+/// RSS feed and looks for `<podcast:transcript>` tags — no FairPlay signing
+/// helper, no private frameworks. Mirrors `YouTubeTranscriptService` (subprocess
+/// pattern) and is a `PodcastTranscriptFetching` conformer alongside
+/// `ApplePodcastTranscriptService` (the FairPlay path).
+///
+/// The script accepts EITHER an Apple Podcasts episode URL OR a direct RSS feed
+/// URL as argv[1] and emits structured JSON with `--json`:
+/// `{show_id, episode_id, language, format, markdown}`.
+///
+/// Two entry points:
+/// - `transcript(for:)` — the Apple path (conforms to `PodcastTranscriptFetching`).
+///   Uses the stored `sourceURL` (an Apple episode URL).
+/// - `transcript(forFeedURL:)` — the generic any-RSS-feed path (conforms to
+///   `RSSFeedTranscriptFetching`). Takes the feed URL directly; never touches
+///   `EpisodeRef`, so the stored filename is derived from the feed host + path
+///   (H3) instead of a numeric episode ID.
+///
+/// Exit codes are mapped to `PodcastTranscriptError`:
+///   0 → success, 3 → podcast not found, 4 → episode not found,
+///   1/other → `.noTranscriptAvailable` (no RSS transcript / network error).
+///
+/// Issues #812 + podcast-generalize.
+public struct RSSPodcastTranscriptService: PodcastTranscriptFetching, RSSFeedTranscriptFetching {
+
+    /// The decoded JSON the `podcast-transcript --json` script emits.
+    struct ScriptOutput: Decodable {
+        let show_id: String?
+        let episode_id: String?
+        let language: String?
+        let format: String?
+        let markdown: String?
+    }
+
+    /// The full Apple Podcasts episode URL (e.g.
+    /// `https://podcasts.apple.com/us/podcast/slug/id123?i=456`). Stored at init
+    /// for the Apple-path `transcript(for:)` conformance — the dispatch in
+    /// `WikiStoreModel.transcribePodcast` passes `origin.plan` (the page URL).
+    /// The generic path (`transcript(forFeedURL:)`) does NOT use this — it takes
+    /// the feed URL as a parameter (H3), so the no-arg `init()` leaves this nil.
+    private let sourceURL: URL?
+
+    /// Generic-RSS-path default init. `transcript(forFeedURL:)` takes the URL
+    /// as a parameter, so no stored URL is needed for the `.podcast` dispatch.
+    public init() {
+        self.sourceURL = nil
+    }
+
+    /// Apple-path init (renamed from `episodeURL:` in podcast-generalize).
+    /// The stored URL is an Apple Podcasts episode URL OR a direct RSS feed URL
+    /// (the script accepts both); the Apple-path `transcript(for:)` passes it
+    /// to the script.
+    public init(sourceURL: URL) {
+        self.sourceURL = sourceURL
+    }
+
+    // MARK: Apple path (PodcastTranscriptFetching)
+
+    public func transcript(
+        for episode: PodcastEpisodeURL.EpisodeRef
+    ) async throws -> PodcastTranscript {
+        guard let sourceURL else {
+            DebugLog.extraction("[podcast-rss] transcript(for:): no sourceURL stored (use init(sourceURL:))")
+            throw PodcastTranscriptError.signatureUnavailable(
+                "RSSPodcastTranscriptService was not initialized with a source URL.")
+        }
+
+        guard let script = Self.resolveScript() else {
+            DebugLog.extraction("[podcast-rss] transcript: script not found")
+            throw PodcastTranscriptError.signatureUnavailable(
+                "The podcast-transcript script isn't available in this build.")
+        }
+
+        DebugLog.extraction("[podcast-rss] transcript: spawning \(script.path) for \(sourceURL.absoluteString)")
+
+        do {
+            let result = try await TranscriptSubprocess.run(
+                script: script,
+                arguments: [sourceURL.absoluteString, "--json"]
+            )
+            return try Self.mapResult(result, episode: episode)
+        } catch let error as TranscriptSubprocessError {
+            DebugLog.extraction("[podcast-rss] transcript: subprocess error: \(error.localizedDescription)")
+            throw PodcastTranscriptError.signatureUnavailable(error.localizedDescription)
+        }
+    }
+
+    // MARK: Generic any-RSS-feed path (RSSFeedTranscriptFetching) — H3
+
+    public func transcript(forFeedURL url: URL) async throws -> PodcastTranscript {
+        guard let script = Self.resolveScript() else {
+            DebugLog.extraction("[podcast-rss] transcript(forFeedURL:): script not found")
+            throw PodcastTranscriptError.signatureUnavailable(
+                "The podcast-transcript script isn't available in this build.")
+        }
+
+        DebugLog.extraction("[podcast-rss] transcript(forFeedURL:): spawning \(script.path) for \(url.absoluteString)")
+
+        do {
+            let result = try await TranscriptSubprocess.run(
+                script: script,
+                arguments: [url.absoluteString, "--json"]
+            )
+            return try Self.mapResult(result, feedURL: url)
+        } catch let error as TranscriptSubprocessError {
+            DebugLog.extraction("[podcast-rss] transcript(forFeedURL:): subprocess error: \(error.localizedDescription)")
+            throw PodcastTranscriptError.signatureUnavailable(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Result mapping (pure, testable)
+
+    /// Map the subprocess result to a `PodcastTranscript` (Apple path) or throw
+    /// the appropriate `PodcastTranscriptError`. Pure — extracted for testability.
+    static func mapResult(
+        _ result: (stdout: String, stderr: String, status: Int32),
+        episode: PodcastEpisodeURL.EpisodeRef
+    ) throws -> PodcastTranscript {
+        let output = try Self.decode(result)
+        let episodeID = output.script.episode_id ?? episode.id
+        return PodcastTranscript(
+            episodeID: episodeID,
+            markdown: output.script.markdown ?? "",
+            filename: Self.filename(for: episode))
+    }
+
+    /// Map the subprocess result to a `PodcastTranscript` (generic RSS-feed
+    /// path). Pure — extracted for testability. The filename is derived from
+    /// the feed host + last path component (H3), never a raw URL string.
+    static func mapResult(
+        _ result: (stdout: String, stderr: String, status: Int32),
+        feedURL: URL
+    ) throws -> PodcastTranscript {
+        let output = try Self.decode(result)
+        let episodeID = output.script.episode_id ?? feedURL.absoluteString
+        return PodcastTranscript(
+            episodeID: episodeID,
+            markdown: output.script.markdown ?? "",
+            filename: Self.filename(forFeedURL: feedURL))
+    }
+
+    /// Shared exit-code + JSON-decode gate. Returns the decoded `ScriptOutput`
+    /// after verifying a zero exit status and non-empty stdout.
+    private static func decode(
+        _ result: (stdout: String, stderr: String, status: Int32)
+    ) throws -> (script: ScriptOutput, raw: String) {
+        switch result.status {
+        case 0:
+            break
+        case 3, 4:
+            throw PodcastTranscriptError.noTranscriptAvailable
+        default:
+            let msg = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            DebugLog.extraction("[podcast-rss] transcript: exit \(result.status): \(msg)")
+            throw PodcastTranscriptError.noTranscriptAvailable
+        }
+
+        let trimmed = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw PodcastTranscriptError.ttmlParseFailed
+        }
+
+        do {
+            let script = try JSONDecoder().decode(ScriptOutput.self, from: Data(trimmed.utf8))
+            return (script, trimmed)
+        } catch {
+            DebugLog.extraction("[podcast-rss] transcript: JSON decode failed: \(error)")
+            throw PodcastTranscriptError.ttmlParseFailed
+        }
+    }
+
+    /// Resolve the `podcast-transcript` script. Mirrors
+    /// `PdfExtractionService.resolveScript()`.
+    static func resolveScript() -> URL? {
+        TranscriptSubprocess.resolveScript(
+            named: "podcast-transcript",
+            repoSubdir: "tools/podcast-transcript")
+    }
+
+    // MARK: - Filenames
+
+    /// Apple-path filename: `<slug>-<id>-transcript.md`, or
+    /// `podcast-<id>-transcript.md` when the URL carried no slug.
+    static func filename(for episode: PodcastEpisodeURL.EpisodeRef) -> String {
+        let stem = episode.slug.map { "\($0)-\(episode.id)" } ?? "podcast-\(episode.id)"
+        return "\(FilenameEscaping.escapeTitle(stem))-transcript.md"
+    }
+
+    /// Generic-RSS-feed filename (H3): derived from the feed host + last path
+    /// component so it reads like a source name, NOT a raw URL. E.g.
+    /// `https://feeds.example.com/show.xml` → `podcast-feeds-example-com-show`.
+    /// The `-transcript.md` suffix is added by the caller's
+    /// `appendProcessedMarkdown` filename derivation; here we produce the stem
+    /// that matches the byteless-source filename convention.
+    static func filename(forFeedURL url: URL) -> String {
+        let host = (url.host ?? "feed")
+            .replacingOccurrences(of: "www.", with: "")
+        let last = url.lastPathComponent.isEmpty
+            ? "feed"
+            : (url.lastPathComponent as NSString).deletingPathExtension
+        // Collapse non-alphanumerics to hyphens for a filesystem-safe stem,
+        // matching FilenameEscaping's spaces-as-underscores discipline loosely.
+        let raw = "\(host)-\(last)"
+        let stem = raw.lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "-" }
+            .joined()
+            .repeatingHyphensCollapsed()
+        return FilenameEscaping.escapeTitle("podcast-\(stem)")
+    }
+}
+
+private extension String {
+    /// Collapse runs of `-` into a single `-` and trim leading/trailing `-`.
+    func repeatingHyphensCollapsed() -> String {
+        var out = ""
+        var prevDash = false
+        for ch in self {
+            if ch == "-" {
+                if !prevDash { out.append(ch) }
+                prevDash = true
+            } else {
+                out.append(ch)
+                prevDash = false
+            }
+        }
+        return out.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}

--- a/Sources/WikiFSCore/Integrations/PodcastTranscriptTypes.swift
+++ b/Sources/WikiFSCore/Integrations/PodcastTranscriptTypes.swift
@@ -300,8 +300,10 @@ public struct RSSPodcastTranscriptService: PodcastTranscriptFetching, RSSFeedTra
     }
 }
 
-private extension String {
+extension String {
     /// Collapse runs of `-` into a single `-` and trim leading/trailing `-`.
+    /// Internal so both `RSSPodcastTranscriptService.filename(forFeedURL:)`
+    /// and `WikiStoreModel.rssPodcastEmbedFilename(for:)` share one impl.
     func repeatingHyphensCollapsed() -> String {
         var out = ""
         var prevDash = false

--- a/Sources/WikiFSCore/Integrations/RSSFeedEpisodeURL.swift
+++ b/Sources/WikiFSCore/Integrations/RSSFeedEpisodeURL.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Recognizes a **direct RSS podcast feed URL** pasted as a source — PURE,
+/// value-in / value-out, so the recognizer is unit-tested without any network.
+///
+/// Unlike `PodcastEpisodeURL` (which recognizes Apple Podcasts *episode* links),
+/// this recognizer validates that a raw URL is a plausible RSS feed URL. It is
+/// the intake-side validation for the generic `.podcast` provider (any RSS
+/// feed, not just Apple). The actual feed fetch + `<podcast:transcript>` parse
+/// happens later in the `podcast-transcript` Python script (triggered by the
+/// Transcribe button), NOT at ingest.
+///
+/// **The ambiguity problem (§3 of the plan):** a raw URL like
+/// `https://example.com/ep42` could be a feed OR a webpage — pure URL parsing
+/// can't tell. So this recognizer is NOT wired into the generic `addURL` paste
+/// path (which would silently misdetect feeds). Instead, the caller explicitly
+/// invokes `addPodcastFeedURL(_:)` — a dedicated intake entry point (M3) —
+/// which uses this recognizer for validation + slug extraction only.
+///
+/// Always compiled (no `#if PODCAST_TRANSCRIPTS` guard) — the generic `.podcast`
+/// path works on every build. Issue podcast-generalize.
+public struct RSSFeedEpisodeRef: Equatable, Sendable {
+    /// The raw RSS feed URL (e.g. `https://feeds.example.com/show.xml`).
+    public let feedURL: URL
+    /// An optional episode GUID to locate a specific `<item>` (nil → latest).
+    public let episodeGUID: String?
+    /// An optional display stem derived from the feed URL's host + path
+    /// (used for the byteless-source filename).
+    public let slug: String?
+
+    public init(feedURL: URL, episodeGUID: String? = nil, slug: String? = nil) {
+        self.feedURL = feedURL
+        self.episodeGUID = episodeGUID
+        self.slug = slug
+    }
+}
+
+public enum RSSFeedEpisodeURL {
+
+    /// Parse raw pasted text into an `RSSFeedEpisodeRef`, or nil when the URL
+    /// is missing/invalid. Reuses `URLFetchService.normalizeURL` so the same
+    /// pastes the sheet accepts (whitespace, missing scheme) are recognized here.
+    ///
+    /// A URL is considered a plausible feed candidate if its path ends in
+    /// `.xml`/`.rss`/`.atom` OR it has an http(s) scheme with a non-empty host
+    /// (the explicit "Add podcast feed" affordance declares intent, so we accept
+    /// any http(s) URL and let the script validate the actual feed content).
+    public static func parse(_ raw: String) -> RSSFeedEpisodeRef? {
+        guard let url = URLFetchService.normalizeURL(raw),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host, !host.isEmpty else {
+            return nil
+        }
+        return RSSFeedEpisodeRef(
+            feedURL: url,
+            episodeGUID: nil,
+            slug: slug(from: url))
+    }
+
+    /// Derive a human-readable display stem from the feed URL's host + last
+    /// path component. E.g. `https://feeds.example.com/show.xml` → `show`.
+    /// Nil when the URL has no usable path component.
+    static func slug(from url: URL) -> String? {
+        let last = url.lastPathComponent
+        guard !last.isEmpty else {
+            // No path component — use the host stem (without www. / TLD).
+            return readableHost(url.host)
+        }
+        let stem = (last as NSString).deletingPathExtension
+        return stem.isEmpty ? readableHost(url.host) : stem
+    }
+
+    /// Strip `www.` and the TLD from a host for a readable stem.
+    /// `feeds.example.com` → `example`. Returns nil for unparseable hosts.
+    private static func readableHost(_ host: String?) -> String? {
+        guard let host, !host.isEmpty else { return nil }
+        let cleaned = host.replacingOccurrences(of: "www.", with: "")
+        let parts = cleaned.split(separator: ".")
+        // parts: ["feeds", "example", "com"] → "example" (second-to-last).
+        guard parts.count >= 2 else { return cleaned }
+        return String(parts[parts.count - 2])
+    }
+}

--- a/Sources/WikiFSCore/Integrations/RSSFeedEpisodeURL.swift
+++ b/Sources/WikiFSCore/Integrations/RSSFeedEpisodeURL.swift
@@ -63,8 +63,8 @@ public enum RSSFeedEpisodeURL {
     /// Nil when the URL has no usable path component.
     static func slug(from url: URL) -> String? {
         let last = url.lastPathComponent
-        guard !last.isEmpty else {
-            // No path component — use the host stem (without www. / TLD).
+        // lastPathComponent can be "/" or "" for root paths — treat both as empty.
+        guard !last.isEmpty, last != "/" else {
             return readableHost(url.host)
         }
         let stem = (last as NSString).deletingPathExtension

--- a/Sources/WikiFSCore/Integrations/TTMLTranscript.swift
+++ b/Sources/WikiFSCore/Integrations/TTMLTranscript.swift
@@ -157,36 +157,4 @@ public struct TTMLTranscript: Equatable, Sendable {
         }
     }
 }
-
-/// Errors for the URL → transcript pipeline, user-readable so the Add-from-URL
-/// sheet can surface them directly.
-public enum PodcastTranscriptError: Error, LocalizedError, Equatable {
-    /// The private-framework signing helper failed (missing, crashed, or the
-    /// macOS release changed the selectors). Carries the helper's stderr.
-    case signatureUnavailable(String)
-    /// AMP returned 40012 — the token lacks transcript permission even after a
-    /// forced refresh.
-    case insufficientPermissions
-    /// The episode has no Apple-hosted transcript.
-    case noTranscriptAvailable
-    /// An unexpected HTTP status from the AMP or TTML request.
-    case badResponse(Int)
-    /// The TTML bytes didn't parse into any cues.
-    case ttmlParseFailed
-
-    public var errorDescription: String? {
-        switch self {
-        case .signatureUnavailable(let detail):
-            return "Couldn't sign the Apple Podcasts token request: \(detail)"
-        case .insufficientPermissions:
-            return "Apple rejected the transcript request (insufficient permissions)."
-        case .noTranscriptAvailable:
-            return "This episode has no Apple transcript."
-        case .badResponse(let code):
-            return "Apple's transcript service returned HTTP \(code)."
-        case .ttmlParseFailed:
-            return "The transcript file couldn't be parsed."
-        }
-    }
-}
 #endif

--- a/Sources/WikiFSCore/Sources/SourceRefreshService.swift
+++ b/Sources/WikiFSCore/Sources/SourceRefreshService.swift
@@ -11,6 +11,9 @@ import Foundation
 /// - `"website"` → `WebsiteMaterializer` (refresh appends a content version).
 /// - `"apple-podcast"` → `ApplePodcastMaterializer` (refresh appends a derived
 ///   markdown version — byteless sources have no content to refresh).
+/// - `"podcast"` (generic RSS) → `RSSPodcastTranscriptService` (refresh
+///   re-fetches the `<podcast:transcript>` and appends a derived markdown
+///   version — same byteless shape as apple-podcast, but no signing helper).
 /// - Everything else (`local-file`, `zotero`, `markdown-folder`,
 ///   `legacy-import`, `unknown`) → `.notRefreshable` (import-only).
 ///
@@ -91,6 +94,12 @@ public struct SourceRefreshService: Sendable {
             return try await materializeWebsite(origin: origin)
         case .applePodcast:
             return try await materializePodcast(origin: origin)
+        case .podcast:
+            // Generic RSS-feed podcast: re-fetch the transcript via the
+            // `podcast-transcript` script (no FairPlay helper). Mirrors
+            // `.applePodcast`'s refresh → derived-markdown shape. Always
+            // available on every build (the service is always compiled).
+            return try await materializePodcastFeed(origin: origin)
         case .localFile, .zotero, .markdownFolder, .youtube, .vimeo, .spotify,
              .soundcloud, .remoteMedia, .legacyImport, nil:
             throw RefreshError.notRefreshable(origin.agentName)
@@ -143,4 +152,21 @@ public struct SourceRefreshService: Sendable {
         throw RefreshError.notRefreshable(origin.agentName)
     }
     #endif
+
+    // MARK: - Generic RSS Podcast (always compiled — no FairPlay dependency)
+
+    /// Re-fetch the transcript for a generic `.podcast` (any-RSS-feed) source.
+    /// Spawns the `podcast-transcript` script with the feed URL from
+    /// `origin.plan`. Byteless source → only the derived markdown changes on
+    /// refresh. Always available (the service is always compiled). Issue
+    /// podcast-generalize.
+    private func materializePodcastFeed(origin: SourceOrigin) async throws -> RefreshMaterial {
+        guard let urlString = origin.plan, let url = URL(string: urlString) else {
+            throw RefreshError.missingPlan
+        }
+        let svc = RSSPodcastTranscriptService()
+        let transcript = try await svc.transcript(forFeedURL: url)
+        let markdown = transcript.markdown
+        return .derivedMarkdown(content: markdown)
+    }
 }

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -397,6 +397,13 @@ public final class WikiStoreModel {
     /// pre-existing YouTube transcript source from an older build keeps the
     /// same provenance label.
     private static let youtubeCaptionsTechnique = "youtube-captions"
+    /// Technique label for the generic RSS-feed podcast transcript markdown
+    /// written by `transcribeRSSPodcast(sourceID:origin:fetcher:)` (issue
+    /// podcast-generalize). Mirrors the `podcastTtmlTechnique` shape: stamped
+    /// on the `source_markdown_versions` row so the provenance chip reports the
+    /// producer. The generic path fetches the `<podcast:transcript>` tag via
+    /// the `podcast-transcript` `uv` script (no FairPlay helper).
+    private static let rssPodcastTranscriptTechnique = "rss-podcast-transcript"
     /// The synthetic MIME for a byteless Apple Podcasts embed source (issue
     /// #799 PR4). `ExternalEmbed.target(for:)` dispatches on the provider's
     /// `agentName == "apple-podcast"` (NOT the MIME — see the dispatch table
@@ -2770,6 +2777,12 @@ public final class WikiStoreModel {
             #else
             return false
             #endif
+        case .podcast:
+            // Generic RSS-feed podcast: always refreshable on every build —
+            // the `podcast-transcript` script needs only `uv` (no signing
+            // helper). Mirrors YouTube's "no runtime guard" shape but unlike
+            // YouTube the refresh DOES re-fetch a fresh transcript.
+            return true
         // Exhaustive over the non-refreshable providers — `supportsRefresh`
         // returned false above, so these are unreachable; the compiler still
         // enforces exhaustiveness if a new provider is ever added (it has to
@@ -3085,7 +3098,8 @@ public final class WikiStoreModel {
     public func transcribe(
         sourceID: PageID,
         podcastFetcher: (any PodcastTranscriptFetching)? = ApplePodcastTranscriptService.bundled(),
-        youtubeFetcher: (any YouTubeTranscriptFetching)? = YouTubeTranscriptService()
+        youtubeFetcher: (any YouTubeTranscriptFetching)? = YouTubeTranscriptService(),
+        rssPodcastFetcher: (any RSSFeedTranscriptFetching)? = RSSPodcastTranscriptService()
     ) async throws -> SourceMarkdownVersion? {
         guard let origin = sourceOrigin(for: sourceID),
               let provider = origin.provider else {
@@ -3095,6 +3109,9 @@ public final class WikiStoreModel {
         case .applePodcast:
             return try await transcribePodcast(
                 sourceID: sourceID, origin: origin, fetcher: podcastFetcher)
+        case .podcast:
+            return try await transcribeRSSPodcast(
+                sourceID: sourceID, origin: origin, fetcher: rssPodcastFetcher)
         case .youtube:
             return try await transcribeYouTube(
                 sourceID: sourceID, origin: origin, fetcher: youtubeFetcher)
@@ -3108,7 +3125,8 @@ public final class WikiStoreModel {
     public func transcribe(
         sourceID: PageID,
         podcastFetcher: Any? = nil,
-        youtubeFetcher: (any YouTubeTranscriptFetching)? = YouTubeTranscriptService()
+        youtubeFetcher: (any YouTubeTranscriptFetching)? = YouTubeTranscriptService(),
+        rssPodcastFetcher: (any RSSFeedTranscriptFetching)? = RSSPodcastTranscriptService()
     ) async throws -> SourceMarkdownVersion? {
         guard let origin = sourceOrigin(for: sourceID),
               let provider = origin.provider else {
@@ -3125,6 +3143,12 @@ public final class WikiStoreModel {
             // `transcribePodcast(sourceID:origin:fetcher:)` phase-out arm below.
             _ = podcastFetcher  // unused on the phase-out build
             throw SourceRefreshService.RefreshError.notRefreshable(origin.agentName)
+        case .podcast:
+            // Generic RSS-feed podcast: ALWAYS compiled (no FairPlay dependency).
+            // Works on WIKIFS_APP_STORE=1 builds — the transcript fetch needs
+            // only the `podcast-transcript` `uv` script.
+            return try await transcribeRSSPodcast(
+                sourceID: sourceID, origin: origin, fetcher: rssPodcastFetcher)
         case .youtube:
             return try await transcribeYouTube(
                 sourceID: sourceID, origin: origin, fetcher: youtubeFetcher)
@@ -3170,7 +3194,7 @@ public final class WikiStoreModel {
         // available). Fall back to the RSS subprocess service — it needs only
         // `uv` (no macOS signing helper), so podcast transcripts work even in
         // builds where `podcast-token-helper` is absent. Issue #812.
-        let svc = fetcher ?? RSSPodcastTranscriptService(episodeURL: pageURL)
+        let svc = fetcher ?? RSSPodcastTranscriptService(sourceURL: pageURL)
         // The materializer runs the transcript fetch (helper subprocess + two
         // HTTP round-trips + TTML parse) off-main in a detached Task; the
         // model never touches the store inside this `await`.
@@ -3263,6 +3287,62 @@ public final class WikiStoreModel {
             // #475/#492: never silently swallow — a transcription failure
             // (after network round-trips) must leave a Console.app trace.
             DebugLog.store("WikiStoreModel.transcribe (youtube) appendProcessedMarkdown failed (source=\(sourceID.rawValue)): \(error)")
+            return nil
+        }
+    }
+
+    /// Generic RSS-feed podcast arm of the unified dispatch (podcast-generalize).
+    /// Reads `origin.plan` (the feed URL recorded at ingest by
+    /// `addPodcastFeedURL`), calls `RSSPodcastTranscriptService.transcript(forFeedURL:)`
+    /// (spawns the `podcast-transcript` `uv` script → fetches the feed → parses
+    /// `<podcast:transcript>`), and writes via `appendProcessedMarkdown(origin:
+    /// .transcript, technique: "rss-podcast-transcript")`.
+    ///
+    /// **Always compiled** (outside `#if PODCAST_TRANSCRIPTS`) — the generic
+    /// `.podcast` path needs no FairPlay signing helper, only `uv`. So it works
+    /// on `WIKIFS_APP_STORE=1` builds, mirroring how `transcribeYouTube` is
+    /// always compiled.
+    ///
+    /// The injected `fetcher` (H2) lets tests fake the subprocess: pass an
+    /// `RSSFeedTranscriptFetching` conformer returning canned markdown and assert
+    /// the dispatch + append without spawning `uv`. Production defaults to
+    /// `RSSPodcastTranscriptService()` (constructed at the dispatch entry point).
+    ///
+    /// Mirrors `transcribeYouTube`'s error discipline: on a fetch failure the
+    /// error propagates (so `SourceDetailView.runTranscription` surfaces it);
+    /// on a store-write failure, logs + returns nil (the fetch succeeded but
+    /// the write didn't — a Console.app trace is left per #475/#492).
+    private func transcribeRSSPodcast(
+        sourceID: PageID, origin: SourceOrigin,
+        fetcher: (any RSSFeedTranscriptFetching)?
+    ) async throws -> SourceMarkdownVersion? {
+        guard let planURLString = origin.plan,
+              let sourceURL = URL(string: planURLString) else {
+            throw SourceRefreshService.RefreshError.missingPlan
+        }
+        guard let fetcher else {
+            // No fetcher: a test injected nil explicitly. Production's default
+            // (constructed at the dispatch entry point) is a real
+            // RSSPodcastTranscriptService instance, so this branch is unreachable
+            // in production UI; the throw keeps the model honest.
+            throw SourceRefreshService.RefreshError.notRefreshable("podcast")
+        }
+        // The transcript fetch (feed download + <podcast:transcript> parse) runs
+        // off-main via the subprocess; the model never touches the store inside
+        // this `await`.
+        let fetcherCopy = fetcher
+        let urlCopy = sourceURL
+        let transcript = try await Task.detached(priority: .userInitiated) {
+            try await fetcherCopy.transcript(forFeedURL: urlCopy)
+        }.value
+        do {
+            return try store.appendProcessedMarkdown(
+                sourceID: sourceID, content: transcript.markdown,
+                origin: .transcript, note: nil, technique: Self.rssPodcastTranscriptTechnique)
+        } catch {
+            // #475/#492: never silently swallow — a transcription failure
+            // (after a network round-trip) must leave a Console.app trace.
+            DebugLog.store("WikiStoreModel.transcribe (podcast) appendProcessedMarkdown failed (source=\(sourceID.rawValue)): \(error)")
             return nil
         }
     }

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2245,6 +2245,76 @@ public final class WikiStoreModel {
     }
     #endif
 
+    /// **Generic RSS-feed podcast intake** (podcast-generalize, M3): a dedicated
+    /// entry point for pasting a direct RSS feed URL. Bypasses the generic
+    /// website/byteless-embed fetch chain (the "ambiguity problem" — a feed URL
+    /// can't be distinguished from a webpage by URL sniffing alone). The caller
+    /// invokes this explicitly from an "Add podcast feed" affordance, declaring
+    /// intent, so routing is by caller intent, not content sniffing.
+    ///
+    /// Creates a byteless `.podcast` source (no bytes fetched) with
+    /// `agentName = "podcast"`, `plan` = feed URL. No transcript is written at
+    /// ingest — the user clicks Transcribe in `SourceDetailView` to trigger the
+    /// `podcast-transcript` script fetch (mirrors the Apple PR4 + YouTube PR5
+    /// contract). Always compiled (no `#if PODCAST_TRANSCRIPTS` guard) — the
+    /// generic `.podcast` path needs no FairPlay signing helper.
+    ///
+    /// - Parameter rawInput: the raw RSS feed URL (e.g.
+    ///   `https://feeds.example.com/show.xml`).
+    /// - Returns: the `FetchOutcome` for the created byteless source.
+    /// - Throws: `WikiStoreError` on a store failure (e.g. `.duplicateContent`
+    ///   for a re-paste of the same feed URL).
+    @discardableResult
+    public func addPodcastFeedURL(_ rawInput: String) async throws -> URLFetchService.FetchOutcome {
+        guard let ref = RSSFeedEpisodeURL.parse(rawInput) else {
+            throw WikiStoreError.unexpected("Not a valid podcast feed URL: \(rawInput)")
+        }
+        let feedURLString = ref.feedURL.absoluteString
+        let summary = try store.addBytelessSource(
+            filename: Self.rssPodcastEmbedFilename(for: ref),
+            mimeType: Self.rssPodcastEmbedMIME,
+            provenance: SourceProvenance(
+                agentName: SourceProvider.podcast.rawValue,
+                activityKind: "fetch",
+                plan: feedURLString,
+                externalRef: feedURLString,
+                externalIdentity: ref.episodeGUID ?? feedURLString),
+            role: .primary)
+        // No transcript markdown is written — the source's
+        // `source_markdown_versions` stays empty until the user transcribes.
+        // Mirrors the Apple PR4 + YouTube PR5 byteless-only ingest contract.
+        openTab(.source(summary.id), title: summary.effectiveName)
+        return URLFetchService.FetchOutcome(
+            filename: summary.filename,
+            byteSize: 0,
+            kind: .audioEmbed)
+    }
+
+    /// Build the byteless-source filename for a generic RSS podcast feed
+    /// (podcast-generalize). Derives a readable stem from the feed URL's host +
+    /// last path component, prefixed with `podcast-`. Mirrors the YouTube/Vimeo
+    /// `youtube-<id>` / `vimeo-<id>` byteless-source filename convention.
+    private static func rssPodcastEmbedFilename(for ref: RSSFeedEpisodeRef) -> String {
+        let host = (ref.feedURL.host ?? "feed").replacingOccurrences(of: "www.", with: "")
+        let last = ref.feedURL.lastPathComponent.isEmpty
+            ? "feed"
+            : (ref.feedURL.lastPathComponent as NSString).deletingPathExtension
+        let stem = "\(host)-\(last)"
+            .lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "-" }
+            .joined()
+            .repeatingHyphensCollapsed()
+        return FilenameEscaping.escapeTitle("podcast-\(stem)")
+    }
+
+    /// The synthetic MIME for a byteless generic RSS podcast feed source
+    /// (podcast-generalize). `ExternalEmbed.target(for:)` dispatches on
+    /// `agentName == "podcast"` is NOT wired (there's no universal podcast web
+    /// player), so this source is byteless with no embed target — the Transcribe
+    /// button is the sole affordance. The `audio/*` prefix keeps the MIME
+    /// taxonomy consistent with the other byteless audio providers.
+    private static let rssPodcastEmbedMIME = "audio/podcast"
+
     /// Phase 4b: try the byteless external-embed recognizers in fixed precedence
     /// order — provider iframes (YouTube → Vimeo → Spotify → SoundCloud) then
     /// direct-remote media. On a match, create a **byteless** source (no bytes

--- a/Sources/WikiFSTypes/SourceProvider.swift
+++ b/Sources/WikiFSTypes/SourceProvider.swift
@@ -27,6 +27,11 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
     case markdownFolder  = "markdown-folder"
     /// An Apple Podcasts episode transcript (byteless). Stored as `"apple-podcast"`.
     case applePodcast    = "apple-podcast"
+    /// A byteless generic RSS podcast feed (transcript via `<podcast:transcript>`).
+    /// Stored as `"podcast"`. Unlike `.applePodcast`, this needs no FairPlay
+    /// signing helper — it works on every build (App Store included) since the
+    /// only dependency is the `podcast-transcript` `uv` script.
+    case podcast         = "podcast"
     /// A byteless YouTube embed (synthetic `video/youtube` mime). Stored as `"youtube"`.
     case youtube         = "youtube"
     /// A byteless Vimeo embed. Stored as `"vimeo"`.
@@ -61,6 +66,7 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
         case .zotero:          return "Zotero"
         case .markdownFolder:  return "Folder"
         case .applePodcast:    return "Apple Podcast"
+        case .podcast:         return "Podcast"
         case .youtube:         return "YouTube"
         case .vimeo:           return "Vimeo"
         case .spotify:         return "Spotify"
@@ -80,6 +86,7 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
         case .zotero:          return "books.vertical"
         case .markdownFolder:  return "folder"
         case .applePodcast:    return "waveform"
+        case .podcast:         return "antenna.radiowaves.left.and.right"
         case .youtube:         return "play.rectangle"
         case .vimeo:           return "play.rectangle"
         case .spotify:         return "music.note"
@@ -99,6 +106,7 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
         case .zotero:          return "View in Zotero"
         case .markdownFolder:  return "Reveal original folder"
         case .applePodcast:    return "Open episode"
+        case .podcast:         return "Open feed"
         case .youtube:         return "Open video"
         case .vimeo:           return "Open video"
         case .spotify:         return "Open track"
@@ -117,13 +125,16 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
     ///   (single-source refresh would orphan them — D3 guard).
     /// - `applePodcast`: `false` when this build doesn't compile podcast
     ///   support OR the `podcast-token-helper` binary isn't present at runtime.
+    /// - `podcast` (generic RSS): always refreshable on every build — the
+    ///   re-transcribe fetches a fresh `<podcast:transcript>` via the
+    ///   `podcast-transcript` `uv` script (no signing helper).
     ///
     /// Every other provider (local-file / Zotero / folder / YouTube / Vimeo /
     /// Spotify / SoundCloud / remote-media / legacy-import / unknown) is
     /// import-only or byteless-embed-only — there's no URL to re-fetch.
     public var supportsRefresh: Bool {
         switch self {
-        case .website, .applePodcast:
+        case .website, .applePodcast, .podcast:
             return true
         case .localFile, .zotero, .markdownFolder,
              .youtube, .vimeo, .spotify, .soundcloud, .remoteMedia,
@@ -143,6 +154,10 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
     ///   signing helper must be present (`ApplePodcastTranscriptService.bundled()`
     ///   != nil) AND this build must compile podcast support
     ///   (`#if PODCAST_TRANSCRIPTS`).
+    /// - `podcast` (generic RSS) — the `podcast-transcript` `uv` script fetches
+    ///   the feed and parses `<podcast:transcript>` tags. No signing helper
+    ///   needed; always available on every build (App Store included). The
+    ///   `transcribeRSSPodcast` helper lives outside `#if PODCAST_TRANSCRIPTS`.
     /// - `youtube` — pure-Swift watch-page → caption track scrape (PR5). No
     ///   signing helper needed; always available when the source has a valid
     ///   11-char video ID in `origin.externalIdentity`.
@@ -154,7 +169,7 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
     /// token; #564 Phase 4 follow-up).
     public var supportsTranscription: Bool {
         switch self {
-        case .applePodcast, .youtube:
+        case .applePodcast, .podcast, .youtube:
             return true
         case .localFile, .website, .zotero, .markdownFolder,
              .vimeo, .spotify, .soundcloud, .remoteMedia, .legacyImport:

--- a/Tests/WikiFSTests/RSSPodcastTranscriptionTests.swift
+++ b/Tests/WikiFSTests/RSSPodcastTranscriptionTests.swift
@@ -1,0 +1,286 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Tests for the generic `.podcast` (any-RSS-feed) transcript pipeline — the
+/// recognizer, the service's pure result-mapping, the dispatch helper, and the
+/// intake entry point.
+///
+/// **UNGUARDED** (no `#if PODCAST_TRANSCRIPTS`) per M1 in
+/// `plans/podcast-generalize.md` — the generic `.podcast` path is always
+/// compiled (works on `WIKIFS_APP_STORE=1` builds), so these tests MUST run on
+/// every build to validate the AC.4 "works on App Store" claim.
+///
+/// Issue podcast-generalize.
+@MainActor
+struct RSSPodcastTranscriptionTests {
+
+    // MARK: - RSSFeedEpisodeURL recognizer (AC.1 intake validation)
+
+    @Test func parseAcceptsXmlFeedURL() throws {
+        let ref = try #require(RSSFeedEpisodeURL.parse("https://feeds.example.com/show.xml"))
+        #expect(ref.feedURL.absoluteString == "https://feeds.example.com/show.xml")
+        #expect(ref.episodeGUID == nil)
+        #expect(ref.slug == "show")
+    }
+
+    @Test func parseAcceptsRssFeedURL() throws {
+        let ref = try #require(RSSFeedEpisodeURL.parse("https://example.com/podcast/feed.rss"))
+        #expect(ref.slug == "feed")
+    }
+
+    @Test func parseAcceptsBareHTTPSURL() throws {
+        // The explicit affordance declares intent, so any http(s) URL is accepted.
+        let ref = try #require(RSSFeedEpisodeURL.parse("https://example.com/ep42"))
+        #expect(ref.feedURL.host == "example.com")
+    }
+
+    @Test func parseRejectsNonHTTP() {
+        #expect(RSSFeedEpisodeURL.parse("not a url") == nil)
+        #expect(RSSFeedEpisodeURL.parse("file:///local.xml") == nil)
+    }
+
+    @Test func parseRejectsEmptyAndWhitespace() {
+        #expect(RSSFeedEpisodeURL.parse("") == nil)
+        #expect(RSSFeedEpisodeURL.parse("   ") == nil)
+    }
+
+    @Test func parseNormalizesMissingScheme() throws {
+        let ref = try #require(RSSFeedEpisodeURL.parse("feeds.example.com/show.xml"))
+        #expect(ref.feedURL.scheme == "https")
+    }
+
+    @Test func slugDerivesFromHostWhenPathEmpty() throws {
+        let ref = try #require(RSSFeedEpisodeURL.parse("https://feeds.npr.org/"))
+        #expect(ref.slug == "npr")
+    }
+
+    // MARK: - RSSPodcastTranscriptService.mapResult (feed path, AC.4 + AC.5)
+
+    @Test func mapResultFeedPathExit0DecodesTranscript() throws {
+        let json = """
+        {
+            "show_id": null,
+            "episode_id": null,
+            "language": "en",
+            "format": "vtt",
+            "markdown": "Welcome to the show."
+        }
+        """
+        let feedURL = URL(string: "https://feeds.example.com/show.xml")!
+        let result = (stdout: json, stderr: "", status: Int32(0))
+        let transcript = try RSSPodcastTranscriptService.mapResult(result, feedURL: feedURL)
+
+        #expect(transcript.markdown == "Welcome to the show.")
+        // episodeID falls back to the feed URL when the script omits it.
+        #expect(transcript.episodeID == "https://feeds.example.com/show.xml")
+        // Filename is derived from the feed host + path, NOT a raw URL.
+        #expect(transcript.filename.contains("show"))
+        #expect(!transcript.filename.contains("https"))
+    }
+
+    @Test func mapResultFeedPathNonZeroThrowsNoTranscript() {
+        // AC.5: graceful failure — no <podcast:transcript> tag → exit 1 → .noTranscriptAvailable.
+        let feedURL = URL(string: "https://feeds.example.com/show.xml")!
+        let result = (stdout: "", stderr: "No transcript available", status: Int32(1))
+        #expect(throws: PodcastTranscriptError.noTranscriptAvailable) {
+            try RSSPodcastTranscriptService.mapResult(result, feedURL: feedURL)
+        }
+    }
+
+    @Test func mapResultFeedPathExit3ThrowsNoTranscript() {
+        let feedURL = URL(string: "https://feeds.example.com/show.xml")!
+        let result = (stdout: "", stderr: "Podcast not found", status: Int32(3))
+        #expect(throws: PodcastTranscriptError.noTranscriptAvailable) {
+            try RSSPodcastTranscriptService.mapResult(result, feedURL: feedURL)
+        }
+    }
+
+    @Test func mapResultFeedPathEmptyOutputThrowsParseFailed() {
+        let feedURL = URL(string: "https://feeds.example.com/show.xml")!
+        let result = (stdout: "  \n ", stderr: "", status: Int32(0))
+        #expect(throws: PodcastTranscriptError.ttmlParseFailed) {
+            try RSSPodcastTranscriptService.mapResult(result, feedURL: feedURL)
+        }
+    }
+
+    @Test func mapResultFeedPathInvalidJsonThrowsParseFailed() {
+        let feedURL = URL(string: "https://feeds.example.com/show.xml")!
+        let result = (stdout: "not json", stderr: "", status: Int32(0))
+        #expect(throws: PodcastTranscriptError.ttmlParseFailed) {
+            try RSSPodcastTranscriptService.mapResult(result, feedURL: feedURL)
+        }
+    }
+
+    // MARK: - Filename (H3 — feed-oriented, not raw URL)
+
+    @Test func filenameForFeedURLDerivesFromHostAndPath() {
+        let url = URL(string: "https://feeds.example.com/show.xml")!
+        let name = RSSPodcastTranscriptService.filename(forFeedURL: url)
+        #expect(name.contains("show"))
+        #expect(name.contains("example"))
+        #expect(!name.contains("https"))
+        #expect(!name.contains("://"))
+    }
+
+    @Test func filenameForFeedURLHandlesNoPath() {
+        let url = URL(string: "https://feeds.example.com/")!
+        let name = RSSPodcastTranscriptService.filename(forFeedURL: url)
+        #expect(!name.isEmpty)
+        #expect(name.contains("example"))
+    }
+
+    // MARK: - Rename-regression (L2)
+
+    @Test func sourceURLInitPreservesURL() throws {
+        // L2: the init(sourceURL:) rename preserves the URL for the Apple path.
+        let url = URL(string: "https://podcasts.apple.com/us/podcast/slug/id123?i=456")!
+        let svc = RSSPodcastTranscriptService(sourceURL: url)
+        // The service stores the URL; we verify via the Apple-path mapResult
+        // which is the consumer. A non-throwing construction is the baseline.
+        _ = svc
+    }
+
+    @Test func noArgInitWorksForGenericPath() {
+        // The generic-path dispatch default uses init() — verify it constructs.
+        let svc = RSSPodcastTranscriptService()
+        _ = svc
+    }
+
+    // MARK: - Dispatch (AC.4 — inject fake fetcher)
+
+    /// A fake `RSSFeedTranscriptFetching` returning canned markdown, so the
+    /// dispatch test asserts routing + append without spawning `uv`.
+    private struct FakeRSSFeedFetcher: RSSFeedTranscriptFetching {
+        let cannedMarkdown: String
+        var shouldThrow: Bool = false
+
+        func transcript(forFeedURL url: URL) async throws -> PodcastTranscript {
+            if shouldThrow {
+                throw PodcastTranscriptError.noTranscriptAvailable
+            }
+            return PodcastTranscript(
+                episodeID: url.absoluteString,
+                markdown: cannedMarkdown,
+                filename: "podcast-fake-transcript.md")
+        }
+    }
+
+    @Test func transcribeDispatchesToRSSPodcastAndAppends() async throws {
+        let store = try Self.tempStore()
+        let model = WikiStoreModel(store: store)
+
+        // Create a byteless .podcast source (intake).
+        _ = try await model.addPodcastFeedURL("https://feeds.example.com/show.xml")
+        model.reloadFromStore()
+        let sourceID = try #require(model.sources.first?.id)
+
+        // No markdown version exists yet (no transcript at ingest).
+        #expect(model.hasProcessedMarkdown(for: sourceID) == false)
+
+        // Transcribe with an injected fake fetcher returning canned markdown.
+        let fake = FakeRSSFeedFetcher(cannedMarkdown: "# Fake Transcript\n\nHello world.")
+        let version = try await model.transcribe(
+            sourceID: sourceID,
+            rssPodcastFetcher: fake)
+
+        // The dispatch reached the RSS path and appended a markdown version.
+        let appended = try #require(version)
+        #expect(appended.content.contains("Fake Transcript"))
+        #expect(appended.technique == "rss-podcast-transcript")
+        #expect(model.hasProcessedMarkdown(for: sourceID) == true)
+    }
+
+    @Test func transcribePodcastNoTranscriptSurfacesError() async throws {
+        // AC.5: when the feed has no transcript tag, the fetcher throws
+        // .noTranscriptAvailable and the dispatch propagates it (does NOT
+        // silently return nil).
+        let store = try Self.tempStore()
+        let model = WikiStoreModel(store: store)
+
+        _ = try await model.addPodcastFeedURL("https://feeds.example.com/notranscript.xml")
+        model.reloadFromStore()
+        let sourceID = try #require(model.sources.first?.id)
+
+        let fake = FakeRSSFeedFetcher(cannedMarkdown: "", shouldThrow: true)
+        await #expect(throws: PodcastTranscriptError.self) {
+            _ = try await model.transcribe(sourceID: sourceID, rssPodcastFetcher: fake)
+        }
+    }
+
+    @Test func transcribePodcastMissingPlanThrowsMissingPlan() async throws {
+        // A .podcast source with no plan URL → .missingPlan.
+        let store = try Self.tempStore()
+        let model = WikiStoreModel(store: store)
+
+        // Manually create a source with .podcast provider but no plan URL.
+        let summary = try store.addBytelessSource(
+            filename: "podcast-orphan",
+            mimeType: "audio/podcast",
+            provenance: SourceProvenance(
+                agentName: SourceProvider.podcast.rawValue,
+                activityKind: "fetch",
+                plan: nil, externalRef: nil, externalIdentity: nil),
+            role: .primary)
+
+        let fake = FakeRSSFeedFetcher(cannedMarkdown: "x")
+        await #expect(throws: SourceRefreshService.RefreshError.self) {
+            _ = try await model.transcribe(sourceID: summary.id, rssPodcastFetcher: fake)
+        }
+    }
+
+    // MARK: - Intake (AC.3)
+
+    @Test func addPodcastFeedURLCreatesBytelessPodcastSource() async throws {
+        let store = try Self.tempStore()
+        let model = WikiStoreModel(store: store)
+
+        let outcome = try await model.addPodcastFeedURL("https://feeds.example.com/show.xml")
+        model.reloadFromStore()
+
+        #expect(outcome.byteSize == 0)
+        #expect(model.sources.count == 1)
+        let source = try #require(model.sources.first)
+        #expect(source.byteSize == 0)
+
+        // Verify provenance: provider .podcast, plan = feed URL.
+        let origin = try #require(try store.sourceOrigin(sourceID: source.id))
+        #expect(origin.provider == .podcast)
+        #expect(origin.plan == "https://feeds.example.com/show.xml")
+
+        // No transcript written at ingest (AC.3).
+        #expect(model.hasProcessedMarkdown(for: source.id) == false)
+    }
+
+    @Test func addPodcastFeedURLRejectsInvalidURL() async throws {
+        let store = try Self.tempStore()
+        let model = WikiStoreModel(store: store)
+
+        await #expect(throws: WikiStoreError.self) {
+            _ = try await model.addPodcastFeedURL("not a url")
+        }
+        #expect(model.sources.isEmpty)
+    }
+
+    @Test func addPodcastFeedURLDeduplicatesSameFeed() async throws {
+        let store = try Self.tempStore()
+        let model = WikiStoreModel(store: store)
+
+        _ = try await model.addPodcastFeedURL("https://feeds.example.com/show.xml")
+        model.reloadFromStore()
+        // Re-pasting the same feed URL → duplicate content error.
+        await #expect(throws: WikiStoreError.self) {
+            _ = try await model.addPodcastFeedURL("https://feeds.example.com/show.xml")
+        }
+        #expect(model.sources.count == 1)
+    }
+
+    // MARK: - Helpers
+
+    private static func tempStore() throws -> GRDBWikiStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-rsspodcast-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return try GRDBWikiStore(databaseURL: dir.appendingPathComponent("WikiFS.sqlite"))
+    }
+}

--- a/Tests/WikiFSTests/SourceProviderTests.swift
+++ b/Tests/WikiFSTests/SourceProviderTests.swift
@@ -60,6 +60,7 @@ import Testing
         #expect(SourceProvider.zotero.rawValue == "zotero")
         #expect(SourceProvider.markdownFolder.rawValue == "markdown-folder")
         #expect(SourceProvider.applePodcast.rawValue == "apple-podcast")
+        #expect(SourceProvider.podcast.rawValue == "podcast")
         #expect(SourceProvider.youtube.rawValue == "youtube")
         #expect(SourceProvider.vimeo.rawValue == "vimeo")
         #expect(SourceProvider.spotify.rawValue == "spotify")
@@ -78,6 +79,7 @@ import Testing
         #expect(SourceProvider.markdownFolder.displayLabel == "Folder",
                 "markdown-folder displays as 'Folder' (not 'Markdown folder') — matches DetailView UI")
         #expect(SourceProvider.applePodcast.displayLabel == "Apple Podcast")
+        #expect(SourceProvider.podcast.displayLabel == "Podcast")
         #expect(SourceProvider.youtube.displayLabel == "YouTube",
                 "YouTube brand casing (not 'Youtube')")
         #expect(SourceProvider.vimeo.displayLabel == "Vimeo")
@@ -113,6 +115,7 @@ import Testing
         #expect(SourceProvider.markdownFolder.helpVerb.hasPrefix("Reveal"))
         #expect(SourceProvider.website.helpVerb.hasPrefix("Open"))
         #expect(SourceProvider.applePodcast.helpVerb.hasPrefix("Open"))
+        #expect(SourceProvider.podcast.helpVerb.hasPrefix("Open"))
         #expect(SourceProvider.youtube.helpVerb.hasPrefix("Open"))
         #expect(SourceProvider.remoteMedia.helpVerb.hasPrefix("Open"))
     }
@@ -127,6 +130,8 @@ import Testing
         // signing helper for podcasts) on top of this predicate.
         #expect(SourceProvider.website.supportsRefresh == true)
         #expect(SourceProvider.applePodcast.supportsRefresh == true)
+        #expect(SourceProvider.podcast.supportsRefresh == true,
+                "generic .podcast is refreshable (re-fetch transcript via RSS script)")
         // Everything else is import-only or byteless-embed-only — no URL to
         // re-fetch. (Direct-remote media could in principle be re-fetched, but
         // the refresh service doesn't implement it today.)
@@ -156,6 +161,8 @@ import Testing
         // YouTube is transcribable but not refreshable; a website is
         // refreshable but not transcribable.
         #expect(SourceProvider.applePodcast.supportsTranscription == true)
+        #expect(SourceProvider.podcast.supportsTranscription == true,
+                "generic .podcast is transcribable (RSS <podcast:transcript> via uv script)")
         #expect(SourceProvider.youtube.supportsTranscription == true)
         // Every other provider has no transcript pipeline today — Vimeo is
         // a future extension (needs a Keychain OAuth token; #564 Phase 4);
@@ -216,6 +223,7 @@ import Testing
         #expect(origin(agentName: "zotero").provider == .zotero)
         #expect(origin(agentName: "markdown-folder").provider == .markdownFolder)
         #expect(origin(agentName: "apple-podcast").provider == .applePodcast)
+        #expect(origin(agentName: "podcast").provider == .podcast)
         #expect(origin(agentName: "youtube").provider == .youtube)
         #expect(origin(agentName: "vimeo").provider == .vimeo)
         #expect(origin(agentName: "spotify").provider == .spotify)
@@ -314,9 +322,9 @@ import Testing
 
     // MARK: - CaseIterable coverage
 
-    @Test("SourceProvider.allCases covers 11 cases")
+    @Test("SourceProvider.allCases covers 12 cases")
     func allCasesCount() {
-        #expect(SourceProvider.allCases.count == 11)
+        #expect(SourceProvider.allCases.count == 12)
         // Spot-check membership so adding a case without updating the count
         // assertion doesn't silently regress coverage.
         #expect(SourceProvider.allCases.contains(.localFile))
@@ -324,6 +332,7 @@ import Testing
         #expect(SourceProvider.allCases.contains(.zotero))
         #expect(SourceProvider.allCases.contains(.markdownFolder))
         #expect(SourceProvider.allCases.contains(.applePodcast))
+        #expect(SourceProvider.allCases.contains(.podcast))
         #expect(SourceProvider.allCases.contains(.youtube))
         #expect(SourceProvider.allCases.contains(.vimeo))
         #expect(SourceProvider.allCases.contains(.spotify))

--- a/plans/podcast-generalize.md
+++ b/plans/podcast-generalize.md
@@ -1,0 +1,138 @@
+# Plan: Generalize Podcast Transcription to Any RSS Feed
+
+> **Status:** Implementation in progress.
+> **Scope:** Tag-first only (`<podcast:transcript>` RSS tags, Podcasting 2.0
+> standard). Graceful failure when a podcast publishes no transcript tag.
+> **Out of scope:** Whisper/speech-to-text (separate future follow-up).
+> **Depends on:** PR #824 (merged into main) — its `RSSPodcastTranscriptService`
+> + `TranscriptSubprocess` are the foundation this plan generalizes.
+
+## 1. Problem Statement
+
+PR #824 added an RSS `<podcast:transcript>` transcript fallback, but it was
+**Apple-locked**: it only accepts Apple Podcasts episode URLs. The
+`podcast-transcript` Python script (#812) requires an Apple Podcasts URL,
+performs an iTunes Lookup API hop to resolve the RSS feed URL, and only then
+parses the standard `<podcast:transcript>` tag. Everything *after* the feed URL
+(RSS parsing, transcript-tag extraction, VTT/SRT/HTML/plain parsing) is already
+podcast-standard and provider-agnostic.
+
+The goal: let a user paste **any podcast RSS feed URL** and get a transcript
+when the feed publishes `<podcast:transcript>` tags — while **keeping** the
+existing Apple Podcasts path (both the FairPlay TTML pipeline *and* the
+RSS-fallback via iTunes Lookup).
+
+## 2. Decision 1 — Provider Model
+
+**Add a new `.podcast` (generic RSS) case.** Do not overload `.applePodcast`.
+
+| Aspect | `.applePodcast` | `.podcast` (new) |
+|--------|-----------------|------------------|
+| Input | Apple episode URL | Raw RSS feed URL |
+| Feed resolution | iTunes Lookup API | Direct (the URL *is* the feed) |
+| Transcript pipeline | FairPlay TTML **or** RSS fallback | RSS `<podcast:transcript>` only |
+| Signing helper needed | Yes (FairPlay) | No |
+| `#if PODCAST_TRANSCRIPTS` | Yes (App Store build excludes it) | **No** — works on every build (needs only `uv`) |
+
+New rawValue: `"podcast"`. Byte-additive — no DB migration.
+
+Switch sites that need a new arm (compiler-enforced exhaustive sites will fail
+to build if missed):
+- `displayLabel` / `systemImage` / `helpVerb` / `supportsRefresh` / `supportsTranscription` (SourceProvider.swift)
+- `materialize(origin:)` (SourceRefreshService.swift)
+- `isSourceRefreshable` (WikiStoreModel.swift)
+- `transcribe(sourceID:)` dispatch (WikiStoreModel.swift, both `#if`/`#else`)
+- `SourceDetailView.isTranscribable` (SourceDetailView.swift)
+- `providerOriginTag(_:)` (SourceDetailView.swift) — [H1]
+- `MediaTitleFetcher.oEmbedURL` (MediaTitleFetcher.swift) — non-exhaustive, manual verify
+
+## 3. Decision 2 — Intake
+
+Accept a **direct RSS feed URL** via a dedicated `addPodcastFeedURL(_:)` entry
+point on `WikiStoreModel` (M3 — explicit affordance, not URL-sniffing, to avoid
+the ambiguity problem of feed-vs-webpage). Single-item feeds auto-resolve;
+multi-item feeds pick the latest by `<pubDate>`.
+
+A new always-compiled recognizer `RSSFeedEpisodeURL` validates the feed URL.
+
+## 4. Decision 3 — Python Script Generalization (§4 + H4)
+
+Add a URL-shape branch in `fetch_transcript`. Keep the Apple path unchanged.
+
+- `_is_apple_podcasts_url(url)` helper.
+- `fetch_transcript` branches: Apple path unchanged; RSS path skips `get_feed_url`.
+- `find_episode_in_feed(feed_url, episode_id: str | None)` — **explicit early
+  branch** as the first statement when `episode_id is None`: return the most
+  recent `<item>` by `<pubDate>`, fallback document order. The existing
+  GUID/link/itunes:episode matching stays for the Apple path. (H4: this is a
+  real contract change, not a simple branch — the current signature is
+  non-optional and does substring matching that would `TypeError` on `None`.)
+- `main()` / `build_parser()` — update help text.
+- `ScriptOutput` JSON — `show_id`/`episode_id` emitted as `null`/omitted on the RSS path.
+
+## 5. Decision 4 — Swift Service Wiring
+
+### 5.1 RSSPodcastTranscriptService (generalize + de-guard)
+
+Rename `episodeURL` → `sourceURL`. Add `transcript(forFeedURL:)` — a feed-oriented
+entry that never touches `EpisodeRef` (H3). Move the service out of
+`#if PODCAST_TRANSCRIPTS` (it has no FairPlay dependency).
+
+### 5.2 transcribeRSSPodcast helper (H2)
+
+Outside `#if PODCAST_TRANSCRIPTS`, mirrors `transcribeYouTube`:
+- Accepts an injected `rssPodcastFetcher` so tests can fake it.
+- Returns `nil` + logs on failure (matches sibling error discipline, not throw).
+- Calls `transcript(forFeedURL:)`.
+
+### 5.3 Dispatch arm
+
+In both `#if`/`#else` `transcribe` switch blocks:
+```swift
+case .podcast:
+    return try await transcribeRSSPodcast(sourceID:sourceID, origin:origin, fetcher: rssPodcastFetcher)
+```
+
+### 5.4 Intake (M3)
+
+New `addPodcastFeedURL(_:)` entry point that bypasses the generic website fetch.
+Creates a byteless `.podcast` source; no transcript at ingest (Transcribe triggers it).
+
+## 6. De-guarding (C1 — critical)
+
+Create `Sources/WikiFSCore/Integrations/PodcastTranscriptTypes.swift` (always
+compiled, no `#if` guard) and move into it:
+- `PodcastTranscript` (struct)
+- `PodcastTranscriptFetching` (protocol)
+- `PodcastTranscriptError` (enum — extract from TTMLTranscript.swift)
+- `RSSPodcastTranscriptService` (move out of ApplePodcastTranscriptService.swift)
+- `PodcastEpisodeURL.EpisodeRef` (move out of the guard; keep `parse`/`displayTitle` gated)
+
+Only FairPlay-specific code stays gated: `ApplePodcastTranscriptService`,
+`ApplePodcastAMP`, `TTMLTranscript` parse logic, `HelperPodcastTokenProvider`.
+
+The App Store build (`WIKIFS_APP_STORE=1`) MUST compile — this is the critical gate.
+
+## 7. Acceptance Criteria (summary)
+
+- AC.1 Provider enum: `.podcast` round-trips; properties set; 6 compiler-enforced switch sites + 2 manually-verified.
+- AC.2 Python script accepts RSS feed URLs; Apple path unchanged; `find_episode_in_feed(url, None)` returns latest/only.
+- AC.3 Generic `.podcast` intake creates byteless source; no transcript at ingest.
+- AC.4 Transcribe dispatch reaches RSS path; works on `WIKIFS_APP_STORE=1`; technique `rss-podcast-transcript`.
+- AC.5 Graceful failure (no transcript tag) → `.noTranscriptAvailable`.
+- AC.6 Apple path unchanged (regression).
+- AC.7 UI gating: `isTranscribable` true for `.podcast` on every build; Transcribe button renders; no media tab.
+
+## 8. Section 11 Corrections (applied)
+
+C1 (critical): de-guarding chain is 5 symbols wide — see §6.
+H1: `providerOriginTag` is an exhaustive switch — add `.podcast` to the URL arm.
+H2: `transcribeRSSPodcast` accepts injected fetcher; nil+log on failure.
+H3: reject synthetic EpisodeRef; add `transcript(forFeedURL:)`.
+H4: `find_episode_in_feed` is a real contract change — add pubDate logic.
+M1: new tests UNGUARDED.
+M2: `ExternalEmbed` not a switch site — no change.
+M3: intake is a concrete `addPodcastFeedURL` entry point.
+M4: rebase moot (PR #824 already merged).
+L1: AC.1 enumerates compiler-enforced vs manual sites.
+L2: rename-regression test.

--- a/tools/podcast-transcript/podcast-transcript
+++ b/tools/podcast-transcript/podcast-transcript
@@ -10,9 +10,17 @@
 """podcast-transcript — Fetch podcast transcripts via RSS <podcast:transcript> tags.
 
 Usage:
-    uv run --script podcast-transcript <apple-podcasts-url> [--json] [--output file.md]
-    uv run --script podcast-transcript <apple-podcasts-url> --transcribe  # Whisper fallback
-    ./podcast-transcript <apple-podcasts-url>  (if uv is in PATH)
+    uv run --script podcast-transcript <url> [--json] [--output file.md]
+    uv run --script podcast-transcript <url> --transcribe  # Whisper fallback
+    ./podcast-transcript <url>  (if uv is in PATH)
+
+<url> may be either:
+  - an Apple Podcasts episode URL
+    (e.g. https://podcasts.apple.com/us/podcast/slug/id1234567890?i=1000123456789)
+  - a direct RSS feed URL (e.g. https://example.com/feed.rss)
+
+For a direct RSS feed URL, the feed is fetched directly (no iTunes Lookup hop),
+and when multiple <item>s exist the most recent (by <pubDate>) is selected.
 
 If uv is not installed, download it first:
     curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -27,9 +35,11 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import re
 import sys
+import urllib.parse
 import xml.etree.ElementTree as ET
 from html.parser import HTMLParser
 from pathlib import Path
@@ -42,6 +52,17 @@ import webvtt
 
 _SHOW_ID_RE = re.compile(r"/id(\d+)")
 _EPISODE_ID_RE = re.compile(r"[?&]i=(\d+)")
+
+
+def _is_apple_podcasts_url(url: str) -> bool:
+    """Return True when ``url`` is an Apple Podcasts episode/show URL.
+
+    A direct RSS feed URL returns False so ``fetch_transcript`` can route it
+    to the feed-direct path (skipping the iTunes Lookup hop).
+    """
+    parsed = urllib.parse.urlparse(url)
+    host = (parsed.hostname or "").lower()
+    return host == "podcasts.apple.com" or host.endswith(".podcasts.apple.com")
 
 
 def parse_apple_podcasts_url(url: str) -> tuple[str, str]:
@@ -108,16 +129,19 @@ _PODCAST_NS = {"podcast": "https://podcastindex.org/namespace/1.0"}
 
 
 def find_episode_in_feed(
-    feed_url: str, episode_id: str
+    feed_url: str, episode_id: str | None
 ) -> tuple[ET.Element, list[ET.Element]] | None:
-    """Find an episode in an RSS feed by episode ID.
+    """Find an episode in an RSS feed.
 
     Args:
         feed_url: RSS feed URL
-        episode_id: Apple Podcasts episode ID
+        episode_id: Apple Podcasts episode ID, or ``None`` to select the most
+            recent ``<item>`` by ``<pubDate>`` (fallback: document order).
+            ``None`` is the generic-RSS-feed path where there is no Apple
+            episode ID to match on.
 
     Returns:
-        (episode_item, transcript_tags) tuple, or None if not found
+        (episode_item, transcript_tags) tuple, or None if the feed has no items
 
     Raises:
         requests.RequestException: If network request fails
@@ -127,7 +151,18 @@ def find_episode_in_feed(
 
     root = ET.fromstring(response.text)
 
-    for item in root.findall(".//item"):
+    items = root.findall(".//item")
+    if not items:
+        return None
+
+    # Generic-RSS path: no Apple episode ID. Pick the most recent <item> by
+    # <pubDate> (RFC 822); fall back to document order when <pubDate> is
+    # absent/unparseable on every item. This is the v1 selection strategy for
+    # multi-item feeds — single-item feeds resolve to that one item naturally.
+    if episode_id is None:
+        return _most_recent_item(items)
+
+    for item in items:
         # Match by guid containing episode ID
         guid = item.find("guid")
         if guid is not None and guid.text is not None and episode_id in guid.text:
@@ -147,6 +182,57 @@ def find_episode_in_feed(
             return item, transcripts
 
     return None
+
+
+def _most_recent_item(
+    items: list[ET.Element],
+) -> tuple[ET.Element, list[ET.Element]] | None:
+    """Select the most recent ``<item>`` by ``<pubDate>``.
+
+    Falls back to document order (the first ``<item>``) when no item carries a
+    parseable ``<pubDate>``. Always returns the first item when the list is
+    non-empty; returns ``None`` only for an empty list (caller handles that).
+    """
+    best_item: ET.Element | None = None
+    best_date: datetime.datetime | None = None
+    for item in items:
+        pub = item.find("pubDate")
+        if pub is None or not pub.text:
+            continue
+        parsed = _parse_pub_date(pub.text)
+        if parsed is None:
+            continue
+        if best_date is None or parsed > best_date:
+            best_date = parsed
+            best_item = item
+    if best_item is None:
+        # No parseable pubDate anywhere — fall back to document order (first).
+        best_item = items[0]
+    transcripts = best_item.findall("podcast:transcript", _PODCAST_NS)
+    return best_item, transcripts
+
+
+def _parse_pub_date(raw: str) -> datetime.datetime | None:
+    """Parse an RFC 822 ``<pubDate>`` value (e.g. ``Wed, 02 Jul 2025 …``).
+
+    Returns ``None`` (not raising) on failure so the caller degrades to
+    document-order selection rather than aborting the whole feed parse.
+    """
+    # email.utils.parsedate_to_datetime handles the RFC 822 forms RSS 2.0
+    # mandates (and the common 4-digit-year variant). Tolerate the trailing
+    # whitespace/punctuation real feeds emit.
+    import email.utils
+    try:
+        dt = email.utils.parsedate_to_datetime(raw.strip())
+    except (TypeError, ValueError):
+        return None
+    if dt is None:
+        return None
+    # Normalize naive datetimes to UTC so comparison is well-defined; feeds
+    # without a tz are treated as UTC (a benign assumption for ordering).
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
 
 
 def get_episode_audio_url(episode_item: ET.Element) -> str | None:
@@ -378,22 +464,36 @@ def transcribe_audio(audio_url: str) -> tuple[str, str, str | None]:
 def fetch_transcript(
     url: str, transcribe_fallback: bool = False
 ) -> dict[str, str | None]:
-    """Fetch a podcast transcript from an Apple Podcasts URL.
+    """Fetch a podcast transcript from an Apple Podcasts URL OR a raw RSS feed URL.
+
+    When ``url`` is an Apple Podcasts episode URL, the show/episode IDs are
+    parsed and the RSS feed URL is resolved via the iTunes Lookup API (the
+    Apple path — unchanged). When ``url`` is any other URL, it is treated as
+    a direct RSS feed URL and fetched directly (no iTunes hop); the most
+    recent ``<item>`` by ``<pubDate>`` is selected (generic-RSS path).
 
     Args:
-        url: Apple Podcasts episode URL
+        url: Apple Podcasts episode URL OR a direct RSS feed URL
         transcribe_fallback: If True, use Whisper transcription when no RSS transcript available
 
     Returns:
-        Dict with keys: show_id, episode_id, language, format, markdown
+        Dict with keys: show_id, episode_id, language, format, markdown.
+        On the generic-RSS path, ``show_id`` and ``episode_id`` are ``None``.
 
     Raises:
         ValueError: If parsing fails
         requests.RequestException: If network request fails
     """
-    show_id, episode_id = parse_apple_podcasts_url(url)
+    if _is_apple_podcasts_url(url):
+        # Apple path — unchanged: parse IDs → iTunes Lookup → feed URL.
+        show_id, episode_id = parse_apple_podcasts_url(url)
+        feed_url = get_feed_url(show_id)
+    else:
+        # Generic-RSS path: the URL IS the feed. No show/episode ID, no hop.
+        show_id = None
+        episode_id = None
+        feed_url = url
 
-    feed_url = get_feed_url(show_id)
     episode_result = find_episode_in_feed(feed_url, episode_id)
 
     if episode_result is None:
@@ -439,7 +539,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Fetch podcast transcripts via RSS <podcast:transcript> tags."
     )
-    parser.add_argument("url", help="Apple Podcasts episode URL")
+    parser.add_argument(
+        "url",
+        help="Apple Podcasts episode URL OR a direct RSS feed URL",
+    )
     parser.add_argument(
         "--output", "-o", type=Path, default=None,
         help="Write markdown to file (default: stdout)",

--- a/tools/podcast-transcript/tests/conftest.py
+++ b/tools/podcast-transcript/tests/conftest.py
@@ -177,3 +177,62 @@ def itunes_lookup_no_results() -> dict:
 def itunes_lookup_no_feed_url() -> dict:
     """iTunes Lookup API response without feedUrl."""
     return _ITUNES_LOOKUP_NO_FEED_URL
+
+
+# ── Generic-RSS-feed fixtures (out-of-order pubDate) ────────────────────────
+
+# A multi-item feed whose <pubDate> values are deliberately OUT OF DOCUMENT
+# ORDER (the 2nd document item is the newest). Used to lock the "most recent
+# by pubDate" selection so a naive first-match implementation fails the test.
+_MULTI_ITEM_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Multi Podcast</title>
+    <item>
+      <title>Oldest Episode</title>
+      <guid>https://example.com/episode/old</guid>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+      <podcast:transcript url="https://example.com/old.vtt" type="text/vtt" lang="en"/>
+    </item>
+    <item>
+      <title>Newest Episode</title>
+      <guid>https://example.com/episode/new</guid>
+      <pubDate>Wed, 03 Jul 2025 12:00:00 GMT</pubDate>
+      <podcast:transcript url="https://example.com/new.vtt" type="text/vtt" lang="en"/>
+    </item>
+    <item>
+      <title>Middle Episode</title>
+      <guid>https://example.com/episode/mid</guid>
+      <pubDate>Fri, 15 Mar 2024 09:30:00 GMT</pubDate>
+      <podcast:transcript url="https://example.com/mid.vtt" type="text/vtt" lang="en"/>
+    </item>
+  </channel>
+</rss>
+"""
+
+# A single-item feed — the common per-episode-feed case.
+_SINGLE_ITEM_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+  <channel>
+    <title>Single Podcast</title>
+    <item>
+      <title>Only Episode</title>
+      <guid>https://example.com/episode/only</guid>
+      <pubDate>Tue, 10 Jun 2025 08:00:00 GMT</pubDate>
+      <podcast:transcript url="https://example.com/only.srt" type="application/x-subrip" lang="en"/>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+@pytest.fixture
+def multi_item_feed() -> str:
+    """Multi-item RSS feed with out-of-order pubDate (newest is 2nd in document order)."""
+    return _MULTI_ITEM_FEED
+
+
+@pytest.fixture
+def single_item_feed() -> str:
+    """Single-item RSS feed."""
+    return _SINGLE_ITEM_FEED

--- a/tools/podcast-transcript/tests/test_podcast_transcript.py
+++ b/tools/podcast-transcript/tests/test_podcast_transcript.py
@@ -503,3 +503,138 @@ class TestMainExitCodes:
                 ["https://podcasts.apple.com/us/podcast/test/id1234567890?i=1000123456793"]
             )
         assert exc.value.code == 1
+
+
+# ── Generic-RSS-feed tests (direct feed URL, no iTunes Lookup) ───────────────
+
+
+class TestIsApplePodcastsURL:
+    def test_true_for_apple_host(self) -> None:
+        assert _podcast_transcript._is_apple_podcasts_url(
+            "https://podcasts.apple.com/us/podcast/slug/id123?i=456"
+        ) is True
+
+    def test_true_for_subdomain(self) -> None:
+        assert _podcast_transcript._is_apple_podcasts_url(
+            "https://podcasts.apple.com/podcast/slug/id123"
+        ) is True
+
+    def test_false_for_rss_feed(self) -> None:
+        assert _podcast_transcript._is_apple_podcasts_url(
+            "https://example.com/feed.rss"
+        ) is False
+
+    def test_false_for_other_host(self) -> None:
+        assert _podcast_transcript._is_apple_podcasts_url(
+            "https://shows.acast.com/shows/foo/episodes/bar"
+        ) is False
+
+    def test_false_for_plain_http(self) -> None:
+        assert _podcast_transcript._is_apple_podcasts_url(
+            "https://example.com/ep42"
+        ) is False
+
+
+class TestFindEpisodeLatest:
+    def test_returns_most_recent_by_pubdate(
+        self, multi_item_feed: str, mocker: MockerFixture
+    ) -> None:
+        """episode_id=None → most recent <item> by <pubDate>, NOT document order.
+
+        H4 lock: the feed's newest item is 2nd in document order, so a naive
+        first-match implementation would return the wrong episode.
+        """
+        mock_get = mocker.patch("requests.get")
+        mock_response = mocker.Mock()
+        mock_response.text = multi_item_feed
+        mock_get.return_value = mock_response
+
+        result = _podcast_transcript.find_episode_in_feed(
+            "https://example.com/feed.rss", None
+        )
+        assert result is not None
+        episode_item, transcript_tags = result
+        # The newest episode is "Newest Episode" (2nd in document order).
+        title = episode_item.find("title")
+        assert title is not None and title.text == "Newest Episode"
+        assert len(transcript_tags) == 1
+        assert transcript_tags[0].get("url") == "https://example.com/new.vtt"
+
+
+class TestFindEpisodeSingleItem:
+    def test_single_item_feed_returns_that_item(
+        self, single_item_feed: str, mocker: MockerFixture
+    ) -> None:
+        mock_get = mocker.patch("requests.get")
+        mock_response = mocker.Mock()
+        mock_response.text = single_item_feed
+        mock_get.return_value = mock_response
+
+        result = _podcast_transcript.find_episode_in_feed(
+            "https://example.com/single.rss", None
+        )
+        assert result is not None
+        episode_item, transcript_tags = result
+        title = episode_item.find("title")
+        assert title is not None and title.text == "Only Episode"
+        assert len(transcript_tags) == 1
+
+
+class TestFetchTranscriptRSSFeed:
+    def test_direct_feed_url_skips_itunes_lookup(
+        self,
+        mocker: MockerFixture,
+        multi_item_feed: str,
+        sample_vtt: str,
+    ) -> None:
+        """A direct RSS feed URL fetches the feed + transcript, never iTunes Lookup."""
+        mock_get = mocker.patch("requests.get")
+
+        def mock_get_side_effect(url, **kwargs):
+            response = mocker.Mock()
+            if "feed.rss" in url:
+                response.text = multi_item_feed
+            elif "new.vtt" in url:
+                response.text = sample_vtt
+            response.raise_for_status = mocker.Mock()
+            return response
+
+        mock_get.side_effect = mock_get_side_effect
+
+        result = _podcast_transcript.fetch_transcript("https://example.com/feed.rss")
+
+        # Generic-RSS path: no Apple IDs.
+        assert result["show_id"] is None
+        assert result["episode_id"] is None
+        # No iTunes Lookup call was made.
+        assert not any(
+            "itunes.apple.com" in str(call)
+            for call in mock_get.call_args_list
+        )
+        assert result["format"] == "vtt"
+        assert "first caption" in result["markdown"]
+
+    def test_direct_feed_no_transcript_raises(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """A feed whose latest item has no <podcast:transcript> → ValueError."""
+        no_transcript_feed = """<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>No Transcript Podcast</title>
+    <item>
+      <title>Ep</title>
+      <guid>x</guid>
+      <pubDate>Wed, 03 Jul 2025 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>
+"""
+        mock_get = mocker.patch("requests.get")
+        mock_response = mocker.Mock()
+        mock_response.text = no_transcript_feed
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ValueError, match="No transcript available"):
+            _podcast_transcript.fetch_transcript("https://example.com/feed.rss")


### PR DESCRIPTION
Generalize podcast transcription to accept ANY RSS feed URL, keeping the Apple path intact. Builds on merged PR #824 (RSSPodcastTranscriptService + TranscriptSubprocess). Tag-first via podcast:transcript RSS tags, graceful failure when no tag is published.

Closes #812 (generalizes the Apple-only scope to any RSS feed).

What changed

Python script (tools/podcast-transcript/podcast-transcript):
- _is_apple_podcasts_url helper routes Apple URLs vs direct RSS feed URLs
- fetch_transcript branches: Apple path byte-for-byte unchanged; RSS path skips the iTunes Lookup API hop entirely
- find_episode_in_feed(episode_id=None) returns the most recent item by pubDate (explicit early branch with pubDate-aware selection, fallback document order) — the previous signature was non-optional and did substring matching that would TypeError on None

Swift:
- New SourceProvider.podcast case ("podcast" rawValue) — byte-additive, no DB migration. The generic path needs only uv (no FairPlay signing helper), so it compiles on EVERY build including WIKIFS_APP_STORE=1
- De-guarding (C1): new always-compiled PodcastTranscriptTypes.swift moves PodcastTranscript, PodcastTranscriptFetching, RSSFeedTranscriptFetching, PodcastTranscriptError, and RSSPodcastTranscriptService out of #if PODCAST_TRANSCRIPTS. PodcastEpisodeURL unguarded so EpisodeRef is always available. Only FairPlay-specific code stays gated (ApplePodcastTranscriptService, ApplePodcastAMP, TTMLTranscript parse, HelperPodcastTokenProvider)
- RSSPodcastTranscriptService generalized: init(sourceURL:) (renamed from episodeURL:) + transcript(forFeedURL:) (H3 — feed-oriented entry that never touches EpisodeRef, derives filename from feed host + path) + RSSFeedTranscriptFetching protocol for test injection
- transcribeRSSPodcast helper (outside #if PODCAST_TRANSCRIPTS, injected fetcher per H2): dispatch arm in both #if/#else transcribe blocks; technique "rss-podcast-transcript"
- RSSFeedEpisodeURL recognizer (always compiled) + addPodcastFeedURL(_:) intake entry point (M3 — explicit affordance that bypasses the generic website fetch, avoiding the feed-vs-webpage ambiguity problem)
- All compiler-enforced exhaustive switch sites updated (SourceRefreshService.materialize + materializePodcastFeed, isSourceRefreshable, SourceDetailView.isTranscribable + providerOriginTag, MediaTitleFetcher.oEmbedURL)

Section 11 corrections applied: C1 (de-guarding 5 symbols), H1 (providerOriginTag exhaustive switch), H2 (injected fetcher + nil/log error discipline), H3 (feed-oriented entry, no synthetic EpisodeRef), H4 (pubDate logic in find_episode_in_feed), M1 (tests unguarded), M2 (ExternalEmbed not a switch site — default handles it), M3 (concrete addPodcastFeedURL entry point).

Verification
- swift build compiles (PODCAST_TRANSCRIPTS on)
- WIKIFS_APP_STORE=1 swift build compiles (the critical C1 gate — generic .podcast path works when the Apple-only #if PODCAST_TRANSCRIPTS is off)
- 55 Python tests pass (46 existing Apple-path + 9 new RSS-feed tests)
- 22 new Swift tests pass (RSSPodcastTranscriptionTests, unguarded per M1)
- Apple-path regression tests pass (#824 RSSPodcastTranscriptTests — 11 tests)
- SourceProviderTests updated for .podcast (12 cases)
- swift test: 3474 pass, 4 pre-existing ACP/quota failures unrelated to this PR

Out of scope
- Whisper/speech-to-text fallback (separate future follow-up)
- Episode-picker UI for multi-item feeds (v1 picks the latest by pubDate)
- Non-Apple podcast episode page URLs (no general show-page to RSS-feed-URL hop exists)
