### PR TITLE
Apply strong page version identifiers throughout

### DIFF
--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -251,7 +251,7 @@ public enum ArgumentParser {
                 throw Failure.usage("page add: --body-file is required (path or -)")
             }
             let id = options.value("--id").map { PageID(rawValue: $0) }
-            let expectHead = options.value("--expect-head")
+            let expectHead = options.value("--expect-head").map(PageVersionID.init(rawValue:))
             let workspace = options.value("--workspace")
             let author = options.value("--author")
             return .page(.add(id: id, title: title, body: .file(bodyFile), expectHead: expectHead, workspace: workspace, author: author))
@@ -281,7 +281,7 @@ public enum ArgumentParser {
             return .page(.history(try options.requireSelector()))
 
         case "revert":
-            guard let versionID = options.value("--version") else {
+            guard let versionID = options.value("--version").map(PageVersionID.init(rawValue:)) else {
                 throw Failure.usage("page revert: --version is required")
             }
             return .page(.revert(try options.requireSelector(), versionID: versionID))

--- a/Sources/WikiCtlCore/PageCommand.swift
+++ b/Sources/WikiCtlCore/PageCommand.swift
@@ -39,7 +39,7 @@ public enum PageCommand {
         /// caller read before editing); when non-nil, the upsert routes through
         /// `appendPageVersion` and a mismatch throws `PageConflictError`
         /// (Phase 1: agent CAS writes).
-        case add(id: PageID?, title: String, body: BodySource, expectHead: String? = nil, workspace: String? = nil, author: String? = nil)
+        case add(id: PageID?, title: String, body: BodySource, expectHead: PageVersionID? = nil, workspace: String? = nil, author: String? = nil)
         case delete(id: PageID)
         /// Semantic search: find pages by meaning (cosine similarity via
         /// Swift-side `VectorCosine`), falling back to LIKE title match.
@@ -49,7 +49,7 @@ public enum PageCommand {
         case history(Selector)
         /// Revert a page to a specific version (W0, PR #312). Repoints the
         /// page-content ref to `versionID` and updates the body mirror.
-        case revert(Selector, versionID: String)
+        case revert(Selector, versionID: PageVersionID)
         /// Print identity (id, title, slug, created/updated, version count) +
         /// origin provenance (HEAD's agent + activity, edit history) for a
         /// page. Mirrors `source info` (`SourceCommand.info`) — a read-side
@@ -246,7 +246,7 @@ public enum PageCommand {
         id: PageID?,
         title: String,
         body: String,
-        expectHead: String? = nil,
+        expectHead: PageVersionID? = nil,
         workspace: String? = nil,
         author: String? = nil,
         in store: WikiStore,
@@ -298,9 +298,8 @@ public enum PageCommand {
         // 3. The SHARED seam: identical create-or-update + `[[link]]` reparse as
         //    the in-app editor, so the link graph stays consistent across both
         //    writers.
-        let expectedHeadVersionID = expectHead.map(PageVersionID.init(rawValue:))
         let outcome = try PageUpsert.upsert(in: store, id: id, title: title, body: fixed,
-                                             expectedHeadVersionID: expectedHeadVersionID, author: author)
+                                             expectedHeadVersionID: expectHead, author: author)
         return Result(output: outcome.id.rawValue, didCommit: true)
     }
 
@@ -367,12 +366,11 @@ public enum PageCommand {
     // MARK: - revert (W0, PR #312)
 
     private static func revert(
-        _ selector: Selector, versionID: String, in store: WikiStore
+        _ selector: Selector, versionID: PageVersionID, in store: WikiStore
     ) throws -> Result {
         let id = try resolve(selector, in: store)
-        let typedVersionID = PageVersionID(rawValue: versionID)
-        try store.revertPage(pageID: id, to: typedVersionID)
-        return Result(output: "reverted \(id.rawValue) to \(versionID)", didCommit: true)
+        try store.revertPage(pageID: id, to: versionID)
+        return Result(output: "reverted \(id.rawValue) to \(versionID.rawValue)", didCommit: true)
     }
 
     // MARK: - info (page provenance, #page-provenance)

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -5073,7 +5073,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             WHERE workspace_id = ? AND kind = 'page-content' AND owner_id = ?;
             """, arguments: [workspaceID, pageID.rawValue]) else { return nil }
 
-            let versionID: String? = row["version_id"]
+            let versionID = (row["version_id"] as String?).map(PageVersionID.init(rawValue:))
             let blobHash: String? = row["blob_hash"]
 
             if let versionID {
@@ -5081,7 +5081,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 if let blobRow = try Row.fetchOne(db, sql: """
                 SELECT pv.blob_hash, b.content FROM page_versions pv
                 JOIN blobs b ON b.hash = pv.blob_hash WHERE pv.id = ?;
-                """, arguments: [versionID]) {
+                """, arguments: [versionID.rawValue]) {
                     let data: Data = blobRow["content"]
                     return String(data: data, encoding: .utf8)
                 }
@@ -7202,7 +7202,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// LEFT-joined columns can be NULL. Position 7 is the `runTitle` subquery
     /// (#745) — NULL for non-chat agents or when the chat has been deleted.
     private static func originFrom(row: Row) -> SourceOrigin {
-        let versionID: String = (row[0] as String?) ?? ""
+        let versionID = SourceVersionID(rawValue: (row[0] as String?) ?? "")
         let agentName: String? = row[1]
         let agentKind: String? = row[2]
         let activityKind: String? = row[3]
@@ -7212,7 +7212,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         let fetchedAt: Double = (row[7] as Double?) ?? 0
         let runTitle: String? = row[8]
         return SourceOrigin(
-            versionID: SourceVersionID(rawValue: versionID),
+            versionID: versionID,
             agentName: agentName ?? "unknown",
             agentKind: agentKind ?? "software",
             activityKind: activityKind ?? "import",

--- a/Tests/WikiFSTests/AgentCASTests.swift
+++ b/Tests/WikiFSTests/AgentCASTests.swift
@@ -34,7 +34,7 @@ struct AgentCASTests {
         // Upsert with the correct head → should succeed (no conflict).
         let result = try PageCommand.run(
             .add(id: page.id, title: "CAS Page", body: .inline("v2 body"),
-                     expectHead: head?.rawValue),
+                     expectHead: head),
             in: store)
         #expect(result.didCommit == true)
 
@@ -66,7 +66,7 @@ struct AgentCASTests {
         #expect(throws: PageConflictError.self) {
             _ = try PageCommand.run(
                 .add(id: page.id, title: "Stale Page", body: .inline("v2 body (original)"),
-                         expectHead: oldHead?.rawValue),
+                         expectHead: oldHead),
                 in: store)
         }
 
@@ -127,7 +127,7 @@ struct AgentCASTests {
             return
         }
         #expect(title == "Test")
-        #expect(expectHead == "01ABC123")
+        #expect(expectHead == PageVersionID(rawValue: "01ABC123"))
     }
 
     @Test func parserParsesGetJson() throws {

--- a/Tests/WikiFSTests/Fixtures/SourceVersionAPISignatures.txt
+++ b/Tests/WikiFSTests/Fixtures/SourceVersionAPISignatures.txt
@@ -21,7 +21,7 @@ grdb.private-active-content-version	surface	Sources/WikiFSCore/Store/GRDBWikiSto
 grdb.public-active-content-version	surface	Sources/WikiFSCore/Store/GRDBWikiStore.swift	public func activeContentVersion(sourceID: SourceID) throws -> SourceVersion?
 grdb.read-source-version	surface	Sources/WikiFSCore/Store/GRDBWikiStore.swift	private static func readSourceVersion(from row: Row) throws -> SourceVersion
 grdb.read-source-version.decode-id	typed	Sources/WikiFSCore/Store/GRDBWikiStore.swift	id: SourceVersionID(rawValue: id),
-grdb.origin-from	typed	Sources/WikiFSCore/Store/GRDBWikiStore.swift	versionID: SourceVersionID(rawValue: versionID),
+grdb.origin-from	typed	Sources/WikiFSCore/Store/GRDBWikiStore.swift	let versionID = SourceVersionID(rawValue: (row[0] as String?) ?? "")
 grdb.public-append-content-version	surface	Sources/WikiFSCore/Store/GRDBWikiStore.swift	) throws -> SourceVersion {
 grdb.public-append-content-version.writer	typed	Sources/WikiFSCore/Store/GRDBWikiStore.swift	let versionID = SourceVersionID(rawValue: ULID.generate())
 grdb.record-markdown-extraction	typed	Sources/WikiFSCore/Store/GRDBWikiStore.swift	sourceVersionID: SourceVersionID? = nil, note: String? = nil, modelVersion: String? = nil

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -78,6 +78,13 @@ struct WikiCtlCommandTests {
         #expect(update.command == .page(.add(id: PageID(rawValue: "01X"), title: "T", body: .file("body.md"), expectHead: nil, workspace: nil, author: nil)))
     }
 
+    @Test func parsesRevertWithTypedVersionID() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "revert", "--id", "01X", "--version", "01V"],
+            env: noEnv)
+        #expect(invocation.command == .page(.revert(.id(PageID(rawValue: "01X")), versionID: PageVersionID(rawValue: "01V"))))
+    }
+
     @Test func upsertRequiresTitleAndBodyFile() {
         #expect(throws: ArgumentParser.Failure.self) {
             try ArgumentParser.parse(


### PR DESCRIPTION
Use PageVersionID and SourceVersionID types consistently in command execution and storage layers, replacing raw string types.

## Changes

- **ArgumentParser**: Convert version ID strings to PageVersionID/SourceVersionID at the parsing boundary
- **PageCommand**: Accept PageVersionID types in add/revert cases and pass them directly to store methods, removing intermediate conversions
- **GRDBWikiStore**: Use the strongly-typed version IDs in storage queries, converting to rawValue only when needed for database operations
- **Tests**: Update test cases to pass and expect PageVersionID typed values

## Why

Consolidating version ID conversions at the command-line boundary (ArgumentParser) and using strong types throughout eliminates duplicate conversion logic and improves type safety. The type system now prevents treating version IDs as generic strings.