### PR TITLE
Add a testable seam for the File Provider domain lifecycle (#919 follow-up)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,54 @@
 # Progress log
 
+## test: a seam for the File Provider domain lifecycle, so #919 can't recur
+
+**Why.** #920 fixed the rename, but the reason nothing *caught* it was
+structural: `FileProviderFacade` fused the decision ("a rename is a display-name
+change") with the effect (`NSFileProviderManager` statics), and only the effect
+is untestable. The repo already splits these once — `DomainRegistrationPolicy`
+is a pure tested enum the facade defers to — the rename path just never got the
+same treatment.
+
+**The seam.** `FileProviderDomainService` (WikiFSCore, no FileProvider import)
+covers exactly the three lifecycle calls: `add` / `remove` / `domains`.
+`SystemFileProviderDomainService` (WikiFS) is the pass-through holding no
+policy; `FileProviderFacade.init` takes one, defaulting to the real thing.
+Item-level resolution (`NSFileProviderManager(for:)` → `getUserVisibleURL` /
+`signalEnumerator`) stays on the concrete API — much wider surface, not where
+the lifecycle bugs have been.
+
+Two design details carry most of the value:
+
+* **`remove(id:reason:)` takes a `DomainRemovalReason`** (`.wikiDeleted` /
+  `.schemaMigration` / `.reenumerateHatch` — a rename is not among them). It
+  makes the destructive call self-documenting at all three legitimate sites, and
+  a test can assert an operation performed *no* teardown and name the
+  illegitimate one in the failure message.
+* **`domains()` returns display names, not just ids.** The old
+  `isDomainRegistered` mapped `\.identifier.rawValue` and threw the name away,
+  so domain *presence* was observable but the display name wasn't — nothing
+  could confirm a rename had landed. `renameDomain` now re-reads the daemon
+  after its `add` and logs a loud MISMATCH if the upsert was silently ignored.
+  The whole #919 fix rests on documented-but-previously-unobservable behaviour;
+  this is what makes it observable.
+
+**Tests** (`FileProviderDomainLifecycleTests`, 8, in `WikiFSAppTests` which
+already depends on `WikiFS`). Verified by reverting `renameDomain` to the old
+remove+re-add: 3 fail, and the register/remove tests correctly stay green.
+
+**What writing them turned up.** `registerDomain`'s "idempotent add-if-absent"
+property is *conditional on no migration being pending* — with the schema
+version unset it removes before adding, which is how the first draft of
+`registerDomainDoesNotRenameAnAlreadyPresentDomain` passed for the wrong reason
+(a fresh test process reads version 0). The suite is `.serialized` and each test
+declares its migration state via `settled()`; `currentSchemaVersion` /
+`schemaVersionKey` went internal so tests state it rather than hardcoding `2`.
+Worth knowing generally: "idempotent" on that method has a precondition.
+
+The test pinning `registerDomain` *cannot* rename is the one to keep. It encodes
+why `renameDomain` can't just call it, so a future simplification that merges
+them fails loudly instead of silently breaking rename.
+
 ## fix: rename a File Provider domain in place instead of remove + re-add (#919)
 
 **What was wrong.** `FileProviderFacade.renameDomain` did a real

--- a/Sources/WikiFS/Window/FileProviderFacade.swift
+++ b/Sources/WikiFS/Window/FileProviderFacade.swift
@@ -32,6 +32,16 @@ final class FileProviderFacade: ChangeSignaler {
     private var activeWikiID: String?
     private var activeDisplayName: String?
 
+    /// The daemon's domain-lifecycle calls (add / remove / list), injected so the
+    /// lifecycle DECISIONS above them are testable without a live `fileproviderd`
+    /// — see `FileProviderDomainService`. Defaults to the real system service;
+    /// tests substitute a fake.
+    private let domainService: FileProviderDomainService
+
+    init(domainService: FileProviderDomainService = SystemFileProviderDomainService()) {
+        self.domainService = domainService
+    }
+
     // MARK: - Resource-change bus subscription (slice 2a)
     //
     // The store emits a `ResourceChangeEvent` at the write seam; the File
@@ -60,8 +70,12 @@ final class FileProviderFacade: ChangeSignaler {
     /// History:
     ///   2 — `files` container renamed to `sources` (source-by-name prefix shared)
     ///   1 — initial schema
-    private static let currentSchemaVersion = 2
-    private static let schemaVersionKey = "FileProviderDomainSchemaVersion"
+    /// Internal rather than private so lifecycle tests can put the process into a
+    /// known migration state instead of hardcoding the literal — a pending
+    /// migration changes what `registerDomain` does (it removes first), so tests
+    /// that don't say which state they're in are testing whichever one they got.
+    static let currentSchemaVersion = 2
+    static let schemaVersionKey = "FileProviderDomainSchemaVersion"
 
     /// Call ONCE at startup, before `registerAllDomains`.  If the stored schema
     /// version is stale, tears down every registered domain so the daemon
@@ -73,9 +87,8 @@ final class FileProviderFacade: ChangeSignaler {
 
         DebugLog.fileprovider("schema migration: \(stored) → \(Self.currentSchemaVersion) — removing \(wikiIDs.count) domain(s)")
         for id in wikiIDs {
-            let d = domain(id: id, displayName: id)
             do {
-                try await NSFileProviderManager.remove(d)
+                try await domainService.remove(id: id, reason: .schemaMigration)
                 DebugLog.fileprovider("schema migration: removed domain \(id)")
             } catch {
                 DebugLog.fileprovider("schema migration: remove domain \(id) failed: \(error.localizedDescription)")
@@ -129,10 +142,8 @@ final class FileProviderFacade: ChangeSignaler {
     /// is an async sleep — it never blocks the main actor.
     @discardableResult
     func registerDomain(id: String, displayName: String) async -> Bool {
-        let domain = domain(id: id, displayName: displayName)
-
         if ProcessInfo.processInfo.environment["WIKIFS_REENUMERATE"] == "1" {
-            do { try await NSFileProviderManager.remove(domain) }
+            do { try await domainService.remove(id: id, reason: .reenumerateHatch) }
             catch { DebugLog.fileprovider("registerDomain: re-enumerate remove failed: \(error)") }
         }
 
@@ -140,7 +151,7 @@ final class FileProviderFacade: ChangeSignaler {
         // the new container layout (e.g. `files` → `sources` rename).
         if needsDomainMigration {
             DebugLog.fileprovider("registerDomain: removing \(id) for schema migration")
-            do { try await NSFileProviderManager.remove(domain) }
+            do { try await domainService.remove(id: id, reason: .schemaMigration) }
             catch { DebugLog.fileprovider("registerDomain: migration remove failed: \(error)") }
         }
 
@@ -150,7 +161,7 @@ final class FileProviderFacade: ChangeSignaler {
             // racing add that won) must not error out the whole flow.
             if !(await isDomainRegistered(id: id)) {
                 do {
-                    try await NSFileProviderManager.add(domain)
+                    try await domainService.add(id: id, displayName: displayName)
                 } catch {
                     // Distinguish benign already-exists (the verify below confirms
                     // presence) from a real failure we must not bury: log it AND
@@ -192,16 +203,7 @@ final class FileProviderFacade: ChangeSignaler {
     /// pure policy helper. A failed `domains()` call reads as "not present" so the
     /// retry loop keeps trying.
     private func isDomainRegistered(id: String) async -> Bool {
-        // NSFileProviderDomain is not Sendable, so calling domains() from a
-        // @MainActor context is a strict-concurrency error under Swift 6.
-        // Run the call in a detached task and extract only the Sendable
-        // raw-value strings before returning to the main actor.
-        let domainIDs = await Task.detached {
-            let domains: [NSFileProviderDomain]
-            do { domains = try await NSFileProviderManager.domains() }
-            catch { DebugLog.fileprovider("isRegistered: list domains failed: \(error)"); domains = [] }
-            return domains.map(\.identifier.rawValue)
-        }.value
+        let domainIDs = await domainService.domains().map(\.id)
         return DomainRegistrationPolicy.isRegistered(domainIDs: domainIDs, wikiID: id)
     }
 
@@ -220,9 +222,8 @@ final class FileProviderFacade: ChangeSignaler {
     /// Remove ONE wiki's domain (on delete). Clears the cached active path if it
     /// belonged to that wiki.
     func removeDomain(id: String) async {
-        let domain = domain(id: id, displayName: id)
         do {
-            try await NSFileProviderManager.remove(domain)
+            try await domainService.remove(id: id, reason: .wikiDeleted)
             if activeWikiID == id {
                 activeWikiID = nil
                 path = nil
@@ -258,16 +259,32 @@ final class FileProviderFacade: ChangeSignaler {
         // we're registering from scratch (and could hit NSFileWriteFileExistsError
         // against a leftover replica). Those fail very differently — worth one
         // `domains()` call on an operation the user triggers by hand.
-        let wasRegistered = await isDomainRegistered(id: id)
+        let previousName = await domainService.displayName(for: id)
         DebugLog.fileprovider("""
             FileProviderFacade.renameDomain(\(id) → \(displayName)): \
-            in-place add; wasRegistered=\(wasRegistered), isActive=\(activeWikiID == id)
+            in-place add; wasRegistered=\(previousName != nil), \
+            daemonName=\(previousName ?? "<absent>"), isActive=\(activeWikiID == id)
             """)
         do {
-            try await NSFileProviderManager.add(domain(id: id, displayName: displayName))
+            try await domainService.add(id: id, displayName: displayName)
             if activeWikiID == id { activeDisplayName = displayName }
             status = "Renamed \(displayName)"
-            DebugLog.fileprovider("FileProviderFacade.renameDomain(\(id)): display name now \(displayName)")
+
+            // Verify the upsert actually landed rather than trusting the header's
+            // word for it. `add` reports success by returning without throwing; a
+            // silently-ignored display-name update would look identical. Since the
+            // whole fix rests on documented-but-unobservable behaviour, confirm it
+            // against what the daemon now reports. Diagnostic only — the operation
+            // has already succeeded as far as the user is concerned.
+            let observed = await domainService.displayName(for: id)
+            if observed != displayName {
+                DebugLog.fileprovider("""
+                    FileProviderFacade.renameDomain(\(id)): MISMATCH — add succeeded but \
+                    daemon reports \(observed ?? "<absent>"), expected \(displayName)
+                    """)
+            } else {
+                DebugLog.fileprovider("FileProviderFacade.renameDomain(\(id)): display name now \(displayName)")
+            }
         } catch {
             DebugLog.fileprovider("FileProviderFacade.renameDomain(\(id) → \(displayName)): add failed: \(error)")
             status = "Rename \(displayName) failed: \(error.localizedDescription)"

--- a/Sources/WikiFS/Window/SystemFileProviderDomainService.swift
+++ b/Sources/WikiFS/Window/SystemFileProviderDomainService.swift
@@ -1,0 +1,51 @@
+@preconcurrency import FileProvider
+import Foundation
+import WikiFSCore
+
+/// The real `FileProviderDomainService` — a thin pass-through to
+/// `NSFileProviderManager`'s domain-lifecycle statics.
+///
+/// Holds NO policy: every decision (add-if-absent, retry budget, whether a rename
+/// may remove anything) lives in `FileProviderFacade` / `DomainRegistrationPolicy`
+/// where it can be tested against a fake. This type exists purely so that those
+/// decisions have something injectable to talk to.
+struct SystemFileProviderDomainService: FileProviderDomainService {
+    func add(id: String, displayName: String) async throws {
+        try await NSFileProviderManager.add(Self.domain(id: id, displayName: displayName))
+    }
+
+    func remove(id: String, reason: DomainRemovalReason) async throws {
+        // Log BEFORE the call, unconditionally: this deletes the daemon's replica,
+        // and #919's crash lands in FileProvider XPC internals with no frame of
+        // ours on the thread. A timestamped "teardown started, because X" line is
+        // the only way a later crash report can be correlated against an
+        // in-flight removal.
+        DebugLog.fileprovider("domainService.remove(\(id)): reason=\(reason.rawValue)")
+        try await NSFileProviderManager.remove(Self.domain(id: id, displayName: id))
+    }
+
+    func domains() async -> [RegisteredDomain] {
+        // NSFileProviderDomain is not Sendable, so calling domains() from a
+        // @MainActor context is a strict-concurrency error under Swift 6. Run the
+        // call detached and extract only Sendable values before returning.
+        await Task.detached {
+            do {
+                return try await NSFileProviderManager.domains()
+                    .map { RegisteredDomain(id: $0.identifier.rawValue, displayName: $0.displayName) }
+            } catch {
+                DebugLog.fileprovider("domainService.domains(): list failed: \(error)")
+                return []
+            }
+        }.value
+    }
+
+    /// Domain identity = the wiki's ULID; `displayName` only sets the Finder mount
+    /// label. `remove` passes the id as the name because removal keys on the
+    /// identifier alone.
+    private static func domain(id: String, displayName: String) -> NSFileProviderDomain {
+        NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier(rawValue: id),
+            displayName: displayName
+        )
+    }
+}

--- a/Sources/WikiFSCore/Core/FileProviderDomainService.swift
+++ b/Sources/WikiFSCore/Core/FileProviderDomainService.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Why a File Provider domain is being torn down.
+///
+/// `remove(domain)` is the single destructive operation in the domain lifecycle:
+/// it deletes the daemon's on-disk replica, not just the registration. Issue #919
+/// was a rename quietly doing exactly that under a doc comment calling it
+/// "cosmetic", so the reason is a REQUIRED parameter rather than a log string —
+/// every teardown has to name itself at the call site, and a test can assert that
+/// an operation performed no removal at all (and say which illegitimate one it
+/// found when it fails).
+///
+/// There are exactly three legitimate reasons. A rename is not among them.
+public enum DomainRemovalReason: String, Equatable, Sendable, CaseIterable {
+    /// The user deleted the wiki. The replica should go with it.
+    case wikiDeleted
+    /// The container hierarchy changed (`DomainRegistrationPolicy` schema bump),
+    /// so the daemon's cache must be rebuilt from scratch.
+    case schemaMigration
+    /// The `WIKIFS_REENUMERATE=1` developer hatch, forcing a clean re-enumeration.
+    case reenumerateHatch
+}
+
+/// One registered File Provider domain as the daemon reports it.
+///
+/// Carries the `displayName` alongside the identifier deliberately. The previous
+/// listing mapped `\.identifier.rawValue` and discarded the name, which meant
+/// domain presence was observable but the *display name* was not — so nothing
+/// could verify that a rename had actually taken effect, only that the domain
+/// still existed. That gap is why #919's in-place `add` upsert needs a
+/// post-condition check rather than trust in the SDK doc comment.
+public struct RegisteredDomain: Equatable, Sendable {
+    public let id: String
+    public let displayName: String
+
+    public init(id: String, displayName: String) {
+        self.id = id
+        self.displayName = displayName
+    }
+}
+
+/// The three daemon calls that make up the domain lifecycle, behind a protocol so
+/// the decisions around them can be tested without a live `fileproviderd`.
+///
+/// Scope is deliberately narrow: registration lifecycle only. Item-level
+/// resolution (`NSFileProviderManager(for:)` → `getUserVisibleURL` /
+/// `signalEnumerator`) stays on the concrete API — it's a much wider surface and
+/// it isn't where the lifecycle bugs have been.
+public protocol FileProviderDomainService: Sendable {
+    /// Register a domain, or update an existing one's display name in place.
+    ///
+    /// This is an upsert keyed by identifier: "If a domain with the same
+    /// identifier already exists, `addDomain` will update the display name and
+    /// hidden state of the domain and succeed" (`NSFileProviderManager.h`).
+    func add(id: String, displayName: String) async throws
+
+    /// Tear down a domain AND its on-disk replica. Destructive — see
+    /// ``DomainRemovalReason``.
+    func remove(id: String, reason: DomainRemovalReason) async throws
+
+    /// The daemon's current domain list. Returns `[]` if the list can't be
+    /// fetched, so callers read a failure as "not present" and keep retrying.
+    func domains() async -> [RegisteredDomain]
+}
+
+extension FileProviderDomainService {
+    /// The display name the daemon currently reports for `id`, or `nil` if the
+    /// domain isn't registered. Used to verify an in-place rename landed.
+    public func displayName(for id: String) async -> String? {
+        await domains().first { $0.id == id }?.displayName
+    }
+}

--- a/Tests/WikiFSAppTests/FileProviderDomainLifecycleTests.swift
+++ b/Tests/WikiFSAppTests/FileProviderDomainLifecycleTests.swift
@@ -1,0 +1,217 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+@testable import WikiFS
+
+/// Lifecycle tests for `FileProviderFacade`'s domain registration, driven through
+/// the `FileProviderDomainService` seam so no live `fileproviderd` is involved.
+///
+/// These exist because of #919: `renameDomain` did a remove + re-add under a doc
+/// comment calling it "cosmetic", and nothing could catch it — the facade called
+/// `NSFileProviderManager` statics directly, so there was no observable to assert
+/// against. The regression that matters is behavioural ("a rename tears down the
+/// replica"), not structural, so the tests below assert on the *calls made*, with
+/// `DomainRemovalReason` naming any illegitimate teardown in the failure message.
+///
+/// Serialized because the schema-migration flag lives in `UserDefaults`, which is
+/// process-global: a pending migration makes `registerDomain` remove before it
+/// adds, so tests that ran in parallel with the migration case would see its
+/// teardowns. Each test declares the migration state it needs via `settled()`.
+@MainActor
+@Suite(.serialized)
+struct FileProviderDomainLifecycleTests {
+
+    /// Put the process in the "no migration pending" state — the steady state for
+    /// every launch after the first. Without this, a fresh defaults domain reads
+    /// version 0, `needsDomainMigration` is true, and `registerDomain` tears the
+    /// domain down before re-adding it.
+    private func settled() {
+        UserDefaults.standard.set(
+            FileProviderFacade.currentSchemaVersion, forKey: FileProviderFacade.schemaVersionKey)
+    }
+
+    /// Records every lifecycle call and models the daemon's one real behaviour
+    /// that matters here: `add` is an upsert keyed by identifier, so re-adding an
+    /// existing id REPLACES its display name rather than erroring or duplicating.
+    ///
+    /// Every stored property is mutated only inside `lock`, and no reference to
+    /// that state escapes an accessor — that invariant is what the unchecked
+    /// conformance rests on. It's needed because `FileProviderDomainService` is
+    /// `Sendable` while a spy is mutable by definition.
+    // swiftlint:disable:next unchecked_sendable
+    private final class FakeDomainService: FileProviderDomainService, @unchecked Sendable {
+        enum Call: Equatable {
+            case add(id: String, displayName: String)
+            case remove(id: String, reason: DomainRemovalReason)
+            case domains
+        }
+
+        private let lock = NSLock()
+        private var _calls: [Call] = []
+        private var registered: [String: String] = [:]
+        private var _addError: (any Error)?
+
+        init(registered: [String: String] = [:]) {
+            self.registered = registered
+        }
+
+        var calls: [Call] { lock.withLock { _calls } }
+        /// Every removal that happened, with its stated reason.
+        var removals: [(id: String, reason: DomainRemovalReason)] {
+            calls.compactMap { if case let .remove(id, reason) = $0 { (id, reason) } else { nil } }
+        }
+        func name(of id: String) -> String? { lock.withLock { registered[id] } }
+
+        /// Make `add` throw instead of applying — models e.g.
+        /// `NSFileWriteFileExistsError` against a leftover replica.
+        func failAdds(with error: any Error) { lock.withLock { _addError = error } }
+
+        func add(id: String, displayName: String) async throws {
+            try lock.withLock {
+                _calls.append(.add(id: id, displayName: displayName))
+                if let _addError { throw _addError }
+                registered[id] = displayName
+            }
+        }
+
+        func remove(id: String, reason: DomainRemovalReason) async throws {
+            lock.withLock {
+                _calls.append(.remove(id: id, reason: reason))
+                registered[id] = nil
+            }
+        }
+
+        func domains() async -> [RegisteredDomain] {
+            lock.withLock {
+                _calls.append(.domains)
+                return registered.map { RegisteredDomain(id: $0.key, displayName: $0.value) }
+            }
+        }
+    }
+
+    private static let wikiID = "01HZZZWIKIONE"
+
+    // MARK: - Rename
+
+    /// THE #919 regression, stated directly. `remove` deletes the daemon's on-disk
+    /// replica; a rename is a display-name change and must not touch it.
+    @Test func renameNeverRemovesTheDomain() async {
+        settled()
+        let service = FakeDomainService(registered: [Self.wikiID: "Old Name"])
+        let facade = FileProviderFacade(domainService: service)
+
+        await facade.renameDomain(id: Self.wikiID, displayName: "New Name")
+
+        #expect(
+            service.removals.isEmpty,
+            "rename tore down the domain, reason(s): \(service.removals.map(\.reason.rawValue))")
+    }
+
+    @Test func renameUpdatesTheDisplayNameForAStableIdentifier() async {
+        settled()
+        let service = FakeDomainService(registered: [Self.wikiID: "Old Name"])
+        let facade = FileProviderFacade(domainService: service)
+
+        await facade.renameDomain(id: Self.wikiID, displayName: "New Name")
+
+        #expect(service.name(of: Self.wikiID) == "New Name")
+    }
+
+    /// A rename against a domain the daemon doesn't currently list must still end
+    /// registered — `add` is the same call either way, so this path self-heals
+    /// rather than silently doing nothing.
+    @Test func renameOfAnUnregisteredDomainStillRegistersIt() async {
+        settled()
+        let service = FakeDomainService()
+        let facade = FileProviderFacade(domainService: service)
+
+        await facade.renameDomain(id: Self.wikiID, displayName: "New Name")
+
+        #expect(service.name(of: Self.wikiID) == "New Name")
+        #expect(service.removals.isEmpty)
+    }
+
+    /// The old remove-then-re-add ordering put the destructive step first and the
+    /// fallible step second, so a failed re-add left the wiki unmounted with
+    /// `activeWikiID`/`path` already cleared. With a single fallible call there is
+    /// nothing to roll back: a failure must surface in `status` and leave the
+    /// active-wiki state untouched.
+    @Test func aFailedRenameSurfacesInStatusAndDoesNotClearTheActiveWiki() async {
+        settled()
+        let service = FakeDomainService(registered: [Self.wikiID: "Old Name"])
+        service.failAdds(with: NSError(
+            domain: NSCocoaErrorDomain, code: NSFileWriteFileExistsError, userInfo: nil))
+        let facade = FileProviderFacade(domainService: service)
+        await facade.activate(id: Self.wikiID, displayName: "Old Name")
+
+        await facade.renameDomain(id: Self.wikiID, displayName: "New Name")
+
+        #expect(facade.status.contains("Rename"))
+        #expect(service.name(of: Self.wikiID) == "Old Name", "failed rename must not disturb the domain")
+        #expect(service.removals.isEmpty)
+    }
+
+    // MARK: - Register
+
+    /// `registerDomain` is deliberately add-if-absent: the presence check is what
+    /// makes it idempotent while `registerAllDomains` races it. The consequence —
+    /// and the trap that makes the naive #919 fix a silent no-op — is that it
+    /// CANNOT rename. Pinned here so a future pass that tries to collapse
+    /// `renameDomain` into `registerDomain` fails loudly instead of quietly
+    /// breaking rename.
+    @Test func registerDomainDoesNotRenameAnAlreadyPresentDomain() async {
+        settled()
+        let service = FakeDomainService(registered: [Self.wikiID: "Old Name"])
+        let facade = FileProviderFacade(domainService: service)
+
+        let ok = await facade.registerDomain(id: Self.wikiID, displayName: "Different Name")
+
+        #expect(ok)
+        #expect(
+            service.name(of: Self.wikiID) == "Old Name",
+            "registerDomain is add-if-absent — use renameDomain to change the display name")
+    }
+
+    @Test func registerDomainAddsAnAbsentDomain() async {
+        settled()
+        let service = FakeDomainService()
+        let facade = FileProviderFacade(domainService: service)
+
+        let ok = await facade.registerDomain(id: Self.wikiID, displayName: "Wiki One")
+
+        #expect(ok)
+        #expect(service.name(of: Self.wikiID) == "Wiki One")
+    }
+
+    // MARK: - Remove
+
+    /// Deleting a wiki is one of the three legitimate teardowns, and it must say
+    /// so — the reason is what lets a crash-report timeline tell a deliberate
+    /// removal apart from an accidental one.
+    @Test func deletingAWikiRemovesItsDomainWithTheDeletedReason() async {
+        settled()
+        let service = FakeDomainService(registered: [Self.wikiID: "Wiki One"])
+        let facade = FileProviderFacade(domainService: service)
+
+        await facade.removeDomain(id: Self.wikiID)
+
+        #expect(service.removals.map(\.reason) == [.wikiDeleted])
+        #expect(service.name(of: Self.wikiID) == nil)
+    }
+
+    @Test func schemaMigrationRemovesEveryDomainWithTheMigrationReason() async {
+        let other = "01HZZZWIKITWO"
+        let service = FakeDomainService(registered: [Self.wikiID: "One", other: "Two"])
+        let facade = FileProviderFacade(domainService: service)
+        // `migrateDomainsIfNeeded` is a one-shot keyed on a UserDefaults version;
+        // clear it so this test drives the migration path rather than the no-op.
+        UserDefaults.standard.removeObject(forKey: "FileProviderDomainSchemaVersion")
+
+        await facade.migrateDomainsIfNeeded(wikiIDs: [Self.wikiID, other])
+
+        #expect(service.removals.allSatisfy { $0.reason == .schemaMigration })
+        #expect(Set(service.removals.map(\.id)) == [Self.wikiID, other])
+    }
+}
+#endif


### PR DESCRIPTION
Follow-up to #920. That PR fixed the rename; this makes it impossible to regress silently.

## Why

The reason nothing *caught* the original bug was structural. `FileProviderFacade` fused the decision ("a rename is a display-name change") with the effect (`NSFileProviderManager` statics), and only the effect is untestable. The repo already splits these once — `DomainRegistrationPolicy` is a pure, tested enum the facade defers to — the rename path just never got the same treatment.

## The seam

`FileProviderDomainService` (WikiFSCore, no FileProvider import) covers exactly the three lifecycle calls: `add` / `remove` / `domains`. `SystemFileProviderDomainService` (WikiFS) is the pass-through holding no policy; `FileProviderFacade.init` takes one, defaulting to the real service.

Scope is deliberately narrow — item-level resolution (`NSFileProviderManager(for:)` → `getUserVisibleURL` / `signalEnumerator`) stays on the concrete API. Much wider surface, and not where the lifecycle bugs have been.

Two details carry most of the value:

- **`remove(id:reason:)` requires a `DomainRemovalReason`** — `.wikiDeleted` / `.schemaMigration` / `.reenumerateHatch`. A rename is not among them. This makes the one destructive call self-documenting at all three legitimate sites, and lets a test assert an operation performed *no* teardown while naming the illegitimate one in the failure message.
- **`domains()` returns display names** instead of discarding them. The old `isDomainRegistered` mapped `\.identifier.rawValue`, so domain *presence* was observable but the display name was not — nothing could confirm a rename had landed. `renameDomain` now re-reads the daemon after its `add` and logs a loud MISMATCH if the upsert was silently ignored. The #920 fix rests on documented-but-unobservable SDK behaviour; this is what makes it observable.

## Tests

Eight, in `WikiFSAppTests` (which already depends on `WikiFS`), driven through a `FakeDomainService` spy — no live `fileproviderd`:

- rename issues no `remove` at all — *the* #919 regression, stated directly
- rename updates the display name for a stable identifier
- rename of an unregistered domain still ends registered
- a failed rename surfaces in `status` and does not clear the active wiki — pinning the old "destructive step first, fallible step second" ordering hazard
- `registerDomain` does **not** rename an already-present domain
- `registerDomain` adds an absent one
- deleting a wiki removes with `.wikiDeleted`
- schema migration removes every domain with `.schemaMigration`

**Verified by reverting `renameDomain` to the old remove+re-add**: three fail, and the register/remove tests correctly stay green.

The `registerDomain` cannot-rename test is the one I'd most want kept — it encodes *why* `renameDomain` can't just call it, so a future simplification that merges them fails loudly instead of quietly breaking rename.

## What writing them turned up

`registerDomain`'s "idempotent add-if-absent" property is **conditional on no migration being pending**. With the schema version unset it removes before adding — which is how the first draft of the cannot-rename test passed for the wrong reason (a fresh test process reads version 0). Worth knowing independently of this PR: "idempotent" on that method has a precondition.

The suite is `.serialized` and each test declares its migration state via `settled()`, since the flag lives in process-global `UserDefaults`. `currentSchemaVersion` / `schemaVersionKey` went internal so tests state the state rather than hardcoding `2`.

## Testing

- `swift build` clean; `swiftlint --strict` clean on all four files.
- `swift test --filter FileProviderDomainLifecycleTests` — 8 passed.
- `swift test --filter "DomainRegistrationPolicyTests|WikiRegistryClientTests"` — 26 passed.
- Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)