### PR TITLE
Move daemon reconnected signal to menu-bar hint popover

### DIFF
--- a/Sources/WikiFS/Queue/DaemonHealthMonitor.swift
+++ b/Sources/WikiFS/Queue/DaemonHealthMonitor.swift
@@ -8,8 +8,8 @@ import WikiFSCore
 ///
 /// Owns the recurring 30 s health-ping loop, the XPC invalidation/interruption
 /// handlers, and the manual ``restart()`` action. Exposes `@Observable` `state`
-/// that drives the menu-bar icon badge and the in-app disconnected/reconnected
-/// banner.
+/// that drives the menu-bar icon badge, the in-app disconnected banner, and the
+/// "reconnected" hint popover.
 ///
 /// The daemon is an **embedded XPC service** — macOS launches it on demand and
 /// terminates it when the app quits. No LaunchAgent or `launchctl` is involved.

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -55,8 +55,9 @@ struct ContentView: View {
 
     var body: some View {
         baseContent
-        // #878: daemon status banner (red disconnected / green reconnected) at
-        // the very top of the content area.
+        // #878: daemon status banner (red disconnected) at the very top of
+        // the content area. The positive "reconnected" signal surfaces as a
+        // menu-bar hint popover, not here.
         .safeAreaInset(edge: .top, spacing: 0) {
             DaemonStatusBanner()
         }

--- a/Sources/WikiFS/Window/DaemonStatusBanner.swift
+++ b/Sources/WikiFS/Window/DaemonStatusBanner.swift
@@ -7,8 +7,12 @@ import WikiCtlCore
 /// - **Red** banner when `.disconnected`: "wikid daemon is not running — some
 ///   features may be unavailable." Dismissible with an X button; reappears on
 ///   the next disconnect.
-/// - **Green** banner on recovery (transition to `.connected` after being
-///   disconnected): "wikid daemon reconnected." Auto-dismisses after 3 seconds.
+///
+/// The positive recovery signal (transition to `.connected` after a disconnect)
+/// is NOT shown here — it surfaces as a small transient popover anchored to the
+/// menu-bar status item, via `MenuBarItemController.showTransientHint` (same
+/// treatment as "Ingest queued" / "Lint queued"). This view only owns the
+/// persistent red banner that needs to stay up until dismissed.
 ///
 /// Reads the `DaemonHealthMonitor` from the environment. When `nil` (no monitor
 /// wired), no banner is shown.
@@ -20,16 +24,13 @@ struct DaemonStatusBanner: View {
     /// banner again.
     @State private var hasDismissedDisconnect = false
 
-    /// Whether the green "reconnected" banner is currently showing.
-    @State private var showReconnectedBanner = false
-
     /// Tracks the previous state to detect transitions.
     @State private var previousState: DaemonConnectionState?
 
     var body: some View {
         Group {
-            if let healthMonitor {
-                bannerContent(for: healthMonitor.state)
+            if let healthMonitor, healthMonitor.state == .disconnected, !hasDismissedDisconnect {
+                disconnectedBanner
             }
         }
         .animation(.easeInOut(duration: 0.2), value: healthMonitor?.state)
@@ -38,15 +39,6 @@ struct DaemonStatusBanner: View {
         }
         .onAppear {
             previousState = healthMonitor?.state
-        }
-    }
-
-    @ViewBuilder
-    private func bannerContent(for state: DaemonConnectionState?) -> some View {
-        if state == .disconnected, !hasDismissedDisconnect {
-            disconnectedBanner
-        } else if showReconnectedBanner {
-            reconnectedBanner
         }
     }
 
@@ -74,47 +66,17 @@ struct DaemonStatusBanner: View {
         .transition(.move(edge: .top).combined(with: .opacity))
     }
 
-    private var reconnectedBanner: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.white)
-            Text("wikid daemon reconnected.")
-                .font(.callout)
-                .foregroundStyle(.white)
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .background(Color.green.opacity(0.9))
-        .transition(.move(edge: .top).combined(with: .opacity))
-    }
-
     /// Handle a state transition. On disconnect, reset the dismiss flag so the
-    /// banner shows. On reconnect (from disconnected), show the green banner
-    /// for 3 seconds.
+    /// banner shows. (The reconnect signal is handled by the menu-bar hint
+    /// popover — see `MenuBarItemController`.)
     private func handleStateChange(to newState: DaemonConnectionState?) {
         guard let newState else { return }
-        let oldState = previousState
         previousState = newState
 
         if newState == .disconnected {
             // New (or recurring) disconnect — reset the dismiss flag so the
             // red banner shows again.
             hasDismissedDisconnect = false
-        }
-
-        if newState == .connected, oldState == .disconnected || oldState == .reconnecting {
-            // Recovery from a disconnected state — show the green banner and
-            // auto-dismiss after 3 seconds.
-            showReconnectedBanner = true
-            Task {
-                // Task.sleep only throws CancellationError — expected, not actionable.
-                // swiftlint:disable:next silent_try_optional
-                try? await Task.sleep(for: .seconds(3))
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    showReconnectedBanner = false
-                }
-            }
         }
     }
 }

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import WikiCtlCore
 import WikiFSCore
 import WikiFSEngine
 
@@ -64,6 +65,12 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     private var lastSnapshot: QueueSnapshot = QueueSnapshot()
     private var hintPopover: NSPopover?
     private var hintDismissTask: Task<Void, Never>?
+    /// Previous daemon connection state, used to detect the
+    /// disconnected/reconnecting → `.connected` transition (which fires the
+    /// "wikid daemon reconnected." hint popover). Seeded in `start()` from the
+    /// monitor's current state so the first transition is a real one, not a
+    /// duplicate of the initial state.
+    private var previousDaemonState: DaemonConnectionState?
 
     // MARK: - Init
 
@@ -139,9 +146,12 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         }
 
         // #878: observe daemon health to swap the icon to a warning variant
-        // when the daemon is disconnected.
-        daemonHealthMonitor?.onStateChange = { [weak self] _ in
-            self?.updateIcon()
+        // when the daemon is disconnected, and to surface a small "reconnected"
+        // hint popover (matching the "Ingest queued" / "Lint queued" treatment)
+        // when the daemon recovers from a disconnected state.
+        previousDaemonState = daemonHealthMonitor?.state
+        daemonHealthMonitor?.onStateChange = { [weak self] newState in
+            self?.handleDaemonStateChange(newState)
         }
         // Reflect the initial state immediately.
         if daemonHealthMonitor?.state == .disconnected {
@@ -160,6 +170,26 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
             NSStatusBar.system.removeStatusItem(item)
             statusItem = nil
         }
+    }
+
+    // MARK: - Daemon health
+
+    /// Handle a daemon connection state transition: refresh the icon on every
+    /// change, and surface a small "reconnected." hint popover when the daemon
+    /// recovers from a disconnected/reconnecting state. This replaces the old
+    /// full-width green banner (`DaemonStatusBanner` now only owns the red
+    /// disconnected banner) so the positive signal matches the "Ingest queued"
+    /// / "Lint queued" treatment.
+    private func handleDaemonStateChange(_ newState: DaemonConnectionState) {
+        let oldState = previousDaemonState
+        previousDaemonState = newState
+        if newState == .connected, oldState == .disconnected || oldState == .reconnecting {
+            showTransientHint(
+                message: "wikid daemon reconnected.",
+                symbol: "checkmark.circle.fill"
+            )
+        }
+        updateIcon()
     }
 
     // MARK: - Menu


### PR DESCRIPTION
Refactors where the "wikid daemon reconnected." notification surfaces when recovering from a disconnected state.

## Changes

- **DaemonStatusBanner**: Removes the green "reconnected" banner and auto-dismiss logic. Now only handles the persistent red disconnected banner that requires explicit dismissal.
- **MenuBarItemController**: Detects the daemon state transition (disconnected/reconnecting → connected) and shows a transient hint popover with the reconnected message, matching the treatment of "Ingest queued" / "Lint queued" hints.
- Updates documentation comments to reflect the new behavior.

## Why

Consolidates transient notifications to the menu bar for consistency and reduces clutter in the main content area. The positive recovery signal is now a small popover in the status bar rather than a full-width banner that interrupts the user's workflow.