### PR TITLE
Source chats.summary from the first message summary, not a rival truncation

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,46 @@
 # Progress log
 
+## fix: Chat summary abbreviated even when a summarizer model was pinned
+
+**Goal:** the chats-list row subtitle was always a truncated first sentence
+ending in `…`, even with a summarizer model pinned. Eliding is only correct for
+the Default "text shortener"; a summary the model already wrote should be stored
+as-is.
+
+**Root cause:** two summary surfaces had diverged. `chat_messages.summary` (the
+per-turn outline entries, chat-summary plan) dispatches on
+`stageProviderIds["summarizer"]` and stores model output verbatim — that path was
+fine. `chats.summary` (issue #411, the row subtitle) was written by a *separate*,
+older path: `AgentLauncher.generateChatSummary()` → `firstSummaryText(from:)` →
+`ChatSummary.summaryExtract(from:maxLength: 60)`, unconditionally, with no
+knowledge of the summarizer mode. The chat-summary plan had flagged this
+explicitly as out of scope ("a separate, already-shipped truncation; leave it
+unless the operator wants to unify" — `plans/chat-summary.md:116`). Worth naming:
+`chats.summary` is *not* a summary of the conversation — it is the gist of the
+opening answer only, since `firstSummaryText` stops at the first assistant event
+and a resumed run seeds `events = historySeed`, pinning it to the original
+response forever.
+
+**What changed:** unified the two — `chats.summary` now MIRRORS the first
+summarizable message's `chat_messages.summary`, so it inherits that summarizer's
+mode (Default ⇒ truncated extract, Model ⇒ the model's sentence verbatim) and
+costs zero extra model calls. New pure `MessageSummarizer.chatSummaryMessageID(in:)`
+picks the source message; both hosts write the chat row alongside the message row.
+The launcher's rival path is **removed**, not bypassed — `generateChatSummary()`,
+`firstSummaryText`, `summarySink`, `summaryGenerated`, and the `onSummary`
+parameter are gone. Leaving it alive would have raced: the launcher fires each
+run and would overwrite a model summary with a truncated one on the next turn.
+
+**Behavior note:** in Default mode the subtitle now comes from the per-message
+extract (`maxLength: 200`) instead of 60. The only consumer is the chats-list
+subtitle, a single-line `NSTextField` with `lineBreakMode = .byTruncatingTail`,
+so it clips to row width at draw time either way. Existing chats keep their old
+truncated summary until their next turn, when the first message is summarized and
+mirrors over it.
+
+**Files:** `Sources/WikiFSEngine/{MessageSummarizer,AgentLauncher,AgentOperationRunner}.swift`,
+`Sources/wikid/DaemonChatHost.swift`; `Tests/WikiFSTests/ChatSummaryTests.swift`.
+
 ## fix: Persisted chat rendered as an empty live stream after daemon session eviction
 
 **Goal:** a chat with a full persisted transcript opened to the empty-composer

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -700,16 +700,6 @@ public final class AgentLauncher {
     /// one-shot runs and whenever no chat has been created for the session (e.g.
     /// `store.startChat` failed). Cleared in `finish()` and `resetRunArtifacts()`.
     @ObservationIgnored private var transcriptSink: (@MainActor ([AgentEvent]) -> Void)?
-    /// Summary sink (issue #411): called once in `finish()` after the final
-    /// `flushTranscript()`, receiving (chatID, summary) so the store can
-    /// persist the one-line model-response summary. `nil` when no chat is
-    /// active (one-shot runs, or the session was never assigned a chatID).
-    /// Cleared in `finish()` and `resetRunArtifacts()` for hygiene.
-    @ObservationIgnored private var summarySink: (@MainActor (PageID, String) -> Void)?
-    /// One-shot guard so the summary is generated only once per session
-    /// (after the first assistant turn completes), not on every turn.
-    /// Reset in `resetRunArtifacts()`.
-    @ObservationIgnored private var summaryGenerated = false
     /// Per-message summary sink (chat-summary plan §6.1). Fired once in
     /// `finish()` with the active chat id so the wired callback can summarize
     /// the assistant messages from this turn + persist via
@@ -2876,7 +2866,6 @@ public final class AgentLauncher {
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
         onTranscript: (@MainActor ([AgentEvent]) -> Void)? = nil,
-        onSummary: (@MainActor (PageID, String) -> Void)? = nil,
         onMessageSummary: (@MainActor (PageID) -> Void)? = nil,
         onStreamingCheckpoint: (@MainActor (PageID, String, AgentEvent, Bool) -> Bool)? = nil
     ) async {
@@ -3008,7 +2997,6 @@ public final class AgentLauncher {
         // both are per-session callbacks assigned once resetRunArtifacts() has run
         // (which clears any stale sink from a prior run).
         transcriptSink = onTranscript
-        summarySink = onSummary
         messageSummarySink = onMessageSummary
         streamingCheckpointSink = onStreamingCheckpoint
         // D2: record the chat row this live session is writing to. This is the
@@ -3291,7 +3279,6 @@ public final class AgentLauncher {
                     self.checkpointTimer?.cancel()
                     self.checkpointTimer = nil
                     self.flushTranscript()
-                    self.generateChatSummary()
                     // Fire per-message summarization on the turn boundary — not
                     // just in finish(). Interactive chats stay alive across many
                     // turns without ever reaching finish(), so the sink must run
@@ -3432,45 +3419,8 @@ public final class AgentLauncher {
         return Array(events[persistedCount...])
     }
 
-    /// Extract the first assistant-text sentence from the event stream (issue
-    /// #411). Iterates `events` to find the first `.assistantText(String)` or
-    /// `.result(isError:text:)` with non-empty text, then extracts the first
-    /// sentence via `ChatSummary.summaryExtract(from:maxLength:)`. Returns `nil`
-    /// if no suitable event is found or the extract is empty. Static so the
-    /// event-selection logic is unit-testable without driving a live launcher.
-    nonisolated static func firstSummaryText(from events: [AgentEvent]) -> String? {
-        for event in events {
-            let text: String
-            switch event {
-            case .assistantText(let s):
-                text = s
-            case .result(_, let s):
-                text = s
-            default:
-                continue
-            }
-            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
-            let extract = ChatSummary.summaryExtract(from: text)
-            guard !extract.isEmpty else { continue }
-            return extract
-        }
-        return nil
-    }
-
-    /// Generate the one-line chat summary from `events` and hand it to
-    /// `summarySink` (issue #411). Called once in `finish()` after the final
-    /// `flushTranscript()` and before `activeChatID = nil`. No-op when no
-    /// summary can be extracted or no sink/chatID is set.
-    private func generateChatSummary() {
-        guard !summaryGenerated else { return }
-        guard let extracted = Self.firstSummaryText(from: events),
-              let chatID = activeChatID else { return }
-        summaryGenerated = true
-        summarySink?(PageID(rawValue: chatID), extracted)
-    }
-
     /// Fire the per-message summary sink (chat-summary plan §6.1). Called once
-    /// in `finish()` after `flushTranscript()` + `generateChatSummary()` and
+    /// in `finish()` after `flushTranscript()` and
     /// before `activeChatID = nil`. No-op when no sink/chatID is set. The sink
     /// owns the mode dispatch + the off-main Task for model mode; this method
     /// just hands it the chat id.
@@ -3710,10 +3660,6 @@ public final class AgentLauncher {
         // Session over: flush any remaining tail (a killed/died session still
         // persists its last events) THEN detach the sink — no further writes.
         flushTranscript()
-        // Generate and persist the one-line chat summary (issue #411). Must
-        // run AFTER flushTranscript() (so the transcript is committed) and
-        // BEFORE activeChatID = nil (so the chat ID is still available).
-        generateChatSummary()
         // Fire the per-message summary sink (chat-summary plan §6.1). Runs
         // AFTER flushTranscript() so the turn's messages are committed (the
         // sink queries `chatMessages(chatID:)` for unsummarized rows), and
@@ -3722,7 +3668,6 @@ public final class AgentLauncher {
         // model mode spawns an off-main Task (the sink closure owns that hop).
         fireMessageSummarySink()
         transcriptSink = nil
-        summarySink = nil
         messageSummarySink = nil
         streamingCheckpointSink = nil
         onAgentEvent = nil
@@ -3858,7 +3803,6 @@ public final class AgentLauncher {
         // A reset starts a new run: a stale sink must never receive a new
         // session's events (issue #119).
         transcriptSink = nil
-        summarySink = nil
         messageSummarySink = nil
         streamingCheckpointSink = nil
         onAgentEvent = nil
@@ -3876,7 +3820,6 @@ public final class AgentLauncher {
         // `resetRunArtifacts()` a pure reset (no side effects on the prior
         // run's already-torn-down Activity state).
         onPendingPermission = nil
-        summaryGenerated = false
         persistedEventCount = 0
         streamingRowDirty = false
         streamingDraftHandle = nil

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -107,9 +107,6 @@ public enum AgentOperationRunner {
             onTranscript: chat.map { chat -> (@MainActor ([AgentEvent]) -> Void) in
                 return { [weak store] events in store?.appendChatEvents(chatID: chat.id, events: events) }
             },
-            onSummary: chat.map { chat -> (@MainActor (PageID, String) -> Void) in
-                return { [weak store] id, summary in store?.updateChatSummary(chatID: id, summary: summary) }
-            },
             onMessageSummary: chat.map { chat -> (@MainActor (PageID) -> Void) in
                 return { [weak store] id in
                     Self.summarizePendingMessages(chatID: id, store: store, launcher: launcher)
@@ -471,9 +468,6 @@ public enum AgentOperationRunner {
             onTranscript: { [weak store] events in
                 store?.appendChatEvents(chatID: chatID, events: events)
             },
-            onSummary: { [weak store] id, summary in
-                store?.updateChatSummary(chatID: id, summary: summary)
-            },
             onMessageSummary: { [weak store] id in
                 Self.summarizePendingMessages(chatID: id, store: store, launcher: launcher)
             },
@@ -601,6 +595,12 @@ public enum AgentOperationRunner {
     /// **Idempotency (AC.6):** only messages with `summary == nil` are
     /// summarized — the store query is the compute-once guard. Re-firing the
     /// sink (e.g. on a second turn) is a no-op for already-summarized rows.
+    ///
+    /// **Chat-level summary (issue #411):** the FIRST summarizable message's
+    /// summary is mirrored into `chats.summary` (the chats-list subtitle) as it
+    /// is written. This is the only writer of that column — the launcher no
+    /// longer computes its own always-truncated version, which is what made the
+    /// subtitle abbreviate even in Model mode.
     @MainActor
     private static func summarizePendingMessages(
         chatID: PageID, store: WikiStoreModel?, launcher: AgentLauncher
@@ -618,6 +618,8 @@ public enum AgentOperationRunner {
             msg.summary == nil
                 && (MessageSummarizer.textToSummarize(from: msg.event)?.isEmpty == false)
         }
+        // The message whose summary doubles as `chats.summary` (issue #411).
+        let chatSummaryMessageID = MessageSummarizer.chatSummaryMessageID(in: messages)
         DebugLog.ingest("summarizePendingMessages: chatID=\(chatID.rawValue) mode=\(mode) pin=\(summarizerPin) pending=\(pending.count)")
 
         guard !pending.isEmpty else {
@@ -636,6 +638,10 @@ public enum AgentOperationRunner {
                 chatID: chatID, messageID: msg.id,
                 summary: summary, kind: .defaultTruncation)
             DebugLog.ingest("summarizePendingMessages: wrote summary for id=\(msg.id.rawValue.prefix(8)) kind=defaultTruncation")
+            if msg.id == chatSummaryMessageID {
+                store.updateChatSummary(chatID: chatID, summary: summary)
+                DebugLog.ingest("summarizePendingMessages: mirrored chat summary from first message")
+            }
         }
         case .model:
             // Off-main via a detached Task. The config + pending messages are
@@ -647,7 +653,7 @@ public enum AgentOperationRunner {
                 await Self.runModelSummarization(
                     chatID: chatID, pending: pending, config: config,
                     containerDir: containerDir, credentialStore: credentialStore,
-                    store: store)
+                    store: store, chatSummaryMessageID: chatSummaryMessageID)
             }
         }
     }
@@ -656,11 +662,15 @@ public enum AgentOperationRunner {
     /// (chat-summary plan §4.3 + §6.4). Runs off-main for the ACP session(s);
     /// marshals each write back to the `@MainActor` store. Called from a
     /// `Task` so it doesn't block `finish()`.
+    ///
+    /// `chatSummaryMessageID` is the message whose summary is also mirrored into
+    /// `chats.summary` — VERBATIM, since the model already wrote a one-sentence
+    /// summary and eliding it would chop the answer.
     @MainActor
     private static func runModelSummarization(
         chatID: PageID, pending: [ChatMessage], config: AgentProvidersConfig,
         containerDir: URL, credentialStore: any ACPCredentialStore,
-        store: WikiStoreModel
+        store: WikiStoreModel, chatSummaryMessageID: PageID?
     ) async {
         guard let profile = MessageSummarizer.resolveProfile(
             config: config, credentialStore: credentialStore) else {
@@ -684,6 +694,10 @@ public enum AgentOperationRunner {
                 chatID: chatID, messageID: msg.id,
                 summary: summary, kind: .model)
             DebugLog.ingest("summarizePendingMessages: wrote summary for id=\(msg.id.rawValue.prefix(8)) kind=model")
+            if msg.id == chatSummaryMessageID {
+                store.updateChatSummary(chatID: chatID, summary: summary)
+                DebugLog.ingest("runModelSummarization: mirrored chat summary from first message")
+            }
         }
     }
 }

--- a/Sources/WikiFSEngine/MessageSummarizer.swift
+++ b/Sources/WikiFSEngine/MessageSummarizer.swift
@@ -80,6 +80,26 @@ public enum MessageSummarizer {
         }
     }
 
+    /// The message whose summary doubles as the CHAT-level summary
+    /// (`chats.summary`, issue #411): the FIRST summarizable message in the
+    /// chat. PURE — `messages` must be in store order.
+    ///
+    /// `chats.summary` is not a summary of the whole conversation; it is the
+    /// gist of the opening answer, shown as the chats-list row subtitle. Rather
+    /// than compute it separately (the pre-#411-unification design, which always
+    /// truncated regardless of the summarizer mode), both hosts now MIRROR the
+    /// first message's cached summary into the chat row. That gives one writer,
+    /// one condensing policy, and — in Model mode — zero extra model calls: the
+    /// chat summary is a copy of a per-message summary that was computed anyway.
+    ///
+    /// Returns nil when no message has summarizable text.
+    public static func chatSummaryMessageID(in messages: [ChatMessage]) -> PageID? {
+        messages.first { msg in
+            guard let text = textToSummarize(from: msg.event) else { return false }
+            return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }?.id
+    }
+
     /// Run a one-shot model summarization via the injected `AgentBackend`
     /// (chat-summary plan §4.3). Mirrors `ACPExtractionClient.convert`: start a
     /// session with `modelSystemPrompt`, send ONE turn, collect `.assistantText`

--- a/Sources/wikid/DaemonChatHost.swift
+++ b/Sources/wikid/DaemonChatHost.swift
@@ -160,9 +160,6 @@ final class DaemonChatHost: @unchecked Sendable {
                 self?.handleTranscript(
                     chatID: chatIDPage, events: events, wikiID: wikiIDCapture)
             },
-            onSummary: { [weak self] id, summary in
-                self?.handleSummary(chatID: id, summary: summary, wikiID: wikiIDCapture)
-            },
             onMessageSummary: { [weak self] id in
                 self?.summarizePendingMessages(
                     chatID: id, wikiID: wikiIDCapture, launcher: launcher)
@@ -272,9 +269,6 @@ final class DaemonChatHost: @unchecked Sendable {
             onTranscript: { [weak self] events in
                 self?.handleTranscript(
                     chatID: chatIDPage, events: events, wikiID: wikiIDCapture)
-            },
-            onSummary: { [weak self] id, summary in
-                self?.handleSummary(chatID: id, summary: summary, wikiID: wikiIDCapture)
             },
             onMessageSummary: { [weak self] id in
                 self?.summarizePendingMessages(
@@ -515,17 +509,6 @@ final class DaemonChatHost: @unchecked Sendable {
         }
     }
 
-    private func handleSummary(
-        chatID: PageID, summary: String, wikiID: String
-    ) {
-        guard let store = storeResolver(wikiID) else { return }
-        do {
-            try store.updateChatSummary(chatID: chatID, summary: summary)
-        } catch {
-            DebugLog.store("DaemonChatHost: updateChatSummary failed: \(error)")
-        }
-    }
-
     // MARK: - Private: message summarization (RC5)
 
     /// Summarize all unsummarized assistant messages in `chatID` per the
@@ -534,6 +517,10 @@ final class DaemonChatHost: @unchecked Sendable {
     ///
     /// RC5: this is the daemon-native generalization of the app's
     /// `summarizePendingMessages` + `runModelSummarization`.
+    ///
+    /// Also mirrors the FIRST summarizable message's summary into
+    /// `chats.summary` (issue #411) — the sole writer of that column now that
+    /// the launcher's always-truncated path is gone.
     private func summarizePendingMessages(
         chatID: PageID, wikiID: String, launcher: AgentLauncher
     ) {
@@ -556,6 +543,9 @@ final class DaemonChatHost: @unchecked Sendable {
         }
         guard !pending.isEmpty else { return }
 
+        // The message whose summary doubles as `chats.summary` (issue #411).
+        let chatSummaryMessageID = MessageSummarizer.chatSummaryMessageID(in: messages)
+
         switch mode {
         case .defaultTruncation:
             for msg in pending {
@@ -566,8 +556,11 @@ final class DaemonChatHost: @unchecked Sendable {
                     try store.updateMessageSummary(
                         chatID: chatID, messageID: msg.id,
                         summary: summary, kind: .defaultTruncation)
+                    if msg.id == chatSummaryMessageID {
+                        try store.updateChatSummary(chatID: chatID, summary: summary)
+                    }
                 } catch {
-                    DebugLog.store("DaemonChatHost: updateMessageSummary failed: \(error)")
+                    DebugLog.store("DaemonChatHost: summary write failed: \(error)")
                 }
             }
         case .model:
@@ -577,7 +570,7 @@ final class DaemonChatHost: @unchecked Sendable {
                 await Self.runModelSummarization(
                     chatID: chatID, pending: pending, config: config,
                     containerDir: containerDir, credentialStore: credentialStore,
-                    store: store)
+                    store: store, chatSummaryMessageID: chatSummaryMessageID)
             }
         }
     }
@@ -588,7 +581,7 @@ final class DaemonChatHost: @unchecked Sendable {
     private static func runModelSummarization(
         chatID: PageID, pending: [ChatMessage], config: AgentProvidersConfig,
         containerDir: URL, credentialStore: any ACPCredentialStore,
-        store: GRDBWikiStore
+        store: GRDBWikiStore, chatSummaryMessageID: PageID?
     ) async {
         guard let profile = MessageSummarizer.resolveProfile(
             config: config, credentialStore: credentialStore) else {
@@ -604,6 +597,11 @@ final class DaemonChatHost: @unchecked Sendable {
                 try store.updateMessageSummary(
                     chatID: chatID, messageID: msg.id,
                     summary: summary, kind: .model)
+                // VERBATIM into the chat row — the model already produced a
+                // one-sentence summary; eliding it would chop the answer.
+                if msg.id == chatSummaryMessageID {
+                    try store.updateChatSummary(chatID: chatID, summary: summary)
+                }
             } catch {
                 DebugLog.store("DaemonChatHost.runModelSummarization: write failed: \(error)")
             }

--- a/Tests/WikiFSTests/ChatSummaryTests.swift
+++ b/Tests/WikiFSTests/ChatSummaryTests.swift
@@ -6,11 +6,18 @@ import Testing
 
 /// Tests for the chat-summary feature (issue #411).
 ///
+/// `chats.summary` is the chats-list row subtitle — the gist of the OPENING
+/// answer, not a summary of the whole conversation. It is no longer computed
+/// separately: it MIRRORS the first summarizable message's `chat_messages.summary`,
+/// so it inherits that summarizer's mode (Default ⇒ truncated extract, Model ⇒
+/// the model's sentence verbatim). Before the unification the launcher wrote its
+/// own always-truncated version, which abbreviated the subtitle even in Model mode.
+///
 /// Three layers:
 ///   - **Pure extract** — `ChatSummary.summaryExtract(from:maxLength:)` is a
 ///     pure function; these tests run in the fast tier.
-///   - **Static event-selection** — `AgentLauncher.firstSummaryText(from:)`
-///     iterates `[AgentEvent]` without a live launcher; fast tier.
+///   - **Source selection** — `MessageSummarizer.chatSummaryMessageID(in:)`
+///     picks which message feeds the chat row; pure, fast tier.
 ///   - **Store round-trip** — `updateChatSummary` + `listChats()` on a real
 ///     SQLite DB; tagged `.integration` (opens a real store).
 @Suite(.timeLimit(.minutes(5)))
@@ -50,44 +57,57 @@ struct ChatSummaryTests {
         #expect(result == "Short text.")
     }
 
-    // MARK: - Static event selection: AgentLauncher.firstSummaryText
+    // MARK: - Chat-summary source selection: MessageSummarizer.chatSummaryMessageID
 
-    @Test func firstSummaryText_assistantText_extractsFirstSentence() {
-        let events: [AgentEvent] = [
+    /// Build a `ChatMessage` list from events with deterministic ids ("m0", "m1", …).
+    private func messages(_ events: [AgentEvent]) -> [ChatMessage] {
+        events.enumerated().map { idx, event in
+            ChatMessage(
+                id: PageID(rawValue: "m\(idx)"), chatID: PageID(rawValue: "chat"),
+                seq: idx, event: event, createdAt: Date(timeIntervalSince1970: 0))
+        }
+    }
+
+    @Test func chatSummaryMessageID_picksFirstAssistantMessage() {
+        // The chat subtitle mirrors the FIRST assistant response's summary —
+        // later assistant turns never overwrite it.
+        let msgs = messages([
             .userText("question"),
-            .assistantText("First sentence here. Second sentence omitted."),
-        ]
-        let result = AgentLauncher.firstSummaryText(from: events)
-        #expect(result == "First sentence here.")
+            .assistantText("First answer."),
+            .assistantText("Second answer."),
+        ])
+        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == PageID(rawValue: "m1"))
     }
 
-    @Test func firstSummaryText_resultEvent_extractsFromResultText() {
-        let events: [AgentEvent] = [
+    @Test func chatSummaryMessageID_acceptsResultEvent() {
+        // Agents that emit everything in .result still seed the chat summary.
+        let msgs = messages([
             .toolUse(name: "Bash", inputSummary: "ls"),
-            .result(isError: false, text: "The answer is 42. More details follow."),
-        ]
-        let result = AgentLauncher.firstSummaryText(from: events)
-        #expect(result == "The answer is 42.")
+            .result(isError: false, text: "The answer is 42."),
+        ])
+        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == PageID(rawValue: "m1"))
     }
 
-    @Test func firstSummaryText_onlyToolEvents_returnsNil() {
-        let events: [AgentEvent] = [
+    @Test func chatSummaryMessageID_skipsWhitespaceOnlyText() {
+        // A blank assistant message is not a summary source — the next one is.
+        let msgs = messages([
+            .assistantText("   "),
+            .assistantText("Real answer."),
+        ])
+        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == PageID(rawValue: "m1"))
+    }
+
+    @Test func chatSummaryMessageID_onlyNonAssistantEvents_returnsNil() {
+        let msgs = messages([
             .userText("question"),
             .toolUse(name: "Bash", inputSummary: "ls"),
             .toolResult(isError: false, summary: "file.txt"),
-        ]
-        #expect(AgentLauncher.firstSummaryText(from: events) == nil)
+        ])
+        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == nil)
     }
 
-    @Test func firstSummaryText_emptyEvents_returnsNil() {
-        #expect(AgentLauncher.firstSummaryText(from: []) == nil)
-    }
-
-    @Test func firstSummaryText_emptyAssistantText_returnsNil() {
-        let events: [AgentEvent] = [
-            .assistantText("   "),
-        ]
-        #expect(AgentLauncher.firstSummaryText(from: events) == nil)
+    @Test func chatSummaryMessageID_emptyMessages_returnsNil() {
+        #expect(MessageSummarizer.chatSummaryMessageID(in: []) == nil)
     }
 
     // MARK: - Store round-trip (integration)


### PR DESCRIPTION
## Problem

The chats-list row subtitle was always a first-sentence extract elided to 60 chars with `…` — **even when a summarizer model was pinned**. Eliding is only correct for the Default "text shortener"; a sentence the model already wrote should be stored as-is.

## Root cause: two summary surfaces, only one mode-aware

|  | `chat_messages.summary` | `chats.summary` |
|---|---|---|
| Cardinality | one per assistant message (per turn) | one per chat |
| Surface | right-hand outline in `ChatDetailView` | chats-list row subtitle |
| Writer | `summarizePendingMessages` | `AgentLauncher.generateChatSummary()` |
| Mode-aware | ✅ Default ⇒ extract, Model ⇒ verbatim | ❌ always `summaryExtract(maxLength: 60)` |

The per-message path (chat-summary plan) dispatches on `stageProviderIds["summarizer"]` and stores model output verbatim — that path was fine. `chats.summary` (#411) was written by a separate, older path that never consulted the mode. The plan had flagged this explicitly as out of scope (`plans/chat-summary.md:116`: *"a separate, already-shipped truncation; leave it unless the operator wants to unify"*). This PR is that unification.

Worth naming while we're here: **`chats.summary` is not a summary of the conversation.** `firstSummaryText` stops at the first assistant event, and a resumed run seeds `events = historySeed`, so it's pinned to the gist of the *opening answer* forever.

## What changed

`chats.summary` now **mirrors** the first summarizable message's `chat_messages.summary`, inheriting that summarizer's mode at **zero extra model cost** — it copies a summary that was computed anyway.

- New pure `MessageSummarizer.chatSummaryMessageID(in:)` selects the source message.
- `AgentOperationRunner` and `DaemonChatHost` write the chat row alongside the message row, in both the Default and Model branches.
- **Removed** the launcher's rival path: `generateChatSummary()`, `firstSummaryText`, `summarySink`, `summaryGenerated`, and the `onSummary` parameter (−59 lines in `AgentLauncher`).

The removal is load-bearing, not cleanup. `generateChatSummary` fires once per run, so leaving it alive would overwrite a model summary with a truncated one on the *next* turn — correct right after the model responds, silently wrong afterwards. That's a subtler bug than the one being fixed.

## Behavior notes

- **Default-mode subtitles are now up to 200 chars, not 60** (the per-message extract length). The only consumer is a single-line `NSTextField` with `lineBreakMode = .byTruncatingTail`, which clips to row width either way.
- **No backfill.** Existing chats keep their old truncated subtitle until their next turn, when the first message is summarized and mirrors over it.

## Tests

`ChatSummaryTests` repointed from the deleted `firstSummaryText` to `chatSummaryMessageID(in:)` — 5 cases: picks the first assistant message (later turns never overwrite), accepts `.result`-only agents, skips whitespace-only text, nil for tool-only chats, nil for empty.

`swift build` ✓. `ChatSummaryTests` + `MessageSummaryTests` ✓ (43 tests, 2 suites). **The full suite was still running when this PR was opened at the operator's request** — 8400+ lines in with no failures, but not confirmed green. Worth a check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)