### PR TITLE
Follow up PR #952 bookmark validation and SourceID signature coverage

### DIFF
--- a/Sources/WikiFSCore/Core/BookmarkNode.swift
+++ b/Sources/WikiFSCore/Core/BookmarkNode.swift
@@ -113,27 +113,47 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
             guard label == nil else {
                 throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "page reference has label")
             }
-            guard let targetRawValue else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "page reference requires target_id")
-            }
+            let targetRawValue = try requiredTargetRawValue(
+                bookmarkID: bookmarkID,
+                targetRawValue: targetRawValue,
+                referenceName: "page reference"
+            )
             return .page(PageID(rawValue: targetRawValue))
         case .sourceRef:
             guard label == nil else {
                 throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "source reference has label")
             }
-            guard let targetRawValue else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "source reference requires target_id")
-            }
+            let targetRawValue = try requiredTargetRawValue(
+                bookmarkID: bookmarkID,
+                targetRawValue: targetRawValue,
+                referenceName: "source reference"
+            )
             return .source(SourceID(rawValue: targetRawValue))
         case .chatRef:
             guard label == nil else {
                 throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "chat reference has label")
             }
-            guard let targetRawValue else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "chat reference requires target_id")
-            }
+            let targetRawValue = try requiredTargetRawValue(
+                bookmarkID: bookmarkID,
+                targetRawValue: targetRawValue,
+                referenceName: "chat reference"
+            )
             return .chat(PageID(rawValue: targetRawValue))
         }
+    }
+
+    private static func requiredTargetRawValue(
+        bookmarkID: String,
+        targetRawValue: String?,
+        referenceName: String
+    ) throws -> String {
+        guard let targetRawValue else {
+            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "\(referenceName) requires target_id")
+        }
+        guard targetRawValue.isEmpty == false else {
+            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "\(referenceName) requires a non-empty target_id")
+        }
+        return targetRawValue
     }
 
     /// Builds a slash-delimited display path for a folder by walking its

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -5858,9 +5858,12 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         try mutate(event: { node in
             self.localEvent(.bookmark, id: node.id, change: .created)
         }) { db in
-            if case .folder(let label) = content, label.isEmpty {
-                throw WikiStoreError.invalidBookmarkRow(id: "<new bookmark>", reason: "folder requires a non-empty label")
-            }
+            _ = try BookmarkNode.content(
+                bookmarkID: "<new bookmark>",
+                kindRawValue: content.kind.rawValue,
+                label: content.label,
+                targetRawValue: content.targetRawValue
+            )
             let id = ULID.generate()
             let now = Date().timeIntervalSince1970
 

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -33,14 +33,24 @@ import SQLite3
         #expect(sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK)
     }
 
-    private func expectInvalidBookmarkRow(_ operation: () throws -> Void) {
+    private func expectInvalidBookmarkRow(
+        id expectedID: String? = nil,
+        reason expectedReason: String? = nil,
+        _ operation: () throws -> Void
+    ) {
         do {
             try operation()
             Issue.record("expected invalid bookmark row")
         } catch let error as WikiStoreError {
-            guard case .invalidBookmarkRow = error else {
+            guard case let .invalidBookmarkRow(id, reason) = error else {
                 Issue.record("unexpected error: \(error)")
                 return
+            }
+            if let expectedID {
+                #expect(id == expectedID)
+            }
+            if let expectedReason {
+                #expect(reason == expectedReason)
             }
         } catch {
             Issue.record("unexpected error: \(error)")
@@ -102,6 +112,51 @@ import SQLite3
         let store = try GRDBWikiStore(databaseURL: url)
         try insertBookmarkRow(at: url, id: "bad-\(name)", kind: kind, label: label, targetID: targetID)
         expectInvalidBookmarkRow { _ = try store.listBookmarkNodes() }
+    }
+
+    @Test(arguments: [
+        ("page_ref", "page reference requires a non-empty target_id"),
+        ("source_ref", "source reference requires a non-empty target_id"),
+        ("chat_ref", "chat reference requires a non-empty target_id"),
+    ]) func emptyReferenceTargetsInPersistedRowsAreRejected(
+        _ kind: String,
+        _ expectedReason: String
+    ) throws {
+        let url = tempDatabaseURL()
+        let store = try GRDBWikiStore(databaseURL: url)
+        let id = "bad-\(kind)-empty-target"
+        try insertBookmarkRow(at: url, id: id, kind: kind, label: nil, targetID: "")
+        expectInvalidBookmarkRow(id: id, reason: expectedReason) {
+            _ = try store.listBookmarkNodes()
+        }
+    }
+
+    @Test(arguments: [
+        (BookmarkNodeKind.pageRef, "page reference requires a non-empty target_id"),
+        (BookmarkNodeKind.sourceRef, "source reference requires a non-empty target_id"),
+        (BookmarkNodeKind.chatRef, "chat reference requires a non-empty target_id"),
+    ]) func emptyReferenceTargetsAreRejectedBeforeWrite(
+        _ kind: BookmarkNodeKind,
+        _ expectedReason: String
+    ) throws {
+        let store = try GRDBWikiStore(databaseURL: tempDatabaseURL())
+        let content: BookmarkNode.Content
+        switch kind {
+        case .pageRef:
+            content = .page(PageID(rawValue: ""))
+        case .sourceRef:
+            content = .source(SourceID(rawValue: ""))
+        case .chatRef:
+            content = .chat(PageID(rawValue: ""))
+        case .folder:
+            Issue.record("folder is not a reference bookmark kind")
+            return
+        }
+
+        expectInvalidBookmarkRow(id: "<new bookmark>", reason: expectedReason) {
+            _ = try store.createBookmarkNode(parentID: nil, position: 0, content: content)
+        }
+        #expect(try store.listBookmarkNodes().isEmpty)
     }
 
     // MARK: - Schema migration (AC.1)

--- a/Tests/WikiFSTests/Fixtures/SourceAPISignatures.txt
+++ b/Tests/WikiFSTests/Fixtures/SourceAPISignatures.txt
@@ -93,7 +93,10 @@ Sources/WikiFSCore/Core/WikiRenderContext.swift	public let sourceIDToName: [Sour
 Sources/WikiFSCore/Core/WikiRenderContext.swift	public let sourceDerivedChain: [SourceID: [PageID]]
 Sources/WikiFSCore/Core/WikiRenderContext.swift	public let siblingMaps: [SourceID: [String: SourceID]]
 Sources/WikiFSCore/Core/WikiRenderContext.swift	public var pinnedExtractionID: (SourceID, Int) -> PageID?
+Sources/WikiFSCore/Core/FilenameEscaping.swift	public static func byIDSourceFilename(sourceID: SourceID, ext: String) -> String
+Sources/WikiFSCore/Core/FilenameEscaping.swift	public static func byNameSourceFilename(filename: String, ext: String, sourceID: SourceID) -> String
 Sources/WikiFSCore/Core/BookmarkNode.swift	case source(SourceID)
+Sources/WikiFSCore/Sources/AgentStaging.swift	public static func shellSafeLeaf(name: String, sourceID: SourceID, ext: String) -> String {
 Sources/WikiFSLinks/WikiLinkMarkdown.swift	        public let id: SourceID
 Sources/WikiFSLinks/WikiLinkMarkdown.swift	        public init(id: SourceID, mimeType: String?, target: EmbedTarget? = nil)
 Sources/WikiFSLinks/WikiLinkIndex.swift	    public let siblingImages: [SourceID: [String: SourceID]]


### PR DESCRIPTION
## Summary

- reject empty bookmark target ids when decoding persisted `bookmark_nodes` rows
- reject empty typed bookmark target ids at `createBookmarkNode(...)` before write
- add Swift Testing coverage for empty page/source/chat bookmark targets from raw SQL and API creation attempts
- extend `SourceAPISignatures.txt` to cover `FilenameEscaping.byIDSourceFilename`, `FilenameEscaping.byNameSourceFilename`, and `AgentStaging.shellSafeLeaf`

Fixes follow-up review findings from #952.

## Verification

- `make prompts`
- `make version`
- `make keychain`
- `swift build --build-tests`
- `swift test --filter BookmarkNodeStoreTests`
- `swift test --filter SourceAPISignatureManifestTests`
- `swift test --filter FilenameEscapingTests`
- `swift test --filter AgentStagingTests`
- `swift test`
- `make lint`
- `git diff --check`
