### PR TITLE
Route transcription through queue engine PR1 (#842)

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -40,7 +40,34 @@ struct ActivityWindowView: View {
     @State private var didAutoSelect = false
 
     private var queueTitle: String {
-        queue == .extraction ? "Extraction Queue" : "Agent Queue"
+        switch queue {
+        case .extraction: return "Extraction Queue"
+        case .ingestion: return "Agent Queue"
+        case .transcription: return "Transcription Queue"
+        }
+    }
+
+    /// The toolbar/menu icon for this queue's window.
+    private var queueControlIcon: String {
+        switch queue {
+        case .extraction: return "doc.text.magnifyingglass"
+        case .ingestion: return "tray.full"
+        case .transcription: return "waveform"
+        }
+    }
+
+    /// The "Configure…" call-to-action shown on configuration errors, or `nil`
+    /// when this queue has no relevant Settings tab (transcription needs no
+    /// credentials — YouTube is a scrape, RSS is `uv`).
+    private var configureCTA: (tab: String, label: String)? {
+        switch queue {
+        case .extraction:
+            return (tab: "extraction", label: "Configure Extraction…")
+        case .ingestion:
+            return (tab: "agents", label: "Configure Agents…")
+        case .transcription:
+            return nil
+        }
     }
 
     private var activeItems: [QueueItem] {
@@ -202,12 +229,19 @@ struct ActivityWindowView: View {
     }
 
     private var emptyState: some View {
-        ContentUnavailableView {
+        let description: String
+        switch queue {
+        case .extraction:
+            description = "PDF extraction tasks appear here as they run."
+        case .ingestion:
+            description = "Ingestion and lint tasks appear here as they run."
+        case .transcription:
+            description = "Transcription tasks (YouTube/podcast) appear here as they run."
+        }
+        return ContentUnavailableView {
             Label("No \(queueTitle) Activity", systemImage: "checkmark.circle")
         } description: {
-            Text(queue == .extraction
-                ? "PDF extraction tasks appear here as they run."
-                : "Ingestion and lint tasks appear here as they run.")
+            Text(description)
         }
     }
 
@@ -384,7 +418,7 @@ struct ActivityWindowView: View {
     @ViewBuilder
     private var queueControlMenu: some View {
         let state = viewModel.snapshot.runStates[queue] ?? .running
-        let icon = queue == .extraction ? "doc.text.magnifyingglass" : "tray.full"
+        let icon = queueControlIcon
         Menu {
             if state == .running {
                 Button("Pause \(queueTitle)", systemImage: "pause.fill") {
@@ -472,15 +506,12 @@ struct ActivityWindowView: View {
                     // provider binary wasn't found, no API key, etc.), show a
                     // call-to-action button that opens Settings on the relevant
                     // tab so the user can fix it without guessing.
-                    if isConfigurationError(error), openWindowBridge != nil {
+                    if isConfigurationError(error), openWindowBridge != nil,
+                       let cta = configureCTA {
                         Button(action: {
-                            let tab = queue == .extraction ? "extraction" : "agents"
-                            openWindowBridge?.openSettings(tab: tab)
+                            openWindowBridge?.openSettings(tab: cta.tab)
                         }) {
-                            Label(
-                                queue == .extraction ? "Configure Extraction…" : "Configure Agents…",
-                                systemImage: "gearshape"
-                            )
+                            Label(cta.label, systemImage: "gearshape")
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
@@ -977,6 +1008,7 @@ struct ActivityWindowView: View {
         switch item.queue {
         case .extraction: return "Extraction"
         case .ingestion: return "Ingestion"
+        case .transcription: return "Transcription"
         }
     }
 

--- a/Sources/WikiFS/Queue/AppQueueTranscriptionProvider.swift
+++ b/Sources/WikiFS/Queue/AppQueueTranscriptionProvider.swift
@@ -1,0 +1,119 @@
+import Foundation
+import WikiFSCore
+import WikiFSEngine
+
+/// The app-layer implementation of `QueueTranscriptionProvider`. Bridges the
+/// headless `QueueEngine` (an actor in `WikiFSEngine`) to the `@MainActor`
+/// `WikiStoreModel`.
+///
+/// The class is `@MainActor` (so it is implicitly `Sendable`). The engine
+/// (running off-main) calls the protocol methods via `await`; Swift hops to
+/// the main actor for each call. The actual transcript fetch runs off-main
+/// inside the worker (the `fetch` closure is `@Sendable` and the fetchers are
+/// `Sendable`).
+///
+/// Mirrors `AppQueueExtractionProvider` minus the PDF bytes — resolves the
+/// source origin, builds the right `@Sendable` fetch closure per provider
+/// (YouTube / RSS podcast / Apple podcast), and persists the result via
+/// `WikiStoreModel.appendTranscriptMarkdown`.
+@MainActor
+final class AppQueueTranscriptionProvider: QueueTranscriptionProvider {
+    private let sessionBox: SessionLookupBox
+
+    init(sessionBox: SessionLookupBox) {
+        self.sessionBox = sessionBox
+    }
+
+    // MARK: - QueueTranscriptionProvider
+
+    func resolveTranscription(
+        wikiID: String,
+        sourceID: PageID
+    ) async throws -> TranscriptionResolution? {
+        guard let store = sessionBox.resolve(wikiID: wikiID) else {
+            DebugLog.extraction("AppQueueTranscriptionProvider: no session for wikiID=\(wikiID)")
+            return nil
+        }
+
+        guard let origin = store.sourceOrigin(for: sourceID),
+              let providerKind = origin.provider else {
+            return nil
+        }
+
+        // Build the right detached fetch per provider, mirroring the three
+        // private helpers in WikiStoreModel (transcribeYouTube/RSS/Podcast).
+        switch providerKind {
+        case .youtube:
+            // externalIdentity IS the 11-char video ID (stored at ingest).
+            // Fall back to re-parsing plan for legacy rows.
+            let videoID = origin.externalIdentity
+                ?? MediaEmbedURL.youtube(origin.plan ?? "")?.externalIdentity
+            guard let videoID else { return nil }
+            let svc = YouTubeTranscriptService()
+            return TranscriptionResolution(
+                fetch: { @Sendable in
+                    try await svc.transcript(forVideoID: videoID).markdown
+                },
+                technique: "youtube-captions")
+
+        case .podcast:
+            // Generic RSS-feed podcast: reads origin.plan (the feed URL
+            // recorded at ingest), fetches via RSSPodcastTranscriptService.
+            guard let planURLString = origin.plan,
+                  let sourceURL = URL(string: planURLString) else {
+                return nil
+            }
+            let svc = RSSPodcastTranscriptService()
+            return TranscriptionResolution(
+                fetch: { @Sendable in
+                    try await svc.transcript(forFeedURL: sourceURL).markdown
+                },
+                technique: "rss-podcast-transcript")
+
+        case .applePodcast:
+            #if PODCAST_TRANSCRIPTS
+            // Apple Podcasts: reconstruct the episode from origin.plan (the
+            // page URL), prefer the FairPlay signing helper, fall back to RSS.
+            guard let planURLString = origin.plan,
+                  let pageURL = URL(string: planURLString),
+                  let episode = PodcastEpisodeURL.parse(planURLString) else {
+                return nil
+            }
+            let fetcher: any PodcastTranscriptFetching =
+                ApplePodcastTranscriptService.bundled()
+                ?? RSSPodcastTranscriptService(sourceURL: pageURL)
+            let materializer = ApplePodcastMaterializer(
+                episode: episode, pageURL: pageURL, fetcher: fetcher)
+            return TranscriptionResolution(
+                fetch: { @Sendable in
+                    let result = try await materializer.materialize()
+                    return String(data: result.data, encoding: .utf8) ?? ""
+                },
+                technique: "apple-ttml")
+            #else
+            // Phase-out build: podcast support isn't compiled (WIKIFS_APP_STORE=1).
+            // The View-level `isTranscribable` predicate returns `false` for
+            // `.applePodcast` outside this flag, so this path is unreachable
+            // in production UI.
+            return nil
+            #endif
+
+        default:
+            return nil
+        }
+    }
+
+    func persistTranscription(
+        wikiID: String,
+        sourceID: PageID,
+        markdown: String,
+        technique: String
+    ) async throws {
+        guard let store = sessionBox.resolve(wikiID: wikiID) else {
+            DebugLog.extraction("AppQueueTranscriptionProvider: persistTranscription — no session for wikiID=\(wikiID)")
+            return
+        }
+        _ = store.appendTranscriptMarkdown(
+            for: sourceID, content: markdown, technique: technique)
+    }
+}

--- a/Sources/WikiFS/Queue/OperationNotifier.swift
+++ b/Sources/WikiFS/Queue/OperationNotifier.swift
@@ -146,6 +146,7 @@ final class OperationNotifier {
     enum OperationKind: Sendable, Equatable {
         case extraction(sourceCount: Int)
         case ingestion(sourceCount: Int)
+        case transcription(sourceCount: Int)
         /// `pageCount` is `nil` for whole-wiki lint (empty `lintPageIDs` array).
         case lint(pageCount: Int?)
     }
@@ -160,6 +161,8 @@ final class OperationNotifier {
                 return .lint(pageCount: lintPageIDs.isEmpty ? nil : lintPageIDs.count)
             }
             return .ingestion(sourceCount: item.payload.sourceIDs.count)
+        case .transcription:
+            return .transcription(sourceCount: item.payload.sourceIDs.count)
         }
     }
 
@@ -171,6 +174,7 @@ final class OperationNotifier {
         switch kind {
         case .extraction: label = "Extraction"
         case .ingestion:  label = "Ingestion"
+        case .transcription: label = "Transcription"
         case .lint:       label = "Lint"
         }
 
@@ -202,6 +206,8 @@ final class OperationNotifier {
             return "\(count) file\(count == 1 ? "" : "s") processed"
         case .ingestion(let count):
             return "\(count) source\(count == 1 ? "" : "s") ingested"
+        case .transcription(let count):
+            return "\(count) transcript\(count == 1 ? "" : "s") fetched"
         case .lint(let pageCount):
             if let pageCount {
                 return "\(pageCount) page\(pageCount == 1 ? "" : "s") linted"
@@ -220,6 +226,8 @@ final class OperationNotifier {
             subject = "\(count) file\(count == 1 ? "" : "s")"
         case .ingestion(let count):
             subject = "\(count) source\(count == 1 ? "" : "s")"
+        case .transcription(let count):
+            subject = "\(count) transcript\(count == 1 ? "" : "s")"
         case .lint(let pageCount):
             if let pageCount {
                 subject = "\(pageCount) page\(pageCount == 1 ? "" : "s")"
@@ -248,6 +256,8 @@ final class OperationNotifier {
             return "\(count) file\(count == 1 ? "" : "s") \u{2014} cancelled"
         case .ingestion(let count):
             return "\(count) source\(count == 1 ? "" : "s") \u{2014} cancelled"
+        case .transcription(let count):
+            return "\(count) transcript\(count == 1 ? "" : "s") \u{2014} cancelled"
         case .lint(let pageCount):
             if let pageCount {
                 return "\(pageCount) page\(pageCount == 1 ? "" : "s") \u{2014} cancelled"

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -87,6 +87,12 @@ final class QueueActivityTracker {
     /// Ingest button disable. Replaces `launcher.ingestingSourceIDs`.
     private(set) var ingestingSourceIDs: Set<PageID> = []
 
+    /// Source IDs currently being transcribed (any transcription queue item in
+    /// `.running` state). Drives the Transcribe button's per-source disable
+    /// + "Transcribing…" label, mirroring `extractingSourceIDs` for the
+    /// `.transcription` queue kind (#842).
+    private(set) var transcribingSourceIDs: Set<PageID> = []
+
     /// Queue item IDs currently running a lint (`.ingestion` items with
     /// `lintPageIDs != nil`). Lint items have empty `sourceIDs`, so they
     /// don't show up in `ingestingSourceIDs` — this set ensures
@@ -134,6 +140,18 @@ final class QueueActivityTracker {
 
     /// True while any ingestion or lint is running.
     var isIngesting: Bool { !ingestingSourceIDs.isEmpty || !lintingItemIDs.isEmpty }
+
+    /// True while any transcription is running. Drives nothing in the sidebar
+    /// spinner today, but kept for parity with `isExtracting`/`isIngesting`.
+    var isTranscribingAny: Bool { !transcribingSourceIDs.isEmpty }
+
+    /// True if a transcription job is actively processing `sourceID`. Used by
+    /// `SourceDetailView` to disable its Transcribe button and reflect the
+    /// running state (the button reads "Transcribing…"), mirroring how
+    /// `isSlotBusyForOtherSource` gates the Extract button (#842 C3/C5).
+    func isTranscribing(sourceID: PageID) -> Bool {
+        transcribingSourceIDs.contains(sourceID)
+    }
 
     /// True if a lint job (page-level or whole-wiki) is actively processing
     /// `pageID` in `wikiID`. A whole-wiki lint (`lintPageIDs == []`) covers
@@ -320,6 +338,7 @@ final class QueueActivityTracker {
         queueEngine = nil
         extractingSourceIDs = []
         ingestingSourceIDs = []
+        transcribingSourceIDs = []
         lintingItemIDs = []
         lintingPageIDs = []
         wholeWikiLintingWikiIDs = []
@@ -544,6 +563,8 @@ final class QueueActivityTracker {
                 } else {
                     ingestingSourceIDs.formUnion(sourceIDs)
                 }
+            case .transcription:
+                transcribingSourceIDs.formUnion(sourceIDs)
             }
 
         case .transcript(let id, let agentEvent):
@@ -664,6 +685,8 @@ final class QueueActivityTracker {
                 extractingSourceIDs.subtract(sourceIDs)
             case .ingestion:
                 ingestingSourceIDs.subtract(sourceIDs)
+            case .transcription:
+                transcribingSourceIDs.subtract(sourceIDs)
             }
         }
         // Lint items are tracked separately — always remove on terminal state.

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -72,16 +72,9 @@ struct SourceDetailView: View {
     /// stay mutually exclusive in the View-level button rendering (each
     /// button dispatches to exactly one of `runExtraction` /
     /// `runHtmlExtraction` / `runRefresh` / `runTranscription`).
-    @State private var isTranscribing = false
-    /// True while a source refresh (re-fetch via provider) is in flight.
     @State private var isRefreshing = false
     /// Set when a refresh fails — surfaced inline below the action row.
     @State private var refreshError: String?
-    /// Set when a transcription (Extract ◂ Transcribe) fails — surfaced inline
-    /// below the action row alongside `refreshError` (issue #799 PR4). Both
-    /// stay scoped to the action button that produced them; the row renders
-    /// whichever error is non-nil.
-    @State private var transcribeError: String?
     /// Whether THIS source can actually be refreshed — the authoritative gate
     /// from `store.isSourceRefreshable(for:)` (mirrors the refresh service's real
     /// decision, incl. the snapshot-with-images guard and podcast-helper
@@ -185,6 +178,13 @@ struct SourceDetailView: View {
     /// `isPodcastEmbed` — `origin.provider` is the single source of truth.
     /// Returns `false` until `origin` loads, same shape as `isRefreshable`.
     private var isYouTubeEmbed: Bool { origin?.provider == .youtube }
+
+    /// True while a transcription queue job is running for this source (C5:
+    /// replaces the old `@State isTranscribing` with a computed property
+    /// derived from the activity tracker's `transcribingSourceIDs`). Drives
+    /// the Transcribe button's disabled state + "Transcribing…" label, so
+    /// re-clicks are prevented while a job is in flight (#842).
+    private var isTranscribing: Bool { tracker.isTranscribing(sourceID: file.id) }
 
     /// `true` when this source can be transcribed right now — the single
     /// source of truth for the Transcribe button's enable state (issue #799
@@ -700,11 +700,6 @@ struct SourceDetailView: View {
 
                     if let refreshError {
                         Text(refreshError)
-                            .font(.callout)
-                            .foregroundStyle(.red)
-                    }
-                    if let transcribeError {
-                        Text(transcribeError)
                             .font(.callout)
                             .foregroundStyle(.red)
                     }
@@ -1509,58 +1504,57 @@ struct SourceDetailView: View {
     /// underlying `isTranscribable` returns `false` via
     /// `isSourceRefreshable`'s phase-out arm), so the podcast path is
     /// unreachable in production; the YouTube path stays available.
+    /// Run transcription through the queue engine instead of calling
+    /// `store.transcribe(sourceID:)` inline (#842). Enqueues a durable
+    /// `.transcription` queue job, waits for completion, and refreshes the
+    /// head version on success — mirroring `runExtraction()`. Errors land
+    /// on the queue item's `error` field + Activity window (not inline
+    /// `transcribeError`, which was removed). The de-dupe / reveal-job
+    /// navigation is PR2 (shared with #837).
     private func runTranscription() async {
-        isTranscribing = true
-        transcribeError = nil
-        defer { isTranscribing = false }
         do {
-            if let head = try await store.transcribe(sourceID: file.id) {
-                headVersion = head
+            let request = QueueItemRequest(
+                queue: .transcription, wikiID: store.eventBus?.wikiID ?? "",
+                payload: QueueItemPayload(sourceIDs: [file.id]))
+            let itemID = try await queueEngine.enqueue(request)
+            let result = await queueEngine.waitForCompletion(of: itemID)
+
+            switch result {
+            case .success:
+                if let head = store.processedMarkdownHead(for: file) {
+                    headVersion = head
+                }
+            case .failure:
+                break  // Tracker records the error from queue events
             }
-        } catch PodcastTranscriptError.signatureUnavailable(let message) {
-            transcribeError = message
-        } catch YouTubeTranscriptError.noCaptions {
-            // YouTube-specific: a video with no captions is a normal case
-            // (some videos don't have them). The error stays surfaced so the
-            // user knows why the transcript button can produce no result.
-            transcribeError = "This video has no captions."
-        } catch YouTubeTranscriptError.playerResponseNotFound {
-            transcribeError = "Couldn't read this video's data (YouTube page changed or the video is restricted)."
-        } catch SourceRefreshService.RefreshError.notRefreshable(let agent) {
-            transcribeError = "Sources from \"\(agent)\" can't be transcribed."
-        } catch SourceRefreshService.RefreshError.missingPlan {
-            transcribeError = "This source has no recorded URL or video ID to transcribe."
         } catch {
-            transcribeError = "Transcribe failed: \(error.localizedDescription)"
+            DebugLog.extraction("SourceDetailView: transcribe enqueue failed (\(file.id.rawValue)): \(error)")
         }
     }
 
-    /// Re-transcription trigger (issue #799 PR4). Called by the
-    /// "Re-transcribe with" menu's podcast branch when the user picks a
-    /// backend from `PodcastTranscriptionBackend.allCases`. Mirrors
-    /// `runHtmlReExtraction(with:)` (PR2) but routes through the inline
-    /// `transcribe(sourceID:podcastFetcher:)` path (PR5). The `backend`
-    /// parameter is currently a placeholder for future backends
-    /// (Whisper / Rev.ai / etc.); `.appleTranscript` is the only backend
-    /// today, so every re-transcribe routes through the same `transcribe`
-    /// path. The picker is the scaffolding for extensibility — adding a
-    /// `case` to `PodcastTranscriptionBackend` and a branch in
-    /// `WikiStoreModel.transcribe` is the future hook.
+    /// Re-transcription trigger (issue #799 PR4). Now enqueues through the
+    /// queue engine too (#842) — the `backend` parameter rides in
+    /// `payload.stageRouting` (placeholder for future backends; only
+    /// `.appleTranscript` exists today).
     private func runTranscription(with backend: PodcastTranscriptionBackend) async {
-        isTranscribing = true
-        transcribeError = nil
-        defer { isTranscribing = false }
-        // The chosen backend is logged here (the only backend today,
-        // `.appleTranscript`, dispatches through `transcribe(sourceID:)`
-        // unchanged; the log entry preserves the user intent for future
-        // auditability when a new backend lands and the dispatch branches).
         DebugLog.extraction("SourceDetailView: Re-transcribe tapped — id=\(file.id.rawValue), backend=\(backend.rawValue)")
         do {
-            if let head = try await store.transcribe(sourceID: file.id) {
-                headVersion = head
+            let request = QueueItemRequest(
+                queue: .transcription, wikiID: store.eventBus?.wikiID ?? "",
+                payload: QueueItemPayload(sourceIDs: [file.id]))
+            let itemID = try await queueEngine.enqueue(request)
+            let result = await queueEngine.waitForCompletion(of: itemID)
+
+            switch result {
+            case .success:
+                if let head = store.processedMarkdownHead(for: file) {
+                    headVersion = head
+                }
+            case .failure:
+                break
             }
         } catch {
-            transcribeError = "Transcribe failed: \(error.localizedDescription)"
+            DebugLog.extraction("SourceDetailView: re-transcribe enqueue failed (\(file.id.rawValue)): \(error)")
         }
     }
 

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -220,6 +220,13 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         extractionItem.target = self
         menu.addItem(extractionItem)
 
+        let transcriptionItem = NSMenuItem(
+            title: "Transcription Queue…",
+            action: #selector(openTranscriptionWindow(_:)),
+            keyEquivalent: "")
+        transcriptionItem.target = self
+        menu.addItem(transcriptionItem)
+
         menu.addItem(.separator())
 
         // #528 spike: today's cumulative token/cost usage. The summary line
@@ -357,6 +364,10 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         showQueueWindow(for: .extraction)
     }
 
+    @objc private func openTranscriptionWindow(_ sender: NSMenuItem?) {
+        showQueueWindow(for: .transcription)
+    }
+
     /// The session menu actions target: the frontmost wiki window's session,
     /// falling back to ANY live session — a status-item menu is reachable
     /// while no wiki window is key, and a silent `return` there reads as a
@@ -477,7 +488,11 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     /// `nonisolated` — pure (no AppKit state) so tests can call without a
     /// main-actor hop.
     nonisolated static func queueWindowAutosaveName(for queue: QueueKind) -> String {
-        queue == .extraction ? "ExtractionQueueWindow" : "AgentQueueWindow"
+        switch queue {
+        case .extraction: return "ExtractionQueueWindow"
+        case .ingestion: return "AgentQueueWindow"
+        case .transcription: return "TranscriptionQueueWindow"
+        }
     }
 
     /// #635: validate a previously-saved NSWindow autosave frame string.

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -45,6 +45,9 @@ struct WikiFSApp: App {
     /// App-wide ingestion provider. Bridges the headless queue engine to the
     /// `@MainActor` `AgentLauncher` + `WikiStoreModel` for ingestion.
     @State private var ingestionProvider: any QueueIngestionProvider
+    /// App-wide transcription provider. Bridges the headless queue engine to
+    /// the `@MainActor` `WikiStoreModel` for YouTube/podcast transcription.
+    @State private var transcriptionProvider: any QueueTranscriptionProvider
     /// Mutable box for the file provider reference — the ingestion provider
     /// uses it to access the `FileProviderFacade` which is only available
     /// after the `@State` property is initialized by SwiftUI.
@@ -174,6 +177,10 @@ struct WikiFSApp: App {
         let extractionFactory = QueueExtractionWorkerFactory(
             provider: extractionProvider,
             emitProgress: { id, line in progressBox.emit?(id, line) })
+        let transcriptionProvider = AppQueueTranscriptionProvider(sessionBox: sessionBox)
+        let transcriptionFactory = QueueTranscriptionWorkerFactory(
+            provider: transcriptionProvider,
+            emitProgress: { id, line in progressBox.emit?(id, line) })
         let ingestionFactory = QueueIngestionWorkerFactory(
             provider: ingestionProvider,
             emitProgress: { id, line in progressBox.emit?(id, line) },
@@ -184,7 +191,8 @@ struct WikiFSApp: App {
             emitPendingPermission: { id, permission in pendingPermissionBox.emit?(id, permission) })
         let workerFactory = CompositeWorkerFactory(factories: [
             .extraction: extractionFactory,
-            .ingestion: ingestionFactory
+            .ingestion: ingestionFactory,
+            .transcription: transcriptionFactory,
         ])
         let queueEngine = QueueEngine(store: queueStore, workerFactory: workerFactory)
         // Wire the progress emit box to the engine's event continuation.
@@ -215,6 +223,7 @@ struct WikiFSApp: App {
         _queueEngine = State(initialValue: queueEngine)
         _extractionProvider = State(initialValue: extractionProvider)
         _ingestionProvider = State(initialValue: ingestionProvider)
+        _transcriptionProvider = State(initialValue: transcriptionProvider)
         _fileProviderBox = State(initialValue: fileProviderBox)
         _activityTracker = State(initialValue: activityTracker)
 

--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -758,7 +758,7 @@ public final class QueueStore: @unchecked Sendable {
         try Self.wrap {
             let queue = try self.queue()
             try queue.write { db in
-                for kind in [QueueKind.extraction, QueueKind.ingestion] {
+                for kind in [QueueKind.extraction, QueueKind.ingestion, QueueKind.transcription] {
                     try db.execute(
                         sql: """
                         DELETE FROM queue_items

--- a/Sources/WikiFSCore/Core/QueueTypes.swift
+++ b/Sources/WikiFSCore/Core/QueueTypes.swift
@@ -11,7 +11,7 @@ public enum StageRoutingKey: String, Sendable {
     case backend
 }
 
-/// The two persistent processing queues. Each `QueueItem` belongs to exactly
+/// The persistent processing queues. Each `QueueItem` belongs to exactly
 /// one queue, and each queue has its own independent run state (running /
 /// paused) and ordering-key sequence.
 public enum QueueKind: String, Codable, Sendable {
@@ -21,6 +21,10 @@ public enum QueueKind: String, Codable, Sendable {
     /// lint operations — a `.ingestion` item with `lintPageIDs` in its
     /// payload runs lint instead of ingestion.
     case ingestion
+    /// Transcription (source → transcript markdown): network/subprocess fetch
+    /// of YouTube captions or podcast feeds. Mirrors extraction's shape but
+    /// has no local bytes (no `ExtractionResolution.pdfData`).
+    case transcription
 }
 
 // MARK: - Item lifecycle states

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -3069,6 +3069,26 @@ public final class WikiStoreModel {
         }
     }
 
+    /// Append a transcript markdown version (origin `.transcript`) to the
+    /// processed-markdown chain for `sourceID`. Used by the queued transcription
+    /// worker's `persistTranscription` path (#842). Thin pass-through to
+    /// `store.appendProcessedMarkdown` — the store-level `mutate()` emission +
+    /// `ResourceChangeEvent` fire inside the store, so no model-level work is
+    /// needed. Mirrors `seedPdfMarkdown`'s shape for extraction.
+    @discardableResult
+    public func appendTranscriptMarkdown(
+        for sourceID: PageID, content: String, technique: String
+    ) -> SourceMarkdownVersion? {
+        do {
+            return try store.appendProcessedMarkdown(
+                sourceID: sourceID, content: content,
+                origin: .transcript, note: nil, technique: technique)
+        } catch {
+            DebugLog.store("WikiStoreModel.appendTranscriptMarkdown failed (source=\(sourceID.rawValue)): \(error)")
+            return nil
+        }
+    }
+
     /// Re-extract a source's content with a given extractor + backend, appending
     /// a COEXISTING alternative (never clobbers the existing head). Resolves the
     /// source bytes + active content version from the store, runs the extractor,

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -118,7 +118,7 @@ public actor QueueEngine {
         await rebuildInMemoryState()
 
         // Load run states.
-        for queue in [QueueKind.extraction, QueueKind.ingestion] {
+        for queue in [QueueKind.extraction, QueueKind.ingestion, QueueKind.transcription] {
             runStates[queue] = (try? store.queueRunState(for: queue)) ?? .running
         }
 
@@ -206,7 +206,7 @@ public actor QueueEngine {
     @discardableResult
     public func cancelAllInFlight() async -> Int {
         var count = 0
-        for queue in [QueueKind.extraction, QueueKind.ingestion] {
+        for queue in [QueueKind.extraction, QueueKind.ingestion, QueueKind.transcription] {
             let active = (try? store.loadActive(for: queue)) ?? []
             for item in active where item.state == .running {
                 await cancelItem(item.id)
@@ -321,6 +321,7 @@ public actor QueueEngine {
         let qs: [QueueKind: QueueRunState] = [
             .extraction: runStates[.extraction] ?? .running,
             .ingestion: runStates[.ingestion] ?? .running,
+            .transcription: runStates[.transcription] ?? .running,
         ]
         return QueueSnapshot(
             activeItems: activeItems,
@@ -551,7 +552,7 @@ public actor QueueEngine {
     /// resolves the provider ID. No `await` separates the check from the set.
     private func dispatchScan() async {
         // For each queue kind that is `.running`, try to dispatch items.
-        for queue in [QueueKind.extraction, QueueKind.ingestion] {
+        for queue in [QueueKind.extraction, QueueKind.ingestion, QueueKind.transcription] {
             guard runStates[queue] == .running else { continue }
 
             let active = (try? store.loadActive(for: queue)) ?? []
@@ -573,6 +574,8 @@ public actor QueueEngine {
                     limit = config.extractionLimit(for: providerID)
                 case .ingestion:
                     limit = config.ingestionLimit(for: providerID)
+                case .transcription:
+                    limit = config.transcriptionLimit
                 }
 
                 // Per-provider capacity check.

--- a/Sources/WikiFSEngine/QueueTranscriptionProvider.swift
+++ b/Sources/WikiFSEngine/QueueTranscriptionProvider.swift
@@ -1,0 +1,79 @@
+import Foundation
+import WikiFSCore
+
+// MARK: - QueueTranscriptionError
+
+/// Errors thrown by the transcription worker.
+public enum QueueTranscriptionError: Error, LocalizedError {
+    /// No source ID in the payload (malformed request).
+    case missingSourceID
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingSourceID: return "Transcription item has no source ID"
+        }
+    }
+}
+
+// MARK: - TranscriptionResolution
+
+/// A resolved transcription request: enough to run the fetch off-main and
+/// persist the result. No `pdfData` — this is a network/subprocess fetch,
+/// mirroring `ExtractionResolution` minus the PDF bytes.
+///
+/// The `fetch` closure is `@Sendable` so the worker can run it off-main
+/// (the actual fetcher instances — `YouTubeTranscriptService`,
+/// `RSSPodcastTranscriptService`, `ApplePodcastMaterializer` — are all
+/// `Sendable`). The provider (app layer, `@MainActor`) builds the right
+/// fetcher from `origin.provider` and hands the worker a closure; the
+/// worker stays fetcher-agnostic and never sees `@MainActor` types.
+public struct TranscriptionResolution: Sendable {
+    /// The off-main transcript fetch closure. Returns the transcript
+    /// markdown string.
+    public let fetch: @Sendable () async throws -> String
+
+    /// Technique tag for the processed-markdown version row (PROV).
+    /// e.g. `"youtube-captions"`, `"rss-podcast-transcript"`,
+    /// `"apple-ttml"`.
+    public let technique: String
+
+    public init(fetch: @escaping @Sendable () async throws -> String, technique: String) {
+        self.fetch = fetch
+        self.technique = technique
+    }
+}
+
+// MARK: - QueueTranscriptionProvider
+
+/// Bridges the `@MainActor WikiStoreModel` into the headless queue engine for
+/// transcription (YouTube captions + podcast feeds). The app provides a
+/// concrete implementation that hops to the main actor internally; the engine
+/// sees only this `Sendable` protocol.
+///
+/// **Two main-actor hops per transcription:**
+/// - `resolveTranscription` → calls `store.sourceOrigin(for:)` (main actor) +
+///   builds the right `@Sendable` fetch closure from `origin.provider`.
+/// - `persistTranscription` → calls `store.appendProcessedMarkdown(origin:
+///   .transcript, ...)` (main actor).
+///
+/// The actual fetch runs off-main inside the worker (the closure is
+/// `@Sendable` and the fetchers are `Sendable`).
+public protocol QueueTranscriptionProvider: Sendable {
+    /// Resolve the fetch closure + technique for a source. Returns `nil` if
+    /// the source isn't transcribable (no provider / no video ID / no feed
+    /// URL) — the item stays queued and is never dispatched (mirrors
+    /// extraction's nil-return).
+    func resolveTranscription(
+        wikiID: String,
+        sourceID: PageID
+    ) async throws -> TranscriptionResolution?
+
+    /// Persist the transcript markdown (app impl:
+    /// `store.appendProcessedMarkdown(origin: .transcript, ...)`).
+    func persistTranscription(
+        wikiID: String,
+        sourceID: PageID,
+        markdown: String,
+        technique: String
+    ) async throws
+}

--- a/Sources/WikiFSEngine/QueueTranscriptionWorker.swift
+++ b/Sources/WikiFSEngine/QueueTranscriptionWorker.swift
@@ -1,0 +1,89 @@
+import Foundation
+import WikiFSCore
+
+// MARK: - QueueTranscriptionWorkerFactory
+
+/// A `QueueWorkerFactory` that creates `QueueTranscriptionWorker` instances.
+/// Mirrors `QueueExtractionWorkerFactory` but for the `.transcription` queue
+/// kind — no PDF bytes, no backend selection, just a network/subprocess
+/// transcript fetch.
+///
+/// **Progress reporting:** the factory receives an `emitProgress` closure
+/// (same pattern as extraction) that yields `.progress(id, line)` events onto
+/// the engine's broadcaster. Today the transcript fetchers produce no
+/// streamed log (unlike pdf2md), so the worker emits a single "Fetching…"
+/// line so the Activity detail pane isn't empty.
+public struct QueueTranscriptionWorkerFactory: QueueWorkerFactory {
+    private let provider: any QueueTranscriptionProvider
+    private let emitProgress: @Sendable (QueueItem.ID, String) -> Void
+
+    /// - Parameters:
+    ///   - provider: Bridges the `@MainActor WikiStoreModel`.
+    ///   - emitProgress: Yields `.progress(id, line)` events onto the engine's
+    ///     `AsyncStream.Continuation`.
+    public init(
+        provider: any QueueTranscriptionProvider,
+        emitProgress: @escaping @Sendable (QueueItem.ID, String) -> Void
+    ) {
+        self.provider = provider
+        self.emitProgress = emitProgress
+    }
+
+    public func providerID(for item: QueueItem) async -> String? {
+        // Resolve to preflight: nil → item stays queued (never dispatched).
+        // A found resolution → "transcription" provider (capacity bucket).
+        guard let sourceID = item.payload.sourceIDs.first,
+              (try? await provider.resolveTranscription(
+                wikiID: item.wikiID, sourceID: sourceID)) != nil
+        else { return nil }
+        return "transcription"
+    }
+
+    public func worker(for item: QueueItem) async throws -> any QueueWorker {
+        QueueTranscriptionWorker(provider: provider, emitProgress: emitProgress)
+    }
+}
+
+// MARK: - QueueTranscriptionWorker
+
+/// A worker that runs one transcription: resolves the fetch closure,
+/// runs it off-main, and persists the transcript markdown. Mirrors
+/// `QueueExtractionWorker` minus the PDF bytes + readiness check.
+///
+/// **Worker idempotency:** like extraction, re-transcription produces the
+/// same/similar markdown (append-processed-markdown adds a new version row),
+/// so a re-dispatch after `halt`/`cancelItem` is safe.
+struct QueueTranscriptionWorker: QueueWorker {
+    let provider: any QueueTranscriptionProvider
+    let emitProgress: @Sendable (QueueItem.ID, String) -> Void
+
+    func execute(_ item: QueueItem) async throws {
+        guard let sourceID = item.payload.sourceIDs.first else {
+            throw QueueTranscriptionError.missingSourceID
+        }
+
+        // Resolve the fetch closure + technique (main-actor hop in the app
+        // impl).
+        guard let resolved = try await provider.resolveTranscription(
+            wikiID: item.wikiID, sourceID: sourceID
+        ) else {
+            // Not transcribable (no video ID / feed URL) — skip (item
+            // .completed), mirroring extraction's nil-return.
+            return
+        }
+
+        // Network/subprocess fetch off-main. Emit a single progress line so
+        // the Activity detail pane isn't empty (today's fetchers don't
+        // stream).
+        emitProgress(item.id, "Fetching transcript…")
+        let markdown = try await resolved.fetch()
+
+        // Persist the transcript markdown (main-actor hop in the app impl).
+        try await provider.persistTranscription(
+            wikiID: item.wikiID,
+            sourceID: sourceID,
+            markdown: markdown,
+            technique: resolved.technique
+        )
+    }
+}

--- a/Sources/WikiFSEngine/QueueWorker.swift
+++ b/Sources/WikiFSEngine/QueueWorker.swift
@@ -181,6 +181,11 @@ public struct QueueEngineConfig: Sendable {
     /// Docling Serve). Default 2.
     public var remoteExtractionLimit: Int
 
+    /// Maximum concurrent transcription jobs. Transcription is a network/
+    /// subprocess fetch (YouTube captions scrape, RSS podcast transcript) with
+    /// no local-subprocess serialization constraint, so 2 is safe. Default 2.
+    public var transcriptionLimit: Int
+
     /// How many terminal items to load for the snapshot's `recentItems`.
     public var recentLimit: Int
 
@@ -188,11 +193,13 @@ public struct QueueEngineConfig: Sendable {
         ingestionLimits: [String: Int] = [:],
         localExtractionLimit: Int = 1,
         remoteExtractionLimit: Int = 2,
+        transcriptionLimit: Int = 2,
         recentLimit: Int = 200
     ) {
         self.ingestionLimits = ingestionLimits
         self.localExtractionLimit = localExtractionLimit
         self.remoteExtractionLimit = remoteExtractionLimit
+        self.transcriptionLimit = transcriptionLimit
         self.recentLimit = recentLimit
     }
 

--- a/Tests/WikiFSAppTests/OperationNotifierSummaryTests.swift
+++ b/Tests/WikiFSAppTests/OperationNotifierSummaryTests.swift
@@ -64,6 +64,12 @@ import WikiFSCore
         #expect(kind == .lint(pageCount: nil))
     }
 
+    @Test func kindTranscription() {
+        let item = makeItem(queue: .transcription, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2")])
+        let kind = OperationNotifier.operationKind(for: item)
+        #expect(kind == .transcription(sourceCount: 2))
+    }
+
     // MARK: - Completed summaries
 
     @Test func completedExtraction() {
@@ -112,6 +118,19 @@ import WikiFSCore
         #expect(s?.body == "All pages linted")
     }
 
+    @Test func completedTranscription() {
+        let item = makeItem(queue: .transcription, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.title == "Transcription Complete")
+        #expect(s?.body == "2 transcripts fetched")
+    }
+
+    @Test func completedTranscriptionSingle() {
+        let item = makeItem(queue: .transcription, sourceIDs: [.init(rawValue: "S1")])
+        let s = OperationNotifier.summary(for: item, outcome: .completed)
+        #expect(s?.body == "1 transcript fetched")
+    }
+
     // MARK: - Failed summaries
 
     @Test func failedExtraction() {
@@ -140,6 +159,13 @@ import WikiFSCore
         let s = OperationNotifier.summary(for: item, outcome: .failed("Agent crashed"))
         #expect(s?.title == "Lint Failed")
         #expect(s?.body == "Wiki-wide lint: Agent crashed")
+    }
+
+    @Test func failedTranscription() {
+        let item = makeItem(queue: .transcription, sourceIDs: [.init(rawValue: "S1")])
+        let s = OperationNotifier.summary(for: item, outcome: .failed("No captions"))
+        #expect(s?.title == "Transcription Failed")
+        #expect(s?.body == "1 transcript: No captions")
     }
 
     @Test func failedEmptyErrorFallsBackToUnknown() {
@@ -180,6 +206,13 @@ import WikiFSCore
         let s = OperationNotifier.summary(for: item, outcome: .cancelled)
         #expect(s?.title == "Lint Cancelled")
         #expect(s?.body == "Wiki-wide lint \u{2014} cancelled")
+    }
+
+    @Test func cancelledTranscription() {
+        let item = makeItem(queue: .transcription, sourceIDs: [.init(rawValue: "S1"), .init(rawValue: "S2")])
+        let s = OperationNotifier.summary(for: item, outcome: .cancelled)
+        #expect(s?.title == "Transcription Cancelled")
+        #expect(s?.body == "2 transcripts \u{2014} cancelled")
     }
 
     // MARK: - Outcome identifier

--- a/Tests/WikiFSAppTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSAppTests/QueueIngestionTests.swift
@@ -62,6 +62,27 @@ struct CompositeWorkerFactoryTests {
         #expect(providerID == "default-ingest")
     }
 
+    @Test("Routes transcription items to transcription factory")
+    func routesTranscriptionItems() async throws {
+        let extractionFactory = FakeFactory(providerIDValue: "local-pdf2md")
+        let ingestionFactory = FakeFactory(providerIDValue: "default-ingest")
+        let transcriptionFactory = FakeFactory(providerIDValue: "transcription")
+        let composite = CompositeWorkerFactory(factories: [
+            .extraction: extractionFactory,
+            .ingestion: ingestionFactory,
+            .transcription: transcriptionFactory
+        ])
+
+        let item = QueueItem(
+            id: "tr1", queue: .transcription, wikiID: "wiki1",
+            payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "src2")]),
+            state: .queued, orderingKey: 1000, attempt: 0,
+            createdAt: 0)
+
+        let providerID = await composite.providerID(for: item)
+        #expect(providerID == "transcription")
+    }
+
     @Test("Missing factory returns nil provider ID")
     func missingFactoryReturnsNil() async throws {
         let extractionFactory = FakeFactory(providerIDValue: "local-pdf2md")
@@ -345,6 +366,66 @@ struct QueueActivityTrackerIngestionTests {
         // Complete ingestion → both clear
         tracker.handleForTesting(.completed(ingestionItem))
         #expect(tracker.ingestingSourceIDs.isEmpty)
+    }
+
+    // MARK: - Transcription source-ID tracking (#842)
+
+    @MainActor
+    @Test("Tracker tracks transcription source IDs on started")
+    func transcriptionStartedAddsSourceIDs() async {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(id: "tr1", queue: .transcription, sourceIDs: [PageID(rawValue: "src1"), PageID(rawValue: "src2")])
+        tracker.start(events: AsyncStream { _ in })
+        tracker.attachForTesting(events: AsyncStream { _ in })
+        tracker.handleForTesting(.started(item))
+
+        #expect(tracker.transcribingSourceIDs == Set([PageID(rawValue: "src1"), PageID(rawValue: "src2")]))
+        #expect(tracker.isTranscribing(sourceID: PageID(rawValue: "src1")) == true)
+        #expect(tracker.isTranscribing(sourceID: PageID(rawValue: "src2")) == true)
+        #expect(tracker.isTranscribing(sourceID: PageID(rawValue: "other")) == false)
+        #expect(tracker.isTranscribingAny == true)
+    }
+
+    @MainActor
+    @Test("Tracker clears transcription source IDs on completed")
+    func transcriptionCompletedClearsSourceIDs() async {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(id: "tr1", queue: .transcription, sourceIDs: [PageID(rawValue: "src1")])
+        tracker.start(events: AsyncStream { _ in })
+        tracker.attachForTesting(events: AsyncStream { _ in })
+        tracker.handleForTesting(.started(item))
+        #expect(tracker.isTranscribing(sourceID: PageID(rawValue: "src1")))
+
+        let completed = makeItem(id: item.id, queue: .transcription, sourceIDs: [PageID(rawValue: "src1")], state: .completed)
+        tracker.handleForTesting(.completed(completed))
+        #expect(tracker.transcribingSourceIDs.isEmpty)
+        #expect(tracker.isTranscribing(sourceID: PageID(rawValue: "src1")) == false)
+        #expect(tracker.isTranscribingAny == false)
+    }
+
+    @MainActor
+    @Test("Tracker does not conflate transcription with extraction")
+    func noTranscriptionConflation() async {
+        let tracker = QueueActivityTracker()
+        let extractionItem = makeItem(id: "ext1", queue: .extraction, sourceIDs: [PageID(rawValue: "src1")])
+        let transcriptionItem = makeItem(id: "tr1", queue: .transcription, sourceIDs: [PageID(rawValue: "src2")])
+        tracker.start(events: AsyncStream { _ in })
+        tracker.attachForTesting(events: AsyncStream { _ in })
+
+        tracker.handleForTesting(.started(extractionItem))
+        tracker.handleForTesting(.started(transcriptionItem))
+
+        #expect(tracker.extractingSourceIDs == Set([PageID(rawValue: "src1")]))
+        #expect(tracker.transcribingSourceIDs == Set([PageID(rawValue: "src2")]))
+
+        // Complete transcription → only transcription clears
+        tracker.handleForTesting(.completed(transcriptionItem))
+        #expect(tracker.transcribingSourceIDs.isEmpty)
+        #expect(tracker.extractingSourceIDs == Set([PageID(rawValue: "src1")]))
+
+        // Complete extraction → both clear
+        tracker.handleForTesting(.completed(extractionItem))
+        #expect(tracker.extractingSourceIDs.isEmpty)
     }
 
     // MARK: - #608: pending-permission surfacing

--- a/Tests/WikiFSTests/QueueTranscriptionTests.swift
+++ b/Tests/WikiFSTests/QueueTranscriptionTests.swift
@@ -1,0 +1,460 @@
+#if os(macOS)
+import Foundation
+import Testing
+import os
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// Tests for the `.transcription` queue kind: `QueueTranscriptionWorker`,
+/// `QueueTranscriptionWorkerFactory`, engine enqueue/waitForCompletion, and
+/// capacity limits. Mirrors `QueueExtractionTests`. Uses fake providers (no
+/// real network/subprocess fetches).
+@Suite(.serialized, .timeLimit(.minutes(2)))
+struct QueueTranscriptionTests {
+
+    // MARK: - Helpers
+
+    private func tempDatabaseURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-transcription-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("queue.sqlite")
+    }
+
+    private func makePayload(sourceID: String = "TESTSRC001") -> QueueItemPayload {
+        QueueItemPayload(sourceIDs: [PageID(rawValue: sourceID)])
+    }
+
+    // MARK: - Enqueue returns immediately
+
+    @Test func testEnqueueReturnsBeforeTranscription() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let gate = CountDownLatch(count: 1)
+        let provider = FakeTranscriptionProvider(
+            resolveResult: .resolved,
+            fetchBehavior: { await gate.wait() }
+        )
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider,
+            emitProgress: { _, _ in }
+        )
+        let config = QueueEngineConfig(transcriptionLimit: 2)
+        let engine = QueueEngine(store: store, config: config, workerFactory: factory)
+        await engine.start()
+
+        let start = Date()
+        _ = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 1.0) // Immediate — not waiting for the worker.
+        gate.release()
+        store.close()
+    }
+
+    // MARK: - Enqueue rejects empty wikiID
+
+    @Test func testEnqueueRejectsEmptyWikiID() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+        let provider = FakeTranscriptionProvider(resolveResult: .resolved)
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store, workerFactory: factory)
+        await engine.start()
+
+        do {
+            _ = try await engine.enqueue(
+                QueueItemRequest(queue: .transcription, wikiID: "", payload: makePayload()))
+            Issue.record("Should have thrown")
+        } catch is QueueStoreError { /* expected */ }
+        store.close()
+    }
+
+    // MARK: - Nil resolution: item stays queued
+
+    @Test func testUnconfiguredProviderStaysQueued() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let provider = FakeTranscriptionProvider(resolveResult: .nilResolution)
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store, workerFactory: factory)
+        await engine.start()
+
+        let id = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let item = try store.getItem(id)
+        #expect(item?.state == .queued) // Never dispatched.
+        store.close()
+    }
+
+    // MARK: - Worker calls provider in order (resolve → fetch → persist)
+
+    @Test func testTranscriptionWorkerCallsProviderInOrder() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let provider = FakeTranscriptionProvider(
+            resolveResult: .resolved,
+            fetchBehavior: { }
+        )
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store,
+                                 config: QueueEngineConfig(transcriptionLimit: 2),
+                                 workerFactory: factory)
+        await engine.start()
+
+        _ = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let calls = provider.callLog
+        // Factory calls resolve during providerID(for:), worker calls it
+        // again before fetch, then persist. Expect at least 2 resolve + 1 persist.
+        #expect(calls.count >= 2)
+        #expect(calls.contains(where: { $0.contains("persist") }))
+        #expect(calls[0].contains("resolve"))
+        // The technique should be the one from the resolution.
+        #expect(provider.lastTechnique == "youtube-captions")
+        store.close()
+    }
+
+    // MARK: - Fetch throws → item .failed
+
+    @Test func testTranscriptionFetchThrowMarksFailed() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        struct TestError: Error {}
+        let provider = FakeTranscriptionProvider(
+            resolveResult: .resolved,
+            fetchBehavior: { throw TestError() }
+        )
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store,
+                                 config: QueueEngineConfig(transcriptionLimit: 2),
+                                 workerFactory: factory)
+        await engine.start()
+
+        let id = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+
+        let result = await engine.waitForCompletion(of: id)
+
+        switch result {
+        case .success: Issue.record("Expected failure, got success")
+        case .failure: break // Expected.
+        }
+
+        let item = try store.getItem(id)
+        #expect(item?.state == .failed)
+        store.close()
+    }
+
+    // MARK: - waitForCompletion success
+
+    @Test func testWaitForCompletionReturnsSuccess() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let provider = FakeTranscriptionProvider(
+            resolveResult: .resolved,
+            fetchBehavior: { }
+        )
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store,
+                                 config: QueueEngineConfig(transcriptionLimit: 2),
+                                 workerFactory: factory)
+        await engine.start()
+
+        let id = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+
+        let result = await engine.waitForCompletion(of: id)
+
+        if case .success = result { /* expected */ } else {
+            Issue.record("Expected .success")
+        }
+
+        let item = try store.getItem(id)
+        #expect(item?.state == .completed)
+        store.close()
+    }
+
+    // MARK: - Capacity: two concurrent, a third waits
+
+    @Test func testTwoConcurrentTranscriptionThirdWaits() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let gate1 = CountDownLatch(count: 1)
+        let gate2 = CountDownLatch(count: 1)
+        let counter = AsyncCounter()
+        let provider = FakeTranscriptionProvider(
+            resolveResult: .resolved,
+            fetchBehavior: {
+                let n = await counter.increment()
+                if n == 1 { await gate1.wait() }
+                if n == 2 { await gate2.wait() }
+            }
+        )
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store,
+                                 config: QueueEngineConfig(transcriptionLimit: 2),
+                                 workerFactory: factory)
+        await engine.start()
+
+        let id1 = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1",
+                             payload: makePayload(sourceID: "SRC1")))
+        let id2 = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1",
+                             payload: makePayload(sourceID: "SRC2")))
+        let id3 = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1",
+                             payload: makePayload(sourceID: "SRC3")))
+
+        // Give the engine time to dispatch.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Item 1 and 2 should be running; item 3 should be queued.
+        let item1 = try store.getItem(id1)
+        let item2 = try store.getItem(id2)
+        let item3 = try store.getItem(id3)
+        #expect(item1?.state == .running)
+        #expect(item2?.state == .running)
+        #expect(item3?.state == .queued) // Third waits — capacity is 2.
+
+        // Release the gates so the engine cleans up.
+        gate1.release()
+        gate2.release()
+        try await Task.sleep(nanoseconds: 500_000_000)
+        store.close()
+    }
+
+    // MARK: - Factory providerID
+
+    @Test func testFactoryProviderIDReturnsTranscriptionWhenResolvable() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+        let provider = FakeTranscriptionProvider(resolveResult: .resolved)
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store, workerFactory: factory)
+        await engine.start()
+
+        let id = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let item = try store.getItem(id)
+        // When dispatched, the providerID should be "transcription".
+        #expect(item?.providerID == "transcription")
+        store.close()
+    }
+
+    @Test func testFactoryProviderIDReturnsNilWhenNotResolvable() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+        let provider = FakeTranscriptionProvider(resolveResult: .nilResolution)
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store, workerFactory: factory)
+        await engine.start()
+
+        let id = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let item = try store.getItem(id)
+        // Never dispatched — no provider ID assigned.
+        #expect(item?.providerID == nil)
+        #expect(item?.state == .queued)
+        store.close()
+    }
+
+    // MARK: - Progress event emitted
+
+    @Test func testProgressEventEmitted() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        let progressHolder = ProgressCollector()
+        let provider = FakeTranscriptionProvider(
+            resolveResult: .resolved,
+            fetchBehavior: { }
+        )
+        let factory = QueueTranscriptionWorkerFactory(
+            provider: provider,
+            emitProgress: { id, line in progressHolder.record(id: id, line: line) })
+        let engine = QueueEngine(store: store,
+                                 config: QueueEngineConfig(transcriptionLimit: 2),
+                                 workerFactory: factory)
+        await engine.start()
+
+        _ = try await engine.enqueue(
+            QueueItemRequest(queue: .transcription, wikiID: "wiki1", payload: makePayload()))
+
+        try await progressHolder.waitForCount(1, timeoutSeconds: 5)
+
+        #expect(progressHolder.lines.count >= 1)
+        #expect(progressHolder.lines[0].line == "Fetching transcript…")
+        store.close()
+    }
+
+    // MARK: - Headless isolation
+
+    @Test func testHeadlessIsolation() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let root = testFile.deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let files = [
+            root.appendingPathComponent("Sources/WikiFSEngine/QueueTranscriptionProvider.swift"),
+            root.appendingPathComponent("Sources/WikiFSEngine/QueueTranscriptionWorker.swift"),
+        ]
+
+        for fileURL in files {
+            let source = try String(contentsOf: fileURL, encoding: .utf8)
+            #expect(!source.contains("import AppKit"),
+                   "\(fileURL.lastPathComponent) must not import AppKit")
+            #expect(!source.contains("import SwiftUI"),
+                   "\(fileURL.lastPathComponent) must not import SwiftUI")
+        }
+    }
+}
+
+// MARK: - Fake transcription provider
+
+private final class FakeTranscriptionProvider: QueueTranscriptionProvider, @unchecked Sendable {
+    enum ResolveResult {
+        case resolved
+        case nilResolution
+    }
+
+    private let lock = OSAllocatedUnfairLock(initialState: State())
+    private let resolveResult: ResolveResult
+    private let fetchBehavior: @Sendable () async throws -> Void
+
+    private struct State {
+        var callLog: [String] = []
+        var lastTechnique: String? = nil
+    }
+
+    var callLog: [String] { lock.withLock { $0.callLog } }
+    var lastTechnique: String? { lock.withLock { $0.lastTechnique } }
+
+    init(
+        resolveResult: ResolveResult,
+        fetchBehavior: @escaping @Sendable () async throws -> Void = { }
+    ) {
+        self.resolveResult = resolveResult
+        self.fetchBehavior = fetchBehavior
+    }
+
+    func resolveTranscription(
+        wikiID: String, sourceID: PageID
+    ) async throws -> TranscriptionResolution? {
+        lock.withLock { state in
+            state.callLog.append("resolve(wikiID:\(wikiID), sourceID:\(sourceID.rawValue))")
+            state.lastTechnique = "youtube-captions"
+        }
+
+        switch resolveResult {
+        case .resolved:
+            return TranscriptionResolution(
+                fetch: { @Sendable in
+                    try await self.fetchBehavior()
+                    return "# Transcript markdown"
+                },
+                technique: "youtube-captions")
+        case .nilResolution:
+            return nil
+        }
+    }
+
+    func persistTranscription(
+        wikiID: String, sourceID: PageID,
+        markdown: String, technique: String
+    ) async throws {
+        lock.withLock { state in
+            state.callLog.append("persist(wikiID:\(wikiID), sourceID:\(sourceID.rawValue), technique:\(technique))")
+        }
+    }
+}
+
+// MARK: - Progress collector + CountDownLatch (same as QueueExtractionTests)
+
+private final class ProgressCollector: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: [(id: QueueItem.ID, line: String)]())
+
+    var lines: [(id: QueueItem.ID, line: String)] {
+        lock.withLock { $0 }
+    }
+
+    func record(id: QueueItem.ID, line: String) {
+        lock.withLock { $0.append((id, line)) }
+    }
+
+    func waitForCount(_ count: Int, timeoutSeconds: TimeInterval) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while true {
+            let current = lines.count
+            if current >= count { return }
+            if Date() > deadline {
+                Issue.record("Timed out waiting for \(count) progress lines, got \(current)")
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}
+
+private final class CountDownLatch: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: (count: 0, waiters: [CheckedContinuation<Void, Never>]()))
+
+    init(count: Int) {
+        lock.withLock { state in state.count = count }
+    }
+
+    func wait() async {
+        let needsWait: Bool = lock.withLock { state in
+            state.count > 0
+        }
+        guard needsWait else { return }
+
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            lock.withLock { state in
+                if state.count <= 0 {
+                    c.resume()
+                } else {
+                    state.waiters.append(c)
+                }
+            }
+        }
+    }
+
+    func release() {
+        lock.withLock { state in
+            state.count -= 1
+            if state.count <= 0 {
+                for w in state.waiters { w.resume() }
+                state.waiters.removeAll()
+            }
+        }
+    }
+}
+
+private actor AsyncCounter {
+    private var count = 0
+    func increment() -> Int {
+        count += 1
+        return count
+    }
+}
+#endif // os(macOS)

--- a/plans/transcription-queue.md
+++ b/plans/transcription-queue.md
@@ -1,0 +1,123 @@
+# Issue #842 — Route transcription through the queue engine
+
+**Goal:** make `SourceDetailView.runTranscription()` enqueue a durable queue
+job instead of running inline, and reveal that job in the Activity window —
+matching how extraction and ingestion are already queued.
+
+**Scope:** YouTube + podcast (Apple/RSS) transcription. No daemon work; no
+live chat. PR1 = queue infrastructure + worker + enqueue (no nav). PR2 =
+reveal-job navigation (shared with #837).
+
+## PR1 scope (corrected per §9)
+
+- Add `.transcription` to `QueueKind` + ALL compile-breaking switch sites (C2):
+  `QueueEngine` (dispatch + arrays + snapshot literal), `QueueActivityTracker`
+  (×2: `.started` + `removeItem`), `OperationNotifier` (enum + switch arm),
+  `QueueStore` (array literal in `pruneHistory`), `ActivityWindowView`
+  (`kindLabel`).
+- Add `transcriptionLimit` (default 2) to `QueueEngineConfig`.
+- Add `transcribingSourceIDs` to `QueueActivityTracker` +
+  `isTranscribing(sourceID:)` (C3).
+- Worker + factory + provider mirroring extraction (`QueueTranscriptionProvider`,
+  `QueueTranscriptionWorker`, `AppQueueTranscriptionProvider`).
+- Migrate `runTranscription()` to enqueue. Replace (don't delete) `isTranscribing`
+  with a computed property from `tracker.transcribingSourceIDs` (C5). Drop the
+  `transcribeError` inline rendering.
+- Activity-window branches: `queueTitle`, `kindLabel`, empty-state, icon, autosave
+  name (C7 — convert ternaries to switches).
+- Tests for every new switch arm + tracker + worker + provider.
+- `swift build` clean is the gate (C2). `swift test` must pass full suite.
+
+## PR2 scope (corrected per §9)
+
+- Parameterize `openActivityWindow` with `QueueKind` (C1).
+- Add `pendingSelectionQueue` guard (C4).
+- `SourceDetailView` sets `pendingSelectionItemID` + calls the parameterized
+  opener (reuse #840's existing seam, NOT a new class).
+- `headVersion` refresh via store change event (C6).
+
+## §9 Plan-Review Corrections (AUTHORITATIVE)
+
+### C1 — PR2's navigation mechanism reuses already-merged PR #840
+`QueueActivityTracker.pendingSelectionItemID` (line 130) is the
+pending-selection rendezvous. `ActivityWindowView.consumePendingSelectionIfNeeded()`
+(lines 116-121) reads + clears on `.onAppear` (line 71) and
+`.onChange(of: pendingSelectionItemID)` (line 78-80). `PageDetailView.swift:303-306`
+is the proven seam. Drop the `PendingActivitySelection` class entirely.
+
+### C2 — Adding `.transcription` breaks exhaustive switches; PR1 will NOT compile
+Compile-breaking switch sites:
+1. `QueueEngine.swift:571-576` — `switch item.queue` capacity dispatch. Also add
+   `transcriptionLimit` to `QueueEngineConfig` (default 2).
+2. `QueueActivityTracker.swift:520` (`.started`) and `:662` (`removeItem`).
+3. `OperationNotifier.swift:155-163` — `operationKind(for:)` + `OperationKind` enum.
+4. `QueueStore.swift:761` — array literal (not a switch, but silently skips).
+
+Also: `QueueEngine.swift:121, 209, 554` — array literals that skip transcription.
+`QueueEngine.swift:321-323` — snapshot `qs` dict literal.
+
+### C3 — `QueueActivityTracker` source-tracking for transcription is missing
+Add a `transcribingSourceIDs` set (mirror `extractingSourceIDs`), wire it in the
+`.started` (`:520`) and `removeItem` (`:662`) switch arms, and expose
+`isTranscribing(sourceID:)`.
+
+### C4 — Add a `pendingSelectionQueue` guard (PR2)
+Add `pendingSelectionQueue: QueueKind?` alongside `pendingSelectionItemID`.
+
+### C5 — Don't delete `isTranscribing`; derive it from the tracker
+Replace `isTranscribing` with a computed property derived from
+`tracker.transcribingSourceIDs`. Wire it into the `:824/:1643/:1662` disabled guards.
+
+### C6 — `headVersion` refresh after async enqueue (PR2)
+Confirm `appendProcessedMarkdown` emits via `mutate()` → `ResourceChangeEvent`,
+and that `SourceDetailView` observes it to call `processedMarkdownHead`.
+
+### C7 — Broaden the switch-site audit
+Convert ternaries (`queueTitle` at `ActivityWindowView:43`,
+`queueWindowAutosaveName` at `MenuBarItemController:480`, icon at `:387`,
+empty-state at `:208`) to switches.
+
+### C8 — Remove `PendingActivitySelection.swift` from file checklist (PR2)
+
+## Architecture
+
+- **New `.transcription` QueueKind** — distinct from `.extraction` because
+  extraction's `ExtractionResolution` is PDF-shaped (`pdfData`,
+  `convert(pdfData:)`, `ExtractionBackend`). A transcript is a network/subprocess
+  fetch keyed by video ID / feed URL with no local bytes.
+- **Protocol** `QueueTranscriptionProvider`: `resolveTranscription(...) ->
+  TranscriptionResolution?` + `persistTranscription(...)`.
+- **`TranscriptionResolution`**: a `@Sendable () async throws -> String` fetch
+  closure + technique tag. No `pdfData`.
+- **Worker** `QueueTranscriptionWorker.execute`: resolve → fetch → persist.
+- **Factory** `QueueTranscriptionWorkerFactory`: `providerID(for:)` (pre-check via
+  resolve) + `worker(for:)`.
+- **App provider** `AppQueueTranscriptionProvider`: `@MainActor`, bridges
+  `SessionLookupBox` → `store.sourceOrigin` + builds the right detached fetch per
+  provider (YouTube/RSS/Apple). `persistTranscription` calls
+  `store.appendProcessedMarkdown(origin: .transcript, ...)`.
+- **Wiring** in `WikiFSApp`: add `.transcription: transcriptionFactory` to
+  `CompositeWorkerFactory(factories:)`.
+- **UI trigger** `runTranscription()`: `QueueItemRequest(queue: .transcription, ...)`
+  → `queueEngine.enqueue` → (PR2: reveal the new job).
+- **Capacity**: single provider id `"transcription"`, limit 2 (no local-subprocess
+  serialization constraint).
+
+## File change checklist (PR1)
+
+| File | Change |
+|---|---|
+| `Sources/WikiFSCore/Core/QueueTypes.swift` | + `case transcription` |
+| `Sources/WikiFSCore/Core/QueueStore.swift` | + `.transcription` in `pruneHistory` array |
+| `Sources/WikiFSEngine/QueueWorker.swift` | + `transcriptionLimit` on `QueueEngineConfig` |
+| `Sources/WikiFSEngine/QueueEngine.swift` | + `.transcription` in dispatch switch + array literals + snapshot dict |
+| `Sources/WikiFSEngine/QueueTranscriptionProvider.swift` | **NEW** — protocol + `TranscriptionResolution` + error |
+| `Sources/WikiFSEngine/QueueTranscriptionWorker.swift` | **NEW** — worker + factory |
+| `Sources/WikiFS/Queue/AppQueueTranscriptionProvider.swift` | **NEW** — `@MainActor` provider |
+| `Sources/WikiFS/Queue/QueueActivityTracker.swift` | + `transcribingSourceIDs` + `.transcription` arms |
+| `Sources/WikiFS/Queue/OperationNotifier.swift` | + `.transcription` in enum + switch |
+| `Sources/WikiFS/Queue/ActivityWindowView.swift` | `.transcription` branches (title, label, empty, icon, CTA) |
+| `Sources/WikiFS/Window/WikiFSApp.swift` | wire transcription provider/factory |
+| `Sources/WikiFS/Window/MenuBarItemController.swift` | transcription window + autosave + menu item |
+| `Sources/WikiFS/Sources/SourceDetailView.swift` | enqueue + replace `isTranscribing`; delete `transcribeError` |
+| `Tests/WikiFSTests/QueueTranscriptionTests.swift` | **NEW** |


### PR DESCRIPTION
## Summary

Route `SourceDetailView.runTranscription()` through the queue engine (enqueue + `waitForCompletion`) instead of calling `store.transcribe(sourceID:)` inline, matching how extraction and ingestion are already queued. This is **PR1** of issue #842 — queue infrastructure + worker + enqueue (no navigation reveal).

Closes #842 (PR1 scope). PR2 (reveal-job navigation, shared with #837) is separate.

## What changed

### New `.transcription` QueueKind

A distinct kind from `.extraction` because extraction's `ExtractionResolution` is PDF-shaped (`pdfData`, `convert(pdfData:)`, `ExtractionBackend`). A transcript is a network/subprocess fetch keyed by video ID / feed URL with no local bytes.

### New engine-layer types (mirroring extraction)

- **`QueueTranscriptionProvider`** protocol + `TranscriptionResolution` (a `@Sendable` fetch closure + technique tag — no `pdfData`)
- **`QueueTranscriptionWorker`** + `QueueTranscriptionWorkerFactory`: resolve → fetch → persist, with a single "Fetching…" progress line

### New app-layer provider

- **`AppQueueTranscriptionProvider`** (`@MainActor`): resolves `sourceOrigin`, builds the right fetcher per provider (YouTube / RSS podcast / Apple podcast), persists via `WikiStoreModel.appendTranscriptMarkdown`

### Migration

- `runTranscription()` and `runTranscription(with:)` now enqueue `QueueItemRequest(queue: .transcription, ...)` and `waitForCompletion`, mirroring `runExtraction()`
- `isTranscribing` replaced with a computed property derived from `tracker.transcribingSourceIDs` (C5 — not deleted)
- `transcribeError` `@State` + its inline render removed (errors now live on the queue item's `error` field + Activity window)
- Fixes the button alignment issue caused by the inline `transcribeError` Text

### §9 plan-review corrections (all applied)

| Correction | What was done |
|---|---|
| **C2** (critical) | Added `.transcription` to ALL exhaustive switch sites: `QueueEngine` dispatch switch + 3 array literals + snapshot dict, `QueueActivityTracker` ×2 (`.started` + `removeItem`), `OperationNotifier` enum + switch + body helpers, `QueueStore` `pruneHistory`, `ActivityWindowView` `kindLabel` |
| **C3** (high) | Added `transcribingSourceIDs` set + `isTranscribing(sourceID:)` to `QueueActivityTracker`, wired in `.started` and `removeItem` arms |
| **C5** (medium) | Replaced `isTranscribing` `@State` with computed property from `tracker.transcribingSourceIDs`; dropped `transcribeError` render |
| **C7** (medium) | Converted all ternaries to switches: `queueTitle`, `queueControlIcon`, `emptyState`, `queueWindowAutosaveName`; added transcription branches for icon (`waveform`), empty-state text, and the Configure CTA (gated out for transcription — no Settings tab) |
| **C2 config** | Added `transcriptionLimit` (default 2) to `QueueEngineConfig` |

### Activity window branches

- `queueTitle`: "Transcription Queue"
- `kindLabel`: "Transcription"  
- `emptyState`: "Transcription tasks (YouTube/podcast) appear here as they run."
- Icon: `waveform`
- Autosave: "TranscriptionQueueWindow"
- Menu item: "Transcription Queue…" in the menu bar

## Tests

- **11 new worker/factory/engine tests** (`QueueTranscriptionTests.swift`): enqueue returns immediately, rejects empty wikiID, nil resolution stays queued, worker calls provider in order, fetch throws → `.failed`, `waitForCompletion` success/failure, capacity (2 concurrent, 3rd waits), factory providerID, progress events, headless isolation
- **5 new notifier tests**: `OperationKind.transcription` kind + completed/failed/cancelled summaries
- **3 new tracker tests**: `transcribingSourceIDs` set on `.started`, cleared on `.completed`, no conflation with extraction
- **1 CompositeWorkerFactory test**: routes transcription items to transcription factory
- **Full suite**: 3598 tests pass

## Gate

- `swift build` clean
- `swift test` — 3598 tests pass
