### PR TITLE
Fix hanging QuoteHighlightWebViewTests + add test-hang watchdog scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ NOTARY_PROFILE ?= wikifs-notary
 PROVISION_PROFILE ?=
 NOTES_FILE       ?=
 
-.PHONY: all deps build check check-release test test-fast test-fast-release release run reload clean install uninstall register help prune-provider-registrations \
+.PHONY: all deps build check check-release test test-watchdog test-fast test-fast-release release run reload clean install uninstall register help prune-provider-registrations \
         check-version notary-setup sign zip-notary notarize staple zip-release \
         checksum verify-release dist github-release print-version icon prompts \
         version keychain mutate mutate-scope check-mutate-tool lint lint-baseline lint-analyze hooks
@@ -132,6 +132,7 @@ help:
 	@echo "  check             Compile only (swift build) — no bundle/sign; CI/agent gate"
 	@echo "  check-release     Compile only in release mode (swift build -c release)"
 	@echo "  test              Run the SwiftPM test suite"
+	@echo "  test-watchdog     Same as test, but with a wall-clock timeout + hang/slow-test report"
 	@echo "  test-fast         Fast test tier (debug) — skips slow SQLite integration suites"
 	@echo "  test-fast-release Fast test tier in release mode (faster runtime, slower compile)"
 	@echo "  lint              SwiftLint: fail on NEW bare try? in Sources/ + tools/"
@@ -273,6 +274,17 @@ test: deps prompts version keychain
 	 pkill -f "[s]wiftpm-testing-helper.*$(CURDIR)/.build" 2>/dev/null || true; \
 	 swift test
 	@echo "✓ tests pass"
+
+# Same full suite as `test`, but with a hard wall-clock timeout and a
+# post-run summary of the slowest tests + whichever test started but never
+# finished. Use this instead of bare `swift test`/`make test` when a hang is
+# suspected: `.timeLimit` traits can't interrupt a stuck `evaluateJavaScript`/
+# `withCheckedContinuation` starved off the cooperative thread pool by another
+# concurrently-running blocking suite (#664/#732) — this wrapper bounds and
+# surfaces that instead of hanging indefinitely. Override the deadline with
+# TEST_TIMEOUT=<seconds> (default 900). Log: tmp/test-logs/swift-test-*.log.
+test-watchdog: deps prompts version keychain
+	@scripts/test-with-watchdog.sh
 
 # Fast test tier (debug) — skips the slow SQLite integration suites for quick
 # PR feedback. Run `make test` for the full suite. (issue #520)

--- a/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
+++ b/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
@@ -16,6 +16,24 @@ import Testing
         DefuddleExtractionService.resolve()
     }
 
+    /// Wait for a process to exit without blocking the cooperative thread
+    /// pool. `Process.waitUntilExit()` is synchronous and parks the calling
+    /// thread; under `swift test`'s shared pool that starves every other
+    /// suite scheduled onto it (#732, same fix as `PdfExtractionServiceTests`).
+    /// Use `terminationHandler` + `CheckedContinuation` instead — same
+    /// semantics, non-blocking.
+    private func asyncWaitUntilExit(_ process: Process) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            if !process.isRunning {
+                cont.resume()
+                return
+            }
+            process.terminationHandler = { _ in
+                cont.resume()
+            }
+        }
+    }
+
     // MARK: - End-to-end extraction (real subprocess)
 
     @Test func extractsMarkdownAndMetadata() async throws {
@@ -126,7 +144,7 @@ import Testing
         reg.untrack(p)
     }
 
-    @Test func processRegistryTerminatesTracked() {
+    @Test func processRegistryTerminatesTracked() async throws {
         let reg = DefuddleExtractionService.ProcessRegistry()
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/bin/sleep")
@@ -136,7 +154,7 @@ import Testing
 
         reg.track(p)
         reg.terminateAllForTesting()
-        p.waitUntilExit()
+        try await asyncWaitUntilExit(p)
         #expect(!p.isRunning)
         #expect(p.terminationStatus != 0)
     }

--- a/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
@@ -54,23 +54,18 @@ struct QuoteHighlightWebViewTests {
     }
 
     /// Run `js` (no expected return value) and await completion.
+    /// Timeout-guarded — see `evaluateJavaScriptWithTimeout` for why this
+    /// suite's live `evaluateJavaScript` calls can otherwise hang forever.
     @MainActor
     private func run(_ webView: WKWebView, _ js: String) async {
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            webView.evaluateJavaScript(js) { _, _ in cont.resume() }
-        }
+        _ = await evaluateJavaScriptWithTimeout(webView, js)
     }
 
-    /// Run `js` and return its result coerced to a String (Sendable-safe: the
-    /// cast happens inside the completion so only a `String?` crosses the
-    /// continuation).
+    /// Run `js` and return its result coerced to a String, or `nil` if it
+    /// times out. Timeout-guarded — see `evaluateJavaScriptWithTimeout`.
     @MainActor
     private func evalString(_ webView: WKWebView, _ js: String) async -> String? {
-        await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
-            webView.evaluateJavaScript(js) { result, _ in
-                cont.resume(returning: result as? String)
-            }
-        }
+        await evaluateJavaScriptWithTimeout(webView, js)
     }
 
     /// Query the DOM for the highlight `<mark>` and return its text (or "").

--- a/Tests/WikiFSAppTests/WKWebViewJSTimeout.swift
+++ b/Tests/WikiFSAppTests/WKWebViewJSTimeout.swift
@@ -1,0 +1,64 @@
+#if os(macOS)
+import Testing
+import WebKit
+
+/// Evaluate `js` against a live `WKWebView` and return the result coerced to a
+/// `String`, or `nil` if the completion handler never fires within `timeout`.
+///
+/// `evaluateJavaScript`'s completion handler is delivered via a block on
+/// Swift's cooperative thread pool. When `swift test` runs the full suite,
+/// other suites in the SAME process can saturate that pool with synchronous
+/// blocking calls (`DispatchSemaphore.wait()`, `Process.waitUntilExit()` —
+/// see `WikiStoreModel.resolveTantivyLegSync`), leaving no thread free to
+/// deliver the reply. A raw `withCheckedContinuation` then suspends forever —
+/// a hang `.timeLimit` cannot interrupt, because cancelling the test's Task
+/// does not resume an abandoned continuation. This is the exact failure mode
+/// already named in `.github/workflows/ci.yml` / #664 / #732, which is why
+/// `QuoteHighlightWebViewTests` and `YouTubeEmbedWebViewTests` are on CI's
+/// skip list — but a bare local `swift test` still hits it (confirmed:
+/// `hostedViewHighlightsQuoteFromPendingAnchor` passes in ~0.2s run alone via
+/// `--filter`, but hangs indefinitely as part of the full suite).
+///
+/// Racing the continuation against a timeout turns that infinite hang into a
+/// bounded, diagnosable failure instead. Both branches resume through `once`
+/// so whichever fires second — the real completion arriving late, or the
+/// timeout — safely no-ops rather than double-resuming.
+@MainActor
+func evaluateJavaScriptWithTimeout(
+    _ webView: WKWebView,
+    _ js: String,
+    timeout: Duration = .seconds(15)
+) async -> String? {
+    final class Once: @unchecked Sendable {
+        private var fired = false
+        private let lock = NSLock()
+        func fire(_ body: () -> Void) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !fired else { return }
+            fired = true
+            body()
+        }
+    }
+    let once = Once()
+    return await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
+        webView.evaluateJavaScript(js) { result, _ in
+            once.fire { cont.resume(returning: result as? String) }
+        }
+        Task {
+            try? await Task.sleep(for: timeout)
+            once.fire {
+                let preview = js.prefix(80)
+                Issue.record(
+                    """
+                    evaluateJavaScript timed out after \(timeout) — likely cooperative \
+                    thread-pool starvation from a concurrently-running blocking suite \
+                    (see #664/#732), not a bug in the JS itself. js=\(preview)
+                    """
+                )
+                cont.resume(returning: nil)
+            }
+        }
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/YouTubeEmbedWebViewTests.swift
+++ b/Tests/WikiFSAppTests/YouTubeEmbedWebViewTests.swift
@@ -50,13 +50,14 @@ struct YouTubeEmbedWebViewTests {
                       userInfo: [NSLocalizedDescriptionKey: "no WKWebView found in hosted window"])
     }
 
-    /// Evaluate `js` and return its result coerced to a String inside the
-    /// completion (Sendable-safe — only the `String?` crosses the continuation).
+    /// Evaluate `js` and return its result coerced to a String, or `nil` if
+    /// it times out. Timeout-guarded — see `evaluateJavaScriptWithTimeout`
+    /// for why this suite's live `evaluateJavaScript` calls can otherwise
+    /// hang forever under cooperative thread-pool starvation from other
+    /// concurrently-running suites (#664/#732).
     @MainActor
     private func evalString(_ webView: WKWebView, _ js: String) async -> String? {
-        await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
-            webView.evaluateJavaScript(js) { result, _ in cont.resume(returning: result as? String) }
-        }
+        await evaluateJavaScriptWithTimeout(webView, js)
     }
 
     /// Poll the live DOM until the reader has painted the embed iframe, returning

--- a/scripts/test-with-watchdog.sh
+++ b/scripts/test-with-watchdog.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Wraps `swift test -v` with a hard wall-clock timeout and a post-run summary,
+# so a hung test is visible in minutes instead of blocking indefinitely.
+#
+# Why this exists: `swift test`'s own `.timeLimit` trait (Swift Testing) only
+# works by cancelling the test's Task — it cannot interrupt a suspended
+# `withCheckedContinuation` whose completion handler never fires (e.g. a
+# WKWebView `evaluateJavaScript` reply starved off the cooperative thread pool
+# by another concurrently-running blocking suite; see #664/#732). That leaves
+# the WHOLE `swift test` process hanging with no diagnostic. This script:
+#   1. Runs the suite with a real timeout (default 900s; override with
+#      TEST_TIMEOUT), tee'd to a timestamped log under tmp/test-logs/.
+#   2. On timeout, kills the swift-test process tree AND its
+#      swiftpm-testing-helper child (same orphan pattern as `make test`'s
+#      trap) and reports exactly which test(s) started but never finished.
+#   3. On any exit, prints the slowest tests (parsed from Swift Testing's own
+#      "passed/failed after N seconds" lines) so a newly-slow test is visible
+#      as a trend, not just a future hang.
+#
+# Usage: scripts/test-with-watchdog.sh [swift test args...]
+#   TEST_TIMEOUT=1200 scripts/test-with-watchdog.sh --filter QueueEngineTests
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+TIMEOUT_SECS="${TEST_TIMEOUT:-900}"
+LOG_DIR="tmp/test-logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/swift-test-$(date +%Y%m%d-%H%M%S).log"
+
+reap_helpers() {
+    pkill -f "[s]wiftpm-testing-helper.*$REPO_ROOT/.build" 2>/dev/null || true
+}
+trap reap_helpers EXIT TERM INT
+
+echo "==> swift test -v $* "
+echo "==> log: $LOG_FILE"
+echo "==> timeout: ${TIMEOUT_SECS}s (override with TEST_TIMEOUT=<seconds>)"
+
+reap_helpers
+swift test -v "$@" >"$LOG_FILE" 2>&1 &
+TEST_PID=$!
+
+START_TS=$(date +%s)
+TIMED_OUT=0
+while kill -0 "$TEST_PID" 2>/dev/null; do
+    ELAPSED=$(( $(date +%s) - START_TS ))
+    if [ "$ELAPSED" -ge "$TIMEOUT_SECS" ]; then
+        TIMED_OUT=1
+        break
+    fi
+    sleep 2
+done
+
+if [ "$TIMED_OUT" -eq 1 ]; then
+    echo ""
+    echo "✗ TIMED OUT after ${TIMEOUT_SECS}s — killing swift test and reaping its helper."
+    kill "$TEST_PID" 2>/dev/null
+    sleep 1
+    kill -9 "$TEST_PID" 2>/dev/null
+    reap_helpers
+    EXIT_CODE=124
+else
+    wait "$TEST_PID"
+    EXIT_CODE=$?
+fi
+
+perl -ne '
+    if (/Test (.+\(.*\)) started\./) { $started{$1} = 1 }
+    if (/Test (.+\(.*\)) (passed|failed) after ([0-9.]+) seconds/) {
+        $finished{$1} = 1;
+        push @durations, [$3 + 0, $2, $1];
+    }
+    END {
+        print "\n==> Slowest tests (top 15):\n";
+        my $shown = 0;
+        for (sort { $b->[0] <=> $a->[0] } @durations) {
+            last if $shown++ >= 15;
+            printf "  %8.3fs  %-7s %s\n", $_->[0], $_->[1], $_->[2];
+        }
+        print "\n==> STARTED BUT NEVER FINISHED (the hang, if any):\n";
+        my $any = 0;
+        for my $name (sort keys %started) {
+            unless ($finished{$name}) { print "  - $name\n"; $any = 1; }
+        }
+        print "  (none)\n" unless $any;
+    }
+' "$LOG_FILE"
+
+echo ""
+echo "==> Full log: $LOG_FILE"
+
+if [ "$TIMED_OUT" -eq 1 ]; then
+    echo "==> Exiting 124 (timeout)."
+fi
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary
- `hostedViewHighlightsQuoteFromPendingAnchor()` (`QuoteHighlightWebViewTests`) hung forever in a bare `swift test` run (passes in ~1.4s isolated via `--filter`). Root cause: its `evaluateJavaScript` calls used a raw `withCheckedContinuation` with no timeout, and under the full suite other tests (`CLITantivyLegResolverTests`, `PathPreflight`-based ACP subprocess tests) block the cooperative thread pool synchronously, starving it of a thread to deliver the JS-eval reply. Same bug class as #664, just a different call site. `.timeLimit` can't rescue this shape — cancelling a Task doesn't resume an abandoned continuation.
- Added `Tests/WikiFSAppTests/WKWebViewJSTimeout.swift`: races `evaluateJavaScript` against a 15s timeout so a starved pool produces a fast, diagnosed failure instead of an infinite hang. Applied to `QuoteHighlightWebViewTests.swift` and `YouTubeEmbedWebViewTests.swift` (same vulnerable pattern in both).
- Fixed `DefuddleExtractionServiceTests.processRegistryTerminatesTracked()`: swapped a raw `p.waitUntilExit()` for the same `terminationHandler`/continuation pattern `PdfExtractionServiceTests` already uses for #732.
- Added `scripts/test-with-watchdog.sh` + `make test-watchdog`: wraps `swift test -v` with a real wall-clock timeout, logs to `tmp/test-logs/` (gitignored), and reports the slowest tests plus anything that started but never finished — so a future hang in this bug class is caught and diagnosable in minutes instead of hanging silently.

Remaining live call sites in this same bug class (`CLITantivyLegResolver`, `PathPreflight`, `WikiStoreModel.resolveTantivyLegSync`, `FileProviderSetupVerifier`) are filed as follow-up in #925 — fixing those is a larger, separate piece of work.

## Test plan
- [x] `swift build` — clean
- [x] `swift test --filter QuoteHighlightWebViewTests --filter YouTubeEmbedWebViewTests` — passes (~1.3s)
- [x] `swift test --filter DefuddleExtractionServiceTests` — passes (~0.24s), `processRegistryTerminatesTracked()` now non-blocking (0.001s)
- [x] `scripts/test-with-watchdog.sh` verified to correctly catch and report a timeout (exercised against the still-open #925 contention while developing this fix)
- [ ] Full `swift test` / `make test` — not run to completion locally (see #925: unrelated blocking-wait call sites still starve the pool during a full run on this machine); CI's `swift` job skip-list already avoids the affected suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)