### PR TITLE
Adopt ACP session lifecycle for chat (#830)

### DIFF
--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -1343,6 +1343,12 @@ struct ChatDetailView: View {
     /// the tab back to the draft state (.newChat). The old chat stays
     /// in history.
     private func startNewChat() {
+        // #830: Clear the old chat's ACP session ID — the old session is gone,
+        // and a future continue of the old chat should start fresh (not retry
+        // a dead resume). Per C8: the caller clears before transitioning.
+        if let chatID {
+            store.updateChatAcpSessionId(chatID: chatID, acpSessionId: nil)
+        }
         launcher.startNewChat()
         // D2 retarget-back: morph the active tab from .chat(id) back to the draft
         // state so the user sees a fresh composer.

--- a/Sources/WikiFSCore/Core/ChatModels.swift
+++ b/Sources/WikiFSCore/Core/ChatModels.swift
@@ -35,11 +35,17 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
     /// When the summary was written, for staleness display. `nil` alongside
     /// `summary`.
     public var summaryAt: Date?
+    /// The ACP session ID for resume (#830). Set after the chat's session is
+    /// created; cleared on terminal teardown (resume permanently failed) or
+    /// successful completion. `nil` for pre-#830 chats and chats whose resume
+    /// permanently failed.
+    public var acpSessionId: String?
 
     public init(
         id: PageID, kind: ChatKind, title: String,
         createdAt: Date, updatedAt: Date, messageCount: Int,
-        summary: String? = nil, summaryAt: Date? = nil
+        summary: String? = nil, summaryAt: Date? = nil,
+        acpSessionId: String? = nil
     ) {
         self.id = id
         self.kind = kind
@@ -49,6 +55,7 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
         self.messageCount = messageCount
         self.summary = summary
         self.summaryAt = summaryAt
+        self.acpSessionId = acpSessionId
     }
 
     /// Derive a chat title from the first user message: first line, trimmed,

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -58,7 +58,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// databases produced by that store carry `PRAGMA user_version` up to 37, and
     /// this store must recognize them as already-current so the ladder is a no-op
     /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 42
+    private static let currentSchemaVersion = 43
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -1223,6 +1223,19 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             version = 41
         }
 
+        // v42→v43: add acp_session_id to the chats table (#830). Stores the ACP
+        // session ID so a continued chat can attempt resumeSession/loadSession
+        // instead of re-seeding a preamble. Nullable: NULL for all existing
+        // chats (they predate resume) and for chats whose resume permanently
+        // failed. Idempotent via the column-existence guard.
+        if version < 43 {
+            if !(try Self.hasColumn("acp_session_id", on: "chats", in: db)) {
+                try db.execute(sql: "ALTER TABLE chats ADD COLUMN acp_session_id TEXT;")
+            }
+            try db.execute(sql: "PRAGMA user_version = 43;")
+            version = 43
+        }
+
         // Catch-all fallback: any DB older than `currentSchemaVersion` whose
         // per-step work has not been added above (the steady-state guard for a
         // genuine currentSchemaVersion bump). Drops FTS5 + stamps
@@ -1436,13 +1449,14 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     private static func createChatTablesV23(in db: Database) throws {
         try db.execute(sql: """
         CREATE TABLE IF NOT EXISTS chats (
-            id         TEXT PRIMARY KEY,
-            kind       TEXT NOT NULL,
-            title      TEXT NOT NULL,
-            created_at REAL NOT NULL,
-            updated_at REAL NOT NULL,
-            summary    TEXT,
-            summary_at REAL
+            id              TEXT PRIMARY KEY,
+            kind            TEXT NOT NULL,
+            title           TEXT NOT NULL,
+            created_at      REAL NOT NULL,
+            updated_at      REAL NOT NULL,
+            summary         TEXT,
+            summary_at      REAL,
+            acp_session_id  TEXT
         );
         """)
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS chats_updated ON chats(updated_at);")
@@ -2465,13 +2479,14 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         // v25: persisted chat history (chats + chat_messages).
         try db.execute(sql: """
         CREATE TABLE IF NOT EXISTS chats (
-            id         TEXT PRIMARY KEY,
-            kind       TEXT NOT NULL,
-            title      TEXT NOT NULL,
-            created_at REAL NOT NULL,
-            updated_at REAL NOT NULL,
-            summary    TEXT,
-            summary_at REAL
+            id              TEXT PRIMARY KEY,
+            kind            TEXT NOT NULL,
+            title           TEXT NOT NULL,
+            created_at      REAL NOT NULL,
+            updated_at      REAL NOT NULL,
+            summary         TEXT,
+            summary_at      REAL,
+            acp_session_id  TEXT
         );
         """)
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS chats_updated ON chats(updated_at);")
@@ -6078,7 +6093,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                   c.summary, c.summary_at
+                   c.summary, c.summary_at, c.acp_session_id
             FROM chats c
             ORDER BY c.updated_at DESC, c.rowid DESC;
             """)
@@ -6186,6 +6201,23 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// Write (or clear) the ACP session ID for resume (#830). Bumps
+    /// `updated_at`. Routes through `mutate(event:_:)` so it emits a
+    /// `.chat .updated` event. Pass `nil` to clear (terminal teardown /
+    /// permanent resume failure).
+    public func updateChatAcpSessionId(chatID: PageID, acpSessionId: String?) throws {
+        try mutate(event: { _ in
+            self.localEvent(.chat, id: chatID.rawValue, change: .updated)
+        }) { db in
+            try db.execute(sql: """
+            UPDATE chats SET acp_session_id = ?, updated_at = ?
+            WHERE id = ?;
+            """, arguments: [acpSessionId, Date().timeIntervalSince1970,
+                            chatID.rawValue])
+            guard db.changesCount > 0 else { throw WikiStoreError.notFound(chatID) }
+        }
+    }
+
     /// Write the cached one-line summary for a single assistant message
     /// (chat-summary plan §3.5). Routes through `mutate(event:_:)` and emits a
     /// `.chat .updated` event on the chat the message belongs to — the
@@ -6214,7 +6246,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                   c.summary, c.summary_at
+                   c.summary, c.summary_at, c.acp_session_id
             FROM chats c
             ORDER BY c.id ASC;
             """)
@@ -6312,7 +6344,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 let rows = try Row.fetchAll(db, sql: """
                     SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                            (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                           cc.embedding
+                           cc.embedding, c.acp_session_id
                     FROM chat_chunks cc
                     JOIN chats c ON c.id = cc.chat_id;
                     """)
@@ -6545,7 +6577,8 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     private static func readChatSummary(
         from row: Row, summary: String?, summaryAt: Date?
     ) -> ChatSummary {
-        ChatSummary(
+        let acpSessionId: String? = row["acp_session_id"]
+        return ChatSummary(
             id: PageID(rawValue: row["id"]),
             kind: ChatKind(rawValue: row["kind"]) ?? .edit,
             title: row["title"],
@@ -6553,7 +6586,8 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             updatedAt: Date(timeIntervalSince1970: row["updated_at"]),
             messageCount: row["msg_count"],
             summary: summary,
-            summaryAt: summaryAt
+            summaryAt: summaryAt,
+            acpSessionId: acpSessionId
         )
     }
 
@@ -7480,7 +7514,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 sql: """
                 SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                        (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                       c.summary, c.summary_at
+                       c.summary, c.summary_at, c.acp_session_id
                 FROM chats c WHERE c.id = ?;
                 """,
                 arguments: [id.rawValue]

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -666,6 +666,14 @@ public protocol WikiStore: Sendable {
     /// bumping `updated_at`. Throws `.notFound` if no chat has `id`.
     func updateChatSummary(chatID: PageID, summary: String) throws
 
+    /// Write or clear the ACP session ID for resume (#830). Pass `nil` to
+    /// clear (terminal teardown / permanent resume failure). Bumps
+    /// `updated_at`.
+    func updateChatAcpSessionId(chatID: PageID, acpSessionId: String?) throws
+
+    /// One chat summary by id. Throws `.notFound` if no chat has `id`.
+    func getChat(id: PageID) throws -> ChatSummary
+
     /// Write the cached one-line summary for a single assistant message
     /// (chat-summary plan §3.5). The chat row is the change-emission resource
     /// (there is no `.message` resource kind); emits `.chat .updated` with the

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -4211,6 +4211,23 @@ public final class WikiStoreModel {
         }
     }
 
+    /// `@MainActor` wrapper for the ACP session ID write/clear (#830). Written
+    /// at spawn time (persist) and on resume failure (clear). No manual reload
+    /// — the bus fires `reloadFromStore()` async after the store write.
+    public func updateChatAcpSessionId(chatID: PageID, acpSessionId: String?) {
+        do {
+            try store.updateChatAcpSessionId(chatID: chatID, acpSessionId: acpSessionId)
+        } catch {
+            DebugLog.store("WikiStoreModel.updateChatAcpSessionId failed: \(error)")
+        }
+    }
+
+    /// `@MainActor` wrapper for `getChat(id:)` (#830). Returns `nil` if the
+    /// chat doesn't exist or the read fails.
+    public func getChat(id: PageID) -> ChatSummary? {
+        try? store.getChat(id: id)
+    }
+
     /// `@MainActor` wrapper for the per-message summary write (chat-summary
     /// plan §3.5). The summarizer's off-main compute marshals back here for the
     /// DB write (no inference inside a transaction). No manual reload — the bus

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -2792,6 +2792,8 @@ public final class AgentLauncher {
         chatID: String? = nil,
         firstMessagePrePersisted: Bool = false,
         historySeed: [AgentEvent] = [],
+        priorAcpSessionId: String? = nil,
+        onAcpSessionId: (@MainActor (String?) -> Void)? = nil,
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
         onTranscript: (@MainActor ([AgentEvent]) -> Void)? = nil,
@@ -2994,23 +2996,71 @@ public final class AgentLauncher {
             debugLogURL: debugFolderURL)
         DebugLog.agent("startInteractiveQuery: profile built providerHints keys=\(profile.providerHints.keys.sorted()) scratch=\(scratch.lastPathComponent)")
 
+        // #830: Attempt to resume a prior ACP session for this chat. Mirrors
+        // the queue-side resume at AgentLauncher.swift:1177-1211. If the chat
+        // row has an acp_session_id and the agent supports cross-process resume,
+        // this restores the full session context — no preamble re-seeding
+        // needed. If resume fails (session GC'd, process dead, agent doesn't
+        // support it), fall through to the fresh-start + preamble path below.
+        var resumedSession: SessionHandle? = nil
+        if let priorAcpSessionId {
+            DebugLog.agent("startInteractiveQuery: attempting to resume ACP session \(priorAcpSessionId) for chat \(chatID ?? "?")")
+            do {
+                if let handle = try await backend.resume(
+                    sessionID: priorAcpSessionId,
+                    profile: profile
+                ) {
+                    resumedSession = handle
+                    DebugLog.agent("startInteractiveQuery: resumed ACP session \(priorAcpSessionId)")
+                } else {
+                    DebugLog.agent("startInteractiveQuery: resume returned nil for session \(priorAcpSessionId), will start fresh")
+                }
+            } catch {
+                DebugLog.agent("startInteractiveQuery: resume threw for session \(priorAcpSessionId): \(error), will start fresh")
+            }
+            // If we had a prior session ID but resume failed, clear it so
+            // future continues don't keep retrying a dead session.
+            if resumedSession == nil {
+                onAcpSessionId?(nil)
+                DebugLog.agent("startInteractiveQuery: clearing stale ACP session ID (resume failed)")
+            }
+        }
+
         do {
-            DebugLog.agent("startInteractiveQuery: backend.start provider=\(provider.id) exe=\(resolvedPath) args=\(provider.command ?? [])")
             let runToken = UUID()
-            let session = try await backend.start(
-                profile: profile,
-                systemPrompt: systemPrompt,
-                onExit: { [weak self] status in
-                    Task { @MainActor [weak self] in
-                        // Only finish if THIS session is still current — a stale
-                        // onExit (a prior session terminating after a new one
-                        // started, e.g. D3's continueChat takeover:
-                        // stopAgent → startInteractiveQuery) must not tear down
-                        // the new session.
-                        guard let self, self.currentRunToken == runToken else { return }
-                        self.finish(status: Int32(status))
+            let session: SessionHandle
+            if let resumed = resumedSession {
+                session = resumed
+                DebugLog.agent("startInteractiveQuery: using resumed ACP session \(session.id)")
+            } else {
+                DebugLog.agent("startInteractiveQuery: backend.start provider=\(provider.id) exe=\(resolvedPath) args=\(provider.command ?? [])")
+                session = try await backend.start(
+                    profile: profile,
+                    systemPrompt: systemPrompt,
+                    onExit: { [weak self] status in
+                        Task { @MainActor [weak self] in
+                            // Only finish if THIS session is still current — a stale
+                            // onExit (a prior session terminating after a new one
+                            // started, e.g. D3's continueChat takeover:
+                            // stopAgent → startInteractiveQuery) must not tear down
+                            // the new session.
+                            guard let self, self.currentRunToken == runToken else { return }
+                            self.finish(status: Int32(status))
+                        }
+                    })
+                // #830: Persist the ACP session ID for chat resume. Mirrors the
+                // queue-side capture at AgentLauncher.swift:1339-1355. The session
+                // ID is available via currentResumableSessionId() right after
+                // createSession sets it (ACPBackend.swift:653). Written to the
+                // chats row so a continued chat can attempt resume instead of
+                // re-seeding a preamble.
+                if let acpBackend = backend as? ACPBackend {
+                    if let sessionId = await acpBackend.currentResumableSessionId() {
+                        onAcpSessionId?(sessionId.value)
+                        DebugLog.agent("startInteractiveQuery: persisted ACP session ID \(sessionId.value) for chat \(chatID ?? "?")")
                     }
-                })
+                }
+            }
             sessionHandle = session
             currentRunToken = runToken
             // SPAWN COMMIT: process is alive. isRunning = true (process alive across turns).
@@ -3036,8 +3086,16 @@ public final class AgentLauncher {
             // steering, and the agent defaults to its built-in behavior (e.g.
             // websearch before wikictl). The `displayText` stays as the user's
             // raw message so the transcript shows what the user typed.
-            let taskPrompt = operation.prompt(wikiRoot: wikiRoot)
-            let composedFirstMessage = "\(taskPrompt)\n\n# USER MESSAGE\n\(firstMessage)"
+            //
+            // #830: On the resume-success path, the resumed session already has
+            // the full task context — send only the user's raw message.
+            let composedFirstMessage: String
+            if resumedSession != nil {
+                composedFirstMessage = firstMessageDisplay ?? firstMessage
+            } else {
+                let taskPrompt = operation.prompt(wikiRoot: wikiRoot)
+                composedFirstMessage = "\(taskPrompt)\n\n# USER MESSAGE\n\(firstMessage)"
+            }
             sendInteractiveMessage(composedFirstMessage, displayText: firstMessageDisplay ?? firstMessage)
             // Mirror `run()`: arm the completion watchdog so a process that exits
             // without a reconciling `onExit` still clears `isRunning`.

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -91,6 +91,14 @@ public enum AgentOperationRunner {
             // The model seeded the first user message at chat creation; tell the
             // launcher so it skips double-inserting it on the first flush.
             firstMessagePrePersisted: chat != nil,
+            onAcpSessionId: chat.map { chat -> (@MainActor (String?) -> Void) in
+                return { [weak store] sessionId in
+                    guard let store else { return }
+                    if let sessionId {
+                        store.updateChatAcpSessionId(chatID: chat.id, acpSessionId: sessionId)
+                    }
+                }
+            },
             onLock: { store.agentRunStarted() },
             onUnlock: { store.agentRunEnded() },
             // Weak store: if the user switches wikis mid-session the model may be
@@ -353,7 +361,10 @@ public enum AgentOperationRunner {
         // Build the condensed transcript + new message as the first prompt.
         let history = store.chatMessages(chatID: chatID)
         let firstMessage = continuationPreamble(from: history, newMessage: trimmed)
-        DebugLog.agent("continueChat: historyRows=\(history.count) preambleChars=\(firstMessage.count) displayMsg=\(trimmed.count)")
+        // #830: Read the chat's prior ACP session ID so startInteractiveQuery
+        // can attempt resume before falling back to the fresh-start + preamble.
+        let priorAcpSessionId = store.getChat(id: chatID)?.acpSessionId
+        DebugLog.agent("continueChat: historyRows=\(history.count) preambleChars=\(firstMessage.count) displayMsg=\(trimmed.count) priorAcpSessionId=\(priorAcpSessionId ?? "nil")")
 
         // Start a fresh session writing to the SAME chat row. activeChatID = chat.id
         // flips ChatDetailView to live for this tab (seq continues, title
@@ -370,6 +381,11 @@ public enum AgentOperationRunner {
             wikictlDirectory: wikictlDirectory,
             chatID: chatID.rawValue,
             historySeed: history.map(\.event),
+            priorAcpSessionId: priorAcpSessionId,
+            onAcpSessionId: { [weak store] sessionId in
+                guard let store else { return }
+                store.updateChatAcpSessionId(chatID: chatID, acpSessionId: sessionId)
+            },
             onLock: { store.agentRunStarted() },
             onUnlock: { store.agentRunEnded() },
             onTranscript: { [weak store] events in

--- a/Tests/WikiFSAppTests/ACPChatResumeTests.swift
+++ b/Tests/WikiFSAppTests/ACPChatResumeTests.swift
@@ -1,0 +1,181 @@
+#if os(macOS)
+import Testing
+import Foundation
+import WikiFSEngine
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// #830: Tests for ACP session resume in the chat lifecycle.
+@MainActor
+@Suite("ACP chat resume (#830)")
+struct ACPChatResumeTests {
+
+    /// Thread-safe box for the `onAcpSessionId` callback's values.
+    private final class SessionIdRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _values: [String?] = []
+        func record(_ value: String?) {
+            lock.lock(); _values.append(value); lock.unlock()
+        }
+        var values: [String?] {
+            lock.lock(); defer { lock.unlock() }
+            return _values
+        }
+    }
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-resume-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dummy = dir.appendingPathComponent("fake-agent")
+        let script = "#!/bin/sh\nexit 0\n"
+        try script.write(to: dummy, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: dummy.path)
+        return dir
+    }
+
+    private func makeLauncher(
+        backend: FakeAgentBackend, dummyPath: String, tempDir: URL
+    ) -> AgentLauncher {
+        let provider = AgentProvider(
+            id: "test-acp", label: "TestACP", command: [dummyPath],
+            env: [:], enabled: true, isDefault: true)
+        let launcher = AgentLauncher()
+        launcher.resolveBackend = { _, _, _ in backend }
+        launcher.acpCredentialStore = InMemoryACPCredentialStore()
+        launcher.resolveSelectedProvider = { provider }
+        let config = AgentProvidersConfig(
+            providers: [provider],
+            selectedModelIds: [provider.id: "fake-model"])
+        try? config.save(to: tempDir)
+        launcher.resolveProvidersContainerDirectory = { tempDir }
+        launcher.containerDirectory = tempDir
+        return launcher
+    }
+
+    /// AC.7: when `priorAcpSessionId` is set and `resume()` returns a handle,
+    /// `backend.start()` is NOT called (resume succeeded) and the first
+    /// message sent is the raw user message (not the task prompt + preamble).
+    @Test func continueChatResumesAndSkipsFreshStart() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let dummyPath = tempDir.appendingPathComponent("fake-agent").path
+        let backend = FakeAgentBackend(
+            behaviors: [FakeSessionBehavior()], resumeSessionID: "resumed-1")
+        let recorder = SessionIdRecorder()
+        let launcher = makeLauncher(
+            backend: backend, dummyPath: dummyPath, tempDir: tempDir)
+
+        await launcher.startInteractiveQuery(
+            firstMessage: "preamble text",
+            firstMessageDisplay: "user question",
+            stateMarkdown: "",
+            wikiID: "test-wiki",
+            wikiRoot: "/tmp",
+            systemPrompt: "",
+            wikictlDirectory: "/tmp",
+            chatID: "chat-1",
+            priorAcpSessionId: "prior-session-id",
+            onAcpSessionId: { recorder.record($0) },
+            onLock: {},
+            onUnlock: {}
+        )
+
+        #expect(launcher.preflightError == nil)
+        let resumedIDs = await backend.resumedSessionIDs
+        #expect(resumedIDs == ["prior-session-id"])
+        let startCount = await backend.startCount
+        #expect(startCount == 0)
+        let sentTexts = try await waitForSendCount(atLeast: 1, on: backend)
+        #expect(sentTexts.count == 1)
+        #expect(sentTexts[0] == "user question")
+    }
+
+    /// AC.8: when `priorAcpSessionId` is set and `resume()` returns nil,
+    /// `backend.start()` IS called (fresh start fallback) and the stale
+    /// session ID is cleared via `onAcpSessionId?(nil)`.
+    @Test func continueChatFallsBackToFreshStartOnResumeFailure() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let dummyPath = tempDir.appendingPathComponent("fake-agent").path
+        let backend = FakeAgentBackend(behaviors: [FakeSessionBehavior()])
+        let recorder = SessionIdRecorder()
+        let launcher = makeLauncher(
+            backend: backend, dummyPath: dummyPath, tempDir: tempDir)
+
+        await launcher.startInteractiveQuery(
+            firstMessage: "preamble text",
+            firstMessageDisplay: "user question",
+            stateMarkdown: "",
+            wikiID: "test-wiki",
+            wikiRoot: "/tmp",
+            systemPrompt: "",
+            wikictlDirectory: "/tmp",
+            chatID: "chat-1",
+            priorAcpSessionId: "prior-session-id",
+            onAcpSessionId: { recorder.record($0) },
+            onLock: {},
+            onUnlock: {}
+        )
+
+        #expect(launcher.preflightError == nil)
+        let resumedIDs = await backend.resumedSessionIDs
+        #expect(resumedIDs == ["prior-session-id"])
+        let startCount = await backend.startCount
+        #expect(startCount == 1)
+        let sentTexts = try await waitForSendCount(atLeast: 1, on: backend)
+        #expect(sentTexts.count >= 1)
+        #expect(sentTexts[0].contains("preamble text") == true)
+        #expect(sentTexts[0] != "user question")
+        #expect(recorder.values.contains(nil) == true)
+    }
+
+    /// AC.8b: when `priorAcpSessionId` is nil (a new chat or pre-#830 chat),
+    /// no resume attempt is made and `backend.start()` runs normally.
+    @Test func startChatWithoutPriorSessionDoesNotAttemptResume() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let dummyPath = tempDir.appendingPathComponent("fake-agent").path
+        let backend = FakeAgentBackend(behaviors: [FakeSessionBehavior()])
+        let recorder = SessionIdRecorder()
+        let launcher = makeLauncher(
+            backend: backend, dummyPath: dummyPath, tempDir: tempDir)
+
+        await launcher.startInteractiveQuery(
+            firstMessage: "hello world",
+            stateMarkdown: "",
+            wikiID: "test-wiki",
+            wikiRoot: "/tmp",
+            systemPrompt: "",
+            wikictlDirectory: "/tmp",
+            chatID: "chat-1",
+            onAcpSessionId: { recorder.record($0) },
+            onLock: {},
+            onUnlock: {}
+        )
+
+        #expect(launcher.preflightError == nil)
+        let resumedIDs = await backend.resumedSessionIDs
+        #expect(resumedIDs.isEmpty)
+        let startCount = await backend.startCount
+        #expect(startCount == 1)
+        #expect(recorder.values.filter { $0 == nil }.isEmpty)
+    }
+
+    private func waitForSendCount(
+        atLeast min: Int, on backend: FakeAgentBackend, timeoutMs: Int = 5000
+    ) async throws -> [String] {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+        while Date() < deadline {
+            let count = await backend.sendCount
+            if count >= min {
+                return await backend.sentTexts
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return await backend.sentTexts
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/FakeAgentBackend.swift
+++ b/Tests/WikiFSAppTests/FakeAgentBackend.swift
@@ -63,6 +63,10 @@ actor FakeAgentBackend: AgentBackend {
     private(set) var allYieldedEvents: [AgentEvent] = []
     /// Model hints seen in start profiles (the `acpSelectedModelId` provider hint).
     private(set) var startModelHints: [String?] = []
+    /// #830: Session IDs passed to `resume()` in call order.
+    private(set) var resumedSessionIDs: [String] = []
+    /// #830: Whether `start()` was called (for asserting resume-success skips fresh start).
+    var startCount_observable: Int { startCount }
 
     // MARK: - Scripted behavior
 
@@ -70,9 +74,14 @@ actor FakeAgentBackend: AgentBackend {
     private var behaviorIndex = 0
     private var sessionCounter = 0
     private var sessionBehaviors: [String: FakeSessionBehavior] = [:]
+    /// #830: If set, `resume()` returns a handle with this id. If nil (default),
+    /// `resume()` returns nil (resume failed — agent doesn't support it or
+    /// session GC'd).
+    var resumeSessionID: String? = nil
 
-    init(behaviors: [FakeSessionBehavior] = []) {
+    init(behaviors: [FakeSessionBehavior] = [], resumeSessionID: String? = nil) {
         self.behaviors = behaviors
+        self.resumeSessionID = resumeSessionID
     }
 
     // MARK: - AgentBackend conformance
@@ -131,6 +140,13 @@ actor FakeAgentBackend: AgentBackend {
     }
 
     func resume(sessionID: String, profile: BackendProfile) async throws -> SessionHandle? {
+        resumedSessionIDs.append(sessionID)
+        if let id = resumeSessionID {
+            sessionCounter += 1
+            startedSessionIDs.append(id)
+            sessionBehaviors[id] = FakeSessionBehavior()
+            return SessionHandle(id: id)
+        }
         return nil
     }
 

--- a/Tests/WikiFSTests/ChatStoreTests.swift
+++ b/Tests/WikiFSTests/ChatStoreTests.swift
@@ -223,4 +223,75 @@ import SQLite3
         #expect(messages.count == 2)
         #expect(messages.map(\.event) == [.userText("before"), .assistantText("after")])
     }
+
+    // MARK: - ACP session ID (#830)
+
+    /// AC.2: a fresh schema has the `acp_session_id` column on the chats table.
+    @Test func freshSchemaHasChatAcpSessionIdColumn() throws {
+        let store = try tempStore()
+        #expect(GRDBWikiStore.schemaVersion == 43)
+        let hasCol = store.scalarText(
+            "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='acp_session_id';")
+        #expect(hasCol == "1")
+    }
+
+    /// AC.3: round-trip write + read + clear of `acpSessionId`.
+    @Test func updateChatAcpSessionIdRoundTrip() throws {
+        let store = try tempStore()
+        let chat = try store.createChat(kind: .edit, title: "Test")
+
+        // Initially nil.
+        #expect(try store.getChat(id: chat.id).acpSessionId == nil)
+
+        // Write.
+        try store.updateChatAcpSessionId(chatID: chat.id, acpSessionId: "acp-123")
+        #expect(try store.getChat(id: chat.id).acpSessionId == "acp-123")
+
+        // Clear.
+        try store.updateChatAcpSessionId(chatID: chat.id, acpSessionId: nil)
+        #expect(try store.getChat(id: chat.id).acpSessionId == nil)
+    }
+
+    /// AC.4: `listChats` includes the `acpSessionId` in the result set.
+    @Test func listChatsIncludesAcpSessionId() throws {
+        let store = try tempStore()
+        let chat = try store.createChat(kind: .edit, title: "Test")
+        try store.updateChatAcpSessionId(chatID: chat.id, acpSessionId: "acp-456")
+        let listed = try store.listChats()
+        #expect(listed.first(where: { $0.id == chat.id })?.acpSessionId == "acp-456")
+    }
+
+    /// AC.4b: `listAllChatsOrderedByID` includes the `acpSessionId`.
+    @Test func listAllChatsIncludesAcpSessionId() throws {
+        let store = try tempStore()
+        let chat = try store.createChat(kind: .edit, title: "Test")
+        try store.updateChatAcpSessionId(chatID: chat.id, acpSessionId: "acp-789")
+        let listed = try store.listAllChatsOrderedByID()
+        #expect(listed.first(where: { $0.id == chat.id })?.acpSessionId == "acp-789")
+    }
+
+    /// AC.1: migration v42→v43 adds the `acp_session_id` column to a DB
+    /// that was at v42 without it.
+    @Test func chatAcpSessionIdMigrationAddsColumn() throws {
+        let url = tempDatabaseURL()
+
+        // Build a v42 DB by hand: chats table WITHOUT acp_session_id, user_version=42.
+        var raw: OpaquePointer?
+        #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        defer { sqlite3_close(raw) }
+        #expect(sqlite3_exec(raw, """
+        CREATE TABLE chats (id TEXT PRIMARY KEY, kind TEXT, title TEXT,
+            created_at REAL, updated_at REAL, summary TEXT, summary_at REAL);
+        """, nil, nil, nil) == SQLITE_OK)
+        #expect(sqlite3_exec(raw, "PRAGMA user_version = 42;", nil, nil, nil) == SQLITE_OK)
+
+        // Open via GRDBWikiStore — triggers the migration ladder.
+        let store = try GRDBWikiStore(databaseURL: url)
+
+        // The column exists and the version is 43.
+        #expect(store.pragmaValue("user_version") == "43")
+        let hasCol = store.scalarText(
+            "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='acp_session_id';")
+        #expect(hasCol == "1")
+    }
 }

--- a/Tests/WikiFSTests/LogIndexTests.swift
+++ b/Tests/WikiFSTests/LogIndexTests.swift
@@ -194,9 +194,9 @@ struct LogIndexTests {
         #expect(token1.log == token0.log)
     }
 
-    // MARK: - v3 → v42 migration (preserves prior data, drops system_prompt, seeds index)
+    // MARK: - v3 → v43 migration (preserves prior data, drops system_prompt, seeds index)
 
-    @Test func migratesV3DatabaseToV42PreservingData() throws {
+    @Test func migratesV3DatabaseToV43PreservingData() throws {
         let url = tempDatabaseURL()
 
         // Build a v3-shaped DB by hand: pages + slug index + sources +
@@ -252,7 +252,7 @@ struct LogIndexTests {
         #expect(prompt.body == SystemPrompt.defaultBody)
         #expect(prompt.version == (SystemPrompt.defaultBody.hashValue & 0x7FFFFFFF))
 
-        // user_version advanced to v42.
+        // user_version advanced to v43.
         var check: OpaquePointer?
         #expect(sqlite3_open(url.path, &check) == SQLITE_OK)
         defer { sqlite3_close(check) }

--- a/Tests/WikiFSTests/MessageSummaryTests.swift
+++ b/Tests/WikiFSTests/MessageSummaryTests.swift
@@ -294,11 +294,11 @@ struct MessageSummaryTests {
 
     // MARK: - Store round-trip (AC.1 + AC.6, integration)
 
-    @Test func freshDB_isAtSchemaVersion42() throws {
-        // AC.1: a fresh DB is at user_version = 42.
+    @Test func freshDB_isAtSchemaVersion43() throws {
+        // AC.1: a fresh DB is at user_version = 43.
         let store = try TestStoreFactory.inMemory()
         let version = Int(store.pragmaValue("user_version")) ?? 0
-        #expect(version == 42)
+        #expect(version == 43)
     }
 
     @Test func summaryNullForNewMessages() throws {

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -646,13 +646,13 @@ struct PageVersionTests {
     }
 
     /// AC.8 (migration ladder sanity) — a fresh DB must report the current
-    /// `user_version`. The v41→42 step drops the `system_prompt` table.
-    @Test func v42SchemaVersionAfterMigration() throws {
-        #expect(GRDBWikiStore.schemaVersion == 42,
-                "schemaVersion must report 42 after the system_prompt table drop")
+    /// `user_version`. The v42→43 step adds `acp_session_id` to chats.
+    @Test func v43SchemaVersionAfterMigration() throws {
+        #expect(GRDBWikiStore.schemaVersion == 43,
+                "schemaVersion must report 43 after the acp_session_id column add")
         let store = try tempStore()
         let v = store.pragmaValue("user_version")
-        #expect(v == "42", "fresh DB stamps user_version = 42 (got \(v))")
+        #expect(v == "43", "fresh DB stamps user_version = 43 (got \(v))")
     }
 
     // MARK: - #817: pageVersionBody (read arbitrary version body)

--- a/Tests/WikiFSTests/StoreEmissionTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionTests.swift
@@ -432,6 +432,20 @@ struct StoreEmissionTests {
         #expect(events.last?.id == chat.id.rawValue)
     }
 
+    /// ACP session ID write/clear (#830). The new `updateChatAcpSessionId`
+    /// mutator MUST route through `mutate()` and emit a `.chat .updated`
+    /// event. Modeled on `updateMessageSummaryEmitsChatUpdated`.
+    @Test func updateChatAcpSessionIdEmitsChatUpdated() async throws {
+        let (store, _, rec) = try makeHarness()
+        let chat = try store.createChat(kind: .edit, title: "Test Chat")
+        try await drain(rec)
+        try store.updateChatAcpSessionId(chatID: chat.id, acpSessionId: "acp-123")
+        let events = try await awaitEvents(rec)
+        #expect(events.last?.kind == .chat)
+        #expect(events.last?.change == .updated)
+        #expect(events.last?.id == chat.id.rawValue)
+    }
+
     // MARK: - Nil-bus store (wikictl path)
 
     @Test func nilBusStoreEmitsSilently() throws {

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -174,8 +174,8 @@ struct SystemPromptTests {
         #expect(prompt.body == SystemPrompt.defaultBody)
         #expect(prompt.version == (SystemPrompt.defaultBody.hashValue & 0x7FFFFFFF))
 
-        // user_version advanced to 42.
-        #expect(Int(store.pragmaValue("user_version")) == 42)
+        // user_version advanced to 43.
+        #expect(Int(store.pragmaValue("user_version")) == 43)
     }
 
     @Test func v40ToV41MigrationSkipsPromptWithoutDollarWikictl() throws {
@@ -200,7 +200,7 @@ struct SystemPromptTests {
 
     // MARK: - v2 → v3 migration no longer creates the table
 
-    @Test func migratesV2DatabaseToV42PreservingData() throws {
+    @Test func migratesV2DatabaseToV43PreservingData() throws {
         let url = tempDatabaseURL()
 
         // Build a v2-shaped DB by hand: pages + slug index + sources +
@@ -243,7 +243,7 @@ struct SystemPromptTests {
         #expect(file.filename == "keep.txt")
         #expect(try store.sourceContent(id: file.id) == Data("keep".utf8))
 
-        // user_version advances through every migration step to head (v42).
+        // user_version advances through every migration step to head (v43).
         var check: OpaquePointer?
         #expect(sqlite3_open(url.path, &check) == SQLITE_OK)
         defer { sqlite3_close(check) }

--- a/plans/chat-acp-resume.md
+++ b/plans/chat-acp-resume.md
@@ -1,0 +1,290 @@
+# Plan: ACP Session Lifecycle for Chat (Issue #830)
+
+**Status:** Ready for implementation
+**Prerequisite for:** Daemon Phase C (chat survives ⌘Q)
+**Depends on:** Nothing new (builds on shipped #813 Phase 3 queue-side resume)
+**Branch:** `feat/chat-acp-resume`
+
+---
+
+## 0. Summary
+
+Today every chat continuation (`continueChat`) spawns a **fresh** ACP session
+and re-seeds context via `continuationPreamble` (a condensed transcript window
+pasted into the first prompt). This works but is the degraded path: it costs a
+full subprocess spawn + loses tool-call history the agent can't replay from
+text.
+
+This plan makes **ACP session resume the primary path** for chat continuation,
+with seeded-preamble demoted to the fallback. It mirrors the queue/ingestion
+resume path shipped in #813 Phase 3 (`AgentLauncher.swift:1177-1211`,
+`AgentLauncher.swift:1339-1355`), adapted for the chat lifecycle.
+
+The work is **primarily wiring** — `ACPBackend.resume()` already exists
+(`ACPBackend.swift:1188`) and handles the full `resumeSession` → `loadSession`
+→ give-up cascade. What's missing is: (1) a schema column to persist the session
+ID, (2) capturing it at chat spawn, (3) attempting resume on continue, and
+(4) clearing it on terminal teardown.
+
+---
+
+## 1. Schema Migration: v42 → v43
+
+### 1.1. Why a new column
+
+The `chats` table currently has no place to store the ACP session ID. Queue
+items store it on `QueueItemPayload.acpSessionId` (`QueueTypes.swift:86`), a
+field on the codable payload. Chats need the same durability — the session ID
+must survive app restart so a reopened chat can attempt resume.
+
+### 1.2. The ALTER TABLE
+
+```sql
+ALTER TABLE chats ADD COLUMN acp_session_id TEXT;
+```
+
+Nullable: `NULL` for all existing rows (pre-migration chats have no session to
+resume) and for chats where resume permanently failed (cleared — see §5).
+
+### 1.3. Migration ladder step
+
+**File:** `Sources/WikiFSCore/Store/GRDBWikiStore.swift`
+
+**Step 1 — bump the constant** (`:61`):
+```swift
+private static let currentSchemaVersion = 43   // was 42
+```
+
+**Step 2 — add the v42→v43 migration block** after the existing v41→v42 block
+ends at `:1200` (before the catch-all at `:1226`):
+
+```swift
+if version < 43 {
+    if !(try Self.hasColumn("acp_session_id", on: "chats", in: db)) {
+        try db.execute(sql: "ALTER TABLE chats ADD COLUMN acp_session_id TEXT;")
+    }
+    try db.execute(sql: "PRAGMA user_version = 43;")
+    version = 43
+}
+```
+
+### 1.4. Fresh-schema path
+
+Per C1: add `acp_session_id TEXT` to BOTH:
+1. `createChatTablesV23` at `:1438` (migration path)
+2. `createFreshSchema` inline CREATE TABLE at `:2467` (fresh-DB path)
+
+Both must produce identical schemas.
+
+---
+
+## 2. Model: `ChatSummary.acpSessionId`
+
+### 2.1. Add the field
+
+**File:** `Sources/WikiFSCore/Core/ChatModels.swift`
+
+Add to `ChatSummary` (after `summaryAt`):
+
+```swift
+public var acpSessionId: String?
+```
+
+Update the `init` to accept `acpSessionId: String? = nil`.
+
+### 2.2. Update all `ChatSummary` construction sites
+
+Per C4, there are FIVE read paths:
+
+| Site | File:Line | Change |
+|------|-----------|--------|
+| `readChatSummary` mapper | `:6545` | Read `row["acp_session_id"]`, pass to init |
+| `listChats` SELECT | `:6079` | Add `c.acp_session_id` to SELECT list |
+| `getChat` SELECT | `:7481` | Add `c.acp_session_id` to SELECT list |
+| `listAllChatsOrderedByID` SELECT | `:6215` | Add `c.acp_session_id` to SELECT list |
+| `searchSimilarChats` SELECT | `:6313` | Add or document nil acceptable |
+
+All call `readChatSummary` which centralizes the mapping.
+
+### 2.3. New store method: `updateChatAcpSessionId`
+
+Routes through `mutate()` and emits a `.chat .updated` event.
+
+### 2.4. Protocol + model wrappers
+
+Add `updateChatAcpSessionId` to the `WikiStore` protocol and an `@MainActor`
+wrapper on `WikiStoreModel`. Also add `getChat(id:)` to the protocol if missing
+(it's currently only on `GRDBWikiStore`).
+
+---
+
+## 3. Persist at Spawn Time
+
+### 3.1. Where to capture
+
+After `backend.start` returns a session handle (mirroring queue-side pattern
+at `AgentLauncher.swift:1339-1355`), call `onAcpSessionId?(sessionId.value)`.
+
+Per C5: use the `onAcpSessionId` closure, NOT `chatStore?.updateChatAcpSessionId`
+(the launcher has no `chatStore` property).
+
+### 3.2. Threading the store reference
+
+Add an optional `onAcpSessionId: (@MainActor (String?) -> Void)? = nil` parameter
+to `startInteractiveQuery`. Callers wire it to the model wrapper.
+
+---
+
+## 4. Resume on Continue
+
+### 4.1. The resume attempt
+
+Before `backend.start`, if `priorAcpSessionId` is set AND the backend is
+`ACPBackend`, attempt `acpBackend.resume(sessionID:profile:)`. If it returns
+a handle, use it as the session instead of calling `backend.start`.
+
+### 4.2. Threading the prior session ID
+
+Add `priorAcpSessionId: String? = nil` to `startInteractiveQuery`.
+`continueChat` passes the chat row's `acpSessionId`; `startChat` passes nil.
+
+### 4.3. When resume succeeds — skip the preamble
+
+On resume success, send only the user's raw message (the display text), not
+the composed task prompt + preamble.
+
+### 4.4. The flow (state machine)
+
+```
+continueChat(chatID, message)
+  → read chatSummary = store.getChat(chatID)
+  → read history = store.chatMessages(chatID)
+  → compose firstMessage = continuationPreamble(history, message)
+  → startInteractiveQuery(firstMessage, priorAcpSessionId: chatSummary.acpSessionId)
+       → if priorAcpSessionId != nil:
+            attempt acpBackend.resume(sessionID, profile)
+            success → session = handle; first turn = raw user message
+            fail/nil → session = backend.start(...); first turn = taskPrompt + preamble
+```
+
+---
+
+## 5. Clearing the Session ID
+
+### 5.1. When to clear
+
+| Case | Where | Action |
+|------|-------|--------|
+| Chat deleted | `deleteChat` | Cascade handles it |
+| `finish(status: 0)` | `AgentLauncher.finish()` | Do NOT clear for interactive sessions |
+| `finish(status: -1)` | `AgentLauncher.finish()` | Do NOT clear for interactive sessions |
+| Resume permanently failed | `startInteractiveQuery` | Clear via `onAcpSessionId?(nil)` |
+| `startNewChat` | `AgentLauncher.startNewChat()` | Clear via ChatDetailView caller (C8) |
+
+### 5.2. Decision: do not clear on `finish` for interactive sessions
+
+Only clear when resume is **attempted and fails**. The queue side only clears
+for one-shot runs; interactive sessions can be continued.
+
+### 5.3. Implementation: clear on resume failure
+
+After the resume attempt, if resume failed AND we had a prior session ID:
+`onAcpSessionId?(nil)`.
+
+### 5.4. Implementation: clear on `startNewChat`
+
+Per C8: the `ChatDetailView` caller calls
+`store.updateChatAcpSessionId(chatID: oldChatID, acpSessionId: nil)` before
+transitioning to a new chat.
+
+---
+
+## 6. Single Source of Truth Invariant
+
+When a chat session is live, the live ACP session is the single source of
+truth for the in-progress turn. SQLite is the **durable record**, flushed at
+turn boundaries. The two must never both claim authority.
+
+---
+
+## 7. Relationship to Existing Issues
+
+| Issue | Relationship |
+|-------|-------------|
+| #825 (smarter preamble) | Complementary — preamble becomes fallback |
+| #826 (persist in-flight turn) | Orthogonal — will use v44 |
+| Daemon Phase C | Hard prerequisite for this |
+| #813 Phase 3 (queue resume) | Reference implementation |
+
+---
+
+## 8. Implementation Order
+
+### Slice 1: Schema + model (no behavior change)
+### Slice 2: Persist at spawn (no behavior change)
+### Slice 3: Resume on continue (behavior change)
+### Slice 4: Cleanup
+
+---
+
+## 9. Tests
+
+### AC.1: Migration v42→v43 adds the column
+### AC.2: Fresh schema has the column
+### AC.3: Round-trip write + read acpSessionId
+### AC.4: listChats includes acpSessionId
+### AC.5: Store emission test for updateChatAcpSessionId
+### AC.6: Persist at spawn (requires FakeACPBackend — C2)
+### AC.7: Resume success — preamble skipped
+### AC.8: Resume failure — fallback to preamble + stale ID cleared
+### AC.9: Clear on new chat
+
+**C2 — FakeACPBackend:** FakeAgentBackend won't work because the persist block
+does `backend as? ACPBackend` and `currentResumableSessionId()` is ACPBackend-
+specific. Build a `FakeACPBackend` actor before writing AC.6-AC.8 tests.
+
+**C3 — StoreEmissionExhaustivenessTests does NOT exist:** Add a per-method
+`@Test` to `StoreEmissionTests.swift` instead.
+
+---
+
+## §13. Plan-Review Corrections (AUTHORITATIVE)
+
+### SCHEMA VERSION COORDINATION
+
+This plan owns v43. Issue #826 will use v44 — do NOT use v44.
+
+### C1 [high] — Fresh-schema CREATE TABLE is in createFreshSchema
+
+Add `acp_session_id TEXT` to BOTH `createChatTablesV23` AND `createFreshSchema`.
+
+### C2 [high] — Need FakeACPBackend for launcher tests
+
+FakeAgentBackend can't test the `as? ACPBackend` / `currentResumableSessionId()`
+paths. Build FakeACPBackend BEFORE writing AC.6-AC.8 tests.
+
+### C3 [medium] — StoreEmissionExhaustivenessTests does NOT exist
+
+Add per-method `@Test` to `StoreEmissionTests.swift`.
+
+### C4 [medium] — FIVE SELECT read paths
+
+Update all five: readChatSummary, listChats, getChat, listAllChatsOrderedByID,
+searchSimilarChats.
+
+### C5 [medium] — Use onAcpSessionId closure, not chatStore
+
+AgentLauncher has no `chatStore` property. Use the closure.
+
+### C6 [medium] — Add AC.* + Acceptance Criteria
+
+Listed in §9 above.
+
+### C7 [low] — §4.3 sends firstMessage on resume success
+
+For v1, sending the preamble on resume success is wasteful but not harmful.
+Override to send raw user message when resumed.
+
+### C8 [low] — §5.4 clearing on startNewChat
+
+ChatDetailView caller calls store.updateChatAcpSessionId before transitioning.


### PR DESCRIPTION
Adopt ACP session lifecycle for chat (#830)

## Summary

Makes ACP session resume the primary path for chat continuation, with seeded-preamble demoted to the fallback. Mirrors the queue/ingestion resume path shipped in #813 Phase 3.

**Schema:** Migration v42→v43 adds `acp_session_id TEXT` to the `chats` table (both `createChatTablesV23` and `createFreshSchema`).

**Model:** `ChatSummary.acpSessionId: String?` field + all five SELECT paths updated (`readChatSummary`, `listChats`, `getChat`, `listAllChatsOrderedByID`, `searchSimilarChats`).

**Store:** `updateChatAcpSessionId(chatID:acpSessionId:)` routes through `mutate()` with emit. `getChat(id:)` exposed on the `WikiStore` protocol + `WikiStoreModel` wrapper.

**Launcher:** `startInteractiveQuery` gains `priorAcpSessionId` + `onAcpSessionId` params. Resume attempt runs before `backend.start` — if it returns a handle, skips fresh spawn + sends raw user message (not preamble). On failure, clears stale ID and falls back to fresh-start + preamble.

**Wiring:** `AgentOperationRunner.continueChat` reads `acpSessionId` from the chat row. `startChat` passes nil (new chat). `ChatDetailView.startNewChat` clears the old chat's session ID.

## Test plan

- [x] AC.1: Migration v42→v43 adds `acp_session_id` column
- [x] AC.2: Fresh schema has the column
- [x] AC.3: Round-trip write + read + clear of `acpSessionId`
- [x] AC.4: `listChats` + `listAllChatsOrderedByID` include `acpSessionId`
- [x] AC.5: Store emission test for `updateChatAcpSessionId`
- [x] AC.7: Resume success — `backend.start()` NOT called, first message is raw user text
- [x] AC.8: Resume failure — `backend.start()` called, preamble sent, stale ID cleared
- [x] AC.8b: No prior session — no resume attempt, `backend.start()` runs normally
- [x] `swift build` clean
- [x] `swift test` — 3665 tests pass in 304 suites

Closes #830.

Plan: `plans/chat-acp-resume.md`
