### PR TITLE
Rename File Provider domains in place instead of remove + re-add (#919)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,51 @@
 # Progress log
 
+## fix: rename a File Provider domain in place instead of remove + re-add (#919)
+
+**What was wrong.** `FileProviderFacade.renameDomain` did a real
+`removeDomain` → `registerDomain` cycle, with a doc comment calling it
+"cosmetic from the extension's point of view". It isn't. `NSFileProviderManager
+.remove(domain)` tears down the daemon's on-disk replica — the same
+migration-strength reset `migrateDomainsIfNeeded` uses *deliberately* to force a
+clean daemon cache — and the header documents that the re-add then fails with
+`NSFileWriteFileExistsError` if that replica location still exists. So a rename
+could leave the wiki unregistered and unmounted, having already cleared
+`activeWikiID`/`path` in `removeDomain`, with nothing but a `status` string to
+show for it. It also opened a window in which the domain resolved to nothing at
+all for any other FileProvider client.
+
+**The API was there all along.** `NSFileProviderManager.h`: "If a domain with
+the same identifier already exists, `addDomain` will update the display name and
+hidden state of the domain and succeed." `add` is an upsert keyed by identifier,
+so a rename never needs the domain to leave the daemon. The reason this was
+missed is that `NSFileProviderDomain.displayName` is `readonly`, which reads as
+"domains are immutable, so rename means replace" — the mutability lives on the
+*manager*, not the model.
+
+**The trap in the fix.** You can't just drop the `removeDomain` line and reuse
+`registerDomain`: that is deliberately **add-if-absent** (its presence check is
+what makes it idempotent and safe against a racing `registerAllDomains`), so it
+short-circuits on the already-present domain and never applies the new name.
+That guard is *why* the remove was there. `renameDomain` now calls
+`NSFileProviderManager.add` directly. The `activate` call is gone too: the
+identifier is stable and the domain never leaves the daemon, so the mount path
+is unchanged and there is nothing to re-resolve — the old code only needed it to
+repair the state `removeDomain` had just destroyed.
+
+**Logging.** The rename path logs `wasRegistered` / `isActive` on entry plus the
+outcome. `wasRegistered` is the diagnostic that matters: present means this was
+the documented in-place update, absent means we registered from scratch and
+could hit the leftover-replica failure. One `domains()` call on a
+hand-triggered operation is cheap.
+
+**On the crash in #919.** This does *not* claim to fix the `EXC_BREAKPOINT` in
+`URL._unconditionallyBridgeFromObjectiveC`. No SDW frame appears on the crashing
+thread and the trapping frame is a private `FPItemManager
+_fetchURLForItemID:...` path we never call; the change is justified on its own
+merits above. It does close the registration gap the issue hypothesised about.
+The nil-`NSURL` force-bridge in Apple's private completion path is still worth
+an Apple Feedback.
+
 ## refactor: ChatRunState as a real FSM; ChatSessionKey replaces the string chat id
 
 **Goal:** the stuck-badge bug was a symptom — `isRunning` vs `isGenerating` is

--- a/Sources/WikiFS/Window/FileProviderFacade.swift
+++ b/Sources/WikiFS/Window/FileProviderFacade.swift
@@ -233,14 +233,44 @@ final class FileProviderFacade: ChangeSignaler {
         }
     }
 
-    /// Refresh a registered domain's display name after a wiki rename. The
-    /// identifier stays stable, so remove+add is cosmetic from the extension's
-    /// point of view: both old and new domains map to the same `<ulid>.sqlite`.
+    /// Refresh a registered domain's display name after a wiki rename, IN PLACE.
+    ///
+    /// `add(domain)` is an upsert keyed by identifier: "if a domain with the same
+    /// identifier already exists, `addDomain` will update the display name and
+    /// hidden state of the domain and succeed" (`NSFileProviderManager.h`). So a
+    /// rename never needs the domain to leave the daemon.
+    ///
+    /// This used to remove+re-add, which was mislabelled "cosmetic" (see #919).
+    /// It is not: `remove(domain)` tears down the daemon's on-disk replica — the
+    /// same migration-strength reset `migrateDomainsIfNeeded` uses deliberately —
+    /// and the re-add can then fail with `NSFileWriteFileExistsError` if that
+    /// location still exists, leaving the wiki unregistered and unmounted with
+    /// only a `status` string to show for it. It also opened a window in which
+    /// the domain resolved to nothing at all for other FileProvider clients.
+    ///
+    /// Note this deliberately does NOT go through `registerDomain`, whose
+    /// add-if-absent guard would short-circuit on the already-present domain and
+    /// never apply the new name. No `activate` either: the identifier is stable
+    /// and the domain never leaves the daemon, so the mount path is unchanged.
     func renameDomain(id: String, displayName: String) async {
-        let wasActive = activeWikiID == id
-        await removeDomain(id: id)
-        if await registerDomain(id: id, displayName: displayName), wasActive {
-            await activate(id: id, displayName: displayName)
+        // Log whether the domain was already present: a present domain means this
+        // `add` is the documented in-place display-name update, an absent one means
+        // we're registering from scratch (and could hit NSFileWriteFileExistsError
+        // against a leftover replica). Those fail very differently — worth one
+        // `domains()` call on an operation the user triggers by hand.
+        let wasRegistered = await isDomainRegistered(id: id)
+        DebugLog.fileprovider("""
+            FileProviderFacade.renameDomain(\(id) → \(displayName)): \
+            in-place add; wasRegistered=\(wasRegistered), isActive=\(activeWikiID == id)
+            """)
+        do {
+            try await NSFileProviderManager.add(domain(id: id, displayName: displayName))
+            if activeWikiID == id { activeDisplayName = displayName }
+            status = "Renamed \(displayName)"
+            DebugLog.fileprovider("FileProviderFacade.renameDomain(\(id)): display name now \(displayName)")
+        } catch {
+            DebugLog.fileprovider("FileProviderFacade.renameDomain(\(id) → \(displayName)): add failed: \(error)")
+            status = "Rename \(displayName) failed: \(error.localizedDescription)"
         }
     }
 


### PR DESCRIPTION
Investigates the `renameDomain` exposure window raised in #919, and fixes it — though on stronger grounds than the issue gives.

## What was wrong

`FileProviderFacade.renameDomain` did a real `removeDomain` → `registerDomain` cycle, with a doc comment calling it "cosmetic from the extension's point of view". It isn't:

- `NSFileProviderManager.remove(domain)` tears down the daemon's on-disk replica — the same migration-strength reset `migrateDomainsIfNeeded` uses *deliberately* to force a clean daemon cache.
- Per `NSFileProviderManager.h`, the re-add then fails with `NSFileWriteFileExistsError` if that replica location still exists. Since `removeDomain` has already cleared `activeWikiID`/`path`, a rename could leave the wiki unregistered and unmounted with nothing but a `status` string to show for it.
- It also opened the window #919 hypothesises about, in which the domain resolved to nothing at all for any other FileProvider client.

## The in-place API was there all along

`NSFileProviderManager.h`:

> If a domain with the same identifier already exists, `addDomain` will update the display name and hidden state of the domain and succeed.

`add` is an upsert keyed by identifier, so a rename never needs the domain to leave the daemon. This is easy to miss because `NSFileProviderDomain.displayName` is `readonly`, which reads as "domains are immutable, so rename means replace" — the mutability lives on the *manager*, not the model.

## The trap in the fix

You can't just drop the `removeDomain` line and reuse `registerDomain`: that is deliberately **add-if-absent**, and its presence check is exactly what makes it idempotent against a racing `registerAllDomains`. It would short-circuit on the already-present domain and never apply the new name — that guard is *why* the remove was there. So `renameDomain` calls `NSFileProviderManager.add` directly.

`activate` goes too: the identifier is stable and the domain never leaves the daemon, so the mount path is unchanged and there's nothing to re-resolve. The old code only needed it to repair the state `removeDomain` had just destroyed.

## Logging

Logs `wasRegistered`/`isActive` on entry plus the outcome. `wasRegistered` is the diagnostic that matters: present means this was the documented in-place update, absent means we registered from scratch and could hit the leftover-replica failure. One `domains()` call on a hand-triggered operation is cheap.

## On the crash itself

This does **not** claim to fix the `EXC_BREAKPOINT` in `URL._unconditionallyBridgeFromObjectiveC`. No SDW frame appears on the crashing thread and the trapping frame is a private `FPItemManager _fetchURLForItemID:...` path we never call — the change stands on the replica-teardown and unmount-failure grounds above. It does close the registration gap outright. The nil-`NSURL` force-bridge in Apple's private completion path is still worth an Apple Feedback (#919 follow-up 3).

## Testing

- `swift build` clean; `swiftlint --strict` clean on the changed file.
- `swift test --filter WikiRegistryClientTests` passes (16 tests) — covers the `renameWiki` → `renameDomain` closure contract.
- No unit test added for `renameDomain` itself: `FileProviderFacade` is main-actor UI code calling `NSFileProviderManager` statics directly with no injection seam, so it's untested throughout. Verifying the in-place update needs a signed build against a live `fileproviderd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)