### PR TITLE
Fix agents view missing terminal jobs

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -205,7 +205,7 @@ struct ActivityWindowView: View {
     @ViewBuilder
     private var sidebar: some View {
         let active = activeItems
-        let recent = Array(recentItems.prefix(30))
+        let recent = Array(recentItems.prefix(200))
         // Precompute all @Observable-derived display data ONCE, so the
         // ForEach row body reads only plain values. This eliminates the
         // per-row swift_task_isMainExecutorImpl isolation checks that

--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -335,6 +335,20 @@ public final class QueueStore: @unchecked Sendable {
         provider_id, attempt, error, created_at, started_at, finished_at
     """
 
+    /// Decode a stored `queue` raw value into a `QueueKind`.
+    ///
+    /// Tolerates the legacy `"lint"` raw value: an abandoned dev-only queue
+    /// kind that was never shipped in `QueueKind` but can survive in databases
+    /// migrated before the v1 cleanup `DELETE`. Lint is a payload variant of
+    /// `.ingestion` (see `QueueKind`), so those rows decode as `.ingestion`.
+    /// Genuinely unrecognized values still throw — so real corruption stays
+    /// visible instead of being silently coerced.
+    private static func decodeQueueKind(_ raw: String) throws -> QueueKind {
+        if let kind = QueueKind(rawValue: raw) { return kind }
+        if raw == "lint" { return .ingestion }
+        throw QueueStoreError.sqlite(code: -1, message: "Unknown queue kind: \(raw)")
+    }
+
     /// Read a `QueueItem` from a GRDB `Row`. Named column access (not positional)
     /// so column order changes are harmless — a key safety improvement over
     /// the old `stmt.text(at: 0)` positional access.
@@ -352,9 +366,7 @@ public final class QueueStore: @unchecked Sendable {
         let startedAt: Int64? = row["started_at"]
         let finishedAt: Int64? = row["finished_at"]
 
-        guard let queue = QueueKind(rawValue: queueRaw) else {
-            throw QueueStoreError.sqlite(code: -1, message: "Unknown queue kind: \(queueRaw)")
-        }
+        let queue = try decodeQueueKind(queueRaw)
         guard let state = QueueItemState(rawValue: stateRaw) else {
             throw QueueStoreError.sqlite(code: -1, message: "Unknown item state: \(stateRaw)")
         }
@@ -1009,9 +1021,6 @@ public final class QueueStore: @unchecked Sendable {
             sql: "SELECT queue FROM queue_items WHERE id = ?;",
             arguments: [id])
         guard let raw else { throw QueueStoreError.notFound(id) }
-        guard let kind = QueueKind(rawValue: raw) else {
-            throw QueueStoreError.sqlite(code: -1, message: "Unknown queue kind: \(raw)")
-        }
-        return kind
+        return try decodeQueueKind(raw)
     }
 }

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -749,6 +749,13 @@ public actor QueueEngine {
 
         // Trigger dispatch for potentially unblocked items.
         await dispatchScan()
+
+        // Maintain the terminal history bound (default 200 per queue).
+        do {
+            try store.pruneHistory(maxPerQueue: config.recentLimit)
+        } catch {
+            DebugLog.store("QueueEngine.handleWorkerFinished: pruneHistory failed: \(error)")
+        }
     }
 
     /// Resume all `waitForCompletion` waiters for an item with the given result

--- a/Tests/WikiFSTests/QueueStoreTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTests.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(CSQLite)
+import CSQLite
+#else
+import SQLite3
+#endif
 import Testing
 @testable import WikiFSCore
 
@@ -218,6 +223,57 @@ struct QueueStoreTests {
         for id in queuedIDs {
             #expect(active.contains { $0.id == id })
         }
+    }
+
+    // MARK: - Legacy `queue = 'lint'` tolerance
+
+    /// A database migrated before the v1 cleanup can still hold rows stamped
+    /// with the abandoned `queue = 'lint'` kind (never shipped in `QueueKind`;
+    /// lint is a payload variant of `.ingestion`). Reading one such row used to
+    /// throw inside `readItem`, which aborts the whole `loadRecent`/`loadActive`
+    /// map — so a *single* legacy row made every terminal job vanish from the
+    /// Agents view. The store now decodes `lint` as `.ingestion` instead.
+    @Test func testLegacyLintRowDecodesAsIngestionInsteadOfHidingAllJobs() throws {
+        let url = tempDatabaseURL()
+
+        // Seed two completed ingestion items through the store, so both rows
+        // carry a valid store-encoded payload. `lintID` is the one we'll stamp
+        // with the legacy queue value.
+        let normalID: QueueItem.ID
+        let lintID: QueueItem.ID
+        do {
+            let store = try QueueStore(databaseURL: url)
+            func completeOne() throws -> QueueItem.ID {
+                let item = try store.enqueue(
+                    QueueItemRequest(queue: .ingestion, wikiID: "wiki1", payload: makePayload()))
+                try store.markRunning(id: item.id, providerID: "p")
+                try store.markCompleted(id: item.id)
+                return item.id
+            }
+            normalID = try completeOne()
+            lintID = try completeOne()
+            store.close()
+        }
+
+        // Stamp one row with the legacy `queue = 'lint'` value directly — there
+        // is (by design) no public API that produces it, so bypass the enum via
+        // raw SQL, the same pattern the canonicalization tests use.
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        let updateSQL = "UPDATE queue_items SET queue = 'lint' WHERE id = '\(lintID)';"
+        #expect(sqlite3_exec(db, updateSQL, nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+
+        // Reopen and load recent history: the load must succeed (not throw), and
+        // the legacy row must surface, decoded onto the `.ingestion` queue.
+        let store = try QueueStore(databaseURL: url)
+        let recent = try store.loadRecent(limit: 200)
+        // One bad row no longer hides the rest — both are visible.
+        #expect(recent.count == 2)
+        #expect(recent.contains { $0.id == normalID })
+        let stamped = recent.first { $0.id == lintID }
+        #expect(stamped != nil)
+        #expect(stamped?.queue == .ingestion)
     }
 
     // MARK: - AC.5: Headless isolation (source-scan)


### PR DESCRIPTION
Two independent causes made completed/failed/cancelled jobs vanish from the Agents (Activity) view:

1. UI truncation: the sidebar only rendered `recentItems.prefix(30)`, while the engine loads up to `recentLimit` (200). Show 200.

2. Poison row aborting the whole load: a database migrated before the v1 cleanup DELETE can still hold rows stamped with the abandoned `queue = 'lint'` kind (never shipped in `QueueKind`; lint is a payload variant of `.ingestion`). `readItem` threw on the unrecognized value, and because `loadRecent`/`loadActive` map over rows, a single such row aborted the entire query — so every terminal job disappeared. Decode `lint` as `.ingestion` via a shared `decodeQueueKind` helper used by both `readItem` and `fetchQueueKind`. Genuinely unrecognized values still throw, so real corruption stays visible rather than being silently coerced.

Also bound terminal history from the engine: prune to `recentLimit` per queue after each worker finishes, matching the window the UI now shows.

Adds a regression test that plants a legacy `queue = 'lint'` row via raw SQL and asserts `loadRecent` returns it as `.ingestion` without hiding the other rows.