### PR TITLE
Apply strong BookmarkID type

### DIFF
--- a/Sources/WikiCtlCore/BookmarkCommand.swift
+++ b/Sources/WikiCtlCore/BookmarkCommand.swift
@@ -66,10 +66,10 @@ public enum BookmarkCommand {
         if json {
             // Manual JSONL — BookmarkNode isn't Codable.
             let lines = nodes.map { node in
-                let parent = node.parentID ?? ""
+                let parent = node.parentID?.rawValue ?? ""
                 let label = node.label ?? ""
                 let target = node.targetRawValue ?? ""
-                return "{\"id\":\"\(escape(node.id))\",\"parentID\":\"\(escape(parent))\",\"position\":\(node.position),\"kind\":\"\(node.kind.rawValue)\",\"label\":\"\(escape(label))\",\"targetID\":\"\(escape(target))\"}"
+                return "{\"id\":\"\(escape(node.id.rawValue))\",\"parentID\":\"\(escape(parent))\",\"position\":\(node.position),\"kind\":\"\(node.kind.rawValue)\",\"label\":\"\(escape(label))\",\"targetID\":\"\(escape(target))\"}"
             }
             return Result(
                 output: lines.joined(separator: "\n"),
@@ -78,7 +78,7 @@ public enum BookmarkCommand {
         }
         // TSV: id <tab> parentID <tab> position <tab> kind <tab> label <tab> targetID
         let lines = nodes.map { node in
-            "\(node.id)\t\(node.parentID ?? "")\t\(node.position)\t\(node.kind.rawValue)\t\(node.label ?? "")\t\(node.targetRawValue ?? "")"
+            "\(node.id.rawValue)\t\(node.parentID?.rawValue ?? "")\t\(node.position)\t\(node.kind.rawValue)\t\(node.label ?? "")\t\(node.targetRawValue ?? "")"
         }
         return Result(
             output: lines.joined(separator: "\n"),
@@ -98,9 +98,9 @@ public enum BookmarkCommand {
 
     private static func createFolder(parentID: String?, name: String, in store: WikiStore) throws -> Result {
         let node = try store.createBookmarkNode(
-            parentID: parentID, position: -1, content: .folder(label: name)
+            parentID: parentID.map(BookmarkID.init(rawValue:)), position: -1, content: .folder(label: name)
         )
-        return Result(output: "Created folder \"\(name)\" (id: \(node.id)).", didCommit: true)
+        return Result(output: "Created folder \"\(name)\" (id: \(node.id.rawValue)).", didCommit: true)
     }
 
     // MARK: - add-ref
@@ -111,7 +111,9 @@ public enum BookmarkCommand {
         guard content.kind != .folder else {
             throw Failure.message("folder is not a reference")
         }
-        let node = try store.createBookmarkNode(parentID: parentID, position: -1, content: content)
+        let node = try store.createBookmarkNode(
+            parentID: parentID.map(BookmarkID.init(rawValue:)), position: -1, content: content
+        )
         let kindLabel: String
         switch content.kind {
         case .pageRef: kindLabel = "page"
@@ -120,7 +122,7 @@ public enum BookmarkCommand {
         case .folder: kindLabel = "folder"
         }
         return Result(
-            output: "Added \(kindLabel) ref (\(content.targetRawValue ?? "")) to bookmarks (id: \(node.id)).",
+            output: "Added \(kindLabel) ref (\(content.targetRawValue ?? "")) to bookmarks (id: \(node.id.rawValue)).",
             didCommit: true
         )
     }
@@ -128,21 +130,23 @@ public enum BookmarkCommand {
     // MARK: - rename
 
     private static func rename(id: String, to newName: String, in store: WikiStore) throws -> Result {
-        try store.renameBookmarkFolder(id: id, to: newName)
+        try store.renameBookmarkFolder(id: BookmarkID(rawValue: id), to: newName)
         return Result(output: "Renamed bookmark node \(id) to \"\(newName)\".", didCommit: true)
     }
 
     // MARK: - delete
 
     private static func delete(id: String, in store: WikiStore) throws -> Result {
-        try store.deleteBookmarkNode(id: id)
+        try store.deleteBookmarkNode(id: BookmarkID(rawValue: id))
         return Result(output: "Deleted bookmark node \(id) (and descendants).", didCommit: true)
     }
 
     // MARK: - move
 
     private static func move(id: String, toParentID: String?, position: Int, in store: WikiStore) throws -> Result {
-        try store.moveBookmarkNode(id: id, toParentID: toParentID, position: position)
+        try store.moveBookmarkNode(
+            id: BookmarkID(rawValue: id), toParentID: toParentID.map(BookmarkID.init(rawValue:)), position: position
+        )
         return Result(output: "Moved bookmark node \(id).", didCommit: true)
     }
 }

--- a/Sources/WikiFS/Bookmarks/BookmarkTargetPickerSheet.swift
+++ b/Sources/WikiFS/Bookmarks/BookmarkTargetPickerSheet.swift
@@ -60,7 +60,7 @@ enum BookmarkFolderSelection: Hashable {
     /// The bookmarks root (`parentID == nil`) — top-level destination.
     case root
     /// A real bookmark folder, by its `BookmarkNode.id`.
-    case folder(String)
+    case folder(BookmarkID)
 }
 
 struct BookmarkTargetPickerSheet: View {
@@ -68,7 +68,7 @@ struct BookmarkTargetPickerSheet: View {
     let targets: BookmarkTargetPickerContext.Targets
     /// Receives the chosen destination folder id (`nil` = bookmarks root).
     /// Main-actor: the caller touches the @MainActor WikiStoreModel.
-    let onConfirm: (@MainActor @Sendable (String?) -> Void)
+    let onConfirm: (@MainActor @Sendable (BookmarkID?) -> Void)
 
     @Environment(\.dismiss) private var dismiss
     @State private var searchText: String = ""
@@ -80,7 +80,7 @@ struct BookmarkTargetPickerSheet: View {
     /// Converts the selection to the `parentID` value expected by `onConfirm`
     /// — the root and a deselected picker both map to `nil` (top level).
     /// Exposed for testing (#243).
-    static func parentID(forSelection selection: BookmarkFolderSelection?) -> String? {
+    static func parentID(forSelection selection: BookmarkFolderSelection?) -> BookmarkID? {
         guard let selection else { return nil }
         switch selection {
         case .root: return nil
@@ -141,7 +141,7 @@ struct BookmarkTargetPickerSheet: View {
                 .keyboardShortcut(.cancelAction)
                 Button("Add") {
                     let parentID = Self.parentID(forSelection: selection)
-                    DebugLog.tabs("BookmarkTargetPickerSheet: Add — parentID=\(parentID ?? "nil"), \(targets.count) items")
+                    DebugLog.tabs("BookmarkTargetPickerSheet: Add — parentID=\(parentID?.rawValue ?? "nil"), \(targets.count) items")
                     onConfirm(parentID)
                     dismiss()
                 }

--- a/Sources/WikiFS/Bookmarks/BookmarksContainerView.swift
+++ b/Sources/WikiFS/Bookmarks/BookmarksContainerView.swift
@@ -11,7 +11,7 @@ struct BookmarksContainerView: View {
     // All closures are main-actor-isolated: they touch the @MainActor
     // WikiStoreModel or present sheets/state on the main actor.
     var onShowPicker: (@MainActor @Sendable (PickerContext) -> Void)
-    var onEdit: (@MainActor @Sendable (String) -> Void)
+    var onEdit: (@MainActor @Sendable (BookmarkID) -> Void)
     var onNewFolder: (@MainActor @Sendable () -> Void)
 
     @State private var searchText: String = ""
@@ -169,7 +169,7 @@ struct BookmarksContainerView: View {
         let byID = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0) })
 
         // Collect ids of nodes that match the query.
-        var matchingIDs = Set<String>()
+        var matchingIDs = Set<BookmarkID>()
         for node in nodes {
             let title = resolveTitle(node)
             if title.localizedCaseInsensitiveContains(q) {
@@ -179,9 +179,9 @@ struct BookmarksContainerView: View {
 
         // Expand to include all ancestors of matching nodes (so a hit inside a
         // nested folder is visible when the folder would otherwise be collapsed).
-        var visibleIDs = Set<String>()
+        var visibleIDs = Set<BookmarkID>()
         for id in matchingIDs {
-            var current: String? = id
+            var current: BookmarkID? = id
             while let cid = current, let node = byID[cid] {
                 visibleIDs.insert(cid)
                 current = node.parentID
@@ -194,11 +194,11 @@ struct BookmarksContainerView: View {
 
 struct PickerContext: Identifiable, Sendable {
     let id: UUID
-    let parentID: String?
+    let parentID: BookmarkID?
     let kind: ItemPickerKind
 }
 
 struct EditBookmarkContext: Identifiable {
     let id = UUID()
-    let nodeID: String
+    let nodeID: BookmarkID
 }

--- a/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
+++ b/Sources/WikiFS/Bookmarks/BookmarksOutlineView.swift
@@ -28,12 +28,12 @@ struct BookmarksOutlineView: NSViewControllerRepresentable {
     var onOpen: (@MainActor @Sendable ([WikiSelection]) -> Void)
     var onOpenBackground: (@MainActor @Sendable ([WikiSelection]) -> Void)
     var onGoToOriginal: (@MainActor @Sendable (WikiSelection) -> Void)
-    var onEdit: (@MainActor @Sendable (String) -> Void)
-    var onDelete: (@MainActor @Sendable ([String]) -> Void)
-    var onAddPage: (@MainActor @Sendable (String?) -> Void)
-    var onAddSource: (@MainActor @Sendable (String?) -> Void)
+    var onEdit: (@MainActor @Sendable (BookmarkID) -> Void)
+    var onDelete: (@MainActor @Sendable ([BookmarkID]) -> Void)
+    var onAddPage: (@MainActor @Sendable (BookmarkID?) -> Void)
+    var onAddSource: (@MainActor @Sendable (BookmarkID?) -> Void)
     var onNewFolder: (@MainActor @Sendable () -> Void)
-    var onNewSubfolder: (@MainActor @Sendable (String) -> Void)
+    var onNewSubfolder: (@MainActor @Sendable (BookmarkID) -> Void)
 
     func makeNSViewController(context: Context) -> BookmarksOutlineViewController {
         let vc = BookmarksOutlineViewController()
@@ -76,12 +76,12 @@ struct BookmarksCallbacks {
     var onOpen: (@MainActor @Sendable ([WikiSelection]) -> Void)
     var onOpenBackground: (@MainActor @Sendable ([WikiSelection]) -> Void)
     var onGoToOriginal: (@MainActor @Sendable (WikiSelection) -> Void)
-    var onEdit: (@MainActor @Sendable (String) -> Void)
-    var onDelete: (@MainActor @Sendable ([String]) -> Void)
-    var onAddPage: (@MainActor @Sendable (String?) -> Void)
-    var onAddSource: (@MainActor @Sendable (String?) -> Void)
+    var onEdit: (@MainActor @Sendable (BookmarkID) -> Void)
+    var onDelete: (@MainActor @Sendable ([BookmarkID]) -> Void)
+    var onAddPage: (@MainActor @Sendable (BookmarkID?) -> Void)
+    var onAddSource: (@MainActor @Sendable (BookmarkID?) -> Void)
     var onNewFolder: (@MainActor @Sendable () -> Void)
-    var onNewSubfolder: (@MainActor @Sendable (String) -> Void)
+    var onNewSubfolder: (@MainActor @Sendable (BookmarkID) -> Void)
 }
 
 /// Carries the right-clicked node + the effective selection (all selected if
@@ -121,7 +121,7 @@ final class BookmarksOutlineViewController: NSViewController {
 
     /// Cached parent→children map (key `nil` = root). Rebuilt once per reload
     /// so data-source callbacks are O(1) lookups instead of O(n) filters.
-    private var childrenMap: [String?: [BookmarkNode]] = [:]
+    private var childrenMap: [BookmarkID?: [BookmarkNode]] = [:]
 
     /// Tracks whether the initial expand-all has run. After that, reloads
     /// preserve the user's expand/collapse choices instead of force-expanding.
@@ -235,13 +235,13 @@ final class BookmarksOutlineViewController: NSViewController {
 
     /// Compact per-node signature covering all rendering-relevant fields.
     private func nodeSignature(_ nodes: [BookmarkNode]) -> String {
-        nodes.map { "\($0.id)|\($0.parentID ?? "")|\($0.position)|\($0.kind.rawValue)|\($0.label ?? "")|\($0.targetRawValue ?? "")" }
+        nodes.map { "\($0.id)|\($0.parentID?.rawValue ?? "")|\($0.position)|\($0.kind.rawValue)|\($0.label ?? "")|\($0.targetRawValue ?? "")" }
             .joined(separator: "\n")
     }
 
     // MARK: - Helpers
 
-    private func children(of parentID: String?) -> [BookmarkNode] {
+    private func children(of parentID: BookmarkID?) -> [BookmarkNode] {
         childrenMap[parentID] ?? []
     }
 
@@ -333,12 +333,12 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             payloads = [SidebarDragPayload(kind: .chat, id: id.rawValue)]
         }
         DebugLog.tabs("[drag] bookmark pasteboardWriterForItem node=\(node.id) kind=\(node.kind) payloadCount=\(payloads.count)")
-        return SidebarDragPasteboardItem(payloads: payloads, bookmarkNodeID: node.id)
+        return SidebarDragPasteboardItem(payloads: payloads, bookmarkNodeID: node.id.rawValue)
     }
 
     /// Recursively collects the resolved page/source/chat target for every leaf
     /// reachable under `folderID`, walking into nested subfolders too.
-    private func leafPayloads(under folderID: String) -> [SidebarDragPayload] {
+    private func leafPayloads(under folderID: BookmarkID) -> [SidebarDragPayload] {
         children(of: folderID).flatMap { child -> [SidebarDragPayload] in
             switch child.content {
             case .folder: return leafPayloads(under: child.id)
@@ -422,7 +422,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
     /// chain — used to refuse moving a folder into itself or one of its own
     /// descendants (would create a cycle). Walks the in-memory children map
     /// (already built for the outline), so it reflects the visible tree.
-    private func isDescendant(_ ancestorID: String, of id: String) -> Bool {
+    private func isDescendant(_ ancestorID: BookmarkID, of id: BookmarkID) -> Bool {
         if ancestorID == id { return true }
         return children(of: id).contains { isDescendant(ancestorID, of: $0.id) }
     }
@@ -434,7 +434,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
     private func acceptSidebarPayloadDrop(_ list: SidebarDragPayloadList,
                                           onto item: Any?, atIndex index: Int,
                                           store: WikiStoreModel) -> Bool {
-        let parentID: String?
+        let parentID: BookmarkID?
         let basePosition: Int
         if let folder = item as? BookmarkNode, folder.kind == .folder {
             parentID = folder.id
@@ -456,7 +456,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             case .chat:
                 store.addChatRef(parentID: parentID, chatID: ChatID(rawValue: payload.id), position: position)
             }
-            DebugLog.tabs("[drop] sidebar-item bookmark created: kind=\(payload.kind) id=\(payload.id) parentID=\(parentID ?? "root") position=\(position)")
+            DebugLog.tabs("[drop] sidebar-item bookmark created: kind=\(payload.kind) id=\(payload.id) parentID=\(parentID?.rawValue ?? "root") position=\(position)")
             position += 1
         }
         return true
@@ -501,7 +501,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
         // Resolve parent + insertion index. `index == -1` (NSOutlineViewDropOnItemIndex)
         // means "drop on the item", so append inside it (or, for a leaf, at the
         // leaf's own slot); `index >= 0` means "insert between siblings".
-        let parentID: String?
+        let parentID: BookmarkID?
         let position: Int
         if let folder = item as? BookmarkNode, folder.kind == .folder {
             parentID = folder.id
@@ -526,7 +526,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             // the drop so a chat wiki-link drag is a no-op rather than a crash.
             return false
         }
-        DebugLog.tabs("[drop] wiki-link bookmark created: kind=\(kind) title=\"\(title)\" parentID=\(parentID ?? "root") position=\(position)")
+        DebugLog.tabs("[drop] wiki-link bookmark created: kind=\(kind) title=\"\(title)\" parentID=\(parentID?.rawValue ?? "root") position=\(position)")
         return true
     }
 
@@ -534,7 +534,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
                      validateDrop info: NSDraggingInfo,
                      proposedItem item: Any?,
                      proposedChildIndex index: Int) -> NSDragOperation {
-        DebugLog.tabs("BookmarksOutlineView.validateDrop: mask=\(info.draggingSourceOperationMask.rawValue) item=\((item as? BookmarkNode)?.id ?? "root") index=\(index)")
+        DebugLog.tabs("BookmarksOutlineView.validateDrop: mask=\(info.draggingSourceOperationMask.rawValue) item=\((item as? BookmarkNode)?.id.rawValue ?? "root") index=\(index)")
         // Wiki-link drop: a `wiki://page?title=…` / `wiki://source?title=…`
         // anchor dragged out of rendered page/source content (issue #169). The
         // default WKWebView link drag vends the href as `.url`/`.string`; accept
@@ -561,7 +561,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
             // [] here gives the right no-drop cursor affordance.
             if let folder = item as? BookmarkNode, folder.kind == .folder {
                 for id in Self.draggedBookmarkNodeIDs(from: info.draggingPasteboard) {
-                    if isDescendant(folder.id, of: id) { return [] }
+                    if isDescendant(folder.id, of: BookmarkID(rawValue: id)) { return [] }
                 }
                 return .move
             }
@@ -590,7 +590,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
                      acceptDrop info: NSDraggingInfo,
                      item: Any?,
                      childIndex index: Int) -> Bool {
-        DebugLog.tabs("BookmarksOutlineView.acceptDrop: item=\((item as? BookmarkNode)?.id ?? "root") index=\(index)")
+        DebugLog.tabs("BookmarksOutlineView.acceptDrop: item=\((item as? BookmarkNode)?.id.rawValue ?? "root") index=\(index)")
         guard let store else { return false }
 
         // Wiki-link drop → create a bookmark pointing at the link's target
@@ -610,10 +610,10 @@ extension BookmarksOutlineViewController: NSOutlineViewDataSource {
         // external sidebar drags (no bookmark-node-id type) fall through to
         // the sidebar-payload branch below.
         if Self.isOutlineInternalDrag(info.draggingPasteboard) {
-            let draggedIDs = Self.draggedBookmarkNodeIDs(from: info.draggingPasteboard)
+            let draggedIDs = Self.draggedBookmarkNodeIDs(from: info.draggingPasteboard).map { BookmarkID(rawValue: $0) }
             guard !draggedIDs.isEmpty else { return false }
 
-            func moveAll(toParentID parentID: String?, startingAt position: Int) -> Bool {
+            func moveAll(toParentID parentID: BookmarkID?, startingAt position: Int) -> Bool {
                 var position = position
                 var succeeded = true
                 for id in draggedIDs {
@@ -909,7 +909,7 @@ extension BookmarksOutlineViewController: NSOutlineViewDelegate {
 
     /// Shared deletion seam for both the context-menu "Delete" action and the
     /// keyboard Delete/Backspace path (`deleteSelection`).
-    private func deleteNodes(_ ids: [String]) {
+    private func deleteNodes(_ ids: [BookmarkID]) {
         guard !ids.isEmpty else { return }
         callbacks?.onDelete(ids)
     }

--- a/Sources/WikiFS/Bookmarks/EditBookmarkSheet.swift
+++ b/Sources/WikiFS/Bookmarks/EditBookmarkSheet.swift
@@ -4,7 +4,7 @@ import WikiFSCore
 /// Sheet for editing a bookmark folder's name.
 struct EditBookmarkSheet: View {
     let store: WikiStoreModel
-    let nodeID: String
+    let nodeID: BookmarkID
     /// Receives the chosen folder name. Main-actor: the caller touches the
     /// @MainActor WikiStoreModel to create bookmark refs.
     let onSave: (@MainActor @Sendable (String) -> Void)

--- a/Sources/WikiFSCore/Core/BookmarkNode.swift
+++ b/Sources/WikiFSCore/Core/BookmarkNode.swift
@@ -53,8 +53,8 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
         }
     }
 
-    public let id: String
-    public var parentID: String?
+    public let id: BookmarkID
+    public var parentID: BookmarkID?
     public var position: Int
     public var content: Content
     /// When the node was first created (issue #242). Epoch default lets
@@ -66,8 +66,8 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
     public var updatedAt: Date
 
     public init(
-        id: String,
-        parentID: String?,
+        id: BookmarkID,
+        parentID: BookmarkID?,
         position: Int,
         content: Content,
         createdAt: Date = Date(timeIntervalSince1970: 0),
@@ -93,26 +93,26 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
     /// Reconstruct the tagged content from one complete persisted row tuple.
     /// This is internal because callers must create typed `Content` directly.
     internal static func content(
-        bookmarkID: String,
+        bookmarkID: BookmarkID,
         kindRawValue: String,
         label: String?,
         targetRawValue: String?
     ) throws -> Content {
         guard let kind = BookmarkNodeKind(rawValue: kindRawValue) else {
-            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "unknown kind '\(kindRawValue)'")
+            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "unknown kind '\(kindRawValue)'")
         }
         switch kind {
         case .folder:
             guard targetRawValue == nil else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "folder has target_id")
+                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "folder has target_id")
             }
             guard let label, !label.isEmpty else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "folder requires a non-empty label")
+                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "folder requires a non-empty label")
             }
             return .folder(label: label)
         case .pageRef:
             guard label == nil else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "page reference has label")
+                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "page reference has label")
             }
             let targetRawValue = try requiredTargetRawValue(
                 bookmarkID: bookmarkID,
@@ -122,7 +122,7 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
             return .page(PageID(rawValue: targetRawValue))
         case .sourceRef:
             guard label == nil else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "source reference has label")
+                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "source reference has label")
             }
             let targetRawValue = try requiredTargetRawValue(
                 bookmarkID: bookmarkID,
@@ -132,7 +132,7 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
             return .source(SourceID(rawValue: targetRawValue))
         case .chatRef:
             guard label == nil else {
-                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "chat reference has label")
+                throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "chat reference has label")
             }
             let targetRawValue = try requiredTargetRawValue(
                 bookmarkID: bookmarkID,
@@ -144,15 +144,15 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
     }
 
     private static func requiredTargetRawValue(
-        bookmarkID: String,
+        bookmarkID: BookmarkID,
         targetRawValue: String?,
         referenceName: String
     ) throws -> String {
         guard let targetRawValue else {
-            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "\(referenceName) requires target_id")
+            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "\(referenceName) requires target_id")
         }
         guard targetRawValue.isEmpty == false else {
-            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID, reason: "\(referenceName) requires a non-empty target_id")
+            throw WikiStoreError.invalidBookmarkRow(id: bookmarkID.rawValue, reason: "\(referenceName) requires a non-empty target_id")
         }
         return targetRawValue
     }
@@ -169,8 +169,8 @@ public struct BookmarkNode: Identifiable, Hashable, Sendable {
     ///     (typically `store.bookmarkNodes`).
     /// - Returns: The joined path, or an empty string if the id isn't found or
     ///   has no label.
-    public static func displayPath(id: String, in nodes: [BookmarkNode]) -> String {
-        var byID: [String: BookmarkNode] = [:]
+    public static func displayPath(id: BookmarkID, in nodes: [BookmarkNode]) -> String {
+        var byID: [BookmarkID: BookmarkNode] = [:]
         byID.reserveCapacity(nodes.count)
         for node in nodes { byID[node.id] = node }
 

--- a/Sources/WikiFSCore/Core/BookmarkTreeBuilder.swift
+++ b/Sources/WikiFSCore/Core/BookmarkTreeBuilder.swift
@@ -17,7 +17,7 @@ public struct BookmarkTreeItem: Identifiable, Hashable, Sendable {
     /// open a tab. Double-click or context-menu "Open" navigates instead.
     /// This keeps bookmarks and tabs fully independent.
     public var selection: WikiSelection? {
-        .bookmark(node.id)
+        .bookmark(node.id.rawValue)
     }
 
     /// The `WikiSelection` to open when the user double-clicks or uses "Open".
@@ -46,12 +46,12 @@ public struct BookmarkTreeItem: Identifiable, Hashable, Sendable {
 /// always expandable. Page/source refs are leaves (`children = nil`).
 public func buildBookmarkTree(nodes: [BookmarkNode]) -> [BookmarkTreeItem] {
     // Group nodes by parentID (nil = root).
-    var childrenByParent: [String?: [BookmarkNode]] = [:]
+    var childrenByParent: [BookmarkID?: [BookmarkNode]] = [:]
     for node in nodes {
         childrenByParent[node.parentID, default: []].append(node)
     }
 
-    func buildChildren(of parentID: String?) -> [BookmarkTreeItem] {
+    func buildChildren(of parentID: BookmarkID?) -> [BookmarkTreeItem] {
         let siblings = (childrenByParent[parentID] ?? []).sorted { $0.position < $1.position }
         return siblings.map { buildItem(from: $0) }
     }
@@ -61,10 +61,10 @@ public func buildBookmarkTree(nodes: [BookmarkNode]) -> [BookmarkTreeItem] {
         case .folder:
             // Always expandable — empty array when no children.
             let children = buildChildren(of: node.id)
-            return BookmarkTreeItem(id: node.id, node: node, children: children)
+            return BookmarkTreeItem(id: node.id.rawValue, node: node, children: children)
         case .page, .source, .chat:
             // Leaf — no disclosure triangle.
-            return BookmarkTreeItem(id: node.id, node: node, children: nil)
+            return BookmarkTreeItem(id: node.id.rawValue, node: node, children: nil)
         }
     }
 

--- a/Sources/WikiFSCore/Core/EditorTab.swift
+++ b/Sources/WikiFSCore/Core/EditorTab.swift
@@ -44,7 +44,7 @@ extension WikiStoreModel {
             guard let source = sources.first(where: { $0.id == id }) else { return "Source" }
             return source.effectiveName.nonEmpty ?? "Source"
         case .bookmark(let id):
-            return bookmarkNodes.first(where: { $0.id == id })?.label ?? "Bookmark"
+            return bookmarkNodes.first(where: { $0.id.rawValue == id })?.label ?? "Bookmark"
         case .chat(let id):
             return chats.first { $0.id == id }?.title ?? "Chat"
         }

--- a/Sources/WikiFSCore/Core/WikiStateSnapshot.swift
+++ b/Sources/WikiFSCore/Core/WikiStateSnapshot.swift
@@ -154,7 +154,7 @@ public struct WikiStateSnapshot: Equatable, Sendable {
   /// show their target id. The indentation level reflects nesting depth.
   static func renderBookmarkTree(_ nodes: [BookmarkNode]) -> String {
     // Build parent→children map for tree traversal.
-    var childrenMap: [String?: [BookmarkNode]] = [:]
+    var childrenMap: [BookmarkID?: [BookmarkNode]] = [:]
     for node in nodes {
       childrenMap[node.parentID, default: []].append(node)
     }
@@ -164,7 +164,7 @@ public struct WikiStateSnapshot: Equatable, Sendable {
     }
 
     var lines: [String] = []
-    func renderChildren(of parentID: String?, depth: Int) {
+    func renderChildren(of parentID: BookmarkID?, depth: Int) {
       let children = childrenMap[parentID] ?? []
       for child in children {
         let indent = String(repeating: "  ", count: depth)

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -5863,12 +5863,13 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 let kind: String = row["kind"]
                 let label: String? = row["label"]
                 let targetRawValue: String? = row["target_id"]
+                let parentIDRaw: String? = row["parent_id"]
                 return BookmarkNode(
-                    id: id,
-                    parentID: row["parent_id"],
+                    id: BookmarkID(rawValue: id),
+                    parentID: parentIDRaw.map(BookmarkID.init(rawValue:)),
                     position: row["position"],
                     content: try BookmarkNode.content(
-                        bookmarkID: id,
+                        bookmarkID: BookmarkID(rawValue: id),
                         kindRawValue: kind,
                         label: label,
                         targetRawValue: targetRawValue
@@ -5882,19 +5883,19 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
 
     public func createBookmarkNode(
-        parentID: String?, position: Int,
+        parentID: BookmarkID?, position: Int,
         content: BookmarkNode.Content
     ) throws -> BookmarkNode {
         try mutate(event: { node in
-            self.localEvent(.bookmark, id: node.id, change: .created)
+            self.localEvent(.bookmark, id: node.id.rawValue, change: .created)
         }) { db in
             _ = try BookmarkNode.content(
-                bookmarkID: "<new bookmark>",
+                bookmarkID: BookmarkID(rawValue: "<new bookmark>"),
                 kindRawValue: content.kind.rawValue,
                 label: content.label,
                 targetRawValue: content.targetRawValue
             )
-            let id = ULID.generate()
+            let id = BookmarkID(rawValue: ULID.generate())
             let now = Date().timeIntervalSince1970
 
             // Shift siblings at >= position up by 1 within the same parent.
@@ -5902,13 +5903,13 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             try db.execute(sql: """
             UPDATE bookmark_nodes SET position = position + 1
             WHERE parent_id IS ? AND position >= ?;
-            """, arguments: [parentID as String?, position])
+            """, arguments: [parentID?.rawValue as String?, position])
 
             try db.execute(sql: """
             INSERT INTO bookmark_nodes (id, parent_id, position, kind, label, target_id, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?);
             """, arguments: [
-                id, parentID as String?, position, content.kind.rawValue,
+                id.rawValue, parentID?.rawValue as String?, position, content.kind.rawValue,
                 content.label as String?, content.targetRawValue as String?, now, now
             ])
 
@@ -5917,7 +5918,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             let parentArg: String?
             if let parentID {
                 parentColumn = "parent_id = ?"
-                parentArg = parentID
+                parentArg = parentID.rawValue
             } else {
                 parentColumn = "parent_id IS NULL"
                 parentArg = nil
@@ -5944,37 +5945,37 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     }
 
 
-    public func renameBookmarkFolder(id: String, to label: String) throws {
+    public func renameBookmarkFolder(id: BookmarkID, to label: String) throws {
         try mutate(event: { _ in
-            self.localEvent(.bookmark, id: id, change: .updated)
+            self.localEvent(.bookmark, id: id.rawValue, change: .updated)
         }) { db in
             guard !label.isEmpty else {
-                throw WikiStoreError.invalidBookmarkRow(id: id, reason: "folder requires a non-empty label")
+                throw WikiStoreError.invalidBookmarkRow(id: id.rawValue, reason: "folder requires a non-empty label")
             }
             let now = Date().timeIntervalSince1970
             try db.execute(sql: """
             UPDATE bookmark_nodes SET label = ?, updated_at = ? WHERE id = ? AND kind = ?;
-            """, arguments: [label, now, id, BookmarkNodeKind.folder.rawValue])
+            """, arguments: [label, now, id.rawValue, BookmarkNodeKind.folder.rawValue])
             guard db.changesCount == 1 else {
-                throw WikiStoreError.invalidBookmarkRow(id: id, reason: "only folders can be renamed")
+                throw WikiStoreError.invalidBookmarkRow(id: id.rawValue, reason: "only folders can be renamed")
             }
         }
     }
 
 
-    public func deleteBookmarkNode(id: String) throws {
+    public func deleteBookmarkNode(id: BookmarkID) throws {
         try mutate(event: { _ in
-            self.localEvent(.bookmark, id: id, change: .deleted)
+            self.localEvent(.bookmark, id: id.rawValue, change: .deleted)
         }) { db in
             // Capture the parent for sibling renumbering after the delete.
             let oldParent: String? = try String.fetchOne(
                 db,
                 sql: "SELECT parent_id FROM bookmark_nodes WHERE id = ?;",
-                arguments: [id]
+                arguments: [id.rawValue]
             )
             try db.execute(
                 sql: "DELETE FROM bookmark_nodes WHERE id = ?;",
-                arguments: [id]
+                arguments: [id.rawValue]
             )
             // Renumber old siblings to be contiguous.
             let parentColumn: String
@@ -6002,17 +6003,17 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     }
 
 
-    public func moveBookmarkNode(id: String, toParentID: String?, position: Int) throws {
+    public func moveBookmarkNode(id: BookmarkID, toParentID: BookmarkID?, position: Int) throws {
         try mutate(event: { _ in
-            self.localEvent(.bookmark, id: id, change: .updated)
+            self.localEvent(.bookmark, id: id.rawValue, change: .updated)
         }) { db in
             // Read the node's current parent.
             guard let row = try Row.fetchOne(
                 db,
                 sql: "SELECT parent_id, position FROM bookmark_nodes WHERE id = ?;",
-                arguments: [id]
+                arguments: [id.rawValue]
             ) else {
-                throw WikiStoreError.unexpected("moveBookmarkNode: node \(id) not found")
+                throw WikiStoreError.unexpected("moveBookmarkNode: node \(id.rawValue) not found")
             }
             let oldParent: String? = row["parent_id"]
 
@@ -6020,11 +6021,11 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             // descendants. Walk up the parent chain from toParentID — if we
             // encounter `id`, it's a descendant (or the node itself).
             if let toParentID {
-                var ancestor: String? = toParentID
+                var ancestor: String? = toParentID.rawValue
                 while let current = ancestor {
-                    if current == id {
+                    if current == id.rawValue {
                         throw WikiStoreError.unexpected(
-                            "moveBookmarkNode: cannot move \(id) into its own descendant \(toParentID)"
+                            "moveBookmarkNode: cannot move \(id.rawValue) into its own descendant \(toParentID.rawValue)"
                         )
                     }
                     ancestor = try String.fetchOne(
@@ -6037,7 +6038,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
 
             let sameParent: Bool
             if let oldParent, let toParentID {
-                sameParent = oldParent == toParentID
+                sameParent = oldParent == toParentID.rawValue
             } else {
                 sameParent = oldParent == nil && toParentID == nil
             }
@@ -6047,23 +6048,23 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             try db.execute(sql: """
             UPDATE bookmark_nodes SET position = position + 1
             WHERE parent_id IS ? AND position >= ? AND id != ?;
-            """, arguments: [toParentID as String?, position, id])
+            """, arguments: [toParentID?.rawValue as String?, position, id.rawValue])
 
             // Step 2: Update the node's parent + position.
             try db.execute(sql: """
             UPDATE bookmark_nodes SET parent_id = ?, position = ? WHERE id = ?;
-            """, arguments: [toParentID as String?, position, id])
+            """, arguments: [toParentID?.rawValue as String?, position, id.rawValue])
 
             // Step 2b: A move to a NEW parent bumps updated_at; a pure same-parent
             // reorder does NOT (organizing siblings shouldn't reshuffle the recency view).
             if !sameParent {
                 try db.execute(sql: """
                 UPDATE bookmark_nodes SET updated_at = ? WHERE id = ?;
-                """, arguments: [Date().timeIntervalSince1970, id])
+                """, arguments: [Date().timeIntervalSince1970, id.rawValue])
             }
 
             // Step 3: Renumber siblings on both old and new parent (or root).
-            for parent in [toParentID, sameParent ? nil : oldParent].compactMap({ $0 }) {
+            for parent in [toParentID?.rawValue, sameParent ? nil : oldParent].compactMap({ $0 }) {
                 let sibRows = try Row.fetchAll(
                     db,
                     sql: "SELECT id FROM bookmark_nodes WHERE parent_id = ? ORDER BY position ASC;",

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -640,20 +640,20 @@ public protocol WikiStore: Sendable {
     /// Returns the inserted node with its generated id.
     @discardableResult
     func createBookmarkNode(
-        parentID: String?,
+        parentID: BookmarkID?,
         position: Int,
         content: BookmarkNode.Content
     ) throws -> BookmarkNode
 
     /// Update the label of a bookmark node (folders only).
-    func renameBookmarkFolder(id: String, to label: String) throws
+    func renameBookmarkFolder(id: BookmarkID, to label: String) throws
 
     /// Delete a bookmark node by id. `ON DELETE CASCADE` removes descendants.
-    func deleteBookmarkNode(id: String) throws
+    func deleteBookmarkNode(id: BookmarkID) throws
 
     /// Move a node to a new parent and/or position. Renumber siblings of both
     /// the old and new parent so positions stay contiguous (0, 1, 2, …).
-    func moveBookmarkNode(id: String, toParentID: String?, position: Int) throws
+    func moveBookmarkNode(id: BookmarkID, toParentID: BookmarkID?, position: Int) throws
 
     // MARK: - Persisted chats (issue #119 phase 1)
 

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -705,7 +705,7 @@ public final class WikiStoreModel {
         guard !query.isEmpty else { return bookmarkNodes }
         let byID = Dictionary(uniqueKeysWithValues: bookmarkNodes.map { ($0.id, $0) })
 
-        var matchingIDs = Set<String>()
+        var matchingIDs = Set<BookmarkID>()
         for node in bookmarkNodes {
             let title = resolveBookmarkTitle(node)
             if title.localizedCaseInsensitiveContains(query) {
@@ -713,9 +713,9 @@ public final class WikiStoreModel {
             }
         }
 
-        var visibleIDs = Set<String>()
+        var visibleIDs = Set<BookmarkID>()
         for id in matchingIDs {
-            var current: String? = id
+            var current: BookmarkID? = id
             while let cid = current, let node = byID[cid] {
                 visibleIDs.insert(cid)
                 current = node.parentID
@@ -3952,7 +3952,7 @@ public final class WikiStoreModel {
     /// Create a folder at root or inside another folder. Returns the new node id,
     /// or `nil` on failure.
     @discardableResult
-    public func createFolder(parentID: String?, name: String) -> String? {
+    public func createFolder(parentID: BookmarkID?, name: String) -> BookmarkID? {
         // Determine the position (append at end of siblings).
         let position = bookmarkNodes.filter { $0.parentID == parentID }.count
         do {
@@ -3969,7 +3969,7 @@ public final class WikiStoreModel {
 
     /// Add a page reference to a folder. Pass `position` to insert at a specific
     /// sibling index (the store shifts later siblings down); omit it to append.
-    public func addPageRef(parentID: String?, pageID: PageID, position: Int? = nil) {
+    public func addPageRef(parentID: BookmarkID?, pageID: PageID, position: Int? = nil) {
         let t0 = DispatchTime.now()
         let pos = position ?? bookmarkNodes.filter { $0.parentID == parentID }.count
         do {
@@ -3986,7 +3986,7 @@ public final class WikiStoreModel {
 
     /// Add a source reference to a folder. Pass `position` to insert at a specific
     /// sibling index (the store shifts later siblings down); omit it to append.
-    public func addSourceRef(parentID: String?, sourceID: SourceID, position: Int? = nil) {
+    public func addSourceRef(parentID: BookmarkID?, sourceID: SourceID, position: Int? = nil) {
         let pos = position ?? bookmarkNodes.filter { $0.parentID == parentID }.count
         do {
             _ = try store.createBookmarkNode(
@@ -4000,7 +4000,7 @@ public final class WikiStoreModel {
 
     /// Add a chat reference to a folder. Pass `position` to insert at a specific
     /// sibling index (the store shifts later siblings down); omit it to append.
-    public func addChatRef(parentID: String?, chatID: ChatID, position: Int? = nil) {
+    public func addChatRef(parentID: BookmarkID?, chatID: ChatID, position: Int? = nil) {
         let pos = position ?? bookmarkNodes.filter { $0.parentID == parentID }.count
         do {
             _ = try store.createBookmarkNode(
@@ -4013,7 +4013,7 @@ public final class WikiStoreModel {
     }
 
     /// Rename a folder.
-    public func renameBookmarkNode(id: String, to label: String) {
+    public func renameBookmarkNode(id: BookmarkID, to label: String) {
         do {
             try store.renameBookmarkFolder(id: id, to: label)
             // No manual reload — the bus fires reloadFromStore() async after the
@@ -4024,7 +4024,7 @@ public final class WikiStoreModel {
     }
 
     /// Delete a bookmark node (cascade-deletes children for folders).
-    public func deleteBookmarkNode(id: String) {
+    public func deleteBookmarkNode(id: BookmarkID) {
         do {
             try store.deleteBookmarkNode(id: id)
             // No manual reload — the bus fires reloadFromStore() async after the
@@ -4037,7 +4037,7 @@ public final class WikiStoreModel {
     /// Move a node to a new parent and/or position. Returns `false` (and logs)
     /// if the store rejects the move — e.g. it would create a parent cycle.
     @discardableResult
-    public func moveBookmarkNode(id: String, toParentID: String?, position: Int) -> Bool {
+    public func moveBookmarkNode(id: BookmarkID, toParentID: BookmarkID?, position: Int) -> Bool {
         do {
             try store.moveBookmarkNode(id: id, toParentID: toParentID, position: position)
             // No manual reload — the bus fires reloadFromStore() async after the

--- a/Sources/WikiFSFileProvider/Projection.swift
+++ b/Sources/WikiFSFileProvider/Projection.swift
@@ -997,10 +997,10 @@ struct Projection {
     /// Map a `BookmarkNode` to its File Provider identifier (kind-dispatched).
     static func bookmarkID(for node: BookmarkNode) -> NSFileProviderItemIdentifier {
         switch node.kind {
-        case .folder:      return Identity.bookmarkFolder(node.id)
-        case .pageRef:     return Identity.bookmarkPageRef(node.id)
-        case .sourceRef:   return Identity.bookmarkSourceRef(node.id)
-        case .chatRef:     return Identity.bookmarkChatRef(node.id)
+        case .folder:      return Identity.bookmarkFolder(node.id.rawValue)
+        case .pageRef:     return Identity.bookmarkPageRef(node.id.rawValue)
+        case .sourceRef:   return Identity.bookmarkSourceRef(node.id.rawValue)
+        case .chatRef:     return Identity.bookmarkChatRef(node.id.rawValue)
         }
     }
 
@@ -1008,7 +1008,7 @@ struct Projection {
     /// the `bookmarks` folder; nested → the parent's folder identifier).
     static func bookmarkParent(for node: BookmarkNode) -> NSFileProviderItemIdentifier {
         if let parentID = node.parentID {
-            return Identity.bookmarkFolder(parentID)
+            return Identity.bookmarkFolder(parentID.rawValue)
         }
         return Identity.bookmarks
     }
@@ -1027,7 +1027,7 @@ struct Projection {
     /// corrupted parent cycle can't loop forever.
     private func bookmarkBaseDir(for node: BookmarkNode,
                                  in nodes: [BookmarkNode]) -> [String] {
-        var byID: [String: BookmarkNode] = [:]
+        var byID: [BookmarkID: BookmarkNode] = [:]
         byID.reserveCapacity(nodes.count)
         for n in nodes { byID[n.id] = n }
 
@@ -1108,19 +1108,19 @@ struct Projection {
         guard let ulid = Identity.bookmarkULID(from: id),
               let store = openReadStore(),
               let nodes = DebugLog.trying("listBookmarkNodes", operation: { try store.listBookmarkNodes() }),
-              let node = nodes.first(where: { $0.id == ulid }) else { return nil }
+              let node = nodes.first(where: { $0.id.rawValue == ulid }) else { return nil }
         return bookmarkNodeItem(for: node, in: store, maps: cachedLinkMaps(), allNodes: nodes)
     }
 
     /// Enumerate the children of a bookmark container (the topLevel folder or a
     /// nested folder). Leaf identifiers return `[]`.
     private func bookmarkChildren(of container: NSFileProviderItemIdentifier) -> [ProjectedNode] {
-        let parentID: String?
+        let parentID: BookmarkID?
         if container == Identity.bookmarks {
             parentID = nil
         } else if container.rawValue.hasPrefix(Identity.bookmarkFolderPrefix),
                   let ulid = Identity.bookmarkULID(from: container) {
-            parentID = ulid
+            parentID = BookmarkID(rawValue: ulid)
         } else {
             return []
         }
@@ -1139,7 +1139,7 @@ struct Projection {
         guard let ulid = Identity.bookmarkULID(from: id),
               let store = openReadStore(),
               let nodes = DebugLog.trying("listBookmarkNodes", operation: { try store.listBookmarkNodes() }),
-              let node = nodes.first(where: { $0.id == ulid }) else { return nil }
+              let node = nodes.first(where: { $0.id.rawValue == ulid }) else { return nil }
         switch node.content {
         case .folder:
             return nil

--- a/Sources/WikiFSTypes/BookmarkID.swift
+++ b/Sources/WikiFSTypes/BookmarkID.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Stable identifier for a `BookmarkNode` in the bookmarks tree. The raw value
+/// is a ULID string.
+///
+/// A bookmark node's identifier belongs to a separate namespace from page,
+/// source, chat, workspace, and wiki identifiers.
+public struct BookmarkID: Hashable, Codable, RawRepresentable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+extension BookmarkID: Identifiable {
+    public var id: String { rawValue }
+}

--- a/Tests/WikiFSAppTests/BookmarkTargetPickerSelectionTests.swift
+++ b/Tests/WikiFSAppTests/BookmarkTargetPickerSelectionTests.swift
@@ -2,6 +2,7 @@
 import Testing
 @testable import WikiFS
 @testable import WikiFSEngine
+import WikiFSCore
 
 /// Tests for `BookmarkTargetPickerSheet.parentID(forSelection:)` — the
 /// `BookmarkFolderSelection` → parentID mapping. Root and a deselected picker
@@ -14,7 +15,7 @@ import Testing
     }
 
     @Test func folderSelectionMapsToItsID() {
-        #expect(BookmarkTargetPickerSheet.parentID(forSelection: .folder("01HZXAMPLE000FOLDER")) == "01HZXAMPLE000FOLDER")
+        #expect(BookmarkTargetPickerSheet.parentID(forSelection: .folder(BookmarkID(rawValue: "01HZXAMPLE000FOLDER"))) == BookmarkID(rawValue: "01HZXAMPLE000FOLDER"))
     }
 
     @Test func nilSelectionMapsToNil() {
@@ -27,7 +28,7 @@ import Testing
         // folder whose id happens to spell the old sentinel. This is the bug
         // class the enum exists to close.
         #expect(BookmarkTargetPickerSheet.parentID(forSelection: .root) == nil)
-        #expect(BookmarkTargetPickerSheet.parentID(forSelection: .folder("__bookmarks_root__")) == "__bookmarks_root__")
+        #expect(BookmarkTargetPickerSheet.parentID(forSelection: .folder(BookmarkID(rawValue: "__bookmarks_root__"))) == BookmarkID(rawValue: "__bookmarks_root__"))
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/BookmarksMultiSelectMenuTests.swift
+++ b/Tests/WikiFSAppTests/BookmarksMultiSelectMenuTests.swift
@@ -49,11 +49,11 @@ struct BookmarksMultiSelectMenuTests {
         case .chatRef:
             content = .chat(ChatID(rawValue: targetID))
         }
-        return BookmarkNode(id: id, parentID: nil, position: 0, content: content)
+        return BookmarkNode(id: BookmarkID(rawValue: id), parentID: nil, position: 0, content: content)
     }
 
     private func folder(_ id: String) -> BookmarkNode {
-        BookmarkNode(id: id, parentID: nil, position: 0, content: .folder(label: "Folder \(id)"))
+        BookmarkNode(id: BookmarkID(rawValue: id), parentID: nil, position: 0, content: .folder(label: "Folder \(id)"))
     }
 
     /// Calls `menuFor` on the VC and returns the non-separator item titles.
@@ -202,7 +202,7 @@ struct BookmarksMultiSelectMenuTests {
         let vc = makeVC(nodes: nodes)
         let outline = vc.outlineView!
 
-        var deletedIDs: [String] = []
+        var deletedIDs: [BookmarkID] = []
         vc.callbacks = BookmarksCallbacks(
             onOpen: { _ in }, onOpenBackground: { _ in },
             onGoToOriginal: { _ in },
@@ -222,7 +222,7 @@ struct BookmarksMultiSelectMenuTests {
         _ = vc.perform(deleteItem.action, with: deleteItem)
 
         #expect(deletedIDs.count == 3)
-        #expect(Set(deletedIDs) == Set(["n1", "n2", "n3"]))
+        #expect(Set(deletedIDs) == Set(["n1", "n2", "n3"].map(BookmarkID.init(rawValue:))))
     }
 
     @Test func openCallbackReceivesOnlyOpenableSelections() {

--- a/Tests/WikiFSAppTests/BookmarksSearchTests.swift
+++ b/Tests/WikiFSAppTests/BookmarksSearchTests.swift
@@ -12,15 +12,15 @@ import WikiFSCore
     // MARK: - Helpers
 
     private func folder(_ id: String, parent: String? = nil, label: String) -> BookmarkNode {
-        BookmarkNode(id: id, parentID: parent, position: 0, content: .folder(label: label))
+        BookmarkNode(id: BookmarkID(rawValue: id), parentID: parent.map(BookmarkID.init(rawValue:)), position: 0, content: .folder(label: label))
     }
 
     private func pageRef(_ id: String, parent: String?, target: String) -> BookmarkNode {
-        BookmarkNode(id: id, parentID: parent, position: 0, content: .page(PageID(rawValue: target)))
+        BookmarkNode(id: BookmarkID(rawValue: id), parentID: parent.map(BookmarkID.init(rawValue:)), position: 0, content: .page(PageID(rawValue: target)))
     }
 
     private func sourceRef(_ id: String, parent: String?, target: String) -> BookmarkNode {
-        BookmarkNode(id: id, parentID: parent, position: 0, content: .source(SourceID(rawValue: target)))
+        BookmarkNode(id: BookmarkID(rawValue: id), parentID: parent.map(BookmarkID.init(rawValue:)), position: 0, content: .source(SourceID(rawValue: target)))
     }
 
     /// A trivial title resolver: maps the raw target to the title,
@@ -61,7 +61,7 @@ import WikiFSCore
         let nodes = [folder("a", label: "Reading List")]
         let result = BookmarksContainerView.filterNodes(nodes, query: "reading", resolveTitle: Self.resolver)
         #expect(result.count == 1)
-        #expect(result[0].id == "a")
+        #expect(result[0].id.rawValue == "a")
     }
 
     // MARK: - Ref title matching
@@ -74,8 +74,8 @@ import WikiFSCore
         let result = BookmarksContainerView.filterNodes(nodes, query: "mars", resolveTitle: Self.resolver)
         // Match + ancestor folder
         #expect(result.count == 2)
-        #expect(result.contains { $0.id == "p" })
-        #expect(result.contains { $0.id == "f" })
+        #expect(result.contains { $0.id.rawValue == "p" })
+        #expect(result.contains { $0.id.rawValue == "f" })
     }
 
     @Test func matchesSourceRefTitle() {
@@ -84,7 +84,7 @@ import WikiFSCore
         ]
         let result = BookmarksContainerView.filterNodes(nodes, query: "nasa", resolveTitle: Self.resolver)
         #expect(result.count == 1)
-        #expect(result[0].id == "s")
+        #expect(result[0].id.rawValue == "s")
     }
 
     // MARK: - Ancestor expansion
@@ -99,7 +99,7 @@ import WikiFSCore
         let result = BookmarksContainerView.filterNodes(nodes, query: "hidden", resolveTitle: Self.resolver)
         // Matching node + 3 ancestor folders
         #expect(result.count == 4)
-        #expect(Set(result.map(\.id)) == Set(["p", "leaf", "mid", "root"]))
+        #expect(Set(result.map { $0.id.rawValue }) == Set(["p", "leaf", "mid", "root"]))
     }
 
     @Test func nonMatchingSiblingIsExcluded() {
@@ -111,7 +111,7 @@ import WikiFSCore
         let result = BookmarksContainerView.filterNodes(nodes, query: "mars", resolveTitle: Self.resolver)
         // Folder + matching page, but NOT the non-matching sibling
         #expect(result.count == 2)
-        #expect(Set(result.map(\.id)) == Set(["f", "p1"]))
+        #expect(Set(result.map { $0.id.rawValue }) == Set(["f", "p1"]))
     }
 
     // MARK: - Multiple matches
@@ -124,7 +124,7 @@ import WikiFSCore
         ]
         let result = BookmarksContainerView.filterNodes(nodes, query: "research", resolveTitle: Self.resolver)
         #expect(result.count == 2)
-        #expect(Set(result.map(\.id)) == Set(["f1", "f2"]))
+        #expect(Set(result.map { $0.id.rawValue }) == Set(["f1", "f2"]))
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/EnumeratorDeletionTests.swift
+++ b/Tests/WikiFSAppTests/EnumeratorDeletionTests.swift
@@ -158,7 +158,7 @@ struct EnumeratorDeletionTests {
         #expect(enumObs.enumerated.count == 1)
 
         let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
-        let deletedID = Projection.Identity.bookmarkPageRef(ref.id)
+        let deletedID = Projection.Identity.bookmarkPageRef(ref.id.rawValue)
         try s.store.deleteBookmarkNode(id: ref.id)
 
         let changeObs = MockChangeObserver()
@@ -210,7 +210,7 @@ struct EnumeratorDeletionTests {
         #expect(enumObs.enumerated.count == 1)
 
         let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
-        let deletedID = Projection.Identity.bookmarkFolder(folder.id)
+        let deletedID = Projection.Identity.bookmarkFolder(folder.id.rawValue)
         try s.store.deleteBookmarkNode(id: folder.id)
 
         let changeObs = MockChangeObserver()

--- a/Tests/WikiFSAppTests/ProjectionTreeTests.swift
+++ b/Tests/WikiFSAppTests/ProjectionTreeTests.swift
@@ -443,7 +443,7 @@ struct ProjectionTreeTests {
 
     @Test func nestedBookmarkFolderEnumeratesChildren() throws {
         let b = try seedBookmarks()
-        let folderID = Projection.Identity.bookmarkFolder(b.nestedNode.id)
+        let folderID = Projection.Identity.bookmarkFolder(b.nestedNode.id.rawValue)
         let children = b.projection.children(of: folderID)
         // "Papers" folder has no children yet.
         #expect(children.isEmpty)
@@ -451,7 +451,7 @@ struct ProjectionTreeTests {
 
     @Test func bookmarkFolderNodeResolves() throws {
         let b = try seedBookmarks()
-        let id = Projection.Identity.bookmarkFolder(b.folderNode.id)
+        let id = Projection.Identity.bookmarkFolder(b.folderNode.id.rawValue)
         guard let node = b.projection.node(for: id) else {
             Issue.record("folder node not found"); return
         }
@@ -462,7 +462,7 @@ struct ProjectionTreeTests {
 
     @Test func bookmarkPageRefServesTargetContent() throws {
         let b = try seedBookmarks()
-        let id = Projection.Identity.bookmarkPageRef(b.pageRefNode.id)
+        let id = Projection.Identity.bookmarkPageRef(b.pageRefNode.id.rawValue)
         guard let node = b.projection.node(for: id) else {
             Issue.record("page ref node not found"); return
         }
@@ -474,7 +474,7 @@ struct ProjectionTreeTests {
 
     @Test func bookmarkSourceRefServesTargetContent() throws {
         let b = try seedBookmarks()
-        let id = Projection.Identity.bookmarkSourceRef(b.sourceRefNode.id)
+        let id = Projection.Identity.bookmarkSourceRef(b.sourceRefNode.id.rawValue)
         guard let node = b.projection.node(for: id) else {
             Issue.record("source ref node not found"); return
         }
@@ -489,7 +489,7 @@ struct ProjectionTreeTests {
         // A ref to a page that doesn't exist.
         let stale = try b.store.createBookmarkNode(
             parentID: nil, position: 99, content: .page(PageID(rawValue: "does-not-exist")))
-        let id = Projection.Identity.bookmarkPageRef(stale.id)
+        let id = Projection.Identity.bookmarkPageRef(stale.id.rawValue)
         guard let node = b.projection.node(for: id) else {
             Issue.record("stale node not found"); return
         }
@@ -502,10 +502,10 @@ struct ProjectionTreeTests {
     @Test func workingSetIncludesAllBookmarkNodes() throws {
         let b = try seedBookmarks()
         let ids = Set(b.projection.children(of: .workingSet).map(\.id))
-        #expect(ids.contains(Projection.Identity.bookmarkFolder(b.folderNode.id)))
-        #expect(ids.contains(Projection.Identity.bookmarkFolder(b.nestedNode.id)))
-        #expect(ids.contains(Projection.Identity.bookmarkPageRef(b.pageRefNode.id)))
-        #expect(ids.contains(Projection.Identity.bookmarkSourceRef(b.sourceRefNode.id)))
+        #expect(ids.contains(Projection.Identity.bookmarkFolder(b.folderNode.id.rawValue)))
+        #expect(ids.contains(Projection.Identity.bookmarkFolder(b.nestedNode.id.rawValue)))
+        #expect(ids.contains(Projection.Identity.bookmarkPageRef(b.pageRefNode.id.rawValue)))
+        #expect(ids.contains(Projection.Identity.bookmarkSourceRef(b.sourceRefNode.id.rawValue)))
     }
 
     @Test func emptyBookmarksFolderIsStillListedAtRoot() throws {
@@ -537,7 +537,7 @@ struct ProjectionTreeTests {
             parentID: nil, position: 0, content: .page(home.id))
         let projection = Projection(wikiID: WikiID(rawValue: "bm-links-\(UUID().uuidString)"), databaseURL: url)
 
-        let id = Projection.Identity.bookmarkPageRef(pageRefNode.id)
+        let id = Projection.Identity.bookmarkPageRef(pageRefNode.id.rawValue)
         guard let node = projection.node(for: id),
               let bytes = projection.contents(for: id) else {
             Issue.record("bookmark page ref node/content not found"); return
@@ -572,7 +572,7 @@ struct ProjectionTreeTests {
             parentID: folder.id, position: 0, content: .page(home.id))
         let projection = Projection(wikiID: WikiID(rawValue: "bm-nested-\(UUID().uuidString)"), databaseURL: url)
 
-        let id = Projection.Identity.bookmarkPageRef(pageRefNode.id)
+        let id = Projection.Identity.bookmarkPageRef(pageRefNode.id.rawValue)
         guard let node = projection.node(for: id),
               let bytes = projection.contents(for: id) else {
             Issue.record("nested bookmark content not found"); return
@@ -601,7 +601,7 @@ struct ProjectionTreeTests {
             parentID: nil, position: 0, content: .chat(chat.id))
         let projection = Projection(wikiID: WikiID(rawValue: "bm-chat-\(UUID().uuidString)"), databaseURL: url)
 
-        let id = Projection.Identity.bookmarkChatRef(chatRefNode.id)
+        let id = Projection.Identity.bookmarkChatRef(chatRefNode.id.rawValue)
         guard let node = projection.node(for: id),
               let bytes = projection.contents(for: id) else {
             Issue.record("bookmark chat ref node/content not found"); return
@@ -627,7 +627,7 @@ struct ProjectionTreeTests {
             parentID: nil, position: 0, content: .source(pdf.id))
         let projection = Projection(wikiID: WikiID(rawValue: "bm-source-\(UUID().uuidString)"), databaseURL: url)
 
-        let id = Projection.Identity.bookmarkSourceRef(sourceRefNode.id)
+        let id = Projection.Identity.bookmarkSourceRef(sourceRefNode.id.rawValue)
         guard let node = projection.node(for: id),
               let bytes = projection.contents(for: id) else {
             Issue.record("bookmark source ref node/content not found"); return

--- a/Tests/WikiFSTests/BookmarkCommandTests.swift
+++ b/Tests/WikiFSTests/BookmarkCommandTests.swift
@@ -66,7 +66,7 @@ import Foundation
         let store = try tempStore()
         let parent = try store.createBookmarkNode(parentID: nil, position: 0, content: .folder(label: "Parent"))
         let result = try BookmarkCommand.run(
-            .createFolder(parentID: parent.id, name: "Child"), in: store
+            .createFolder(parentID: parent.id.rawValue, name: "Child"), in: store
         )
         #expect(result.didCommit == true)
         let nodes = try store.listBookmarkNodes()
@@ -118,7 +118,7 @@ import Foundation
         let store = try tempStore()
         let node = try store.createBookmarkNode(parentID: nil, position: 0, content: .folder(label: "Old"))
         let result = try BookmarkCommand.run(
-            .rename(id: node.id, to: "New"), in: store
+            .rename(id: node.id.rawValue, to: "New"), in: store
         )
         #expect(result.didCommit == true)
         #expect(result.output.contains("New"))
@@ -131,7 +131,7 @@ import Foundation
     @Test func deleteCommits() throws {
         let store = try tempStore()
         let node = try store.createBookmarkNode(parentID: nil, position: 0, content: .folder(label: "ToDelete"))
-        let result = try BookmarkCommand.run(.delete(id: node.id), in: store)
+        let result = try BookmarkCommand.run(.delete(id: node.id.rawValue), in: store)
         #expect(result.didCommit == true)
         let nodes = try store.listBookmarkNodes()
         #expect(nodes.isEmpty)
@@ -143,7 +143,7 @@ import Foundation
         let store = try tempStore()
         let node = try store.createBookmarkNode(parentID: nil, position: 0, content: .folder(label: "Movable"))
         let result = try BookmarkCommand.run(
-            .move(id: node.id, toParentID: nil, position: 5), in: store
+            .move(id: node.id.rawValue, toParentID: nil, position: 5), in: store
         )
         #expect(result.didCommit == true)
     }

--- a/Tests/WikiFSTests/BookmarkNodeDisplayPathTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeDisplayPathTests.swift
@@ -8,45 +8,45 @@ import Foundation
 
     @Test func rootFolderReturnsItsLabel() {
         let nodes = [
-            BookmarkNode(id: "a", parentID: nil, position: 0, content: .folder(label: "Reading List")),
+            BookmarkNode(id: BookmarkID(rawValue: "a"), parentID: nil, position: 0, content: .folder(label: "Reading List")),
         ]
-        #expect(BookmarkNode.displayPath(id: "a", in: nodes) == "Reading List")
+        #expect(BookmarkNode.displayPath(id: BookmarkID(rawValue: "a"), in: nodes) == "Reading List")
     }
 
     @Test func nestedFolderJoinsParentChain() {
         let nodes = [
-            BookmarkNode(id: "root", parentID: nil, position: 0, content: .folder(label: "Research")),
-            BookmarkNode(id: "mid", parentID: "root", position: 0, content: .folder(label: "Papers")),
-            BookmarkNode(id: "leaf", parentID: "mid", position: 0, content: .folder(label: "2026")),
+            BookmarkNode(id: BookmarkID(rawValue: "root"), parentID: nil, position: 0, content: .folder(label: "Research")),
+            BookmarkNode(id: BookmarkID(rawValue: "mid"), parentID: BookmarkID(rawValue: "root"), position: 0, content: .folder(label: "Papers")),
+            BookmarkNode(id: BookmarkID(rawValue: "leaf"), parentID: BookmarkID(rawValue: "mid"), position: 0, content: .folder(label: "2026")),
         ]
-        #expect(BookmarkNode.displayPath(id: "leaf", in: nodes) == "Research / Papers / 2026")
-        #expect(BookmarkNode.displayPath(id: "mid", in: nodes) == "Research / Papers")
+        #expect(BookmarkNode.displayPath(id: BookmarkID(rawValue: "leaf"), in: nodes) == "Research / Papers / 2026")
+        #expect(BookmarkNode.displayPath(id: BookmarkID(rawValue: "mid"), in: nodes) == "Research / Papers")
     }
 
     @Test func unknownIDReturnsEmptyString() {
         let nodes = [
-            BookmarkNode(id: "a", parentID: nil, position: 0, content: .folder(label: "A")),
+            BookmarkNode(id: BookmarkID(rawValue: "a"), parentID: nil, position: 0, content: .folder(label: "A")),
         ]
-        #expect(BookmarkNode.displayPath(id: "missing", in: nodes) == "")
+        #expect(BookmarkNode.displayPath(id: BookmarkID(rawValue: "missing"), in: nodes) == "")
     }
 
     @Test func emptyLabelSegmentsAreSkipped() {
         // A reference has no label, so only its named parent contributes.
         let nodes = [
-            BookmarkNode(id: "parent", parentID: nil, position: 0, content: .folder(label: "Parent")),
-            BookmarkNode(id: "page", parentID: "parent", position: 0, content: .page(PageID(rawValue: "page"))),
+            BookmarkNode(id: BookmarkID(rawValue: "parent"), parentID: nil, position: 0, content: .folder(label: "Parent")),
+            BookmarkNode(id: BookmarkID(rawValue: "page"), parentID: BookmarkID(rawValue: "parent"), position: 0, content: .page(PageID(rawValue: "page"))),
         ]
-        #expect(BookmarkNode.displayPath(id: "page", in: nodes) == "Parent")
+        #expect(BookmarkNode.displayPath(id: BookmarkID(rawValue: "page"), in: nodes) == "Parent")
     }
 
     @Test func parentCycleIsCappedNotInfinite() {
         // Corrupted store data: two folders pointing at each other. Must not
         // loop forever; result is non-crashing and bounded.
         let nodes = [
-            BookmarkNode(id: "x", parentID: "y", position: 0, content: .folder(label: "X")),
-            BookmarkNode(id: "y", parentID: "x", position: 0, content: .folder(label: "Y")),
+            BookmarkNode(id: BookmarkID(rawValue: "x"), parentID: BookmarkID(rawValue: "y"), position: 0, content: .folder(label: "X")),
+            BookmarkNode(id: BookmarkID(rawValue: "y"), parentID: BookmarkID(rawValue: "x"), position: 0, content: .folder(label: "Y")),
         ]
-        let path = BookmarkNode.displayPath(id: "x", in: nodes)
+        let path = BookmarkNode.displayPath(id: BookmarkID(rawValue: "x"), in: nodes)
         #expect(!path.isEmpty)
         // Cap is 64 hops — even in the worst case the segment count is bounded.
         #expect(path.components(separatedBy: " / ").count <= 64)

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -64,7 +64,7 @@ import SQLite3
         let page = try store.createPage(title: "Page")
         let node = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(page.id))
         #expect(node.content == .page(page.id))
-        #expect(store.scalarText("SELECT kind || '|' || COALESCE(label, 'NULL') || '|' || target_id FROM bookmark_nodes WHERE id = '\(node.id)';") == "page_ref|NULL|\(page.id.rawValue)")
+        #expect(store.scalarText("SELECT kind || '|' || COALESCE(label, 'NULL') || '|' || target_id FROM bookmark_nodes WHERE id = '\(node.id.rawValue)';") == "page_ref|NULL|\(page.id.rawValue)")
     }
 
     @Test func sourceTargetRoundTrips() throws {
@@ -72,7 +72,7 @@ import SQLite3
         let source = try store.addSource(filename: "source.txt", data: Data("source".utf8))
         let node = try store.createBookmarkNode(parentID: nil, position: 0, content: .source(source.id))
         #expect(node.content == .source(source.id))
-        #expect(store.scalarText("SELECT kind || '|' || COALESCE(label, 'NULL') || '|' || target_id FROM bookmark_nodes WHERE id = '\(node.id)';") == "source_ref|NULL|\(source.id.rawValue)")
+        #expect(store.scalarText("SELECT kind || '|' || COALESCE(label, 'NULL') || '|' || target_id FROM bookmark_nodes WHERE id = '\(node.id.rawValue)';") == "source_ref|NULL|\(source.id.rawValue)")
     }
 
     @Test func chatTargetRoundTrips() throws {
@@ -80,14 +80,14 @@ import SQLite3
         let chat = try store.createChat(kind: .edit, title: "Chat")
         let node = try store.createBookmarkNode(parentID: nil, position: 0, content: .chat(chat.id))
         #expect(node.content == .chat(chat.id))
-        #expect(store.scalarText("SELECT kind || '|' || COALESCE(label, 'NULL') || '|' || target_id FROM bookmark_nodes WHERE id = '\(node.id)';") == "chat_ref|NULL|\(chat.id.rawValue)")
+        #expect(store.scalarText("SELECT kind || '|' || COALESCE(label, 'NULL') || '|' || target_id FROM bookmark_nodes WHERE id = '\(node.id.rawValue)';") == "chat_ref|NULL|\(chat.id.rawValue)")
     }
 
     @Test func folderRoundTrips() throws {
         let store = try GRDBWikiStore(databaseURL: tempDatabaseURL())
         let node = try store.createBookmarkNode(parentID: nil, position: 0, content: .folder(label: "Folder"))
         #expect(node.content == .folder(label: "Folder"))
-        #expect(store.scalarText("SELECT kind || '|' || label || '|' || COALESCE(target_id, 'NULL') FROM bookmark_nodes WHERE id = '\(node.id)';") == "folder|Folder|NULL")
+        #expect(store.scalarText("SELECT kind || '|' || label || '|' || COALESCE(target_id, 'NULL') FROM bookmark_nodes WHERE id = '\(node.id.rawValue)';") == "folder|Folder|NULL")
     }
 
     @Test func emptyFolderContentIsRejectedBeforeWrite() throws {

--- a/Tests/WikiFSTests/BookmarkStateSnapshotTests.swift
+++ b/Tests/WikiFSTests/BookmarkStateSnapshotTests.swift
@@ -19,7 +19,7 @@ import Foundation
 
     @Test func rootFolderRendersWithLabel() {
         let nodes = [
-            BookmarkNode(id: "f1", parentID: nil, position: 0, content: .folder(label: "Research")),
+            BookmarkNode(id: BookmarkID(rawValue: "f1"), parentID: nil, position: 0, content: .folder(label: "Research")),
         ]
         let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
         #expect(tree.contains("📁 Research"))
@@ -27,8 +27,8 @@ import Foundation
 
     @Test func nestedFoldersRenderIndented() {
         let nodes = [
-            BookmarkNode(id: "root", parentID: nil, position: 0, content: .folder(label: "Root")),
-            BookmarkNode(id: "child", parentID: "root", position: 0, content: .folder(label: "Child")),
+            BookmarkNode(id: BookmarkID(rawValue: "root"), parentID: nil, position: 0, content: .folder(label: "Root")),
+            BookmarkNode(id: BookmarkID(rawValue: "child"), parentID: BookmarkID(rawValue: "root"), position: 0, content: .folder(label: "Child")),
         ]
         let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
         let lines = tree.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
@@ -41,7 +41,7 @@ import Foundation
 
     @Test func pageRefRendersWithTargetID() {
         let nodes = [
-            BookmarkNode(id: "p1", parentID: nil, position: 0, content: .page(PageID(rawValue: "01PAGE"))),
+            BookmarkNode(id: BookmarkID(rawValue: "p1"), parentID: nil, position: 0, content: .page(PageID(rawValue: "01PAGE"))),
         ]
         let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
         #expect(tree.contains("📄"))
@@ -50,7 +50,7 @@ import Foundation
 
     @Test func sourceRefRendersWithTargetID() {
         let nodes = [
-            BookmarkNode(id: "s1", parentID: nil, position: 0, content: .source(SourceID(rawValue: "01SRC"))),
+            BookmarkNode(id: BookmarkID(rawValue: "s1"), parentID: nil, position: 0, content: .source(SourceID(rawValue: "01SRC"))),
         ]
         let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
         #expect(tree.contains("source:01SRC"))
@@ -58,7 +58,7 @@ import Foundation
 
     @Test func chatRefRendersWithTargetID() {
         let nodes = [
-            BookmarkNode(id: "c1", parentID: nil, position: 0, content: .chat(ChatID(rawValue: "01CHAT"))),
+            BookmarkNode(id: BookmarkID(rawValue: "c1"), parentID: nil, position: 0, content: .chat(ChatID(rawValue: "01CHAT"))),
         ]
         let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
         #expect(tree.contains("chat:01CHAT"))
@@ -66,10 +66,10 @@ import Foundation
 
     @Test func mixedTreeRendersInOrder() {
         let nodes = [
-            BookmarkNode(id: "f1", parentID: nil, position: 0, content: .folder(label: "Research")),
-            BookmarkNode(id: "p1", parentID: "f1", position: 1, content: .page(PageID(rawValue: "01PAGE"))),
-            BookmarkNode(id: "p2", parentID: "f1", position: 0, content: .page(PageID(rawValue: "02PAGE"))),
-            BookmarkNode(id: "f2", parentID: nil, position: 1, content: .folder(label: "Notes")),
+            BookmarkNode(id: BookmarkID(rawValue: "f1"), parentID: nil, position: 0, content: .folder(label: "Research")),
+            BookmarkNode(id: BookmarkID(rawValue: "p1"), parentID: BookmarkID(rawValue: "f1"), position: 1, content: .page(PageID(rawValue: "01PAGE"))),
+            BookmarkNode(id: BookmarkID(rawValue: "p2"), parentID: BookmarkID(rawValue: "f1"), position: 0, content: .page(PageID(rawValue: "02PAGE"))),
+            BookmarkNode(id: BookmarkID(rawValue: "f2"), parentID: nil, position: 1, content: .folder(label: "Notes")),
         ]
         let tree = WikiStateSnapshot.renderBookmarkTree(nodes)
         let lines = tree.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
@@ -85,7 +85,7 @@ import Foundation
 
     @Test func bookmarkSectionIncludedInStateFile() {
         let nodes = [
-            BookmarkNode(id: "f1", parentID: nil, position: 0, content: .folder(label: "Research")),
+            BookmarkNode(id: BookmarkID(rawValue: "f1"), parentID: nil, position: 0, content: .folder(label: "Research")),
         ]
         let snapshot = WikiStateSnapshot.make(
             allTitles: ["Page A"], indexBody: "", logLines: [],

--- a/Tests/WikiFSTests/BookmarkTreeBuilderTests.swift
+++ b/Tests/WikiFSTests/BookmarkTreeBuilderTests.swift
@@ -9,31 +9,31 @@ import Foundation
 
     @Test func buildFlatTree() {
         let nodes = [
-            BookmarkNode(id: "b", parentID: nil, position: 1, content: .folder(label: "B")),
-            BookmarkNode(id: "a", parentID: nil, position: 0, content: .folder(label: "A")),
+            BookmarkNode(id: BookmarkID(rawValue: "b"), parentID: nil, position: 1, content: .folder(label: "B")),
+            BookmarkNode(id: BookmarkID(rawValue: "a"), parentID: nil, position: 0, content: .folder(label: "A")),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
         #expect(tree.count == 2)
         // Sorted by position.
-        #expect(tree[0].node.id == "a")
-        #expect(tree[1].node.id == "b")
+        #expect(tree[0].node.id.rawValue == "a")
+        #expect(tree[1].node.id.rawValue == "b")
     }
 
     @Test func buildNestedTree() {
         let nodes = [
-            BookmarkNode(id: "parent", parentID: nil, position: 0, content: .folder(label: "P")),
-            BookmarkNode(id: "child", parentID: "parent", position: 0, content: .folder(label: "C")),
+            BookmarkNode(id: BookmarkID(rawValue: "parent"), parentID: nil, position: 0, content: .folder(label: "P")),
+            BookmarkNode(id: BookmarkID(rawValue: "child"), parentID: BookmarkID(rawValue: "parent"), position: 0, content: .folder(label: "C")),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
         #expect(tree.count == 1)
-        #expect(tree[0].node.id == "parent")
+        #expect(tree[0].node.id.rawValue == "parent")
         #expect(tree[0].children?.count == 1)
-        #expect(tree[0].children?.first?.node.id == "child")
+        #expect(tree[0].children?.first?.node.id.rawValue == "child")
     }
 
     @Test func emptyFolderHasEmptyArrayChildren() {
         let nodes = [
-            BookmarkNode(id: "empty", parentID: nil, position: 0, content: .folder(label: "E")),
+            BookmarkNode(id: BookmarkID(rawValue: "empty"), parentID: nil, position: 0, content: .folder(label: "E")),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
         #expect(tree.count == 1)
@@ -45,7 +45,7 @@ import Foundation
 
     @Test func pageRefIsLeaf() {
         let nodes = [
-            BookmarkNode(id: "ref", parentID: nil, position: 0, content: .page(PageID(rawValue: "page1"))),
+            BookmarkNode(id: BookmarkID(rawValue: "ref"), parentID: nil, position: 0, content: .page(PageID(rawValue: "page1"))),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
         #expect(tree.count == 1)
@@ -55,21 +55,21 @@ import Foundation
 
     @Test func folderWithChildrenRendersRecursively() {
         let nodes = [
-            BookmarkNode(id: "l1", parentID: nil, position: 0, content: .folder(label: "L1")),
-            BookmarkNode(id: "l2", parentID: "l1", position: 0, content: .folder(label: "L2")),
-            BookmarkNode(id: "l3", parentID: "l2", position: 0, content: .folder(label: "L3")),
+            BookmarkNode(id: BookmarkID(rawValue: "l1"), parentID: nil, position: 0, content: .folder(label: "L1")),
+            BookmarkNode(id: BookmarkID(rawValue: "l2"), parentID: BookmarkID(rawValue: "l1"), position: 0, content: .folder(label: "L2")),
+            BookmarkNode(id: BookmarkID(rawValue: "l3"), parentID: BookmarkID(rawValue: "l2"), position: 0, content: .folder(label: "L3")),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
-        #expect(tree[0].node.id == "l1")
-        #expect(tree[0].children?[0].node.id == "l2")
-        #expect(tree[0].children?[0].children?[0].node.id == "l3")
+        #expect(tree[0].node.id.rawValue == "l1")
+        #expect(tree[0].children?[0].node.id.rawValue == "l2")
+        #expect(tree[0].children?[0].children?[0].node.id.rawValue == "l3")
     }
 
     // MARK: - Selection
 
     @Test func pageRefSelection() {
         let nodes = [
-            BookmarkNode(id: "ref", parentID: nil, position: 0, content: .page(PageID(rawValue: "p1"))),
+            BookmarkNode(id: BookmarkID(rawValue: "ref"), parentID: nil, position: 0, content: .page(PageID(rawValue: "p1"))),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
         // Selection is always .bookmark(nodeID) — does NOT open a tab.
@@ -80,7 +80,7 @@ import Foundation
 
     @Test func sourceRefSelection() {
         let nodes = [
-            BookmarkNode(id: "ref", parentID: nil, position: 0, content: .source(SourceID(rawValue: "s1"))),
+            BookmarkNode(id: BookmarkID(rawValue: "ref"), parentID: nil, position: 0, content: .source(SourceID(rawValue: "s1"))),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
         #expect(tree[0].selection == .bookmark("ref"))
@@ -89,7 +89,7 @@ import Foundation
 
     @Test func folderHasBookmarkSelection() {
         let nodes = [
-            BookmarkNode(id: "f", parentID: nil, position: 0, content: .folder(label: "F")),
+            BookmarkNode(id: BookmarkID(rawValue: "f"), parentID: nil, position: 0, content: .folder(label: "F")),
         ]
         let tree = buildBookmarkTree(nodes: nodes)
         #expect(tree[0].selection == .bookmark("f"))

--- a/Tests/WikiFSTests/Fixtures/SourceAPISignatures.txt
+++ b/Tests/WikiFSTests/Fixtures/SourceAPISignatures.txt
@@ -86,7 +86,7 @@ Sources/WikiFSCore/Store/WikiStoreModel.swift	        for sourceID: SourceID, co
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func setActiveMarkdown(for sourceID: SourceID, to versionID: SourceMarkdownVersionID)
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func processedMarkdownAgentNames(for sourceID: SourceID) -> [SourceMarkdownVersionID: String]
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func processedMarkdownAlternatives(for sourceID: SourceID) -> [ExtractionAlternative]
-Sources/WikiFSCore/Store/WikiStoreModel.swift	public func addSourceRef(parentID: String?, sourceID: SourceID, position: Int? = nil)
+Sources/WikiFSCore/Store/WikiStoreModel.swift	public func addSourceRef(parentID: BookmarkID?, sourceID: SourceID, position: Int? = nil)
 Sources/WikiFSCore/Core/QueueTypes.swift	public var sourceIDs: [SourceID]
 Sources/WikiFSCore/Core/WikiSelection.swift	case source(SourceID)
 Sources/WikiFSCore/Core/WikiRenderContext.swift	public let sourceIDToName: [SourceID: String]

--- a/Tests/WikiFSTests/StoreEmissionTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionTests.swift
@@ -441,7 +441,7 @@ struct StoreEmissionTests {
         let events = try await awaitEvents(rec)
         #expect(events.last?.kind == .bookmark)
         #expect(events.last?.change == .created)
-        #expect(events.last?.id == node.id)
+        #expect(events.last?.id == node.id.rawValue)
     }
 
     @Test func updateBookmarkNodeEmitsBookmarkUpdated() async throws {
@@ -452,7 +452,7 @@ struct StoreEmissionTests {
         let events = try await awaitEvents(rec)
         #expect(events.last?.kind == .bookmark)
         #expect(events.last?.change == .updated)
-        #expect(events.last?.id == node.id)
+        #expect(events.last?.id == node.id.rawValue)
     }
 
     @Test func deleteBookmarkNodeEmitsBookmarkDeleted() async throws {
@@ -463,7 +463,7 @@ struct StoreEmissionTests {
         let events = try await awaitEvents(rec)
         #expect(events.last?.kind == .bookmark)
         #expect(events.last?.change == .deleted)
-        #expect(events.last?.id == node.id)
+        #expect(events.last?.id == node.id.rawValue)
     }
 
     @Test func moveBookmarkNodeEmitsBookmarkUpdated() async throws {
@@ -474,7 +474,7 @@ struct StoreEmissionTests {
         let events = try await awaitEvents(rec)
         #expect(events.last?.kind == .bookmark)
         #expect(events.last?.change == .updated)
-        #expect(events.last?.id == node.id)
+        #expect(events.last?.id == node.id.rawValue)
     }
 
     // MARK: - Chats (#119)


### PR DESCRIPTION
Introduce a new `BookmarkID` wrapper type for bookmark node identifiers, replacing raw `String` throughout the codebase.

## Changes
- Created `BookmarkID` type in `WikiFSTypes` module (Hashable, Codable, RawRepresentable, Sendable)
- Updated `BookmarkNode` to use `BookmarkID` for both `id` and `parentID` fields
- Applied type to all bookmark-related APIs in `WikiStore` protocol and `GRDBWikiStore` implementation
- Updated UI components (`BookmarksContainerView`, `BookmarksOutlineView`, `EditBookmarkSheet`, `BookmarkTargetPickerSheet`) to use `BookmarkID`
- Updated file provider projection, state snapshot, tree builder, and editor tab logic
- Updated all related test files

## Rationale
Provides compile-time type safety and prevents accidentally mixing bookmark IDs with other ID types (PageID, SourceID, ChatID, WorkspaceID, etc.). Consistent with the strong-typing approach applied to other identifiers in the codebase.