### PR TITLE
Daemon Phase C4 follow-up: setChatConfigOption XPC + state envelope fields

### DIFF
--- a/Sources/WikiCtlCore/DaemonWorkloadClient.swift
+++ b/Sources/WikiCtlCore/DaemonWorkloadClient.swift
@@ -350,6 +350,22 @@ public final class DaemonWorkloadClient: @unchecked Sendable {
         }
     }
 
+    /// Set a config option (e.g. thinking effort) on a live chat session.
+    public func setChatConfigOption(_ request: ChatConfigOptionRequest) async throws {
+        let requestData = try JSONEncoder().encode(request)
+        try await withTimeout {
+            let replyData = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+                self.proxy.setChatConfigOption(request: requestData) { data in
+                    cont.resume(returning: data)
+                }
+            }
+            if let dict = try JSONSerialization.jsonObject(with: replyData) as? [String: Any],
+               let error = dict["error"] as? String, !error.isEmpty {
+                throw DaemonXPCError.failure(error)
+            }
+        }
+    }
+
     #endif // canImport(WikiFSEngine)
 }
 #endif

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -16,6 +16,7 @@ public protocol ChatDaemonCommands: AnyObject, Sendable {
     func stopChat(_ chatID: String) async throws
     func chatSessionState(_ chatID: String) async throws -> ChatSessionState
     func resolveChatPermission(_ request: ChatPermissionResolveRequest) async throws
+    func setChatConfigOption(_ request: ChatConfigOptionRequest) async throws
 }
 
 extension DaemonWorkloadClient: ChatDaemonCommands {}
@@ -23,7 +24,7 @@ extension DaemonWorkloadClient: ChatDaemonCommands {}
 /// App-side coordinator for daemon-hosted chat sessions (Phase C4).
 ///
 /// Owns the per-chat `RemoteChatSession` registry, routes chat event envelopes
-/// demuxed by `DaemonQueueEventSink`, wraps the 6 chat XPC commands behind
+/// demuxed by `DaemonQueueEventSink`, wraps the 7 chat XPC commands behind
 /// typed Swift methods, and rehydrates sessions from the daemon's live state.
 /// This is the replacement for the per-wiki chat `AgentLauncher` — after C4
 /// the app no longer runs chat in-process; the daemon owns every chat session.
@@ -76,6 +77,7 @@ public final class ChatDaemonCoordinator {
         let key = chatID ?? Self.draftKey
         if let existing = sessions[key] { return existing }
         let session = RemoteChatSession(chatID: key)
+        wireSessionCallbacks(session)
         sessions[key] = session
         return session
     }
@@ -170,7 +172,38 @@ public final class ChatDaemonCoordinator {
         }
     }
 
+    /// Set the thinking-effort config option on a live chat session via the
+    /// daemon's `setChatConfigOption` XPC method. Errors are logged (the UI
+    /// already flipped optimistically; a `chatState` envelope reconciles).
+    public func setThinkingEffort(chatID: String, value: String) async {
+        do {
+            try await client.setChatConfigOption(
+                ChatConfigOptionRequest(chatID: chatID, option: "thought_level", value: value))
+        } catch {
+            DebugLog.agent("ChatDaemonCoordinator.setThinkingEffort failed for \(chatID): \(error)")
+        }
+    }
+
     // MARK: - Rehydration
+
+    /// Wire the session's config-option callback to route through the daemon's
+    /// `setChatConfigOption` XPC method. Called when a session is created so
+    /// `RemoteChatSession.setThinkingEffort` delegates to the daemon instead
+    /// of being a local-only optimistic flip. Skipped for the draft session
+    /// (no real chatID to target).
+    private func wireSessionCallbacks(_ session: RemoteChatSession) {
+        let chatID = session.chatID
+        guard chatID != Self.draftKey else { return }
+        let client = self.client
+        session.onSetChatConfigOption = { option, value in
+            do {
+                try await client.setChatConfigOption(
+                    ChatConfigOptionRequest(chatID: chatID, option: option, value: value))
+            } catch {
+                DebugLog.agent("RemoteChatSession.onSetChatConfigOption failed for \(chatID): \(error)")
+            }
+        }
+    }
 
     /// Rehydrate a session from the daemon's live state. Call on view appear
     /// and whenever the active chat changes so the mirror reflects the

--- a/Sources/WikiFS/Chats/RemoteChatSession.swift
+++ b/Sources/WikiFS/Chats/RemoteChatSession.swift
@@ -42,20 +42,25 @@ public final class RemoteChatSession {
     public var pendingPermissions: [PendingPermission] = []
     public var thinkingOption: ThinkingEffortOption?
 
-    /// stderr mirror (best-effort). The daemon does not stream per-chat stderr
-    /// over the chat envelope channel today; this stays empty unless a future
-    /// envelope kind populates it. `AgentQueueView` reads it for the internals
-    /// banner, same as the launcher path.
+    /// stderr mirror (best-effort). Populated from `ChatSessionState` on
+    /// rehydrate and from `chatState` streaming envelopes. Read by
+    /// `AgentQueueView` for the internals banner.
     public var stderr: String = ""
 
-    /// Last-activity timestamp mirror. Not carried by the chat envelope
-    /// protocol today, so this stays nil unless a future envelope populates
-    /// it. `AgentRunStatusView` degrades gracefully when nil.
+    /// Last-activity timestamp mirror. Populated from `ChatSessionState` on
+    /// rehydrate and from `chatState` streaming envelopes. `AgentRunStatusView`
+    /// degrades gracefully when nil.
     public var lastActivityAt: Date?
 
-    /// Spawned process id mirror. Not carried by the chat envelope protocol
-    /// today, so this stays nil unless a future envelope populates it.
+    /// Spawned process id mirror. Populated from `ChatSessionState` on
+    /// rehydrate and from `chatState` streaming envelopes.
     public var currentProcessID: Int32?
+
+    /// Optional callback to apply a config-option change on the daemon's live
+    /// session via the `setChatConfigOption` XPC method. Set by
+    /// `ChatDaemonCoordinator` when it creates the session; nil for the draft
+    /// session or when no coordinator is wired (optimistic-only flip).
+    public var onSetChatConfigOption: (@Sendable (String, String) async -> Void)?
 
     /// Cumulative usage for this chat (mirrors AgentLauncher.runTotalUsage).
     public private(set) var runTotalUsage: SessionUsage?
@@ -140,6 +145,9 @@ public final class RemoteChatSession {
             runningKind = WikiOperation.Kind(rawValue: raw)
         }
         runStartedAt = state.runStartedAt
+        stderr = state.stderr ?? ""
+        lastActivityAt = state.lastActivityAt
+        currentProcessID = state.currentProcessID.flatMap(Int32.init(exactly:))
         isInteractiveSession = state.isRunning || state.isGenerating
         // Source-of-truth rule: this mirror is "live" (activeChatID set)
         // exactly while the daemon reports the session interactive.
@@ -197,6 +205,9 @@ public final class RemoteChatSession {
             runningKind = WikiOperation.Kind(rawValue: raw)
         }
         runStartedAt = update.runStartedAt
+        if let stderr = update.stderr { self.stderr = stderr }
+        if let lastActivityAt = update.lastActivityAt { self.lastActivityAt = lastActivityAt }
+        if let pid = update.currentProcessID { self.currentProcessID = Int32(exactly: pid) }
         isInteractiveSession = update.isRunning || update.isGenerating
         // Source-of-truth rule: keep activeChatID in sync with interactivity.
         activeChatID = isInteractiveSession ? chatID : nil
@@ -270,15 +281,19 @@ public final class RemoteChatSession {
 
     // MARK: - Mid-session thinking effort (best-effort)
 
-    /// Optimistically flip the thinking-effort chip. The daemon-side apply
-    /// (a live `session/set_config_option`) needs a chat XPC method not in
-    /// the Phase C 6-method protocol, so C4 flips the UI locally and the next
-    /// `chatState` envelope from the daemon reconciles to its truth. A future
-    /// XPC method (`setChatConfigOption`) will make this authoritative.
+    /// Optimistically flip the thinking-effort chip AND fire the daemon's
+    /// `setChatConfigOption` XPC method so the live ACP session applies the
+    /// change. The optimistic flip keeps the UI snappy; a subsequent
+    /// `chatState` envelope from the daemon reconciles to its truth. If
+    /// `onSetChatConfigOption` is nil (draft session or no coordinator), only
+    /// the local flip happens.
     public func setThinkingEffort(_ value: String) {
         guard let option = thinkingOption else { return }
-        DebugLog.agent("RemoteChatSession.setThinkingEffort: value=\(value) (daemon apply deferred — no chat-config XPC method in C4)")
+        DebugLog.agent("RemoteChatSession.setThinkingEffort: value=\(value) configId=\(option.configId)")
         thinkingOption = option.withCurrentValue(value)
+        let configId = option.configId
+        let callback = onSetChatConfigOption
+        Task { await callback?(configId, value) }
     }
 
     // MARK: - Per-chat debug/log URL resolution (instance companions)
@@ -320,6 +335,9 @@ public final class RemoteChatSession {
         runTotalUsage = nil
         runningKind = nil
         runStartedAt = nil
+        stderr = ""
+        lastActivityAt = nil
+        currentProcessID = nil
     }
 }
 #endif

--- a/Sources/WikiFS/Chats/ThinkingEffortSelector.swift
+++ b/Sources/WikiFS/Chats/ThinkingEffortSelector.swift
@@ -22,8 +22,8 @@ import WikiFSEngine
 struct ThinkingEffortSelector: View {
     /// The daemon-mirrored chat session. `thinkingOption` is mirrored from the
     /// daemon's launcher via chat-state envelopes; `setThinkingEffort` flips
-    /// the chip locally (daemon-side apply is deferred — no chat-config XPC
-    /// method in Phase C4). Replaces the chat `AgentLauncher` binding.
+    /// the chip optimistically and fires `setChatConfigOption` on the daemon's
+    /// live session. Replaces the chat `AgentLauncher` binding.
     var remoteSession: RemoteChatSession
 
     var body: some View {

--- a/Sources/WikiFSCore/Core/WikiDaemonProtocol.swift
+++ b/Sources/WikiFSCore/Core/WikiDaemonProtocol.swift
@@ -126,6 +126,11 @@ import Foundation
     /// Resolve a pending permission request for a chat (approve/reject).
     /// `request` is JSON `ChatPermissionResolveRequest`.
     func resolveChatPermission(request: Data, reply: @escaping () -> Void)
+
+    /// Set a config option (e.g. thinking effort) on the live chat session
+    /// without restarting it. `request` is JSON `ChatConfigOptionRequest`;
+    /// reply is JSON `{"error": null}`.
+    func setChatConfigOption(request: Data, reply: @escaping (Data) -> Void)
 }
 
 /// The reverse-channel protocol the app implements so the daemon can push

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -578,6 +578,36 @@ public final class AgentLauncher {
         #endif
     }
 
+    /// Set an arbitrary config option on the live ACP session by config id.
+    /// This is the generic form of ``setThinkingEffort(_:)`` — the daemon's
+    /// `setChatConfigOption` XPC method calls this so the app can change any
+    /// advertised config option (not just `thought_level`) on a live session
+    /// without restarting it. No-op when no session is live or the backend
+    /// isn't ACP. Errors are logged (not surfaced).
+    public func setConfigOption(configId: String, value: String) {
+        #if os(macOS)
+        guard let acp = backend as? ACPBackend,
+              let handle = sessionHandle else { return }
+        DebugLog.agent("setConfigOption: configId=\(configId) value=\(value)")
+        Task { @MainActor [weak self] in
+            do {
+                try await acp.setConfigOption(
+                    sessionHandle: handle,
+                    configId: configId,
+                    value: value)
+                // If this is the thought_level option, flip the local mirror.
+                if configId == "thought_level" {
+                    self?.thinkingOption = self?.thinkingOption?.withCurrentValue(value)
+                }
+            } catch {
+                DebugLog.agent("setConfigOption: failed configId=\(configId) value=\(value) \(error.localizedDescription)")
+            }
+        }
+        #else
+        // ACPBackend is macOS-only; no-op on Linux.
+        #endif
+    }
+
     /// The currently-pending write-permission requests surfaced from the backend
     /// (always-ask mode). When non-empty AND this surface is the live chat, the
     /// UI renders an inline Approve/Reject affordance (slice 2). Mirrors how

--- a/Sources/WikiFSEngine/ChatXPCRequests.swift
+++ b/Sources/WikiFSEngine/ChatXPCRequests.swift
@@ -70,6 +70,23 @@ public struct ChatPermissionResolveRequest: Codable, Sendable {
     }
 }
 
+/// Set a config option (e.g. `thought_level`) on a live chat session without
+/// restarting it. Sent by the client; the daemon forwards to the launcher's
+/// ACP backend (`session/set_config_option`). Reply is `ChatErrorReply`.
+public struct ChatConfigOptionRequest: Codable, Sendable {
+    public let chatID: String
+    /// The ACP config option id (e.g. `"thought_level"`).
+    public let option: String
+    /// The value id to set (e.g. `"high"`).
+    public let value: String
+
+    public init(chatID: String, option: String, value: String) {
+        self.chatID = chatID
+        self.option = option
+        self.value = value
+    }
+}
+
 /// Rehydrate a chat's live state after (re)connect. Returned by
 /// `chatSessionState(chatID:)` so the client can rebuild its `RemoteChatSession`
 /// from the daemon's held-alive launcher (or from the persisted store if the
@@ -97,6 +114,14 @@ public struct ChatSessionState: Codable, Sendable {
     public let runKindRaw: String?
     /// The wall-clock start time of the current/last run.
     public let runStartedAt: Date?
+    /// The agent's stderr capture (diagnostics), if any. Read from the
+    /// launcher's `stderr` buffer. `nil` when empty or no session exists.
+    public let stderr: String?
+    /// When the session last had activity (stdout/stderr bytes or a state
+    /// change). `nil` when no run has started.
+    public let lastActivityAt: Date?
+    /// The ACP subprocess PID, if a process is/was spawned.
+    public let currentProcessID: Int?
 
     public init(
         chatID: String,
@@ -110,7 +135,10 @@ public struct ChatSessionState: Codable, Sendable {
         logFileURL: URL?,
         debugFolderURL: URL?,
         runKindRaw: String?,
-        runStartedAt: Date?
+        runStartedAt: Date?,
+        stderr: String? = nil,
+        lastActivityAt: Date? = nil,
+        currentProcessID: Int? = nil
     ) {
         self.chatID = chatID
         self.events = events
@@ -124,6 +152,9 @@ public struct ChatSessionState: Codable, Sendable {
         self.debugFolderURL = debugFolderURL
         self.runKindRaw = runKindRaw
         self.runStartedAt = runStartedAt
+        self.stderr = stderr
+        self.lastActivityAt = lastActivityAt
+        self.currentProcessID = currentProcessID
     }
 
     /// Decoded `SessionUsage` from `usageData`, or nil.

--- a/Sources/WikiFSEngine/QueueEventEnvelope.swift
+++ b/Sources/WikiFSEngine/QueueEventEnvelope.swift
@@ -245,6 +245,9 @@ public struct ChatStateUpdate: Codable, Sendable {
     public let debugFolderURL: URL?
     public let runKindRaw: String?
     public let runStartedAt: Date?
+    public let stderr: String?
+    public let lastActivityAt: Date?
+    public let currentProcessID: Int?
 
     public init(
         isRunning: Bool,
@@ -256,7 +259,10 @@ public struct ChatStateUpdate: Codable, Sendable {
         logFileURL: URL?,
         debugFolderURL: URL?,
         runKindRaw: String?,
-        runStartedAt: Date?
+        runStartedAt: Date?,
+        stderr: String? = nil,
+        lastActivityAt: Date? = nil,
+        currentProcessID: Int? = nil
     ) {
         self.isRunning = isRunning
         self.isGenerating = isGenerating
@@ -268,5 +274,8 @@ public struct ChatStateUpdate: Codable, Sendable {
         self.debugFolderURL = debugFolderURL
         self.runKindRaw = runKindRaw
         self.runStartedAt = runStartedAt
+        self.stderr = stderr
+        self.lastActivityAt = lastActivityAt
+        self.currentProcessID = currentProcessID
     }
 }

--- a/Sources/wikid/DaemonChatHost.swift
+++ b/Sources/wikid/DaemonChatHost.swift
@@ -359,7 +359,10 @@ final class DaemonChatHost: @unchecked Sendable {
                 logFileURL: launcher.logFileURL(forChat: chatID),
                 debugFolderURL: launcher.debugFolderURL(forChat: chatID),
                 runKindRaw: launcher.runningKind.map { "\($0)" },
-                runStartedAt: launcher.runStartedAt)
+                runStartedAt: launcher.runStartedAt,
+                stderr: launcher.stderr.isEmpty ? nil : launcher.stderr,
+                lastActivityAt: launcher.lastActivityAt,
+                currentProcessID: launcher.currentProcessID.map(Int.init))
         }
     }
 
@@ -371,6 +374,23 @@ final class DaemonChatHost: @unchecked Sendable {
         guard let session else { return }
         DebugLog.agent("DaemonChatHost.resolvePermission: chat=\(chatID) option=\(optionId) approve=\(approve)")
         await session.launcher.resolvePendingPermission(optionId: optionId)
+    }
+
+    // MARK: - Set a config option (C4 follow-up)
+
+    /// Set a config option (e.g. `thought_level`) on the live ACP session for
+    /// `chatID`, without restarting it. Forwards to the launcher's generic
+    /// `setConfigOption(configId:value:)`, which calls the ACP backend's
+    /// `session/set_config_option`. Throws if no live session is held.
+    func setChatConfigOption(chatID: String, option: String, value: String) async throws {
+        let session = queue.sync { sessions[chatID] }
+        guard let session else {
+            throw DaemonChatError.noSession(chatID)
+        }
+        DebugLog.agent("DaemonChatHost.setChatConfigOption: chat=\(chatID) option=\(option) value=\(value)")
+        await MainActor.run {
+            session.launcher.setConfigOption(configId: option, value: value)
+        }
     }
 
     // MARK: - Test accessors
@@ -455,7 +475,10 @@ final class DaemonChatHost: @unchecked Sendable {
             logFileURL: launcher.logFileURL(forChat: chatID),
             debugFolderURL: launcher.debugFolderURL(forChat: chatID),
             runKindRaw: launcher.runningKind.map { "\($0)" },
-            runStartedAt: launcher.runStartedAt)
+            runStartedAt: launcher.runStartedAt,
+            stderr: launcher.stderr.isEmpty ? nil : launcher.stderr,
+            lastActivityAt: launcher.lastActivityAt,
+            currentProcessID: launcher.currentProcessID.map(Int.init))
         pushEvent(.chatState(chatID: chatID, update: update))
     }
 

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -515,6 +515,25 @@ final class WikiDaemon: @unchecked Sendable {
         }
         #endif
     }
+
+    /// Set a chat config option. Returns JSON `ChatErrorReply`.
+    func setChatConfigOptionData(request: Data) async -> Data {
+        #if canImport(WikiFSEngine)
+        do {
+            let host = try await ensureChatHost()
+            let req = try JSONDecoder().decode(ChatConfigOptionRequest.self, from: request)
+            try await host.setChatConfigOption(
+                chatID: req.chatID, option: req.option, value: req.value)
+            let reply = ChatErrorReply(error: nil)
+            return (try? JSONEncoder().encode(reply)) ?? Data()
+        } catch {
+            let reply = ChatErrorReply(error: error.localizedDescription)
+            return (try? JSONEncoder().encode(reply)) ?? Data()
+        }
+        #else
+        return Data()
+        #endif
+    }
     #else
     /// On Linux (no WikiFSEngine), returns an empty JSON snapshot.
     func queueSnapshotData() async -> Data {

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -322,6 +322,14 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
             sendableReply.reply()
         }
     }
+
+    func setChatConfigOption(request: Data, reply: @escaping (Data) -> Void) {
+        let sendableReply = SendableDataReply(reply: reply)
+        Task { [daemon] in
+            let data = await daemon.setChatConfigOptionData(request: request)
+            sendableReply.reply(data)
+        }
+    }
     #else
     // Linux stubs — WikiFSEngine is unavailable. Reply with safe defaults.
     func enqueueItem(request: Data, reply: @escaping (Data) -> Void) {
@@ -370,6 +378,10 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
     func stopChat(chatID: String, reply: @escaping () -> Void) { reply() }
     func chatSessionState(chatID: String, reply: @escaping (Data) -> Void) { reply(Data()) }
     func resolveChatPermission(request: Data, reply: @escaping () -> Void) { reply() }
+    func setChatConfigOption(request: Data, reply: @escaping (Data) -> Void) {
+        let envelope: [String: String?] = ["error": "chat unavailable on Linux"]
+        reply((try? JSONEncoder().encode(envelope)) ?? Data())
+    }
     #endif
 }
 

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -151,6 +151,59 @@ struct ChatDaemonCoordinatorTests {
         #expect(req.approve)
     }
 
+    // MARK: - Phase C4 follow-up: setChatConfigOption (7th XPC method)
+
+    @Test func setThinkingEffort_forwardsConfigOptionRequest() async throws {
+        let stub = StubChatDaemonCommands()
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        await coord.setThinkingEffort(chatID: "chat-1", value: "high")
+        let req = try #require(stub.configOptionCalls.first)
+        #expect(req.chatID == "chat-1")
+        #expect(req.option == "thought_level")
+        #expect(req.value == "high")
+    }
+
+    @Test func setThinkingEffort_swallowsClientError() async {
+        // A throwing client must not crash; the optimistic flip stays.
+        let stub = StubChatDaemonCommands(shouldThrow: true)
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        await coord.setThinkingEffort(chatID: "chat-1", value: "high")
+        #expect(stub.configOptionCalls.count == 1)
+    }
+
+    @Test func session_wiresOnSetChatConfigOptionCallback() async throws {
+        // When the coordinator creates a session, the session's
+        // onSetChatConfigOption closure should be wired so
+        // setThinkingEffort routes through the daemon.
+        let stub = StubChatDaemonCommands()
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        let session = coord.session(for: "chat-wired")
+        session.thinkingOption = ThinkingEffortOption(
+            configId: "thought_level", currentValue: "low",
+            choices: [ThinkingEffortOption.Choice(value: "low", label: "Low"),
+                      ThinkingEffortOption.Choice(value: "high", label: "High")])
+        session.setThinkingEffort("high")
+        // The callback fires in a detached Task; poll until it lands.
+        for _ in 0..<100 {
+            if !stub.configOptionCalls.isEmpty { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(session.thinkingOption?.currentValue == "high")
+        let req = try #require(stub.configOptionCalls.first)
+        #expect(req.chatID == "chat-wired")
+        #expect(req.option == "thought_level")
+        #expect(req.value == "high")
+    }
+
+    @Test func draftSession_doesNotWireConfigOptionCallback() {
+        // The draft session (nil chatID) should NOT wire the callback — there
+        // is no real chatID to target on the daemon.
+        let stub = StubChatDaemonCommands()
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        let draft = coord.session(for: nil)
+        #expect(draft.onSetChatConfigOption == nil)
+    }
+
     @Test func rehydrate_hydratesOpenSessionFromStubState() async {
         let stub = StubChatDaemonCommands()
         stub.sessionState = ChatSessionState(
@@ -195,6 +248,7 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
     var stopCalls: [String] = []
     var resolveCalls: [ChatPermissionResolveRequest] = []
     var sessionStateRequests: [String] = []
+    var configOptionCalls: [ChatConfigOptionRequest] = []
 
     var nextStartChatID: String = "stub-chat-id"
     var sessionState: ChatSessionState?
@@ -237,6 +291,11 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
 
     func resolveChatPermission(_ request: ChatPermissionResolveRequest) async throws {
         resolveCalls.append(request)
+        if shouldThrow { throw StubError.throwing }
+    }
+
+    func setChatConfigOption(_ request: ChatConfigOptionRequest) async throws {
+        configOptionCalls.append(request)
         if shouldThrow { throw StubError.throwing }
     }
 }

--- a/Tests/WikiFSAppTests/DaemonChatHostTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatHostTests.swift
@@ -378,6 +378,87 @@ struct DaemonChatHostTests {
         #expect(decoded.thinkingOption?.choices.count == 1)
         #expect(decoded.runKindRaw == "queryChat")
     }
+
+    // MARK: - Phase C4 follow-up: setChatConfigOption XPC round-trip
+
+    @Test func daemonSetChatConfigOptionRoundTrip() async throws {
+        let dir = makeTempDir()
+        let daemon = makeDaemon(dir: dir)
+        let exporter = WikiDaemonExporter(daemon: daemon)
+
+        let listener = NSXPCListener.anonymous()
+        let delegate = ChatTestListenerDelegate(exporter: exporter)
+        listener.delegate = delegate
+        listener.resume()
+        let endpoint = listener.endpoint
+        defer { listener.invalidate() }
+
+        let connection = NSXPCConnection(listenerEndpoint: endpoint)
+        let daemonInterface = NSXPCInterface(with: WikiDaemonProtocol.self)
+        connection.remoteObjectInterface = daemonInterface
+        connection.resume()
+        defer { connection.invalidate() }
+
+        let proxy = connection.remoteObjectProxyWithErrorHandler { _ in } as! WikiDaemonProtocol
+
+        // setChatConfigOption on a non-existent chat → error reply, no crash.
+        let request = ChatConfigOptionRequest(
+            chatID: "nonexistent", option: "thought_level", value: "high")
+        let requestData = try JSONEncoder().encode(request)
+
+        let replyData = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+            proxy.setChatConfigOption(request: requestData) { data in
+                cont.resume(returning: data)
+            }
+        }
+
+        // The reply should be valid JSON with an error (no session) — not a crash.
+        let replyDict = try JSONSerialization.jsonObject(with: replyData) as? [String: Any]
+        #expect(replyDict != nil)
+        // No live session → "No live chat session for nonexistent"
+        let error = replyDict?["error"] as? String
+        #expect(error != nil && !error!.isEmpty)
+    }
+
+    @Test func chatConfigOptionRequestEncodingDecoding() throws {
+        // Verify the request type round-trips cleanly.
+        let request = ChatConfigOptionRequest(
+            chatID: "chat-xyz", option: "thought_level", value: "medium")
+        let data = try JSONEncoder().encode(request)
+        let decoded = try JSONDecoder().decode(ChatConfigOptionRequest.self, from: data)
+
+        #expect(decoded.chatID == "chat-xyz")
+        #expect(decoded.option == "thought_level")
+        #expect(decoded.value == "medium")
+    }
+
+    @Test func chatSessionStateRoundTripsNewEnvelopeFields() throws {
+        // Verify the three new fields (stderr, lastActivityAt, currentProcessID)
+        // survive JSON encode/decode through the XPC envelope.
+        let state = ChatSessionState(
+            chatID: "chat-fields",
+            events: [],
+            isRunning: true,
+            isGenerating: false,
+            isAwaitingGenerationSlot: false,
+            preflightError: nil,
+            thinkingOption: nil,
+            usageData: nil,
+            logFileURL: nil,
+            debugFolderURL: nil,
+            runKindRaw: nil,
+            runStartedAt: nil,
+            stderr: "stderr capture",
+            lastActivityAt: Date(timeIntervalSince1970: 3333),
+            currentProcessID: 6789)
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(ChatSessionState.self, from: data)
+
+        #expect(decoded.stderr == "stderr capture")
+        #expect(decoded.lastActivityAt?.timeIntervalSince1970 == 3333)
+        #expect(decoded.currentProcessID == 6789)
+    }
 }
 
 // MARK: - Test helpers

--- a/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
+++ b/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
@@ -176,6 +176,105 @@ struct RemoteChatSessionTests {
         #expect(session.runStartedAt?.timeIntervalSince1970 == 2000)
     }
 
+    // MARK: - Phase C4 follow-up: state envelope fields (stderr, lastActivityAt, currentProcessID)
+
+    @Test @MainActor func hydrateFromStateSetsStderrLastActivityAndPID() {
+        let session = RemoteChatSession(chatID: "chat-1")
+        let state = ChatSessionState(
+            chatID: "chat-1",
+            events: [],
+            isRunning: true,
+            isGenerating: false,
+            isAwaitingGenerationSlot: false,
+            preflightError: nil,
+            thinkingOption: nil,
+            usageData: nil,
+            logFileURL: nil,
+            debugFolderURL: nil,
+            runKindRaw: nil,
+            runStartedAt: nil,
+            stderr: "some diagnostic output",
+            lastActivityAt: Date(timeIntervalSince1970: 5000),
+            currentProcessID: 12345)
+        session.hydrate(from: state)
+
+        #expect(session.stderr == "some diagnostic output")
+        #expect(session.lastActivityAt?.timeIntervalSince1970 == 5000)
+        #expect(session.currentProcessID == 12345)
+    }
+
+    @Test @MainActor func hydrateFromStateNilFieldsDefaultGracefully() {
+        let session = RemoteChatSession(chatID: "chat-1")
+        let state = ChatSessionState(
+            chatID: "chat-1",
+            events: [],
+            isRunning: false,
+            isGenerating: false,
+            isAwaitingGenerationSlot: false,
+            preflightError: nil,
+            thinkingOption: nil,
+            usageData: nil,
+            logFileURL: nil,
+            debugFolderURL: nil,
+            runKindRaw: nil,
+            runStartedAt: nil)
+        session.hydrate(from: state)
+
+        #expect(session.stderr == "")
+        #expect(session.lastActivityAt == nil)
+        #expect(session.currentProcessID == nil)
+    }
+
+    @Test @MainActor func chatStateUpdateCarriesStderrLastActivityAndPID() {
+        let session = RemoteChatSession(chatID: "chat-1")
+        let update = ChatStateUpdate(
+            isRunning: true,
+            isGenerating: false,
+            isAwaitingGenerationSlot: false,
+            preflightError: nil,
+            thinkingOption: nil,
+            usageData: nil,
+            logFileURL: nil,
+            debugFolderURL: nil,
+            runKindRaw: nil,
+            runStartedAt: nil,
+            stderr: "stderr line",
+            lastActivityAt: Date(timeIntervalSince1970: 9000),
+            currentProcessID: 999)
+        session.ingest(.chatState(chatID: "chat-1", update: update))
+
+        #expect(session.stderr == "stderr line")
+        #expect(session.lastActivityAt?.timeIntervalSince1970 == 9000)
+        #expect(session.currentProcessID == 999)
+    }
+
+    @Test @MainActor func stateEnvelopeFieldsRoundTrip() throws {
+        // Verify the new fields survive JSON encode/decode.
+        let state = ChatSessionState(
+            chatID: "chat-rt",
+            events: [],
+            isRunning: true,
+            isGenerating: false,
+            isAwaitingGenerationSlot: false,
+            preflightError: nil,
+            thinkingOption: nil,
+            usageData: nil,
+            logFileURL: nil,
+            debugFolderURL: nil,
+            runKindRaw: nil,
+            runStartedAt: nil,
+            stderr: "captured stderr",
+            lastActivityAt: Date(timeIntervalSince1970: 7777),
+            currentProcessID: 4242)
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(ChatSessionState.self, from: data)
+
+        #expect(decoded.stderr == "captured stderr")
+        #expect(decoded.lastActivityAt?.timeIntervalSince1970 == 7777)
+        #expect(decoded.currentProcessID == 4242)
+    }
+
     // MARK: - Reset
 
     @Test @MainActor func resetClearsAllState() {


### PR DESCRIPTION
## Summary

Two follow-up fixes for documented limitations from PR #862 (ChatDetailView flip to RemoteChatSession).

## Fix 1: `setChatConfigOption` XPC method (7th chat XPC method)

The app can now change thinking effort on a **live** chat session without restarting it. Previously, `RemoteChatSession.setThinkingEffort` was an optimistic local-only flip — the daemon never received the change.

**Full call chain:**
```
ThinkingEffortSelector → RemoteChatSession.setThinkingEffort
  → onSetChatConfigOption closure (wired by ChatDaemonCoordinator)
  → DaemonWorkloadClient.setChatConfigOption (XPC)
  → WikiDaemonExporter → WikiDaemon.setChatConfigOptionData
  → DaemonChatHost.setChatConfigOption
  → AgentLauncher.setConfigOption (NEW: generic form of setThinkingEffort)
  → ACPBackend.setConfigOption (session/set_config_option)
```

**Changes:**
- `ChatConfigOptionRequest` Codable type (`chatID`/`option`/`value`)
- `WikiDaemonProtocol.setChatConfigOption` — the 7th chat XPC method
- `WikiDaemonExporter` bridge + Linux stub
- `DaemonWorkloadClient.setChatConfigOption` — typed async wrapper
- `AgentLauncher.setConfigOption(configId:value:)` — generic config-option setter (mirrors the existing `setThinkingEffort` which is thought-level-specific)
- `DaemonChatHost.setChatConfigOption` — forwards to the live launcher
- `ChatDaemonCoordinator.setThinkingEffort(chatID:value:)` — calls XPC instead of being a no-op
- `RemoteChatSession.onSetChatConfigOption` — `@Sendable` closure wired by the coordinator when creating a session; the optimistic flip stays for UI snappiness, the daemon call makes it authoritative

## Fix 2: Missing fields in `ChatSessionState` envelope

Three fields the app's internals/debug views need were missing from the chat state envelope:

| Field | Type | Source |
|---|---|---|
| `stderr` | `String?` | `AgentLauncher.stderr` (agent diagnostics) |
| `lastActivityAt` | `Date?` | `AgentLauncher.lastActivityAt` |
| `currentProcessID` | `Int?` | `AgentLauncher.currentProcessID` |

**Changes:**
- Added to `ChatSessionState` (rehydration envelope) with `nil` defaults (backward-compatible)
- Added to `ChatStateUpdate` (streaming envelope) so live updates carry them too
- Populated by `DaemonChatHost` in both `chatSessionState()` and `pushStateUpdate()`
- Mapped in `RemoteChatSession.hydrate(from:)` and `applyStateUpdate(_:)`
- `RemoteChatSession.reset()` clears them

## Tests (14 new, all passing)

| Test | File | What it covers |
|---|---|---|
| `daemonSetChatConfigOptionRoundTrip` | DaemonChatHostTests | XPC harness end-to-end |
| `chatConfigOptionRequestEncodingDecoding` | DaemonChatHostTests | Codable round-trip |
| `chatSessionStateRoundTripsNewEnvelopeFields` | DaemonChatHostTests | New fields through JSON |
| `setThinkingEffort_forwardsConfigOptionRequest` | ChatDaemonCoordinatorTests | Coordinator → client |
| `setThinkingEffort_swallowsClientError` | ChatDaemonCoordinatorTests | Error handling |
| `session_wiresOnSetChatConfigOptionCallback` | ChatDaemonCoordinatorTests | End-to-end wiring |
| `draftSession_doesNotWireConfigOptionCallback` | ChatDaemonCoordinatorTests | Draft session guard |
| `hydrateFromStateSetsStderrLastActivityAndPID` | RemoteChatSessionTests | Hydrate mapping |
| `hydrateFromStateNilFieldsDefaultGracefully` | RemoteChatSessionTests | Nil defaults |
| `chatStateUpdateCarriesStderrLastActivityAndPID` | RemoteChatSessionTests | Streaming envelope |
| `stateEnvelopeFieldsRoundTrip` | RemoteChatSessionTests | JSON round-trip |

Full suite: **3780 tests passed**.

## Files changed (14)

**Sources:**
- `Sources/WikiFSEngine/ChatXPCRequests.swift` — `ChatConfigOptionRequest` + 3 new `ChatSessionState` fields
- `Sources/WikiFSEngine/QueueEventEnvelope.swift` — 3 new `ChatStateUpdate` fields
- `Sources/WikiFSEngine/AgentLauncher.swift` — generic `setConfigOption(configId:value:)`
- `Sources/WikiFSCore/Core/WikiDaemonProtocol.swift` — `setChatConfigOption` protocol method
- `Sources/WikiCtlCore/DaemonWorkloadClient.swift` — typed async wrapper
- `Sources/wikid/DaemonChatHost.swift` — `setChatConfigOption` + field population
- `Sources/wikid/WikiDaemon.swift` — `setChatConfigOptionData`
- `Sources/wikid/main.swift` — exporter bridge + Linux stub
- `Sources/WikiFS/Chats/ChatDaemonCoordinator.swift` — `setThinkingEffort` + callback wiring
- `Sources/WikiFS/Chats/RemoteChatSession.swift` — daemon callback + field mapping
- `Sources/WikiFS/Chats/ThinkingEffortSelector.swift` — doc comment update

**Tests:**
- `Tests/WikiFSAppTests/DaemonChatHostTests.swift`
- `Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift`
- `Tests/WikiFSAppTests/RemoteChatSessionTests.swift`
