### PR TITLE
Fix: replace in-memory SQLite fallbacks with user-visible errors (#881)

### DIFF
--- a/Sources/WikiFS/Window/RootScene.swift
+++ b/Sources/WikiFS/Window/RootScene.swift
@@ -61,12 +61,43 @@ struct RootScene: View {
                         Text(report.alertMessage)
                     }
             } else if let wikiID {
-                // The wiki ID is known but the session isn't resolved yet.
-                ProgressView("Opening wiki…")
-                    .onAppear { resolveSession(for: wikiID) }
-                    .onAppear {
-                        DebugLog.tabs("RootScene [Opening wiki…]: wikiID=\(wikiID)")
+                // The wiki ID is known but the session isn't resolved yet, OR
+                // the store failed to open (issue #881 — no in-memory fallback).
+                // Show a user-visible error view instead of silently degrading
+                // to an empty wiki, so the user understands their data isn't gone.
+                if let errorMessage = sessionManager.openError(for: wikiID) {
+                    VStack(spacing: 16) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 40))
+                            .foregroundStyle(.orange)
+                        Text("Couldn’t Open Wiki")
+                            .font(.title2.bold())
+                        Text(errorMessage)
+                            .multilineTextAlignment(.center)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: 420)
+                        HStack {
+                            Button("Retry") {
+                                sessionManager.clearOpenError(for: wikiID)
+                                session = nil
+                                resolveSession(for: wikiID)
+                            }
+                            Button("Reveal Database") {
+                                let dbURL = sessionManager.containerDirectory
+                                    .appendingPathComponent("\(wikiID).sqlite", isDirectory: false)
+                                NSWorkspace.shared.activateFileViewerSelecting([dbURL])
+                            }
+                        }
                     }
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ProgressView("Opening wiki…")
+                        .onAppear { resolveSession(for: wikiID) }
+                        .onAppear {
+                            DebugLog.tabs("RootScene [Opening wiki…]: wikiID=\(wikiID)")
+                        }
+                }
             } else {
                 // No wiki ID from the WindowGroup binding AND no activeWikiID
                 // adoption yet. This happens when the main WindowGroup creates
@@ -189,7 +220,15 @@ struct RootScene: View {
             // Yield first so the spinner paints before the store opens.
             await Task.yield()
             guard session == nil else { return }  // re-check after suspension
-            let resolved = sessionManager.session(for: wikiID, descriptor: descriptor)
+            // `session(for:)` throws when the on-disk store can't be opened
+            // (issue #881). SessionManager records the error so the error
+            // branch above renders; `session` stays nil.
+            let resolved: WikiSession
+            do {
+                resolved = try sessionManager.session(for: wikiID, descriptor: descriptor)
+            } catch {
+                return
+            }
             session = resolved
             // Wire the File Provider bus subscription for this wiki's session.
             fileProvider.subscribeBus(for: wikiID, bus: resolved.store.eventBus)

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -57,6 +57,12 @@ struct WikiFSApp: App {
     @State private var showingLaunchLocationWarning: Bool
     @State private var fileProviderSetupWarning: FileProviderSetupWarning?
     @State private var showingFileProviderSetupWarning = false
+    /// Issue #881: user-visible error shown when the local `queue.sqlite`
+    /// could not be opened at launch (no silent `:memory:` fallback). Drives
+    /// an alert over the main window so the user understands ingestion /
+    /// extraction are unavailable (instead of silently dropping every
+    /// enqueued item on restart).
+    @State private var queueStoreError: String?
     /// Drives the Settings TabView selection so the activity windows can open
     /// Settings on the relevant tab (gear button → extraction/agents config).
     @AppStorage("settings.selectedTab") private var settingsSelectedTabRaw = SettingsTab.zotero.rawValue
@@ -194,17 +200,23 @@ struct WikiFSApp: App {
         // Always construct a local engine first — it's the fallback if the
         // daemon isn't running (dev mode without `make install-daemon`) AND
         // the recovery target if the daemon dies mid-session.
-        let localEngine = Self.makeLocalQueueEngine(
+        let localEngineResult = Self.makeLocalQueueEngine(
             directory: directory,
             sessionBox: sessionBox,
             fileProviderBox: fileProviderBox,
             extractionProvider: extractionProvider)
 
+        // Issue #881: surface a user-visible error if `queue.sqlite` could not
+        // be opened (no silent `:memory:` fallback). `localEngine` may be an
+        // `UnavailableQueueEngine` — the app stays usable for browsing, but
+        // ingest/extract throw a clear error.
+        _queueStoreError = State(initialValue: localEngineResult.openError)
+
         // Wrap in the hot-swap router so a mid-session daemon death can swap
         // back to a fresh local engine transparently — all consumers
         // (SessionManager, MenuBarItemController, QueueActivityTracker) hold
         // the router, never the inner engine.
-        let router = QueueEngineHotSwap(localEngine)
+        let router = QueueEngineHotSwap(localEngineResult.engine)
         queueEngineRouter = router
         activityTracker.attach(engine: router)
         Task { await activityTracker.rehydrate(from: router) }
@@ -484,7 +496,15 @@ struct WikiFSApp: App {
                             sessionBox: sessionBox,
                             fileProviderBox: fileProviderBoxValue,
                             extractionProvider: extractionProviderValue)
-                        router?.swap(to: local)
+                        // Issue #881: if the local queue store also failed to
+                        // open, `local.engine` is an `UnavailableQueueEngine`.
+                        // The enqueue path surfaces the error to the user; the
+                        // launch-time alert (`queueStoreError`) covers the
+                        // initial-failure UX.
+                        if let disconnectError = local.openError {
+                            DebugLog.store("WikiFSApp: local queue engine unavailable after daemon disconnect: \(disconnectError)")
+                        }
+                        router?.swap(to: local.engine)
                         chatDaemonCoordinator = nil
                     }
                     healthMonitor?.onReconnect = { newConn in
@@ -515,13 +535,20 @@ struct WikiFSApp: App {
     /// Construct a local `QueueEngine` as the fallback for when the daemon is
     /// unavailable or has died mid-session. Extracted from the former inline
     /// init() block so it can be called on initial launch AND on disconnect.
+    ///
+    /// - Returns: A tuple of the engine to wire into the hot-swap router and an
+    ///   optional user-visible error message. When the on-disk `queue.sqlite`
+    ///   cannot be opened, the engine is an `UnavailableQueueEngine` (so the app
+    ///   stays usable for browsing but ingest/extract throw a clear error) and
+    ///   `openError` carries the failure reason for the app-level alert (issue
+    ///   #881 — no silent `:memory:` fallback that drops every item on restart).
     @MainActor
     private static func makeLocalQueueEngine(
         directory: URL,
         sessionBox: SessionLookupBox,
         fileProviderBox: FileProviderBox,
         extractionProvider: any QueueExtractionProvider
-    ) -> QueueEngine {
+    ) -> (engine: any QueueEngineClient, openError: String?) {
         DebugLog.store("WikiFSApp: constructing local QueueEngine fallback")
         let queueDBURL = (try? DatabaseLocation.queueDatabaseURL())
             ?? directory.appendingPathComponent("queue.sqlite", isDirectory: false)
@@ -529,9 +556,13 @@ struct WikiFSApp: App {
         do {
             queueStore = try QueueStore(databaseURL: queueDBURL)
         } catch {
-            DebugLog.store("QueueEngine: failed to open queue.sqlite — using in-memory: \(error)")
-            // swiftlint:disable:next force_try
-            queueStore = try! QueueStore(databaseURL: URL(fileURLWithPath: ":memory:"))
+            // Issue #881: no in-memory fallback. Surface a user-visible error
+            // and use an `UnavailableQueueEngine` so the app stays usable for
+            // browsing while ingest/extract throw a clear error (instead of
+            // silently dropping every enqueued item on restart).
+            let reason = "Could not open the queue database at \(queueDBURL.path). Ingestion and extraction will be unavailable until this is resolved. \(error)"
+            DebugLog.store("QueueEngine: failed to open queue.sqlite — queue unavailable: \(error)")
+            return (UnavailableQueueEngine(reason: reason), reason)
         }
         let ingestionProvider = AppQueueIngestionProvider(
             sessionBox: sessionBox,
@@ -567,7 +598,7 @@ struct WikiFSApp: App {
         Task { logPathsBox.emit = await localEngine.makeEmitLogPaths() }
         Task { pendingPermissionBox.emit = await localEngine.makeEmitPendingPermission() }
         Task { await localEngine.start() }
-        return localEngine
+        return (localEngine, nil)
     }
 
     var body: some Scene {
@@ -622,6 +653,22 @@ struct WikiFSApp: App {
                 Button("OK", role: .cancel) {}
             } message: { warning in
                 Text(warning.message)
+            }
+            // Issue #881: surface a queue-database open failure (the local
+            // `queue.sqlite` could not be opened). No silent in-memory
+            // fallback — ingestion / extraction are unavailable until the
+            // underlying issue is resolved.
+            .alert(
+                "Queue Database Unavailable",
+                isPresented: Binding(
+                    get: { queueStoreError != nil },
+                    set: { if !$0 { queueStoreError = nil } }
+                ),
+                presenting: queueStoreError
+            ) { _ in
+                Button("OK", role: .cancel) {}
+            } message: { message in
+                Text(message)
             }
             // Keep the bridge's Darwin observations in lockstep with the wiki
             // set: a freshly-created wiki's CLI writes must be heard; a

--- a/Sources/WikiFSEngine/SessionManager.swift
+++ b/Sources/WikiFSEngine/SessionManager.swift
@@ -28,6 +28,21 @@ public final class SessionManager {
     /// shares ONE session (one store, one bus, one gate).
     public private(set) var sessions: [String: WikiSession] = [:]
 
+    /// Per-wiki store-open failures (issue #881). When `session(for:)` throws
+    /// (the on-disk DB couldn't be opened), the error message is recorded here
+    /// keyed by wiki ID so `RootScene` can render a user-visible error view
+    /// ("Could not open wiki database…") instead of silently showing an empty
+    /// wiki. Cleared by ``clearOpenError(for:)`` (Retry button) so the next
+    /// `session(for:)` call attempts a fresh open.
+    public private(set) var openErrors: [String: String] = [:]
+
+    /// The user-visible error message for a wiki that failed to open, or nil.
+    public func openError(for wikiID: String) -> String? { openErrors[wikiID] }
+
+    /// Clear a recorded open error so the next `session(for:)` retry attempts a
+    /// fresh open (Retry button in the error view).
+    public func clearOpenError(for wikiID: String) { openErrors.removeValue(forKey: wikiID) }
+
     /// The wiki ID of the frontmost window. Updated by per-window scenePhase
     /// transitions (`.active`). Used by `VacuumCommands` (which lives at the
     /// scene level — `.commands` is a `Scene` modifier, not a `View`
@@ -87,6 +102,12 @@ public final class SessionManager {
     /// model is deliberately NOT config-aware).
     public let podcastBackendResolver: @MainActor () -> PodcastTranscriptionBackend?
 
+    /// Injection seam for the store factory (mirrors `WikiSession.makeStore`).
+    /// Defaults to `StoreBackend.current.makeStore(databaseURL:)`. Tests inject
+    /// a throwing closure to exercise the open-failure path (issue #881)
+    /// without relying on filesystem corruption.
+    public let makeStore: @Sendable (URL) throws -> WikiStore
+
     public init(
         containerDirectory: URL,
         extractionCoordinator: ExtractionCoordinator,
@@ -96,7 +117,8 @@ public final class SessionManager {
         htmlMarkdownExtractorFactory: @escaping @MainActor () -> (any HtmlMarkdownExtractor)? = { nil },
         htmlBackendResolver: @escaping @MainActor () -> HtmlExtractionBackend? = { nil },
         podcastBackendResolver: @escaping @MainActor () -> PodcastTranscriptionBackend? = { nil },
-        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
+        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in },
+        makeStore: @escaping @Sendable (URL) throws -> WikiStore = { try StoreBackend.current.makeStore(databaseURL: $0) }
     ) {
         self.containerDirectory = containerDirectory
         self.extractionCoordinator = extractionCoordinator
@@ -107,6 +129,7 @@ public final class SessionManager {
         self.htmlBackendResolver = htmlBackendResolver
         self.podcastBackendResolver = podcastBackendResolver
         self.interactiveUsageRecorder = interactiveUsageRecorder
+        self.makeStore = makeStore
     }
 
     // MARK: - Session lifecycle
@@ -114,26 +137,48 @@ public final class SessionManager {
     /// Get or create a session for `wikiID`. If a session already exists for
     /// this wiki (open in another window), returns the existing instance —
     /// so two windows over the same wiki share one store + bus + gate.
-    public func session(for wikiID: String, descriptor: WikiDescriptor) -> WikiSession {
+    ///
+    /// - Throws: If the wiki's on-disk store cannot be opened, the error is
+    ///   recorded in ``openErrors`` (so `RootScene` can show a user-visible
+    ///   message) and rethrown. There is no in-memory fallback (#881) — a
+    ///   failed open leaves `sessions[wikiID]` unset, and the caller renders
+    ///   an error view instead of an empty wiki.
+    public func session(for wikiID: String, descriptor: WikiDescriptor) throws -> WikiSession {
         if let existing = sessions[wikiID] {
             // Refresh the descriptor in case the registry mutated (rename /
             // set home page) since this session was created.
             existing.updateDescriptor(descriptor)
             return existing
         }
-        let newSession = WikiSession(
-            wikiID: wikiID,
-            descriptor: descriptor,
-            containerDirectory: containerDirectory,
-            extractionCoordinator: extractionCoordinator,
-            queueEngine: queueEngine,
-            extractionProvider: extractionProvider,
-            pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
-            htmlMarkdownExtractorFactory: htmlMarkdownExtractorFactory,
-            htmlBackendResolver: htmlBackendResolver,
-            podcastBackendResolver: podcastBackendResolver,
-            interactiveUsageRecorder: interactiveUsageRecorder
-        )
+        let newSession: WikiSession
+        do {
+            newSession = try WikiSession(
+                wikiID: wikiID,
+                descriptor: descriptor,
+                containerDirectory: containerDirectory,
+                extractionCoordinator: extractionCoordinator,
+                queueEngine: queueEngine,
+                extractionProvider: extractionProvider,
+                makeStore: makeStore,
+                pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
+                htmlMarkdownExtractorFactory: htmlMarkdownExtractorFactory,
+                htmlBackendResolver: htmlBackendResolver,
+                podcastBackendResolver: podcastBackendResolver,
+                interactiveUsageRecorder: interactiveUsageRecorder
+            )
+        } catch {
+            // Record a user-visible message so RootScene can render an error
+            // view. No in-memory fallback (#881) — the on-disk file is left
+            // untouched for recovery.
+            let dbPath = containerDirectory
+                .appendingPathComponent("\(wikiID).sqlite", isDirectory: false).path
+            let message = "Could not open the wiki database at \(dbPath). The file may be corrupt. \(error)"
+            DebugLog.store("SessionManager: failed to open wiki \(wikiID): \(error)")
+            openErrors[wikiID] = message
+            throw error
+        }
+        // A successful open clears any previously-recorded error for this wiki.
+        openErrors.removeValue(forKey: wikiID)
         // Transfer any deferred wiki-link click (registered by
         // `applyOrStashWikiLink` for a wiki whose window wasn't open yet)
         // onto the new session. `RootView` consumes it on appear.

--- a/Sources/WikiFSEngine/UnavailableQueueEngine.swift
+++ b/Sources/WikiFSEngine/UnavailableQueueEngine.swift
@@ -1,0 +1,93 @@
+import Foundation
+import WikiFSCore
+
+/// A `QueueEngineClient` whose backing store could not be opened (issue #881).
+///
+/// Replaces the former silent `:memory:` fallback in `WikiFSApp`: when
+/// `queue.sqlite` fails to open, the app now constructs an
+/// `UnavailableQueueEngine` so the rest of the app stays usable for browsing,
+/// while every enqueue / retry surfaces a clear, user-visible error instead of
+/// silently dropping work on the floor (the in-memory fallback lost every
+/// enqueued item on restart).
+///
+/// - `enqueue` / `retryItem` throw `UnavailableQueueEngine.Error.unavailable`
+///   so the ingest/extract path can present the failure to the user.
+/// - Read accessors (`snapshot`, `loadTranscript`, …) return empty results.
+/// - `events` is a finished stream (no items will ever be produced).
+///
+/// The error message is captured at construction time so callers can surface
+/// the original `QueueStore` open failure (path + underlying error).
+public final class UnavailableQueueEngine: QueueEngineClient, @unchecked Sendable {
+
+    /// The error thrown by every mutating operation on this engine.
+    public enum Error: Swift.Error, LocalizedError, CustomStringConvertible {
+        /// The queue database could not be opened. `reason` is the original
+        /// failure (path + underlying error) captured at construction time.
+        case unavailable(reason: String)
+
+        public var description: String {
+            switch self {
+            case .unavailable(let reason):
+                return "Queue unavailable: \(reason)"
+            }
+        }
+
+        public var errorDescription: String? { description }
+    }
+
+    /// The original open-failure reason (path + underlying error). Surfaced to
+    /// the user via the app-level alert in `WikiFSApp`.
+    public let reason: String
+
+    /// A finished event stream — no items are ever produced.
+    private let finishedStream: AsyncStream<QueueEvent>
+
+    public init(reason: String) {
+        self.reason = reason
+        // A finished stream: subscribers drain immediately with no events.
+        var continuation: AsyncStream<QueueEvent>.Continuation!
+        let stream = AsyncStream<QueueEvent> { c in
+            continuation = c
+        }
+        continuation.finish()
+        self.finishedStream = stream
+    }
+
+    // MARK: - QueueEngineClient conformance
+
+    public var events: AsyncStream<QueueEvent> { finishedStream }
+
+    @discardableResult
+    public func enqueue(_ request: QueueItemRequest) async throws -> QueueItem.ID {
+        throw Error.unavailable(reason: reason)
+    }
+
+    public func cancelItem(_ id: QueueItem.ID) async {}
+
+    @discardableResult
+    public func cancelAllInFlight() async -> Int { 0 }
+
+    public func retryItem(_ id: QueueItem.ID) async throws {
+        throw Error.unavailable(reason: reason)
+    }
+
+    public func pause(_ queue: QueueKind) async {}
+
+    public func resume(_ queue: QueueKind) async {}
+
+    public func halt(_ queue: QueueKind) async {}
+
+    public func reorderItem(id: QueueItem.ID, beforeItemID: QueueItem.ID?) async {}
+
+    public func snapshot() async -> QueueSnapshot { QueueSnapshot() }
+
+    public func hasActiveWork(for wikiID: String) async -> Bool { false }
+
+    public func waitForCompletion(of id: QueueItem.ID) async -> Result<Void, Swift.Error> {
+        .failure(Error.unavailable(reason: reason))
+    }
+
+    public func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] { [] }
+
+    public func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot] { [:] }
+}

--- a/Sources/WikiFSEngine/WikiSession.swift
+++ b/Sources/WikiFSEngine/WikiSession.swift
@@ -133,6 +133,13 @@ public final class WikiSession {
     /// DBs), and create the per-session launchers. If the store has no pages,
     /// seeds a Home page and wires it as the wiki's home page (#315).
     ///
+    /// - Throws: If the on-disk store cannot be opened (e.g. a corrupt DB the
+    ///   migration self-heal couldn't repair), the underlying `WikiStoreError`
+    ///   is rethrown. There is **no in-memory fallback** — the caller
+    ///   (`SessionManager`) records the error and surfaces a user-visible
+    ///   message so the user understands their data isn't gone, the file just
+    ///   couldn't be opened (issue #881).
+    ///
     /// - Parameters:
     ///   - wikiID: The wiki's ULID.
     ///   - descriptor: The registry descriptor (display name / home page).
@@ -158,7 +165,7 @@ public final class WikiSession {
         htmlBackendResolver: @escaping @MainActor () -> HtmlExtractionBackend? = { nil },
         podcastBackendResolver: @escaping @MainActor () -> PodcastTranscriptionBackend? = { nil },
         interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
-    ) {
+    ) throws {
         self.wikiID = wikiID
         self.extractionCoordinator = extractionCoordinator
         self.queueEngine = queueEngine
@@ -170,57 +177,38 @@ public final class WikiSession {
 
         let url = containerDirectory.appendingPathComponent("\(wikiID).sqlite", isDirectory: false)
         let model: WikiStoreModel
-        // Captured across both store-open branches (file-backed + in-memory
-        // fallback) so the Phase 1 Tantivy shadow service can read from the
+        // Captured so the Phase 1 Tantivy shadow service can read from the
         // same `WikiStore` the model wraps (the model keeps it `private`).
         var shadowStore: WikiStore?
-        do {
-            // `var`: the bus is set via the protocol's computed setter, which
-            // the compiler treats as mutating through the `WikiStore`
-            // existential.
-            var store = try makeStore(url)
-            // Attach the per-wiki event bus BEFORE the model is created, so the
-            // model's `.external`→reload subscription (in its init) sees it. The
-            // File Provider signaler and the change bridge subscribe to the
-            // same bus from the app layer. See `plans/event-bus.md`.
-            store.eventBus = WikiEventBus(wikiID: wikiID)
-            shadowStore = store
-            model = WikiStoreModel(store: store)
-            // Seed a Home page when the store is empty (mirrors
-            // `openActive` lines 334–341 + `createWiki`'s #315
-            // linkage: a freshly-seeded Home page becomes the wiki's home
-            // page when none is set yet).
-            if model.summaries.isEmpty, let homeID = model.newPage(title: "Home") {
-                if sessionDescriptor.homePageID == nil {
-                    sessionDescriptor.homePageID = homeID
-                }
+        // Open the on-disk store. There is NO in-memory fallback anymore
+        // (issue #881): a failure here is rethrown so `SessionManager` can
+        // surface a user-visible error instead of silently showing an empty
+        // wiki (which made users think their data was gone).
+        // `var`: the bus is set via the protocol's computed setter, which
+        // the compiler treats as mutating through the `WikiStore`
+        // existential.
+        var store = try makeStore(url)
+        // Attach the per-wiki event bus BEFORE the model is created, so the
+        // model's `.external`→reload subscription (in its init) sees it. The
+        // File Provider signaler and the change bridge subscribe to the
+        // same bus from the app layer. See `plans/event-bus.md`.
+        store.eventBus = WikiEventBus(wikiID: wikiID)
+        shadowStore = store
+        model = WikiStoreModel(store: store)
+        // Seed a Home page when the store is empty (mirrors
+        // `openActive` lines 334–341 + `createWiki`'s #315
+        // linkage: a freshly-seeded Home page becomes the wiki's home
+        // page when none is set yet).
+        if model.summaries.isEmpty, let homeID = model.newPage(title: "Home") {
+            if sessionDescriptor.homePageID == nil {
+                sessionDescriptor.homePageID = homeID
             }
-            // Off-main snapshot reads (debounced search) go through a
-            // read-only pool over the same file. Only for real file-backed
-            // DBs — a second connection to `:memory:` would see a different,
-            // empty database.
-            if FileManager.default.fileExists(atPath: url.path) {
-                model.readPool = WikiReadPool(databaseURL: url)
-            }
-        } catch {
-            // Opening the on-disk store failed (e.g. a corrupt DB the migration
-            // self-heal couldn't repair). Degrade to an ephemeral in-memory
-            // store so the app stays usable — the user sees an empty wiki rather
-            // than a crash, and the on-disk file is left untouched for recovery.
-            DebugLog.store("WikiSession: failed to open wiki \(wikiID), using in-memory: \(error)")
-            let memory: GRDBWikiStore
-            do {
-                memory = try GRDBWikiStore(databaseURL: URL(fileURLWithPath: ":memory:"))
-            } catch {
-                // A fresh in-memory store builds only the current schema (no
-                // ladder, no existing data), so this is unreachable in practice.
-                // If it ever fails the process is unrecoverable — surface an
-                // actionable message instead of an opaque `try!` trap.
-                fatalError("WikiSession: in-memory fallback store failed to open for wiki \(wikiID): \(error)")
-            }
-            memory.eventBus = WikiEventBus(wikiID: wikiID)
-            shadowStore = memory
-            model = WikiStoreModel(store: memory)
+        }
+        // Off-main snapshot reads (debounced search) go through a read-only
+        // pool over the same file. Only for real file-backed DBs — a second
+        // connection to an in-memory DB would see a different, empty database.
+        if FileManager.default.fileExists(atPath: url.path) {
+            model.readPool = WikiReadPool(databaseURL: url)
         }
         self.store = model
         self.descriptor = sessionDescriptor

--- a/Tests/WikiFSAppTests/PageDetailViewHostedTests.swift
+++ b/Tests/WikiFSAppTests/PageDetailViewHostedTests.swift
@@ -140,7 +140,7 @@ struct PageDetailViewHostedTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        return WikiSession(
+        return try WikiSession(
             wikiID: descriptor.id,
             descriptor: descriptor,
             containerDirectory: dir,

--- a/Tests/WikiFSAppTests/WikiChangeBridgeTests.swift
+++ b/Tests/WikiFSAppTests/WikiChangeBridgeTests.swift
@@ -32,13 +32,13 @@ struct WikiChangeBridgeTests {
     /// Helper: create a session for a wiki + return it.
     private func makeSession(
         wikiID: String, descriptor: WikiDescriptor, dir: URL
-    ) -> WikiSession {
+    ) throws -> WikiSession {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
         let queueEngine = try! makeTestQueueEngine()
         let provider = StubExtractionProvider()
-        return WikiSession(
+        return try WikiSession(
             wikiID: wikiID,
             descriptor: descriptor,
             containerDirectory: dir,
@@ -52,11 +52,11 @@ struct WikiChangeBridgeTests {
     /// the session's store received a `ResourceChangeEvent` — i.e. the store's
     /// `summaries` get rebuilt (a side effect of the bus subscription's
     /// reload path).
-    @Test func testFlushPokesSessionBusForMatchingWiki() async {
+    @Test func testFlushPokesSessionBusForMatchingWiki() async throws {
         let dir = tempDirectory()
         let registry = makeSeededRegistry(dir: dir)
         let descriptor = registry.wikis.first!
-        let session = makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
+        let session = try makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
 
         let fileProvider = FileProviderFacade()
         let bridge = WikiChangeBridge(registry: registry, fileProvider: fileProvider)
@@ -82,7 +82,7 @@ struct WikiChangeBridgeTests {
     /// Two sessions with the SAME wiki ID both get poked by flush (multi-window:
     /// a second window over the same wiki shares the session, but the lookup
     /// returns all matching sessions — verify the bridge iterates them all).
-    @Test func testFlushPokesAllMatchingSessions() async {
+    @Test func testFlushPokesAllMatchingSessions() async throws {
         let dir = tempDirectory()
         let registry = makeSeededRegistry(dir: dir)
         let descriptor = registry.wikis.first!
@@ -90,8 +90,8 @@ struct WikiChangeBridgeTests {
         // Two sessions for the SAME wiki ID (simulates two windows over one
         // wiki — in practice they share one session, but the bridge must
         // handle the lookup returning multiple).
-        let session1 = makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
-        let session2 = makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
+        let session1 = try makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
+        let session2 = try makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
 
         let fileProvider = FileProviderFacade()
         let bridge = WikiChangeBridge(registry: registry, fileProvider: fileProvider)
@@ -115,7 +115,7 @@ struct WikiChangeBridgeTests {
     }
 
     /// A session with a DIFFERENT wiki ID is not poked.
-    @Test func testFlushDoesNotPokeNonMatchingSessions() async {
+    @Test func testFlushDoesNotPokeNonMatchingSessions() async throws {
         let dir = tempDirectory()
         let registry = makeSeededRegistry(dir: dir)
         let descriptorA = registry.wikis.first!
@@ -125,8 +125,8 @@ struct WikiChangeBridgeTests {
         let urlB = dir.appendingPathComponent("\(descriptorB.id).sqlite", isDirectory: false)
         _ = try? GRDBWikiStore(databaseURL: urlB)
 
-        let sessionA = makeSession(wikiID: descriptorA.id, descriptor: descriptorA, dir: dir)
-        let sessionB = makeSession(wikiID: descriptorB.id, descriptor: descriptorB, dir: dir)
+        let sessionA = try makeSession(wikiID: descriptorA.id, descriptor: descriptorA, dir: dir)
+        let sessionB = try makeSession(wikiID: descriptorB.id, descriptor: descriptorB, dir: dir)
 
         let fileProvider = FileProviderFacade()
         let bridge = WikiChangeBridge(registry: registry, fileProvider: fileProvider)
@@ -151,11 +151,11 @@ struct WikiChangeBridgeTests {
     /// The bridge always signals the File Provider, even for a wiki with no
     /// matching session — the bridge should not crash and should not poke any
     /// bus (no matching sessions).
-    @Test func testFlushSignalsFileProviderForAnyWiki() async {
+    @Test func testFlushSignalsFileProviderForAnyWiki() async throws {
         let dir = tempDirectory()
         let registry = makeSeededRegistry(dir: dir)
         let descriptor = registry.wikis.first!
-        let session = makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
+        let session = try makeSession(wikiID: descriptor.id, descriptor: descriptor, dir: dir)
 
         let fileProvider = FileProviderFacade()
         let bridge = WikiChangeBridge(registry: registry, fileProvider: fileProvider)

--- a/Tests/WikiFSTests/SessionManagerTests.swift
+++ b/Tests/WikiFSTests/SessionManagerTests.swift
@@ -53,7 +53,7 @@ struct SessionManagerTests {
         let manager = makeSessionManager(dir: dir)
         let descriptor = registry.wikis.first!
 
-        let session = manager.session(for: descriptor.id, descriptor: descriptor)
+        let session = try! manager.session(for: descriptor.id, descriptor: descriptor)
 
         #expect(session.wikiID == descriptor.id)
         #expect(session.store.eventBus != nil)
@@ -67,8 +67,8 @@ struct SessionManagerTests {
         let manager = makeSessionManager(dir: dir)
         let descriptor = registry.wikis.first!
 
-        let session1 = manager.session(for: descriptor.id, descriptor: descriptor)
-        let session2 = manager.session(for: descriptor.id, descriptor: descriptor)
+        let session1 = try! manager.session(for: descriptor.id, descriptor: descriptor)
+        let session2 = try! manager.session(for: descriptor.id, descriptor: descriptor)
 
         // Two calls with the same wiki ID return the IDENTICAL instance.
         #expect(session1 === session2)
@@ -87,8 +87,8 @@ struct SessionManagerTests {
         let url2 = dir.appendingPathComponent("\(descriptor2.id).sqlite", isDirectory: false)
         _ = try? StoreBackend.current.makeStore(databaseURL: url2)
 
-        let session1 = manager.session(for: descriptor1.id, descriptor: descriptor1)
-        let session2 = manager.session(for: descriptor2.id, descriptor: descriptor2)
+        let session1 = try! manager.session(for: descriptor1.id, descriptor: descriptor1)
+        let session2 = try! manager.session(for: descriptor2.id, descriptor: descriptor2)
 
         // Different wiki IDs get distinct sessions.
         #expect(session1 !== session2)
@@ -105,7 +105,7 @@ struct SessionManagerTests {
         let manager = makeSessionManager(dir: dir)
         let descriptor = registry.wikis.first!
 
-        _ = manager.session(for: descriptor.id, descriptor: descriptor)
+        _ = try! manager.session(for: descriptor.id, descriptor: descriptor)
         #expect(manager.sessions[descriptor.id] != nil)
 
         manager.releaseSession(for: descriptor.id)
@@ -120,7 +120,7 @@ struct SessionManagerTests {
         let manager = makeSessionManager(dir: dir)
         let descriptor = registry.wikis.first!
 
-        let session = manager.session(for: descriptor.id, descriptor: descriptor)
+        let session = try! manager.session(for: descriptor.id, descriptor: descriptor)
         // releaseSession should call flushPendingSaves on the store before
         // removing — we can't easily observe the flush (no public dirty flag),
         // but we verify the session is gone and no crash occurs.
@@ -146,8 +146,8 @@ struct SessionManagerTests {
         let url2 = dir.appendingPathComponent("\(descriptor2.id).sqlite", isDirectory: false)
         _ = try? StoreBackend.current.makeStore(databaseURL: url2)
 
-        _ = manager.session(for: descriptor1.id, descriptor: descriptor1)
-        _ = manager.session(for: descriptor2.id, descriptor: descriptor2)
+        _ = try! manager.session(for: descriptor1.id, descriptor: descriptor1)
+        _ = try! manager.session(for: descriptor2.id, descriptor: descriptor2)
 
         // flushAllSessions should flush both sessions' pending saves without
         // removing them from the cache — no crash, sessions still present.
@@ -174,8 +174,8 @@ struct SessionManagerTests {
         let url2 = dir.appendingPathComponent("\(descriptor2.id).sqlite", isDirectory: false)
         _ = try? StoreBackend.current.makeStore(databaseURL: url2)
 
-        let session1 = manager.session(for: descriptor1.id, descriptor: descriptor1)
-        let session2 = manager.session(for: descriptor2.id, descriptor: descriptor2)
+        let session1 = try! manager.session(for: descriptor1.id, descriptor: descriptor1)
+        let session2 = try! manager.session(for: descriptor2.id, descriptor: descriptor2)
 
         // Two sessions have distinct GenerationGate instances.
         #expect(session1.generationGate !== session2.generationGate)
@@ -193,7 +193,7 @@ struct SessionManagerTests {
         let manager = makeSessionManager(dir: dir)
         let descriptor = registry.wikis.first!
 
-        let session = manager.session(for: descriptor.id, descriptor: descriptor)
+        let session = try! manager.session(for: descriptor.id, descriptor: descriptor)
 
         // No frontmost ID set yet → nil.
         #expect(manager.frontmostSession == nil)
@@ -247,7 +247,7 @@ struct SessionManagerTests {
         #expect(manager.pendingWikiLinks[descriptor.id] != nil)
 
         // Creating the session transfers the stash onto it.
-        let session = manager.session(for: descriptor.id, descriptor: descriptor)
+        let session = try! manager.session(for: descriptor.id, descriptor: descriptor)
 
         #expect(session.pendingWikiLink?.url == url)
         #expect(session.pendingWikiLink?.openInNewTab == true)
@@ -262,9 +262,122 @@ struct SessionManagerTests {
         let descriptor = registry.wikis.first!
 
         // No stash → the new session's pendingWikiLink is nil.
-        let session = manager.session(for: descriptor.id, descriptor: descriptor)
+        let session = try! manager.session(for: descriptor.id, descriptor: descriptor)
 
         #expect(session.pendingWikiLink == nil)
+    }
+
+    // MARK: - Store-open failure (issue #881 — no in-memory fallback)
+
+    /// When the on-disk store cannot be opened, `session(for:)` records a
+    /// user-visible error in `openErrors` and rethrows — no silent in-memory
+    /// fallback that would show an empty wiki.
+    @Test func testSessionOpenFailureRecordsErrorAndRethrows() {
+        let dir = tempDirectory()
+        let registry = makeSeededRegistry(dir: dir)
+        let descriptor = registry.wikis.first!
+
+        struct StoreOpenFailure: Error {}
+        // Inject a store factory that always throws — simulates a corrupt /
+        // unopenable DB without filesystem tricks.
+        let coordinator = ExtractionCoordinator(
+            containerDirectory: dir,
+            localExtractorFactory: { StubExtractor() })
+        let manager = SessionManager(
+            containerDirectory: dir,
+            extractionCoordinator: coordinator,
+            queueEngine: try! makeTestQueueEngine(),
+            extractionProvider: StubExtractionProvider(),
+            pdf2mdScriptPathResolver: { nil },
+            makeStore: { _ in throw StoreOpenFailure() })
+
+        #expect(throws: StoreOpenFailure.self) {
+            _ = try manager.session(for: descriptor.id, descriptor: descriptor)
+        }
+
+        // The error is recorded for the wiki so RootScene can render it.
+        #expect(manager.openError(for: descriptor.id) != nil)
+        // No session was cached.
+        #expect(manager.sessions[descriptor.id] == nil)
+    }
+
+    /// `clearOpenError(for:)` removes the recorded error so a Retry can attempt
+    /// a fresh open.
+    @Test func testClearOpenErrorRemovesRecordedError() {
+        let dir = tempDirectory()
+        let registry = makeSeededRegistry(dir: dir)
+        let descriptor = registry.wikis.first!
+
+        struct StoreOpenFailure: Error {}
+        let coordinator = ExtractionCoordinator(
+            containerDirectory: dir,
+            localExtractorFactory: { StubExtractor() })
+        let manager = SessionManager(
+            containerDirectory: dir,
+            extractionCoordinator: coordinator,
+            queueEngine: try! makeTestQueueEngine(),
+            extractionProvider: StubExtractionProvider(),
+            pdf2mdScriptPathResolver: { nil },
+            makeStore: { _ in throw StoreOpenFailure() })
+
+        #expect(throws: StoreOpenFailure.self) {
+            _ = try manager.session(for: descriptor.id, descriptor: descriptor)
+        }
+        #expect(manager.openError(for: descriptor.id) != nil)
+
+        manager.clearOpenError(for: descriptor.id)
+        #expect(manager.openError(for: descriptor.id) == nil)
+    }
+
+    /// A successful open after a prior failure clears the recorded error
+    /// (recovery path — Retry button → healthy DB).
+    @Test func testSuccessfulOpenClearsRecordedError() throws {
+        let dir = tempDirectory()
+        let registry = makeSeededRegistry(dir: dir)
+        let descriptor = registry.wikis.first!
+
+        struct StoreOpenFailure: Error {}
+        // First throw, then succeed on retry. `@unchecked Sendable` with an
+        // internal NSLock — the `makeStore` closure is `@Sendable`.
+        final class FailingToggle: @unchecked Sendable {
+            private let lock = NSLock()
+            private var shouldFail = true
+            /// Returns true the first time (consume the failure), then false.
+            func consume() -> Bool {
+                lock.withLock {
+                    if shouldFail { shouldFail = false; return true }
+                    return false
+                }
+            }
+        }
+        let toggle = FailingToggle()
+        let coordinator = ExtractionCoordinator(
+            containerDirectory: dir,
+            localExtractorFactory: { StubExtractor() })
+        let manager = SessionManager(
+            containerDirectory: dir,
+            extractionCoordinator: coordinator,
+            queueEngine: try! makeTestQueueEngine(),
+            extractionProvider: StubExtractionProvider(),
+            pdf2mdScriptPathResolver: { nil },
+            makeStore: { url in
+                if toggle.consume() { throw StoreOpenFailure() }
+                return try StoreBackend.current.makeStore(databaseURL: url)
+            })
+
+        // First attempt fails and records an error.
+        #expect(throws: StoreOpenFailure.self) {
+            _ = try manager.session(for: descriptor.id, descriptor: descriptor)
+        }
+        #expect(manager.openError(for: descriptor.id) != nil)
+
+        // Clear error (Retry button), then the next attempt succeeds.
+        manager.clearOpenError(for: descriptor.id)
+        let session = try manager.session(for: descriptor.id, descriptor: descriptor)
+        // A successful open clears any recorded error.
+        #expect(manager.openError(for: descriptor.id) == nil)
+        #expect(manager.sessions[descriptor.id] != nil)
+        #expect(session.wikiID == descriptor.id)
     }
 }
 

--- a/Tests/WikiFSTests/UnavailableQueueEngineTests.swift
+++ b/Tests/WikiFSTests/UnavailableQueueEngineTests.swift
@@ -1,0 +1,108 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// `UnavailableQueueEngine` tests (issue #881): when the local `queue.sqlite`
+/// cannot be opened, the app wires this engine in instead of silently falling
+/// back to an in-memory store. Enqueue/retry surface a clear error; reads
+/// return empty; the event stream finishes immediately.
+@Suite(.timeLimit(.minutes(2)))
+struct UnavailableQueueEngineTests {
+
+    private let reason = "queue.sqlite is missing (test)"
+
+    @Test func enqueueThrowsUnavailableError() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        let request = QueueItemRequest(
+            queue: .extraction,
+            wikiID: "wiki",
+            payload: QueueItemPayload(sourceIDs: [])
+        )
+        await #expect(throws: UnavailableQueueEngine.Error.self) {
+            _ = try await engine.enqueue(request)
+        }
+    }
+
+    @Test func retryItemThrowsUnavailableError() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        await #expect(throws: UnavailableQueueEngine.Error.self) {
+            try await engine.retryItem("some-item")
+        }
+    }
+
+    @Test func waitForCompletionReturnsFailure() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        let result = await engine.waitForCompletion(of: "some-item")
+        if case .failure(let error) = result {
+            #expect(error is UnavailableQueueEngine.Error)
+        } else {
+            Issue.record("expected .failure")
+        }
+    }
+
+    @Test func snapshotIsEmpty() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        let snapshot = await engine.snapshot()
+        #expect(snapshot.activeItems.isEmpty)
+        #expect(snapshot.recentItems.isEmpty)
+        #expect(snapshot.activeIngestionWikis.isEmpty)
+    }
+
+    @Test func hasActiveWorkIsFalse() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        let hasWork = await engine.hasActiveWork(for: "wiki")
+        #expect(hasWork == false)
+    }
+
+    @Test func cancelAndReorderAreNoOps() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        // These must not throw — they're idempotent no-ops.
+        await engine.cancelItem("item")
+        let n = await engine.cancelAllInFlight()
+        #expect(n == 0)
+        await engine.pause(.extraction)
+        await engine.resume(.extraction)
+        await engine.halt(.extraction)
+        await engine.reorderItem(id: "item", beforeItemID: nil)
+    }
+
+    @Test func readsReturnEmpty() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        #expect(await engine.loadTranscript(for: "item").isEmpty)
+        #expect(await engine.loadAllActivitySnapshots().isEmpty)
+    }
+
+    @Test func reasonIsExposedForUserVisibleError() {
+        let engine = UnavailableQueueEngine(reason: reason)
+        #expect(engine.reason == reason)
+    }
+
+    @Test func eventsStreamFinishesImmediately() async {
+        let engine = UnavailableQueueEngine(reason: reason)
+        // The stream should finish right away (no events produced).
+        let count = await taskCount(engine)
+        #expect(count == 0)
+    }
+
+    private func taskCount(_ engine: UnavailableQueueEngine) async -> Int {
+        var n = 0
+        for await _ in engine.events { n += 1 }
+        return n
+    }
+
+    @Test func conformsToQueueEngineClient() {
+        // Compile-time proof: UnavailableQueueEngine can be assigned to the
+        // existential protocol (mirrors QueueEngineClientConformanceTests).
+        let engine = UnavailableQueueEngine(reason: reason)
+        let client: any QueueEngineClient = engine
+        #expect(client is UnavailableQueueEngine)
+    }
+
+    @Test func errorDescriptionIncludesReason() {
+        let error = UnavailableQueueEngine.Error.unavailable(reason: reason)
+        #expect(String(describing: error).contains(reason))
+    }
+}
+#endif

--- a/Tests/WikiFSTests/WikiSessionTests.swift
+++ b/Tests/WikiFSTests/WikiSessionTests.swift
@@ -36,7 +36,7 @@ struct WikiSessionTests {
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
 
-        let session = WikiSession(
+        let session = try! WikiSession(
             wikiID: descriptor.id,
             descriptor: descriptor,
             containerDirectory: dir,
@@ -60,14 +60,14 @@ struct WikiSessionTests {
             containerDirectory: dirA,
             localExtractorFactory: { StubExtractor() })
 
-        let sessionA = WikiSession(
+        let sessionA = try! WikiSession(
             wikiID: registryA.wikis.first!.id,
             descriptor: registryA.wikis.first!,
             containerDirectory: dirA,
             extractionCoordinator: coordinator,
             queueEngine: try! makeTestQueueEngine(),
             extractionProvider: StubExtractionProvider())
-        let sessionB = WikiSession(
+        let sessionB = try! WikiSession(
             wikiID: registryB.wikis.first!.id,
             descriptor: registryB.wikis.first!,
             containerDirectory: dirB,
@@ -96,14 +96,14 @@ struct WikiSessionTests {
             containerDirectory: dirA,
             localExtractorFactory: { StubExtractor() })
 
-        let sessionA = WikiSession(
+        let sessionA = try! WikiSession(
             wikiID: registryA.wikis.first!.id,
             descriptor: registryA.wikis.first!,
             containerDirectory: dirA,
             extractionCoordinator: coordinator,
             queueEngine: try! makeTestQueueEngine(),
             extractionProvider: StubExtractionProvider())
-        let sessionB = WikiSession(
+        let sessionB = try! WikiSession(
             wikiID: registryB.wikis.first!.id,
             descriptor: registryB.wikis.first!,
             containerDirectory: dirB,
@@ -130,7 +130,7 @@ struct WikiSessionTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        let session = WikiSession(
+        let session = try! WikiSession(
             wikiID: registry.wikis.first!.id,
             descriptor: registry.wikis.first!,
             containerDirectory: dir,
@@ -155,7 +155,7 @@ struct WikiSessionTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        let session = WikiSession(
+        let session = try! WikiSession(
             wikiID: registry.wikis.first!.id,
             descriptor: registry.wikis.first!,
             containerDirectory: dir,
@@ -182,7 +182,7 @@ struct WikiSessionTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        let session = WikiSession(
+        let session = try! WikiSession(
             wikiID: registry.wikis.first!.id,
             descriptor: registry.wikis.first!,
             containerDirectory: dir,
@@ -194,6 +194,33 @@ struct WikiSessionTests {
         await session.upgradeSearchIndex()
         // The store still works — no crash, no hang.
         #expect(session.store.eventBus != nil)
+    }
+
+    // MARK: - Store-open failure (issue #881 — no in-memory fallback)
+
+    /// When the on-disk store cannot be opened, `WikiSession.init` MUST throw
+    /// instead of silently degrading to an in-memory store (the old behavior
+    /// showed an empty wiki and made users think their data was gone).
+    @Test func testInitThrowsWhenStoreOpenFails_NoInMemoryFallback() {
+        let dir = tempDirectory()
+        let registry = makeSeededRegistry(dir: dir)
+        let descriptor = registry.wikis.first!
+        let coordinator = ExtractionCoordinator(
+            containerDirectory: dir,
+            localExtractorFactory: { StubExtractor() })
+
+        struct StoreOpenFailure: Error {}
+        // `makeStore` always throws — simulates a corrupt / unopenable DB.
+        #expect(throws: StoreOpenFailure.self) {
+            _ = try WikiSession(
+                wikiID: descriptor.id,
+                descriptor: descriptor,
+                containerDirectory: dir,
+                extractionCoordinator: coordinator,
+                queueEngine: try! makeTestQueueEngine(),
+                extractionProvider: StubExtractionProvider(),
+                makeStore: { _ in throw StoreOpenFailure() })
+        }
     }
 }
 


### PR DESCRIPTION
# Fix: replace in-memory SQLite fallbacks with user-visible errors (#881)

Removes both production in-memory SQLite fallbacks. When a real `.sqlite` file can't be opened, the app now surfaces a **user-visible error** instead of silently degrading to an ephemeral DB.

## What changed

### 1. QueueStore — `WikiFSApp.makeLocalQueueEngine`
- **Before:** when `queue.sqlite` failed to open, it created `QueueStore(databaseURL: URL(fileURLWithPath: ":memory:"))` via `try!`. Every enqueued item was silently lost on restart; the user clicked Ingest, it "worked," then disappeared.
- **After:** constructs a new `UnavailableQueueEngine` (`QueueEngineClient`) so the app stays usable for browsing while ingest/extract throw a clear `UnavailableQueueEngine.Error`, and surfaces a **"Queue Database Unavailable"** alert at launch. No `:memory:` literal.

### 2. GRDBWikiStore — `WikiSession.init`
- **Before:** when a wiki's `.sqlite` failed to open, it fell back to `GRDBWikiStore(databaseURL: URL(fileURLWithPath: ":memory:"))`, silently showing an empty wiki that made users think their data was gone.
- **After:** `WikiSession.init` **throws**. `SessionManager` records the error in `openErrors`, and `RootScene` renders a **"Couldn't Open Wiki"** view (message + **Retry** + **Reveal Database**) instead of an empty wiki. The on-disk file is left untouched for recovery.

## No in-memory SQLite in production
No `":memory:"` literal remains in `Sources/`. In-memory SQLite now lives only in test code (`TestStoreFactory.inMemory()` / the `#if DEBUG` `GRDBWikiStore.init()`), which is untouched.

## API changes
- `WikiSession.init` and `SessionManager.session(for:)` are now **`throws`**.
- `SessionManager` gains `openErrors`, `openError(for:)`, `clearOpenError(for:)` (Retry path), and a `makeStore` injection seam (mirrors `WikiSession.makeStore`) for testability.

## Tests
Every new code path is covered:
- `WikiSessionTests.testInitThrowsWhenStoreOpenFails_NoInMemoryFallback` — init rethrows instead of degrading.
- `SessionManagerTests` — error recording + rethrow, `clearOpenError`, and recovery (successful open after failure clears the error).
- `UnavailableQueueEngineTests` — full surface: enqueue/retry throw, reads return empty, `events` finishes immediately, snapshot empty, conformance to `QueueEngineClient`.
- Existing call sites updated (`try` / `try!`).

## Verification
- `make prompts`, `make version`, `make keychain`, `swift build` ✅
- Affected suites pass: `WikiSessionTests`, `SessionManagerTests`, `UnavailableQueueEngineTests`, `WikiChangeBridgeTests`, `PageDetailViewHostedTests`, `QueueEngineClientConformanceTests` ✅
- Full `swift test`: 3870 tests, only pre-existing flaky daemon-XPC-timing failures (`DaemonHealthMonitorTests` — pass in isolation, unrelated to store/SQLite code).
