### PR TITLE
Fix #931: guard chat queries on not-yet-migrated read-only DBs

### DIFF
--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -6275,8 +6275,32 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     }
 
 
+    /// True when the `chats` table has all columns the chat-summary queries
+    /// depend on (`acp_session_id` from v43, `model_provider_id` / `model_id`
+    /// from v45). A read-only File Provider connection opened before the main
+    /// app has migrated the DB will see an older schema; without this guard the
+    /// query throws "no such column: c.acp_session_id" on every retry, causing
+    /// a busy-loop (#931). Returning early with an empty result mirrors the
+    /// `wikiIndexDocument()` graceful-fallback pattern for not-yet-migrated DBs.
+    private func chatsSchemaIsReady(in db: Database) -> Bool {
+        // Intentionally swallows the error: if the `chats` table doesn't exist
+        // at all (even older schema), pragma_table_info returns empty and the
+        // optimistic column checks below just fail — the desired "not ready"
+        // result.
+        do {
+            let columns = try Self.tableColumnInfo("chats", in: db)
+            return columns.contains("acp_session_id")
+                && columns.contains("model_provider_id")
+                && columns.contains("model_id")
+        } catch {
+            // swiftlint:disable:next silent_try_optional
+            return false
+        }
+    }
+
     public func listChats() throws -> [ChatSummary] {
         try dbWriter.read { db in
+            guard chatsSchemaIsReady(in: db) else { return [] }
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
@@ -6454,6 +6478,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
     public func listAllChatsOrderedByID() throws -> [ChatSummary] {
         try dbWriter.read { db in
+            guard chatsSchemaIsReady(in: db) else { return [] }
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
@@ -6540,6 +6565,10 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
     public func searchSimilarChats(query: String, limit: Int, bm25Leg: [ChatSummary]?) throws -> [ChatSummary] {
         try dbWriter.read { db in
+            // Guard: if the chats schema is not yet migrated (read-only File
+            // Provider connection, #931), return BM25-only results — the
+            // cosine leg queries c.acp_session_id and would throw.
+            let schemaReady = chatsSchemaIsReady(in: db)
             let pool = max(limit * 2, limit)
             // --- BM25 leg (Tantivy) ---
             // Sole lexical leg post-#634. nil/empty → no BM25 results, only the
@@ -6549,7 +6578,8 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             // --- Semantic (cosine) pass + RRF ---
             // Swift-side dot product (issue #628) over L2-normalized chunk
             // embeddings. Same shape as `searchSimilar` (pages).
-            if EmbeddingService.isAvailable,
+            if schemaReady,
+               EmbeddingService.isAvailable,
                let queryBlob = EmbeddingService.embeddingBlob(for: query),
                let queryVec = VectorCosine.decode(queryBlob) {
                 DebugLog.store("search[chats]: query=\(query) \(ftsRows.isEmpty ? "no-BM25" : "Tantivy-BM25"), cosine=true")
@@ -7729,6 +7759,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// SQLiteWikiStore.getChat(id:).
     public func getChat(id: PageID) throws -> ChatSummary {
         try dbWriter.read { db in
+            guard chatsSchemaIsReady(in: db) else { throw WikiStoreError.notFound(id) }
             guard let row = try Row.fetchOne(
                 db,
                 sql: """

--- a/Tests/WikiFSTests/ReadOnlyStoreTests.swift
+++ b/Tests/WikiFSTests/ReadOnlyStoreTests.swift
@@ -1,5 +1,10 @@
 import Foundation
 import Testing
+#if canImport(CSQLite)
+import CSQLite
+#else
+import SQLite3
+#endif
 @testable import WikiFSCore
 
 /// Tests for the read-only (`query_only`) store the File Provider extension
@@ -63,6 +68,55 @@ struct ReadOnlyStoreTests {
         }
         #expect(throws: (any Error).self) {
             _ = try reader.createPage(title: "Should Fail")
+        }
+    }
+
+    // MARK: - not-yet-migrated schema (#931)
+
+    /// A read-only connection opened against a DB that hasn't been migrated to
+    /// v43+ (missing `acp_session_id`) or v45+ (missing `model_provider_id` /
+    /// `model_id`) must NOT throw "no such column" on chat queries — it should
+    /// return an empty / not-found result, mirroring the `wikiIndexDocument()`
+    /// graceful fallback. Without the guard this busy-loops ~50 times/sec in
+    /// the File Provider extension (#931).
+    @Test func chatQueriesDontThrowOnPreMigrationSchema() throws {
+        let url = tempDatabaseURL()
+
+        // Build a v42 DB by hand: a `chats` table WITHOUT the v43/v45 columns.
+        var raw: OpaquePointer?
+        #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        defer { sqlite3_close(raw) }
+        #expect(sqlite3_exec(raw, """
+        CREATE TABLE chats (id TEXT PRIMARY KEY, kind TEXT, title TEXT,
+            created_at REAL, updated_at REAL, summary TEXT, summary_at REAL);
+        """, nil, nil, nil) == SQLITE_OK)
+        #expect(sqlite3_exec(raw, """
+        CREATE TABLE chat_messages (id TEXT PRIMARY KEY, chat_id TEXT, seq INTEGER,
+            role TEXT, event_json TEXT, text TEXT, created_at REAL,
+            summary TEXT, summary_kind TEXT, summary_at REAL);
+        """, nil, nil, nil) == SQLITE_OK)
+        // Insert a chat row so we can verify the guard fires (not just empty table).
+        #expect(sqlite3_exec(raw, """
+        INSERT INTO chats (id, kind, title, created_at, updated_at)
+        VALUES ('01TEST0000000000000000000A', 'edit', 'Old Chat', 1000.0, 1000.0);
+        """, nil, nil, nil) == SQLITE_OK)
+        #expect(sqlite3_exec(raw, "PRAGMA user_version = 42;", nil, nil, nil) == SQLITE_OK)
+
+        // Open read-only — the File Provider extension path.
+        let reader = try GRDBWikiStore(readOnlyURL: url)
+
+        // listAllChatsOrderedByID: returns [] instead of throwing.
+        let ordered = try reader.listAllChatsOrderedByID()
+        #expect(ordered.isEmpty)
+
+        // listChats: returns [] instead of throwing.
+        let listed = try reader.listChats()
+        #expect(listed.isEmpty)
+
+        // getChat: throws notFound instead of "no such column".
+        let chatID = PageID(rawValue: "01TEST0000000000000000000A")
+        #expect(throws: WikiStoreError.self) {
+            _ = try reader.getChat(id: chatID)
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #931.

The File Provider extension (`WikiFSFileProvider`) opens a **read-only** `GRDBWikiStore` per wiki. Read-only connections can't run write migrations, so if the main app hasn't opened+migrated a given wiki's database yet this session, the extension hits a not-yet-migrated schema.

This was already handled for `index.md` — `wikiIndexDocument()` explicitly falls back to a seeded default when the read fails against a not-yet-migrated DB. The chat-listing path had no equivalent fallback, causing a busy-loop (~50 times/sec) of `no such column: c.acp_session_id` errors in Console.app.

## Fix

Added a `chatsSchemaIsReady(in:)` guard to `GRDBWikiStore` that checks via `pragma_table_info` whether all three migration-added columns exist on the `chats` table:
- `acp_session_id` (v43, #830)
- `model_provider_id` (v45)
- `model_id` (v45)

When the columns are absent (not-yet-migrated DB on a read-only connection), the chat queries gracefully return empty/`notFound` instead of throwing a SQL error — mirroring the existing `wikiIndexDocument()` graceful-fallback pattern.

Applied to:
- `listChats()` → returns `[]`
- `listAllChatsOrderedByID()` → returns `[]`
- `getChat(id:)` → throws `.notFound(id)` (same behavior as a missing chat row)
- `searchSimilarChats()` cosine semantic leg → skipped, BM25-only results returned

## Test

Added `chatQueriesDontThrowOnPreMigrationSchema` to `ReadOnlyStoreTests.swift`. It builds a v42-schema DB by hand (chats table without `acp_session_id`/`model_provider_id`/`model_id`), inserts a chat row, opens a read-only connection, and asserts:
- `listAllChatsOrderedByID()` returns `[]` (not a throw)
- `listChats()` returns `[]` (not a throw)
- `getChat(id:)` throws `WikiStoreError` (not "no such column")

All existing `ReadOnlyStoreTests` (4/4) and `ChatStoreTests` (22/22) pass.
