### PR TITLE
Add Confirm Before Quitting toggle to menu-bar status menu

### DIFF
--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -351,6 +351,19 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         settingsItem.target = self
         menu.addItem(settingsItem)
 
+        // Confirm-before-quit toggle. The Settings UI toggle for this was
+        // removed along with the old Permissions tab, but `AppDelegate` still
+        // reads `confirmBeforeQuitting` to gate the quit dialog — this menu
+        // item is now the only way to turn it off, so it lives in the
+        // always-reachable status menu rather than Settings.
+        let confirmQuitItem = NSMenuItem(
+            title: "Confirm Before Quitting",
+            action: #selector(toggleConfirmBeforeQuitting(_:)),
+            keyEquivalent: "")
+        confirmQuitItem.target = self
+        confirmQuitItem.state = AppDelegate.confirmBeforeQuitting ? .on : .off
+        menu.addItem(confirmQuitItem)
+
         // About + Quit.
         let aboutItem = NSMenuItem(
             title: "About Self Driving Wiki",
@@ -405,6 +418,12 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         } else {
             backgroundIngestCoordinator?.stop()
         }
+    }
+
+    @objc private func toggleConfirmBeforeQuitting(_ sender: NSMenuItem?) {
+        let newValue = !AppDelegate.confirmBeforeQuitting
+        UserDefaults.standard.set(newValue, forKey: AppDelegate.confirmQuitKey)
+        sender?.state = newValue ? .on : .off
     }
 
     @objc private func openIngestionWindow(_ sender: NSMenuItem?) {


### PR DESCRIPTION
## Summary
- Restores a UI control for `AppDelegate.confirmBeforeQuitting`, which has continued to gate the quit dialog since its Settings toggle was removed with the old Permissions tab.
- Adds a "Confirm Before Quitting" checkbox item to the menu-bar status menu (below Settings…), mirroring the existing Continuous Ingest toggle pattern.

## Test plan
- [x] `swift build --target WikiFS` succeeds
- [ ] Manually verify: toggle off in status menu → quitting with no active operations skips the confirm dialog
- [ ] Manually verify: toggle on → quitting always shows the confirm dialog
- [ ] Manually verify: state persists across menu reopens and app relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)