### PR TITLE
Gate PageContextMenuHostedTests into HostedAppKitTestGate (#984)

### DIFF
--- a/Tests/WikiFSAppTests/AgentLauncherSpawnRefusalTests.swift
+++ b/Tests/WikiFSAppTests/AgentLauncherSpawnRefusalTests.swift
@@ -135,7 +135,7 @@ import WikiFSCore
         opencodeDefault.isDefault = true
         let configWithModel = AgentProvidersConfig(
             providers: [opencodeDefault],
-            selectedModelIds: ["opencode": "glm-4.7"])
+            selectedModelIds: ["opencode": ModelID(rawValue: "glm-4.7")])
         try configWithModel.save(to: tmp)
 
         let launcher = AgentLauncher()
@@ -149,8 +149,8 @@ import WikiFSCore
         // Pin the chat path's guard input contract — what
         // `startInteractiveQuery` actually feeds into `SpawnModelGuard.validate`.
         #expect(provider.id == ProviderID(rawValue: "opencode"))
-        #expect(modelId == "glm-4.7")
-        #expect(SpawnModelGuard.validate(provider: provider, modelId: modelId) == nil)
+        #expect(modelId?.rawValue == "glm-4.7")
+        #expect(SpawnModelGuard.validate(provider: provider, modelId: modelId?.rawValue) == nil)
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/PageContextMenuHostedTests.swift
+++ b/Tests/WikiFSAppTests/PageContextMenuHostedTests.swift
@@ -48,6 +48,13 @@ struct PageContextMenuHostedTests {
     }
 
     @Test func mountedReaderOffersBackForwardAndPrint() async throws {
+        // This mounts a live NSWindow + WKWebView in the single `swift test`
+        // host process, same as every sibling hosted suite — without this
+        // lease it can overlap with another window-owning suite (e.g. the
+        // Editor/Composer autocomplete or QuoteHighlight suites) and wedge
+        // the shared AppKit/WebKit environment (see AutocompleteHostedTestGate.swift).
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         _ = Self.app
         let (model, store) = try tempModel()
         let a = try store.createPage(title: "A")

--- a/Tests/WikiFSAppTests/RunAwaitsTurnTests.swift
+++ b/Tests/WikiFSAppTests/RunAwaitsTurnTests.swift
@@ -57,7 +57,7 @@ struct RunAwaitsTurnTests {
                     isDefault: true
                 )
             ],
-            selectedModelIds: ["fake": "fake-model"])
+            selectedModelIds: ["fake": ModelID(rawValue: "fake-model")])
         try? providerConfig.save(to: tempDir)
         launcher.resolveProvidersContainerDirectory = { tempDir }
         launcher.containerDirectory = tempDir


### PR DESCRIPTION
## Summary

Fixes the concrete gap behind #984's aggregate app-test hangs: `PageContextMenuHostedTests` mounts a live `NSWindow` + real `WKWebView` in the shared `swift test` host process, but never acquired `HostedAppKitTestGate` — the serialization mechanism every other hosted-UI suite (`EditorAutocompleteHostedTests`, `ComposerAutocompleteHostedTests`, `AddressBarLayoutHostedTests`, `QuoteHighlightWebViewTests`, `PageDetailViewHostedTests`, ...) already uses before mounting a window.

The gate is a cooperative mutex (`Tests/WikiFSAppTests/AutocompleteHostedTestGate.swift`), not an OS-level lock: it only protects tests that opt in. One ungated participant can still race a gated suite for the single shared AppKit/WebKit host environment and wedge it — which matches #984's report of the aggregate run parking at a *different* hosted-suite boundary on each attempt (`QuoteHighlightWebViewTests`/`EditorAutocompleteHostedTests` one run, `ComposerAutocompleteHostedTests` another), rather than one deterministic hang.

- Add `let lease = await HostedAppKitTestGate.shared.acquire(); defer { lease.release() }` to `mountedReaderOffersBackForwardAndPrint()`, matching the exact pattern used everywhere else.
- Incidentally fixes two pre-existing `WikiFSAppTests`-only compile breaks (`String` literals where `AgentProvidersConfig.selectedModelIds` now expects `ModelID`, from #975) in `RunAwaitsTurnTests.swift` and `AgentLauncherSpawnRefusalTests.swift`. These blocked building the target with `WIKIFS_APP_TESTS=1` while verifying this fix.

## Scope note

While verifying, `WIKIFS_APP_TESTS=1 swift build --build-tests` turned out to fail on `main` independent of this fix — a much larger, unrelated compile break spans ~15 more `WikiFSAppTests` files (`ModelID`/`ProviderID`/`ToolCallID` call sites left over from #975 and the #983 typed-chat-domain phase, neither of which touched this CI-excluded target). That's a build break, not the hang #984 reports, and out of scope for this PR — filing a separate issue for it.

## Test plan

- [x] `swift build` (default target, unaffected by these changes) — untouched by this change, no need to re-verify
- [x] The two touched compile-fix files build cleanly in isolation (confirmed via targeted `WIKIFS_APP_TESTS=1 swift build --build-tests` output before hitting the unrelated pre-existing errors in other files)
- [ ] Full aggregate `WIKIFS_APP_TESTS=1 make test-watchdog` run to confirm the hang no longer reproduces — blocked until the separate ~15-file compile break (see scope note) is fixed, since the target can't fully build yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)