### PR TITLE
Lint button: navigate to lint job in Activity window (#837)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,43 @@
 # Progress log
 
+## feat: Lint button navigates to lint job in Activity window (#837)
+
+**Goal:** when a lint job is running/queued for a page, the Lint button in
+PageDetailView navig to the specific lint job in the Activity window instead
+of showing a static alert.
+
+**Approach:**
+- Added `lintItemID(for:wikiID:)` to `QueueActivityTracker` that resolves the
+  running lint item for a given page (page-level match by page ID, whole-wiki
+  match by wiki ID). Backed by two new tracking dicts (`itemToLintPageIDs`,
+  `itemToLintWikiID`) populated on `.started` and cleaned up on terminal state.
+- Added `pendingSelectionItemID` property to the tracker — a shared
+  `@Observable` "pending selection" that `PageDetailView` sets before opening
+  the Activity window. `ActivityWindowView` consumes it on appear + onChange,
+  setting `selectedItemID` and clearing the pending value.
+- `PageDetailView.lintButton`: when linting, the button swaps to "View Lint"
+  with `checkmark.seal.fill`, stays enabled, and taps resolve the lint item ID
+  → set pending selection → call `openActivityWindow?()`. Removed the old
+  `.disabled` + alert behavior entirely.
+- `ActivityWindowView`: added `consumePendingSelectionIfNeeded()` called from
+  `.onAppear` + `.onChange(of: activityTracker.pendingSelectionItemID)`, plus
+  a safety-net comment on the existing `autoSelectIfNeeded` onChange handlers.
+- 9 new tests covering page-level resolution, whole-wiki resolution, cross-wiki
+  scoping, unlisted-page nil, mapping cleanup on completion/cancellation, and
+  pending selection default/stop behavior.
+
+**Files touched:**
+- `Sources/WikiFS/Queue/QueueActivityTracker.swift` — new tracking dicts +
+  `lintItemID(for:wikiID:)` + `pendingSelectionItemID` + cleanup in
+  `.started`/`removeItem`/`stop()`
+- `Sources/WikiFS/Queue/ActivityWindowView.swift` —
+  `consumePendingSelectionIfNeeded()` + `.onChange(of: pendingSelectionItemID)`
+  + `.onAppear` call
+- `Sources/WikiFS/Pages/PageDetailView.swift` — `openActivityWindow` env,
+  removed alert + `.disabled`, new navigation action
+- `Tests/WikiFSAppTests/QueueIngestionTests.swift` — 9 tests in
+  `QueueActivityTrackerLintItemIDTests`
+
 ## feat: Versions tab — browse/diff/restore page history (#817)
 
 **Goal:** a "Versions" surface that browses page versions at any point in time,

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -42,12 +42,12 @@ struct PageDetailView: View {
     @State private var findVersion = 0
 
     /// The app-wide queue activity tracker — used to reflect an in-flight lint
-    /// on this page's "Lint" button (icon + disable + warning when tapped).
+    /// on this page's "Lint" button (icon + label + navigation when running).
     @Environment(QueueActivityTracker.self) private var activityTracker
-    /// Shown when the Lint button is tapped while a lint is already running on
-    /// this page (whole-wiki or page-level). Explains the running state rather
-    /// than silently enqueuing a duplicate.
-    @State private var isShowingLintActiveAlert = false
+    /// Opens the Activity (queue) window — injected from the environment
+    /// (#745). Used by the Lint button to navigate to the running lint job
+    /// when a lint is already in flight for this page (#837).
+    @Environment(\.openActivityWindow) private var openActivityWindow
     /// Opens the value-driven Versions `WindowGroup` (#817). Captured from the
     /// environment (only available inside a `WindowGroup`'s view hierarchy).
     @Environment(\.openWindow) private var openWindow
@@ -105,11 +105,6 @@ struct PageDetailView: View {
         }
         .background(Color(nsColor: .textBackgroundColor))
         .frame(minWidth: PageEditorMetrics.detailMinWidth)
-        .alert("Lint Already Running", isPresented: $isShowingLintActiveAlert) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text("A lint job is already running on this page. It will appear in the Activity window when it finishes.")
-        }
         .onAppear {
             lastKnownActiveTabID = store.activeTabID
             // Seed edit mode from the active tab on first mount. `.onChange(of:
@@ -289,23 +284,34 @@ struct PageDetailView: View {
 
     /// The page-level "Lint" action button. Reflects an in-flight lint on this
     /// page: when a lint (whole-wiki or page-level) is running, the button swaps
-    /// to a filled "Linting…" state, disables itself, and would warn if tapped
-    /// — though `.disabled` prevents the tap. The alert covers the keyboard /
-    /// accessibility path where the action could still fire.
+    /// to a filled "View Lint" state and taps navigate to that specific lint job
+    /// in the Activity window (#837). When no lint is running, tapping enqueues
+    /// a new page-level lint.
     @ViewBuilder
     private var lintButton: some View {
         if case .page(let id) = store.selection {
             let pageIsLinting = activityTracker.isLinting(
                 pageID: id, wikiID: session.wikiID)
-            Button(pageIsLinting ? "Linting…" : "Lint",
+            Button(pageIsLinting ? "View Lint" : "Lint",
                    systemImage: pageIsLinting
                    ? "checkmark.seal.fill"
                    : "checkmark.seal") {
                 if pageIsLinting {
                     // A lint is already active for this page (whole-wiki or
-                    // page-level) — warn instead of enqueuing a duplicate.
-                    isShowingLintActiveAlert = true
-                    DebugLog.ingest("Lint button: already running for page \(id) in wiki \(session.wikiID.prefix(8)); warning shown")
+                    // page-level) — navigate to the job in the Activity window
+                    // instead of enqueuing a duplicate (#837).
+                    if let itemID = activityTracker.lintItemID(
+                        for: id, wikiID: session.wikiID) {
+                        activityTracker.pendingSelectionItemID = itemID
+                        openActivityWindow?()
+                        DebugLog.ingest("Lint button: navigating to lint job \(itemID.prefix(8)) for page \(id) in wiki \(session.wikiID.prefix(8))")
+                    } else {
+                        // isLinting returned true but we couldn't resolve the
+                        // specific item (race: item just finished). Fall back to
+                        // opening the Activity window without a selection.
+                        openActivityWindow?()
+                        DebugLog.ingest("Lint button: lint in flight for page \(id) but item not found; opening Activity window")
+                    }
                 } else {
                     Task {
                         try? await session.queueEngine.enqueue(QueueItemRequest(
@@ -316,9 +322,8 @@ struct PageDetailView: View {
                     }
                 }
             }
-            .disabled(pageIsLinting)
             .help(pageIsLinting
-                  ? "A lint is already running on this page"
+                  ? "View the running lint job in the Activity window"
                   : "Fix [[wiki-link]] syntax and run LLM lint on this page")
         }
     }

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -66,10 +66,23 @@ struct ActivityWindowView: View {
                 queueControlMenu
             }
         }
-        .onAppear { viewModel.attach(engine: queueEngine) }
+        .onAppear {
+            viewModel.attach(engine: queueEngine)
+            consumePendingSelectionIfNeeded()
+        }
         .onDisappear { viewModel.detach() }
+        // #837: when a specific item selection is requested from outside the
+        // Activity window (e.g. PageDetailView's "View Lint" button), consume
+        // it immediately so an already-open window switches selection without
+        // needing an onAppear (which only fires once per window lifecycle).
+        .onChange(of: activityTracker.pendingSelectionItemID) { _, _ in
+            consumePendingSelectionIfNeeded()
+        }
         // Auto-select the most interesting item once, when the first snapshot
         // lands — a window opened from "1 running" should show that run.
+        // Also a safety net for #837: if the pending selection was consumed
+        // in onAppear before the snapshot arrived, the item is already
+        // selected; autoSelectIfNeeded is a no-op when selectedItemID != nil.
         .onChange(of: activeItems.map(\.id)) { _, _ in
             autoSelectIfNeeded()
         }
@@ -92,6 +105,19 @@ struct ActivityWindowView: View {
             selectedItemID = first.id
             didAutoSelect = true
         }
+    }
+
+    /// Consume a pending item selection requested from outside the Activity
+    /// window (#837). Set on `activityTracker.pendingSelectionItemID` before
+    /// the window-opening closure fires; read here and cleared. Overrides
+    /// the current selection — the user explicitly asked to see this item.
+    /// Marks `didAutoSelect` so `autoSelectIfNeeded` won't override it back
+    /// when the first snapshot lands.
+    private func consumePendingSelectionIfNeeded() {
+        guard let pending = activityTracker.pendingSelectionItemID else { return }
+        activityTracker.pendingSelectionItemID = nil
+        selectedItemID = pending
+        didAutoSelect = true
     }
 
     // MARK: - Reorder

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -107,6 +107,28 @@ final class QueueActivityTracker {
     /// lint on one wiki doesn't mark another wiki's pages as linting.
     private(set) var wholeWikiLintingWikiIDs: Set<String> = []
 
+    /// Maps a lint item ID → the page IDs it lints (empty = whole-wiki).
+    /// Used by ``lintItemID(for:wikiID:)`` to resolve which running lint job
+    /// covers a given page, so the Lint button can navigate to that specific
+    /// job in the Activity window (#837). Mirrors the `itemToSourceIDs`
+    /// mapping that exists for extraction items.
+    private var itemToLintPageIDs: [QueueItem.ID: [PageID]] = [:]
+
+    /// Maps a lint item ID → its wiki ID. Needed so
+    /// ``lintItemID(for:wikiID:)`` can distinguish a whole-wiki lint (empty
+    /// `lintPageIDs`) that covers EVERY page in its wiki from a page-level
+    /// lint in a different wiki. Whole-wiki lints match by wiki ID; page-level
+    /// lints match by page ID (ULIDs are globally unique across wikis).
+    private var itemToLintWikiID: [QueueItem.ID: String] = [:]
+
+    /// A pending item selection requested from outside the Activity window —
+    /// e.g. PageDetailView's "View Lint" button (#837). Set before calling the
+    /// `openActivityWindow` environment closure; consumed by
+    /// `ActivityWindowView` on appear / change, which sets `selectedItemID`
+    /// and clears this back to nil. Drives "open Activity window focused on a
+    /// SPECIFIC queue item" without changing the closure's no-arg signature.
+    var pendingSelectionItemID: QueueItem.ID? = nil
+
     /// True while any extraction is running. Drives the sidebar spinner.
     var isExtracting: Bool { !extractingSourceIDs.isEmpty }
 
@@ -120,6 +142,26 @@ final class QueueActivityTracker {
     /// unique), so the page-level branch needs no wiki check.
     func isLinting(pageID: PageID, wikiID: String) -> Bool {
         lintingPageIDs.contains(pageID) || wholeWikiLintingWikiIDs.contains(wikiID)
+    }
+
+    /// Returns the queue item ID of the lint job (page-level or whole-wiki)
+    /// currently running for `pageID` in `wikiID`, or `nil` if no lint is in
+    /// flight. Used by `PageDetailView`'s Lint button to navigate to the
+    /// specific job in the Activity window when a lint is already running
+    /// (#837). Page-level lints match by page ID (ULIDs are globally unique);
+    /// whole-wiki lints match by wiki ID (empty `lintPageIDs` covers every
+    /// page in that wiki).
+    func lintItemID(for pageID: PageID, wikiID: String) -> QueueItem.ID? {
+        for (itemID, lintPageIDs) in itemToLintPageIDs {
+            guard itemToLintWikiID[itemID] == wikiID else { continue }
+            if lintPageIDs.isEmpty {
+                return itemID
+            }
+            if lintPageIDs.contains(pageID) {
+                return itemID
+            }
+        }
+        return nil
     }
 
     /// Per-item typed agent events, for the Activity window's transcript view.
@@ -281,6 +323,9 @@ final class QueueActivityTracker {
         lintingItemIDs = []
         lintingPageIDs = []
         wholeWikiLintingWikiIDs = []
+        itemToLintPageIDs.removeAll()
+        itemToLintWikiID.removeAll()
+        pendingSelectionItemID = nil
         extractionLog = ""
         extractionPID = nil
         currentExtractionItemID = nil
@@ -483,6 +528,10 @@ final class QueueActivityTracker {
                 if let pageIDs = item.payload.lintPageIDs {
                     // Lint item — track separately (empty sourceIDs).
                     lintingItemIDs.insert(item.id)
+                    // Track the lint scope so `lintItemID(for:wikiID:)` can
+                    // resolve which running job covers a given page (#837).
+                    itemToLintPageIDs[item.id] = pageIDs
+                    itemToLintWikiID[item.id] = item.wikiID
                     if pageIDs.isEmpty {
                         // Whole-wiki lint: covers every page in this wiki.
                         wholeWikiLintingWikiIDs.insert(item.wikiID)
@@ -619,6 +668,8 @@ final class QueueActivityTracker {
         }
         // Lint items are tracked separately — always remove on terminal state.
         lintingItemIDs.remove(item.id)
+        itemToLintPageIDs.removeValue(forKey: item.id)
+        itemToLintWikiID.removeValue(forKey: item.id)
         if let pageIDs = item.payload.lintPageIDs {
             if pageIDs.isEmpty {
                 // Whole-wiki lint. Safe to remove by wiki ID: the `.ingest`

--- a/Tests/WikiFSAppTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSAppTests/QueueIngestionTests.swift
@@ -928,4 +928,136 @@ struct QueueActivityTrackerRehydrateTests {
         #expect(tracker.progressLog(for: "never-existed") == "")
     }
 }
+
+// MARK: - Lint item ID resolution (#837)
+
+@Suite("QueueActivityTracker lint item ID resolution")
+struct QueueActivityTrackerLintItemIDTests {
+
+    /// Mirrors the helper in the transcript tests but with a configurable wikiID
+    /// so cross-wiki scoping can be exercised.
+    private func makeLintItem(
+        id: String,
+        wikiID: String = "w1",
+        lintPageIDs: [PageID],
+        state: QueueItemState = .running
+    ) -> QueueItem {
+        QueueItem(
+            id: id, queue: .ingestion, wikiID: wikiID,
+            payload: QueueItemPayload(sourceIDs: [], lintPageIDs: lintPageIDs),
+            state: state, orderingKey: 1000, attempt: 0,
+            createdAt: 0)
+    }
+
+    @MainActor
+    @Test("Page-level lint resolves to the correct item ID")
+    func pageLevelLintResolvesItemID() {
+        let tracker = QueueActivityTracker()
+        let pageA = PageID(rawValue: "pageA")
+        let pageB = PageID(rawValue: "pageB")
+        let item = makeLintItem(id: "lint-1", lintPageIDs: [pageA, pageB])
+
+        tracker.handleForTesting(.started(item))
+
+        #expect(tracker.lintItemID(for: pageA, wikiID: "w1") == "lint-1")
+        #expect(tracker.lintItemID(for: pageB, wikiID: "w1") == "lint-1")
+    }
+
+    @MainActor
+    @Test("Whole-wiki lint resolves for any page in that wiki")
+    func wholeWikiLintResolvesForAnyPage() {
+        let tracker = QueueActivityTracker()
+        let anyPage = PageID(rawValue: "any-page")
+        let item = makeLintItem(id: "lint-wiki", lintPageIDs: [])
+
+        tracker.handleForTesting(.started(item))
+
+        #expect(tracker.lintItemID(for: anyPage, wikiID: "w1") == "lint-wiki")
+    }
+
+    @MainActor
+    @Test("Nil when no lint is running for the page")
+    func nilWhenNoLintRunning() {
+        let tracker = QueueActivityTracker()
+        let page = PageID(rawValue: "lonely")
+
+        #expect(tracker.lintItemID(for: page, wikiID: "w1") == nil)
+    }
+
+    @MainActor
+    @Test("Whole-wiki lint does not cross wiki boundaries")
+    func wholeWikiLintWikiScoped() {
+        let tracker = QueueActivityTracker()
+        let page = PageID(rawValue: "p1")
+        let item = makeLintItem(id: "lint-w2", wikiID: "w2", lintPageIDs: [])
+
+        tracker.handleForTesting(.started(item))
+
+        // A whole-wiki lint in w2 should not match a page in w1.
+        #expect(tracker.lintItemID(for: page, wikiID: "w1") == nil)
+        #expect(tracker.lintItemID(for: page, wikiID: "w2") == "lint-w2")
+    }
+
+    @MainActor
+    @Test("Page-level lint does not match a page not in its set")
+    func pageLevelLintDoesNotMatchUnlistedPage() {
+        let tracker = QueueActivityTracker()
+        let pageA = PageID(rawValue: "pageA")
+        let pageC = PageID(rawValue: "pageC")
+        let item = makeLintItem(id: "lint-2", lintPageIDs: [pageA])
+
+        tracker.handleForTesting(.started(item))
+
+        #expect(tracker.lintItemID(for: pageA, wikiID: "w1") == "lint-2")
+        #expect(tracker.lintItemID(for: pageC, wikiID: "w1") == nil)
+    }
+
+    @MainActor
+    @Test("Mapping cleared after completion")
+    func mappingClearedOnCompletion() {
+        let tracker = QueueActivityTracker()
+        let page = PageID(rawValue: "done-page")
+        let item = makeLintItem(id: "lint-done", lintPageIDs: [page])
+
+        tracker.handleForTesting(.started(item))
+        #expect(tracker.lintItemID(for: page, wikiID: "w1") == "lint-done")
+
+        let completed = makeLintItem(id: "lint-done", lintPageIDs: [page], state: .completed)
+        tracker.handleForTesting(.completed(completed))
+
+        #expect(tracker.lintItemID(for: page, wikiID: "w1") == nil)
+    }
+
+    @MainActor
+    @Test("Mapping cleared after cancellation")
+    func mappingClearedOnCancellation() {
+        let tracker = QueueActivityTracker()
+        let page = PageID(rawValue: "cancelled-page")
+        let item = makeLintItem(id: "lint-cancel", lintPageIDs: [page])
+
+        tracker.handleForTesting(.started(item))
+        #expect(tracker.lintItemID(for: page, wikiID: "w1") == "lint-cancel")
+
+        let cancelled = makeLintItem(id: "lint-cancel", lintPageIDs: [page], state: .cancelled)
+        tracker.handleForTesting(.cancelled(cancelled))
+
+        #expect(tracker.lintItemID(for: page, wikiID: "w1") == nil)
+    }
+
+    @MainActor
+    @Test("pendingSelectionItemID defaults to nil")
+    func pendingSelectionDefaultsNil() {
+        let tracker = QueueActivityTracker()
+        #expect(tracker.pendingSelectionItemID == nil)
+    }
+
+    @MainActor
+    @Test("pendingSelectionItemID cleared by stop()")
+    func pendingSelectionClearedByStop() {
+        let tracker = QueueActivityTracker()
+        tracker.pendingSelectionItemID = "some-item"
+        tracker.stop()
+        #expect(tracker.pendingSelectionItemID == nil)
+    }
+}
 #endif


### PR DESCRIPTION
## Summary

Closes #837. When a lint job is running or queued for a page, the Lint button in `PageDetailView` now navigates to the specific lint job in the Activity window instead of showing a static alert.

## Changes

**QueueActivityTracker** (`Sources/WikiFS/Queue/QueueActivityTracker.swift`):
- Added `lintItemID(for:wikiID:)` — resolves the running lint item ID for a given page. Page-level lints match by page ID (ULIDs are globally unique); whole-wiki lints match by wiki ID.
- Added two internal tracking dicts (`itemToLintPageIDs`, `itemToLintWikiID`) populated on `.started` and cleaned up on terminal state (`removeItem`) and `stop()`.
- Added `pendingSelectionItemID` — a shared `@Observable` "pending selection" property that the page view sets before opening the Activity window and the Activity view consumes.

**ActivityWindowView** (`Sources/WikiFS/Queue/ActivityWindowView.swift`):
- Added `consumePendingSelectionIfNeeded()` — reads the pending selection from the tracker, sets `selectedItemID`, and clears it. Called from `.onAppear` (new window) and `.onChange(of: activityTracker.pendingSelectionItemID)` (already-open window).
- The existing `autoSelectIfNeeded` is unaffected — it already checks `selectedItemID == nil`, so a consumed pending selection won't be overridden when the first snapshot lands.

**PageDetailView** (`Sources/WikiFS/Pages/PageDetailView.swift`):
- When `pageIsLinting` is true, the button now reads "View Lint" with `checkmark.seal.fill`, stays **enabled**, and tapping it resolves the lint item ID → sets `pendingSelectionItemID` → calls `openActivityWindow?()`.
- Removed the old `.disabled(pageIsLinting)`, the `isShowingLintActiveAlert` state, and the `.alert("Lint Already Running", ...)` modifier entirely.
- Added `@Environment(\.openActivityWindow)` (already injected via `.appEnvironment`).

**Tests** (`Tests/WikiFSAppTests/QueueIngestionTests.swift`):
- 9 new tests in `QueueActivityTrackerLintItemIDTests`: page-level resolution, whole-wiki resolution, nil when no lint, cross-wiki scoping, unlisted-page nil, mapping cleared on completion/cancellation, pending selection default + stop.

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (3512 tests, including 9 new)
