### PR TITLE
Apply strong WikiID type throughout file provider domain service

### DIFF
--- a/Sources/WikiFS/Window/FileProviderFacade.swift
+++ b/Sources/WikiFS/Window/FileProviderFacade.swift
@@ -88,7 +88,7 @@ final class FileProviderFacade: ChangeSignaler {
         DebugLog.fileprovider("schema migration: \(stored) → \(Self.currentSchemaVersion) — removing \(wikiIDs.count) domain(s)")
         for id in wikiIDs {
             do {
-                try await domainService.remove(id: id.rawValue, reason: .schemaMigration)
+                try await domainService.remove(id: id, reason: .schemaMigration)
                 DebugLog.fileprovider("schema migration: removed domain \(id.rawValue)")
             } catch {
                 DebugLog.fileprovider("schema migration: remove domain \(id.rawValue) failed: \(error.localizedDescription)")
@@ -143,7 +143,7 @@ final class FileProviderFacade: ChangeSignaler {
     @discardableResult
     func registerDomain(id: WikiID, displayName: String) async -> Bool {
         if ProcessInfo.processInfo.environment["WIKIFS_REENUMERATE"] == "1" {
-            do { try await domainService.remove(id: id.rawValue, reason: .reenumerateHatch) }
+            do { try await domainService.remove(id: id, reason: .reenumerateHatch) }
             catch { DebugLog.fileprovider("registerDomain: re-enumerate remove failed: \(error)") }
         }
 
@@ -151,7 +151,7 @@ final class FileProviderFacade: ChangeSignaler {
         // the new container layout (e.g. `files` → `sources` rename).
         if needsDomainMigration {
             DebugLog.fileprovider("registerDomain: removing \(id.rawValue) for schema migration")
-            do { try await domainService.remove(id: id.rawValue, reason: .schemaMigration) }
+            do { try await domainService.remove(id: id, reason: .schemaMigration) }
             catch { DebugLog.fileprovider("registerDomain: migration remove failed: \(error)") }
         }
 
@@ -161,7 +161,7 @@ final class FileProviderFacade: ChangeSignaler {
             // racing add that won) must not error out the whole flow.
             if !(await isDomainRegistered(id: id)) {
                 do {
-                    try await domainService.add(id: id.rawValue, displayName: displayName)
+                    try await domainService.add(id: id, displayName: displayName)
                 } catch {
                     // Distinguish benign already-exists (the verify below confirms
                     // presence) from a real failure we must not bury: log it AND
@@ -223,7 +223,7 @@ final class FileProviderFacade: ChangeSignaler {
     /// belonged to that wiki.
     func removeDomain(id: WikiID) async {
         do {
-            try await domainService.remove(id: id.rawValue, reason: .wikiDeleted)
+            try await domainService.remove(id: id, reason: .wikiDeleted)
             if activeWikiID == id {
                 activeWikiID = nil
                 path = nil
@@ -259,14 +259,14 @@ final class FileProviderFacade: ChangeSignaler {
         // we're registering from scratch (and could hit NSFileWriteFileExistsError
         // against a leftover replica). Those fail very differently — worth one
         // `domains()` call on an operation the user triggers by hand.
-        let previousName = await domainService.displayName(for: id.rawValue)
+        let previousName = await domainService.displayName(for: id)
         DebugLog.fileprovider("""
             FileProviderFacade.renameDomain(\(id.rawValue) → \(displayName)): \
             in-place add; wasRegistered=\(previousName != nil), \
             daemonName=\(previousName ?? "<absent>"), isActive=\(activeWikiID == id)
             """)
         do {
-            try await domainService.add(id: id.rawValue, displayName: displayName)
+            try await domainService.add(id: id, displayName: displayName)
             if activeWikiID == id { activeDisplayName = displayName }
             status = "Renamed \(displayName)"
 
@@ -276,7 +276,7 @@ final class FileProviderFacade: ChangeSignaler {
             // whole fix rests on documented-but-unobservable behaviour, confirm it
             // against what the daemon now reports. Diagnostic only — the operation
             // has already succeeded as far as the user is concerned.
-            let observed = await domainService.displayName(for: id.rawValue)
+            let observed = await domainService.displayName(for: id)
             if observed != displayName {
                 DebugLog.fileprovider("""
                     FileProviderFacade.renameDomain(\(id.rawValue)): MISMATCH — add succeeded but \

--- a/Sources/WikiFS/Window/SystemFileProviderDomainService.swift
+++ b/Sources/WikiFS/Window/SystemFileProviderDomainService.swift
@@ -10,18 +10,18 @@ import WikiFSCore
 /// where it can be tested against a fake. This type exists purely so that those
 /// decisions have something injectable to talk to.
 struct SystemFileProviderDomainService: FileProviderDomainService {
-    func add(id: String, displayName: String) async throws {
+    func add(id: WikiID, displayName: String) async throws {
         try await NSFileProviderManager.add(Self.domain(id: id, displayName: displayName))
     }
 
-    func remove(id: String, reason: DomainRemovalReason) async throws {
+    func remove(id: WikiID, reason: DomainRemovalReason) async throws {
         // Log BEFORE the call, unconditionally: this deletes the daemon's replica,
         // and #919's crash lands in FileProvider XPC internals with no frame of
         // ours on the thread. A timestamped "teardown started, because X" line is
         // the only way a later crash report can be correlated against an
         // in-flight removal.
-        DebugLog.fileprovider("domainService.remove(\(id)): reason=\(reason.rawValue)")
-        try await NSFileProviderManager.remove(Self.domain(id: id, displayName: id))
+        DebugLog.fileprovider("domainService.remove(\(id.rawValue)): reason=\(reason.rawValue)")
+        try await NSFileProviderManager.remove(Self.domain(id: id, displayName: id.rawValue))
     }
 
     func domains() async -> [RegisteredDomain] {
@@ -31,7 +31,7 @@ struct SystemFileProviderDomainService: FileProviderDomainService {
         await Task.detached {
             do {
                 return try await NSFileProviderManager.domains()
-                    .map { RegisteredDomain(id: $0.identifier.rawValue, displayName: $0.displayName) }
+                    .map { RegisteredDomain(id: WikiID(rawValue: $0.identifier.rawValue), displayName: $0.displayName) }
             } catch {
                 DebugLog.fileprovider("domainService.domains(): list failed: \(error)")
                 return []
@@ -42,9 +42,9 @@ struct SystemFileProviderDomainService: FileProviderDomainService {
     /// Domain identity = the wiki's ULID; `displayName` only sets the Finder mount
     /// label. `remove` passes the id as the name because removal keys on the
     /// identifier alone.
-    private static func domain(id: String, displayName: String) -> NSFileProviderDomain {
+    private static func domain(id: WikiID, displayName: String) -> NSFileProviderDomain {
         NSFileProviderDomain(
-            identifier: NSFileProviderDomainIdentifier(rawValue: id),
+            identifier: NSFileProviderDomainIdentifier(rawValue: id.rawValue),
             displayName: displayName
         )
     }

--- a/Sources/WikiFSCore/Core/DomainRegistrationPolicy.swift
+++ b/Sources/WikiFSCore/Core/DomainRegistrationPolicy.swift
@@ -55,7 +55,7 @@ public enum DomainRegistrationPolicy {
     /// Whether `wikiID` is present in a daemon-reported list of domain
     /// identifiers. Factored out so the caller's `domains()` → identifier mapping
     /// has one tested home (an exact match on the raw ULID identifier).
-    public static func isRegistered(domainIDs: [String], wikiID: WikiID) -> Bool {
-        domainIDs.contains(wikiID.rawValue)
+    public static func isRegistered(domainIDs: [WikiID], wikiID: WikiID) -> Bool {
+        domainIDs.contains(wikiID)
     }
 }

--- a/Sources/WikiFSCore/Core/FileProviderDomainService.swift
+++ b/Sources/WikiFSCore/Core/FileProviderDomainService.swift
@@ -30,10 +30,10 @@ public enum DomainRemovalReason: String, Equatable, Sendable, CaseIterable {
 /// still existed. That gap is why #919's in-place `add` upsert needs a
 /// post-condition check rather than trust in the SDK doc comment.
 public struct RegisteredDomain: Equatable, Sendable {
-    public let id: String
+    public let id: WikiID
     public let displayName: String
 
-    public init(id: String, displayName: String) {
+    public init(id: WikiID, displayName: String) {
         self.id = id
         self.displayName = displayName
     }
@@ -52,11 +52,11 @@ public protocol FileProviderDomainService: Sendable {
     /// This is an upsert keyed by identifier: "If a domain with the same
     /// identifier already exists, `addDomain` will update the display name and
     /// hidden state of the domain and succeed" (`NSFileProviderManager.h`).
-    func add(id: String, displayName: String) async throws
+    func add(id: WikiID, displayName: String) async throws
 
     /// Tear down a domain AND its on-disk replica. Destructive — see
     /// ``DomainRemovalReason``.
-    func remove(id: String, reason: DomainRemovalReason) async throws
+    func remove(id: WikiID, reason: DomainRemovalReason) async throws
 
     /// The daemon's current domain list. Returns `[]` if the list can't be
     /// fetched, so callers read a failure as "not present" and keep retrying.
@@ -66,7 +66,7 @@ public protocol FileProviderDomainService: Sendable {
 extension FileProviderDomainService {
     /// The display name the daemon currently reports for `id`, or `nil` if the
     /// domain isn't registered. Used to verify an in-place rename landed.
-    public func displayName(for id: String) async -> String? {
+    public func displayName(for id: WikiID) async -> String? {
         await domains().first { $0.id == id }?.displayName
     }
 }

--- a/Tests/WikiFSAppTests/FileProviderDomainLifecycleTests.swift
+++ b/Tests/WikiFSAppTests/FileProviderDomainLifecycleTests.swift
@@ -67,25 +67,25 @@ struct FileProviderDomainLifecycleTests {
         /// `NSFileWriteFileExistsError` against a leftover replica.
         func failAdds(with error: any Error) { lock.withLock { _addError = error } }
 
-        func add(id: String, displayName: String) async throws {
+        func add(id: WikiID, displayName: String) async throws {
             try lock.withLock {
-                _calls.append(.add(id: id, displayName: displayName))
+                _calls.append(.add(id: id.rawValue, displayName: displayName))
                 if let _addError { throw _addError }
-                registered[id] = displayName
+                registered[id.rawValue] = displayName
             }
         }
 
-        func remove(id: String, reason: DomainRemovalReason) async throws {
+        func remove(id: WikiID, reason: DomainRemovalReason) async throws {
             lock.withLock {
-                _calls.append(.remove(id: id, reason: reason))
-                registered[id] = nil
+                _calls.append(.remove(id: id.rawValue, reason: reason))
+                registered[id.rawValue] = nil
             }
         }
 
         func domains() async -> [RegisteredDomain] {
             lock.withLock {
                 _calls.append(.domains)
-                return registered.map { RegisteredDomain(id: $0.key, displayName: $0.value) }
+                return registered.map { RegisteredDomain(id: WikiID(rawValue: $0.key), displayName: $0.value) }
             }
         }
     }

--- a/Tests/WikiFSTests/DomainRegistrationPolicyTests.swift
+++ b/Tests/WikiFSTests/DomainRegistrationPolicyTests.swift
@@ -12,11 +12,15 @@ struct DomainRegistrationPolicyTests {
     // MARK: - isRegistered
 
     @Test func registeredWhenIDPresent() {
-        #expect(DomainRegistrationPolicy.isRegistered(domainIDs: ["A", "B", "C"], wikiID: WikiID(rawValue: "B")))
+        #expect(DomainRegistrationPolicy.isRegistered(
+            domainIDs: [WikiID(rawValue: "A"), WikiID(rawValue: "B"), WikiID(rawValue: "C")],
+            wikiID: WikiID(rawValue: "B")))
     }
 
     @Test func notRegisteredWhenIDAbsent() {
-        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: ["A", "C"], wikiID: WikiID(rawValue: "B")))
+        #expect(!DomainRegistrationPolicy.isRegistered(
+            domainIDs: [WikiID(rawValue: "A"), WikiID(rawValue: "C")],
+            wikiID: WikiID(rawValue: "B")))
     }
 
     @Test func notRegisteredAgainstEmptyList() {
@@ -25,7 +29,9 @@ struct DomainRegistrationPolicyTests {
 
     @Test func matchIsExactNotPrefix() {
         // ULIDs share prefixes; a partial match must NOT count as registered.
-        #expect(!DomainRegistrationPolicy.isRegistered(domainIDs: ["01ABCDEF"], wikiID: WikiID(rawValue: "01AB")))
+        #expect(!DomainRegistrationPolicy.isRegistered(
+            domainIDs: [WikiID(rawValue: "01ABCDEF")],
+            wikiID: WikiID(rawValue: "01AB")))
     }
 
     // MARK: - decide


### PR DESCRIPTION
Replace String parameters with WikiID type across the file provider domain service API and its callers, extending the type-safety improvements from recent strong typing initiatives.

## Changes

- **FileProviderDomainService protocol**: Update `add()` and `remove()` signatures to accept `WikiID` instead of `String`
- **RegisteredDomain struct**: Change `id` property from `String` to `WikiID`
- **DomainRegistrationPolicy.isRegistered()**: Accept `[WikiID]` instead of `[String]` for domain IDs
- **SystemFileProviderDomainService**: Update implementation to accept `WikiID` and convert to raw value when interfacing with NSFileProviderManager
- **FileProviderFacade**: Update all call sites to pass `WikiID` directly instead of `.rawValue`
- **Tests**: Update mock implementation and test cases to work with `WikiID` arrays

## Why

Strong typing prevents accidental string confusion and provides compile-time guarantees that domain identifiers are actual wiki IDs, not arbitrary strings. This aligns with the ongoing type-safety improvements across the codebase.