### PR TITLE
Remove daemon status banner from content view

### DIFF
--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -55,12 +55,6 @@ struct ContentView: View {
 
     var body: some View {
         baseContent
-        // #878: daemon status banner (red disconnected) at the very top of
-        // the content area. The positive "reconnected" signal surfaces as a
-        // menu-bar hint popover, not here.
-        .safeAreaInset(edge: .top, spacing: 0) {
-            DaemonStatusBanner()
-        }
         .sheet(item: $pendingAddURL) { pending in
             AddFromURLSheet(store: store, initialURL: pending.url)
         }


### PR DESCRIPTION
Removes the daemon status banner that was displayed at the top of the content area. The connection status indication is now provided solely through the menu bar hint popover, making this top-level visual redundant.

Related to #878.