### PR TITLE
Remove extraction settings lock + empty pdf2md section (#855)

### DIFF
--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -18,10 +18,8 @@ struct ExtractionSettingsView: View {
     let containerDirectory: URL
     let credentialStore: any ExtractionCredentialStore
     let fetcher: any HTTPRequestFetcher
-    /// Observed so the panel can lock itself while a PDF extraction is running —
-    /// changing the backend or keys mid-conversion is unsafe.
+    /// Provides the enabled-provider list for the ACP backend picker.
     let launcher: AgentLauncher
-    @Environment(QueueActivityTracker.self) private var tracker
 
     // Drafts initialized from config + Keychain in `init`; every change is
     // written straight back by `persistAll()`.
@@ -81,14 +79,6 @@ struct ExtractionSettingsView: View {
 
     var body: some View {
         Form {
-            if extractionInProgress {
-                Section {
-                    Label("PDF extraction is in progress. Extraction settings are locked until it finishes or is cancelled.", systemImage: "lock.fill")
-                        .font(.callout)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
             Section {
                 Picker("Backend", selection: $draftBackend) {
                     ForEach(ExtractionBackend.allCases, id: \.self) { backend in
@@ -146,7 +136,6 @@ struct ExtractionSettingsView: View {
         }
         .formStyle(.grouped)
         .frame(minWidth: Metrics.width, minHeight: Metrics.height)
-        .disabled(extractionInProgress)
         .alert("Couldn't Connect to Claude", isPresented: anthropicErrorBinding,
                presenting: anthropicErrorMessage) { _ in
             Button("OK", role: .cancel) {}
@@ -171,22 +160,11 @@ struct ExtractionSettingsView: View {
 
     @ViewBuilder private var backendConfigSection: some View {
         switch draftBackend {
-        case .localPdf2md: localSection
+        case .localPdf2md: EmptyView()
         case .acp: acpSection
         case .anthropic: claudeSection
         case .gemini: geminiSection
         case .doclingServe: doclingSection
-        }
-    }
-
-    @ViewBuilder private var localSection: some View {
-        Section {
-            Text("Local pdf2md runs on-device via the bundled docling + granite VLM. It needs a one-time ~2 GB dependency download, triggered from the ingest flow the first time you extract a PDF. There's nothing to configure here.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        } header: {
-            Text("Local pdf2md")
         }
     }
 
@@ -308,13 +286,6 @@ struct ExtractionSettingsView: View {
     }
     private var doclingErrorMessage: String? {
         if case .failed(let m) = doclingTest { return m }; return nil
-    }
-
-    /// True while a PDF extraction holds the slot (ingest-path or standalone).
-    /// While busy the whole panel is disabled so a mid-extraction backend or key
-    /// change can't derail the running conversion.
-    private var extractionInProgress: Bool {
-        !tracker.extractingSourceIDs.isEmpty
     }
 
     /// `Picker`'s `selection:` can't bind directly to `@State var x: T?` when


### PR DESCRIPTION
Closes #855.

## What

Two cleanups to `Sources/WikiFS/Sources/ExtractionSettingsView.swift`:

1. **Remove the extraction-settings lock.** Deletes the orange "Extraction settings are locked" banner, the `.disabled(extractionInProgress)` form modifier, the `extractionInProgress` computed property, and the now-unused `@Environment(QueueActivityTracker.self) var tracker`.
2. **Delete the empty Local pdf2md section.** Removes the `localSection` view (a static-text caption with no controls) and its call site.

## Why

Extraction now runs through the **QueueEngine**: the backend is resolved at dispatch time and the worker receives a config snapshot. Changing settings mid-extraction therefore only affects the *next* job, not the one currently running — so locking the panel serves no purpose and just blocks the user.

The Local pdf2md section was a placeholder ("nothing to configure here"). The backend option stays selectable in the picker (it's part of `ExtractionBackend.allCases`); its config case now emits `EmptyView()` so selecting it simply shows no config rows.

## Notes

- `launcher: AgentLauncher` is retained — it still backs the ACP provider list in `acpSection`.
- The misleading doc comment on `launcher` (which described the old locking behavior) is updated to reflect its real purpose.

## Verification

- `make test` — 3696 tests in 306 suites passed.
