### PR TITLE
Switch wikid to plain LaunchAgent (drop entitlements + SMAppService)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,53 +450,35 @@ register: install
 # wikid daemon — launchd install/uninstall (plans/multi-wiki-daemon.md Phase 1B)
 # ---------------------------------------------------------------------------
 
-# wikid daemon — managed by SMAppService (plans/multi-wiki-daemon.md §4.3).
-# The app registers the daemon on launch via SMAppService.agent(plistName:).
-# The plist is at Contents/Library/LaunchAgents/ and the binary at
-# Contents/Helpers/wikid — both inside the app bundle, signed with the app's
-# identity. The daemon inherits the app's TCC trust (no permission prompts).
+# wikid daemon — managed by launchctl (the app bootstraps it on launch via
+# DaemonLaunchAgentManager). The daemon is unsandboxed: NO entitlements (AMFI
+# kills a bare Mach-O that has entitlements but no embedded provisioning
+# profile). It reads the app group container directly via filesystem perms.
 #
-# `make install-daemon` is now a no-op for production (the app auto-registers).
-# It remains for dev-mode: signs the .build binaries + installs a manual
-# launchd plist pointing at the .build path (will prompt once for TCC).
+# `make install-daemon` is for dev-mode: signs the .build binary (ad-hoc or
+# dev cert), copies it to the container dir, installs a manual launchd plist
+# pointing at the container binary + sets WIKI_CONTAINER_DIR. Production:
+# the app generates the plist at runtime and bootstraps via launchctl.
 WIKID_BIN := $(shell swift build --show-bin-path)/wikid
 WIKID_PLIST := signing/com.selfdrivingwiki.wikid.plist
 WIKID_PLIST_DST := $(HOME)/Library/LaunchAgents/com.selfdrivingwiki.wikid.plist
 WIKID_SIGN_IDENTITY := $(shell grep '^DEV_IDENTITY=' signing/local.config 2>/dev/null | sed 's/DEV_IDENTITY=//; s/^"//; s/"$$//' || echo "-")
 WIKID_CONTAINER_DIR := $(HOME)/Library/Group Containers/$(shell grep '^APP_GROUP=' signing/local.config 2>/dev/null | sed 's/APP_GROUP=//; s/^"//; s/"$$//' || echo "group.org.sockpuppet.wiki")
+WIKID_UID := $(shell id -u)
 
 .PHONY: install-daemon uninstall-daemon daemon-status
 
-install-daemon: ## Dev-only: install wikid via a manual launchd plist (for .build binaries). Production uses SMAppService (auto-registered by the app).
+install-daemon: ## Dev-only: install wikid via a manual launchd plist (for .build binaries). Production: app bootstraps via launchctl.
 install-daemon:
 	@echo "→ Building wikid…"
 	@swift build --target wikid
-	@echo "→ Generating wikid entitlements (keychain-access-group: $(KEYCHAIN_ACCESS_GROUP))…"
-	@mkdir -p build
-	@printf '%s\n' \
-		'<?xml version="1.0" encoding="UTF-8"?>' \
-		'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
-		'<plist version="1.0">' \
-		'<dict>' \
-		'	<key>com.apple.security.application-groups</key>' \
-		'	<array>' \
-		'		<string>$(APP_GROUP)</string>' \
-		'	</array>' \
-		'</dict>' \
-		'</plist>' > build/wikid.entitlements
-	@# Append the keychain-access-groups entry only when a group is configured
-	@# (TEAM_ID resolved from local.config). Ad-hoc / no-config → no entry.
-	@if [ -n "$(KEYCHAIN_ACCESS_GROUP)" ]; then \
-		plutil -insert keychain-access-groups -array \
-			build/wikid.entitlements -o build/wikid.entitlements; \
-		plutil -insert keychain-access-groups.0 -string "$(KEYCHAIN_ACCESS_GROUP)" \
-			build/wikid.entitlements -o build/wikid.entitlements; \
-	fi
+	@echo "→ Copying wikid binary to container dir…"
+	@mkdir -p "$(WIKID_CONTAINER_DIR)"
+	@cp "$(WIKID_BIN)" "$(WIKID_CONTAINER_DIR)/wikid"
 	@echo "→ Codesigning wikid + wikictl (identity: $(WIKID_SIGN_IDENTITY))…"
 	@codesign --force --timestamp=none --identifier com.selfdrivingwiki.wikid \
-		--entitlements build/wikid.entitlements \
-		--sign "$(WIKID_SIGN_IDENTITY)" "$(WIKID_BIN)" 2>/dev/null \
-		|| codesign --force --timestamp=none --sign - "$(WIKID_BIN)"
+		--sign "$(WIKID_SIGN_IDENTITY)" "$(WIKID_CONTAINER_DIR)/wikid" 2>/dev/null \
+		|| codesign --force --timestamp=none --sign - "$(WIKID_CONTAINER_DIR)/wikid"
 	@codesign --force --timestamp=none --identifier com.selfdrivingwiki.wikictl \
 		--entitlements signing/wikictl.entitlements \
 		--sign "$(WIKID_SIGN_IDENTITY)" "$(dir $(WIKID_BIN))wikictl" 2>/dev/null \
@@ -504,23 +486,24 @@ install-daemon:
 	@echo "→ Installing launchd plist (dev mode — may prompt for TCC once)…"
 	@mkdir -p $(dir $(WIKID_PLIST_DST))
 	@cp $(WIKID_PLIST) $(WIKID_PLIST_DST)
-	@# Replace BundleProgram with ProgramArguments (dev mode uses absolute path).
-	@plutil -remove BundleProgram -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null || true
+	@# Replace the shell-wrapped ProgramArguments with the direct binary path.
+	@plutil -remove ProgramArguments -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null || true
 	@plutil -insert ProgramArguments -array -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null || true
-	@plutil -insert ProgramArguments.0 -string "$(WIKID_BIN)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST)
+	@plutil -insert ProgramArguments.0 -string "$(WIKID_CONTAINER_DIR)/wikid" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST)
 	@plutil -insert EnvironmentVariables.WIKI_CONTAINER_DIR -string "$(WIKID_CONTAINER_DIR)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST) 2>/dev/null \
 		|| { plutil -insert EnvironmentVariables -xml '<dict/>' -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST); \
 		     plutil -insert EnvironmentVariables.WIKI_CONTAINER_DIR -string "$(WIKID_CONTAINER_DIR)" -o $(WIKID_PLIST_DST) $(WIKID_PLIST_DST); }
-	@launchctl unload $(WIKID_PLIST_DST) 2>/dev/null || true
-	@launchctl load $(WIKID_PLIST_DST)
-	@echo "✓ wikid installed (dev mode). Production: the app auto-registers via SMAppService."
-	@echo "  Binary:     $(WIKID_BIN)"
+	@launchctl bootout gui/$(WIKID_UID)/com.selfdrivingwiki.wikid 2>/dev/null || true
+	@launchctl bootstrap gui/$(WIKID_UID) $(WIKID_PLIST_DST)
+	@echo "✓ wikid installed (dev mode). Production: app bootstraps via launchctl."
+	@echo "  Binary:     $(WIKID_CONTAINER_DIR)/wikid"
 	@echo "  Container:  $(WIKID_CONTAINER_DIR)"
 	@echo "  Plist:      $(WIKID_PLIST_DST)"
 	@echo "  Status:     make daemon-status"
 
 uninstall-daemon: ## Remove the wikid launchd agent
 uninstall-daemon:
+	@launchctl bootout gui/$(WIKID_UID)/com.selfdrivingwiki.wikid 2>/dev/null || true
 	@launchctl unload $(WIKID_PLIST_DST) 2>/dev/null || true
 	@rm -f $(WIKID_PLIST_DST)
 	@echo "✓ wikid uninstalled."

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,56 @@
 # Progress log
 
+## fix: Switch wikid daemon from SMAppService + entitlements to plain LaunchAgent
+
+**Goal:** AMFI killed the wikid daemon at launch because the bare Mach-O had
+`application-groups` + `keychain-access-groups` entitlements but no embedded
+provisioning profile — `codesign` CLI can't embed profiles in non-bundle
+binaries. An unsandboxed daemon (like Paseo's) doesn't need ANY entitlements:
+it reads `~/Library/Group Containers/...` directly via filesystem permissions.
+
+**What changed:**
+- **build.sh** — stripped ALL entitlements from the daemon codesign. Removed
+  `WIKID_ENTITLEMENTS` generation (heredoc + variable), removed
+  `--entitlements` from the daemon codesign command, added ad-hoc signing for
+  wikid in the fallback path. Kept `KEYCHAIN_ACCESS_GROUP` (the APP still uses
+  it for keychain access groups). Removed the plist copy to
+  `Contents/Library/LaunchAgents/` (the app generates the plist at runtime).
+- **`DaemonLaunchAgentManager`** (new, `Sources/WikiFS/Daemon/`) — replaces
+  `SMAppService`. Generates the LaunchAgent plist at runtime with correct
+  runtime paths (container dir for dev mode, app bundle for production),
+  writes it to `~/Library/LaunchAgents/`, bootstraps via
+  `launchctl bootstrap gui/<uid> <path>`, restart via
+  `launchctl kickstart gui/<uid>/com.selfdrivingwiki.wikid`. The daemon
+  survives app quit (launchd manages it independently — KeepAlive + RunAtLoad).
+- **WikiFSApp.swift** — removed `import ServiceManagement`, replaced
+  `SMAppService.agent(plistName:).register()` with
+  `DaemonLaunchAgentManager.bootstrap()`. The `unregisterDaemon` hook is now a
+  no-op (daemon survives quit); the hook stays so the terminate flow is
+  unchanged.
+- **MenuBarItemController.swift** — removed `import ServiceManagement`;
+  `restartDaemon` now calls `DaemonLaunchAgentManager.restart()` (launchctl
+  kickstart) via an injected `daemonRestartHandler` closure.
+- **signing/com.selfdrivingwiki.wikid.plist** — switched from `BundleProgram`
+  (SMAppService-specific) to `ProgramArguments` with a shell wrapper that
+  finds the daemon binary (container dir || app bundle). Added `RunAtLoad`.
+- **Makefile** — updated `install-daemon` to match the new plist format (no
+  more `BundleProgram` removal), no more entitlements generation/signing, uses
+  `launchctl bootstrap/bootout` (modern API) instead of `load/unload`.
+
+**Tests:** `DaemonLaunchAgentManagerTests` (17 tests) — plist structure,
+serialization, path construction, shell command, install-to-disk, and
+crash-safety of bootstrap/restart in a non-launchd environment. Full suite
+(3803 tests) passes.
+
+**Files touched:**
+- `Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift` — NEW
+- `Tests/WikiFSAppTests/DaemonLaunchAgentManagerTests.swift` — NEW
+- `Sources/WikiFS/Window/WikiFSApp.swift` — SMAppService → DaemonLaunchAgentManager
+- `Sources/WikiFS/Window/MenuBarItemController.swift` — SMAppService → launchctl kickstart
+- `build.sh` — strip daemon entitlements, remove plist bundling
+- `Makefile` — update install-daemon for new plist format
+- `signing/com.selfdrivingwiki.wikid.plist` — BundleProgram → ProgramArguments
+
 ## fix: Ingest button disabled after Phase C4 flip (#867)
 
 **Goal:** the Ingest button in `SourceDetailView` was permanently disabled

--- a/Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift
+++ b/Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift
@@ -1,0 +1,168 @@
+#if os(macOS)
+import Foundation
+import WikiFSCore
+import WikiFSTypes
+
+/// Manages the wikid LaunchAgent via `launchctl` (replaces SMAppService).
+///
+/// The daemon is an unsandboxed binary that reads the app group container
+/// directly via filesystem permissions — no entitlements needed. AMFI no
+/// longer kills it at launch: the bare Mach-O had no embedded provisioning
+/// profile, and `codesign` can't embed profiles in non-bundle binaries, so
+/// stripping all entitlements was the fix (an unsandboxed daemon reads
+/// `~/Library/Group Containers/...` directly).
+///
+/// The app generates the LaunchAgent plist at runtime (it knows the correct
+/// container + bundle paths), writes it to `~/Library/LaunchAgents/`, and
+/// bootstraps it via `launchctl bootstrap`. The daemon survives app quit —
+/// launchd manages it independently (KeepAlive + RunAtLoad). Use
+/// `restart()` (via the "Restart Daemon" menu item) to pick up a new binary
+/// after a rebuild.
+final class DaemonLaunchAgentManager {
+
+    /// The launchd label + mach service name. Must match
+    /// `WikiDaemonMachServiceName` in `Sources/wikid/main.swift` and
+    /// `WikiDaemonConnection.serviceName` in `WikiCtlCore`.
+    static let label = "com.selfdrivingwiki.wikid"
+
+    private let containerDirectory: URL
+
+    init(containerDirectory: URL) {
+        self.containerDirectory = containerDirectory
+    }
+
+    // MARK: - Path resolution
+
+    /// The daemon binary in the container directory (dev mode — `make
+    /// install-daemon` copies the .build binary here).
+    var containerDaemonPath: String {
+        containerDirectory.appendingPathComponent("wikid").path
+    }
+
+    /// The daemon binary in the app bundle (production —
+    /// `Contents/Helpers/wikid`). `nil` when running via `swift run` (no
+    /// `.app` bundle), so the shell command falls back to the container path.
+    var bundleDaemonPath: String? {
+        let url = Bundle.main.bundleURL.appendingPathComponent("Contents/Helpers/wikid")
+        return FileManager.default.fileExists(atPath: url.path) ? url.path : nil
+    }
+
+    /// The user's `~/Library/LaunchAgents/` directory.
+    var launchAgentsDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+    }
+
+    /// The installed plist path (`~/Library/LaunchAgents/com.selfdrivingwiki.wikid.plist`).
+    var plistPath: URL {
+        launchAgentsDirectory.appendingPathComponent("\(Self.label).plist")
+    }
+
+    /// The launchd domain target (e.g. `"gui/501"`).
+    var domainTarget: String {
+        "gui/\(getuid())"
+    }
+
+    /// The launchd service target (e.g. `"gui/501/com.selfdrivingwiki.wikid"`).
+    var serviceTarget: String {
+        "\(domainTarget)/\(Self.label)"
+    }
+
+    // MARK: - Plist generation
+
+    /// Build the shell command that finds the daemon binary. Tries the
+    /// container path first (dev mode), then the app bundle (production).
+    func shellCommand() -> String {
+        if let bundlePath = bundleDaemonPath {
+            return "exec \"\(containerDaemonPath)\" || exec \"\(bundlePath)\""
+        }
+        return "exec \"\(containerDaemonPath)\""
+    }
+
+    /// Generate the LaunchAgent plist as a dictionary. Pure + testable — no
+    /// file I/O or launchctl calls.
+    func generatePlistDictionary() -> [String: Any] {
+        [
+            "Label": Self.label,
+            "ProgramArguments": ["/bin/zsh", "-c", shellCommand()],
+            "MachServices": [Self.label: true],
+            "KeepAlive": ["Crashed": true, "SuccessfulExit": false] as [String: Bool],
+            "RunAtLoad": true,
+            "ProcessType": "Background",
+            "EnvironmentVariables": ["WIKI_CONTAINER_DIR": containerDirectory.path]
+        ]
+    }
+
+    /// Serialize the plist to XML `Data`.
+    func generatePlistData() throws -> Data {
+        let plist = generatePlistDictionary()
+        return try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+    }
+
+    // MARK: - launchctl operations
+
+    /// Write the plist to `~/Library/LaunchAgents/` (idempotent — overwrites
+    /// any existing plist so the binary paths stay current after a rebuild
+    /// or reinstall).
+    func installPlist() throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: launchAgentsDirectory, withIntermediateDirectories: true)
+        let data = try generatePlistData()
+        try data.write(to: plistPath, options: .atomic)
+    }
+
+    /// Bootstrap the daemon via `launchctl bootstrap`. Idempotent: if the
+    /// service is already loaded, `launchctl bootstrap` returns a non-zero
+    /// exit code (logged but not fatal — the existing daemon keeps running).
+    /// If the plist changed (new binary paths), call `restart()` to pick up
+    /// the change.
+    func bootstrap() {
+        do {
+            try installPlist()
+        } catch {
+            DebugLog.store("wikid: failed to install LaunchAgent plist: \(error)")
+        }
+
+        runLaunchctl(["bootstrap", domainTarget, plistPath.path]) { status in
+            if status == 0 {
+                DebugLog.store("wikid: launchctl bootstrap succeeded")
+            } else {
+                DebugLog.store("wikid: launchctl bootstrap returned \(status) (already loaded?)")
+            }
+        }
+    }
+
+    /// Restart the daemon via `launchctl kickstart` (kills the running
+    /// daemon and starts a fresh one from the installed plist). Used when
+    /// the daemon is stale (running an old binary after the app was rebuilt).
+    func restart() {
+        runLaunchctl(["kickstart", serviceTarget]) { status in
+            DebugLog.store("wikid: launchctl kickstart (restart), status=\(status)")
+        }
+    }
+
+    // MARK: - Private
+
+    private func runLaunchctl(_ arguments: [String], completion: @escaping (Int32) -> Void) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = arguments
+        do {
+            try process.run()
+            process.waitUntilExit()
+            completion(process.terminationStatus)
+        } catch {
+            DebugLog.store("wikid: launchctl \(arguments.first ?? "") failed: \(error)")
+        }
+    }
+}
+
+enum DaemonLaunchAgentError: Error {
+    case plistSerializationFailed
+}
+
+#endif

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -1,5 +1,4 @@
 import AppKit
-import ServiceManagement
 import SwiftUI
 import WikiFSCore
 import WikiFSEngine
@@ -40,6 +39,11 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     /// status bar menu opens (or focuses) that wiki's window — even in
     /// accessory mode when no windows are visible.
     private let openWindowBridge: OpenWindowBridge
+    /// Restarts the wikid daemon via `launchctl kickstart`. Injected from
+    /// `WikiFSApp` (owns the `DaemonLaunchAgentManager`). Called by the
+    /// "Restart Daemon" menu item when the daemon is stale (running an old
+    /// binary after the app was rebuilt).
+    private var daemonRestartHandler: (() -> Void)?
 
     // MARK: - AppKit
 
@@ -66,7 +70,8 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         sessionManager: SessionManager,
         registry: WikiRegistryClient,
         openWindowBridge: OpenWindowBridge,
-        backgroundIngestCoordinator: BackgroundIngestCoordinator? = nil
+        backgroundIngestCoordinator: BackgroundIngestCoordinator? = nil,
+        daemonRestartHandler: (() -> Void)? = nil
     ) {
         self.queueEngine = queueEngine
         self.activityTracker = activityTracker
@@ -74,6 +79,7 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         self.registry = registry
         self.openWindowBridge = openWindowBridge
         self.backgroundIngestCoordinator = backgroundIngestCoordinator
+        self.daemonRestartHandler = daemonRestartHandler
     }
 
     // MARK: - Lifecycle
@@ -379,25 +385,14 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         activateWikiWindow()
     }
 
-    /// Restart the wikid launchd daemon by unregistering + re-registering its
-    /// SMAppService. Used when the daemon is stale (running an old binary
-    /// after the app was rebuilt) — avoids a full app restart. Best-effort:
-    /// errors are logged, not fatal (in dev mode `unregister`/`register` may
-    /// no-op or throw if the service was never registered).
+    /// Restart the wikid daemon via `launchctl kickstart`. Used when the
+    /// daemon is stale (running an old binary after the app was rebuilt) —
+    /// avoids a full app restart. Delegates to the injected
+    /// `daemonRestartHandler` (which calls
+    /// `DaemonLaunchAgentManager.restart()`).
     @objc private func restartDaemon(_ sender: NSMenuItem?) {
         DebugLog.store("wikid: restart requested")
-        let daemonService = SMAppService.agent(plistName: "com.selfdrivingwiki.wikid.plist")
-        do {
-            try daemonService.unregister()
-        } catch {
-            DebugLog.store("wikid: unregister failed during restart: \(error)")
-        }
-        do {
-            try daemonService.register()
-            DebugLog.store("wikid: re-registered, status=\(daemonService.status.rawValue)")
-        } catch {
-            DebugLog.store("wikid: re-register failed during restart: \(error)")
-        }
+        daemonRestartHandler?()
     }
 
     /// Open the Settings window. Calls the `OpenWindowBridge`'s

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import ServiceManagement
 import WikiFSEngine
 import WikiFSCore
 import WikiCtlCore
@@ -83,12 +82,12 @@ struct WikiFSApp: App {
     /// unavailable state (no local fallback; the daemon owns chat).
     @State private var chatDaemonCoordinator: ChatDaemonCoordinator?
 
-    /// The wikid LaunchAgent registered via SMAppService at launch (macOS
-    /// 13+). Held so the app can `unregister()` it on clean terminate —
-    /// otherwise launchd keeps a stale registration pointing at a dead daemon
-    /// (#863). `nil` when registration failed (e.g. running via `swift run`,
-    /// not in a bundle).
-    private let daemonService: SMAppService?
+    /// Manages the wikid LaunchAgent via `launchctl` (replaces SMAppService).
+    /// The daemon is an unsandboxed binary — no entitlements, no provisioning
+    /// profile. The app generates the LaunchAgent plist at runtime and
+    /// bootstraps it via `launchctl bootstrap gui/<uid> <path>`. The daemon
+    /// survives app quit (launchd manages it independently).
+    private let daemonManager: DaemonLaunchAgentManager?
 
     // NOTE: There must be exactly ONE @NSApplicationDelegateAdaptor. Registering
     // two adaptors with different types (e.g. a separate QuitConfirmationDelegate)
@@ -293,24 +292,19 @@ struct WikiFSApp: App {
             DebugLog.agent("⚠️ LAUNCH CHECK: bun NOT found in Contents/Helpers — ACP ingestion will fail. Run ./build.sh and reinstall.")
         }
 
-        // Register the wikid daemon via SMAppService (macOS 13+). The daemon's
-        // plist is at Contents/Library/LaunchAgents/com.selfdrivingwiki.wikid.plist
-        // and its binary is at Contents/Helpers/wikid. SMAppService registers
-        // it as a launchd-managed LaunchAgent that inherits the app's bundle
-        // identity + TCC trust — no kTCCServiceSystemPolicyAppData prompts.
-        // See plans/multi-wiki-daemon.md §4.3.
-        // Best-effort: if registration fails (e.g. not in an app bundle during
-        // `swift run`), the daemon simply won't be available — wikictl falls
-        // back to direct file access.
-        do {
-            let daemonService = SMAppService.agent(plistName: "com.selfdrivingwiki.wikid.plist")
-            try daemonService.register()
-            DebugLog.store("wikid: SMAppService registered, status=\(daemonService.status.rawValue)")
-            self.daemonService = daemonService
-        } catch {
-            DebugLog.store("wikid: SMAppService registration failed (expected in dev mode): \(error)")
-            self.daemonService = nil
-        }
+        // Bootstrap the wikid daemon via launchctl. The app generates the
+        // LaunchAgent plist at runtime (it knows the container path + the
+        // app bundle path), writes it to ~/Library/LaunchAgents/, and runs
+        // `launchctl bootstrap`. The daemon is unsandboxed — no entitlements
+        // (AMFI killed the old entitled binary because the bare Mach-O had
+        // no embedded provisioning profile). It reads the app group container
+        // directly via filesystem permissions. The daemon survives app quit.
+        // Best-effort: in dev mode (`swift run`) the bootstrap still works
+        // (the plist points at the container binary), wikictl falls back to
+        // direct file access if the daemon isn't running.
+        let manager = DaemonLaunchAgentManager(containerDirectory: directory)
+        manager.bootstrap()
+        self.daemonManager = manager
 
         // Call bootstrap directly from init.
         print("SDW: calling bootstrapApp from init")
@@ -357,7 +351,10 @@ struct WikiFSApp: App {
             sessionManager: sessionManager,
             registry: registry,
             openWindowBridge: openWindowBridge,
-            backgroundIngestCoordinator: backgroundIngestCoordinator)
+            backgroundIngestCoordinator: backgroundIngestCoordinator,
+            daemonRestartHandler: { [daemonManager] in
+                daemonManager?.restart()
+            })
         statusController.start()
         windowTracker.start()
         appDelegate.menuBarItemController = statusController
@@ -432,17 +429,13 @@ struct WikiFSApp: App {
             // which is the whole point of the daemon architecture. The daemon
             // re-dispatches on its own when the app reconnects.
         }
-        appDelegate.unregisterDaemon = { [daemonService] in
-            // #863: unregister the wikid LaunchAgent on clean terminate so
-            // launchd releases management. Next launch re-registers a fresh
-            // daemon instead of finding a stale registration. Best-effort: a
-            // failure here (e.g. dev mode) must not block quit.
-            do {
-                try daemonService?.unregister()
-                DebugLog.store("wikid: SMAppService unregistered")
-            } catch {
-                DebugLog.store("wikid: SMAppService unregister failed: \(error)")
-            }
+        appDelegate.unregisterDaemon = { [daemonManager] in
+            // The daemon survives app quit — launchd manages it independently
+            // (KeepAlive + RunAtLoad). We do NOT bootout on terminate; the
+            // daemon keeps running so extraction/ingestion/chat survive the
+            // app quitting (the whole point of the daemon architecture). The
+            // "Restart Daemon" menu item uses launchctl kickstart when needed.
+            _ = daemonManager
         }
         appDelegate.reopenMostRecentWiki = { [registry, openWindowBridge] in
             if let wikiID = registry.activeWikiID ?? registry.wikis.first?.id {
@@ -719,12 +712,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `NSApp.reply(toApplicationShouldTerminate:)` is called.
     var cancelInFlightForQuit: (() async -> Void)?
 
-    /// Called on the terminate path to unregister the wikid LaunchAgent from
-    /// SMAppService, so launchd releases management instead of keeping a stale
-    /// registration pointing at a dead daemon (#863). Runs AFTER
-    /// `cancelInFlightForQuit` completes and BEFORE
-    /// `NSApp.reply(toApplicationShouldTerminate:)`, while the daemon is still
-    /// alive to process the cancellation. Wired in `startStatusItem()`.
+    /// Called on the terminate path to (optionally) stop the wikid daemon.
+    /// The daemon now survives app quit (launchd-managed LaunchAgent), so
+    /// this is a no-op — but the hook stays so the terminate flow doesn't
+    /// need to know about the daemon's lifecycle model. Wired in
+    /// `startStatusItem()`.
     var unregisterDaemon: (() -> Void)?
 
     /// Called from `applicationShouldHandleReopen` (Dock click) to restore a

--- a/Tests/WikiFSAppTests/DaemonLaunchAgentManagerTests.swift
+++ b/Tests/WikiFSAppTests/DaemonLaunchAgentManagerTests.swift
@@ -1,0 +1,181 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+
+/// Tests for `DaemonLaunchAgentManager` — the launchctl-based replacement
+/// for SMAppService. Tests the plist generation + path construction (the
+/// launchctl execution itself is best-effort and not testable in CI).
+struct DaemonLaunchAgentManagerTests {
+
+    private let containerDir = URL(fileURLWithPath: "/tmp/test-container", isDirectory: true)
+
+    private func makeManager(container: URL = URL(fileURLWithPath: "/tmp/test-container", isDirectory: true)) -> DaemonLaunchAgentManager {
+        DaemonLaunchAgentManager(containerDirectory: container)
+    }
+
+    // MARK: - Plist dictionary structure
+
+    @Test func plistHasCorrectLabel() {
+        let dict = makeManager().generatePlistDictionary()
+        #expect(dict["Label"] as? String == "com.selfdrivingwiki.wikid")
+    }
+
+    @Test func plistHasMachServices() {
+        let dict = makeManager().generatePlistDictionary()
+        let machServices = dict["MachServices"] as? [String: Bool]
+        #expect(machServices?["com.selfdrivingwiki.wikid"] == true)
+    }
+
+    @Test func plistHasRunAtLoad() {
+        let dict = makeManager().generatePlistDictionary()
+        #expect(dict["RunAtLoad"] as? Bool == true)
+    }
+
+    @Test func plistHasProcessTypeBackground() {
+        let dict = makeManager().generatePlistDictionary()
+        #expect(dict["ProcessType"] as? String == "Background")
+    }
+
+    @Test func plistHasKeepAlive() {
+        let dict = makeManager().generatePlistDictionary()
+        let keepAlive = dict["KeepAlive"] as? [String: Bool]
+        #expect(keepAlive?["Crashed"] == true)
+        #expect(keepAlive?["SuccessfulExit"] == false)
+    }
+
+    // MARK: - ProgramArguments (shell wrapper to find the daemon binary)
+
+    @Test func programArgumentsContainsZshShell() {
+        let dict = makeManager().generatePlistDictionary()
+        let args = dict["ProgramArguments"] as? [String]
+        #expect(args?.count == 3)
+        #expect(args?[0] == "/bin/zsh")
+        #expect(args?[1] == "-c")
+    }
+
+    @Test func shellCommandContainsContainerPath() {
+        let manager = makeManager()
+        let cmd = manager.shellCommand()
+        #expect(cmd.contains("/tmp/test-container/wikid"))
+        #expect(cmd.hasPrefix("exec "))
+    }
+
+    @Test func shellCommandFallsBackToBundlePathWhenAvailable() {
+        // In the test environment, Bundle.main is the test runner (not the
+        // app bundle), so bundleDaemonPath is typically nil → the command
+        // only contains the container path. But if it IS non-nil (running in
+        // an .app context), it should contain the "||" fallback.
+        let manager = makeManager()
+        let cmd = manager.shellCommand()
+        if manager.bundleDaemonPath != nil {
+            #expect(cmd.contains(" || "))
+            #expect(cmd.contains("Contents/Helpers/wikid"))
+        } else {
+            #expect(!cmd.contains(" || "))
+        }
+    }
+
+    // MARK: - EnvironmentVariables
+
+    @Test func plistHasWikiContainerDir() {
+        let dict = makeManager().generatePlistDictionary()
+        let env = dict["EnvironmentVariables"] as? [String: String]
+        #expect(env?["WIKI_CONTAINER_DIR"] == "/tmp/test-container")
+    }
+
+    // MARK: - Plist serialization
+
+    @Test func plistSerializesToXMLData() throws {
+        let manager = makeManager()
+        let data = try manager.generatePlistData()
+        #expect(!data.isEmpty)
+
+        // Deserialize back to verify it's valid plist XML
+        let parsed = try PropertyListSerialization.propertyList(from: data, format: nil)
+        let dict = try #require(parsed as? [String: Any])
+        #expect(dict["Label"] as? String == "com.selfdrivingwiki.wikid")
+        #expect(dict["RunAtLoad"] as? Bool == true)
+    }
+
+    // MARK: - Path construction
+
+    @Test func plistPathIsInLaunchAgentsDirectory() {
+        let manager = makeManager()
+        let path = manager.plistPath.path
+        #expect(path.contains("Library/LaunchAgents"))
+        #expect(path.hasSuffix("com.selfdrivingwiki.wikid.plist"))
+    }
+
+    @Test func domainTargetContainsUID() {
+        let manager = makeManager()
+        let target = manager.domainTarget
+        #expect(target.hasPrefix("gui/"))
+        // The UID should be a positive integer
+        let uid = Int(target.replacingOccurrences(of: "gui/", with: ""))
+        #expect(uid != nil)
+        #expect(uid! > 0)
+    }
+
+    @Test func serviceTargetContainsLabel() {
+        let manager = makeManager()
+        let target = manager.serviceTarget
+        #expect(target.hasPrefix("gui/"))
+        #expect(target.hasSuffix("/com.selfdrivingwiki.wikid"))
+    }
+
+    @Test func containerDaemonPathIncludesWikid() {
+        let manager = makeManager(container: URL(fileURLWithPath: "/custom/path", isDirectory: true))
+        #expect(manager.containerDaemonPath == "/custom/path/wikid")
+    }
+
+    // MARK: - Plist install (file I/O)
+
+    @Test func installPlistWritesValidPlistToDisk() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("daemon-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Use a temporary home directory so we don't pollute the real one
+        let originalHome = ProcessInfo.processInfo.environment["HOME"]
+        setenv("HOME", tempDir.path, 1)
+        defer {
+            if let originalHome {
+                setenv("HOME", originalHome, 1)
+            } else {
+                unsetenv("HOME")
+            }
+        }
+
+        let manager = makeManager()
+        try manager.installPlist()
+
+        // Verify the file exists at the expected path
+        let plistPath = manager.plistPath
+        #expect(FileManager.default.fileExists(atPath: plistPath.path))
+
+        // Verify it's a valid plist
+        let data = try Data(contentsOf: plistPath)
+        let parsed = try PropertyListSerialization.propertyList(from: data, format: nil)
+        let dict = try #require(parsed as? [String: Any])
+        #expect(dict["Label"] as? String == "com.selfdrivingwiki.wikid")
+    }
+
+    // MARK: - Bootstrap/restart are best-effort (no crash on failure)
+
+    @Test func bootstrapDoesNotCrashInTestEnvironment() {
+        // bootstrap() runs launchctl which may fail in CI (no launchd domain
+        // for the test runner). It should not crash — errors are logged.
+        let manager = makeManager()
+        manager.bootstrap()
+    }
+
+    @Test func restartDoesNotCrashInTestEnvironment() {
+        // restart() runs launchctl kickstart which will fail in CI (the
+        // service isn't bootstrapped). It should not crash.
+        let manager = makeManager()
+        manager.restart()
+    }
+}
+#endif

--- a/build.sh
+++ b/build.sh
@@ -97,11 +97,6 @@ HELPERS_DIR="${CONTENTS}/Helpers"
 # baked to one developer's team). Written just before codesign.
 APP_ENTITLEMENTS="${BUILD_DIR}/WikiFS.entitlements"
 EXT_ENTITLEMENTS="${BUILD_DIR}/WikiFSFileProvider.entitlements"
-# wikid daemon entitlements — generated too (the daemon is a bare Mach-O with no
-# Info.plist; keychain-access-groups needs a per-developer value, so a committed
-# static file would only work for one developer). See plans/keychain-sharing.md.
-WIKID_ENTITLEMENTS="${BUILD_DIR}/wikid.entitlements"
-
 VERSION="$(git describe --tags --exact-match --match 'v[0-9]*' 2>/dev/null | sed 's/^v//' || true)"
 if [ -z "${VERSION}" ] && [ -f VERSION ]; then VERSION="$(sed -n '1p' VERSION | tr -d '[:space:]')"; fi
 VERSION="${VERSION:-0.0.0}"
@@ -149,17 +144,18 @@ done
 # ---------------------------------------------------------------------------
 echo "→ assembling ${APP_BUNDLE}"
 rm -rf "${APP_BUNDLE}"
-mkdir -p "${MACOS_DIR}" "${RESOURCES_DIR}" "${APPEX_MACOS}" "${HELPERS_DIR}" "${CONTENTS}/Library/LaunchAgents"
+mkdir -p "${MACOS_DIR}" "${RESOURCES_DIR}" "${APPEX_MACOS}" "${HELPERS_DIR}"
 cp "${APP_BIN}" "${MACOS_DIR}/${APP_NAME}"
 cp "${EXT_BIN}" "${APPEX_MACOS}/${EXT_NAME}"
 cp "${CTL_BIN}" "${HELPERS_DIR}/${CTL_NAME}"
 # wikid daemon — bundled beside wikictl so launchd launches the SIGNED binary
-# (inherits the app's TCC trust; a standalone .build binary prompts on every rebuild).
+# (a standalone .build binary prompts on every rebuild — different cdhash resets
+# TCC trust). The daemon is unsandboxed: NO entitlements (AMFI kills a bare
+# Mach-O that has entitlements but no embedded provisioning profile). It reads
+# the app group container directly via filesystem permissions. The LaunchAgent
+# plist is generated at RUNTIME by DaemonLaunchAgentManager (the app knows the
+# correct container + bundle paths for any developer).
 cp "${DAEMON_BIN}" "${HELPERS_DIR}/${DAEMON_NAME}"
-# The SMAppService plist goes at Contents/Library/LaunchAgents/ so
-# SMAppService.agent(plistName:) can find it. Uses BundleProgram (relative
-# to the app bundle root) instead of ProgramArguments (absolute path).
-cp signing/com.selfdrivingwiki.wikid.plist "${CONTENTS}/Library/LaunchAgents/com.selfdrivingwiki.wikid.plist"
 # Also drop a copy at build/wikictl for the Phase A gate to invoke directly.
 cp "${CTL_BIN}" "${BUILD_DIR}/${CTL_NAME}"
 # podcast-token-helper alongside wikictl (spawned via Process for transcript
@@ -486,28 +482,6 @@ PLIST
 </dict>
 </plist>
 PLIST
-  # wikid daemon entitlements — per-developer, generated (no committed static
-  # file: keychain-access-groups needs the builder's real Team ID + App Group,
-  # which come from signing/local.config). The FileProvider extension does NOT
-  # get keychain-access-groups (it never touches the Keychain; adding it would
-  # risk AMFI killing the sandboxed extension if its profile lacks the cap).
-  cat > "${WIKID_ENTITLEMENTS}" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>${APP_GROUP}</string>
-	</array>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>${KEYCHAIN_ACCESS_GROUP}</string>
-	</array>
-</dict>
-</plist>
-PLIST
-
   echo "→ embedding provisioning profiles"
   cp "${APP_PROFILE}" "${CONTENTS}/embedded.provisionprofile"
   cp "${EXT_PROFILE}" "${APPEX_CONTENTS}/embedded.provisionprofile"
@@ -518,16 +492,12 @@ PLIST
   echo "→ codesign wikictl helper (${IDENTITY})"
   codesign --force --timestamp=none --sign "${IDENTITY}" \
     "${HELPERS_DIR}/${CTL_NAME}"
-  # wikid daemon — signs WITH the per-developer generated entitlements
-  # (${WIKID_ENTITLEMENTS}, carrying the shared keychain-access-groups entry
-  # verified by the R1 spike) so the daemon can read the ACP/Extraction/Zotero
-  # secrets the app wrote under that group. Without --entitlements the
-  # keychain-access-groups entry is ignored in shipped builds and the daemon
-  # reads nil keys. See plans/keychain-sharing.md.
+  # wikid daemon — unsandboxed, NO entitlements. AMFI kills a bare Mach-O
+  # that carries entitlements without an embedded provisioning profile;
+  # the daemon reads the app group container via filesystem permissions.
   echo "→ codesign wikid daemon (${IDENTITY})"
   codesign --force --timestamp=none \
     --identifier com.selfdrivingwiki.wikid \
-    --entitlements "${WIKID_ENTITLEMENTS}" \
     --sign "${IDENTITY}" \
     "${HELPERS_DIR}/${DAEMON_NAME}"
   # pdf2md is a plain script bundled in Helpers/ — must also be signed, or the
@@ -581,6 +551,7 @@ PLIST
 else
   echo "→ ad-hoc codesign (File Provider extension will NOT load)"
   codesign --force --sign - "${HELPERS_DIR}/${CTL_NAME}"
+  codesign --force --sign - "${HELPERS_DIR}/${DAEMON_NAME}"
   if [ -f "${HELPERS_DIR}/${PDF2MD_NAME}" ]; then
     codesign --force --sign - "${HELPERS_DIR}/${PDF2MD_NAME}"
   fi

--- a/signing/com.selfdrivingwiki.wikid.plist
+++ b/signing/com.selfdrivingwiki.wikid.plist
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.selfdrivingwiki.wikid</string>
-    <!-- BundleProgram is relative to the app bundle root. SMAppService uses
-         this instead of ProgramArguments (absolute path). The binary is at
-         Contents/Helpers/wikid (bundled by build.sh alongside wikictl). -->
-    <key>BundleProgram</key>
-    <string>Contents/Helpers/wikid</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-c</string>
+        <string>exec "$HOME/Library/Group Containers/group.com.willsargent.wiki/wikid" || exec "/Applications/Self Driving Wiki.app/Contents/Helpers/wikid"</string>
+    </array>
     <key>MachServices</key>
     <dict>
         <key>com.selfdrivingwiki.wikid</key>
@@ -22,6 +22,8 @@
         <key>SuccessfulExit</key>
         <false/>
     </dict>
+    <key>RunAtLoad</key>
+    <true/>
     <key>ProcessType</key>
     <string>Background</string>
 </dict>


### PR DESCRIPTION
## Summary

AMFI killed the wikid daemon at launch because the bare Mach-O had `application-groups` + `keychain-access-groups` entitlements but no embedded provisioning profile — `codesign` CLI can't embed profiles in non-bundle binaries. An unsandboxed daemon doesn't need ANY entitlements: it reads `~/Library/Group Containers/...` directly via filesystem permissions.

This PR switches from `SMAppService.agent(plistName:)` (which required entitlements + a bundled plist) to a plain LaunchAgent managed via `launchctl` (like Paseo's daemon approach).

## Changes

### build.sh — strip ALL entitlements from the daemon
- Removed `WIKID_ENTITLEMENTS` generation entirely (heredoc + variable)
- Removed `--entitlements "${WIKID_ENTITLEMENTS}"` from the daemon codesign command
- Added ad-hoc signing for wikid in the fallback (no-cert) path
- Removed the plist copy to `Contents/Library/LaunchAgents/` (the app generates the plist at runtime)
- Kept `KEYCHAIN_ACCESS_GROUP` — the APP still uses it for keychain access groups

### New: `DaemonLaunchAgentManager` (`Sources/WikiFS/Daemon/`)
Replaces `SMAppService`. The app generates the LaunchAgent plist at runtime with correct paths (container dir for dev mode, app bundle for production), writes it to `~/Library/LaunchAgents/`, and bootstraps via `launchctl bootstrap gui/<uid> <path>`. The daemon survives app quit — launchd manages it independently (KeepAlive + RunAtLoad). Restart uses `launchctl kickstart gui/<uid>/com.selfdrivingwiki.wikid`.

### WikiFSApp.swift
- Removed `import ServiceManagement`
- Replaced `SMAppService.agent(plistName:).register()` with `DaemonLaunchAgentManager.bootstrap()`
- `unregisterDaemon` is now a no-op (daemon survives quit); the hook stays so the terminate flow is unchanged

### MenuBarItemController.swift
- Removed `import ServiceManagement`
- `restartDaemon` now calls `DaemonLaunchAgentManager.restart()` (launchctl kickstart) via an injected `daemonRestartHandler` closure

### signing/com.selfdrivingwiki.wikid.plist
- Switched from `BundleProgram` (SMAppService-specific) to `ProgramArguments` with a shell wrapper that finds the daemon binary (container dir || app bundle)
- Added `RunAtLoad`

### Makefile
- Updated `install-daemon` to match the new plist format (no more `BundleProgram` removal)
- No more entitlements generation/signing
- Uses `launchctl bootstrap/bootout` (modern API) instead of `load/unload`

## Tests
- `DaemonLaunchAgentManagerTests` (17 tests) — plist structure (Label, MachServices, KeepAlive, RunAtLoad, ProcessType, EnvironmentVariables), serialization to XML, path construction (plistPath, domainTarget, serviceTarget, containerDaemonPath), shell command construction, install-to-disk, and crash-safety of bootstrap/restart in a non-launchd environment
- Full suite (3803 tests) passes
