### PR TITLE
Route transcription through queue PR2: reveal-job navigation (#842)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,88 @@
 # Progress log
 
+## feat: Route transcription through queue PR2: reveal-job navigation (#842)
+
+**Goal:** when a transcription is running/queued for a source, clicking
+Transcribe navigates the user to that job in the Activity window — mirroring
+the "View Lint" pattern from #837. PR1 (#845, merged) added the
+`.transcription` QueueKind + worker + enqueue; PR2 adds the navigation.
+
+**Files touched:**
+- **C1 — Parameterize `openActivityWindow` with `QueueKind`:**
+  `Sources/WikiFS/Environment/ActivityWindowEnvironmentKey.swift`
+  (the closure type changed from `(() -> Void)?` to
+  `((QueueKind) -> Void)?` so callers can target the ingestion, extraction,
+  or transcription Activity window),
+  `Sources/WikiFS/Window/OpenWindowBridge.swift`
+  (`openActivityWindow` property follows),
+  `Sources/WikiFS/Window/MenuBarItemController.swift`
+  (the assignment at `start()` forwards the `queue` argument through
+  `openQueueWindow?(queue)`),
+  `Sources/WikiFS/Window/WikiFSApp.swift`
+  (`appEnvironment` signature + all three call sites: main `WindowGroup`,
+  wiki `WindowGroup(for: String.self)`, and the Activity
+  `WindowGroup(for: QueueKind.self)` — the last now routes the queue argument
+  to `openQueueWindow?(queue)` instead of hardcoding `.ingestion`),
+  `Sources/WikiFS/Pages/PageDetailView.swift`
+  (the two `openActivityWindow?()` calls now pass `.ingestion`),
+  `Sources/WikiFS/Detail/ProvenancePanel.swift`
+  (the `openActivityWindow?()` call now passes `.ingestion`).
+- **C4 — `pendingSelectionQueue` guard:**
+  `Sources/WikiFS/Queue/QueueActivityTracker.swift`
+  (added `var pendingSelectionQueue: QueueKind? = nil` alongside
+  `pendingSelectionItemID`; cleared in `stop()`),
+  `Sources/WikiFS/Queue/ActivityWindowView.swift`
+  (`consumePendingSelectionIfNeeded()` now checks
+  `pendingSelectionQueue == queue` before consuming — prevents a
+  cross-window race when both `.transcription` and `.ingestion` windows
+  exist: a lint pending-selection is not consumed by the transcription
+  window, and vice versa).
+- **C5 — `transcriptionItemID(for:)` + SourceDetailView navigation:**
+  `Sources/WikiFS/Queue/QueueActivityTracker.swift`
+  (added `itemToTranscriptionSourceIDs` tracking dict populated in the
+  `.transcription` arm of `.started`, cleared in `removeItem` and `stop()`;
+  added `func transcriptionItemID(for sourceID: PageID) -> QueueItem.ID?`
+  that resolves the running transcription job for a given source — mirroring
+  `lintItemID(for:wikiID:)` from #837),
+  `Sources/WikiFS/Sources/SourceDetailView.swift`
+  (added `@Environment(\.openActivityWindow)`; the Transcribe button swaps
+  to "View Transcription" with `checkmark.seal.fill` icon when
+  `isTranscribing` is true, stays enabled, and on tap sets
+  `tracker.pendingSelectionItemID` + `tracker.pendingSelectionQueue = .transcription`
+  then calls `openActivityWindow?(.transcription)` — reusing #840's existing
+  `pendingSelectionItemID` seam, NOT building a new class; when not
+  transcribing, the button enqueues as before; the `.disabled` guard was
+  split: disable for the enqueue path but not for the navigate path).
+- **C6 — `headVersion` refresh via store change event:**
+  `Sources/WikiFS/Sources/SourceDetailView.swift`
+  (added `.onChange(of: store.sources)` that re-reads
+  `processedMarkdownHead` when not editing — picks up the
+  `ResourceChangeEvent(.source, .updated)` from
+  `appendProcessedMarkdown` → `mutate()` → bus → `reloadFromStore()` →
+  `reloadSources()` → `sources` bump; works across windows so another wiki
+  window viewing the same source sees the new transcript without the
+  initiating view's post-completion refresh),
+  `Tests/WikiFSTests/StoreEmissionTests.swift`
+  (added `appendProcessedMarkdownTranscriptOriginEmitsSourceUpdated` —
+  verifies the `.transcript` origin emits a `ResourceChangeEvent(.source,
+  .updated)`, mirroring the existing `.extraction` origin test).
+- **Tests:** `Tests/WikiFSAppTests/QueueIngestionTests.swift`
+  (11 new tests in `QueueActivityTrackerLintItemIDTests`:
+  `pendingSelectionQueue` defaults/stop, `transcriptionItemID` resolution,
+  nil-when-idle, no-cross-kind-conflation with extraction, cleanup on
+  completion/cancellation, cross-kind ID non-conflation).
+
+**Reused #840's navigation seam** — `pendingSelectionItemID` +
+`consumePendingSelectionIfNeeded()` — no new `PendingActivitySelection`
+class. The `pendingSelectionQueue` guard extends the seam to be
+queue-aware, preventing cross-window consumption when both
+`.transcription` and `.ingestion` Activity windows are open.
+
+**Verified:** `make version prompts && swift build` clean (128s); `swift
+test` — 3665 tests in 303 suites passed (21.9s). The 11 new tracker tests
++ 1 new emission test pass via
+`swift test --filter "transcription|pendingSelection|transcriptOrigin|appendProcessedMarkdown"`.
+
 ## fix: Queue window sidebar rendering behind traffic lights (#835)
 
 **Symptom:** the Agent Queue / Extraction Queue window's sidebar `List`

--- a/Sources/WikiFS/Detail/ProvenancePanel.swift
+++ b/Sources/WikiFS/Detail/ProvenancePanel.swift
@@ -230,7 +230,7 @@ struct ProvenancePanel: View {
             store?.openTab(.chat(id))
         case .agent:
             DebugLog.tabs("ProvenancePanel: opening Activity window for \(entry.agentName)")
-            openActivityWindow?()
+            openActivityWindow?(.ingestion)
         case .user, .legacyImport, .other:
             // No navigation target for non-chat / non-agent authors.
             break

--- a/Sources/WikiFS/Environment/ActivityWindowEnvironmentKey.swift
+++ b/Sources/WikiFS/Environment/ActivityWindowEnvironmentKey.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WikiFSCore
 
 /// Environment key for opening the Activity (queue) window (#745).
 ///
@@ -10,14 +11,21 @@ import SwiftUI
 ///
 /// Defaults to `nil` (no-op) when not injected — a no-op is the correct
 /// degradation for views that don't need Activity navigation.
+///
+/// PR2 (#842): the closure takes a `QueueKind` argument so callers can open
+/// the transcription, extraction, or ingestion Activity window — the
+/// `WindowGroup(for: QueueKind.self)` deduplicates by `==`, so the correct
+/// window is focused or created.
 private struct ActivityWindowEnvironmentKey: EnvironmentKey {
-    nonisolated(unsafe) static let defaultValue: (() -> Void)? = nil
+    nonisolated(unsafe) static let defaultValue: ((QueueKind) -> Void)? = nil
 }
 
 extension EnvironmentValues {
-    /// A closure that opens the Activity (queue) window. Injected at the
-    /// scene root (`WikiFSApp`) so any descendant view can call it.
-    var openActivityWindow: (() -> Void)? {
+    /// A closure that opens the Activity (queue) window for the given queue
+    /// kind. Injected at the scene root (`WikiFSApp`) so any descendant view
+    /// can call it. PR2 (#842): parameterized with `QueueKind` so the
+    /// transcription Activity window can be opened from `SourceDetailView`.
+    var openActivityWindow: ((QueueKind) -> Void)? {
         get { self[ActivityWindowEnvironmentKey.self] }
         set { self[ActivityWindowEnvironmentKey.self] = newValue }
     }

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -303,13 +303,13 @@ struct PageDetailView: View {
                     if let itemID = activityTracker.lintItemID(
                         for: id, wikiID: session.wikiID) {
                         activityTracker.pendingSelectionItemID = itemID
-                        openActivityWindow?()
+                        openActivityWindow?(.ingestion)
                         DebugLog.ingest("Lint button: navigating to lint job \(itemID.prefix(8)) for page \(id) in wiki \(session.wikiID.prefix(8))")
                     } else {
                         // isLinting returned true but we couldn't resolve the
                         // specific item (race: item just finished). Fall back to
                         // opening the Activity window without a selection.
-                        openActivityWindow?()
+                        openActivityWindow?(.ingestion)
                         DebugLog.ingest("Lint button: lint in flight for page \(id) but item not found; opening Activity window")
                     }
                 } else {

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -144,14 +144,25 @@ struct ActivityWindowView: View {
     }
 
     /// Consume a pending item selection requested from outside the Activity
-    /// window (#837). Set on `activityTracker.pendingSelectionItemID` before
-    /// the window-opening closure fires; read here and cleared. Overrides
-    /// the current selection — the user explicitly asked to see this item.
-    /// Marks `didAutoSelect` so `autoSelectIfNeeded` won't override it back
-    /// when the first snapshot lands.
+    /// window (#837, #842 PR2 C4). Set on `activityTracker.pendingSelectionItemID`
+    /// (and `pendingSelectionQueue`) before the window-opening closure fires;
+    /// read here and cleared. The `pendingSelectionQueue` guard ensures the
+    /// item belongs to THIS window's queue — prevents a cross-window race when
+    /// both `.transcription` and `.ingestion` windows exist (a lint pending-
+    /// selection must not be consumed by the transcription window, and vice
+    /// versa). Overrides the current selection — the user explicitly asked to
+    /// see this item. Marks `didAutoSelect` so `autoSelectIfNeeded` won't
+    /// override it back when the first snapshot lands.
     private func consumePendingSelectionIfNeeded() {
         guard let pending = activityTracker.pendingSelectionItemID else { return }
+        // C4: verify the pending item belongs to this window's queue. When
+        // the guard is nil (backward-compat), skip the check.
+        if let guardQueue = activityTracker.pendingSelectionQueue,
+           guardQueue != queue {
+            return
+        }
         activityTracker.pendingSelectionItemID = nil
+        activityTracker.pendingSelectionQueue = nil
         selectedItemID = pending
         didAutoSelect = true
     }

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -128,12 +128,22 @@ final class QueueActivityTracker {
     private var itemToLintWikiID: [QueueItem.ID: String] = [:]
 
     /// A pending item selection requested from outside the Activity window —
-    /// e.g. PageDetailView's "View Lint" button (#837). Set before calling the
+    /// e.g. PageDetailView's "View Lint" button (#837) or SourceDetailView's
+    /// "View Transcription" button (#842 PR2). Set before calling the
     /// `openActivityWindow` environment closure; consumed by
     /// `ActivityWindowView` on appear / change, which sets `selectedItemID`
     /// and clears this back to nil. Drives "open Activity window focused on a
-    /// SPECIFIC queue item" without changing the closure's no-arg signature.
+    /// SPECIFIC queue item" without changing the closure's signature.
     var pendingSelectionItemID: QueueItem.ID? = nil
+
+    /// The queue kind the pending selection belongs to (#842 PR2 C4). Set
+    /// alongside `pendingSelectionItemID` so `ActivityWindowView` can verify
+    /// the item belongs to the consuming window's queue — prevents a
+    /// cross-window race when both `.transcription` and `.ingestion` windows
+    /// exist (a lint pending-selection must not be consumed by the
+    /// transcription window, and vice versa). `nil` means "no queue guard"
+    /// (backward-compat for any future caller that doesn't set it).
+    var pendingSelectionQueue: QueueKind? = nil
 
     /// True while any extraction is running. Drives the sidebar spinner.
     var isExtracting: Bool { !extractingSourceIDs.isEmpty }
@@ -182,7 +192,20 @@ final class QueueActivityTracker {
         return nil
     }
 
-    /// Per-item typed agent events, for the Activity window's transcript view.
+    /// Returns the queue item ID of the transcription job currently running
+    /// for `sourceID`, or `nil` if no transcription is in flight. Used by
+    /// `SourceDetailView`'s Transcribe button to navigate to the specific job
+    /// in the Activity window when a transcription is already running (#842
+    /// PR2 C5). Mirrors `lintItemID(for:wikiID:)` (#837). Source IDs are
+    /// ULIDs (globally unique), so no wiki-scoping is needed.
+    func transcriptionItemID(for sourceID: PageID) -> QueueItem.ID? {
+        for (itemID, sourceIDs) in itemToTranscriptionSourceIDs {
+            if sourceIDs.contains(sourceID) {
+                return itemID
+            }
+        }
+        return nil
+    }
     /// Bounded — pruned only when items are pruned from history (not on
     /// terminal state, so users can view completed/failed/cancelled transcripts).
     private(set) var transcripts: [QueueItem.ID: [AgentEvent]] = [:]
@@ -264,6 +287,13 @@ final class QueueActivityTracker {
     /// `extractingSourceIDs` when items finish.
     private var itemToSourceIDs: [QueueItem.ID: Set<PageID>] = [:]
 
+    /// Maps transcription queue item ID → source IDs, so
+    /// ``transcriptionItemID(for:)`` can resolve which running transcription
+    /// job covers a given source, so the Transcribe button can navigate to
+    /// that specific job in the Activity window (#842 PR2 C5). Mirrors the
+    /// `itemToLintPageIDs` mapping that exists for lint items (#837).
+    private var itemToTranscriptionSourceIDs: [QueueItem.ID: Set<PageID>] = [:]
+
     /// Items whose transcript's last row is an in-progress streamed assistant
     /// reply — the next `.assistantTextDelta` grows that row in place instead
     /// of appending a new one (mirrors `AgentLauncher.mergeOrAppend`; without
@@ -344,7 +374,9 @@ final class QueueActivityTracker {
         wholeWikiLintingWikiIDs = []
         itemToLintPageIDs.removeAll()
         itemToLintWikiID.removeAll()
+        itemToTranscriptionSourceIDs.removeAll()
         pendingSelectionItemID = nil
+        pendingSelectionQueue = nil
         extractionLog = ""
         extractionPID = nil
         currentExtractionItemID = nil
@@ -565,6 +597,10 @@ final class QueueActivityTracker {
                 }
             case .transcription:
                 transcribingSourceIDs.formUnion(sourceIDs)
+                // Track the source mapping so `transcriptionItemID(for:)`
+                // can resolve which running job covers a given source
+                // (#842 PR2 C5).
+                itemToTranscriptionSourceIDs[item.id] = sourceIDs
             }
 
         case .transcript(let id, let agentEvent):
@@ -693,6 +729,9 @@ final class QueueActivityTracker {
         lintingItemIDs.remove(item.id)
         itemToLintPageIDs.removeValue(forKey: item.id)
         itemToLintWikiID.removeValue(forKey: item.id)
+        // Transcription items are tracked separately — remove the source
+        // mapping so `transcriptionItemID(for:)` stops resolving (#842 PR2).
+        itemToTranscriptionSourceIDs.removeValue(forKey: item.id)
         if let pageIDs = item.payload.lintPageIDs {
             if pageIDs.isEmpty {
                 // Whole-wiki lint. Safe to remove by wiki ID: the `.ingest`

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -105,6 +105,12 @@ struct SourceDetailView: View {
     /// Opens the Compare Extractions window (value-driven `WindowGroup`).
     @Environment(\.openWindow) private var openWindow
 
+    /// Opens the Activity (queue) window for a specific queue kind — injected
+    /// from the environment (#745, #842 PR2). Used by the Transcribe button to
+    /// navigate to the running transcription job when one is in flight for
+    /// this source (#842 PR2 C5).
+    @Environment(\.openActivityWindow) private var openActivityWindow
+
     // Find bar state. Shared via environment (see `ContentView`) so the address
     // bar's "Find on Page…" menu item and Cmd+F drive the same model (#157).
     @Environment(FindModel.self) private var findModel
@@ -587,6 +593,21 @@ struct SourceDetailView: View {
             }
         }
         .onChange(of: store.selection) { flushEditIfDirty(); isEditing = false }
+        // #842 PR2 C6: refresh the transcript head when the store's source list
+        // changes. `appendProcessedMarkdown` routes through `mutate()` → emits
+        // a `ResourceChangeEvent(.source, .updated)` → the model's bus
+        // subscriber calls `reloadFromStore()` → `reloadSources()` bumps
+        // `store.sources`. This onChange picks up that bump and re-reads
+        // `processedMarkdownHead` so the reader shows the new transcript
+        // immediately after the queue worker persists it — without relying
+        // solely on `runTranscription`'s post-completion refresh (which only
+        // fires for the view that initiated the job; another wiki window
+        // viewing the same source would see the stale head without this).
+        .onChange(of: store.sources) { _, _ in
+            if !isEditing {
+                headVersion = store.processedMarkdownHead(for: file)
+            }
+        }
         .background { findShortcutButton }
         .overlay(alignment: .top) { findBarOverlay }
         .onChange(of: file.id) { findModel.dismiss() }
@@ -828,26 +849,49 @@ struct SourceDetailView: View {
                         // a network fetch (signed bearer → AMP → TTML → parse
                         // for podcasts; watch-page scrape → caption track →
                         // parse for YouTube), NOT a bytes→markdown transform —
-                        // so it dispatches to the inline `runTranscription`
-                        // path (NOT the queue engine, which is PDF-coupled via
-                        // `ExtractionResolution.pdfData`). Disabled for podcasts
-                        // when the signing helper binary is unavailable
-                        // (`isTranscribable` mirrors `isSourceRefreshable`'s
-                        // `.applePodcast` runtime guard); YouTube needs no
-                        // signing helper, so it's always enabled when the
-                        // provider matches.
-                        Button(isTranscribing ? "Transcribing…" : "Transcribe",
-                               systemImage: "waveform") {
-                            DebugLog.extraction("SourceDetailView: Transcribe tapped — id=\(file.id.rawValue)")
-                            Task { await runTranscription() }
+                        // so it dispatches to the queue engine (`runTranscription`).
+                        // Disabled for podcasts when the signing helper binary
+                        // is unavailable (`isTranscribable` mirrors
+                        // `isSourceRefreshable`'s `.applePodcast` runtime guard);
+                        // YouTube needs no signing helper, so it's always
+                        // enabled when the provider matches.
+                        //
+                        // #842 PR2 C5: when a transcription is already in flight
+                        // for this source, the button swaps to "View
+                        // Transcription" (stays enabled) and navigates to the
+                        // running job in the Activity window — mirroring
+                        // PageDetailView's "View Lint" pattern (#837). Reuses
+                        // the existing `pendingSelectionItemID` seam (set it,
+                        // set `pendingSelectionQueue = .transcription`, then
+                        // call `openActivityWindow?(.transcription)`).
+                        Button(isTranscribing ? "View Transcription" : "Transcribe",
+                               systemImage: isTranscribing
+                               ? "checkmark.seal.fill"
+                               : "waveform") {
+                            if isTranscribing {
+                                if let itemID = tracker.transcriptionItemID(for: file.id) {
+                                    tracker.pendingSelectionItemID = itemID
+                                    tracker.pendingSelectionQueue = .transcription
+                                    openActivityWindow?(.transcription)
+                                    DebugLog.extraction("Transcribe button: navigating to transcription job \(itemID.prefix(8)) for source \(file.id.rawValue)")
+                                } else {
+                                    openActivityWindow?(.transcription)
+                                    DebugLog.extraction("Transcribe button: transcription in flight for source \(file.id.rawValue) but item not found; opening Activity window")
+                                }
+                            } else {
+                                DebugLog.extraction("SourceDetailView: Transcribe tapped — id=\(file.id.rawValue)")
+                                Task { await runTranscription() }
+                            }
                         }
                         .buttonStyle(.borderedProminent)
-                        .disabled(isTranscribing
-                                  || isThisFileExtracting
-                                  || tracker.isSlotBusyForOtherSource(file.id))
-                        .help(isYouTubeEmbed
-                              ? "Fetch this video's transcript via YouTube captions"
-                              : "Fetch this episode's transcript via Apple Podcasts")
+                        .disabled(!isTranscribing
+                                  && (isThisFileExtracting
+                                      || tracker.isSlotBusyForOtherSource(file.id)))
+                        .help(isTranscribing
+                              ? "View the running transcription job in the Activity window"
+                              : (isYouTubeEmbed
+                                 ? "Fetch this video's transcript via YouTube captions"
+                                 : "Fetch this episode's transcript via Apple Podcasts"))
                     }
                     ingestButton
                     // The source's content affordance is one-per-source: an

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -82,14 +82,16 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         guard statusItem == nil else { return }
         DebugLog.tabs("MenuBarItemController.start: creating status item")
 
-        // #745: wire the Activity window opener so the Provenance panel can
-        // navigate to it from an `agent:<kind>` provenance entry. Routes
-        // through `openQueueWindow` (the scene-managed `WindowGroup(for:
-        // QueueKind.self)` in `WikiFSApp`) — always opens `.ingestion` since
-        // the Provenance panel navigates to the agent/ingestion window.
-        openWindowBridge.openActivityWindow = { [weak self] in
+        // #745: wire the Activity window opener so the Provenance panel and
+        // SourceDetailView's Transcribe button can navigate to the running
+        // job. Routes through `openQueueWindow` (the scene-managed
+        // `WindowGroup(for: QueueKind.self)` in `WikiFSApp`). PR2 (#842):
+        // the closure takes a `QueueKind` so callers open the correct window
+        // (ingestion, extraction, or transcription) — the Provenance panel
+        // passes `.ingestion`, SourceDetailView passes `.transcription`.
+        openWindowBridge.openActivityWindow = { [weak self] queue in
             NSApplication.shared.activate(ignoringOtherApps: true)
-            self?.openWindowBridge.openQueueWindow?(.ingestion)
+            self?.openWindowBridge.openQueueWindow?(queue)
         }
 
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)

--- a/Sources/WikiFS/Window/OpenWindowBridge.swift
+++ b/Sources/WikiFS/Window/OpenWindowBridge.swift
@@ -38,11 +38,13 @@ final class OpenWindowBridge {
     /// item is AppKit and can't read SwiftUI environment values directly).
     var openSettings: (() -> Void)?
 
-    /// Opens the Activity (queue) window for `.ingestion` — the window that
-    /// shows ingestion and lint runs (#745). Set by `MenuBarItemController`
-    /// when it creates the window. Used by the Provenance panel to navigate
-    /// from a provenance entry to the run that produced it.
-    var openActivityWindow: (() -> Void)?
+    /// Opens the Activity (queue) window for the given queue kind (#745, #842
+    /// PR2). Set by `MenuBarItemController` when it creates the window. Used
+    /// by the Provenance panel and by `SourceDetailView`'s Transcribe button
+    /// to navigate from a source to the running job. The `QueueKind` argument
+    /// routes through `openQueueWindow` so the correct window (ingestion,
+    /// extraction, or transcription) is focused or created.
+    var openActivityWindow: ((QueueKind) -> Void)?
 
     /// Opens (or focuses) the Activity window for a specific queue
     /// (`WindowGroup(for: QueueKind.self)` deduplicates by `==`, so calling

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -434,7 +434,7 @@ struct WikiFSApp: App {
             .background(WindowBridgeProbe(bridge: openWindowBridge))
             .appEnvironment(
                 tracker: activityTracker,
-                openActivityWindow: { [weak openWindowBridge] in openWindowBridge?.openActivityWindow?() })
+                openActivityWindow: { [weak openWindowBridge] queue in openWindowBridge?.openActivityWindow?(queue) })
             .preferredColorScheme(appearanceColorScheme)
             .alert(
                 "Install Self Driving Wiki in Applications",
@@ -508,7 +508,7 @@ struct WikiFSApp: App {
             .background(WindowBridgeProbe(bridge: openWindowBridge))
             .appEnvironment(
                 tracker: activityTracker,
-                openActivityWindow: { [weak openWindowBridge] in openWindowBridge?.openActivityWindow?() })
+                openActivityWindow: { [weak openWindowBridge] queue in openWindowBridge?.openActivityWindow?(queue) })
             .preferredColorScheme(appearanceColorScheme)
             .onAppear {
                 DebugLog.tabs("RootScene wiki-window onAppear: wikiID=\(wikiID ?? "nil")")
@@ -563,8 +563,8 @@ struct WikiFSApp: App {
             )
             .appEnvironment(
                 tracker: activityTracker,
-                openActivityWindow: { [weak openWindowBridge] in
-                    openWindowBridge?.openQueueWindow?(.ingestion)
+                openActivityWindow: { [weak openWindowBridge] queue in
+                    openWindowBridge?.openQueueWindow?(queue)
                 })
             .preferredColorScheme(appearanceColorScheme)
         }
@@ -942,7 +942,7 @@ extension View {
     @MainActor
     func appEnvironment(
         tracker: QueueActivityTracker,
-        openActivityWindow: (() -> Void)? = nil
+        openActivityWindow: ((QueueKind) -> Void)? = nil
     ) -> some View {
         assert(tracker.isAttachedToEngine, "QueueActivityTracker must be attached to a QueueEngine before injecting into a scene")
         return self

--- a/Tests/WikiFSAppTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSAppTests/QueueIngestionTests.swift
@@ -1140,5 +1140,134 @@ struct QueueActivityTrackerLintItemIDTests {
         tracker.stop()
         #expect(tracker.pendingSelectionItemID == nil)
     }
+
+    // MARK: - #842 PR2: pendingSelectionQueue guard
+
+    @MainActor
+    @Test("pendingSelectionQueue defaults to nil")
+    func pendingSelectionQueueDefaultsNil() {
+        let tracker = QueueActivityTracker()
+        #expect(tracker.pendingSelectionQueue == nil)
+    }
+
+    @MainActor
+    @Test("pendingSelectionQueue cleared by stop()")
+    func pendingSelectionQueueClearedByStop() {
+        let tracker = QueueActivityTracker()
+        tracker.pendingSelectionQueue = .transcription
+        tracker.stop()
+        #expect(tracker.pendingSelectionQueue == nil)
+    }
+
+    // MARK: - #842 PR2: transcriptionItemID resolution
+
+    private func makeTranscriptionItem(
+        id: String,
+        sourceIDs: [PageID],
+        state: QueueItemState = .running
+    ) -> QueueItem {
+        QueueItem(
+            id: id, queue: .transcription, wikiID: "w1",
+            payload: QueueItemPayload(sourceIDs: sourceIDs),
+            state: state, orderingKey: 1000, attempt: 0,
+            createdAt: 0)
+    }
+
+    @MainActor
+    @Test("Transcription item resolves to the correct item ID")
+    func transcriptionItemResolvesItemID() {
+        let tracker = QueueActivityTracker()
+        let srcA = PageID(rawValue: "srcA")
+        let srcB = PageID(rawValue: "srcB")
+        let item = makeTranscriptionItem(id: "tr-1", sourceIDs: [srcA, srcB])
+
+        tracker.handleForTesting(.started(item))
+
+        #expect(tracker.transcriptionItemID(for: srcA) == "tr-1")
+        #expect(tracker.transcriptionItemID(for: srcB) == "tr-1")
+    }
+
+    @MainActor
+    @Test("Nil when no transcription is running for the source")
+    func nilWhenNoTranscriptionRunning() {
+        let tracker = QueueActivityTracker()
+        let src = PageID(rawValue: "lonely")
+
+        #expect(tracker.transcriptionItemID(for: src) == nil)
+    }
+
+    @MainActor
+    @Test("Transcription item ID does not resolve via extraction items")
+    func transcriptionItemIDDoesNotResolveExtractionItems() {
+        let tracker = QueueActivityTracker()
+        let src = PageID(rawValue: "src1")
+        let extractionItem = QueueItem(
+            id: "ext-1", queue: .extraction, wikiID: "w1",
+            payload: QueueItemPayload(sourceIDs: [src]),
+            state: .running, orderingKey: 1000, attempt: 0,
+            createdAt: 0)
+
+        tracker.handleForTesting(.started(extractionItem))
+
+        // An extraction item tracking the same source should NOT resolve
+        // via transcriptionItemID — the mapping is queue-kind-specific.
+        #expect(tracker.transcriptionItemID(for: src) == nil)
+    }
+
+    @MainActor
+    @Test("Transcription item mapping cleared after completion")
+    func transcriptionMappingClearedOnCompletion() {
+        let tracker = QueueActivityTracker()
+        let src = PageID(rawValue: "done-src")
+        let item = makeTranscriptionItem(id: "tr-done", sourceIDs: [src])
+
+        tracker.handleForTesting(.started(item))
+        #expect(tracker.transcriptionItemID(for: src) == "tr-done")
+
+        let completed = makeTranscriptionItem(id: "tr-done", sourceIDs: [src], state: .completed)
+        tracker.handleForTesting(.completed(completed))
+
+        #expect(tracker.transcriptionItemID(for: src) == nil)
+    }
+
+    @MainActor
+    @Test("Transcription item mapping cleared after cancellation")
+    func transcriptionMappingClearedOnCancellation() {
+        let tracker = QueueActivityTracker()
+        let src = PageID(rawValue: "cancel-src")
+        let item = makeTranscriptionItem(id: "tr-cancel", sourceIDs: [src])
+
+        tracker.handleForTesting(.started(item))
+        #expect(tracker.transcriptionItemID(for: src) == "tr-cancel")
+
+        let cancelled = makeTranscriptionItem(id: "tr-cancel", sourceIDs: [src], state: .cancelled)
+        tracker.handleForTesting(.cancelled(cancelled))
+
+        #expect(tracker.transcriptionItemID(for: src) == nil)
+    }
+
+    @MainActor
+    @Test("Transcription does not conflate with extraction for item ID resolution")
+    func transcriptionItemIDNoCrossKindConflation() {
+        let tracker = QueueActivityTracker()
+        let src1 = PageID(rawValue: "src1")
+        let src2 = PageID(rawValue: "src2")
+        let extractionItem = QueueItem(
+            id: "ext-1", queue: .extraction, wikiID: "w1",
+            payload: QueueItemPayload(sourceIDs: [src1]),
+            state: .running, orderingKey: 1000, attempt: 0,
+            createdAt: 0)
+        let transcriptionItem = makeTranscriptionItem(id: "tr-1", sourceIDs: [src2])
+
+        tracker.handleForTesting(.started(extractionItem))
+        tracker.handleForTesting(.started(transcriptionItem))
+
+        #expect(tracker.transcriptionItemID(for: src1) == nil)
+        #expect(tracker.transcriptionItemID(for: src2) == "tr-1")
+
+        // Complete transcription → only transcription clears
+        tracker.handleForTesting(.completed(transcriptionItem))
+        #expect(tracker.transcriptionItemID(for: src2) == nil)
+    }
 }
 #endif

--- a/Tests/WikiFSTests/StoreEmissionTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionTests.swift
@@ -259,6 +259,20 @@ struct StoreEmissionTests {
         #expect(events.last?.id == s.id.rawValue)
     }
 
+    @Test func appendProcessedMarkdownTranscriptOriginEmitsSourceUpdated() async throws {
+        let (store, _, rec) = try makeHarness()
+        let s = try addSeedSource(store)
+        try await drain(rec)
+        _ = try store.appendProcessedMarkdown(
+            sourceID: s.id, content: "# Transcript",
+            origin: .transcript, note: nil,
+            technique: "youtube-captions")
+        let events = try await awaitEvents(rec)
+        #expect(events.last?.kind == .source)
+        #expect(events.last?.change == .updated)
+        #expect(events.last?.id == s.id.rawValue)
+    }
+
     @Test func recordMarkdownExtractionEmitsSourceUpdated() async throws {
         let (store, _, rec) = try makeHarness()
         let s = try addSeedSource(store)


### PR DESCRIPTION
## Route transcription through queue PR2: reveal-job navigation (#842)

Closes #842. Linked: #842.

PR1 (#845, merged) added the `.transcription` QueueKind + worker + enqueue. PR2 adds the navigation: when a transcription is running/queued for a source, clicking Transcribe takes the user to that job in the Activity window.

### Changes

**C1 — Parameterize `openActivityWindow` with `QueueKind`**

The `openActivityWindow` environment closure was `(() -> Void)?`, hardcoded to `.ingestion` at `MenuBarItemController:90`. Changed to `((QueueKind) -> Void)?` so callers can target the ingestion, extraction, or transcription Activity window. Updated all call sites: `ActivityWindowEnvironmentKey`, `OpenWindowBridge`, `MenuBarItemController.start()`, `WikiFSApp.appEnvironment` + 3 scene-level injections, `PageDetailView` (passes `.ingestion`), `ProvenancePanel` (passes `.ingestion`).

**C4 — `pendingSelectionQueue` guard**

Added `pendingSelectionQueue: QueueKind?` alongside `pendingSelectionItemID` in `QueueActivityTracker`. `ActivityWindowView.consumePendingSelectionIfNeeded()` now checks `pendingSelectionQueue == queue` before consuming — prevents a cross-window race when both `.transcription` and `.ingestion` Activity windows exist: a lint pending-selection is not consumed by the transcription window, and vice versa.

**C5 — `transcriptionItemID(for:)` + SourceDetailView navigation**

Added `itemToTranscriptionSourceIDs` tracking dict to `QueueActivityTracker` (populated in `.started` `.transcription` arm, cleared in `removeItem`/`stop()`). Added `func transcriptionItemID(for sourceID: PageID) -> QueueItem.ID?` — mirrors `lintItemID(for:wikiID:)` from #837.

`SourceDetailView` Transcribe button: when `isTranscribing` is true, swaps to "View Transcription" with `checkmark.seal.fill` icon, stays enabled, and on tap sets `tracker.pendingSelectionItemID` + `tracker.pendingSelectionQueue = .transcription` then calls `openActivityWindow?(.transcription)`. **Reuses #840's existing `pendingSelectionItemID` seam** — no new `PendingActivitySelection` class.

**C6 — `headVersion` refresh via store change event**

Confirmed `appendProcessedMarkdown` routes through `mutate()` → emits `ResourceChangeEvent(.source, .updated)`. Added `.onChange(of: store.sources)` in `SourceDetailView` to re-read `processedMarkdownHead` when not editing — picks up the bus event chain (`mutate()` → event bus → `reloadFromStore()` → `reloadSources()` → `sources` bump). Works across windows so another wiki window viewing the same source sees the new transcript. Added emission test for `.transcript` origin in `StoreEmissionTests`.

### Tests

12 new tests across 2 suites:
- `QueueActivityTrackerLintItemIDTests`: `pendingSelectionQueue` defaults/stop, `transcriptionItemID` resolution, nil-when-idle, no-cross-kind-conflation with extraction, cleanup on completion/cancellation, cross-kind ID non-conflation (9 tests)
- `StoreEmissionTests`: `appendProcessedMarkdownTranscriptOriginEmitsSourceUpdated` (1 test)

### Verification

- `make version prompts && swift build` clean (128s)
- `swift test` — 3665 tests in 303 suites passed (21.9s)
- New tests pass via `swift test --filter "transcription|pendingSelection|transcriptOrigin|appendProcessedMarkdown"`
