### PR TITLE
fix(youtube-transcript): migrate to youtube-transcript-api v1.x instance API

### DIFF
--- a/tools/youtube-transcript/tests/test_youtube_transcript.py
+++ b/tools/youtube-transcript/tests/test_youtube_transcript.py
@@ -99,39 +99,39 @@ class TestLanguagePreference:
     def test_primary_lookup_passes_language_list(self, mocker, mock_yta):
         """get_transcript receives the full language preference list."""
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.return_value = build_mock_segments()
 
         _yt._fetch_transcript("dQw4w9WgXcQ", "en")
 
-        call_kwargs = mock_yta.YouTubeTranscriptApi.get_transcript.call_args.kwargs
+        call_kwargs = mock_yta.YouTubeTranscriptApi.return_value.fetch.call_args.kwargs
         assert call_kwargs["languages"][0] == "en"
         assert "en-US" in call_kwargs["languages"]
 
     def test_custom_lang_prepended(self, mocker, mock_yta):
         """A custom language is first, English fallbacks follow."""
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.return_value = build_mock_segments()
 
         _yt._fetch_transcript("dQw4w9WgXcQ", "fr")
 
-        call_kwargs = mock_yta.YouTubeTranscriptApi.get_transcript.call_args.kwargs
+        call_kwargs = mock_yta.YouTubeTranscriptApi.return_value.fetch.call_args.kwargs
         assert call_kwargs["languages"][0] == "fr"
         assert "en" in call_kwargs["languages"]
 
     def test_fallback_to_first_available(self, mocker, mock_yta):
         """When get_transcript raises NoTranscriptFound, use list_transcripts."""
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = NoTranscriptFound("test")
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.side_effect = NoTranscriptFound("test")
 
         fallback_segments = [{"text": "Bonjour tout le monde", "start": 0.0, "duration": 2.0}]
         fallback_transcript = MockTranscript("fr", fallback_segments)
-        mock_yta.YouTubeTranscriptApi.list_transcripts.return_value = [fallback_transcript]
+        mock_yta.YouTubeTranscriptApi.return_value.list.return_value = [fallback_transcript]
 
         segments, language = _yt._fetch_transcript("dQw4w9WgXcQ", "en")
 
         assert language == "fr"
         assert segments == fallback_segments
-        mock_yta.YouTubeTranscriptApi.list_transcripts.assert_called_once_with("dQw4w9WgXcQ")
+        mock_yta.YouTubeTranscriptApi.return_value.list.assert_called_once_with("dQw4w9WgXcQ")
 
 
 # ── Output formatting ──────────────────────────────────────────────────
@@ -264,7 +264,7 @@ class TestArgParsing:
 class TestMainSuccess:
     def test_markdown_to_stdout(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.return_value = build_mock_segments()
 
         _yt.main(argv=["dQw4w9WgXcQ"])
 
@@ -274,7 +274,7 @@ class TestMainSuccess:
 
     def test_json_to_stdout(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.return_value = build_mock_segments()
 
         _yt.main(argv=["dQw4w9WgXcQ", "--json"])
 
@@ -286,7 +286,7 @@ class TestMainSuccess:
 
     def test_markdown_to_file(self, mocker, mock_yta, tmp_path, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.return_value = build_mock_segments()
 
         out_file = tmp_path / "transcript.md"
         _yt.main(argv=["dQw4w9WgXcQ", "--output", str(out_file)])
@@ -299,7 +299,7 @@ class TestMainSuccess:
 
     def test_timestamps_flag(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.return_value = build_mock_segments()
 
         _yt.main(argv=["dQw4w9WgXcQ", "--timestamps"])
 
@@ -309,13 +309,13 @@ class TestMainSuccess:
 
     def test_url_input(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.return_value = build_mock_segments()
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.return_value = build_mock_segments()
 
         _yt.main(argv=["https://www.youtube.com/watch?v=dQw4w9WgXcQ"])
 
         out = capsys.readouterr().out
         assert "# YouTube Transcript: dQw4w9WgXcQ" in out
-        call_args = mock_yta.YouTubeTranscriptApi.get_transcript.call_args.args
+        call_args = mock_yta.YouTubeTranscriptApi.return_value.fetch.call_args.args
         assert call_args[0] == "dQw4w9WgXcQ"
 
 
@@ -325,8 +325,8 @@ class TestMainSuccess:
 class TestExitCodes:
     def test_exit_no_transcript(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = NoTranscriptFound("test")
-        mock_yta.YouTubeTranscriptApi.list_transcripts.side_effect = NoTranscriptFound("test")
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.side_effect = NoTranscriptFound("test")
+        mock_yta.YouTubeTranscriptApi.return_value.list.side_effect = NoTranscriptFound("test")
 
         with pytest.raises(SystemExit) as exc:
             _yt.main(argv=["dQw4w9WgXcQ"])
@@ -337,7 +337,7 @@ class TestExitCodes:
 
     def test_exit_transcripts_disabled(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = TranscriptsDisabled("test")
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.side_effect = TranscriptsDisabled("test")
 
         with pytest.raises(SystemExit) as exc:
             _yt.main(argv=["dQw4w9WgXcQ"])
@@ -348,7 +348,7 @@ class TestExitCodes:
 
     def test_exit_video_unavailable(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = VideoUnavailable("test")
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.side_effect = VideoUnavailable("test")
 
         with pytest.raises(SystemExit) as exc:
             _yt.main(argv=["dQw4w9WgXcQ"])
@@ -359,7 +359,7 @@ class TestExitCodes:
 
     def test_exit_unknown_error(self, mocker, mock_yta, capsys):
         mocker.patch.object(_yt, "_import_api", return_value=mock_yta)
-        mock_yta.YouTubeTranscriptApi.get_transcript.side_effect = RuntimeError("network failure")
+        mock_yta.YouTubeTranscriptApi.return_value.fetch.side_effect = RuntimeError("network failure")
 
         with pytest.raises(SystemExit) as exc:
             _yt.main(argv=["dQw4w9WgXcQ"])

--- a/tools/youtube-transcript/youtube-transcript
+++ b/tools/youtube-transcript/youtube-transcript
@@ -151,8 +151,8 @@ def _fetch_transcript(
 ) -> tuple[list[dict[str, str | float]], str]:
     """Fetch transcript with language preference chain.
 
-    Tries the requested language and English fallbacks via get_transcript,
-    then falls back to the first available track of any language.
+    Tries the requested language and English fallbacks via the v1.x fetch
+    API, then falls back to the first available track of any language.
 
     Raises TranscriptFetchError with the appropriate exit_code on failure.
     """
@@ -175,29 +175,41 @@ def _fetch_transcript(
         raise TranscriptFetchError(str(e), exit_code=1) from e
 
 
+def _to_raw_segments(fetched: Any) -> list[dict[str, str | float]]:
+    """Normalize a fetched transcript to a list of segment dicts.
+
+    youtube-transcript-api v1.x returns a FetchedTranscript object exposing
+    .to_raw_data(); older shapes (and test mocks) return a plain list.
+    """
+    if hasattr(fetched, "to_raw_data"):
+        return list(fetched.to_raw_data())
+    return list(fetched)
+
+
 def _try_fetch(
     yta: Any, video_id: str, lang: str
 ) -> tuple[list[dict[str, str | float]], str]:
     """Try language preference, then first available track.
 
-    Raises youtube_transcript_api exceptions on failure.
+    Uses the youtube-transcript-api v1.x instance API
+    (YouTubeTranscriptApi().fetch/.list). Raises youtube_transcript_api
+    exceptions on failure.
     """
     langs = _build_language_list(lang)
-    segments: list[dict[str, str | float]] = []
+    api = yta.YouTubeTranscriptApi()
 
     try:
-        segments = list(
-            yta.YouTubeTranscriptApi.get_transcript(video_id, languages=langs)
-        )
+        fetched = api.fetch(video_id, languages=langs)
+        segments = _to_raw_segments(fetched)
         if segments:
-            return segments, langs[0]
+            return segments, getattr(fetched, "language_code", langs[0])
     except yta.NoTranscriptFound:
         pass  # Fall through to first available
 
     # Fallback: first available track of any language
-    transcript_list = yta.YouTubeTranscriptApi.list_transcripts(video_id)
+    transcript_list = api.list(video_id)
     for transcript_obj in transcript_list:
-        segments = list(transcript_obj.fetch())
+        segments = _to_raw_segments(transcript_obj.fetch())
         if segments:
             return segments, transcript_obj.language_code
 


### PR DESCRIPTION
## Problem

Transcribing a YouTube source failed with:

```
Installed 7 packages in 10ms
Error: type object 'YouTubeTranscriptApi' has no attribute 'get_transcript'
```

The `tools/youtube-transcript/youtube-transcript` PEP 723 script called `YouTubeTranscriptApi.get_transcript()` / `.list_transcripts()` — classmethods that **youtube-transcript-api v1.0 removed** in favor of the instance methods `YouTubeTranscriptApi().fetch()` / `.list()`. The unbounded `>=1.0` dependency pin resolved to the v1.x API, so the removed classmethods blew up at runtime. This script is exactly the subprocess `YouTubeTranscriptService` spawns, so it surfaced as the on-page "Transcribe failed" error.

## Fix

- Migrate `_try_fetch` to the v1.x instance API: `YouTubeTranscriptApi().fetch(video_id, languages=…)` and `.list(video_id)`.
- Normalize the new `FetchedTranscript` return via `to_raw_data()` (helper `_to_raw_segments`, which also tolerates the plain-list shape used by test mocks), so all downstream formatting is unchanged.
- Prefer the actual `fetched.language_code` when available.
- Update the test mocks to the instance shape (`YouTubeTranscriptApi.return_value.fetch` / `.list`).

## Verification

- `pytest` — **50 passed**.
- Live run against a real video (`dQw4w9WgXcQ`) now returns a transcript.

## Not in scope

Routing transcription through the queue engine (enqueue + reveal job, instead of the inline path that renders errors on the page) is tracked separately in #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)