### PR TITLE
Broaden SwiftLint with zero-violation bug-class rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,14 +1,39 @@
 # SwiftLint — scoped deliberately narrow.
 #
-# This config enables ONLY custom rules (`only_rules: [custom_rules]`). It is
-# not a general Swift style gate. Turning on SwiftLint's ~200 default rules
-# against this codebase would emit thousands of line_length / identifier_name /
-# type_body_length violations and drown the one rule that exists to catch a
-# class of bug that has actually bitten us. Broaden later if you want, but do it
-# as its own change with its own baseline.
+# This is a BUG-CLASS GATE, not a general Swift style gate. Turning on
+# SwiftLint's ~200 default rules against this codebase would emit thousands of
+# line_length / identifier_name / type_body_length violations and drown the
+# rules that exist to catch classes of bug that have actually bitten us.
+#
+# Admission test for a new rule: does a violation mean *a failure disappears
+# silently*, or that an AGENTS.md invariant is broken? If it's merely "this
+# could be written more prettily", it does not belong here.
+#
+# Every rule below was measured against the tree before being enabled, and all
+# of them are at ZERO violations — this file is pure prevention, not cleanup.
+# Rules with a non-zero count (force_unwrapping 52, @unchecked Sendable 85,
+# force_try 7, …) are deliberately NOT here; adding them is a separate change
+# with its own baseline growth to review.
+#
+# GOTCHA: `only_rules` and `opt_in_rules` are mutually exclusive. To turn on a
+# built-in rule, add its name to `only_rules` below — there is no second list.
 
 only_rules:
   - custom_rules
+  # Built-ins, all at 0 violations as of this commit. Free ratchets: they cost
+  # nothing today and stop the class from ever entering the tree.
+  - force_cast                        # `as!` — 0 in Sources/ + tools/
+  - weak_delegate                     # strong delegate = retain cycle; we have
+                                      # many NSViewRepresentable Coordinators
+  - notification_center_detachment    # deinit-time removeObserver misuse
+  - unused_setter_value               # a setter that drops newValue on the floor
+  - overridden_super_call             # missing super in a lifecycle override
+  - prohibited_super_call             # super called where it must not be
+  # 3 pre-existing sites, all annotated at the call site with a reason rather
+  # than baselined — they are once-only, app-lifetime willTerminate observers
+  # where there is genuinely nothing to remove. Anywhere else, discarding the
+  # token means the observer can never be detached.
+  - discarded_notification_center_observer
 
 # Production code only. Tests/ is excluded on purpose: a `try?` in test setup
 # fails the test anyway, whereas a `try?` in Sources/ silently drops data.
@@ -55,4 +80,58 @@ custom_rules:
       saying why, then `// swiftlint:disable:next silent_try_optional` directly
       above the offending line — in that order, since disable:next takes the
       very next line. See AGENTS.md.
+    severity: error
+
+  diagnostic_print:
+    name: "print() for diagnostics"
+    # Same `match_kinds` trick as above: `print` lexes as an identifier only in
+    # real code, so the prose mention in ReaderTiming.swift is excluded
+    # structurally. `(?<![.\w])` avoids matching `sprint(` and member calls like
+    # `formatter.print(`. Known loophole: `Swift.print(…)` slips past the
+    # lookbehind — use `swiftlint:disable:next`, not that, as the escape hatch.
+    regex: '(?-s)(?<![.\w])print[ \t]*\('
+    match_kinds:
+      - identifier
+    # Per-rule `excluded` is a REGEX on the file path, not a glob. Real CLI
+    # stdout is the documented exception in AGENTS.md, so the executable targets
+    # whose whole job is printing are exempt.
+    excluded: ".*/(wikictl|versiongen|keychaingen|FuzzHarness|podcast-token-helper)/.*"
+    message: >-
+      `print` goes nowhere when the app is launched by launchd, XPC or the File
+      Provider — the diagnostic is simply lost. Route it through the appropriate
+      `DebugLog.<channel>` (os_log → Console.app, subsystem
+      com.selfdrivingwiki.debug) so it is visible no matter how the process
+      started. Genuine CLI command output belongs in wikictl/ or tools/.
+      See AGENTS.md.
+    severity: error
+
+  raw_sql_begin:
+    name: "Raw BEGIN"
+    # `match_kinds: [string]` because SQL lives in string literals. This is what
+    # keeps the three prose mentions of "BEGIN IMMEDIATE" in GRDBWikiStore's doc
+    # comments from tripping the rule.
+    regex: '(?i)(?-s)\bBEGIN[ \t]+(IMMEDIATE|EXCLUSIVE|DEFERRED|TRANSACTION)\b'
+    match_kinds:
+      - string
+    message: >-
+      A raw BEGIN breaks savepoint nesting — an inner one hits "cannot start a
+      transaction within a transaction" and an outer rollback silently discards
+      the inner work. Compose multi-step writes through `withTransaction`.
+      See docs/skills/sqlite-concurrency/SKILL.md.
+    severity: error
+
+  entry_macro:
+    name: "@Entry macro"
+    regex: '(?-s)@Entry\b'
+    # `typeidentifier` is what SourceKit lexes an unresolved macro name as (the
+    # macro doesn't expand under SwiftPM, which is the whole point of the rule).
+    # `attribute.id` is listed too in case a future toolchain resolves it.
+    # Without this, the rule fires on prose mentioning @Entry in comments.
+    match_kinds:
+      - typeidentifier
+      - attribute.id
+    message: >-
+      `@Entry` resolves only under Xcode's build system; this repo must build
+      with `swift build` from the command line. Use the manual
+      `EnvironmentKey`/`FocusedValueKey` pattern instead. See AGENTS.md.
     severity: error

--- a/Sources/WikiFS/Sources/DefuddleExtractionService.swift
+++ b/Sources/WikiFS/Sources/DefuddleExtractionService.swift
@@ -326,6 +326,10 @@ enum DefuddleExtractionService {
             defer { lock.unlock() }
             guard !registered else { return }
             registered = true
+            // Token discarded on purpose: `registered` makes this once-only for
+            // the life of the process, and the observer fires during app
+            // termination — there is no point at which we would detach it.
+            // swiftlint:disable:next discarded_notification_center_observer
             NotificationCenter.default.addObserver(
                 forName: NSApplication.willTerminateNotification,
                 object: nil, queue: .main

--- a/Sources/WikiFSCore/Integrations/TranscriptSubprocess.swift
+++ b/Sources/WikiFSCore/Integrations/TranscriptSubprocess.swift
@@ -49,6 +49,10 @@ enum TranscriptSubprocess {
             guard !registered else { return }
             registered = true
             #if os(macOS)
+            // Token discarded on purpose: `registered` makes this once-only for
+            // the life of the process, and the observer fires during app
+            // termination — there is no point at which we would detach it.
+            // swiftlint:disable:next discarded_notification_center_observer
             NotificationCenter.default.addObserver(
                 forName: NSApplication.willTerminateNotification,
                 object: nil, queue: .main

--- a/Sources/WikiFSEngine/PdfExtractionService.swift
+++ b/Sources/WikiFSEngine/PdfExtractionService.swift
@@ -23,6 +23,10 @@ public enum PdfExtractionService {
             defer { lock.unlock() }
             guard !registered else { return }
             registered = true
+            // Token discarded on purpose: `registered` makes this once-only for
+            // the life of the process, and the observer fires during app
+            // termination — there is no point at which we would detach it.
+            // swiftlint:disable:next discarded_notification_center_observer
             NotificationCenter.default.addObserver(
                 forName: NSApplication.willTerminateNotification,
                 object: nil, queue: .main


### PR DESCRIPTION
Broadens the lint gate from one custom rule to ten, **all measured at 0 violations against the tree first**. No cleanup, no baseline growth — `.swiftlint-baseline.json` stays `[]`.

The admission test I used, now written into the config: *does a violation mean a failure disappears silently, or that an AGENTS.md invariant is broken?* If it's "this could be written more prettily", it doesn't belong here. That keeps the signal-to-noise that #894 deliberately set up.

## Built-in rules

Added to `only_rules` — note that `only_rules` and `opt_in_rules` are mutually exclusive, so there's no second list to grow.

| Rule | Count |
|---|---|
| `force_cast` | 0 |
| `weak_delegate` | 0 |
| `notification_center_detachment` | 0 |
| `unused_setter_value` | 0 |
| `overridden_super_call` | 0 |
| `prohibited_super_call` | 0 |
| `discarded_notification_center_observer` | 3, annotated (below) |

## Custom rules

Three AGENTS.md invariants that regex can actually enforce. Each uses `match_kinds` the same way `silent_try_optional` does, so comments and string literals are excluded structurally rather than by regex gymnastics.

- **`diagnostic_print`** — `print` goes nowhere when the app is launched by launchd, XPC or the File Provider; the diagnostic is simply lost. Per-rule `excluded` (a **regex on the file path**, not a glob) exempts `wikictl`/`tools`, where real CLI stdout is the documented exception. `match_kinds: [identifier]` means the prose mention of `print()` in `ReaderTiming.swift` doesn't trip it.
- **`raw_sql_begin`** — matches only inside string literals, where SQL lives. That's what keeps the three prose mentions of "BEGIN IMMEDIATE" in `GRDBWikiStore`'s doc comments clean. A raw `BEGIN` breaks savepoint nesting.
- **`entry_macro`** — `@Entry` resolves only under Xcode's build system; this repo must build with `swift build` from the CLI.

## On the three observer sites

They are **not** leaks, so they're annotated at the call site with a reason rather than baselined. All three are the same copy-pasted `ProcessRegistry`: a once-only registration guarded by a `registered` flag, observing `NSApplication.willTerminateNotification` with `[weak self]`. There's no point at which the token would be used to detach — the app is exiting when it fires. Worth saying so in the code, and it keeps the rule useful for new code, where a discarded token really does mean an observer that can never be removed.

## Verification

Every rule was checked to **actually fire** against a fixture, not merely to report zero — a broken rule and a clean tree look identical otherwise. That caught a real bug before it landed: `entry_macro` was matching prose in comments because I'd given it no `match_kinds`. The correct kind turns out to be `typeidentifier`, which is how SourceKit lexes an unresolved macro name (the macro doesn't expand under SwiftPM — which is the whole point of the rule).

- `make lint` → 0 violations, 361 files
- `make build` → clean

## Deliberately not included

Left for a separate change with its own reviewable baseline growth: `force_unwrapping` (52), `@unchecked Sendable` (85, custom), `implicitly_unwrapped_optional` (14), `duplicate_imports` (8), `force_try` (7 — all `static let regex = try! NSRegularExpression(...)` with literal patterns).

`unhandled_throwing_task` is **rejected outright**, not deferred. It looked like the ideal fit — 16 hits, same "error vanishes" shape as bare `try?` — but the hits are false positives caused by the helper #894 introduced:

```swift
Task { [daemon] in
    do {
        let engine = try await daemon.ensureQueueEngine()
        let data = DebugLog.trying("encode") { try JSONEncoder().encode(envelope) }  // ← trips it
    } catch { … }   // catch exists
}
```

SwiftLint's syntactic walker sees a `try` inside the closure argument and can't know `DebugLog.trying` swallows it. Since that idiom is now repo-wide across 379 conversion sites, the rule would be permanent noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
