### PR TITLE
Fix live chat transcript freeze and cross-chat bleed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,48 @@ PROGRESS.md" and trust it's up to speed with this codebase.
 * Use the macos-design skill to make sure the UI we come up with makes sense as a modern
   macOS app, with modern professional macOS idioms. Keep things simple.
 
+## Modeling rules
+
+* **Avoid stringly-typed variables.** A bare `String` (or `String?`) that
+  actually means "a chat id" / "a queue item id" / "a provider name" makes two
+  different id spaces compare equal, lets a typo pass the type checker, and
+  gives the reader no idea what values are legal. Wrap it: a `RawRepresentable`
+  struct (`PageID`) when it's one id space, an `enum` when it's a closed set of
+  cases, and a **namespaced enum** when one field must carry ids from several
+  spaces (`TranscriptID.chat(PageID)` / `.queueItem(QueueItem.ID)` — the case
+  tag is what makes a chat ULID unable to collide with a queue ULID). Same for
+  file paths (`URL`), durations (`Duration`), and raw enum-backed strings —
+  convert at the boundary, not at every use site.
+
+  **A sentinel string is the same smell.** `ChatSessionKey.draft` /
+  `.chat(PageID)` replaced a `String` key whose draft was spelled
+  `"__wiki_draft_chat__"`: that sentinel shared a namespace with real chat
+  ULIDs, so "is this the draft?" was a comparison against a magic constant that
+  every call site had to remember. Give the special case its own case, and the
+  compiler asks the question for you — `.draft` carries no `PageID`, so a draft
+  cannot satisfy an id comparison even by accident.
+
+* **Prefer enums (or named constants) over magic numbers.** A bare literal at a
+  use site — `if attempt > 3`, `rowHeight = 36`, `case 2: …` — hides both its
+  meaning and the fact that the same number is load-bearing somewhere else. If
+  it names one of a closed set of choices, make it an `enum`; if it's a tuning
+  value, hoist it to a named `static let` in the type or metrics enum that owns
+  it (`ChatMetrics`, `PageEditorMetrics`) so the name carries the rationale and
+  there is exactly one place to change it. The same goes for raw values
+  crossing a boundary: decode into an `enum` at the edge rather than comparing
+  integers or strings downstream.
+
+* **Prefer a finite state machine over a cluster of flags.** Several
+  `Bool`/optional properties that are really one lifecycle are a denormalized
+  enum: they can encode impossible combinations, and every write site has to
+  remember to update all of them coherently (see `ChatRunState`, which replaced
+  `isRunning`/`isGenerating`/`isAwaitingGenerationSlot`/`isInteractiveSession`/
+  `activeChatID` after a missed write in one of them shipped a bug). Model the
+  states as an `enum`, make it the single stored source of truth, and derive
+  the flags as computed properties — impossible states stop being
+  representable, and a missed write site becomes a compile error rather than an
+  incoherent runtime state.
+
 ## Design skills — sources
 
 The three design skills above are vendored in this repo at

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,155 @@
 # Progress log
 
+## refactor: ChatRunState as a real FSM; ChatSessionKey replaces the string chat id
+
+**Goal:** the stuck-badge bug was a symptom — `isRunning` vs `isGenerating` is
+still a flag cluster, and the chat id was still a bare `String` with a sentinel
+for the draft. Both are the modeling rules in AGENTS.md applied to the code that
+motivated them.
+
+**ChatRunState — what was wrong.** The first version was a *lossy* mapping,
+which is how an FSM reintroduces the bug it was meant to prevent:
+
+* `.thinking` was defined as `isRunning && !isGenerating`. `setGenerating(true)`
+  fires at **turn start** (`sendInteractiveMessage: turn start`), not at first
+  token — so `isGenerating` already covers the thinking phase, and
+  `isRunning && !isGenerating` for an interactive chat *only ever* means "warm,
+  between turns". The case was misnamed for its sole reachable input, and that
+  misnomer is what taught the sidebar to badge a warm session as "responding…".
+* `if isRunning` was tested **before** `isAwaitingSlot`. A turn queued on the
+  generation gate has both flags set, so `.queued` was swallowed and reported as
+  `.thinking` — `isAwaitingGenerationSlot` read false exactly when it was true.
+
+**What changed:** cases are now `idle` / `queued` / `warm` / `answering`, with
+precedence `answering → queued → warm → idle` (narrowest claim wins), and two
+derived predicates that keep the two questions apart at the source: `isLive`
+("render the streaming mirror, not the persisted rows") and `isAnswering`
+("every spinner, badge, and Stop affordance"). All eight boolean combinations
+are pinned by test rather than sampled, the two regressions above named
+explicitly.
+
+**Behavior changes (deliberate, both tested):**
+1. `.queued` is now **live**. It previously reported `isRunning == false` /
+   `activeChatID == nil`, which sent the chat surface to the persisted rows
+   mid-conversation while a turn waited on the gate.
+2. `ChatDetailView.transcriptIsRunning` keys off `isAnswering`, not `isRunning`.
+   With the corrected shims `isRunning` means "session alive", so leaving it
+   would have shown "Waiting for the Agent…" on a warm idle chat — trading one
+   conflation for another.
+
+**ChatSessionKey.** `RemoteChatSession.chatID` was a `String`, and the draft
+composer was spelled `"__wiki_draft_chat__"` — a sentinel sharing a namespace
+with real chat ULIDs, so "is this the draft?" was a comparison against a magic
+constant every call site had to remember. It is now
+`ChatSessionKey.draft` / `.chat(PageID)`; `activeChatID` is `PageID?`; the
+coordinator's registry, generating-set, and public API all take `PageID`. The
+`.draft` case carries no `PageID`, so a draft **cannot** satisfy the
+`activeChatID == chatID` liveness rule even by accident — previously it could in
+principle, since `activeChatID` returned the sentinel.
+
+**The wire stays `String`.** `QueueEventEnvelope` and the XPC request DTOs are
+unchanged; conversion happens at exactly two boundaries (`ChatDaemonCoordinator.route`,
+`RemoteChatSession.ingest`). The compiler enforced that line repeatedly while
+the tests were being migrated — every place the app-side type leaked onto the
+wire failed to build.
+
+## fix: Chat transcript froze mid-stream and bled messages between chats
+
+**Goal:** three reported symptoms — a live chat's responses never appeared as
+they streamed; switching to another pane and back made them all appear at once;
+and messages from one chat showed up inside another just by clicking between
+them.
+
+**Root cause:** one bug, in view identity. `WikiDetailView.detailContent`
+renders every chat from the same `switch` branch (`case .chat(let id)`), and a
+differing associated value does **not** change SwiftUI structural identity — so
+chat A → chat B reused a single `ChatDetailView` instance and, under it, a
+single `ChatWebView` `WKWebView` + `Coordinator`. That coordinator renders
+*incrementally* (it appends only `events[renderedCount...]` so an in-progress
+text selection survives streaming), and its anchors — `renderedCount`,
+`renderedEvents`, `renderedLastEvent` — described whichever chat was rendered
+last. What you saw depended entirely on how the two chats' event counts
+compared: B larger ⇒ B's tail spliced onto A's DOM; B equal ⇒ A's transcript
+with one row swapped; B smaller ⇒ a full reload, which looked correct. Landing
+on a chat with a stale-high `renderedCount` also froze streaming outright —
+`count > renderedCount` never became true, so `appendRows` never fired even
+though events were reaching the model. Switching to a *page* tab is a different
+`_ConditionalContent` branch, which tore the view down and rebuilt it — the
+"click another pane and come back" workaround.
+
+**What changed:** `ChatWebView` gained a `transcriptID` input and rebuilds when
+it changes. The three rebuild triggers (identity change, `showsInternals`
+toggle, count decrease) are now one pure `nonisolated static needsFullReload`,
+testable without a WebKit view tree. The identity check runs *before* the
+`isLoaded` guard so a switch landing mid-load also replaces `pendingEvents` —
+otherwise `didFinish` would render the previous transcript and seed
+`renderedCount` from it. `ActivityWindowView` was the same bug class (selecting
+a different queue item reused the coordinator) and passes `.queueItem(item.id)`.
+`WikiDetailView` also puts `.id(chatID)` on the chat surface: the transcript fix
+alone left the `@State` leak, where `persistedMessages` rendered under the wrong
+chat's title and `attachments`/`queuedMessages` would fire on the *next* chat's
+turn.
+
+**`TranscriptID` is a namespaced enum**, not a `String` — chat rows and queue
+items are both ULIDs, so a raw-string key would let a collision read as "same
+transcript", the exact failure the field exists to prevent. Pinned by a test.
+
+**Ruled out:** the `ChatRunState` FSM (#912) was the initial suspect, since it
+converted five stored run flags into computed shims and computed properties are
+a classic observation trap. It is not implicated — `withObservationTracking`
+around `activeChatID`/`isRunning` fires correctly, because the `@Observable`
+macro tracks the stored `runState` the getters read.
+
+## fix: Stuck "responding…" badge — `isRunning` is not "is answering"
+
+**Goal:** the sidebar badge latched on and never cleared after a chat replied.
+
+**Root cause:** the app misread a correct daemon signal. Six `os_log` seams
+across the pipeline (daemon push → XPC route → coordinator set → sidebar body →
+representable update → row reconfigure) showed every stage firing in ~0ms and in
+the right order, which cleared the UI layer and pointed upstream. The trace:
+
+```
+10:42:41.116  1.daemon.push running=true gen=true
+10:42:41.116  2.app.route   running=true gen=true
+10:42:47.214  6.sidebar.reload live=[01KYD5YE…] reconfigured=5/5   ← badge ON, correct
+10:43:05.616  1.daemon.push running=true gen=false                 ← turn ends, session warm
+   …no further pushes: nothing changed, so the fingerprint didn't change.
+```
+
+For an **interactive** chat, `AgentLauncher.isRunning` means "the agent process
+is alive ACROSS TURNS" (its own comment: "SPAWN COMMIT: process is alive.
+isRunning = true (process alive across turns)"), so it stays true while the
+session idles waiting for the next message. `isGenerating` is the per-turn flag,
+and `AgentLauncher` states the contract outright: "Every UI spinner / Stop
+affordance keys off this rather than the raw `isRunning`."
+
+`ChatDaemonCoordinator` did `setChatRunning(chatID, running: update.isRunning ||
+update.isGenerating)` — where the `isRunning` disjunct dominates — so the badge
+keyed on *process liveness* rather than *answering*, pinning it on for the life
+of the session. The `gen=false` push at 10:43:05 was the signal that should have
+cleared it, OR'd away.
+
+**What changed:** the badge keys off `isGenerating` alone, and the names no
+longer invite the misreading — `runningChatIDs` → `generatingChatIDs`,
+`isChatRunning` → `isChatGenerating`, `anyChatRunning` → `anyChatGenerating`,
+and the session fallback `s.isRunning || s.isGenerating` → `s.isGenerating`.
+Four existing tests failed, all four having encoded the bug (`isRunning: true,
+isGenerating: false` expecting the badge on); they now assert the real contract,
+plus two new regression tests replaying the exact log sequence.
+
+**Behavior note:** `anyChatGenerating` also gates the ⌘Q confirmation, so
+quitting with a warm-but-idle chat session no longer prompts. That reads correct
+(daemon work deliberately survives app quit — see the comment directly below the
+call site), but it is a change beyond the badge.
+
+**Worth naming:** this is the `ChatRunState` FSM problem one layer up.
+`isRunning` carries two meanings — "process alive" and "work in flight" — so no
+mapping of `(isRunning, isGenerating, isAwaitingSlot)` can separate them, and the
+FSM inherited the ambiguity: `.thinking` means both "processing before the first
+token" and "idle between turns". Distinguishing them properly needs a new signal
+from the daemon, not a better mapping.
+
 ## fix: Chat summary abbreviated even when a summarizer model was pinned
 
 **Goal:** the chats-list row subtitle was always a truncated first sentence

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -36,7 +36,7 @@ extension DaemonWorkloadClient: ChatDaemonCommands {}
 ///
 /// **Live indicator aggregate:** the coordinator tracks the set of chatIDs the
 /// daemon reports as running (from `chatState` envelopes), even for chats the
-/// app has not opened. `isChatRunning(_:)` / `anyChatRunning` back the sidebar
+/// app has not opened. `isChatGenerating(_:)` / `anyChatGenerating` back the sidebar
 /// + chats-list "responding…" indicators that previously read
 /// `chatLauncher.activeChatID` / `chatLauncher.isRunning`.
 @MainActor
@@ -46,27 +46,34 @@ public final class ChatDaemonCoordinator {
     private let client: ChatDaemonCommands
     private let eventSink: DaemonQueueEventSink
 
-    /// chatID → mirror session. The draft (.newChat) state uses `draftKey`.
-    private var sessions: [String: RemoteChatSession] = [:]
+    /// chat key → mirror session. The draft (.newChat) state uses `.draft`.
+    private var sessions: [ChatSessionKey: RemoteChatSession] = [:]
 
-    /// chatIDs the daemon currently reports as running/generating (from
-    /// `chatState` envelopes), regardless of whether the app has an open
-    /// session for them. Lets the sidebar badge a chat the daemon is running
-    /// (e.g. one started via `wikictl`) that the user hasn't opened here.
-    private var runningChatIDs: Set<String> = []
+    /// chatIDs the daemon currently reports as **generating** (from `chatState`
+    /// envelopes), regardless of whether the app has an open session for them.
+    /// Lets the sidebar badge a chat the daemon is answering (e.g. one started
+    /// via `wikictl`) that the user hasn't opened here.
+    ///
+    /// Deliberately NOT `isRunning`. For an interactive chat session
+    /// `AgentLauncher.isRunning` means "the agent process is alive **across
+    /// turns**" (see its declaration: "SPAWN COMMIT: process is alive.
+    /// isRunning = true (process alive across turns)"), so it stays true while
+    /// the session sits idle waiting for your next message. `isGenerating` is
+    /// the per-turn flag — set when a message is sent, cleared on the terminal
+    /// `.result`/`.messageStop` — and `AgentLauncher` states the contract
+    /// outright: "Every UI spinner / Stop affordance keys off this rather than
+    /// the raw `isRunning`."
+    private var generatingChatIDs: Set<PageID> = []
 
-    /// Bumped whenever `runningChatIDs` changes, so SwiftUI views that badge
-    /// chats (the sidebar list) re-render when a chat starts or stops running.
-    /// `runningChatIDs` is private and read only inside `isChatRunning(_:)`,
+    /// Bumped whenever `generatingChatIDs` changes, so SwiftUI views that badge
+    /// chats (the sidebar list) re-render when a chat starts or stops
+    /// answering. The set is private and read only inside `isChatGenerating(_:)`,
     /// which the table data source calls *outside* SwiftUI's tracked body — so
     /// a dedicated observable signal is the only way the sidebar learns a chat
     /// finished (otherwise the "responding…" badge sticks forever).
     public private(set) var runningStateToken: Int = 0
 
     private var routerTask: Task<Void, Never>?
-
-    /// Key for the draft (.newChat) session — `chatID == nil` at the view level.
-    static let draftKey = "__wiki_draft_chat__"
 
     init(client: ChatDaemonCommands, eventSink: DaemonQueueEventSink) {
         // Intentionally non-`public` — `DaemonQueueEventSink` is internal, so
@@ -81,8 +88,8 @@ public final class ChatDaemonCoordinator {
 
     /// Get-or-create the `RemoteChatSession` for a chat id. `nil` chatID
     /// returns the shared draft-state session (the `.newChat` composer).
-    public func session(for chatID: String?) -> RemoteChatSession {
-        let key = chatID ?? Self.draftKey
+    public func session(for chatID: PageID?) -> RemoteChatSession {
+        let key: ChatSessionKey = chatID.map(ChatSessionKey.chat) ?? .draft
         if let existing = sessions[key] { return existing }
         let session = RemoteChatSession(chatID: key)
         wireSessionCallbacks(session)
@@ -92,13 +99,13 @@ public final class ChatDaemonCoordinator {
 
     /// Drop the cached session for a chat (e.g. when retargeting the tab to a
     /// fresh draft). The daemon's own session is unaffected.
-    public func discard(chatID: String?) {
-        sessions.removeValue(forKey: chatID ?? Self.draftKey)
+    public func discard(chatID: PageID?) {
+        sessions.removeValue(forKey: chatID.map(ChatSessionKey.chat) ?? .draft)
     }
 
     /// Replace the draft session with a fresh one (used by "start new chat").
     public func resetDraft() {
-        sessions[Self.draftKey] = RemoteChatSession(chatID: Self.draftKey)
+        sessions[.draft] = RemoteChatSession(chatID: .draft)
     }
 
     // MARK: - Event routing
@@ -113,46 +120,62 @@ public final class ChatDaemonCoordinator {
         }
     }
 
-    private func route(chatID: String, envelope: QueueEventEnvelope) {
+    /// `chatID` arrives in wire form (a ULID string) off the daemon's envelope
+    /// stream. This is the boundary where it becomes a `PageID` — nothing past
+    /// here handles a raw chat-id string.
+    private func route(chatID rawChatID: String, envelope: QueueEventEnvelope) {
+        let chatID = PageID(rawValue: rawChatID)
         // Track the running set from state envelopes so the sidebar can badge
         // chats the daemon is running even without an open app session.
         if envelope.kind == .chatState, let update = envelope.chatStateUpdate {
-            setChatRunning(chatID, running: update.isRunning || update.isGenerating)
+            // TEMPORARY (stuck "responding…" badge): seam 2 of 6. Seam 1 firing
+            // without this one means the envelope never crossed XPC into the
+            // app — an event-sink blackout, not a UI bug (cf. #904/#907).
+            DebugLog.chatLive(
+                "2.app.route chat=\(chatID) running=\(update.isRunning) "
+                + "gen=\(update.isGenerating) awaiting=\(update.isAwaitingGenerationSlot)")
+            setChatGenerating(chatID, generating: update.isGenerating)
         }
         // Deliver to the open session if one exists.
-        sessions[chatID]?.ingest(envelope)
+        sessions[.chat(chatID)]?.ingest(envelope)
     }
 
     // MARK: - Sidebar liveness aggregate
 
-    /// The single mutator for `runningChatIDs`. Updates the set and bumps
+    /// The single mutator for `generatingChatIDs`. Updates the set and bumps
     /// `runningStateToken` **only when membership actually changes**, so every
-    /// liveness transition flows through one place (both the event-router
-    /// `route()` and `rehydrate()`). Centralizing this guarantees the
-    /// observable signal always fires — forgetting the token bump in a new
-    /// call site would silently stick the sidebar "responding…" badge.
-    private func setChatRunning(_ chatID: String, running: Bool) {
-        let didChange = running
-            ? runningChatIDs.insert(chatID).inserted
-            : runningChatIDs.remove(chatID) != nil
+    /// transition flows through one place (both the event-router `route()` and
+    /// `rehydrate()`). Centralizing this guarantees the observable signal
+    /// always fires — forgetting the token bump in a new call site would
+    /// silently stick the sidebar "responding…" badge.
+    private func setChatGenerating(_ chatID: PageID, generating: Bool) {
+        let didChange = generating
+            ? generatingChatIDs.insert(chatID).inserted
+            : generatingChatIDs.remove(chatID) != nil
         if didChange { runningStateToken &+= 1 }
+        // TEMPORARY (stuck "responding…" badge): seam 3 of 8.
+        DebugLog.chatLive(
+            "3.app.setGenerating chat=\(chatID) generating=\(generating) didChange=\(didChange) "
+            + "token=\(runningStateToken) set=[\(generatingChatIDs.map(\.rawValue).sorted().joined(separator: ","))]")
     }
 
-    /// True if the daemon reports this chat as running/generating. Backs the
-    /// sidebar + chats-list live indicator (replaces
-    /// `chatLauncher.activeChatID == id && chatLauncher.isRunning`).
-    public func isChatRunning(_ chatID: String) -> Bool {
-        if runningChatIDs.contains(chatID) { return true }
-        if let s = sessions[chatID], s.isRunning || s.isGenerating { return true }
+    /// True while the daemon is actively answering this chat. Backs the sidebar
+    /// + chats-list "responding…" indicator.
+    ///
+    /// Keys off `isGenerating`, never `isRunning` — see `generatingChatIDs` for
+    /// why (an interactive session's process stays alive between turns, so
+    /// `isRunning` would pin the badge on for the life of the session).
+    public func isChatGenerating(_ chatID: PageID) -> Bool {
+        if generatingChatIDs.contains(chatID) { return true }
+        if let s = sessions[.chat(chatID)], s.isGenerating { return true }
         return false
     }
 
-    /// True if any chat is running/generating on the daemon. Backs the
-    /// menu-bar / app-level "is the agent busy" check that previously read
-    /// `session.chatLauncher.isRunning`.
-    public var anyChatRunning: Bool {
-        if !runningChatIDs.isEmpty { return true }
-        return sessions.values.contains { $0.isRunning || $0.isGenerating }
+    /// True if any chat is currently being answered on the daemon. Backs the
+    /// app-level "is the agent busy" check (the ⌘Q confirmation).
+    public var anyChatGenerating: Bool {
+        if !generatingChatIDs.isEmpty { return true }
+        return sessions.values.contains { $0.isGenerating }
     }
 
     // MARK: - Commands (wrap DaemonWorkloadClient)
@@ -209,13 +232,14 @@ public final class ChatDaemonCoordinator {
     /// of being a local-only optimistic flip. Skipped for the draft session
     /// (no real chatID to target).
     private func wireSessionCallbacks(_ session: RemoteChatSession) {
-        let chatID = session.chatID
-        guard chatID != Self.draftKey else { return }
+        // The draft has no daemon-side session to target, and now says so in
+        // the type: `.draft` has no `PageID`.
+        guard let chatID = session.chatID.pageID else { return }
         let client = self.client
         session.onSetChatConfigOption = { option, value in
             do {
                 try await client.setChatConfigOption(
-                    ChatConfigOptionRequest(chatID: chatID, option: option, value: value))
+                    ChatConfigOptionRequest(chatID: chatID.rawValue, option: option, value: value))
             } catch {
                 DebugLog.agent("RemoteChatSession.onSetChatConfigOption failed for \(chatID): \(error)")
             }
@@ -225,12 +249,12 @@ public final class ChatDaemonCoordinator {
     /// Rehydrate a session from the daemon's live state. Call on view appear
     /// and whenever the active chat changes so the mirror reflects the
     /// daemon's held-alive launcher (or the persisted rows once evicted).
-    public func rehydrate(chatID: String) async {
+    public func rehydrate(chatID: PageID) async {
         let session = self.session(for: chatID)
         do {
-            let state = try await client.chatSessionState(chatID)
+            let state = try await client.chatSessionState(chatID.rawValue)
             session.hydrate(from: state)
-            setChatRunning(chatID, running: state.isRunning || state.isGenerating)
+            setChatGenerating(chatID, generating: state.isGenerating)
         } catch {
             // A rehydrate failure (e.g. the daemon evicted the session, so
             // `chatSessionState` throws `noSession`) is non-fatal — but the
@@ -240,7 +264,7 @@ public final class ChatDaemonCoordinator {
             // `ChatDetailView` renders that empty stream instead of the
             // persisted transcript.
             session.markNotLive()
-            setChatRunning(chatID, running: false)
+            setChatGenerating(chatID, generating: false)
             DebugLog.agent("ChatDaemonCoordinator.rehydrate failed for \(chatID): \(error) — marked not live")
         }
     }

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -77,7 +77,27 @@ struct ChatDetailView: View {
     /// false, it sources from the persisted `store.chatMessages(chatID:)`.
     private var isLiveChat: Bool {
         guard let chatID else { return false }
-        return remoteSession.activeChatID == chatID.rawValue
+        return remoteSession.activeChatID == chatID
+    }
+
+    /// TEMPORARY (chat transcript freezes mid-stream): seam 7 of 8 — which
+    /// SOURCE this surface is rendering from. This is the discriminator the
+    /// other seams can't give: `live=false` means the transcript is coming from
+    /// `persistedMessages` (which only reloads on `.task(id:)` /
+    /// `store.messageVersion`), so a frozen transcript is a liveness bug in the
+    /// mirror. `live=true` with a growing `liveEvents` but a frozen screen is a
+    /// differ bug, and seam 8 says which.
+    private var liveDebugKey: String {
+        // Built in steps: as one chained interpolation the type checker times
+        // out (`unable to type-check this expression in reasonable time`).
+        let id = chatID?.rawValue ?? "draft"
+        let active = remoteSession.activeChatID?.rawValue ?? "nil"
+        let state = String(describing: remoteSession.runState)
+        let liveCount = remoteSession.events.count
+        let persistedCount = persistedMessages.count
+        let displayCount = displayMessages.count
+        return "chat=\(id) live=\(isLiveChat) activeChatID=\(active) runState=\(state) "
+            + "liveEvents=\(liveCount) persisted=\(persistedCount) display=\(displayCount)"
     }
 
     /// Pure source-of-truth selector (D2): the live session streams from
@@ -141,8 +161,12 @@ struct ChatDetailView: View {
     /// True only when THIS surface is the active live stream — so a persisted
     /// chat never shows the "Waiting for the Agent…" placeholder even while its
     /// launcher is generating a different chat.
+    /// Keys off `isAnswering`, not `isLive`: a warm session between turns is
+    /// live (its transcript is the mirror's) but nothing is running, so it must
+    /// not show "Waiting for the Agent…". This is the same conflation that
+    /// pinned the sidebar "responding…" badge on for the life of a session.
     private var transcriptIsRunning: Bool {
-        isLiveChat && remoteSession.isRunning
+        isLiveChat && remoteSession.runState.isAnswering
     }
 
     var body: some View {
@@ -209,7 +233,7 @@ struct ChatDetailView: View {
                 // daemon's held-alive launcher (or the persisted rows once the
                 // launcher was evicted). Best-effort — a rehydrate failure
                 // leaves the session on its last-known state.
-                await coordinator.rehydrate(chatID: chatID.rawValue)
+                await coordinator.rehydrate(chatID: chatID)
             } else {
                 persistedMessages = []
                 // Omnibox "Ask" action (#288): if a pending question was set
@@ -229,6 +253,13 @@ struct ChatDetailView: View {
             if let chatID, !isLiveChat {
                 persistedMessages = store.chatMessages(chatID: chatID)
             }
+        }
+        // TEMPORARY (chat transcript freezes mid-stream): seam 7 of 8. Keyed on
+        // a composed string so it emits one line per real transition rather
+        // than one per body pass; `initial: true` captures the state the
+        // surface opened in.
+        .onChange(of: liveDebugKey, initial: true) { _, key in
+            DebugLog.chatLive("7.detail \(key)")
         }
         // Reload persisted messages when the store changes (e.g. a new message
         // appended to a persisted chat — D3 continues append here, and this keeps
@@ -426,6 +457,7 @@ struct ChatDetailView: View {
                     }
                     ChatTranscriptView(
                         events: displayMessages,
+                        transcriptID: chatID.map(TranscriptID.chat),
                         timestamps: displayTimestamps,
                         emptyStateMessage: transcriptEmptyMessage,
                         isRunning: transcriptIsRunning,

--- a/Sources/WikiFS/Chats/ChatRunState.swift
+++ b/Sources/WikiFS/Chats/ChatRunState.swift
@@ -5,34 +5,70 @@
 /// this as a denormalized enum — and could represent impossible
 /// combinations (e.g. "not live but running", the `markNotLive` bug).
 ///
-/// The flags are hierarchical: the daemon never reports `isGenerating`
-/// without `isRunning` (a session must be active to stream), so they map
-/// cleanly to exclusive states via the `from(...)` factory.
+/// ## Why the cases are what they are
+///
+/// The daemon's flags carry meanings that are easy to misread, and the first
+/// version of this enum misread two of them:
+///
+/// * `isGenerating` is **not** "streaming tokens". `AgentLauncher.setGenerating(true)`
+///   fires at *turn start* (`sendInteractiveMessage: turn start`), so it covers
+///   the whole turn — thinking and streaming alike. It is the flag
+///   `AgentLauncher` documents as the one "every UI spinner / Stop affordance
+///   keys off".
+/// * `isRunning` is **not** "a turn is in flight". For an interactive chat it
+///   means the agent *process* is alive **across turns** (`AgentLauncher`:
+///   "SPAWN COMMIT: process is alive. isRunning = true (process alive across
+///   turns)"), so it stays true while the session sits idle between messages.
+///
+/// The previous mapping therefore lost information twice. It defined
+/// `.thinking` as `isRunning && !isGenerating` — a combination that for an
+/// interactive session *only ever* means "warm, between turns", never thinking
+/// — and that misnomer is what led the sidebar to badge a warm session as
+/// "responding…" for the rest of its life. It also tested `isRunning` **before**
+/// `isAwaitingSlot`, so a turn queued on the generation gate (which has both
+/// flags set) was reported as `.thinking` and `isAwaitingGenerationSlot` read
+/// false exactly when it was true.
 public enum ChatRunState: Sendable, Equatable {
-    /// No active run. The session is idle or the daemon has no live session.
+    /// No live session on the daemon. The chat renders from persisted rows.
     case idle
-    /// The daemon reported `isAwaitingGenerationSlot` — a turn is queued
-    /// waiting for the concurrency gate.
+    /// A turn has been submitted and is waiting for the shared concurrency
+    /// gate (another session is answering). The session is live.
     case queued
-    /// The agent is processing (`isRunning` true, not yet streaming).
-    case thinking
-    /// The agent is streaming tokens (`isGenerating` true; implies running).
-    case generating
+    /// The session is alive with **no turn in flight** — the state a chat sits
+    /// in between messages, holding its warm agent process. Live (its
+    /// transcript is the mirror's), but emphatically *not* answering.
+    case warm
+    /// A turn is in flight: the agent is working on a reply, whether or not
+    /// tokens have started arriving. This is the only state that means
+    /// "responding…".
+    case answering
 
     /// Map from the daemon's flat boolean DTO to the most-specific state.
-    /// `isGenerating` wins over `isRunning` (generating implies running),
-    /// and `isRunning` wins over `isAwaitingGenerationSlot`.
+    ///
+    /// Precedence matters and is the reverse of the obvious reading: the
+    /// *narrowest* claim wins. `isGenerating` (a turn is in flight) beats
+    /// `isAwaitingSlot` (a turn is queued) beats `isRunning` (the process is
+    /// merely alive), because each earlier flag implies the later ones.
     public static func from(
         isRunning: Bool, isGenerating: Bool, isAwaitingSlot: Bool
     ) -> ChatRunState {
-        if isGenerating    { return .generating }
-        if isRunning       { return .thinking }
-        if isAwaitingSlot  { return .queued }
+        if isGenerating   { return .answering }
+        if isAwaitingSlot { return .queued }
+        if isRunning      { return .warm }
         return .idle
     }
 
-    /// True while the daemon is actively working on this session
-    /// (thinking or generating). Backs `isInteractiveSession` and
+    /// True while the daemon holds a session for this chat — so the chat
+    /// surface should render the streaming mirror (`RemoteChatSession.events`)
+    /// rather than the persisted rows. Backs `isInteractiveSession` and
     /// `activeChatID != nil`.
-    public var isActive: Bool { self == .thinking || self == .generating }
+    ///
+    /// Deliberately *not* the same question as `isAnswering`: a warm session
+    /// between turns is live (its transcript is authoritative) while nothing
+    /// is running. Conflating the two is the bug this enum exists to prevent.
+    public var isLive: Bool { self != .idle }
+
+    /// True while a turn is actually in flight. **Every** spinner, "responding…"
+    /// badge, and Stop affordance keys off this — never off `isLive`.
+    public var isAnswering: Bool { self == .answering }
 }

--- a/Sources/WikiFS/Chats/ChatSessionKey.swift
+++ b/Sources/WikiFS/Chats/ChatSessionKey.swift
@@ -1,0 +1,38 @@
+#if os(macOS)
+import WikiFSTypes
+
+/// Identifies which chat a `RemoteChatSession` mirrors.
+///
+/// Replaces a bare `String` plus the sentinel `"__wiki_draft_chat__"` that
+/// stood in for the not-yet-persisted composer. That encoding had two failure
+/// modes the type system now rules out:
+///
+/// * The sentinel shared a namespace with real chat ULIDs, so "is this the
+///   draft?" was a string comparison against a magic constant that any call
+///   site could forget (or misspell) — and a chat whose id happened to equal
+///   the sentinel would have been silently treated as the draft.
+/// * `activeChatID` returned that sentinel for a live draft, so the draft could
+///   in principle satisfy a `activeChatID == chatID` liveness check. The
+///   `.draft` case has no `PageID` at all, so it cannot.
+public enum ChatSessionKey: Hashable, Sendable {
+    /// The `.newChat` composer — no persisted row exists yet. The daemon
+    /// assigns a real id on the first send, at which point the tab retargets
+    /// to `.chat(id)` and a fresh session is created under that key.
+    case draft
+    /// A persisted chat row.
+    case chat(PageID)
+
+    /// The persisted chat id, or `nil` for the draft. The conversion point
+    /// between this typed key and the `String` chat ids that cross XPC.
+    public var pageID: PageID? {
+        switch self {
+        case .draft: return nil
+        case .chat(let id): return id
+        }
+    }
+
+    /// The wire form (a chat ULID), or `nil` for the draft — which has no
+    /// daemon-side session and so is never a valid XPC target.
+    public var rawValue: String? { pageID?.rawValue }
+}
+#endif

--- a/Sources/WikiFS/Chats/ChatTranscriptView.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptView.swift
@@ -10,6 +10,12 @@ struct ChatTranscriptView: View {
     /// The transcript-visible events to render (caller pre-filters via
     /// `[AgentEvent].transcriptVisible`).
     let events: [AgentEvent]
+    /// Identity of the conversation `events` belongs to, forwarded to
+    /// `ChatWebView` so its incremental differ rebuilds instead of splicing
+    /// when this view is reused for a different chat (see
+    /// `ChatWebView.transcriptID`). `nil` for the draft composer, which never
+    /// reaches the web view (it renders the empty-state placeholder).
+    var transcriptID: TranscriptID? = nil
     /// Wall-clock timestamps parallel to `events` (after the same filtering).
     /// `nil` entries produce no "Worked for" footer. Used to render the
     /// duration metadata under assistant responses.
@@ -63,6 +69,7 @@ struct ChatTranscriptView: View {
                 ChatWebView(
                     events: visibleEvents,
                     style: .chat,
+                    transcriptID: transcriptID,
                     onWikiLink: onWikiLink,
                     renderContext: renderContext,
                     blobStore: blobStore,

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -20,8 +20,10 @@ import WikiFSCore
 /// contract): new events are inserted into the live DOM via `appendRows`, and an
 /// in-place growth of the last row is patched via `replaceLastRow`, rather than a
 /// full reload — so an in-progress text selection survives a streaming run. A
-/// count *decrease* (a reset) or a `showsInternals` change (which changes which
-/// underlying events are visible) forces a full rebuild.
+/// count *decrease* (a reset), a `showsInternals` change (which changes which
+/// underlying events are visible), or a `transcriptID` change (the events now
+/// describe a different conversation entirely) forces a full rebuild.
+///
 /// A versioned request to scroll the chat transcript to a user turn. Mirrors the
 /// reader's anchor-version pattern: `version` bumps to signal a new request;
 /// `turnIndex` is the 0-based index among the `.chat-user` rows the transcript
@@ -42,6 +44,23 @@ struct ChatHighlightRequest: Equatable {
     let quote: String
 }
 
+/// Identity of the transcript a `ChatWebView` renders — the key its
+/// incremental differ uses to decide whether the DOM it already built belongs
+/// to the same conversation as the incoming `events`.
+///
+/// Namespaced by case rather than a bare `String`, so an id from one space can
+/// never compare equal to an id from another: chat rows and queue items are
+/// both ULIDs, and a raw-string key would silently treat a collision as "same
+/// transcript" — precisely the failure this type exists to prevent.
+enum TranscriptID: Hashable, Sendable {
+    /// A chat's persisted row (`ChatDetailView` → `ChatTranscriptView`). The
+    /// draft composer (`chatID == nil`) has no transcript to render, so there
+    /// is deliberately no draft case.
+    case chat(PageID)
+    /// A queue item's activity feed (`ActivityWindowView`).
+    case queueItem(QueueItem.ID)
+}
+
 struct ChatWebView: NSViewRepresentable {
     /// `.activityFeed` is the inspector look (labeled rows, tool calls,
     /// diagnostics). `.chat` is the Query page look (right-aligned capsule
@@ -53,6 +72,23 @@ struct ChatWebView: NSViewRepresentable {
 
     let events: [AgentEvent]
     let style: VisualStyle
+    /// Identity of the transcript these `events` belong to (a chat ULID, a
+    /// queue item id, …). The coordinator renders **incrementally** — it
+    /// appends only `events[renderedCount...]` — which is only sound while
+    /// successive `events` arrays are successive states of the SAME transcript.
+    ///
+    /// SwiftUI reuses an `NSViewRepresentable`'s view + coordinator whenever
+    /// structural identity is unchanged, and switching between two chat tabs
+    /// (or two queue items) does not change structural identity — the branch of
+    /// the enclosing `switch` is the same, only the associated value differs.
+    /// Without this key the differ would splice transcript B's tail onto
+    /// transcript A's DOM (`count > renderedCount` → append) or patch only the
+    /// last row (`count == renderedCount`), leaving the previous chat's
+    /// messages on screen and freezing subsequent streaming appends.
+    ///
+    /// A change forces a full rebuild. `nil` (the default) opts out — for
+    /// call sites that render exactly one transcript for the view's lifetime.
+    var transcriptID: TranscriptID? = nil
     /// A value that, when it changes, forces a full rebuild rather than an
     /// append — for callers whose event→visible-row filtering can change
     /// retroactively (e.g. `AgentQueueView`'s "Show internals" toggle).
@@ -135,7 +171,8 @@ struct ChatWebView: NSViewRepresentable {
         context.coordinator.style = style
         context.coordinator.onWikiLink = onWikiLink
         context.coordinator.renderContext = renderContext
-        context.coordinator.reload(events: events, showsInternals: showsInternals, timestamps: timestamps)
+        context.coordinator.reload(events: events, showsInternals: showsInternals,
+                                   timestamps: timestamps, transcriptID: transcriptID)
         return webView
     }
 
@@ -148,7 +185,8 @@ struct ChatWebView: NSViewRepresentable {
         if let handler = webView.configuration.urlSchemeHandler(forURLScheme: BlobSchemeHandler.scheme) as? BlobSchemeHandler {
             handler.store = blobStore
         }
-        context.coordinator.apply(events: events, showsInternals: showsInternals, timestamps: timestamps)
+        context.coordinator.apply(events: events, showsInternals: showsInternals,
+                                  timestamps: timestamps, transcriptID: transcriptID)
         // Outline click → scroll the i-th user bubble into view. Only fires when
         // the version advances, so unrelated re-renders (streaming) don't re-scroll.
         if let req = scrollRequest, req.version != context.coordinator.appliedScrollVersion {
@@ -193,6 +231,12 @@ struct ChatWebView: NSViewRepresentable {
         var appliedHighlightVersion: Int = -1
         private var renderedCount = 0
         private var renderedShowsInternals: Bool?
+        /// The `transcriptID` the currently-rendered DOM was built from. When
+        /// the incoming id differs, the incremental differ's anchors
+        /// (`renderedCount`/`renderedEvents`/`renderedLastEvent`) describe a
+        /// *different* transcript and must not be used — see
+        /// `ChatWebView.transcriptID`.
+        private var renderedTranscriptID: TranscriptID?
         private var isLoaded = false
         private var pendingEvents: [AgentEvent] = []
         /// Pending timestamps to render once the page finishes loading (stashed by
@@ -214,9 +258,34 @@ struct ChatWebView: NSViewRepresentable {
         /// the current `WikiRenderContext` (or nil → constant-true behavior).
         private func currentContext() -> WikiRenderContext? { renderContext?() }
 
-        func reload(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = []) {
+        /// Pure predicate for "this render pass cannot append/patch — rebuild
+        /// the whole document". Extracted so the three rebuild triggers are
+        /// testable without a WebKit view tree.
+        ///
+        /// - A `transcriptID` change means the DOM belongs to a different
+        ///   transcript entirely (chat tab switch, queue item switch).
+        /// - A `showsInternals` change retroactively changes which events are
+        ///   visible, so previously-rendered rows are wrong.
+        /// - A count *decrease* is the reset contract (`events = []`).
+        ///
+        /// `nonisolated`: a pure predicate over value types, so tests can call
+        /// it without hopping to the main actor (same discipline as
+        /// `ChatDetailView.displayMessages`).
+        nonisolated static func needsFullReload(
+            transcriptID: TranscriptID?, renderedTranscriptID: TranscriptID?,
+            showsInternals: Bool, renderedShowsInternals: Bool?,
+            eventCount: Int, renderedCount: Int
+        ) -> Bool {
+            if transcriptID != renderedTranscriptID { return true }
+            if showsInternals != renderedShowsInternals { return true }
+            return eventCount < renderedCount
+        }
+
+        func reload(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = [],
+                    transcriptID: TranscriptID? = nil) {
             renderedCount = 0
             renderedShowsInternals = showsInternals
+            renderedTranscriptID = transcriptID
             renderedLastEvent = nil
             renderedEvents = events
             self.timestamps = timestamps
@@ -226,19 +295,39 @@ struct ChatWebView: NSViewRepresentable {
             webView?.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
         }
 
-        func apply(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = []) {
+        func apply(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = [],
+                   transcriptID: TranscriptID? = nil) {
             self.timestamps = timestamps
-            if renderedShowsInternals != showsInternals {
-                reload(events: events, showsInternals: showsInternals, timestamps: timestamps)
+            // Checked BEFORE the `isLoaded` guard, so a transcript switch that
+            // lands mid-load also replaces `pendingEvents` — otherwise
+            // `didFinish` would render the PREVIOUS transcript's rows and seed
+            // `renderedCount` from them, and the new chat would then be diffed
+            // against a DOM it never produced.
+            //
+            // This also hoists the count-decrease check above the guard, where
+            // it used to sit below. That is a no-op rather than a behavior
+            // change: `reload` sets `renderedCount = 0` and `isLoaded = false`
+            // together, and only `didFinish` sets either back — so while
+            // unloaded `renderedCount` is always 0 and `count < 0` is
+            // unreachable.
+            if Self.needsFullReload(
+                transcriptID: transcriptID, renderedTranscriptID: renderedTranscriptID,
+                showsInternals: showsInternals, renderedShowsInternals: renderedShowsInternals,
+                eventCount: events.count, renderedCount: renderedCount) {
+                // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8.
+                DebugLog.chatLive(
+                    "8.web.reload count=\(events.count) renderedCount=\(renderedCount)")
+                reload(events: events, showsInternals: showsInternals,
+                       timestamps: timestamps, transcriptID: transcriptID)
                 return
             }
             guard isLoaded else {
+                // TEMPORARY: rows arriving before the shell finishes loading are
+                // stashed, not drawn. A run of these with no `8.web.didFinish`
+                // after them means the shell load never completed.
+                DebugLog.chatLive("8.web.pending count=\(events.count)")
                 pendingEvents = events
                 pendingTimestamps = timestamps
-                return
-            }
-            if events.count < renderedCount {
-                reload(events: events, showsInternals: showsInternals, timestamps: timestamps)
                 return
             }
             guard events.count > renderedCount else {
@@ -264,6 +353,12 @@ struct ChatWebView: NSViewRepresentable {
                renderedEvents.count > 0 {
                 replaceLastRow(prevLast, at: renderedEvents.count - 1, isStreaming: false, allEvents: events, context: context)
             }
+            // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8. The
+            // `from` index is the tell — a non-zero `from` on a chat's FIRST
+            // append means rows 0..<from were never drawn (the missing
+            // "thinking" rows before "read").
+            DebugLog.chatLive(
+                "8.web.append from=\(renderedCount) to=\(events.count)")
             appendRows(Array(events[renderedCount...]), startingIndex: renderedCount, context: context)
             renderedCount = events.count
             renderedLastEvent = events.last
@@ -272,6 +367,8 @@ struct ChatWebView: NSViewRepresentable {
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             isLoaded = true
+            // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8.
+            DebugLog.chatLive("8.web.didFinish pending=\(pendingEvents.count)")
             let toRender = pendingEvents
             pendingEvents = []
             pendingTimestamps = []

--- a/Sources/WikiFS/Chats/ChatsListView.swift
+++ b/Sources/WikiFS/Chats/ChatsListView.swift
@@ -35,6 +35,10 @@ struct ChatsListView: NSViewControllerRepresentable {
         let visible = store.chatSearchQuery.isEmpty ? store.chats : store.chatSearchResults
         let needs = vc.needsReload(visible)
         DebugLog.tabs("ChatsListView.updateNSVC: count=\(visible.count) needsReload=\(needs)")
+        // TEMPORARY (stuck "responding…" badge): seam 5 of 6. Seam 4 firing
+        // without this one means `AgentToolsView`'s re-render did not reach the
+        // representable (an unchanged-input short-circuit above us).
+        DebugLog.chatLive("5.sidebar.updateNSVC rows=\(visible.count) needsReload=\(needs)")
         if needs {
             vc.reloadData(from: visible)
         } else {
@@ -77,7 +81,7 @@ final class ChatsListViewController: NSViewController {
     var tableView: ChatsNSTableView!
     var store: WikiStoreModel?
     /// The daemon coordinator (Phase C4) — drives the per-row live indicator
-    /// via `isChatRunning(_:)`.
+    /// via `isChatGenerating(_:)`.
     var chatDaemon: ChatDaemonCoordinator?
     var callbacks: ChatsListCallbacks?
 
@@ -86,6 +90,9 @@ final class ChatsListViewController: NSViewController {
     private var lastSignature = ""
     /// Re-entrancy guard: selecting a row programmatically must not loop back.
     private var isReconcilingHighlight = false
+    /// TEMPORARY (stuck "responding…" badge): last live set reported by
+    /// `logLiveState`, so the trace emits one line per transition.
+    private var loggedLiveIDs: Set<PageID> = []
 
     override func loadView() {
         scrollView = NSScrollView()
@@ -132,6 +139,7 @@ final class ChatsListViewController: NSViewController {
         lastCount = rows.count
         lastSignature = signature(rows)
         tableView.reloadData()
+        logLiveState("reload", reconfigured: rows.count, candidates: rows.count)
     }
 
     /// Re-evaluate the live ("responding…") indicator on visible rows WITHOUT
@@ -141,14 +149,38 @@ final class ChatsListViewController: NSViewController {
     /// selection/scroll glitches of a full table rebuild.
     func reconfigureLiveState() {
         let range = tableView.rows(in: tableView.visibleRect)
-        guard range.length > 0 else { return }
+        guard range.length > 0 else {
+            logLiveState("reconfigure", reconfigured: 0, candidates: 0)
+            return
+        }
+        var reconfigured = 0
+        var candidates = 0
         for row in range.location..<(range.location + range.length) {
             guard row < items.count else { continue }
+            candidates += 1
             if let cell = tableView.view(atColumn: 0, row: row,
                                           makeIfNecessary: false) as? ChatsCellView {
                 cell.configure(chat: items[row], isLive: isLive(items[row]))
+                reconfigured += 1
             }
         }
+        logLiveState("reconfigure", reconfigured: reconfigured, candidates: candidates)
+    }
+
+    /// TEMPORARY (stuck "responding…" badge): seam 6 of 6 — what the rows were
+    /// actually told. Emits only when the live set changes, so the trace stays
+    /// one line per real transition instead of one per re-render.
+    ///
+    /// `reconfigured < candidates` means a visible row was skipped because its
+    /// cell was not materialized (`makeIfNecessary: false`) — the badge would
+    /// then keep whatever it was last configured with.
+    private func logLiveState(_ reason: String, reconfigured: Int, candidates: Int) {
+        let live = Set(items.map(\.id).filter { chatDaemon?.isChatGenerating($0) ?? false })
+        guard live != loggedLiveIDs else { return }
+        loggedLiveIDs = live
+        DebugLog.chatLive(
+            "6.sidebar.\(reason) live=[\(live.map(\.rawValue).sorted().joined(separator: ","))] "
+            + "reconfigured=\(reconfigured)/\(candidates)")
     }
 
     private func signature(_ rows: [ChatSummary]) -> String {
@@ -212,7 +244,7 @@ final class ChatsListViewController: NSViewController {
     /// check with the coordinator's per-chat aggregate, which also covers chats
     /// the daemon is running that the app hasn't opened).
     private func isLive(_ chat: ChatSummary) -> Bool {
-        chatDaemon?.isChatRunning(chat.id.rawValue) ?? false
+        chatDaemon?.isChatGenerating(chat.id) ?? false
     }
 }
 

--- a/Sources/WikiFS/Chats/RemoteChatSession.swift
+++ b/Sources/WikiFS/Chats/RemoteChatSession.swift
@@ -37,16 +37,24 @@ public final class RemoteChatSession {
 
     // MARK: - Backward-compatible run-flag shims (computed from runState)
 
-    public var isRunning: Bool { runState == .thinking || runState == .generating }
-    public var isGenerating: Bool { runState == .generating }
+    /// Mirrors `AgentLauncher.isRunning` — "the agent process is alive", which
+    /// for an interactive chat is true *across turns*. NOT "a turn is in
+    /// flight"; use `isGenerating` (or `runState.isAnswering`) for that.
+    public var isRunning: Bool { runState.isLive }
+    /// Mirrors `AgentLauncher.isGenerating` — a turn is in flight, covering the
+    /// thinking phase as well as streaming. The flag every spinner keys off.
+    public var isGenerating: Bool { runState.isAnswering }
     public var isAwaitingGenerationSlot: Bool { runState == .queued }
-    public var isInteractiveSession: Bool { runState.isActive }
+    public var isInteractiveSession: Bool { runState.isLive }
     /// The chat id this mirror currently reflects as the LIVE session, or nil
     /// when this chat is not the daemon's active session (persisted/idle).
     /// Derived from `runState` so the `ChatDetailView` source-of-truth rule
     /// (`activeChatID == chatID`) flips a chat live precisely when the daemon
     /// is running it.
-    public var activeChatID: String? { runState.isActive ? chatID : nil }
+    /// `PageID?`, not `String?` — so `ChatDetailView`'s liveness rule compares
+    /// two chat ids rather than two strings, and the draft (which has no
+    /// `PageID`) can never satisfy it.
+    public var activeChatID: PageID? { runState.isLive ? chatID.pageID : nil }
     public var exitStatus: Int32?
     public var runningKind: WikiOperation.Kind?
     public var runStartedAt: Date?
@@ -80,13 +88,13 @@ public final class RemoteChatSession {
     /// The chat's most-recent run's log file URL (pure disk resolve).
     public var logFileURL: URL? {
         guard let chatID = activeChatID else { return nil }
-        return AgentLauncher.logFileURLStatic(forChat: chatID)
+        return AgentLauncher.logFileURLStatic(forChat: chatID.rawValue)
     }
 
     /// The chat's debug folder URL.
     public var debugFolderURL: URL? {
         guard let chatID = activeChatID else { return nil }
-        return AgentLauncher.debugFolderURLStatic(forChat: chatID)
+        return AgentLauncher.debugFolderURLStatic(forChat: chatID.rawValue)
     }
 
     /// Available thinking-effort choices (derived from `thinkingOption`).
@@ -94,11 +102,36 @@ public final class RemoteChatSession {
         thinkingOption?.choices ?? []
     }
 
+    // MARK: - Private: streaming-row bookkeeping
+
+    /// Which kind of row (if any) `events.last` is still accumulating from
+    /// streamed delta chunks. A delta extends that row instead of starting a
+    /// new one; a *finished* row is never extended by the next block.
+    ///
+    /// An enum rather than a pair of booleans: the two states are mutually
+    /// exclusive (a row cannot be mid-assistant-text and mid-thinking at once),
+    /// so booleans would make that impossible combination representable and
+    /// oblige every branch to remember to clear the other one — the same
+    /// denormalized-flags trap `ChatRunState` exists to close.
+    private enum StreamingRow {
+        /// No row is accumulating; the next delta starts a fresh one.
+        case none
+        /// `events.last` is an `.assistantText` row built from `.assistantTextDelta`.
+        case assistant
+        /// `events.last` is a `.thinking` row built from `.thinkingDelta`.
+        case thinking
+    }
+
+    /// `@ObservationIgnored`: internal merge bookkeeping, not view state. It
+    /// changes on every delta and no view reads it, so tracking it would
+    /// invalidate the transcript on writes nothing renders.
+    @ObservationIgnored private var streamingRow: StreamingRow = .none
+
     // MARK: - Identity
 
-    public let chatID: String
+    public let chatID: ChatSessionKey
 
-    public init(chatID: String) {
+    public init(chatID: ChatSessionKey) {
         self.chatID = chatID
         // A fresh mirror knows NOTHING about the daemon yet, so it must not
         // claim liveness: `runState` defaults to `.idle`, which makes the
@@ -119,6 +152,7 @@ public final class RemoteChatSession {
     /// always renderable; an empty live stream is not).
     func markNotLive() {
         runState = .idle
+        streamingRow = .none
     }
 
     // MARK: - Envelope ingestion
@@ -127,7 +161,9 @@ public final class RemoteChatSession {
     /// Called by the app's chat-event router (which demuxes from
     /// `DaemonQueueEventSink`).
     func ingest(_ envelope: QueueEventEnvelope) {
-        guard envelope.chatID == chatID else { return }
+        // Envelopes carry the wire form; convert at this boundary rather than
+        // letting raw chat-id strings leak past it.
+        guard envelope.chatID == chatID.rawValue else { return }
         switch envelope.kind {
         case .chatEvent:
             if let event = envelope.chatAgentEvent {
@@ -163,8 +199,17 @@ public final class RemoteChatSession {
 
     /// Apply a full state snapshot (from `chatSessionState` rehydration).
     func hydrate(from state: ChatSessionState) {
-        events = state.events
-        eventTimestamps = Array(repeating: Date(), count: state.events.count)
+        // Same contract as `mergeOrAppendEvent`: a rehydrated history is one of
+        // the "OTHER consumers of the raw stream" `mergingStreamDeltas` names,
+        // so raw `.assistantTextDelta`/`.thinkingDelta` chunks in the snapshot
+        // must be folded here too — otherwise a rehydrate would re-break a
+        // transcript the live path had already assembled correctly. Idempotent:
+        // an already-merged array contains no deltas and passes through.
+        let merged = AgentEvent.mergingStreamDeltas(state.events)
+        events = merged
+        eventTimestamps = Array(repeating: Date(), count: merged.count)
+        // The snapshot is a complete history, not a row mid-flight.
+        streamingRow = .none
         runState = .from(isRunning: state.isRunning,
                           isGenerating: state.isGenerating,
                           isAwaitingSlot: state.isAwaitingGenerationSlot)
@@ -182,38 +227,89 @@ public final class RemoteChatSession {
 
     // MARK: - Private: event merge logic
 
-    /// Mirror `AgentLauncher.mergeOrAppend` for the remote case: delta
-    /// continuations replace the last event; everything else appends.
+    /// Mirror `AgentLauncher.mergeOrAppend` for the remote case: streamed
+    /// deltas coalesce into the in-progress row, and a final full-text event
+    /// replaces that row rather than duplicating it.
+    ///
+    /// **Folding the deltas is not cosmetic — without it the transcript renders
+    /// nothing at all.** The daemon streams a turn as `.assistantTextDelta` /
+    /// `.thinkingDelta` chunks, and both are `isInternalTranscriptEvent`, so
+    /// `transcriptVisible` filters every one of them out. Appending them raw
+    /// (the old `default:` branch) produced hundreds of events that the
+    /// transcript could not show: a live chat sat frozen on its user message
+    /// and tool-call rows while `events` climbed past 500, and the reply only
+    /// appeared after switching away and back — which re-read the *persisted*
+    /// rows, where the daemon had written properly coalesced text.
+    ///
+    /// `AgentEvent.mergingStreamDeltas` states the contract this satisfies:
+    /// "any OTHER consumer of the raw stream (queue transcripts, rehydrated
+    /// histories) must apply it too, or a streamed reply renders as one row per
+    /// word-fragment." This mirror is such a consumer. The logic here is the
+    /// incremental (event-at-a-time) form of that same fold; the two must stay
+    /// in step.
     private func mergeOrAppendEvent(_ event: AgentEvent) {
         let now = Date()
         switch event {
+        case .assistantTextDelta(let delta):
+            if streamingRow == .assistant, case .assistantText(let existing) = events.last {
+                // Keep the original timestamp — the row's "first seen" time.
+                events[events.count - 1] = .assistantText(existing + delta)
+            } else {
+                events.append(.assistantText(delta))
+                eventTimestamps.append(now)
+            }
+            streamingRow = .assistant
+
         case .assistantText(let text):
-            // If the last event is also .assistantText and the new text
-            // starts with the old text (delta continuation), replace.
-            if let last = events.last, case .assistantText(let existing) = last,
-               text.hasPrefix(existing) {
-                events[events.count - 1] = event
-                if !eventTimestamps.isEmpty {
-                    eventTimestamps[eventTimestamps.count - 1] = now
-                }
+            // The authoritative full text for a block we were streaming
+            // replaces the in-progress row instead of appending a duplicate.
+            if streamingRow == .assistant, case .assistantText = events.last {
+                replaceLastEvent(with: event, at: now)
+            } else if let last = events.last, case .assistantText(let existing) = last,
+                      text.hasPrefix(existing) {
+                // Providers that resend cumulative full text (no delta events)
+                // still collapse onto one row.
+                replaceLastEvent(with: event, at: now)
             } else {
                 events.append(event)
                 eventTimestamps.append(now)
             }
+            streamingRow = .none
+
+        case .thinkingDelta(let delta):
+            if streamingRow == .thinking, case .thinking(let existing) = events.last {
+                events[events.count - 1] = .thinking(existing + delta)
+            } else {
+                events.append(.thinking(delta))
+                eventTimestamps.append(now)
+            }
+            streamingRow = .thinking
+
         case .thinking(let text):
-            if let last = events.last, case .thinking(let existing) = last,
-               text.hasPrefix(existing) {
-                events[events.count - 1] = event
-                if !eventTimestamps.isEmpty {
-                    eventTimestamps[eventTimestamps.count - 1] = now
-                }
+            if streamingRow == .thinking, case .thinking = events.last {
+                replaceLastEvent(with: event, at: now)
+            } else if let last = events.last, case .thinking(let existing) = last,
+                      text.hasPrefix(existing) {
+                replaceLastEvent(with: event, at: now)
             } else {
                 events.append(event)
                 eventTimestamps.append(now)
             }
+            streamingRow = .none
+
         default:
             events.append(event)
             eventTimestamps.append(now)
+            streamingRow = .none
+        }
+    }
+
+    /// Overwrite the last event, keeping `eventTimestamps` parallel.
+    private func replaceLastEvent(with event: AgentEvent, at now: Date) {
+        guard !events.isEmpty else { return }
+        events[events.count - 1] = event
+        if !eventTimestamps.isEmpty {
+            eventTimestamps[eventTimestamps.count - 1] = now
         }
     }
 
@@ -347,6 +443,7 @@ public final class RemoteChatSession {
         events = []
         eventTimestamps = []
         runState = .idle
+        streamingRow = .none
         exitStatus = nil
         preflightError = nil
         pendingPermissions = []

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -633,6 +633,11 @@ struct ActivityWindowView: View {
             ChatWebView(
                 events: events,
                 style: .activityFeed,
+                // Selecting a different queue item reuses this representable's
+                // web view + coordinator (same structural identity, different
+                // associated value), so the differ needs the item id to know
+                // the DOM it built belongs to a different run.
+                transcriptID: .queueItem(item.id),
                 showsInternals: false,
                 onWikiLink: wikiLinkHandler(for: item.wikiID),
                 // Resolve ghost-link coloring + blob serving from THIS item's

--- a/Sources/WikiFS/Settings/AgentToolsView.swift
+++ b/Sources/WikiFS/Settings/AgentToolsView.swift
@@ -25,9 +25,13 @@ struct AgentToolsView: View {
         // Touch the daemon's running-state token so SwiftUI re-renders (and
         // re-evaluates each row's "responding…" badge) when a chat starts or
         // stops. `runningStateToken` is read here — in the tracked body —
-        // because `isChatRunning(_:)` is called from the NSTableView data
+        // because `isChatGenerating(_:)` is called from the NSTableView data
         // source, which SwiftUI can't observe.
         let _ = chatDaemon?.runningStateToken
+        // TEMPORARY (stuck "responding…" badge): seam 4 of 6. A token bump at
+        // seam 3 with no matching line here means the read above did not
+        // register with Observation, so the sidebar is never invalidated.
+        let _ = DebugLog.chatLive("4.sidebar.body token=\(chatDaemon?.runningStateToken ?? -1)")
         VStack(spacing: 0) {
             chatsHeader
             chatSearchBar

--- a/Sources/WikiFS/Window/WikiDetailView.swift
+++ b/Sources/WikiFS/Window/WikiDetailView.swift
@@ -224,11 +224,24 @@ struct WikiDetailView: View {
             ChatDetailView(
                 chatID: chatID,
                 store: store,
-                remoteSession: chatDaemon.session(for: chatID?.rawValue),
+                remoteSession: chatDaemon.session(for: chatID),
                 coordinator: chatDaemon,
                 session: session,
                 fileProvider: fileProvider
             )
+            // Give each chat its own view identity. Both chat tabs render from
+            // the SAME `switch` branch (`case .chat(let id)`), and a differing
+            // associated value does not change structural identity — so without
+            // this, switching from chat A to chat B reuses one `ChatDetailView`
+            // instance and every `@State` it owns carries over: chat A's
+            // `persistedMessages` render under chat B's title, and A's
+            // `attachments`/`queuedMessages` would be sent on B's next turn.
+            //
+            // Switching to a *page* tab and back already forced a rebuild (a
+            // different `switch` branch is a different `_ConditionalContent`
+            // case), which is why that route showed the correct transcript —
+            // this makes chat→chat behave the same way.
+            .id(chatID)
         } else {
             chatDaemonUnavailable
         }

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -389,7 +389,7 @@ struct WikiFSApp: App {
             }
             // Phase C4: chat runs on the daemon — check the coordinator's
             // aggregate rather than a per-wiki chat launcher.
-            if chatDaemonCoordinator?.anyChatRunning == true {
+            if chatDaemonCoordinator?.anyChatGenerating == true {
                 return "A chat session"
             }
             return nil

--- a/Sources/WikiFSTypes/DebugLog.swift
+++ b/Sources/WikiFSTypes/DebugLog.swift
@@ -28,6 +28,16 @@ public enum DebugLog {
     /// edit-guard events). Distinct from `tabs` (sidebar/tab/open) so editor
     /// events surface cleanly in Console.app.
     public static func editor(_ message: @autoclosure () -> String) { emit("editor", message()) }
+    /// The chat run-state → sidebar "responding…" badge pipeline, end to end:
+    /// the daemon's `pushStateUpdate`, the app's envelope `route`, the
+    /// coordinator's `runningChatIDs` membership + `runningStateToken` bump,
+    /// and the sidebar table's re-render path. Its own category so the trace
+    /// reads as one ordered story instead of being interleaved with `agent`
+    /// (per-event streaming) and `store` (everything else).
+    ///
+    ///     log show --predicate 'subsystem == "com.selfdrivingwiki.debug" AND category == "chatlive"' \
+    ///              --style compact --info --last 10m
+    public static func chatLive(_ message: @autoclosure () -> String) { emit("chatlive", message()) }
 
     // MARK: - try? replacement
 
@@ -132,6 +142,7 @@ public enum DebugLog {
         "fileprovider": Logger(subsystem: subsystem, category: "fileprovider"),
         "reader": Logger(subsystem: subsystem, category: "reader"),
         "editor": Logger(subsystem: subsystem, category: "editor"),
+        "chatlive": Logger(subsystem: subsystem, category: "chatlive"),
     ]
 
     // `.default` is the "notice" level (persisted by `log show`); `.debug` is

--- a/Sources/wikid/DaemonChatHost.swift
+++ b/Sources/wikid/DaemonChatHost.swift
@@ -479,6 +479,12 @@ final class DaemonChatHost: @unchecked Sendable {
             stderr: launcher.stderr.isEmpty ? nil : launcher.stderr,
             lastActivityAt: launcher.lastActivityAt,
             currentProcessID: launcher.currentProcessID.map(Int.init))
+        // TEMPORARY (stuck "responding…" badge): seam 1 of 6. If the terminal
+        // update (running=false gen=false) never appears here, the daemon never
+        // observed the session end and nothing downstream can clear the badge.
+        DebugLog.chatLive(
+            "1.daemon.push chat=\(chatID) running=\(launcher.isRunning) "
+            + "gen=\(launcher.isGenerating) awaiting=\(launcher.isAwaitingGenerationSlot)")
         pushEvent(.chatState(chatID: chatID, update: update))
     }
 

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -16,25 +16,25 @@ struct ChatDaemonCoordinatorTests {
 
     @Test func sessionForChatID_isGetOrCreate_sameInstance() {
         let coord = makeCoordinator()
-        let a = coord.session(for: "chat-1")
-        let b = coord.session(for: "chat-1")
+        let a = coord.session(for: PageID(rawValue: "chat-1"))
+        let b = coord.session(for: PageID(rawValue: "chat-1"))
         #expect(a === b)
-        #expect(a.chatID == "chat-1")
+        #expect(a.chatID == .chat(PageID(rawValue: "chat-1")))
     }
 
     @Test func sessionForNil_returnsSharedDraftSession() {
         let coord = makeCoordinator()
         let draft = coord.session(for: nil)
-        #expect(draft.chatID == ChatDaemonCoordinator.draftKey)
+        #expect(draft.chatID == .draft)
         // Repeated nil lookups return the same draft instance.
         #expect(coord.session(for: nil) === draft)
     }
 
     @Test func discard_removesCachedSession() {
         let coord = makeCoordinator()
-        let first = coord.session(for: "chat-1")
-        coord.discard(chatID: "chat-1")
-        let second = coord.session(for: "chat-1")
+        let first = coord.session(for: PageID(rawValue: "chat-1"))
+        coord.discard(chatID: PageID(rawValue: "chat-1"))
+        let second = coord.session(for: PageID(rawValue: "chat-1"))
         // After discard, a fresh session is created.
         #expect(first !== second)
     }
@@ -50,7 +50,7 @@ struct ChatDaemonCoordinatorTests {
 
     @Test func ingestForTesting_deliversChatEventToOpenSession() {
         let coord = makeCoordinator()
-        let session = coord.session(for: "chat-1")
+        let session = coord.session(for: PageID(rawValue: "chat-1"))
         coord.ingestForTesting(.chatEvent(chatID: "chat-1", event: .assistantText("hello")))
         #expect(session.events == [.assistantText("hello")])
     }
@@ -60,22 +60,22 @@ struct ChatDaemonCoordinatorTests {
         // running-set tracker but does NOT materialize a session.
         let coord = makeCoordinator()
         coord.ingestForTesting(.chatEvent(chatID: "chat-orphan", event: .assistantText("x")))
-        #expect(coord.isChatRunning("chat-orphan") == false)
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-orphan")) == false)
     }
 
     // MARK: - Running-set aggregate (sidebar liveness)
 
-    @Test func isChatRunning_trueAfterRunningStateEnvelope() {
+    @Test func isChatGenerating_trueWhileAnswering() {
         let coord = makeCoordinator()
         coord.ingestForTesting(.chatState(chatID: "chat-run", update: ChatStateUpdate(
             isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
-        #expect(coord.isChatRunning("chat-run"))
-        #expect(coord.anyChatRunning)
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-run")))
+        #expect(coord.anyChatGenerating)
     }
 
-    @Test func isChatRunning_falseAfterIdleStateEnvelope() {
+    @Test func isChatGenerating_falseAfterSessionEnds() {
         let coord = makeCoordinator()
         coord.ingestForTesting(.chatState(chatID: "chat-run", update: ChatStateUpdate(
             isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
@@ -85,8 +85,8 @@ struct ChatDaemonCoordinatorTests {
             isRunning: false, isGenerating: false, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
-        #expect(!coord.isChatRunning("chat-run"))
-        #expect(!coord.anyChatRunning)
+        #expect(!coord.isChatGenerating(PageID(rawValue: "chat-run")))
+        #expect(!coord.anyChatGenerating)
     }
 
     @Test func runningStateToken_bumpsOnRunningStateChange() {
@@ -116,16 +116,56 @@ struct ChatDaemonCoordinatorTests {
         #expect(coord.runningStateToken == afterStart + 1)
     }
 
-    @Test func isChatRunning_reflectsOpenSessionRunFlag() {
-        // An open session that reports running via hydrate also counts.
+    @Test func isChatGenerating_reflectsOpenSessionGeneratingFlag() {
+        // An open session that reports generating via hydrate also counts.
         let coord = makeCoordinator()
-        let session = coord.session(for: "chat-open")
+        let session = coord.session(for: PageID(rawValue: "chat-open"))
         session.hydrate(from: ChatSessionState(
             chatID: "chat-open", events: [],
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil))
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-open")))
+    }
+
+    @Test func isChatGenerating_falseForWarmIdleInteractiveSession() {
+        // REGRESSION: the stuck "responding…" badge. For an interactive chat,
+        // `AgentLauncher.isRunning` means "the agent process is alive ACROSS
+        // TURNS", so it stays true while the session sits idle waiting for the
+        // next message — the daemon pushes exactly this state
+        // (running=true gen=false) the moment a turn ends, and kept pushing
+        // nothing after, because nothing had changed.
+        //
+        // The badge previously keyed off `isRunning || isGenerating`, so it
+        // latched on for the whole life of the session. It must key off
+        // `isGenerating` alone (the flag `AgentLauncher` documents as the one
+        // "every UI spinner / Stop affordance keys off").
+        let coord = makeCoordinator()
+        coord.ingestForTesting(.chatState(chatID: "chat-warm", update: ChatStateUpdate(
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-warm")), "badge on while answering")
+
+        // Turn ends; the process stays warm for the next message.
+        coord.ingestForTesting(.chatState(chatID: "chat-warm", update: ChatStateUpdate(
+            isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
+            preflightError: nil, thinkingOption: nil, usageData: nil,
+            logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
+        #expect(!coord.isChatGenerating(PageID(rawValue: "chat-warm")), "badge must clear when the turn ends")
+        #expect(!coord.anyChatGenerating)
+    }
+
+    @Test func isChatGenerating_falseForOpenSessionThatIsMerelyAlive() {
+        // Same contract via the hydrate path rather than the envelope path.
+        let coord = makeCoordinator()
+        let session = coord.session(for: PageID(rawValue: "chat-warm-hydrate"))
+        session.hydrate(from: ChatSessionState(
+            chatID: "chat-warm-hydrate", events: [],
             isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil))
-        #expect(coord.isChatRunning("chat-open"))
+        #expect(!coord.isChatGenerating(PageID(rawValue: "chat-warm-hydrate")))
     }
 
     // MARK: - Commands (forwarded to the daemon client stub)
@@ -204,7 +244,7 @@ struct ChatDaemonCoordinatorTests {
         // setThinkingEffort routes through the daemon.
         let stub = StubChatDaemonCommands()
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
-        let session = coord.session(for: "chat-wired")
+        let session = coord.session(for: PageID(rawValue: "chat-wired"))
         session.thinkingOption = ThinkingEffortOption(
             configId: "thought_level", currentValue: "low",
             choices: [ThinkingEffortOption.Choice(value: "low", label: "Low"),
@@ -235,15 +275,15 @@ struct ChatDaemonCoordinatorTests {
         let stub = StubChatDaemonCommands()
         stub.sessionState = ChatSessionState(
             chatID: "chat-1", events: [.userText("seed")],
-            isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
-        await coord.rehydrate(chatID: "chat-1")
-        let session = coord.session(for: "chat-1")
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-1"))
+        let session = coord.session(for: PageID(rawValue: "chat-1"))
         #expect(session.events == [.userText("seed")])
         #expect(session.isRunning)
-        #expect(coord.isChatRunning("chat-1"))
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-1")))
     }
 
     @Test func rehydrate_swallowsClientFailure() async {
@@ -251,9 +291,9 @@ struct ChatDaemonCoordinatorTests {
         // not crash; the session keeps its prior state.
         let stub = StubChatDaemonCommands(shouldThrow: true)
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
-        await coord.rehydrate(chatID: "chat-1")
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-1"))
         // No assertion crash; session simply remains default-empty.
-        #expect(coord.session(for: "chat-1").events.isEmpty)
+        #expect(coord.session(for: PageID(rawValue: "chat-1")).events.isEmpty)
     }
 
     @Test func rehydrateFailure_clearsLivenessSoPersistedRowsRender() async {
@@ -264,11 +304,11 @@ struct ChatDaemonCoordinatorTests {
         // persisted transcript showed "Ask a question to start a chat.".
         let stub = StubChatDaemonCommands(shouldThrow: true)
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
-        await coord.rehydrate(chatID: "chat-evicted")
-        let session = coord.session(for: "chat-evicted")
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-evicted"))
+        let session = coord.session(for: PageID(rawValue: "chat-evicted"))
         #expect(session.activeChatID == nil)
         #expect(session.isInteractiveSession == false)
-        #expect(coord.isChatRunning("chat-evicted") == false)
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-evicted")) == false)
     }
 
     @Test func freshSessionDoesNotClaimLivenessBeforeHydration() async {
@@ -276,7 +316,7 @@ struct ChatDaemonCoordinatorTests {
         // source-of-truth rule: `activeChatID` is daemon-derived, so it stays
         // nil until `hydrate`/`applyStateUpdate` sets it.
         let coord = makeCoordinator()
-        #expect(coord.session(for: "chat-new").activeChatID == nil)
+        #expect(coord.session(for: PageID(rawValue: "chat-new")).activeChatID == nil)
         #expect(coord.session(for: nil).activeChatID == nil)
     }
 
@@ -290,25 +330,25 @@ struct ChatDaemonCoordinatorTests {
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
-        await coord.rehydrate(chatID: "chat-idle")
-        #expect(coord.session(for: "chat-idle").activeChatID == nil)
-        #expect(coord.isChatRunning("chat-idle") == false)
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-idle"))
+        #expect(coord.session(for: PageID(rawValue: "chat-idle")).activeChatID == nil)
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-idle")) == false)
     }
 
     // MARK: - runningStateToken (rehydrate path)
 
-    @Test func rehydrateRunning_bumpsRunningStateToken() async {
+    @Test func rehydrateGenerating_bumpsRunningStateToken() async {
         let stub = StubChatDaemonCommands()
         stub.sessionState = ChatSessionState(
             chatID: "chat-run", events: [],
-            isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
         let before = coord.runningStateToken
-        await coord.rehydrate(chatID: "chat-run")
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-run"))
         #expect(coord.runningStateToken == before + 1)
-        #expect(coord.isChatRunning("chat-run"))
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-run")))
     }
 
     @Test func rehydrateIdle_doesNotBumpTokenWhenAlreadyIdle() async {
@@ -320,7 +360,7 @@ struct ChatDaemonCoordinatorTests {
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
         let before = coord.runningStateToken
-        await coord.rehydrate(chatID: "chat-idle")
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-idle"))
         // Was idle, stays idle → no change → no bump.
         #expect(coord.runningStateToken == before)
     }
@@ -332,21 +372,21 @@ struct ChatDaemonCoordinatorTests {
         let stub = StubChatDaemonCommands()
         stub.sessionState = ChatSessionState(
             chatID: "chat-evicted", events: [],
-            isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
+            isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
         let coord = ChatDaemonCoordinator(client: stub, eventSink: DaemonQueueEventSink())
-        await coord.rehydrate(chatID: "chat-evicted")
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-evicted"))
         let afterRunning = coord.runningStateToken
-        #expect(coord.isChatRunning("chat-evicted"))
+        #expect(coord.isChatGenerating(PageID(rawValue: "chat-evicted")))
 
         // Now the daemon evicts the session — rehydrate throws.
         stub.shouldThrow = true
-        await coord.rehydrate(chatID: "chat-evicted")
+        await coord.rehydrate(chatID: PageID(rawValue: "chat-evicted"))
         #expect(coord.runningStateToken == afterRunning + 1)
-        // Both liveness sources clear: runningChatIDs via setChatRunning, and
-        // the session's isRunning via markNotLive (which now clears the flags).
-        #expect(!coord.isChatRunning("chat-evicted"))
+        // Both liveness sources clear: generatingChatIDs via setChatGenerating, and
+        // the session's isGenerating via markNotLive (which now clears the flags).
+        #expect(!coord.isChatGenerating(PageID(rawValue: "chat-evicted")))
     }
 
     // MARK: - Helpers

--- a/Tests/WikiFSAppTests/ChatRunStateTests.swift
+++ b/Tests/WikiFSAppTests/ChatRunStateTests.swift
@@ -2,8 +2,12 @@ import Testing
 @testable import WikiFS
 
 /// Exhaustive tests for `ChatRunState.from(...)` — the factory that maps the
-/// daemon's three flat boolean flags into a single exclusive state, and for
-/// `isActive`.
+/// daemon's three flat boolean flags into a single exclusive state — and for
+/// the two derived predicates the UI keys off.
+///
+/// The `from(...)` table is the whole point of this type: the previous version
+/// lost information twice (see `ChatRunState`'s doc comment), so every one of
+/// the eight boolean combinations is pinned here rather than sampled.
 struct ChatRunStateTests {
 
     // MARK: - from(...) — all 8 boolean combinations
@@ -18,47 +22,70 @@ struct ChatRunStateTests {
             isRunning: false, isGenerating: false, isAwaitingSlot: true) == .queued)
     }
 
-    @Test func from_thinking_whenOnlyRunning() {
+    @Test func from_warm_whenOnlyRunning() {
+        // REGRESSION: this combination was mapped to `.thinking`. For an
+        // interactive chat it is the ONLY way to spell "session alive, no turn
+        // in flight" — `isGenerating` is set at turn start, so a real thinking
+        // phase always has `isGenerating == true`. Calling it `.thinking` is
+        // what taught the sidebar to badge a warm session as "responding…".
         #expect(ChatRunState.from(
-            isRunning: true, isGenerating: false, isAwaitingSlot: false) == .thinking)
+            isRunning: true, isGenerating: false, isAwaitingSlot: false) == .warm)
     }
 
-    @Test func from_thinking_whenRunningAndAwaiting() {
-        // running wins over awaiting
+    @Test func from_queued_whenRunningAndAwaiting() {
+        // REGRESSION: `isRunning` used to be tested BEFORE `isAwaitingSlot`, so
+        // this combination — the actual shape of a queued turn, whose process
+        // is alive while it waits for the gate — was reported as `.thinking`
+        // and `isAwaitingGenerationSlot` read false exactly when it was true.
         #expect(ChatRunState.from(
-            isRunning: true, isGenerating: false, isAwaitingSlot: true) == .thinking)
+            isRunning: true, isGenerating: false, isAwaitingSlot: true) == .queued)
     }
 
-    @Test func from_generating_whenOnlyGenerating() {
+    @Test func from_answering_whenOnlyGenerating() {
         #expect(ChatRunState.from(
-            isRunning: false, isGenerating: true, isAwaitingSlot: false) == .generating)
+            isRunning: false, isGenerating: true, isAwaitingSlot: false) == .answering)
     }
 
-    @Test func from_generating_whenGeneratingAndRunning() {
-        // most-specific wins
+    @Test func from_answering_whenGeneratingAndRunning() {
+        // The ordinary in-flight turn: process alive + turn in flight.
         #expect(ChatRunState.from(
-            isRunning: true, isGenerating: true, isAwaitingSlot: false) == .generating)
+            isRunning: true, isGenerating: true, isAwaitingSlot: false) == .answering)
     }
 
-    @Test func from_generating_whenAllTrue() {
+    @Test func from_answering_whenGeneratingAndAwaiting() {
         #expect(ChatRunState.from(
-            isRunning: true, isGenerating: true, isAwaitingSlot: true) == .generating)
+            isRunning: false, isGenerating: true, isAwaitingSlot: true) == .answering)
     }
 
-    @Test func from_generating_whenGeneratingAndAwaiting() {
+    @Test func from_answering_whenAllTrue() {
+        // Narrowest claim wins.
         #expect(ChatRunState.from(
-            isRunning: false, isGenerating: true, isAwaitingSlot: true) == .generating)
+            isRunning: true, isGenerating: true, isAwaitingSlot: true) == .answering)
     }
 
-    // MARK: - isActive
+    // MARK: - isLive — "render the streaming mirror, not the persisted rows"
 
-    @Test func isActive_falseForIdleAndQueued() {
-        #expect(ChatRunState.idle.isActive == false)
-        #expect(ChatRunState.queued.isActive == false)
+    @Test func isLive_falseOnlyForIdle() {
+        #expect(ChatRunState.idle.isLive == false)
+        #expect(ChatRunState.queued.isLive == true)
+        #expect(ChatRunState.warm.isLive == true)
+        #expect(ChatRunState.answering.isLive == true)
     }
 
-    @Test func isActive_trueForThinkingAndGenerating() {
-        #expect(ChatRunState.thinking.isActive == true)
-        #expect(ChatRunState.generating.isActive == true)
+    // MARK: - isAnswering — "responding…", spinners, Stop
+
+    @Test func isAnswering_trueOnlyForAnswering() {
+        #expect(ChatRunState.idle.isAnswering == false)
+        #expect(ChatRunState.queued.isAnswering == false)
+        #expect(ChatRunState.warm.isAnswering == false)
+        #expect(ChatRunState.answering.isAnswering == true)
+    }
+
+    @Test func isLiveAndIsAnswering_areDistinctForWarm() {
+        // The invariant the whole enum exists to protect: a session can be live
+        // without answering. Any code that uses one where it means the other
+        // reintroduces the badge bug.
+        #expect(ChatRunState.warm.isLive == true)
+        #expect(ChatRunState.warm.isAnswering == false)
     }
 }

--- a/Tests/WikiFSAppTests/ChatWebViewTranscriptIDTests.swift
+++ b/Tests/WikiFSAppTests/ChatWebViewTranscriptIDTests.swift
@@ -1,0 +1,118 @@
+#if os(macOS)
+import Testing
+import WikiFSCore
+import WikiFSTypes
+@testable import WikiFS
+
+/// `ChatWebView.Coordinator` renders **incrementally** — it appends only
+/// `events[renderedCount...]` and patches the last row in place. That is sound
+/// only while successive `events` arrays are successive states of the same
+/// conversation.
+///
+/// SwiftUI reuses an `NSViewRepresentable`'s view + coordinator across a chat
+/// tab switch (both chats render from the same `switch` branch, so structural
+/// identity is unchanged), which previously spliced one chat's tail onto
+/// another chat's DOM. `transcriptID` is the guard; these tests pin the pure
+/// decision function behind it.
+struct ChatWebViewTranscriptIDTests {
+
+    private let chatA = TranscriptID.chat(PageID(rawValue: "chat-a"))
+    private let chatB = TranscriptID.chat(PageID(rawValue: "chat-b"))
+
+    // MARK: - Transcript identity
+
+    @Test func rebuildsWhenTranscriptIDChanges_evenThoughEventsGrew() {
+        // The regression: chat B has MORE events than chat A had rendered, so
+        // the count check alone reads as "rows were appended" and splices B's
+        // tail onto A's DOM.
+        #expect(ChatWebView.Coordinator.needsFullReload(
+            transcriptID: chatB, renderedTranscriptID: chatA,
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 20, renderedCount: 12))
+    }
+
+    @Test func rebuildsWhenTranscriptIDChanges_atIdenticalEventCount() {
+        // The quieter half of the same bug: equal counts took the
+        // "patch the last row only" path, leaving chat A's whole transcript on
+        // screen with a single row swapped.
+        #expect(ChatWebView.Coordinator.needsFullReload(
+            transcriptID: chatB, renderedTranscriptID: chatA,
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 12, renderedCount: 12))
+    }
+
+    @Test func rebuildsWhenArrivingFromNoTranscript() {
+        #expect(ChatWebView.Coordinator.needsFullReload(
+            transcriptID: chatA, renderedTranscriptID: nil,
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 3, renderedCount: 3))
+    }
+
+    @Test func chatIDsAndQueueIDsNeverCollide() {
+        // The reason `TranscriptID` is a namespaced enum rather than a String:
+        // chat rows and queue items are both ULIDs, so the same raw value in
+        // two id spaces must still read as two different transcripts.
+        let shared = "01JQ0000000000000000000000"
+        #expect(ChatWebView.Coordinator.needsFullReload(
+            transcriptID: .queueItem(shared),
+            renderedTranscriptID: .chat(PageID(rawValue: shared)),
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 5, renderedCount: 5))
+    }
+
+    // MARK: - The incremental path stays incremental
+
+    @Test func appendsWithinTheSameTranscript() {
+        // Streaming: same chat, rows appended. Must NOT rebuild — a full
+        // reload would drop an in-progress text selection every delta.
+        #expect(!ChatWebView.Coordinator.needsFullReload(
+            transcriptID: chatA, renderedTranscriptID: chatA,
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 13, renderedCount: 12))
+    }
+
+    @Test func patchesLastRowWithinTheSameTranscript() {
+        // A streamed delta merged into the in-progress `.assistantText` grows
+        // the last event in place without changing the count (issue #121).
+        #expect(!ChatWebView.Coordinator.needsFullReload(
+            transcriptID: chatA, renderedTranscriptID: chatA,
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 12, renderedCount: 12))
+    }
+
+    @Test func nilTranscriptIDOptsOutOfIdentityChecks() {
+        // Call sites that render one transcript for the view's lifetime
+        // (`AgentQueueView`) pass nil and keep the historical behavior.
+        #expect(!ChatWebView.Coordinator.needsFullReload(
+            transcriptID: nil, renderedTranscriptID: nil,
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 9, renderedCount: 4))
+    }
+
+    // MARK: - Pre-existing rebuild triggers still fire
+
+    @Test func rebuildsOnEventCountDecrease() {
+        // The reset contract (`events = []`).
+        #expect(ChatWebView.Coordinator.needsFullReload(
+            transcriptID: chatA, renderedTranscriptID: chatA,
+            showsInternals: false, renderedShowsInternals: false,
+            eventCount: 0, renderedCount: 12))
+    }
+
+    @Test func rebuildsOnShowsInternalsToggle() {
+        // Retroactively changes which events are visible rows.
+        #expect(ChatWebView.Coordinator.needsFullReload(
+            transcriptID: chatA, renderedTranscriptID: chatA,
+            showsInternals: true, renderedShowsInternals: false,
+            eventCount: 12, renderedCount: 12))
+    }
+
+    @Test func rebuildsOnFirstApplyBeforeAnythingRendered() {
+        // `renderedShowsInternals` is nil until the first `reload`.
+        #expect(ChatWebView.Coordinator.needsFullReload(
+            transcriptID: nil, renderedTranscriptID: nil,
+            showsInternals: false, renderedShowsInternals: nil,
+            eventCount: 0, renderedCount: 0))
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
+++ b/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
@@ -14,7 +14,7 @@ struct RemoteChatSessionTests {
     // MARK: - chatEvent ingestion
 
     @Test @MainActor func chatEventAppendsNewEvent() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let envelope = QueueEventEnvelope.chatEvent(
             chatID: "chat-1", event: .assistantText("hello"))
         session.ingest(envelope)
@@ -23,7 +23,7 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func chatEventReplacesDeltaContinuation() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         // First event: partial assistant text
         session.ingest(.chatEvent(chatID: "chat-1", event: .assistantText("Hello")))
         #expect(session.events.count == 1)
@@ -35,7 +35,7 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func chatEventAppendsDifferentEvent() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         session.ingest(.chatEvent(chatID: "chat-1", event: .userText("question")))
         session.ingest(.chatEvent(chatID: "chat-1", event: .assistantText("answer")))
         #expect(session.events.count == 2)
@@ -44,13 +44,13 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func chatEventIgnoresWrongChatID() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         session.ingest(.chatEvent(chatID: "chat-2", event: .assistantText("other")))
         #expect(session.events.isEmpty)
     }
 
     @Test @MainActor func chatEventHandlesToolUseAndResult() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         session.ingest(.chatEvent(chatID: "chat-1", event: .toolUse(
             name: "wikictl", inputSummary: "page list")))
         session.ingest(.chatEvent(chatID: "chat-1", event: .toolResult(
@@ -61,7 +61,7 @@ struct RemoteChatSessionTests {
     // MARK: - chatState ingestion
 
     @Test @MainActor func chatStateUpdatesRunFlags() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let update = ChatStateUpdate(
             isRunning: true,
             isGenerating: true,
@@ -83,7 +83,7 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func chatStateUpdatesPreflightError() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let update = ChatStateUpdate(
             isRunning: false,
             isGenerating: false,
@@ -100,7 +100,7 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func chatStateUpdatesThinkingOption() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let option = ThinkingEffortOption(
             configId: "thought_level",
             currentValue: "high",
@@ -126,7 +126,7 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func chatStateUpdatesUsage() throws {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let usage = SessionUsage(
             inputTokens: 1000, outputTokens: 500,
             totalTokens: 1500,
@@ -154,7 +154,7 @@ struct RemoteChatSessionTests {
     // MARK: - Hydration from ChatSessionState
 
     @Test @MainActor func hydrateFromStateSetsAllFields() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let state = ChatSessionState(
             chatID: "chat-1",
             events: [.userText("hi"), .assistantText("hello")],
@@ -179,7 +179,7 @@ struct RemoteChatSessionTests {
     // MARK: - Phase C4 follow-up: state envelope fields (stderr, lastActivityAt, currentProcessID)
 
     @Test @MainActor func hydrateFromStateSetsStderrLastActivityAndPID() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let state = ChatSessionState(
             chatID: "chat-1",
             events: [],
@@ -204,7 +204,7 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func hydrateFromStateNilFieldsDefaultGracefully() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let state = ChatSessionState(
             chatID: "chat-1",
             events: [],
@@ -226,7 +226,7 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func chatStateUpdateCarriesStderrLastActivityAndPID() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let update = ChatStateUpdate(
             isRunning: true,
             isGenerating: false,
@@ -278,7 +278,7 @@ struct RemoteChatSessionTests {
     // MARK: - Reset
 
     @Test @MainActor func resetClearsAllState() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         session.ingest(.chatEvent(chatID: "chat-1", event: .assistantText("test")))
         // Set isRunning via a state update
         session.ingest(.chatState(chatID: "chat-1", update: ChatStateUpdate(
@@ -298,7 +298,7 @@ struct RemoteChatSessionTests {
     // MARK: - chatPendingPermission ingestion
 
     @Test @MainActor func chatPendingPermissionSetsPendingList() {
-        let session = RemoteChatSession(chatID: "chat-1")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-1")))
         let envelope = QueueEventEnvelope.chatPendingPermission(
             chatID: "chat-1",
             permission: PendingPermission(
@@ -386,21 +386,21 @@ struct RemoteChatSessionTests {
         // Hydrating with isRunning=true marks this mirror as the live session
         // (activeChatID == chatID) so ChatDetailView's source-of-truth rule
         // renders the streaming path.
-        let session = RemoteChatSession(chatID: "chat-live")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-live")))
         let state = ChatSessionState(
             chatID: "chat-live", events: [],
             isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
         session.hydrate(from: state)
-        #expect(session.activeChatID == "chat-live")
+        #expect(session.activeChatID == PageID(rawValue: "chat-live"))
         #expect(session.isInteractiveSession == true)
     }
 
     @Test @MainActor func activeChatIDNilWhenHydratedIdle() {
         // An idle persisted chat is NOT live — activeChatID clears so the view
         // renders the persisted rows instead of an empty live stream.
-        let session = RemoteChatSession(chatID: "chat-idle")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-idle")))
         let state = ChatSessionState(
             chatID: "chat-idle", events: [.userText("old")],
             isRunning: false, isGenerating: false, isAwaitingGenerationSlot: false,
@@ -414,12 +414,12 @@ struct RemoteChatSessionTests {
     @Test @MainActor func chatStateEnvelopeFlipsActiveChatIDWithRunFlag() {
         // A chatState envelope with isGenerating=true flips the mirror live;
         // a later one with both flags false flips it back to persisted.
-        let session = RemoteChatSession(chatID: "chat-flip")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-flip")))
         session.ingest(.chatState(chatID: "chat-flip", update: ChatStateUpdate(
             isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
-        #expect(session.activeChatID == "chat-flip")
+        #expect(session.activeChatID == PageID(rawValue: "chat-flip"))
 
         session.ingest(.chatState(chatID: "chat-flip", update: ChatStateUpdate(
             isRunning: false, isGenerating: false, isAwaitingGenerationSlot: false,
@@ -431,7 +431,7 @@ struct RemoteChatSessionTests {
     // MARK: - Phase C4: mid-session thinking + reset
 
     @Test @MainActor func setThinkingEffortOptimisticallyFlipsCurrentValue() {
-        let session = RemoteChatSession(chatID: "chat-think")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-think")))
         session.thinkingOption = ThinkingEffortOption(
             configId: "thought_level", currentValue: "low",
             choices: [
@@ -443,20 +443,20 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func setThinkingEffortNoOpWhenNoOptionAdvertised() {
-        let session = RemoteChatSession(chatID: "chat-think")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-think")))
         // thinkingOption is nil by default (agent advertises no thought_level).
         session.setThinkingEffort("high")
         #expect(session.thinkingOption == nil)
     }
 
     @Test @MainActor func startNewChatClearsStateAndActiveChatID() {
-        let session = RemoteChatSession(chatID: "chat-reset")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-reset")))
         session.ingest(.chatEvent(chatID: "chat-reset", event: .assistantText("hi")))
         session.ingest(.chatState(chatID: "chat-reset", update: ChatStateUpdate(
             isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
-        #expect(session.activeChatID == "chat-reset")
+        #expect(session.activeChatID == PageID(rawValue: "chat-reset"))
         #expect(session.events.count == 1)
 
         session.startNewChat()
@@ -470,23 +470,23 @@ struct RemoteChatSessionTests {
         // new mirror passed `ChatDetailView.isLiveChat` with an empty `events`
         // array — the view then rendered that empty live stream instead of the
         // chat's persisted rows.
-        let session = RemoteChatSession(chatID: "chat-fresh")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-fresh")))
         #expect(session.activeChatID == nil)
         #expect(session.isInteractiveSession == false)
     }
 
     @Test @MainActor func markNotLiveRelinquishesLivenessClaim() {
-        let session = RemoteChatSession(chatID: "chat-evicted")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-evicted")))
         session.ingest(.chatState(chatID: "chat-evicted", update: ChatStateUpdate(
             isRunning: true, isGenerating: false, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
-        #expect(session.activeChatID == "chat-evicted")
+        #expect(session.activeChatID == PageID(rawValue: "chat-evicted"))
 
         session.markNotLive()
         #expect(session.activeChatID == nil)
         #expect(session.isInteractiveSession == false)
-        // The running flags must also clear — `isChatRunning` checks them, so
+        // The running flags must also clear — `isChatGenerating` checks them, so
         // leaving them set would stick the sidebar "responding…" badge.
         #expect(session.isRunning == false)
         #expect(session.isGenerating == false)
@@ -495,7 +495,7 @@ struct RemoteChatSessionTests {
     // MARK: - ChatRunState FSM integration
 
     @Test @MainActor func runState_reflectsFullLifecycle() {
-        let session = RemoteChatSession(chatID: "chat-life")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-life")))
 
         func state(_ running: Bool, _ generating: Bool, _ awaiting: Bool) -> ChatStateUpdate {
             ChatStateUpdate(
@@ -505,25 +505,31 @@ struct RemoteChatSessionTests {
                 logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)
         }
 
-        // idle → queued → thinking → generating → idle
+        // idle → queued → warm → answering → idle
         session.ingest(.chatState(chatID: "chat-life", update: state(false, false, false)))
         #expect(session.runState == .idle)
 
         session.ingest(.chatState(chatID: "chat-life", update: state(false, false, true)))
         #expect(session.runState == .queued)
-        // Verify shim reads at the queued step (most-novel factory mapping).
+        // Shim reads at the queued step. A queued turn means the daemon HAS a
+        // session for this chat, so it is live (the mirror's transcript is the
+        // authoritative one) even though nothing is answering yet. This is a
+        // deliberate change: `.queued` used to report `isRunning == false` /
+        // `activeChatID == nil`, which sent the surface to the persisted rows
+        // mid-conversation.
         #expect(session.isAwaitingGenerationSlot == true)
-        #expect(session.isRunning == false)
-        #expect(session.isInteractiveSession == false)
-        #expect(session.activeChatID == nil)
+        #expect(session.isGenerating == false)
+        #expect(session.isRunning == true)
+        #expect(session.isInteractiveSession == true)
+        #expect(session.activeChatID == PageID(rawValue: "chat-life"))
 
         session.ingest(.chatState(chatID: "chat-life", update: state(true, false, false)))
-        #expect(session.runState == .thinking)
-        #expect(session.activeChatID == "chat-life")
+        #expect(session.runState == .warm)
+        #expect(session.activeChatID == PageID(rawValue: "chat-life"))
 
         session.ingest(.chatState(chatID: "chat-life", update: state(true, true, false)))
-        #expect(session.runState == .generating)
-        #expect(session.activeChatID == "chat-life")
+        #expect(session.runState == .answering)
+        #expect(session.activeChatID == PageID(rawValue: "chat-life"))
 
         session.ingest(.chatState(chatID: "chat-life", update: state(false, false, false)))
         #expect(session.runState == .idle)
@@ -531,12 +537,12 @@ struct RemoteChatSessionTests {
     }
 
     @Test @MainActor func markNotLive_resetsRunStateToIdle() {
-        let session = RemoteChatSession(chatID: "chat-evict")
+        let session = RemoteChatSession(chatID: .chat(PageID(rawValue: "chat-evict")))
         session.ingest(.chatState(chatID: "chat-evict", update: ChatStateUpdate(
             isRunning: true, isGenerating: true, isAwaitingGenerationSlot: false,
             preflightError: nil, thinkingOption: nil, usageData: nil,
             logFileURL: nil, debugFolderURL: nil, runKindRaw: nil, runStartedAt: nil)))
-        #expect(session.runState == .generating)
+        #expect(session.runState == .answering)
 
         session.markNotLive()
 


### PR DESCRIPTION
Closes #916.

## Symptoms

Three reported chat bugs, bundled because the first instrumentation pass kept surfacing the others:

1. **A live chat rendered nothing as it streamed.** You'd see the user message and a tool-call row, then the transcript sat frozen for the whole turn. Switching to another tab and back showed the complete reply at once. Thinking blocks never appeared live.
2. **Messages from one chat bled into another** just by clicking between chat tabs.
3. **The sidebar "responding…" badge latched on** and never cleared after a chat replied.

## Root causes

Three distinct bugs, found while chasing #916.

### 1. Streamed deltas never folded → frozen transcript (#916)

`RemoteChatSession.mergeOrAppendEvent` handled `.assistantText` / `.thinking` but sent `.assistantTextDelta` / `.thinkingDelta` to its `default:` branch, appending each chunk as its own event. Both delta types are `isInternalTranscriptEvent`, so `transcriptVisible` discarded every one — the assistant's reply existed in the mirror *only* as unmerged deltas, which the transcript is designed never to show. `events` climbed past 500 while `displayMessages` sat at 2. Switching away and back re-read the *persisted* rows (where the daemon wrote properly coalesced text), which is why that "fixed" it.

`AgentEvent.mergingStreamDeltas` documents the contract this missed: "any OTHER consumer of the raw stream must apply [the fold] too, or a streamed reply renders as one row per word-fragment."

### 2. Shared view identity → cross-chat bleed + streaming freeze

`WikiDetailView` renders every chat from the same `switch` branch (`case .chat(let id)`), and a differing associated value does **not** change SwiftUI structural identity — so chat A → chat B reused one `ChatDetailView` and, under it, one `ChatWebView` `WKWebView` + `Coordinator`. That coordinator renders incrementally (it appends only `events[renderedCount...]` so an in-progress text selection survives streaming), and its anchors described whichever chat was rendered last. Depending on relative event counts, B's tail got spliced onto A's DOM, or a stale-high `renderedCount` froze streaming outright (`count > renderedCount` never became true).

### 3. `isRunning` is not "is answering" → stuck badge

`ChatDaemonCoordinator` did `setChatRunning(chatID, running: update.isRunning || update.isGenerating)`. For an interactive chat, `AgentLauncher.isRunning` means "process alive **across turns**", so it stays true while the session sits idle — the `isRunning` disjunct dominated and pinned the badge on for the life of the session. `isGenerating` is the per-turn flag the contract says every spinner should key off.

## What changed

- **Delta folding** — `RemoteChatSession` now coalesces `.assistantTextDelta` / `.thinkingDelta` into the in-progress row via a `StreamingRow` enum (`none` / `assistant` / `thinking`, mutually exclusive). The same fold runs in `hydrate(from:)`.
- **Transcript identity** — `ChatWebView` gains a `transcriptID` (a namespaced `TranscriptID` enum: `.chat(PageID)` / `.queueItem(QueueItem.ID)`) that forces a full rebuild when it changes; the rebuild decision is one pure, testable `needsFullReload`. `WikiDetailView` adds `.id(chatID)` on the chat surface; `ActivityWindowView` passes `.queueItem(item.id)`.
- **Badge** — keys off `isGenerating` alone; renames `runningChatIDs` → `generatingChatIDs`, `isChatRunning` → `isChatGenerating`, `anyChatRunning` → `anyChatGenerating`.
- **`ChatRunState` FSM** — cases are now `idle` / `queued` / `warm` / `answering` (narrowest-claim-wins precedence), replacing the lossy `.thinking` / `.generating` mapping that reintroduced the bug it prevented. `.queued` is now correctly **live**. Two derived predicates (`isLive`, `isAnswering`) keep "render the streaming mirror" and "show spinners/badges" separate. All eight boolean combinations are pinned by test.
- **`ChatSessionKey`** — replaces the bare `String` chat id + `"__wiki_draft_chat__"` sentinel with `ChatSessionKey.draft` / `.chat(PageID)`; `activeChatID` is now `PageID?`. The wire (`QueueEventEnvelope`, XPC DTOs) stays `String`; conversion happens at two boundaries.

## Behavior changes (deliberate, both tested)

- `.queued` is now **live**: it previously reported `isRunning == false` / `activeChatID == nil`, sending the chat surface to persisted rows mid-conversation while a turn waited on the generation gate.
- `ChatDetailView.transcriptIsRunning` keys off `isAnswering`, not `isRunning` — with the corrected shims `isRunning` means "session alive", so the old check would have shown "Waiting for the Agent…" on a warm idle chat.
- `anyChatGenerating` also gates the ⌘Q confirmation, so quitting with a warm-but-idle session no longer prompts (daemon work deliberately survives app quit).

## Tests

- New `ChatWebViewTranscriptIDTests` covering `needsFullReload` without a WebKit view tree.
- `ChatRunStateTests` rewritten to pin all eight `(isRunning, isGenerating, isAwaitingSlot)` combinations, including the two regressions named explicitly.
- `RemoteChatSessionTests` / `ChatDaemonCoordinatorTests` migrated to `ChatSessionKey` / `PageID` and the renamed FSM cases, with two new regression tests replaying the exact log sequence from the badge trace.

## Relationship to #915

#915 fixed a different bug with overlapping symptoms (a shared `WKWebView` coordinator splicing one chat's transcript onto another's). That was real, but it was never the cause of the freeze on a freshly started chat — the freeze reproduced with that fix in place, which motivated the instrumentation that found #916.
