### PR TITLE
Gate macOS integration tests behind opt-in

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,10 @@ import Foundation
 // drops the helper target AND compiles the feature out of the Swift sources via the
 // `PODCAST_TRANSCRIPTS` compilation condition. See plans/podcast-transcripts.md.
 let podcastTranscriptsEnabled = ProcessInfo.processInfo.environment["WIKIFS_APP_STORE"] == nil
+/// The macOS integration target can wedge SwiftPM's shared test helper when its
+/// AppKit, WebKit, File Provider, and daemon suites overlap. Keep it out of the
+/// default test graph; opt in with `WIKIFS_APP_TESTS=1 swift test`.
+let appTestsEnabled = ProcessInfo.processInfo.environment["WIKIFS_APP_TESTS"] == "1"
 let podcastSwiftSettings: [SwiftSetting] = podcastTranscriptsEnabled ? [.define("PODCAST_TRANSCRIPTS")] : []
 /// Treat compiler warnings as errors so they never silently accumulate (#493).
 let strictSwiftSettings: [SwiftSetting] = podcastSwiftSettings + [.unsafeFlags(["-warnings-as-errors"])]
@@ -431,6 +435,7 @@ let package = Package(
         //
         // NOTE: wikid is intentionally NOT filtered — it has a Linux
         // stdio-JSON-RPC transport path (#else // Linux at main.swift:120).
+        if $0.name == "WikiFSAppTests" && !appTestsEnabled { return false }
         #if os(Linux)
         if $0.name == "podcast-token-helper" { return false }
         if $0.name == "wikictl" { return false }

--- a/Tests/WikiFSAppTests/ActivityPermissionPendingRowTests.swift
+++ b/Tests/WikiFSAppTests/ActivityPermissionPendingRowTests.swift
@@ -62,10 +62,12 @@ struct ActivityPermissionPendingRowTests {
     /// height (the height the view requests when given unlimited vertical
     /// space). Mirrors `AddressBarLayoutHostedTests.renderedWidth(...)`.
     private func renderedHeight<V: View>(_ view: V) async -> CGFloat {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         _ = Self.app
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
-        window.makeKeyAndOrderFront(nil)
+        window.orderFront(nil)
         defer { window.orderOut(nil) }
         // Give SwiftUI a layout pass before reading geometry. ~150ms is what
         // the other hosted tests use; sufficient for a single pass on a leaf

--- a/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
+++ b/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
@@ -36,6 +36,8 @@ struct AddressBarLayoutHostedTests {
     /// Hosts the real `AddressBarView` at a fixed `detailWidth` and returns its
     /// rendered width — the width NSToolbar would center as the `.principal` item.
     private func renderedWidth(detailWidth: CGFloat, sidebarVisible: Bool = true) async throws -> CGFloat {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         _ = Self.app
         let store = try StoreBackend.current.makeStore(databaseURL: tempDatabaseURL())
         let model = WikiStoreModel(store: store)
@@ -48,7 +50,7 @@ struct AddressBarLayoutHostedTests {
             .environment(FindModel())
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
-        window.makeKeyAndOrderFront(nil)
+        window.orderFront(nil)
         defer { window.orderOut(nil) }
         // Give SwiftUI a layout pass before reading geometry.
         try await Task.sleep(nanoseconds: 150_000_000)

--- a/Tests/WikiFSAppTests/AutocompleteHostedTestGate.swift
+++ b/Tests/WikiFSAppTests/AutocompleteHostedTestGate.swift
@@ -1,8 +1,16 @@
 #if os(macOS)
 import Foundation
 
-actor AutocompleteHostedTestGate {
-    static let shared = AutocompleteHostedTestGate()
+/// Shared lifecycle harness for tests that mount live AppKit or WebKit views
+/// inside the single `swift test` host process. These suites are correct in
+/// production under user-driven interaction, but the CLI host's single
+/// AppKit/WebKit environment can wedge when multiple window-owning suites
+/// overlap under Swift Testing's default suite-level parallelism.
+///
+/// Keep this gate in `Tests/` so the serialization policy is explicit test
+/// infrastructure rather than production behavior.
+actor HostedAppKitTestGate {
+    static let shared = HostedAppKitTestGate()
 
     private var held = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
@@ -45,7 +53,7 @@ actor AutocompleteHostedTestGate {
             }
             isReleased = true
             lock.unlock()
-            Task {
+            Task.detached { [onRelease = self.onRelease] in
                 await onRelease()
             }
         }
@@ -55,4 +63,6 @@ actor AutocompleteHostedTestGate {
         }
     }
 }
+
+typealias AutocompleteHostedTestGate = HostedAppKitTestGate
 #endif

--- a/Tests/WikiFSAppTests/ComposerTextViewTests.swift
+++ b/Tests/WikiFSAppTests/ComposerTextViewTests.swift
@@ -6,7 +6,7 @@ import Testing
 @testable import WikiFSEngine
 
 @MainActor
-@Suite struct ComposerTextViewTests {
+struct ComposerTextViewTests {
 
     // MARK: - clampedHeight matrix
 
@@ -80,7 +80,8 @@ import Testing
         text: Binding<String>,
         isEditable: Bool,
         measuredHeight: Binding<CGFloat>
-    ) -> (window: NSWindow, textView: NSTextView, coordinator: ComposerTextView.Coordinator) {
+    ) async -> (lease: HostedAppKitTestGate.Lease, window: NSWindow, textView: NSTextView, coordinator: ComposerTextView.Coordinator) {
+        let lease = await HostedAppKitTestGate.shared.acquire()
         let parent = ComposerTextView(
             text: text,
             isEditable: isEditable,
@@ -100,7 +101,7 @@ import Testing
         let window = makeWindow()
         window.contentView?.addSubview(scrollView)
 
-        return (window, textView, coordinator)
+        return (lease, window, textView, coordinator)
     }
 
     @Test func largePasteClampsToSixLineMaximum() async {
@@ -109,9 +110,9 @@ import Testing
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
-        let (window, textView, coordinator) = makeHostedComposer(
+        let (lease, window, textView, coordinator) = await makeHostedComposer(
             text: textBinding, isEditable: true, measuredHeight: heightBinding)
-        defer { window.orderOut(nil) }
+        defer { window.orderOut(nil); lease.release() }
 
         let pasted = Array(repeating: "Line of pasted markdown text.", count: 150).joined(separator: "\n")
         textView.string = pasted
@@ -126,15 +127,15 @@ import Testing
         #expect(heightBinding.wrappedValue == expectedMax)
     }
 
-    @Test func editPropagatesToBoundText() {
+    @Test func editPropagatesToBoundText() async {
         var text = "initial"
         var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
-        let (window, textView, coordinator) = makeHostedComposer(
+        let (lease, window, textView, coordinator) = await makeHostedComposer(
             text: textBinding, isEditable: true, measuredHeight: heightBinding)
-        defer { window.orderOut(nil) }
+        defer { window.orderOut(nil); lease.release() }
 
         textView.string = "edited by the user"
         coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
@@ -148,9 +149,9 @@ import Testing
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
-        let (window, textView, coordinator) = makeHostedComposer(
+        let (lease, window, textView, coordinator) = await makeHostedComposer(
             text: textBinding, isEditable: true, measuredHeight: heightBinding)
-        defer { window.orderOut(nil) }
+        defer { window.orderOut(nil); lease.release() }
         textView.postsFrameChangedNotifications = true
         coordinator.observeFrameChanges(for: textView)
 
@@ -173,15 +174,15 @@ import Testing
         #expect(heightBinding.wrappedValue == expectedMax)
     }
 
-    @Test func isEditableTogglesTextViewEditability() {
+    @Test func isEditableTogglesTextViewEditability() async {
         var text = "hello"
         var measuredHeight: CGFloat = ComposerTextView.oneLineHeight(for: bodyFont)
         let textBinding = Binding(get: { text }, set: { text = $0 })
         let heightBinding = Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
 
-        let (window, textView, _) = makeHostedComposer(
+        let (lease, window, textView, _) = await makeHostedComposer(
             text: textBinding, isEditable: true, measuredHeight: heightBinding)
-        defer { window.orderOut(nil) }
+        defer { window.orderOut(nil); lease.release() }
         #expect(textView.isEditable == true)
         #expect(textView.isSelectable == true)
 

--- a/Tests/WikiFSAppTests/DropLinkTextViewDropTests.swift
+++ b/Tests/WikiFSAppTests/DropLinkTextViewDropTests.swift
@@ -129,7 +129,9 @@ struct DropLinkTextViewDropTests {
     /// moment it appears. Pin that: put the view in a window WITHOUT ever making
     /// it first responder or calling `registerForDraggedTypes` by hand, and the
     /// sidebar type must already be registered.
-    @Test func viewDidMoveToWindow_eagerlyRegistersSidebarType() {
+    @Test func viewDidMoveToWindow_eagerlyRegistersSidebarType() async {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         let tv = ScrollableTextEditor.makeConfiguredTextView(
             font: .monospacedSystemFont(ofSize: 13, weight: .regular))
         let sidebarType = NSPasteboard.PasteboardType(UTType.wikiSidebarItem.identifier)

--- a/Tests/WikiFSAppTests/PageDetailViewHostedTests.swift
+++ b/Tests/WikiFSAppTests/PageDetailViewHostedTests.swift
@@ -47,10 +47,12 @@ struct PageDetailViewHostedTests {
     /// NSView subtree. WKWebView presence ⇒ the reader branch rendered; its
     /// absence ⇒ the editor branch rendered.
     private func hasWebViewAfterMount<V: View>(_ view: V, expectWebView: Bool) async throws -> Bool {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         _ = Self.app
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
-        window.makeKeyAndOrderFront(nil)
+        window.orderFront(nil)
         defer { window.orderOut(nil) }
 
         // Poll up to ~2s. The WKWebView mounts asynchronously after the first

--- a/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
@@ -88,7 +88,8 @@ struct QuoteHighlightWebViewTests {
     }
 
     @MainActor
-    private func makeHostedWebView() -> (window: NSWindow, webView: WKWebView) {
+    private func makeHostedWebView() async -> (lease: HostedAppKitTestGate.Lease, window: NSWindow, webView: WKWebView) {
+        let lease = await HostedAppKitTestGate.shared.acquire()
         _ = Self.app
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
         let window = NSWindow(
@@ -102,8 +103,8 @@ struct QuoteHighlightWebViewTests {
         webView.autoresizingMask = [.width, .height]
         Self.retainedWindow?.orderOut(nil)
         Self.retainedWindow = window
-        window.makeKeyAndOrderFront(nil)
-        return (window, webView)
+        window.orderFront(nil)
+        return (lease, window, webView)
     }
 
     /// Run `js` (no expected return value) and await completion.
@@ -141,8 +142,8 @@ struct QuoteHighlightWebViewTests {
     // MARK: - Tests
 
     @Test func debugHighlightState() async throws {
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p>The data show a clear improvement in throughput.</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
         await run(webView, WikiReaderRep.highlightJS(quote: "clear improvement"))
@@ -163,8 +164,8 @@ struct QuoteHighlightWebViewTests {
     }
 
     @Test func highlightWrapsExactQuoteInMark() async throws {
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<h2 id=\"results\">Results</h2><p>The data show a clear improvement in throughput.</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -177,8 +178,8 @@ struct QuoteHighlightWebViewTests {
     @Test func highlightMatchesAcrossCollapsedWhitespace() async throws {
         // The source has extra internal whitespace / a newline; the quote is
         // single-spaced. The index-map fallback must still wrap the match.
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p>The  data show a clear\nimprovement here.</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -193,8 +194,8 @@ struct QuoteHighlightWebViewTests {
         // documentHTML, then the same highlight JS the reader runs.
         let markdown = "# Study\n\nThe results show a 30% improvement in latency."
         let body = MarkdownHTMLRenderer.render(ReaderMarkdown.prepared(markdown) { _, _ in true })
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
         await run(webView, WikiReaderRep.highlightJS(quote: "30% improvement"))
@@ -207,8 +208,8 @@ struct QuoteHighlightWebViewTests {
         // A quote that spans a <strong> boundary lives in TWO text nodes — the
         // common case for real source prose with inline formatting. The
         // highlight must still find + mark it (across both segments) and scroll.
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p><strong>AI is an amplifier.</strong> It magnifies the strengths of organizations.</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -231,8 +232,8 @@ struct QuoteHighlightWebViewTests {
         As Nathen Harvey said in the 2025 DORA report: “ [AI is an amplifier.](https://services.google.com/fh/files/misc/2025_state_of_ai_assisted_software_development.pdf) It magnifies the strengths of high-performing organizations and the dysfunctions of struggling ones.” AI will not solve for a lack of discipline.
         """
         let body = MarkdownHTMLRenderer.render(ReaderMarkdown.prepared(markdown) { _, _ in true })
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
         let quote = "AI is an amplifier. It magnifies the strengths of high-performing organizations and the dysfunctions of struggling ones."
@@ -249,8 +250,8 @@ struct QuoteHighlightWebViewTests {
         // "vo-" / "litional") into the MIDDLE of the sentence, so the full quote
         // never appears contiguously. The fallback must still highlight the
         // longest contiguous run that IS present and scroll to it.
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = """
         <p>More recently, the vo-</p>\
         <p>For reprints write to: Irving Kirsch, Ph.D., Department of Psychology, U-20.</p>\
@@ -270,8 +271,8 @@ struct QuoteHighlightWebViewTests {
     @Test func noFallbackHighlightForShortUnmatchedQuote() async throws {
         // A short quote (<4 words) that isn't present must NOT trigger a noisy
         // partial highlight — the fallback floor is 4 words.
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p>alpha beta gamma delta epsilon</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -282,8 +283,8 @@ struct QuoteHighlightWebViewTests {
 
     @Test func reHighlightClearsThePreviousMark() async throws {
         // A second highlight must remove the first mark, not stack them.
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p>alpha beta gamma delta</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -301,8 +302,8 @@ struct QuoteHighlightWebViewTests {
     /// `WikiReaderRep.apply(.quote, in:)` is what the Coordinator runs once the
     /// page has painted. Confirms the seam the pending-anchor consume drives.
     @Test func applyQuoteRunsHighlightJS() async throws {
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p>The data show a clear improvement in throughput.</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -317,8 +318,8 @@ struct QuoteHighlightWebViewTests {
     /// `pageLoaded` — exactly the lifecycle that runs in `didFinish`. If this
     /// fails, the trigger (not the JS) is where the source highlight breaks.
     @Test func coordinatorAppliesQuoteHighlightOnceLoaded() async throws {
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p>The data show a clear improvement in throughput.</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -338,8 +339,8 @@ struct QuoteHighlightWebViewTests {
     /// it (the version gate holds), so it doesn't re-run highlight on every
     /// `updateNSView`.
     @Test func coordinatorDoesNotReapplySameVersion() async throws {
-        let (window, webView) = makeHostedWebView()
-        defer { Self.releaseWindow(window) }
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
         let body = "<p>alpha beta gamma</p>"
         try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML(body))
 
@@ -420,10 +421,14 @@ struct QuoteHighlightWebViewTests {
         store.selectSource(byDisplayName: "paper", anchor: "\"clear improvement\"")
 
         let view = WikiReaderView(markdown: markdown, currentSelection: store.selection, store: store)
+        let lease = await HostedAppKitTestGate.shared.acquire()
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
-        window.makeKeyAndOrderFront(nil)
-        defer { window.orderOut(nil) }
+        window.orderFront(nil)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
 
         let webView = try await waitForWebView(in: window)
         let mark = await waitForMark(in: webView, tries: 40)

--- a/Tests/WikiFSAppTests/SidebarSelectAllShortcutTests.swift
+++ b/Tests/WikiFSAppTests/SidebarSelectAllShortcutTests.swift
@@ -14,7 +14,7 @@ import Testing
 /// hierarchy for every key-down, not just to the first responder — so the table
 /// must confirm it actually owns focus before consuming Cmd+A.
 @MainActor
-@Suite struct SidebarSelectAllShortcutTests {
+struct SidebarSelectAllShortcutTests {
 
     // MARK: - Helpers
 
@@ -33,12 +33,14 @@ import Testing
             keyCode: 0)
     }
 
-    private func makeWindow() -> NSWindow {
-        NSWindow(
+    private func makeWindow() async -> (HostedAppKitTestGate.Lease, NSWindow) {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 400),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false)
+        return (lease, window)
     }
 
     // MARK: - Pure gating predicate (no window/visibility dependency)
@@ -71,10 +73,10 @@ import Testing
 
     // MARK: - Integration: the reported bug (issue #154)
 
-    @Test func pagesTableDoesNotStealCmdAFromOmniboxField() throws {
+    @Test func pagesTableDoesNotStealCmdAFromOmniboxField() async throws {
         let event = try #require(cmdAEvent())
-        let window = makeWindow()
-        defer { window.orderOut(nil) }
+        let (lease, window) = await makeWindow()
+        defer { window.orderOut(nil); lease.release() }
         let table = PagesNSTableView()
         window.contentView?.addSubview(table)
         let omnibox = NSTextField(string: "omnibox text")
@@ -91,10 +93,10 @@ import Testing
         #expect(table.performKeyEquivalent(with: event) == false)
     }
 
-    @Test func sourcesTableDoesNotStealCmdAFromOmniboxField() throws {
+    @Test func sourcesTableDoesNotStealCmdAFromOmniboxField() async throws {
         let event = try #require(cmdAEvent())
-        let window = makeWindow()
-        defer { window.orderOut(nil) }
+        let (lease, window) = await makeWindow()
+        defer { window.orderOut(nil); lease.release() }
         let table = SourcesNSTableView()
         window.contentView?.addSubview(table)
         let omnibox = NSTextField(string: "omnibox text")
@@ -109,13 +111,13 @@ import Testing
 
     // MARK: - Only Cmd+A is intercepted
 
-    @Test func pagesTableDoesNotInterceptOtherCommandKeys() throws {
+    @Test func pagesTableDoesNotInterceptOtherCommandKeys() async throws {
         let event = try #require(NSEvent.keyEvent(
             with: .keyDown, location: .zero, modifierFlags: .command, timestamp: 0,
             windowNumber: 0, context: nil, characters: "b",
             charactersIgnoringModifiers: "b", isARepeat: false, keyCode: 11))
-        let window = makeWindow()
-        defer { window.orderOut(nil) }
+        let (lease, window) = await makeWindow()
+        defer { window.orderOut(nil); lease.release() }
         let table = PagesNSTableView()
         window.contentView?.addSubview(table)
         // Anything that isn't Cmd+A defers to super regardless of focus.

--- a/Tests/WikiFSAppTests/SplitDiffSnapshotTests.swift
+++ b/Tests/WikiFSAppTests/SplitDiffSnapshotTests.swift
@@ -11,7 +11,16 @@ import Testing
 /// dark window, lets async work settle, then writes PNGs so the redesigned diff
 /// and chrome can be eyeballed (the "acceptance test is a screenshot" this
 /// layout rework needs). A light structural assertion keeps them honest.
-@Suite
+///
+/// Opt-in only: these hosted snapshot renders can trigger macOS UI approval
+/// prompts in some local environments, so the default `swift test` path skips
+/// them unless the operator explicitly asks for this manual suite.
+@Suite(
+    "ManualSplitDiffSnapshotTests",
+    .disabled(
+        if: ProcessInfo.processInfo.environment["WIKIFS_UI_DIFF_SNAPSHOTS"] == nil,
+        "Set WIKIFS_UI_DIFF_SNAPSHOTS=1 to run the manual diff snapshot UI suite.")
+)
 @MainActor
 struct SplitDiffSnapshotTests {
     private static let snapshotsDirectory: URL = {
@@ -37,7 +46,7 @@ struct SplitDiffSnapshotTests {
         let window = NSWindow(contentViewController: hosting)
         window.appearance = NSAppearance(named: .darkAqua)
         window.setContentSize(size)
-        window.makeKeyAndOrderFront(nil)
+        window.orderFront(nil)
         defer { window.orderOut(nil) }
 
         for _ in 0..<settle { try await Task.sleep(for: .milliseconds(30)) }
@@ -60,6 +69,8 @@ struct SplitDiffSnapshotTests {
     // MARK: - SplitDiffView in isolation
 
     @Test func renderDiffPaneToPNG() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         let left = SampleDiff.left, right = SampleDiff.right
         let view = SplitDiffView(leftLabel: "Legacy", rightLabel: "Unknown",
                                  left: left, right: right)
@@ -70,6 +81,8 @@ struct SplitDiffSnapshotTests {
     // MARK: - Full ExtractionCompareSheet (chrome + HSplitView context + nominate)
 
     @Test func renderFullSheetBothModesAndNominate() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         let store = try makeTwoBackendStore()
         let sourceID = store.sources.first { $0.filename.hasSuffix(".pdf") }!.id
 

--- a/Tests/WikiFSAppTests/YouTubeEmbedWebViewTests.swift
+++ b/Tests/WikiFSAppTests/YouTubeEmbedWebViewTests.swift
@@ -76,13 +76,14 @@ struct YouTubeEmbedWebViewTests {
     }
 
     @MainActor
-    private func hostedReader(markdown: String, store: WikiStoreModel) throws
-        -> (window: NSWindow, webView: WKWebView) {
+    private func hostedReader(markdown: String, store: WikiStoreModel) async throws
+        -> (lease: HostedAppKitTestGate.Lease, window: NSWindow, webView: WKWebView) {
+        let lease = await HostedAppKitTestGate.shared.acquire()
         let view = WikiReaderView(markdown: markdown, currentSelection: store.selection, store: store)
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
-        window.makeKeyAndOrderFront(nil)
-        return (window, findWebView(window.contentView!) ?? WKWebView())
+        window.orderFront(nil)
+        return (lease, window, findWebView(window.contentView!) ?? WKWebView())
     }
 
     /// The gold-standard AC.9 reproduction: seed a byteless YouTube source, render
@@ -112,8 +113,11 @@ struct YouTubeEmbedWebViewTests {
         // WikiRenderContext.embedInfo → ExternalEmbed.target.
         let markdown = "# Watch\n\n![[source:youtube-\(videoID)]]"
 
-        let (window, _) = try hostedReader(markdown: markdown, store: store)
-        defer { window.orderOut(nil) }
+        let (lease, window, _) = try await hostedReader(markdown: markdown, store: store)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
         let webView = try await waitForWebView(in: window)
 
         // 1. The iframe painted with the corrected embed URL (origin threaded in).


### PR DESCRIPTION
## Summary

- restore the hosted AppKit and WebKit test serialization changes omitted from the final PR #945 merge tree
- keep window-owning tests from stealing key focus
- exclude the macOS integration test target from the default SwiftPM test graph
- enable the target with `WIKIFS_APP_TESTS=1 swift test`
- keep manual diff snapshots behind `WIKIFS_UI_DIFF_SNAPSHOTS=1`

## Reason

The macOS integration suites pass in smaller groups, but the combined target can wedge SwiftPM's shared test helper. The default test command then leaves an orphaned helper and never exits. The portable target does not reproduce the problem.

## Verification

- `swift test`: 2,480 tests passed in 8.87 seconds
- default `swift test list`: 0 WikiFSAppTests cases
- `WIKIFS_APP_TESTS=1 swift test list`: 1,479 WikiFSAppTests cases and the target compiles
- commit hook: 373 Swift files linted, 0 violations
- `git diff --check`: passed