### PR TITLE
Fix daemon LaunchAgent plist: [ -x ] test instead of exec || exec

### DIFF
--- a/Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift
+++ b/Sources/WikiFS/Daemon/DaemonLaunchAgentManager.swift
@@ -73,8 +73,12 @@ final class DaemonLaunchAgentManager {
     /// Build the shell command that finds the daemon binary. Tries the
     /// container path first (dev mode), then the app bundle (production).
     func shellCommand() -> String {
+        // Use [ -x ] test instead of exec || exec — exec replaces the shell
+        // process, so if the first binary doesn't exist the shell exits 127
+        // before reaching the fallback. Testing first, then exec, ensures
+        // the fallback works.
         if let bundlePath = bundleDaemonPath {
-            return "exec \"\(containerDaemonPath)\" || exec \"\(bundlePath)\""
+            return "DAEMON=\"\(containerDaemonPath)\"; [ -x \"$DAEMON\" ] || DAEMON=\"\(bundlePath)\"; exec \"$DAEMON\""
         }
         return "exec \"\(containerDaemonPath)\""
     }


### PR DESCRIPTION
The DaemonLaunchAgentManager generates the LaunchAgent plist at runtime and writes it to ~/Library/LaunchAgents/. The shellCommand() method was using 'exec ... || exec ...' which fails with exit 127 — exec replaces the shell process so if the first binary doesn't exist, the shell exits before reaching the fallback.

Fix: use [ -x "$DAEMON" ] to test first, then exec. This ensures the fallback to the app bundle binary works.

This was the root cause of the daemon consistently failing to start with exit 127 after app relaunch.