### PR TITLE
Add pre-commit hook to run swiftlint

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Runs `make lint` (swiftlint --strict) before every commit. See the `hooks:`
+# target in Makefile for how this directory gets wired up via
+# core.hooksPath, and .swiftlint.yml for what the lint gate actually checks.
+#
+# Bypass for a genuine emergency: git commit --no-verify.
+
+make lint

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"


### PR DESCRIPTION
## Summary
- `Makefile`'s `hooks:` target has pointed `core.hooksPath` at `.githooks` and documented a "pre-commit try? guard" since it was written, but the `.githooks/` directory itself never existed — `make hooks` had nothing to activate.
- Adds `.githooks/pre-commit`, which runs `make lint` (`swiftlint lint --strict`) before every commit.
- Copies the four git-lfs shims (`post-checkout`, `post-commit`, `post-merge`, `pre-push`) from `.git/hooks/` into `.githooks/` so repointing `core.hooksPath` doesn't silently disable Git LFS.

## Test plan
- [x] Ran `make hooks` to point `core.hooksPath` at `.githooks` and verified it prints the expected confirmation.
- [x] Ran `.githooks/pre-commit` directly — completes in ~1.6s, 0 violations.
- [x] Made this commit with the hook active; `make lint` ran automatically and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)