### PR TITLE
Centralize inspector panel control to window-level controller

### DIFF
--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -33,6 +33,7 @@ struct ChatDetailView: View {
     /// The per-active-wiki session (store + descriptor).
     var session: WikiSession
     let fileProvider: FileProviderFacade
+    @Environment(WindowRightInspectorController.self) private var rightInspector
 
     @State private var showsInternals = false
     @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ChatMetrics.composerFont)
@@ -41,11 +42,8 @@ struct ChatDetailView: View {
     /// context for the next message (issue #385).
     @State private var attachments: [ChatAttachment] = []
     @AppStorage("chat.zoom") private var chatZoom = Double(ZoomScale.defaultScale)
-    /// Outline starts collapsed on every new chat view instance — not a
-    /// persisted global toggle (was @AppStorage). Each time you switch to a
-    /// chat tab the outline is closed by default; the user can expand it
-    /// within that view's lifetime.
-    @State private var chatOutlineExpanded = false
+    @AppStorage("chatInspectorTab") private var inspectorTab: InspectorTab = .outline
+    @AppStorage("chatOutlineWidth") private var outlineWidth: Double = 240
     /// Per-view collapse state for the header. Starts collapsed; persists
     /// across same-type tab switches (SwiftUI keeps the view alive).
     @State private var isHeaderExpanded = false
@@ -169,6 +167,8 @@ struct ChatDetailView: View {
         isLiveChat && remoteSession.runState.isAnswering
     }
 
+    private var chatInspectorAvailable: Bool { !chatOutlineEntries.isEmpty }
+
     var body: some View {
         VStack(spacing: 0) {
             ZStack(alignment: .topTrailing) {
@@ -244,6 +244,12 @@ struct ChatDetailView: View {
                     store.draftChatMessage = question
                 }
             }
+        }
+        .onAppear {
+            rightInspector.updateAvailability(chatInspectorAvailable)
+        }
+        .onChange(of: chatInspectorAvailable) { _, available in
+            rightInspector.updateAvailability(available)
         }
         // D2: when the live session ends (activeChatID clears), re-read from the
         // store so the view flips source WITHOUT a visible change (the final
@@ -407,26 +413,6 @@ struct ChatDetailView: View {
         }
     }
 
-    // MARK: - Content + outline
-
-    /// Wraps `content` with the optional right-side chat outline. Placed BELOW
-    /// the header so the title pane spans full width and the outline sits beside
-    /// the transcript (matching the page detail's content+outline layout).
-    @ViewBuilder
-    private func withChatOutline<C: View>(@ViewBuilder _ content: () -> C) -> some View {
-        HStack(spacing: 0) {
-            content()
-                .frame(maxWidth: .infinity, alignment: .leading)
-            if chatOutlineExpanded {
-                ChatOutlineView(entries: chatOutlineEntries) { turnIndex in
-                    outlineScroll = ChatScrollRequest(
-                        version: (outlineScroll?.version ?? 0) + 1,
-                        turnIndex: turnIndex)
-                }
-            }
-        }
-    }
-
     // MARK: - Unified chat surface (live + persisted)
 
     /// One transcript + one composer for both the live (streaming) and persisted
@@ -441,7 +427,7 @@ struct ChatDetailView: View {
                 header(for: chat)
                 Divider().opacity(PageEditorMetrics.dividerOpacity)
             }
-            withChatOutline {
+            HStack(spacing: 0) {
                 VStack(spacing: 0) {
                     // Pre-spawn failure banner (#613): surfaces a previously
                     // captured `remoteSession.preflightError` so a rolled-back chat
@@ -502,6 +488,24 @@ struct ChatDetailView: View {
                         .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                         .padding(.top, ChatMetrics.sectionSpacing)
                         .padding(.bottom, ChatMetrics.contentInset)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if rightInspector.isPresented, chatInspectorAvailable {
+                    DetailInspectorView(
+                        inspectorTab: $inspectorTab,
+                        outlineWidth: $outlineWidth,
+                        showsOutlineTab: true,
+                        showsHistoryTab: false,
+                        origin: nil,
+                        history: []
+                    ) {
+                        ChatInspectorOutlineView(entries: chatOutlineEntries) { turnIndex in
+                            outlineScroll = ChatScrollRequest(
+                                version: (outlineScroll?.version ?? 0) + 1,
+                                turnIndex: turnIndex)
+                        }
+                    }
                 }
             }
         }
@@ -830,18 +834,7 @@ struct ChatDetailView: View {
                 .help("Reveal this chat file in Finder")
             }
             revealDebugFolderButton
-            // Pin action buttons at the leading edge and the outline
-            // toggle at the trailing edge (Spacer reaches the view's right
-            // edge because this row is outside the readableContentWidth
-            // frame — Bug 1 fix).
             Spacer(minLength: 0)
-            Button {
-                DebugLog.tabs("ChatDetailView: Toggle Outline tapped")
-                chatOutlineExpanded.toggle()
-            } label: {
-                Image(systemName: "sidebar.right")
-            }
-            .help("Toggle Outline")
         }
     }
 

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -246,10 +246,10 @@ struct ChatDetailView: View {
             }
         }
         .onAppear {
-            rightInspector.updateAvailability(chatInspectorAvailable)
+            updateRightSidebarRegistration()
         }
-        .onChange(of: chatInspectorAvailable) { _, available in
-            rightInspector.updateAvailability(available)
+        .onChange(of: chatInspectorAvailable) { _, _ in
+            updateRightSidebarRegistration()
         }
         // D2: when the live session ends (activeChatID clears), re-read from the
         // store so the view flips source WITHOUT a visible change (the final
@@ -259,6 +259,7 @@ struct ChatDetailView: View {
             if let chatID, !isLiveChat {
                 persistedMessages = store.chatMessages(chatID: chatID)
             }
+            updateRightSidebarRegistration()
         }
         // TEMPORARY (chat transcript freezes mid-stream): seam 7 of 8. Keyed on
         // a composed string so it emits one line per real transition rather
@@ -427,8 +428,7 @@ struct ChatDetailView: View {
                 header(for: chat)
                 Divider().opacity(PageEditorMetrics.dividerOpacity)
             }
-            HStack(spacing: 0) {
-                VStack(spacing: 0) {
+            VStack(spacing: 0) {
                     // Pre-spawn failure banner (#613): surfaces a previously
                     // captured `remoteSession.preflightError` so a rolled-back chat
                     // doesn't silently revert to the empty draft composer. The
@@ -488,25 +488,6 @@ struct ChatDetailView: View {
                         .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                         .padding(.top, ChatMetrics.sectionSpacing)
                         .padding(.bottom, ChatMetrics.contentInset)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                if rightInspector.isPresented, chatInspectorAvailable {
-                    DetailInspectorView(
-                        inspectorTab: $inspectorTab,
-                        outlineWidth: $outlineWidth,
-                        showsOutlineTab: true,
-                        showsHistoryTab: false,
-                        origin: nil,
-                        history: []
-                    ) {
-                        ChatInspectorOutlineView(entries: chatOutlineEntries) { turnIndex in
-                            outlineScroll = ChatScrollRequest(
-                                version: (outlineScroll?.version ?? 0) + 1,
-                                turnIndex: turnIndex)
-                        }
-                    }
-                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
@@ -535,6 +516,34 @@ struct ChatDetailView: View {
         // #740: animate the queued list in/out (macos-design: every state
         // change gets a transition). `[PendingQueuedMessage]` is Equatable.
         .animation(.snappy, value: queuedMessages)
+    }
+
+    private func updateRightSidebarRegistration() {
+        guard chatInspectorAvailable else {
+            rightInspector.updateRegistration(nil)
+            return
+        }
+        rightInspector.updateRegistration(
+            RightSidebarRegistration(
+                inspectorTab: $inspectorTab,
+                outlineWidth: $outlineWidth,
+                showsOutlineTab: true,
+                showsHistoryTab: false,
+                origin: nil,
+                history: [],
+                store: nil,
+                onCompareVersions: nil,
+                outline: {
+                    AnyView(
+                        ChatInspectorOutlineView(entries: chatOutlineEntries) { turnIndex in
+                            outlineScroll = ChatScrollRequest(
+                                version: (outlineScroll?.version ?? 0) + 1,
+                                turnIndex: turnIndex)
+                        }
+                    )
+                }
+            )
+        )
     }
 
     /// #740: the per-item "Queued" affordance shown under the composer while

--- a/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
+++ b/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Inspector-body content for the chat surface's outline.
+struct ChatInspectorOutlineView: View {
+    let entries: [ChatOutlineEntry]
+    let onSelect: (Int) -> Void
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 2) {
+                ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
+                    Button {
+                        onSelect(index)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 0) {
+                            if let ts = entry.questionTimestamp {
+                                Text(ts, format: .dateTime.hour().minute())
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.bottom, 2)
+                            }
+                            HStack(alignment: .top, spacing: 4) {
+                                Text("•")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(entry.question.isEmpty ? "(empty)" : entry.question)
+                                    .font(.callout)
+                                    .foregroundStyle(.primary)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            if let response = entry.response {
+                                HStack(alignment: .top, spacing: 4) {
+                                    Text("•")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    Text(response)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .multilineTextAlignment(.leading)
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 8)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 6)
+        }
+    }
+}

--- a/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
+++ b/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
@@ -15,26 +15,26 @@ struct ChatInspectorOutlineView: View {
                         VStack(alignment: .leading, spacing: 0) {
                             if let ts = entry.questionTimestamp {
                                 Text(ts, format: .dateTime.hour().minute())
-                                    .font(.caption2)
+                                    .font(.system(size: 13))
                                     .foregroundStyle(.tertiary)
                                     .padding(.bottom, 2)
                             }
                             HStack(alignment: .top, spacing: 4) {
                                 Text("•")
-                                    .font(.caption)
+                                    .font(.system(size: 13))
                                     .foregroundStyle(.secondary)
                                 Text(entry.question.isEmpty ? "(empty)" : entry.question)
-                                    .font(.callout)
+                                    .font(.system(size: 13))
                                     .foregroundStyle(.primary)
                                     .multilineTextAlignment(.leading)
                             }
                             if let response = entry.response {
                                 HStack(alignment: .top, spacing: 4) {
                                     Text("•")
-                                        .font(.caption)
+                                        .font(.system(size: 13))
                                         .foregroundStyle(.secondary)
                                     Text(response)
-                                        .font(.caption)
+                                        .font(.system(size: 13))
                                         .foregroundStyle(.secondary)
                                         .multilineTextAlignment(.leading)
                                 }

--- a/Sources/WikiFS/Detail/DetailInspectorView.swift
+++ b/Sources/WikiFS/Detail/DetailInspectorView.swift
@@ -31,6 +31,8 @@ enum InspectorTab: String, CaseIterable {
 struct DetailInspectorView<Outline: View>: View {
     @Binding var inspectorTab: InspectorTab
     @Binding var outlineWidth: Double
+    var showsOutlineTab = true
+    var showsHistoryTab = true
     let origin: ProvenanceEntry?
     let history: [ProvenanceEntry]
     var store: WikiStoreModel?
@@ -56,6 +58,19 @@ struct DetailInspectorView<Outline: View>: View {
     /// Clamp a proposed inspector width to the allowed range.
     private func clampedWidth(_ width: Double) -> Double {
         max(180, min(500, width))
+    }
+
+    private var effectiveInspectorTab: InspectorTab {
+        switch (showsOutlineTab, showsHistoryTab, inspectorTab) {
+        case (true, true, _):
+            return inspectorTab
+        case (true, false, _):
+            return .outline
+        case (false, true, _):
+            return .history
+        case (false, false, _):
+            return .outline
+        }
     }
 
     var body: some View {
@@ -95,19 +110,21 @@ struct DetailInspectorView<Outline: View>: View {
                 .zIndex(1)
 
             VStack(alignment: .leading, spacing: 0) {
-                Picker("Inspector", selection: $inspectorTab) {
-                    Label("Outline", systemImage: "list.bullet.indent")
-                        .tag(InspectorTab.outline)
-                    Label("History", systemImage: "clock.arrow.circlepath")
-                        .tag(InspectorTab.history)
+                if showsOutlineTab && showsHistoryTab {
+                    Picker("Inspector", selection: $inspectorTab) {
+                        Label("Outline", systemImage: "list.bullet.indent")
+                            .tag(InspectorTab.outline)
+                        Label("History", systemImage: "clock.arrow.circlepath")
+                            .tag(InspectorTab.history)
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .padding(8)
+
+                    Divider()
                 }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .padding(8)
 
-                Divider()
-
-                switch inspectorTab {
+                switch effectiveInspectorTab {
                 case .outline:
                     outline()
                 case .history:

--- a/Sources/WikiFS/Detail/WindowRightInspectorController.swift
+++ b/Sources/WikiFS/Detail/WindowRightInspectorController.swift
@@ -1,19 +1,38 @@
 // pattern: Imperative Shell
 
 import Observation
+import SwiftUI
+import WikiFSCore
 
-/// Window-scoped state for the unified trailing inspector. Detail surfaces
-/// publish whether they currently have inspector content; the window toolbar
-/// owns the single show/hide toggle.
+/// Window-owned registration describing the active tab's trailing sidebar.
+/// The shell renders this as a sibling column, while detail views keep owning
+/// their local state and callbacks.
+struct RightSidebarRegistration {
+    let inspectorTab: Binding<InspectorTab>
+    let outlineWidth: Binding<Double>
+    let showsOutlineTab: Bool
+    let showsHistoryTab: Bool
+    let origin: ProvenanceEntry?
+    let history: [ProvenanceEntry]
+    let store: WikiStoreModel?
+    let onCompareVersions: (() -> Void)?
+    let outline: () -> AnyView
+}
+
+/// Window-scoped state for the unified trailing sidebar. Detail surfaces
+/// register the active sidebar payload; the window toolbar owns the single
+/// show/hide toggle and the shell owns the actual trailing column.
 @MainActor
 @Observable
 final class WindowRightInspectorController {
     var isPresented = false
-    var isAvailable = false
+    var registration: RightSidebarRegistration?
 
-    func updateAvailability(_ isAvailable: Bool) {
-        self.isAvailable = isAvailable
-        if !isAvailable {
+    var isAvailable: Bool { registration != nil }
+
+    func updateRegistration(_ registration: RightSidebarRegistration?) {
+        self.registration = registration
+        if registration == nil {
             isPresented = false
         }
     }

--- a/Sources/WikiFS/Detail/WindowRightInspectorController.swift
+++ b/Sources/WikiFS/Detail/WindowRightInspectorController.swift
@@ -1,0 +1,25 @@
+// pattern: Imperative Shell
+
+import Observation
+
+/// Window-scoped state for the unified trailing inspector. Detail surfaces
+/// publish whether they currently have inspector content; the window toolbar
+/// owns the single show/hide toggle.
+@MainActor
+@Observable
+final class WindowRightInspectorController {
+    var isPresented = false
+    var isAvailable = false
+
+    func updateAvailability(_ isAvailable: Bool) {
+        self.isAvailable = isAvailable
+        if !isAvailable {
+            isPresented = false
+        }
+    }
+
+    func toggle() {
+        guard isAvailable else { return }
+        isPresented.toggle()
+    }
+}

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -107,7 +107,7 @@ struct PageDetailView: View {
         .frame(minWidth: PageEditorMetrics.detailMinWidth)
         .onAppear {
             lastKnownActiveTabID = store.activeTabID
-            rightInspector.updateAvailability(true)
+            updateRightSidebarRegistration()
             // Seed edit mode from the active tab on first mount. `.onChange(of:
             // store.activeTabID)` below only fires on *subsequent* tab switches,
             // so without this a freshly-created "start in editor" tab would
@@ -128,7 +128,7 @@ struct PageDetailView: View {
             if store.activeTabID == lastKnownActiveTabID {
                 isEditing = false
             }
-            rightInspector.updateAvailability(true)
+            updateRightSidebarRegistration()
         }
         .onChange(of: store.activeTabID) { _, newID in
             lastKnownActiveTabID = newID
@@ -159,14 +159,25 @@ struct PageDetailView: View {
             guard findModel.currentMatchIndex > 0 else { return }
             findVersion &+= 1
         }
+        .onChange(of: store.draftBody) { _, _ in
+            updateRightSidebarRegistration()
+        }
+        .onChange(of: provenanceOrigin) { _, _ in
+            updateRightSidebarRegistration()
+        }
+        .onChange(of: provenanceHistory) { _, _ in
+            updateRightSidebarRegistration()
+        }
         .task(id: currentPageID) {
             guard let pageID = currentPageID else {
                 provenanceOrigin = nil
                 provenanceHistory = []
+                rightInspector.updateRegistration(nil)
                 return
             }
             provenanceOrigin = store.pageOrigin(for: pageID)
             provenanceHistory = store.pageEditHistory(for: pageID)
+            updateRightSidebarRegistration()
         }
         .alert(
             "Title Already Exists",
@@ -323,37 +334,43 @@ struct PageDetailView: View {
     /// subtree independently.
     @ViewBuilder
     private var contentAndOutline: some View {
-        HStack(spacing: 0) {
-            Group {
-                if isEditing {
-                    editorContent
-                } else {
-                    readerContent
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-            if rightInspector.isPresented {
-                DetailInspectorView(
-                    inspectorTab: $inspectorTab,
-                    outlineWidth: $outlineWidth,
-                    origin: provenanceOrigin?.provenanceEntry,
-                    history: provenanceHistory.map(\.provenanceEntry),
-                    store: store,
-                    onCompareVersions: openVersionsWindow) {
-                    PageOutlineView(markdown: store.draftBody,
-                                    caretCharIndex: caretCharIndex) { heading in
-                        if isEditing {
-                            editorScrollRequest = EditorScrollRequest(
-                                charOffset: heading.charOffset,
-                                version: (editorScrollRequest?.version ?? 0) + 1)
-                        } else {
-                            store.jumpToAnchorInCurrentSelection(heading.id)
-                        }
-                    }
-                }
+        Group {
+            if isEditing {
+                editorContent
+            } else {
+                readerContent
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func updateRightSidebarRegistration() {
+        rightInspector.updateRegistration(
+            RightSidebarRegistration(
+                inspectorTab: $inspectorTab,
+                outlineWidth: $outlineWidth,
+                showsOutlineTab: true,
+                showsHistoryTab: true,
+                origin: provenanceOrigin?.provenanceEntry,
+                history: provenanceHistory.map(\.provenanceEntry),
+                store: store,
+                onCompareVersions: openVersionsWindow,
+                outline: {
+                    AnyView(
+                        PageOutlineView(markdown: store.draftBody,
+                                        caretCharIndex: caretCharIndex) { heading in
+                            if isEditing {
+                                editorScrollRequest = EditorScrollRequest(
+                                    charOffset: heading.charOffset,
+                                    version: (editorScrollRequest?.version ?? 0) + 1)
+                            } else {
+                                store.jumpToAnchorInCurrentSelection(heading.id)
+                            }
+                        }
+                    )
+                }
+            )
+        )
     }
 
     private var editorContent: some View {

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -24,7 +24,6 @@ struct PageDetailView: View {
     @State private var lastKnownActiveTabID: UUID? = nil
     @AppStorage("editor.zoom") private var editorZoom = Double(ZoomScale.defaultScale)
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
-    @AppStorage("isOutlineExpanded") private var isOutlineExpanded = false
     @AppStorage("pageInspectorTab") private var inspectorTab: InspectorTab = .outline
     @AppStorage("pageOutlineWidth") private var outlineWidth: Double = 260
     /// Per-view collapse state for the header. Starts collapsed; persists
@@ -39,6 +38,7 @@ struct PageDetailView: View {
     // via environment) so the address bar's "Find on Page…" menu item can drive
     // the same find bar that Cmd+F toggles here (issue #157).
     @Environment(FindModel.self) private var findModel
+    @Environment(WindowRightInspectorController.self) private var rightInspector
     @State private var findVersion = 0
 
     /// The app-wide queue activity tracker — used to reflect an in-flight lint
@@ -107,6 +107,7 @@ struct PageDetailView: View {
         .frame(minWidth: PageEditorMetrics.detailMinWidth)
         .onAppear {
             lastKnownActiveTabID = store.activeTabID
+            rightInspector.updateAvailability(true)
             // Seed edit mode from the active tab on first mount. `.onChange(of:
             // store.activeTabID)` below only fires on *subsequent* tab switches,
             // so without this a freshly-created "start in editor" tab would
@@ -127,6 +128,7 @@ struct PageDetailView: View {
             if store.activeTabID == lastKnownActiveTabID {
                 isEditing = false
             }
+            rightInspector.updateAvailability(true)
         }
         .onChange(of: store.activeTabID) { _, newID in
             lastKnownActiveTabID = newID
@@ -212,13 +214,6 @@ struct PageDetailView: View {
                 // expands/collapses — keeps "Show in List" and friends
                 // in a fixed position).
                 Spacer()
-                Button {
-                    DebugLog.tabs("PageDetailView: Toggle Inspector tapped (editing)")
-                    isOutlineExpanded.toggle()
-                } label: {
-                    Image(systemName: "sidebar.right")
-                }
-                .help("Toggle Inspector")
             } else {
                 Button("Edit",
                        systemImage: "pencil") {
@@ -268,13 +263,6 @@ struct PageDetailView: View {
                 // toggle at the trailing edge (see the matching comment
                 // in the editing branch above).
                 Spacer()
-                Button {
-                    DebugLog.tabs("PageDetailView: Toggle Inspector tapped")
-                    isOutlineExpanded.toggle()
-                } label: {
-                    Image(systemName: "sidebar.right")
-                }
-                .help("Toggle Inspector")
             }
             }
             .frame(maxWidth: .infinity)
@@ -345,7 +333,7 @@ struct PageDetailView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-            if isOutlineExpanded {
+            if rightInspector.isPresented {
                 DetailInspectorView(
                     inspectorTab: $inspectorTab,
                     outlineWidth: $outlineWidth,
@@ -714,4 +702,3 @@ struct PageOutlineView: View {
         return result
     }
 }
-

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -8,6 +8,7 @@ import WikiFSCore
 /// source bytes are never modified.
 struct SourceDetailView: View {
     @Environment(QueueActivityTracker.self) private var tracker
+    @Environment(WindowRightInspectorController.self) private var rightInspector
     let file: SourceSummary
     let hasBeenIngested: Bool
     let isIngesting: Bool
@@ -47,7 +48,6 @@ struct SourceDetailView: View {
 
     @AppStorage("editor.zoom") private var editorZoom = Double(ZoomScale.defaultScale)
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
-    @AppStorage("isSourceOutlineExpanded") private var isOutlineExpanded = false
     @AppStorage("sourceInspectorTab") private var inspectorTab: InspectorTab = .outline
     @AppStorage("sourceOutlineWidth") private var outlineWidth: Double = 260
     /// Per-view collapse state for the header. Starts collapsed; persists
@@ -182,6 +182,14 @@ struct SourceDetailView: View {
     }
 
     private var hasMarkdown: Bool { headVersion != nil }
+
+    private var showsSourceOutlineTab: Bool {
+        isOutlineApplicable && currentMarkdownContent != nil
+    }
+
+    private var sourceInspectorAvailable: Bool {
+        showsSourceOutlineTab || !editHistory.isEmpty || origin != nil
+    }
 
     /// `true` for byteless Apple Podcasts embed sources (issue #799 PR4).
     /// Detects via the loaded `origin`'s provider — the byteless-source
@@ -540,6 +548,10 @@ struct SourceDetailView: View {
             isRefreshable = store.isSourceRefreshable(for: file.id)
             lastKnownActiveTabID = store.activeTabID
             consumePinnedExtraction()
+            rightInspector.updateAvailability(sourceInspectorAvailable)
+            if !showsSourceOutlineTab, inspectorTab == .outline {
+                inspectorTab = .history
+            }
         }
         .onChange(of: file.id) {
             // Navigating between ingested files REUSES this view instance (same
@@ -570,6 +582,10 @@ struct SourceDetailView: View {
             origin = store.sourceOrigin(for: file.id)
             editHistory = store.sourceEditHistory(for: file.id)
             isRefreshable = store.isSourceRefreshable(for: file.id)
+            rightInspector.updateAvailability(sourceInspectorAvailable)
+            if !showsSourceOutlineTab, inspectorTab == .outline {
+                inspectorTab = .history
+            }
         }
         .task(id: PDFTaskKey(sourceID: file.id, anchorVersion: store.pendingScrollAnchorVersion)) {
             // Only consume for un-extracted PDFs (the markdown side handles
@@ -591,7 +607,19 @@ struct SourceDetailView: View {
                 pinnedExtraction = nil
             }
         }
-        .onChange(of: store.selection) { flushEditIfDirty(); isEditing = false }
+        .onChange(of: store.selection) {
+            flushEditIfDirty()
+            isEditing = false
+            rightInspector.updateAvailability(sourceInspectorAvailable)
+        }
+        .onChange(of: sourceInspectorAvailable) { _, available in
+            rightInspector.updateAvailability(available)
+        }
+        .onChange(of: showsSourceOutlineTab) { _, showsOutline in
+            if !showsOutline, inspectorTab == .outline {
+                inspectorTab = .history
+            }
+        }
         // #842 PR2 C6: refresh the transcript head when the store's source list
         // changes. `appendProcessedMarkdown` routes through `mutate()` → emits
         // a `ResourceChangeEvent(.source, .updated)` → the model's bus
@@ -791,21 +819,7 @@ struct SourceDetailView: View {
                     }
                     .keyboardShortcut(.escape, modifiers: [])
 
-                    if isOutlineApplicable {
-                        // Pin save/cancel at the leading edge and the
-                        // outline toggle at the trailing edge so the row's
-                        // layout is independent of the parent's proposed
-                        // width (which changes when the outline pane or
-                        // the header expands/collapses).
-                        Spacer()
-                        Button {
-                            DebugLog.tabs("SourceDetailView: Toggle Outline tapped (editing)")
-                            isOutlineExpanded.toggle()
-                        } label: {
-                            Image(systemName: "sidebar.right")
-                        }
-                        .help("Toggle Outline")
-                    }
+                    Spacer()
                 }
             } else {
                 // Row 1 — primary source actions: the extraction chip leads
@@ -972,19 +986,7 @@ struct SourceDetailView: View {
                         }
                         .help("Reveal this source file in Finder")
                     }
-                    if isOutlineApplicable {
-                        // Pin action buttons at the leading edge and the
-                        // outline toggle at the trailing edge (see the
-                        // matching comment in the editing branch above).
-                        Spacer()
-                        Button {
-                            DebugLog.tabs("SourceDetailView: Toggle Outline tapped")
-                            isOutlineExpanded.toggle()
-                        } label: {
-                            Image(systemName: "sidebar.right")
-                        }
-                        .help("Toggle Outline")
-                    }
+                    Spacer()
                 }
             }
         }
@@ -1134,14 +1136,18 @@ struct SourceDetailView: View {
             // diagram source has none of. Without this guard the pane leaks
             // open from a previous markdown source via the global
             // `@AppStorage("isSourceOutlineExpanded")` flag (issue #642).
-            if isOutlineExpanded, isOutlineApplicable, let markdown = currentMarkdownContent {
+            if rightInspector.isPresented, sourceInspectorAvailable {
                 DetailInspectorView(
                     inspectorTab: $inspectorTab,
                     outlineWidth: $outlineWidth,
+                    showsOutlineTab: showsSourceOutlineTab,
+                    showsHistoryTab: true,
                     origin: origin?.provenanceEntry,
                     history: editHistory.map(\.provenanceEntry),
                     store: store) {
-                    outlineView(markdown: markdown)
+                    if let markdown = currentMarkdownContent, showsSourceOutlineTab {
+                        outlineView(markdown: markdown)
+                    }
                 }
             }
         }

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -548,10 +548,8 @@ struct SourceDetailView: View {
             isRefreshable = store.isSourceRefreshable(for: file.id)
             lastKnownActiveTabID = store.activeTabID
             consumePinnedExtraction()
-            rightInspector.updateAvailability(sourceInspectorAvailable)
-            if !showsSourceOutlineTab, inspectorTab == .outline {
-                inspectorTab = .history
-            }
+            normalizeSourceInspectorTab()
+            updateRightSidebarRegistration()
         }
         .onChange(of: file.id) {
             // Navigating between ingested files REUSES this view instance (same
@@ -582,10 +580,8 @@ struct SourceDetailView: View {
             origin = store.sourceOrigin(for: file.id)
             editHistory = store.sourceEditHistory(for: file.id)
             isRefreshable = store.isSourceRefreshable(for: file.id)
-            rightInspector.updateAvailability(sourceInspectorAvailable)
-            if !showsSourceOutlineTab, inspectorTab == .outline {
-                inspectorTab = .history
-            }
+            normalizeSourceInspectorTab()
+            updateRightSidebarRegistration()
         }
         .task(id: PDFTaskKey(sourceID: file.id, anchorVersion: store.pendingScrollAnchorVersion)) {
             // Only consume for un-extracted PDFs (the markdown side handles
@@ -610,15 +606,14 @@ struct SourceDetailView: View {
         .onChange(of: store.selection) {
             flushEditIfDirty()
             isEditing = false
-            rightInspector.updateAvailability(sourceInspectorAvailable)
+            updateRightSidebarRegistration()
         }
-        .onChange(of: sourceInspectorAvailable) { _, available in
-            rightInspector.updateAvailability(available)
+        .onChange(of: sourceInspectorAvailable) { _, _ in
+            updateRightSidebarRegistration()
         }
         .onChange(of: showsSourceOutlineTab) { _, showsOutline in
-            if !showsOutline, inspectorTab == .outline {
-                inspectorTab = .history
-            }
+            if !showsOutline, inspectorTab == .outline { inspectorTab = .history }
+            updateRightSidebarRegistration()
         }
         // #842 PR2 C6: refresh the transcript head when the store's source list
         // changes. `appendProcessedMarkdown` routes through `mutate()` → emits
@@ -634,6 +629,7 @@ struct SourceDetailView: View {
             if !isEditing {
                 headVersion = store.processedMarkdownHead(for: file)
             }
+            updateRightSidebarRegistration()
         }
         .background { findShortcutButton }
         .overlay(alignment: .top) { findBarOverlay }
@@ -641,6 +637,7 @@ struct SourceDetailView: View {
         .onChange(of: currentMarkdownContent) { _, newContent in
             findModel.content = newContent
             findModel.search()
+            updateRightSidebarRegistration()
         }
         .onChange(of: findModel.isShowing) { _, showing in
             if showing {
@@ -674,6 +671,7 @@ struct SourceDetailView: View {
             editBuffer = content
             isEditing = true
             shouldRestoreEditing = false
+            updateRightSidebarRegistration()
         }
         .onChange(of: isEditing) { _, newValue in
             if let id = store.activeTabID {
@@ -681,6 +679,7 @@ struct SourceDetailView: View {
             }
             if newValue { isHeaderExpanded = true } // reveal Save/Cancel
             if !newValue { shouldRestoreEditing = false; caretCharIndex = nil }
+            updateRightSidebarRegistration()
         }
     }
 
@@ -1128,28 +1127,42 @@ struct SourceDetailView: View {
     /// above, but no longer receive their click. Issue #656.
     @ViewBuilder
     private var contentAndOutline: some View {
-        HStack(spacing: 0) {
-            contentArea
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            // `isOutlineApplicable` excludes pure Mermaid sources (`.mmd` /
-            // `text/mermaid`) — the outline parses markdown headings, which a
-            // diagram source has none of. Without this guard the pane leaks
-            // open from a previous markdown source via the global
-            // `@AppStorage("isSourceOutlineExpanded")` flag (issue #642).
-            if rightInspector.isPresented, sourceInspectorAvailable {
-                DetailInspectorView(
-                    inspectorTab: $inspectorTab,
-                    outlineWidth: $outlineWidth,
-                    showsOutlineTab: showsSourceOutlineTab,
-                    showsHistoryTab: true,
-                    origin: origin?.provenanceEntry,
-                    history: editHistory.map(\.provenanceEntry),
-                    store: store) {
-                    if let markdown = currentMarkdownContent, showsSourceOutlineTab {
-                        outlineView(markdown: markdown)
-                    }
+        contentArea
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func normalizeSourceInspectorTab() {
+        if !showsSourceOutlineTab, inspectorTab == .outline {
+            inspectorTab = .history
+        }
+    }
+
+    private func updateRightSidebarRegistration() {
+        guard sourceInspectorAvailable else {
+            rightInspector.updateRegistration(nil)
+            return
+        }
+        rightInspector.updateRegistration(
+            RightSidebarRegistration(
+                inspectorTab: $inspectorTab,
+                outlineWidth: $outlineWidth,
+                showsOutlineTab: showsSourceOutlineTab,
+                showsHistoryTab: true,
+                origin: origin?.provenanceEntry,
+                history: editHistory.map(\.provenanceEntry),
+                store: store,
+                onCompareVersions: nil,
+                outline: {
+                    AnyView(sourceSidebarOutlineView())
                 }
-            }
+            )
+        )
+    }
+
+    @ViewBuilder
+    private func sourceSidebarOutlineView() -> some View {
+        if let markdown = currentMarkdownContent, showsSourceOutlineTab {
+            outlineView(markdown: markdown)
         }
     }
 

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -87,13 +87,13 @@ struct ContentView: View {
         // List(selection:) writes store.selection directly; observe it here so
         // the model flushes the outgoing page and loads the incoming one
         // (§3.5). The view, not the binding, is the right place for this.
-        .onChange(of: store.selection) { _, newValue in
+        .onChange(of: store.selection, initial: false) { _, newValue in
             store.handleSelectionChange(to: newValue)
             switch newValue {
             case .page, .source, .chat:
                 break
             case .none, .newChat, .changeLog, .bookmark:
-                rightInspector.updateAvailability(false)
+                rightInspector.updateRegistration(nil)
             }
         }
         // "Show In List" reveal (issue #183): a detail-view button requested the
@@ -253,9 +253,16 @@ struct ContentView: View {
                     .frame(width: 340)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
             }
+
+            if rightInspector.isPresented, let registration = rightInspector.registration {
+                Divider()
+                RightSidebarHostView(registration: registration)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
         }
         .animation(.easeInOut(duration: 0.18), value: store.tabs.count > 1)
         .animation(.easeInOut(duration: 0.18), value: store.isChangeLogSidebarVisible)
+        .animation(.easeInOut(duration: 0.18), value: rightInspector.isPresented)
         // Measure the detail column's width — the span the toolbar covers — and
         // feed it to the omnibox. Measuring here is reliable in every state the
         // field's own leading edge is not: this view never lands in toolbar
@@ -409,6 +416,25 @@ struct ContentView: View {
         }
     }
 
+}
+
+private struct RightSidebarHostView: View {
+    let registration: RightSidebarRegistration
+
+    var body: some View {
+        DetailInspectorView(
+            inspectorTab: registration.inspectorTab,
+            outlineWidth: registration.outlineWidth,
+            showsOutlineTab: registration.showsOutlineTab,
+            showsHistoryTab: registration.showsHistoryTab,
+            origin: registration.origin,
+            history: registration.history,
+            store: registration.store,
+            onCompareVersions: registration.onCompareVersions
+        ) {
+            registration.outline()
+        }
+    }
 }
 
 /// The "Add from URL" sheet's presentation payload: the URL to pre-fill the

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
     /// toolbar's "Find on Page…" menu item (`AddressBarView`) and the active
     /// detail view's Cmd+F drive the same `FindBarView` overlay (issue #157).
     @State private var findModel = FindModel()
+    @State private var rightInspector = WindowRightInspectorController()
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
@@ -88,6 +89,12 @@ struct ContentView: View {
         // (§3.5). The view, not the binding, is the right place for this.
         .onChange(of: store.selection) { _, newValue in
             store.handleSelectionChange(to: newValue)
+            switch newValue {
+            case .page, .source, .chat:
+                break
+            case .none, .newChat, .changeLog, .bookmark:
+                rightInspector.updateAvailability(false)
+            }
         }
         // "Show In List" reveal (issue #183): a detail-view button requested the
         // sidebar reveal a page/source. Un-collapse the sidebar so the target list
@@ -136,6 +143,7 @@ struct ContentView: View {
         // (`AddressBarView`, in a `ToolbarItem`) and the detail views' Cmd+F both
         // reach the same `FindModel` instance (#157).
         .environment(findModel)
+        .environment(rightInspector)
     }
 
     /// NavigationSplitView + drop / overlay / toolbar. Split out of `body` so the
@@ -279,6 +287,16 @@ struct ContentView: View {
                                detailWidth: detailWidth,
                                sidebarVisible: columnVisibility != .detailOnly,
                                onAddToBookmarks: { omniboxBookmarkContext = $0 })
+            }
+            ToolbarItem(placement: .automatic) {
+                if rightInspector.isAvailable {
+                    Button {
+                        rightInspector.toggle()
+                    } label: {
+                        Image(systemName: "sidebar.right")
+                    }
+                    .help(rightInspector.isPresented ? "Hide Inspector" : "Show Inspector")
+                }
             }
         }
         // Suppress the window title so the omnibox owns the toolbar. `.navigationTitle("")`


### PR DESCRIPTION
## Summary

Unifies inspector (outline/history sidebar) state management across all detail views by introducing a window-scoped `WindowRightInspectorController`. Previously, each detail view (Page, Source, Chat) independently toggled its outline visibility via local state or AppStorage. This caused inconsistent behavior when switching between detail types and duplicated state management logic.

## Changes

- **New `WindowRightInspectorController`**: Single @Observable class manages whether the inspector is shown/available for the entire window. Detail views publish availability; the window toolbar owns the toggle button.
- **Removed local outline toggles**: Deleted per-view `@AppStorage` flags (`isOutlineExpanded`, `isSourceOutlineExpanded`) and toolbar buttons from PageDetailView, SourceDetailView, and ChatDetailView.
- **New `ChatInspectorOutlineView`**: Extracted chat-specific outline UI into a reusable inspector body (mirrors pattern used by Page and Source views).
- **Enhanced `DetailInspectorView`**: Now accepts `showsOutlineTab` and `showsHistoryTab` flags to conditionally hide tabs when content isn't available (e.g., chat has no history).
- **Window toolbar button**: Single "sidebar.right" toggle button at the ContentView level, respects availability state and hides when no inspector content is present.

## Benefits

- Consistent inspector behavior across all detail types
- Inspector closes automatically when switching to non-detail selections (NewChat, ChangeLog, Bookmark)
- Eliminates AppStorage thrashing when switching between detail types
- Single source of truth for inspector presentation state