### PR TITLE
Expandable chat continuation context: adaptive preamble window (#825)

### DIFF
--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -199,32 +199,34 @@ public enum AgentOperationRunner {
         return .idle
     }
 
-    /// Build the first prompt for a seeded-fallback continue: a "continuing an
-    /// earlier chat" preamble carrying the last N user/assistant turns
-    /// (the `.text` projection — never `event_json`), byte-capped, followed by
-    /// the new user message.
-    ///
-    /// Pure and unit-tested: the caller hands in the persisted `chat_messages`
-    /// (already ordered by `seq`) and the new message; this returns the exact
-    /// string sent as the first turn of the fresh session.
-    ///
-    /// - Only `user` and `assistant` roles contribute (tool calls / results /
-    ///   system rows are noise for re-seeding context).
-    /// - The most recent N *matching* rows are kept (last-wins), then the whole
-    ///   preamble is trimmed from the front so the UTF-8 byte budget holds.
-    /// - The new user message is ALWAYS included in full (it is the actual
-    ///   question); only the transcript window is elided to fit the budget.
-    static func continuationPreamble(
-        from messages: [ChatMessage],
-        newMessage: String,
-        maxTurns: Int = 10,
-        maxBytes: Int = 12_000
-    ) -> String {
-        // Project to (role, text) for user/assistant rows only. `.result`
-        // duplicates `.assistantText` (same turn, same text) — skip it when
-        // the preceding turn is an `.assistantText` with identical text. A
-        // standalone `.result` (no preceding `.assistantText`) is kept so a
-        // turn that only emitted a result is not lost.
+    // MARK: - Adaptive preamble budget (#825)
+
+    // The preamble window scales with conversation depth rather than a flat
+    // 10-turn / 12 KB cap, so deep conversations keep more early context. Every
+    // value is bounded by the ceilings below, so the preamble can never blow
+    // the model's context window. See `adaptivePreambleBudget`.
+
+    /// Eligible-turn depth at and below which the floor (legacy) budget applies.
+    static let adaptiveFloorDepth = 10
+    /// Eligible-turn depth at and above which the ceiling budget is reached.
+    static let adaptiveCeilingDepth = 80
+    /// Floor of the turn-count window (also the legacy flat cap).
+    static let adaptiveFloorTurns = 10
+    /// Ceiling of the turn-count window.
+    static let adaptiveCeilingTurns = 40
+    /// Floor of the byte budget, in UTF-8 bytes (also the legacy flat cap).
+    static let adaptiveFloorBytes = 12_000
+    /// Ceiling of the byte budget, in UTF-8 bytes.
+    static let adaptiveCeilingBytes = 48_000
+
+    /// Project persisted messages to the (role, text) turns the preamble
+    /// re-seeds: `.userText` and `.assistantText` rows, plus a standalone
+    /// `.result`'s text, deduplicated against an identical preceding
+    /// `.assistantText`. Pure, and shared by `continuationPreamble` and the
+    /// adaptive budget so depth is measured the same way the window is filled.
+    static func projectedPreambleTurns(
+        from messages: [ChatMessage]
+    ) -> [(role: String, text: String)] {
         var turns: [(role: String, text: String)] = []
         for msg in messages {
             switch msg.event {
@@ -241,6 +243,66 @@ public enum AgentOperationRunner {
                 break
             }
         }
+        return turns
+    }
+
+    /// Compute the adaptive (maxTurns, maxBytes) preamble window for a
+    /// conversation of `eligibleTurns` user/assistant turns (#825). The window
+    /// grows with depth so deep conversations don't lose all early context, and
+    /// is bounded by `adaptiveCeilingTurns` / `adaptiveCeilingBytes`.
+    ///
+    /// Pure and unit-tested. Piecewise-linear ramp over depth:
+    ///   - depth ≤ `adaptiveFloorDepth` → floor budget (the legacy cap).
+    ///   - floor < depth < ceiling → linear interpolation floor → ceiling.
+    ///   - depth ≥ `adaptiveCeilingDepth` → ceiling budget (saturated).
+    ///
+    /// `eligibleTurns` is `projectedPreambleTurns(from:).count`. Depth 0 still
+    /// yields the floor budget; `continuationPreamble` then just bounds the
+    /// header + new message, as before.
+    static func adaptivePreambleBudget(
+        eligibleTurns depth: Int
+    ) -> (maxTurns: Int, maxBytes: Int) {
+        let lo = Self.adaptiveFloorDepth
+        let hi = Self.adaptiveCeilingDepth
+        guard hi > lo else {
+            return (Self.adaptiveCeilingTurns, Self.adaptiveCeilingBytes)
+        }
+        let clamped = min(max(depth, lo), hi)
+        let t = Double(clamped - lo) / Double(hi - lo)  // 0…1 across the ramp
+        let maxTurns = Int((Double(Self.adaptiveFloorTurns)
+            + t * Double(Self.adaptiveCeilingTurns - Self.adaptiveFloorTurns)).rounded())
+        let maxBytes = Int((Double(Self.adaptiveFloorBytes)
+            + t * Double(Self.adaptiveCeilingBytes - Self.adaptiveFloorBytes)).rounded())
+        return (maxTurns, maxBytes)
+    }
+
+    /// Build the first prompt for a seeded-fallback continue: a "continuing an
+    /// earlier chat" preamble carrying the last N user/assistant turns
+    /// (the `.text` projection — never `event_json`), byte-capped, followed by
+    /// the new user message.
+    ///
+    /// Pure and unit-tested: the caller hands in the persisted `chat_messages`
+    /// (already ordered by `seq`) and the new message; this returns the exact
+    /// string sent as the first turn of the fresh session.
+    ///
+    /// - Only `user` and `assistant` roles contribute (tool calls / results /
+    ///   system rows are noise for re-seeding context).
+    /// - The most recent N *matching* rows are kept (last-wins), then the whole
+    ///   preamble is trimmed from the front so the UTF-8 byte budget holds.
+    /// - The new user message is ALWAYS included in full (it is the actual
+    ///   question); only the transcript window is elided to fit the budget.
+    ///
+    /// `maxTurns` / `maxBytes` default to the legacy flat cap for backward
+    /// compatibility; `continueChat` passes an adaptive budget from
+    /// `adaptivePreambleBudget` (#825).
+    static func continuationPreamble(
+        from messages: [ChatMessage],
+        newMessage: String,
+        maxTurns: Int = 10,
+        maxBytes: Int = 12_000
+    ) -> String {
+        // Project to (role, text) turns (shared with the adaptive budget).
+        let turns = projectedPreambleTurns(from: messages)
 
         // Take the last N matching rows (most recent context wins).
         let recent: [(role: String, text: String)] = {
@@ -369,8 +431,17 @@ public enum AgentOperationRunner {
         store.finalizeStaleDrafts(forChat: chatID)
 
         // Build the condensed transcript + new message as the first prompt.
+        // #825: the preamble window is adaptive — it scales with conversation
+        // depth (more turns for longer chats, up to a ceiling) instead of the
+        // legacy flat 10-turn / 12 KB cap. This is the FALLBACK path (used when
+        // ACP resume fails / returns nil); the resume path sends the raw
+        // `trimmed` message via `firstMessageDisplay`, which is unaffected here.
         let history = store.chatMessages(chatID: chatID)
-        let firstMessage = continuationPreamble(from: history, newMessage: trimmed)
+        let budget = Self.adaptivePreambleBudget(
+            eligibleTurns: Self.projectedPreambleTurns(from: history).count)
+        let firstMessage = continuationPreamble(
+            from: history, newMessage: trimmed,
+            maxTurns: budget.maxTurns, maxBytes: budget.maxBytes)
         // #830: Read the chat's prior ACP session ID so startInteractiveQuery
         // can attempt resume before falling back to the fresh-start + preamble.
         let priorAcpSessionId = store.getChat(id: chatID)?.acpSessionId

--- a/Tests/WikiFSAppTests/ChatContinueD3Tests.swift
+++ b/Tests/WikiFSAppTests/ChatContinueD3Tests.swift
@@ -264,5 +264,161 @@ struct ChatContinueD3Tests {
         let after = model.chats.sorted { $0.updatedAt > $1.updatedAt }
         #expect(after.first?.id == chat.id)
     }
+
+    // MARK: - (d) adaptive preamble budget (#825)
+
+    @Test func adaptiveBudget_shortConversation_usesFloorBudget() {
+        // A shallow conversation (depth ≤ floorDepth) gets the legacy cap.
+        let budget = AgentOperationRunner.adaptivePreambleBudget(eligibleTurns: 3)
+        #expect(budget.maxTurns == AgentOperationRunner.adaptiveFloorTurns)
+        #expect(budget.maxBytes == AgentOperationRunner.adaptiveFloorBytes)
+    }
+
+    @Test func adaptiveBudget_atFloorDepth_usesFloorBudget() {
+        // Exactly at the floor depth → still the floor budget (ramp starts above).
+        let budget = AgentOperationRunner.adaptivePreambleBudget(
+            eligibleTurns: AgentOperationRunner.adaptiveFloorDepth)
+        #expect(budget.maxTurns == AgentOperationRunner.adaptiveFloorTurns)
+        #expect(budget.maxBytes == AgentOperationRunner.adaptiveFloorBytes)
+    }
+
+    @Test func adaptiveBudget_zeroDepthStillYieldsFloor() {
+        // Depth 0 (empty/fresh chat) is clamped to the floor — never negative
+        // or zero, so the header + new message still render as before.
+        let budget = AgentOperationRunner.adaptivePreambleBudget(eligibleTurns: 0)
+        #expect(budget.maxTurns == AgentOperationRunner.adaptiveFloorTurns)
+        #expect(budget.maxBytes == AgentOperationRunner.adaptiveFloorBytes)
+    }
+
+    @Test func adaptiveBudget_rampsUpBetweenFloorAndCeiling() {
+        // A mid-depth conversation lands strictly between floor and ceiling.
+        let midDepth = (AgentOperationRunner.adaptiveFloorDepth
+                        + AgentOperationRunner.adaptiveCeilingDepth) / 2
+        let floor = AgentOperationRunner.adaptivePreambleBudget(
+            eligibleTurns: AgentOperationRunner.adaptiveFloorDepth)
+        let mid = AgentOperationRunner.adaptivePreambleBudget(eligibleTurns: midDepth)
+        let ceiling = AgentOperationRunner.adaptivePreambleBudget(
+            eligibleTurns: AgentOperationRunner.adaptiveCeilingDepth)
+
+        // Monotonic: floor ≤ mid ≤ ceiling in both dimensions.
+        #expect(mid.maxTurns >= floor.maxTurns)
+        #expect(mid.maxTurns <= ceiling.maxTurns)
+        #expect(mid.maxBytes >= floor.maxBytes)
+        #expect(mid.maxBytes <= ceiling.maxBytes)
+        // The ramp actually grows past the floor for a deep-ish conversation.
+        #expect(mid.maxTurns > floor.maxTurns)
+        #expect(mid.maxBytes > floor.maxBytes)
+    }
+
+    @Test func adaptiveBudget_atCeilingDepth_reachesCeiling() {
+        // At the ceiling depth the budget saturates at the ceiling values.
+        let budget = AgentOperationRunner.adaptivePreambleBudget(
+            eligibleTurns: AgentOperationRunner.adaptiveCeilingDepth)
+        #expect(budget.maxTurns == AgentOperationRunner.adaptiveCeilingTurns)
+        #expect(budget.maxBytes == AgentOperationRunner.adaptiveCeilingBytes)
+    }
+
+    @Test func adaptiveBudget_farAboveCeiling_saturates() {
+        // Far beyond the ceiling depth → identical to the at-ceiling budget.
+        let atCeiling = AgentOperationRunner.adaptivePreambleBudget(
+            eligibleTurns: AgentOperationRunner.adaptiveCeilingDepth)
+        let farAbove = AgentOperationRunner.adaptivePreambleBudget(
+            eligibleTurns: AgentOperationRunner.adaptiveCeilingDepth * 10)
+        #expect(farAbove.maxTurns == atCeiling.maxTurns)
+        #expect(farAbove.maxBytes == atCeiling.maxBytes)
+    }
+
+    @Test func adaptiveBudget_isMonotonicNonDecreasingAcrossDepth() {
+        // Sweeping depth 0…ceiling+20 must never decrease either dimension.
+        var prev = AgentOperationRunner.adaptivePreambleBudget(eligibleTurns: 0)
+        for depth in 1...(AgentOperationRunner.adaptiveCeilingDepth + 20) {
+            let cur = AgentOperationRunner.adaptivePreambleBudget(eligibleTurns: depth)
+            #expect(cur.maxTurns >= prev.maxTurns)
+            #expect(cur.maxBytes >= prev.maxBytes)
+            prev = cur
+        }
+    }
+
+    @Test func adaptiveBudget_neverExceedsCeiling() {
+        // Bounded: no depth, however large, exceeds the ceiling budget.
+        for depth in [0, 1, 10, 50, 80, 100, 1_000, 1_000_000] {
+            let budget = AgentOperationRunner.adaptivePreambleBudget(eligibleTurns: depth)
+            #expect(budget.maxTurns <= AgentOperationRunner.adaptiveCeilingTurns)
+            #expect(budget.maxBytes <= AgentOperationRunner.adaptiveCeilingBytes)
+        }
+    }
+
+    @Test func projectedPreambleTurns_countsEligibleUserAssistantRows() {
+        // Depth is measured the same way the window is filled: user/assistant
+        // text rows only, with the .result-duplicates-.assistantText dedup.
+        let messages: [ChatMessage] = [
+            msg(0, .userText("q")),
+            msg(1, .assistantText("a")),
+            msg(2, .toolUse(name: "Bash", inputSummary: "x")),
+            msg(3, .toolResult(isError: false, summary: "y")),
+            msg(4, .systemInit(model: "m")),
+            msg(5, .result(isError: false, text: "a")),  // dup of msg1 → dropped
+        ]
+        let turns = AgentOperationRunner.projectedPreambleTurns(from: messages)
+        #expect(turns.count == 2)
+        #expect(turns.map(\.role) == ["user", "assistant"])
+    }
+
+    @Test func preambleAdaptiveWindowKeepsMoreTurnsForDeepConversations() {
+        // A 40-turn conversation. The legacy flat 10-turn cap would keep only
+        // turn30…turn39; the adaptive window scales maxTurns up for this depth,
+        // so it retains early turns the flat cap would have lost. Byte budget
+        // is generous here so the turn-count window is the binding constraint.
+        var messages: [ChatMessage] = []
+        for i in 0..<40 {
+            messages.append(msg(i, .userText("turn\(i)")))
+        }
+        let depth = AgentOperationRunner.projectedPreambleTurns(from: messages).count
+        let budget = AgentOperationRunner.adaptivePreambleBudget(eligibleTurns: depth)
+
+        #expect(depth == 40)
+        #expect(budget.maxTurns > AgentOperationRunner.adaptiveFloorTurns)   // ramp grew
+        #expect(budget.maxTurns <= AgentOperationRunner.adaptiveCeilingTurns)
+
+        let preamble = AgentOperationRunner.continuationPreamble(
+            from: messages, newMessage: "next",
+            maxTurns: budget.maxTurns, maxBytes: budget.maxBytes)
+
+        // Parse the surviving turn indices per-line (avoids the "turn1" ⊂
+        // "turn10" substring trap).
+        let prefix = "[user] turn"
+        let kept: Set<Int> = Set(
+            preamble.split(separator: "\n").compactMap { line -> Int? in
+                let s = String(line)
+                guard s.hasPrefix(prefix) else { return nil }
+                return Int(s.dropFirst(prefix.count))
+            }
+        )
+        #expect(kept.contains(39))                 // most recent always survives
+        let lowestKept = kept.min() ?? -1
+        #expect(lowestKept >= 0 && lowestKept < 30)  // an early turn legacy cap drops
+    }
+
+    @Test func preambleAdaptiveWindowStillRespectsByteCeiling() {
+        // Even with the grown byte budget, deep + verbose conversations stay
+        // within the ceiling; the new message is always included in full.
+        let big = String(repeating: "x", count: 400)
+        var messages: [ChatMessage] = []
+        for i in 0..<100 {  // well past the ceiling depth → ceiling budget
+            messages.append(msg(i, .userText("Q\(i) " + big)))
+            messages.append(msg(i + 100, .assistantText("A\(i) " + big)))
+        }
+        let budget = AgentOperationRunner.adaptivePreambleBudget(
+            eligibleTurns: AgentOperationRunner.projectedPreambleTurns(from: messages).count)
+        #expect(budget.maxBytes == AgentOperationRunner.adaptiveCeilingBytes)
+
+        let preamble = AgentOperationRunner.continuationPreamble(
+            from: messages, newMessage: "the real new question",
+            maxTurns: budget.maxTurns, maxBytes: budget.maxBytes)
+
+        // Bounded by the ceiling (+ a couple bytes slack for head-trim rounding).
+        #expect(preamble.utf8.count <= AgentOperationRunner.adaptiveCeilingBytes + 8)
+        #expect(preamble.hasSuffix("the real new question"))
+    }
 }
 #endif


### PR DESCRIPTION
Closes #825.

## Summary

Now that #830 (ACP session resume) is merged, the seeded-preamble is the **fallback** path (used when resume fails / returns nil). This PR makes that fallback's window **adaptive**: it scales with conversation depth instead of the legacy flat 10-turn / 12 KB cap, so deep conversations don't lose all early context.

This is **approach 1 only** (adaptive budget — cheap, no model call), as the operator chose. No Whisper / summarization / digest.

## Changes

- **`adaptivePreambleBudget(eligibleTurns:)`** — new pure function. A piecewise-linear ramp:
  - depth ≤ 10  → floor budget (the legacy cap: **10 turns / 12 KB**)
  - 10 < depth < 80 → linear interpolation floor → ceiling
  - depth ≥ 80  → ceiling budget (saturated: **40 turns / 48 KB**)
  - Always bounded — can never blow the context window.
- **`projectedPreambleTurns(from:)`** — extracted the existing user/assistant text projection (with the `.result`-dedupes-`.assistantText` rule) into a pure helper, so **depth is measured the same way the window is filled**. `continuationPreamble` now reuses it (no behavior change).
- **`continueChat`** passes the adaptive budget to `continuationPreamble`.

## Purity & the fallback path (directive 3)

- `continuationPreamble` stays **pure** with its existing signature and legacy defaults (`maxTurns = 10`, `maxBytes = 12_000`) — source-compatible, existing tests unchanged.
- The adaptive scaling is an isolated pure calculation.
- The **resume path is untouched**: it still sends the user's raw message via `firstMessageDisplay`. The preamble is only what the fresh-start fallback sends. `ACPChatResumeTests` still green (resume-success sends raw msg; resume-failure sends preamble).

## Tests (`ChatContinueD3Tests`, 11 new)

- `adaptiveBudget_shortConversation_usesFloorBudget`
- `adaptiveBudget_atFloorDepth_usesFloorBudget`
- `adaptiveBudget_zeroDepthStillYieldsFloor`
- `adaptiveBudget_rampsUpBetweenFloorAndCeiling` (mid strictly > floor, ≤ ceiling)
- `adaptiveBudget_atCeilingDepth_reachesCeiling`
- `adaptiveBudget_farAboveCeiling_saturates`
- `adaptiveBudget_isMonotonicNonDecreasingAcrossDepth` (sweep 0…100)
- `adaptiveBudget_neverExceedsCeiling`
- `projectedPreambleTurns_countsEligibleUserAssistantRows`
- `preambleAdaptiveWindowKeepsMoreTurnsForDeepConversations` (40-turn chat keeps an early turn the flat cap drops)
- `preambleAdaptiveWindowStillRespectsByteCeiling`

## Verification

- `swift build` ✅
- `swift test` → 3706/3707 pass. The single failure (`PdfExtractionServiceTests.streamProcessCapturesStderrLines`) is **unrelated** (PDF subprocess pipe draining) and **passes in isolation** — flaky under parallel load, not touched by this PR.
- `ChatContinueD3Tests` (26) and `ACPChatResumeTests` (3) fully green.
