### PR TITLE
Fix source detail action bar offset when no markdown

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -755,7 +755,11 @@ struct SourceDetailView: View {
 
             if isHeaderExpanded {
                 sourceActionBar
-                    .frame(maxWidth: .infinity)
+                    // Anchor leading: without an alignment the default is
+                    // `.center`, which offsets the whole bar when there's no
+                    // trailing `Spacer` to force full width (e.g. a source
+                    // with no markdown → `isOutlineApplicable` false).
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .transition(.opacity)
             }
         }


### PR DESCRIPTION
## Problem

In the source detail view, the action buttons (Transcribe, Ingest, Show in List, Share, Reveal in Finder) were offset toward the center instead of pinned to the left. This happened only for some sources — specifically those with no extracted markdown (e.g. a YouTube source before transcription).

## Root cause

The header action bar was framed with `.frame(maxWidth: .infinity)` and no `alignment` argument, so it defaulted to `.center`. The inner `VStack(alignment: .leading)` only aligns its children within the VStack's own bounds — it doesn't make the VStack fill the available width.

The offset was masked whenever the row contained a trailing `Spacer()`, which appears only when `isOutlineApplicable` is true (there's markdown with an outline). The `Spacer` stretched the bar to full width, so the leading buttons landed at the left edge. With no markdown → no outline toggle → no `Spacer` → the bar collapsed to its intrinsic width and the default `.center` alignment pushed it toward the middle.

## Fix

Anchor the frame to the leading edge: `.frame(maxWidth: .infinity, alignment: .leading)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)