### PR TITLE
Make CLI tantivy resolution fully async

### DIFF
--- a/Sources/WikiCtlCore/CLITantivyLegResolver.swift
+++ b/Sources/WikiCtlCore/CLITantivyLegResolver.swift
@@ -19,8 +19,7 @@ import WikiFSCore
 /// This resolver constructs a CLI-owned `TantivySearchService` over the SAME
 /// on-disk index the app builds/maintains (the index is a derived artifact, so
 /// concurrently opening it read-only is safe — SQLite remains the source of
-/// truth), runs the kind-scoped search via the actor (bridged async→sync with
-/// a semaphore, mirroring `wikid`'s `runRefresh` pattern), and resolves the
+/// truth), runs the kind-scoped search asynchronously via the actor, and resolves the
 /// hits to typed summaries (`WikiPageSummary` / `SourceSummary` / `ChatSummary`)
 /// via the store's list APIs — preserving Tantivy's best-first rank order, the
 /// same mapping `WikiStoreModel.resolveTantivyLeg(query:kind:limit:catalog:)`
@@ -34,6 +33,9 @@ import WikiFSCore
 /// has been opened in the app at least once (the app kicks off the initial
 /// build via `TantivyShadowSync.start()`), the Tantivy leg is populated.
 public enum CLITantivyLegResolver {
+    private enum SearchRetryPolicy {
+        static let maximumAttempts = 5
+    }
 
     /// Resolve a Tantivy BM25 leg for `wikictl page search`. Returns `nil`
     /// when the index is unavailable/empty — post-#634 that means no BM25
@@ -45,11 +47,11 @@ public enum CLITantivyLegResolver {
         store: WikiStore,
         query: String,
         limit: Int
-    ) -> [WikiPageSummary]? {
+    ) async -> [WikiPageSummary]? {
         guard let svc = makeService(wikiID: wikiID, containerDirectory: containerDirectory, store: store) else {
             return nil
         }
-        let hits = runSearch(svc: svc, query: query, kind: .page, limit: limit)
+        let hits = await runSearch(svc: svc, query: query, kind: .page, limit: limit)
         guard !hits.isEmpty else { return nil }
         let catalog: [WikiPageSummary]
         do {
@@ -69,11 +71,11 @@ public enum CLITantivyLegResolver {
         store: WikiStore,
         query: String,
         limit: Int
-    ) -> [SourceSummary]? {
+    ) async -> [SourceSummary]? {
         guard let svc = makeService(wikiID: wikiID, containerDirectory: containerDirectory, store: store) else {
             return nil
         }
-        let hits = runSearch(svc: svc, query: query, kind: .source, limit: limit)
+        let hits = await runSearch(svc: svc, query: query, kind: .source, limit: limit)
         guard !hits.isEmpty else { return nil }
         let catalog: [SourceSummary]
         do {
@@ -93,11 +95,11 @@ public enum CLITantivyLegResolver {
         store: WikiStore,
         query: String,
         limit: Int
-    ) -> [ChatSummary]? {
+    ) async -> [ChatSummary]? {
         guard let svc = makeService(wikiID: wikiID, containerDirectory: containerDirectory, store: store) else {
             return nil
         }
-        let hits = runSearch(svc: svc, query: query, kind: .chat, limit: limit)
+        let hits = await runSearch(svc: svc, query: query, kind: .chat, limit: limit)
         guard !hits.isEmpty else { return nil }
         let catalog: [ChatSummary]
         do {
@@ -133,12 +135,6 @@ public enum CLITantivyLegResolver {
         }
     }
 
-    /// Bridge `TantivySearchService.search` to synchronous execution, mirroring
-    /// `wikictl`'s existing `runRefresh` async→sync semaphore pattern at
-    /// `Sources/wikictl/main.swift:180-200`. Safe because the search runs on
-    /// the `TantivyIndexer` actor (off-main); the dispatched `Task` signals
-    /// the semaphore from a thread that never needs the main thread.
-    ///
     /// Calls `rebuildIfNeeded()` before querying — opening a fresh
     /// `TantivySearchService` against an existing on-disk index can initially
     /// report `count == 0` until the rebuild path runs (the index open seems
@@ -154,18 +150,18 @@ public enum CLITantivyLegResolver {
         query: String,
         kind: TantivyDocumentKind,
         limit: Int
-    ) -> [TantivyShadowSearchResult] {
-        let box = SearchBox()
-        let semaphore = DispatchSemaphore(value: 0)
-        Task {
+    ) async -> [TantivyShadowSearchResult] {
+        for attempt in 1...SearchRetryPolicy.maximumAttempts {
             // Mirror TantivyShadowSync.start()'s rebuild-on-open: cheap
             // (count-check) when the index is populated, essential when empty.
             await svc.rebuildIfNeeded()
-            box.result = await svc.search(query: query, kinds: [kind], limit: limit)
-            semaphore.signal()
+            let hits = await svc.search(query: query, kinds: [kind], limit: limit)
+            if !hits.isEmpty || attempt == SearchRetryPolicy.maximumAttempts {
+                return hits
+            }
         }
-        semaphore.wait()
-        return box.result ?? []
+
+        return []
     }
 
     /// Map best-first Tantivy hits to typed summaries via the supplied catalog,
@@ -194,36 +190,22 @@ public enum CLITantivyLegResolver {
     }
 }
 
-/// Thread-safe result box for the async→sync semaphore bridge. Mirrors
-/// `RefreshResultBox` at `Sources/wikictl/main.swift` — `@unchecked Sendable`
-/// is belt-and-suspenders; the semaphore guarantees the `Task`'s write
-/// happens-before the read after `semaphore.wait()` returns.
-private final class SearchBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _result: [TantivyShadowSearchResult]?
-
-    var result: [TantivyShadowSearchResult]? {
-        get { lock.lock(); defer { lock.unlock() }; return _result }
-        set { lock.lock(); defer { lock.unlock() }; _result = newValue }
-    }
-}
-
 #else
 /// Linux stub: Tantivy is unavailable. All resolvers return nil (no BM25 leg).
 public enum CLITantivyLegResolver {
     public static func resolvePageLeg(
         wikiID: WikiID, containerDirectory: URL, store: WikiStore,
         query: String, limit: Int
-    ) -> [WikiPageSummary]? { nil }
+    ) async -> [WikiPageSummary]? { nil }
 
     public static func resolveSourceLeg(
         wikiID: WikiID, containerDirectory: URL, store: WikiStore,
         query: String, limit: Int
-    ) -> [SourceSummary]? { nil }
+    ) async -> [SourceSummary]? { nil }
 
     public static func resolveChatLeg(
         wikiID: WikiID, containerDirectory: URL, store: WikiStore,
         query: String, limit: Int
-    ) -> [ChatSummary]? { nil }
+    ) async -> [ChatSummary]? { nil }
 }
 #endif

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -94,7 +94,7 @@ func run() async -> Int32 {
         }
         let store = try GRDBWikiStore(databaseURL: resolver.databaseURL(for: descriptor))
 
-        let result = try execute(
+        let result = try await execute(
             command,
             in: store,
             wikiID: descriptor.id,
@@ -153,10 +153,14 @@ func execute(
     in store: GRDBWikiStore,
     wikiID: WikiID,
     containerDirectory: URL
-) throws -> SourceCommand.Result {
+) async throws -> SourceCommand.Result {
     switch command {
     case .page(let action):
-        let leg: [WikiPageSummary]? = cliPageLegIfSearch(action, wikiID: wikiID, containerDirectory: containerDirectory, store: store)
+        let leg = await cliPageLegIfSearch(
+            action,
+            wikiID: wikiID,
+            containerDirectory: containerDirectory,
+            store: store)
         let r = try PageCommand.run(action, in: store, bm25Leg: leg)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .logAppend(let kind, let title, let note, let source):
@@ -168,36 +172,27 @@ func execute(
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .source(let action):
         if case .refresh(let selector) = action {
-            // `runRefresh` is async (network I/O). Bridge it to the sync
-            // `execute` context via a semaphore — the standard CLI async→sync
-            // pattern. Safe because `DispatchSemaphore.wait()` blocks only the
-            // main thread; the async task signals from its own continuation
-            // thread, which never needs to acquire the main thread to signal
-            // (signaling is thread-agnostic). WebsiteMaterializer does not hop
-            // to the main actor, so no deadlock.
-            let box = RefreshResultBox()
-            let semaphore = DispatchSemaphore(value: 0)
-            Task {
-                do {
-                    box.result = try await SourceCommand.runRefresh(
-                        selector, in: store, fetcher: URLSessionFetcher())
-                } catch {
-                    box.error = error
-                }
-                semaphore.signal()
-            }
-            semaphore.wait()
-            if let error = box.error { throw error }
-            return box.result ?? SourceCommand.Result(payload: .text(""), didCommit: false)
+            return try await SourceCommand.runRefresh(
+                selector,
+                in: store,
+                fetcher: URLSessionFetcher())
         }
         return try SourceCommand.run(
             action, in: store,
             cwd: FileManager.default.currentDirectoryPath,
-            bm25Leg: cliSourceLegIfSearch(action, wikiID: wikiID, containerDirectory: containerDirectory, store: store))
+            bm25Leg: await cliSourceLegIfSearch(
+                action,
+                wikiID: wikiID,
+                containerDirectory: containerDirectory,
+                store: store))
     case .admin(let action):
         return try AdminCommand.run(action, in: store)
     case .chat(let action):
-        return try runChatCommand(action, in: store, wikiID: wikiID, containerDirectory: containerDirectory)
+        return try await runChatCommand(
+            action,
+            in: store,
+            wikiID: wikiID,
+            containerDirectory: containerDirectory)
     case .bookmark(let action):
         let r = try BookmarkCommand.run(action, in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
@@ -225,10 +220,10 @@ private func runChatCommand(
     in store: GRDBWikiStore,
     wikiID: WikiID,
     containerDirectory: URL
-) throws -> SourceCommand.Result {
+) async throws -> SourceCommand.Result {
     let leg: [ChatSummary]?
     if case .search(let query, let limit) = action {
-        leg = CLITantivyLegResolver.resolveChatLeg(
+        leg = await CLITantivyLegResolver.resolveChatLeg(
             wikiID: wikiID, containerDirectory: containerDirectory,
             store: store, query: query, limit: limit)
     } else {
@@ -247,9 +242,9 @@ private func cliSourceLegIfSearch(
     wikiID: WikiID,
     containerDirectory: URL,
     store: GRDBWikiStore
-) -> [SourceSummary]? {
+) async -> [SourceSummary]? {
     guard case .search(let query, let limit) = action else { return nil }
-    return CLITantivyLegResolver.resolveSourceLeg(
+    return await CLITantivyLegResolver.resolveSourceLeg(
         wikiID: wikiID, containerDirectory: containerDirectory,
         store: store, query: query, limit: limit)
 }
@@ -263,30 +258,11 @@ private func cliPageLegIfSearch(
     wikiID: WikiID,
     containerDirectory: URL,
     store: GRDBWikiStore
-) -> [WikiPageSummary]? {
+) async -> [WikiPageSummary]? {
     guard case .search(let query, let limit) = action else { return nil }
-    return CLITantivyLegResolver.resolvePageLeg(
+    return await CLITantivyLegResolver.resolvePageLeg(
         wikiID: wikiID, containerDirectory: containerDirectory,
         store: store, query: query, limit: limit)
-}
-
-/// Thread-safe box for the wikictl async→sync semaphore bridge (Phase 3b).
-/// `@unchecked Sendable` — the semaphore guarantees the write (in the async
-/// task) happens-before the read (after `semaphore.wait()` returns), so the
-/// lock is belt-and-suspenders for Swift 6's data-race checker.
-final class RefreshResultBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _result: SourceCommand.Result?
-    private var _error: Error?
-
-    var result: SourceCommand.Result? {
-        get { lock.lock(); defer { lock.unlock() }; return _result }
-        set { lock.lock(); defer { lock.unlock() }; _result = newValue }
-    }
-    var error: Error? {
-        get { lock.lock(); defer { lock.unlock() }; return _error }
-        set { lock.lock(); defer { lock.unlock() }; _error = newValue }
-    }
 }
 
 /// Read an upsert body: `-` reads stdin to EOF; anything else is a file path.

--- a/Tests/WikiFSAppTests/CLITantivyLegResolverTests.swift
+++ b/Tests/WikiFSAppTests/CLITantivyLegResolverTests.swift
@@ -19,14 +19,7 @@ import Testing
 /// (3-5 docs), and call one resolver method per test. They live in the fast
 /// CI tier (not skip-listed).
 ///
-/// `.serialized` (#925, mirrors #664's fallback direction): every resolver
-/// call in this suite funnels through `CLITantivyLegResolver.runSearch`,
-/// which blocks a cooperative-pool thread on `DispatchSemaphore.wait()`.
-/// Under full-suite `swift test` concurrency this can starve the pool
-/// alongside other suites; `.serialized` removes intra-suite concurrency so
-/// this suite's own semaphore waits don't compound. `.timeLimit` is the
-/// per-test backstop against a hang that still gets through.
-@Suite(.timeLimit(.minutes(5)), .serialized)
+@Suite(.timeLimit(.minutes(5)))
 struct CLITantivyLegResolverTests {
 
     // MARK: - Helpers
@@ -50,7 +43,7 @@ struct CLITantivyLegResolverTests {
 
     // MARK: - resolvePageLeg
 
-    @Test func resolvePageLegReturnsNilWhenIndexEmpty() throws {
+    @Test func resolvePageLegReturnsNilWhenIndexEmpty() async throws {
         let (container, fm) = try makeTempContainer()
         defer { try? fm.removeItem(at: container) }
         let wikiID = WikiID(rawValue: "01TEST0001")
@@ -59,7 +52,7 @@ struct CLITantivyLegResolverTests {
         // (the app would normally kick it off in `TantivyShadowSync.start()`).
         // The resolver must return nil so the store falls back to FTS5
         // (the #637 contract — empty leg = no BM25 signal).
-        let leg = CLITantivyLegResolver.resolvePageLeg(
+        let leg = await CLITantivyLegResolver.resolvePageLeg(
             wikiID: wikiID, containerDirectory: container,
             store: store, query: "anything", limit: 10)
         #expect(leg == nil)
@@ -83,7 +76,7 @@ struct CLITantivyLegResolverTests {
         // pre-build it in the test. The first call pays the rebuild cost;
         // subsequent calls see a populated index and short-circuit on
         // `count()`.
-        let leg = CLITantivyLegResolver.resolvePageLeg(
+        let leg = await CLITantivyLegResolver.resolvePageLeg(
             wikiID: wikiID, containerDirectory: container,
             store: store, query: "rust", limit: 10)
         // The leg is non-nil (the index returned hits) and contains BOTH pages.
@@ -112,7 +105,7 @@ struct CLITantivyLegResolverTests {
         // matching (edit-distance 1) should still surface the page. The
         // resolver's internal `rebuildIfNeeded()` populates the index from
         // the store on first call.
-        let leg = CLITantivyLegResolver.resolvePageLeg(
+        let leg = await CLITantivyLegResolver.resolvePageLeg(
             wikiID: wikiID, containerDirectory: container,
             store: store, query: "erikson", limit: 10)
         #expect(leg != nil, "fuzzy match should find Erickson despite the typo")
@@ -136,7 +129,7 @@ struct CLITantivyLegResolverTests {
             content: "A longitudinal study of autonomous vehicle safety.",
             origin: .extraction, note: nil, technique: nil)
 
-        let leg = CLITantivyLegResolver.resolveSourceLeg(
+        let leg = await CLITantivyLegResolver.resolveSourceLeg(
             wikiID: wikiID, containerDirectory: container,
             store: store, query: "autonomous", limit: 10)
         #expect(leg != nil)
@@ -156,7 +149,7 @@ struct CLITantivyLegResolverTests {
             .assistantText("We discussed terraforming the Martian surface."),
         ])
 
-        let leg = CLITantivyLegResolver.resolveChatLeg(
+        let leg = await CLITantivyLegResolver.resolveChatLeg(
             wikiID: wikiID, containerDirectory: container,
             store: store, query: "terraforming", limit: 10)
         #expect(leg != nil)
@@ -164,9 +157,143 @@ struct CLITantivyLegResolverTests {
         #expect(leg?.first?.id == chat.id)
     }
 
+    @Test func concurrentResolversReturnExpectedResults() async throws {
+        enum SearchKind: Sendable {
+            case page
+            case source
+            case chat
+        }
+
+        struct SearchOutcome: Sendable {
+            let kind: SearchKind
+            let id: PageID?
+        }
+
+        let (pageContainer, pageFM) = try makeTempContainer()
+        defer { try? pageFM.removeItem(at: pageContainer) }
+        let pageWikiID = WikiID(rawValue: "01TEST0007")
+        let pageStore = try tempStore(in: pageContainer, wikiID: pageWikiID)
+        let page = try pageStore.createPage(title: "Rust Ownership")
+        try pageStore.updatePage(
+            id: page.id,
+            title: "Rust Ownership",
+            body: "ownership borrowing lifetimes ownership")
+
+        let (sourceContainer, sourceFM) = try makeTempContainer()
+        defer { try? sourceFM.removeItem(at: sourceContainer) }
+        let sourceWikiID = WikiID(rawValue: "01TEST0008")
+        let sourceStore = try tempStore(in: sourceContainer, wikiID: sourceWikiID)
+        _ = try sourceStore.addSource(filename: "async-search.pdf", data: Data("%PDF".utf8))
+        let source = try #require(sourceStore.listSources().first)
+        _ = try sourceStore.appendProcessedMarkdown(
+            sourceID: source.id,
+            content: "Concurrent search regression coverage for wikictl tantivy.",
+            origin: .extraction,
+            note: nil,
+            technique: nil)
+
+        let (chatContainer, chatFM) = try makeTempContainer()
+        defer { try? chatFM.removeItem(at: chatContainer) }
+        let chatWikiID = WikiID(rawValue: "01TEST0009")
+        let chatStore = try tempStore(in: chatContainer, wikiID: chatWikiID)
+        let chat = try chatStore.createChat(kind: .edit, title: "Async Search")
+        _ = try chatStore.appendChatMessages(chatID: chat.id, events: [
+            .assistantText("Async search should not block concurrent resolver calls."),
+        ])
+
+        let initialPageLeg = await CLITantivyLegResolver.resolvePageLeg(
+            wikiID: pageWikiID,
+            containerDirectory: pageContainer,
+            store: pageStore,
+            query: "ownership",
+            limit: 5)
+        let initialSourceLeg = await CLITantivyLegResolver.resolveSourceLeg(
+            wikiID: sourceWikiID,
+            containerDirectory: sourceContainer,
+            store: sourceStore,
+            query: "Concurrent",
+            limit: 5)
+        let initialChatLeg = await CLITantivyLegResolver.resolveChatLeg(
+            wikiID: chatWikiID,
+            containerDirectory: chatContainer,
+            store: chatStore,
+            query: "concurrent",
+            limit: 5)
+        #expect(initialPageLeg?.first?.id == page.id)
+        #expect(initialSourceLeg?.first?.id == source.id)
+        #expect(initialChatLeg?.first?.id == chat.id)
+
+        let outcomes = await withTaskGroup(of: SearchOutcome.self, returning: [SearchOutcome].self) { group in
+            for _ in 0..<3 {
+                group.addTask {
+                    _ = await CLITantivyLegResolver.resolvePageLeg(
+                        wikiID: pageWikiID,
+                        containerDirectory: pageContainer,
+                        store: pageStore,
+                        query: "ownership",
+                        limit: 5)
+                    let leg = await CLITantivyLegResolver.resolvePageLeg(
+                        wikiID: pageWikiID,
+                        containerDirectory: pageContainer,
+                        store: pageStore,
+                        query: "ownership",
+                        limit: 5)
+                    return SearchOutcome(kind: .page, id: leg?.first?.id)
+                }
+                group.addTask {
+                    _ = await CLITantivyLegResolver.resolveSourceLeg(
+                        wikiID: sourceWikiID,
+                        containerDirectory: sourceContainer,
+                        store: sourceStore,
+                        query: "Concurrent",
+                        limit: 5)
+                    let leg = await CLITantivyLegResolver.resolveSourceLeg(
+                        wikiID: sourceWikiID,
+                        containerDirectory: sourceContainer,
+                        store: sourceStore,
+                        query: "Concurrent",
+                        limit: 5)
+                    return SearchOutcome(kind: .source, id: leg?.first?.id)
+                }
+                group.addTask {
+                    _ = await CLITantivyLegResolver.resolveChatLeg(
+                        wikiID: chatWikiID,
+                        containerDirectory: chatContainer,
+                        store: chatStore,
+                        query: "concurrent",
+                        limit: 5)
+                    let leg = await CLITantivyLegResolver.resolveChatLeg(
+                        wikiID: chatWikiID,
+                        containerDirectory: chatContainer,
+                        store: chatStore,
+                        query: "concurrent",
+                        limit: 5)
+                    return SearchOutcome(kind: .chat, id: leg?.first?.id)
+                }
+            }
+
+            var collected: [SearchOutcome] = []
+            for await outcome in group {
+                collected.append(outcome)
+            }
+            return collected
+        }
+
+        #expect(outcomes.count == 9)
+        let pageHits = outcomes.filter { $0.kind == .page }
+        let sourceHits = outcomes.filter { $0.kind == .source }
+        let chatHits = outcomes.filter { $0.kind == .chat }
+        #expect(pageHits.count == 3)
+        #expect(sourceHits.count == 3)
+        #expect(chatHits.count == 3)
+        #expect(pageHits.allSatisfy { $0.id == page.id }, "pageHits: \(pageHits)")
+        #expect(sourceHits.allSatisfy { $0.id == source.id }, "sourceHits: \(sourceHits)")
+        #expect(chatHits.allSatisfy { $0.id == chat.id }, "chatHits: \(chatHits)")
+    }
+
     // MARK: - FTS5 fallback when no Tantivy service can be built
 
-    @Test func resolvePageLegReturnsNilWhenServiceConstructionFails() throws {
+    @Test func resolvePageLegReturnsNilWhenServiceConstructionFails() async throws {
         // Point the resolver at a container path that doesn't exist and can't
         // be created (a file in place of the container dir). `makeService`
         // catches the throw and returns nil — the store then falls back to
@@ -184,7 +311,7 @@ struct CLITantivyLegResolverTests {
         let wikiID = WikiID(rawValue: "01TEST0006")
         let store = try tempStore(in: container, wikiID: wikiID)
 
-        let leg = CLITantivyLegResolver.resolvePageLeg(
+        let leg = await CLITantivyLegResolver.resolvePageLeg(
             wikiID: wikiID, containerDirectory: fileAsContainer,
             store: store, query: "anything", limit: 10)
         #expect(leg == nil)


### PR DESCRIPTION
## Summary

Eliminate the async→sync bridge pattern (DispatchSemaphore + SearchBox/RefreshResultBox) from CLI tantivy resolution by making the entire call stack async. This allows the CLI to properly suspend on I/O rather than blocking thread-pool threads.

## Changes

- **CLITantivyLegResolver**: Made all resolver methods async (`resolvePageLeg`, `resolveSourceLeg`, `resolveChatLeg`). Replaced the semaphore-based `runSearch` bridge with a retry loop (max 5 attempts) to handle initially-empty indexes when a TantivySearchService is first opened.
- **wikictl main.swift**: Propagated async through the call stack (`execute`, `runChatCommand`, `cliPageLegIfSearch`, `cliSourceLegIfSearch`). Removed `RefreshResultBox` and replaced Task + semaphore pattern with direct `await`.
- **Tests**: Removed `.serialized` suite modifier (no longer needed to avoid semaphore starvation). Made all tests async and added `concurrentResolversReturnExpectedResults` to verify concurrent resolver calls work correctly.

## Benefits

- Eliminates thread-pool starvation risk from blocking on semaphores
- Cleaner, more idiomatic Swift async/await throughout the stack
- Enables safe concurrent resolver calls without coordination overhead