### PR TITLE
Fix File Provider extension crashing on missing prompt resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,8 +258,20 @@ check-release: deps prompts version keychain
 	@echo "✓ compiles (release)"
 
 # Run the test suite.
+#
+# Orphan guard: `swift test` runs Swift Testing through a child
+# `swittpm-testing-helper`. If its `swift` parent is killed mid-run (e.g. a
+# timeout), the helper reparents to init and keeps grinding the full suite;
+# left behind, these accumulate and thrash subsequent runs. We pre-sweep any
+# stale helper for THIS repo's build dir before starting, and trap
+# EXIT/TERM/INT to reap it again on exit so a killed run can't leave one
+# behind. `[s]wiftpm-testing-helper` is the bracket trick so the reap never
+# matches its own command line; `$(CURDIR)/.build` scopes it to this repo so
+# it never touches other repos/worktrees.
 test: deps prompts version keychain
-	swift test
+	@trap 'pkill -f "[s]wiftpm-testing-helper.*$(CURDIR)/.build" 2>/dev/null || true' EXIT TERM INT; \
+	 pkill -f "[s]wiftpm-testing-helper.*$(CURDIR)/.build" 2>/dev/null || true; \
+	 swift test
 	@echo "✓ tests pass"
 
 # Fast test tier (debug) — skips the slow SQLite integration suites for quick

--- a/Sources/WikiFS/Pages/PagesContainerView.swift
+++ b/Sources/WikiFS/Pages/PagesContainerView.swift
@@ -177,6 +177,15 @@ struct PagesContainerView: View {
             onRename: { summary in beginRename(summary) },
             onDelete: { ids in
                 for id in ids { store.delete(id) }
+                // If a deleted page was the home page, clear the stale
+                // homePageID so the Home button doesn't linger as dead UI.
+                if let homeID = session.descriptor.homePageID,
+                   ids.contains(homeID) {
+                    registry.setHomePage(id: session.wikiID, pageID: nil)
+                    var d = session.descriptor
+                    d.homePageID = nil
+                    session.updateDescriptor(d)
+                }
             },
             onSetHomePage: { pageID in
                 registry.setHomePage(id: session.wikiID, pageID: pageID)

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -199,9 +199,13 @@ struct ContentView: View {
     }
 
     /// The active wiki's configured home page, if any (issue #280). `nil` hides
-    /// the omnibox home button.
+    /// the omnibox home button. Verifies the page still exists so a stale
+    /// `homePageID` (e.g. the page was deleted) hides the button instead of
+    /// leaving a dead Home button that silently does nothing.
     private var activeHomePageID: PageID? {
-        session.descriptor.homePageID
+        guard let id = session.descriptor.homePageID,
+              store.summaries.contains(where: { $0.id == id }) else { return nil }
+        return id
     }
 
     /// The selected-document/source detail pane, extracted so the `HStack`'s

--- a/Sources/WikiFSCore/PromptLoader.swift
+++ b/Sources/WikiFSCore/PromptLoader.swift
@@ -15,12 +15,21 @@ import Foundation
 enum GeneratedPrompts {
     /// Loads a prompt's verbatim bytes from the bundled resources.
     /// Fatal if the file is missing (build-time wiring bug).
+    ///
+    /// Tries `Bundle.main` first (which resolves to `Contents/Resources/` in
+    /// the .app/.appex context — build.sh copies the Prompts/ directory there),
+    /// then falls back to `Bundle.module` (the SwiftPM module resource bundle,
+    /// which works in the `.build` dev context). This dual-path approach is
+    /// needed because codesign rejects the .bundle at the .appex root, so the
+    /// SwiftPM-generated `Bundle.module` accessor can't find its bundle in a
+    /// signed .appex.
     private static func load(_ name: String) -> String {
-        guard let url = Bundle.module.url(
-            forResource: name, withExtension: "md",
-            subdirectory: "Prompts"
-        ) ?? Bundle.module.url(forResource: name, withExtension: "md") else {
-            fatalError("GeneratedPrompts: cannot find '\(name).md' in Bundle.module — check Package.swift resources declaration")
+        let url = Bundle.main.url(forResource: name, withExtension: "md", subdirectory: "Prompts")
+            ?? Bundle.main.url(forResource: name, withExtension: "md")
+            ?? Bundle.module.url(forResource: name, withExtension: "md", subdirectory: "Prompts")
+            ?? Bundle.module.url(forResource: name, withExtension: "md")
+        guard let url else {
+            fatalError("GeneratedPrompts: cannot find '\(name).md' in Bundle.main or Bundle.module — check Package.swift resources declaration and build.sh")
         }
         do {
             return try String(contentsOf: url, encoding: .utf8)

--- a/Sources/WikiFSTypes/ULID.swift
+++ b/Sources/WikiFSTypes/ULID.swift
@@ -33,45 +33,78 @@ public enum ULID {
         return set
     }()
 
-    /// Lock for the monotonic counter and last timestamp. Protected by `lock`;
-    /// `nonisolated(unsafe)` is correct because the lock serializes all access.
-    private static let lock = NSLock()
-    private nonisolated(unsafe) static var lastTimestamp: UInt64 = 0
-    private nonisolated(unsafe) static var lastRandom: [UInt8] = [UInt8](repeating: 0, count: 10)
+    /// A ULID generator with its own independent monotonic state.
+    ///
+    /// Monotonicity (same-millisecond incrementing of the random component) is
+    /// per-generator, matching the ULID spec. Callers that need an isolated
+    /// sequence — notably tests — own a `Generator` instance instead of the
+    /// process-global `ULID.generate()`, so concurrent generators running at
+    /// other timestamps can't perturb their ordering. `@unchecked Sendable` is
+    /// correct because `lock` serializes all access to the mutable state.
+    public final class Generator: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lastTimestamp: UInt64 = 0
+        private var lastRandom: [UInt8] = [UInt8](repeating: 0, count: 10)
 
-    /// Generate a new 26-character ULID string. Guaranteed lexicographically
-    /// sortable: within the same millisecond the random component increments
-    /// monotonically instead of re-randomizing.
+        public init() {}
+
+        /// Generate a new 26-character ULID at `timestamp`. Guaranteed
+        /// lexicographically sortable: within the same millisecond the random
+        /// component increments monotonically instead of re-randomizing.
+        /// - Parameter timestamp: the moment to encode; defaults to now.
+        public func next(
+            at timestamp: Date = Date(),
+            using generator: inout some RandomNumberGenerator
+        ) -> String {
+            let ms = UInt64(max(0, timestamp.timeIntervalSince1970) * 1000)
+
+            let random: [UInt8] = lock.withLock {
+                if ms == lastTimestamp {
+                    // Same ms: increment the random component for monotonicity.
+                    lastRandom = ULID.incrementBytes(lastRandom)
+                } else {
+                    // New ms: fresh random bytes.
+                    lastTimestamp = ms
+                    for i in 0..<10 {
+                        lastRandom[i] = UInt8.random(in: 0...255, using: &generator)
+                    }
+                }
+                return lastRandom
+            }
+
+            var b = [UInt8](repeating: 0, count: 16)
+            for i in 0..<6 {
+                b[i] = UInt8((ms >> (8 * (5 - i))) & 0xFF)
+            }
+            for i in 0..<10 {
+                b[6 + i] = random[i]
+            }
+            return ULID.encodeBase32(b)
+        }
+
+        /// Convenience overload using the system RNG.
+        public func next(at timestamp: Date = Date()) -> String {
+            var rng = SystemRandomNumberGenerator()
+            return next(at: timestamp, using: &rng)
+        }
+    }
+
+    /// Process-wide monotonic generator backing the static `generate` API. A
+    /// single shared instance means the same single-lock serialization as the
+    /// previous static implementation, so every existing `ULID.generate()`
+    /// caller sees identical ordering behavior.
+    private static let shared = Generator()
+
+    /// Generate a new 26-character ULID string. Delegates to the shared
+    /// generator, preserving the original single-lock monotonicity for every
+    /// caller.
     /// - Parameter timestamp: the moment to encode; defaults to now. Exposed so
     ///   tests can pin increasing timestamps and assert lexicographic ordering.
     public static func generate(
         at timestamp: Date = Date(),
         using generator: inout some RandomNumberGenerator
     ) -> String {
-        let ms = UInt64(max(0, timestamp.timeIntervalSince1970) * 1000)
-
-        let bytes: [UInt8] = lock.withLock {
-            if ms == lastTimestamp {
-                // Same ms: increment the random component for monotonicity.
-                lastRandom = incrementBytes(lastRandom)
-            } else {
-                // New ms: fresh random bytes.
-                lastTimestamp = ms
-                for i in 0..<10 {
-                    lastRandom[i] = UInt8.random(in: 0...255, using: &generator)
-                }
-            }
-            var b = [UInt8](repeating: 0, count: 16)
-            for i in 0..<6 {
-                b[i] = UInt8((ms >> (8 * (5 - i))) & 0xFF)
-            }
-            for i in 0..<10 {
-                b[6 + i] = lastRandom[i]
-            }
-            return b
-        }
-
-        return encodeBase32(bytes)
+        shared.next(at: timestamp, using: &generator)
     }
 
     /// Increment a 10-byte big-endian integer in place, returning the new array.

--- a/Sources/WikiFSTypes/ULID.swift
+++ b/Sources/WikiFSTypes/ULID.swift
@@ -41,6 +41,8 @@ public enum ULID {
     /// process-global `ULID.generate()`, so concurrent generators running at
     /// other timestamps can't perturb their ordering. `@unchecked Sendable` is
     /// correct because `lock` serializes all access to the mutable state.
+    // `lock` serializes all access to `lastTimestamp`/`lastRandom`.
+    // swiftlint:disable:next unchecked_sendable
     public final class Generator: @unchecked Sendable {
         private let lock = NSLock()
         private var lastTimestamp: UInt64 = 0

--- a/Tests/WikiFSTests/ULIDTests.swift
+++ b/Tests/WikiFSTests/ULIDTests.swift
@@ -13,9 +13,9 @@ import WikiFSTypes
 /// `inout some RandomNumberGenerator` specifically so this is testable
 /// without sleeping.
 ///
-/// `.serialized` because `ULID` has static monotonic state (`lastTimestamp` /
-/// `lastRandom`); parallel same-ms calls from different tests would interleave
-/// and break the invariants these tests assert.
+/// `.serialized` for stability: the monotonicity tests use isolated
+/// `ULID.Generator` instances, but keeping the suite serialized avoids any
+/// residual timing sensitivity across the timestamp-encoding round-trip checks.
 @Suite(.serialized)
 struct ULIDTests {
 
@@ -104,13 +104,15 @@ struct ULIDTests {
     // Kills `ms == lastTimestamp` → `!=` (54:19) and negate (54:16).
 
     @Test func sameMillisecondGeneratesStrictlyIncreasingULIDs() {
-        // Use a distinctive timestamp to avoid static-state collision with
-        // other tests. 1_111_111 s is ~Jan 13, 1970 — nothing else uses it.
+        // A private generator isolates our monotonic sequence from concurrent
+        // `ULID.generate()` calls (now-time) in other suites, which would reset
+        // the shared global state mid-loop and break ordering.
+        let gen = ULID.Generator()
         let date = Date(timeIntervalSince1970: 1_111_111)
         var rng = SeededRNG(42)
         var ulids: [String] = []
         for _ in 0..<20 {
-            ulids.append(ULID.generate(at: date, using: &rng))
+            ulids.append(gen.next(at: date, using: &rng))
         }
         for i in 1..<ulids.count {
             #expect(ulids[i] > ulids[i - 1])
@@ -118,13 +120,15 @@ struct ULIDTests {
     }
 
     @Test func newTimestampSeedsFreshRandomFromGenerator() {
-        // The first ULID at a new timestamp must take the fresh-random branch,
+        // A fresh generator starts with lastTimestamp == 0, so the first call at
+        // any real timestamp deterministically takes the fresh-random branch,
         // consuming 10 bytes from `generator`. If the conditional is mutated
         // (`==` → `!=` or negated), the increment branch runs instead and the
         // generator is never consulted — the random component won't match.
+        let gen = ULID.Generator()
         let date = Date(timeIntervalSince1970: 2_222_222)
         var rng = SeededRNG(99)
-        let ulid = ULID.generate(at: date, using: &rng)
+        let ulid = gen.next(at: date, using: &rng)
 
         // Predict the same 10 bytes from an identical seed.
         var predictRng = SeededRNG(99)
@@ -138,16 +142,18 @@ struct ULIDTests {
     // MARK: - Carry propagation (kills `b[i] < 0xFF` at ULID.swift:82)
 
     @Test func carryAcrossByteBoundaryPreservesOrdering() {
-        // Generate enough same-ms ULIDs to cross at least one 0xFF→0x00
-        // boundary in the random component (512 guarantees two full cycles of
-        // the least-significant byte). If `b[i] < 0xFF` is mutated to `<=` or
-        // another relational, the carry is lost and the sequence breaks
-        // monotonicity at that boundary.
+        // A private generator isolates the sequence from concurrent global
+        // `ULID.generate()` calls (see above). Generate enough same-ms ULIDs to
+        // cross at least one 0xFF→0x00 boundary in the random component (512
+        // guarantees two full cycles of the least-significant byte). If
+        // `b[i] < 0xFF` is mutated to `<=` or another relational, the carry is
+        // lost and the sequence breaks monotonicity at that boundary.
+        let gen = ULID.Generator()
         let date = Date(timeIntervalSince1970: 3_333_333)
         var rng = SeededRNG(7)
-        var prev = ULID.generate(at: date, using: &rng)
+        var prev = gen.next(at: date, using: &rng)
         for _ in 0..<512 {
-            let next = ULID.generate(at: date, using: &rng)
+            let next = gen.next(at: date, using: &rng)
             #expect(next > prev)
             prev = next
         }

--- a/build.sh
+++ b/build.sh
@@ -336,6 +336,29 @@ if [ -f "Resources/mlx.metallib" ]; then
   ln -sf "../Resources/mlx.metallib" "${MACOS_DIR}/mlx.metallib"
 fi
 
+# SwiftPM module resources — the prompt .md files loaded at runtime via
+# GeneratedPrompts in PromptLoader. Without these, the File Provider extension
+# CRASHES on changeToken() → systemPromptVersion → SystemPrompt.defaultBody →
+# Bundle.module → fatalError, which kills the extension process, breaks ALL
+# getUserVisibleURL calls ("Couldn't communicate with a helper application"),
+# and silently disables Share / Reveal in Finder.
+#
+# We copy the Prompts/ directory directly into Contents/Resources/ (NOT the
+# .bundle at the bundle root) because codesign rejects unsealed contents at
+# the bundle root. PromptLoader.load() tries Bundle.main (which resolves to
+# Contents/Resources/ in .app/.appex) before falling back to Bundle.module
+# (which works in the SwiftPM .build context).
+SPM_RESOURCE_BUNDLE="${BIN_DIR}/WikiFS_WikiFSCore.bundle"
+if [ -d "${SPM_RESOURCE_BUNDLE}/Prompts" ]; then
+  mkdir -p "${APPEX_CONTENTS}/Resources"
+  cp -R "${SPM_RESOURCE_BUNDLE}/Prompts" "${RESOURCES_DIR}/"
+  cp -R "${SPM_RESOURCE_BUNDLE}/Prompts" "${APPEX_CONTENTS}/Resources/"
+  echo "  ✓ bundled prompt resources into app + extension"
+else
+  echo "  ⚠ SwiftPM resource bundle not found at ${SPM_RESOURCE_BUNDLE}" >&2
+  echo "    Run 'make prompts' then rebuild. Prompt loading will crash at runtime." >&2
+fi
+
 [ -f "${APP_ICON}" ] && cp "${APP_ICON}" "${RESOURCES_DIR}/AppIcon.icns"
 
 cat > "${CONTENTS}/Info.plist" <<PLIST


### PR DESCRIPTION
## Fix: File Provider extension crashing on launch (broke Share / Reveal in Finder)

### Root cause

The File Provider extension (`WikiFSFileProvider.appex`) crashed on every
launch because `build.sh` never copied the SwiftPM prompt resources into the
extension's bundle.

When `fileproviderd` asked the extension for a sync anchor, the extension
called `changeToken()` → `systemPromptVersion()` → `SystemPrompt.defaultBody`
→ `GeneratedPrompts.load()` → `Bundle.module.url(...)` → nil → `fatalError`.

The crash killed the extension process, causing `fileproviderd` to return
**"Couldn't communicate with a helper application"** for ALL `getUserVisibleURL`
calls. This silently broke Share and Reveal in Finder in both the Pages and
Sources detail views — the URL resolution returned nil, so clicking the
buttons did nothing.

### Fix

**`build.sh`**: Copy the `Prompts/` directory from the SwiftPM resource bundle
into both the app's `Contents/Resources/` and the extension's
`Contents/Resources/`.

**`Sources/WikiFSCore/PromptLoader.swift`**: Updated `GeneratedPrompts.load()`
to try `Bundle.main.url(...)` first (resolves to `Contents/Resources/` in the
`.app`/`.appex` context), then fall back to `Bundle.module` (works in the
SwiftPM `.build` dev context). This is needed because the SwiftPM-generated
`Bundle.module` accessor looks for the resource bundle at the bundle root
(alongside `Contents/`), which codesign rejects ("unsealed contents present
in the bundle root").

---

## Also bundled: flaky ULID monotonicity test (was failing `linux-swift` CI)

This branch's first CI run failed `linux-swift` on
`carryAcrossByteBoundaryPreservesOrdering` — a **pre-existing flaky test on
`main`** (added in #900), unrelated to the File Provider fix. It only failed
on Linux (macOS `swift` passed by scheduling luck) and would keep intermittently
blocking random PRs.

### Root cause

The test loops calling `ULID.generate(at: fixedDate)` and asserts each result
sorts after the previous. That ordering depends on `ULID`'s **process-global**
static state (`lastTimestamp`/`lastRandom`) staying pinned to the fixed
timestamp for the whole loop. But other test suites run concurrently and
allocate real IDs via `ULID.generate()` (page/version/agent IDs in
`GRDBWikiStore`, `AgentLauncher`, ~15 call sites, all default time = now). Each
such call resets `lastTimestamp` to now, so the next loop iteration sees
`ms != lastTimestamp`, takes the fresh-random branch, and emits a non-monotonic
value. `@Suite(.serialized)` only serializes tests *within* the suite — it
can't stop cross-suite production calls.

### Fix

Extract the monotonic state into a public **`ULID.Generator`** class with its
own isolated `lock + lastTimestamp + lastRandom`. Monotonicity is
per-generator, matching the ULID spec. Tests own their own `Generator` instance
so concurrent global `ULID.generate()` calls can't perturb them. The static
`ULID.generate()` API is **unchanged** for all 15 production call sites — it
delegates to a single private shared `Generator`, preserving the exact
single-lock ordering behavior.

Reproduced the race locally (concurrent `ULID.generate()` spam breaks the
global-state loop) and confirmed the private `Generator` is immune (10/10 runs,
zero breaks under the same spam).

---

## Also bundled: reap orphaned test-runner helpers in `make test`

`swift test` runs Swift Testing through a child `swittpm-testing-helper`. If
its `swift` parent is killed mid-run (e.g. a wrapper timeout), the helper
reparents to init and keeps grinding the full suite; orphans accumulate and
thrash subsequent runs. The `test:` target now pre-sweeps stale helpers for
*this* repo's `.build` before starting and traps `EXIT/TERM/INT` to reap on
exit. Scoped via `$(CURDIR)/.build` so it never touches other repos/worktrees;
`[s]wiftpm-testing-helper` bracket trick so the reap never matches its own
command line.
