### PR TITLE
Fix wikid daemon ingestion broken by XPC-service migration (#887)

### DIFF
--- a/Sources/WikiFSCore/Core/HelpersLocation.swift
+++ b/Sources/WikiFSCore/Core/HelpersLocation.swift
@@ -27,6 +27,24 @@ public enum HelpersLocation {
         return bundleHelpersDirectory().path
     }
 
+    /// Resolve a named helper binary (`bun`, `uv`, `wikictl`, …) bundled in the
+    /// app's `Contents/Helpers`, searching the same candidate directories as
+    /// ``wikictlDirectory``. Returns the absolute path if it exists and is
+    /// executable, or `nil` if no candidate holds it.
+    ///
+    /// This is the single source of truth for "find a bundled helper" — it is
+    /// XPC-service-aware (see ``bundleHelpersDirectory()``), so both the app and
+    /// the `wikid.xpc` daemon resolve to the SAME `App.app/Contents/Helpers`.
+    public static func bundledHelperPath(_ name: String) -> String? {
+        for candidate in candidateDirectories() {
+            let binary = candidate.appendingPathComponent(name, isDirectory: false)
+            if FileManager.default.isExecutableFile(atPath: binary.path) {
+                return binary.path
+            }
+        }
+        return nil
+    }
+
     private static func candidateDirectories() -> [URL] {
         var directories: [URL] = []
         // 1. The signed app bundle's Contents/Helpers (production).
@@ -41,9 +59,39 @@ public enum HelpersLocation {
         return directories
     }
 
+    /// The enclosing app bundle's `Contents/Helpers` directory.
+    ///
+    /// `build.sh` copies every helper (bun, uv, wikictl, …) into the OUTER app's
+    /// `Contents/Helpers`. But when the running process is a nested bundle —
+    /// notably the `wikid` daemon, now shipped as a bundled XPC service at
+    /// `App.app/Contents/XPCServices/wikid.xpc` (#887) — `Bundle.main` is the
+    /// `.xpc`, so a naive `Bundle.main.bundleURL/Contents/Helpers` points at
+    /// `wikid.xpc/Contents/Helpers`, which does not exist. That silently broke
+    /// bun/wikictl resolution in the daemon (ACP ingestion → "bun was not found
+    /// on your PATH"). Walk up to the enclosing `.app` so nested bundles resolve
+    /// to the app-level Helpers; fall back to `Bundle.main` for a `swift run`
+    /// CLI with no `.app` ancestor (candidateDirectories covers that case).
     private static func bundleHelpersDirectory() -> URL {
-        Bundle.main.bundleURL
+        let base = enclosingAppBundleURL(from: Bundle.main.bundleURL) ?? Bundle.main.bundleURL
+        return base
             .appendingPathComponent("Contents", isDirectory: true)
             .appendingPathComponent("Helpers", isDirectory: true)
+    }
+
+    /// Nearest ancestor (or self) of `bundleURL` whose path component ends in
+    /// `.app`, or `nil` when the process isn't running from inside a `.app`
+    /// bundle (e.g. a `swift run` CLI launched from `.build/debug/`).
+    ///
+    /// Pure (takes the URL rather than reading `Bundle.main`) so the XPC-service
+    /// nesting case can be unit-tested without an actual bundle.
+    static func enclosingAppBundleURL(from bundleURL: URL) -> URL? {
+        var url = bundleURL
+        for _ in 0..<8 {
+            if url.pathExtension == "app" { return url }
+            let parent = url.deletingLastPathComponent()
+            if parent.path == url.path { break }   // reached filesystem root
+            url = parent
+        }
+        return nil
     }
 }

--- a/Sources/WikiFSCore/Core/WikiIdentifiers.swift
+++ b/Sources/WikiFSCore/Core/WikiIdentifiers.swift
@@ -96,23 +96,52 @@ public enum WikiIdentifiers {
     /// file is absent — i.e. for the `.app`/`.appex` (which use the Info.plist
     /// path) and for plain test runs.
     ///
-    /// Two locations are checked, in order, relative to the running executable:
+    /// Locations checked, in order, relative to the running executable:
     /// `build/wikictl` reads it from its own directory (the Phase A gate copy);
     /// the bundled `Contents/Helpers/wikictl` reads it from `../Resources`
-    /// (build.sh can't leave plain files in the code-only Helpers dir).
+    /// (build.sh can't leave plain files in the code-only Helpers dir); and the
+    /// **enclosing `.app`'s `Contents/Resources`** — required by the `wikid`
+    /// daemon, which as a bundled XPC service
+    /// (`…/App.app/Contents/XPCServices/wikid.xpc`) has its executable four
+    /// levels below the app's Resources. Without that third candidate the daemon
+    /// finds NO sidecar (its own `.xpc/Contents/Resources` is empty) and — since
+    /// a nested XPC service's `Bundle.main` Info.plist custom keys don't reliably
+    /// surface either — falls through to the `group.org.sockpuppet.wiki` default,
+    /// reading the WRONG App Group container (empty registry → "No store for
+    /// wikiID" at ingest, and a stale 1-provider agent config). #887 follow-up.
     private static let sidecar: [String: String] = {
         guard let exeDir = executableDir else { return [:] }
-        let candidates = [
+        var candidates = [
             exeDir.appendingPathComponent("wiki-identifiers.env"),
             exeDir.deletingLastPathComponent()
                 .appendingPathComponent("Resources/wiki-identifiers.env"),
         ]
+        if let appResources = enclosingAppResourcesDirectory(from: exeDir) {
+            candidates.append(appResources.appendingPathComponent("wiki-identifiers.env"))
+        }
         guard let text = candidates.lazy
             .compactMap({ try? String(contentsOf: $0, encoding: .utf8) })
             .first
         else { return [:] }
         return parseKV(text)
     }()
+
+    /// `<enclosing .app>/Contents/Resources`, found by walking up from `exeDir`
+    /// to the nearest ancestor whose path component ends in `.app`, or `nil` if
+    /// the executable isn't inside a `.app` (e.g. a `swift run` dev CLI). Lets a
+    /// nested bundle (the `wikid.xpc` daemon) read the app-level id sidecar.
+    static func enclosingAppResourcesDirectory(from exeDir: URL) -> URL? {
+        var url = exeDir
+        for _ in 0..<8 {
+            if url.pathExtension == "app" {
+                return url.appendingPathComponent("Contents/Resources", isDirectory: true)
+            }
+            let parent = url.deletingLastPathComponent()
+            if parent.path == url.path { break }   // reached filesystem root
+            url = parent
+        }
+        return nil
+    }
 
     /// `signing/local.config` (gitignored, per-developer) parsed once — the SAME
     /// file `build.sh` reads to build the `.app`. Keys are the build.sh names

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -2642,21 +2642,19 @@ public final class AgentLauncher {
         DebugLog.agent("captureInteractiveUsage: emitted delta in=\(delta.inputTokens) out=\(delta.outputTokens) cost=\(delta.cost ?? 0) model=\(delta.modelId ?? "nil") provider=\(delta.providerLabel ?? "nil") (cumulative session in=\(enriched.inputTokens) out=\(enriched.outputTokens))")
     }
 
-    /// Resolve the path to a binary bundled in `Contents/Helpers/`, or nil if
-    /// not present or not executable.
+    /// Resolve the path to a binary bundled in the app's `Contents/Helpers/`, or
+    /// nil if not present or not executable.
     ///
     /// `Bundle.url(forAuxiliaryExecutable:)` does NOT search `Contents/Helpers/`
-    /// (it only looks in `Contents/MacOS/` and `Contents/Resources/`), so we
-    /// construct the path manually. This is the fix for "bun not found on your
-    /// path" — bun was correctly bundled in Helpers but the old API call never
-    /// found it.
+    /// (it only looks in `Contents/MacOS/` and `Contents/Resources/`), so this
+    /// is resolved manually via ``HelpersLocation``. Delegating there is what
+    /// makes it XPC-service-aware: the `wikid` daemon (a bundled XPC service,
+    /// #887) has `Bundle.main` = `wikid.xpc`, so resolving Helpers relative to
+    /// `Bundle.main` looked inside the `.xpc` (no bun there) and ACP ingestion
+    /// failed with "bun was not found on your PATH". `HelpersLocation` walks up
+    /// to the enclosing `.app` so the app and the daemon share one Helpers dir.
     public static nonisolated func bundledHelperPath(_ name: String) -> String? {
-        let path = Bundle.main.bundleURL
-            .appendingPathComponent("Contents")
-            .appendingPathComponent("Helpers")
-            .appendingPathComponent(name)
-            .path
-        return FileManager.default.isExecutableFile(atPath: path) ? path : nil
+        HelpersLocation.bundledHelperPath(name)
     }
 
     /// A quick readiness probe for an agent provider — checks whether

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -414,13 +414,25 @@ private struct SendableBoolReply: @unchecked Sendable {
 
 // MARK: - Main
 
-// Resolve the App Group container path. As a bundled XPC service WITH the
-// `application-groups` entitlement + embedded provisioning profile, the daemon
-// can access `~/Library/Group Containers/<id>/` directly via
-// DatabaseLocation.appGroupContainerDirectory() without TCC prompts (same as
-// the app). For ad-hoc / dev builds without a provisioning profile, accept the
-// container path from (1) a --container arg, or (2) the WIKI_CONTAINER_DIR env
-// var (set by `make install-daemon` in dev mode) as a fallback.
+// Resolve the App Group container path. The daemon reaches the SHARED group
+// container through the security API —
+// `containerURL(forSecurityApplicationGroupIdentifier:)`, via
+// `DatabaseLocation.extensionContainerDirectory()` — which the
+// `application-groups` entitlement maps to the real
+// `~/Library/Group Containers/<id>/` the app writes to. This is robust whether
+// or not the daemon is sandboxed.
+//
+// History (#887): the XPC migration briefly sandboxed the daemon AND resolved
+// the container via `appGroupContainerDirectory()`, whose LITERAL
+// `homeDirectoryForCurrentUser/Library/Group Containers/<id>` path resolves to
+// the SANDBOX home inside a sandbox — an empty sandbox-local dir with no
+// `wikis.json` → every ingest failed "No store for wikiID". The daemon is now
+// un-sandboxed (it must spawn arbitrary agent CLIs), but the security-API
+// resolution is kept as the explicit, correct way to reach the shared container.
+//
+// Precedence: (1) a `--container` arg or (2) `WIKI_CONTAINER_DIR` env (dev, set
+// by `make install-daemon`), then (3) the security-API shared container, then
+// (4) the literal path as a last resort (dev build with no app-group entitlement).
 let containerDirectory: URL
 if let argPath = CommandLine.arguments.dropFirst().first(where: { !$0.hasPrefix("-") }),
    FileManager.default.fileExists(atPath: argPath) {
@@ -428,9 +440,21 @@ if let argPath = CommandLine.arguments.dropFirst().first(where: { !$0.hasPrefix(
 } else if let envPath = ProcessInfo.processInfo.environment["WIKI_CONTAINER_DIR"],
           FileManager.default.fileExists(atPath: envPath) {
     containerDirectory = URL(fileURLWithPath: envPath, isDirectory: true)
+} else if let shared = DatabaseLocation.extensionContainerDirectory() {
+    containerDirectory = shared
 } else {
     containerDirectory = try DatabaseLocation.appGroupContainerDirectory()
 }
+
+// Diagnostic: log the RESOLVED App Group id + container the daemon will use.
+// The group id comes from `WikiIdentifiers.appGroupID` (read from the id sidecar
+// bundled in the daemon's own Contents/Resources). If that sidecar is missing,
+// resolution falls back to the `group.org.sockpuppet.wiki` default → a container
+// with NO wikis → "No store for wikiID" at ingest. This line is the fastest way
+// to see that mismatch: grep for `appGroup=` and confirm it matches the app's
+// real group, and `container=` points at ~/Library/Group Containers (not a
+// sandbox-local path). (#887.)
+DebugLog.store("wikid: resolved appGroup=\(WikiIdentifiers.appGroupID) container=\(containerDirectory.path)")
 
 let daemon = WikiDaemon(containerDirectory: containerDirectory)
 

--- a/Tests/WikiFSTests/HelpersLocationTests.swift
+++ b/Tests/WikiFSTests/HelpersLocationTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Regression tests for `HelpersLocation` bundle resolution.
+///
+/// The `wikid` daemon shipped as a bundled XPC service (#887), which changed
+/// its `Bundle.main` from the app bundle to `…/App.app/Contents/XPCServices/
+/// wikid.xpc`. A naive `Bundle.main.bundleURL/Contents/Helpers` then resolved
+/// to `wikid.xpc/Contents/Helpers` — where `build.sh` copies NO helpers — so
+/// bun/wikictl were unresolvable in the daemon and ACP ingestion failed with
+/// "‘bun’ was not found on your PATH". `enclosingAppBundleURL(from:)` walks up
+/// to the enclosing `.app` so nested bundles share the app-level Helpers dir.
+struct HelpersLocationTests {
+
+    @Test func enclosingApp_fromXPCService_walksUpToApp() {
+        // The exact nesting the XPC-service migration introduced.
+        let xpc = URL(fileURLWithPath:
+            "/Applications/Self Driving Wiki.app/Contents/XPCServices/wikid.xpc")
+        let app = HelpersLocation.enclosingAppBundleURL(from: xpc)
+        #expect(app?.path == "/Applications/Self Driving Wiki.app")
+    }
+
+    @Test func enclosingApp_fromAppBundle_returnsItself() {
+        // The main app process: Bundle.main IS the .app — behavior unchanged.
+        let app = URL(fileURLWithPath: "/Applications/Self Driving Wiki.app")
+        #expect(HelpersLocation.enclosingAppBundleURL(from: app)?.path
+                == "/Applications/Self Driving Wiki.app")
+    }
+
+    @Test func enclosingApp_fromAppExtension_walksUpToApp() {
+        // The File Provider extension nests one level deeper under PlugIns.
+        let appex = URL(fileURLWithPath:
+            "/Applications/Self Driving Wiki.app/Contents/PlugIns/WikiFSFileProvider.appex")
+        #expect(HelpersLocation.enclosingAppBundleURL(from: appex)?.path
+                == "/Applications/Self Driving Wiki.app")
+    }
+
+    @Test func enclosingApp_fromDevBuildDir_returnsNil() {
+        // `swift run` from `.build/debug/` has no `.app` ancestor — the caller
+        // falls back to Bundle.main / the executable-dir candidate.
+        let dev = URL(fileURLWithPath:
+            "/Users/dev/project/.build/debug")
+        #expect(HelpersLocation.enclosingAppBundleURL(from: dev) == nil)
+    }
+}

--- a/Tests/WikiFSTests/WikiIdentifiersSidecarTests.swift
+++ b/Tests/WikiFSTests/WikiIdentifiersSidecarTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Regression tests for `WikiIdentifiers`' enclosing-app sidecar resolution.
+///
+/// The `wikid` daemon is a bundled XPC service whose executable lives at
+/// `App.app/Contents/XPCServices/wikid.xpc/Contents/MacOS/wikid` — four levels
+/// below `App.app/Contents/Resources`, where `build.sh` writes the
+/// `wiki-identifiers.env` id sidecar. With only the two exe-relative candidates
+/// the daemon found no sidecar and (a nested XPC service's Bundle.main Info.plist
+/// custom keys not surfacing reliably) fell through to the
+/// `group.org.sockpuppet.wiki` default → wrong App Group container → "No store
+/// for wikiID" at ingest. `enclosingAppResourcesDirectory(from:)` walks up to the
+/// enclosing `.app` so the daemon reads the app-level sidecar. #887 follow-up.
+struct WikiIdentifiersSidecarTests {
+
+    @Test func daemonExe_resolvesEnclosingAppResources() {
+        let exe = URL(fileURLWithPath:
+            "/Applications/Self Driving Wiki.app/Contents/XPCServices/wikid.xpc/Contents/MacOS")
+        let res = WikiIdentifiers.enclosingAppResourcesDirectory(from: exe)
+        #expect(res?.path == "/Applications/Self Driving Wiki.app/Contents/Resources")
+    }
+
+    @Test func appExe_resolvesOwnResources() {
+        let exe = URL(fileURLWithPath:
+            "/Applications/Self Driving Wiki.app/Contents/MacOS")
+        let res = WikiIdentifiers.enclosingAppResourcesDirectory(from: exe)
+        #expect(res?.path == "/Applications/Self Driving Wiki.app/Contents/Resources")
+    }
+
+    @Test func appexExe_resolvesEnclosingAppResources() {
+        let exe = URL(fileURLWithPath:
+            "/Applications/Self Driving Wiki.app/Contents/PlugIns/WikiFSFileProvider.appex/Contents/MacOS")
+        let res = WikiIdentifiers.enclosingAppResourcesDirectory(from: exe)
+        #expect(res?.path == "/Applications/Self Driving Wiki.app/Contents/Resources")
+    }
+
+    @Test func devBuildExe_returnsNil() {
+        // `swift run` / `.build/debug/wikid` — no `.app` ancestor.
+        let exe = URL(fileURLWithPath: "/Users/dev/project/.build/debug")
+        #expect(WikiIdentifiers.enclosingAppResourcesDirectory(from: exe) == nil)
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -231,6 +231,17 @@ EOF
 }
 write_id_sidecar "${RESOURCES_DIR}"
 write_id_sidecar "${BUILD_DIR}"
+# The wikid daemon is a SANDBOXED bundled XPC service. It cannot read the outer
+# app's Contents/Resources sidecar (outside its sandbox container), and a nested
+# XPC service's Bundle.main custom Info.plist keys don't surface reliably — so
+# without a sidecar it falls through to the group.org.sockpuppet.wiki default and
+# reads the WRONG App Group container (empty registry → "No store for wikiID" at
+# ingest; stale 1-provider agent config). Drop the sidecar into the daemon's OWN
+# Contents/Resources, which it can always read; WikiIdentifiers resolves it via
+# its executable's ../Resources candidate. MUST be written BEFORE `codesign
+# wikid.xpc` so it's sealed into the daemon bundle. (#887 follow-up.)
+mkdir -p "${DAEMON_XPC_CONTENTS}/Resources"
+write_id_sidecar "${DAEMON_XPC_CONTENTS}/Resources"
 # Bundle the pdf2md PEP 723 script alongside wikictl so PdfExtractionService
 # can spawn it at ingest time.
 if [ -f "${PDF2MD_SRC}" ]; then
@@ -416,9 +427,9 @@ PLIST
 # Application launches ONE instance per connecting app and ties its lifetime
 # to that app — the service terminates when the app exits (or on idle). This
 # is what we want: the daemon must NOT survive app quit. NOTE: ServiceType
-# controls instancing/lifetime, NOT sandboxing — confinement comes purely from
-# the `com.apple.security.app-sandbox` entitlement in the generated
-# DAEMON_ENTITLEMENTS below. This is a SANDBOXED service.
+# controls instancing/lifetime only. The daemon runs UN-sandboxed (see
+# DAEMON_ENTITLEMENTS below — no com.apple.security.app-sandbox) because it must
+# spawn user-configured agent CLIs at arbitrary paths, which App Sandbox forbids.
 cat > "${DAEMON_XPC_CONTENTS}/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -432,6 +443,14 @@ cat > "${DAEMON_XPC_CONTENTS}/Info.plist" <<PLIST
 	<key>CFBundleVersion</key><string>${BUILD_VERSION}</string>
 	<key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
 	<key>LSMinimumSystemVersion</key><string>${MIN_MACOS}</string>
+	<!-- App Group / File Provider ids, read by WikiIdentifiers via -->
+	<!-- Bundle.main.object(forInfoDictionaryKey:). MUST match the app + -->
+	<!-- appex plists (lines ~351/409) — as a bundled XPC service the -->
+	<!-- daemon's Bundle.main is wikid.xpc, so without these it falls -->
+	<!-- through to the group.org.sockpuppet.wiki default and reads the -->
+	<!-- WRONG App Group container ("No store for wikiID …" at ingest). -->
+	<key>WIKIAppGroupID</key><string>${APP_GROUP}</string>
+	<key>WIKIFileProviderID</key><string>${EXT_BUNDLE_ID}</string>
 	<key>XPCService</key>
 	<dict>
 		<key>ServiceType</key>
@@ -537,20 +556,20 @@ PLIST
 	<string>${TEAM_ID}.${DAEMON_BUNDLE_ID}</string>
 	<key>com.apple.developer.team-identifier</key>
 	<string>${TEAM_ID}</string>
-	<!-- SANDBOXED XPC service. Unlike the main app (which runs un-sandboxed),
-	     the daemon is confined by App Sandbox: it reaches the shared SQLite DB
-	     ONLY through the App Group container (application-groups) and the shared
-	     secrets ONLY through the keychain access group. The sandbox entitlement
-	     REQUIRES the daemon provisioning profile to authorize it (${DAEMON_PROFILE});
-	     the ad-hoc fallback below cannot carry it, so ad-hoc dev builds run
-	     UN-sandboxed. -->
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<!-- The daemon runs the agent-execution engine (ACP backends, chat,
-	     extraction) which talks to LLM APIs + fetches URLs — sandboxed
-	     processes have no network by default. -->
-	<key>com.apple.security.network.client</key>
-	<true/>
+	<!-- UN-sandboxed, like the main app. The daemon's core job is spawning
+	     USER-CONFIGURED agent CLIs (claude-acp via the bundled bun, opencode from
+	     Homebrew, custom provider binaries) that live at arbitrary paths anywhere
+	     on the system. App Sandbox confines a process to its own .xpc bundle +
+	     container, so a sandboxed daemon can execute NONE of them (not even the
+	     bundled bun, which lives in the app bundle outside the .xpc) → ingestion
+	     is impossible. It also can't reach the SHARED App Group container: inside
+	     the sandbox `homeDirectoryForCurrentUser` is the sandbox home, so the
+	     literal container path lands in an empty sandbox-local dir with no wikis
+	     ("No store for wikiID"). Un-sandboxing restores both. This reverts the
+	     app-sandbox that the #887 XPC migration added; the daemon still reaches
+	     the shared DB via the App Group container and secrets via the keychain
+	     access group — same boundaries the un-sandboxed app already uses.
+	     `com.apple.security.app-sandbox` is intentionally ABSENT. -->
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>${APP_GROUP}</string>


### PR DESCRIPTION
## Summary

The bundled XPC-service migration (#887) left the `wikid` daemon unable to run **any** ingestion. Symptoms surfaced in sequence as each layer was fixed:

1. `'bun' was not found on your PATH`
2. `No store for wikiID=…`
3. selected provider `NOT READY` / can't launch any agent CLI

Root cause was a chain of **nested-bundle + sandbox path-resolution** bugs: a `wikid.xpc`'s `Bundle.main` is the `.xpc` (not the app), and the migration also **sandboxed** the daemon — which is fundamentally incompatible with its job of spawning user-configured agent CLIs.

## Fixes

| Area | Change |
|------|--------|
| **Bundled helpers** (`HelpersLocation.swift`) | Resolve `bun`/`wikictl`/… relative to the enclosing `.app`, not `Bundle.main` (the `.xpc`'s `Contents/Helpers` is empty). `AgentLauncher.bundledHelperPath` delegates here. |
| **App Group id** (`build.sh`, `WikiIdentifiers.swift`) | Daemon fell through to the `group.org.sockpuppet.wiki` default (nested-XPC `Bundle.main` Info.plist keys don't surface reliably; a sandboxed daemon can't read the app-level id sidecar). Now the `wiki-identifiers.env` sidecar is written into the daemon's **own** `Contents/Resources`, and `WikiIdentifiers` also checks the enclosing `.app`'s Resources. |
| **Container** (`wikid/main.swift`) | Daemon read the shared container via the LITERAL `$HOME/…` path → inside a sandbox that's the sandbox home → empty sandbox-local dir with no wikis (`No store for wikiID`). Now resolves via the security API (`containerURL(forSecurityApplicationGroupIdentifier:)`). |
| **Un-sandbox the daemon** (`build.sh` entitlements) | The daemon must spawn agent CLIs at arbitrary paths (opencode, bundled bun, custom); App Sandbox forbids that and also prevents cleanly `sandbox-exec`-ing children. Matches the already-un-sandboxed main app. |
| **Diagnostics** (`wikid/main.swift`) | Startup log: `wikid: resolved appGroup=… container=…`. |

## ACP sandboxing is preserved

Un-sandboxing the **daemon** does not unconfine agents. ACP processes are sandboxed **per-spawn** via the `sandbox-exec` seatbelt profile (`SandboxProfile` + `AgentLauncher.resolveSandboxInvocation`), which is "always on" for ingest/edit and never depended on the daemon's own App Sandbox. An app-sandboxed daemon actually *breaks* that seatbelt.

## Testing

- New regression tests (8) for the enclosing-`.app` walk-up from the daemon's XPC-service executable path — `HelpersLocationTests`, `WikiIdentifiersSidecarTests`.
- Verified end-to-end on a real install: daemon un-sandboxed, resolves `appGroup=group.com.willsargent.wiki` + the real `~/Library/Group Containers/…` container, reads the real 3-provider config, and `runIngestion: begin` fires (ingestion confirmed working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)