### PR TITLE
Fix toolbar omnibox layout

### DIFF
--- a/Sources/WikiFS/Editor/AddressBarView.swift
+++ b/Sources/WikiFS/Editor/AddressBarView.swift
@@ -2,9 +2,9 @@ import AppKit
 import SwiftUI
 import WikiFSCore
 
-/// A Safari-style omnibox that lives in the window's **toolbar** as a centered
-/// `.principal` item, replacing the window title. Serves two roles depending on
-/// focus state — no explicit mode switch required:
+/// A Safari-style omnibox that lives in the window's **toolbar** as a compact
+/// centered `.principal` item. Serves two roles depending on focus state — no
+/// explicit mode switch required:
 ///
 /// 1. **Idle (not focused):** shows the active page's wikilink (`[[Page Title]]`)
 ///    as the field's text — the "where am I" indicator, like a browser URL bar.
@@ -16,24 +16,22 @@ import WikiFSCore
 /// SwiftUI `TextField` can't take first responder inside an `NSToolbar` item —
 /// and the suggestions live in a non-activating child panel.
 ///
-/// The Back/Forward/Home nav cluster is a *separate* `.navigation` toolbar item
-/// (`OmniboxNavButtons`), flush-left like Safari's; this view is only the
-/// centered field. Its width comes from `OmniboxLayout.fieldWidth(detailWidth:)`
-/// — a fraction of the detail region with margins on each side — and NSToolbar
-/// centers it. Nothing here predicts NSToolbar's insets, so the field can no
-/// longer tip the toolbar into the `»` overflow.
+/// The Back/Forward/Home nav cluster lives in a separate `.navigation` toolbar
+/// item. This field's width comes from
+/// `OmniboxLayout.fieldWidth(detailWidth:)`, leaving room for fixed toolbar
+/// chrome so the centered item stays out of overflow.
 struct AddressBarView: View {
     @Bindable var store: WikiStoreModel
     @Binding var isFocused: Bool
     /// The width of the detail column (the region the toolbar spans), measured by a
     /// `GeometryReader` in `ContentView`. This shrinks when the left sidebar opens
     /// and is unaffected by the right transcript panel — exactly the omnibox's
-    /// usable toolbar span. Drives the centered pill's width (see `OmniboxLayout`).
+    /// usable toolbar span. Drives the centered pill's width (see
+    /// `OmniboxLayout`).
     var detailWidth: CGFloat
-    /// Whether the left sidebar is shown. Selects the side margin the centered pill
-    /// keeps: with the sidebar hidden the field centers across the whole window and
-    /// must reserve more room to clear the traffic-light + toggle chrome on its
-    /// left (see `OmniboxLayout.Metrics.sideMarginClosed`).
+    /// Whether the left sidebar is shown. Selects the side margin the centered
+    /// pill keeps; with the sidebar hidden the toolbar row also has to account
+    /// for traffic lights and the system sidebar toggle.
     var sidebarVisible: Bool
 
     @State private var queryText = ""
@@ -57,12 +55,9 @@ struct AddressBarView: View {
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
 
     var body: some View {
-        // The omnibox is the toolbar's `.principal` item — NSToolbar centers it in
-        // the detail region. This view is *only* the field; the Back/Forward/Home
-        // cluster is a separate flush-left `.navigation` item (`OmniboxNavButtons`).
-        // The field's width comes from `OmniboxLayout.fieldWidth(detailWidth:)` — a
-        // fraction of the detail region with margins on each side — so it never
-        // fills the region edge-to-edge and can't tip the toolbar into overflow.
+        // The field's width comes from `OmniboxLayout.fieldWidth(detailWidth:)`.
+        // It sits in `.principal` and uses a compact cap so fixed toolbar chrome
+        // can keep its slots.
         omniboxField
             // Cmd-L flips `isFocused`; turn that into a focus request for the field.
             .onChange(of: isFocused) { _, focused in
@@ -216,9 +211,8 @@ struct AddressBarView: View {
     }
 
     /// The omnibox field's width, from the measured detail-region width. The
-    /// centered-pill arithmetic lives in `OmniboxLayout` so it can be unit-tested;
-    /// here we only supply the measurement. NSToolbar centers the `.principal`
-    /// item, so there's no leading/trailing position math to do.
+    /// centered toolbar arithmetic lives in `OmniboxLayout` so it can be
+    /// unit-tested; here we only supply the measurement.
     private var fieldWidth: CGFloat {
         OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: sidebarVisible)
     }
@@ -358,15 +352,11 @@ struct AddressBarView: View {
 
 // MARK: - Nav buttons
 
-/// The Back / Forward (+ Home when the active wiki has one configured) cluster,
-/// a *separate* flush-left `.navigation` toolbar item from the centered omnibox
-/// field (`AddressBarView`) — the Safari layout: nav pinned to the leading edge,
-/// URL field centered. Kept its own item (not folded into the field) so NSToolbar
-/// can center the principal field independently of this fixed-width cluster.
+/// The Back / Forward / Home cluster shown at the leading edge of the toolbar.
 struct OmniboxNavButtons: View {
     @Bindable var store: WikiStoreModel
-    /// The active wiki's configured home page (issue #280). `nil` hides the Home
-    /// button — there's nowhere to navigate to yet.
+    /// The active wiki's configured home page (issue #280). `nil` disables the
+    /// Home button, but the button stays visible so the toolbar layout is stable.
     var homePageID: PageID?
 
     var body: some View {
@@ -381,8 +371,10 @@ struct OmniboxNavButtons: View {
             }
             .keyboardShortcut("]", modifiers: .command)
 
-            if let homePageID {
-                navButton("house", help: "Go to home page", enabled: true) {
+            navButton("house",
+                      help: homePageID == nil ? "No home page set" : "Go to home page",
+                      enabled: homePageID != nil) {
+                if let homePageID {
                     _ = store.selectPage(byID: homePageID)
                 }
             }

--- a/Sources/WikiFS/Editor/OmniboxLayout.swift
+++ b/Sources/WikiFS/Editor/OmniboxLayout.swift
@@ -3,68 +3,52 @@ import CoreGraphics
 /// Pure sizing math for the toolbar omnibox, factored out of `AddressBarView` so
 /// the centered/expandable behavior can be unit-tested without a running window.
 ///
-/// **Design (Safari-style centered omnibox).** The field lives in a `.principal`
-/// toolbar item, which NSToolbar *centers* in the detail region for us — so this
-/// type no longer tries to predict NSToolbar's internal insets to hand-position
-/// the field (the old leading-chrome / trailing-margin / overflow-spacer math,
-/// which was a stack of hand-tuned constants that tipped the whole `.navigation`
-/// group into the `»` overflow whenever any guess was slightly off).
+/// **Design (smaller centered omnibox).** The field lives in a `.principal`
+/// toolbar item, which NSToolbar centers in the detail region. Its width stays
+/// conservative so fixed leading and trailing toolbar items keep their slots and
+/// the toolbar avoids the `»` overflow.
 ///
 /// All that remains is the field's **width**: it grows with the detail region,
-/// keeping a comfortable margin on each side (so it reads as a centered pill, and
-/// crucially never approaches 100% of the region — the condition that used to
-/// trigger the all-or-nothing toolbar overflow), and it stops growing at a
-/// readable cap so it isn't one unbroken line on a very wide monitor. Centering
-/// is NSToolbar's job; this is only how wide the pill is at a given window size.
+/// keeps enough symmetrical margin to clear surrounding chrome, and stops at a
+/// compact cap.
 enum OmniboxLayout {
     struct Metrics: Equatable {
-        /// Breathing room reserved on *each* side of the centered field when the
-        /// **sidebar is shown**. The field is a symmetrically-centered `.principal`
-        /// item, so in the growing regime its side margin equals this value — and
-        /// NSToolbar bails the whole group to the `»` overflow if centering would
-        /// crowd the flush-left leading chrome. With the sidebar shown the traffic
-        /// lights sit over the sidebar, so the only leading chrome inside the
-        /// detail region is the `OmniboxNavButtons` cluster (~102pt with its
-        /// bubble inset); this must clear it with room to spare.
+        /// Breathing room reserved on each side of the centered field when the
+        /// left sidebar is shown. This clears the nav-button cluster.
         var sideMarginOpen: CGFloat
-        /// Same, but when the **sidebar is hidden** — then the detail region spans
-        /// the whole window and the field centers across it, so its left margin
-        /// must clear the traffic lights + sidebar-toggle + nav cluster (~250pt),
-        /// not just the nav cluster. Symmetric centering can't give the left side
-        /// more than the right, so BOTH margins must be this large or the group
-        /// overflows on any window narrow enough that the margin drops below the
-        /// chrome. This is the single reason the omnibox needs to know the sidebar
-        /// state at all.
+        /// Breathing room reserved on each side of the centered field when the
+        /// left sidebar is hidden. The detail region then spans the window, so
+        /// traffic lights and the system sidebar toggle also need room.
         var sideMarginClosed: CGFloat
         /// The field never shrinks below this (a couple of words) — on a very
         /// narrow window the margins give instead.
         var minWidth: CGFloat
-        /// The field never grows beyond this, so it stays a readable pill rather
-        /// than one edge-to-edge line on a wide monitor; past this width the side
-        /// margins simply grow.
+        /// The field never grows beyond this compact cap, so it stays centered
+        /// without competing with trailing toolbar controls.
         var maxWidth: CGFloat
+        /// Width reserved for trailing toolbar chrome that shares the detail
+        /// region with the centered field: the wiki switcher and persistent
+        /// right-inspector toggle.
+        var trailingChromeWidth: CGFloat
 
         static let `default` = Metrics(
-            sideMarginOpen: 150,
-            sideMarginClosed: 290,
+            sideMarginOpen: 220,
+            sideMarginClosed: 320,
             minWidth: 240,
-            maxWidth: 820)
+            maxWidth: 560,
+            trailingChromeWidth: 220)
     }
 
     /// The side margin reserved on each side of the centered field, chosen by
-    /// sidebar state (see `sideMarginOpen`/`sideMarginClosed`).
+    /// sidebar state and trailing toolbar chrome.
     static func sideMargin(sidebarVisible: Bool, metrics: Metrics = .default) -> CGFloat {
-        sidebarVisible ? metrics.sideMarginOpen : metrics.sideMarginClosed
+        max(sidebarVisible ? metrics.sideMarginOpen : metrics.sideMarginClosed,
+            metrics.trailingChromeWidth)
     }
 
     /// The omnibox field's width for a given detail-region width and sidebar state.
-    /// It's the region minus a (sidebar-dependent) margin on each side — so the
-    /// centered pill keeps enough breathing room to clear the leading chrome and
-    /// never fills the region (the old overflow trigger) — clamped to
-    /// `[minWidth, maxWidth]`. Centering itself is handled by the `.principal`
-    /// toolbar placement; the margin only has to be wide enough that the centered
-    /// field doesn't crowd the flush-left chrome (which is larger when the sidebar
-    /// is hidden — see `sideMarginClosed`).
+    /// It's the region minus a safe margin on each side, clamped to
+    /// `[minWidth, maxWidth]`. Centering itself is handled by `.principal`.
     ///
     /// - Parameters:
     ///   - detailWidth: the width of the detail column the toolbar spans, measured
@@ -74,7 +58,8 @@ enum OmniboxLayout {
     static func fieldWidth(detailWidth: CGFloat, sidebarVisible: Bool,
                            metrics: Metrics = .default) -> CGFloat {
         guard detailWidth > 0 else { return metrics.minWidth }
-        let available = detailWidth - 2 * sideMargin(sidebarVisible: sidebarVisible, metrics: metrics)
+        let available = detailWidth - 2 * sideMargin(sidebarVisible: sidebarVisible,
+                                                     metrics: metrics)
         return min(max(available, metrics.minWidth), metrics.maxWidth)
     }
 }

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -266,20 +266,12 @@ struct ContentView: View {
         // Hidden buttons for keyboard shortcuts.
         .background { keyboardShortcutButtons }
         // The toolbar is declared on the DETAIL column (not the split-view root)
-        // on purpose: a `.principal` item on the root centers across the whole
-        // window and overlaps the open sidebar, which makes NSToolbar dump the
-        // whole group into the `»` overflow. Declared here it centers within the
-        // detail region, so it survives the sidebar opening.
+        // on purpose: a centered `.principal` item then centers within the detail
+        // region rather than across the whole split-view window.
         .toolbar {
-            // Safari layout: the Back/Forward/Home cluster is pinned flush-left
-            // (`.navigation`) and the omnibox field is centered (`.principal`).
-            // Splitting them into two items lets NSToolbar center the field
-            // independently of the fixed-width nav cluster. The field is sized to
-            // a fraction of the detail region (`OmniboxLayout.fieldWidth`) with
-            // margins on each side, so it never fills the region edge-to-edge —
-            // the condition that used to tip the whole group into the `»`
-            // overflow. The empty title space is reclaimed by hiding the window
-            // title (`.toolbar(removing: .title)` below).
+            // Centered layout: Back/Forward/Home stays flush-left, the omnibox is
+            // a smaller `.principal` item, and the right controls stay together
+            // after a flexible spacer.
             ToolbarItem(placement: .navigation) {
                 OmniboxNavButtons(store: store, homePageID: activeHomePageID)
             }
@@ -289,18 +281,16 @@ struct ContentView: View {
                                sidebarVisible: columnVisibility != .detailOnly,
                                onAddToBookmarks: { omniboxBookmarkContext = $0 })
             }
-            ToolbarItem(placement: .automatic) {
+            ToolbarSpacer(.flexible)
+            ToolbarItemGroup(placement: .automatic) {
                 WikiSwitcher(registry: registry, currentWikiID: session.wikiID)
-            }
-            ToolbarItem(placement: .automatic) {
-                if rightInspector.isAvailable {
-                    Button {
-                        rightInspector.toggle()
-                    } label: {
-                        Image(systemName: "sidebar.right")
-                    }
-                    .help(rightInspector.isPresented ? "Hide Inspector" : "Show Inspector")
+                Button {
+                    rightInspector.toggle()
+                } label: {
+                    Image(systemName: "sidebar.right")
                 }
+                .disabled(!rightInspector.isAvailable)
+                .help(rightInspectorHelp)
             }
         }
         // Suppress the window title so the omnibox owns the toolbar. `.navigationTitle("")`
@@ -331,6 +321,11 @@ struct ContentView: View {
         )
         .frame(maxWidth: .infinity)
         .swipeNavigation(store: store)
+    }
+
+    private var rightInspectorHelp: String {
+        guard rightInspector.isAvailable else { return "No Inspector Available" }
+        return rightInspector.isPresented ? "Hide Inspector" : "Show Inspector"
     }
 
     private func runIngest(sourceID: SourceID) {

--- a/Sources/WikiFS/Window/WikiSwitcher.swift
+++ b/Sources/WikiFS/Window/WikiSwitcher.swift
@@ -90,6 +90,7 @@ struct WikiSwitcher: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
+            .frame(maxWidth: WikiSwitcherMetrics.toolbarLabelMaxWidth, alignment: .leading)
         }
         .menuStyle(.button)
         .buttonStyle(.borderless)
@@ -182,6 +183,10 @@ struct WikiSwitcher: View {
         importSourceURL = sourceURL
         importWikiName = sourceURL.deletingPathExtension().lastPathComponent
     }
+}
+
+private enum WikiSwitcherMetrics {
+    static let toolbarLabelMaxWidth: CGFloat = 168
 }
 
 /// A small sheet to name a new wiki. Kept separate so the create flow has a

--- a/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
+++ b/Tests/WikiFSAppTests/AddressBarLayoutHostedTests.swift
@@ -10,8 +10,7 @@ import Testing
 /// renders the width `OmniboxLayout` computes. `OmniboxLayoutTests` only proves the
 /// pure math is right; it can't catch the field silently growing past its cap or an
 /// implicit spacing eating into the frame. Render the actual `AddressBarView` (which
-/// is now *only* the field — the nav cluster is a separate `.navigation` item) and
-/// read its rendered width back.
+/// is the field itself) and read its rendered width back.
 ///
 /// `NSHostingController.view.fittingSize` is used rather than a real `NSToolbar`
 /// (which needs an on-screen window with a toolbar). Since the field carries an
@@ -34,7 +33,7 @@ struct AddressBarLayoutHostedTests {
     }
 
     /// Hosts the real `AddressBarView` at a fixed `detailWidth` and returns its
-    /// rendered width — the width NSToolbar would center as the `.principal` item.
+    /// rendered width — the width NSToolbar centers as the `.principal` item.
     private func renderedWidth(detailWidth: CGFloat, sidebarVisible: Bool = true) async throws -> CGFloat {
         let lease = await HostedAppKitTestGate.shared.acquire()
         defer { lease.release() }
@@ -72,8 +71,8 @@ struct AddressBarLayoutHostedTests {
         #expect(abs(rendered - OmniboxLayout.fieldWidth(detailWidth: 700, sidebarVisible: true)) < 1)
     }
 
-    /// Past the readability cap the pill freezes: a wider window adds side margin,
-    /// not field width, so the rendered width stops moving.
+    /// Past the readability cap the pill freezes: a wider window leaves extra
+    /// toolbar room outside the field, so the rendered width stops moving.
     @Test func renderedWidthFreezesAtTheCap() async throws {
         let m = OmniboxLayout.Metrics.default
         // Both points are past the cap (region - margins exceeds maxWidth).

--- a/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
+++ b/Tests/WikiFSAppTests/OmniboxLayoutTests.swift
@@ -4,23 +4,23 @@ import Testing
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// Sizing behavior of the centered toolbar omnibox. Uses a fixed `Metrics` so the
-/// thresholds are exact and independent of any future retuning. Centering itself
-/// is NSToolbar's job (the field is a `.principal` item); these tests cover only
-/// the pill's *width* as the detail region grows, and that the width leaves a
-/// large enough margin to clear the leading chrome in each sidebar state.
+/// Sizing behavior of the compact centered toolbar omnibox. Uses a fixed
+/// `Metrics` so the thresholds are exact and independent of any future retuning.
+/// These tests cover only the pill's *width* as the detail region grows, and
+/// that the width leaves enough room for surrounding toolbar chrome.
 @Suite struct OmniboxLayoutTests {
-    // sideMarginOpen 150, sideMarginClosed 290, min 240, max 820.
+    // sideMarginOpen 220, sideMarginClosed 320, min 240, max 560,
+    // trailingChromeWidth 220.
     let m = OmniboxLayout.Metrics.default
 
-    // MARK: Grows with the region, keeping side margins
+    // MARK: Grows with the region, keeping safe side margins
 
     @Test func fieldTakesTheRegionMinusAMarginOnEachSide() {
-        // Sidebar shown: 900 - 2*150 = 600.
-        #expect(OmniboxLayout.fieldWidth(detailWidth: 900, sidebarVisible: true) == 600)
-        // Sidebar hidden: 900 - 2*290 = 320 (a larger margin clears the traffic
-        // lights + toggle that now sit in the field's left margin).
-        #expect(OmniboxLayout.fieldWidth(detailWidth: 900, sidebarVisible: false) == 320)
+        // Sidebar shown: 900 - 2*220 = 460.
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 900, sidebarVisible: true) == 460)
+        // Sidebar hidden: 900 - 2*320 = 260. The larger margin clears the
+        // traffic lights + sidebar toggle.
+        #expect(OmniboxLayout.fieldWidth(detailWidth: 900, sidebarVisible: false) == 260)
     }
 
     @Test func widerRegionGrowsTheFieldOneForOneBelowTheCap() {
@@ -32,22 +32,31 @@ import Testing
     }
 
     @Test func hiddenSidebarReservesMoreMarginSoTheFieldIsNarrower() {
-        // Same region, but hiding the sidebar puts more chrome in the left margin,
-        // so the field must be narrower by exactly twice the margin difference.
+        // Same region, but hiding the sidebar puts more chrome into the centered
+        // field's side margin, so the field must be narrower by twice the margin
+        // difference.
         let open = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true)
         let closed = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: false)
         #expect(open - closed == 2 * (m.sideMarginClosed - m.sideMarginOpen))
     }
 
+    @Test func sideMarginDependsOnSidebarVisibility() {
+        #expect(OmniboxLayout.sideMargin(sidebarVisible: true) == m.sideMarginOpen)
+        #expect(OmniboxLayout.sideMargin(sidebarVisible: false) == m.sideMarginClosed)
+    }
+
+    @Test func trailingChromeIsAlwaysReservedBelowTheCap() {
+        let width = OmniboxLayout.fieldWidth(detailWidth: 1000, sidebarVisible: true)
+        #expect((1000 - width) / 2 >= m.trailingChromeWidth)
+    }
+
     @Test func sideMarginIsPreservedBelowTheCap() {
-        // (region - field) / 2 == the state's side margin, so the centered pill
-        // can never touch the region edges (the old overflow trigger). Widths
-        // chosen to sit in each state's growing regime.
-        for detailWidth: CGFloat in [700, 900, 1100] {
+        // Widths chosen to sit in each state's growing regime.
+        for detailWidth: CGFloat in [700, 900, 1000] {
             let open = OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: true)
             #expect((detailWidth - open) / 2 == m.sideMarginOpen)
         }
-        for detailWidth: CGFloat in [900, 1100, 1300] {
+        for detailWidth: CGFloat in [900, 1100, 1200] {
             let closed = OmniboxLayout.fieldWidth(detailWidth: detailWidth, sidebarVisible: false)
             #expect((detailWidth - closed) / 2 == m.sideMarginClosed)
         }
@@ -57,7 +66,7 @@ import Testing
 
     @Test func neverShrinksBelowTheFloor() {
         // Very narrow region: region - margins would go below the floor, so the
-        // floor holds and the margins give instead (never a negative width).
+        // floor holds instead (never a negative width).
         #expect(OmniboxLayout.fieldWidth(detailWidth: 500, sidebarVisible: true) == m.minWidth)
         #expect(OmniboxLayout.fieldWidth(detailWidth: 700, sidebarVisible: false) == m.minWidth)
     }
@@ -68,14 +77,13 @@ import Testing
     }
 
     @Test func marginsGrowPastTheCap() {
-        // Once the field is capped, extra window width becomes margin — the pill
-        // stays a fixed readable width and floats centered with more air around it.
+        // Once the field is capped, extra window width becomes margin.
         let wide = OmniboxLayout.fieldWidth(detailWidth: 1600, sidebarVisible: true)
         let wider = OmniboxLayout.fieldWidth(detailWidth: 2000, sidebarVisible: true)
         #expect(wide == m.maxWidth)
         #expect(wider == m.maxWidth)
-        #expect((1600 - wide) / 2 == 390)
-        #expect((2000 - wider) / 2 == 590)
+        #expect((1600 - wide) / 2 == 520)
+        #expect((2000 - wider) / 2 == 720)
     }
 
     // MARK: Unmeasured region


### PR DESCRIPTION
## Summary
- keep Back/Forward/Home width stable by always rendering the Home toolbar button
- center the omnibox as a compact principal toolbar item with tighter overflow-safe sizing
- keep the wiki switcher and right-sidebar toggle grouped on the trailing side, with the switcher label capped

## Testing
- `swift build --disable-sandbox --scratch-path /Users/wsargent/work/selfdrivingwiki/.swiftpm/xcode/.build-agent`
- commit hook: `swiftlint lint --strict`
