### PR TITLE
Fix: health-check daemon connection + log XPC failures (#878)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,48 @@
 # Progress log
 
+## fix: Health-check daemon connection + log XPC failures (#878)
+
+**Goal:** The app falsely logged "connected to wikid daemon" even when the
+daemon wasn't running. `NSXPCConnection` is lazy — `connect()`/`resume()`
+always succeeds regardless of whether anything is listening — so the app
+believed it had a live daemon, then every XPC call failed or hung, with no
+fallback to the local `QueueEngine`.
+
+**What changed:**
+- **`WikiDaemonConnection.connect()`** — now runs a **health check** after
+  `resume()`: a trivial read-only `listWikis` call through a proxy carrying an
+  error handler, bounded by a 5s timeout (bridged async→sync via
+  `DispatchSemaphore`, matching the codebase's existing semaphore pattern in
+  `CLITantivyLegResolver`). If the daemon doesn't reply, `connect()` throws and
+  callers fall back. On failure the half-open connection is invalidated (no
+  leak). `connect()` stays synchronous because all call sites are sync
+  (`WikiFSApp.init`, `wikictl` main); the XPC reply dispatches on an internal
+  queue so there's no self-deadlock.
+- **`invalidationHandler`** — installed on the connection; logs
+  "daemon connection invalidated — XPC calls will fail until restart" when the
+  daemon dies mid-session. `[weak self]` avoids a connection→handler→self
+  retain cycle. An `internal var onInvalidation` test seam lets tests observe
+  the fire.
+- **Test seams** — `internal connect(serviceName:healthCheckTimeout:)` (point at
+  a non-existent mach service to assert failure) and `connect(endpoint:)`
+  (in-process anonymous-listener round-trip, no launchd) + `invalidate()`.
+- **`WikiFSApp.swift`** — fallback log now says "daemon not responding to health
+  check — using local QueueEngine fallback" (the existing `try?` already
+  triggers the local `QueueEngine` path; only the message changed).
+- **`XPCQueueEngineProxy`** — already converted (prior #867): every former
+  silent `try?` is a `do/catch` + `DebugLog.ingest`. No change needed here.
+
+**Tests:** `WikiDaemonConnectionHealthCheckTests` (3 tests) — `connect()`
+throws for a non-existent mach service; `connect()` succeeds + is usable
+against a live in-process daemon; the `invalidationHandler` fires on
+invalidate. Full suite (3831 tests) passes.
+
+**Files touched:**
+- `Sources/WikiCtlCore/WikiDaemonConnection.swift` — health check +
+  invalidation handler + test seams.
+- `Sources/WikiFS/Window/WikiFSApp.swift` — fallback log message.
+- `Tests/WikiFSAppTests/WikiDaemonConnectionHealthCheckTests.swift` — new.
+
 ## fix: Switch wikid daemon from SMAppService + entitlements to plain LaunchAgent
 
 **Goal:** AMFI killed the wikid daemon at launch because the bare Mach-O had

--- a/Sources/WikiCtlCore/WikiDaemonConnection.swift
+++ b/Sources/WikiCtlCore/WikiDaemonConnection.swift
@@ -35,6 +35,12 @@ public final class WikiDaemonConnection {
     private let connection: NSXPCConnection
     internal var proxy: WikiDaemonProtocol { connection.remoteObjectProxy as! WikiDaemonProtocol }
 
+    /// Invoked from the connection's `invalidationHandler` after the daemon
+    /// connection breaks (daemon quit / crash). Production leaves this nil —
+    /// the handler just logs via `DebugLog`. Tests set it to observe that the
+    /// handler actually fires (#878).
+    internal var onInvalidation: (() -> Void)?
+
     private init(connection: NSXPCConnection) {
         self.connection = connection
     }
@@ -42,12 +48,72 @@ public final class WikiDaemonConnection {
     /// Connect to the daemon. The connection auto-launches via launchd if the
     /// daemon isn't running.
     ///
+    /// After `resume()`, a **health check** probes the daemon with a trivial
+    /// read-only call (`listWikis`) bounded by a timeout. `NSXPCConnection`
+    /// is lazy: `resume()` succeeds even when no daemon is listening, so this
+    /// probe is what actually verifies a live daemon (#878). If it times out or
+    /// the connection errors, `connect()` throws and callers fall back to the
+    /// local `QueueEngine` (app) or a direct-file path (`wikictl`).
+    ///
     /// The `WikiDaemonProtocol` interface is set up with the
     /// `WikiDaemonEventSink` sub-interface on the `registerEventSink(_:)`
     /// selector, so XPC creates a proxy for the sink parameter (bidirectional
-    /// XPC) rather than trying to serialize it.
+    /// XPC) rather than trying to serialize it. An `invalidationHandler` logs
+    /// when the daemon dies mid-session.
     public static func connect() throws -> WikiDaemonConnection {
-        let connection = NSXPCConnection(machServiceName: serviceName)
+        try connect(serviceName: serviceName)
+    }
+
+    /// Internal overload: target a specific mach service name. Tests point this
+    /// at a non-existent service to assert the health check fails when nothing
+    /// is listening (#878).
+    internal static func connect(
+        serviceName: String,
+        healthCheckTimeout: TimeInterval = 5
+    ) throws -> WikiDaemonConnection {
+        try makeAndProbe(
+            connection: NSXPCConnection(machServiceName: serviceName),
+            timeout: healthCheckTimeout)
+    }
+
+    /// Internal overload: connect to an in-process daemon via an anonymous
+    /// listener endpoint (no launchd required). Used by tests to exercise a
+    /// *healthy* round-trip + invalidation against a real `WikiDaemon`.
+    internal static func connect(
+        endpoint: NSXPCListenerEndpoint,
+        healthCheckTimeout: TimeInterval = 5
+    ) throws -> WikiDaemonConnection {
+        try makeAndProbe(
+            connection: NSXPCConnection(listenerEndpoint: endpoint),
+            timeout: healthCheckTimeout)
+    }
+
+    /// Shared by every connect path: wrap the connection, configure the XPC
+    /// interface + invalidation handler, resume, then probe. On probe failure
+    /// the half-open connection is invalidated before throwing so no leak is
+    /// left behind.
+    private static func makeAndProbe(
+        connection: NSXPCConnection,
+        timeout: TimeInterval
+    ) throws -> WikiDaemonConnection {
+        let conn = WikiDaemonConnection(connection: connection)
+        conn.configureInterfaceAndInvalidation()
+        connection.resume()
+        do {
+            try conn.healthCheck(timeout: timeout)
+        } catch {
+            connection.invalidate()
+            throw error
+        }
+        return conn
+    }
+
+    /// Apply the daemon interface (with the bidirectional event-sink sub-
+    /// interface) and install an `invalidationHandler` that logs when the
+    /// daemon connection breaks mid-session, then forwards to ``onInvalidation``
+    /// for test observation. `[weak self]` avoids a connection→handler→self
+    /// retain cycle.
+    private func configureInterfaceAndInvalidation() {
         let daemonInterface = NSXPCInterface(with: WikiDaemonProtocol.self)
         let sinkInterface = NSXPCInterface(with: WikiDaemonEventSink.self)
         daemonInterface.setInterface(
@@ -57,8 +123,51 @@ public final class WikiDaemonConnection {
             ofReply: false
         )
         connection.remoteObjectInterface = daemonInterface
-        connection.resume()
-        return WikiDaemonConnection(connection: connection)
+        connection.invalidationHandler = { [weak self] in
+            DebugLog.store("wikid: daemon connection invalidated — XPC calls will fail until restart")
+            self?.onInvalidation?()
+        }
+    }
+
+    /// Verify the daemon is actually responding. `NSXPCConnection` is lazy, so
+    /// a successful `resume()` proves nothing — we must exchange a message.
+    /// Issues a trivial read-only `listWikis` call through a proxy with an error
+    /// handler, bounded by `timeout`. Success ⟺ the daemon replied.
+    ///
+    /// Bridges the inherently-async XPC reply to this synchronous `connect()`
+    /// path via a `DispatchSemaphore` — safe because XPC replies dispatch on an
+    /// internal queue, never the calling (main) thread, so there is no
+    /// self-deadlock. The timeout is the worst-case ceiling; a missing mach
+    /// service errors well inside it.
+    private func healthCheck(timeout: TimeInterval) throws {
+        var outcome: Result<Void, Error>?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        // A fresh proxy carrying an error handler — the stored `proxy` has none,
+        // so a broken connection would otherwise hang until the timeout instead
+        // of surfacing the connection error.
+        let probe = connection.remoteObjectProxyWithErrorHandler { error in
+            outcome = .failure(error)
+            semaphore.signal()
+        } as! WikiDaemonProtocol
+
+        probe.listWikis { _ in
+            // The daemon replied — we don't care about the payload, only that
+            // it answered. It is alive.
+            outcome = .success(())
+            semaphore.signal()
+        }
+
+        if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+            throw WikiDaemonError.connectionFailed
+        }
+        try outcome?.get()
+    }
+
+    /// Invalidate the underlying connection (test/cleanup seam). Triggers the
+    /// `invalidationHandler` installed by ``connect()``.
+    internal func invalidate() {
+        connection.invalidate()
     }
 
     // MARK: - Registry

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -194,7 +194,7 @@ struct WikiFSApp: App {
             chatDaemonCoordinator = ChatDaemonCoordinator(
                 client: workloadClient, eventSink: eventSink)
         } else {
-            DebugLog.store("WikiFSApp: daemon not available — falling back to local QueueEngine")
+            DebugLog.store("wikid: daemon not responding to health check — using local QueueEngine fallback")
             let queueDBURL = (try? DatabaseLocation.queueDatabaseURL())
                 ?? directory.appendingPathComponent("queue.sqlite", isDirectory: false)
             let queueStore: QueueStore

--- a/Tests/WikiFSAppTests/WikiDaemonConnectionHealthCheckTests.swift
+++ b/Tests/WikiFSAppTests/WikiDaemonConnectionHealthCheckTests.swift
@@ -1,0 +1,149 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import WikiCtlCore
+@testable import wikid
+
+/// Tests for the #878 daemon connection health check.
+///
+/// `NSXPCConnection` is lazy: `resume()` succeeds even when no daemon is
+/// listening. Before #878, `WikiDaemonConnection.connect()` returned a
+/// connection that *looked* healthy and the app logged "connected to wikid
+/// daemon" while no daemon existed — every subsequent XPC call then failed or
+/// hung. These tests pin the new behavior:
+///
+/// 1. `connect()` throws when pointed at a mach service nobody registered.
+/// 2. `connect()` succeeds (health check passes) against a live in-process daemon,
+///    and the returned connection is actually usable.
+/// 3. The `invalidationHandler` installed by `connect()` fires when the
+///    connection breaks, so a mid-session daemon death is observable/logged.
+struct WikiDaemonConnectionHealthCheckTests {
+
+    private func makeTempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikid-healthcheck-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Builds an anonymous in-process daemon listener (no launchd) and returns
+    /// a handle exposing its endpoint. Caller owns invalidating the listener.
+    ///
+    /// `NSXPCListener.delegate` is a *weak* reference, so the handle retains the
+    /// delegate privately — callers just need to keep the handle alive for the
+    /// life of the test, or the listener will refuse every connection
+    /// (error 4097) once the delegate is deallocated.
+    private func makeDaemonEndpoint() -> DaemonListenerHandle {
+        let daemon = WikiDaemon(containerDirectory: makeTempDir())
+        let exporter = WikiDaemonExporter(daemon: daemon)
+        let listener = NSXPCListener.anonymous()
+        let delegate = HealthCheckListenerDelegate(exporter: exporter)
+        listener.delegate = delegate
+        listener.resume()
+        return DaemonListenerHandle(listener: listener, delegate: delegate)
+    }
+
+    // MARK: - Health check fails when no daemon is listening (#878 core case)
+
+    /// Pointing `connect` at a mach service name that launchd does not know
+    /// about must throw — not return a zombie connection. A missing service
+    /// errors well inside the timeout, so this stays fast. (The exact error is
+    /// launchd-dependent — either a `connectionFailed` timeout or a propagated
+    /// connection `NSError` — so we only assert that *some* error is thrown.)
+    @Test func connectThrowsWhenNoDaemonListening() throws {
+        let bogusService = "com.selfdrivingwiki.wikid.nonexistent.\(UUID().uuidString)"
+        #expect(throws: (any Error).self) {
+            try WikiDaemonConnection.connect(
+                serviceName: bogusService,
+                healthCheckTimeout: 4)
+        }
+    }
+
+    // MARK: - Health check passes against a live daemon
+
+    /// Against a real in-process daemon, `connect()` must succeed and return a
+    /// connection whose calls actually work — proving the health check doesn't
+    /// reject healthy daemons.
+    @Test func connectSucceedsAndIsUsableAgainstLiveDaemon() async throws {
+        let handle = makeDaemonEndpoint()
+        defer { handle.listener.invalidate() }
+
+        let conn = try WikiDaemonConnection.connect(
+            endpoint: handle.endpoint, healthCheckTimeout: 5)
+
+        // The health check passed; prove the connection really works by making
+        // a second call through it. A fresh registry has no wikis.
+        let wikis = try await conn.listWikis()
+        #expect(wikis.isEmpty)
+    }
+
+    // MARK: - Invalidation handler fires on connection break
+
+    /// The `invalidationHandler` installed in `connect()` must fire when the
+    /// connection breaks, so a mid-session daemon death is logged (#878 §2).
+    @Test func invalidationHandlerFiresOnInvalidate() async throws {
+        let handle = makeDaemonEndpoint()
+        defer { handle.listener.invalidate() }
+
+        let conn = try WikiDaemonConnection.connect(
+            endpoint: handle.endpoint, healthCheckTimeout: 5)
+
+        actor Flag { var fired = false; func set() { fired = true }; var value: Bool { fired } }
+        let flag = Flag()
+        conn.onInvalidation = { Task { await flag.set() } }
+
+        conn.invalidate()
+
+        // invalidationHandler dispatches asynchronously; poll briefly.
+        var observed = false
+        for _ in 0..<30 {
+            if await flag.value { observed = true; break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(observed, "invalidationHandler did not fire after invalidate()")
+    }
+}
+
+// MARK: - Test helpers
+
+/// Owns an anonymous listener + the (weakly-held-by-the-listener) delegate so
+/// the delegate survives for the life of the test. Exposes `listener` and
+/// `endpoint`; the delegate is retained privately.
+private final class DaemonListenerHandle {
+    let listener: NSXPCListener
+    let endpoint: NSXPCListenerEndpoint
+    private let delegate: HealthCheckListenerDelegate
+
+    init(listener: NSXPCListener, delegate: HealthCheckListenerDelegate) {
+        self.listener = listener
+        self.endpoint = listener.endpoint
+        self.delegate = delegate
+    }
+}
+
+/// Listener delegate that exports a `WikiDaemonExporter`, including the
+/// bidirectional event-sink sub-interface (matches the daemon's real surface).
+private final class HealthCheckListenerDelegate: NSObject, NSXPCListenerDelegate {
+    private let exporter: WikiDaemonExporter
+
+    init(exporter: WikiDaemonExporter) {
+        self.exporter = exporter
+    }
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        let daemonInterface = NSXPCInterface(with: WikiDaemonProtocol.self)
+        let sinkInterface = NSXPCInterface(with: WikiDaemonEventSink.self)
+        daemonInterface.setInterface(
+            sinkInterface,
+            for: #selector(WikiDaemonProtocol.registerEventSink(_:)),
+            argumentIndex: 0,
+            ofReply: false
+        )
+        newConnection.exportedInterface = daemonInterface
+        newConnection.exportedObject = exporter
+        newConnection.resume()
+        return true
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Fixes #878.

The app falsely logged "connected to wikid daemon" even when the daemon wasn't running. `NSXPCConnection` is lazy — `resume()` always succeeds regardless of whether anything is listening — so the app believed it had a live daemon, then every subsequent XPC call failed or hung, with no fallback to the local `QueueEngine`.

## Changes

- **`WikiDaemonConnection.connect()` health check** — after `resume()`, probes the daemon with a trivial read-only `listWikis` call through a proxy carrying an error handler, bounded by a 5s timeout. If the daemon doesn't reply (times out or the connection errors), `connect()` throws so callers fall back. The half-open connection is invalidated on failure (no leak).
  - `connect()` stays **synchronous** (`throws`) because all call sites are sync (`WikiFSApp.init`, `wikictl` main). The async XPC reply is bridged to sync via a `DispatchSemaphore` — safe because XPC replies dispatch on an internal queue, never the calling (main) thread, so there is no self-deadlock. (Matches the codebase's existing semaphore pattern in `CLITantivyLegResolver`.)
- **`invalidationHandler`** — installed on the connection; logs "daemon connection invalidated — XPC calls will fail until restart" when the daemon dies mid-session. `[weak self]` avoids a retain cycle.
- **`WikiFSApp.swift`** — the existing `try? WikiDaemonConnection.connect()` already falls back to the local `QueueEngine`; the fallback log now reflects that the daemon failed the health check.
- **`XPCQueueEngineProxy`** — already logs every XPC failure via `DebugLog.ingest` (done in #867); no change needed here.

## Test seams

- `internal connect(serviceName:healthCheckTimeout:)` — point at a non-existent mach service to assert failure.
- `internal connect(endpoint:)` — in-process anonymous-listener round-trip (no launchd) to assert success + usability.
- `internal invalidate()` + `internal var onInvalidation` — observe the invalidation handler firing.

## Tests

New `WikiDaemonConnectionHealthCheckTests` (3 tests):
- `connect()` **throws** for a non-existent mach service (no daemon listening).
- `connect()` **succeeds + is usable** against a live in-process daemon (proves the health check doesn't reject healthy daemons).
- The **`invalidationHandler` fires** when the connection breaks.

Full suite: **3831 tests pass** (`swift test`).

## Verification

```
make version prompts
swift build      # ✓
swift test       # ✓ 3831 passed
```
