### PR TITLE
Strip source YAML frontmatter before rendering

### DIFF
--- a/Sources/WikiFS/Reader/ReaderMarkdown.swift
+++ b/Sources/WikiFS/Reader/ReaderMarkdown.swift
@@ -11,14 +11,29 @@ import WikiFSCore
 /// so missing links aren't dimmed there yet — ghost coloring for the web reader
 /// is a follow-up.
 enum ReaderMarkdown {
+    /// The document class selects source-specific normalization while keeping
+    /// chat and page Markdown verbatim.
+    enum ContentKind {
+        case document
+        case source
+    }
+
     static func prepared(
         _ raw: String,
+        contentKind: ContentKind = .document,
         isResolved: (String, ParsedLink.LinkType) -> Bool,
         embedInfo: ((String) -> WikiLinkMarkdown.SourceEmbedInfo?)? = nil,
         displayName: (String, ParsedLink.LinkType) -> String? = { _, _ in nil },
         pinnedExtractionID: ((SourceID, Int) -> SourceMarkdownVersionID?)? = nil
     ) -> String {
-        let renderedFootnotes = WikiFootnoteMarkdown.rendered(raw)
+        let markdown: String
+        switch contentKind {
+        case .document:
+            markdown = raw
+        case .source:
+            markdown = SourceMarkdownFormat.stripped(body: raw)
+        }
+        let renderedFootnotes = WikiFootnoteMarkdown.rendered(markdown)
         let body = WikiLinkMarkdown.linkified(renderedFootnotes.bodyMarkdown,
                                               isResolved: isResolved,
                                               embedInfo: embedInfo,

--- a/Sources/WikiFS/Reader/TransclusionEmbedder.swift
+++ b/Sources/WikiFS/Reader/TransclusionEmbedder.swift
@@ -55,16 +55,20 @@ enum TransclusionEmbedder {
         context: WikiRenderContext
     ) throws -> String {
         let raw: String?
+        let contentKind: ReaderMarkdown.ContentKind
         switch target {
         case .page(let id):
             let page = try store.getPage(id: id)
             raw = PageMarkdownFormat.stripped(body: page.bodyMarkdown, title: page.title)
+            contentKind = .document
         case .source(let id):
             raw = try sourceEmbedBody(store: store, id: id)
+            contentKind = .source
         }
         guard let raw, !raw.isEmpty else { return emptySentinel }
         let prepared = ReaderMarkdown.prepared(
             raw,
+            contentKind: contentKind,
             isResolved: context.isResolved,
             embedInfo: context.embedInfo,
             displayName: context.displayName,

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1058,8 +1058,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
             // The rendered source's own sibling map (nil for pages — no sibling
             // images). Selection-specific, so it stays here, not in the context.
             var renderedSourceMap: [String: SourceID]? = nil
+            let contentKind: ReaderMarkdown.ContentKind
             if case .source(let sourceID) = currentSelection {
                 renderedSourceMap = context?.siblingMaps[sourceID]
+                contentKind = .source
+            } else {
+                contentKind = .document
             }
 
             let loadStartVal = loadStart
@@ -1097,6 +1101,7 @@ internal struct WikiReaderRep: NSViewRepresentable {
                     pinnedExtractionID = nil
                 }
                 let prepared = ReaderMarkdown.prepared(markdown,
+                    contentKind: contentKind,
                     isResolved: isResolved,
                     embedInfo: embedInfo,
                     displayName: displayName,

--- a/Sources/WikiFSCore/Markdown/PageMarkdownFormat.swift
+++ b/Sources/WikiFSCore/Markdown/PageMarkdownFormat.swift
@@ -80,6 +80,31 @@ public enum PageMarkdownFormat {
 /// (origin, processing date, extraction technique) without a side channel.
 public enum SourceMarkdownFormat {
 
+    /// Return the Markdown body without a delimiter-balanced leading YAML
+    /// frontmatter block. Source storage remains verbatim so metadata readers
+    /// and File Provider projections retain the original frontmatter.
+    ///
+    /// An opening delimiter without a matching closing delimiter is ordinary
+    /// Markdown and is therefore preserved unchanged.
+    public static func stripped(body: String) -> String {
+        let lines = body.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
+            return body
+        }
+
+        guard let closingIndex = lines.dropFirst().firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == "---"
+        }) else {
+            return body
+        }
+
+        let content = lines.index(after: closingIndex)
+        let bodyStart = lines[content...].drop(while: {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        })
+        return bodyStart.joined(separator: "\n")
+    }
+
     public static func fileContent(for version: SourceMarkdownVersion, metadata: SourceOKFMetadata) -> String {
         let fm = OKFFrontmatter.concept(
             type: .source,

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -10,6 +10,28 @@ import Testing
 /// these feed standard Markdown and assert the HTML structure.
 struct MarkdownHTMLRendererTests {
 
+    @Test func sourceFrontmatterIsExcludedBeforeRendering() {
+        let markdown = """
+        ---
+        title: Example source
+        tags:
+          - demo
+        ---
+
+        # Hello
+
+        This is the source body.
+        """
+
+        let prepared = ReaderMarkdown.prepared(
+            markdown,
+            contentKind: .source,
+            isResolved: { _, _ in true })
+        let html = MarkdownHTMLRenderer.render(prepared)
+
+        #expect(html == "<h1 id=\"hello\">Hello</h1><p>This is the source body.</p>")
+    }
+
     @Test func headingWithSlug() {
         #expect(MarkdownHTMLRenderer.render("# Hello") == "<h1 id=\"hello\">Hello</h1>")
     }

--- a/Tests/WikiFSTests/PageMarkdownFormatTests.swift
+++ b/Tests/WikiFSTests/PageMarkdownFormatTests.swift
@@ -4,6 +4,23 @@ import WikiFSCore
 
 struct PageMarkdownFormatTests {
 
+    // MARK: - source frontmatter
+
+    @Test func sourceStripsBalancedLeadingFrontmatter() {
+        let body = "---\ntitle: Example source\n---\n\n# Hello"
+        #expect(SourceMarkdownFormat.stripped(body: body) == "# Hello")
+    }
+
+    @Test func sourceRetainsUnterminatedFrontmatter() {
+        let body = "---\ntitle: Example source\n\n# Hello"
+        #expect(SourceMarkdownFormat.stripped(body: body) == body)
+    }
+
+    @Test func sourceWithoutFrontmatterIsUnchanged() {
+        let body = "# Hello\n\nThis is the source body."
+        #expect(SourceMarkdownFormat.stripped(body: body) == body)
+    }
+
     // MARK: - stripped: H1 present
 
     @Test func stripsMatchingH1() {


### PR DESCRIPTION
Fixes https://github.com/tqbf/selfdrivingwiki/issues/993

## Summary

- Add `SourceMarkdownFormat.stripped()` to remove leading YAML frontmatter blocks from source markdown
- Introduce `ReaderMarkdown.ContentKind` enum to differentiate rendering paths between documents and sources
- Apply frontmatter stripping when preparing sources for display in transcluded embeds and direct rendering

## Why

Source documents store metadata as leading YAML frontmatter, but this should not appear in rendered output. By stripping frontmatter only during rendering while keeping storage verbatim, we ensure File Provider projections and metadata readers retain the original content structure, while users see clean rendered content without metadata headers.