### PR TITLE
Fix stuck 'responding' badge and outline summary abbreviation

### DIFF
--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -55,6 +55,14 @@ public final class ChatDaemonCoordinator {
     /// (e.g. one started via `wikictl`) that the user hasn't opened here.
     private var runningChatIDs: Set<String> = []
 
+    /// Bumped whenever `runningChatIDs` changes, so SwiftUI views that badge
+    /// chats (the sidebar list) re-render when a chat starts or stops running.
+    /// `runningChatIDs` is private and read only inside `isChatRunning(_:)`,
+    /// which the table data source calls *outside* SwiftUI's tracked body — so
+    /// a dedicated observable signal is the only way the sidebar learns a chat
+    /// finished (otherwise the "responding…" badge sticks forever).
+    public private(set) var runningStateToken: Int = 0
+
     private var routerTask: Task<Void, Never>?
 
     /// Key for the draft (.newChat) session — `chatID == nil` at the view level.
@@ -109,17 +117,26 @@ public final class ChatDaemonCoordinator {
         // Track the running set from state envelopes so the sidebar can badge
         // chats the daemon is running even without an open app session.
         if envelope.kind == .chatState, let update = envelope.chatStateUpdate {
-            if update.isRunning || update.isGenerating {
-                runningChatIDs.insert(chatID)
-            } else {
-                runningChatIDs.remove(chatID)
-            }
+            setChatRunning(chatID, running: update.isRunning || update.isGenerating)
         }
         // Deliver to the open session if one exists.
         sessions[chatID]?.ingest(envelope)
     }
 
     // MARK: - Sidebar liveness aggregate
+
+    /// The single mutator for `runningChatIDs`. Updates the set and bumps
+    /// `runningStateToken` **only when membership actually changes**, so every
+    /// liveness transition flows through one place (both the event-router
+    /// `route()` and `rehydrate()`). Centralizing this guarantees the
+    /// observable signal always fires — forgetting the token bump in a new
+    /// call site would silently stick the sidebar "responding…" badge.
+    private func setChatRunning(_ chatID: String, running: Bool) {
+        let didChange = running
+            ? runningChatIDs.insert(chatID).inserted
+            : runningChatIDs.remove(chatID) != nil
+        if didChange { runningStateToken &+= 1 }
+    }
 
     /// True if the daemon reports this chat as running/generating. Backs the
     /// sidebar + chats-list live indicator (replaces
@@ -213,11 +230,7 @@ public final class ChatDaemonCoordinator {
         do {
             let state = try await client.chatSessionState(chatID)
             session.hydrate(from: state)
-            if state.isRunning || state.isGenerating {
-                runningChatIDs.insert(chatID)
-            } else {
-                runningChatIDs.remove(chatID)
-            }
+            setChatRunning(chatID, running: state.isRunning || state.isGenerating)
         } catch {
             // A rehydrate failure (e.g. the daemon evicted the session, so
             // `chatSessionState` throws `noSession`) is non-fatal — but the
@@ -227,7 +240,7 @@ public final class ChatDaemonCoordinator {
             // `ChatDetailView` renders that empty stream instead of the
             // persisted transcript.
             session.markNotLive()
-            runningChatIDs.remove(chatID)
+            setChatRunning(chatID, running: false)
             DebugLog.agent("ChatDaemonCoordinator.rehydrate failed for \(chatID): \(error) — marked not live")
         }
     }

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -1707,7 +1707,6 @@ struct ChatOutlineView: View {
                                             Text(response)
                                                 .font(.caption)
                                                 .foregroundStyle(.secondary)
-                                                .lineLimit(3)
                                                 .multilineTextAlignment(.leading)
                                         }
                                     }

--- a/Sources/WikiFS/Chats/ChatsListView.swift
+++ b/Sources/WikiFS/Chats/ChatsListView.swift
@@ -35,7 +35,14 @@ struct ChatsListView: NSViewControllerRepresentable {
         let visible = store.chatSearchQuery.isEmpty ? store.chats : store.chatSearchResults
         let needs = vc.needsReload(visible)
         DebugLog.tabs("ChatsListView.updateNSVC: count=\(visible.count) needsReload=\(needs)")
-        if needs { vc.reloadData(from: visible) }
+        if needs {
+            vc.reloadData(from: visible)
+        } else {
+            // The store signature is unchanged, but a chat may have started or
+            // stopped running (signaled by `runningStateToken`). Re-evaluate
+            // the live badge on visible rows without a full reload.
+            vc.reconfigureLiveState()
+        }
         vc.reconcileHighlight(activeSelection: store.activeTab?.selection)
         if let pending = store.pendingSidebarReveal, case .chat(let id) = pending {
             _ = vc.revealAndSelect(id: id)
@@ -125,6 +132,23 @@ final class ChatsListViewController: NSViewController {
         lastCount = rows.count
         lastSignature = signature(rows)
         tableView.reloadData()
+    }
+
+    /// Re-evaluate the live ("responding…") indicator on visible rows WITHOUT
+    /// a full reload. Called from `updateNSViewController` when the store
+    /// signature is unchanged but the daemon's running set changed (a chat just
+    /// started or finished). Cheaper than `reloadData()` and avoids the
+    /// selection/scroll glitches of a full table rebuild.
+    func reconfigureLiveState() {
+        let range = tableView.rows(in: tableView.visibleRect)
+        guard range.length > 0 else { return }
+        for row in range.location..<(range.location + range.length) {
+            guard row < items.count else { continue }
+            if let cell = tableView.view(atColumn: 0, row: row,
+                                          makeIfNecessary: false) as? ChatsCellView {
+                cell.configure(chat: items[row], isLive: isLive(items[row]))
+            }
+        }
     }
 
     private func signature(_ rows: [ChatSummary]) -> String {

--- a/Sources/WikiFS/Chats/RemoteChatSession.swift
+++ b/Sources/WikiFS/Chats/RemoteChatSession.swift
@@ -109,6 +109,11 @@ public final class RemoteChatSession {
     func markNotLive() {
         activeChatID = nil
         isInteractiveSession = false
+        // Fully relinquish the liveness claim — `isChatRunning` also checks
+        // these session-local flags, so leaving them set would keep the sidebar
+        // "responding…" badge after the daemon evicts the session.
+        isRunning = false
+        isGenerating = false
     }
 
     // MARK: - Envelope ingestion

--- a/Sources/WikiFS/Settings/AgentToolsView.swift
+++ b/Sources/WikiFS/Settings/AgentToolsView.swift
@@ -22,6 +22,12 @@ struct AgentToolsView: View {
     @State private var renameDraft: String = ""
 
     var body: some View {
+        // Touch the daemon's running-state token so SwiftUI re-renders (and
+        // re-evaluates each row's "responding…" badge) when a chat starts or
+        // stops. `runningStateToken` is read here — in the tracked body —
+        // because `isChatRunning(_:)` is called from the NSTableView data
+        // source, which SwiftUI can't observe.
+        let _ = chatDaemon?.runningStateToken
         VStack(spacing: 0) {
             chatsHeader
             chatSearchBar

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -89,6 +89,33 @@ struct ChatDaemonCoordinatorTests {
         #expect(!coord.anyChatRunning)
     }
 
+    @Test func runningStateToken_bumpsOnRunningStateChange() {
+        let coord = makeCoordinator()
+        let before = coord.runningStateToken
+
+        // Start → token bumps.
+        coord.ingestForTesting(.chatState(chatID: "chat-run", update: ChatStateUpdate(
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
+        let afterStart = coord.runningStateToken
+        #expect(afterStart == before + 1)
+
+        // Duplicate running envelope (no change) → token does NOT bump.
+        coord.ingestForTesting(.chatState(chatID: "chat-run", update: ChatStateUpdate(
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
+        #expect(coord.runningStateToken == afterStart)
+
+        // Stop → token bumps again.
+        coord.ingestForTesting(.chatState(chatID: "chat-run", update: ChatStateUpdate(
+            isRunning: false, isGenerating: false, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
+        #expect(coord.runningStateToken == afterStart + 1)
+    }
+
     @Test func isChatRunning_reflectsOpenSessionRunFlag() {
         // An open session that reports running via hydrate also counts.
         let coord = makeCoordinator()
@@ -266,6 +293,60 @@ struct ChatDaemonCoordinatorTests {
         await coord.rehydrate(chatID: "chat-idle")
         #expect(coord.session(for: "chat-idle").activeChatID == nil)
         #expect(coord.isChatRunning("chat-idle") == false)
+    }
+
+    // MARK: - runningStateToken (rehydrate path)
+
+    @Test func rehydrateRunning_bumpsRunningStateToken() async {
+        let stub = StubChatDaemonCommands()
+        stub.sessionState = ChatSessionState(
+            chatID: "chat-run", events: [],
+            isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        let before = coord.runningStateToken
+        await coord.rehydrate(chatID: "chat-run")
+        #expect(coord.runningStateToken == before + 1)
+        #expect(coord.isChatRunning("chat-run"))
+    }
+
+    @Test func rehydrateIdle_doesNotBumpTokenWhenAlreadyIdle() async {
+        let stub = StubChatDaemonCommands()
+        stub.sessionState = ChatSessionState(
+            chatID: "chat-idle", events: [],
+            isRunning: false, isGenerating: false, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        let before = coord.runningStateToken
+        await coord.rehydrate(chatID: "chat-idle")
+        // Was idle, stays idle → no change → no bump.
+        #expect(coord.runningStateToken == before)
+    }
+
+    @Test func rehydrateFailure_bumpsTokenWhenClearingPriorLiveness() async {
+        // A chat that was running (token already bumped) then gets a rehydrate
+        // failure (daemon evicted the session). Clearing the stale liveness
+        // claim must bump the token so the sidebar drops "responding…".
+        let stub = StubChatDaemonCommands()
+        stub.sessionState = ChatSessionState(
+            chatID: "chat-evicted", events: [],
+            isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
+        let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
+        await coord.rehydrate(chatID: "chat-evicted")
+        let afterRunning = coord.runningStateToken
+        #expect(coord.isChatRunning("chat-evicted"))
+
+        // Now the daemon evicts the session — rehydrate throws.
+        stub.shouldThrow = true
+        await coord.rehydrate(chatID: "chat-evicted")
+        #expect(coord.runningStateToken == afterRunning + 1)
+        // Both liveness sources clear: runningChatIDs via setChatRunning, and
+        // the session's isRunning via markNotLive (which now clears the flags).
+        #expect(!coord.isChatRunning("chat-evicted"))
     }
 
     // MARK: - Helpers

--- a/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
+++ b/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
@@ -486,6 +486,10 @@ struct RemoteChatSessionTests {
         session.markNotLive()
         #expect(session.activeChatID == nil)
         #expect(session.isInteractiveSession == false)
+        // The running flags must also clear — `isChatRunning` checks them, so
+        // leaving them set would stick the sidebar "responding…" badge.
+        #expect(session.isRunning == false)
+        #expect(session.isGenerating == false)
     }
 }
 #endif


### PR DESCRIPTION
## Summary

Fixes two chat UI bugs and hardens the daemon liveness model.

### 1. Chat outline abbreviates model-generated summaries

The right-side `ChatOutlineView` capped response text with `.lineLimit(3)`,
truncating long one-sentence model summaries with `…` even though the
summarizer already produced a concise single-sentence summary. Removed the
line limit so cached model/default summaries render in full.

### 2. "responding…" badge never clears in the chat list

When a chat finished, the sidebar's blue "responding…" indicator stuck
forever. Two root causes:

- **No observable signal:** `ChatDaemonCoordinator` is `@Observable`, but
  `runningChatIDs` is `private` and read only inside `isChatRunning()`,
  which the `NSTableView` data source calls *outside* SwiftUI's tracked
  body. When a chat stopped running, nothing re-rendered.
- **Live state excluded from reload decision:** `needsReload` compared only
  the store signature (title/summary/updatedAt), never the running state,
  so even an unrelated re-render wouldn't reconfigure the badge.

**Fix:** Added `runningStateToken` (bumped only on actual running-set
change) to `ChatDaemonCoordinator`, read in `AgentToolsView.body` so
SwiftUI re-renders. Added `ChatsListViewController.reconfigureLiveState()`
to re-evaluate `isLive` on visible rows without a full `reloadData()`.

### 3. `markNotLive()` didn't fully relinquish liveness

`markNotLive()` cleared `activeChatID` + `isInteractiveSession` but not
`isRunning` / `isGenerating`. Since `isChatRunning` checks the session-local
flags too, a daemon-evicted session could still report running. Now clears
both flags. (Tracked as a broader FSM refactor in #912.)

### 4. Centralized the running-set mutation

Extracted `setChatRunning(_:running:)` as the single mutator for
`runningChatIDs` + `runningStateToken`. Both `route()` and `rehydrate()`
(success + failure) now funnel through it, so the token-bump invariant is
structurally enforced.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter 'ChatDaemonCoordinator|RemoteChatSession'` — 55 tests pass
- [ ] Manual: send a chat, confirm "responding…" clears and summary appears when the turn finishes
- [ ] Manual: open a chat with a model-generated summary, confirm the outline shows the full summary (no `…`)

Ref: #912 (FSM follow-up)
