### PR TITLE
Fix: lazily open store in daemon storeResolver (#867)

### DIFF
--- a/Sources/WikiFS/Queue/QueueIngestionHelper.swift
+++ b/Sources/WikiFS/Queue/QueueIngestionHelper.swift
@@ -88,7 +88,10 @@ func enqueueIngestion(
                 payload: QueueItemPayload(sourceIDs: [sourceID]))
             do {
                 let itemID = try await queueEngine.enqueue(request)
-                _ = await queueEngine.waitForCompletion(of: itemID)
+                let result = await queueEngine.waitForCompletion(of: itemID)
+                if case .failure(let error) = result {
+                    DebugLog.ingest("enqueueIngestion: extraction waitForCompletion failed for \(sourceID.rawValue): \(error.localizedDescription)")
+                }
             } catch {
                 DebugLog.ingest("enqueueIngestion: extraction failed for \(sourceID.rawValue) — \(error.localizedDescription)")
             }

--- a/Sources/WikiFS/Queue/XPCQueueEngineProxy.swift
+++ b/Sources/WikiFS/Queue/XPCQueueEngineProxy.swift
@@ -19,6 +19,12 @@ import WikiFSEngine
 /// RC3: pure pass-through — every call goes to the daemon's `QueueEngine`.
 /// RC4: all XPC calls go through `DaemonWorkloadClient` which adds a 30s
 /// timeout + error envelope.
+///
+/// Error visibility: no call swallows XPC failures silently. Every `try?`
+/// that previously fell back to an empty/default value is now a `do/catch`
+/// that logs the failure via `DebugLog.ingest` before returning the fallback,
+/// so a daemon-side error (timeout, connection drop, decode failure) is always
+/// visible in Console.app instead of looking like an empty queue (#867).
 final class XPCQueueEngineProxy: QueueEngineClient {
     private let workloadClient: DaemonWorkloadClient
     private let eventSink: DaemonQueueEventSink
@@ -36,12 +42,21 @@ final class XPCQueueEngineProxy: QueueEngineClient {
     }
 
     func cancelItem(_ id: QueueItem.ID) async {
-        try? await workloadClient.cancelItem(id)
+        do {
+            try await workloadClient.cancelItem(id)
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.cancelItem failed for \(id): \(error.localizedDescription)")
+        }
     }
 
     @discardableResult
     func cancelAllInFlight() async -> Int {
-        (try? await workloadClient.cancelAllInFlight()) ?? 0
+        do {
+            return try await workloadClient.cancelAllInFlight()
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.cancelAllInFlight failed: \(error.localizedDescription)")
+            return 0
+        }
     }
 
     func retryItem(_ id: QueueItem.ID) async throws {
@@ -49,27 +64,53 @@ final class XPCQueueEngineProxy: QueueEngineClient {
     }
 
     func pause(_ queue: QueueKind) async {
-        try? await workloadClient.pause(queue)
+        do {
+            try await workloadClient.pause(queue)
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.pause(\(queue)) failed: \(error.localizedDescription)")
+        }
     }
 
     func resume(_ queue: QueueKind) async {
-        try? await workloadClient.resume(queue)
+        do {
+            try await workloadClient.resume(queue)
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.resume(\(queue)) failed: \(error.localizedDescription)")
+        }
     }
 
     func halt(_ queue: QueueKind) async {
-        try? await workloadClient.halt(queue)
+        do {
+            try await workloadClient.halt(queue)
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.halt(\(queue)) failed: \(error.localizedDescription)")
+        }
     }
 
     func reorderItem(id: QueueItem.ID, beforeItemID: QueueItem.ID?) async {
-        try? await workloadClient.reorderItem(id: id, beforeItemID: beforeItemID)
+        do {
+            try await workloadClient.reorderItem(id: id, beforeItemID: beforeItemID)
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.reorderItem failed for \(id): \(error.localizedDescription)")
+        }
     }
 
     func snapshot() async -> QueueSnapshot {
-        (try? await workloadClient.queueSnapshot()) ?? QueueSnapshot()
+        do {
+            return try await workloadClient.queueSnapshot()
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.snapshot failed: \(error.localizedDescription)")
+            return QueueSnapshot()
+        }
     }
 
     func hasActiveWork(for wikiID: String) async -> Bool {
-        (try? await workloadClient.hasActiveWork(for: wikiID)) ?? false
+        do {
+            return try await workloadClient.hasActiveWork(for: wikiID)
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.hasActiveWork failed for \(wikiID): \(error.localizedDescription)")
+            return false
+        }
     }
 
     func waitForCompletion(of id: QueueItem.ID) async -> Result<Void, Error> {
@@ -82,11 +123,22 @@ final class XPCQueueEngineProxy: QueueEngineClient {
     }
 
     func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] {
-        (try? await workloadClient.loadTranscript(for: itemID)) ?? []
+        do {
+            return try await workloadClient.loadTranscript(for: itemID)
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.loadTranscript failed for \(itemID): \(error.localizedDescription)")
+            return []
+        }
     }
 
     func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot] {
-        let data = (try? await workloadClient.loadAllActivitySnapshots()) ?? [:]
+        let data: [String: QueueEngine.ActivitySnapshotData]
+        do {
+            data = try await workloadClient.loadAllActivitySnapshots()
+        } catch {
+            DebugLog.ingest("XPCQueueEngineProxy.loadAllActivitySnapshots failed: \(error.localizedDescription)")
+            data = [:]
+        }
         var result: [QueueItem.ID: QueueEngine.ActivitySnapshot] = [:]
         for (id, snapshot) in data {
             result[id] = QueueEngine.ActivitySnapshot(

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -188,6 +188,34 @@ final class WikiDaemon: @unchecked Sendable {
         }
     }
 
+    /// Lazily resolve (and cache) the `GRDBWikiStore` for `wikiID`.
+    ///
+    /// Backs the queue-engine and chat-host `storeResolver` closures so a
+    /// workload for a wiki the daemon hasn't explicitly opened still resolves:
+    /// if the store isn't already cached in `openStores` but the wiki is
+    /// registered, open it read-write (running the bootstrap ladder on first
+    /// open) and cache it. Returns `nil` for an unregistered wikiID or if the
+    /// open throws. Same lazy-open pattern as `openStore(wikiID:)`, but returns
+    /// the store instead of a `Bool` (#867).
+    func resolveStoreLazily(wikiID: String) -> GRDBWikiStore? {
+        queue.sync { () -> GRDBWikiStore? in
+            if let store = openStores[wikiID] {
+                return store
+            }
+            guard registry.descriptor(id: wikiID) != nil else { return nil }
+            let dbURL = databaseURL(forWikiID: wikiID)
+            do {
+                let store = try GRDBWikiStore(databaseURL: dbURL)
+                openStores[wikiID] = store
+                DebugLog.store("wikid: store lazily opened for \(wikiID)")
+                return store
+            } catch {
+                DebugLog.store("wikid: lazy openStore failed for \(wikiID): \(error)")
+                return nil
+            }
+        }
+    }
+
     /// Sentinel returned by ``changeToken(wikiID:)`` when reading the store's
     /// change token throws. A genuine change token is always colon-joined
     /// integers (e.g. `"0:0:0:…"`), so this is syntactically distinguishable
@@ -282,8 +310,7 @@ final class WikiDaemon: @unchecked Sendable {
         }
 
         let storeResolver: @Sendable (String) -> GRDBWikiStore? = { [weak self] wikiID in
-            guard let self else { return nil }
-            return self.queue.sync { self.openStores[wikiID] }
+            self?.resolveStoreLazily(wikiID: wikiID)
         }
 
         let queueStore = try QueueStore(databaseURL: queueDatabaseURL)
@@ -392,8 +419,7 @@ final class WikiDaemon: @unchecked Sendable {
         }
 
         let storeResolver: @Sendable (String) -> GRDBWikiStore? = { [weak self] wikiID in
-            guard let self else { return nil }
-            return self.queue.sync { self.openStores[wikiID] }
+            self?.resolveStoreLazily(wikiID: wikiID)
         }
 
         let dir = containerDirectory

--- a/Tests/WikiFSAppTests/DaemonStoreResolverTests.swift
+++ b/Tests/WikiFSAppTests/DaemonStoreResolverTests.swift
@@ -1,0 +1,77 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import wikid
+
+/// Tests for the daemon's lazy store resolution (#867).
+///
+/// The queue-engine and chat-host `storeResolver` closures both delegate to
+/// `WikiDaemon.resolveStoreLazily(wikiID:)`. Before #867, the resolver only
+/// consulted `openStores[wikiID]` and returned `nil` for any wiki the daemon
+/// hadn't explicitly opened — so the first ingestion/chat for a wiki failed
+/// with "No store for wikiID=…". These tests pin the lazy-open contract:
+///
+/// 1. An unregistered wikiID resolves to `nil`.
+/// 2. A registered wiki whose store isn't cached gets lazily opened (and the
+///    opened store actually works — the seeded Home page is readable).
+/// 3. The second resolution returns the already-cached instance (no double-open).
+struct DaemonStoreResolverTests {
+
+    private func makeTempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikid-store-resolver-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Create a registered wiki and return the daemon + its wikiID, with the
+    /// store dropped from the cache so the resolver must lazy-open it.
+    private func makeDaemonWithUncachedWiki() throws -> (WikiDaemon, String) {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        let wikiData = try #require(daemon.createWiki(name: "ResolverTestWiki"))
+        let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: wikiData)
+        // `createWiki` opens + caches the store; drop it so the resolver hits
+        // the lazy-open path (registry entry + DB file exist, cache empty).
+        daemon.closeStore(wikiID: descriptor.id)
+        return (daemon, descriptor.id)
+    }
+
+    // MARK: - AC.1 — unknown wikiID resolves to nil
+
+    @Test func resolveStoreLazilyReturnsNilForUnknownWikiID() {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        // Registry is empty → no lazy open possible.
+        #expect(daemon.resolveStoreLazily(wikiID: "not-a-registered-wiki") == nil)
+    }
+
+    // MARK: - AC.2 — registered wiki is lazily opened and cached
+
+    @Test func resolveStoreLazilyOpensAndCachesStoreForKnownWikiID() async throws {
+        let (daemon, wikiID) = try makeDaemonWithUncachedWiki()
+
+        // Lazy-open: the store wasn't cached, but the wiki is registered and
+        // its DB file exists on disk → the resolver opens + caches it.
+        let store = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+
+        // It's a real, correctly-opened store: the Home page `createWiki`
+        // seeded is readable through it (proves we didn't get a stale/empty
+        // handle and the bootstrap data round-tripped through the re-open).
+        let pages = try store.listPages(sortBy: .newestFirst)
+        #expect(pages.contains { $0.title == "Home" })
+    }
+
+    // MARK: - AC.3 — second call returns the already-open store (no double-open)
+
+    @Test func resolveStoreLazilyReturnsCachedStoreOnSecondCall() async throws {
+        let (daemon, wikiID) = try makeDaemonWithUncachedWiki()
+
+        let first = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+        let second = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+
+        // `GRDBWikiStore` is a reference type — identity equality proves the
+        // second call served the cached instance rather than re-opening.
+        #expect(first === second)
+    }
+}
+#endif

--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,7 @@ MIN_MACOS="14.0"
 
 APP_PROFILE="signing/WikiFS.provisionprofile"
 EXT_PROFILE="signing/WikiFSFileProvider.provisionprofile"
+DAEMON_PROFILE="signing/wikid.provisionprofile"
 APP_ICON="build/AppIcon.icns"
 
 BUILD_DIR="build"
@@ -487,10 +488,13 @@ PLIST
 </plist>
 PLIST
   # wikid daemon entitlements — per-developer, generated (no committed static
-  # file: keychain-access-groups needs the builder's real Team ID + App Group,
-  # which come from signing/local.config). The FileProvider extension does NOT
-  # get keychain-access-groups (it never touches the Keychain; adding it would
-  # risk AMFI killing the sandboxed extension if its profile lacks the cap).
+  # file: application-groups needs the builder's real App Group, which comes
+  # from signing/local.config). The daemon does NOT get keychain-access-groups:
+  # it is a bare Mach-O (no bundle), so codesign can't embed a provisioning
+  # profile in it, and without an embedded profile AMFI can't authorize a
+  # team-prefixed keychain group — the entitlement would risk a SIGKILL at exec
+  # (or be silently ignored). The FileProvider extension likewise gets no
+  # keychain-access-groups (it never touches the Keychain).
   cat > "${WIKID_ENTITLEMENTS}" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -499,10 +503,6 @@ PLIST
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>${APP_GROUP}</string>
-	</array>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>${KEYCHAIN_ACCESS_GROUP}</string>
 	</array>
 </dict>
 </plist>
@@ -519,11 +519,11 @@ PLIST
   codesign --force --timestamp=none --sign "${IDENTITY}" \
     "${HELPERS_DIR}/${CTL_NAME}"
   # wikid daemon — signs WITH the per-developer generated entitlements
-  # (${WIKID_ENTITLEMENTS}, carrying the shared keychain-access-groups entry
-  # verified by the R1 spike) so the daemon can read the ACP/Extraction/Zotero
-  # secrets the app wrote under that group. Without --entitlements the
-  # keychain-access-groups entry is ignored in shipped builds and the daemon
-  # reads nil keys. See plans/keychain-sharing.md.
+  # (${WIKID_ENTITLEMENTS}, carrying only application-groups). It does NOT get
+  # keychain-access-groups: as a bare Mach-O it can't carry an embedded
+  # provisioning profile, so AMFI can't authorize a team-prefixed keychain
+  # group — the entitlement is dropped to avoid an exec-time SIGKILL.
+  # See plans/keychain-sharing.md.
   echo "→ codesign wikid daemon (${IDENTITY})"
   codesign --force --timestamp=none \
     --identifier com.selfdrivingwiki.wikid \


### PR DESCRIPTION
## Summary

Fixes the "No store for wikiID=…" failure where the first ingestion/chat for a wiki the daemon hadn't explicitly opened returned `nil` from `storeResolver`.

## Changes

### 1. Lazy store resolution (`Sources/wikid/WikiDaemon.swift`) — #867
Both `storeResolver` closures (queue engine **and** chat host) only read `openStores[wikiID]`, so any wiki the daemon hadn't explicitly opened failed instantly. Extracted `resolveStoreLazily(wikiID:)` — same lazy-open pattern as `openStore(wikiID:)`, but returns the store: cache hit → registry check → open read-write (runs the bootstrap ladder) → cache → return. Both closures now delegate to it. Logged via `DebugLog.store` (`wikid: store lazily opened for …` / `wikid: lazy openStore failed for …`).

### 2. Error propagation in the XPC path (no more silent `try?`)
Previously daemon-side failures (timeout, connection drop, decode failure) looked like an empty queue. Now every fallback logs via `DebugLog.ingest`:
- **`XPCQueueEngineProxy`** — every `try?` is now a `do/catch` (`snapshot`, `loadTranscript`, `loadAllActivitySnapshots`, `hasActiveWork`, `cancelAllInFlight`, plus the void control methods `cancelItem`/`pause`/`resume`/`halt`/`reorderItem`).
- **`QueueIngestionHelper`** — the extraction `waitForCompletion` `Result` is now captured and `.failure` logged, instead of `_ =` discarded.

### 3. `build.sh` — daemon entitlements
Dropped `keychain-access-groups` from the wikid daemon entitlements heredoc. The daemon is a **bare Mach-O** (no bundle), so `codesign` can't embed a provisioning profile in it; without an embedded profile AMFI can't authorize a team-prefixed keychain group and SIGKILLs at launch. Added the `DAEMON_PROFILE` variable for the per-developer wikid profile. The app's own entitlements (which DO carry `keychain-access-groups`, embedded with its profile) are unchanged.

### 4. Tests (`Tests/WikiFSAppTests/DaemonStoreResolverTests.swift`)
- `resolveStoreLazily` returns `nil` for an unregistered wikiID.
- For a registered wiki dropped from the cache, it lazily opens a working store (the seeded `Home` page is readable through it).
- The second call returns the **same** instance (`===`) — no double-open.

## Verification
- `swift build` ✅
- `swift test --filter DaemonStoreResolverTests` ✅ (3/3)
- `swift test` (full suite) ✅ — **3784 tests, 0 failures**

## Notes
- `DAEMON_PROFILE` is defined per the plan but not wired into the real-signing gate, since `.provisionprofile` files are per-developer/gitignored and the daemon (bare Mach-O) can't embed a profile anyway. Flag if you'd like it gated.
