### PR TITLE
Add verbose logging flag for high-frequency event logs

### DIFF
--- a/Sources/WikiFSTypes/DebugLog.swift
+++ b/Sources/WikiFSTypes/DebugLog.swift
@@ -29,6 +29,34 @@ public enum DebugLog {
     /// events surface cleanly in Console.app.
     public static func editor(_ message: @autoclosure () -> String) { emit("editor", message()) }
 
+    /// When true, high-frequency diagnostic logs (per-event `pushQueueEvent`/
+    /// `pushChatEnvelope`, etc.) are emitted. Off by default to avoid flooding
+    /// Console.app during active extraction/ingestion — the daemon pushes one
+    /// event per queue/chat transition, which is hundreds of lines per ingest
+    /// run (#872). Toggle at runtime via
+    /// `defaults write com.willsargent.WikiFS debugVerboseLogging -bool YES`,
+    /// or set `DebugLog.verboseLogging = true` directly from a debug menu/test.
+    ///
+    /// `nonisolated(unsafe)` matches the codebase convention for mutable
+    /// test-injectable statics (see `DisplayNameResolver.pdfTitleExtractor`,
+    /// `EmbeddingService.miniLMFactory`): a simple Bool read on the verbose
+    /// path and written rarely, so a torn read at worst yields one stale
+    /// emit/skip — never a correctness issue (it only gates a log line).
+    public nonisolated(unsafe) static var verboseLogging: Bool = {
+        UserDefaults.standard.bool(forKey: "debugVerboseLogging")
+    }()
+
+    /// Like the category helpers but only emits when ``verboseLogging`` is true.
+    /// Use for high-frequency per-event traces (e.g. every `pushQueueEvent`/
+    /// `pushChatEnvelope` success) that would flood Console.app during active
+    /// ingestion. Routed through the `store` category so it groups with the
+    /// existing daemon diagnostics in Console.app. Signal-worthy events
+    /// (errors, empty-sinks drops) should still use `store`/`debug` directly.
+    public static func verbose(_ message: @autoclosure () -> String) {
+        guard verboseLogging else { return }
+        emit("store", message())
+    }
+
     private static let subsystem = "com.selfdrivingwiki.debug"
 
     #if canImport(os)

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -578,6 +578,16 @@ final class WikiDaemon: @unchecked Sendable {
         guard let envelope = QueueEventEnvelope(from: event) else { return }
         guard let data = try? JSONEncoder().encode(envelope) else { return }
         let sinks = queue.sync { eventSinks }
+        // The empty-sinks case is the diagnostic that matters (the #871 symptom:
+        // events produced with nowhere to go) — keep it unconditional. The
+        // normal success path is high-frequency (one log per event) so it goes
+        // through `DebugLog.verbose`, which only emits when the verbose flag is
+        // on (#872).
+        if sinks.isEmpty {
+            DebugLog.store("wikid: pushQueueEvent kind=\(envelope.kind.rawValue) — no sinks registered (drop)")
+        } else {
+            DebugLog.verbose("wikid: pushQueueEvent kind=\(envelope.kind.rawValue) sinks=\(sinks.count)")
+        }
         for sink in sinks {
             sink.deliverEvent(data)
         }
@@ -590,6 +600,13 @@ final class WikiDaemon: @unchecked Sendable {
     func pushChatEnvelope(_ envelope: QueueEventEnvelope) {
         guard let data = try? JSONEncoder().encode(envelope) else { return }
         let sinks = queue.sync { eventSinks }
+        // Same split as `pushQueueEvent`: empty-sinks drop is unconditional
+        // (signal-worthy — chat events lost), success is verbose-only (#872).
+        if sinks.isEmpty {
+            DebugLog.store("wikid: pushChatEnvelope kind=\(envelope.kind.rawValue) — no sinks registered (drop)")
+        } else {
+            DebugLog.verbose("wikid: pushChatEnvelope kind=\(envelope.kind.rawValue) sinks=\(sinks.count)")
+        }
         for sink in sinks {
             sink.deliverEvent(data)
         }

--- a/Tests/WikiFSAppTests/DebugLogVerboseTests.swift
+++ b/Tests/WikiFSAppTests/DebugLogVerboseTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+import WikiFSCore
+
+/// Tests for `DebugLog.verbose` / `DebugLog.verboseLogging` (#872).
+///
+/// The verbose flag gates high-frequency per-event daemon logs
+/// (`pushQueueEvent` / `pushChatEnvelope`) so they don't flood Console.app
+/// during active ingestion. The os_log sink can't be intercepted from a unit
+/// test, so these tests assert the gating contract (no-crash in either state,
+/// flag is mutable) rather than the emitted bytes.
+///
+/// `verboseLogging` is a shared mutable static, so the suite is `.serialized`
+/// to keep the save/toggle/restore sequence free of cross-test races.
+@Suite(.serialized)
+struct DebugLogVerboseTests {
+
+    /// Calling `verbose` with the flag off must be a cheap no-op (the default
+    /// state in tests / fresh installs — `debugVerboseLogging` is absent from
+    /// UserDefaults). Regression guard: this is the hot path hit once per
+    /// daemon event; it must never crash or throw.
+    @Test
+    func verboseIsNoOpWhenFlagOff() {
+        let saved = DebugLog.verboseLogging
+        defer { DebugLog.verboseLogging = saved }
+        DebugLog.verboseLogging = false
+
+        DebugLog.verbose("wikid: pushQueueEvent kind=progress sinks=1")
+        DebugLog.verbose("wikid: pushChatEnvelope kind=chatEvent sinks=2")
+        // No crash / no throw => the guard short-circuits before `emit`.
+    }
+
+    /// The flag is a mutable runtime toggle (defaults menu / `defaults write`
+    /// / direct assignment). Round-trip both states and confirm `verbose` is
+    /// safe to call while the flag is on (it then reaches `emit` → os_log).
+    @Test
+    func verboseFlagCanBeToggled() {
+        let saved = DebugLog.verboseLogging
+        defer { DebugLog.verboseLogging = saved }
+
+        DebugLog.verboseLogging = true
+        #expect(DebugLog.verboseLogging == true)
+        DebugLog.verbose("wikid: pushQueueEvent kind=progress sinks=1")
+
+        DebugLog.verboseLogging = false
+        #expect(DebugLog.verboseLogging == false)
+        DebugLog.verbose("wikid: pushQueueEvent kind=progress sinks=1")
+    }
+
+    /// The `@autoclosure` argument must not be evaluated when the flag is off —
+    /// otherwise an expensive `String` build (interpolating an `envelope.kind`
+    /// or a `sinks.count`) would still be paid on every event even though the
+    /// line is dropped, defeating the whole point of gating (#872).
+    @Test
+    func verboseDoesNotEvaluateArgumentWhenOff() {
+        let saved = DebugLog.verboseLogging
+        defer { DebugLog.verboseLogging = saved }
+        DebugLog.verboseLogging = false
+
+        var evaluated = false
+        DebugLog.verbose({
+            evaluated = true
+            return "should not be built"
+        }())
+        #expect(evaluated == false)
+    }
+}

--- a/Tests/WikiFSAppTests/WikiDaemonEventSinkTests.swift
+++ b/Tests/WikiFSAppTests/WikiDaemonEventSinkTests.swift
@@ -97,6 +97,41 @@ struct WikiDaemonEventSinkTests {
         #expect(daemon.registeredEventSinks.count == 2)
     }
 
+    // MARK: - pushChatEnvelope logging paths (#872)
+
+    /// With no sinks registered, `pushChatEnvelope` hits the unconditional
+    /// "no sinks registered (drop)" `DebugLog.store` path and must not crash.
+    /// This is the #871 diagnostic — events produced with nowhere to go — and
+    /// it stays unconditional precisely so it surfaces in Console.app.
+    @Test func pushChatEnvelopeWithNoSinksDoesNotCrash() throws {
+        let dir = makeTempDir()
+        let daemon = WikiDaemon(containerDirectory: dir)
+        let envelope = QueueEventEnvelope(kind: .chatEvent, chatID: "chat-1")
+
+        daemon.pushChatEnvelope(envelope)
+        // No crash / no throw => the empty-sinks drop path executed cleanly.
+    }
+
+    /// With a sink registered, `pushChatEnvelope` takes the success path
+    /// (verbose-only log) and actually delivers the JSON payload. Verifying
+    /// delivery confirms we didn't accidentally regress the forward path while
+    /// re-routing its log line.
+    @Test func pushChatEnvelopeDeliversToRegisteredSink() throws {
+        let dir = makeTempDir()
+        let daemon = WikiDaemon(containerDirectory: dir)
+        let sink = TestEventSink()
+        daemon.registerEventSink(sink)
+
+        let envelope = QueueEventEnvelope(kind: .chatEvent, chatID: "chat-2")
+        daemon.pushChatEnvelope(envelope)
+
+        #expect(sink.receivedPayloads.count == 1)
+        let decoded = try JSONDecoder().decode(
+            QueueEventEnvelope.self, from: sink.receivedPayloads[0])
+        #expect(decoded.kind == .chatEvent)
+        #expect(decoded.chatID == "chat-2")
+    }
+
     // MARK: - Helpers
 
     private func makeTempDir() -> URL {


### PR DESCRIPTION
## What

Adds a `DebugLog.verboseLogging` flag and routes the daemon's high-frequency per-event logs through it. Fixes the log-flooding finding from the pr-reviewer (#872).

## Why

`pushQueueEvent` / `pushChatEnvelope` fire once per queue/chat transition — hundreds of lines per ingest run — which floods Console.app and buries real signal. The per-event success log is noise by default; the **empty-sinks drop** (#871 symptom: events produced with nowhere to go) is signal and must always surface.

## Changes

- **`Sources/WikiFSTypes/DebugLog.swift`** — add `verboseLogging` (off by default; seeded from `UserDefaults` key `debugVerboseLogging`) and a `verbose(_:)` helper that no-ops when the flag is off.
  - `nonisolated(unsafe)` per the codebase convention for mutable test-injectable statics (matches `DisplayNameResolver.pdfTitleExtractor`, `EmbeddingService.miniLMFactory`) — required to compile under Swift 6 + `-warnings-as-errors`.
  - Toggle: `defaults write com.willsargent.WikiFS debugVerboseLogging -bool YES`, or `DebugLog.verboseLogging = true` directly.
- **`Sources/wikid/WikiDaemon.swift`** — split the log path in both `pushQueueEvent` and `pushChatEnvelope`:
  - `sinks.isEmpty` → unconditional `DebugLog.store("... — no sinks registered (drop)")` (the #871 diagnostic).
  - success → `DebugLog.verbose(...)` (only when the flag is on).
- **Tests**
  - `Tests/WikiFSAppTests/DebugLogVerboseTests.swift` (new): verbose is a no-op when off, flag is mutable, and the `@autoclosure` argument is **not evaluated** when off (so the gating actually saves the string-build cost).
  - `WikiDaemonEventSinkTests.swift`: `pushChatEnvelope` no-crash on the empty-sinks path, and still delivers on the success path.

## Verify

- `make version keychain prompts && swift build` ✅
- `swift test` — 3811 tests pass ✅
- `swift test --filter "DebugLogVerboseTests|WikiDaemonEventSinkTests"` — 11 tests pass ✅
