### PR TITLE
Add Restart Daemon menu item to Maintenance menu

### DIFF
--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ServiceManagement
 import SwiftUI
 import WikiFSCore
 import WikiFSEngine
@@ -276,6 +277,8 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         let maintenanceMenu = NSMenu()
         maintenanceMenu.addItem(withTitle: "Vacuum All…",
             action: #selector(vacuumAll(_:)), keyEquivalent: "").target = self
+        maintenanceMenu.addItem(withTitle: "Restart Daemon",
+            action: #selector(restartDaemon(_:)), keyEquivalent: "").target = self
         maintenanceItem.submenu = maintenanceMenu
         menu.addItem(maintenanceItem)
 
@@ -374,6 +377,27 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     @objc private func vacuumAll(_ sender: NSMenuItem?) {
         targetSession?.previewVacuumAll()
         activateWikiWindow()
+    }
+
+    /// Restart the wikid launchd daemon by unregistering + re-registering its
+    /// SMAppService. Used when the daemon is stale (running an old binary
+    /// after the app was rebuilt) — avoids a full app restart. Best-effort:
+    /// errors are logged, not fatal (in dev mode `unregister`/`register` may
+    /// no-op or throw if the service was never registered).
+    @objc private func restartDaemon(_ sender: NSMenuItem?) {
+        DebugLog.store("wikid: restart requested")
+        let daemonService = SMAppService.agent(plistName: "com.selfdrivingwiki.wikid.plist")
+        do {
+            try daemonService.unregister()
+        } catch {
+            DebugLog.store("wikid: unregister failed during restart: \(error)")
+        }
+        do {
+            try daemonService.register()
+            DebugLog.store("wikid: re-registered, status=\(daemonService.status.rawValue)")
+        } catch {
+            DebugLog.store("wikid: re-register failed during restart: \(error)")
+        }
     }
 
     /// Open the Settings window. Calls the `OpenWindowBridge`'s

--- a/Tests/WikiFSAppTests/MenuBarItemMaintenanceMenuTests.swift
+++ b/Tests/WikiFSAppTests/MenuBarItemMaintenanceMenuTests.swift
@@ -1,0 +1,98 @@
+#if os(macOS)
+import AppKit
+import Testing
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// Pins the menu-bar Maintenance submenu shape: it must contain a
+/// "Restart Daemon" item wired (target + action) back to the
+/// `MenuBarItemController`. The `SMAppService` unregister/register calls
+/// inside the action can't be exercised in a unit test (launchd state is
+/// not controllable from here), so this only verifies the menu wiring —
+/// that the item exists, is enabled, targets the controller, and resolves
+/// to the `restartDaemon:` selector. A regression that removes the item,
+/// drops its target, or renames the selector is caught here.
+@MainActor
+struct MenuBarItemMaintenanceMenuTests {
+
+    @Test("Maintenance submenu includes a wired Restart Daemon item")
+    func restartDaemonMenuItemExists() throws {
+        let controller = try makeController()
+        let menu = NSMenu()
+        controller.menuNeedsUpdate(menu)
+
+        // Locate the Maintenance submenu.
+        let maintenance = try #require(
+            menu.items.first(where: { $0.title == "Maintenance" }),
+            "Maintenance menu item should be present")
+        let submenu = try #require(maintenance.submenu, "Maintenance should have a submenu")
+
+        // Vacuum All… is the anchor item — assert it's still there so a
+        // future edit can't silently drop the pre-existing entry.
+        #expect(submenu.items.contains(where: { $0.title == "Vacuum All…" }))
+
+        let restart = try #require(
+            submenu.items.first(where: { $0.title == "Restart Daemon" }),
+            "Restart Daemon item should be present in the Maintenance submenu")
+
+        #expect(restart.isEnabled)
+        #expect(restart.target === controller)
+        // `restartDaemon(_:)` is private, so resolve the selector by name
+        // rather than via `#selector` (which can't reach private members).
+        #expect(restart.action == NSSelectorFromString("restartDaemon:"))
+    }
+
+    // MARK: - Wiring helpers
+
+    /// Build a real `MenuBarItemController` with lightweight, in-memory
+    /// dependencies. `buildMenu` only reads `registry.wikis` (empty here) and
+    /// `activityTracker.todayUsage` (no data on a fresh tracker), so none of
+    /// the heavier session/engine machinery is exercised by the menu build.
+    private func makeController() throws -> MenuBarItemController {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("menu-item-controller-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let engine = try makeTestQueueEngine()
+        let coordinator = ExtractionCoordinator(
+            containerDirectory: dir,
+            localExtractorFactory: { StubExtractor() })
+        let sessionManager = SessionManager(
+            containerDirectory: dir,
+            extractionCoordinator: coordinator,
+            queueEngine: engine,
+            extractionProvider: StubExtractionProvider(),
+            pdf2mdScriptPathResolver: { nil })
+        let registry = WikiRegistryClient(containerDirectory: dir)
+
+        return MenuBarItemController(
+            queueEngine: engine,
+            activityTracker: QueueActivityTracker(),
+            sessionManager: sessionManager,
+            registry: registry,
+            openWindowBridge: OpenWindowBridge())
+    }
+}
+
+// MARK: - Minimal stubs (mirror PageDetailViewHostedTests)
+
+@MainActor
+private final class StubExtractor: MarkdownExtractor {
+    nonisolated var displayName: String { "Stub" }
+    func readiness() async -> ExtractionReadiness { .ready }
+    func convert(pdfData: Data, filename: String, onProgress: (@Sendable (String) -> Void)?) async throws -> String { "" }
+}
+
+private struct StubExtractionProvider: QueueExtractionProvider {
+    func resolveExtraction(wikiID: String, sourceID: PageID, backendOverride: ExtractionBackend?) async throws -> ExtractionResolution? { nil }
+    func persistExtraction(wikiID: String, sourceID: PageID, markdown: String, backend: ExtractionBackend, modelVersion: String?, technique: String?) async throws {}
+}
+
+private func makeTestQueueEngine() throws -> QueueEngine {
+    let store = try QueueStore(databaseURL: URL(fileURLWithPath: ":memory:"))
+    let provider = StubExtractionProvider()
+    let factory = QueueExtractionWorkerFactory(provider: provider, emitProgress: { _, _ in })
+    return QueueEngine(store: store, workerFactory: factory)
+}
+#endif


### PR DESCRIPTION
## Summary

Adds a **Restart Daemon** item to the menu-bar **Maintenance** submenu so the user can refresh a stale `wikid` daemon (e.g. one still running an old binary after the app was rebuilt) without quitting the app.

## Changes

- **`Sources/WikiFS/Window/MenuBarItemController.swift`**
  - `import ServiceManagement`
  - New "Restart Daemon" entry in the Maintenance submenu (next to "Vacuum All…").
  - `restartDaemon(_:)` action: reconstructs `SMAppService.agent(plistName: "com.selfdrivingwiki.wikid.plist")` (the same service registered in `WikiFSApp`), calls `unregister()` then `register()` to kill + relaunch the daemon, and logs via `DebugLog.store("wikid: restart requested")`. Best-effort — errors at each step are logged, not fatal (in dev mode `unregister`/`register` may no-op or throw if the service was never registered).
- **`Tests/WikiFSAppTests/MenuBarItemMaintenanceMenuTests.swift`** (new)
  - Pins the menu wiring: builds the real menu via `menuNeedsUpdate`, asserts the Maintenance submenu contains an enabled "Restart Daemon" item whose `target` is the controller and whose `action` resolves to `restartDaemon:`. (The `SMAppService` calls themselves aren't unit-testable — launchd state isn't controllable from a test — so only the wiring is asserted.)

## Verification

- `swift build` ✅
- `swift test` — full suite (3770 tests) ✅, including the new `MenuBarItemMaintenanceMenuTests`.
