### PR TITLE
Fix #905: Handle legacy transcription and unknown queue kinds

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -41,7 +41,7 @@ struct ActivityWindowView: View {
 
     private var queueTitle: String {
         switch queue {
-        case .extraction: return "Extraction Queue"
+        case .extraction, .transcription: return "Extraction Queue"
         case .ingestion: return "Agent Queue"
         }
     }
@@ -49,7 +49,7 @@ struct ActivityWindowView: View {
     /// The toolbar/menu icon for this queue's window.
     private var queueControlIcon: String {
         switch queue {
-        case .extraction: return "doc.text.magnifyingglass"
+        case .extraction, .transcription: return "doc.text.magnifyingglass"
         case .ingestion: return "tray.full"
         }
     }
@@ -58,7 +58,7 @@ struct ActivityWindowView: View {
     /// when this queue has no relevant Settings tab.
     private var configureCTA: (tab: String, label: String)? {
         switch queue {
-        case .extraction:
+        case .extraction, .transcription:
             return (tab: "extraction", label: "Configure Extraction…")
         case .ingestion:
             return (tab: "agents", label: "Configure Agents…")
@@ -246,7 +246,7 @@ struct ActivityWindowView: View {
     private var emptyState: some View {
         let description: String
         switch queue {
-        case .extraction:
+        case .extraction, .transcription:
             description = "PDF extraction and transcription tasks appear here as they run."
         case .ingestion:
             description = "Ingestion and lint tasks appear here as they run."
@@ -1024,7 +1024,7 @@ struct ActivityWindowView: View {
     private func kindLabel(for item: QueueItem) -> String {
         if item.payload.lintPageIDs != nil { return "Lint" }
         switch item.queue {
-        case .extraction: return "Extraction"
+        case .extraction, .transcription: return "Extraction"
         case .ingestion: return "Ingestion"
         }
     }

--- a/Sources/WikiFS/Queue/OperationNotifier.swift
+++ b/Sources/WikiFS/Queue/OperationNotifier.swift
@@ -153,7 +153,7 @@ final class OperationNotifier {
     /// Determine the operation kind from a queue item.
     nonisolated static func operationKind(for item: QueueItem) -> OperationKind {
         switch item.queue {
-        case .extraction:
+        case .extraction, .transcription:
             return .extraction(sourceCount: item.payload.sourceIDs.count)
         case .ingestion:
             if let lintPageIDs = item.payload.lintPageIDs {

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -631,7 +631,7 @@ final class QueueActivityTracker {
             // #622: Optimistically reflect the queued state in the UI spinners
             // immediately, rather than waiting for .started.
             switch item.queue {
-            case .extraction:
+            case .extraction, .transcription:
                 extractingSourceIDs.formUnion(sourceIDs)
             case .ingestion:
                 if item.payload.lintPageIDs == nil {
@@ -646,7 +646,7 @@ final class QueueActivityTracker {
             itemToSourceIDs[item.id] = sourceIDs
             itemToQueue[item.id] = item.queue
             switch item.queue {
-            case .extraction:
+            case .extraction, .transcription:
                 extractingSourceIDs.formUnion(sourceIDs)
                 extractionLog = ""
                 extractionPID = nil
@@ -809,7 +809,7 @@ final class QueueActivityTracker {
         let queue = itemToQueue.removeValue(forKey: id)
         if let sourceIDs = itemToSourceIDs.removeValue(forKey: id) {
             switch queue {
-            case .extraction:
+            case .extraction, .transcription:
                 extractingSourceIDs.subtract(sourceIDs)
             case .ingestion:
                 ingestingSourceIDs.subtract(sourceIDs)

--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -341,12 +341,33 @@ public final class QueueStore: @unchecked Sendable {
     /// kind that was never shipped in `QueueKind` but can survive in databases
     /// migrated before the v1 cleanup `DELETE`. Lint is a payload variant of
     /// `.ingestion` (see `QueueKind`), so those rows decode as `.ingestion`.
+    /// Also tolerates legacy `"transcription"` rows from before transcript
+    /// work merged into `.extraction`.
     /// Genuinely unrecognized values still throw — so real corruption stays
     /// visible instead of being silently coerced.
     private static func decodeQueueKind(_ raw: String) throws -> QueueKind {
-        if let kind = QueueKind(rawValue: raw) { return kind }
+        if let kind = QueueKind(rawValue: raw) { return kind.canonical }
         if raw == "lint" { return .ingestion }
         throw QueueStoreError.sqlite(code: -1, message: "Unknown queue kind: \(raw)")
+    }
+
+    /// Decode rows one-by-one so a single unknown legacy/corrupt queue raw
+    /// value does not hide every other item in the same snapshot section.
+    private static func readItemsSkippingUnknownQueues(from rows: [Row]) throws -> [QueueItem] {
+        var items: [QueueItem] = []
+        items.reserveCapacity(rows.count)
+
+        for row in rows {
+            do {
+                items.append(try readItem(from: row))
+            } catch let QueueStoreError.sqlite(code, message)
+                where code == -1 && message.hasPrefix("Unknown queue kind:") {
+                let rowID = (row["id"] as String?) ?? "<missing-id>"
+                DebugLog.store("QueueStore: skipping row id=\(rowID) with \(message)")
+            }
+        }
+
+        return items
     }
 
     /// Read a `QueueItem` from a GRDB `Row`. Named column access (not positional)
@@ -499,7 +520,7 @@ public final class QueueStore: @unchecked Sendable {
                         ORDER BY ordering_key ASC;
                         """)
                 }
-                return try rows.map { try Self.readItem(from: $0) }
+                return try Self.readItemsSkippingUnknownQueues(from: rows)
             }
         }
     }
@@ -520,7 +541,7 @@ public final class QueueStore: @unchecked Sendable {
                     LIMIT ?;
                     """,
                     arguments: [Int64(limit)])
-                return try rows.map { try Self.readItem(from: $0) }
+                return try Self.readItemsSkippingUnknownQueues(from: rows)
             }
         }
     }

--- a/Sources/WikiFSCore/Core/QueueTypes.swift
+++ b/Sources/WikiFSCore/Core/QueueTypes.swift
@@ -20,10 +20,20 @@ public enum QueueKind: String, Hashable, Codable, Sendable {
     /// transcript sources resolve to a `transcriptFetch` closure in the
     /// `ExtractionResolution` instead of bytes-based extraction.
     case extraction
+    /// Legacy persisted raw value for transcript jobs from before
+    /// transcription merged into `.extraction`. Kept so older `queue.sqlite`
+    /// rows still decode in every linked target; runtime code should
+    /// canonicalize it back to `.extraction`.
+    case transcription
     /// Content ingestion (extracted markdown → wiki pages). Also covers
     /// lint operations — a `.ingestion` item with `lintPageIDs` in its
     /// payload runs lint instead of ingestion.
     case ingestion
+
+    /// Canonical live queue kind used by current runtime code.
+    public var canonical: QueueKind {
+        self == .transcription ? .extraction : self
+    }
 }
 
 // MARK: - Item lifecycle states

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -684,7 +684,7 @@ public actor QueueEngine {
                 // post-claim state (counts updated, wiki inserted).
                 let limit: Int
                 switch item.queue {
-                case .extraction:
+                case .extraction, .transcription:
                     limit = config.extractionLimit(for: providerID)
                 case .ingestion:
                     limit = config.ingestionLimit(for: providerID)
@@ -972,4 +972,3 @@ public final class QueueEventBroadcaster: @unchecked Sendable {
         }
     }
 }
-

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -196,7 +196,7 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
         let sendableReply = SendableVoidReply(reply: reply)
         Task { [daemon] in
             if let engine = await DebugLog.trying("ensureQueueEngine", operation: { try await daemon.ensureQueueEngine() }),
-               let queueKind = QueueKind(rawValue: queue) {
+               let queueKind = QueueKind(rawValue: queue)?.canonical {
                 await engine.pause(queueKind)
             }
             sendableReply.reply()
@@ -207,7 +207,7 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
         let sendableReply = SendableVoidReply(reply: reply)
         Task { [daemon] in
             if let engine = await DebugLog.trying("ensureQueueEngine", operation: { try await daemon.ensureQueueEngine() }),
-               let queueKind = QueueKind(rawValue: queue) {
+               let queueKind = QueueKind(rawValue: queue)?.canonical {
                 await engine.resume(queueKind)
             }
             sendableReply.reply()
@@ -218,7 +218,7 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
         let sendableReply = SendableVoidReply(reply: reply)
         Task { [daemon] in
             if let engine = await DebugLog.trying("ensureQueueEngine", operation: { try await daemon.ensureQueueEngine() }),
-               let queueKind = QueueKind(rawValue: queue) {
+               let queueKind = QueueKind(rawValue: queue)?.canonical {
                 await engine.halt(queueKind)
             }
             sendableReply.reply()

--- a/Tests/WikiFSAppTests/WikiDaemonWorkloadHostTests.swift
+++ b/Tests/WikiFSAppTests/WikiDaemonWorkloadHostTests.swift
@@ -1,5 +1,10 @@
 #if os(macOS)
 import Foundation
+#if canImport(CSQLite)
+import CSQLite
+#else
+import SQLite3
+#endif
 import Testing
 import WikiDaemonContract
 @testable import WikiFSCore
@@ -60,6 +65,34 @@ struct WikiDaemonWorkloadHostTests {
         // Empty engine → empty snapshot.
         #expect(snapshot.activeItems.isEmpty)
         #expect(snapshot.recentItems.isEmpty)
+    }
+
+    @Test func queueSnapshotDataDecodesLegacyTranscriptionRowsAsExtraction() async throws {
+        let dir = makeTempDir()
+        let queueURL = dir.appendingPathComponent("queue.sqlite")
+        let store = try QueueStore(databaseURL: queueURL)
+        let item = try store.enqueue(
+            QueueItemRequest(
+                queue: .extraction,
+                wikiID: WikiID(rawValue: "legacy-wiki"),
+                payload: QueueItemPayload(sourceIDs: [PageID(rawValue: "legacy-src")])
+            )
+        )
+        store.close()
+
+        var db: OpaquePointer?
+        #expect(sqlite3_open(queueURL.path, &db) == SQLITE_OK)
+        let updateSQL = "UPDATE queue_items SET queue = 'transcription' WHERE id = '\(item.id.rawValue)';"
+        #expect(sqlite3_exec(db, updateSQL, nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+
+        let daemon = WikiDaemon(containerDirectory: dir)
+        let data = await daemon.queueSnapshotData()
+        let snapshot = try JSONDecoder().decode(QueueSnapshot.self, from: data)
+
+        let restored = snapshot.activeItems.first { $0.id == item.id }
+        #expect(restored != nil)
+        #expect(restored?.queue == .extraction)
     }
 
     @Test func queueSnapshotDataIsConsistent() async throws {

--- a/Tests/WikiFSTests/QueueStoreTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTests.swift
@@ -218,7 +218,7 @@ struct QueueStoreTests {
         #expect(completedCount <= 200)
 
         // Queued items should be untouched.
-        let active = try store.loadActive(for: .extraction)
+        let active = try store.loadActive()
         #expect(active.count == 5)
         for id in queuedIDs {
             #expect(active.contains { $0.id == id })
@@ -260,7 +260,7 @@ struct QueueStoreTests {
         // raw SQL, the same pattern the canonicalization tests use.
         var db: OpaquePointer?
         #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
-        let updateSQL = "UPDATE queue_items SET queue = 'lint' WHERE id = '\(lintID)';"
+        let updateSQL = "UPDATE queue_items SET queue = 'lint' WHERE id = '\(lintID.rawValue)';"
         #expect(sqlite3_exec(db, updateSQL, nil, nil, nil) == SQLITE_OK)
         sqlite3_close(db)
 
@@ -274,6 +274,39 @@ struct QueueStoreTests {
         let stamped = recent.first { $0.id == lintID }
         #expect(stamped != nil)
         #expect(stamped?.queue == .ingestion)
+    }
+
+    /// Unknown queue raw values should be isolated to the bad row, not abort
+    /// the whole active-items read. This preserves daemon/app snapshots when a
+    /// single stale or corrupt row is present.
+    @Test func testUnknownQueueRowIsSkippedWithoutHidingOtherActiveItems() throws {
+        let url = tempDatabaseURL()
+
+        let validID: QueueItem.ID
+        let unknownID: QueueItem.ID
+        do {
+            let store = try QueueStore(databaseURL: url)
+            validID = try store.enqueue(
+                QueueItemRequest(queue: .extraction, wikiID: WikiID(rawValue: "wiki1"), payload: makePayload())
+            ).id
+            unknownID = try store.enqueue(
+                QueueItemRequest(queue: .extraction, wikiID: WikiID(rawValue: "wiki1"), payload: makePayload())
+            ).id
+            store.close()
+        }
+
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        let updateSQL = "UPDATE queue_items SET queue = 'totally-unknown-queue' WHERE id = '\(unknownID.rawValue)';"
+        #expect(sqlite3_exec(db, updateSQL, nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+
+        let store = try QueueStore(databaseURL: url)
+        let active = try store.loadActive()
+
+        #expect(active.count == 1)
+        #expect(active.first?.id == validID)
+        #expect(active.contains { $0.id == unknownID } == false)
     }
 
     // MARK: - AC.5: Headless isolation (source-scan)


### PR DESCRIPTION
## Summary

Gracefully handle legacy `"transcription"` queue rows from databases that predate the merge of transcription work into `.extraction`, and isolate truly unknown queue kinds so a single corrupt row doesn't abort an entire snapshot read.

## Changes

### Type System
- Added `transcription` as a legacy case in `QueueKind` enum with documentation
- Introduced `canonical` property to normalize `.transcription` → `.extraction` at runtime

### Decoding & Resilience  
- Updated `decodeQueueKind` to apply canonicalization, converting legacy "transcription" rows to `.extraction`
- Added `readItemsSkippingUnknownQueues` to decode rows one-by-one, logging unknown kinds but continuing the read instead of failing entirely
- Prevents a single stale/corrupt row from hiding all other active items in a snapshot

### Pattern Consistency
- Updated switch statements across UI, tracking, and engine layers to handle `.extraction` and `.transcription` identically
- Applied `.canonical` to raw queue-kind conversions in `wikid` daemon RPC handlers

### Test Coverage
- Added test for legacy "transcription" row decoding and canonicalization
- Added test verifying truly unknown queue kinds are skipped without aborting the read