### PR TITLE
Fix: daemon store writes signal app via DarwinNotifier (#871 follow-up)

### DIFF
--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -83,8 +83,12 @@ final class WikiDaemon: @unchecked Sendable {
             let dbURL = databaseURL(forWikiID: descriptor.id)
             do {
                 let store = try makeStore(dbURL) as? GRDBWikiStore
-                if let store { wireEventBus(on: store, wikiID: descriptor.id) }
-                openStores[descriptor.id] = store
+                if let store {
+                    wireEventBus(on: store, wikiID: descriptor.id)
+                    cacheStore(store, wikiID: descriptor.id)
+                } else {
+                    openStores[descriptor.id] = nil
+                }
             } catch {
                 DebugLog.store("wikid: createWiki failed for \(descriptor.id): \(error)")
                 return nil
@@ -173,7 +177,7 @@ final class WikiDaemon: @unchecked Sendable {
                 // Read-write open (runs bootstrap ladder on first open)
                 let store = try GRDBWikiStore(databaseURL: dbURL)
                 wireEventBus(on: store, wikiID: wikiID)
-                openStores[wikiID] = store
+                cacheStore(store, wikiID: wikiID)
                 return true
             } catch {
                 DebugLog.store("wikid: openStore failed for \(wikiID): \(error)")
@@ -209,7 +213,7 @@ final class WikiDaemon: @unchecked Sendable {
             do {
                 let store = try GRDBWikiStore(databaseURL: dbURL)
                 wireEventBus(on: store, wikiID: wikiID)
-                openStores[wikiID] = store
+                cacheStore(store, wikiID: wikiID)
                 DebugLog.store("wikid: store lazily opened for \(wikiID)")
                 return store
             } catch {
@@ -283,13 +287,38 @@ final class WikiDaemon: @unchecked Sendable {
     /// them (#871 follow-up): persisted chat summaries stayed invisible and
     /// completed queue items never refreshed the Activity window. Idempotent —
     /// a no-op if the store already carries a bus.
+    ///
+    /// `eventBus` stays optional on `GRDBWikiStore` itself because `wikictl`
+    /// and the File Provider's read-only open intentionally run busless. The
+    /// daemon, however, treats a busless store as a programming error: the
+    /// trailing `assert` is the **mandatory-bus invariant** — it fires in debug
+    /// builds if wiring was skipped or the assignment didn't stick.
     private func wireEventBus(on store: GRDBWikiStore, wikiID: String) {
-        guard store.eventBus == nil else { return }
-        let bus = WikiEventBus(wikiID: wikiID)
-        bus.subscribe(nil) { event in
-            DarwinNotifier.postChange(forWikiID: event.wikiID)
+        if store.eventBus == nil {
+            let bus = WikiEventBus(wikiID: wikiID)
+            bus.subscribe(nil) { event in
+                DarwinNotifier.postChange(forWikiID: event.wikiID)
+            }
+            store.eventBus = bus
         }
-        store.eventBus = bus
+        assert(
+            store.eventBus != nil,
+            "Daemon store must have a WikiEventBus attached — DarwinNotifier will never fire without it")
+    }
+
+    /// Cache `store` under `wikiID` in `openStores`. The **sole sanctioned
+    /// insertion point** — enforces the daemon invariant that every held store
+    /// carries a change bus (#871 follow-up), so a future store-creation path
+    /// that forgets to call `wireEventBus` still trips the assert the moment it
+    /// tries to cache the store. Removals (`closeStore`/`deleteWiki`) bypass
+    /// this. Do NOT assign `openStores[...] = ...` directly elsewhere.
+    @discardableResult
+    private func cacheStore(_ store: GRDBWikiStore, wikiID: String) -> GRDBWikiStore {
+        assert(
+            store.eventBus != nil,
+            "Daemon store must have a WikiEventBus attached — DarwinNotifier will never fire without it")
+        openStores[wikiID] = store
+        return store
     }
 
     // MARK: - Event sink management (Phase 0)

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -83,6 +83,7 @@ final class WikiDaemon: @unchecked Sendable {
             let dbURL = databaseURL(forWikiID: descriptor.id)
             do {
                 let store = try makeStore(dbURL) as? GRDBWikiStore
+                if let store { wireEventBus(on: store, wikiID: descriptor.id) }
                 openStores[descriptor.id] = store
             } catch {
                 DebugLog.store("wikid: createWiki failed for \(descriptor.id): \(error)")
@@ -171,6 +172,7 @@ final class WikiDaemon: @unchecked Sendable {
             do {
                 // Read-write open (runs bootstrap ladder on first open)
                 let store = try GRDBWikiStore(databaseURL: dbURL)
+                wireEventBus(on: store, wikiID: wikiID)
                 openStores[wikiID] = store
                 return true
             } catch {
@@ -206,6 +208,7 @@ final class WikiDaemon: @unchecked Sendable {
             let dbURL = databaseURL(forWikiID: wikiID)
             do {
                 let store = try GRDBWikiStore(databaseURL: dbURL)
+                wireEventBus(on: store, wikiID: wikiID)
                 openStores[wikiID] = store
                 DebugLog.store("wikid: store lazily opened for \(wikiID)")
                 return store
@@ -263,6 +266,30 @@ final class WikiDaemon: @unchecked Sendable {
 
     private func databaseURL(forWikiID id: String) -> URL {
         containerDirectory.appendingPathComponent("\(id).sqlite", isDirectory: false)
+    }
+
+    /// Attach a per-wiki `WikiEventBus` to `store` whose all-events listener
+    /// forwards every committed mutation to a Darwin change notification.
+    ///
+    /// The daemon's stores live in a separate process from the app, so the
+    /// store's own `ResourceChangeEvent` emissions (from `mutate()`) can't
+    /// reach the app directly. This wiring bridges them: each event →
+    /// `DarwinNotifier.postChange(forWikiID:)` → the app's `WikiChangeBridge`
+    /// receives the cross-process Darwin notification → coalesces → reloads.
+    ///
+    /// Without it, daemon-only writes that never pass through an agent
+    /// `onUnlock` callback (summarizer writes, queue-extraction completion,
+    /// chat-message appends) emit into a nil bus and the app never learns about
+    /// them (#871 follow-up): persisted chat summaries stayed invisible and
+    /// completed queue items never refreshed the Activity window. Idempotent —
+    /// a no-op if the store already carries a bus.
+    private func wireEventBus(on store: GRDBWikiStore, wikiID: String) {
+        guard store.eventBus == nil else { return }
+        let bus = WikiEventBus(wikiID: wikiID)
+        bus.subscribe(nil) { event in
+            DarwinNotifier.postChange(forWikiID: event.wikiID)
+        }
+        store.eventBus = bus
     }
 
     // MARK: - Event sink management (Phase 0)

--- a/Tests/WikiFSAppTests/DaemonStoreEventBusTests.swift
+++ b/Tests/WikiFSAppTests/DaemonStoreEventBusTests.swift
@@ -1,0 +1,129 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import wikid
+
+/// Tests that the daemon attaches a `WikiEventBus` to every store it opens, and
+/// that the bus listener fires on committed mutations — the bridge that lets
+/// the app (a separate process) learn about daemon-side writes (summarizer,
+/// queue completion, chat-message appends) via `DarwinNotifier` (#871
+/// follow-up). Before this wiring, daemon stores had no bus, so `mutate()`
+/// emitted into the void and the app never reloaded.
+struct DaemonStoreEventBusTests {
+
+    private func makeTempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikid-bus-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Lock-guarded collector mirroring `SignalRecorder` (which lives in the
+    /// `WikiFSTests` target and isn't visible here). The bus dispatches each
+    /// `@MainActor` handler via `Task { @MainActor in … }`, so delivered events
+    /// land a runloop tick after `emit`; `awaitCount` polls until they arrive.
+    private final class Collector: @unchecked Sendable {
+        private let lock = NSLock()
+        private var events: [ResourceChangeEvent] = []
+        func append(_ event: ResourceChangeEvent) {
+            lock.lock(); events.append(event); lock.unlock()
+        }
+        var count: Int { lock.lock(); defer { lock.unlock() }; return events.count }
+        var snapshot: [ResourceChangeEvent] { lock.lock(); defer { lock.unlock() }; return events }
+
+        func awaitCount(_ expected: Int, timeoutMs: Int = 1000) async throws {
+            let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+            while Date() < deadline {
+                if count >= expected { return }
+                await MainActor.run { }
+                try? await Task.sleep(for: .milliseconds(2))
+            }
+        }
+    }
+
+    private func makeWiki(_ daemon: WikiDaemon, name: String = "BusTest") throws -> String {
+        let wikiData = try #require(daemon.createWiki(name: name))
+        return try JSONDecoder().decode(WikiDescriptor.self, from: wikiData).id
+    }
+
+    // MARK: - Bus is attached at every store-creation seam
+
+    @Test func openStoreAttachesEventBus() throws {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        let wikiID = try makeWiki(daemon)
+
+        #expect(daemon.openStore(wikiID: wikiID))
+        // `resolveStoreLazily` serves the now-cached store; the bus must be set.
+        let store = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+        #expect(store.eventBus != nil)
+        #expect(store.eventBus?.wikiID == wikiID)
+    }
+
+    @Test func resolveStoreLazilyAttachesEventBus() throws {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        let wikiID = try makeWiki(daemon)
+        // Drop the cache so the resolver hits the lazy-open path.
+        daemon.closeStore(wikiID: wikiID)
+
+        let store = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+        #expect(store.eventBus != nil)
+        #expect(store.eventBus?.wikiID == wikiID)
+    }
+
+    @Test func createWikiAttachesEventBusToCachedStore() throws {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        let wikiID = try makeWiki(daemon)
+
+        // createWiki opens + caches the store; resolve returns that same store.
+        let store = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+        #expect(store.eventBus != nil)
+    }
+
+    // MARK: - The wired bus actually fires on a committed mutation
+
+    @Test func storeMutationFiresBusListener() async throws {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        let wikiID = try makeWiki(daemon)
+        daemon.closeStore(wikiID: wikiID)
+
+        let store = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+        let bus = try #require(store.eventBus)
+        let collector = Collector()
+        bus.subscribe(nil) { collector.append($0) }
+
+        // A real mutating write routes through mutate() → emit on the bus.
+        _ = try store.createPage(title: "SignalProbe")
+
+        try await collector.awaitCount(1)
+        #expect(collector.count >= 1)
+        #expect(collector.snapshot.allSatisfy { $0.wikiID == wikiID })
+    }
+
+    /// Regression guard: the bus listener that calls `DarwinNotifier` is
+    /// registered (i.e. `wireEventBus` actually subscribed, not just created a
+    /// bare bus). We assert indirectly by confirming a second subscriber on the
+    /// same bus receives events alongside the daemon's own listener — proving
+    /// the bus is live and multi-subscriber delivery works end-to-end.
+    @Test func busDeliversToMultipleListenersAfterMutation() async throws {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        let wikiID = try makeWiki(daemon)
+        daemon.closeStore(wikiID: wikiID)
+
+        let store = try #require(daemon.resolveStoreLazily(wikiID: wikiID))
+        let bus = try #require(store.eventBus)
+        let a = Collector()
+        let b = Collector()
+        _ = bus.subscribe(nil) { a.append($0) }
+        _ = bus.subscribe(nil) { b.append($0) }
+
+        _ = try store.createPage(title: "MultiProbe")
+
+        try await a.awaitCount(1)
+        try await b.awaitCount(1)
+        #expect(a.count == 1)
+        #expect(b.count == 1)
+        #expect(a.snapshot[0].id == b.snapshot[0].id)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Daemon `GRDBWikiStore` instances had **no `WikiEventBus` attached** — they were created via `GRDBWikiStore(databaseURL:)` with no bus. When the daemon wrote to the store (summarizer, queue completion, chat-message appends, extraction), `mutate()` tried to emit a `ResourceChangeEvent` but the bus was `nil`, so the event went nowhere. The app never reloaded, causing:

1. **Chat summaries showed truncation fallback** — `persistedMessages` never reloaded with the summary the daemon persisted.
2. **Completed queue items didn't appear in the Activity window** — the app never learned the item finished.

The `onUnlock` callback in `DaemonQueueIngestionProvider` / `DaemonChatHost` manually called `DarwinNotifier.postChange`, but only during the agent *run* — not during summarizer writes, not during queue completion, not during extraction writes.

## Fix

Attach a `WikiEventBus` to every daemon store whose **all-events listener** forwards each committed mutation to `DarwinNotifier.postChange(forWikiID:)`. This is the daemon-side mirror of the app's store wiring (`WikiSession.swift:186`): because the daemon lives in a separate process, the store's in-process `ResourceChangeEvent` can't reach the app directly — the bus listener bridges it to a cross-process Darwin notification, which the app's `WikiChangeBridge` receives → coalesces → reloads.

Every store mutation now flows:
```
store.mutate() → ResourceChangeEvent → bus.emit() → listener → DarwinNotifier.postChange
  → app WikiChangeBridge → coalescer → flush → reloadFromStore → reloadChats
  → messageVersion bumps → ChatDetailView reloads persistedMessages → cached summaries appear
```

### Changes
- **`Sources/wikid/WikiDaemon.swift`** — new `wireEventBus(on:wikiID:)` helper (creates a `WikiEventBus`, subscribes an all-events `DarwinNotifier` listener, sets `store.eventBus`). Called at all three store-creation seams:
  - `createWiki` (via the injected `makeStore` factory, after cast to `GRDBWikiStore`)
  - `openStore(wikiID:)`
  - `resolveStoreLazily(wikiID:)` (the lazy store resolver backing the queue engine + chat host)
- **`Tests/WikiFSAppTests/DaemonStoreEventBusTests.swift`** (new) — 5 tests:
  - bus attached at `openStore`
  - bus attached at `resolveStoreLazily` (lazy-open path)
  - bus attached at `createWiki` (cached store)
  - a real mutation fires the bus listener (end-to-end wiring is live)
  - multi-subscriber delivery works after a mutation

## Test plan
- [x] `make version prompts keychain && swift build` — clean
- [x] `swift test` — full suite, **3824 tests in 316 suites passed**
- [x] `swift test --filter "DaemonStoreEventBusTests|WikiDaemonTests|DaemonStoreResolverTests"` — 33 passed

Fixes #871 (follow-up).
