### PR TITLE
Fix chat outline not showing cached summaries (#858)

### DIFF
--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -220,7 +220,11 @@ struct ChatDetailView: View {
         // Reload persisted messages when the store changes (e.g. a new message
         // appended to a persisted chat — D3 continues append here, and this keeps
         // the persisted view live for renames/count updates when not live).
-        .onChange(of: store.chats) { _, _ in
+        // Keyed on `messageVersion` (not `chats`) because `ChatSummary` doesn't
+        // carry per-message fields — a `chat_messages.summary` write leaves the
+        // `chats` array `==`, so `.onChange(of: chats)` would miss it (#858).
+        // `messageVersion` bumps unconditionally in `reloadChats()`.
+        .onChange(of: store.messageVersion) { _, _ in
             if let chatID, !isLiveChat {
                 persistedMessages = store.chatMessages(chatID: chatID)
             }
@@ -630,9 +634,9 @@ struct ChatDetailView: View {
                     let cached = i < cachedSummaries.count ? cachedSummaries[i] : nil
                     let summary = cached ?? ChatSummary.summaryExtract(from: text, maxLength: 200)
                     if cached != nil {
-                        DebugLog.debug("chatOutlineEntries: seq=\(i) using cached summary (kind=\(visiblePersistedMessages[i].summaryKind?.rawValue ?? "unknown"))")
+                        DebugLog.ingest("chatOutlineEntries: seq=\(i) using cached summary (kind=\(visiblePersistedMessages[i].summaryKind?.rawValue ?? "unknown"))")
                     } else {
-                        DebugLog.debug("chatOutlineEntries: seq=\(i) no cache, using truncation fallback")
+                        DebugLog.ingest("chatOutlineEntries: seq=\(i) no cache, using truncation fallback")
                     }
                     entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
                                                     questionTimestamp: pendingQuestionTS, responseTimestamp: ts))
@@ -644,9 +648,9 @@ struct ChatDetailView: View {
                     let cached = i < cachedSummaries.count ? cachedSummaries[i] : nil
                     let summary = cached ?? ChatSummary.summaryExtract(from: text, maxLength: 200)
                     if cached != nil {
-                        DebugLog.debug("chatOutlineEntries: seq=\(i) using cached summary (kind=\(visiblePersistedMessages[i].summaryKind?.rawValue ?? "unknown"))")
+                        DebugLog.ingest("chatOutlineEntries: seq=\(i) using cached summary (kind=\(visiblePersistedMessages[i].summaryKind?.rawValue ?? "unknown"))")
                     } else {
-                        DebugLog.debug("chatOutlineEntries: seq=\(i) no cache, using truncation fallback")
+                        DebugLog.ingest("chatOutlineEntries: seq=\(i) no cache, using truncation fallback")
                     }
                     entries.append(ChatOutlineEntry(question: q, response: summary.isEmpty ? nil : summary,
                                                     questionTimestamp: pendingQuestionTS, responseTimestamp: ts))

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -194,6 +194,17 @@ public final class WikiStoreModel {
     /// like `bookmarkNodes`.
     public private(set) var chats: [ChatSummary] = []
 
+    /// Monotonic counter bumped on every `reloadChats()`. `ChatSummary` (the
+    /// chat-list model) doesn't carry per-message fields, so a
+    /// `chat_messages.summary` write produces an `==` `chats` array and
+    /// `.onChange(of: chats)` never fires — leaving the outline on a stale nil
+    /// summary (#858). This counter always changes, so views observe it via
+    /// `.onChange(of: messageVersion)` to reload per-message state after any
+    /// store mutation (local writes self-manage through `reloadChats()`;
+    /// external writes arrive via the `WikiEventBus` → `reloadFromStore()` →
+    /// `reloadChats()`).
+    public private(set) var messageVersion: Int = 0
+
     /// A pending question to pre-fill the chat composer, set by the omnibox
     /// "Ask" action (#288). Consumed by `ChatDetailView` on first appearance, then
     /// cleared. `nil` means no pre-fill is waiting.
@@ -203,6 +214,7 @@ public final class WikiStoreModel {
     /// degrading to empty on a store hiccup must never crash the sidebar.
     public func reloadChats() {
         chats = (try? store.listChats()) ?? []
+        messageVersion &+= 1
     }
 
     /// Computed tree for the Bookmarks section.

--- a/Tests/WikiFSTests/MessageSummaryTests.swift
+++ b/Tests/WikiFSTests/MessageSummaryTests.swift
@@ -373,5 +373,65 @@ struct MessageSummaryTests {
         let pending = messages.filter { $0.summary == nil }
         #expect(pending.isEmpty, "already-summarized message should be filtered out")
     }
+
+    // MARK: - Model-level messageVersion (#858)
+
+    /// The core bug: `ChatSummary` has no per-message fields, so writing a
+    /// `chat_messages.summary` leaves the `chats` array `==` after
+    /// `reloadChats()`. `.onChange(of: chats)` would never fire. The
+    /// `messageVersion` counter fixes this — it bumps unconditionally in
+    /// `reloadChats()`, giving SwiftUI an always-changing observable.
+    @Test @MainActor func messageVersion_bumpsEvenWhenChatsUnchanged() throws {
+        let store = try TestStoreFactory.inMemory()
+        let model = WikiStoreModel(store: store)
+        let chat = try store.createChat(kind: .edit, title: "Chat")
+        let inserted = try store.appendChatMessages(
+            chatID: chat.id, events: [.assistantText("Long answer.")])
+        let target = try #require(inserted.first)
+
+        model.reloadChats()
+        let chatsBefore = model.chats
+        let versionBefore = model.messageVersion
+
+        // Write a per-message summary — changes `chat_messages` but NOT any
+        // `ChatSummary` field (summary is per-message, not per-chat).
+        try store.updateMessageSummary(
+            chatID: chat.id, messageID: target.id,
+            summary: "Cached.", kind: .model)
+
+        model.reloadChats()
+
+        // Root cause: chats array is structurally identical.
+        #expect(model.chats == chatsBefore,
+                "chats array must be unchanged — ChatSummary has no per-message fields")
+        // Fix: messageVersion bumped anyway.
+        #expect(model.messageVersion > versionBefore,
+                "messageVersion must bump even when chats is ==")
+
+        // The summary IS in the DB — readable via chatMessages.
+        let msgs = model.chatMessages(chatID: chat.id)
+        let updated = try #require(msgs.first { $0.id == target.id })
+        #expect(updated.summary == "Cached.")
+        #expect(updated.summaryKind == .model)
+    }
+
+    /// `messageVersion` bumps on every `reloadChats()` call, even back-to-back
+    /// with no store change at all. This guarantees `.onChange` fires after
+    /// every mutation that routes through `reloadFromStore()` → `reloadChats()`.
+    @Test @MainActor func messageVersion_bumpsOnEveryReloadChats() throws {
+        let store = try TestStoreFactory.inMemory()
+        let model = WikiStoreModel(store: store)
+        _ = try store.createChat(kind: .edit, title: "Chat")
+
+        model.reloadChats()
+        let v0 = model.messageVersion
+        model.reloadChats()
+        let v1 = model.messageVersion
+        model.reloadChats()
+        let v2 = model.messageVersion
+
+        #expect(v1 > v0)
+        #expect(v2 > v1)
+    }
 }
 #endif // os(macOS)


### PR DESCRIPTION
## Summary

Fixes #858 — the chat outline showed on-the-fly truncation instead of the DB-cached per-message summary.

## Root cause

`WikiStoreModel.updateMessageSummary` writes `chat_messages.summary` via the store, which emits a `ResourceChangeEvent` on the `WikiEventBus`. The model's bus subscription calls `reloadFromStore()` → `reloadChats()`, which rebuilds `chats: [ChatSummary]`. But `ChatSummary` is the **chat-list** model — it carries chat-level fields (`title`, `messageCount`, `summary`) but **no per-message fields**. So the rebuilt `chats` array was structurally `==` to the previous one, `.onChange(of: store.chats)` in `ChatDetailView` never fired, `persistedMessages` never reloaded, and `chatOutlineEntries` read a stale `nil` summary → truncation fallback.

## Fix

**`messageVersion` counter** (`WikiStoreModel.swift`):
- Added `public private(set) var messageVersion: Int = 0` — a monotonic counter bumped unconditionally in `reloadChats()`.
- This decouples the reload trigger from `chats` array equality. Any store mutation (local or external via `WikiEventBus`) bumps it, giving SwiftUI an always-changing observable.

**`ChatDetailView.swift`**:
- Switched `.onChange(of: store.chats)` → `.onChange(of: store.messageVersion)` for the `persistedMessages` reload. This is a strict superset: `messageVersion` bumps on every `reloadChats()` call (which happens after every mutation), catching per-message summary writes that `chats` equality missed.
- Upgraded `chatOutlineEntries` logging from `DebugLog.debug` (`.debug` level — only visible with `--debug` flag) to `DebugLog.ingest` (`.default`/notice level — persisted by default), so the cached-vs-fallback decision is visible in the default log filter.

## Tests

Two new model-level tests in `MessageSummaryTests.swift`:

1. **`messageVersion_bumpsEvenWhenChatsUnchanged`** — directly demonstrates the bug and fix: writes a per-message summary, calls `reloadChats()`, asserts `chats` array is `==` (root cause) but `messageVersion` did bump (fix), and the summary is readable via `chatMessages`.

2. **`messageVersion_bumpsOnEveryReloadChats`** — verifies the counter is monotonic across consecutive `reloadChats()` calls with no store change.

All 3709 tests pass.
