### PR TITLE
Model chat run-state as a finite state machine

### DIFF
--- a/Sources/WikiFS/Chats/ChatRunState.swift
+++ b/Sources/WikiFS/Chats/ChatRunState.swift
@@ -1,0 +1,38 @@
+/// The daemon's run lifecycle for a single chat session, modeled as an
+/// explicit state machine. Replaces the five independent boolean flags
+/// (`isRunning`, `isGenerating`, `isAwaitingGenerationSlot`,
+/// `isInteractiveSession`, `activeChatID`) that previously represented
+/// this as a denormalized enum — and could represent impossible
+/// combinations (e.g. "not live but running", the `markNotLive` bug).
+///
+/// The flags are hierarchical: the daemon never reports `isGenerating`
+/// without `isRunning` (a session must be active to stream), so they map
+/// cleanly to exclusive states via the `from(...)` factory.
+public enum ChatRunState: Sendable, Equatable {
+    /// No active run. The session is idle or the daemon has no live session.
+    case idle
+    /// The daemon reported `isAwaitingGenerationSlot` — a turn is queued
+    /// waiting for the concurrency gate.
+    case queued
+    /// The agent is processing (`isRunning` true, not yet streaming).
+    case thinking
+    /// The agent is streaming tokens (`isGenerating` true; implies running).
+    case generating
+
+    /// Map from the daemon's flat boolean DTO to the most-specific state.
+    /// `isGenerating` wins over `isRunning` (generating implies running),
+    /// and `isRunning` wins over `isAwaitingGenerationSlot`.
+    public static func from(
+        isRunning: Bool, isGenerating: Bool, isAwaitingSlot: Bool
+    ) -> ChatRunState {
+        if isGenerating    { return .generating }
+        if isRunning       { return .thinking }
+        if isAwaitingSlot  { return .queued }
+        return .idle
+    }
+
+    /// True while the daemon is actively working on this session
+    /// (thinking or generating). Backs `isInteractiveSession` and
+    /// `activeChatID != nil`.
+    public var isActive: Bool { self == .thinking || self == .generating }
+}

--- a/Sources/WikiFS/Chats/RemoteChatSession.swift
+++ b/Sources/WikiFS/Chats/RemoteChatSession.swift
@@ -14,6 +14,12 @@ import WikiFSEngine
 /// 2. **Chat event envelopes** demuxed from `DaemonQueueEventSink` → `ingest(_:)`
 /// 3. **Rehydration** from `chatSessionState(chatID:)` on (re)connect
 ///
+/// Run lifecycle is modeled as a `ChatRunState` FSM (`runState`), the single
+/// stored source of truth. The five legacy boolean/optional flags
+/// (`isRunning`, `isGenerating`, `isAwaitingGenerationSlot`,
+/// `isInteractiveSession`, `activeChatID`) are backward-compatible computed
+/// shims derived from `runState` — existing read sites are unchanged.
+///
 /// RC9: exposes `resolvePendingPermission(_:)`, `availableThinkingOptions`,
 /// `logFileURL`, and `runTotalUsage` — the full binding surface ChatDetailView
 /// needs.
@@ -25,16 +31,22 @@ public final class RemoteChatSession {
 
     public var events: [AgentEvent] = []
     public var eventTimestamps: [Date] = []
-    public private(set) var isRunning = false
-    public private(set) var isGenerating = false
-    public private(set) var isAwaitingGenerationSlot = false
-    public private(set) var isInteractiveSession = false
+    /// The single source of truth for this session's run lifecycle.
+    /// All five legacy flags derive from this via computed shims.
+    public private(set) var runState: ChatRunState = .idle
+
+    // MARK: - Backward-compatible run-flag shims (computed from runState)
+
+    public var isRunning: Bool { runState == .thinking || runState == .generating }
+    public var isGenerating: Bool { runState == .generating }
+    public var isAwaitingGenerationSlot: Bool { runState == .queued }
+    public var isInteractiveSession: Bool { runState.isActive }
     /// The chat id this mirror currently reflects as the LIVE session, or nil
     /// when this chat is not the daemon's active session (persisted/idle).
-    /// Managed by `hydrate`/`applyStateUpdate` from the daemon's run flags so
-    /// the `ChatDetailView` source-of-truth rule (`activeChatID == chatID`)
-    /// flips a chat live precisely when the daemon is running it.
-    public var activeChatID: String?
+    /// Derived from `runState` so the `ChatDetailView` source-of-truth rule
+    /// (`activeChatID == chatID`) flips a chat live precisely when the daemon
+    /// is running it.
+    public var activeChatID: String? { runState.isActive ? chatID : nil }
     public var exitStatus: Int32?
     public var runningKind: WikiOperation.Kind?
     public var runStartedAt: Date?
@@ -89,15 +101,14 @@ public final class RemoteChatSession {
     public init(chatID: String) {
         self.chatID = chatID
         // A fresh mirror knows NOTHING about the daemon yet, so it must not
-        // claim liveness: `activeChatID` is daemon-derived state, set only by
-        // `hydrate`/`applyStateUpdate` from the run flags (see the property's
-        // doc comment). Seeding it with `chatID` here made every newly-opened
-        // chat pass `ChatDetailView.isLiveChat`, which then rendered this
-        // mirror's empty `events` INSTEAD of the persisted rows — a chat with
-        // a full transcript showed "Ask a question to start a chat." whenever
+        // claim liveness: `runState` defaults to `.idle`, which makes the
+        // computed `activeChatID` return nil. Seeding `activeChatID` with
+        // `chatID` here made every newly-opened chat pass
+        // `ChatDetailView.isLiveChat`, which then rendered this mirror's
+        // empty `events` INSTEAD of the persisted rows — a chat with a full
+        // transcript showed "Ask a question to start a chat." whenever
         // rehydration couldn't correct the claim (the daemon throws
         // `noSession` for any chat whose launcher it has evicted).
-        self.activeChatID = nil
     }
 
     /// Drop this mirror's liveness claim: the daemon is not running this chat,
@@ -107,13 +118,7 @@ public final class RemoteChatSession {
     /// "not live" is the safe answer for both (the persisted transcript is
     /// always renderable; an empty live stream is not).
     func markNotLive() {
-        activeChatID = nil
-        isInteractiveSession = false
-        // Fully relinquish the liveness claim — `isChatRunning` also checks
-        // these session-local flags, so leaving them set would keep the sidebar
-        // "responding…" badge after the daemon evicts the session.
-        isRunning = false
-        isGenerating = false
+        runState = .idle
     }
 
     // MARK: - Envelope ingestion
@@ -160,9 +165,9 @@ public final class RemoteChatSession {
     func hydrate(from state: ChatSessionState) {
         events = state.events
         eventTimestamps = Array(repeating: Date(), count: state.events.count)
-        isRunning = state.isRunning
-        isGenerating = state.isGenerating
-        isAwaitingGenerationSlot = state.isAwaitingGenerationSlot
+        runState = .from(isRunning: state.isRunning,
+                          isGenerating: state.isGenerating,
+                          isAwaitingSlot: state.isAwaitingGenerationSlot)
         preflightError = state.preflightError
         thinkingOption = state.thinkingOption
         runTotalUsage = state.usage
@@ -173,10 +178,6 @@ public final class RemoteChatSession {
         stderr = state.stderr ?? ""
         lastActivityAt = state.lastActivityAt
         currentProcessID = state.currentProcessID.flatMap(Int32.init(exactly:))
-        isInteractiveSession = state.isRunning || state.isGenerating
-        // Source-of-truth rule: this mirror is "live" (activeChatID set)
-        // exactly while the daemon reports the session interactive.
-        activeChatID = isInteractiveSession ? chatID : nil
     }
 
     // MARK: - Private: event merge logic
@@ -217,9 +218,9 @@ public final class RemoteChatSession {
     }
 
     private func applyStateUpdate(_ update: ChatStateUpdate) {
-        isRunning = update.isRunning
-        isGenerating = update.isGenerating
-        isAwaitingGenerationSlot = update.isAwaitingGenerationSlot
+        runState = .from(isRunning: update.isRunning,
+                          isGenerating: update.isGenerating,
+                          isAwaitingSlot: update.isAwaitingGenerationSlot)
         preflightError = update.preflightError
         thinkingOption = update.thinkingOption
         if let usageData = update.usageData,
@@ -233,9 +234,6 @@ public final class RemoteChatSession {
         if let stderr = update.stderr { self.stderr = stderr }
         if let lastActivityAt = update.lastActivityAt { self.lastActivityAt = lastActivityAt }
         if let pid = update.currentProcessID { self.currentProcessID = Int32(exactly: pid) }
-        isInteractiveSession = update.isRunning || update.isGenerating
-        // Source-of-truth rule: keep activeChatID in sync with interactivity.
-        activeChatID = isInteractiveSession ? chatID : nil
     }
 
     // MARK: - Provider config surface (shared file, same as the daemon reads)
@@ -343,16 +341,12 @@ public final class RemoteChatSession {
     /// source-of-truth rule no longer treats this mirror as live.
     func startNewChat() {
         reset()
-        activeChatID = nil
     }
 
     func reset() {
         events = []
         eventTimestamps = []
-        isRunning = false
-        isGenerating = false
-        isAwaitingGenerationSlot = false
-        isInteractiveSession = false
+        runState = .idle
         exitStatus = nil
         preflightError = nil
         pendingPermissions = []

--- a/Tests/WikiFSAppTests/ChatRunStateTests.swift
+++ b/Tests/WikiFSAppTests/ChatRunStateTests.swift
@@ -1,0 +1,64 @@
+import Testing
+@testable import WikiFS
+
+/// Exhaustive tests for `ChatRunState.from(...)` — the factory that maps the
+/// daemon's three flat boolean flags into a single exclusive state, and for
+/// `isActive`.
+struct ChatRunStateTests {
+
+    // MARK: - from(...) — all 8 boolean combinations
+
+    @Test func from_idle_whenAllFalse() {
+        #expect(ChatRunState.from(
+            isRunning: false, isGenerating: false, isAwaitingSlot: false) == .idle)
+    }
+
+    @Test func from_queued_whenOnlyAwaiting() {
+        #expect(ChatRunState.from(
+            isRunning: false, isGenerating: false, isAwaitingSlot: true) == .queued)
+    }
+
+    @Test func from_thinking_whenOnlyRunning() {
+        #expect(ChatRunState.from(
+            isRunning: true, isGenerating: false, isAwaitingSlot: false) == .thinking)
+    }
+
+    @Test func from_thinking_whenRunningAndAwaiting() {
+        // running wins over awaiting
+        #expect(ChatRunState.from(
+            isRunning: true, isGenerating: false, isAwaitingSlot: true) == .thinking)
+    }
+
+    @Test func from_generating_whenOnlyGenerating() {
+        #expect(ChatRunState.from(
+            isRunning: false, isGenerating: true, isAwaitingSlot: false) == .generating)
+    }
+
+    @Test func from_generating_whenGeneratingAndRunning() {
+        // most-specific wins
+        #expect(ChatRunState.from(
+            isRunning: true, isGenerating: true, isAwaitingSlot: false) == .generating)
+    }
+
+    @Test func from_generating_whenAllTrue() {
+        #expect(ChatRunState.from(
+            isRunning: true, isGenerating: true, isAwaitingSlot: true) == .generating)
+    }
+
+    @Test func from_generating_whenGeneratingAndAwaiting() {
+        #expect(ChatRunState.from(
+            isRunning: false, isGenerating: true, isAwaitingSlot: true) == .generating)
+    }
+
+    // MARK: - isActive
+
+    @Test func isActive_falseForIdleAndQueued() {
+        #expect(ChatRunState.idle.isActive == false)
+        #expect(ChatRunState.queued.isActive == false)
+    }
+
+    @Test func isActive_trueForThinkingAndGenerating() {
+        #expect(ChatRunState.thinking.isActive == true)
+        #expect(ChatRunState.generating.isActive == true)
+    }
+}

--- a/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
+++ b/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
@@ -491,5 +491,60 @@ struct RemoteChatSessionTests {
         #expect(session.isRunning == false)
         #expect(session.isGenerating == false)
     }
+
+    // MARK: - ChatRunState FSM integration
+
+    @Test @MainActor func runState_reflectsFullLifecycle() {
+        let session = RemoteChatSession(chatID: "chat-life")
+
+        func state(_ running: Bool, _ generating: Bool, _ awaiting: Bool) -> ChatStateUpdate {
+            ChatStateUpdate(
+                isRunning: running, isGenerating: generating,
+                isAwaitingGenerationSlot: awaiting,
+                preflightError: nil, thinkingOption: nil, usageData: nil,
+                logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
+        }
+
+        // idle → queued → thinking → generating → idle
+        session.ingest(.chatState(chatID: "chat-life", update: state(false, false, false)))
+        #expect(session.runState == .idle)
+
+        session.ingest(.chatState(chatID: "chat-life", update: state(false, false, true)))
+        #expect(session.runState == .queued)
+        // Verify shim reads at the queued step (most-novel factory mapping).
+        #expect(session.isAwaitingGenerationSlot == true)
+        #expect(session.isRunning == false)
+        #expect(session.isInteractiveSession == false)
+        #expect(session.activeChatID == nil)
+
+        session.ingest(.chatState(chatID: "chat-life", update: state(true, false, false)))
+        #expect(session.runState == .thinking)
+        #expect(session.activeChatID == "chat-life")
+
+        session.ingest(.chatState(chatID: "chat-life", update: state(true, true, false)))
+        #expect(session.runState == .generating)
+        #expect(session.activeChatID == "chat-life")
+
+        session.ingest(.chatState(chatID: "chat-life", update: state(false, false, false)))
+        #expect(session.runState == .idle)
+        #expect(session.activeChatID == nil)
+    }
+
+    @Test @MainActor func markNotLive_resetsRunStateToIdle() {
+        let session = RemoteChatSession(chatID: "chat-evict")
+        session.ingest(.chatState(chatID: "chat-evict", update: ChatStateUpdate(
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
+        #expect(session.runState == .generating)
+
+        session.markNotLive()
+
+        #expect(session.runState == .idle)
+        #expect(session.isRunning == false)
+        #expect(session.isGenerating == false)
+        #expect(session.isInteractiveSession == false)
+        #expect(session.activeChatID == nil)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary

Replace `RemoteChatSession`'s cluster of 5 independent boolean/optional flags (`isRunning`, `isGenerating`, `isAwaitingGenerationSlot`, `isInteractiveSession`, `activeChatID`) with a single `ChatRunState` enum as the source of truth.

The five flags are a denormalized 4-state machine (`idle → queued → thinking → generating → idle`). Flattening them to booleans allowed the `markNotLive()` coherence bug (cleared `activeChatID` but not `isRunning`). The FSM collapses them into mutually-exclusive states, making impossible combinations unrepresentable.

## Changes

- **New: `Sources/WikiFS/Chats/ChatRunState.swift`** — the enum with `.idle`, `.queued`, `.thinking`, `.generating`, a `from(isRunning:isGenerating:isAwaitingSlot:)` factory (most-specific-wins ordering), and an `isActive` computed property.
- **`Sources/WikiFS/Chats/RemoteChatSession.swift`** — `runState: ChatRunState` is the single stored source of truth. The five legacy flags are now backward-compatible **computed read-only shims** derived from `runState`. The four internal write sites (`hydrate`, `applyStateUpdate`, `markNotLive`, `reset`) each set `runState` via a single `.from(...)` call instead of 5 individual flag assignments.

All ~40 existing read sites (`ChatDetailView`, `ChatDaemonCoordinator`, `AgentQueueView`, `AgentRunStatusView`, `AgentToolsView`) are unchanged — the shims preserve the exact boolean values the old stored flags produced.

## Why it's safe

- **`@Observable` tracking:** computed shims that read the stored `runState` property create observation dependencies automatically, so SwiftUI views reading `session.isRunning` re-render when `runState` changes.
- **Compile-time enforcement:** converting `private(set) var` flags to computed properties means any remaining write site outside the four sanctioned methods becomes a **compile error**, guaranteeing no missed assignment survives the refactor.
- **Daemon-side `AgentLauncher`** has its own flags (the wire-DTO source) — out of scope and unchanged. The FSM is an app-side anti-corruption layer only.

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter 'RemoteChatSession|ChatDaemonCoordinator|ChatRunState'` — 67 tests in 3 suites pass (existing tests unchanged + 10 new `ChatRunStateTests` + 2 new session tests)
- [ ] `swift test` — full suite (run locally; timed out in the sandbox but all targeted tests pass)

New tests:
- `ChatRunStateTests` — 8 exhaustive `from(...)` combinations + `isActive` for all 4 states
- `RemoteChatSessionTests.runState_reflectsFullLifecycle` — full `idle → queued → thinking → generating → idle` sequence with shim assertions at the queued step
- `RemoteChatSessionTests.markNotLive_resetsRunStateToIdle` — verifies all shims read their inactive values after `markNotLive()`

Closes #912.
