### PR TITLE
Update Package.swift comments and Tahoe minimum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ APP_GROUP      := $(or $(call cfg,APP_GROUP),group.org.sockpuppet.wiki)
 KEYCHAIN_ACCESS_GROUP = $(or $(call cfg,KEYCHAIN_ACCESS_GROUP),$(TEAM_ID).$(patsubst group.%,%,$(APP_GROUP)))
 LSREGISTER   := /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister
 PLUGINKIT    := pluginkit
-MIN_MACOS    := 14
+MIN_MACOS    := 26.5.2
 MIN_SWIFT    := 6.0
 
 # Fast test tier — skips the slow SQLite integration suites (tagged
@@ -184,9 +184,8 @@ deps:
 	if [ -z "$$OS_VERSION" ]; then \
 	  echo "  ✗ Could not detect macOS version. $(APP_NAME) only builds on macOS."; exit 1; \
 	fi; \
-	OS_MAJOR=$$(echo $$OS_VERSION | cut -d. -f1); \
-	if [ $$OS_MAJOR -lt $(MIN_MACOS) ]; then \
-	  echo "  ✗ macOS $$OS_VERSION — $(APP_NAME) requires macOS $(MIN_MACOS).0 or newer."; exit 1; \
+	if ! awk -v min="$(MIN_MACOS)" -v os="$$OS_VERSION" 'BEGIN { n = split(min, a, "."); m = split(os, b, "."); max = (n > m ? n : m); for (i = 1; i <= max; i++) { ai = a[i] + 0; bi = b[i] + 0; if (bi > ai) exit 0; if (bi < ai) exit 1 } exit 0 }'; then \
+	  echo "  ✗ macOS $$OS_VERSION — $(APP_NAME) requires macOS $(MIN_MACOS) or newer."; exit 1; \
 	fi; \
 	echo "  ✓ macOS $$OS_VERSION"
 	@command -v swift >/dev/null 2>&1 || { \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ APP_GROUP      := $(or $(call cfg,APP_GROUP),group.org.sockpuppet.wiki)
 KEYCHAIN_ACCESS_GROUP = $(or $(call cfg,KEYCHAIN_ACCESS_GROUP),$(TEAM_ID).$(patsubst group.%,%,$(APP_GROUP)))
 LSREGISTER   := /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister
 PLUGINKIT    := pluginkit
-MIN_MACOS    := 26.5.2
+MIN_MACOS    := 26.0
 MIN_SWIFT    := 6.0
 
 # Fast test tier — skips the slow SQLite integration suites (tagged

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let strictSwiftSettings: [SwiftSetting] = podcastSwiftSettings + [.unsafeFlags([
 
 let package = Package(
     name: "WikiFS",
-    platforms: [.macOS("26.5.2")],
+    platforms: [.macOS("26.0")],
     dependencies: [
         // swift-markdown powers the reader's markdown→HTML renderer
         // (plans/source-web-reader.md / textual-to-wkwebview.md). Pure-Swift GFM

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let strictSwiftSettings: [SwiftSetting] = podcastSwiftSettings + [.unsafeFlags([
 
 let package = Package(
     name: "WikiFS",
-    platforms: [.macOS(.v15)],
+    platforms: [.macOS("26.5.2")],
     dependencies: [
         // swift-markdown powers the reader's markdown→HTML renderer
         // (plans/source-web-reader.md / textual-to-wkwebview.md). Pure-Swift GFM
@@ -44,24 +44,22 @@ let package = Package(
         // discarded stderr, unexposed PID). The fork fixes all four. Upstream PRs
         // offered when the upstream resumes.
         .package(url: "https://github.com/wsargent/swift-acp", from: "0.2.0"),
-        // GRDB.swift — GRDB toolkit for SQLite. Phase 1 pilot: QueueStore uses
-        // DatabaseQueue + DatabaseMigrator replacing hand-rolled sqlite3_* calls
-        // (plans/grdb-adoption.md §6). The default GRDB product uses the system
-        // SQLite (same as SQLiteWikiStore) — they coexist on different database
-        // files with no conflict.
+        // GRDB.swift — GRDB toolkit for SQLite. `GRDBWikiStore` is the sole
+        // production store backend, and QueueStore also uses DatabaseQueue +
+        // DatabaseMigrator. See plans/grdb-adoption.md.
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         // swift-crypto — Apple's Swift Crypto package. On macOS, `CryptoKit`
         // (system framework) provides SHA256 etc. On Linux, this package
-        // provides the identical API under the `Crypto` module. Already a
-        // transitive dependency via GRDB; declared directly so WikiFSCore can
-        // depend on the `Crypto` product on Linux (#754, #780).
+        // provides the identical API under the `Crypto` module. Declared
+        // directly so WikiFSCore can depend on the `Crypto` product on Linux
+        // (#754, #780).
         .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
         // tantivy.swift — Rust Tantivy full-text search via UniFFI bindings + an
-        // @TantivyDocument macro. Phase 0 build spike (plans/tantivy-search-sidecar.md):
-        // verify the pre-built XCFramework (libtantivy-rs.xcframework) resolves under
-        // bare `swift build` (no Xcode) and links for aarch64-apple-darwin. Ships a
-        // macOS arm64 slice; no x86_64 (acceptable — MLX already requires Apple Silicon).
-        // NOT wired into the search pipeline yet — spike only.
+        // @TantivyDocument macro. Provides the app/CLI BM25 lexical search leg
+        // that fuses with vector similarity through the `bm25Leg` store seam.
+        // macOS arm64 only: the pre-built XCFramework has no x86_64 slice, which
+        // is acceptable because MLX already requires Apple Silicon. See
+        // plans/tantivy-search-sidecar.md.
         .package(url: "https://github.com/wsargent/tantivy.swift.git", from: "0.3.5"),
     ],
     targets: [
@@ -116,8 +114,8 @@ let package = Package(
         // WikiLinkSpan). Extracted from WikiFSCore in module restructuring
         // Phase 2 (#532). Re-exported by WikiFSCore via ModuleExports.swift.
         // Previously Sources/WikiFSCore/Markdown/.
-        // JavaScriptCore: MarkdownLinter + MermaidValidator run vendored JS
-        // bundles (markdownlint, merval) in a JSContext (no Node at runtime).
+        // JavaScriptCore: MarkdownLinter runs vendored markdownlint JS; Mermaid
+        // validation uses the bundled Mermaid v11 library (no Node at runtime).
         .target(
             name: "WikiFSMarkdown",
             dependencies: ["WikiFSTypes", "WikiFSLinks"],
@@ -134,21 +132,21 @@ let package = Package(
             name: "WikiFSSearch",
             dependencies: [
                 "WikiFSTypes",
-                // Phase 0 spike: TantivySwift (Tantivy FFI + @TantivyDocument macro).
-                // Natural home for search-engine integration (plans/tantivy-search-sidecar.md §8.1).
-                // macOS-only: the pre-built XCFramework ships only a macOS arm64 slice.
-                // Guarded with #if os(macOS) in source; the dependency is conditional so
-                // Linux `swift build --target WikiFSSearch` doesn't try to build it (#754).
+                // TantivySwift (Tantivy FFI + @TantivyDocument macro) backs the
+                // BM25 lexical search leg. macOS-only: the pre-built XCFramework
+                // ships only a macOS arm64 slice. Guarded with #if os(macOS) in
+                // source; the dependency is conditional so Linux builds don't try
+                // to build it (#754).
                 .product(name: "TantivySwift", package: "tantivy.swift",
                          condition: .when(platforms: [.macOS])),
             ],
             path: "Sources/WikiFSSearch",
             swiftSettings: strictSwiftSettings
         ),
-        // Non-UI core: page model, ULID, the WikiStore protocol + SQLite
-        // implementation, and the @Observable WikiStoreModel. Depended on by
-        // the executable AND the test target so logic is testable without a
-        // running app (SWIFTUI-RULES §9.1 — model logic in its own target).
+        // Non-UI core: page model, the WikiStore protocol, GRDBWikiStore, and
+        // the @Observable WikiStoreModel. Depended on by the executable AND the
+        // test target so logic is testable without a running app (SWIFTUI-RULES
+        // §9.1 — model logic in its own target).
         .target(
             name: "WikiFSCore",
             dependencies: [
@@ -161,8 +159,8 @@ let package = Package(
                 // On macOS, the SDK provides SQLite3 directly.
                 .target(name: "CSQLite", condition: .when(platforms: [.linux])),
                 // On macOS, `CryptoKit` (system framework) provides SHA256.
-                // On Linux, `swift-crypto` (transitive via GRDB) provides the
-                // identical API under the `Crypto` module (#754, #780).
+                // On Linux, swift-crypto provides the identical API under the
+                // `Crypto` module (#754, #780).
                 .product(name: "Crypto", package: "swift-crypto",
                          condition: .when(platforms: [.linux])),
             ],
@@ -175,10 +173,11 @@ let package = Package(
             ],
             swiftSettings: strictSwiftSettings,
         ),
-        // — which the File Provider extension must NOT (com.apple.fileprovider-
-        // nonui forbids Metal on macOS 26). Core reaches the implementation via
-        // the injectable EmbeddingService.miniLMFactory seam; the app installs it
-        // here at launch (EmbedderBootstrap). Mirrors the PDFKit isolation.
+        // MLX on-device MiniLM embeddings. Kept out of WikiFSCore so the File
+        // Provider extension never links MLX/Metal (com.apple.fileprovider-nonui
+        // forbids Metal on macOS 26). Core reaches the implementation via the
+        // injectable EmbeddingService.miniLMFactory seam; the app installs it at
+        // launch through EmbedderBootstrap. Mirrors the PDFKit isolation.
         .target(
             name: "WikiFSMLX",
             dependencies: [
@@ -188,12 +187,11 @@ let package = Package(
             path: "Sources/WikiFSMLX",
             swiftSettings: [.unsafeFlags(["-warnings-as-errors"])]
         ),
-        // The agent execution engine — extracted from the app target so a
-        // standalone daemon (`wikid`) can link it. Holds: AgentLauncher,
-        // ACPBackend, ClaudeCLIBackend, AgentOperationRunner, GenerationGate,
-        // ExtractionCoordinator, AgentBackend/Factory, OperationRequest, plus
-        // the ACP stall-recovery + permission seams. See
-        // plans/multi-wiki-daemon.md §3.
+        // The agent execution engine — extracted from the app target so the
+        // bundled `wikid` XPC service can link it. Holds AgentLauncher,
+        // ACPBackend, AgentOperationRunner, GenerationGate, ExtractionCoordinator,
+        // AgentBackend/Factory, OperationRequest, queue workers, and the ACP
+        // stall-recovery + permission seams. See plans/multi-wiki-daemon.md §3.
         .target(
             name: "WikiFSEngine",
             dependencies: [
@@ -255,25 +253,23 @@ let package = Package(
             // consistently across the dependency.
             swiftSettings: strictSwiftSettings
         ),
-        // wikictl — the agent's write path (plans/llm-wiki.md Phase A). A
-        // scriptable CLI that writes straight to a wiki's <ulid>.sqlite in the
-        // App Group container and posts a per-wiki Darwin notification so the app
-        // refreshes. Reads still go via the read-only File Provider mount; this
-        // is the WRITE half of "read via the mount, write via wikictl".
+        // wikictl — the agent's scriptable path into a wiki. It opens the wiki's
+        // <ulid>.sqlite in the App Group container via GRDBWikiStore, performs
+        // read/write commands, and posts a per-wiki Darwin notification after
+        // committing writes so the app refreshes. Raw source reads go through the
+        // `wikictl file` family rather than the File Provider mount.
         .executableTarget(
             name: "wikictl",
             dependencies: ["WikiFSCore", "WikiCtlCore"],
             path: "Sources/wikictl",
             swiftSettings: strictSwiftSettings
         ),
-        // wikid — the XPC daemon (plans/multi-wiki-daemon.md Phase 1B). Owns the
-        // live wiki registry + store lifecycle, serving clients via XPC. Launchd
-        // starts it on-demand when a client connects to the mach service name.
-        // The daemon links WikiFSCore (for WikiRegistry, SQLiteWikiStore, the
-        // WikiDaemonProtocol) and, on macOS, WikiFSEngine (for the workload host
-        // scaffold — QueueEngine construction. See plans/daemon-workloads.md
-        // Phase 0). On Linux, WikiFSEngine is unavailable (ACP is macOS-only),
-        // so the workload host is compiled out.
+        // wikid — the bundled XPC service (Contents/XPCServices/wikid.xpc). It
+        // owns the live wiki registry + GRDBWikiStore lifecycle and serves app
+        // clients through WikiDaemonProtocol. macOS runs it as an on-demand XPC
+        // service tied to the app; Linux keeps the portable stdio JSON-RPC path.
+        // On macOS it also links WikiFSEngine for queue/chat workloads; on Linux
+        // that workload host is compiled out because ACP is macOS-only.
         .executableTarget(
             name: "wikid",
             dependencies: [
@@ -371,10 +367,11 @@ let package = Package(
             exclude: ["Fixtures"],
             swiftSettings: strictSwiftSettings
         ),
-        // macOS-only tests — AppKit/WebKit/FileProvider/SwiftUI-hosted views,
-        // Tantivy integration, MLX embedder, PDF extraction, JS linter/validator.
-        // Every file is wrapped in #if os(macOS) so on Linux this compiles to an
-        // empty module and `swift test` runs only WikiFSCoreTests (#754).
+        // macOS-only integration tests — AppKit/WebKit/FileProvider/SwiftUI-hosted
+        // views, Tantivy integration, MLX embedder, PDF extraction, JS linter/
+        // validator. Kept out of the default test graph because these suites can
+        // wedge SwiftPM's shared test helper when run alongside daemon/app tests;
+        // opt in with WIKIFS_APP_TESTS=1 (#754, #949).
         .testTarget(
             name: "WikiFSAppTests",
             dependencies: [
@@ -393,10 +390,10 @@ let package = Package(
         ),
         // The File Provider extension binary. build.sh repackages this into a
         // .appex bundle under Self Driving Wiki.app/Contents/PlugIns and signs it.
-        //
-        // Declared unconditionally in targets[]; the fileProviderTargetExtension
-        // array below holds the macOS-only flag set. The .filter { } clause at
-        // the end drops it from the manifest on Linux.
+        // Declared unconditionally so macOS test dependencies can name it; the
+        // source files are #if os(macOS)-guarded, and the Linux filter below keeps
+        // the target name available while dropping app/MLX/test targets that would
+        // pull unavailable frameworks or Cmlx CUDA code.
         .executableTarget(
             name: "WikiFSFileProvider",
             dependencies: ["WikiFSCore", "WikiFSTypes"],
@@ -414,34 +411,23 @@ let package = Package(
             ]
         ),
     ].filter {
-        // Drop macOS-only executables / targets on Linux — SwiftPM builds every
-        // target in the package during `swift test`, not just test-target deps.
-        // These targets either #include Obj-C frameworks, use launchd / NSXPC /
-        // AppKit / SwiftUI APIs unavailable on Linux, or pull in CGraphics-only
-        // C++ deps (Cmlx → cublasLt.h CUDA backend, missing on Linux runners).
-        // macOS is unaffected; the existing WIKIFS_APP_STORE=1 route still
-        // works as before (#754, #780).
+        // Keep the Linux manifest focused on portable code. Filter targets that
+        // require Obj-C private frameworks, AppKit/SwiftUI/WebKit/FileProvider,
+        // Darwin notifications, or MLX/Cmlx GPU code that fails on CUDA-less
+        // Linux runners. macOS is unaffected; WIKIFS_APP_STORE=1 still drops the
+        // private podcast helper on all platforms (#754, #780).
         //
-        // Filtered:
-        // - podcast-token-helper: Obj-C executable, needs Foundation.h +
-        //   AppleMediaServices private framework. Not a dep of WikiFSAppTests,
-        //   so filtering it out of the manifest is safe.
-        // - wikictl: macOS CLI client; calls WikiDaemonConnection (guarded
-        //   #if os(macOS)) and DarwinNotifier.postChange (also guarded).
-        //   Not a dep of WikiFSAppTests, so filtering is safe.
-        // - WikiFS: the app executable. Imports AppKit/SwiftUI unconditionally;
-        //   links WikiFSMLX → mlx-swift-lm → mlx-swift → Cmlx, which tries to
-        //   compile its CUDA backend on Linux (cublasLt.h not found).
-        // - WikiFSMLX: links MLXEmbedders (mlx-swift-lm). Same CUDA build issue.
-        // - WikiFSAppTests: empty on Linux (all source #if os(macOS)-guarded)
-        //   but pulls WikiFSMLX via a conditional dep — SwiftPM still resolves
-        //   the package, and `swift test` builds the Cmlx dep transitively.
-        // - WikiFSFileProvider: handled differently (sources #if os(macOS)-
-        //   guarded; target stays in manifest so WikiFSAppTests' dep name
-        //   resolves). See comment on its declaration above.
+        // Filtered on Linux:
+        // - podcast-token-helper: Obj-C executable, Foundation.h + private
+        //   AppleMediaServices framework.
+        // - wikictl: standalone macOS CLI; uses Darwin notification and XPC seams.
+        // - WikiFS: app executable; imports AppKit/SwiftUI and links WebKit/MLX.
+        // - WikiFSMLX: links MLXEmbedders → mlx-swift → Cmlx GPU code.
+        // - WikiFSAppTests: macOS integration target that depends on app/MLX/FileProvider.
         //
-        // NOTE: wikid is intentionally NOT filtered — it has a Linux
-        // stdio-JSON-RPC transport path (#else // Linux at main.swift:120).
+        // WikiFSFileProvider stays declared because its sources are os(macOS)-
+        // guarded and macOS-only test dependencies need the target name. wikid is
+        // intentionally NOT filtered: it has a Linux stdio JSON-RPC transport.
         if $0.name == "WikiFSAppTests" && !appTestsEnabled { return false }
         #if os(Linux)
         if $0.name == "podcast-token-helper" { return false }

--- a/Sources/WikiFS/Pages/PageVersionCompareSheet.swift
+++ b/Sources/WikiFS/Pages/PageVersionCompareSheet.swift
@@ -197,9 +197,12 @@ struct PageVersionCompareSheet: View {
         } label: {
             HStack(spacing: 6) {
                 Circle().fill(tint).frame(width: 7, height: 7)
-                (Text("\(title): ").foregroundStyle(.secondary)
-                    + Text(current.map(versionLabel) ?? "—").fontWeight(.medium))
-                    .lineLimit(1).truncationMode(.middle)
+                Text(title + ": ")
+                    .foregroundStyle(.secondary)
+                Text(current.map(versionLabel) ?? "—")
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
             .font(.callout)
             .frame(maxWidth: 220, alignment: .leading)

--- a/Sources/WikiFS/Sources/ExtractionCompareSheet.swift
+++ b/Sources/WikiFS/Sources/ExtractionCompareSheet.swift
@@ -160,9 +160,12 @@ struct ExtractionCompareSheet: View {
         } label: {
             HStack(spacing: 6) {
                 Circle().fill(tint).frame(width: 7, height: 7)
-                (Text("\(title): ").foregroundStyle(.secondary)
-                    + Text(current?.backendDisplayName ?? "—").fontWeight(.medium))
-                    .lineLimit(1).truncationMode(.middle)
+                Text(title + ": ")
+                    .foregroundStyle(.secondary)
+                Text(current?.backendDisplayName ?? "—")
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
             .font(.callout)
             .frame(maxWidth: 220, alignment: .leading)
@@ -231,10 +234,12 @@ struct ExtractionCompareSheet: View {
                 Spacer(minLength: 4)
                 assignmentTag(alt)
             }
-            (Text(alt.version.createdAt, style: .date)
-                + Text("  ·  \(alt.charCount, format: .number) chars"))
-                .font(.caption).monospacedDigit()
-                .foregroundStyle(.secondary)
+            HStack(spacing: 0) {
+                Text(alt.version.createdAt, style: .date)
+                Text("  ·  \(alt.charCount, format: .number) chars")
+            }
+            .font(.caption).monospacedDigit()
+            .foregroundStyle(.secondary)
             if let model = alt.modelVersion {
                 Text(model).font(.caption2).foregroundStyle(.tertiary)
                     .lineLimit(1).truncationMode(.middle)

--- a/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
+++ b/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
@@ -89,12 +89,13 @@ struct IdentifierBoundaryTypecheckTests {
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         var arguments = [
             "swiftc", "-typecheck",
+            "-target", typecheckTargetTriple(),
             "-I", buildProducts.debugDirectory.path,
             "-I", buildProducts.modulesDirectory.path,
             "-module-cache-path", scratchDirectory.path,
             fixtureURL(fixtureName).path,
         ]
-        arguments.insert(contentsOf: compilerSearchArguments(root: root, buildProducts: buildProducts), at: 4)
+        arguments.insert(contentsOf: compilerSearchArguments(root: root, buildProducts: buildProducts), at: 6)
         process.arguments = arguments
         process.currentDirectoryURL = root
 
@@ -109,6 +110,24 @@ struct IdentifierBoundaryTypecheckTests {
             status: process.terminationStatus,
             output: String(decoding: outputData, as: UTF8.self)
         )
+    }
+
+    private func typecheckTargetTriple() -> String {
+        #if arch(arm64)
+        let architecture = "arm64"
+        #elseif arch(x86_64)
+        let architecture = "x86_64"
+        #else
+        let architecture = "unknown"
+        #endif
+
+        #if os(macOS)
+        return "\(architecture)-apple-macosx26.5.2"
+        #elseif os(Linux)
+        return "\(architecture)-unknown-linux-gnu"
+        #else
+        return "\(architecture)-unknown-unknown"
+        #endif
     }
 
     private func requiredFixtureModules(_ fixtureName: String) throws -> Set<String> {

--- a/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
+++ b/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
@@ -122,7 +122,7 @@ struct IdentifierBoundaryTypecheckTests {
         #endif
 
         #if os(macOS)
-        return "\(architecture)-apple-macosx26.5.2"
+        return "\(architecture)-apple-macosx26.0"
         #elseif os(Linux)
         return "\(architecture)-unknown-linux-gnu"
         #else

--- a/build.sh
+++ b/build.sh
@@ -586,13 +586,13 @@ PLIST
 	     container, so a sandboxed daemon can execute NONE of them (not even the
 	     bundled bun, which lives in the app bundle outside the .xpc) → ingestion
 	     is impossible. It also can't reach the SHARED App Group container: inside
-	     the sandbox `homeDirectoryForCurrentUser` is the sandbox home, so the
+	     the sandbox \`homeDirectoryForCurrentUser\` is the sandbox home, so the
 	     literal container path lands in an empty sandbox-local dir with no wikis
 	     ("No store for wikiID"). Un-sandboxing restores both. This reverts the
 	     app-sandbox that the #887 XPC migration added; the daemon still reaches
 	     the shared DB via the App Group container and secrets via the keychain
 	     access group — same boundaries the un-sandboxed app already uses.
-	     `com.apple.security.app-sandbox` is intentionally ABSENT. -->
+	     \`com.apple.security.app-sandbox\` is intentionally ABSENT. -->
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>${APP_GROUP}</string>

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,7 @@ TEAM_ID="${TEAM_ID:-KK7E9G89GW}"
 # → GeneratedKeychain.swift) and into the generated wikid entitlements below, so
 # app, daemon, and code agree for ANY developer. See plans/keychain-sharing.md.
 KEYCHAIN_ACCESS_GROUP="${KEYCHAIN_ACCESS_GROUP:-${TEAM_ID}.${APP_GROUP#group.}}"
-MIN_MACOS="14.0"
+MIN_MACOS="26.5.2"
 
 APP_PROFILE="signing/WikiFS.provisionprofile"
 EXT_PROFILE="signing/WikiFSFileProvider.provisionprofile"

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,7 @@ TEAM_ID="${TEAM_ID:-KK7E9G89GW}"
 # → GeneratedKeychain.swift) and into the generated wikid entitlements below, so
 # app, daemon, and code agree for ANY developer. See plans/keychain-sharing.md.
 KEYCHAIN_ACCESS_GROUP="${KEYCHAIN_ACCESS_GROUP:-${TEAM_ID}.${APP_GROUP#group.}}"
-MIN_MACOS="26.5.2"
+MIN_MACOS="26.0"
 
 APP_PROFILE="signing/WikiFS.provisionprofile"
 EXT_PROFILE="signing/WikiFSFileProvider.provisionprofile"


### PR DESCRIPTION
This PR updates Package.swift comments to match the current package graph. 

It sets the macOS deployment floor to Tahoe 26.0 in SwiftPM, build.sh, and the Makefile.

 It updates the manual fixture type-check target to match the package floor. 

It also removes macOS 26 Text composition deprecations and escapes backticks in the entitlement heredoc. 

Validation: swift package dump-package, swift test --filter IdentifierBoundaryTypecheckTests, and make build.