### PR TITLE
Fix: daemon connection startup race + retry on failure

### DIFF
--- a/Sources/WikiFS/Queue/DaemonHealthMonitor.swift
+++ b/Sources/WikiFS/Queue/DaemonHealthMonitor.swift
@@ -56,7 +56,16 @@ final class DaemonHealthMonitor {
     var healthPingInterval: Duration = .seconds(30)
 
     /// Health-check timeout passed to `WikiDaemonConnection.healthCheck`.
-    var healthCheckTimeout: TimeInterval = 5
+    /// 10 s — gives a freshly-bootstrapped daemon time to finish opening
+    /// SQLite + constructing its QueueEngine before we declare it unhealthy.
+    var healthCheckTimeout: TimeInterval = 10
+
+    /// Injectable connection factory used by the reconnect path. Defaults to
+    /// `WikiDaemonConnection.connect()` (launchd auto-launch). Tests override
+    /// this to return a mock/controlled connection.
+    var connectionFactory: @Sendable () throws -> WikiDaemonConnection = {
+        try WikiDaemonConnection.connect()
+    }
 
     private var connection: WikiDaemonConnection?
     private var healthPingTask: Task<Void, Never>?
@@ -74,8 +83,25 @@ final class DaemonHealthMonitor {
         isMonitoring = true
         setState(.connected)
         installInvalidationHandler(connection)
-        startHealthPings()
+        startHealthPings(delayFirstPing: true)
         DebugLog.store("wikid: DaemonHealthMonitor started — state=.connected")
+    }
+
+    /// Begin monitoring WITHOUT an active connection — the initial
+    /// `connectToDaemon()` attempt failed (the freshly-bootstrapped daemon
+    /// hadn't finished starting up). State stays `.disconnected`; the
+    /// health-ping loop attempts to reconnect on each tick (launchd
+    /// auto-launches the daemon), firing ``onReconnect`` when it succeeds.
+    /// The first attempt is immediate (no 30 s wait).
+    func startRetrying() {
+        stop()
+        self.connection = nil
+        isMonitoring = true
+        // State stays .disconnected — performHealthPing's reconnect branch
+        // fires onReconnect (not onDisconnect) when the daemon comes up.
+        setState(.disconnected)
+        startHealthPings(delayFirstPing: false)
+        DebugLog.store("wikid: DaemonHealthMonitor started in retry mode — awaiting daemon startup")
     }
 
     /// Stop monitoring (cancel the ping loop, clear the connection reference).
@@ -123,15 +149,17 @@ final class DaemonHealthMonitor {
 
     // MARK: - Recurring health ping (#878 BLOCKER 1.1)
 
-    private func startHealthPings() {
+    private func startHealthPings(delayFirstPing: Bool) {
         healthPingTask?.cancel()
         let interval = healthPingInterval
         let timeout = healthCheckTimeout
+        let initialDelay: Duration = delayFirstPing ? interval : .zero
         healthPingTask = Task { [weak self] in
+            try? await Task.sleep(for: initialDelay)
             while !Task.isCancelled {
-                try? await Task.sleep(for: interval)
                 guard !Task.isCancelled, let self else { break }
                 await self.performHealthPing(timeout: timeout)
+                try? await Task.sleep(for: interval)
             }
         }
     }
@@ -161,7 +189,7 @@ final class DaemonHealthMonitor {
         // daemon on the new NSXPCConnection).
         setState(.reconnecting)
         DebugLog.store("wikid: attempting reconnect via launchd auto-launch")
-        guard let newConn = try? WikiDaemonConnection.connect() else {
+        guard let newConn = try? connectionFactory() else {
             DebugLog.store("wikid: reconnect failed — still disconnected")
             setState(.disconnected)
             return

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -429,86 +429,113 @@ struct WikiFSApp: App {
     // MARK: - Daemon connection (#878 BLOCKER 2 — async, non-blocking)
 
     /// Attempt to connect to the wikid daemon after the first render. Called
-    /// from the main WindowGroup's `.task`. If the daemon is healthy, swaps the
-    /// queue engine router from the local fallback to the XPC proxy and starts
-    /// the health monitor. Never blocks the main thread.
+    /// from the main WindowGroup's `.task` (and the wiki WindowGroup's `.task`
+    /// as a fallback for state-restoration that opens only a wiki window).
+    ///
+    /// If the daemon is healthy, swaps the queue engine router from the local
+    /// fallback to the XPC proxy and starts the health monitor. If the daemon
+    /// isn't ready yet (the freshly-bootstrapped daemon is still starting up),
+    /// starts the health monitor in retry mode — it reconnects on its own and
+    /// fires `onReconnect` to swap to the XPC proxy once the daemon is up.
+    /// Never blocks the main thread.
     @MainActor
     private static var didConnectDaemon = false
+
+    /// The initial health-check timeout — longer than the monitor's recurring
+    /// ping timeout because a cold daemon start (process launch → open
+    /// queue.sqlite → construct QueueEngine → open first wiki → answer XPC)
+    /// can take several seconds on the first launch.
+    private static let initialHealthCheckTimeout: TimeInterval = 15
+
     @MainActor
     private func connectToDaemon() {
         guard !Self.didConnectDaemon else { return }
-        Self.didConnectDaemon = true
 
         let directory = containerDirectory
         guard let sessionBox = sessionLookupBox else { return }
         let fileProviderBoxValue = fileProviderBox
         let extractionProviderValue = extractionProvider
 
-        Task { [weak healthMonitor, weak queueEngineRouter] in
+        // Wire the monitor's reconnect/disconnect closures BEFORE the
+        // connection attempt. Whether the initial connect succeeds immediately
+        // or the monitor reconnects later via its retry loop, the closures are
+        // in place to swap the queue engine + register the event sink.
+        wireDaemonHealthMonitor(
+            directory: directory,
+            sessionBox: sessionBox,
+            fileProviderBox: fileProviderBoxValue,
+            extractionProvider: extractionProviderValue)
+
+        Task { [weak healthMonitor] in
             guard let conn = try? WikiDaemonConnection.connect() else {
-                DebugLog.store("WikiFSApp: daemon not available — staying on local QueueEngine")
+                DebugLog.store("WikiFSApp: daemon not available yet — starting retry loop")
+                await MainActor.run { healthMonitor?.startRetrying() }
                 return
             }
-            let healthy = await conn.healthCheck()
+            let healthy = await conn.healthCheck(timeout: Self.initialHealthCheckTimeout)
             guard healthy else {
-                DebugLog.store("WikiFSApp: daemon health check failed — staying on local QueueEngine")
+                DebugLog.store("WikiFSApp: daemon health check timed out (cold start) — starting retry loop")
                 conn.invalidate()
+                await MainActor.run { healthMonitor?.startRetrying() }
                 return
             }
 
+            // Success — mark as connected so future .task calls are no--ops.
+            Self.didConnectDaemon = true
             await MainActor.run {
                 DebugLog.store("WikiFSApp: connected to wikid daemon — swapping to XPC proxy")
-                do {
-                    let workloadClient = try DaemonWorkloadClient(connection: conn)
-                    let eventSink = DaemonQueueEventSink()
-                    workloadClient.registerEventSink(eventSink)
-                    let proxy = XPCQueueEngineProxy(
-                        workloadClient: workloadClient, eventSink: eventSink)
-                    queueEngineRouter?.swap(to: proxy)
-
-                    // Phase C4: the coordinator owns chat sessions over the
-                    // same connection + event sink.
-                    chatDaemonCoordinator = ChatDaemonCoordinator(
-                        client: workloadClient, eventSink: eventSink)
-
-                    // Wire the health monitor: on disconnect, swap back to a
-                    // fresh local engine; on reconnect, swap to a new XPC proxy.
-                    // WikiFSApp is a struct (value type), so there's no retain
-                    // cycle — the closures capture the router (a class ref)
-                    // and directory/box values by value.
-                    let router = queueEngineRouter
-                    healthMonitor?.onDisconnect = {
-                        DebugLog.store("WikiFSApp: daemon disconnected — falling back to local QueueEngine")
-                        let local = Self.makeLocalQueueEngine(
-                            directory: directory,
-                            sessionBox: sessionBox,
-                            fileProviderBox: fileProviderBoxValue,
-                            extractionProvider: extractionProviderValue)
-                        router?.swap(to: local)
-                        chatDaemonCoordinator = nil
-                    }
-                    healthMonitor?.onReconnect = { newConn in
-                        DebugLog.store("WikiFSApp: daemon reconnected — swapping back to XPC proxy")
-                        do {
-                            let workloadClient = try DaemonWorkloadClient(connection: newConn)
-                            let eventSink = DaemonQueueEventSink()
-                            workloadClient.registerEventSink(eventSink)
-                            let proxy = XPCQueueEngineProxy(
-                                workloadClient: workloadClient, eventSink: eventSink)
-                            router?.swap(to: proxy)
-                            chatDaemonCoordinator = ChatDaemonCoordinator(
-                                client: workloadClient, eventSink: eventSink)
-                        } catch {
-                            DebugLog.store("WikiFSApp: reconnect failed to create workload client: \(error)")
-                        }
-                    }
-
-                    healthMonitor?.start(connection: conn)
-                } catch {
-                    DebugLog.store("WikiFSApp: failed to create daemon workload client: \(error)")
-                    conn.invalidate()
-                }
+                activateDaemonConnection(conn)
+                healthMonitor?.start(connection: conn)
             }
+        }
+    }
+
+    /// Wire `DaemonHealthMonitor.onDisconnect` / `onReconnect`. Called once
+    /// before the initial connection attempt so the closures are in place
+    /// regardless of whether the daemon was immediately available. Both fire
+    /// on the main actor.
+    @MainActor
+    private func wireDaemonHealthMonitor(
+        directory: URL,
+        sessionBox: SessionLookupBox,
+        fileProviderBox: FileProviderBox,
+        extractionProvider: any QueueExtractionProvider
+    ) {
+        let router = queueEngineRouter
+        healthMonitor.onDisconnect = {
+            DebugLog.store("WikiFSApp: daemon disconnected — falling back to local QueueEngine")
+            let local = Self.makeLocalQueueEngine(
+                directory: directory,
+                sessionBox: sessionBox,
+                fileProviderBox: fileProviderBox,
+                extractionProvider: extractionProvider)
+            router?.swap(to: local)
+            chatDaemonCoordinator = nil
+        }
+        healthMonitor.onReconnect = { newConn in
+            DebugLog.store("WikiFSApp: daemon reconnected — swapping back to XPC proxy")
+            activateDaemonConnection(newConn)
+        }
+    }
+
+    /// Create the XPC proxy + event sink from a connection, swap the queue
+    /// engine router to it, and wire the chat daemon coordinator. Shared by
+    /// the initial connect success path and the `onReconnect` callback so
+    /// both go through the exact same setup.
+    @MainActor
+    private func activateDaemonConnection(_ conn: WikiDaemonConnection) {
+        do {
+            let workloadClient = try DaemonWorkloadClient(connection: conn)
+            let eventSink = DaemonQueueEventSink()
+            workloadClient.registerEventSink(eventSink)
+            let proxy = XPCQueueEngineProxy(
+                workloadClient: workloadClient, eventSink: eventSink)
+            queueEngineRouter?.swap(to: proxy)
+            chatDaemonCoordinator = ChatDaemonCoordinator(
+                client: workloadClient, eventSink: eventSink)
+        } catch {
+            DebugLog.store("WikiFSApp: failed to create daemon workload client: \(error)")
+            conn.invalidate()
         }
     }
 
@@ -676,6 +703,12 @@ struct WikiFSApp: App {
             .task {
                 bootstrapApp()
                 startStatusItem()
+                // Fallback: if macOS state restoration opens only a wiki window
+                // (the main window was closed last session), the main
+                // WindowGroup's .task never fires. connectToDaemon is
+                // idempotent (guarded by didConnectDaemon), so calling it here
+                // is a safe no-op when the main window already connected.
+                connectToDaemon()
             }
             // The presented value can arrive AFTER first render (state
             // restoration) or change in place (openWindow(value:) routing to

--- a/Tests/WikiFSAppTests/DaemonHealthMonitorTests.swift
+++ b/Tests/WikiFSAppTests/DaemonHealthMonitorTests.swift
@@ -124,6 +124,167 @@ struct DaemonHealthMonitorTests {
         // caused a transition). Let me be lenient.
         #expect(changeCount >= 1)
     }
+
+    // MARK: - startRetrying (#880 startup race: daemon not ready on first connect)
+
+    @Test func startRetryingSetsMonitoringAndStaysDisconnected() {
+        let monitor = DaemonHealthMonitor()
+        #expect(!monitor.isMonitoring)
+        #expect(monitor.state == .disconnected)
+
+        monitor.startRetrying()
+
+        #expect(monitor.isMonitoring)
+        #expect(monitor.state == .disconnected)
+
+        monitor.stop()
+    }
+
+    @Test func startRetryingDoesNotFireOnDisconnect() {
+        let monitor = DaemonHealthMonitor()
+
+        var disconnectFired = false
+        monitor.onDisconnect = { disconnectFired = true }
+
+        monitor.startRetrying()
+
+        // onDisconnect must NOT fire — the app is already on the local
+        // fallback QueueEngine. Only onReconnect should fire when the daemon
+        // eventually comes up.
+        #expect(!disconnectFired)
+
+        monitor.stop()
+    }
+
+    @Test func startRetryingStaysDisconnectedWhenFactoryThrows() async throws {
+        let monitor = DaemonHealthMonitor()
+        monitor.healthPingInterval = .milliseconds(10)
+        monitor.healthCheckTimeout = 0.5
+        monitor.connectionFactory = { throw WikiDaemonError.connectionFailed }
+
+        var reconnectFired = false
+        monitor.onReconnect = { _ in reconnectFired = true }
+
+        var sawReconnecting = false
+        monitor.onStateChange = { if $0 == .reconnecting { sawReconnecting = true } }
+
+        monitor.startRetrying()
+
+        // Wait for the immediate first ping + failed reconnect attempt.
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(monitor.state == .disconnected)
+        #expect(!reconnectFired)
+        // Seeing .reconnecting proves the ping loop ran and tried to connect.
+        #expect(sawReconnecting)
+
+        monitor.stop()
+    }
+
+    @Test func startRetryingFirstPingIsImmediate() async throws {
+        let monitor = DaemonHealthMonitor()
+        // Long interval — if the first ping were delayed by it, the probe
+        // would never be set within our 300 ms wait.
+        monitor.healthPingInterval = .seconds(60)
+        monitor.healthCheckTimeout = 0.5
+
+        let probe = FactoryCallProbe()
+        monitor.connectionFactory = {
+            probe.markCalled()
+            throw WikiDaemonError.connectionFailed
+        }
+
+        monitor.startRetrying()
+
+        // delayFirstPing: false means the ping loop pings immediately.
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(probe.wasCalled)
+
+        monitor.stop()
+    }
+
+    @Test func startRetryingReconnectsWhenDaemonBecomesHealthy() async throws {
+        // Verify the full retry → reconnect path when a healthy daemon is
+        // available. If the daemon isn't running, this test passes vacuously
+        // (the factory returns an unhealthy connection and we assert the
+        // disconnected state).
+        let probe = FactoryCallProbe()
+        let monitor = DaemonHealthMonitor()
+        monitor.healthPingInterval = .seconds(60) // one ping is enough
+        monitor.healthCheckTimeout = 3
+
+        // Try a real daemon connection for the factory. If the daemon is up,
+        // healthCheck passes and the monitor reconnects.
+        let conn = try #require(try? WikiDaemonConnection.connect())
+        let isHealthy = await conn.healthCheck(timeout: 2)
+
+        if isHealthy {
+            // Daemon is running — the factory returns a fresh healthy connection.
+            let freshConn = try WikiDaemonConnection.connect()
+            monitor.connectionFactory = {
+                probe.markCalled()
+                return freshConn
+            }
+
+            var reconnectFired = false
+            monitor.onReconnect = { _ in reconnectFired = true }
+
+            monitor.startRetrying()
+
+            // Wait for the immediate first ping + health check.
+            try? await Task.sleep(for: .milliseconds(500))
+
+            #expect(probe.wasCalled)
+            #expect(monitor.state == .connected)
+            #expect(reconnectFired)
+
+            monitor.stop()
+            freshConn.invalidate()
+        } else {
+            // Daemon not running — factory returns an invalidated connection.
+            conn.invalidate()
+            monitor.connectionFactory = {
+                probe.markCalled()
+                return conn
+            }
+
+            monitor.startRetrying()
+
+            try? await Task.sleep(for: .milliseconds(500))
+
+            #expect(probe.wasCalled)
+            #expect(monitor.state == .disconnected)
+
+            monitor.stop()
+        }
+    }
+
+    @Test func healthCheckTimeoutDefaultIsBumpedTo10() {
+        let monitor = DaemonHealthMonitor()
+        // The default was 5 (too tight for a cold daemon start). Bumped to 10
+        // so a reconnect ping gives the daemon time to finish starting up.
+        #expect(monitor.healthCheckTimeout == 10)
+    }
+
+    @Test func connectionFactoryIsInjectable() {
+        let monitor = DaemonHealthMonitor()
+
+        let probe = FactoryCallProbe()
+        monitor.connectionFactory = {
+            probe.markCalled()
+            throw WikiDaemonError.connectionFailed
+        }
+        _ = try? monitor.connectionFactory()
+        #expect(probe.wasCalled)
+    }
+}
+
+/// Test helper — records whether the connection factory was called.
+/// @unchecked Sendable is safe: all access is @MainActor in tests.
+private final class FactoryCallProbe: @unchecked Sendable {
+    private(set) var wasCalled = false
+    func markCalled() { wasCalled = true }
 }
 
 /// Tests for `WikiDaemonConnection` health-check + invalidation (#878).


### PR DESCRIPTION
## Problem

`bootoutAndBootstrap()` kills and restarts the daemon on launch, but `connectToDaemon()` immediately fires a 5s health check that times out before the daemon finishes starting up. The early return + `didConnectDaemon = true` permanently prevented any retry — `registerEventSink` was never called, the daemon had zero event sinks, and the app was stuck on the local fallback QueueEngine with events never flowing.

## Root cause

1. App calls `bootoutAndBootstrap()` on launch — kills and restarts the daemon
2. `connectToDaemon()` calls `healthCheck(timeout: 5)` immediately
3. Daemon still starting up (QueueEngine construction, SQLite open) — 5s timeout expires
4. `connectToDaemon()` returns early — no retry
5. `didConnectDaemon = true` prevents any future connection attempt
6. `registerEventSink` never called — daemon has zero event sinks

## Fix

### DaemonHealthMonitor
- **`startRetrying()`** — new lifecycle method that starts the ping loop WITHOUT an active connection. State stays `.disconnected`; the ping loop attempts reconnection on each tick via launchd auto-launch, firing `onReconnect` when the daemon responds. The first attempt is immediate (`delayFirstPing: false`) — no 30s wait.
- **`connectionFactory`** — injectable connection factory (defaults to `WikiDaemonConnection.connect()`) so the reconnect path is testable.
- **`healthCheckTimeout`** bumped from 5s → 10s for recurring reconnect pings.
- **`startHealthPings(delayFirstPing:)`** — restructured to support an immediate first ping (retry mode) vs delayed first ping (normal connected mode).

### WikiFSApp.connectToDaemon()
- **Retry on failure** — on connect failure or health-check timeout, calls `healthMonitor.startRetrying()` instead of returning silently.
- **`didConnectDaemon` only on success** — no longer set at the start of the attempt, so future `.task` calls can retry.
- **Closures wired before connect** — `onDisconnect`/`onReconnect` extracted to `wireDaemonHealthMonitor()`, called before the connection attempt so they're in place regardless of outcome.
- **`activateDaemonConnection()`** — extracted shared setup for the initial success path and `onReconnect` callback (creates workload client, registers event sink, swaps engine, sets chat coordinator).
- **15s initial timeout** — cold daemon start needs more time than the recurring 10s ping.

### Wiki WindowGroup `.task`
- Added `connectToDaemon()` as a fallback for macOS state restoration that opens only a wiki window (main window was closed last session). Idempotent — guarded by `didConnectDaemon`.

## Tests

7 new tests in `DaemonHealthMonitorTests`:
- `startRetryingSetsMonitoringAndStaysDisconnected` — basic state machine
- `startRetryingDoesNotFireOnDisconnect` — no spurious disconnect callback
- `startRetryingStaysDisconnectedWhenFactoryThrows` — factory failure path
- `startRetryingFirstPingIsImmediate` — proves `delayFirstPing: false` works
- `startRetryingReconnectsWhenDaemonBecomesHealthy` — full retry → reconnect path (gracefully handles daemon-not-running)
- `healthCheckTimeoutDefaultIsBumpedTo10` — regression guard on the timeout bump
- `connectionFactoryIsInjectable` — factory injection works

Fixes #880.
