### PR TITLE
Fix persisted chat rendering as an empty live stream

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,48 @@
 # Progress log
 
+## fix: Persisted chat rendered as an empty live stream after daemon session eviction
+
+**Goal:** a chat with a full persisted transcript opened to the empty-composer
+state ("Ask a question to start a chat.") instead of its messages. Reproduced on
+the "Fun Stuff" wiki with chat `01KYBG3AWRCKBKDPTWEFDY4PP0` — 8 rows present in
+`chat_messages`, none rendered.
+
+**Root cause:** `ChatDetailView.isLiveChat` selects between the streaming mirror
+and the persisted rows purely on `remoteSession.activeChatID == chatID`.
+`RemoteChatSession.init` was seeding `activeChatID = chatID` unconditionally, so
+**every freshly-created mirror claimed to be the live session** with an empty
+`events` array — violating the invariant its own doc comment states
+("Managed by `hydrate`/`applyStateUpdate` from the daemon's run flags").
+`rehydrate` normally corrects the claim, but `DaemonChatHost.chatSessionState`
+throws `noSession` for any chat whose launcher the daemon has evicted (i.e. every
+chat from a previous app run) → `WikiDaemon` returns empty `Data()` → the client
+throws `unexpectedReply`. The catch block's comment promised "the persisted rows
+remain the source of truth" but never actually dropped the stale liveness claim,
+so the view rendered the empty live stream forever.
+
+**What changed:** `RemoteChatSession.init` now leaves `activeChatID` nil — a
+fresh mirror knows nothing about the daemon and must not claim liveness. New
+`markNotLive()` clears both `activeChatID` and `isInteractiveSession`;
+`ChatDaemonCoordinator.rehydrate`'s catch calls it and drops the chat from
+`runningChatIDs`, so a failed rehydrate genuinely falls back to the persisted
+transcript. Related to #904 (event-sink blackout) but independent: this path
+fails even with a healthy event sink.
+
+**Files:** `Sources/WikiFS/Chats/RemoteChatSession.swift`,
+`Sources/WikiFS/Chats/ChatDaemonCoordinator.swift`;
+`Tests/WikiFSAppTests/{RemoteChatSessionTests,ChatDaemonCoordinatorTests}.swift`.
+
+**Evidence:** root cause confirmed against the running app —
+`ChatDaemonCoordinator.rehydrate failed for 01KYBG3AWRCKBKDPTWEFDY4PP0:
+unexpectedReply` in the unified log, with the 8 rows verified present via
+`sqlite3`. 6 new regression tests (fresh session doesn't claim liveness,
+`markNotLive`, rehydrate-failure clears liveness, idle rehydrate stays
+not-live). `swift build` ✓; full `WikiFSAppTests` run 1428 tests / 141 suites,
+the only failure a pre-existing `MiniLMEmbedder` GPU-latency threshold
+(median 21.68 ms vs 20 ms) unrelated to this change.
+
+---
+
 ## refactor: Extract the app↔daemon XPC contract into a `WikiDaemonContract` module
 
 **Goal:** make the XPC boundary between the `wikid` service and its clients

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -219,10 +219,16 @@ public final class ChatDaemonCoordinator {
                 runningChatIDs.remove(chatID)
             }
         } catch {
-            // A rehydrate failure (e.g. the daemon evicted the session) is
-            // non-fatal — the session keeps its last-known state and the
-            // persisted rows remain the source of truth.
-            DebugLog.agent("ChatDaemonCoordinator.rehydrate failed for \(chatID): \(error)")
+            // A rehydrate failure (e.g. the daemon evicted the session, so
+            // `chatSessionState` throws `noSession`) is non-fatal — but the
+            // mirror must actively RELINQUISH its liveness claim, not merely
+            // keep its last-known state. Otherwise a session that never got a
+            // successful hydrate stays flagged live with zero events, and
+            // `ChatDetailView` renders that empty stream instead of the
+            // persisted transcript.
+            session.markNotLive()
+            runningChatIDs.remove(chatID)
+            DebugLog.agent("ChatDaemonCoordinator.rehydrate failed for \(chatID): \(error) — marked not live")
         }
     }
 

--- a/Sources/WikiFS/Chats/RemoteChatSession.swift
+++ b/Sources/WikiFS/Chats/RemoteChatSession.swift
@@ -88,7 +88,27 @@ public final class RemoteChatSession {
 
     public init(chatID: String) {
         self.chatID = chatID
-        self.activeChatID = chatID
+        // A fresh mirror knows NOTHING about the daemon yet, so it must not
+        // claim liveness: `activeChatID` is daemon-derived state, set only by
+        // `hydrate`/`applyStateUpdate` from the run flags (see the property's
+        // doc comment). Seeding it with `chatID` here made every newly-opened
+        // chat pass `ChatDetailView.isLiveChat`, which then rendered this
+        // mirror's empty `events` INSTEAD of the persisted rows — a chat with
+        // a full transcript showed "Ask a question to start a chat." whenever
+        // rehydration couldn't correct the claim (the daemon throws
+        // `noSession` for any chat whose launcher it has evicted).
+        self.activeChatID = nil
+    }
+
+    /// Drop this mirror's liveness claim: the daemon is not running this chat,
+    /// so `ChatDetailView` must fall back to the persisted rows. Called by
+    /// `ChatDaemonCoordinator.rehydrate` when the state fetch fails — an
+    /// evicted session is indistinguishable from a transport error here, and
+    /// "not live" is the safe answer for both (the persisted transcript is
+    /// always renderable; an empty live stream is not).
+    func markNotLive() {
+        activeChatID = nil
+        isInteractiveSession = false
     }
 
     // MARK: - Envelope ingestion

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -229,6 +229,45 @@ struct ChatDaemonCoordinatorTests {
         #expect(coord.session(for: "chat-1").events.isEmpty)
     }
 
+    @Test func rehydrateFailure_clearsLivenessSoPersistedRowsRender() async {
+        // Regression: the daemon throws `noSession` for any chat whose launcher
+        // it has evicted (every chat from a previous app run). If the mirror is
+        // left claiming liveness, `ChatDetailView.isLiveChat` is true with zero
+        // events and the view renders an empty live stream — a chat with a full
+        // persisted transcript showed "Ask a question to start a chat.".
+        let stub = StubChatDaemonCommands(shouldThrow: true)
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        await coord.rehydrate(chatID: "chat-evicted")
+        let session = coord.session(for: "chat-evicted")
+        #expect(session.activeChatID == nil)
+        #expect(session.isInteractiveSession == false)
+        #expect(coord.isChatRunning("chat-evicted") == false)
+    }
+
+    @Test func freshSessionDoesNotClaimLivenessBeforeHydration() async {
+        // A mirror the daemon has never reported on must not pass the
+        // source-of-truth rule: `activeChatID` is daemon-derived, so it stays
+        // nil until `hydrate`/`applyStateUpdate` sets it.
+        let coord = makeCoordinator()
+        #expect(coord.session(for: "chat-new").activeChatID == nil)
+        #expect(coord.session(for: nil).activeChatID == nil)
+    }
+
+    @Test func rehydrateIdleState_leavesSessionNotLive() async {
+        // The daemon still holds the launcher but reports it idle — the mirror
+        // must render persisted rows, not the launcher's in-memory events.
+        let stub = StubChatDaemonCommands()
+        stub.sessionState = ChatSessionState(
+            chatID: "chat-idle", events: [],
+            isRunning: false, isGenerating: false, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        await coord.rehydrate(chatID: "chat-idle")
+        #expect(coord.session(for: "chat-idle").activeChatID == nil)
+        #expect(coord.isChatRunning("chat-idle") == false)
+    }
+
     // MARK: - Helpers
 
     private func makeCoordinator() -> ChatDaemonCoordinator {

--- a/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
+++ b/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
@@ -464,5 +464,28 @@ struct RemoteChatSessionTests {
         #expect(session.activeChatID == nil)
         #expect(session.isRunning == false)
     }
+
+    @Test @MainActor func freshSessionIsNotLiveUntilDaemonSaysSo() {
+        // Regression: `init` used to seed `activeChatID = chatID`, so a brand
+        // new mirror passed `ChatDetailView.isLiveChat` with an empty `events`
+        // array — the view then rendered that empty live stream instead of the
+        // chat's persisted rows.
+        let session = RemoteChatSession(chatID: "chat-fresh")
+        #expect(session.activeChatID == nil)
+        #expect(session.isInteractiveSession == false)
+    }
+
+    @Test @MainActor func markNotLiveRelinquishesLivenessClaim() {
+        let session = RemoteChatSession(chatID: "chat-evicted")
+        session.ingest(.chatState(chatID: "chat-evicted", update: ChatStateUpdate(
+            isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
+        #expect(session.activeChatID == "chat-evicted")
+
+        session.markNotLive()
+        #expect(session.activeChatID == nil)
+        #expect(session.isInteractiveSession == false)
+    }
 }
 #endif


### PR DESCRIPTION
## Symptom

Opening a chat that has a full persisted transcript shows the empty-composer
state — **"Ask a question to start a chat."** — instead of its messages.

Reproduced on the "Fun Stuff" wiki with chat `01KYBG3AWRCKBKDPTWEFDY4PP0`:
8 rows present in `chat_messages`, all `is_draft = 0`, none rendered.

## Root cause

`ChatDetailView.isLiveChat` picks the data source with one rule:

```swift
private var isLiveChat: Bool {
    guard let chatID else { return false }
    return remoteSession.activeChatID == chatID.rawValue   // live → stream; else → DB
}
```

`RemoteChatSession.init` was seeding `activeChatID = chatID` unconditionally, so
**every freshly-created mirror claimed to be the live session** while holding an
empty `events` array. That inverts the source-of-truth rule: `displayMessages`
returns `[]` and `transcriptEmptyMessage` takes the *live* branch. The property's
own doc comment already stated the invariant it broke three lines later —
"Managed by `hydrate`/`applyStateUpdate` from the daemon's run flags".

`rehydrate` normally corrects the claim. But `DaemonChatHost.chatSessionState`
throws `noSession` for any chat whose launcher the daemon has evicted — i.e.
**every chat from a previous app run**. That path is:

`noSession` → `WikiDaemon.chatSessionStateData` returns empty `Data()` →
`DaemonWorkloadClient` fails to decode → throws `unexpectedReply` →
`rehydrate`'s catch.

The catch block's comment promised "the persisted rows remain the source of
truth" but never actually dropped the stale liveness claim, so the view rendered
the empty live stream indefinitely.

Confirmed against the running app:

```
07:11:04 Self Driving Wiki: ChatDaemonCoordinator.rehydrate failed for
         01KYBG3AWRCKBKDPTWEFDY4PP0: unexpectedReply
```

The existing tests verify the invariant *after* hydration
(`RemoteChatSessionTests.swift:385-428`) and never at construction, so the gap
sat in the blind spot between "constructed" and "daemon has spoken".

## Fix

- `RemoteChatSession.init` leaves `activeChatID` nil. A fresh mirror knows
  nothing about the daemon and must not claim liveness.
- New `markNotLive()` clears both `activeChatID` and `isInteractiveSession`.
- `ChatDaemonCoordinator.rehydrate`'s catch calls it and drops the chat from
  `runningChatIDs`, so a failed rehydrate genuinely falls back to the persisted
  transcript. The log line now ends `— marked not live` so the path is visible
  in Console.

## Behavioral note

For a *newly started* chat there is now a brief window between tab retarget and
the daemon's first `chatState` envelope where the view renders persisted rows
rather than the live stream. This is strictly better than before: if envelopes
are not arriving, `events` stays empty either way — previously that produced a
blank live view, now it shows the rows the daemon actually wrote. `submitMessage`
branches on `isInteractiveSession` (not `activeChatID`), so the send path is
unaffected.

## Relationship to #904

#904 was the **live-path** half of this symptom family: the app's
`WikiDaemonEventSink` was never registered with the running daemon, so every
pushed envelope was dropped (0 `event sink registered` vs 216
`no sinks registered (drop)`) and replies never streamed. That was the #877
bootout/bootstrap race, and **#907 resolved it** — moving wikid to an embedded
XPC service removes launchd's ability to swap the daemon out from under the app
(`WikiDaemonConnection.swift:46,83`: "no LaunchAgent, no launchctl"), and carried
in the `setInterruptionHandler` hardening #906 had proposed
(`WikiDaemonConnection.swift:176`, installed at `DaemonHealthMonitor.swift:196`,
with three `registerEventSink` sites at `WikiFSApp.swift:470,515,534`).

This PR fixes the **fallback** half. When live events don't arrive — for any
reason — the view is supposed to fall back to the persisted rows. It couldn't:
`persistedMessages` was loaded on every `.task` and then ignored, because
`isLiveChat` was permanently true. That is also why #904's own proposed fix
item 3 ("if the open chat has no live stream, re-read persisted `chat_messages`
so the transcript is never stuck") could not have worked as written.

The two are genuinely independent: this path fails even with a perfectly healthy
event sink, and reproduces on any chat whose daemon launcher has been evicted —
i.e. every chat from a previous app run.

## Tests

6 new regression tests:

- `freshSessionIsNotLiveUntilDaemonSaysSo`
- `markNotLiveRelinquishesLivenessClaim`
- `rehydrateFailure_clearsLivenessSoPersistedRowsRender`
- `freshSessionDoesNotClaimLivenessBeforeHydration`
- `rehydrateIdleState_leavesSessionNotLive`
- (plus the existing `rehydrate_swallowsClientFailure` retained)

`swift build` clean. Full `WikiFSAppTests`: **1428 tests in 141 suites**, one
failure — `MiniLMEmbedder` "Per-chunk latency <= 20 ms" (median 21.68 ms), a
pre-existing GPU timing threshold unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
