### PR TITLE
Fix: restart daemon on app launch (bootout + bootstrap) (#876)

### DIFF
--- a/Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift
+++ b/Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift
@@ -145,6 +145,25 @@ final class DaemonLaunchAgentManager {
         }
     }
 
+    /// Restart the daemon fresh on app launch: bootout (unload) any existing
+    /// service, wait for it to exit, then bootstrap (reload). Guarantees the
+    /// daemon picks up the current binary after a rebuild — a plain
+    /// `bootstrap` returns "already loaded" (error 5) and leaves the stale
+    /// daemon running with the old binary, so two daemons can race on
+    /// queue.sqlite (#876). Errors from bootout (e.g. "not loaded" when the
+    /// daemon wasn't running) are silently ignored — that just means there
+    /// was nothing to unload.
+    func bootoutAndBootstrap() {
+        DebugLog.store("wikid: restarting daemon (bootout + bootstrap)")
+        runLaunchctl(["bootout", serviceTarget]) { status in
+            // Non-zero is expected when the daemon isn't loaded yet — ignore.
+            DebugLog.store("wikid: launchctl bootout returned \(status) (ignored if not loaded)")
+        }
+        // Let the old process fully exit before the new one starts.
+        Thread.sleep(forTimeInterval: 1)
+        bootstrap()
+    }
+
     // MARK: - Private
 
     private func runLaunchctl(_ arguments: [String], completion: @escaping (Int32) -> Void) {

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -299,15 +299,19 @@ struct WikiFSApp: App {
         // Bootstrap the wikid daemon via launchctl. The app generates the
         // LaunchAgent plist at runtime (it knows the container path + the
         // app bundle path), writes it to ~/Library/LaunchAgents/, and runs
-        // `launchctl bootstrap`. The daemon is unsandboxed — no entitlements
-        // (AMFI killed the old entitled binary because the bare Mach-O had
-        // no embedded provisioning profile). It reads the app group container
-        // directly via filesystem permissions. The daemon survives app quit.
-        // Best-effort: in dev mode (`swift run`) the bootstrap still works
-        // (the plist points at the container binary), wikictl falls back to
-        // direct file access if the daemon isn't running.
+        // `launchctl bootout` then `launchctl bootstrap`. The daemon is
+        // unsandboxed — no entitlements (AMFI killed the old entitled binary
+        // because the bare Mach-O had no embedded provisioning profile). It
+        // reads the app group container directly via filesystem permissions.
+        // The daemon survives app quit. Best-effort: in dev mode (`swift run`)
+        // the bootstrap still works (the plist points at the container
+        // binary), wikictl falls back to direct file access if the daemon
+        // isn't running.
+        // #876: bootout before bootstrap so a stale daemon (running an old
+        // binary after a rebuild) is always unloaded and restarted fresh — a
+        // plain bootstrap returns "already loaded" and leaves the old daemon.
         let manager = DaemonLaunchAgentManager(containerDirectory: directory)
-        manager.bootstrap()
+        manager.bootoutAndBootstrap()
         self.daemonManager = manager
 
         // Call bootstrap directly from init.

--- a/Tests/WikiFSAppTests/DaemonLaunchAgentManagerTests.swift
+++ b/Tests/WikiFSAppTests/DaemonLaunchAgentManagerTests.swift
@@ -177,5 +177,13 @@ struct DaemonLaunchAgentManagerTests {
         let manager = makeManager()
         manager.restart()
     }
+
+    @Test func bootoutAndBootstrapDoesNotCrashInTestEnvironment() {
+        // bootoutAndBootstrap() runs launchctl bootout + bootstrap which will
+        // fail in CI (no launchd domain for the test runner, and the service
+        // isn't loaded). It should not crash — errors are logged and ignored.
+        let manager = makeManager()
+        manager.bootoutAndBootstrap()
+    }
 }
 #endif


### PR DESCRIPTION
## Problem (#876)

When the app is quit and relaunched after a rebuild, the old `wikid` daemon process stays alive (the LaunchAgent doesn't restart it). The app called `launchctl bootstrap`, which returns "already loaded" (error 5), so the old daemon kept running with the old binary. Two daemons can race on `queue.sqlite`.

## Fix

`WikiFSApp` now calls `DaemonLaunchAgentManager.bootoutAndBootstrap()` on launch instead of plain `bootstrap()`:

1. **`launchctl bootout`** — unload any existing service. Errors (e.g. "not loaded") are silently ignored; that just means the daemon wasn't running.
2. **`sleep 1`** — give the old process time to fully exit before the new one starts.
3. **`launchctl bootstrap`** — load the (just-rewritten) plist fresh, starting the new binary.

This mirrors the intent of the existing "Restart Daemon" menu item (`kickstart`), but is stronger: `bootout` fully removes the service from launchd before `bootstrap` reloads it, guaranteeing the new binary is picked up even across app restarts.

## Testing

- `swift build` ✅
- `swift test` — full suite, 3829 tests ✅
- Added `bootoutAndBootstrapDoesNotCrashInTestEnvironment` (best-effort, like the existing bootstrap/restart tests).

## Files

- `Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift` — new `bootoutAndBootstrap()`.
- `Sources/WikiFS/Window/WikiFSApp.swift` — call site switched from `bootstrap()` to `bootoutAndBootstrap()`.
- `Tests/WikiFSAppTests/DaemonLaunchAgentManagerTests.swift` — new test.
