### PR TITLE
Fix Ingest button disabled after Phase C4 (#867)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,44 @@
 # Progress log
 
+## fix: Ingest button disabled after Phase C4 flip (#867)
+
+**Goal:** the Ingest button in `SourceDetailView` was permanently disabled
+after the Phase C4 flip (#862) because its `.disabled()` still gated on
+`launcher.isRunning` — a flag on the local in-process `agentLauncher` that,
+post-C4, is no longer on the ingest/lint path (both are enqueued to the daemon
+queue). A stale/stuck `isRunning` therefore wedged the button with no path to
+clear it.
+
+**Root cause:** `SourceDetailView.ingestButton` computed
+`.disabled((isRunning && !isAnySourceIngesting) || isEditLockedExternally ||
+!canIngest)`, where `isRunning` is a snapshot of `launcher.isRunning` captured
+in `WikiDetailView.swift:177`. The gate pre-dated the queue architecture: it
+existed to avoid a launcher preflight refusal when a lint was mid-run
+in-process. After C4, ingest **and** lint go through the daemon (or local
+`QueueEngine` fallback), so the local launcher's `isRunning` is disconnected
+from ingest/lint state. The queue engine already serializes ingestion/
+extraction and `enqueueIngestion` dedupes a source already active in the
+queue — so the launcher gate is obsolete in both the daemon and fallback paths.
+
+**Fix:** dropped the `isRunning`-based gate. Extracted the predicate into a
+pure, `internal static` seam — `SourceDetailView.ingestButtonDisabled(
+isEditLockedExternally:canIngest:)` (mirrors the existing
+`extractionAffordance` seam) — so the regression is pinnable. The button now
+disables only on `isEditLockedExternally || !canIngest`.
+
+**Files touched:**
+- `Sources/WikiFS/Sources/SourceDetailView.swift` — new
+  `ingestButtonDisabled(...)` seam; `ingestButton` calls it (dropping the
+  `isRunning && !isAnySourceIngesting` term); updated comment with the #867
+  rationale.
+- **New:** `Tests/WikiFSAppTests/IngestButtonDisabledTests.swift` — 5 tests
+  pinning the decision table + the structural #867 guarantee that no launcher
+  `isRunning` flag can reach the predicate.
+
+**Verification:** `swift build` clean (after `make prompts version
+keychain`); `swift test` green — 3786 tests pass, incl. the new suite.
+
+
 ## feat: Daemon Phase C4 — ChatDetailView flip to RemoteChatSession
 
 **Goal:** the final slice of daemon Phase C (#861). The app's `ChatDetailView`

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -1912,13 +1912,19 @@ struct SourceDetailView: View {
         // Don't disable during an active ingestion or extraction — the queue
         // engine serializes both (ingestion maxConcurrent=1 per provider;
         // extraction limit 1 for local pdf2md). A second tap just appends to
-        // the queue. `isRunning` (the ingest/lint launcher — NOT the separate
-        // chat launcher) blocks only when a lint is mid-run with no ingest
-        // active, to avoid a launcher preflight refusal; a chat run leaves this
-        // launcher idle, so it does not block.
-        .disabled((isRunning && !isAnySourceIngesting)
-                  || isEditLockedExternally
-                  || !canIngest)
+        // the queue, and `enqueueIngestion` dedupes a source already active.
+        //
+        // #867: before the Phase C4 flip this ALSO gated on
+        // `launcher.isRunning` to avoid a preflight refusal when a lint was
+        // mid-run in-process. After C4, ingest AND lint are enqueued to the
+        // daemon queue — the local `agentLauncher` is no longer on either
+        // path, so its `isRunning` flag is disconnected from ingest/lint state
+        // and must NOT gate the button (a stale/stuck flag permanently wedged
+        // it). The predicate lives in the pure, tested
+        // `ingestButtonDisabled(...)` seam so the regression is pinned.
+        .disabled(Self.ingestButtonDisabled(
+            isEditLockedExternally: isEditLockedExternally,
+            canIngest: canIngest))
         .confirmationDialog(
             "Ingest Again?",
             isPresented: $showReingestConfirmation,
@@ -2061,5 +2067,25 @@ extension SourceDetailView {
         case .podcastTranscript, .youtubeTranscript:   return .transcribe
         case nil:                                       return .none
         }
+    }
+
+    /// The Ingest button's disabled predicate, extracted as a pure,
+    /// `internal static` seam (mirrors `extractionAffordance`) so the
+    /// regression suite can pin it without instantiating a `SourceDetailView`.
+    ///
+    /// #867 (Phase C4): ingest and lint are enqueued to the daemon queue, not
+    /// run through the in-process `agentLauncher`. The button therefore MUST
+    /// NOT consult `launcher.isRunning` — that flag is disconnected from
+    /// ingest/lint state (and a stale/stuck value permanently wedged the
+    /// button). The queue engine serializes ingestion/extraction and
+    /// `enqueueIngestion` dedupes a source already active in the queue, so a
+    /// re-tap is safe and requires no launcher-level gating. The only real
+    /// gates left are "another agent holds the edit lock" and "this source has
+    /// no ingestible content".
+    nonisolated static func ingestButtonDisabled(
+        isEditLockedExternally: Bool,
+        canIngest: Bool
+    ) -> Bool {
+        isEditLockedExternally || !canIngest
     }
 }

--- a/Tests/WikiFSAppTests/IngestButtonDisabledTests.swift
+++ b/Tests/WikiFSAppTests/IngestButtonDisabledTests.swift
@@ -1,0 +1,59 @@
+#if os(macOS)
+import Testing
+@testable import WikiFS
+
+/// Pins the Ingest button's disabled predicate (#867).
+///
+/// After the Phase C4 flip, ingest (and lint) are enqueued to the daemon
+/// queue — the session's local `agentLauncher` is no longer on either path.
+/// The button therefore must NOT consult `launcher.isRunning`: that flag is
+/// disconnected from ingest/lint state, and a stale/stuck value permanently
+/// wedged the button. The queue engine serializes runs and
+/// `enqueueIngestion` dedupes an already-active source, so the launcher flag
+/// is not part of the decision at all.
+///
+/// These tests exercise the pure `SourceDetailView.ingestButtonDisabled(...)`
+/// seam directly. The decisive regression assertion is that there is NO
+/// `isRunning` input to the function — a stuck launcher flag cannot reach it.
+@Suite struct IngestButtonDisabledTests {
+
+    @Test("Normal ingestible source — button enabled")
+    func enabledWhenIngestibleAndUnlocked() {
+        #expect(!SourceDetailView.ingestButtonDisabled(
+            isEditLockedExternally: false, canIngest: true))
+    }
+
+    @Test("Byteless source with no markdown — disabled (!canIngest)")
+    func disabledWhenNotIngestible() {
+        #expect(SourceDetailView.ingestButtonDisabled(
+            isEditLockedExternally: false, canIngest: false))
+    }
+
+    @Test("Edit lock held by another agent — disabled")
+    func disabledWhenEditLockedExternally() {
+        // canIngest is true here — the lock is the sole reason.
+        #expect(SourceDetailView.ingestButtonDisabled(
+            isEditLockedExternally: true, canIngest: true))
+    }
+
+    @Test("Lock + not ingestible — disabled (both gates agree)")
+    func disabledWhenBothGatesTrip() {
+        #expect(SourceDetailView.ingestButtonDisabled(
+            isEditLockedExternally: true, canIngest: false))
+    }
+
+    // MARK: - #867 regression: no launcher isRunning dependency
+
+    @Test("#867: a stuck launcher isRunning flag cannot disable the button")
+    func launcherIsRunningIsNotPartOfTheDecision() {
+        // The fix for #867 is structural: `ingestButtonDisabled` takes NO
+        // launcher/lint/process-state parameter. After Phase C4, ingest is
+        // daemon-queued, so `launcher.isRunning` is disconnected from
+        // ingest/lint. This assertion pins that contract — a stuck launcher
+        // flag has no path into the predicate, so an ingestible, unlocked
+        // source stays enabled regardless of any launcher state.
+        #expect(!SourceDetailView.ingestButtonDisabled(
+            isEditLockedExternally: false, canIngest: true))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Fixes #867 — the Ingest button in `SourceDetailView` was permanently disabled after the Phase C4 flip (#862).

## Root cause

`SourceDetailView.ingestButton` gated `.disabled()` on a snapshot of `launcher.isRunning` (read at `WikiDetailView.swift:177`):

```swift
.disabled((isRunning && !isAnySourceIngesting) || isEditLockedExternally || !canIngest)
```

That gate pre-dated the queue architecture — it existed to avoid a launcher preflight refusal when a **lint** was mid-run in-process. After Phase C4, ingest **and** lint are enqueued to the daemon queue (or the local `QueueEngine` fallback); the session's local `agentLauncher` is no longer on either path. So `launcher.isRunning` is disconnected from ingest/lint state, and a stale/stuck value permanently wedged the button with no path to clear it.

## Fix

Dropped the obsolete `isRunning`-based gate. The predicate is extracted into a pure, `internal static` seam — `SourceDetailView.ingestButtonDisabled(isEditLockedExternally:canIngest:)` (mirrors the existing `extractionAffordance` seam) — so the regression is pinnable. The button now disables only on `isEditLockedExternally || !canIngest`.

This is safe in **both** the daemon and fallback paths:
- The queue engine already serializes ingestion (`maxConcurrent=1` per provider) and extraction (limit 1 for local pdf2md).
- `enqueueIngestion` (`QueueIngestionHelper`) dedupes a source already active (`.queued`/`.running`) in either queue — a second tap is a no-op, not a duplicate run.
- The existing comment's intent ("Don't disable during an active ingestion or extraction … a second tap just appends to the queue") is now fully realized.

## Files

- `Sources/WikiFS/Sources/SourceDetailView.swift` — new `ingestButtonDisabled(...)` seam; `ingestButton` calls it; updated rationale comment.
- **New:** `Tests/WikiFSAppTests/IngestButtonDisabledTests.swift` — 5 tests covering the decision table + the structural #867 guarantee that no launcher `isRunning` flag can reach the predicate.

## Verification

- `make prompts version keychain` then `swift build` — clean.
- `swift test` — 3786 tests pass, including the new `IngestButtonDisabledTests` suite.
