### PR TITLE
Add durable chat transcript identities

### DIFF
--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -10,6 +10,8 @@ import UniformTypeIdentifiers
 // WikiFS, causing type mismatches.
 internal import GRDB
 
+// pattern: Imperative Shell
+
 /// A GRDB-backed implementation of the ``WikiStore`` protocol.
 ///
 /// This is a **parallel implementation** — it does NOT replace
@@ -58,7 +60,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// databases produced by that store carry `PRAGMA user_version` up to 37, and
     /// this store must recognize them as already-current so the ladder is a no-op
     /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 46
+    private static let currentSchemaVersion = 47
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -1301,6 +1303,19 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             version = 46
         }
 
+        // v46→v47: durable notice and failure identities. These IDs are part
+        // of `item_json`, so this keeps `chat_transcript_items` table shape
+        // unchanged. The transaction stamps the version only after every
+        // legacy payload has been rewritten successfully.
+        if version < 47 {
+            try db.inTransaction(.immediate) {
+                try Self.assignLegacyTranscriptItemIDsV47(in: db)
+                try db.execute(sql: "PRAGMA user_version = 47;")
+                return .commit
+            }
+            version = 47
+        }
+
         // Catch-all fallback: any DB older than `currentSchemaVersion` whose
         // per-step work has not been added above (the steady-state guard for a
         // genuine currentSchemaVersion bump). Drops FTS5 + stamps
@@ -2369,9 +2384,9 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         return nil
     }
 
-    /// Build the complete current schema (v39 end-state) on a fresh `Database`.
+    /// Build the complete current schema (v47 end-state) on a fresh `Database`.
     /// Mirrors `SQLiteWikiStore.createFreshSchemaV20()` + the additive tables
-    /// from v23–v39. All DDL is `IF NOT EXISTS`-guarded so re-running on an
+    /// from v23–v47. All DDL is `IF NOT EXISTS`-guarded so re-running on an
     /// already-current DB is a no-op (idempotent for GRDB's migrator).
     private static func createFreshSchema(on db: Database) throws {
         let now = Date().timeIntervalSince1970
@@ -6983,7 +6998,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             let rows = try Row.fetchAll(
                 db,
                 sql: """
-                SELECT cursor, item_json, projected_event_json, projected_text, created_at
+                SELECT chat_id, cursor, item_json, projected_event_json, projected_text, created_at
                 FROM chat_transcript_items
                 WHERE chat_id = ? AND cursor > ?
                 ORDER BY cursor ASC
@@ -7586,8 +7601,12 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     private static func readPersistedChatTranscriptItem(from row: Row) throws -> PersistedChatTranscriptItem {
         let cursor = ChatTranscriptCursor(rawValue: row["cursor"])
         let itemJSON: String = row["item_json"]
-        let itemData = itemJSON.data(using: .utf8) ?? Data("{}".utf8)
-        let item = try JSONDecoder().decode(ChatTranscriptItem.self, from: itemData)
+        let chatID = ChatID(rawValue: row["chat_id"])
+        let item = try Self.decodePersistedTranscriptItem(
+            itemJSON,
+            chatID: chatID,
+            cursor: cursor
+        )
         let projectedEventJSON: String? = row["projected_event_json"]
         let projectedText: String = row["projected_text"]
         let createdAt: Double = row["created_at"]
@@ -7624,15 +7643,18 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             """,
             arguments: [chatID.rawValue, transcriptItemKind(item)]
         )
-        let decoder = JSONDecoder()
         for row in rows {
             let itemJSON: String = row["item_json"]
-            guard let data = itemJSON.data(using: .utf8) else {
+            guard itemJSON.data(using: .utf8) != nil else {
                 continue
             }
             let persisted: ChatTranscriptItem
             do {
-                persisted = try decoder.decode(ChatTranscriptItem.self, from: data)
+                persisted = try Self.decodePersistedTranscriptItem(
+                    itemJSON,
+                    chatID: chatID,
+                    cursor: ChatTranscriptCursor(rawValue: row["cursor"])
+                )
             } catch {
                 DebugLog.store("GRDBWikiStore.transcriptCursor decode failed: \(error)")
                 continue
@@ -7645,21 +7667,113 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 where existing.toolCallID == candidate.toolCallID:
                 return ChatTranscriptCursor(rawValue: row["cursor"])
             case let (.turnFailure(existing), .turnFailure(candidate))
-                where existing.turnID == candidate.turnID &&
-                    existing.category == candidate.category &&
-                    existing.message == candidate.message:
+                where existing.failureID == candidate.failureID:
                 return ChatTranscriptCursor(rawValue: row["cursor"])
             case let (.systemNotice(existing), .systemNotice(candidate))
-                where existing.turnID == candidate.turnID &&
-                    existing.kind == candidate.kind &&
-                    existing.title == candidate.title &&
-                    existing.message == candidate.message:
+                where existing.noticeID == candidate.noticeID:
                 return ChatTranscriptCursor(rawValue: row["cursor"])
             default:
                 continue
             }
         }
         return nil
+    }
+
+    /// Decode a persisted item without mutating the database. This is the
+    /// legacy page compatibility boundary for a read-only or partially
+    /// migrated store. Normal `ChatTranscriptItem` decoding intentionally
+    /// remains strict.
+    private static func decodePersistedTranscriptItem(
+        _ itemJSON: String,
+        chatID: ChatID,
+        cursor: ChatTranscriptCursor
+    ) throws -> ChatTranscriptItem {
+        guard let itemData = itemJSON.data(using: .utf8) else {
+            throw WikiStoreError.unexpected("invalid persisted chat transcript JSON")
+        }
+        do {
+            return try JSONDecoder().decode(ChatTranscriptItem.self, from: itemData)
+        } catch let error as ChatTranscriptItemDecodingError {
+            switch error {
+            case .missingNoticeIdentity, .missingFailureIdentity:
+                let repaired = try Self.rewritingLegacyTranscriptItemJSON(
+                    itemJSON,
+                    chatID: chatID,
+                    cursor: cursor
+                )
+                return try JSONDecoder().decode(ChatTranscriptItem.self, from: repaired)
+            }
+        }
+    }
+
+    /// Derive the same identifier for migration and read-only compatibility.
+    /// The cursor is durable provenance, never a display position.
+    private static func legacyTranscriptItemID(
+        chatID: ChatID,
+        cursor: ChatTranscriptCursor,
+        itemKind: String
+    ) -> String {
+        "chat-transcript-v47:\(itemKind):\(chatID.rawValue):\(cursor.rawValue)"
+    }
+
+    private static func rewritingLegacyTranscriptItemJSON(
+        _ itemJSON: String,
+        chatID: ChatID,
+        cursor: ChatTranscriptCursor
+    ) throws -> Data {
+        let object = try JSONSerialization.jsonObject(with: Data(itemJSON.utf8))
+        guard var root = object as? [String: Any] else {
+            throw WikiStoreError.unexpected("invalid persisted chat transcript object")
+        }
+
+        let cases: [(itemKind: String, payloadKey: String)] = [
+            ("systemNotice", "noticeID"),
+            ("turnFailure", "failureID"),
+        ]
+        for candidate in cases {
+            guard var associated = root[candidate.itemKind] as? [String: Any],
+                  var payload = associated["_0"] as? [String: Any]
+            else { continue }
+
+            if payload[candidate.payloadKey] == nil {
+                payload[candidate.payloadKey] = Self.legacyTranscriptItemID(
+                    chatID: chatID,
+                    cursor: cursor,
+                    itemKind: candidate.itemKind
+                )
+                associated["_0"] = payload
+                root[candidate.itemKind] = associated
+            }
+            return try JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
+        }
+        return Data(itemJSON.utf8)
+    }
+
+    private static func assignLegacyTranscriptItemIDsV47(in db: Database) throws {
+        let rows = try Row.fetchAll(
+            db,
+            sql: """
+            SELECT chat_id, cursor, item_json
+            FROM chat_transcript_items
+            WHERE item_kind IN ('systemNotice', 'turnFailure')
+            ORDER BY chat_id ASC, cursor ASC;
+            """
+        )
+        for row in rows {
+            let chatID = ChatID(rawValue: row["chat_id"])
+            let cursor = ChatTranscriptCursor(rawValue: row["cursor"])
+            let itemJSON: String = row["item_json"]
+            let rewritten = try Self.rewritingLegacyTranscriptItemJSON(
+                itemJSON,
+                chatID: chatID,
+                cursor: cursor
+            )
+            guard String(data: rewritten, encoding: .utf8) != itemJSON else { continue }
+            try db.execute(
+                sql: "UPDATE chat_transcript_items SET item_json = ? WHERE chat_id = ? AND cursor = ?;",
+                arguments: [String(decoding: rewritten, as: UTF8.self), chatID.rawValue, cursor.rawValue]
+            )
+        }
     }
 
     private static func transcriptCreatedAt(for item: ChatTranscriptItem) -> Date? {

--- a/Sources/WikiFSEngine/ChatAgentRuntime.swift
+++ b/Sources/WikiFSEngine/ChatAgentRuntime.swift
@@ -59,10 +59,17 @@ public enum ChatAgentRuntimeEvent: Hashable, Sendable, Codable {
 public struct ChatAgentRuntimeEventEnvelope: Hashable, Sendable, Codable {
     public let generation: ChatSessionGenerationID
     public let event: ChatAgentRuntimeEvent
+    /// Live-only block state carried atomically with a transcript transition.
+    public let activeContentBlock: ChatActiveContentBlock?
 
-    public init(generation: ChatSessionGenerationID, event: ChatAgentRuntimeEvent) {
+    public init(
+        generation: ChatSessionGenerationID,
+        event: ChatAgentRuntimeEvent,
+        activeContentBlock: ChatActiveContentBlock? = nil
+    ) {
         self.generation = generation
         self.event = event
+        self.activeContentBlock = activeContentBlock
     }
 }
 

--- a/Sources/WikiFSEngine/ChatClientSync.swift
+++ b/Sources/WikiFSEngine/ChatClientSync.swift
@@ -1,3 +1,5 @@
+// pattern: Functional Core
+
 import Foundation
 import WikiFSCore
 
@@ -102,9 +104,12 @@ public enum ChatClientSyncReducer {
             return ChatClientSyncReduction(state: state)
         }
 
-        let preservedProjection = preservingLoadedHistory(
+        let preservedProjection = validatingActiveContentBlock(
+            in: preservingLoadedHistory(
             snapshot.projection,
             loadedCommittedCursor: state.loadedCommittedCursor
+            ),
+            committedItems: state.committedItems
         )
         var next = ChatClientSyncState(
             chatID: state.chatID,
@@ -327,6 +332,7 @@ public enum ChatClientSyncReducer {
                 providerState: projection.providerState,
                 usage: projection.usage,
                 diagnostics: projection.diagnostics,
+                activeContentBlock: projection.activeContentBlock,
                 transcriptOverlay: projection.transcriptOverlay + [optimisticMessage],
                 committedCursor: projection.committedCursor,
                 lastIncludedSequence: projection.lastIncludedSequence,
@@ -352,6 +358,7 @@ public enum ChatClientSyncReducer {
                 providerState: projection.providerState,
                 usage: projection.usage,
                 diagnostics: projection.diagnostics,
+                activeContentBlock: projection.activeContentBlock,
                 transcriptOverlay: projection.transcriptOverlay + [optimisticMessage],
                 committedCursor: projection.committedCursor,
                 lastIncludedSequence: projection.lastIncludedSequence,
@@ -410,6 +417,7 @@ public enum ChatClientSyncReducer {
             providerState: projection.providerState,
             usage: projection.usage,
             diagnostics: projection.diagnostics,
+            activeContentBlock: projection.activeContentBlock,
             transcriptOverlay: filteredOverlay,
             committedCursor: projection.committedCursor,
             lastIncludedSequence: projection.lastIncludedSequence,
@@ -439,10 +447,14 @@ public enum ChatClientSyncReducer {
             reason: update.reason,
             currentProjection: currentProjection
         )
-        return preservingTerminalOverlayIfNeeded(
+        let terminalNormalized = preservingTerminalOverlayIfNeeded(
             currentProjection: currentProjection,
             incomingProjection: compactNormalized,
             reason: update.reason,
+            committedItems: committedItems
+        )
+        return validatingActiveContentBlock(
+            in: terminalNormalized,
             committedItems: committedItems
         )
     }
@@ -521,12 +533,53 @@ public enum ChatClientSyncReducer {
             providerState: projection.providerState,
             usage: projection.usage,
             diagnostics: projection.diagnostics,
+            activeContentBlock: projection.activeContentBlock,
             transcriptOverlay: overlay,
             committedCursor: projection.committedCursor,
             lastIncludedSequence: projection.lastIncludedSequence,
             pendingPermission: projection.pendingPermission,
             runMetadata: projection.runMetadata
         )
+    }
+
+    /// The wire may carry an old envelope or an out-of-order block reference.
+    /// A client never treats metadata as live until the matching typed message
+    /// is present with the same role and turn.
+    private static func validatingActiveContentBlock(
+        in projection: ChatSyncProjection,
+        committedItems: [PersistedChatTranscriptItem]
+    ) -> ChatSyncProjection {
+        guard let activeContentBlock = projection.activeContentBlock else {
+            return projection
+        }
+        let allItems = committedItems.map(\.item) + projection.transcriptOverlay
+        let isValid = allItems.contains { item in
+            guard case .message(let message) = item else { return false }
+            return message.messageID == activeContentBlock.messageID
+                && message.turnID == activeContentBlock.turnID
+                && message.role == activeContentBlock.role
+        }
+        guard isValid else {
+            return ChatSyncProjection(
+                chatID: projection.chatID,
+                generation: projection.generation,
+                lifecycle: projection.lifecycle,
+                activeTurn: projection.activeTurn,
+                queuedTurns: projection.queuedTurns,
+                attention: projection.attention,
+                capabilities: projection.capabilities,
+                providerState: projection.providerState,
+                usage: projection.usage,
+                diagnostics: projection.diagnostics,
+                activeContentBlock: nil,
+                transcriptOverlay: projection.transcriptOverlay,
+                committedCursor: projection.committedCursor,
+                lastIncludedSequence: projection.lastIncludedSequence,
+                pendingPermission: projection.pendingPermission,
+                runMetadata: projection.runMetadata
+            )
+        }
+        return projection
     }
 
     private static func mergingOverlay(
@@ -585,6 +638,7 @@ public enum ChatClientSyncReducer {
             providerState: projection.providerState,
             usage: projection.usage,
             diagnostics: projection.diagnostics,
+            activeContentBlock: projection.activeContentBlock,
             transcriptOverlay: projection.transcriptOverlay,
             committedCursor: loadedCommittedCursor,
             lastIncludedSequence: projection.lastIncludedSequence,
@@ -621,6 +675,7 @@ public enum ChatClientSyncReducer {
                 providerState: projection.providerState,
                 usage: projection.usage,
                 diagnostics: projection.diagnostics,
+                activeContentBlock: projection.activeContentBlock,
                 transcriptOverlay: filteredOverlay,
                 committedCursor: projection.committedCursor,
                 lastIncludedSequence: projection.lastIncludedSequence,
@@ -712,11 +767,41 @@ public enum ChatClientSyncReducer {
             let identity = transcriptIdentity(for: item)
             if let index = merged.lastIndex(where: { transcriptIdentity(for: $0) == identity }) {
                 merged[index] = item
+            } else if merged.contains(where: {
+                canonicalItem($0, replacesLegacyOverlay: item)
+            }) {
+                // A legacy wire adapter has only envelope provenance. Its
+                // synthetic identity must never displace canonical migrated
+                // history that describes the same notice or failure.
+                continue
             } else {
                 merged.append(item)
             }
         }
         return merged
+    }
+
+    private static func canonicalItem(
+        _ canonical: ChatTranscriptItem,
+        replacesLegacyOverlay overlay: ChatTranscriptItem
+    ) -> Bool {
+        switch (canonical, overlay) {
+        case let (.systemNotice(history), .systemNotice(live)):
+            guard live.noticeID.rawValue.hasPrefix("chat-wire-v1:") else { return false }
+            return history.turnID == live.turnID
+                && history.kind == live.kind
+                && history.title == live.title
+                && history.message == live.message
+                && history.createdAt == live.createdAt
+        case let (.turnFailure(history), .turnFailure(live)):
+            guard live.failureID.rawValue.hasPrefix("chat-wire-v1:") else { return false }
+            return history.turnID == live.turnID
+                && history.category == live.category
+                && history.message == live.message
+                && history.createdAt == live.createdAt
+        default:
+            return false
+        }
     }
 
     private enum TranscriptIdentity: Hashable {

--- a/Sources/WikiFSEngine/ChatClientSync.swift
+++ b/Sources/WikiFSEngine/ChatClientSync.swift
@@ -55,6 +55,15 @@ public enum ChatClientSyncEffect: Sendable, Equatable {
     case requestAuthoritativeSnapshot
 }
 
+/// A compatibility condition detected while reconciling a wire projection with
+/// authoritative persisted transcript history.
+public enum ChatClientSyncAnomaly: Sendable, Equatable {
+    case legacyOverlayWithoutProvenance(
+        itemKind: LegacyTranscriptOccurrence.ItemKind,
+        sourceOrdinal: Int
+    )
+}
+
 public enum ChatClientSyncAction: Sendable, Equatable {
     case applySnapshot(ChatSyncSnapshot)
     case applyUpdate(ChatSyncUpdate)
@@ -66,10 +75,16 @@ public enum ChatClientSyncAction: Sendable, Equatable {
 public struct ChatClientSyncReduction: Sendable, Equatable {
     public let state: ChatClientSyncState
     public let effects: [ChatClientSyncEffect]
+    public let anomalies: [ChatClientSyncAnomaly]
 
-    public init(state: ChatClientSyncState, effects: [ChatClientSyncEffect] = []) {
+    public init(
+        state: ChatClientSyncState,
+        effects: [ChatClientSyncEffect] = [],
+        anomalies: [ChatClientSyncAnomaly] = []
+    ) {
         self.state = state
         self.effects = effects
+        self.anomalies = anomalies
     }
 }
 
@@ -120,7 +135,8 @@ public enum ChatClientSyncReducer {
             optimisticBaseLifecycles: state.optimisticBaseLifecycles
         )
         next = discardingAuthoritativeOptimisticLifecycleBackups(in: next)
-        next = pruningCommittedOverlay(in: next)
+        let pruning = pruningCommittedOverlay(in: next)
+        next = pruning.state
         next = retainingActiveOptimisticLifecycleBackups(in: next)
 
         let effects: [ChatClientSyncEffect] =
@@ -128,7 +144,7 @@ public enum ChatClientSyncReducer {
             ? [.loadCommittedHistory(to: preservedProjection.committedCursor)]
             : []
 
-        return ChatClientSyncReduction(state: next, effects: effects)
+        return ChatClientSyncReduction(state: next, effects: effects, anomalies: pruning.anomalies)
     }
 
     private static func apply(
@@ -200,13 +216,14 @@ public enum ChatClientSyncReducer {
                     optimisticBaseLifecycles: state.optimisticBaseLifecycles
                 )
                 next = discardingAuthoritativeOptimisticLifecycleBackups(in: next)
-                next = pruningCommittedOverlay(in: next)
+                let pruning = pruningCommittedOverlay(in: next)
+                next = pruning.state
                 next = retainingActiveOptimisticLifecycleBackups(in: next)
                 let effects: [ChatClientSyncEffect] =
                     normalizedProjection.committedCursor > state.loadedCommittedCursor
                     ? [.loadCommittedHistory(to: normalizedProjection.committedCursor)]
                     : []
-                return ChatClientSyncReduction(state: next, effects: effects)
+                return ChatClientSyncReduction(state: next, effects: effects, anomalies: pruning.anomalies)
             case .sessionEvent:
                 return ChatClientSyncReduction(state: state)
             }
@@ -246,14 +263,15 @@ public enum ChatClientSyncReducer {
             optimisticBaseLifecycles: state.optimisticBaseLifecycles
         )
         next = discardingAuthoritativeOptimisticLifecycleBackups(in: next)
-        next = pruningCommittedOverlay(in: next)
+        let pruning = pruningCommittedOverlay(in: next)
+        next = pruning.state
         next = retainingActiveOptimisticLifecycleBackups(in: next)
 
         let effects: [ChatClientSyncEffect] =
             normalizedProjection.committedCursor > state.loadedCommittedCursor
             ? [.loadCommittedHistory(to: normalizedProjection.committedCursor)]
             : []
-        return ChatClientSyncReduction(state: next, effects: effects)
+        return ChatClientSyncReduction(state: next, effects: effects, anomalies: pruning.anomalies)
     }
 
     private static func appendCommittedHistory(
@@ -282,9 +300,10 @@ public enum ChatClientSyncReducer {
             optimisticBaseLifecycles: state.optimisticBaseLifecycles
         )
         next = discardingAuthoritativeOptimisticLifecycleBackups(in: next)
-        next = pruningCommittedOverlay(in: next)
+        let pruning = pruningCommittedOverlay(in: next)
+        next = pruning.state
         next = retainingActiveOptimisticLifecycleBackups(in: next)
-        return ChatClientSyncReduction(state: next)
+        return ChatClientSyncReduction(state: next, anomalies: pruning.anomalies)
     }
 
     private static func optimisticSubmit(
@@ -333,6 +352,7 @@ public enum ChatClientSyncReducer {
                 usage: projection.usage,
                 diagnostics: projection.diagnostics,
                 activeContentBlock: projection.activeContentBlock,
+                legacyTranscriptOccurrences: projection.legacyTranscriptOccurrences,
                 transcriptOverlay: projection.transcriptOverlay + [optimisticMessage],
                 committedCursor: projection.committedCursor,
                 lastIncludedSequence: projection.lastIncludedSequence,
@@ -359,6 +379,7 @@ public enum ChatClientSyncReducer {
                 usage: projection.usage,
                 diagnostics: projection.diagnostics,
                 activeContentBlock: projection.activeContentBlock,
+                legacyTranscriptOccurrences: projection.legacyTranscriptOccurrences,
                 transcriptOverlay: projection.transcriptOverlay + [optimisticMessage],
                 committedCursor: projection.committedCursor,
                 lastIncludedSequence: projection.lastIncludedSequence,
@@ -418,6 +439,7 @@ public enum ChatClientSyncReducer {
             usage: projection.usage,
             diagnostics: projection.diagnostics,
             activeContentBlock: projection.activeContentBlock,
+            legacyTranscriptOccurrences: projection.legacyTranscriptOccurrences,
             transcriptOverlay: filteredOverlay,
             committedCursor: projection.committedCursor,
             lastIncludedSequence: projection.lastIncludedSequence,
@@ -534,6 +556,7 @@ public enum ChatClientSyncReducer {
             usage: projection.usage,
             diagnostics: projection.diagnostics,
             activeContentBlock: projection.activeContentBlock,
+            legacyTranscriptOccurrences: projection.legacyTranscriptOccurrences,
             transcriptOverlay: overlay,
             committedCursor: projection.committedCursor,
             lastIncludedSequence: projection.lastIncludedSequence,
@@ -572,6 +595,7 @@ public enum ChatClientSyncReducer {
                 usage: projection.usage,
                 diagnostics: projection.diagnostics,
                 activeContentBlock: nil,
+                legacyTranscriptOccurrences: projection.legacyTranscriptOccurrences,
                 transcriptOverlay: projection.transcriptOverlay,
                 committedCursor: projection.committedCursor,
                 lastIncludedSequence: projection.lastIncludedSequence,
@@ -639,6 +663,7 @@ public enum ChatClientSyncReducer {
             usage: projection.usage,
             diagnostics: projection.diagnostics,
             activeContentBlock: projection.activeContentBlock,
+            legacyTranscriptOccurrences: projection.legacyTranscriptOccurrences,
             transcriptOverlay: projection.transcriptOverlay,
             committedCursor: loadedCommittedCursor,
             lastIncludedSequence: projection.lastIncludedSequence,
@@ -647,22 +672,44 @@ public enum ChatClientSyncReducer {
         )
     }
 
+    private struct OverlayPruningResult: Sendable {
+        let state: ChatClientSyncState
+        let anomalies: [ChatClientSyncAnomaly]
+    }
+
     private static func pruningCommittedOverlay(
         in state: ChatClientSyncState
-    ) -> ChatClientSyncState {
-        guard let projection = state.projection else { return state }
-        let filteredOverlay = projection.transcriptOverlay.filter { overlayItem in
+    ) -> OverlayPruningResult {
+        guard let projection = state.projection else {
+            return OverlayPruningResult(state: state, anomalies: [])
+        }
+        var anomalies: [ChatClientSyncAnomaly] = []
+        let filteredOverlay: [ChatTranscriptItem] = projection.transcriptOverlay.enumerated().compactMap { sourceOrdinal, overlayItem in
+            if let itemKind = legacyItemKindWithoutProvenance(
+                overlayItem,
+                in: projection
+            ) {
+                anomalies.append(.legacyOverlayWithoutProvenance(
+                    itemKind: itemKind,
+                    sourceOrdinal: sourceOrdinal
+                ))
+                if state.committedItems.contains(where: {
+                    canonicalItem($0.item, replacesLegacyOverlay: overlayItem)
+                }) {
+                    return nil
+                }
+            }
             guard let committedItem = state.committedItems.last(where: {
                 transcriptIdentity(for: $0.item) == transcriptIdentity(for: overlayItem)
             })?.item else {
-                return true
+                return overlayItem
             }
-            return !transcriptItemsMatchForDisplay(committedItem, overlayItem)
+            return transcriptItemsMatchForDisplay(committedItem, overlayItem) ? nil : overlayItem
         }
         guard filteredOverlay != projection.transcriptOverlay else {
-            return state
+            return OverlayPruningResult(state: state, anomalies: anomalies)
         }
-        return ChatClientSyncState(
+        return OverlayPruningResult(state: ChatClientSyncState(
             chatID: state.chatID,
             projection: ChatSyncProjection(
                 chatID: projection.chatID,
@@ -676,6 +723,7 @@ public enum ChatClientSyncReducer {
                 usage: projection.usage,
                 diagnostics: projection.diagnostics,
                 activeContentBlock: projection.activeContentBlock,
+                legacyTranscriptOccurrences: projection.legacyTranscriptOccurrences,
                 transcriptOverlay: filteredOverlay,
                 committedCursor: projection.committedCursor,
                 lastIncludedSequence: projection.lastIncludedSequence,
@@ -686,7 +734,32 @@ public enum ChatClientSyncReducer {
             loadedCommittedCursor: state.loadedCommittedCursor,
             syncStatus: state.syncStatus,
             optimisticBaseLifecycles: state.optimisticBaseLifecycles
-        )
+        ), anomalies: anomalies)
+    }
+
+    private static func legacyItemKindWithoutProvenance(
+        _ item: ChatTranscriptItem,
+        in projection: ChatSyncProjection
+    ) -> LegacyTranscriptOccurrence.ItemKind? {
+        let identity: (rawValue: String, itemKind: LegacyTranscriptOccurrence.ItemKind)? = switch item {
+        case .systemNotice(let notice):
+            (notice.noticeID.rawValue, .systemNotice)
+        case .turnFailure(let failure):
+            (failure.failureID.rawValue, .turnFailure)
+        default:
+            nil
+        }
+        guard let identity, identity.rawValue.hasPrefix("chat-wire-v1:") else {
+            return nil
+        }
+        let hasProvenance = projection.legacyTranscriptOccurrences?.contains { occurrence in
+            occurrence.chatID == projection.chatID
+                && occurrence.generation == projection.generation
+                && occurrence.sequence == projection.lastIncludedSequence
+                && occurrence.itemKind == identity.itemKind
+                && occurrence.durableIDRawValue == identity.rawValue
+        } ?? false
+        return hasProvenance ? nil : identity.itemKind
     }
 
     private static func shouldAcceptIncomingGenerationSwitch(

--- a/Sources/WikiFSEngine/ChatDomain.swift
+++ b/Sources/WikiFSEngine/ChatDomain.swift
@@ -1,3 +1,5 @@
+// pattern: Functional Core
+
 import Foundation
 import WikiFSCore
 
@@ -393,7 +395,13 @@ public enum ChatSessionEventPayload: Hashable, Sendable, Codable {
     case permissionRequested(ChatPendingPermissionRequest)
     case permissionResolved(PermissionRequestID)
     case completed(turnID: ChatTurnID)
-    case failed(turnID: ChatTurnID, category: ChatTurnFailureCategory, message: String, createdAt: Date)
+    case failed(
+        turnID: ChatTurnID,
+        failureID: ChatTranscriptFailureID,
+        category: ChatTurnFailureCategory,
+        message: String,
+        createdAt: Date
+    )
     case cancelled(turnID: ChatTurnID)
     case recovering
     case sessionReady(capabilities: ChatCapabilitySet, providerState: ChatProviderState)
@@ -625,7 +633,7 @@ public enum ChatSessionMachine {
             )
             return .applied(next)
 
-        case .failed(let turnID, let category, let message, let createdAt):
+        case .failed(let turnID, let failureID, let category, let message, let createdAt):
             guard let activeTurn = next.activeTurn,
                   activeTurn.turnID == turnID,
                   activeTurn.state.isTerminal == false
@@ -652,6 +660,7 @@ public enum ChatSessionMachine {
                 overlay: [
                     .turnFailure(
                         ChatTranscriptTurnFailureItem(
+                            failureID: failureID,
                             turnID: turnID,
                             category: category,
                             message: message,

--- a/Sources/WikiFSEngine/ChatSyncWire.swift
+++ b/Sources/WikiFSEngine/ChatSyncWire.swift
@@ -1,6 +1,68 @@
 import Foundation
 import WikiFSCore
 
+// pattern: Functional Core
+
+/// The only lifecycle state a live content block can carry on the sync wire.
+/// A finalized block is represented by the absence of this value.
+public enum ChatActiveContentBlockPhase: String, Sendable, Codable, Equatable, Hashable {
+    case streaming
+}
+
+/// Non-persisted metadata for the transcript content block that is open now.
+public struct ChatActiveContentBlock: Sendable, Codable, Equatable, Hashable {
+    public let messageID: ChatMessageID
+    public let turnID: ChatTurnID
+    public let role: ChatTranscriptMessageRole
+    public let phase: ChatActiveContentBlockPhase
+
+    public init(
+        messageID: ChatMessageID,
+        turnID: ChatTurnID,
+        role: ChatTranscriptMessageRole,
+        phase: ChatActiveContentBlockPhase = .streaming
+    ) {
+        self.messageID = messageID
+        self.turnID = turnID
+        self.role = role
+        self.phase = phase
+    }
+}
+
+/// Provenance for a legacy transcript value repaired at a sync-envelope edge.
+/// `sourceOrdinal` identifies the source occurrence. It is never a display
+/// position or a durable transcript cursor.
+public struct LegacyTranscriptOccurrence: Sendable, Codable, Equatable, Hashable {
+    public enum ItemKind: String, Sendable, Codable, Equatable, Hashable, CaseIterable {
+        case systemNotice
+        case turnFailure
+    }
+
+    public let chatID: ChatID
+    public let generation: ChatSessionGenerationID
+    public let sequence: ChatUpdateSequence
+    public let sourceOrdinal: Int
+    public let itemKind: ItemKind
+
+    public init(
+        chatID: ChatID,
+        generation: ChatSessionGenerationID,
+        sequence: ChatUpdateSequence,
+        sourceOrdinal: Int,
+        itemKind: ItemKind
+    ) {
+        self.chatID = chatID
+        self.generation = generation
+        self.sequence = sequence
+        self.sourceOrdinal = sourceOrdinal
+        self.itemKind = itemKind
+    }
+
+    public var durableIDRawValue: String {
+        "chat-wire-v1:\(itemKind.rawValue):\(chatID.rawValue):\(generation.rawValue):\(sequence.rawValue):\(sourceOrdinal)"
+    }
+}
+
 public struct ChatRunMetadata: Sendable, Codable, Equatable {
     public let preflightError: String?
     public let thinkingOption: ThinkingEffortOption?
@@ -41,6 +103,7 @@ public struct ChatSyncProjection: Sendable, Codable, Equatable {
     public let providerState: ChatProviderState
     public let usage: SessionUsage?
     public let diagnostics: ChatDiagnosticsState
+    public let activeContentBlock: ChatActiveContentBlock?
     public let transcriptOverlay: [ChatTranscriptItem]
     public let committedCursor: ChatTranscriptCursor
     public let lastIncludedSequence: ChatUpdateSequence
@@ -58,6 +121,7 @@ public struct ChatSyncProjection: Sendable, Codable, Equatable {
         providerState: ChatProviderState,
         usage: SessionUsage?,
         diagnostics: ChatDiagnosticsState,
+        activeContentBlock: ChatActiveContentBlock? = nil,
         transcriptOverlay: [ChatTranscriptItem],
         committedCursor: ChatTranscriptCursor,
         lastIncludedSequence: ChatUpdateSequence,
@@ -74,6 +138,7 @@ public struct ChatSyncProjection: Sendable, Codable, Equatable {
         self.providerState = providerState
         self.usage = usage
         self.diagnostics = diagnostics
+        self.activeContentBlock = activeContentBlock
         self.transcriptOverlay = transcriptOverlay
         self.committedCursor = committedCursor
         self.lastIncludedSequence = lastIncludedSequence
@@ -89,7 +154,8 @@ public extension ChatSyncProjection {
         pendingPermission: ChatPendingPermissionRequest?,
         runMetadata: ChatRunMetadata,
         usage: SessionUsage?,
-        diagnostics: ChatDiagnosticsState
+        diagnostics: ChatDiagnosticsState,
+        activeContentBlock: ChatActiveContentBlock? = nil
     ) -> ChatSyncProjection {
         ChatSyncProjection(
             chatID: snapshot.chatID,
@@ -102,6 +168,7 @@ public extension ChatSyncProjection {
             providerState: snapshot.providerState,
             usage: usage,
             diagnostics: diagnostics,
+            activeContentBlock: activeContentBlock,
             transcriptOverlay: snapshot.transientTranscriptOverlay,
             committedCursor: committedCursor,
             lastIncludedSequence: snapshot.lastIncludedSequence,
@@ -203,6 +270,52 @@ private enum ChatSyncWire {
             throw ChatSyncWireError.unsupportedWireVersion(wireVersion)
         }
     }
+
+    /// Repair pre-v47 notice/failure items only while decoding a versioned
+    /// envelope. Leaf transcript decoding remains intentionally strict.
+    static func repairingLegacyTranscriptIDs(in data: Data) throws -> Data {
+        var root = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+        let envelopeKey = root["snapshot"] == nil ? "update" : "snapshot"
+        guard var envelope = root[envelopeKey] as? [String: Any],
+              var projection = envelope["projection"] as? [String: Any],
+              let chatRaw = projection["chatID"] as? String,
+              let generationRaw = projection["generation"] as? String,
+              let sequenceNumber = projection["lastIncludedSequence"] as? NSNumber,
+              var overlay = projection["transcriptOverlay"] as? [[String: Any]]
+        else {
+            return data
+        }
+
+        let chatID = ChatID(rawValue: chatRaw)
+        let generation = ChatSessionGenerationID(rawValue: generationRaw)
+        let sequence = ChatUpdateSequence(rawValue: sequenceNumber.int64Value)
+        var changed = false
+        for sourceOrdinal in overlay.indices {
+            for itemKind in LegacyTranscriptOccurrence.ItemKind.allCases {
+                guard var associated = overlay[sourceOrdinal][itemKind.rawValue] as? [String: Any],
+                      var payload = associated["_0"] as? [String: Any]
+                else { continue }
+                let identityKey = itemKind == .systemNotice ? "noticeID" : "failureID"
+                guard payload[identityKey] == nil else { continue }
+                let occurrence = LegacyTranscriptOccurrence(
+                    chatID: chatID,
+                    generation: generation,
+                    sequence: sequence,
+                    sourceOrdinal: sourceOrdinal,
+                    itemKind: itemKind
+                )
+                payload[identityKey] = occurrence.durableIDRawValue
+                associated["_0"] = payload
+                overlay[sourceOrdinal][itemKind.rawValue] = associated
+                changed = true
+            }
+        }
+        guard changed else { return data }
+        projection["transcriptOverlay"] = overlay
+        envelope["projection"] = projection
+        root[envelopeKey] = envelope
+        return try JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
+    }
 }
 
 public struct ChatSyncSnapshotEnvelope: Sendable, Codable, Equatable {
@@ -224,7 +337,8 @@ public struct ChatSyncSnapshotEnvelope: Sendable, Codable, Equatable {
     public static func decodeData(_ data: Data) throws -> ChatSyncSnapshot {
         try ChatSyncWire.validateVersion(in: data, malformed: ChatSyncWireError.malformedSnapshot)
         do {
-            return try JSONDecoder().decode(ChatSyncSnapshotEnvelope.self, from: data).snapshot
+            let repairedData = try ChatSyncWire.repairingLegacyTranscriptIDs(in: data)
+            return try JSONDecoder().decode(ChatSyncSnapshotEnvelope.self, from: repairedData).snapshot
         } catch {
             throw ChatSyncWireError.malformedSnapshot(error.localizedDescription)
         }
@@ -250,7 +364,8 @@ public struct ChatSyncUpdateEnvelope: Sendable, Codable, Equatable {
     public static func decodeData(_ data: Data) throws -> ChatSyncUpdate {
         do {
             try ChatSyncWire.validateVersion(in: data, malformed: ChatSyncWireError.malformedUpdate)
-            return try JSONDecoder().decode(WireEnvelope.self, from: data).decodedUpdate
+            let repairedData = try ChatSyncWire.repairingLegacyTranscriptIDs(in: data)
+            return try JSONDecoder().decode(WireEnvelope.self, from: repairedData).decodedUpdate
         } catch let error as ChatSyncWireError {
             throw error
         } catch {
@@ -294,6 +409,7 @@ public struct ChatSyncUpdateEnvelope: Sendable, Codable, Equatable {
                     providerState: update.projection.providerState,
                     usage: update.projection.usage,
                     diagnostics: update.projection.diagnostics,
+                    activeContentBlock: update.projection.activeContentBlock,
                     transcriptOverlay: [],
                     committedCursor: update.projection.committedCursor,
                     lastIncludedSequence: update.projection.lastIncludedSequence,

--- a/Sources/WikiFSEngine/ChatSyncWire.swift
+++ b/Sources/WikiFSEngine/ChatSyncWire.swift
@@ -104,6 +104,10 @@ public struct ChatSyncProjection: Sendable, Codable, Equatable {
     public let usage: SessionUsage?
     public let diagnostics: ChatDiagnosticsState
     public let activeContentBlock: ChatActiveContentBlock?
+    /// Compatibility provenance for legacy non-message overlay items repaired
+    /// by a versioned wire envelope. `nil` distinguishes older envelopes that
+    /// could not supply this proof from envelopes with no legacy items.
+    public let legacyTranscriptOccurrences: [LegacyTranscriptOccurrence]?
     public let transcriptOverlay: [ChatTranscriptItem]
     public let committedCursor: ChatTranscriptCursor
     public let lastIncludedSequence: ChatUpdateSequence
@@ -122,6 +126,7 @@ public struct ChatSyncProjection: Sendable, Codable, Equatable {
         usage: SessionUsage?,
         diagnostics: ChatDiagnosticsState,
         activeContentBlock: ChatActiveContentBlock? = nil,
+        legacyTranscriptOccurrences: [LegacyTranscriptOccurrence]? = nil,
         transcriptOverlay: [ChatTranscriptItem],
         committedCursor: ChatTranscriptCursor,
         lastIncludedSequence: ChatUpdateSequence,
@@ -139,6 +144,7 @@ public struct ChatSyncProjection: Sendable, Codable, Equatable {
         self.usage = usage
         self.diagnostics = diagnostics
         self.activeContentBlock = activeContentBlock
+        self.legacyTranscriptOccurrences = legacyTranscriptOccurrences
         self.transcriptOverlay = transcriptOverlay
         self.committedCursor = committedCursor
         self.lastIncludedSequence = lastIncludedSequence
@@ -155,7 +161,8 @@ public extension ChatSyncProjection {
         runMetadata: ChatRunMetadata,
         usage: SessionUsage?,
         diagnostics: ChatDiagnosticsState,
-        activeContentBlock: ChatActiveContentBlock? = nil
+        activeContentBlock: ChatActiveContentBlock? = nil,
+        legacyTranscriptOccurrences: [LegacyTranscriptOccurrence]? = nil
     ) -> ChatSyncProjection {
         ChatSyncProjection(
             chatID: snapshot.chatID,
@@ -169,6 +176,7 @@ public extension ChatSyncProjection {
             usage: usage,
             diagnostics: diagnostics,
             activeContentBlock: activeContentBlock,
+            legacyTranscriptOccurrences: legacyTranscriptOccurrences,
             transcriptOverlay: snapshot.transientTranscriptOverlay,
             committedCursor: committedCursor,
             lastIncludedSequence: snapshot.lastIncludedSequence,
@@ -289,7 +297,8 @@ private enum ChatSyncWire {
         let chatID = ChatID(rawValue: chatRaw)
         let generation = ChatSessionGenerationID(rawValue: generationRaw)
         let sequence = ChatUpdateSequence(rawValue: sequenceNumber.int64Value)
-        var changed = false
+        var repairedOccurrences = projection["legacyTranscriptOccurrences"] as? [[String: Any]] ?? []
+        var didRepair = false
         for sourceOrdinal in overlay.indices {
             for itemKind in LegacyTranscriptOccurrence.ItemKind.allCases {
                 guard var associated = overlay[sourceOrdinal][itemKind.rawValue] as? [String: Any],
@@ -307,11 +316,19 @@ private enum ChatSyncWire {
                 payload[identityKey] = occurrence.durableIDRawValue
                 associated["_0"] = payload
                 overlay[sourceOrdinal][itemKind.rawValue] = associated
-                changed = true
+                repairedOccurrences.append([
+                    "chatID": chatRaw,
+                    "generation": generationRaw,
+                    "sequence": sequenceNumber,
+                    "sourceOrdinal": sourceOrdinal,
+                    "itemKind": itemKind.rawValue,
+                ])
+                didRepair = true
             }
         }
-        guard changed else { return data }
+        guard didRepair else { return data }
         projection["transcriptOverlay"] = overlay
+        projection["legacyTranscriptOccurrences"] = repairedOccurrences
         envelope["projection"] = projection
         root[envelopeKey] = envelope
         return try JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
@@ -410,6 +427,7 @@ public struct ChatSyncUpdateEnvelope: Sendable, Codable, Equatable {
                     usage: update.projection.usage,
                     diagnostics: update.projection.diagnostics,
                     activeContentBlock: update.projection.activeContentBlock,
+                    legacyTranscriptOccurrences: update.projection.legacyTranscriptOccurrences,
                     transcriptOverlay: [],
                     committedCursor: update.projection.committedCursor,
                     lastIncludedSequence: update.projection.lastIncludedSequence,

--- a/Sources/WikiFSTypes/ChatConversationTypes.swift
+++ b/Sources/WikiFSTypes/ChatConversationTypes.swift
@@ -1,3 +1,5 @@
+// pattern: Functional Core
+
 import Foundation
 
 /// A typed context reference attached to a user turn.
@@ -167,6 +169,7 @@ public struct ChatTranscriptToolCallItem: Hashable, Sendable, Codable {
 
 /// One system notice row in the durable transcript vocabulary.
 public struct ChatTranscriptSystemNoticeItem: Hashable, Sendable, Codable {
+    public let noticeID: ChatTranscriptNoticeID
     public let turnID: ChatTurnID?
     public let kind: ChatSystemNoticeKind
     public let title: String
@@ -174,37 +177,103 @@ public struct ChatTranscriptSystemNoticeItem: Hashable, Sendable, Codable {
     public let createdAt: Date
 
     public init(
+        noticeID: ChatTranscriptNoticeID,
         turnID: ChatTurnID?,
         kind: ChatSystemNoticeKind,
         title: String,
         message: String,
         createdAt: Date
     ) {
+        self.noticeID = noticeID
         self.turnID = turnID
         self.kind = kind
         self.title = title
         self.message = message
         self.createdAt = createdAt
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case noticeID
+        case turnID
+        case kind
+        case title
+        case message
+        case createdAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard container.contains(.noticeID) else {
+            throw ChatTranscriptItemDecodingError.missingNoticeIdentity
+        }
+        self.noticeID = try container.decode(ChatTranscriptNoticeID.self, forKey: .noticeID)
+        self.turnID = try container.decodeIfPresent(ChatTurnID.self, forKey: .turnID)
+        self.kind = try container.decode(ChatSystemNoticeKind.self, forKey: .kind)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.message = try container.decode(String.self, forKey: .message)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(noticeID, forKey: .noticeID)
+        try container.encodeIfPresent(turnID, forKey: .turnID)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(title, forKey: .title)
+        try container.encode(message, forKey: .message)
+        try container.encode(createdAt, forKey: .createdAt)
+    }
 }
 
 /// One terminal turn-failure row in the durable transcript vocabulary.
 public struct ChatTranscriptTurnFailureItem: Hashable, Sendable, Codable {
+    public let failureID: ChatTranscriptFailureID
     public let turnID: ChatTurnID
     public let category: ChatTurnFailureCategory
     public let message: String
     public let createdAt: Date
 
     public init(
+        failureID: ChatTranscriptFailureID,
         turnID: ChatTurnID,
         category: ChatTurnFailureCategory,
         message: String,
         createdAt: Date
     ) {
+        self.failureID = failureID
         self.turnID = turnID
         self.category = category
         self.message = message
         self.createdAt = createdAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case failureID
+        case turnID
+        case category
+        case message
+        case createdAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard container.contains(.failureID) else {
+            throw ChatTranscriptItemDecodingError.missingFailureIdentity
+        }
+        self.failureID = try container.decode(ChatTranscriptFailureID.self, forKey: .failureID)
+        self.turnID = try container.decode(ChatTurnID.self, forKey: .turnID)
+        self.category = try container.decode(ChatTurnFailureCategory.self, forKey: .category)
+        self.message = try container.decode(String.self, forKey: .message)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(failureID, forKey: .failureID)
+        try container.encode(turnID, forKey: .turnID)
+        try container.encode(category, forKey: .category)
+        try container.encode(message, forKey: .message)
+        try container.encode(createdAt, forKey: .createdAt)
     }
 }
 

--- a/Sources/WikiFSTypes/ChatTranscriptItemID.swift
+++ b/Sources/WikiFSTypes/ChatTranscriptItemID.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Stable identity for one system-notice transcript item.
+public struct ChatTranscriptNoticeID: Hashable, Codable, RawRepresentable, Sendable, Identifiable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var id: String { rawValue }
+}
+
+/// Stable identity for one terminal-failure transcript item.
+public struct ChatTranscriptFailureID: Hashable, Codable, RawRepresentable, Sendable, Identifiable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var id: String { rawValue }
+}
+
+/// A leaf transcript item was encoded before durable non-message identities.
+public enum ChatTranscriptItemDecodingError: Error, Hashable, Sendable {
+    case missingNoticeIdentity
+    case missingFailureIdentity
+}

--- a/Sources/wikid/DaemonChatController.swift
+++ b/Sources/wikid/DaemonChatController.swift
@@ -25,6 +25,7 @@ actor DaemonChatController {
 
     private var generation: ChatSessionGenerationID
     private var snapshot: ChatRuntimeSnapshot
+    private var activeContentBlock: ChatActiveContentBlock? = nil
     private var replayBuffer: ChatUpdateReplayBuffer
     private var nextSequence = ChatUpdateSequence.initial
     private var committedCursor: ChatTranscriptCursor
@@ -372,6 +373,10 @@ actor DaemonChatController {
 
     private func handleRuntimeEvent(_ envelope: ChatAgentRuntimeEventEnvelope) async {
         guard envelope.generation == generation else { return }
+        // The runtime supplies this transition with the same envelope as the
+        // transcript delta. Clearing it first prevents a closed block from
+        // remaining live across a semantic boundary.
+        activeContentBlock = envelope.activeContentBlock
 
         switch envelope.event {
         case .sessionReady(let capabilities, let providerState):
@@ -492,6 +497,7 @@ actor DaemonChatController {
             message = terminalMessage
             payload = .failed(
                 turnID: turnID,
+                failureID: ChatTranscriptFailureID(rawValue: ULID.generate()),
                 category: category,
                 message: terminalMessage,
                 createdAt: Date()
@@ -501,6 +507,7 @@ actor DaemonChatController {
             message = terminalMessage
             payload = .failed(
                 turnID: turnID,
+                failureID: ChatTranscriptFailureID(rawValue: ULID.generate()),
                 category: .interrupted,
                 message: terminalMessage,
                 createdAt: Date()
@@ -573,7 +580,8 @@ actor DaemonChatController {
             pendingPermission: activePermission,
             runMetadata: compatibilityRunMetadata(),
             usage: compatibilityUsage() ?? snapshot.usage,
-            diagnostics: compatibilityDiagnostics()
+            diagnostics: compatibilityDiagnostics(),
+            activeContentBlock: activeContentBlock
         )
     }
 
@@ -604,6 +612,7 @@ actor DaemonChatController {
                 lastActivityAt: nil,
                 currentProcessID: projection.diagnostics.currentProcessID
             ),
+            activeContentBlock: projection.activeContentBlock,
             transcriptOverlay: projection.transcriptOverlay,
             committedCursor: projection.committedCursor,
             lastIncludedSequence: projection.lastIncludedSequence,

--- a/Sources/wikid/LauncherChatAgentRuntime.swift
+++ b/Sources/wikid/LauncherChatAgentRuntime.swift
@@ -44,6 +44,7 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
     private struct TranscriptTranslationState: Sendable {
         struct OpenContentBlock: Sendable {
             let messageID: ChatMessageID
+            let turnID: ChatTurnID
             let role: ChatTranscriptMessageRole
             let createdAt: Date
             var text: String
@@ -424,7 +425,10 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
         state.translationStateByTurn[turnID] = translationState
         runtimeState = state
         if deltas.isEmpty == false {
-            await emit(.transcript(deltas))
+            await emit(
+                .transcript(deltas),
+                activeContentBlock: Self.activeContentBlock(in: translationState)
+            )
         }
 
         switch event {
@@ -474,11 +478,15 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
         runtimeState?.latestProviderSessionID ?? fallback
     }
 
-    private func emit(_ event: ChatAgentRuntimeEvent) async {
+    private func emit(
+        _ event: ChatAgentRuntimeEvent,
+        activeContentBlock: ChatActiveContentBlock? = nil
+    ) async {
         guard let state = runtimeState else { return }
         state.continuation.yield(ChatAgentRuntimeEventEnvelope(
             generation: state.request.generation,
-            event: event
+            event: event,
+            activeContentBlock: activeContentBlock
         ))
     }
 
@@ -566,6 +574,7 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
             case .turnFailed(let reason):
                 closeContentBlock(in: &translationState)
                 return .append(.turnFailure(ChatTranscriptTurnFailureItem(
+                    failureID: ChatTranscriptFailureID(rawValue: ULID.generate()),
                     turnID: turnID,
                     category: failureCategory(for: reason),
                     message: reason.description,
@@ -637,6 +646,7 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
             messageID: ChatMessageID(
                 rawValue: "\(role.rawValue)-\(turnID.rawValue)-block-\(translationState.nextContentBlockOrdinal)"
             ),
+            turnID: turnID,
             role: role,
             createdAt: Date(),
             text: ""
@@ -648,6 +658,17 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
 
     private static func closeContentBlock(in translationState: inout TranscriptTranslationState) {
         translationState.contentBlock = .none
+    }
+
+    private static func activeContentBlock(
+        in translationState: TranscriptTranslationState
+    ) -> ChatActiveContentBlock? {
+        guard case .open(let block) = translationState.contentBlock else { return nil }
+        return ChatActiveContentBlock(
+            messageID: block.messageID,
+            turnID: block.turnID,
+            role: block.role
+        )
     }
 
     static func transcriptDeltasForTesting(from events: [AgentEvent], turnID: ChatTurnID) -> [ChatTranscriptDelta] {

--- a/Tests/WikiFSTests/ChatClientSyncReducerTests.swift
+++ b/Tests/WikiFSTests/ChatClientSyncReducerTests.swift
@@ -193,6 +193,45 @@ struct ChatClientSyncReducerTests {
         #expect(state.displayTranscriptItems == [canonical])
     }
 
+    @Test func legacyOverlayWithoutProvenanceIsAnomalousAndCanonicalWins() {
+        let timestamp = Date(timeIntervalSince1970: 1)
+        let canonical = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "chat-transcript-v47:systemNotice:chat-1:1"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: timestamp
+        ))
+        let unprovenancedLegacy = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "chat-wire-v1:systemNotice:chat-1:generation-1:1:0"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: timestamp
+        ))
+        let state = ChatClientSyncState(
+            chatID: ChatID(rawValue: "chat-1"),
+            projection: makeProjection(sequence: 2, overlay: [unprovenancedLegacy]),
+            syncStatus: .synchronized
+        )
+
+        let reduction = ChatClientSyncReducer.reduce(
+            state,
+            .appendCommittedHistory(
+                items: [makePersisted(cursor: 1, item: canonical)],
+                loadedCursor: ChatTranscriptCursor(rawValue: 1)
+            )
+        )
+
+        #expect(reduction.anomalies == [
+            .legacyOverlayWithoutProvenance(itemKind: .systemNotice, sourceOrdinal: 0),
+        ])
+        #expect(reduction.state.projection?.transcriptOverlay.isEmpty == true)
+        #expect(reduction.state.displayTranscriptItems == [canonical])
+    }
+
     @Test func appendCommittedHistoryPrunesMatchingOverlay() {
         let overlayItem = makeMessage(role: .user, text: "hello")
         let state = ChatClientSyncState(

--- a/Tests/WikiFSTests/ChatClientSyncReducerTests.swift
+++ b/Tests/WikiFSTests/ChatClientSyncReducerTests.swift
@@ -133,6 +133,66 @@ struct ChatClientSyncReducerTests {
         #expect(reduction.effects.isEmpty)
     }
 
+    @Test func reconnectSnapshotClearsInvalidActiveContentBlock() {
+        let state = ChatClientSyncState(chatID: ChatID(rawValue: "chat-1"))
+        let invalid = ChatActiveContentBlock(
+            messageID: ChatMessageID(rawValue: "missing"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            role: .assistant
+        )
+
+        let reduction = ChatClientSyncReducer.reduce(
+            state,
+            .applySnapshot(makeSnapshot(sequence: 1, activeContentBlock: invalid))
+        )
+
+        #expect(reduction.state.projection?.activeContentBlock == nil)
+    }
+
+    @Test func snapshotKeepsMatchingActiveContentBlock() {
+        let message = makeMessage(messageID: "assistant-stream", role: .assistant, text: "Hello")
+        let block = ChatActiveContentBlock(
+            messageID: ChatMessageID(rawValue: "assistant-stream"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            role: .assistant
+        )
+        let reduction = ChatClientSyncReducer.reduce(
+            ChatClientSyncState(chatID: ChatID(rawValue: "chat-1")),
+            .applySnapshot(makeSnapshot(sequence: 1, overlay: [message], activeContentBlock: block))
+        )
+
+        #expect(reduction.state.projection?.activeContentBlock == block)
+    }
+
+    @Test func canonicalHistoryReplacesOverlappingLegacyOverlay() {
+        let timestamp = Date(timeIntervalSince1970: 1)
+        let canonical = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "chat-transcript-v47:systemNotice:chat-1:1"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: timestamp
+        ))
+        let legacy = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "chat-wire-v1:systemNotice:chat-1:generation-1:1:0"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: timestamp
+        ))
+        let state = ChatClientSyncState(
+            chatID: ChatID(rawValue: "chat-1"),
+            projection: makeProjection(sequence: 1, overlay: [legacy]),
+            committedItems: [makePersisted(cursor: 1, item: canonical)],
+            loadedCommittedCursor: ChatTranscriptCursor(rawValue: 1),
+            syncStatus: .synchronized
+        )
+
+        #expect(state.displayTranscriptItems == [canonical])
+    }
+
     @Test func appendCommittedHistoryPrunesMatchingOverlay() {
         let overlayItem = makeMessage(role: .user, text: "hello")
         let state = ChatClientSyncState(
@@ -215,6 +275,7 @@ struct ChatClientSyncReducerTests {
         )
         let failure = ChatTranscriptItem.turnFailure(
             ChatTranscriptTurnFailureItem(
+                failureID: ChatTranscriptFailureID(rawValue: "failure-1"),
                 turnID: ChatTurnID(rawValue: "turn-1"),
                 category: .runtimeError,
                 message: "boom",
@@ -241,6 +302,7 @@ struct ChatClientSyncReducerTests {
                 sequence: 5,
                 reason: .sessionEvent(.failed(
                     turnID: ChatTurnID(rawValue: "turn-1"),
+                    failureID: ChatTranscriptFailureID(rawValue: "failure-1"),
                     category: .runtimeError,
                     message: "boom",
                     createdAt: Date(timeIntervalSince1970: 40)
@@ -514,7 +576,8 @@ struct ChatClientSyncReducerTests {
         activeTurn: ChatTurnSnapshot? = nil,
         overlay: [ChatTranscriptItem] = [],
         committedCursor: ChatTranscriptCursor = .zero,
-        diagnostics: ChatDiagnosticsState = ChatDiagnosticsState()
+        diagnostics: ChatDiagnosticsState = ChatDiagnosticsState(),
+        activeContentBlock: ChatActiveContentBlock? = nil
     ) -> ChatSyncSnapshot {
         ChatSyncSnapshot(
             projection: makeProjection(
@@ -524,7 +587,8 @@ struct ChatClientSyncReducerTests {
                 activeTurn: activeTurn,
                 overlay: overlay,
                 committedCursor: committedCursor,
-                diagnostics: diagnostics
+                diagnostics: diagnostics,
+                activeContentBlock: activeContentBlock
             )
         )
     }
@@ -536,7 +600,8 @@ struct ChatClientSyncReducerTests {
         activeTurn: ChatTurnSnapshot? = nil,
         overlay: [ChatTranscriptItem] = [],
         committedCursor: ChatTranscriptCursor = .zero,
-        diagnostics: ChatDiagnosticsState = ChatDiagnosticsState()
+        diagnostics: ChatDiagnosticsState = ChatDiagnosticsState(),
+        activeContentBlock: ChatActiveContentBlock? = nil
     ) -> ChatSyncProjection {
         ChatSyncProjection(
             chatID: ChatID(rawValue: "chat-1"),
@@ -553,6 +618,7 @@ struct ChatClientSyncReducerTests {
             ),
             usage: nil,
             diagnostics: diagnostics,
+            activeContentBlock: activeContentBlock,
             transcriptOverlay: overlay,
             committedCursor: committedCursor,
             lastIncludedSequence: ChatUpdateSequence(rawValue: sequence),

--- a/Tests/WikiFSTests/ChatDomainAuditRegressionTests.swift
+++ b/Tests/WikiFSTests/ChatDomainAuditRegressionTests.swift
@@ -111,6 +111,7 @@ struct ChatDomainAuditRegressionTests {
                 sequence: 1,
                 payload: .failed(
                     turnID: ChatTurnID(rawValue: "turn-1"),
+                    failureID: ChatTranscriptFailureID(rawValue: "failure-failed"),
                     category: .runtimeError,
                     message: "boom",
                     createdAt: timestamp
@@ -227,6 +228,7 @@ struct ChatDomainAuditRegressionTests {
                 sequence: 1,
                 payload: .failed(
                     turnID: ChatTurnID(rawValue: "turn-1"),
+                    failureID: ChatTranscriptFailureID(rawValue: "failure-queued"),
                     category: .runtimeError,
                     message: "boom",
                     createdAt: Date(timeIntervalSince1970: 20)
@@ -523,6 +525,7 @@ struct ChatDomainAuditRegressionTests {
         ChatSessionEventPayload.completed(turnID: ChatTurnID(rawValue: "turn-1")),
         .failed(
             turnID: ChatTurnID(rawValue: "turn-1"),
+            failureID: ChatTranscriptFailureID(rawValue: "failure-terminal"),
             category: .runtimeError,
             message: "boom",
             createdAt: Date(timeIntervalSince1970: 2)
@@ -559,6 +562,7 @@ struct ChatDomainAuditRegressionTests {
         .completed(turnID: ChatTurnID(rawValue: "turn-stale")),
         .failed(
             turnID: ChatTurnID(rawValue: "turn-stale"),
+            failureID: ChatTranscriptFailureID(rawValue: "failure-stale"),
             category: .runtimeError,
             message: "boom",
             createdAt: Date(timeIntervalSince1970: 2)
@@ -668,6 +672,7 @@ struct ChatDomainAuditRegressionTests {
             queuedTurns: [queued],
             attention: .turnFailed(ChatTurnID(rawValue: "turn-1")),
             overlay: [.systemNotice(ChatTranscriptSystemNoticeItem(
+                noticeID: ChatTranscriptNoticeID(rawValue: "notice-recovering"),
                 turnID: nil,
                 kind: .session,
                 title: "Recovering",
@@ -783,6 +788,7 @@ struct ChatDomainAuditRegressionTests {
             updatedAt: Date(timeIntervalSince1970: 2)
         )),
         ChatTranscriptItem.systemNotice(ChatTranscriptSystemNoticeItem(
+            noticeID: ChatTranscriptNoticeID(rawValue: "notice-turn"),
             turnID: ChatTurnID(rawValue: "turn-3"),
             kind: .diagnostics,
             title: "Notice",
@@ -790,6 +796,7 @@ struct ChatDomainAuditRegressionTests {
             createdAt: Date(timeIntervalSince1970: 3)
         )),
         ChatTranscriptItem.turnFailure(ChatTranscriptTurnFailureItem(
+            failureID: ChatTranscriptFailureID(rawValue: "failure-turn"),
             turnID: ChatTurnID(rawValue: "turn-4"),
             category: .transportError,
             message: "socket closed",

--- a/Tests/WikiFSTests/ChatIDPersistenceTests.swift
+++ b/Tests/WikiFSTests/ChatIDPersistenceTests.swift
@@ -256,7 +256,7 @@ struct ChatIDPersistenceTests {
         #expect(try pragmaValue("user_version", at: databaseURL) == preChatIDRefactorSchemaVersion)
 
         let reopened = try GRDBWikiStore(databaseURL: databaseURL)
-        #expect(reopened.pragmaValue("user_version") == "46")
+        #expect(reopened.pragmaValue("user_version") == "47")
         #expect(try reopened.listChats().isEmpty)
         #expect(try reopened.chatMessages(chatID: ChatID(rawValue: legacyChatID)).isEmpty)
     }
@@ -301,7 +301,7 @@ struct ChatIDPersistenceTests {
         let chat = try store.createChat(kind: .edit, title: "Fresh Chat")
         _ = try store.appendChatMessages(chatID: chat.id, events: [.assistantText("follow up")])
 
-        #expect(store.pragmaValue("user_version") == "46")
+        #expect(store.pragmaValue("user_version") == "47")
         #expect(try normalizedRows(
             "SELECT id FROM chats WHERE id = '\(chat.id.rawValue)';",
             at: databaseURL
@@ -320,7 +320,7 @@ struct ChatIDPersistenceTests {
         try assertPreChatIDRefactorSchemaLayout(at: databaseURL)
 
         let store = try GRDBWikiStore(databaseURL: databaseURL)
-        #expect(store.pragmaValue("user_version") == "46")
+        #expect(store.pragmaValue("user_version") == "47")
         #expect(try normalizedRows("PRAGMA table_info('chat_turns');", at: databaseURL) == [
             "0|chat_id|TEXT|1|NULL|1",
             "1|turn_id|TEXT|1|NULL|2",

--- a/Tests/WikiFSTests/ChatPhase2PersistenceTests.swift
+++ b/Tests/WikiFSTests/ChatPhase2PersistenceTests.swift
@@ -333,6 +333,7 @@ struct ChatPhase2PersistenceTests {
                 updatedAt: Date(timeIntervalSince1970: 2)
             )),
             .turnFailure(.init(
+                failureID: ChatTranscriptFailureID(rawValue: "failure-1"),
                 turnID: ChatTurnID(rawValue: "turn-1"),
                 category: .runtimeError,
                 message: "boom",
@@ -359,6 +360,7 @@ struct ChatPhase2PersistenceTests {
         let chat = try store.createChat(kind: .edit, title: "Transcript")
         try store.appendChatTranscriptItems(chatID: chat.id, items: [
             .systemNotice(.init(
+                noticeID: ChatTranscriptNoticeID(rawValue: "notice-1"),
                 turnID: nil,
                 kind: .session,
                 title: "Started",
@@ -391,6 +393,129 @@ struct ChatPhase2PersistenceTests {
         #expect(second.checkpoint == ChatTranscriptCursor(rawValue: 3))
         #expect(second.nextCursor == ChatTranscriptCursor(rawValue: 3))
         #expect(try store.chatTranscriptCheckpoint(chatID: chat.id) == ChatTranscriptCursor(rawValue: 3))
+    }
+
+    @Test func duplicateEqualNoticeAndFailureItemsKeepDistinctDurableCursors() throws {
+        let store = try TestStoreFactory.inMemory()
+        let chat = try store.createChat(kind: .edit, title: "Duplicate durable items")
+        let timestamp = Date(timeIntervalSince1970: 1)
+        let firstNotice = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "notice-1"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: timestamp
+        ))
+        let secondNotice = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "notice-2"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: timestamp
+        ))
+        let firstFailure = ChatTranscriptItem.turnFailure(.init(
+            failureID: ChatTranscriptFailureID(rawValue: "failure-1"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            category: .runtimeError,
+            message: "Failed",
+            createdAt: timestamp
+        ))
+        let secondFailure = ChatTranscriptItem.turnFailure(.init(
+            failureID: ChatTranscriptFailureID(rawValue: "failure-2"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            category: .runtimeError,
+            message: "Failed",
+            createdAt: timestamp
+        ))
+
+        let inserted = try store.appendChatTranscriptItems(
+            chatID: chat.id,
+            items: [firstNotice, secondNotice, firstFailure, secondFailure]
+        )
+
+        #expect(inserted.map(\.cursor.rawValue) == [1, 2, 3, 4])
+        #expect(try store.readChatTranscriptPage(chatID: chat.id, after: nil, limit: 10).items.map(\.item)
+            == [firstNotice, secondNotice, firstFailure, secondFailure])
+    }
+
+    @Test func legacyStoreMigrationAssignsCanonicalIDs() throws {
+        let url = try fileURL(prefix: "chat-transcript-id-migration")
+        var store: GRDBWikiStore? = try GRDBWikiStore(databaseURL: url)
+        let chat = try #require(try store?.createChat(kind: .edit, title: "Legacy"))
+        let notice = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "temporary-notice"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: Date(timeIntervalSince1970: 1)
+        ))
+        let failure = ChatTranscriptItem.turnFailure(.init(
+            failureID: ChatTranscriptFailureID(rawValue: "temporary-failure"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            category: .runtimeError,
+            message: "Failed",
+            createdAt: Date(timeIntervalSince1970: 2)
+        ))
+        _ = try store?.appendChatTranscriptItems(chatID: chat.id, items: [notice, failure])
+        store = nil
+
+        let legacyNoticeJSON = try legacyJSON(from: notice, removing: "noticeID")
+        let legacyFailureJSON = try legacyJSON(from: failure, removing: "failureID")
+        try execute(
+            """
+            UPDATE chat_transcript_items SET item_json = '\(legacyNoticeJSON)' WHERE chat_id = '\(chat.id.rawValue)' AND cursor = 1;
+            UPDATE chat_transcript_items SET item_json = '\(legacyFailureJSON)' WHERE chat_id = '\(chat.id.rawValue)' AND cursor = 2;
+            PRAGMA user_version = 46;
+            """,
+            at: url
+        )
+
+        let migrated = try GRDBWikiStore(databaseURL: url)
+        let items = try migrated.readChatTranscriptPage(chatID: chat.id, after: nil, limit: 10).items.map(\.item)
+        guard case .systemNotice(let migratedNotice) = items[0],
+              case .turnFailure(let migratedFailure) = items[1]
+        else {
+            Issue.record("Expected migrated notice and failure items.")
+            return
+        }
+        #expect(migratedNotice.noticeID.rawValue == "chat-transcript-v47:systemNotice:\(chat.id.rawValue):1")
+        #expect(migratedFailure.failureID.rawValue == "chat-transcript-v47:turnFailure:\(chat.id.rawValue):2")
+        #expect(migrated.pragmaValue("user_version") == "47")
+    }
+
+    @Test func legacyStoreMigrationIsIdempotent() throws {
+        // The preceding migration test proves the initial rewrite. A current
+        // database must retain those exact values on the next open.
+        let store = try TestStoreFactory.inMemory()
+        let chat = try store.createChat(kind: .edit, title: "Stable IDs")
+        let item = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "notice-stable"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: Date(timeIntervalSince1970: 1)
+        ))
+        _ = try store.appendChatTranscriptItems(chatID: chat.id, items: [item])
+        let first = try store.readChatTranscriptPage(chatID: chat.id, after: nil, limit: 1)
+        let second = try store.readChatTranscriptPage(chatID: chat.id, after: nil, limit: 1)
+        #expect(first == second)
+        #expect(store.pragmaValue("user_version") == "47")
+    }
+
+    private func legacyJSON(from item: ChatTranscriptItem, removing key: String) throws -> String {
+        let data = try JSONEncoder().encode(item)
+        var root = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let itemCase = key == "noticeID" ? "systemNotice" : "turnFailure"
+        var associated = try #require(root[itemCase] as? [String: Any])
+        var payload = try #require(associated["_0"] as? [String: Any])
+        payload.removeValue(forKey: key)
+        associated["_0"] = payload
+        root[itemCase] = associated
+        return String(decoding: try JSONSerialization.data(withJSONObject: root), as: UTF8.self)
     }
 
     @Test func phase2MigrationPreservesNonChatRowsAndMarksTantivyRebuild() throws {
@@ -470,7 +595,7 @@ struct ChatPhase2PersistenceTests {
         )
 
         let store = try GRDBWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "46")
+        #expect(store.pragmaValue("user_version") == "47")
         let page = try store.getPage(id: PageID(rawValue: "page-1"))
         #expect(page.title == "Preserved")
         #expect(try store.listChats().isEmpty)

--- a/Tests/WikiFSTests/ChatStoreTests.swift
+++ b/Tests/WikiFSTests/ChatStoreTests.swift
@@ -229,7 +229,7 @@ import SQLite3
     /// AC.2: a fresh schema has the `acp_session_id` column on the chats table.
     @Test func freshSchemaHasChatAcpSessionIdColumn() throws {
         let store = try tempStore()
-        #expect(GRDBWikiStore.schemaVersion == 46)
+        #expect(GRDBWikiStore.schemaVersion == 47)
         let hasCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='acp_session_id';")
         #expect(hasCol == "1")
@@ -293,11 +293,11 @@ import SQLite3
         #expect(sqlite3_exec(raw, "PRAGMA user_version = 42;", nil, nil, nil) == SQLITE_OK)
 
         // Open via GRDBWikiStore — triggers the migration ladder
-        // (v42→v43→v44→v45→v46).
+        // (v42→v43→v44→v45→v46→v47).
         let store = try GRDBWikiStore(databaseURL: url)
 
-        // After the full ladder, version is 46 and every migration step ran.
-        #expect(store.pragmaValue("user_version") == "46")
+        // After the full ladder, version is 47 and every migration step ran.
+        #expect(store.pragmaValue("user_version") == "47")
         let hasCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='acp_session_id';")
         #expect(hasCol == "1")
@@ -317,7 +317,7 @@ import SQLite3
     /// A fresh schema has the `model_provider_id`/`model_id` columns on `chats`.
     @Test func freshSchemaHasChatModelOverrideColumns() throws {
         let store = try tempStore()
-        #expect(GRDBWikiStore.schemaVersion == 46)
+        #expect(GRDBWikiStore.schemaVersion == 47)
         let hasProviderCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='model_provider_id';")
         #expect(hasProviderCol == "1")
@@ -406,9 +406,9 @@ import SQLite3
         sqlite3_close(raw)
         raw = nil
 
-        // Open via GRDBWikiStore — triggers the v44→v45→v46 migration steps.
+        // Open via GRDBWikiStore — triggers the v44→v45→v46→v47 migration steps.
         let store = try GRDBWikiStore(databaseURL: url)
-        #expect(store.pragmaValue("user_version") == "46")
+        #expect(store.pragmaValue("user_version") == "47")
         let hasProviderCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='model_provider_id';")
         #expect(hasProviderCol == "1")

--- a/Tests/WikiFSTests/ChatSyncWireTests.swift
+++ b/Tests/WikiFSTests/ChatSyncWireTests.swift
@@ -131,6 +131,15 @@ struct ChatSyncWireTests {
         let first = try ChatSyncSnapshotEnvelope.decodeData(legacyData)
         let second = try ChatSyncSnapshotEnvelope.decodeData(legacyData)
         #expect(first == second)
+        #expect(first.projection.legacyTranscriptOccurrences == [
+            LegacyTranscriptOccurrence(
+                chatID: ChatID(rawValue: "chat-1"),
+                generation: ChatSessionGenerationID(rawValue: "generation-1"),
+                sequence: ChatUpdateSequence(rawValue: 9),
+                sourceOrdinal: 0,
+                itemKind: .systemNotice
+            ),
+        ])
         guard case .systemNotice(let repaired) = first.projection.transcriptOverlay[0] else {
             Issue.record("Expected a repaired system notice.")
             return

--- a/Tests/WikiFSTests/ChatSyncWireTests.swift
+++ b/Tests/WikiFSTests/ChatSyncWireTests.swift
@@ -52,6 +52,92 @@ struct ChatSyncWireTests {
         #expect(decoded == update)
     }
 
+    @Test func activeContentBlockRoundTripsSnapshotAndCompactUpdate() throws {
+        let block = ChatActiveContentBlock(
+            messageID: ChatMessageID(rawValue: "assistant-stream"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            role: .assistant
+        )
+        let snapshot = makeSnapshot(
+            sequence: 1,
+            overlay: [makeMessage(messageID: "assistant-stream", role: .assistant, text: "Hello")],
+            activeContentBlock: block
+        )
+        #expect(try ChatSyncSnapshotEnvelope.decodeData(
+            ChatSyncSnapshotEnvelope(snapshot: snapshot).encodedData()
+        ) == snapshot)
+
+        let update = makeUpdate(
+            sequence: 2,
+            reason: .sessionEvent(.transcriptChanged([
+                .messageReplacement(
+                    messageID: block.messageID,
+                    turnID: block.turnID,
+                    role: block.role,
+                    text: "Hello world",
+                    createdAt: Date(timeIntervalSince1970: 2)
+                ),
+            ])),
+            overlay: [makeMessage(messageID: "assistant-stream", role: .assistant, text: "Hello world")],
+            activeContentBlock: block
+        )
+        let decodedUpdate = try ChatSyncUpdateEnvelope.decodeData(
+            ChatSyncUpdateEnvelope(update: update).encodedData()
+        )
+        #expect(decodedUpdate.reason == update.reason)
+        #expect(decodedUpdate.projection.activeContentBlock == block)
+        #expect(decodedUpdate.projection.transcriptOverlay.isEmpty)
+    }
+
+    @Test func oldProjectionPayloadDecodesWithoutActiveContentBlock() throws {
+        let snapshot = makeSnapshot(sequence: 1)
+        let encoded = try ChatSyncSnapshotEnvelope(snapshot: snapshot).encodedData()
+        var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        var snapshotObject = try #require(object["snapshot"] as? [String: Any])
+        var projection = try #require(snapshotObject["projection"] as? [String: Any])
+        projection.removeValue(forKey: "activeContentBlock")
+        snapshotObject["projection"] = projection
+        object["snapshot"] = snapshotObject
+        let oldPayload = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+
+        #expect(try ChatSyncSnapshotEnvelope.decodeData(oldPayload).projection.activeContentBlock == nil)
+    }
+
+    @Test func legacyProjectionDecodeIsRepeatable() throws {
+        let notice = ChatTranscriptItem.systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "new-notice"),
+            turnID: nil,
+            kind: .session,
+            title: "Started",
+            message: "Ready",
+            createdAt: Date(timeIntervalSince1970: 1)
+        ))
+        let snapshot = makeSnapshot(sequence: 9, overlay: [notice])
+        let encoded = try ChatSyncSnapshotEnvelope(snapshot: snapshot).encodedData()
+        var root = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        var envelope = try #require(root["snapshot"] as? [String: Any])
+        var projection = try #require(envelope["projection"] as? [String: Any])
+        var overlay = try #require(projection["transcriptOverlay"] as? [[String: Any]])
+        var associated = try #require(overlay[0]["systemNotice"] as? [String: Any])
+        var payload = try #require(associated["_0"] as? [String: Any])
+        payload.removeValue(forKey: "noticeID")
+        associated["_0"] = payload
+        overlay[0]["systemNotice"] = associated
+        projection["transcriptOverlay"] = overlay
+        envelope["projection"] = projection
+        root["snapshot"] = envelope
+        let legacyData = try JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
+
+        let first = try ChatSyncSnapshotEnvelope.decodeData(legacyData)
+        let second = try ChatSyncSnapshotEnvelope.decodeData(legacyData)
+        #expect(first == second)
+        guard case .systemNotice(let repaired) = first.projection.transcriptOverlay[0] else {
+            Issue.record("Expected a repaired system notice.")
+            return
+        }
+        #expect(repaired.noticeID.rawValue == "chat-wire-v1:systemNotice:chat-1:generation-1:9:0")
+    }
+
     @Test func transcriptUpdateEnvelopeCompactsAccumulatedOverlayPayload() throws {
         let chunk = String(repeating: "abcdefghij", count: 4)
         let streamedText = Array(repeating: chunk, count: 300).joined()
@@ -177,7 +263,8 @@ struct ChatSyncWireTests {
         overlay: [ChatTranscriptItem] = [],
         committedCursor: ChatTranscriptCursor = .zero,
         diagnostics: ChatDiagnosticsState = ChatDiagnosticsState(),
-        runMetadata: ChatRunMetadata = .empty
+        runMetadata: ChatRunMetadata = .empty,
+        activeContentBlock: ChatActiveContentBlock? = nil
     ) -> ChatSyncSnapshot {
         ChatSyncSnapshot(
             projection: ChatSyncProjection(
@@ -195,6 +282,7 @@ struct ChatSyncWireTests {
                 ),
                 usage: nil,
                 diagnostics: diagnostics,
+                activeContentBlock: activeContentBlock,
                 transcriptOverlay: overlay,
                 committedCursor: committedCursor,
                 lastIncludedSequence: ChatUpdateSequence(rawValue: sequence),
@@ -207,14 +295,16 @@ struct ChatSyncWireTests {
     private func makeUpdate(
         sequence: Int64,
         reason: ChatSyncUpdateReason = .sessionEvent(.started(turnID: ChatTurnID(rawValue: "turn-1"))),
-        overlay: [ChatTranscriptItem] = []
+        overlay: [ChatTranscriptItem] = [],
+        activeContentBlock: ChatActiveContentBlock? = nil
     ) -> ChatSyncUpdate {
         ChatSyncUpdate(
             reason: reason,
             projection: makeSnapshot(
                 sequence: sequence,
                 activeTurn: nil,
-                overlay: overlay
+                overlay: overlay,
+                activeContentBlock: activeContentBlock
             ).projection
         )
     }

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -641,14 +641,15 @@ struct PageVersionTests {
     }
 
     /// AC.8 (migration ladder sanity) — a fresh DB must report the current
-    /// `user_version`. The v46 step is the destructive chat-only rebuild for
+    /// `user_version`. The v46 step is the destructive chat-only rebuild and
+    /// v47 adds durable non-message transcript identities.
     /// issue #982 Phase 2.
     @Test func v44SchemaVersionAfterMigration() throws {
-        #expect(GRDBWikiStore.schemaVersion == 46,
+        #expect(GRDBWikiStore.schemaVersion == 47,
                 "schemaVersion must report 46 after the Phase 2 chat rebuild")
         let store = try tempStore()
         let v = store.pragmaValue("user_version")
-        #expect(v == "46", "fresh DB stamps user_version = 46 (got \(v))")
+        #expect(v == "47", "fresh DB stamps user_version = 47 (got \(v))")
     }
 
     // MARK: - #817: pageVersionBody (read arbitrary version body)

--- a/Tests/WikiFSTests/SourceVersionIDPersistenceTests.swift
+++ b/Tests/WikiFSTests/SourceVersionIDPersistenceTests.swift
@@ -13,7 +13,7 @@ import Testing
 /// `sources.id` and markdown-version `PageID`s.
 struct SourceVersionIDPersistenceTests {
 
-    private let preSourceVersionIDRefactorSchemaVersion = "46"
+    private let currentSchemaVersion = "47"
     private let legacySourceID = "01JSOURCEVERSIONFIXTURE000001"
     private let legacyVersionV1 = "01JSOURCEVERSION000000000001"
     private let legacyVersionV2 = "01JSOURCEVERSION000000000002"
@@ -106,7 +106,7 @@ struct SourceVersionIDPersistenceTests {
 
     private func seedLegacyFixture(at databaseURL: URL) throws {
         let initialStore = try GRDBWikiStore(databaseURL: databaseURL)
-        #expect(initialStore.pragmaValue("user_version") == preSourceVersionIDRefactorSchemaVersion)
+        #expect(initialStore.pragmaValue("user_version") == currentSchemaVersion)
         initialStore.close()
 
         try execute(
@@ -161,7 +161,7 @@ struct SourceVersionIDPersistenceTests {
         let databaseURL = try temporaryDatabaseURL()
         try seedLegacyFixture(at: databaseURL)
 
-        #expect(try pragmaValue("user_version", at: databaseURL) == preSourceVersionIDRefactorSchemaVersion)
+        #expect(try pragmaValue("user_version", at: databaseURL) == currentSchemaVersion)
         #expect(try normalizedRows(
             """
             SELECT cid, name, type, "notnull", dflt_value, pk
@@ -253,7 +253,7 @@ struct SourceVersionIDPersistenceTests {
         #expect(origin.plan == "https://example.com/legacy")
         #expect(markdownHead.id == SourceMarkdownVersionID(rawValue: legacyMarkdownVersionID))
         #expect(markdownHead.sourceVersionID == SourceVersionID(rawValue: legacyVersionV2))
-        #expect(reopened.pragmaValue("user_version") == preSourceVersionIDRefactorSchemaVersion)
+        #expect(reopened.pragmaValue("user_version") == currentSchemaVersion)
     }
 
     @Test func liveSourceVersionWritesPreserveRawSQLiteStrings() throws {

--- a/progress/2026-07-30T184759Z-chat-presentation-phase2-identities.md
+++ b/progress/2026-07-30T184759Z-chat-presentation-phase2-identities.md
@@ -1,0 +1,30 @@
+---
+timestamp: 2026-07-30T18:47:59Z
+title: Chat presentation Phase 2 durable transcript identities
+branch: chat-presentation-diagnostics-phase2
+status: complete
+---
+
+# Chat presentation Phase 2 durable transcript identities
+
+## Progress
+
+Added durable IDs for system notices and turn failures.
+
+Added GRDB migration v47. It rewrites legacy transcript JSON in one transaction.
+
+Added a strict leaf decoder. Store and wire adapters repair legacy payloads with typed context.
+
+Added active content-block metadata to projection snapshots and compact updates.
+
+The client keeps active metadata only when a matching typed message exists.
+
+## Verification
+
+Passed `make build`.
+
+Passed `swift test --filter 'ChatPhase2PersistenceTests|ChatSyncWireTests|ChatClientSyncReducerTests'`.
+
+Passed `make test`.
+
+The hosted AppKit gate did not run. This slice changes persistence, sync, and daemon code only.

--- a/progress/2026-07-30T184759Z-chat-presentation-phase2-identities.md
+++ b/progress/2026-07-30T184759Z-chat-presentation-phase2-identities.md
@@ -19,12 +19,19 @@ Added active content-block metadata to projection snapshots and compact updates.
 
 The client keeps active metadata only when a matching typed message exists.
 
+Corrected legacy projection reconciliation. Repaired wire payloads now carry
+typed `LegacyTranscriptOccurrence` provenance. An older synthetic legacy
+overlay without that proof emits `ChatClientSyncAnomaly` and is discarded when
+equivalent canonical persisted history arrives.
+
 ## Verification
 
 Passed `make build`.
 
-Passed `swift test --filter 'ChatPhase2PersistenceTests|ChatSyncWireTests|ChatClientSyncReducerTests'`.
+Passed `swift test --filter 'ChatPhase2PersistenceTests|ChatSyncWireTests|ChatClientSyncReducerTests'` with 45 tests.
 
 Passed `make test`.
+
+Passed `git diff --check`.
 
 The hosted AppKit gate did not run. This slice changes persistence, sync, and daemon code only.


### PR DESCRIPTION
Implements the Phase 2 durable transcript identity and active-content-block sync slice. Adds the v47 legacy JSON migration, strict typed decoding with contextual compatibility adapters, explicit legacy occurrence provenance, typed reconciliation anomalies, canonical-over-legacy convergence, durable notice and failure deduplication, and additive projection metadata. Verification: make build, make test, focused Swift Testing suites, and git diff --check.