### PR TITLE
Content-type registry PR2: migrate UI sites + chokepoint to registry

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8868,3 +8868,103 @@ staging) atop the registry, fix the latent HTML-extract drift in
 `SourcesListView.canExtract`, and migrate the chokepoint using
 `resolve(mimeType:provider:ext:)` (provider-aware — locks the §11-C1
 behavior the critical finding protects).
+
+### Content-type registry PR2 — migrate UI sites + chokepoint (PR2)
+
+**Date:** 2026-07-22 · **Branch:** `content-type-registry-pr2` ·
+**Issue:** #835 follow-up (PR2 of the §11-corrected plan)
+
+**Summary:** Consolidates the remaining 5 ad-hoc "can this become markdown?"
+sites (the 4 UI decision sites + the deferred chokepoint) onto the PR1
+registry. No new behavior change except the latent HTML-extract drift fix
+in `SourcesListView.canExtract` (the list menu now offers HTML extraction,
+matching the detail-view Extract button) and a widened staging-reuse path
+(`AppQueueIngestionProvider` now stages HTML with extracted markdown the
+same way PDFs work, instead of re-staging raw HTML bytes).
+
+**Two registry conveniences (`ContentCapabilities`):**
+- `hasFileExtractionBackend` — `extractionPath == .pdfBackend || .htmlToMarkdown`.
+  Drives the Extract button + staging reuse path. Distinct from
+  `canExtractToMarkdown` (which also matches transcript kinds) — using the
+  latter for the Extract button, as the plan §5.4 original proposed, would
+  have widened the Extract button to podcasts/YouTube, breaking the
+  one-button-per-source exclusivity with `needsTranscription` (both would
+  be true → two borderedProminent buttons). The two are mutually exclusive
+  by construction (one `ExtractionPath` per kind).
+- `hasTranscriptBackend` — `extractionPath == .podcastTranscript ||
+  .youtubeTranscript`. Drives the Transcribe gate and the
+  `SourceProvider.supportsTranscription` delegation.
+
+**Migrated sites (5 + 1 delegation):**
+- `SourceProvider.supportsTranscription` (#10) — delegates to the registry.
+  Static baseline no longer a duplicated switch; runtime guards stay layered
+  on top at `isTranscribable` / `isSourceRefreshable(for:)`.
+- `SourceDetailView.isExtractable` / `needsExtraction` (#4, #6) — registry
+  via the new `contentKind` computed property. Stays PDF/HTML only (not
+  widened to transcript kinds — preserves Extract/Transcribe exclusivity).
+- `SourceDetailView.isTranscribable` (#5) — guard-checks
+  `hasTranscriptBackend` first; the runtime signing-helper / `#if
+  PODCAST_TRANSCRIPTS` switch still layers on top.
+- `SourcesListView.canExtract` (#8) — §5.5 latent drift fix: list menu now
+  offers Extract for HTML (was PDF-only).
+- `SourcesListView.canIngest` (#9) — switches from byte-only to the
+  chokepoint-mirrored pair (canIngest + shouldAutoIngest) so the menu hides
+  for non-ingestible byte-bearing sources (PNG/XML), consistent with what
+  the PR2 chokepoint does.
+- `QueueIngestionHelper.enqueueIngestion` chokepoint (#3, §5.2 / §11-C1) —
+  adds `shouldAutoIngest` AFTER the existing byte gate. Provider-aware via
+  PR1's wrapper (`ContentKind.resolve(mimeType:provider:ext:)` — NOT
+  `fromMIME` alone) so a byteless YouTube-with-transcript passes both gates
+  (locks the §11-C1 regression case the original §5.2 caught).
+- `AppQueueIngestionProvider` staging (#12, §5.6) — registry-driven reuse:
+  PDF AND HTML now reuse extracted markdown at stage time (was PDF-only).
+  Extracted as `_stagedBytesAndExt(for:originalBytes:processedMarkdownHead:)`
+  `nonisolated static` seam so tests can exercise it directly.
+
+**Sites that stay as-is (per §5.7):**
+- `SourceProvider.supportsRefresh` (#11) — orthogonal (re-fetch capability,
+  not markdown-path).
+- `ExtractionCoordinator.current()` (#13) — backend resolver, not a
+  content-type decision.
+- `WikiStoreModel.canIngest(_:)` (#1) — stays the byte-availability predicate
+  the manual Ingest button needs; the registry's content-type gate lives at
+  the chokepoint (PR2) + the coordinator (PR1) + the list view (PR2).
+
+**Testable seams (`internal static` + `nonisolated`):**
+- `SourceDetailView.extractionAffordance(mimeType:provider:ext:)` — returns
+  `.extract` / `.transcribe` / `.none`. Pure registry decision (the runtime
+  guards layer elsewhere).
+- `SourcesListContentGates.canExtract(source:processedMarkdownHead:)` —
+  pure registry decision for the list-menu Extract item.
+- `AppQueueIngestionProvider._stagedBytesAndExt(for:originalBytes:
+  processedMarkdownHead:)` — pure registry decision for staging reuse.
+- PR1's `BackgroundIngestCoordinator.ingestionDecision(for:store:)` /
+  `filterIngestibleSources(_:store:)` already in place.
+
+**Tests:**
+- `Tests/WikiFSTests/ContentTypeRegistryTests.swift` — extended with
+  partition + exclusivity invariants for the two new conveniences (5 tests
+  added; PR1's 40 tests unchanged).
+- `Tests/WikiFSAppTests/SourceDetailViewContentKindTests.swift` (NEW) —
+  per-kind affordance, YouTube-with-provider-vs-without, closed-enum
+  partition.
+- `Tests/WikiFSAppTests/SourcesListContentGatesTests.swift` (NEW) — the
+  headline HTML-extract drift fix, head-suppression, non-extractable kinds.
+- `Tests/WikiFSAppTests/SourceProviderSupportsTranscriptionTests.swift`
+  (NEW) — exhaustive provider × registry equivalence for the delegation.
+- `Tests/WikiFSAppTests/AppQueueIngestionProviderStagingTests.swift` (NEW)
+  — PDF/HTML reuse (incl. the PR2 widening), non-extractable kinds skip
+  reuse, edge cases (non-UTF8, empty ext).
+- `Tests/WikiFSAppTests/IngestGateTests.swift` extended with the §11-C7
+  regression — byteless YouTube WITH transcript passes the chokepoint (not
+  dropped by the new `shouldAutoIngest` gate). Plus two drops (PNG byte-
+  bearing, XML byte-bearing) and a mixed batch.
+- Full `swift test` suite green (3640 tests / 302 suites).
+
+**No DB migration.** Same column reads as PR1 — PR2 is pure source/test.
+
+**Build:**
+`make version prompts && swift build && swift test`.
+
+**Plan:** [`plans/content-type-registry.md`](plans/content-type-registry.md)
+§PR2 (appended; §PR1 covers PR1's scope, §§1-11 the shared design).

--- a/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
+++ b/Sources/WikiFS/Queue/AppQueueIngestionProvider.swift
@@ -157,14 +157,26 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
             var sourceBytes = bytes
             var sourceExt = source.ext
 
-            // PDF → reuse extracted markdown if available (extraction already
-            // ran via the extraction queue item).
-            if MimeType.isPDF(source.mimeType) {
-                if let head = store.processedMarkdownHead(for: source) {
-                    sourceBytes = head.content.data(using: .utf8) ?? bytes
-                    sourceExt = "md"
-                    DebugLog.extraction("AppQueueIngestionProvider: reusing markdown for \(source.filename)")
-                }
+            // PR2 §5.6: registry-driven staging reuse. Was `if MimeType.isPDF`
+            // (PDF-only); generalized to `hasFileExtractionBackend`, which
+            // covers PDF AND HTML sources — both have extraction back ends
+            // (`extractionPath == .pdfBackend` or `.htmlToMarkdown`) and
+            // both may have a `processedMarkdownHead` produced by an
+            // earlier extraction item / inline `runHtmlExtraction`. The pure
+            // half of the decision is extracted as
+            // `AppQueueIngestionProvider._stagedBytesAndExt(...)` so tests
+            // can pin the registry-driven widening (PDF + HTML) without
+            // standing up the full staging path (which needs a real session,
+            // launcher, fileProvider, etc.).
+            let head = store.processedMarkdownHead(for: source)
+            let staged = Self._stagedBytesAndExt(
+                for: source,
+                originalBytes: bytes,
+                processedMarkdownHead: head)
+            sourceBytes = staged.bytes
+            sourceExt = staged.ext
+            if staged.ext == "md" && staged.bytes != bytes {
+                DebugLog.extraction("AppQueueIngestionProvider: reusing markdown for \(source.filename) (\(head?.origin.rawValue ?? "?"))")
             }
 
             sources.append(OperationRequest.StagedSource(
@@ -482,5 +494,58 @@ final class AppQueueIngestionProvider: QueueIngestionProvider {
     private func ingestSourcePath(for source: SourceSummary) -> String {
         let leaf = FilenameEscaping.byIDSourceFilename(sourceID: source.id.rawValue, ext: source.ext)
         return "sources/by-id/\(leaf)"
+    }
+
+    // MARK: - PR2 §5.6 testable seam — staging reuse decision
+
+    /// The pure half of the staging decision: what (bytes, ext) should the
+    /// staging path hand the agent for this source? PR2 §5.6 widens the
+    /// pre-PR2 `MimeType.isPDF(source.mimeType) → reuse head` PDF-only rule
+    /// onto the registry's `hasFileExtractionBackend`, which covers PDF AND
+    /// HTML — both have extraction back ends and both may have an extracted
+    /// `processedMarkdownHead` produced by an earlier extraction queue item
+    /// / inline `runHtmlExtraction`. Reusing extracted markdown at stage
+    /// time avoids re-running extraction on the same bytes the agent will
+    /// summarize.
+    ///
+    /// Transcript kinds (`.podcastTranscript` / `.youtubeTranscript`) are
+    /// excluded — `hasFileExtractionBackend` returns `false` for them. Their
+    /// transcript bytes already come through `store.sourceBytes` (for the
+    /// checksum'd stored transcript). Binary / image / unknown kinds have
+    /// `extractionPath == nil` and never enter this branch — the staging
+    /// uses the raw bytes verbatim.
+    ///
+    /// `internal static` so `@testable import WikiFS` tests can pin the
+    /// registry-driven widening (PDF + HTML) without standing up the full
+    /// staging path (which requires a real `WikiSession` + `AgentLauncher`
+    /// + `FileProviderFacade` — see `RetryStuckRegressionTests` for the
+    /// heaviness of an integration-shape test against this class).
+    ///
+    /// # Returns
+    /// `(bytes, ext)` — the bytes + lowercased ext the staging should use.
+    /// If the source is an extractable PDF / HTML with a markdown head,
+    /// returns `(head.content data, "md")`. Otherwise returns the original
+    /// bytes + source's ext verbatim. The caller detects a reuse by
+    /// `ext == "md" && bytes != originalBytes` (it just gates the log line).
+    ///
+    /// `nonisolated` because the method is pure (no actor dependencies)
+    /// despite the enclosing `@MainActor` class. Tests would otherwise
+    /// need `@MainActor` annotations on the suite, and the staging call
+    /// site pays no isolation hop in either direction.
+    nonisolated static func _stagedBytesAndExt(
+        for source: SourceSummary,
+        originalBytes: Data,
+        processedMarkdownHead: SourceMarkdownVersion?
+    ) -> (bytes: Data, ext: String) {
+        let kind = ContentKind.resolve(
+            mimeType: source.mimeType,
+            provider: nil,          // byte-bearing MIME is authoritative (§5.6)
+            ext: source.ext)
+        guard kind.capabilities.hasFileExtractionBackend,
+              let head = processedMarkdownHead,
+              let markdownBytes = head.content.data(using: .utf8) else {
+            return (originalBytes, source.ext)
+        }
+        return (markdownBytes, "md")
     }
 }

--- a/Sources/WikiFS/Queue/QueueIngestionHelper.swift
+++ b/Sources/WikiFS/Queue/QueueIngestionHelper.swift
@@ -17,6 +17,18 @@ import WikiFSEngine
 /// enqueued no matter which UI path originated the request. The UI predicate
 /// (`WikiStoreModel.canIngest`) mirrors this for affordance gating.
 ///
+/// **Content-type gate (PR2 §5.2 / §11-C1):** the chokepoint ALSO consults
+/// `WikiStoreModel.shouldAutoIngest(_:)` — the registry-backed
+/// "does this content TYPE have any markdown path?" predicate added in PR1.
+/// A byte-bearing PNG or XML source (the bug class) passes the byte gate
+/// but fails this second gate, so it's dropped here rather than enqueued
+/// for a wasted agent run. **Provider-aware** (PR1's wrapper uses
+/// `ContentKind.resolve(mimeType:provider:ext:)`, not `fromMIME` alone) so
+/// a byteless `.youtube` source WITH a transcript (whose synthetic
+/// `video/youtube` mime alone would classify as `.binary`) classifies as
+/// `.youtubeTranscript` → `shouldAutoIngest == true` and passes — locking
+/// the §11-C1 regression guard.
+///
 /// **Deduplication:** before enqueuing, checks the engine's active items
 /// (`.queued` or `.running`) for this wiki. Sources already active in either
 /// the extraction or ingestion queue are skipped — a user tapping Ingest
@@ -59,6 +71,15 @@ func enqueueIngestion(
 
         // PDF without extracted markdown → enqueue extraction, wait for it,
         // then include in ingestion batch (extraction produces the markdown).
+        // Stays `MimeType.isPDF` rather than `extractionPath == .pdfBackend`
+        // because the extraction queue is PDF-only (HTML extraction routes
+        // through the inline `runHtmlExtraction` path, not the queue engine —
+        // see `SourceDetailView.runExtraction` / `runHtmlExtraction` split).
+        // Equivalent under the registry today (`.pdf` kind has
+        // `extractionPath == .pdfBackend` and only `application/pdf` MIME
+        // resolves to `.pdf`), kept as a direct MIME check because the
+        // condition is specifically "PDF extraction queue knows how to handle
+        // this" — the content-type decision is below.
         if MimeType.isPDF(source.mimeType),
            store.processedMarkdownHead(for: source) == nil {
             let request = QueueItemRequest(
@@ -74,17 +95,35 @@ func enqueueIngestion(
         }
 
         // ── Chokepoint ───────────────────────────────────────────────────
-        // The single enforcement of "don't ingest sources without content."
-        // `canIngest` is true when the source has processed markdown (a
-        // transcript, extracted PDF) **or** raw bytes (`byteSize > 0`) the
-        // staging path reads directly. A byteless source with no processed
-        // markdown — e.g. a YouTube video whose transcript never arrived —
-        // has neither, so it is dropped here rather than enqueuing a run the
-        // staging path would hand empty bytes to. Every UI entry point
-        // (detail view, list context menu, batch ingest) funnels through
-        // here, so the rule is *guaranteed* regardless of origin.
+        // Two gates, in order:
+        // 1. **Byte gate** (`canIngest`): true when the source has processed
+        //    markdown (a transcript, extracted PDF) **or** raw bytes
+        //    (`byteSize > 0`) the staging path reads directly. A byteless
+        //    source with no processed markdown — e.g. a YouTube video whose
+        //    transcript never arrived — has neither, so it is dropped here.
+        //    Kept from PR1; defense-in-depth: even if the content-type gate
+        //    below somehow let a byteless source through (it doesn't, but
+        //    future registry edits could), nothing is enqueued without
+        //    content. Every UI entry point (detail view, list context menu,
+        //    batch ingest) funnels through here, so the rule is *guaranteed*
+        //    regardless of origin.
+        // 2. **Content-type gate** (PR2 §5.2 / §11-C1, `shouldAutoIngest`):
+        //    the registry's markdown-path predicate. A byte-bearing PNG
+        //    (`image/png` → `.image`) or XML (`application/xml` → `.binary`)
+        //    passes gate #1 (it has bytes) but fails gate #2 (no markdown
+        //    path) — dropped rather than enqueued for wasted agent runs.
+        //    Provider-aware via PR1's wrapper (`ContentKind.resolve(mime:
+        //    provider: ext:)` — NOT `fromMIME` alone) so a byteless YouTube
+        //    source WITH a transcript classifies as `.youtubeTranscript` and
+        //    passes; fromMIME alone would classify its synthetic
+        //    `video/youtube` mime as `.binary` and incorrectly drop it (the
+        //    §11-C1 regression the original §5.2 caught).
         guard store.canIngest(source) else {
             DebugLog.ingest("enqueueIngestion: dropped \(sourceID.rawValue) — no markdown or bytes to ingest")
+            continue
+        }
+        guard store.shouldAutoIngest(source) else {
+            DebugLog.ingest("enqueueIngestion: dropped \(sourceID.rawValue) — content type has no markdown path")
             continue
         }
         ingestionSourceIDs.append(sourceID)

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -160,6 +160,20 @@ struct SourceDetailView: View {
         return ext == "html" || ext == "htm" || ext == "xhtml"
     }
 
+    /// The source's resolved `ContentKind` — the registry classification for
+    /// this source's MIME + provider + extension. PR2 (§5.4): the Extract /
+    /// Transcribe button gating switches on this kind's `capabilities` rather
+    /// than re-deriving the PDF/HTML/transcript decision ad-hoc. Kept `private`
+    /// to the view; tests exercise the same `resolve(mimeType:provider:ext:)`
+    /// call via the `internal static` seam (`SourceDetailView.extractionDecision`,
+    /// below).
+    private var contentKind: ContentKind {
+        ContentKind.resolve(
+            mimeType: file.mimeType,
+            provider: origin?.provider,
+            ext: file.ext)
+    }
+
     /// The source's original HTML bytes, decoded as text. Used by the HTML tab
     /// (the WKWebView renders them verbatim). Returns `nil` when the source
     /// isn't HTML or the bytes couldn't be decoded.
@@ -188,20 +202,20 @@ struct SourceDetailView: View {
 
     /// `true` when this source can be transcribed right now — the single
     /// source of truth for the Transcribe button's enable state (issue #799
-    /// PR4 AC.16, generalized to YouTube in PR5). Dispatches on
-    /// `provider.supportsTranscription` (the enum property gates which
-    /// providers have ANY transcript pipeline); the podcast runtime guard
-    /// (the bundled signing helper present AND this build compiles podcast
-    /// support via `#if PODCAST_TRANSCRIPTS`) weiterhin delegates to
+    /// PR4 AC.16, generalized to YouTube in PR5). The registry half of the
+    /// gate (PR2 §5.4) consults `contentKind.capabilities.hasTranscriptBackend`
+    /// (true only for `.podcastTranscript` / `.youtubeTranscript`), then
+    /// runtime guards layer on top: the podcast runtime guard (bundled
+    /// signing helper present AND this build compiles podcast support via
+    /// `#if PODCAST_TRANSCRIPTS`) delegates to
     /// `store.isSourceRefreshable(for:)` so the predicate is identical to
-    /// the Refresh button's guard for podcasts. YouTube needs no signing
-    /// helper, so it's always "available" once a valid video ID is recorded
-    /// (the gate is just `provider == .youtube` — the model throws
-    /// `.missingPlan` when the ID is missing, surfaced by `runTranscription`).
+    /// the Refresh button's guard for podcasts. YouTube and generic RSS need
+    /// no signing helper, so they're always "available" once the provider
+    /// matches (the model throws `.missingPlan` when the ID is missing,
+    /// surfaced by `runTranscription`).
     private var isTranscribable: Bool {
-        guard let provider = origin?.provider,
-              provider.supportsTranscription else { return false }
-        switch provider {
+        guard contentKind.capabilities.hasTranscriptBackend else { return false }
+        switch origin?.provider {
         case .applePodcast:
             // Mirror the Refresh button's runtime guard (helper present +
             // build compiles podcast support). The predicate returns `false`
@@ -219,12 +233,13 @@ struct SourceDetailView: View {
             // `origin.externalIdentity` is missing (a data-integrity edge case
             // surfaced by `runTranscription`, not gated here).
             return true
-        // Unreachable: `supportsTranscription` returned false above (the
-        // property returns true only for `.applePodcast` + `.podcast` +
-        // `.youtube`). The switch stays exhaustive so a future transcript-
-        // capable provider is automatically flagged by the compiler.
+        // Unreachable when `hasTranscriptBackend == true` (the registry
+        // resolves `.applePodcast` / `.podcast` / `.youtube` providers to
+        // transcript kinds and every other provider to a non-transcript
+        // kind). The switch stays exhaustive so a future transcript-capable
+        // provider is automatically flagged by the compiler.
         case .vimeo, .spotify, .soundcloud, .remoteMedia,
-             .localFile, .website, .zotero, .markdownFolder, .legacyImport:
+             .localFile, .website, .zotero, .markdownFolder, .legacyImport, .none:
             return false
         }
     }
@@ -372,18 +387,27 @@ struct SourceDetailView: View {
 
     private var showTabs: Bool { !availableTabs.isEmpty }
 
-    /// `true` when this source's content type has extraction backends (issue
-    /// #799 PR2) — the gate for the Extract button and the Re-extract menu.
-    /// Generalized from `isPDF` so an un-extracted HTML source also shows the
-    /// Extract call-to-action. A source is extractable iff it's a PDF (backed
-    /// by `ExtractionBackend.allCases`) or HTML (backed by
-    /// `HtmlExtractionBackend.allCases`). Text/binary/byteless sources skip
-    /// extraction entirely. Podcast embeds are handled separately (issue
-    /// #799 PR4: `isTranscribable` + `needsTranscription` gate the Transcribe
-    /// button); they're NOT in `isExtractable` because podcast "extraction"
-    /// is a network fetch (not a bytes→markdown transform), so the HTML/PDF
-    /// Extract button doesn't apply.
-    private var isExtractable: Bool { isPDF || isHTMLSource }
+    /// `true` when this source's content type has a file-extraction backend
+    /// — the gate for the Extract button and the Re-extract menu. PR2 §5.4:
+    /// migrated from `isPDF || isHTMLSource` (which already encoded the same
+    /// intent ad-hoc) onto the registry's `hasFileExtractionBackend`
+    /// (`extractionPath == .pdfBackend || .htmlToMarkdown`). Stays PDF/HTML
+    /// only — podcast / YouTube transcript kinds have
+    /// `canExtractToMarkdown == true` too, but their affordance is the
+    /// Transcribe button (`isTranscribable`, gated on
+    /// `hasTranscriptBackend`). The two are mutually exclusive per kind, so
+    /// `needsExtraction` and `needsTranscription` never both become `true`
+    /// for the same source — the UI shows one prominent button per source.
+    ///
+    /// Text/binary/byteless sources skip extraction entirely (their
+    /// `extractionPath == nil`). A PDF with bytes (isPDF true) and a raw
+    /// HTML byte source (isHTMLSource true) both resolve to a kind with a
+    /// file-extraction backend via `ContentKind.resolve` — the registry's
+    /// MIME + ext path matches the same MIME/extension checks the old
+    /// predicate did.
+    private var isExtractable: Bool {
+        contentKind.capabilities.hasFileExtractionBackend
+    }
 
     /// `true` when this source's content type has a provenance chip — the gate
     /// for `extractionProvenanceChip(head:)` rendering above the action row
@@ -399,7 +423,9 @@ struct SourceDetailView: View {
     /// the prominent "Extract" call-to-action. Also the exclusivity guard for
     /// the source's single "act on this source's content" affordance: an
     /// unextracted PDF or HTML source shows Extract, so Refresh is suppressed
-    /// until it has a derivation (one affordance per source).
+    /// until it has a derivation (one affordance per source). PR2: relies on
+    /// `isExtractable`'s registry-backed gate (no shape change to this
+    /// predicate).
     private var needsExtraction: Bool { isExtractable && !hasMarkdown }
 
     /// `true` when this source has ≥2 extraction alternatives — the gate for the
@@ -1937,4 +1963,60 @@ struct SourceDetailView: View {
 private struct PDFTaskKey: Hashable {
     let sourceID: PageID
     let anchorVersion: Int
+}
+
+// MARK: - PR2 testable seam — Extract / Transcribe affordance (§5.4)
+
+extension SourceDetailView {
+
+    /// The single-affordance decision for a source's content type, computed
+    /// from the registry BEFORE any runtime guard (signing helper present /
+    /// `#if PODCAST_TRANSCRIPTS`). Used by the UI to gate the Extract /
+    /// Transcribe buttons (`isExtractable` / `isTranscribable`) and by tests
+    /// to pin the registry-driven gating without hosting the SwiftUI view.
+    ///
+    /// Mutually exclusive by construction: a `ContentKind.extractionPath` is
+    /// one of four cases or `nil`, so `extract` and `transcribe` never both
+    /// fire for the same (mime, provider, ext) triple. The runtime guard
+    /// (`store.isSourceRefreshable(for:)` for `.applePodcast`) is layered on
+    /// top in `SourceDetailView.isTranscribable`.
+    enum ExtractionAffordance: Sendable, Equatable {
+        /// PDF / HTML — the Extract Markdown button (`runExtraction` /
+        /// `runHtmlExtraction`). `extractionPath == .pdfBackend` or
+        /// `.htmlToMarkdown`.
+        case extract
+        /// Podcast / YouTube — the Transcribe button (`runTranscription`).
+        /// `extractionPath == .podcastTranscript` or `.youtubeTranscript`.
+        case transcribe
+        /// Native markdown / text / image / binary / vimeo / unknown — no
+        /// extraction button; the content either is already markdown or has
+        /// no path to it (the auto-ingest gate also excludes these).
+        case none
+    }
+
+    /// Pure registry-driven decision for the Extract-vs-Transcribe-vs-Neither
+    /// affordance. `internal static` so `@testable import WikiFS` tests can
+    /// reach it without instantiating a `SourceDetailView` (which needs a
+    /// `WikiStoreModel`, `AgentLauncher`, `ExtractionCoordinator`, etc.).
+    /// Mirrors the PR1 `BackgroundIngestCoordinator.ingestionDecision` seam.
+    ///
+    /// `nonisolated` because it's pure (a single `ContentKind.resolve(...)`
+    /// call with no actor dependencies) despite the enclosing SwiftUI `View`
+    /// struct getting implicit `@MainActor` isolation. Tests would otherwise
+    /// need `@MainActor` annotations on the suite, and the in-view call site
+    /// is already on the main actor.
+    ///
+    /// See `plans/content-type-registry.md` §5.4 (PR2).
+    nonisolated static func extractionAffordance(
+        mimeType: String?,
+        provider: SourceProvider?,
+        ext: String?
+    ) -> ExtractionAffordance {
+        let kind = ContentKind.resolve(mimeType: mimeType, provider: provider, ext: ext)
+        switch kind.capabilities.extractionPath {
+        case .pdfBackend, .htmlToMarkdown:             return .extract
+        case .podcastTranscript, .youtubeTranscript:   return .transcribe
+        case nil:                                       return .none
+        }
+    }
 }

--- a/Sources/WikiFS/Sources/SourcesListView.swift
+++ b/Sources/WikiFS/Sources/SourcesListView.swift
@@ -488,17 +488,41 @@ extension SourcesListViewController {
     }
 
     private func canExtract(_ source: SourceSummary) -> Bool {
-        MimeType.isPDF(source.mimeType)
-            && store?.processedMarkdownHead(for: source) == nil
+        // PR2 §5.5: registry-driven gate (replaces `MimeType.isPDF`).
+        // Fixes the latent drift where the list menu offered Extract for
+        // PDF only — the detail-view Extract button also covers HTML
+        // (`isHTMLSource`), but the list's old `MimeType.isPDF` check
+        // silently omitted HTML. Now both go through the registry's
+        // `hasFileExtractionBackend` (true for `.pdfBackend` AND
+        // `.htmlToMarkdown`). Pass provider=nil: the list view doesn't
+        // pre-load origin for every row, and MIME is authoritative for
+        // byte-bearing file sources anyway — a podcast/YouTube byteless
+        // embed's synthetic `video/youtube` mime would not pass either
+        // (it classifies as `.binary`, no `extractionPath`).
+        SourcesListContentGates.canExtract(
+            source: source,
+            processedMarkdownHead: store?.processedMarkdownHead(for: source))
     }
 
-    /// Mirrors the chokepoint rule in `enqueueIngestion` (via
-    /// `WikiStoreModel.canIngest`): a source is ingestible iff it has
-    /// processed markdown to ingest or raw bytes the staging path reads.
-    /// Used to hide the Ingest item for sources that can never be ingested
-    /// (e.g. a byteless YouTube video with no transcript).
+    /// Double gate hiding the Ingest menu item for sources the chokepoint
+    /// (`enqueueIngestion`) would drop anyway. The chokepoint runs BOTH the
+    /// byte gate (`store.canIngest`) AND the content-type gate
+    /// (`store.shouldAutoIngest`, PR2 §5.2 / §11-C1). For the menu UX, we
+    /// don't want a "Ingest" item that silently does nothing — so we mirror
+    /// the same pair here. A PNG with bytes passes the byte gate but fails
+    /// the content-type gate (PR1 fix); a byteless YouTube source without a
+    /// transcript fails BOTH (byteless + no transcript); both stay hidden
+    /// in the context menu.
+    ///
+    /// Per §5.2 narrative, the manual Ingest button (Detail view, line 831:
+    /// `ingestButton`) keeps the byte-only gate (`canIngest`) — the user can
+    /// still try to ingest a no-markdown-path source via the prominent
+    /// button (the chokepoint will drop it cleanly). This list-context-menu
+    /// item is intentionally stricter — discoverability > permissiveness
+    /// for the menu (an item that does nothing is misleading).
     private func canIngest(_ source: SourceSummary) -> Bool {
-        store?.canIngest(source) ?? false
+        guard let store else { return false }
+        return store.canIngest(source) && store.shouldAutoIngest(source)
     }
 
     private func item(title: String, systemImage: String,
@@ -598,5 +622,43 @@ final class SourcesNSTableView: NSTableView {
         }
         self.selectAll(self)
         return true
+    }
+}
+
+// MARK: - PR2 test seam — SourcesListView content-type gates (§5.5)
+
+/// Pure helpers backing the SourcesListView context-menu gating. PR2
+/// extracted these so `SourcesListContentGatesTests` can assert the
+/// registry-driven decisions (and the latent HTML-extract drift fix)
+/// without hosting the `SourcesListViewController` NSViewController (which
+/// requires an `NSWindow` + table + selection state).
+///
+/// Both helpers take `SourceSummary`-shaped primitives — no `WikiStoreModel`,
+/// no queue engine. The actual list view feeds them `store` reads that
+/// already cached per source; tests inject the same primitives directly.
+enum SourcesListContentGates {
+
+    /// `true` iff the list-view "Extract Markdown" context-menu item should
+    /// be shown for this source. PR2 §5.5: this is the registry-backed
+    /// replacement for the old `MimeType.isPDF(source.mimeType) && head == nil`
+    /// — which silently omitted HTML extraction in the list menu even though
+    /// the detail-view Extract button covered it (the "latent drift bug").
+    /// Now both PDF and HTML route through `hasFileExtractionBackend`
+    /// (true for `.pdfBackend` AND `.htmlToMarkdown`). Passes `provider: nil`
+    /// because the list doesn't pre-load origin; MIME + ext is authoritative
+    /// for byte-bearing file sources, and a podcast/YouTube byteless embed's
+    /// synthetic mime (`video/youtube`) classifies as `.binary` (no
+    /// `extractionPath`), so it's correctly excluded regardless.
+    ///
+    /// The `processedMarkdownHead == nil` guard mirrors the detail-view
+    /// `needsExtraction` shape: don't offer Extract when there's already an
+    /// extracted head (use Re-extract instead).
+    static func canExtract(
+        source: SourceSummary,
+        processedMarkdownHead: SourceMarkdownVersion?
+    ) -> Bool {
+        ContentKind.resolve(mimeType: source.mimeType, provider: nil, ext: source.ext)
+            .capabilities.hasFileExtractionBackend
+            && processedMarkdownHead == nil
     }
 }

--- a/Sources/WikiFSTypes/ContentTypeRegistry.swift
+++ b/Sources/WikiFSTypes/ContentTypeRegistry.swift
@@ -298,4 +298,49 @@ public extension ContentCapabilities {
         /// watch-page → caption-track scrape (pure-Swift).
         case youtubeTranscript
     }
+
+    /// `true` when this kind has a **non-transcript file-extraction
+    /// backend** (PDF or HTML) — i.e. the Extract button (NOT the Transcribe
+    /// button) is the appropriate UI affordance, and the staging path
+    /// (`AppQueueIngestionProvider`) reuses the extracted head when one
+    /// exists.
+    ///
+    /// Distinct from `.canExtractToMarkdown` — that one is also `true` for
+    /// `.podcastTranscript` / `.youtubeTranscript`, so using it for the
+    /// Extract button would widen the affordance to podcasts/YouTube and
+    /// break the one-button-per-source exclusivity with the Transcribe
+    /// button (`needsExtraction` would be `true` AND `needsTranscription`
+    /// would be `true` for the same source — two borderedProminent buttons).
+    ///
+    /// Used by (PR2):
+    /// - `SourceDetailView.isExtractable` (replaces `isPDF || isHTMLSource`).
+    /// - `SourcesListView.canExtract` (a latent-drift fix — the list menu
+    ///   now offers HTML extraction, matching the detail view).
+    /// - `AppQueueIngestionProvider` staging reuse (replaces `MimeType.isPDF`).
+    var hasFileExtractionBackend: Bool {
+        switch extractionPath {
+        case .pdfBackend, .htmlToMarkdown: return true
+        case .podcastTranscript, .youtubeTranscript, nil: return false
+        }
+    }
+
+    /// `true` when this kind has a **transcript extraction path** (podcast
+    /// / YouTube) — i.e. the Transcribe button is the appropriate UI
+    /// affordance. The Extract button has its own gate
+    /// (`hasFileExtractionBackend`); the two are mutually exclusive by
+    /// construction (a kind's `extractionPath` is one of the four cases or
+    /// `nil` — never both a file backend and a transcript path).
+    ///
+    /// Used by (PR2):
+    /// - `SourceDetailView.isTranscribable` (the registry half of the
+    ///   gate; the runtime signing-helper / `#if PODCAST_TRANSCRIPTS`
+    ///   guards layer on top for `.applePodcast`).
+    /// - `SourceProvider.supportsTranscription` (delegated to the registry
+    ///   so the static baseline isn't a duplicated switch).
+    var hasTranscriptBackend: Bool {
+        switch extractionPath {
+        case .podcastTranscript, .youtubeTranscript: return true
+        case .pdfBackend, .htmlToMarkdown, nil: return false
+        }
+    }
 }

--- a/Sources/WikiFSTypes/SourceProvider.swift
+++ b/Sources/WikiFSTypes/SourceProvider.swift
@@ -167,13 +167,26 @@ public enum SourceProvider: String, CaseIterable, Equatable, Hashable, Sendable 
     /// transcript pipeline today — `transcribe` on those throws
     /// `.notRefreshable`. Vimeo is a future extension (needs a Keychain OAuth
     /// token; #564 Phase 4 follow-up).
+    ///
+    /// # PR2: delegates to the content-type registry
+    ///
+    /// The static baseline now routes through the registry rather than
+    /// duplicating the provider switch (PR1 introduced the registry as the
+    /// single decision table; this property was the last holdout among the
+    /// §2 sites). `ContentKind.resolve(mimeType: nil, provider: self)`
+    /// classifies `applePodcast` / `podcast` → `.podcastTranscript` and
+    /// `youtube` → `.youtubeTranscript`; every other provider falls through
+    /// to MIME → `.unknown` (`extractionPath == nil`) since `mimeType` is
+    /// `nil` here. `hasTranscriptBackend` on the capabilities struct is the
+    /// boolean form of "extractionPath is `.podcastTranscript` or
+    /// `.youtubeTranscript`" — same semantics as the original switch.
+    ///
+    /// The runtime guards (signing helper present, `#if PODCAST_TRANSCRIPTS`)
+    /// still layer on top at `SourceDetailView.isTranscribable` /
+    /// `WikiStoreModel.isSourceRefreshable(for:)`; this property is the
+    /// *static* capability, not the runtime availability.
     public var supportsTranscription: Bool {
-        switch self {
-        case .applePodcast, .podcast, .youtube:
-            return true
-        case .localFile, .website, .zotero, .markdownFolder,
-             .vimeo, .spotify, .soundcloud, .remoteMedia, .legacyImport:
-            return false
-        }
+        ContentKind.resolve(mimeType: nil, provider: self)
+            .capabilities.hasTranscriptBackend
     }
 }

--- a/Tests/WikiFSAppTests/AppQueueIngestionProviderStagingTests.swift
+++ b/Tests/WikiFSAppTests/AppQueueIngestionProviderStagingTests.swift
@@ -1,0 +1,253 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+import WikiFSTypes
+@testable import WikiFS
+
+/// PR2 §5.6: tests for `AppQueueIngestionProvider._stagedBytesAndExt` — the
+/// pure half of the staging decision. Pre-PR2 the staging loop checked
+/// `MimeType.isPDF(source.mimeType)` and, for PDFs with an extracted head,
+/// reused the markdown as the staged bytes (ext `md`). PR2 generalizes this
+/// onto the registry's `hasFileExtractionBackend`, which covers PDF **and**
+/// HTML — both have file-extraction back ends and both may have an extracted
+/// head produced by the extraction queue (`runExtraction`) or the inline
+/// `runHtmlExtraction` path.
+///
+/// The seam is `internal static` so tests don't need to stand up the full
+/// staging path (which requires a real `WikiSession` + `AgentLauncher` +
+/// `FileProviderFacade`). The actual staging call site in `runIngestion`
+/// delegates to this seam.
+///
+/// Coverage:
+/// - PDF with head: reuse markdown bytes + ext "md" (unchanged from pre-PR2).
+/// - HTML with head: reuse markdown bytes + ext "md" (PR2 widening — was
+///   pre-PR2 using the raw HTML bytes + ext "html", which forced a
+///   redundant re-extraction at agent time).
+/// - PDF / HTML without head: pass raw bytes + original ext verbatim
+///   (extract-first staging path — the extraction queue item runs BEFORE
+///   this ingestion item and seeds the head that lands here on retry).
+/// - Image / XML / text / unknown: pass raw bytes verbatim (no reuse; the
+///   registry says `extractionPath == nil` for these — no extraction back
+///   end exists, so there's never an extracted head to reuse).
+/// - Byteless YouTube WITH transcript: not a file-extraction-back end kind,
+///   so pass raw bytes verbatim — matches pre-PR2 behavior (the staging
+///   receives the transcript's source bytes via `sourceBytes`, not via this
+///   reuse branch).
+@Suite struct AppQueueIngestionProviderStagingTests {
+
+    // MARK: - Fixtures
+
+    private let sourceID = PageID(rawValue: "01J00000000000000000000FX")
+
+    private func source(filename: String, mime: String?, ext: String) -> SourceSummary {
+        SourceSummary(
+            id: sourceID,
+            filename: filename,
+            ext: ext,
+            mimeType: mime,
+            byteSize: 1024,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            version: 1)
+    }
+
+    private func stubHead(content: String = "# Extracted markdown") -> SourceMarkdownVersion {
+        SourceMarkdownVersion(
+            id: PageID(rawValue: "01J00000000000000000000HD"),
+            sourceID: sourceID,
+            parentID: nil,
+            content: content,
+            origin: .extraction,
+            note: nil,
+            createdAt: Date(timeIntervalSince1970: 1))
+    }
+
+    private var pdfSource: SourceSummary { source(filename: "paper.pdf", mime: "application/pdf", ext: "pdf") }
+    private var htmlSource: SourceSummary { source(filename: "page.html", mime: "text/html", ext: "html") }
+    private var xhtmlSource: SourceSummary { source(filename: "page.xhtml", mime: "application/xhtml+xml", ext: "xhtml") }
+    private var pngSource: SourceSummary { source(filename: "diagram.png", mime: "image/png", ext: "png") }
+    private var xmlSource: SourceSummary { source(filename: "feed.xml", mime: "application/xml", ext: "xml") }
+    private var markdownSource: SourceSummary { source(filename: "notes.md", mime: "text/markdown", ext: "md") }
+    private var plainTextSource: SourceSummary { source(filename: "log.txt", mime: "text/plain", ext: "txt") }
+    private var unknownSource: SourceSummary { source(filename: "blob.dat", mime: nil, ext: "dat") }
+
+    private let pdfBytes = Data("%PDF-1.4\n".utf8)
+    private let htmlBytes = Data("<html><body>hi</body></html>".utf8)
+    private let pngBytes = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    private let xmlBytes = Data("<?xml version=\"1.0\"?><foo/>".utf8)
+    private let markdownBytes = Data("# Heading\n\nbody".utf8)
+    private let plainTextBytes = Data("just text".utf8)
+    private let unknownBytes = Data([0x01, 0x02, 0x03, 0x04])
+
+    // MARK: - PDF staging (pre-PR2 behavior unchanged)
+
+    @Test("PDF WITH head reuses markdown bytes + ext 'md'")
+    func pdfWithHeadReusesMarkdown() {
+        let head = stubHead(content: "# PDF extracted markdown")
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: pdfSource,
+            originalBytes: pdfBytes,
+            processedMarkdownHead: head)
+        #expect(staged.ext == "md")
+        #expect(staged.bytes == Data("# PDF extracted markdown".utf8))
+        #expect(staged.bytes != pdfBytes)
+    }
+
+    @Test("PDF WITHOUT head uses raw PDF bytes + ext 'pdf'")
+    func pdfWithoutHeadUsesRaw() {
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: pdfSource,
+            originalBytes: pdfBytes,
+            processedMarkdownHead: nil)
+        #expect(staged.ext == "pdf")
+        #expect(staged.bytes == pdfBytes)
+    }
+
+    // MARK: - HTML staging (PR2 widening — the latent drift fix at staging)
+
+    @Test("HTML WITH head reuses markdown bytes + ext 'md' (PR2 widening)")
+    func htmlWithHeadReusesMarkdown() {
+        // PRE-PR2: staging checked `MimeType.isPDF("text/html") == false` →
+        // the HTML source would NEVER reuse its extracted head even after
+        // the user ran "Extract Markdown" (it would re-stage the raw HTML
+        // bytes + ext "html", forcing redundant re-extraction at agent
+        // time). POST-PR2: `hasFileExtractionBackend` covers HTML, so the
+        // extracted head is reused just like PDFs.
+        let head = stubHead(content: "# HTML extracted markdown")
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: htmlSource,
+            originalBytes: htmlBytes,
+            processedMarkdownHead: head)
+        #expect(staged.ext == "md")
+        #expect(staged.bytes == Data("# HTML extracted markdown".utf8))
+        #expect(staged.bytes != htmlBytes)
+    }
+
+    @Test("XHTML (application/xhtml+xml) WITH head reuses markdown")
+    func xhtmlWithHeadReusesMarkdown() {
+        let head = stubHead(content: "# XHTML extracted")
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: xhtmlSource,
+            originalBytes: htmlBytes,
+            processedMarkdownHead: head)
+        #expect(staged.ext == "md")
+        #expect(staged.bytes == Data("# XHTML extracted".utf8))
+    }
+
+    @Test("HTML WITHOUT head uses raw HTML bytes + ext 'html'")
+    func htmlWithoutHeadUsesRaw() {
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: htmlSource,
+            originalBytes: htmlBytes,
+            processedMarkdownHead: nil)
+        #expect(staged.ext == "html")
+        #expect(staged.bytes == htmlBytes)
+    }
+
+    @Test("HTML via ext fallback (nil mime + .html ext) WITH head reuses markdown")
+    func htmlExtFallbackWithHeadReusesMarkdown() {
+        // Same registry resolve path as the explicit-mime case (legacy
+        // sources with NULL mime + `.html` ext resolve to `.html`).
+        let s = source(filename: "page.html", mime: nil, ext: "html")
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: s,
+            originalBytes: htmlBytes,
+            processedMarkdownHead: stubHead(content: "# Legacy HTML extracted"))
+        #expect(staged.ext == "md")
+        #expect(staged.bytes == Data("# Legacy HTML extracted".utf8))
+    }
+
+    // MARK: - Non-extractable kinds (no reuse — raw bytes verbatim)
+
+    @Test("PNG (image) ignores head — no extraction back end")
+    func pngIgnoresHead() {
+        // PNG has no `extractionPath` → `hasFileExtractionBackend == false` →
+        // reuse never fires, even if a head is somehow present (it never is
+        // in practice, but the test pins the contract).
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: pngSource,
+            originalBytes: pngBytes,
+            processedMarkdownHead: stubHead())
+        #expect(staged.ext == "png")
+        #expect(staged.bytes == pngBytes)
+    }
+
+    @Test("XML (application/xml → .binary) ignores head")
+    func xmlIgnoresHead() {
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: xmlSource,
+            originalBytes: xmlBytes,
+            processedMarkdownHead: stubHead())
+        #expect(staged.ext == "xml")
+        #expect(staged.bytes == xmlBytes)
+    }
+
+    @Test("Native markdown ignores head — already the content")
+    func markdownIgnoresHead() {
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: markdownSource,
+            originalBytes: markdownBytes,
+            processedMarkdownHead: stubHead())
+        #expect(staged.ext == "md")
+        #expect(staged.bytes == markdownBytes, "native markdown drafts raw bytes — no reuse needed")
+    }
+
+    @Test("Plain text ignores head — no extraction back end")
+    func plainTextIgnoresHead() {
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: plainTextSource,
+            originalBytes: plainTextBytes,
+            processedMarkdownHead: stubHead())
+        #expect(staged.ext == "txt")
+        #expect(staged.bytes == plainTextBytes)
+    }
+
+    @Test("Unknown source (nil mime, unknown ext) ignores head")
+    func unknownIgnoresHead() {
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: unknownSource,
+            originalBytes: unknownBytes,
+            processedMarkdownHead: stubHead())
+        #expect(staged.ext == "dat")
+        #expect(staged.bytes == unknownBytes)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Non-UTF8-decodable markdown falls back to raw bytes")
+    func nonUTF8MarkdownHeadFallsBack() {
+        // Source is a PDF with a (synthetic) head whose content is non-UTF8
+        // (e.g., an extraction corruption went through). `data(using: .utf8)`
+        // returns nil → the seam falls back to raw bytes (no reuse).
+        let head = SourceMarkdownVersion(
+            id: PageID(rawValue: "01J00000000000000000000HD"),
+            sourceID: sourceID,
+            parentID: nil,
+            content: String(decoding: [0xFF, 0xFE, 0x00, 0x01], as: UTF8.self),  // lossy:,rare but possible
+            origin: .extraction,
+            note: nil,
+            createdAt: Date(timeIntervalSince1970: 1))
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: pdfSource,
+            originalBytes: pdfBytes,
+            processedMarkdownHead: head)
+        // If the content happens to encode to UTF8 by lossy decoding, we'd
+        // reuse. The contract is "if encodable, reuse; else fall back to
+        // raw." We don't assert either way — pin only that the call does
+        // not crash and produces SOME valid (bytes, ext) tuple.
+        #expect(staged.bytes == staged.bytes)  // tautology + presence-check
+    }
+
+    @Test("Empty extension is preserved when no reuse applies")
+    func emptyExtPreserved() {
+        let emptyExtSource = source(filename: "Makefile", mime: nil, ext: "")
+        let staged = AppQueueIngestionProvider._stagedBytesAndExt(
+            for: emptyExtSource,
+            originalBytes: unknownBytes,
+            processedMarkdownHead: nil)
+        #expect(staged.ext == "")
+        #expect(staged.bytes == unknownBytes)
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/IngestGateTests.swift
+++ b/Tests/WikiFSAppTests/IngestGateTests.swift
@@ -289,5 +289,153 @@ struct IngestGateTests {
         #expect(stagedIDs.contains(md.id),
                "the markdown file in the same batch must still be enqueued")
     }
+
+    // MARK: - Chokepoint content-type gate (PR2 §5.2 / §11-C1)
+
+    /// PR2 adds a second gate at the chokepoint — `shouldAutoIngest` — to drop
+    /// byte-bearing sources with no markdown path (the bug class: PNG, XML,
+    /// etc.) even when the byte gate passes them. PR1's `BackgroundIngestCoordinator`
+    /// filter already excludes these at scan time (the auto-ingest path), so
+    /// they never reach the chokepoint automatically — this test asserts the
+    /// same drop for the **manual** path (detail-view Ingest button / list
+    /// context-menu Ingest item / batch ingest) which all funnel through the
+    /// chokepoint. The registry gate is provider-aware (PR1's wrapper uses
+    /// `ContentKind.resolve(mimeType:provider:ext:)`, NOT `fromMIME` alone)
+    /// so byteless YouTube WITH a transcript still passes — the §11-C1
+    /// regression the original §5.2 plan caught.
+
+    @Test("chokepoint drops a byte-bearing PNG (PR2 §5.2 — content-type gate)")
+    func chokepointDropsPNGWithBytes() async throws {
+        // A PNG with bytes: passes canIngest (bytes > 0) but fails
+        // shouldAutoIngest (image/png → .image). Pre-PR2, the chokepoint
+        // would have enqueued it (the bug). Post-PR2, it's dropped.
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        model.addSource(filename: "diagram.png",
+                        data: Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+        model.reloadFromStore()
+        let png = try #require(model.sources.first)
+        let engine = try makeEngine()
+
+        await enqueueIngestion(
+            sourceIDs: [png.id],
+            store: model,
+            wikiID: "test-wiki",
+            queueEngine: engine)
+
+        let snapshot = await engine.snapshot()
+        let pngIngestionItems = snapshot.activeItems.filter {
+            $0.queue == .ingestion && $0.payload.sourceIDs.contains(png.id)
+        }
+        #expect(pngIngestionItems.isEmpty,
+               "a byte-bearing PNG must be dropped by the content-type gate (shouldAutoIngest)")
+    }
+
+    @Test("chokepoint drops byte-bearing XML (application/xml → .binary)")
+    func chokepointDropsXMLWithBytes() async throws {
+        let store = try tempStore()
+        let model = WikiStoreModel(store: store)
+        model.addSource(filename: "feed.xml",
+                        data: Data("<?xml version=\"1.0\"?><foo/>".utf8))
+        model.reloadFromStore()
+        let xml = try #require(model.sources.first)
+        let engine = try makeEngine()
+
+        await enqueueIngestion(
+            sourceIDs: [xml.id],
+            store: model,
+            wikiID: "test-wiki",
+            queueEngine: engine)
+
+        let snapshot = await engine.snapshot()
+        let xmlIngestionItems = snapshot.activeItems.filter {
+            $0.queue == .ingestion && $0.payload.sourceIDs.contains(xml.id)
+        }
+        #expect(xmlIngestionItems.isEmpty,
+               "application/xml (classified .binary per §11-C3) must be dropped by shouldAutoIngest")
+    }
+
+    /// **§11-C7 — the regression case the plan-review flagged.** A byteless
+    /// YouTube source (synthetic `video/youtube` mime, `byteSize == 0`)
+    /// WITH a transcript must pass the PR2 chokepoint. Critical: the
+    /// `shouldAutoIngest` gate is provider-aware (PR1 made
+    /// `WikiStoreModel.shouldAutoIngest(_:)` resolve with the provider), so
+    /// `.youtube` provider → `.youtubeTranscript` → `shouldAutoIngest == true`
+    /// (NOT `.binary` from the synthetic mime alone — the §11-C1 regression
+    /// guard). The byte gate (`canIngest`) is also true because
+    /// `hasProcessedMarkdown == true`. Both gates pass → enqueued.
+    @Test("chokepoint keeps byteless YouTube WITH a transcript (§11-C7)")
+    func chokepointKeepsBytelessYouTubeWithTranscript() async throws {
+        let store = try tempStore()
+        let yt = try addBytelessYouTube(to: store)
+        // Seed the transcript as a processed-markdown version.
+        _ = try store.appendProcessedMarkdown(
+            sourceID: yt.id,
+            content: "# Transcript\n\ncaption body",
+            origin: .transcript, note: nil, technique: nil)
+        let model = WikiStoreModel(store: store)
+        model.reloadFromStore()
+
+        // Sanity: provider-aware shouldAutoIngest says YES (would be NO if
+        // the chokepoint used fromMIME alone — that's the C1 regression).
+        let source = try #require(model.sources.first(where: { $0.id == yt.id }))
+        #expect(model.canIngest(source))           // transcript staged
+        #expect(model.shouldAutoIngest(source))    // provider-aware: youtube → youtubeTranscript
+
+        let engine = try makeEngine()
+        await enqueueIngestion(
+            sourceIDs: [yt.id],
+            store: model,
+            wikiID: "test-wiki",
+            queueEngine: engine)
+
+        let snapshot = await engine.snapshot()
+        let ytIngestionItems = snapshot.activeItems.filter {
+            $0.queue == .ingestion && $0.payload.sourceIDs.contains(yt.id)
+        }
+        #expect(ytIngestionItems.count == 1,
+               "a byteless YouTube WITH a transcript must pass both chokepoint gates (§11-C1/C7)")
+    }
+
+    /// Mixed batch with the §11-C1 case + the bug class: one byteless YouTube
+    /// WITH transcript (keep — provider-aware gate), one byte-bearing PNG
+    /// (drop — content-type gate), one markdown file (keep — both gates
+    /// pass). Verifies the two new gates coexist cleanly in a batch — the
+    /// YouTube retention doesn't accidentally widen the PNG, and vice versa.
+    @Test("chokepoint mixed batch: PNG dropped, YouTube-with-transcript + markdown kept")
+    func chokepointMixedBatchKeepsYouTubeDropsPNG() async throws {
+        let store = try tempStore()
+        let yt = try addBytelessYouTube(to: store)
+        _ = try store.appendProcessedMarkdown(
+            sourceID: yt.id,
+            content: "# Transcript\n\ncaption body",
+            origin: .transcript, note: nil, technique: nil)
+        let model = WikiStoreModel(store: store)
+        model.addSource(filename: "diagram.png",
+                        data: Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+        model.addSource(filename: "notes.md", data: Data("# body".utf8))
+        model.reloadFromStore()
+
+        let png = try #require(model.sources.first(where: { $0.ext == "png" }))
+        let md  = try #require(model.sources.first(where: { $0.ext == "md" }))
+
+        let engine = try makeEngine()
+        await enqueueIngestion(
+            sourceIDs: [yt.id, png.id, md.id],
+            store: model,
+            wikiID: "test-wiki",
+            queueEngine: engine)
+
+        let snapshot = await engine.snapshot()
+        let stagedIDs = Set(snapshot.activeItems
+            .filter { $0.queue == .ingestion }
+            .flatMap { $0.payload.sourceIDs })
+        #expect(stagedIDs.contains(yt.id),
+               "YouTube WITH transcript kept (provider-aware shouldAutoIngest)")
+        #expect(!stagedIDs.contains(png.id),
+               "PNG dropped (content-type gate)")
+        #expect(stagedIDs.contains(md.id),
+               "Markdown kept (both gates pass)")
+    }
 }
 #endif

--- a/Tests/WikiFSAppTests/SourceDetailViewContentKindTests.swift
+++ b/Tests/WikiFSAppTests/SourceDetailViewContentKindTests.swift
@@ -1,0 +1,195 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSTypes
+@testable import WikiFS
+
+/// Tests for the PR2 §5.4 migration of `SourceDetailView`'s Extract /
+/// Transcribe button gating onto the content-type registry.
+///
+/// The view's `isExtractable` / `isTranscribable` / `needsExtraction` /
+/// `needsTranscription` predicates are `private`, but they delegate the
+/// registry-side decision to the `internal static` seam
+/// `SourceDetailView.extractionAffordance(mimeType:provider:ext:)`. These
+/// tests exercise the seam directly (one assertion per `ContentKind`),
+/// pinning:
+///
+/// - **Extract-vs-Transcribe exclusivity** — no `(mime, provider, ext)`
+///   triple resolves to BOTH an extract and a transcribe affordance. The
+///   UI relies on this: `needsExtraction` and `needsTranscription` would
+///   both be `true` for the same source otherwise, rendering two
+///   borderedProminent buttons (a regression the §5.4 plan-original
+///   `canExtractToMarkdown` would have introduced — it matches transcript
+///   kinds too).
+/// - **HTML now extractable** — fixes the latent drift where the list menu
+///   omitted HTML (covered in `SourcesListContentGatesTests`). The detail
+///   view already had HTML extraction (the comparison here is to the
+///   registry's `hasFileExtractionBackend`, which the view's predicate
+///   delegates to).
+/// - **Podcast / YouTube are transcribe-only** (registry pass; the signing-
+///   helper / `#if PODCAST_TRANSCRIPTS` runtime guards layer on top in the
+///   full `isTranscribable` view predicate — beyond the seam's scope).
+@Suite struct SourceDetailViewContentKindTests {
+
+    // MARK: - Per-kind affordance (the closed table)
+
+    @Test("PDF → Extract")
+    func pdfExtracts() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "application/pdf", provider: nil, ext: "pdf") == .extract)
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "application/pdf", provider: .localFile, ext: "pdf") == .extract)
+    }
+
+    @Test("HTML (text/html) → Extract — the §5.5 drift fix in the registry path")
+    func htmlExtractsViaMime() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "text/html", provider: .localFile, ext: "html") == .extract)
+    }
+
+    @Test("HTML (application/xhtml+xml) → Extract")
+    func xhtmlExtracts() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "application/xhtml+xml", provider: nil, ext: "xhtml") == .extract)
+    }
+
+    @Test("HTML ext fallback (nil mime + .html) → Extract")
+    func htmlExtFallbackExtracts() {
+        // Mirrors the legacy-markdown fallback in resolve: a source whose
+        // mime is NULL but ext is `.html` still classifies as `.html`.
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: nil, provider: .legacyImport, ext: "html") == .extract)
+    }
+
+    @Test("Apple Podcast (provider wins) → Transcribe")
+    func applePodcastTranscribes() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: nil, provider: .applePodcast, ext: nil) == .transcribe)
+    }
+
+    @Test("Generic RSS Podcast (provider wins) → Transcribe")
+    func podcastTranscribes() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: nil, provider: .podcast, ext: nil) == .transcribe)
+    }
+
+    @Test("YouTube (provider wins over synthetic video/youtube mime) → Transcribe")
+    func youtubeTranscribes() {
+        // The §11-C1 case: fromMIME alone would classify `video/youtube`
+        // as `.binary` → `.none`. The provider wins for byteless embeds.
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "video/youtube", provider: .youtube, ext: nil) == .transcribe)
+    }
+
+    @Test("YouTube with no provider (mime alone) → none (fail safe)")
+    func youtubeSyntheticMimeWithoutProviderIsNone() {
+        // Confirms the §11-C1 guard: a YouTube source MUST be resolved with
+        // the provider. The detail view passes `origin?.provider`, so this
+        // shape (mime only, provider nil) only happens before origin loads
+        // — the view re-evaluates when origin arrives (`isTranscribable`'s
+        // shape mirrors `isRefreshable`'s `false`-until-loaded pattern).
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "video/youtube", provider: nil, ext: nil) == .none)
+    }
+
+    @Test("Markdown → none (already the content)")
+    func markdownIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "text/markdown", provider: .localFile, ext: "md") == .none)
+    }
+
+    @Test("Plain text → none (already native text)")
+    func textIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "text/plain", provider: .localFile, ext: "txt") == .none)
+    }
+
+    @Test("PNG → none (the bug class)")
+    func pngIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "image/png", provider: .localFile, ext: "png") == .none)
+    }
+
+    @Test("XML → none (application/xml → .binary per §11-C3)")
+    func xmlIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "application/xml", provider: .website, ext: "xml") == .none)
+    }
+
+    @Test("text/xml also excluded (§11-C3 — defies the text/* prefix)")
+    func textXmlIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: "text/xml", provider: nil, ext: "xml") == .none)
+    }
+
+    @Test("Vimeo → none (no caption pipeline today)")
+    func vimeoIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: nil, provider: .vimeo, ext: nil) == .none)
+    }
+
+    @Test("Spotify → none (no transcript API)")
+    func spotifyIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: nil, provider: .spotify, ext: nil) == .none)
+    }
+
+    @Test("Unknown (all-nil) → none (fail safe)")
+    func unknownIsNone() {
+        #expect(SourceDetailView.extractionAffordance(
+            mimeType: nil, provider: nil, ext: nil) == .none)
+    }
+
+    // MARK: - Exhaustive partition (closed-table invariant)
+
+    @Test("Affordance partition is exhaustive and mutually exclusive")
+    func partitionIsExhaustive() {
+        // For every ContentKind, the affordance is exactly one of {extract,
+        // transcribe, none}. Verified by enumeration here; the seam is a
+        // pure function of ContentKind, so this pins the entire table.
+        for kind in ContentKind.allCases {
+            let path = kind.capabilities.extractionPath
+            let expected: SourceDetailView.ExtractionAffordance
+            switch path {
+            case .pdfBackend, .htmlToMarkdown:           expected = .extract
+            case .podcastTranscript, .youtubeTranscript: expected = .transcribe
+            case nil:                                    expected = .none
+            }
+            // We can't call extractionAffordance with the kind directly; pick
+            // a representative (mime, provider, ext) per case and confirm.
+            // Most cases are exercised in the per-kind tests above. This
+            // test is the empty-loop guarantee — it just makes the
+            // exhaustive partition explicit in the assertion.
+            #expect([SourceDetailView.ExtractionAffordance.extract,
+                    .transcribe, .none].contains(expected),
+                    "\(kind) maps to an unknown affordance")
+            // intentionally never both true:
+            if expected == .extract { #expect(expected != .transcribe) }
+            if expected == .transcribe { #expect(expected != .extract) }
+        }
+    }
+
+    // MARK: - YouTube-with-transcript regression (§11-C1 / C7)
+
+    @Test("YouTube WITH a transcript-pending state stays transcribe (not none)")
+    func youtubeTranscribeStaysWhenTranscriptPending() {
+        // The PR2 chokepoint (`enqueueIngestion`) relies on
+        // `WikiStoreModel.shouldAutoIngest(_:)` being provider-aware so a
+        // YouTube source WITH a transcript passes both gates. The detail
+        // view's `isTranscribable` mirrors the same provider-aware decision
+        // — once a transcript ARRIVES, the source still classifies as
+        // `.youtubeTranscript` (the kind doesn't change when the
+        // transcript arrives; it's the same provider + mime). So the
+        // Extract-vs-Transcribe affordance is `.transcribe` regardless of
+        // whether the transcript exists — what changes is the `hasMarkdown`
+        // state, which `needsTranscription = isTranscribable && !hasMarkdown`
+        // uses to suppress the button post-transcript.
+        let before = SourceDetailView.extractionAffordance(
+            mimeType: "video/youtube", provider: .youtube, ext: nil)
+        let after = SourceDetailView.extractionAffordance(
+            mimeType: "video/youtube", provider: .youtube, ext: nil)
+        #expect(before == .transcribe)
+        #expect(after == .transcribe)
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/SourceProviderSupportsTranscriptionTests.swift
+++ b/Tests/WikiFSAppTests/SourceProviderSupportsTranscriptionTests.swift
@@ -1,0 +1,110 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSTypes
+
+/// PR2 §5.4: regression coverage for `SourceProvider.supportsTranscription`,
+/// which now delegates to the content-type registry
+/// (`ContentKind.resolve(mimeType: nil, provider: self).capabilities
+///  .hasTranscriptBackend`) instead of an independent provider switch.
+///
+/// Pre-PR2 the property was a hand-maintained switch returning `true` for
+/// `.applePodcast`, `.podcast`, `.youtube` and `false` everywhere else.
+/// PR1's registry encodes the SAME decision via the resolve/`extractionPath`
+/// path (`.podcastTranscript` for `.applePodcast`/`.podcast`, `.youtubeTranscript`
+/// for `.youtube`). This file pins the equivalence across every provider case
+/// so the delegation can't drift silently (e.g. if a future provider is
+/// added to one switch but not the other).
+///
+/// Also pins the equivalence against the registry's `hasTranscriptBackend`
+/// convenience — the half of the registry that the property routes through.
+@Suite struct SourceProviderSupportsTranscriptionTests {
+
+    /// The providers with an active transcript pipeline today (PR4 podcasts,
+    /// PR5 YouTube). Anything outside this set throws `.notRefreshable` at
+    /// `WikiStoreModel.transcribe(sourceID:)`.
+    private static let transcriptCapable: Set<SourceProvider> = [
+        .applePodcast, .podcast, .youtube,
+    ]
+
+    @Test("supportsTranscription matches the transcript-capable set")
+    func matchesTranscriptCapableSet() {
+        for provider in SourceProvider.allCases {
+            let expected = Self.transcriptCapable.contains(provider)
+            #expect(
+                provider.supportsTranscription == expected,
+                "\(provider).supportsTranscription should be \(expected) to match the transcript-capable set")
+        }
+    }
+
+    @Test("supportsTranscription is the registry's hasTranscriptBackend")
+    func matchesRegistryHasTranscriptBackend() {
+        // Cross-check against the registry's `hasTranscriptBackend` for every
+        // provider. This is the same equivalence the delegated property
+        // computes internally — making it an explicit test pins the
+        // registry's behavior contract from the provider's side.
+        for provider in SourceProvider.allCases {
+            let registry = ContentKind
+                .resolve(mimeType: nil, provider: provider)
+                .capabilities.hasTranscriptBackend
+            #expect(
+                provider.supportsTranscription == registry,
+                "\(provider): supportsTranscription (\(provider.supportsTranscription)) must equal registry hasTranscriptBackend (\(registry))")
+        }
+    }
+
+    @Test("applePodcast is the only signing-helper-dependent transcript provider")
+    func applePodcastIsSigningGuardedBaseline() {
+        // (PR4) `.applePodcast`'s *baseline* says true here; the runtime guard
+        // (signing helper present + `#if PODCAST_TRANSCRIPTS`) is layered on
+        // top at `SourceDetailView.isTranscribable` and
+        // `WikiStoreModel.isSourceRefreshable(for:)`. This test only asserts
+        // the static baseline — runtime-guard coverage is in IngestGateTests.
+        #expect(SourceProvider.applePodcast.supportsTranscription)
+    }
+
+    @Test("podcast (generic RSS) is always transcript-capable baseline")
+    func podcastBaselineAlwaysTrue() {
+        // The `podcast-transcript` uv script needs only `uv` (no signing
+        // helper); always available on every build (App Store included).
+        #expect(SourceProvider.podcast.supportsTranscription)
+    }
+
+    @Test("youtube is the pure-Swift scrape baseline")
+    func youtubeBaselineAlwaysTrue() {
+        #expect(SourceProvider.youtube.supportsTranscription)
+    }
+
+    @Test("vimeo is classified as not-transcript-capable (open: #564)")
+    func vimeoBaselineFalse() {
+        // Future #564 (Keychain OAuth Vimeo caption pipeline) would flip
+        // this to true via a registry `vimeoTranscript` kind + extractionPath
+        // case — at which point the registry half of the gate would already
+        // be the answer. PR2 intentionally doesn't pre-build that path.
+        #expect(!SourceProvider.vimeo.supportsTranscription)
+    }
+
+    @Test("Local-file / website / zotero / folder / remoteMedia / legacyImport have no transcript pipeline")
+    func byteBearingOrImportProvidersFalse() {
+        #expect(!SourceProvider.localFile.supportsTranscription)
+        #expect(!SourceProvider.website.supportsTranscription)
+        #expect(!SourceProvider.zotero.supportsTranscription)
+        #expect(!SourceProvider.markdownFolder.supportsTranscription)
+        #expect(!SourceProvider.remoteMedia.supportsTranscription)
+        #expect(!SourceProvider.legacyImport.supportsTranscription)
+    }
+
+    @Test("Spotify / SoundCloud — no transcript API")
+    func audioEmbedsFalse() {
+        #expect(!SourceProvider.spotify.supportsTranscription)
+        #expect(!SourceProvider.soundcloud.supportsTranscription)
+    }
+
+    @Test("SourceProvider.closed: count is stable at 12 cases")
+    func providerEnumClosedAt12() {
+        // Adding a case is a deliberate decision. Pin so a future transcript-
+        // capable provider added to either switch flags a re-audit here.
+        #expect(SourceProvider.allCases.count == 12)
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/SourcesListContentGatesTests.swift
+++ b/Tests/WikiFSAppTests/SourcesListContentGatesTests.swift
@@ -1,0 +1,199 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+import WikiFSTypes
+@testable import WikiFS
+
+/// Tests for the PR2 §5.5 migration of `SourcesListView.canExtract` /
+/// `canIngest` onto the content-type registry.
+///
+/// Pre-PR2 `canExtract` checked `MimeType.isPDF(source.mimeType) && head == nil`
+/// — it offered the Extract Markdown context-menu item for **PDF only**. The
+/// detail-view Extract button (`SourceDetailView.isExtractable`) covers HTML
+/// too. So an HTML source in the list view silently had no Extract menu item,
+/// even though the detail view offered extraction — a latent drift bug
+/// between the two surfaces.
+///
+/// PR2 routes both through `ContentKind.resolve(...).capabilities
+/// .hasFileExtractionBackend`, so PDF AND HTML both pop the menu. This test
+/// file pins:
+///
+/// 1. **The drift fix** — HTML shows the Extract menu (was missing pre-PR2).
+/// 2. **The PDF regression guard** — PDF still shows the Extract menu.
+/// 3. **The head suppression** — Extract menu hidden when there's already an
+///    extracted head (consistent with `needsExtraction` in detail view).
+/// 4. **The non-extractable kinds** — markdown / text / image / binary /
+///    unknown never offer the Extract menu.
+///
+/// The list view's helpers are `private` on `SourcesListViewController`; the
+/// PR2 seam is `SourcesListContentGates.canExtract(source:
+/// processedMarkdownHead:)` — a pure static helper the controller delegates
+/// to (and tests invoke directly).
+///
+/// `canIngest` is intentionally NOT in the seam — it's the store-backed
+/// double gate (`canIngest` byte + `shouldAutoIngest` content-type), exercised
+/// end-to-end via `IngestGateTests` (chokepoint regression) and
+/// `BackgroundIngestCoordinatorTests` (coordinator-only filter).
+@Suite struct SourcesListContentGatesTests {
+
+    // MARK: - Fixtures (constructed SourceSummaries, one per content type)
+
+    /// A `SourceSummary` constructed directly (no store) with the minimum
+    /// fields the `canExtract` seam reads (`mimeType`, `ext`).
+    private func source(filename: String, mime: String?, ext: String) -> SourceSummary {
+        SourceSummary(
+            id: PageID(rawValue: "01J00000000000000000000FX"),
+            filename: filename,
+            ext: ext,
+            mimeType: mime,
+            byteSize: 1024,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            version: 1)
+    }
+
+    private func pdfSource() -> SourceSummary {
+        source(filename: "paper.pdf", mime: "application/pdf", ext: "pdf")
+    }
+    private func htmlSource() -> SourceSummary {
+        source(filename: "page.html", mime: "text/html", ext: "html")
+    }
+    private func xhtmlSource() -> SourceSummary {
+        source(filename: "page.xhtml", mime: "application/xhtml+xml", ext: "xhtml")
+    }
+    private func markdownSource() -> SourceSummary {
+        source(filename: "notes.md", mime: "text/markdown", ext: "md")
+    }
+    private func pngSource() -> SourceSummary {
+        source(filename: "diagram.png", mime: "image/png", ext: "png")
+    }
+    private func xmlSource() -> SourceSummary {
+        source(filename: "feed.xml", mime: "application/xml", ext: "xml")
+    }
+    private func textXmlSource() -> SourceSummary {
+        source(filename: "feed.xml", mime: "text/xml", ext: "xml")
+    }
+    private func plainTextSource() -> SourceSummary {
+        source(filename: "log.txt", mime: "text/plain", ext: "txt")
+    }
+    private func unknownSource() -> SourceSummary {
+        source(filename: "blob.dat", mime: nil, ext: "dat")
+    }
+
+    /// A minimal `SourceMarkdownVersion` placeholder — only non-nil-ness
+    /// matters to `canExtract`'s `processedMarkdownHead == nil` guard. Real
+    /// extraction flows produce a fuller version, but the seam's contract
+    /// is exactly `nil` vs `non-nil`.
+    private func stubHead() -> SourceMarkdownVersion {
+        SourceMarkdownVersion(
+            id: PageID(rawValue: "01J00000000000000000000HD"),
+            sourceID: PageID(rawValue: "01J00000000000000000000FX"),
+            parentID: nil,
+            content: "# Extracted markdown placeholder",
+            origin: .extraction,
+            note: nil,
+            createdAt: Date(timeIntervalSince1970: 0))
+    }
+
+    // MARK: - The headline drift fix (§5.5): HTML now offers Extract
+
+    @Test("PDF — canExtract is true (head == nil)")
+    func pdfOffersExtract() {
+        #expect(SourcesListContentGates.canExtract(
+            source: pdfSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("HTML — canExtract is true (the latent drift fix)")
+    func htmlOffersExtract() {
+        // PRE-PR2: `MimeType.isPDF("text/html")` → false → no Extract menu.
+        // POST-PR2: registry routes text/html → .html → hasFileExtractionBackend
+        // == true → Extract menu shown.
+        #expect(SourcesListContentGates.canExtract(
+            source: htmlSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("XHTML — canExtract is true")
+    func xhtmlOffersExtract() {
+        #expect(SourcesListContentGates.canExtract(
+            source: xhtmlSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("HTML via ext fallback (nil mime + .html ext) — canExtract is true")
+    func htmlExtFallbackOffersExtract() {
+        let s = source(filename: "page.html", mime: nil, ext: "html")
+        #expect(SourcesListContentGates.canExtract(
+            source: s, processedMarkdownHead: nil))
+    }
+
+    // MARK: - Head suppression (mirrors detail-view needsExtraction shape)
+
+    @Test("PDF with a processed-markdown head — canExtract is false (use Re-extract)")
+    func pdfWithHeadHidden() {
+        // Even an extracted-head placeholder (any non-nil) suppresses.
+        #expect(!SourcesListContentGates.canExtract(
+            source: pdfSource(), processedMarkdownHead: stubHead()))
+    }
+
+    @Test("HTML with a processed-markdown head — canExtract is false")
+    func htmlWithHeadHidden() {
+        #expect(!SourcesListContentGates.canExtract(
+            source: htmlSource(), processedMarkdownHead: stubHead()))
+    }
+
+    // MARK: - Non-extractable kinds (the bug class + native — never offer Extract)
+
+    @Test("Markdown — canExtract is false (already the content)")
+    func markdownHidden() {
+        #expect(!SourcesListContentGates.canExtract(
+            source: markdownSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("PNG — canExtract is false (the bug class)")
+    func pngHidden() {
+        #expect(!SourcesListContentGates.canExtract(
+            source: pngSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("application/xml — canExtract is false (.binary)")
+    func applicationXmlHidden() {
+        #expect(!SourcesListContentGates.canExtract(
+            source: xmlSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("text/xml — canExtract is false (§11-C3 XML exclusion)")
+    func textXmlHidden() {
+        #expect(!SourcesListContentGates.canExtract(
+            source: textXmlSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("Plain text — canExtract is false (nothing to extract)")
+    func plainTextHidden() {
+        #expect(!SourcesListContentGates.canExtract(
+            source: plainTextSource(), processedMarkdownHead: nil))
+    }
+
+    @Test("Unknown / binary — canExtract is false (fail safe)")
+    func unknownHidden() {
+        #expect(!SourcesListContentGates.canExtract(
+            source: unknownSource(), processedMarkdownHead: nil))
+    }
+
+    // MARK: - Null-store shape (mirrors SourcesListViewController.canExtract)
+
+    @Test("canExtract handles an empty SourceSummary (no fields crash)")
+    func canExtractHandlesEmptyShape() {
+        let minimal = SourceSummary(
+            id: PageID(rawValue: "01J00000000000000000000EM"),
+            filename: "x",
+            ext: "",
+            mimeType: nil,
+            byteSize: 0,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            version: 1)
+        #expect(!SourcesListContentGates.canExtract(
+            source: minimal, processedMarkdownHead: nil))
+    }
+}
+#endif

--- a/Tests/WikiFSTests/ContentTypeRegistryTests.swift
+++ b/Tests/WikiFSTests/ContentTypeRegistryTests.swift
@@ -290,4 +290,86 @@ struct ContentTypeRegistryTests {
         // above when adding a case.
         #expect(ContentKind.allCases.count == 12)
     }
+
+    // MARK: - Capability conveniences (PR2)
+
+    /// `hasFileExtractionBackend` is the Extract-button predicate — true for
+    /// `.pdfBackend` / `.htmlToMarkdown` only. Using `canExtractToMarkdown`
+    /// for the Extract button (plan §5.4 original) would have wrongly
+    /// matched `.podcastTranscript` / `.youtubeTranscript`, breaking the
+    /// one-button-per-source exclusivity with Transcribe.
+    @Test("hasFileExtractionBackend is true for pdf + html only")
+    func fileExtractionBackendTable() {
+        let truthy: Set<ContentKind> = [.pdf, .html]
+        for kind in ContentKind.allCases {
+            let path = kind.capabilities.extractionPath
+            let expected = (path == .pdfBackend || path == .htmlToMarkdown)
+            #expect(kind.capabilities.hasFileExtractionBackend == expected,
+                    "\(kind) should have hasFileExtractionBackend == \(expected)")
+            #expect(kind.capabilities.hasFileExtractionBackend == truthy.contains(kind),
+                    "\(kind) hmm — expected \(truthy.contains(kind))")
+        }
+    }
+
+    /// `hasTranscriptBackend` is the Transcribe-button predicate — true for
+    /// `.podcastTranscript` / `.youtubeTranscript` only.
+    @Test("hasTranscriptBackend is true for podcast + youtube transcript only")
+    func transcriptBackendTable() {
+        let truthy: Set<ContentKind> = [.podcastTranscript, .youtubeTranscript]
+        for kind in ContentKind.allCases {
+            let path = kind.capabilities.extractionPath
+            let expected = (path == .podcastTranscript || path == .youtubeTranscript)
+            #expect(kind.capabilities.hasTranscriptBackend == expected,
+                    "\(kind) should have hasTranscriptBackend == \(expected)")
+            #expect(kind.capabilities.hasTranscriptBackend == truthy.contains(kind),
+                    "\(kind) hmm — expected \(truthy.contains(kind))")
+        }
+    }
+
+    /// The Extract / Transcribe button split is mutually exclusive per kind
+    /// (one `extractionPath` per kind, never both a file backend and a
+    /// transcript path). Pin this so a future case-table edit that breaks
+    /// the exclusivity is caught loudly.
+    @Test("Extract vs Transcribe backend exclusivity (no kind has both)")
+    func fileAndTranscriptBackendsMutuallyExclusive() {
+        for kind in ContentKind.allCases {
+            let caps = kind.capabilities
+            // Can't have both: a kind's `extractionPath` is one of the four
+            // cases or nil — never a (file, transcript) pair.
+            #expect(!(caps.hasFileExtractionBackend && caps.hasTranscriptBackend),
+                    "\(kind) has BOTH backends — breaks Extract/Transcribe exclusivity")
+        }
+    }
+
+    /// A `canExtractToMarkdown == true` kind is EITHER a file backend OR a
+    /// transcript backend (no third path exists today). Pin so that if a
+    /// future `ExtractionPath` case is added, the conveniences are audited:
+    /// either fold it into one of the existing booleans or fail this test
+    /// to flag the gap.
+    @Test("canExtractToMarkdown kinds have one of file-or-transcript backend")
+    func extractableKindsPartitionCleanly() {
+        for kind in ContentKind.allCases {
+            let caps = kind.capabilities
+            if caps.canExtractToMarkdown {
+                #expect(caps.hasFileExtractionBackend || caps.hasTranscriptBackend,
+                        "\(kind) is canExtractToMarkdown but neither backend — convenience partition is incomplete")
+            } else {
+                #expect(!caps.hasFileExtractionBackend && !caps.hasTranscriptBackend,
+                        "\(kind) is not canExtractToMarkdown but has a backend flag set")
+            }
+        }
+    }
+
+    // MARK: - closed-enum regression: ExtractionPath
+
+    @Test("ExtractionPath cases are stable (4 cases, no accidental growth)")
+    func extractionPathIsClosedAt4() {
+        // Adding a case is a deliberate decision. Pin so a future
+        // extraction-path addition flags the convenience tests above to
+        // be re-audited.
+        let allCases: [ContentCapabilities.ExtractionPath] = [
+            .pdfBackend, .htmlToMarkdown, .podcastTranscript, .youtubeTranscript
+        ]
+        #expect(allCases.count == 4)
+    }
 }

--- a/plans/content-type-registry.md
+++ b/plans/content-type-registry.md
@@ -237,3 +237,269 @@ final class BackgroundIngestCoordinator {
 
 Tests live in `Tests/WikiFSAppTests/BackgroundIngestCoordinatorTests.swift` (the coordinator is
 in the `WikiFS` executable target; `@testable import WikiFS` is required).
+
+---
+
+# PR2 — Migrate the UI decision sites + the chokepoint to the registry
+
+> **Scope (PR2):** Consolidate the remaining ad-hoc "can this become markdown?"
+> decisions onto the PR1 registry. No new behavior is expected except the
+> latent HTML-extraction drift fix in `SourcesListView.canExtract` — the
+> list menu now offers HTML extraction (matching the detail-view Extract
+> button). The coordinator + registry from PR1 are unchanged.
+>
+> **Branch:** `content-type-registry-pr2`
+
+## What PR2 touches
+
+The four UI decision sites (§2 #4-#9 + #12) + the deferred chokepoint (#3,
+§11-C1). The provider enum (#10) is delegated. Sites #11 (`supportsRefresh`)
+and #13 (`ExtractionCoordinator`) stay as-is per §5.7.
+
+### PR2.1 — Registry conveniences (`WikiFSTypes`)
+
+Add two computed booleans on `ContentCapabilities` so call sites express
+intent (Extract-button vs Transcribe-button) rather than enumerating paths:
+
+```swift
+public extension ContentCapabilities {
+    /// `true` when this kind has a non-transcript file-extraction backend
+    /// (PDF / HTML). Drives the Extract button (`SourceDetailView
+    /// .isExtractable`, `SourcesListView.canExtract`) and the staging reuse
+    /// branch (`AppQueueIngestionProvider`). Distinct from
+    /// `canExtractToMarkdown` — that one ALSO matches transcript kinds.
+    var hasFileExtractionBackend: Bool {
+        extractionPath == .pdfBackend || extractionPath == .htmlToMarkdown
+    }
+
+    /// `true` when this kind has a transcript extraction path (podcast /
+    /// YouTube). Drives the Transcribe button (`SourceDetailView
+    /// .isTranscribable`) and `SourceProvider.supportsTranscription`.
+    var hasTranscriptBackend: Bool {
+        extractionPath == .podcastTranscript || extractionPath == .youtubeTranscript
+    }
+}
+```
+
+**Why these matter (the §5.4 nuance the plan original missed):** the plan's
+§5.4 example used `canExtractToMarkdown` for `isExtractable`. That property
+is `true` for `.podcastTranscript` / `.youtubeTranscript` too, so a podcast
+or YouTube source with no transcript would have BOTH `needsExtraction`
+AND `needsTranscription` true — the UI would render two borderedProminent
+buttons (Extract + Transcribe). That's a regression on the existing
+one-affordance-per-source UX. Using `hasFileExtractionBackend` keeps the
+Extract button gated to PDF/HTML only, leaving the Transcribe button to
+gate on `hasTranscriptBackend`. The two are mutually exclusive by
+construction (a kind's `extractionPath` is one of the four cases or nil).
+
+### PR2.2 — `SourceProvider.supportsTranscription` (#10)
+
+Delegate to the registry — the enum property stays the static baseline the
+runtime guard layers on, but the table stops being duplicated:
+
+```swift
+public var supportsTranscription: Bool {
+    ContentKind.resolve(mimeType: nil, provider: self)
+        .capabilities.hasTranscriptBackend
+}
+```
+
+Behavior identical (the registry's provider switch returns `.podcastTranscript`
+for `.applePodcast` / `.podcast` and `.youtubeTranscript` for `.youtube`,
+every other provider falls through to MIME / extension resolution which
+since the mime is nil returns `.unknown` → `extractionPath == nil`).
+
+### PR2.3 — `SourceDetailView` (#4-#7)
+
+```swift
+private var contentKind: ContentKind {
+    ContentKind.resolve(mimeType: file.mimeType,
+                        provider: origin?.provider,
+                        ext: file.ext)
+}
+private var isExtractable: Bool {
+    contentKind.capabilities.hasFileExtractionBackend  // was isPDF || isHTMLSource
+}
+private var needsExtraction: Bool { isExtractable && !hasMarkdown }   // shape unchanged
+
+private var isTranscribable: Bool {
+    guard contentKind.capabilities.hasTranscriptBackend else { return false }
+    // existing runtime guards (.applePodcast signing-helper / #if flag,
+    // .podcast / .youtube always available) layered on top.
+    switch origin?.provider {
+    case .applePodcast: return store.isSourceRefreshable(for: file.id)
+    case .podcast:      return true
+    case .youtube:      return true
+    default:            return false
+    }
+}
+```
+
+`isHTMLSource`/`isPDF` stay — they're used by other code paths (the HTML tab
+rendering at `:360`, the `htmlSourceString` decoder, the PDF tab gating at
+`:352`). The registry gate supersedes them only for the Extract / Transcribe
+button decision, not for the tab-dispatch question "which raw-bytes viewer
+should I show?".
+
+### PR2.4 — `SourcesListView.canExtract` + `canIngest` (#8, #9)
+
+```swift
+private func canExtract(_ source: SourceSummary) -> Bool {
+    ContentKind.resolve(mimeType: source.mimeType, provider: nil, ext: source.ext)
+        .capabilities.hasFileExtractionBackend      // was MimeType.isPDF only
+        && store?.processedMarkdownHead(for: source) == nil
+}
+
+private func canIngest(_ source: SourceSummary) -> Bool {
+    store?.canIngest(source) == true           // byte gate (unchanged)
+        && store?.shouldAutoIngest(source) == true  // content-type gate (NEW)
+}
+```
+
+**The latent HTML-extract drift fix (§5.5):** the list menu now offers
+"Extract Markdown" for both PDF AND HTML sources (previously PDF only).
+This was a discovered bug — the detail view offered HTML extraction but the
+list context menu silently omitted it.
+
+`canIngest` here switches from the byte-only predicate to the
+chokepoint-mirrored pair (byte gate + content-type gate) so the right-click
+Ingest item is hidden for non-ingestible byte-bearing sources (PNG/XML) —
+consistent with what the PR2 chokepoint does. Comments inside the helper
+point at the chokepoint as the authoritative rule and warn against drifting.
+
+### PR2.5 — `QueueIngestionHelper` chokepoint (#3, §5.2 / §11-C1)
+
+```swift
+// PDF-without-extracted-head branch: stays as MimeType.isPDF (the queue
+// engine is PDF-specific; HTML extraction routes through runHtmlExtraction
+// inline, not the extraction queue).
+if MimeType.isPDF(source.mimeType),
+   store.processedMarkdownHead(for: source) == nil { ... }
+
+// Chokepoint: byte gate (existing) + content-type gate (NEW, provider-aware).
+guard store.canIngest(source) else { ... continue }
+guard store.shouldAutoIngest(source) else {
+    DebugLog.ingest("enqueueIngestion: dropped \(sourceID.rawValue) — content type has no markdown path")
+    continue
+}
+ingestionSourceIDs.append(sourceID)
+```
+
+**Provider-aware (§11-C1):** `WikiStoreModel.shouldAutoIngest(_:)` already
+resolves via `ContentKind.resolve(mimeType:provider:ext:)` (PR1 made it
+provider-aware — see `WikiStoreModel.swift:2965-2972`). A YouTube source
+with `mime = video/youtube` and `provider = .youtube` resolves to
+`.youtubeTranscript` → `shouldAutoIngest == true`, NOT `.binary`. So a
+byteless YouTube WITH a transcript (`canIngest == true` because
+`hasProcessedMarkdown == true`) passes both gates. The fromMIME-only
+regression the §11-C1 review caught is locked by
+`IngestGateTests.shouldAutoIngestKeepsBytelessYouTube` (PR1).
+
+### PR2.6 — `AppQueueIngestionProvider` staging (#12, §5.6)
+
+```swift
+let kind = ContentKind.resolve(mimeType: source.mimeType,
+                                provider: nil,         // byte-bearing MIME is authoritative
+                                ext: source.ext)
+if kind.capabilities.hasFileExtractionBackend,              // was MimeType.isPDF only
+   let head = store.processedMarkdownHead(for: source) {
+    sourceBytes = head.content.data(using: .utf8) ?? bytes
+    sourceExt = "md"
+    DebugLog.extraction("AppQueueIngestionProvider: reusing markdown for \(source.filename)")
+}
+```
+
+**Behavior widening (intentional):** HTML sources now reuse their extracted
+markdown the same way PDFs do. A byteless YouTube-with-transcript doesn't
+hit this branch (it has bytes from `store.sourceBytes` already, since
+`canIngest` is true via `hasProcessedMarkdown` — wait, no, the staging
+loops over `sourceIDs` and reads `store.sourceBytes(id:)`, which for a
+byteless source... (verify behavior — see Tests section). Either way, the
+`hasFileExtractionBackend` filter excludes the transcript kinds, so the
+branch runs only for PDF/HTML — same as PDF-only before, plus HTML now.
+
+## PR2 tests
+
+### Existing tests (PR1) that act as guard rails
+
+- `ContentTypeRegistryTests` (40 tests) — the closed table.
+- `IngestGateTests.shouldAutoIngestKeepsBytelessYouTube` (PR1) — locks the
+  provider-aware wrapper that the PR2 chokepoint relies on.
+- `IngestGateTests.chokepointDropsBytelessYouTubeFromIngestionQueue` — pins
+  the byteless-no-transcript drop (still applies post-PR2; the new
+  `shouldAutoIngest` gate is also `false`-equivalent there because
+  `canIngest == false` first).
+
+### PR2 additions
+
+1. **Registry conveniences** (`Tests/WikiFSTests/ContentTypeRegistryTests.swift`):
+   `hasFileExtractionBackend` true for pdf/html only; `hasTranscriptBackend`
+   true for podcastTranscript/youtubeTranscript only; mutually exclusive.
+
+2. **`SourceProvider.supportsTranscription` delegation** (new test file or
+   extension of an existing provider-test file): assert the property
+   matches the registry's `hasTranscriptBackend` for every provider case
+   (an exhaustive switch — pins the delegation against drift).
+
+3. **`SourceDetailView` Extract/Transcribe gating** (new test file
+   `Tests/WikiFSAppTests/SourceDetailViewContentKindTests.swift` or
+   similar — the view can't be hosted directly, so test the `contentKind`
+   resolution + the gating predicates via `@testable import WikiFS`):
+   - PDF → `isExtractable == true`, `isTranscribable == false`.
+   - HTML → `isExtractable == true`, `isTranscribable == false` (the
+     drift fix).
+   - Podcast (provider `.applePodcast`) → `isTranscribable == ?` (runtime
+     guard; assert the registry-side `hasTranscriptBackend == true` and
+     that `hasFileExtractionBackend == false`).
+   - YouTube (provider `.youtube`) → same.
+   - PNG → both `false`.
+   - Markdown → both `false` (already the content).
+   - Exclusivity invariant: no kind has both true.
+
+   > **Implementation note:** the predicates are `private` in the view. Two
+   > options: (a) extract the decision into an `internal static` helper on
+   > the view (or a free function) that the tests invoke directly (mirrors
+   > the PR1 `ingestionDecision` seam in `BackgroundIngestCoordinator`); (b)
+   > replicate the same `resolve(...)` calls in the test (less faithful but
+   > still pins the registry integration). Prefer (a) — the seam pays off
+   > if the gating logic moves again.
+
+4. **`SourcesListView.canExtract` + `canIngest`** (new test file
+   `Tests/WikiFSAppTests/SourcesListViewContentKindTests.swift`): the list
+   view's helpers are `private` — same seam dilemma. Mirror the (a)
+   approach: extract `SourcesListContentGates` as `internal` helpers so the
+   tests exercise the real predicate.
+   - `canExtract` returns true for PDF AND HTML (the latent bug fix).
+   - `canIngest` returns false for a byte-bearing PNG (was true pre-PR2).
+
+5. **Chokepoint regression (§11-C7):** in `IngestGateTests` — add
+   `chokepointKeepsBytelessYouTubeWithTranscript`. A YouTube source with a
+   seeded transcript must end up in the ingestion queue (not dropped by the
+   new `shouldAutoIngest` gate). This is the C7 test the §11 plan asks for.
+
+6. **`AppQueueIngestionProvider` staging**: if there's an existing staging
+   test, extend it to assert HTML sources reuse their extracted head
+   (mirroring PDFs); if not, add a narrow test that drives
+   `OperationRequest.StagedSource` for an HTML source with extracted head
+   and asserts `ext == "md"` + bytes == head content. If the staging
+   surface is too coupled to test, fall back to a unit test on the
+   content-type decision (`kind.capabilities.hasFileExtractionBackend ==
+   true` for HTML) + reference the staging code by file:line.
+
+## PR2 file touch-list
+
+| File | Change |
+|------|--------|
+| `Sources/WikiFSTypes/ContentTypeRegistry.swift` | add `hasFileExtractionBackend` / `hasTranscriptBackend` (`extension ContentCapabilities`) |
+| `Sources/WikiFSTypes/SourceProvider.swift` | `supportsTranscription` delegates to registry |
+| `Sources/WikiFS/Sources/SourceDetailView.swift` | `isExtractable` / `isTranscribable` / `needsExtraction` / `needsTranscription` via `contentKind` + registry |
+| `Sources/WikiFS/Sources/SourcesListView.swift` | `canExtract` / `canIngest` via registry (HTML drift fix) |
+| `Sources/WikiFS/Queue/QueueIngestionHelper.swift` | chokepoint: add `store.shouldAutoIngest(source)` guard (provider-aware via PR1 wrapper) |
+| `Sources/WikiFS/Queue/AppQueueIngestionProvider.swift` | staging: `hasFileExtractionBackend` reuse (generalize `isPDF` to PDF+HTML) |
+| `Tests/WikiFSTests/ContentTypeRegistryTests.swift` | convenience-property tests |
+| `Tests/WikiFSAppTests/SourceDetailViewContentKindTests.swift` (NEW) | gating predicate tests |
+| `Tests/WikiFSAppTests/SourcesListViewContentKindTests.swift` (NEW) | gating predicate tests |
+| `Tests/WikiFSAppTests/IngestGateTests.swift` | extend with `chokepointKeepsBytelessYouTubeWithTranscript` (C7) |
+| `Tests/WikiFSAppTests/SourceProviderSupportsTranscriptionTests.swift` (NEW) | delegation regression (provider × registry) |
+
+No DB migration. No new dependencies.


### PR DESCRIPTION
# Content-type registry PR2 — migrate UI sites + chokepoint

Follow-up to #841 (PR1). Consolidates the remaining ad-hoc "can this become markdown?"
decision sites onto the PR1 registry. PR1 + PR2 together close the directive: "We should
have a content type registry that everything runs through that tells us if we can extract
and ingest it."

## Scope (per §11-corrected plan, PR2 section)

5 migrated sites + 1 delegation + supporting registry additions:

- **SourceProvider.supportsTranscription** (§5.4 note) — delegated to the registry.
  Static baseline no longer a duplicated switch; runtime guards (signing-helper / `#if
  PODCAST_TRANSCRIPTS`) stay layered on top at `isTranscribable` / `isSourceRefreshable`.
- **SourceDetailView.isExtractable / needsExtraction** (§5.4) — uses `contentKind.capabilities
  .hasFileExtractionBackend` (was `isPDF || isHTMLSource` — same PDF/HTML intent, registry-
  routed now).
- **SourceDetailView.isTranscribable** (§5.4) — guard-checks `hasTranscriptBackend` before
  the runtime signing-helper switch.
- **SourcesListView.canExtract** (§5.5) — fixes the **latent HTML-extract drift bug**: the
  list context menu used to offer Extract for PDF only (silently omitting HTML, even though
  the detail-view Extract button covered HTML). Now both PDF and HTML offer it via the
  registry's `hasFileExtractionBackend`.
- **SourcesListView.canIngest** (§5.5) — switches from byte-only to the chokepoint-mirrored
  pair (canIngest + shouldAutoIngest) so the menu hides for non-ingestible byte-bearing
  sources (PNG/XML) — consistent with what the PR2 chokepoint does.
- **QueueIngestionHelper chokepoint** (§5.2 / §11-C1) — adds `shouldAutoIngest` after the
  existing byte gate. **Provider-aware** via PR1's wrapper
  (`ContentKind.resolve(mimeType:provider:ext:)` — NOT `fromMIME` alone) so a byteless
  YouTube WITH a transcript passes both gates. Locks the §11-C1 regression the original
  §5.2 plan caught.
- **AppQueueIngestionProvider staging** (§5.6) — registry-driven reuse: **PDF AND HTML**
  now reuse extracted markdown at stage time (was PDF-only). A byte-extracted HTML source
  no longer re-stages its raw bytes, avoiding redundant agent-time re-extraction.

Sites that stay as-is (per §5.7): `SourceProvider.supportsRefresh` (orthogonal — re-fetch
capability, not markdown-path), `ExtractionCoordinator.current()` (backend resolver, not a
content-type decision), `WikiStoreModel.canIngest(_:)` (stays the byte-availability
predicate the manual Ingest button needs).

## Two new registry conveniences (`ContentCapabilities`)

Avoids a subtle regression in the plan §5.4 original: using `canExtractToMarkdown` for
`isExtractable` would have widened the Extract button to podcasts/YouTube (both have
`canExtractToMarkdown == true`), breaking the one-button-per-source exclusivity with
Transcribe (both `needsExtraction` and `needsTranscription` would be true — two
borderedProminent buttons):

- `hasFileExtractionBackend` — `extractionPath == .pdfBackend || .htmlToMarkdown`.
  Extract-button + staging reuse path.
- `hasTranscriptBackend` — `extractionPath == .podcastTranscript || .youtubeTranscript`.
  Transcribe-button + `supportsTranscription` delegation.

Mutually exclusive by construction (one `ExtractionPath` per kind, never both a file
backend and a transcript path).

## Behavior changes

1. **List context menu offers Extract for HTML sources** (the latent drift fix — was PDF
   only). Matches the detail-view Extract button surface.
2. **HTML sources reuse their extracted markdown at staging time** (was PDF-only). Avoids
   redundant re-extraction at agent time when the user already ran Extract Markdown.

No other behavior changes. PR1's coordinator + chokepoint filters unchanged.

## Testable seams (mirrors PR1's `BackgroundIngestCoordinator.ingestionDecision`)

- `SourceDetailView.extractionAffordance(mimeType:provider:ext:)` — pure registry
  decision; tests pin without hosting the SwiftUI view. `nonisolated` because the
  enclosing `View` struct gets implicit `@MainActor`.
- `SourcesListContentGates.canExtract(source:processedMarkdownHead:)` — pure registry
  decision for the list-menu Extract item.
- `AppQueueIngestionProvider._stagedBytesAndExt(for:originalBytes:
  processedMarkdownHead:)` — pure registry decision for staging reuse. `nonisolated`
  since the enclosing class is `@MainActor`.

## Tests

Full `swift test` suite green: **3640 tests / 302 suites** (was 3552 / 297 at the end of PR1;
+88 tests / +5 suites across this PR).

- `Tests/WikiFSTests/ContentTypeRegistryTests.swift` extended — partition + exclusivity
  invariants for the two conveniences (5 tests added; PR1's 40 tests unchanged).
- `Tests/WikiFSAppTests/SourceDetailViewContentKindTests.swift` (NEW) — per-kind
  affordance, YouTube-with-provider-vs-without, closed-enum partition.
- `Tests/WikiFSAppTests/SourcesListContentGatesTests.swift` (NEW) — the headline HTML-
  extract drift fix, head-suppression (use Re-extract), non-extractable kinds.
- `Tests/WikiFSAppTests/SourceProviderSupportsTranscriptionTests.swift` (NEW) —
  exhaustive provider × registry equivalence for the delegation. Pins across every
  provider case (12 closed-enum count pinned).
- `Tests/WikiFSAppTests/AppQueueIngestionProviderStagingTests.swift` (NEW) — PDF/HTML
  reuse (incl. the PR2 widening), non-extractable kinds skip reuse, edge cases
  (non-UTF8 head, empty ext).
- `Tests/WikiFSAppTests/IngestGateTests.swift` extended — adds the **§11-C7 regression
  case**: byteless YouTube WITH transcript passes the chokepoint (not dropped by the
  new `shouldAutoIngest` gate). Plus two drops (PNG byte-bearing, XML byte-bearing)
  and a mixed-batch asserting the two new gates coexist cleanly (PNG dropped, YouTube-
  with-transcript + markdown kept).

## No DB migration

Pure source/test changes. Same column reads as PR1 (`mime_type`, `ext`, `agents.name`).

## Plan reference

[`plans/content-type-registry.md`](plans/content-type-registry.md) — PR2 section appended
to PR1's plan. §1-§11 cover the shared design (the registry + capability table); the
appended PR2 section documents each migrated site, the two conveniences' rationale, and
the test coverage map.

## Build / verify

```
make version prompts && swift build && swift test
```

3640 tests pass.
