### PR TITLE
Fix queue event streaming from daemon to app (#871)

### DIFF
--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -288,6 +288,13 @@ final class QueueActivityTracker {
     /// extractions.
     private var itemToSourceIDs: [QueueItem.ID: Set<PageID>] = [:]
 
+    /// Maps queue item ID → its `QueueKind`. Populated on `.enqueued`/`.started`
+    /// so snapshot reconciliation (#871 self-heal) can clear the correct
+    /// running-state set when a terminal event never arrived: a source ID may
+    /// be tracked under both extraction and ingestion by different items, so
+    /// the queue kind is needed to avoid subtracting from the wrong set.
+    private var itemToQueue: [QueueItem.ID: QueueKind] = [:]
+
     /// Items whose transcript's last row is an in-progress streamed assistant
     /// reply — the next `.assistantTextDelta` grows that row in place instead
     /// of appending a new one (mirrors `AgentLauncher.mergeOrAppend`; without
@@ -309,6 +316,11 @@ final class QueueActivityTracker {
 
     /// The stream consumer task.
     private var streamTask: Task<Void, Never>?
+
+    /// The periodic snapshot-reconciliation watchdog (#871 self-heal). Polls
+    /// the daemon's snapshot and clears running-state for items the daemon no
+    /// longer considers active, so a broken event stream can't pin the spinner.
+    private var watchdogTask: Task<Void, Never>?
 
     // MARK: - Lifecycle
 
@@ -343,6 +355,58 @@ final class QueueActivityTracker {
         }
     }
 
+    /// Reconcile the tracker's notion of "running" against the daemon's
+    /// ground-truth snapshot. Any item the tracker treats as active that is
+    /// NOT in `snapshot.activeItems` is cleared from the running-state sets —
+    /// the daemon finished (or never had) it, but the terminal event was lost.
+    ///
+    /// This is the #871 self-heal: when the event stream from daemon → app is
+    /// broken (sink invalidated, envelope dropped), `isExtracting` /
+    /// `isIngesting` would stay `true` forever. A periodic snapshot poll feeds
+    /// this method so the spinner clears once the daemon reports the item gone.
+    ///
+    /// Removal-only — it never adds running state, so a transient snapshot read
+    /// can't fabricate activity. Items still active on the daemon are left
+    /// untouched; their terminal event (or a later reconcile) clears them.
+    func reconcile(with snapshot: QueueSnapshot) {
+        let activeIDs = Set(snapshot.activeItems.map { $0.id })
+        let recentByID = Dictionary(
+            snapshot.recentItems.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first })
+
+        // Consider every item the tracker currently believes is running.
+        let trackedIDs = Set(itemToSourceIDs.keys).union(lintingItemIDs)
+        for id in trackedIDs where !activeIDs.contains(id) {
+            if let item = recentByID[id] {
+                // The daemon has it as terminal — clean up via the proven
+                // `removeItem` path (uses the item's own queue + payload).
+                removeItem(item)
+            } else {
+                // Not active AND not in recent history (pruned / unknown).
+                // Fall back to the ID-only cleanup using stored maps.
+                forgetRunningItem(id)
+            }
+        }
+    }
+
+    /// Start a low-frequency watchdog that polls the daemon's snapshot and
+    /// reconciles, so a broken event stream can't pin the spinner forever
+    /// (#871). Idempotent — calling again replaces the prior watchdog.
+    /// Cancels automatically if the engine is released (the weak ref goes nil).
+    func startSnapshotWatchdog(engine: any QueueEngineClient, interval: Duration = .seconds(5)) {
+        watchdogTask?.cancel()
+        watchdogTask = Task { @MainActor [weak self, weak engine] in
+            while !Task.isCancelled {
+                if Task.isCancelled { return }
+                guard let self, let engine else { return }
+                let snapshot = await engine.snapshot()
+                if Task.isCancelled { return }
+                self.reconcile(with: snapshot)
+                try? await Task.sleep(for: interval)
+            }
+        }
+    }
+
     /// Start consuming `events`. Spawns a `@MainActor` Task that iterates the
     /// stream and dispatches each event to `handle(_:)`.
     func start(events: AsyncStream<QueueEvent>) {
@@ -359,6 +423,8 @@ final class QueueActivityTracker {
     func stop() {
         streamTask?.cancel()
         streamTask = nil
+        watchdogTask?.cancel()
+        watchdogTask = nil
         queueEngine = nil
         extractingSourceIDs = []
         ingestingSourceIDs = []
@@ -373,6 +439,7 @@ final class QueueActivityTracker {
         extractionPID = nil
         currentExtractionItemID = nil
         itemToSourceIDs.removeAll()
+        itemToQueue.removeAll()
         transcripts.removeAll()
         progressLogs.removeAll()
         itemUsage.removeAll()
@@ -490,6 +557,7 @@ final class QueueActivityTracker {
         itemLogURLs.removeValue(forKey: itemID)
         itemDebugURLs.removeValue(forKey: itemID)
         pendingPermissions.removeValue(forKey: itemID)
+        itemToQueue.removeValue(forKey: itemID)
         streamingTranscriptItemIDs.remove(itemID)
         streamingThinkingItemIDs.remove(itemID)
     }
@@ -556,10 +624,12 @@ final class QueueActivityTracker {
             // Track the mapping so we can clean up on completion.
             let sourceIDs = Set(item.payload.sourceIDs)
             itemToSourceIDs[item.id] = sourceIDs
+            itemToQueue[item.id] = item.queue
 
         case .started(let item):
             let sourceIDs = Set(item.payload.sourceIDs)
             itemToSourceIDs[item.id] = sourceIDs
+            itemToQueue[item.id] = item.queue
             switch item.queue {
             case .extraction:
                 extractingSourceIDs.formUnion(sourceIDs)
@@ -701,43 +771,68 @@ final class QueueActivityTracker {
 
     /// Remove an item from the active set and clean up its mapping.
     private func removeItem(_ item: QueueItem) {
-        if let sourceIDs = itemToSourceIDs.removeValue(forKey: item.id) {
-            switch item.queue {
+        // Ensure the per-item maps are populated even if `.started` was the
+        // event that got dropped (#871) — `forgetRunningItem` reads them.
+        itemToQueue[item.id] = item.queue
+        if item.queue == .ingestion, let pageIDs = item.payload.lintPageIDs {
+            itemToLintPageIDs[item.id] = pageIDs
+            itemToLintWikiID[item.id] = item.wikiID
+        }
+        forgetRunningItem(item.id)
+    }
+
+    /// Clear ALL running-state for an item ID using the tracker's stored maps.
+    /// Shared by terminal-event handling (via `removeItem`) and by snapshot
+    /// reconciliation (#871 self-heal), which calls it directly when the daemon
+    /// reports an item is no longer active but no terminal event arrived.
+    ///
+    /// Queue-kind aware: a source ID can be tracked under both extraction and
+    /// ingestion by different items, so `itemToQueue` selects the correct set.
+    /// When the queue kind is unknown (an item we never saw `.started` for),
+    /// source IDs are left untouched to avoid clearing a sibling item's spinner.
+    private func forgetRunningItem(_ id: QueueItem.ID) {
+        let queue = itemToQueue.removeValue(forKey: id)
+        if let sourceIDs = itemToSourceIDs.removeValue(forKey: id) {
+            switch queue {
             case .extraction:
                 extractingSourceIDs.subtract(sourceIDs)
             case .ingestion:
                 ingestingSourceIDs.subtract(sourceIDs)
+            case .none:
+                // Unknown queue — leave the running sets alone; a sibling item
+                // owning the same source ID will clear it on its own terminal
+                // event / reconciliation.
+                break
             }
         }
         // Lint items are tracked separately — always remove on terminal state.
-        lintingItemIDs.remove(item.id)
-        itemToLintPageIDs.removeValue(forKey: item.id)
-        itemToLintWikiID.removeValue(forKey: item.id)
-        if let pageIDs = item.payload.lintPageIDs {
+        lintingItemIDs.remove(id)
+        if let pageIDs = itemToLintPageIDs.removeValue(forKey: id) {
+            let wikiID = itemToLintWikiID.removeValue(forKey: id)
             if pageIDs.isEmpty {
                 // Whole-wiki lint. Safe to remove by wiki ID: the `.ingest`
                 // lane limit is 1 per session, so at most one whole-wiki lint
                 // runs per wiki at a time — this item was the only one.
-                wholeWikiLintingWikiIDs.remove(item.wikiID)
+                if let wikiID { wholeWikiLintingWikiIDs.remove(wikiID) }
             } else {
                 for pageID in pageIDs { lintingPageIDs.remove(pageID) }
             }
         }
-        if currentExtractionItemID == item.id {
+        if currentExtractionItemID == id {
             currentExtractionItemID = nil
         }
         // #544: drop the in-progress usage snapshot on terminal state. Failed
         // and cancelled items never emit a `.usage` event, so without this the
         // live snapshot would linger. Completed items have already dropped it
         // in the `.usage` handler (this is a redundant-clear safety net then).
-        liveUsage.removeValue(forKey: item.id)
+        liveUsage.removeValue(forKey: id)
         // #608: clear any surfaced pending permission on terminal state. The
         // launcher's poller is torn down in `finish()` — a resolved/rejected/
         // auto-rejected request would already have cleared this via the
         // `.pendingPermission(_, nil)` event, but a terminal state arriving
         // first (e.g. cancelled mid-prompt) needs this safety net so the
         // yellow row doesn't linger on a completed/failed/cancelled row.
-        pendingPermissions.removeValue(forKey: item.id)
+        pendingPermissions.removeValue(forKey: id)
     }
 
     /// Parse a PID from a progress line if the local backend reports one.

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -183,6 +183,10 @@ struct WikiFSApp: App {
                 workloadClient: workloadClient, eventSink: eventSink)
             activityTracker.attach(engine: queueEngine)
             Task { await activityTracker.rehydrate(from: queueEngine) }
+            // #871 self-heal: if the daemon → app event stream breaks (sink
+            // invalidated, envelope dropped), poll the snapshot so a finished
+            // item still clears the spinner instead of spinning forever.
+            activityTracker.startSnapshotWatchdog(engine: queueEngine)
             // Phase C4: the coordinator owns chat sessions over the same
             // connection + event sink (chat envelopes are demuxed alongside
             // queue events). Routes envelopes per chatID + wraps the 6 chat

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -272,9 +272,11 @@ final class WikiDaemon: @unchecked Sendable {
     /// `WikiDaemonExporter.registerEventSink`.
     #if os(macOS)
     func registerEventSink(_ sink: WikiDaemonEventSink) {
-        queue.sync {
+        let total = queue.sync { () -> Int in
             eventSinks.append(sink)
+            return eventSinks.count
         }
+        DebugLog.store("wikid: event sink registered, total=\(total)")
     }
 
     /// All currently-registered event-sink proxies. Used by future phases to
@@ -575,9 +577,19 @@ final class WikiDaemon: @unchecked Sendable {
     /// the sole path by which engine events reach the app over XPC.
     func pushQueueEvent(_ event: QueueEvent) {
         #if canImport(WikiFSEngine)
-        guard let envelope = QueueEventEnvelope(from: event) else { return }
-        guard let data = try? JSONEncoder().encode(envelope) else { return }
+        guard let envelope = QueueEventEnvelope(from: event) else {
+            DebugLog.store("wikid: pushQueueEvent — failed to create envelope")
+            return
+        }
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(envelope)
+        } catch {
+            DebugLog.store("wikid: pushQueueEvent — JSON encode failed for kind=\(envelope.kind.rawValue): \(error)")
+            return
+        }
         let sinks = queue.sync { eventSinks }
+        DebugLog.store("wikid: pushQueueEvent kind=\(envelope.kind.rawValue) sinks=\(sinks.count)")
         for sink in sinks {
             sink.deliverEvent(data)
         }
@@ -588,8 +600,15 @@ final class WikiDaemon: @unchecked Sendable {
     /// on all registered event sinks. The sole path by which chat events
     /// reach the app over XPC.
     func pushChatEnvelope(_ envelope: QueueEventEnvelope) {
-        guard let data = try? JSONEncoder().encode(envelope) else { return }
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(envelope)
+        } catch {
+            DebugLog.store("wikid: pushChatEnvelope — JSON encode failed for kind=\(envelope.kind.rawValue): \(error)")
+            return
+        }
         let sinks = queue.sync { eventSinks }
+        DebugLog.store("wikid: pushChatEnvelope kind=\(envelope.kind.rawValue) chatID=\(envelope.chatID ?? "nil") sinks=\(sinks.count)")
         for sink in sinks {
             sink.deliverEvent(data)
         }

--- a/Tests/WikiFSAppTests/QueueActivityTrackerReconcileTests.swift
+++ b/Tests/WikiFSAppTests/QueueActivityTrackerReconcileTests.swift
@@ -1,0 +1,219 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+import WikiFSEngine
+@testable import WikiFS
+
+/// Tests for `QueueActivityTracker.reconcile(with:)` — the app-side #871
+/// self-heal. When the daemon → app event stream is broken, a `.completed`
+/// event may never arrive, leaving `isExtracting`/`isIngesting` true forever
+/// (spinner stuck). Reconciliation clears running-state for any item the
+/// daemon's snapshot no longer considers active.
+@MainActor
+struct QueueActivityTrackerReconcileTests {
+
+    // MARK: - The bug: spinner stuck when the terminal event is dropped
+
+    @Test func reconcileClearsExtractionSpinnerWhenItemFinishedOnDaemon() {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(id: "ext1", queue: .extraction, sourceIDs: ["src1"])
+
+        // .started arrived → spinner on.
+        tracker.handle(.started(item))
+        #expect(tracker.isExtracting)
+
+        // Daemon finished the item (it's in recent history, not active) but
+        // the .completed event was dropped — the exact #871 scenario.
+        let snapshot = QueueSnapshot(activeItems: [], recentItems: [item])
+        tracker.reconcile(with: snapshot)
+
+        // Reconcile clears the spinner even though no terminal event arrived.
+        #expect(!tracker.isExtracting)
+    }
+
+    @Test func reconcileClearsIngestionSpinnerWhenItemFinishedOnDaemon() {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(id: "ing1", queue: .ingestion, sourceIDs: ["src9"])
+
+        tracker.handle(.started(item))
+        #expect(tracker.isIngesting)
+
+        tracker.reconcile(with: QueueSnapshot(activeItems: [], recentItems: [item]))
+
+        #expect(!tracker.isIngesting)
+    }
+
+    // MARK: - Safety: never clears / fabricates activity for still-running items
+
+    @Test func reconcileLeavesStillActiveItemsRunning() {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(id: "ext1", queue: .extraction, sourceIDs: ["src1"])
+
+        tracker.handle(.started(item))
+        #expect(tracker.isExtracting)
+
+        // Daemon still has it active → leave the spinner alone.
+        tracker.reconcile(with: QueueSnapshot(activeItems: [item], recentItems: []))
+
+        #expect(tracker.isExtracting)
+    }
+
+    @Test func reconcileIsRemovalOnlyAndNeverFabricatesActivity() {
+        let tracker = QueueActivityTracker()
+
+        // Daemon is running an item the tracker never saw .started for.
+        let unknown = makeItem(id: "unknown", queue: .extraction, sourceIDs: ["srcX"])
+        tracker.reconcile(with: QueueSnapshot(activeItems: [unknown], recentItems: []))
+
+        // Removal-only: the tracker does not synthesize running-state from a
+        // snapshot (that would race with the live event stream). The unknown
+        // item is ignored.
+        #expect(tracker.extractingSourceIDs.isEmpty)
+        #expect(!tracker.isExtracting)
+    }
+
+    // MARK: - Queue-kind awareness: shared source ID across two items
+
+    @Test func reconcileClearsOnlyTheFinishedQueueWhenSourceIDShared() {
+        let tracker = QueueActivityTracker()
+        // Same source ID, different queue kinds — extract then ingest the
+        // same file. Both spinners are on; only extraction finished.
+        let extraction = makeItem(id: "ext1", queue: .extraction, sourceIDs: ["src1"])
+        let ingestion = makeItem(id: "ing1", queue: .ingestion, sourceIDs: ["src1"])
+
+        tracker.handle(.started(extraction))
+        tracker.handle(.started(ingestion))
+        #expect(tracker.isExtracting)
+        #expect(tracker.isIngesting)
+
+        // Daemon: extraction finished (recent), ingestion still active.
+        let snapshot = QueueSnapshot(activeItems: [ingestion], recentItems: [extraction])
+        tracker.reconcile(with: snapshot)
+
+        // Extraction spinner cleared, ingestion spinner untouched — the
+        // per-item queue map prevented subtracting src1 from ingestion.
+        #expect(!tracker.isExtracting)
+        #expect(tracker.isIngesting)
+    }
+
+    // MARK: - Lint self-heal
+
+    @Test func reconcileClearsPageLevelLintWhenItemFinishedOnDaemon() {
+        let tracker = QueueActivityTracker()
+        let page = PageID(rawValue: "page1")
+        let item = makeItem(
+            id: "lint1", queue: .ingestion, sourceIDs: [],
+            lintPageIDs: [page])
+
+        tracker.handle(.started(item))
+        #expect(tracker.isLinting(pageID: page, wikiID: "wiki1"))
+
+        tracker.reconcile(with: QueueSnapshot(activeItems: [], recentItems: [item]))
+
+        #expect(!tracker.isLinting(pageID: page, wikiID: "wiki1"))
+    }
+
+    @Test func reconcileClearsWholeWikiLintWhenItemFinishedOnDaemon() {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(
+            id: "lint2", queue: .ingestion, sourceIDs: [],
+            lintPageIDs: [])  // empty → whole-wiki lint
+
+        tracker.handle(.started(item))
+        #expect(tracker.isLinting(pageID: PageID(rawValue: "anyPage"), wikiID: "wiki1"))
+
+        tracker.reconcile(with: QueueSnapshot(activeItems: [], recentItems: [item]))
+
+        #expect(!tracker.isLinting(pageID: PageID(rawValue: "anyPage"), wikiID: "wiki1"))
+    }
+
+    // MARK: - Idempotency
+
+    @Test func reconcileIsIdempotent() {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(id: "ext1", queue: .extraction, sourceIDs: ["src1"])
+        tracker.handle(.started(item))
+
+        let snapshot = QueueSnapshot(activeItems: [], recentItems: [item])
+        tracker.reconcile(with: snapshot)
+        tracker.reconcile(with: snapshot)  // second pass must be a no-op
+
+        #expect(!tracker.isExtracting)
+    }
+
+    // MARK: - Watchdog integration: the periodic poll drives reconcile end-to-end
+
+    @Test func snapshotWatchdogClearsSpinnerViaPeriodicPoll() async throws {
+        let tracker = QueueActivityTracker()
+        let item = makeItem(id: "ext1", queue: .extraction, sourceIDs: ["src1"])
+        tracker.handle(.started(item))
+        #expect(tracker.isExtracting)
+
+        // Daemon reports the item finished; the watchdog polls this snapshot.
+        let engine = FakeQueueEngineClient()
+        await engine.setSnapshotValue(QueueSnapshot(activeItems: [], recentItems: [item]))
+
+        tracker.startSnapshotWatchdog(engine: engine, interval: .milliseconds(50))
+
+        // The first iteration reconciles before sleeping, so this should clear
+        // well within the polling budget.
+        var cleared = false
+        for _ in 0..<40 {
+            if !tracker.isExtracting {
+                cleared = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(cleared)
+    }
+
+    // MARK: - Helpers
+
+    private func makeItem(
+        id: String,
+        queue: QueueKind,
+        sourceIDs: [String] = [],
+        lintPageIDs: [PageID]? = nil,
+        wikiID: String = "wiki1"
+    ) -> QueueItem {
+        QueueItem(
+            id: id, queue: queue, wikiID: wikiID,
+            payload: QueueItemPayload(
+                sourceIDs: sourceIDs.map { PageID(rawValue: $0) },
+                lintPageIDs: lintPageIDs),
+            state: .running, orderingKey: 1000, attempt: 0, createdAt: 0)
+    }
+}
+
+/// Minimal `QueueEngineClient` fake for tracker tests. An `actor` (matching
+/// the real `QueueEngine` conformer) so the `Sendable` conformance doesn't
+/// cross actor isolation. Only `snapshot()` is meaningful (configurable).
+actor FakeQueueEngineClient: QueueEngineClient {
+    var snapshotValue: QueueSnapshot = QueueSnapshot()
+
+    /// Cross-isolation setter so tests can configure the snapshot from the
+    /// `@MainActor` test function (`await engine.setSnapshotValue(...)`).
+    func setSnapshotValue(_ snapshot: QueueSnapshot) {
+        snapshotValue = snapshot
+    }
+
+    nonisolated var events: AsyncStream<QueueEvent> { AsyncStream { _ in } }
+    @discardableResult
+    nonisolated func enqueue(_ request: QueueItemRequest) async throws -> QueueItem.ID { "fake" }
+    nonisolated func cancelItem(_ id: QueueItem.ID) async {}
+    @discardableResult
+    nonisolated func cancelAllInFlight() async -> Int { 0 }
+    nonisolated func retryItem(_ id: QueueItem.ID) async throws {}
+    nonisolated func pause(_ queue: QueueKind) async {}
+    nonisolated func resume(_ queue: QueueKind) async {}
+    nonisolated func halt(_ queue: QueueKind) async {}
+    nonisolated func reorderItem(id: QueueItem.ID, beforeItemID: QueueItem.ID?) async {}
+    func snapshot() async -> QueueSnapshot { snapshotValue }
+    nonisolated func hasActiveWork(for wikiID: String) async -> Bool { false }
+    nonisolated func waitForCompletion(of id: QueueItem.ID) async -> Result<Void, Error> { .success(()) }
+    nonisolated func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] { [] }
+    nonisolated func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot] { [:] }
+}
+#endif

--- a/Tests/WikiFSAppTests/WikiDaemonEventSinkTests.swift
+++ b/Tests/WikiFSAppTests/WikiDaemonEventSinkTests.swift
@@ -97,6 +97,95 @@ struct WikiDaemonEventSinkTests {
         #expect(daemon.registeredEventSinks.count == 2)
     }
 
+    // MARK: - Event delivery (#871): events must reach registered sinks
+
+    /// Regression for #871: `pushQueueEvent` must deliver every lifecycle
+    /// event to a registered sink, encoded as a decodable envelope. The bug
+    /// was that failures in envelope construction / JSON encoding were
+    /// swallowed by silent `guard`/`try?` with no logging, so the app spun
+    /// forever with no diagnostic.
+    @Test func pushQueueEventDeliversLifecycleEventsToRegisteredSink() throws {
+        let dir = makeTempDir()
+        let daemon = WikiDaemon(containerDirectory: dir)
+        let sink = TestEventSink()
+        daemon.registerEventSink(sink)
+
+        let item = makeItem()
+        let events: [QueueEvent] = [
+            .enqueued(item),
+            .started(item),
+            .completed(item),
+            .failed(item, error: "boom"),
+            .cancelled(item),
+        ]
+        for event in events {
+            daemon.pushQueueEvent(event)
+        }
+
+        #expect(sink.receivedPayloads.count == events.count)
+
+        let decodedKinds = try sink.receivedPayloads.map {
+            try JSONDecoder().decode(QueueEventEnvelope.self, from: $0).kind
+        }
+        #expect(decodedKinds == [.enqueued, .started, .completed, .failed, .cancelled])
+
+        // Each envelope must round-trip back to a QueueEvent carrying the
+        // original item (decode succeeds, item id survives).
+        for payload in sink.receivedPayloads {
+            let envelope = try JSONDecoder().decode(QueueEventEnvelope.self, from: payload)
+            let reconstructed = try #require(envelope.toQueueEvent())
+            #expect(reconstructed.item?.id == item.id)
+        }
+    }
+
+    /// Regression for #871: with no sinks registered, `pushQueueEvent` must
+    /// not crash (it logs the empty-sink count and returns). This is the
+    /// silent-drop condition where the app's sink never reached the daemon.
+    @Test func pushQueueEventIsSafeWithNoRegisteredSinks() {
+        let dir = makeTempDir()
+        let daemon = WikiDaemon(containerDirectory: dir)
+
+        // No sinks registered — must not crash, must not deliver.
+        daemon.pushQueueEvent(.enqueued(makeItem()))
+    }
+
+    /// Regression for #871: an event must be fanned out to EVERY registered
+    /// sink (multiple app connections / windows).
+    @Test func pushQueueEventFansOutToAllSinks() throws {
+        let dir = makeTempDir()
+        let daemon = WikiDaemon(containerDirectory: dir)
+        let sink1 = TestEventSink()
+        let sink2 = TestEventSink()
+        daemon.registerEventSink(sink1)
+        daemon.registerEventSink(sink2)
+
+        daemon.pushQueueEvent(.started(makeItem()))
+
+        #expect(sink1.receivedPayloads.count == 1)
+        #expect(sink2.receivedPayloads.count == 1)
+        let env1 = try JSONDecoder().decode(QueueEventEnvelope.self, from: sink1.receivedPayloads[0])
+        let env2 = try JSONDecoder().decode(QueueEventEnvelope.self, from: sink2.receivedPayloads[0])
+        #expect(env1.kind == .started)
+        #expect(env2.kind == .started)
+    }
+
+    /// Regression for #871: `pushChatEnvelope` must deliver chat envelopes to
+    /// registered sinks (the chat event stream — same silent-drop surface).
+    @Test func pushChatEnvelopeDeliversToRegisteredSink() throws {
+        let dir = makeTempDir()
+        let daemon = WikiDaemon(containerDirectory: dir)
+        let sink = TestEventSink()
+        daemon.registerEventSink(sink)
+
+        let envelope = QueueEventEnvelope(kind: .chatEvent, chatID: "chat-1")
+        daemon.pushChatEnvelope(envelope)
+
+        #expect(sink.receivedPayloads.count == 1)
+        let decoded = try JSONDecoder().decode(QueueEventEnvelope.self, from: sink.receivedPayloads[0])
+        #expect(decoded.kind == .chatEvent)
+        #expect(decoded.chatID == "chat-1")
+    }
+
     // MARK: - Helpers
 
     private func makeTempDir() -> URL {
@@ -104,6 +193,13 @@ struct WikiDaemonEventSinkTests {
             .appendingPathComponent("wikid-sink-tests-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
+    }
+
+    private func makeItem() -> QueueItem {
+        QueueItem(
+            id: "01ABCDEF", queue: .extraction, wikiID: "wiki1",
+            payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "src1")]),
+            state: .queued, orderingKey: 1000, attempt: 0, createdAt: 0)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #871 — queue events not streaming from daemon to app. The daemon completed ingestion but the app's spinner spun forever because events never arrived, with zero diagnostics.

## Root cause

`WikiDaemon.pushQueueEvent` / `pushChatEnvelope` silently dropped events at three points with bare `guard`/`try?` and no logging anywhere in the push/register path:
1. `QueueEventEnvelope(from:)` returning nil → dropped
2. `JSONEncoder().encode(...)` failing → dropped
3. `eventSinks` empty (the app's `registerEventSink` call didn't reach the daemon, or the XPC sink proxy was invalidated) → no events flow

Because every failure path was silent, the broken stream was invisible.

## Changes

### Daemon — stop the silent drops (`Sources/wikid/WikiDaemon.swift`)
- `registerEventSink` now logs the registered-sink count.
- `pushQueueEvent` / `pushChatEnvelope`: replaced the silent `guard let` / `try?` with explicit `do/catch` + `DebugLog.store(...)`, and log `kind` + `sinks.count` on every push. Encode failures and empty-sink conditions are now visible in Console.app instead of looking like a healthy empty queue.

### App — self-heal so a broken stream can't pin the spinner (`QueueActivityTracker`)
Even with logging, a broken XPC stream (invalidated sink proxy, connection drop mid-run) could still leave `isExtracting`/`isIngesting` true forever once a `.started` had arrived but the matching `.completed` was lost. Added a removal-only snapshot reconciliation:
- `reconcile(with:)` — clears running-state for any item the tracker believes is active that the daemon's snapshot no longer considers active. Queue-kind aware (a source ID tracked under both extraction and ingestion is only cleared from the finished queue). Never fabricates activity.
- `startSnapshotWatchdog(engine:interval:)` — polls `snapshot()` every 5s and reconciles. Wired in `WikiFSApp` alongside `attach`/`rehydrate`.

## Tests
- `WikiDaemonEventSinkTests`: lifecycle events reach a registered sink and round-trip; chat envelope delivery; fan-out to multiple sinks; safe (no crash) with no sinks.
- `QueueActivityTrackerReconcileTests` (new): reconcile clears extraction/ingestion/page-level/whole-wiki lint spinners; leaves still-active items running; removal-only (no fabricated activity); queue-kind correctness when two items share a source ID; idempotent; plus a watchdog integration test driving reconcile end-to-end via a fake engine.

`swift test` — all 3819 tests pass.

## Notes
- The issue text referred to `pushChatEvent`; the actual method is `pushChatEnvelope` — fixed in place.
- `make version`, `make keychain`, and `make prompts` were run locally to satisfy the generated-file prerequisites; only source/test files are in this PR.
