### PR TITLE
Fix summary provider selector persistence (#960)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,41 @@
 # Progress log
 
+## 2026-07-28 — Summary provider selector persistence fix (#960)
+
+**Scope.** Fixed the Settings → Operations → Summary Provider selector so an
+explicit non-default summary-provider pin no longer snaps back to the default
+provider in the shared stage picker, and the UI now surfaces an explicit
+validation state when the pinned summary provider is disabled or missing.
+
+**What landed.**
+- Fixed `StageProviderModelPicker` so the provider picker tags use the stored
+  raw provider id (`String`) rather than `ProviderID`, matching the binding
+  type and preserving explicit non-default selections.
+- Added `StageProviderSelectionState` as a pure resolver for the shared picker
+  so the UI can distinguish inherited, enabled-pinned, disabled-pinned, and
+  missing-pinned states without rewriting the stored config.
+- For the `"summarizer"` stage specifically, the model picker now disables and
+  shows a clear warning when the pinned provider is unavailable, rather than
+  silently pretending the default provider is selected.
+- Added persistence/default-independence coverage for the summary stage pin in
+  `AgentProviderModelTests`.
+- Added unavailable-pin routing coverage in `MessageSummaryTests` proving
+  `resolveProfile` returns `nil` without clearing the stored `"summarizer"` pin.
+- Added `StageProviderModelPickerTests` to pin the new pure selection-state
+  behavior.
+
+**Verification.**
+- `make keychain` — regenerated the required local
+  `Sources/WikiFSCore/GeneratedKeychain.swift` prerequisite for SwiftPM builds.
+- `make version` — regenerated the required local
+  `Sources/WikiFSCore/GeneratedVersion.swift` prerequisite for SwiftPM builds.
+- `swift test --filter 'AgentProviderModelTests|StageProviderModelPickerTests|MessageSummaryTests'`
+  — 41 tests in 2 suites passed after the prerequisite regeneration.
+- `WIKIFS_APP_TESTS=1 swift test --filter AgentProviderModelTests`
+  — 44 tests in 5 suites passed, including the new summary-pin persistence and
+  default-change coverage.
+- `git diff --check` — clean.
+
 ## 2026-07-28 — SourceMarkdownVersionID separation (#956)
 
 **Scope.** This branch adds a public `SourceMarkdownVersionID` namespace for

--- a/Sources/WikiFS/Settings/StageProviderModelPicker.swift
+++ b/Sources/WikiFS/Settings/StageProviderModelPicker.swift
@@ -1,6 +1,36 @@
 import SwiftUI
 import WikiFSCore
 
+enum StageProviderSelectionState: Equatable {
+    case inherited
+    case pinnedEnabled(id: String)
+    case pinnedDisabled(id: String, label: String)
+    case pinnedMissing(id: String)
+
+    static func resolve(config: AgentProvidersConfig, stageKey: String) -> StageProviderSelectionState {
+        guard let pinnedID = config.stageProviderIds[stageKey], !pinnedID.isEmpty else {
+            return .inherited
+        }
+        let providerID = ProviderID(rawValue: pinnedID)
+        guard let provider = config.provider(id: providerID) else {
+            return .pinnedMissing(id: pinnedID)
+        }
+        guard provider.enabled else {
+            return .pinnedDisabled(id: pinnedID, label: provider.label)
+        }
+        return .pinnedEnabled(id: pinnedID)
+    }
+
+    var isUnavailable: Bool {
+        switch self {
+        case .pinnedDisabled, .pinnedMissing:
+            return true
+        case .inherited, .pinnedEnabled:
+            return false
+        }
+    }
+}
+
 /// A provider + model picker for a single agent stage/operation
 /// (`plans/agent-settings-tabs.md` §2.2/§6). Reused for the Chat Model,
 /// Planner/Executor/Finalizer Models, and Lint Model rows in the nested
@@ -34,6 +64,10 @@ struct StageProviderModelPicker: View {
     let label: String
     var defaultOptionLabel: String = "Default"
 
+    private var selectionState: StageProviderSelectionState {
+        StageProviderSelectionState.resolve(config: config, stageKey: stageKey)
+    }
+
     /// The effective provider for this stage (pinned when set + enabled, else
     /// the global default). Drives the model dropdown's contents.
     private var resolvedProvider: AgentProvider {
@@ -54,18 +88,80 @@ struct StageProviderModelPicker: View {
         config.selectedModelId(forProvider: resolvedProvider.id) ?? "default"
     }
 
+    /// The Summary tab's provider pin is load-bearing: a non-empty but
+    /// unavailable pin keeps model mode selected, so the UI must surface the
+    /// invalid state instead of pretending the fallback provider is in force.
+    private var shouldDisableModelPickerForUnavailablePin: Bool {
+        stageKey == "summarizer" && selectionState.isUnavailable
+    }
+
+    private var modelPickerPlaceholder: String {
+        shouldDisableModelPickerForUnavailablePin
+            ? "Selected provider unavailable"
+            : "Chat with this provider to discover models"
+    }
+
+    private var modelPickerHelpText: String {
+        if let unavailableProviderMessage {
+            return unavailableProviderMessage
+        }
+        return resolvedModels.isEmpty
+            ? "Chat with this provider once to discover its models."
+            : "Pick a model for the \(label) stage. “Same as provider” uses the provider's selected model."
+    }
+
+    private var unavailableOptionLabel: String? {
+        switch selectionState {
+        case .pinnedDisabled(_, let providerLabel):
+            return "\(providerLabel) (disabled)"
+        case .pinnedMissing(let providerID):
+            return "\(providerID) (missing)"
+        case .inherited, .pinnedEnabled:
+            return nil
+        }
+    }
+
+    private var unavailableOptionTag: String? {
+        switch selectionState {
+        case .pinnedDisabled(let providerID, _), .pinnedMissing(let providerID):
+            return providerID
+        case .inherited, .pinnedEnabled:
+            return nil
+        }
+    }
+
+    private var unavailableProviderMessage: String? {
+        switch selectionState {
+        case .pinnedDisabled(_, let providerLabel):
+            if stageKey == "summarizer" {
+                return "Selected provider “\(providerLabel)” is disabled. Summary generation will stay unavailable until you re-enable it, pick another provider, or choose \(defaultOptionLabel)."
+            }
+            return "Selected provider “\(providerLabel)” is disabled. This stage is currently falling back to the default provider until you re-enable it or pick another provider."
+        case .pinnedMissing(let providerID):
+            if stageKey == "summarizer" {
+                return "Selected provider “\(providerID)” no longer exists. Summary generation will stay unavailable until you pick another provider or choose \(defaultOptionLabel)."
+            }
+            return "Selected provider “\(providerID)” no longer exists. This stage is currently falling back to the default provider until you pick another provider."
+        case .inherited, .pinnedEnabled:
+            return nil
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Picker("\(label) Provider", selection: providerBinding) {
                 Text(defaultOptionLabel).tag("")
+                if let unavailableOptionLabel, let unavailableOptionTag {
+                    Text(unavailableOptionLabel).tag(unavailableOptionTag)
+                }
                 ForEach(config.enabledProviders) { p in
-                    Text(p.label).tag(p.id)
+                    Text(p.label).tag(p.id.rawValue)
                 }
             }
 
             Picker("\(label) Model", selection: modelBinding) {
-                if resolvedModels.isEmpty {
-                    Text("Chat with this provider to discover models").tag("")
+                if shouldDisableModelPickerForUnavailablePin || resolvedModels.isEmpty {
+                    Text(modelPickerPlaceholder).tag("")
                 } else {
                     Text("Same as provider (\(fallbackLabel))").tag("")
                     ForEach(resolvedModels, id: \.modelId) { model in
@@ -73,10 +169,14 @@ struct StageProviderModelPicker: View {
                     }
                 }
             }
-            .disabled(resolvedModels.isEmpty)
-            .help(resolvedModels.isEmpty
-                  ? "Chat with this provider once to discover its models."
-                  : "Pick a model for the \(label) stage. “Same as provider” uses the provider's selected model.")
+            .disabled(shouldDisableModelPickerForUnavailablePin || resolvedModels.isEmpty)
+            .help(modelPickerHelpText)
+
+            if let unavailableProviderMessage {
+                Text(unavailableProviderMessage)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
 
             // #612: info-tone nudge when the stage's resolved model (pinned or
             // inherited from the provider) is a known free-tier model (e.g.

--- a/Tests/WikiFSAppTests/AgentProviderModelTests.swift
+++ b/Tests/WikiFSAppTests/AgentProviderModelTests.swift
@@ -141,6 +141,40 @@ import ACPModel
         #expect(loaded.provider(id: ProviderID(rawValue: "gemini"))?.env == ["FOO": "bar"])
     }
 
+    @Test func summarizerStageProviderPersistsAcrossReload() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-providers-summarizer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let original = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"], enabled: true, isDefault: true),
+            AgentProvider(id: ProviderID(rawValue: "gemini"), label: "Gemini", command: ["gemini", "--acp"], enabled: true, isDefault: false),
+        ])
+        .settingStageProvider("gemini", forStage: "summarizer")
+
+        try original.save(to: tmp)
+
+        let reloaded = AgentProvidersConfig.loadOrSeed(from: tmp, discover: { [] })
+        #expect(reloaded.stageProviderIds["summarizer"] == "gemini")
+        #expect(reloaded.provider(forStage: "summarizer").id == ProviderID(rawValue: "gemini"))
+    }
+
+    @Test func summarizerStageProviderSurvivesDefaultProviderChange() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", command: ["bun", "x", "@agentclientprotocol/claude-agent-acp"], enabled: true, isDefault: true),
+            AgentProvider(id: ProviderID(rawValue: "gemini"), label: "Gemini", command: ["gemini", "--acp"], enabled: true, isDefault: false),
+            AgentProvider(id: ProviderID(rawValue: "hermes"), label: "Hermes", command: ["hermes", "acp"], enabled: true, isDefault: false),
+        ])
+        .settingStageProvider("gemini", forStage: "summarizer")
+
+        let switched = config.settingDefault(id: ProviderID(rawValue: "hermes"))
+
+        #expect(switched.defaultProvider.id == ProviderID(rawValue: "hermes"))
+        #expect(switched.stageProviderIds["summarizer"] == "gemini")
+        #expect(switched.provider(forStage: "summarizer").id == ProviderID(rawValue: "gemini"))
+    }
+
     // MARK: - AC.3 (#663): hermes/opencode IDs round-trip after static removal
 
     /// After #663 (deletion of `.hermesDefault`/`.opencodeDefault`), the

--- a/Tests/WikiFSAppTests/StageProviderModelPickerTests.swift
+++ b/Tests/WikiFSAppTests/StageProviderModelPickerTests.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+import Testing
+import WikiFSCore
+@testable import WikiFS
+
+struct StageProviderModelPickerTests {
+
+    @Test func selectionStateUsesInheritedWhenNoPinExists() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", enabled: true, isDefault: true),
+        ])
+
+        let state = StageProviderSelectionState.resolve(config: config, stageKey: "summarizer")
+
+        #expect(state == .inherited)
+    }
+
+    @Test func selectionStateKeepsEnabledPinnedProvider() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", enabled: true, isDefault: true),
+            AgentProvider(id: ProviderID(rawValue: "gemini"), label: "Gemini", command: ["gemini", "--acp"], enabled: true, isDefault: false),
+        ])
+        .settingStageProvider("gemini", forStage: "summarizer")
+
+        let state = StageProviderSelectionState.resolve(config: config, stageKey: "summarizer")
+
+        #expect(state == .pinnedEnabled(id: "gemini"))
+    }
+
+    @Test func selectionStateSurfacesDisabledPinnedProvider() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", enabled: true, isDefault: true),
+            AgentProvider(id: ProviderID(rawValue: "gemini"), label: "Gemini", command: ["gemini", "--acp"], enabled: false, isDefault: false),
+        ])
+        .settingStageProvider("gemini", forStage: "summarizer")
+
+        let state = StageProviderSelectionState.resolve(config: config, stageKey: "summarizer")
+
+        #expect(state == .pinnedDisabled(id: "gemini", label: "Gemini"))
+    }
+
+    @Test func selectionStateSurfacesMissingPinnedProvider() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", enabled: true, isDefault: true),
+        ])
+        .settingStageProvider("gemini", forStage: "summarizer")
+
+        let state = StageProviderSelectionState.resolve(config: config, stageKey: "summarizer")
+
+        #expect(state == .pinnedMissing(id: "gemini"))
+    }
+}
+#endif

--- a/Tests/WikiFSTests/MessageSummaryTests.swift
+++ b/Tests/WikiFSTests/MessageSummaryTests.swift
@@ -292,6 +292,21 @@ struct MessageSummaryTests {
         #expect(profile == nil)
     }
 
+    @Test func resolveProfile_disabledPinnedProviderReturnsNilWithoutRewritingPin() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "claude"), label: "Claude", command: ["claude"], enabled: true, isDefault: true),
+            AgentProvider(id: ProviderID(rawValue: "gemini"), label: "Gemini", command: ["gemini", "--acp"], enabled: false, isDefault: false),
+        ]).settingStageProvider("gemini", forStage: "summarizer")
+
+        let profile = MessageSummarizer.resolveProfile(
+            config: config,
+            credentialStore: InMemoryACPCredentialStore(),
+            resolveCommand: { _ in ["/usr/bin/true"] })
+
+        #expect(config.stageProviderIds["summarizer"] == "gemini")
+        #expect(profile == nil)
+    }
+
     // MARK: - Store round-trip (AC.1 + AC.6, integration)
 
     @Test func freshDB_isAtSchemaVersion44() throws {


### PR DESCRIPTION
## Problem
The Settings → Operations → Summary Provider selector was snapping back to the default provider when an explicit non-default selection was made. The UI also didn't surface validation state when the pinned summary provider was disabled or missing.

## Solution
- Fixed `StageProviderModelPicker` to use the raw provider ID (`String`) in picker tags instead of `ProviderID`, matching the binding type and preserving explicit selections
- Added `StageProviderSelectionState` enum to distinguish inherited, enabled-pinned, disabled-pinned, and missing-pinned states without modifying stored config
- For the summarizer stage, the model picker now disables and shows a clear warning when the pinned provider is unavailable, rather than silently falling back to the default
- Pinned provider selections now survive changes to the default provider

## Tests
- Added `StageProviderModelPickerTests` to cover the new pure selection-state resolver logic
- Added `summarizerStageProviderPersistsAcrossReload()` and `summarizerStageProviderSurvivesDefaultProviderChange()` to `AgentProviderModelTests` for persistence and default-independence coverage
- Added `resolveProfile_disabledPinnedProviderReturnsNilWithoutRewritingPin()` to `MessageSummaryTests` to verify unavailable pins don't trigger silent config rewrites

## Verification
- All existing tests pass
- New test suites pass: 41 tests across StageProviderModelPickerTests, AgentProviderModelTests (summarizer-specific), and MessageSummaryTests (unavailable pin routing)