### PR TITLE
Replace String wikiID parameters with WikiID type in FileProvider

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -396,7 +396,7 @@ let package = Package(
         // the end drops it from the manifest on Linux.
         .executableTarget(
             name: "WikiFSFileProvider",
-            dependencies: ["WikiFSCore"],
+            dependencies: ["WikiFSCore", "WikiFSTypes"],
             path: "Sources/WikiFSFileProvider",
             swiftSettings: [.unsafeFlags(["-warnings-as-errors"])],
             linkerSettings: [

--- a/Sources/WikiCtlCore/WikiDaemonConnection.swift
+++ b/Sources/WikiCtlCore/WikiDaemonConnection.swift
@@ -222,20 +222,20 @@ public final class WikiDaemonConnection: @unchecked Sendable {
     }
 
     /// Delete a wiki by ID.
-    public func deleteWiki(id: String) async throws -> Bool {
+    public func deleteWiki(id: WikiID) async throws -> Bool {
         let proxy = try daemonProxy()
         return try await withCheckedThrowingContinuation { cont in
-            proxy.deleteWiki(id: id) { success in
+            proxy.deleteWiki(id: id.rawValue) { success in
                 cont.resume(returning: success)
             }
         }
     }
 
     /// Rename a wiki (display name only).
-    public func renameWiki(id: String, name: String) async throws -> Bool {
+    public func renameWiki(id: WikiID, name: String) async throws -> Bool {
         let proxy = try daemonProxy()
         return try await withCheckedThrowingContinuation { cont in
-            proxy.renameWiki(id: id, name: name) { success in
+            proxy.renameWiki(id: id.rawValue, name: name) { success in
                 cont.resume(returning: success)
             }
         }

--- a/Sources/WikiCtlCore/WikiDaemonConnection.swift
+++ b/Sources/WikiCtlCore/WikiDaemonConnection.swift
@@ -263,17 +263,17 @@ public final class WikiDaemonConnection: @unchecked Sendable {
     // MARK: - Store lifecycle
 
     /// Open (or confirm open) the store for a wiki.
-    public func openStore(wikiID: String) async throws -> Bool {
+    public func openStore(wikiID: WikiID) async throws -> Bool {
         let proxy = try daemonProxy()
         return try await withCheckedThrowingContinuation { cont in
-            proxy.openStore(wikiID: wikiID) { success in
+            proxy.openStore(wikiID: wikiID.rawValue) { success in
                 cont.resume(returning: success)
             }
         }
     }
 
     /// Close the daemon's held-open store for a wiki.
-    public func closeStore(wikiID: String) async {
+    public func closeStore(wikiID: WikiID) async {
         let proxy: WikiDaemonProtocol
         do {
             proxy = try daemonProxy()
@@ -282,17 +282,17 @@ public final class WikiDaemonConnection: @unchecked Sendable {
             return
         }
         await withCheckedContinuation { cont in
-            proxy.closeStore(wikiID: wikiID) {
+            proxy.closeStore(wikiID: wikiID.rawValue) {
                 cont.resume()
             }
         }
     }
 
     /// The current changeToken for a wiki.
-    public func changeToken(wikiID: String) async throws -> String {
+    public func changeToken(wikiID: WikiID) async throws -> String {
         let proxy = try daemonProxy()
         return try await withCheckedThrowingContinuation { cont in
-            proxy.changeToken(wikiID: wikiID) { token in
+            proxy.changeToken(wikiID: wikiID.rawValue) { token in
                 cont.resume(returning: token)
             }
         }

--- a/Sources/WikiFS/Window/FileProviderFacade.swift
+++ b/Sources/WikiFS/Window/FileProviderFacade.swift
@@ -204,7 +204,7 @@ final class FileProviderFacade: ChangeSignaler {
     /// retry loop keeps trying.
     private func isDomainRegistered(id: WikiID) async -> Bool {
         let domainIDs = await domainService.domains().map(\.id)
-        return DomainRegistrationPolicy.isRegistered(domainIDs: domainIDs, wikiID: id.rawValue)
+        return DomainRegistrationPolicy.isRegistered(domainIDs: domainIDs, wikiID: id)
     }
 
     /// Nudge the freshly-registered domain's root + working-set enumerator so the

--- a/Sources/WikiFSCore/Core/DomainRegistrationPolicy.swift
+++ b/Sources/WikiFSCore/Core/DomainRegistrationPolicy.swift
@@ -55,7 +55,7 @@ public enum DomainRegistrationPolicy {
     /// Whether `wikiID` is present in a daemon-reported list of domain
     /// identifiers. Factored out so the caller's `domains()` → identifier mapping
     /// has one tested home (an exact match on the raw ULID identifier).
-    public static func isRegistered(domainIDs: [String], wikiID: String) -> Bool {
-        domainIDs.contains(wikiID)
+    public static func isRegistered(domainIDs: [String], wikiID: WikiID) -> Bool {
+        domainIDs.contains(wikiID.rawValue)
     }
 }

--- a/Sources/WikiFSFileProvider/FileProviderExtension.swift
+++ b/Sources/WikiFSFileProvider/FileProviderExtension.swift
@@ -1,5 +1,6 @@
 #if os(macOS)  // File Provider extension — macOS-only (FileProvider framework)
 import FileProvider
+import WikiFSTypes
 
 /// The replicated File Provider extension principal class. Read-only: it serves
 /// metadata, enumerates containers, and materializes file content on demand;
@@ -18,7 +19,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private let projection: Projection
 
     required init(domain: NSFileProviderDomain) {
-        projection = Projection(wikiID: domain.identifier.rawValue)
+        projection = Projection(wikiID: WikiID(rawValue: domain.identifier.rawValue))
         super.init()
     }
 

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -25,7 +25,7 @@ struct Projection {
 
     /// The wiki this projection serves: the ULID from the FP domain identifier.
     /// `openReadStore()` maps it to `<ulid>.sqlite` in the App Group container.
-    let wikiID: String
+    let wikiID: WikiID
 
     /// Optional override for the wiki DB URL. Production (the File Provider
     /// extension) leaves this `nil` and resolves the wiki's DB via
@@ -36,7 +36,7 @@ struct Projection {
     let databaseURL: URL?
 
     /// `databaseURL` defaults to `nil` (production resolves via `DatabaseLocation`).
-    init(wikiID: String, databaseURL: URL? = nil) {
+    init(wikiID: WikiID, databaseURL: URL? = nil) {
         self.wikiID = wikiID
         self.databaseURL = databaseURL
     }
@@ -311,7 +311,7 @@ struct Projection {
     /// collide.
     private func indexData(for id: NSFileProviderItemIdentifier) -> Data? {
         guard let index = Self.generatedIndexes.first(where: { $0.id == id }) else { return nil }
-        return Self.indexCache.data(forKey: "\(wikiID)/\(id.rawValue)", token: changeToken()) {
+        return Self.indexCache.data(forKey: "\(wikiID.rawValue)/\(id.rawValue)", token: changeToken()) {
             index.generate(self)
         }
     }
@@ -342,7 +342,7 @@ struct Projection {
     /// single-threaded — one File Provider callback).
     final class ReadScope: @unchecked Sendable {
         private let databaseURL: URL?
-        private let wikiID: String
+        private let wikiID: WikiID
         private let lock = NSLock()
         private var cachedStore: GRDBWikiStore?
         private var cachedToken: String?
@@ -363,7 +363,7 @@ struct Projection {
         /// `cachedLinkMaps`.
         private var cachedHeads: [String: SourceMarkdownVersion]?
 
-        init(databaseURL: URL?, wikiID: String) {
+        init(databaseURL: URL?, wikiID: WikiID) {
             self.databaseURL = databaseURL
             self.wikiID = wikiID
         }
@@ -372,9 +372,9 @@ struct Projection {
         var store: GRDBWikiStore? {
             lock.lock(); defer { lock.unlock() }
             if cachedStore == nil {
-                let url = databaseURL ?? DatabaseLocation.extensionContainerURL(forWikiID: wikiID)
+                let url = databaseURL ?? DatabaseLocation.extensionContainerURL(forWikiID: wikiID.rawValue)
                 if let url, FileManager.default.fileExists(atPath: url.path) {
-                    DebugLog.fileprovider("ReadScope opening cached read-only connection wikiID=\(wikiID) thread=\(Thread.current)")
+                    DebugLog.fileprovider("ReadScope opening cached read-only connection wikiID=\(wikiID.rawValue) thread=\(Thread.current)")
                     cachedStore = DebugLog.trying("GRDBWikiStore.init", operation: { try GRDBWikiStore(readOnlyURL: url) })
                 }
             }
@@ -432,9 +432,9 @@ struct Projection {
     /// container/DB is unavailable.
     private func openReadStore() -> GRDBWikiStore? {
         if let scope = readStoreHolder { return scope.store }
-        let url = databaseURL ?? DatabaseLocation.extensionContainerURL(forWikiID: wikiID)
+        let url = databaseURL ?? DatabaseLocation.extensionContainerURL(forWikiID: wikiID.rawValue)
         guard let url, FileManager.default.fileExists(atPath: url.path) else { return nil }
-        DebugLog.fileprovider("openReadStore opening short-lived read-only connection wikiID=\(wikiID) thread=\(Thread.current)")
+        DebugLog.fileprovider("openReadStore opening short-lived read-only connection wikiID=\(wikiID.rawValue) thread=\(Thread.current)")
         return DebugLog.trying("GRDBWikiStore.init", operation: { try GRDBWikiStore(readOnlyURL: url) })
     }
 
@@ -1711,7 +1711,7 @@ struct Projection {
         in store: GRDBWikiStore
     ) -> Data? {
         Self.chatContentCache.data(
-            forKey: "\(wikiID)/\(id.rawValue)", token: changeToken()
+            forKey: "\(wikiID.rawValue)/\(id.rawValue)", token: changeToken()
         ) {
             let messages = (DebugLog.trying("chatMessages", operation: { try store.chatMessages(chatID: chat.id) })) ?? []
             let raw = ChatTranscriptRenderer.render(summary: chat, messages: messages)

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -347,17 +347,18 @@ func runWikiCreate(name: String) async -> Int32 {
 
 func runWikiDelete(id: String) async -> Int32 {
     do {
+        let wikiID = WikiID(rawValue: id)
         let resolver = try WikiResolver.appGroupContainer()
         let container = resolver.containerDirectory
         var registry = WikiRegistry.load(from: container)
-        guard let descriptor = registry.descriptor(id: WikiID(rawValue: id)) else {
+        guard let descriptor = registry.descriptor(id: wikiID) else {
             FileHandle.standardError.write(Data("wikictl: no wiki matching \(id)\n".utf8))
             return 1
         }
 
         // Remove from the registry first, then drop the DB files (main + WAL
         // sidecars). Mirrors WikiDaemon.deleteWiki.
-        registry.remove(id: WikiID(rawValue: id))
+        registry.remove(id: wikiID)
         try registry.save(to: container)
 
         let dbURL = resolver.databaseURL(for: descriptor)
@@ -381,12 +382,13 @@ func runWikiRename(id: String, name: String) async -> Int32 {
             FileHandle.standardError.write(Data("wikictl: wiki rename requires a non-empty name\n".utf8))
             return 1
         }
+        let wikiID = WikiID(rawValue: id)
         var registry = WikiRegistry.load(from: container)
-        guard registry.descriptor(id: WikiID(rawValue: id)) != nil else {
+        guard registry.descriptor(id: wikiID) != nil else {
             FileHandle.standardError.write(Data("wikictl: no wiki matching \(id)\n".utf8))
             return 1
         }
-        registry.rename(id: WikiID(rawValue: id), to: trimmed)
+        registry.rename(id: wikiID, to: trimmed)
         try registry.save(to: container)
         return 0
     } catch {

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -218,9 +218,8 @@ final class WikiDaemon: @unchecked Sendable {
         }
     }
 
-    func deleteWiki(id: String) -> Bool {
+    func deleteWiki(id wikiID: WikiID) -> Bool {
         queue.sync { () -> Bool in
-            let wikiID = WikiID(rawValue: id)
             // Close the held store if open
             openStores.removeValue(forKey: wikiID)
 
@@ -239,11 +238,10 @@ final class WikiDaemon: @unchecked Sendable {
         }
     }
 
-    func renameWiki(id: String, name: String) -> Bool {
+    func renameWiki(id wikiID: WikiID, name: String) -> Bool {
         queue.sync { () -> Bool in
             let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return false }
-            let wikiID = WikiID(rawValue: id)
             guard registry.descriptor(id: wikiID) != nil else { return false }
             registry.rename(id: wikiID, to: trimmed)
             DebugLog.trying("registry.save", operation: { try registry.save(to: containerDirectory) })

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -83,11 +83,11 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
     }
 
     func deleteWiki(id: String, reply: @escaping (Bool) -> Void) {
-        reply(daemon.deleteWiki(id: id))
+        reply(daemon.deleteWiki(id: WikiID(rawValue: id)))
     }
 
     func renameWiki(id: String, name: String, reply: @escaping (Bool) -> Void) {
-        reply(daemon.renameWiki(id: id, name: name))
+        reply(daemon.renameWiki(id: WikiID(rawValue: id), name: name))
     }
 
     func resolveWiki(selector: String, reply: @escaping (Data?) -> Void) {
@@ -607,11 +607,11 @@ while let line = readLine() {
         }
     case "deleteWiki":
         let idStr = params["id"] as? String ?? ""
-        result = daemon.deleteWiki(id: idStr)
+        result = daemon.deleteWiki(id: WikiID(rawValue: idStr))
     case "renameWiki":
         let idStr = params["id"] as? String ?? ""
         let name = params["name"] as? String ?? ""
-        result = daemon.renameWiki(id: idStr, name: name)
+        result = daemon.renameWiki(id: WikiID(rawValue: idStr), name: name)
     case "resolveWiki":
         let selector = params["selector"] as? String ?? ""
         if let data = daemon.resolveWiki(selector: selector) {

--- a/Tests/WikiFSAppTests/EnumeratorDeletionTests.swift
+++ b/Tests/WikiFSAppTests/EnumeratorDeletionTests.swift
@@ -61,7 +61,7 @@ struct EnumeratorDeletionTests {
         let s1 = try store.addSource(filename: "a.txt", data: Data("aaa".utf8), mimeType: "text/plain")
         let s2 = try store.addSource(filename: "b.txt", data: Data("bbb".utf8), mimeType: "text/plain")
         let s3 = try store.addSource(filename: "c.txt", data: Data("ccc".utf8), mimeType: "text/plain")
-        let projection = Projection(wikiID: "enum-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "enum-\(UUID().uuidString)"), databaseURL: url)
         return Seeded(projection: projection, store: store, sources: [s1, s2, s3])
     }
 

--- a/Tests/WikiFSAppTests/ProjectionTreeTests.swift
+++ b/Tests/WikiFSAppTests/ProjectionTreeTests.swift
@@ -49,7 +49,7 @@ struct ProjectionTreeTests {
         let textSource = try store.addSource(
             filename: "notes.txt", data: Data("plain text".utf8), mimeType: "text/plain")
         let pages = try store.listAllPagesOrderedByID()   // ULID order
-        let projection = Projection(wikiID: "proj-tree-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "proj-tree-\(UUID().uuidString)"), databaseURL: url)
         return Seeded(projection: projection, store: store, pages: pages,
                       textSource: textSource, pdfSource: pdfSource)
     }
@@ -118,7 +118,7 @@ struct ProjectionTreeTests {
             id: src.id, title: "Home",
             body: "See [[page:\(target.id.rawValue)|the target]] and "
                 + "[[source:\(pdf.id.rawValue)|the paper]].")
-        let projection = Projection(wikiID: "links-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "links-\(UUID().uuidString)"), databaseURL: url)
 
         let id = Projection.Identity.pageByTitle(src.id.rawValue)
         guard let node = projection.node(for: id),
@@ -214,7 +214,7 @@ struct ProjectionTreeTests {
             originalPath: "assets/pic.png", sourceURL: URL(string: "https://example.com/pic.png")!,
             activityID: activityID, role: .media)
 
-        let projection = Projection(wikiID: "snapshot-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "snapshot-\(UUID().uuidString)"), databaseURL: url)
 
         // Verify by-name view: node size must match served content.
         let id = Projection.Identity.sourceByName(mdSource.id.rawValue)
@@ -246,7 +246,7 @@ struct ProjectionTreeTests {
         let textSource = try store.addSource(
             filename: "lonely.md", data: originalData, mimeType: "text/markdown")
 
-        let projection = Projection(wikiID: "no-image-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "no-image-\(UUID().uuidString)"), databaseURL: url)
 
         // By-name view.
         let id = Projection.Identity.sourceByName(textSource.id.rawValue)
@@ -422,7 +422,7 @@ struct ProjectionTreeTests {
             parentID: nil, position: 2, content: .source(pdfSource.id))
         let nestedNode = try store.createBookmarkNode(
             parentID: folderNode.id, position: 0, content: .folder(label: "Papers"))
-        let projection = Projection(wikiID: "proj-bm-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "proj-bm-\(UUID().uuidString)"), databaseURL: url)
         return Bookmarked(projection: projection, store: store, pages: pages,
                           pdfSource: pdfSource, folderNode: folderNode, nestedNode: nestedNode,
                           pageRefNode: pageRefNode, sourceRefNode: sourceRefNode)
@@ -535,7 +535,7 @@ struct ProjectionTreeTests {
             body: "See [[page:\(target.id.rawValue)|t]].")
         let pageRefNode = try store.createBookmarkNode(
             parentID: nil, position: 0, content: .page(home.id))
-        let projection = Projection(wikiID: "bm-links-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "bm-links-\(UUID().uuidString)"), databaseURL: url)
 
         let id = Projection.Identity.bookmarkPageRef(pageRefNode.id)
         guard let node = projection.node(for: id),
@@ -570,7 +570,7 @@ struct ProjectionTreeTests {
             parentID: nil, position: 0, content: .folder(label: "Research"))
         let pageRefNode = try store.createBookmarkNode(
             parentID: folder.id, position: 0, content: .page(home.id))
-        let projection = Projection(wikiID: "bm-nested-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "bm-nested-\(UUID().uuidString)"), databaseURL: url)
 
         let id = Projection.Identity.bookmarkPageRef(pageRefNode.id)
         guard let node = projection.node(for: id),
@@ -599,7 +599,7 @@ struct ProjectionTreeTests {
                      .assistantText("Sure.")])
         let chatRefNode = try store.createBookmarkNode(
             parentID: nil, position: 0, content: .chat(chat.id))
-        let projection = Projection(wikiID: "bm-chat-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "bm-chat-\(UUID().uuidString)"), databaseURL: url)
 
         let id = Projection.Identity.bookmarkChatRef(chatRefNode.id)
         guard let node = projection.node(for: id),
@@ -625,7 +625,7 @@ struct ProjectionTreeTests {
             filename: "doc.pdf", data: pdfBytes, mimeType: "application/pdf")
         let sourceRefNode = try store.createBookmarkNode(
             parentID: nil, position: 0, content: .source(pdf.id))
-        let projection = Projection(wikiID: "bm-source-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "bm-source-\(UUID().uuidString)"), databaseURL: url)
 
         let id = Projection.Identity.bookmarkSourceRef(sourceRefNode.id)
         guard let node = projection.node(for: id),
@@ -661,7 +661,7 @@ struct ProjectionTreeTests {
             chatID: first.id, events: [.userText("Hello"), .assistantText("Hi there")])
         _ = try store.createChat(kind: .edit, title: "Second Chat")
         let chats = try store.listAllChatsOrderedByID()   // ULID (creation) order
-        let projection = Projection(wikiID: "proj-chat-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "proj-chat-\(UUID().uuidString)"), databaseURL: url)
         return Chatted(projection: projection, store: store, chats: chats)
     }
 
@@ -731,7 +731,7 @@ struct ProjectionTreeTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikifs-chat-empty-\(UUID().uuidString).sqlite")
         let store = try GRDBWikiStore(databaseURL: url)
-        let projection = Projection(wikiID: "proj-chat-empty-\(UUID().uuidString)", databaseURL: url)
+        let projection = Projection(wikiID: WikiID(rawValue: "proj-chat-empty-\(UUID().uuidString)"), databaseURL: url)
         _ = store  // seed nothing
         let names = projection.children(of: .rootContainer).map(\.name)
         #expect(names.contains("chats"))

--- a/Tests/WikiFSAppTests/WikiDaemonTests.swift
+++ b/Tests/WikiFSAppTests/WikiDaemonTests.swift
@@ -158,7 +158,7 @@ struct WikiDaemonTests {
         let data = try #require(daemon.createWiki(name: "Delete Me"))
         let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
 
-        let success = daemon.deleteWiki(id: descriptor.id.rawValue)
+        let success = daemon.deleteWiki(id: descriptor.id)
         #expect(success)
 
         let registry = WikiRegistry.load(from: dir)
@@ -173,7 +173,7 @@ struct WikiDaemonTests {
         let dbURL = dir.appendingPathComponent("\(descriptor.id.rawValue).sqlite")
         #expect(FileManager.default.fileExists(atPath: dbURL.path))
 
-        _ = daemon.deleteWiki(id: descriptor.id.rawValue)
+        _ = daemon.deleteWiki(id: descriptor.id)
         #expect(!FileManager.default.fileExists(atPath: dbURL.path))
         #expect(!FileManager.default.fileExists(atPath: dbURL.path + "-wal"))
         #expect(!FileManager.default.fileExists(atPath: dbURL.path + "-shm"))
@@ -187,7 +187,7 @@ struct WikiDaemonTests {
         let data = try #require(daemon.createWiki(name: "Old Name"))
         let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
 
-        let success = daemon.renameWiki(id: descriptor.id.rawValue, name: "New Name")
+        let success = daemon.renameWiki(id: descriptor.id, name: "New Name")
         #expect(success)
 
         let resolveData = try #require(daemon.resolveWiki(selector: descriptor.id.rawValue))
@@ -202,14 +202,14 @@ struct WikiDaemonTests {
         let data = try #require(daemon.createWiki(name: "Test"))
         let descriptor = try JSONDecoder().decode(WikiDescriptor.self, from: data)
 
-        let success = daemon.renameWiki(id: descriptor.id.rawValue, name: "   ")
+        let success = daemon.renameWiki(id: descriptor.id, name: "   ")
         #expect(!success)
     }
 
     @Test func renameWikiReturnsFalseForUnknownID() {
         let dir = tempDirectory()
         let daemon = makeDaemon(dir: dir)
-        let success = daemon.renameWiki(id: "nonexistent", name: "Whatever")
+        let success = daemon.renameWiki(id: WikiID(rawValue: "nonexistent"), name: "Whatever")
         #expect(!success)
     }
 
@@ -330,7 +330,7 @@ struct WikiDaemonTests {
         #expect(!tokenB.isEmpty)
 
         // Deleting A doesn't affect B
-        _ = daemon.deleteWiki(id: a.id.rawValue)
+        _ = daemon.deleteWiki(id: a.id)
         #expect(daemon.openStore(wikiID: b.id))
     }
 }

--- a/Tests/WikiFSTests/DomainRegistrationPolicyTests.swift
+++ b/Tests/WikiFSTests/DomainRegistrationPolicyTests.swift
@@ -12,20 +12,20 @@ struct DomainRegistrationPolicyTests {
     // MARK: - isRegistered
 
     @Test func registeredWhenIDPresent() {
-        #expect(DomainRegistrationPolicy.isRegistered(domainIDs: ["A", "B", "C"], wikiID: "B"))
+        #expect(DomainRegistrationPolicy.isRegistered(domainIDs: ["A", "B", "C"], wikiID: WikiID(rawValue: "B")))
     }
 
     @Test func notRegisteredWhenIDAbsent() {
-        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: ["A", "C"], wikiID: "B"))
+        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: ["A", "C"], wikiID: WikiID(rawValue: "B")))
     }
 
     @Test func notRegisteredAgainstEmptyList() {
-        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: [], wikiID: "B"))
+        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: [], wikiID: WikiID(rawValue: "B")))
     }
 
     @Test func matchIsExactNotPrefix() {
         // ULIDs share prefixes; a partial match must NOT count as registered.
-        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: ["01ABCDEF"], wikiID: "01AB"))
+        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: ["01ABCDEF"], wikiID: WikiID(rawValue: "01AB")))
     }
 
     // MARK: - decide


### PR DESCRIPTION
## Summary

Continues the type-safety migration by replacing `String` wikiID parameters with the `WikiID` strong type throughout the File Provider and related APIs.

## Changes

- **WikiDaemonConnection**: Updated method signatures (`openStore`, `closeStore`, `changeToken`) to accept `WikiID` instead of `String`, extracting `.rawValue` when calling daemon proxy methods
- **DomainRegistrationPolicy**: Changed `isRegistered()` to accept `WikiID` parameter, extracting raw value internally
- **Projection**: Converted `wikiID` property and initializer from `String` to `WikiID`, updating all cache key and logging calls to use `.rawValue`
- **FileProviderExtension**: Added `WikiFSTypes` import and wrapped domain identifier string in `WikiID` during initialization
- **FileProviderFacade**: Pass `WikiID` object directly to `DomainRegistrationPolicy.isRegistered()`
- **Tests**: Updated test fixtures to wrap generated UUIDs in `WikiID(rawValue:)` constructor
- **Package.swift**: Added `WikiFSTypes` to FileProvider extension dependencies

## Why

Type safety: using `WikiID` throughout prevents accidental string confusion and makes the wiki identifier intent explicit at compile time. Maintains the invariant that wikiID values are properly formed ULIDs.