### PR TITLE
Fix #925: Non-blocking context-menu search with lazy loading

### DIFF
--- a/Sources/WikiFS/Reader/WikiLinkMenuNSItems.swift
+++ b/Sources/WikiFS/Reader/WikiLinkMenuNSItems.swift
@@ -91,32 +91,190 @@ enum WikiLinkMenuNSItems {
     }
 
     /// A submenu listing the closest pages to `query`; choosing one navigates to
-    /// it. Shows a disabled "No similar pages" item when the search is empty so
-    /// the submenu is never mysteriously blank.
+    /// it. Shows a disabled "No similar pages" item when the search finds
+    /// nothing so the submenu is never mysteriously blank.
     ///
-    /// #637: builds with `store.searchSimilarResolvingTantivy(query:limit:)`
+    /// #637: searches with `store.searchSimilarResolvingTantivy(query:limit:)`
     /// (rather than the FTS5-fallback `searchSimilar(query:limit:)`) so the menu
     /// surfaces Tantivy-BM25-fused results — gaining the indexer's `fuzzyFields`
     /// edit-distance-1 matches (already configured at
     /// `TantivyIndexer.swift:108-111`) for free, and surviving #634's FTS5 drop
     /// without regression.
+    ///
+    /// #925: that search is now `async`, so this returns immediately with a
+    /// disabled "Searching…" row and a ``SimilarPagesMenuLoader`` delegate that
+    /// fills the submenu in when the user actually opens it. Nothing runs at
+    /// right-click time; nothing blocks the main actor.
     private static func similarPagesItem(
         title: String, query: String, store: WikiStoreModel
     ) -> NSMenuItem {
+        similarPagesItem(
+            title: title,
+            query: query,
+            search: { query, limit in await store.searchSimilarResolvingTantivy(query: query, limit: limit) },
+            navigate: { page in
+                // Prefer the rename-stable id path (#922 strong types); fall back
+                // to the title lookup when the summary list hasn't reloaded since
+                // the search, which is the only case `selectPage(byID:)` rejects.
+                if !store.selectPage(byID: page.id) { store.selectPage(byTitle: page.title) }
+            })
+    }
+
+    /// Seam-injected form of ``similarPagesItem(title:query:store:)`` — the
+    /// production overload wires `store`; tests pass a controlled `search` to
+    /// drive the lazy submenu deterministically.
+    static func similarPagesItem(
+        title: String,
+        query: String,
+        search: @escaping SimilarPagesMenuLoader.Search,
+        navigate: @escaping SimilarPagesMenuLoader.Navigate
+    ) -> NSMenuItem {
         let parent = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        let matches = query.isEmpty ? [] : store.searchSimilarResolvingTantivy(query: query, limit: 8)
         let menu = NSMenu()
-        if matches.isEmpty {
-            let none = NSMenuItem(title: "No similar pages", action: nil, keyEquivalent: "")
-            none.isEnabled = false
-            menu.addItem(none)
-        } else {
-            for page in matches {
-                menu.addItem(.wikiItem(page.title) { store.selectPage(byTitle: page.title) })
-            }
+        // An empty query can never match, so skip the loader entirely and show
+        // the settled empty state rather than a "Searching…" row that resolves
+        // to the same thing.
+        guard !query.isEmpty else {
+            menu.addItem(SimilarPagesMenuLoader.disabledItem(SimilarPagesMenuLoader.noResultsTitle))
+            parent.submenu = menu
+            return parent
         }
+        menu.addItem(SimilarPagesMenuLoader.disabledItem(SimilarPagesMenuLoader.searchingTitle))
+        let loader = SimilarPagesMenuLoader(query: query, search: search, navigate: navigate)
+        menu.delegate = loader
+        // `NSMenu.delegate` is a weak reference, so the loader needs an owner for
+        // the submenu's lifetime. The parent item's `representedObject` is that
+        // owner (same trick `wikiItem` uses for its closure target) and is not a
+        // cycle: the loader holds neither the item nor the menu strongly.
+        parent.representedObject = loader
         parent.submenu = menu
         return parent
+    }
+}
+
+// MARK: - Lazy "Suggest…" / "Find Similar…" submenu
+
+/// Fills a "Suggest…" / "Find Similar…" submenu when it is about to open,
+/// replacing the disabled "Searching…" placeholder with ranked page titles.
+///
+/// #925: the search this drives (`searchSimilarResolvingTantivy`) is async
+/// because resolving the Tantivy BM25 leg hops to the indexer actor. AppKit
+/// builds a context menu synchronously, so the work cannot happen during
+/// construction — it happens here, on `menuNeedsUpdate(_:)`, which AppKit calls
+/// just before the submenu is displayed. A right-click that never opens the
+/// submenu therefore performs no search at all.
+///
+/// Lifecycle:
+/// - Retained by the parent `NSMenuItem`'s `representedObject` (`NSMenu.delegate`
+///   is weak). The loader captures neither back, so there is no cycle.
+/// - `menuNeedsUpdate(_:)` fires every time the submenu is displayed *and* can
+///   repeat for a single display pass, so the `State` machine — not a pile of
+///   booleans — is what makes "exactly one search per open" true.
+/// - `menuDidClose(_:)` cancels an in-flight search and bumps `generation`, so a
+///   late completion cannot mutate a submenu the user has already dismissed.
+///   Reopening starts a fresh search from the placeholder that is still in place.
+@MainActor
+final class SimilarPagesMenuLoader: NSObject, NSMenuDelegate {
+
+    /// Runs the page search. `(query, limit) -> ranked pages`.
+    typealias Search = @MainActor (String, Int) async -> [WikiPageSummary]
+    /// Navigates to a chosen result.
+    typealias Navigate = @MainActor (WikiPageSummary) -> Void
+
+    /// #637 parity: the submenu has always shown at most 8 pages.
+    static let resultLimit = 8
+    /// Transient placeholder shown while the async search runs (#925).
+    static let searchingTitle = "Searching…"
+    /// Settled empty state — unchanged user-visible label.
+    static let noResultsTitle = "No similar pages"
+
+    /// One lifecycle, one stored value: `.idle` may start a search, `.searching`
+    /// owns the cancellable task, `.loaded` is terminal for this open. Encoding
+    /// this as separate `isSearching` / `hasLoaded` flags would make "searching
+    /// *and* loaded" representable and put the duplicate-search guard in two
+    /// places.
+    private enum State {
+        case idle
+        case searching(generation: Int, task: Task<Void, Never>)
+        case loaded
+    }
+
+    private let query: String
+    private let search: Search
+    private let navigate: Navigate
+    private var state: State = .idle
+    /// Bumped on every start and every close; a completion whose captured value
+    /// no longer matches is stale and must not touch the menu.
+    private var generation = 0
+
+    init(query: String, search: @escaping Search, navigate: @escaping Navigate) {
+        self.query = query
+        self.search = search
+        self.navigate = navigate
+        super.init()
+    }
+
+    /// A disabled, action-less row. `NSMenu.autoenablesItems` would disable a
+    /// nil-action item anyway; setting it explicitly keeps the intent readable
+    /// and assertable before the menu is ever displayed.
+    static func disabledItem(_ title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        return item
+    }
+
+    // MARK: - NSMenuDelegate
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        // Only `.idle` starts work: repeated update callbacks during one display
+        // pass, and reopening an already-filled submenu, are both no-ops.
+        guard case .idle = state else { return }
+        generation += 1
+        let started = generation
+        let task = Task { [weak self, weak menu] in
+            guard let self else { return }
+            let matches = await self.search(self.query, Self.resultLimit)
+            // Three ways to be stale: the task was cancelled, the menu closed and
+            // bumped the generation, or the menu itself was torn down.
+            guard !Task.isCancelled, started == self.generation, let menu else { return }
+            self.apply(matches, to: menu)
+            self.state = .loaded
+        }
+        // Safe to assign after creating the task: this method is main-actor
+        // isolated and has no suspension point, so the task cannot start (and
+        // overwrite `state` with `.loaded`) before this line runs.
+        state = .searching(generation: started, task: task)
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        guard case .searching(_, let task) = state else { return }
+        task.cancel()
+        generation += 1
+        // Back to `.idle` — the "Searching…" placeholder is still in the menu, so
+        // the next open simply retries.
+        state = .idle
+    }
+
+    // MARK: - Internals
+
+    private func apply(_ matches: [WikiPageSummary], to menu: NSMenu) {
+        menu.removeAllItems()
+        guard !matches.isEmpty else {
+            menu.addItem(Self.disabledItem(Self.noResultsTitle))
+            return
+        }
+        // Rank order is the search's; the menu preserves it verbatim.
+        for page in matches {
+            menu.addItem(.wikiItem(page.title) { [navigate] in navigate(page) })
+        }
+    }
+
+    /// Test seam: the in-flight search, so AppKit menu tests can `await` a
+    /// settled submenu instead of polling or sleeping. `nil` when idle or
+    /// loaded. Reading it before `menuDidClose(_:)` is also how the stale-
+    /// completion test keeps a handle on a task the loader has let go of.
+    var inFlightSearch: Task<Void, Never>? {
+        if case .searching(_, let task) = state { task } else { nil }
     }
 }
 

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -618,21 +618,25 @@ public final class WikiStoreModel {
 
     /// #637: one-shot page search that resolves a Tantivy BM25 leg before
     /// calling the store's 3-arg `searchSimilar` — mirrors `scheduleSearch()`
-    /// but synchronous (the caller — `WikiLinkMenuNSItems.similarPagesItem` —
-    /// builds its submenu once per right-click, not per render, so blocking the
-    /// main actor for the Tantivy query is the same trade-off the existing
-    /// `searchSimilar(query:limit:)` already makes for MiniLM inference).
+    /// without the debounce, for callers that search once per user gesture
+    /// rather than per keystroke (the "Suggest…" / "Find Similar…" link
+    /// submenu, via `WikiLinkMenuNSItems`).
     ///
-    /// The Tantivy `indexer.search` runs on its actor (off-main); the async→
-    /// sync bridge uses `Task { ... }.value` on `@MainActor` — safe because
-    /// the search never hops back to the main actor to make progress. Returns
-    /// cosine-only results (`bm25Leg: nil`) when Tantivy is unavailable or
-    /// returns no hits — post-#634 that's the documented contract (FTS5 was
+    /// #925: this used to bridge the actor-isolated Tantivy query back to a
+    /// synchronous main-actor call with a `DispatchSemaphore`. That parked the
+    /// main thread *and* a cooperative-pool thread on every right-click, which
+    /// is one of the four starvation sites the issue tracks; the awaited leg
+    /// below is the whole fix. Callers that need a menu item synchronously must
+    /// render a placeholder and fill it in when this returns — see
+    /// `SimilarPagesMenuLoader`.
+    ///
+    /// Returns cosine-only results (`bm25Leg: nil`) when Tantivy is unavailable
+    /// or returns no hits — post-#634 that's the documented contract (FTS5 was
     /// dropped; nil leg = no BM25 leg, cosine still answers when
     /// NLEmbedding/MLX are loaded).
-    public func searchSimilarResolvingTantivy(query: String, limit: Int = 8) -> [WikiPageSummary] {
+    public func searchSimilarResolvingTantivy(query: String, limit: Int = 8) async -> [WikiPageSummary] {
         guard !query.isEmpty else { return [] }
-        let leg = resolveTantivyLegSync(query: query, kind: .page, limit: limit, catalog: summaries)
+        let leg = await resolveTantivyLeg(query: query, kind: .page, limit: limit, catalog: summaries)
         do {
             return try store.searchSimilar(query: query, limit: limit, bm25Leg: leg)
         } catch {
@@ -3775,66 +3779,6 @@ public final class WikiStoreModel {
         return resolved.isEmpty ? nil : resolved
     }
 
-    /// #637: synchronous variant of ``resolveTantivyLeg(query:kind:limit:catalog:)``
-    /// for one-shot main-actor callers that need the leg inline (the "Find
-    /// Similar…" right-click menu — `WikiLinkMenuNSItems.similarPagesItem`).
-    /// Bridges the actor-isolated `TantivySearchService.search` to the
-    /// main-actor sync contract the existing `searchSimilar(query:limit:)`
-    /// wrapper already upholds.
-    ///
-    /// Deadlock safety: the awaited `TantivySearchService.search` runs on the
-    /// `TantivyIndexer` actor (pure off-main compute — touches no SQLite file,
-    /// no actor needs the main thread to release a lock). The semaphore-bridge
-    /// (mirrors `wikictl`'s `runRefresh` async→sync pattern at
-    /// `Sources/wikictl/main.swift:180-200`) blocks only the calling main
-    /// thread; the `Task.detached` body runs in the cooperative pool and hops
-    /// to the indexer actor to query — never back to the main actor — so
-    /// `semaphore.wait()` cannot self-deadlock. `Task.detached` (not
-    /// `Task { ... }`) is intentional: an unstructured `Task` would inherit
-    /// the main-actor executor and could starve under load.
-    ///
-    /// Returns `nil` (→ store falls back to FTS5) when `tantivySearch` is
-    /// `nil`, the index returned no hits, or every hit was missing from
-    /// `catalog`. Same contract as the async variant.
-    @MainActor
-    private func resolveTantivyLegSync<T: Identifiable & Sendable>(
-        query: String,
-        kind: TantivyDocumentKind,
-        limit: Int,
-        catalog: [T]
-    ) -> [T]? where T.ID == PageID {
-        guard let svc = tantivySearch, !query.isEmpty else { return nil }
-        let box = TantivyLegBox()
-        let semaphore = DispatchSemaphore(value: 0)
-        Task.detached {
-            box.result = await svc.search(query: query, kinds: [kind], limit: limit)
-            semaphore.signal()
-        }
-        semaphore.wait()
-        guard let hits = box.result, !hits.isEmpty else { return nil }
-        let byID = Dictionary(catalog.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
-        let resolved = hits.compactMap { hit -> T? in
-            let id = PageID(rawValue: hit.ulid)
-            return byID[id]
-        }
-        return resolved.isEmpty ? nil : resolved
-    }
-
-    /// Thread-safe box for the sync Tantivy leg bridge — mirrors
-    /// `RefreshResultBox` at `Sources/wikictl/main.swift`. `@unchecked Sendable`
-    /// is belt-and-suspenders: the semaphore guarantees the `Task.detached`
-    /// write happens-before the read after `semaphore.wait()` returns, so the
-    /// NSLock exists only to satisfy Swift 6's data-race checker.
-    private final class TantivyLegBox: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _result: [TantivyShadowSearchResult]?
-
-        var result: [TantivyShadowSearchResult]? {
-            get { lock.lock(); defer { lock.unlock() }; return _result }
-            set { lock.lock(); defer { lock.unlock() }; _result = newValue }
-        }
-    }
-
     #else
     // Linux: Tantivy is unavailable — the BM25 leg is always nil (FTS5 fallback).
     private func resolveTantivyLeg<T: Identifiable & Sendable>(
@@ -3843,14 +3787,6 @@ public final class WikiStoreModel {
         limit: Int,
         catalog: [T]
     ) async -> [T]? where T.ID == PageID { nil }
-
-    @MainActor
-    private func resolveTantivyLegSync<T: Identifiable & Sendable>(
-        query: String,
-        kind: TantivyDocumentKind,
-        limit: Int,
-        catalog: [T]
-    ) -> [T]? where T.ID == PageID { nil }
     #endif
 
     /// Phase 2 shadow-comparison log. With Option B the FTS5 leg isn't run

--- a/Tests/WikiFSAppTests/WikiLinkMenuNSItemsTests.swift
+++ b/Tests/WikiFSAppTests/WikiLinkMenuNSItemsTests.swift
@@ -1,0 +1,234 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import Testing
+import WikiFSCore
+@testable import WikiFS
+
+/// #925: the "Suggest…" / "Find Similar…" submenu used to be filled by a
+/// `DispatchSemaphore` bridge that blocked the main thread (and pinned a
+/// cooperative-pool thread) on every right-click. It is now a lazy
+/// `NSMenuDelegate` that searches when the submenu opens.
+///
+/// These tests drive the real `NSMenu`/`NSMenuItem` objects through the
+/// injected-search seam, so they cover construction, the open callback, the
+/// ranked/empty completions, and stale completion after a close. Waiting is
+/// condition-based (`Task.yield()` until the probe records a call) or a direct
+/// `await` on the loader's task — never a sleep or a wall-clock assertion.
+@MainActor
+struct WikiLinkMenuNSItemsTests {
+
+    // MARK: - Fixtures
+
+    private static func page(_ title: String, id: String) -> WikiPageSummary {
+        WikiPageSummary(id: PageID(rawValue: id), title: title, updatedAt: .now, createdAt: .now)
+    }
+
+    /// Records every search the loader starts and holds the result until the
+    /// test releases it, so "is the placeholder still up?" is decidable without
+    /// racing the scheduler.
+    @MainActor
+    private final class SearchProbe {
+        private(set) var calls: [(query: String, limit: Int)] = []
+        private var gate: CheckedContinuation<Void, Never>?
+        private var isOpen = false
+        var result: [WikiPageSummary] = []
+
+        /// Matches `SimilarPagesMenuLoader.Search`.
+        func search(_ query: String, _ limit: Int) async -> [WikiPageSummary] {
+            calls.append((query: query, limit: limit))
+            if !isOpen {
+                await withCheckedContinuation { gate = $0 }
+            }
+            return result
+        }
+
+        /// Lets the pending (and every future) search return.
+        func release() {
+            isOpen = true
+            gate?.resume()
+            gate = nil
+        }
+    }
+
+    /// A loader that is open (never gated) and answers with `results`.
+    private func openItem(
+        title: String = "Find Similar…",
+        query: String = "Alpha",
+        results: [WikiPageSummary] = [],
+        navigate: @escaping SimilarPagesMenuLoader.Navigate = { _ in }
+    ) -> (item: NSMenuItem, probe: SearchProbe) {
+        let probe = SearchProbe()
+        probe.result = results
+        probe.release()
+        let item = WikiLinkMenuNSItems.similarPagesItem(
+            title: title, query: query,
+            search: { q, l in await probe.search(q, l) },
+            navigate: navigate)
+        return (item, probe)
+    }
+
+    private func loader(of item: NSMenuItem) throws -> SimilarPagesMenuLoader {
+        try #require(item.representedObject as? SimilarPagesMenuLoader)
+    }
+
+    /// Condition-based wait: yields the main actor until `condition` holds.
+    /// Bounded so a genuine hang fails the test instead of spinning forever.
+    private func yieldUntil(_ condition: () -> Bool) async {
+        for _ in 0..<200 {
+            if condition() { return }
+            await Task.yield()
+        }
+    }
+
+    // MARK: - Construction (AC.7)
+
+    @Test func menuConstructionReturnsSearchingPlaceholder() throws {
+        let (item, probe) = openItem(query: "Alpha")
+        let submenu = try #require(item.submenu)
+
+        #expect(item.title == "Find Similar…")
+        #expect(submenu.items.count == 1)
+        #expect(submenu.items.first?.title == "Searching…")
+        #expect(submenu.items.first?.isEnabled == false)
+        // The whole point of #925: building the context menu does no searching.
+        #expect(probe.calls.isEmpty)
+        #expect(submenu.delegate is SimilarPagesMenuLoader)
+    }
+
+    @Test func emptyQueryShowsNoSimilarPagesWithoutSearching() {
+        let (item, probe) = openItem(query: "")
+        #expect(item.submenu?.items.map(\.title) == ["No similar pages"])
+        #expect(item.submenu?.items.first?.isEnabled == false)
+        #expect(probe.calls.isEmpty)
+        // No loader is attached at all — there is nothing to search.
+        #expect(item.representedObject == nil)
+        #expect(item.submenu?.delegate == nil)
+    }
+
+    // MARK: - Opening (AC.8)
+
+    @Test func openingSubmenuStartsOneSearch() async throws {
+        let (item, probe) = openItem(query: "Alpha", results: [Self.page("Beta", id: "01B")])
+        let submenu = try #require(item.submenu)
+        let loader = try loader(of: item)
+
+        // AppKit can call `menuNeedsUpdate(_:)` more than once per display pass.
+        loader.menuNeedsUpdate(submenu)
+        loader.menuNeedsUpdate(submenu)
+        loader.menuNeedsUpdate(submenu)
+        await loader.inFlightSearch?.value
+
+        #expect(probe.calls.count == 1)
+        #expect(probe.calls.first?.query == "Alpha")
+        #expect(probe.calls.first?.limit == 8)
+
+        // Reopening an already-filled submenu does not search again either.
+        loader.menuNeedsUpdate(submenu)
+        #expect(probe.calls.count == 1)
+    }
+
+    @Test func rankedResultsReplacePlaceholderAndNavigate() async throws {
+        let ranked = [
+            Self.page("First", id: "01A"),
+            Self.page("Second", id: "01B"),
+            Self.page("Third", id: "01C"),
+        ]
+        let navigated = Navigated()
+        let (item, _) = openItem(query: "Alpha", results: ranked, navigate: { navigated.ids.append($0.id) })
+        let submenu = try #require(item.submenu)
+        let loader = try loader(of: item)
+
+        loader.menuNeedsUpdate(submenu)
+        await loader.inFlightSearch?.value
+
+        // Rank order is the search's, verbatim — no placeholder left behind.
+        #expect(submenu.items.map(\.title) == ["First", "Second", "Third"])
+
+        let second = try #require(submenu.items.dropFirst().first)
+        let target = try #require(second.target)
+        let action = try #require(second.action)
+        _ = target.perform(action)
+        #expect(navigated.ids == [PageID(rawValue: "01B")])
+    }
+
+    @Test func emptyResultsShowNoSimilarPages() async throws {
+        let (item, _) = openItem(query: "Alpha", results: [])
+        let submenu = try #require(item.submenu)
+        let loader = try loader(of: item)
+
+        loader.menuNeedsUpdate(submenu)
+        await loader.inFlightSearch?.value
+
+        #expect(submenu.items.map(\.title) == ["No similar pages"])
+        #expect(submenu.items.first?.isEnabled == false)
+    }
+
+    @Test func cancelledOrClosedMenuIgnoresStaleCompletion() async throws {
+        let probe = SearchProbe()
+        probe.result = [Self.page("First", id: "01A")]
+        let navigated = Navigated()
+        let item = WikiLinkMenuNSItems.similarPagesItem(
+            title: "Suggest…", query: "Alpha",
+            search: { q, l in await probe.search(q, l) },
+            navigate: { navigated.ids.append($0.id) })
+        let submenu = try #require(item.submenu)
+        let loader = try loader(of: item)
+
+        loader.menuNeedsUpdate(submenu)
+        await yieldUntil { probe.calls.count == 1 }
+        // Hold the handle the loader is about to drop, so the stale completion
+        // is awaitable rather than merely "probably done by now".
+        let stale = try #require(loader.inFlightSearch)
+
+        loader.menuDidClose(submenu)
+        #expect(stale.isCancelled)
+
+        probe.release()
+        await stale.value
+
+        // The dismissed submenu was not mutated by the late result.
+        #expect(submenu.items.map(\.title) == ["Searching…"])
+        #expect(navigated.ids.isEmpty)
+
+        // Reopening retries from the placeholder and completes normally — the
+        // stale completion did not leave the loader wedged or double-complete.
+        loader.menuNeedsUpdate(submenu)
+        await loader.inFlightSearch?.value
+        #expect(probe.calls.count == 2)
+        #expect(submenu.items.map(\.title) == ["First"])
+    }
+
+    // MARK: - Source guard (AC.7)
+
+    @Test func wikiStoreModelHasNoSynchronousTantivyBridge() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let model = root.appending(path: "Sources/WikiFSCore/Store/WikiStoreModel.swift")
+        let text = try String(contentsOf: model, encoding: .utf8)
+
+        // Doc/comment lines are excluded so the #925 rationale can name the
+        // removed symbols in prose without tripping its own guard.
+        let banned = ["resolveTantivyLegSync", "TantivyLegBox", "DispatchSemaphore", "semaphore.wait"]
+        var offenders: [String] = []
+        for (i, line) in text.components(separatedBy: "\n").enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("//") { continue }
+            for symbol in banned where trimmed.contains(symbol) {
+                offenders.append("WikiStoreModel.swift:\(i + 1): \(symbol)")
+            }
+        }
+        #expect(offenders.isEmpty, "#925: synchronous Tantivy bridge reappeared — \(offenders)")
+    }
+
+    /// Main-actor recorder for the navigate closure. A plain `var` captured by
+    /// an escaping `@MainActor` closure would need `inout`; a reference type is
+    /// the straightforward way to observe the call.
+    @MainActor
+    private final class Navigated {
+        var ids: [PageID] = []
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Eliminate main-actor blocking on right-click by making the context-menu page search lazy and async. The submenu now shows a disabled "Searching…" placeholder immediately and fills results when the user actually opens it — or stays empty if they never open it.

## Changes

- **WikiLinkMenuNSItems.swift**: Replaced synchronous search with `SimilarPagesMenuLoader`, a new `NSMenuDelegate` that:
  - Constructs quickly with a placeholder ("Searching…" or "No similar pages")
  - Searches asynchronously only when `menuNeedsUpdate(_:)` fires (submenu opens)
  - Cancels and restarts if the menu closes before completion (stale completion guard via generation counter)
  - Captures neither the menu nor item, so no reference cycles despite being retained by `representedObject`

- **WikiStoreModel.swift**: 
  - Made `searchSimilarResolvingTantivy(query:limit:)` async
  - Removed the synchronous `resolveTantivyLegSync` method and its `DispatchSemaphore` bridge
  - Removed `TantivyLegBox` thread-safe box
  - This was one of four starvation sites tracked by #925: a semaphore on the main thread pinned a cooperative-pool thread on every right-click

- **WikiLinkMenuNSItemsTests.swift** (new):
  - Tests construction (placeholder shown, no search at build time)
  - Tests opening (one search per display, repeated updates are idempotent)
  - Tests ranked results and navigation
  - Tests stale completion after close (mutation ignored, menu stays at placeholder)
  - Tests empty query (no search, no loader attached)
  - Source guard ensuring `resolveTantivyLegSync` and `DispatchSemaphore` don't reappear

## Why

The async/await bridge with a `DispatchSemaphore` was correct but punishing: every right-click blocked the main thread until Tantivy finished, and parked a cooperative-pool thread waiting for it. This serialized right-clicks under load and consumed thread-pool capacity without progress. Lazy loading defers the search to when it's actually needed — most right-clicks never open the submenu, so most searches don't run at all.