### PR TITLE
Move WikiSwitcher from sidebar to toolbar

### DIFF
--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -290,6 +290,9 @@ struct ContentView: View {
                                onAddToBookmarks: { omniboxBookmarkContext = $0 })
             }
             ToolbarItem(placement: .automatic) {
+                WikiSwitcher(registry: registry, currentWikiID: session.wikiID)
+            }
+            ToolbarItem(placement: .automatic) {
                 if rightInspector.isAvailable {
                     Button {
                         rightInspector.toggle()

--- a/Sources/WikiFS/Window/SidebarView.swift
+++ b/Sources/WikiFS/Window/SidebarView.swift
@@ -71,17 +71,6 @@ struct SidebarView: View {
             Divider()
             bookmarksOrList
         }
-        // Wiki switcher pinned to the sidebar's bottom bar — like Xcode's
-        // navigator footer or Finder's status bar. It collapses with the
-        // sidebar when the leading panel toggle hides it, leaving the toolbar
-        // to hold only the nav cluster + omnibox.
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            Divider()
-            WikiSwitcher(registry: registry, currentWikiID: session.wikiID)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(.bar)
-        }
         .navigationTitle(activeWikiName)
         .navigationSplitViewColumnWidth(min: PageEditorMetrics.sidebarMinWidth,
                                          ideal: PageEditorMetrics.sidebarIdealWidth)


### PR DESCRIPTION
## Summary

Relocates the `WikiSwitcher` component from the sidebar's bottom safe area inset to a toolbar item in the main content view.

## Changes

- Removed `WikiSwitcher` from `SidebarView`'s `.safeAreaInset(edge: .bottom)` modifier
- Added `WikiSwitcher` as a `ToolbarItem` in `ContentView`

## Rationale

The sidebar-based wiki switcher was inaccessible when the sidebar was hidden (collapsed state), requiring users to expand the sidebar to switch wikis. Placing it in the toolbar ensures the wiki switcher remains always visible and accessible, improving discoverability and workflow consistency with other toolbar-resident controls.