### PR TITLE
mutation-testing config: bump timeout + exclude SourceProvider (#823)

### DIFF
--- a/.swift-mutation-testing.yml
+++ b/.swift-mutation-testing.yml
@@ -6,7 +6,7 @@
 test-target: WikiFSCoreTests
 
 # Per-mutant test timeout in seconds (default: 30 for SPM)
-timeout: 30
+timeout: 900
 
 # Disable result cache (re-runs all mutants on every execution)
 # no-cache: true
@@ -19,6 +19,7 @@ output: mutation-report.json
 # Source file glob patterns to exclude from mutation
 exclude:
   - "/WikiFSCoreTests/"
+  - "SourceProvider.swift"
 
 # Mutation operators
 mutators:


### PR DESCRIPTION
mutation-testing config: bump timeout + exclude SourceProvider (#823)

- Increase timeout from 30s to 900s for sandbox clean builds
- Exclude SourceProvider.swift to work around schematization bug