### PR TITLE
Clarify summary truncation mode and hide irrelevant model picker

### DIFF
--- a/Sources/WikiFS/Settings/OperationsSettingsView.swift
+++ b/Sources/WikiFS/Settings/OperationsSettingsView.swift
@@ -112,11 +112,11 @@ struct OperationsSettingsView: View {
                     config: $config,
                     containerDirectory: containerDirectory,
                     label: "Summary",
-                    defaultOptionLabel: "Default (first few sentences)")
+                    defaultOptionLabel: "No AI (first few sentences)")
             } header: {
                 Text("Message Summary")
             } footer: {
-                Text("“Default (first few sentences)” is free truncation — no model call. Pin a provider + model to summarize each assistant message with an LLM (computed once, cached).")
+                Text("“No AI (first few sentences)” is free truncation — no model call. Pin a provider + model to summarize each assistant message with an LLM (computed once, cached).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/WikiFS/Settings/StageProviderModelPicker.swift
+++ b/Sources/WikiFS/Settings/StageProviderModelPicker.swift
@@ -48,7 +48,7 @@ enum StageProviderSelectionState: Equatable {
 ///   in the provider dropdown. Defaults to `"Default"` (inherit the global
 ///   default provider). **Stage-specific semantic for `"summarizer"`**: an empty
 ///   pin means "no model — truncation" (NOT "inherit the global provider"), so
-///   the Summary tab passes `"Default (first few sentences)"` to convey the
+///   the Summary tab passes `"No AI (first few sentences)"` to convey the
 ///   actual behavior (`plans/chat-summary.md` §5.2).
 ///
 /// The provider dropdown includes a **"Default"** first option (sentinel `""` =
@@ -66,6 +66,12 @@ struct StageProviderModelPicker: View {
 
     private var selectionState: StageProviderSelectionState {
         StageProviderSelectionState.resolve(config: config, stageKey: stageKey)
+    }
+
+    /// Summary's inherited provider is the explicit no-model mode: summaries
+    /// are produced by truncating locally.
+    private var isNoProviderSummary: Bool {
+        stageKey == "summarizer" && selectionState == .inherited
     }
 
     /// The effective provider for this stage (pinned when set + enabled, else
@@ -159,18 +165,20 @@ struct StageProviderModelPicker: View {
                 }
             }
 
-            Picker("\(label) Model", selection: modelBinding) {
-                if shouldDisableModelPickerForUnavailablePin || resolvedModels.isEmpty {
-                    Text(modelPickerPlaceholder).tag("")
-                } else {
-                    Text("Same as provider (\(fallbackLabel))").tag("")
-                    ForEach(resolvedModels, id: \.modelId) { model in
-                        Text(model.displayLabel).tag(model.modelId)
+            if !isNoProviderSummary {
+                Picker("\(label) Model", selection: modelBinding) {
+                    if shouldDisableModelPickerForUnavailablePin || resolvedModels.isEmpty {
+                        Text(modelPickerPlaceholder).tag("")
+                    } else {
+                        Text("Same as provider (\(fallbackLabel))").tag("")
+                        ForEach(resolvedModels, id: \.modelId) { model in
+                            Text(model.displayLabel).tag(model.modelId)
+                        }
                     }
                 }
+                .disabled(shouldDisableModelPickerForUnavailablePin || resolvedModels.isEmpty)
+                .help(modelPickerHelpText)
             }
-            .disabled(shouldDisableModelPickerForUnavailablePin || resolvedModels.isEmpty)
-            .help(modelPickerHelpText)
 
             if let unavailableProviderMessage {
                 Text(unavailableProviderMessage)


### PR DESCRIPTION
## Summary
- Renamed the Summary stage’s default option from “Default (first few sentences)” to “No AI (first few sentences)” to make the behavior explicit.
- Updated the explanatory copy in Operations settings to match the new label.
- Suppressed the Summary model picker when the stage is in the inherited/no-model state, since that mode always uses local truncation instead of an LLM.

## Why
The previous wording implied a provider default, which blurred the distinction between an inherited AI-backed summary and the explicit non-AI truncation mode. This change makes the UI match the actual behavior and avoids presenting a model selector when it cannot affect the result.

## Notes
- The Summary stage still supports provider/model pinning when an LLM summary is desired.
- When Summary is left inherited, it now reads as a deliberate “No AI” mode instead of an ambiguous default.