### PR TITLE
Add typed chat display projection

### DIFF
--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -36,7 +36,7 @@ extension DaemonWorkloadClient: ChatDaemonCommands {}
 /// daemon reports as running (from `chatState` envelopes), even for chats the
 /// app has not opened. `isChatGenerating(_:)` / `anyChatGenerating` back the sidebar
 /// + chats-list "responding…" indicators that previously read
-/// `chatLauncher.activeChatID` / `chatLauncher.isRunning`.
+    /// the session's `chatID` / `runState`.
 @MainActor
 @Observable
 public final class ChatDaemonCoordinator {
@@ -151,7 +151,7 @@ public final class ChatDaemonCoordinator {
     /// `isRunning` would pin the badge on for the life of the session).
     public func isChatGenerating(_ chatID: ChatID) -> Bool {
         if generatingChatIDs.contains(chatID) { return true }
-        if let s = sessions[.chat(chatID)], s.isGenerating { return true }
+        if let s = sessions[.chat(chatID)], s.runState.isAnswering { return true }
         return false
     }
 
@@ -159,7 +159,7 @@ public final class ChatDaemonCoordinator {
     /// app-level "is the agent busy" check (the ⌘Q confirmation).
     public var anyChatGenerating: Bool {
         if !generatingChatIDs.isEmpty { return true }
-        return sessions.values.contains { $0.isGenerating }
+        return sessions.values.contains { $0.runState.isAnswering }
     }
 
     // MARK: - Commands (wrap DaemonWorkloadClient)
@@ -179,10 +179,15 @@ public final class ChatDaemonCoordinator {
     }
 
     /// Resolve a pending permission request (approve/reject). Errors logged.
-    public func resolvePermission(chatID: ChatID, optionId: String, approve: Bool) async {
+    func resolvePermission(chatID: ChatID, intent: ChatPermissionResolutionIntent) async {
         do {
             try await client.resolveChatPermission(
-                ChatPermissionResolveRequest(chatID: chatID, optionId: optionId, approve: approve))
+                ChatPermissionResolveRequest(
+                    chatID: chatID,
+                    optionId: intent.optionID.rawValue,
+                    approve: intent.isApproval
+                )
+            )
         } catch {
             DebugLog.agent("ChatDaemonCoordinator.resolvePermission failed for \(chatID.rawValue): \(error)")
         }

--- a/Sources/WikiFS/Chats/ChatDetailControlsView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailControlsView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 struct ChatDetailControlsView: View {
     let showsDebugControls: Bool
-    let isGenerating: Bool
+    let isAnswering: Bool
     @Binding var showsInternals: Bool
     @Binding var hideToolCalls: Bool
     let exitStatus: Int32?
@@ -14,7 +14,7 @@ struct ChatDetailControlsView: View {
     var body: some View {
         HStack(spacing: 8) {
             if showsDebugControls {
-                if isGenerating {
+                if isAnswering {
                     ProgressView()
                         .controlSize(.small)
                 }

--- a/Sources/WikiFS/Chats/ChatDetailPresentation.swift
+++ b/Sources/WikiFS/Chats/ChatDetailPresentation.swift
@@ -57,8 +57,7 @@ struct ChatDetailPresentation {
         chatSummary: ChatSummary?,
         showsInternals: Bool,
         remoteSession: RemoteState,
-        persistedTranscriptItems: [ChatTranscriptItem],
-        persistedResponseSummaries: [ChatMessageID: String] = [:],
+        persistedTranscriptItems: [PersistedChatTranscriptItem],
         queuedMessages: [PendingQueuedMessage],
         hasDraftText: Bool,
         isChatOperationConfigured: Bool
@@ -69,7 +68,7 @@ struct ChatDetailPresentation {
         let displayTranscript = isLiveChat
             ? remoteSession.transcript
             : ChatDisplayProjection.project(
-                items: persistedTranscriptItems,
+                items: persistedTranscriptItems.map(\.item),
                 activeContentBlock: nil
             ).transcript
         let controls = Controls(
@@ -96,7 +95,9 @@ struct ChatDetailPresentation {
         )
         let outlineEntries = buildOutlineEntries(
             displayTranscript: displayTranscript,
-            cachedResponseSummaries: isLiveChat ? [:] : persistedResponseSummaries
+            cachedResponseSummaries: isLiveChat
+                ? [:]
+                : cachedResponseSummaries(from: persistedTranscriptItems)
         )
         let contentState: ContentState
         if showsInternals && controls.showsDebugControls {
@@ -207,6 +208,24 @@ struct ChatDetailPresentation {
                 responseTimestamp: response?.timestamp
             )
         }
+    }
+
+    /// Summary cache and display row identity meet only at the persisted
+    /// transcript boundary. `cachedResponseSummary` was joined by cursor/seq;
+    /// this extracts the transcript message ID from that same row rather than
+    /// converting the unrelated compatibility `chat_messages.id` namespace.
+    private static func cachedResponseSummaries(
+        from persistedItems: [PersistedChatTranscriptItem]
+    ) -> [ChatMessageID: String] {
+        var summaries: [ChatMessageID: String] = [:]
+        for persistedItem in persistedItems {
+            guard let summary = persistedItem.cachedResponseSummary,
+                  case .message(let message) = persistedItem.item,
+                  message.role == .assistant
+            else { continue }
+            summaries[message.messageID] = summary
+        }
+        return summaries
     }
 
     private static func isComposerEnabled(

--- a/Sources/WikiFS/Chats/ChatDetailPresentation.swift
+++ b/Sources/WikiFS/Chats/ChatDetailPresentation.swift
@@ -58,6 +58,7 @@ struct ChatDetailPresentation {
         showsInternals: Bool,
         remoteSession: RemoteState,
         persistedTranscriptItems: [ChatTranscriptItem],
+        persistedResponseSummaries: [ChatMessageID: String] = [:],
         queuedMessages: [PendingQueuedMessage],
         hasDraftText: Bool,
         isChatOperationConfigured: Bool
@@ -93,7 +94,10 @@ struct ChatDetailPresentation {
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured
         )
-        let outlineEntries = buildOutlineEntries(displayTranscript: displayTranscript)
+        let outlineEntries = buildOutlineEntries(
+            displayTranscript: displayTranscript,
+            cachedResponseSummaries: isLiveChat ? [:] : persistedResponseSummaries
+        )
         let contentState: ContentState
         if showsInternals && controls.showsDebugControls {
             contentState = .internals
@@ -175,7 +179,10 @@ struct ChatDetailPresentation {
         return pendingPermissions.first
     }
 
-    static func buildOutlineEntries(displayTranscript: ChatDisplayTranscript) -> [ChatOutlineEntry] {
+    static func buildOutlineEntries(
+        displayTranscript: ChatDisplayTranscript,
+        cachedResponseSummaries: [ChatMessageID: String] = [:]
+    ) -> [ChatOutlineEntry] {
         displayTranscript.sections.compactMap { section -> ChatOutlineEntry? in
             guard case .turn(let turn) = section,
                   let prompt = turn.prompt else { return nil }
@@ -183,11 +190,19 @@ struct ChatDetailPresentation {
                 if case .assistantMessage = row { return true }
                 return false
             }
+            let cachedSummary: String?
+            if case .assistantMessage(let responseID, _, _, _, _) = response {
+                cachedSummary = cachedResponseSummaries[responseID]
+            } else {
+                cachedSummary = nil
+            }
+            let summary = cachedSummary ?? response.map {
+                ChatSummary.summaryExtract(from: $0.textForSearch, maxLength: 200)
+            }
             return ChatOutlineEntry(
                 id: .turn(turnID: turn.turnID, promptRowID: prompt.id),
                 question: humanizeAttachmentRefs(in: prompt.textForSearch),
-                response: response.map { ChatSummary.summaryExtract(from: $0.textForSearch, maxLength: 200) }
-                    .flatMap { $0.isEmpty ? nil : $0 },
+                response: summary.flatMap { $0.isEmpty ? nil : $0 },
                 questionTimestamp: prompt.timestamp,
                 responseTimestamp: response?.timestamp
             )

--- a/Sources/WikiFS/Chats/ChatDetailPresentation.swift
+++ b/Sources/WikiFS/Chats/ChatDetailPresentation.swift
@@ -13,19 +13,14 @@ struct ChatDetailPresentation {
 
     struct RemoteState {
         let runState: ChatRunState
-        let activeChatID: ChatID?
+        let sessionChatID: ChatID?
         let runningKind: WikiOperation.Kind?
         let preflightError: String?
         let pendingPermissions: [PendingPermission]
         let runStartedAt: Date?
-        let events: [AgentEvent]
-        let eventTimestamps: [Date?]
+        let transcript: ChatDisplayTranscript
         let exitStatus: Int32?
 
-        var isRunning: Bool { runState.isLive }
-        var isGenerating: Bool { runState.isAnswering }
-        var isAwaitingGenerationSlot: Bool { runState == .queued }
-        var isInteractiveSession: Bool { runState.isLive }
     }
 
     struct Controls {
@@ -33,10 +28,9 @@ struct ChatDetailPresentation {
     }
 
     struct Transcript {
-        let events: [AgentEvent]
-        let timestamps: [Date?]
+        let displayTranscript: ChatDisplayTranscript
         let emptyStateMessage: String
-        let isRunning: Bool
+        let isAnswering: Bool
     }
 
     struct Composer {
@@ -63,31 +57,27 @@ struct ChatDetailPresentation {
         chatSummary: ChatSummary?,
         showsInternals: Bool,
         remoteSession: RemoteState,
-        persistedMessages: [ChatMessage],
+        persistedTranscriptItems: [ChatTranscriptItem],
         queuedMessages: [PendingQueuedMessage],
         hasDraftText: Bool,
         isChatOperationConfigured: Bool
     ) -> Self {
-        let isLiveChat = chatID.map { remoteSession.activeChatID == $0 } ?? false
-        let displayEvents = displayMessages(
-            isLiveChat: isLiveChat,
-            launcherEvents: remoteSession.events,
-            persistedEvents: persistedMessages.map(\.event)
-        )
-        let displayTimestamps = displayTimestamps(
-            isLiveChat: isLiveChat,
-            launcherEvents: remoteSession.events,
-            launcherTimestamps: remoteSession.eventTimestamps,
-            persistedMessages: persistedMessages
-        )
+        let isLiveChat = chatID.map {
+            remoteSession.sessionChatID == $0 && remoteSession.runState.isLive
+        } ?? false
+        let displayTranscript = isLiveChat
+            ? remoteSession.transcript
+            : ChatDisplayProjection.project(
+                items: persistedTranscriptItems,
+                activeContentBlock: nil
+            ).transcript
         let controls = Controls(
             showsDebugControls: showsDebugControls(
-                isGenerating: remoteSession.isGenerating,
-                isAwaitingGenerationSlot: remoteSession.isAwaitingGenerationSlot,
+                runState: remoteSession.runState,
                 runningKind: remoteSession.runningKind
             )
         )
-        let transcriptIsRunning = transcriptIsRunning(
+        let transcriptIsAnswering = transcriptIsAnswering(
             isLiveChat: isLiveChat,
             runState: remoteSession.runState
         )
@@ -97,21 +87,13 @@ struct ChatDetailPresentation {
             remoteSession: remoteSession,
             isChatOperationConfigured: isChatOperationConfigured
         )
-        let canType = canType(remoteSession: remoteSession)
         let canSend = canSendPredicate(
             hasMount: true,
-            canType: canType,
-            isGenerating: remoteSession.isGenerating,
-            isAwaitingSlot: remoteSession.isAwaitingGenerationSlot,
+            runState: remoteSession.runState,
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured
         )
-        let outlineEntries = buildOutlineEntries(
-            displayMessages: displayEvents,
-            displayTimestamps: displayTimestamps,
-            isLiveChat: isLiveChat,
-            persistedMessages: persistedMessages
-        )
+        let outlineEntries = buildOutlineEntries(displayTranscript: displayTranscript)
         let contentState: ContentState
         if showsInternals && controls.showsDebugControls {
             contentState = .internals
@@ -125,18 +107,16 @@ struct ChatDetailPresentation {
             contentState: contentState,
             controls: controls,
             transcript: Transcript(
-                events: displayEvents,
-                timestamps: displayTimestamps,
+                displayTranscript: displayTranscript,
                 emptyStateMessage: transcriptEmptyMessage(chatID: chatID, isLiveChat: isLiveChat),
-                isRunning: transcriptIsRunning
+                isAnswering: transcriptIsAnswering
             ),
             composer: Composer(
                 isEnabled: composerEnabled,
                 caption: composerCaptionText(
-                    isAwaitingGenerationSlot: remoteSession.isAwaitingGenerationSlot,
+                    runState: remoteSession.runState,
                     hasChatID: chatID != nil,
                     isLiveChat: isLiveChat,
-                    isGenerating: remoteSession.isGenerating,
                     isChatOperationConfigured: isChatOperationConfigured
                 ),
                 canSend: canSend,
@@ -145,12 +125,11 @@ struct ChatDetailPresentation {
                     queuedMessages: queuedMessages
                 ),
                 showsStopButton: showsStopButton(
-                    isGenerating: remoteSession.isGenerating,
-                    isAwaitingGenerationSlot: remoteSession.isAwaitingGenerationSlot,
+                    runState: remoteSession.runState,
                     runningKind: remoteSession.runningKind
                 ),
                 showsQueueButton: showsQueueButton(
-                    isGenerating: remoteSession.isGenerating,
+                    runState: remoteSession.runState,
                     runningKind: remoteSession.runningKind,
                     queuedMessages: queuedMessages
                 )
@@ -164,39 +143,10 @@ struct ChatDetailPresentation {
                 chatID: chatID,
                 isLiveChat: isLiveChat
             ),
-            showsThinkingIndicator: transcriptIsRunning && remoteSession.isGenerating,
+            showsThinkingIndicator: transcriptIsAnswering,
             outlineEntries: outlineEntries,
             chatInspectorAvailable: !outlineEntries.isEmpty
         )
-    }
-
-    static func displayMessages(
-        isLiveChat: Bool,
-        launcherEvents: [AgentEvent],
-        persistedEvents: [AgentEvent]
-    ) -> [AgentEvent] {
-        (isLiveChat ? launcherEvents : persistedEvents).transcriptVisible
-    }
-
-    static func displayTimestamps(
-        isLiveChat: Bool,
-        launcherEvents: [AgentEvent],
-        launcherTimestamps: [Date?],
-        persistedMessages: [ChatMessage]
-    ) -> [Date?] {
-        let indices: [Int]
-        if isLiveChat {
-            indices = launcherEvents.transcriptVisibleIndices
-            return indices.map { idx in
-                idx < launcherTimestamps.count ? launcherTimestamps[idx] : nil
-            }
-        }
-
-        let persistedEvents = persistedMessages.map(\.event)
-        indices = persistedEvents.transcriptVisibleIndices
-        return indices.map { idx in
-            idx < persistedMessages.count ? persistedMessages[idx].createdAt : nil
-        }
     }
 
     static func transcriptEmptyMessage(chatID: ChatID?, isLiveChat: Bool) -> String {
@@ -206,16 +156,15 @@ struct ChatDetailPresentation {
         return isLiveChat ? "Ask a question to start a chat." : "No messages were persisted for this chat."
     }
 
-    static func transcriptIsRunning(isLiveChat: Bool, runState: ChatRunState) -> Bool {
+    static func transcriptIsAnswering(isLiveChat: Bool, runState: ChatRunState) -> Bool {
         isLiveChat && runState.isAnswering
     }
 
     static func showsDebugControls(
-        isGenerating: Bool,
-        isAwaitingGenerationSlot: Bool,
+        runState: ChatRunState,
         runningKind: WikiOperation.Kind?
     ) -> Bool {
-        (isGenerating || isAwaitingGenerationSlot) && runningKind == .query
+        (runState.isAnswering || runState == .queued) && runningKind == .query
     }
 
     static func livePendingPermission(
@@ -226,96 +175,22 @@ struct ChatDetailPresentation {
         return pendingPermissions.first
     }
 
-    static func buildOutlineEntries(
-        displayMessages: [AgentEvent],
-        displayTimestamps: [Date?],
-        isLiveChat: Bool,
-        persistedMessages: [ChatMessage]
-    ) -> [ChatOutlineEntry] {
-        let cachedSummaries: [String?]
-        let cachedSummaryKinds: [ChatMessageSummaryKind?]
-        if isLiveChat {
-            cachedSummaries = Array(repeating: nil, count: displayMessages.count)
-            cachedSummaryKinds = Array(repeating: nil, count: displayMessages.count)
-        } else {
-            let visiblePersistedMessages = visiblePersistedMessages(persistedMessages)
-            cachedSummaries = visiblePersistedMessages.map(\.summary)
-            cachedSummaryKinds = visiblePersistedMessages.map(\.summaryKind)
-        }
-
-        var entries: [ChatOutlineEntry] = []
-        var pendingQuestion: String?
-        var pendingQuestionTimestamp: Date?
-
-        for (index, event) in displayMessages.enumerated() {
-            let timestamp = index < displayTimestamps.count ? displayTimestamps[index] : nil
-            switch event {
-            case .userText(let text):
-                if let pendingQuestion {
-                    entries.append(
-                        ChatOutlineEntry(
-                            question: pendingQuestion,
-                            response: nil,
-                            questionTimestamp: pendingQuestionTimestamp,
-                            responseTimestamp: nil
-                        )
-                    )
-                }
-                pendingQuestion = humanizeAttachmentRefs(in: text)
-                pendingQuestionTimestamp = timestamp
-
-            case .assistantText(let text), .result(_, let text):
-                guard let question = pendingQuestion else { continue }
-                let cachedSummary = index < cachedSummaries.count ? cachedSummaries[index] : nil
-                let summary = cachedSummary ?? ChatSummary.summaryExtract(from: text, maxLength: 200)
-                if let cachedSummary {
-                    let kind = index < cachedSummaryKinds.count ? cachedSummaryKinds[index]?.rawValue ?? "unknown" : "unknown"
-                    DebugLog.ingest("chatOutlineEntries: seq=\(index) using cached summary (kind=\(kind))")
-                    entries.append(
-                        ChatOutlineEntry(
-                            question: question,
-                            response: cachedSummary.isEmpty ? nil : cachedSummary,
-                            questionTimestamp: pendingQuestionTimestamp,
-                            responseTimestamp: timestamp
-                        )
-                    )
-                } else {
-                    DebugLog.ingest("chatOutlineEntries: seq=\(index) no cache, using truncation fallback")
-                    entries.append(
-                        ChatOutlineEntry(
-                            question: question,
-                            response: summary.isEmpty ? nil : summary,
-                            questionTimestamp: pendingQuestionTimestamp,
-                            responseTimestamp: timestamp
-                        )
-                    )
-                }
-                pendingQuestion = nil
-                pendingQuestionTimestamp = nil
-
-            default:
-                break
+    static func buildOutlineEntries(displayTranscript: ChatDisplayTranscript) -> [ChatOutlineEntry] {
+        displayTranscript.sections.compactMap { section -> ChatOutlineEntry? in
+            guard case .turn(let turn) = section,
+                  let prompt = turn.prompt else { return nil }
+            let response = turn.rows.first { row in
+                if case .assistantMessage = row { return true }
+                return false
             }
-        }
-
-        if let pendingQuestion {
-            entries.append(
-                ChatOutlineEntry(
-                    question: pendingQuestion,
-                    response: nil,
-                    questionTimestamp: pendingQuestionTimestamp,
-                    responseTimestamp: nil
-                )
+            return ChatOutlineEntry(
+                id: .turn(turnID: turn.turnID, promptRowID: prompt.id),
+                question: humanizeAttachmentRefs(in: prompt.textForSearch),
+                response: response.map { ChatSummary.summaryExtract(from: $0.textForSearch, maxLength: 200) }
+                    .flatMap { $0.isEmpty ? nil : $0 },
+                questionTimestamp: prompt.timestamp,
+                responseTimestamp: response?.timestamp
             )
-        }
-
-        return entries
-    }
-
-    private static func visiblePersistedMessages(_ persistedMessages: [ChatMessage]) -> [ChatMessage] {
-        let indices = persistedMessages.map(\.event).transcriptVisibleIndices
-        return indices.compactMap { idx in
-            idx < persistedMessages.count ? persistedMessages[idx] : nil
         }
     }
 
@@ -326,34 +201,24 @@ struct ChatDetailPresentation {
         isChatOperationConfigured: Bool
     ) -> Bool {
         guard isChatOperationConfigured else { return false }
-        guard chatID != nil else {
-            return remoteSession.isInteractiveSession || !remoteSession.isRunning || remoteSession.isGenerating
-        }
-        if isLiveChat {
-            return remoteSession.isInteractiveSession || !remoteSession.isRunning || remoteSession.isGenerating
-        }
-        return !remoteSession.isGenerating && !remoteSession.isAwaitingGenerationSlot
-    }
-
-    private static func canType(remoteSession: RemoteState) -> Bool {
-        remoteSession.isInteractiveSession || !remoteSession.isRunning || remoteSession.isGenerating
+        guard chatID != nil, !isLiveChat else { return true }
+        return remoteSession.runState != .answering && remoteSession.runState != .queued
     }
 
     static func composerCaptionText(
-        isAwaitingGenerationSlot: Bool,
+        runState: ChatRunState,
         hasChatID: Bool,
         isLiveChat: Bool,
-        isGenerating: Bool,
         isChatOperationConfigured: Bool
     ) -> String? {
         _ = hasChatID
         if isChatOperationConfigured == false {
             return "Configure an enabled provider and model in Settings → Providers before sending."
         }
-        if isAwaitingGenerationSlot {
+        if runState == .queued {
             return "Waiting for the other session to finish before sending…"
         }
-        if isGenerating {
+        if runState.isAnswering {
             return isLiveChat
                 ? "Agent is responding…"
                 : "Another chat is responding — wait or stop it."
@@ -363,45 +228,45 @@ struct ChatDetailPresentation {
 
     static func canSendPredicate(
         hasMount: Bool,
-        canType: Bool,
-        isGenerating: Bool,
-        isAwaitingSlot: Bool,
+        runState: ChatRunState,
         hasDraftText: Bool,
         isChatOperationConfigured: Bool
     ) -> Bool {
         _ = hasMount
-        return isChatOperationConfigured && canType && !isGenerating && !isAwaitingSlot && hasDraftText
+        return isChatOperationConfigured
+            && !runState.isAnswering
+            && runState != .queued
+            && hasDraftText
     }
 
     private static func showsStopButton(
-        isGenerating: Bool,
-        isAwaitingGenerationSlot: Bool,
+        runState: ChatRunState,
         runningKind: WikiOperation.Kind?
     ) -> Bool {
-        (isGenerating || isAwaitingGenerationSlot) && runningKind == .query
+        (runState.isAnswering || runState == .queued) && runningKind == .query
     }
 
     private static func showsQueueButton(
-        isGenerating: Bool,
+        runState: ChatRunState,
         runningKind: WikiOperation.Kind?,
         queuedMessages: [PendingQueuedMessage]
     ) -> Bool {
-        isGenerating && runningKind == .query && queuedMessages.isEmpty
+        runState.isAnswering && runningKind == .query && queuedMessages.isEmpty
     }
 
     private static func sendButtonTitle(
         remoteSession: RemoteState,
         queuedMessages: [PendingQueuedMessage]
     ) -> String {
-        if remoteSession.isAwaitingGenerationSlot {
+        if remoteSession.runState == .queued {
             return "Waiting for the other session to finish before sending…"
         }
-        if remoteSession.isGenerating {
+        if remoteSession.runState.isAnswering {
             return queuedMessages.isEmpty
                 ? "Queue for when the response finishes"
                 : "Queued — will send when the response finishes"
         }
-        return remoteSession.isInteractiveSession ? "Send" : "Start Query"
+        return remoteSession.runState.isLive ? "Send" : "Start Query"
     }
 
     static func shouldShowPreflightBanner(

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -21,8 +21,7 @@ struct ChatDetailView: View {
 
     @State private var showsInternals = false
     @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ChatMetrics.composerFont)
-    @State private var persistedTranscriptItems: [ChatTranscriptItem] = []
-    @State private var persistedResponseSummaries: [ChatMessageID: String] = [:]
+    @State private var persistedTranscriptItems: [PersistedChatTranscriptItem] = []
     @State private var attachments: [ChatAttachment] = []
     @AppStorage("chat.zoom") private var chatZoom = Double(ZoomScale.defaultScale)
     @AppStorage("chatInspectorTab") private var inspectorTab: InspectorTab = .outline
@@ -63,7 +62,6 @@ struct ChatDetailView: View {
             showsInternals: showsInternals,
             remoteSession: remotePresentationState,
             persistedTranscriptItems: persistedTranscriptItems,
-            persistedResponseSummaries: persistedResponseSummaries,
             queuedMessages: queuedMessages,
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured
@@ -147,7 +145,6 @@ struct ChatDetailView: View {
                 await coordinator.rehydrate(chatID: chatID)
             } else {
                 persistedTranscriptItems = []
-                persistedResponseSummaries = [:]
                 if let question = store.pendingChatQuestion {
                     store.pendingChatQuestion = nil
                     store.draftChatMessage = question
@@ -623,7 +620,7 @@ struct ChatDetailView: View {
     }
 
     private func loadPersistedTranscript(chatID: ChatID) {
-        var items: [ChatTranscriptItem] = []
+        var items: [PersistedChatTranscriptItem] = []
         var cursor: ChatTranscriptCursor?
         while true {
             let page = store.readChatTranscriptPage(
@@ -631,18 +628,12 @@ struct ChatDetailView: View {
                 after: cursor,
                 limit: RemoteChatSession.committedHistoryPageSize
             )
-            items += page.items.map(\.item)
+            items += page.items
             guard let nextCursor = page.nextCursor,
                   nextCursor != cursor else { break }
             cursor = nextCursor
         }
         persistedTranscriptItems = items
-        persistedResponseSummaries = Dictionary(
-            uniqueKeysWithValues: store.chatMessages(chatID: chatID).compactMap { message in
-                guard let summary = message.summary else { return nil }
-                return (ChatMessageID(rawValue: message.id.rawValue), summary)
-            }
-        )
     }
 }
 

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -22,6 +22,7 @@ struct ChatDetailView: View {
     @State private var showsInternals = false
     @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ChatMetrics.composerFont)
     @State private var persistedTranscriptItems: [ChatTranscriptItem] = []
+    @State private var persistedResponseSummaries: [ChatMessageID: String] = [:]
     @State private var attachments: [ChatAttachment] = []
     @AppStorage("chat.zoom") private var chatZoom = Double(ZoomScale.defaultScale)
     @AppStorage("chatInspectorTab") private var inspectorTab: InspectorTab = .outline
@@ -62,6 +63,7 @@ struct ChatDetailView: View {
             showsInternals: showsInternals,
             remoteSession: remotePresentationState,
             persistedTranscriptItems: persistedTranscriptItems,
+            persistedResponseSummaries: persistedResponseSummaries,
             queuedMessages: queuedMessages,
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured
@@ -145,6 +147,7 @@ struct ChatDetailView: View {
                 await coordinator.rehydrate(chatID: chatID)
             } else {
                 persistedTranscriptItems = []
+                persistedResponseSummaries = [:]
                 if let question = store.pendingChatQuestion {
                     store.pendingChatQuestion = nil
                     store.draftChatMessage = question
@@ -634,6 +637,12 @@ struct ChatDetailView: View {
             cursor = nextCursor
         }
         persistedTranscriptItems = items
+        persistedResponseSummaries = Dictionary(
+            uniqueKeysWithValues: store.chatMessages(chatID: chatID).compactMap { message in
+                guard let summary = message.summary else { return nil }
+                return (ChatMessageID(rawValue: message.id.rawValue), summary)
+            }
+        )
     }
 }
 

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -21,7 +21,7 @@ struct ChatDetailView: View {
 
     @State private var showsInternals = false
     @State private var composerHeight: CGFloat = ComposerTextView.oneLineHeight(for: ChatMetrics.composerFont)
-    @State private var persistedMessages: [ChatMessage] = []
+    @State private var persistedTranscriptItems: [ChatTranscriptItem] = []
     @State private var attachments: [ChatAttachment] = []
     @AppStorage("chat.zoom") private var chatZoom = Double(ZoomScale.defaultScale)
     @AppStorage("chatInspectorTab") private var inspectorTab: InspectorTab = .outline
@@ -35,7 +35,7 @@ struct ChatDetailView: View {
 
     private var isLiveChat: Bool {
         guard let chatID else { return false }
-        return remoteSession.activeChatID == chatID
+        return remoteSession.chatID.chatID == chatID && remoteSession.runState.isLive
     }
 
     private var chatSummary: ChatSummary? {
@@ -45,13 +45,12 @@ struct ChatDetailView: View {
     private var remotePresentationState: ChatDetailPresentation.RemoteState {
         .init(
             runState: remoteSession.runState,
-            activeChatID: remoteSession.activeChatID,
+            sessionChatID: remoteSession.chatID.chatID,
             runningKind: remoteSession.runningKind,
             preflightError: remoteSession.preflightError,
             pendingPermissions: remoteSession.pendingPermissions,
             runStartedAt: remoteSession.runStartedAt,
-            events: remoteSession.events,
-            eventTimestamps: remoteSession.eventTimestamps,
+            transcript: remoteSession.displayTranscript,
             exitStatus: remoteSession.exitStatus
         )
     }
@@ -62,7 +61,7 @@ struct ChatDetailView: View {
             chatSummary: chatSummary,
             showsInternals: showsInternals,
             remoteSession: remotePresentationState,
-            persistedMessages: persistedMessages,
+            persistedTranscriptItems: persistedTranscriptItems,
             queuedMessages: queuedMessages,
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured
@@ -85,14 +84,14 @@ struct ChatDetailView: View {
 
     private var liveDebugKey: String {
         let id = chatID?.rawValue ?? "draft"
-        let active = remoteSession.activeChatID?.rawValue ?? "nil"
+        let sessionChatID = remoteSession.chatID.chatID?.rawValue ?? "draft"
         let state = String(describing: remoteSession.runState)
-        return "chat=\(id) live=\(isLiveChat) activeChatID=\(active) runState=\(state) "
-            + "liveEvents=\(remoteSession.events.count) persisted=\(persistedMessages.count) display=\(presentation.transcript.events.count)"
+        return "chat=\(id) live=\(isLiveChat) sessionChatID=\(sessionChatID) runState=\(state) "
+            + "liveRows=\(remoteSession.displayTranscript.rows.count) persisted=\(persistedTranscriptItems.count) display=\(presentation.transcript.displayTranscript.rows.count)"
     }
 
-    private var displayMessages: [AgentEvent] {
-        presentation.transcript.events
+    private var displayRows: [ChatDisplayRow] {
+        presentation.transcript.displayTranscript.rows
     }
 
     var body: some View {
@@ -101,7 +100,7 @@ struct ChatDetailView: View {
                 content
                 ChatDetailControlsView(
                     showsDebugControls: presentation.controls.showsDebugControls,
-                    isGenerating: remoteSession.isGenerating,
+                    isAnswering: remoteSession.runState.isAnswering,
                     showsInternals: $showsInternals,
                     hideToolCalls: $hideToolCalls,
                     exitStatus: remoteSession.exitStatus,
@@ -118,15 +117,12 @@ struct ChatDetailView: View {
         .onChange(of: chatZoom) { _, _ in
             composerHeight = ComposerTextView.oneLineHeight(for: composerFont)
         }
-        .onChange(of: remoteSession.isRunning) { _, isRunning in
-            if !isRunning { showsInternals = false }
-            if !isRunning, !queuedMessages.isEmpty {
+        .onChange(of: remoteSession.runState) { _, runState in
+            if !runState.isLive { showsInternals = false }
+            if !runState.isLive, !queuedMessages.isEmpty {
                 firePendingQueuedMessage()
             }
-        }
-        .onChange(of: remoteSession.isGenerating) { _, isGenerating in
-            guard !isGenerating else { return }
-            guard remoteSession.isRunning, !queuedMessages.isEmpty else { return }
+            guard !runState.isAnswering, runState.isLive, !queuedMessages.isEmpty else { return }
             firePendingQueuedMessage()
         }
         .onReceive(NotificationCenter.default.publisher(for: .agentProvidersConfigDidChange)) { notification in
@@ -138,7 +134,7 @@ struct ChatDetailView: View {
         }
         .task(id: ChatHydrationTaskKey(chatID: chatID, sessionID: remoteSession.instanceID)) {
             if let chatID {
-                persistedMessages = store.chatMessages(chatID: chatID)
+                loadPersistedTranscript(chatID: chatID)
                 remoteSession.installHistoryLoader { afterCursor in
                     store.readChatTranscriptPage(
                         chatID: chatID,
@@ -148,7 +144,7 @@ struct ChatDetailView: View {
                 }
                 await coordinator.rehydrate(chatID: chatID)
             } else {
-                persistedMessages = []
+                persistedTranscriptItems = []
                 if let question = store.pendingChatQuestion {
                     store.pendingChatQuestion = nil
                     store.draftChatMessage = question
@@ -161,9 +157,9 @@ struct ChatDetailView: View {
         .onChange(of: presentation.chatInspectorAvailable) { _, _ in
             updateRightSidebarRegistration()
         }
-        .onChange(of: remoteSession.activeChatID) { _, _ in
+        .onChange(of: remoteSession.runState) { _, _ in
             if let chatID, !isLiveChat {
-                persistedMessages = store.chatMessages(chatID: chatID)
+                loadPersistedTranscript(chatID: chatID)
             }
             updateRightSidebarRegistration()
         }
@@ -172,19 +168,19 @@ struct ChatDetailView: View {
         }
         .onChange(of: store.messageVersion) { _, _ in
             if let chatID, !isLiveChat {
-                persistedMessages = store.chatMessages(chatID: chatID)
+                loadPersistedTranscript(chatID: chatID)
             }
         }
         .task(id: ChatAnchorTaskKey(
             chatID: chatID,
             anchorVersion: store.pendingScrollAnchorVersion,
-            messageCount: displayMessages.count
+            messageCount: displayRows.count
         )) {
-            guard let chatID, !displayMessages.isEmpty else { return }
+            guard let chatID, !displayRows.isEmpty else { return }
             guard let fragment = store.consumePendingScrollAnchor(for: .chat(chatID)) else { return }
             let quote = ChatQuoteResolver.quoteText(fragment)
             guard !quote.isEmpty,
-                  ChatQuoteResolver.messageIndex(of: fragment, in: displayMessages) != nil
+                  displayRows.contains(where: { $0.textForSearch.wikiNormalized.lowercased().contains(quote.wikiNormalized.lowercased()) })
             else { return }
             quoteAnchor = ChatHighlightRequest(
                 version: (quoteAnchor?.version ?? 0) + 1,
@@ -269,13 +265,12 @@ struct ChatDetailView: View {
             outlineScroll: outlineScroll,
             quoteAnchor: quoteAnchor,
             hideToolCalls: hideToolCalls
-        ) { optionID, approve in
+        ) { intent in
             guard let chatID else { return }
             Task {
                 await coordinator.resolvePermission(
                     chatID: chatID,
-                    optionId: optionID,
-                    approve: approve
+                    intent: intent
                 )
             }
         }
@@ -344,10 +339,10 @@ struct ChatDetailView: View {
                 onCompareVersions: nil,
                 outline: {
                     AnyView(
-                        ChatInspectorOutlineView(entries: presentation.outlineEntries) { turnIndex in
+                        ChatInspectorOutlineView(entries: presentation.outlineEntries) { target in
                             outlineScroll = ChatScrollRequest(
                                 version: (outlineScroll?.version ?? 0) + 1,
-                                turnIndex: turnIndex
+                                target: target
                             )
                         }
                     )
@@ -473,7 +468,7 @@ struct ChatDetailView: View {
 
     private func sendMessage() {
         guard isChatOperationConfigured else { return }
-        if remoteSession.isGenerating {
+        if remoteSession.runState.isAnswering {
             queueMessage()
             return
         }
@@ -487,7 +482,7 @@ struct ChatDetailView: View {
     }
 
     private func queueMessage() {
-        guard isChatOperationConfigured, remoteSession.isGenerating else { return }
+        guard isChatOperationConfigured, remoteSession.runState.isAnswering else { return }
         let message = store.draftChatMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
         queuedMessages.append(
@@ -568,18 +563,6 @@ struct ChatDetailView: View {
         }
     }
 
-    nonisolated static func displayMessages(
-        isLiveChat: Bool,
-        launcherEvents: [AgentEvent],
-        persistedEvents: [AgentEvent]
-    ) -> [AgentEvent] {
-        ChatDetailPresentation.displayMessages(
-            isLiveChat: isLiveChat,
-            launcherEvents: launcherEvents,
-            persistedEvents: persistedEvents
-        )
-    }
-
     nonisolated static func debugFolderButtonHelpText(debugURL: URL?) -> String {
         ChatDetailPresentation.debugFolderButtonHelpText(debugURL: debugURL)
     }
@@ -609,37 +592,48 @@ struct ChatDetailView: View {
     }
 
     static func composerCaptionText(
-        isAwaitingGenerationSlot: Bool,
+        runState: ChatRunState,
         hasChatID: Bool,
         isLiveChat: Bool,
-        isGenerating: Bool,
         isChatOperationConfigured: Bool
     ) -> String? {
         ChatDetailPresentation.composerCaptionText(
-            isAwaitingGenerationSlot: isAwaitingGenerationSlot,
+            runState: runState,
             hasChatID: hasChatID,
             isLiveChat: isLiveChat,
-            isGenerating: isGenerating,
             isChatOperationConfigured: isChatOperationConfigured
         )
     }
 
     nonisolated static func canSendPredicate(
         hasMount: Bool,
-        canType: Bool,
-        isGenerating: Bool,
-        isAwaitingSlot: Bool,
+        runState: ChatRunState,
         hasDraftText: Bool,
         isChatOperationConfigured: Bool
     ) -> Bool {
         ChatDetailPresentation.canSendPredicate(
             hasMount: hasMount,
-            canType: canType,
-            isGenerating: isGenerating,
-            isAwaitingSlot: isAwaitingSlot,
+            runState: runState,
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured
         )
+    }
+
+    private func loadPersistedTranscript(chatID: ChatID) {
+        var items: [ChatTranscriptItem] = []
+        var cursor: ChatTranscriptCursor?
+        while true {
+            let page = store.readChatTranscriptPage(
+                chatID: chatID,
+                after: cursor,
+                limit: RemoteChatSession.committedHistoryPageSize
+            )
+            items += page.items.map(\.item)
+            guard let nextCursor = page.nextCursor,
+                  nextCursor != cursor else { break }
+            cursor = nextCursor
+        }
+        persistedTranscriptItems = items
     }
 }
 
@@ -716,6 +710,11 @@ enum ChatMetrics {
 }
 
 struct ChatOutlineEntry: Hashable {
+    enum ID: Hashable {
+        case turn(turnID: ChatTurnID, promptRowID: ChatDisplayRowID)
+    }
+
+    let id: ID
     let question: String
     let response: String?
     let questionTimestamp: Date?

--- a/Sources/WikiFS/Chats/ChatDisplayProjection.swift
+++ b/Sources/WikiFS/Chats/ChatDisplayProjection.swift
@@ -1,0 +1,414 @@
+// pattern: Functional Core
+
+import Foundation
+import WikiFSCore
+import WikiFSEngine
+import WikiFSTypes
+
+/// Stable, namespaced identity for one display row. These identifiers preserve
+/// the durable transcript namespace all the way to presentation.
+enum ChatDisplayRowID: Hashable, Sendable, Identifiable {
+    case message(ChatMessageID)
+    case toolCall(ToolCallID)
+    case notice(ChatTranscriptNoticeID)
+    case failure(ChatTranscriptFailureID)
+
+    var id: Self { self }
+}
+
+/// Lifecycle state deliberately available only on assistant and reasoning rows.
+enum ChatDisplayContentState: Hashable, Sendable {
+    case streaming
+    case final
+}
+
+/// One typed transcript row ready for presentation. It is app-only: durable
+/// transcript vocabulary remains in `WikiFSTypes` and sync vocabulary remains
+/// in `WikiFSEngine`.
+enum ChatDisplayRow: Hashable, Sendable, Identifiable {
+    case userMessage(
+        id: ChatMessageID,
+        turnID: ChatTurnID,
+        text: String,
+        createdAt: Date
+    )
+    case assistantMessage(
+        id: ChatMessageID,
+        turnID: ChatTurnID,
+        text: String,
+        createdAt: Date,
+        contentState: ChatDisplayContentState
+    )
+    case reasoning(
+        id: ChatMessageID,
+        turnID: ChatTurnID,
+        text: String,
+        createdAt: Date,
+        contentState: ChatDisplayContentState
+    )
+    case toolCall(
+        id: ToolCallID,
+        turnID: ChatTurnID,
+        toolName: String,
+        status: ChatToolCallStatus,
+        detail: String?,
+        permissionRequestID: PermissionRequestID?,
+        updatedAt: Date
+    )
+    case notice(
+        id: ChatTranscriptNoticeID,
+        turnID: ChatTurnID?,
+        kind: ChatSystemNoticeKind,
+        title: String,
+        message: String,
+        createdAt: Date
+    )
+    case failure(
+        id: ChatTranscriptFailureID,
+        turnID: ChatTurnID,
+        category: ChatTurnFailureCategory,
+        message: String,
+        createdAt: Date
+    )
+
+    var id: ChatDisplayRowID {
+        switch self {
+        case .userMessage(let id, _, _, _),
+             .assistantMessage(let id, _, _, _, _),
+             .reasoning(let id, _, _, _, _):
+            .message(id)
+        case .toolCall(let id, _, _, _, _, _, _):
+            .toolCall(id)
+        case .notice(let id, _, _, _, _, _):
+            .notice(id)
+        case .failure(let id, _, _, _, _):
+            .failure(id)
+        }
+    }
+
+    var turnID: ChatTurnID? {
+        switch self {
+        case .userMessage(_, let turnID, _, _),
+             .assistantMessage(_, let turnID, _, _, _),
+             .reasoning(_, let turnID, _, _, _),
+             .toolCall(_, let turnID, _, _, _, _, _),
+             .failure(_, let turnID, _, _, _):
+            turnID
+        case .notice(_, let turnID, _, _, _, _):
+            turnID
+        }
+    }
+
+    var contentState: ChatDisplayContentState? {
+        switch self {
+        case .assistantMessage(_, _, _, _, let state), .reasoning(_, _, _, _, let state):
+            state
+        case .userMessage, .toolCall, .notice, .failure:
+            nil
+        }
+    }
+
+    var isPrompt: Bool {
+        if case .userMessage = self { return true }
+        return false
+    }
+
+    var textForSearch: String {
+        switch self {
+        case .userMessage(_, _, let text, _),
+             .assistantMessage(_, _, let text, _, _),
+             .reasoning(_, _, let text, _, _),
+             .failure(_, _, _, let text, _):
+            text
+        case .toolCall(_, _, let toolName, _, let detail, _, _):
+            [toolName, detail].compactMap { $0 }.joined(separator: "\n")
+        case .notice(_, _, _, let title, let message, _):
+            [title, message].joined(separator: "\n")
+        }
+    }
+
+    var timestamp: Date {
+        switch self {
+        case .userMessage(_, _, _, let createdAt),
+             .assistantMessage(_, _, _, let createdAt, _),
+             .reasoning(_, _, _, let createdAt, _),
+             .notice(_, _, _, _, _, let createdAt),
+             .failure(_, _, _, _, let createdAt):
+            createdAt
+        case .toolCall(_, _, _, _, _, _, let updatedAt):
+            updatedAt
+        }
+    }
+}
+
+enum ChatDisplaySectionID: Hashable, Sendable, Identifiable {
+    case turn(turnID: ChatTurnID, firstRow: ChatDisplayRowID)
+    case unattributed(rows: [ChatDisplayRowID])
+
+    var id: Self { self }
+}
+
+struct ChatDisplayTurn: Hashable, Sendable, Identifiable {
+    let id: ChatDisplaySectionID
+    let turnID: ChatTurnID
+    /// A page beginning mid-turn has no user prompt; retaining that absence is
+    /// more honest than inventing an empty prompt.
+    let prompt: ChatDisplayRow?
+    let rows: [ChatDisplayRow]
+}
+
+struct ChatDisplayUnattributedSection: Hashable, Sendable, Identifiable {
+    let id: ChatDisplaySectionID
+    let rows: [ChatDisplayRow]
+}
+
+enum ChatDisplaySection: Hashable, Sendable, Identifiable {
+    case turn(ChatDisplayTurn)
+    case unattributed(ChatDisplayUnattributedSection)
+
+    var id: ChatDisplaySectionID {
+        switch self {
+        case .turn(let turn): turn.id
+        case .unattributed(let section): section.id
+        }
+    }
+
+    var rows: [ChatDisplayRow] {
+        switch self {
+        case .turn(let turn): turn.rows
+        case .unattributed(let section): section.rows
+        }
+    }
+}
+
+struct ChatDisplayTranscript: Hashable, Sendable {
+    let sections: [ChatDisplaySection]
+
+    static let empty = ChatDisplayTranscript(sections: [])
+
+    var rows: [ChatDisplayRow] { sections.flatMap(\.rows) }
+}
+
+/// Selection intent emitted by the typed outline. The WebKit bridge resolves
+/// this durable target to its temporary DOM index at the rendering boundary.
+struct ChatScrollRequest: Equatable {
+    let version: Int
+    let target: ChatOutlineEntry.ID
+}
+
+/// Proof that an active block names a present assistant/reasoning row. The
+/// projection accepts this value rather than raw wire metadata so invalid live
+/// state cannot accidentally mark a row streaming.
+struct ChatDisplayActiveContentBlock: Hashable, Sendable {
+    let messageID: ChatMessageID
+    let turnID: ChatTurnID
+    let role: ChatTranscriptMessageRole
+
+    init?(validating block: ChatActiveContentBlock, among items: [ChatTranscriptItem]) {
+        guard block.role == .assistant || block.role == .reasoning else { return nil }
+        guard items.contains(where: { item in
+            guard case .message(let message) = item else { return false }
+            return message.messageID == block.messageID
+                && message.turnID == block.turnID
+                && message.role == block.role
+        }) else { return nil }
+        self.messageID = block.messageID
+        self.turnID = block.turnID
+        self.role = block.role
+    }
+}
+
+enum ChatDisplayProjectionAnomaly: Hashable, Sendable {
+    case noncontiguousTurn(turnID: ChatTurnID)
+    case duplicateInputRowID(ChatDisplayRowID)
+    case lostRow(expected: ChatDisplayRowID)
+    case duplicatedRow(actual: ChatDisplayRowID)
+    case reorderedRow(expected: ChatDisplayRowID, actual: ChatDisplayRowID)
+}
+
+enum ChatDisplayProjection {
+    struct Result: Hashable, Sendable {
+        let transcript: ChatDisplayTranscript
+        let anomalies: [ChatDisplayProjectionAnomaly]
+    }
+
+    static func project(
+        items: [ChatTranscriptItem],
+        activeContentBlock: ChatDisplayActiveContentBlock?
+    ) -> Result {
+        let rows = items.map { row(from: $0, activeContentBlock: activeContentBlock) }
+        var anomalies = duplicateInputAnomalies(for: rows.map(\.id))
+        var sections: [ChatDisplaySection] = []
+        var currentTurnID: ChatTurnID?
+        var currentTurnRows: [ChatDisplayRow] = []
+        var unattributedRows: [ChatDisplayRow] = []
+        var encounteredTurnIDs: Set<ChatTurnID> = []
+
+        func appendCurrentTurn() {
+            guard let currentTurnID, let firstRow = currentTurnRows.first else { return }
+            sections.append(.turn(ChatDisplayTurn(
+                id: .turn(turnID: currentTurnID, firstRow: firstRow.id),
+                turnID: currentTurnID,
+                prompt: currentTurnRows.first(where: \.isPrompt),
+                rows: currentTurnRows
+            )))
+            currentTurnRows = []
+        }
+
+        func appendUnattributed() {
+            guard unattributedRows.isEmpty == false else { return }
+            sections.append(.unattributed(ChatDisplayUnattributedSection(
+                id: .unattributed(rows: unattributedRows.map(\.id)),
+                rows: unattributedRows
+            )))
+            unattributedRows = []
+        }
+
+        for row in rows {
+            guard let turnID = row.turnID else {
+                appendCurrentTurn()
+                currentTurnID = nil
+                unattributedRows.append(row)
+                continue
+            }
+
+            appendUnattributed()
+            if currentTurnID != turnID {
+                appendCurrentTurn()
+                if encounteredTurnIDs.contains(turnID),
+                   encounteredTurnIDs.contains(where: { $0 != turnID }) {
+                    anomalies.append(.noncontiguousTurn(turnID: turnID))
+                }
+                currentTurnID = turnID
+                encounteredTurnIDs.insert(turnID)
+            }
+            currentTurnRows.append(row)
+        }
+        appendCurrentTurn()
+        appendUnattributed()
+
+        let transcript = ChatDisplayTranscript(sections: sections)
+        anomalies += validationAnomalies(input: rows.map(\.id), output: transcript.rows.map(\.id))
+        return Result(transcript: transcript, anomalies: anomalies)
+    }
+
+    private static func row(
+        from item: ChatTranscriptItem,
+        activeContentBlock: ChatDisplayActiveContentBlock?
+    ) -> ChatDisplayRow {
+        switch item {
+        case .message(let message):
+            switch message.role {
+            case .user:
+                .userMessage(
+                    id: message.messageID,
+                    turnID: message.turnID,
+                    text: message.text,
+                    createdAt: message.createdAt
+                )
+            case .assistant:
+                .assistantMessage(
+                    id: message.messageID,
+                    turnID: message.turnID,
+                    text: message.text,
+                    createdAt: message.createdAt,
+                    contentState: contentState(for: message, activeContentBlock: activeContentBlock)
+                )
+            case .reasoning:
+                .reasoning(
+                    id: message.messageID,
+                    turnID: message.turnID,
+                    text: message.text,
+                    createdAt: message.createdAt,
+                    contentState: contentState(for: message, activeContentBlock: activeContentBlock)
+                )
+            }
+        case .toolCall(let toolCall):
+            .toolCall(
+                id: toolCall.toolCallID,
+                turnID: toolCall.turnID,
+                toolName: toolCall.toolName,
+                status: toolCall.status,
+                detail: toolCall.detail,
+                permissionRequestID: toolCall.permissionRequestID,
+                updatedAt: toolCall.updatedAt
+            )
+        case .systemNotice(let notice):
+            .notice(
+                id: notice.noticeID,
+                turnID: notice.turnID,
+                kind: notice.kind,
+                title: notice.title,
+                message: notice.message,
+                createdAt: notice.createdAt
+            )
+        case .turnFailure(let failure):
+            .failure(
+                id: failure.failureID,
+                turnID: failure.turnID,
+                category: failure.category,
+                message: failure.message,
+                createdAt: failure.createdAt
+            )
+        }
+    }
+
+    private static func contentState(
+        for message: ChatTranscriptMessageItem,
+        activeContentBlock: ChatDisplayActiveContentBlock?
+    ) -> ChatDisplayContentState {
+        guard activeContentBlock?.messageID == message.messageID,
+              activeContentBlock?.turnID == message.turnID,
+              activeContentBlock?.role == message.role else {
+            return .final
+        }
+        return .streaming
+    }
+
+    private static func duplicateInputAnomalies(for ids: [ChatDisplayRowID]) -> [ChatDisplayProjectionAnomaly] {
+        var seen: Set<ChatDisplayRowID> = []
+        return ids.compactMap { id in
+            seen.insert(id).inserted ? nil : .duplicateInputRowID(id)
+        }
+    }
+
+    private static func validationAnomalies(
+        input: [ChatDisplayRowID],
+        output: [ChatDisplayRowID]
+    ) -> [ChatDisplayProjectionAnomaly] {
+        var anomalies: [ChatDisplayProjectionAnomaly] = []
+        var remaining = input
+        for id in output {
+            guard let index = remaining.firstIndex(of: id) else {
+                anomalies.append(.duplicatedRow(actual: id))
+                continue
+            }
+            if index != remaining.startIndex {
+                anomalies.append(.reorderedRow(expected: remaining[remaining.startIndex], actual: id))
+            }
+            remaining.remove(at: index)
+        }
+        anomalies += remaining.map { .lostRow(expected: $0) }
+        return anomalies
+    }
+}
+
+/// The app-side approval callback contract. It carries the namespaced option
+/// identity and intent together, instead of letting a caller reconstruct a
+/// semantic action from a raw string and a Boolean.
+enum ChatPermissionResolutionIntent: Hashable, Sendable {
+    case approve(optionID: PermissionOptionID)
+    case deny(optionID: PermissionOptionID)
+    case cancel(optionID: PermissionOptionID)
+
+    var optionID: PermissionOptionID {
+        switch self {
+        case .approve(let optionID), .deny(let optionID), .cancel(let optionID): optionID
+        }
+    }
+
+    var isApproval: Bool {
+        if case .approve = self { return true }
+        return false
+    }
+}

--- a/Sources/WikiFS/Chats/ChatDisplayProjection.swift
+++ b/Sources/WikiFS/Chats/ChatDisplayProjection.swift
@@ -243,6 +243,7 @@ enum ChatDisplayProjection {
         var currentTurnRows: [ChatDisplayRow] = []
         var unattributedRows: [ChatDisplayRow] = []
         var encounteredTurnIDs: Set<ChatTurnID> = []
+        var lastClosedTurnID: ChatTurnID?
 
         func appendCurrentTurn() {
             guard let currentTurnID, let firstRow = currentTurnRows.first else { return }
@@ -252,6 +253,7 @@ enum ChatDisplayProjection {
                 prompt: currentTurnRows.first(where: \.isPrompt),
                 rows: currentTurnRows
             )))
+            lastClosedTurnID = currentTurnID
             currentTurnRows = []
         }
 
@@ -276,7 +278,8 @@ enum ChatDisplayProjection {
             if currentTurnID != turnID {
                 appendCurrentTurn()
                 if encounteredTurnIDs.contains(turnID),
-                   encounteredTurnIDs.contains(where: { $0 != turnID }) {
+                   let lastClosedTurnID,
+                   lastClosedTurnID != turnID {
                     anomalies.append(.noncontiguousTurn(turnID: turnID))
                 }
                 currentTurnID = turnID

--- a/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
+++ b/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
@@ -3,14 +3,14 @@ import SwiftUI
 /// Inspector-body content for the chat surface's outline.
 struct ChatInspectorOutlineView: View {
     let entries: [ChatOutlineEntry]
-    let onSelect: (Int) -> Void
+    let onSelect: (ChatOutlineEntry.ID) -> Void
 
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 2) {
-                ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
+                ForEach(entries, id: \.id) { entry in
                     Button {
-                        onSelect(index)
+                        onSelect(entry.id)
                     } label: {
                         VStack(alignment: .leading, spacing: 0) {
                             if let ts = entry.questionTimestamp {

--- a/Sources/WikiFS/Chats/ChatRunState.swift
+++ b/Sources/WikiFS/Chats/ChatRunState.swift
@@ -59,7 +59,7 @@ public enum ChatRunState: Sendable, Equatable {
     }
 
     /// True while the daemon holds a session for this chat — so the chat
-    /// surface should render the streaming mirror (`RemoteChatSession.events`)
+    /// surface should render the streaming mirror (`RemoteChatSession.displayTranscript`)
     /// rather than the persisted rows. Backs `isInteractiveSession` and
     /// `activeChatID != nil`.
     ///

--- a/Sources/WikiFS/Chats/ChatTranscriptPaneView.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptPaneView.swift
@@ -16,9 +16,10 @@ struct ChatTranscriptPaneView: View {
     let outlineScroll: ChatScrollRequest?
     let quoteAnchor: ChatHighlightRequest?
     let hideToolCalls: Bool
-    let onResolvePermission: (String, Bool) -> Void
+    let onResolvePermission: (ChatPermissionResolutionIntent) -> Void
 
     var body: some View {
+        let rendererInput = ChatTranscriptRenderingInput(transcript: transcript.displayTranscript)
         VStack(spacing: 0) {
             if let preflightBannerMessage {
                 preflightBanner(preflightBannerMessage)
@@ -27,16 +28,15 @@ struct ChatTranscriptPaneView: View {
                     .padding(.bottom, ChatMetrics.sectionSpacing / 2)
             }
             ChatTranscriptView(
-                events: transcript.events,
+                rendering: rendererInput,
                 transcriptID: chatID.map(TranscriptID.chat),
-                timestamps: transcript.timestamps,
                 emptyStateMessage: transcript.emptyStateMessage,
-                isRunning: transcript.isRunning,
+                isStreaming: transcript.isAnswering,
                 onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
                 renderContext: { [weak store] in store?.renderContext() },
                 blobStore: store,
                 zoom: chatZoom,
-                scrollRequest: outlineScroll,
+                scrollRequest: rendererInput.webScrollRequest(for: outlineScroll),
                 quoteAnchor: quoteAnchor,
                 hideToolCalls: hideToolCalls
             )
@@ -51,11 +51,8 @@ struct ChatTranscriptPaneView: View {
                     .padding(.bottom, ChatMetrics.sectionSpacing / 2)
             }
             if let livePendingPermission {
-                PermissionApprovalView(permission: livePendingPermission) { optionId in
-                    let approve = livePendingPermission.options
-                        .first { $0.optionId == optionId }?
-                        .kind.hasPrefix("allow") ?? false
-                    onResolvePermission(optionId, approve)
+                PermissionApprovalView(permission: livePendingPermission) { intent in
+                    onResolvePermission(intent)
                 }
                 .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                 .padding(.bottom, ChatMetrics.sectionSpacing / 2)

--- a/Sources/WikiFS/Chats/ChatTranscriptView.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptView.swift
@@ -1,32 +1,23 @@
 import SwiftUI
 import WikiFSCore
 
-/// The reusable chat-transcript component for BOTH the live (streaming) and the
-/// persisted (read-only) chat surfaces. Rendered from a caller-supplied `events`
-/// array (already `transcriptVisible`-filtered), so the live path feeds
-/// `launcher.events` and the persisted path feeds `store.chatMessages` through
-/// the same view — collapsing the old dual render sites in `ChatDetailView`.
+/// The reusable chat transcript renderer. Its input is a single renderer-only
+/// bridge from the typed app presentation model, not an app event contract.
 struct ChatTranscriptView: View {
-    /// The transcript-visible events to render (caller pre-filters via
-    /// `[AgentEvent].transcriptVisible`).
-    let events: [AgentEvent]
+    let rendering: ChatTranscriptRenderingInput
     /// Identity of the conversation `events` belongs to, forwarded to
     /// `ChatWebView` so its incremental differ rebuilds instead of splicing
     /// when this view is reused for a different chat (see
     /// `ChatWebView.transcriptID`). `nil` for the draft composer, which never
     /// reaches the web view (it renders the empty-state placeholder).
     var transcriptID: TranscriptID? = nil
-    /// Wall-clock timestamps parallel to `events` (after the same filtering).
-    /// `nil` entries produce no "Worked for" footer. Used to render the
-    /// duration metadata under assistant responses.
-    var timestamps: [Date?] = []
     /// Idle/fallback empty-state message. Overridden by "Waiting for the
-    /// Agent…" while `isRunning` (the live streaming case).
+    /// Agent…" while `isStreaming` (the live streaming case).
     var emptyStateMessage: String
     /// True while a live session is streaming into this transcript. Shows the
     /// "Waiting for the Agent…" placeholder and the streaming hint; the
     /// persisted surface passes `false` (it is never the active stream).
-    var isRunning: Bool = false
+    var isStreaming: Bool = false
     /// Forwards wiki-link clicks in the transcript to the detail column. Built
     /// where the store lives (the parent `ChatDetailView`) and forwarded unchanged to
     /// the transcript web view.
@@ -43,7 +34,7 @@ struct ChatTranscriptView: View {
     /// `chat.zoom` AppStorage by the chat surface.
     var zoom: Double = Double(ZoomScale.defaultScale)
     /// Versioned scroll-to-turn request, forwarded to the transcript web view.
-    var scrollRequest: ChatScrollRequest? = nil
+    var scrollRequest: ChatWebScrollRequest? = nil
     /// Versioned quote-anchor highlight request (`[[chat:Title#"quote"]]`,
     /// issue #281), forwarded to the transcript web view.
     var quoteAnchor: ChatHighlightRequest? = nil
@@ -54,13 +45,18 @@ struct ChatTranscriptView: View {
         // Mirror the hideToolCalls filter on both events and timestamps so
         // they stay parallel. When hideToolCalls is on, remove tool-call
         // events and their corresponding timestamps.
-        let visibleEvents = hideToolCalls ? events.filter { !$0.isToolCall } : events
+        let transcriptIndices = rendering.events.transcriptVisibleIndices
+        let transcriptEvents = transcriptIndices.map { rendering.events[$0] }
+        let transcriptTimestamps = transcriptIndices.map { index in
+            index < rendering.timestamps.count ? rendering.timestamps[index] : nil
+        }
+        let visibleEvents = hideToolCalls ? transcriptEvents.filter { !$0.isToolCall } : transcriptEvents
         let visibleTimestamps = hideToolCalls
-            ? events.indices.compactMap { idx -> Date? in
-                guard !events[idx].isToolCall else { return nil }
-                return idx < timestamps.count ? timestamps[idx] : nil
+            ? transcriptEvents.indices.compactMap { idx -> Date? in
+                guard !transcriptEvents[idx].isToolCall else { return nil }
+                return idx < transcriptTimestamps.count ? transcriptTimestamps[idx] : nil
             }
-            : timestamps
+            : transcriptTimestamps
         return Group {
             if visibleEvents.isEmpty {
                 placeholder
@@ -85,14 +81,14 @@ struct ChatTranscriptView: View {
 
     private var placeholder: some View {
         VStack(spacing: 7) {
-            Text(isRunning ? "Waiting for the Agent..." : emptyStateMessage)
+            Text(isStreaming ? "Waiting for the Agent..." : emptyStateMessage)
                 .font(.headline)
                 .fontWeight(.medium)
                 .foregroundStyle(.primary)
             // The streaming hint only applies while the agent is actively
             // working this transcript; a persisted (read-only) empty state shows
             // just its message.
-            if isRunning {
+            if isStreaming {
                 Text("Answers appear here; one-line tool-call summaries show as the agent works. Full detail is available under “Show internals.”")
                     .font(.callout)
                     .foregroundStyle(.secondary)
@@ -105,6 +101,50 @@ struct ChatTranscriptView: View {
 
 private enum ChatTranscriptMetrics {
     static let emptyStatePadding: CGFloat = 24
+}
+
+/// Narrow renderer bridge retained until Phase 4 replaces the existing WebKit
+/// event renderer. Presentation state never stores these compatibility events
+/// or exposes a timestamp-array API.
+struct ChatTranscriptRenderingInput {
+    let rows: [ChatDisplayRow]
+    let events: [AgentEvent]
+    let timestamps: [Date?]
+
+    init(transcript: ChatDisplayTranscript) {
+        self.rows = transcript.rows
+        self.events = rows.map(Self.event)
+        self.timestamps = rows.map { $0.timestamp }
+    }
+
+    func webScrollRequest(for request: ChatScrollRequest?) -> ChatWebScrollRequest? {
+        guard let request,
+              case .turn(_, let promptRowID) = request.target,
+              let rowIndex = rows.firstIndex(where: { $0.id == promptRowID }) else {
+            return nil
+        }
+        let turnIndex = rows[..<rowIndex].reduce(into: 0) { count, row in
+            if row.isPrompt { count += 1 }
+        }
+        return ChatWebScrollRequest(version: request.version, turnIndex: turnIndex)
+    }
+
+    private static func event(for row: ChatDisplayRow) -> AgentEvent {
+        switch row {
+        case .userMessage(_, _, let text, _):
+            .userText(text)
+        case .assistantMessage(_, _, let text, _, _):
+            .assistantText(text)
+        case .reasoning(_, _, let text, _, _):
+            .thinking(text)
+        case .toolCall(_, _, let toolName, _, let detail, _, _):
+            .toolUse(name: toolName, inputSummary: detail ?? "")
+        case .notice(_, _, _, let title, let message, _):
+            .raw([title, message].joined(separator: "\n"))
+        case .failure(_, _, _, let message, _):
+            .turnFailed(reason: .agentError(message))
+        }
+    }
 }
 
 extension [AgentEvent] {

--- a/Sources/WikiFS/Chats/ChatTranscriptView.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptView.swift
@@ -137,10 +137,17 @@ struct ChatTranscriptRenderingInput {
             .assistantText(text)
         case .reasoning(_, _, let text, _, _):
             .thinking(text)
-        case .toolCall(_, _, let toolName, _, let detail, _, _):
-            .toolUse(name: toolName, inputSummary: detail ?? "")
+        case .toolCall(_, _, let toolName, let status, let detail, _, _):
+            switch status {
+            case .pending, .running:
+                .toolUse(name: toolName, inputSummary: detail ?? "")
+            case .completed:
+                .toolResult(isError: false, summary: detail ?? toolName)
+            case .failed, .cancelled:
+                .toolResult(isError: true, summary: detail ?? toolName)
+            }
         case .notice(_, _, _, let title, let message, _):
-            .raw([title, message].joined(separator: "\n"))
+            .assistantText("\(title)\n\n\(message)")
         case .failure(_, _, _, let message, _):
             .turnFailed(reason: .agentError(message))
         }

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -28,7 +28,7 @@ import WikiFSCore
 /// reader's anchor-version pattern: `version` bumps to signal a new request;
 /// `turnIndex` is the 0-based index among the `.chat-user` rows the transcript
 /// renders. Consumed in `ChatWebView.updateNSView`.
-struct ChatScrollRequest: Equatable {
+struct ChatWebScrollRequest: Equatable {
     let version: Int
     let turnIndex: Int
 }
@@ -125,7 +125,7 @@ struct ChatWebView: NSViewRepresentable {
     var zoom: Double = Double(ZoomScale.defaultScale)
     /// Versioned request to scroll to a user turn (outline click). `nil` (default)
     /// never scrolls; consumed in `updateNSView`.
-    var scrollRequest: ChatScrollRequest? = nil
+    var scrollRequest: ChatWebScrollRequest? = nil
     /// Versioned request to highlight + scroll to a `[[chat:Title#"quote"]]`
     /// passage (issue #281). `nil` (default) never highlights; consumed in
     /// `updateNSView` (re-click on a loaded transcript) and `didFinish` (fresh
@@ -270,7 +270,7 @@ struct ChatWebView: NSViewRepresentable {
         ///
         /// `nonisolated`: a pure predicate over value types, so tests can call
         /// it without hopping to the main actor (same discipline as
-        /// `ChatDetailView.displayMessages`).
+        /// `ChatTranscriptRenderingInput`).
         nonisolated static func needsFullReload(
             transcriptID: TranscriptID?, renderedTranscriptID: TranscriptID?,
             showsInternals: Bool, renderedShowsInternals: Bool?,

--- a/Sources/WikiFS/Chats/RemoteChatSession.swift
+++ b/Sources/WikiFS/Chats/RemoteChatSession.swift
@@ -5,9 +5,8 @@ import Observation
 import WikiFSCore
 import WikiFSEngine
 
-/// Compatibility adapter over the Phase 4 reducer-owned chat client state.
-/// Call sites still bind the legacy launcher-shaped surface, but authoritative
-/// sync now flows through `ChatClientSyncReducer`.
+/// App-side observable mirror over reducer-owned chat client state. Transcript
+/// consumers bind `displayTranscript`, never launcher-shaped event arrays.
 @MainActor
 @Observable
 public final class RemoteChatSession {
@@ -22,16 +21,12 @@ public final class RemoteChatSession {
     public let instanceID = UUID()
 
     public private(set) var syncState: ChatClientSyncState?
-    public private(set) var events: [AgentEvent] = []
-    public private(set) var eventTimestamps: [Date?] = []
+    private(set) var displayTranscript: ChatDisplayTranscript = .empty
+    /// Compatibility only for the separate queue/activity-feed surface. Chat
+    /// presentation must use `displayTranscript`.
+    public private(set) var activityFeedEvents: [AgentEvent] = []
     public private(set) var runState: ChatRunState = .idle
     public var syncStatus: ChatClientSyncStatus? { syncState?.syncStatus }
-
-    public var isRunning: Bool { runState.isLive }
-    public var isGenerating: Bool { runState.isAnswering }
-    public var isAwaitingGenerationSlot: Bool { runState == .queued }
-    public var isInteractiveSession: Bool { runState.isLive }
-    public var activeChatID: ChatID? { runState.isLive ? chatID.chatID : nil }
 
     public var exitStatus: Int32?
     public var runningKind: WikiOperation.Kind?
@@ -124,14 +119,14 @@ public final class RemoteChatSession {
         if reduction.state.syncStatus == .synchronized {
             clearAuthoritativeSnapshotRetryBackoff()
         }
-        projectCompatibilitySurface()
+        projectDisplayState()
         runEffects(reduction.effects)
     }
 
-    private func projectCompatibilitySurface() {
+    private func projectDisplayState() {
         guard let syncState else {
-            events = []
-            eventTimestamps = []
+            displayTranscript = .empty
+            activityFeedEvents = []
             runState = .idle
             exitStatus = nil
             runningKind = nil
@@ -146,8 +141,17 @@ public final class RemoteChatSession {
             return
         }
 
-        events = syncState.displayEvents
-        eventTimestamps = syncState.displayEventTimestamps
+        let items = syncState.displayTranscriptItems
+        let activeContentBlock = syncState.projection.flatMap { projection in
+            projection.activeContentBlock.flatMap { block in
+                ChatDisplayActiveContentBlock(validating: block, among: items)
+            }
+        }
+        displayTranscript = ChatDisplayProjection.project(
+            items: items,
+            activeContentBlock: activeContentBlock
+        ).transcript
+        activityFeedEvents = items.map(ChatTranscriptProjection.project)
 
         guard let projection = syncState.projection else {
             runState = .idle
@@ -397,8 +401,8 @@ public final class RemoteChatSession {
 
     func reset() {
         syncState = chatID.chatID.map { ChatClientSyncState(chatID: $0) }
-        events = []
-        eventTimestamps = []
+        displayTranscript = .empty
+        activityFeedEvents = []
         runState = .idle
         exitStatus = nil
         runningKind = nil

--- a/Sources/WikiFS/Queue/AgentQueueView.swift
+++ b/Sources/WikiFS/Queue/AgentQueueView.swift
@@ -8,7 +8,7 @@ import WikiFSCore
 struct AgentQueueView: View {
     /// The daemon-mirrored chat session (replaces the in-process chat
     /// `AgentLauncher` after Phase C4). Run-state reads (`events`,
-    /// `preflightError`, `stderr`, `isRunning`, `runningKind`) come from the
+    /// `preflightError`, `stderr`, `runState`, `runningKind`) come from the
     /// daemon's live launcher via chat envelopes.
     var remoteSession: RemoteChatSession
     let showsResultEvents: Bool
@@ -67,7 +67,7 @@ struct AgentQueueView: View {
     }
 
     private var renderedEvents: [AgentEvent] {
-        remoteSession.events.filter { event in
+        remoteSession.activityFeedEvents.filter { event in
             if !showsInternals && event.isInternalTranscriptEvent {
                 return false
             }
@@ -80,7 +80,7 @@ struct AgentQueueView: View {
 
     @ViewBuilder
     private var placeholder: some View {
-        if remoteSession.isRunning {
+        if remoteSession.runState.isLive {
             HStack(spacing: 8) {
                 ProgressView().controlSize(.small)
                 Text(showsInternals ? (remoteSession.runningKind.map { "Starting \($0.title)…" } ?? "Starting…") : "Waiting for output…")
@@ -135,5 +135,3 @@ struct AgentQueueView: View {
 private enum ActivityMetrics {
     static let padding: CGFloat = 10
 }
-
-

--- a/Sources/WikiFS/Queue/AgentRunStatusView.swift
+++ b/Sources/WikiFS/Queue/AgentRunStatusView.swift
@@ -11,7 +11,7 @@ struct AgentRunStatusView: View {
     let now: Date
 
     var body: some View {
-        if remoteSession.isRunning, let startedAt = remoteSession.runStartedAt {
+        if remoteSession.runState.isLive, let startedAt = remoteSession.runStartedAt {
             HStack(spacing: 6) {
                 Image(systemName: isQuiet ? "hourglass" : "waveform.path")
                     .font(.caption)

--- a/Sources/WikiFS/Settings/PermissionApprovalView.swift
+++ b/Sources/WikiFS/Settings/PermissionApprovalView.swift
@@ -16,7 +16,7 @@ import ACPModel
 /// card announces itself to VoiceOver.
 struct PermissionApprovalView: View {
     let permission: PendingPermission
-    let onResolve: (String) -> Void
+    let onResolve: (ChatPermissionResolutionIntent) -> Void
 
     /// Split the offered options into the allow (Approve) and deny (Reject)
     /// buckets. An option whose `kind` starts with `allow` is Approve; the
@@ -55,13 +55,13 @@ struct PermissionApprovalView: View {
             Spacer(minLength: 8)
             HStack(spacing: 8) {
                 if let reject = rejectOption {
-                    Button("Reject") { onResolve(reject.optionId) }
+                    Button("Reject") { onResolve(resolutionIntent(for: reject)) }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                         .help("Deny this request")
                 }
                 if let allow = allowOption {
-                    Button("Approve") { onResolve(allow.optionId) }
+                    Button("Approve") { onResolve(resolutionIntent(for: allow)) }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
                         .help("Allow this request")
@@ -95,5 +95,16 @@ struct PermissionApprovalView: View {
     /// caption.
     private var showsDetail: Bool {
         detailText != nil
+    }
+
+    private func resolutionIntent(for option: PermissionOption) -> ChatPermissionResolutionIntent {
+        let optionID = PermissionOptionID(rawValue: option.optionId)
+        if option.kind.hasPrefix("allow") {
+            return .approve(optionID: optionID)
+        }
+        if option.kind == "cancel" {
+            return .cancel(optionID: optionID)
+        }
+        return .deny(optionID: optionID)
     }
 }

--- a/Sources/WikiFS/Settings/ProviderSelector.swift
+++ b/Sources/WikiFS/Settings/ProviderSelector.swift
@@ -130,7 +130,7 @@ struct ProviderSelector: View {
         .onAppear { refresh() }
         // Keep in sync if a session flips (the composer is rebuilt when a chat
         // becomes live).
-        .onChange(of: remoteSession.activeChatID) { _, _ in refresh() }
+        .onChange(of: remoteSession.runState) { _, _ in refresh() }
         .onChange(of: remoteSession.providerConfiguration) { _, _ in refresh() }
     }
 

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -6869,6 +6869,15 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 sql: "SELECT COALESCE(MAX(seq), -1) FROM chat_messages WHERE chat_id = ?;",
                 arguments: [chatID.rawValue]
             ) ?? -1
+            // Every durable transcript item has exactly one compatibility row.
+            // Do not silently create an offset mapping after a legacy-only
+            // write: summaries would then attach to the wrong transcript item.
+            let expectedCompatibilityMax = Int(transcriptMax) - 1
+            guard compatibilityMax == expectedCompatibilityMax else {
+                throw WikiStoreError.unexpected(
+                    "chat transcript and compatibility projection are out of sync"
+                )
+            }
 
             let itemEncoder = JSONEncoder()
             let eventEncoder = JSONEncoder()
@@ -6995,13 +7004,18 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             ) ?? 0
             let checkpoint = ChatTranscriptCursor(rawValue: checkpointRaw)
             let lowerBound = cursor?.rawValue ?? 0
+            // `chat_messages` is the compatibility projection: its dense
+            // zero-based seq is the one-based durable transcript cursor minus one.
             let rows = try Row.fetchAll(
                 db,
                 sql: """
-                SELECT chat_id, cursor, item_json, projected_event_json, projected_text, created_at
-                FROM chat_transcript_items
-                WHERE chat_id = ? AND cursor > ?
-                ORDER BY cursor ASC
+                SELECT ti.chat_id, ti.cursor, ti.item_json, ti.projected_event_json,
+                       ti.projected_text, ti.created_at, m.summary AS cached_response_summary
+                FROM chat_transcript_items AS ti
+                LEFT JOIN chat_messages AS m
+                    ON m.chat_id = ti.chat_id AND m.seq = ti.cursor - 1
+                WHERE ti.chat_id = ? AND ti.cursor > ?
+                ORDER BY ti.cursor ASC
                 LIMIT ?;
                 """,
                 arguments: [chatID.rawValue, lowerBound, max(0, limit)]
@@ -7610,12 +7624,14 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         let projectedEventJSON: String? = row["projected_event_json"]
         let projectedText: String = row["projected_text"]
         let createdAt: Double = row["created_at"]
+        let cachedResponseSummary: String? = row["cached_response_summary"]
         return PersistedChatTranscriptItem(
             cursor: cursor,
             item: item,
             projectedEventJSON: projectedEventJSON,
             projectedPlainText: projectedText,
-            createdAt: Date(timeIntervalSince1970: createdAt)
+            createdAt: Date(timeIntervalSince1970: createdAt),
+            cachedResponseSummary: cachedResponseSummary
         )
     }
 

--- a/Sources/WikiFSEngine/ChatClientSync.swift
+++ b/Sources/WikiFSEngine/ChatClientSync.swift
@@ -40,14 +40,6 @@ public extension ChatClientSyncState {
         guard let projection else { return base }
         return ChatClientSyncReducer.mergingCommitted(base, with: projection.transcriptOverlay)
     }
-
-    var displayEvents: [AgentEvent] {
-        displayTranscriptItems.map(ChatTranscriptProjection.project)
-    }
-
-    var displayEventTimestamps: [Date?] {
-        displayTranscriptItems.map(ChatClientSyncReducer.timestamp(for:))
-    }
 }
 
 public enum ChatClientSyncEffect: Sendable, Equatable {

--- a/Sources/WikiFSTypes/ChatConversationTypes.swift
+++ b/Sources/WikiFSTypes/ChatConversationTypes.swift
@@ -368,7 +368,29 @@ public struct PersistedChatTranscriptItem: Hashable, Sendable, Codable {
     public let projectedEventJSON: String?
     public let projectedPlainText: String
     public let createdAt: Date
+    /// Cached summary from the compatibility `chat_messages` row at this
+    /// cursor. The store joins it by the durable cursor/sequence relationship;
+    /// it is deliberately not keyed by the compatibility row's `PageID`.
+    public let cachedResponseSummary: String?
 
+    public init(
+        cursor: ChatTranscriptCursor,
+        item: ChatTranscriptItem,
+        projectedEventJSON: String?,
+        projectedPlainText: String,
+        createdAt: Date,
+        cachedResponseSummary: String?
+    ) {
+        self.cursor = cursor
+        self.item = item
+        self.projectedEventJSON = projectedEventJSON
+        self.projectedPlainText = projectedPlainText
+        self.createdAt = createdAt
+        self.cachedResponseSummary = cachedResponseSummary
+    }
+
+    /// Source-compatible initializer for callers that do not have a cached
+    /// summary (newly appended rows and existing test fixtures).
     public init(
         cursor: ChatTranscriptCursor,
         item: ChatTranscriptItem,
@@ -381,6 +403,7 @@ public struct PersistedChatTranscriptItem: Hashable, Sendable, Codable {
         self.projectedEventJSON = projectedEventJSON
         self.projectedPlainText = projectedPlainText
         self.createdAt = createdAt
+        self.cachedResponseSummary = nil
     }
 }
 

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -45,8 +45,8 @@ struct ChatDaemonCoordinatorTests {
             )
         )
 
-        #expect(session.events == [.assistantText("hello")])
-        #expect(session.isGenerating)
+        #expect(session.displayTranscript.rows.count == 1)
+        #expect(session.runState.isAnswering)
         #expect(coordinator.isChatGenerating(ChatID(rawValue: "chat-1")))
         #expect(coordinator.anyChatGenerating)
     }
@@ -100,7 +100,10 @@ struct ChatDaemonCoordinatorTests {
                 )
             )
         )
-        await coordinator.resolvePermission(chatID: ChatID(rawValue: "chat-1"), optionId: "allow", approve: true)
+        await coordinator.resolvePermission(
+            chatID: ChatID(rawValue: "chat-1"),
+            intent: .approve(optionID: PermissionOptionID(rawValue: "allow"))
+        )
         await coordinator.setThinkingEffort(chatID: ChatID(rawValue: "chat-1"), value: "high")
         await coordinator.stop(chatID: ChatID(rawValue: "chat-1"))
 
@@ -123,8 +126,8 @@ struct ChatDaemonCoordinatorTests {
         await coordinator.rehydrate(chatID: ChatID(rawValue: "chat-1"))
 
         let session = coordinator.session(for: ChatID(rawValue: "chat-1"))
-        #expect(session.events == [.assistantText("seed")])
-        #expect(session.isGenerating)
+        #expect(session.displayTranscript.rows.count == 1)
+        #expect(session.runState.isAnswering)
         #expect(coordinator.isChatGenerating(ChatID(rawValue: "chat-1")))
     }
 
@@ -139,7 +142,7 @@ struct ChatDaemonCoordinatorTests {
         await coordinator.rehydrate(chatID: ChatID(rawValue: "chat-1"))
 
         let session = coordinator.session(for: ChatID(rawValue: "chat-1"))
-        #expect(session.activeChatID == nil)
+        #expect(session.runState == .idle)
         #expect(!coordinator.isChatGenerating(ChatID(rawValue: "chat-1")))
     }
 
@@ -190,7 +193,7 @@ struct ChatDaemonCoordinatorTests {
         )
 
         let session = coordinator.session(for: ChatID(rawValue: "chat-1"))
-        await expectEventually(session.isGenerating)
+        await expectEventually(session.runState.isAnswering)
         #expect(stub.sessionStateRequests.isEmpty)
     }
 

--- a/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
@@ -51,7 +51,7 @@ struct ChatDetailPresentationTests {
                 createdAt: .distantPast
             ))
         ], activeContentBlock: nil).transcript
-        let persistedItems: [ChatTranscriptItem] = [
+        let persistedItems = persisted([
             .message(.init(
                 messageID: ChatMessageID(rawValue: "persisted-message"),
                 turnID: ChatTurnID(rawValue: "persisted-turn"),
@@ -59,7 +59,7 @@ struct ChatDetailPresentationTests {
                 text: "Persisted response",
                 createdAt: .distantPast
             ))
-        ]
+        ])
         let live = ChatDetailPresentation.make(
             chatID: chatID,
             chatSummary: ChatSummary.fixture(id: chatID),
@@ -91,37 +91,70 @@ struct ChatDetailPresentationTests {
         #expect(persisted.transcript.isAnswering == false)
     }
 
-    @Test func persistedOutlinePrefersTheCachedResponseSummary() {
-        let chatID = ChatID(rawValue: "01J" + String(repeating: "H", count: 22))
-        let answerID = ChatMessageID(rawValue: "answer-message")
-        let presentation = ChatDetailPresentation.make(
-            chatID: chatID,
-            chatSummary: ChatSummary.fixture(id: chatID),
-            showsInternals: false,
-            remoteSession: .fixture(),
-            persistedTranscriptItems: [
+    @Test func persistedOutlineUsesModelSummaryReturnedByTranscriptPage() throws {
+        let store = try TestStoreFactory.inMemory()
+        let chat = try store.createChat(kind: .edit, title: "Summary round-trip")
+        let turnID = ChatTurnID(rawValue: "turn-summary")
+        let assistantMessageID = ChatMessageID(rawValue: "transcript-assistant-id")
+        let assistantText = "Raw response opening that must not become the outline summary."
+        _ = try store.appendChatTranscriptItems(
+            chatID: chat.id,
+            items: [
                 .message(.init(
-                    messageID: ChatMessageID(rawValue: "question-message"),
-                    turnID: ChatTurnID(rawValue: "turn-1"),
+                    messageID: ChatMessageID(rawValue: "transcript-user-id"),
+                    turnID: turnID,
                     role: .user,
                     text: "What changed?",
                     createdAt: .distantPast
                 )),
                 .message(.init(
-                    messageID: answerID,
-                    turnID: ChatTurnID(rawValue: "turn-1"),
+                    messageID: assistantMessageID,
+                    turnID: turnID,
                     role: .assistant,
-                    text: "A long response whose opening is not the model summary.",
+                    text: assistantText,
                     createdAt: .distantPast
                 )),
-            ],
-            persistedResponseSummaries: [answerID: "Model-generated summary."],
+            ]
+        )
+        let compatibilityAssistant = try #require(
+            store.chatMessages(chatID: chat.id).first { message in
+                message.event == .assistantText(assistantText)
+            }
+        )
+        // The compatibility message id is independently generated. This makes
+        // a PageID-to-ChatMessageID conversion unable to find the summary.
+        #expect(compatibilityAssistant.id.rawValue != assistantMessageID.rawValue)
+        #expect(compatibilityAssistant.seq == 1)
+        try store.updateMessageSummary(
+            chatID: chat.id,
+            messageID: compatibilityAssistant.id,
+            summary: "Distinctive model summary.",
+            kind: .model
+        )
+
+        let page = try store.readChatTranscriptPage(chatID: chat.id, after: nil, limit: 10)
+        let persistedAssistant = try #require(page.items.first { item in
+            guard case .message(let message) = item.item else { return false }
+            return message.messageID == assistantMessageID
+        })
+        #expect(persistedAssistant.cursor.rawValue - 1 == Int64(compatibilityAssistant.seq))
+        #expect(persistedAssistant.cachedResponseSummary == "Distinctive model summary.")
+        let presentation = ChatDetailPresentation.make(
+            chatID: chat.id,
+            chatSummary: chat,
+            showsInternals: false,
+            remoteSession: .fixture(),
+            persistedTranscriptItems: page.items,
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
         )
 
-        #expect(presentation.outlineEntries.first?.response == "Model-generated summary.")
+        #expect(presentation.outlineEntries.first?.response == "Distinctive model summary.")
+        #expect(presentation.outlineEntries.first?.response != ChatSummary.summaryExtract(
+            from: assistantText,
+            maxLength: 200
+        ))
     }
 
     @Test func pendingPermissionOnlySurfacesForLiveChat() {
@@ -240,6 +273,18 @@ struct ChatDetailPresentationTests {
         )
 
         #expect(presentation.outlineEntries.isEmpty)
+    }
+}
+
+private func persisted(_ items: [ChatTranscriptItem]) -> [PersistedChatTranscriptItem] {
+    items.enumerated().map { index, item in
+        PersistedChatTranscriptItem(
+            cursor: ChatTranscriptCursor(rawValue: Int64(index + 1)),
+            item: item,
+            projectedEventJSON: nil,
+            projectedPlainText: ChatTranscriptProjection.project(item).plainText,
+            createdAt: .distantPast
+        )
     }
 }
 

--- a/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
@@ -14,8 +14,8 @@ struct ChatDetailPresentationTests {
             chatID: ChatID(rawValue: "01J" + String(repeating: "A", count: 22)),
             chatSummary: nil,
             showsInternals: true,
-            remoteSession: .fixture(isGenerating: true, runningKind: .query),
-            persistedMessages: [],
+            remoteSession: .fixture(runState: .answering, runningKind: .query),
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
@@ -31,7 +31,7 @@ struct ChatDetailPresentationTests {
             chatSummary: nil,
             showsInternals: false,
             remoteSession: .fixture(),
-            persistedMessages: [],
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
@@ -40,37 +40,24 @@ struct ChatDetailPresentationTests {
         #expect(presentation.contentState == .missingChat)
     }
 
-    @Test func transcriptProjectionUsesLiveEventsAndKeepsTimestampsAlignedAfterFiltering() {
-        let liveTimestamps = [
-            Date(timeIntervalSince1970: 10),
-            Date(timeIntervalSince1970: 20),
-            Date(timeIntervalSince1970: 30),
-        ]
+    @Test func transcriptProjectionUsesTheTypedLiveTranscript() {
         let presentation = ChatDetailPresentation.make(
             chatID: ChatID(rawValue: "01J" + String(repeating: "C", count: 22)),
             chatSummary: ChatSummary.fixture(id: ChatID(rawValue: "01J" + String(repeating: "C", count: 22))),
             showsInternals: false,
             remoteSession: .fixture(
-                activeChatID: ChatID(rawValue: "01J" + String(repeating: "C", count: 22)),
-                isGenerating: true,
-                events: [
-                    .userText("hello"),
-                    .toolResult(isError: false, summary: "ok"),
-                    .assistantText("world"),
-                ],
-                eventTimestamps: liveTimestamps
+                sessionChatID: ChatID(rawValue: "01J" + String(repeating: "C", count: 22)),
+                runState: .answering,
+                transcript: ChatDisplayProjection.project(items: [], activeContentBlock: nil).transcript
             ),
-            persistedMessages: [
-                ChatMessage.fixture(seq: 0, event: .userText("persisted")),
-            ],
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
         )
 
-        #expect(presentation.transcript.events == [.userText("hello"), .assistantText("world")])
-        #expect(presentation.transcript.timestamps == [liveTimestamps[0], liveTimestamps[2]])
-        #expect(presentation.transcript.isRunning)
+        #expect(presentation.transcript.displayTranscript.rows.isEmpty)
+        #expect(presentation.transcript.isAnswering)
     }
 
     @Test func pendingPermissionOnlySurfacesForLiveChat() {
@@ -92,8 +79,8 @@ struct ChatDetailPresentationTests {
             chatID: liveChatID,
             chatSummary: ChatSummary.fixture(id: liveChatID),
             showsInternals: false,
-            remoteSession: .fixture(activeChatID: liveChatID, pendingPermissions: [request]),
-            persistedMessages: [],
+            remoteSession: .fixture(sessionChatID: liveChatID, runState: .warm, pendingPermissions: [request]),
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
@@ -103,7 +90,7 @@ struct ChatDetailPresentationTests {
             chatSummary: ChatSummary.fixture(id: liveChatID),
             showsInternals: false,
             remoteSession: .fixture(pendingPermissions: [request]),
-            persistedMessages: [],
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
@@ -120,11 +107,11 @@ struct ChatDetailPresentationTests {
             chatSummary: ChatSummary.fixture(id: liveChatID),
             showsInternals: false,
             remoteSession: .fixture(
-                activeChatID: liveChatID,
-                isGenerating: true,
+                sessionChatID: liveChatID,
+                runState: .answering,
                 runningKind: .query
             ),
-            persistedMessages: [],
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: true,
             isChatOperationConfigured: true
@@ -143,11 +130,11 @@ struct ChatDetailPresentationTests {
             chatSummary: ChatSummary.fixture(id: liveChatID),
             showsInternals: false,
             remoteSession: .fixture(
-                activeChatID: liveChatID,
-                isGenerating: true,
+                sessionChatID: liveChatID,
+                runState: .answering,
                 runningKind: .query
             ),
-            persistedMessages: [],
+            persistedTranscriptItems: [],
             queuedMessages: [.fixture(preview: "next up")],
             hasDraftText: true,
             isChatOperationConfigured: true
@@ -164,7 +151,7 @@ struct ChatDetailPresentationTests {
             chatSummary: nil,
             showsInternals: false,
             remoteSession: .fixture(),
-            persistedMessages: [],
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: true,
             isChatOperationConfigured: false
@@ -175,62 +162,42 @@ struct ChatDetailPresentationTests {
         #expect(presentation.composer.caption == "Configure an enabled provider and model in Settings → Providers before sending.")
     }
 
-    @Test func outlineProjectionUsesCachedPersistedSummaryWhenAvailable() throws {
+    @Test func pagedTranscriptWithoutPromptDoesNotCreateOutlineEntry() {
         let chatID = ChatID(rawValue: "01J" + String(repeating: "G", count: 22))
         let presentation = ChatDetailPresentation.make(
             chatID: chatID,
             chatSummary: ChatSummary.fixture(id: chatID),
             showsInternals: false,
             remoteSession: .fixture(),
-            persistedMessages: [
-                .fixture(chatID: chatID, seq: 0, event: .userText("[[page:Project Plan]]\n\nWhat changed?")),
-                .fixture(
-                    chatID: chatID,
-                    seq: 1,
-                    event: .assistantText("Fallback summary should not win."),
-                    summary: "Cached persisted summary",
-                    summaryKind: .model
-                ),
-            ],
+            persistedTranscriptItems: [],
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
         )
 
-        let entry = try #require(presentation.outlineEntries.first)
-        #expect(entry.question == "Project Plan\n\nWhat changed?")
-        #expect(entry.response == "Cached persisted summary")
+        #expect(presentation.outlineEntries.isEmpty)
     }
 }
 
 private extension ChatDetailPresentation.RemoteState {
     static func fixture(
-        activeChatID: ChatID? = nil,
-        runState: ChatRunState? = nil,
-        isGenerating: Bool = false,
-        isAwaitingGenerationSlot: Bool = false,
+        sessionChatID: ChatID? = nil,
+        runState: ChatRunState = .idle,
         runningKind: WikiOperation.Kind? = nil,
         preflightError: String? = nil,
         pendingPermissions: [PendingPermission] = [],
         runStartedAt: Date? = nil,
-        events: [AgentEvent] = [],
-        eventTimestamps: [Date?] = [],
+        transcript: ChatDisplayTranscript = .empty,
         exitStatus: Int32? = nil
     ) -> Self {
         .init(
-            runState: runState ?? {
-                if isGenerating { return .answering }
-                if isAwaitingGenerationSlot { return .queued }
-                if activeChatID != nil { return .warm }
-                return .idle
-            }(),
-            activeChatID: activeChatID,
+            runState: runState,
+            sessionChatID: sessionChatID,
             runningKind: runningKind,
             preflightError: preflightError,
             pendingPermissions: pendingPermissions,
             runStartedAt: runStartedAt,
-            events: events,
-            eventTimestamps: eventTimestamps,
+            transcript: transcript,
             exitStatus: exitStatus
         )
     }

--- a/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
@@ -40,24 +40,88 @@ struct ChatDetailPresentationTests {
         #expect(presentation.contentState == .missingChat)
     }
 
-    @Test func transcriptProjectionUsesTheTypedLiveTranscript() {
-        let presentation = ChatDetailPresentation.make(
-            chatID: ChatID(rawValue: "01J" + String(repeating: "C", count: 22)),
-            chatSummary: ChatSummary.fixture(id: ChatID(rawValue: "01J" + String(repeating: "C", count: 22))),
+    @Test func transcriptProjectionSelectsTheTypedLiveTranscriptInsteadOfPersistedRows() {
+        let chatID = ChatID(rawValue: "01J" + String(repeating: "C", count: 22))
+        let liveTranscript = ChatDisplayProjection.project(items: [
+            .message(.init(
+                messageID: ChatMessageID(rawValue: "live-message"),
+                turnID: ChatTurnID(rawValue: "live-turn"),
+                role: .assistant,
+                text: "Live response",
+                createdAt: .distantPast
+            ))
+        ], activeContentBlock: nil).transcript
+        let persistedItems: [ChatTranscriptItem] = [
+            .message(.init(
+                messageID: ChatMessageID(rawValue: "persisted-message"),
+                turnID: ChatTurnID(rawValue: "persisted-turn"),
+                role: .assistant,
+                text: "Persisted response",
+                createdAt: .distantPast
+            ))
+        ]
+        let live = ChatDetailPresentation.make(
+            chatID: chatID,
+            chatSummary: ChatSummary.fixture(id: chatID),
             showsInternals: false,
             remoteSession: .fixture(
-                sessionChatID: ChatID(rawValue: "01J" + String(repeating: "C", count: 22)),
+                sessionChatID: chatID,
                 runState: .answering,
-                transcript: ChatDisplayProjection.project(items: [], activeContentBlock: nil).transcript
+                transcript: liveTranscript
             ),
-            persistedTranscriptItems: [],
+            persistedTranscriptItems: persistedItems,
+            queuedMessages: [],
+            hasDraftText: false,
+            isChatOperationConfigured: true
+        )
+        let persisted = ChatDetailPresentation.make(
+            chatID: chatID,
+            chatSummary: ChatSummary.fixture(id: chatID),
+            showsInternals: false,
+            remoteSession: .fixture(transcript: liveTranscript),
+            persistedTranscriptItems: persistedItems,
             queuedMessages: [],
             hasDraftText: false,
             isChatOperationConfigured: true
         )
 
-        #expect(presentation.transcript.displayTranscript.rows.isEmpty)
-        #expect(presentation.transcript.isAnswering)
+        #expect(live.transcript.displayTranscript.rows.first?.textForSearch == "Live response")
+        #expect(live.transcript.isAnswering)
+        #expect(persisted.transcript.displayTranscript.rows.first?.textForSearch == "Persisted response")
+        #expect(persisted.transcript.isAnswering == false)
+    }
+
+    @Test func persistedOutlinePrefersTheCachedResponseSummary() {
+        let chatID = ChatID(rawValue: "01J" + String(repeating: "H", count: 22))
+        let answerID = ChatMessageID(rawValue: "answer-message")
+        let presentation = ChatDetailPresentation.make(
+            chatID: chatID,
+            chatSummary: ChatSummary.fixture(id: chatID),
+            showsInternals: false,
+            remoteSession: .fixture(),
+            persistedTranscriptItems: [
+                .message(.init(
+                    messageID: ChatMessageID(rawValue: "question-message"),
+                    turnID: ChatTurnID(rawValue: "turn-1"),
+                    role: .user,
+                    text: "What changed?",
+                    createdAt: .distantPast
+                )),
+                .message(.init(
+                    messageID: answerID,
+                    turnID: ChatTurnID(rawValue: "turn-1"),
+                    role: .assistant,
+                    text: "A long response whose opening is not the model summary.",
+                    createdAt: .distantPast
+                )),
+            ],
+            persistedResponseSummaries: [answerID: "Model-generated summary."],
+            queuedMessages: [],
+            hasDraftText: false,
+            isChatOperationConfigured: true
+        )
+
+        #expect(presentation.outlineEntries.first?.response == "Model-generated summary.")
     }
 
     @Test func pendingPermissionOnlySurfacesForLiveChat() {

--- a/Tests/WikiFSAppTests/ChatDisplayMessagesTests.swift
+++ b/Tests/WikiFSAppTests/ChatDisplayMessagesTests.swift
@@ -1,50 +1,24 @@
 #if os(macOS)
 import Testing
 import Foundation
-import WikiFSCore
+import WikiFSEngine
+import WikiFSTypes
 @testable import WikiFS
-@testable import WikiFSEngine
 
-/// Unit tests for `ChatDetailView.displayMessages` (AC.6) — the pure source-of-truth
-/// selector that collapses the live/persisted transcript render path into one
-/// `ChatTranscriptView(events:)` call site. Covers source selection (live →
-/// launcher events, non-live → persisted) and the `transcriptVisible` filter,
-/// without a SwiftUI view-tree harness.
+/// The typed display projection replaces the launcher-event selector.
 struct ChatDisplayMessagesTests {
-
-    @Test func selectsLauncherEventsWhenLive() {
-        let live: [AgentEvent] = [.userText("hello"), .assistantText("streaming")]
-        let persisted: [AgentEvent] = [.userText("old"), .assistantText("old answer")]
-        let result = ChatDetailView.displayMessages(
-            isLiveChat: true, launcherEvents: live, persistedEvents: persisted)
-        #expect(result == [.userText("hello"), .assistantText("streaming")])
-    }
-
-    @Test func selectsPersistedEventsWhenNotLive() {
-        let live: [AgentEvent] = [.userText("hello")]
-        let persisted: [AgentEvent] = [.userText("old"), .assistantText("old answer")]
-        let result = ChatDetailView.displayMessages(
-            isLiveChat: false, launcherEvents: live, persistedEvents: persisted)
-        #expect(result == [.userText("old"), .assistantText("old answer")])
-    }
-
-    @Test func appliesTranscriptVisibleFilter() {
-        // A successful tool result is NOT transcript-visible (only failures
-        // surface); userText/assistantText survive.
-        let events: [AgentEvent] = [
-            .userText("q"),
-            .toolResult(isError: false, summary: "ok"),
-            .assistantText("a"),
-        ]
-        let result = ChatDetailView.displayMessages(
-            isLiveChat: true, launcherEvents: events, persistedEvents: [])
-        #expect(result == [.userText("q"), .assistantText("a")])
-    }
-
-    @Test func emptyWhenNoSourceEvents() {
-        let result = ChatDetailView.displayMessages(
-            isLiveChat: false, launcherEvents: [.userText("x")], persistedEvents: [])
-        #expect(result.isEmpty)
+    @Test func typedRowsDoNotDropToolCalls() {
+        let item = ChatTranscriptItem.toolCall(.init(
+            toolCallID: ToolCallID(rawValue: "tool"),
+            turnID: ChatTurnID(rawValue: "turn"),
+            toolName: "Read",
+            status: .completed,
+            detail: nil,
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        ))
+        let result = ChatDisplayProjection.project(items: [item], activeContentBlock: nil)
+        #expect(result.transcript.rows.map(\.id) == [.toolCall(ToolCallID(rawValue: "tool"))])
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/ChatDisplayProjectionTests.swift
+++ b/Tests/WikiFSAppTests/ChatDisplayProjectionTests.swift
@@ -68,6 +68,17 @@ struct ChatDisplayProjectionTests {
         #expect(result.anomalies.contains(.noncontiguousTurn(turnID: ChatTurnID(rawValue: "turn-1"))))
     }
 
+    @Test func noticeSeparatedRowsOfTheSameTurnDoNotReportANoncontiguousTurn() {
+        let result = ChatDisplayProjection.project(items: [
+            userMessage(id: "message-1", turn: "turn-1", text: "Question"),
+            notice(id: "notice-1", turn: nil),
+            assistantMessage(id: "message-2", turn: "turn-1", text: "Answer"),
+        ], activeContentBlock: nil)
+
+        #expect(result.transcript.sections.count == 3)
+        #expect(result.anomalies.contains(.noncontiguousTurn(turnID: ChatTurnID(rawValue: "turn-1"))) == false)
+    }
+
     @Test func onlyValidatedAssistantOrReasoningActiveRowsStream() {
         let streamingAssistant = assistantMessage(id: "message-1", turn: "turn-1", text: "Partial")
         let validBlock = ChatDisplayActiveContentBlock(
@@ -190,6 +201,105 @@ struct ChatDisplayProjectionTests {
             title: "Notice",
             message: "Message",
             createdAt: .distantPast
+        ))
+    }
+}
+
+@MainActor
+struct ChatTranscriptRenderingInputTests {
+    @Test func failedReadOnlyToolCallSurvivesTheRendererBridgeWithErrorSemantics() {
+        let input = renderingInput(for: .toolCall(.init(
+            toolCallID: ToolCallID(rawValue: "tool-read"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            toolName: "Read",
+            status: .failed,
+            detail: "permission denied",
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )))
+
+        #expect(input.events == [.toolResult(isError: true, summary: "permission denied")])
+        #expect(input.events.transcriptVisible == input.events)
+        let html = ChatWebView.Coordinator.chatRowHTML(for: input.events[0])
+        #expect(html.isEmpty == false)
+        #expect(html.contains("is-error"))
+        #expect(html.contains("permission denied"))
+    }
+
+    @Test func completedToolCallUsesTerminalSuccessSemanticsAndRemainsFiltered() {
+        let input = renderingInput(for: .toolCall(.init(
+            toolCallID: ToolCallID(rawValue: "tool-write"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            toolName: "Write",
+            status: .completed,
+            detail: "updated page.md",
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )))
+
+        #expect(input.events == [.toolResult(isError: false, summary: "updated page.md")])
+        #expect(input.events.transcriptVisible.isEmpty)
+        #expect(ChatWebView.Coordinator.chatRowHTML(for: input.events[0]).isEmpty)
+    }
+
+    @Test func cancelledToolCallUsesTerminalErrorSemantics() {
+        let input = renderingInput(for: .toolCall(.init(
+            toolCallID: ToolCallID(rawValue: "tool-cancelled"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            toolName: "Write",
+            status: .cancelled,
+            detail: nil,
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )))
+
+        #expect(input.events == [.toolResult(isError: true, summary: "Write")])
+        #expect(input.events.transcriptVisible == input.events)
+    }
+
+    @Test func pendingAndRunningToolCallsRemainVisibleProgressRows() {
+        let pending = renderingInput(for: toolCall(status: .pending))
+        let running = renderingInput(for: toolCall(status: .running))
+
+        #expect(pending.events == [.toolUse(name: "Edit", inputSummary: "page.md")])
+        #expect(running.events == [.toolUse(name: "Edit", inputSummary: "page.md")])
+        #expect(pending.events.transcriptVisible == pending.events)
+        #expect(running.events.transcriptVisible == running.events)
+    }
+
+    @Test func noticeRemainsVisibleAndRenderableAtTheRendererBoundary() {
+        let input = renderingInput(for: .systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: "notice-1"),
+            turnID: nil,
+            kind: .session,
+            title: "Context updated",
+            message: "The agent resumed the session.",
+            createdAt: .distantPast
+        )))
+
+        #expect(input.events == [.assistantText("Context updated\n\nThe agent resumed the session.")])
+        #expect(input.events.transcriptVisible == input.events)
+        let html = ChatWebView.Coordinator.chatRowHTML(for: input.events[0])
+        #expect(html.isEmpty == false)
+        #expect(html.contains("Context updated"))
+        #expect(html.contains("The agent resumed the session."))
+    }
+
+    private func renderingInput(for item: ChatTranscriptItem) -> ChatTranscriptRenderingInput {
+        ChatTranscriptRenderingInput(
+            transcript: ChatDisplayProjection.project(items: [item], activeContentBlock: nil).transcript
+        )
+    }
+
+    private func toolCall(status: ChatToolCallStatus) -> ChatTranscriptItem {
+        .toolCall(.init(
+            toolCallID: ToolCallID(rawValue: "tool-edit"),
+            turnID: ChatTurnID(rawValue: "turn-1"),
+            toolName: "Edit",
+            status: status,
+            detail: "page.md",
+            permissionRequestID: nil,
+            updatedAt: .distantPast
         ))
     }
 }

--- a/Tests/WikiFSAppTests/ChatDisplayProjectionTests.swift
+++ b/Tests/WikiFSAppTests/ChatDisplayProjectionTests.swift
@@ -1,0 +1,196 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSEngine
+import WikiFSTypes
+@testable import WikiFS
+
+struct ChatDisplayProjectionTests {
+    @Test func preservesDurableRowIdentityAndGlobalOrder() {
+        let rows = [
+            userMessage(id: "message-1", turn: "turn-1", text: "Question"),
+            toolCall(id: "tool-1", turn: "turn-1"),
+            assistantMessage(id: "message-2", turn: "turn-1", text: "Answer"),
+            notice(id: "notice-1", turn: nil),
+            userMessage(id: "message-3", turn: "turn-2", text: "Next question"),
+        ]
+
+        let result = ChatDisplayProjection.project(items: rows, activeContentBlock: nil)
+
+        #expect(result.transcript.rows.map(\.id) == [
+            .message(ChatMessageID(rawValue: "message-1")),
+            .toolCall(ToolCallID(rawValue: "tool-1")),
+            .message(ChatMessageID(rawValue: "message-2")),
+            .notice(ChatTranscriptNoticeID(rawValue: "notice-1")),
+            .message(ChatMessageID(rawValue: "message-3")),
+        ])
+        #expect(result.anomalies.isEmpty)
+    }
+
+    @Test func preservesNoticesOutsideTurnsAsDeterministicUnattributedSections() throws {
+        let before = notice(id: "notice-before", turn: nil)
+        let between = notice(id: "notice-between", turn: nil)
+        let result = ChatDisplayProjection.project(items: [
+            before,
+            userMessage(id: "message-1", turn: "turn-1", text: "Question"),
+            between,
+            userMessage(id: "message-2", turn: "turn-2", text: "Next question"),
+        ], activeContentBlock: nil)
+
+        let first = try #require(result.transcript.sections.first)
+        let middle = try #require(result.transcript.sections.dropFirst(2).first)
+        #expect(first.id == .unattributed(rows: [.notice(ChatTranscriptNoticeID(rawValue: "notice-before"))]))
+        #expect(middle.id == .unattributed(rows: [.notice(ChatTranscriptNoticeID(rawValue: "notice-between"))]))
+    }
+
+    @Test func pagedTurnWithoutPromptKeepsItsRows() throws {
+        let result = ChatDisplayProjection.project(items: [
+            assistantMessage(id: "message-1", turn: "turn-1", text: "Earlier page answer"),
+        ], activeContentBlock: nil)
+
+        let section = try #require(result.transcript.sections.first)
+        guard case .turn(let turn) = section else {
+            Issue.record("Expected a turn section.")
+            return
+        }
+        #expect(turn.prompt == nil)
+        #expect(turn.rows.map(\.id) == [.message(ChatMessageID(rawValue: "message-1"))])
+    }
+
+    @Test func noncontiguousTurnStartsAnotherSectionAndReportsTypedAnomaly() {
+        let result = ChatDisplayProjection.project(items: [
+            userMessage(id: "message-1", turn: "turn-1", text: "Question"),
+            userMessage(id: "message-2", turn: "turn-2", text: "Other question"),
+            assistantMessage(id: "message-3", turn: "turn-1", text: "Late answer"),
+        ], activeContentBlock: nil)
+
+        #expect(result.transcript.sections.count == 3)
+        #expect(result.anomalies.contains(.noncontiguousTurn(turnID: ChatTurnID(rawValue: "turn-1"))))
+    }
+
+    @Test func onlyValidatedAssistantOrReasoningActiveRowsStream() {
+        let streamingAssistant = assistantMessage(id: "message-1", turn: "turn-1", text: "Partial")
+        let validBlock = ChatDisplayActiveContentBlock(
+            validating: .init(
+                messageID: ChatMessageID(rawValue: "message-1"),
+                turnID: ChatTurnID(rawValue: "turn-1"),
+                role: .assistant
+            ),
+            among: [streamingAssistant]
+        )
+        let orphanedBlock = ChatDisplayActiveContentBlock(
+            validating: .init(
+                messageID: ChatMessageID(rawValue: "missing"),
+                turnID: ChatTurnID(rawValue: "turn-1"),
+                role: .assistant
+            ),
+            among: [streamingAssistant]
+        )
+        let malformedBlock = ChatDisplayActiveContentBlock(
+            validating: .init(
+                messageID: ChatMessageID(rawValue: "message-1"),
+                turnID: ChatTurnID(rawValue: "turn-1"),
+                role: .user
+            ),
+            among: [streamingAssistant]
+        )
+
+        let streaming = ChatDisplayProjection.project(items: [streamingAssistant], activeContentBlock: validBlock)
+        let final = ChatDisplayProjection.project(items: [streamingAssistant], activeContentBlock: orphanedBlock)
+
+        #expect(streaming.transcript.rows.first?.contentState == .streaming)
+        #expect(final.transcript.rows.first?.contentState == .final)
+        #expect(orphanedBlock == nil)
+        #expect(malformedBlock == nil)
+    }
+
+    @Test func duplicateInputIdentityIsRetainedAndReported() {
+        let duplicate = notice(id: "notice-1", turn: nil)
+        let result = ChatDisplayProjection.project(items: [duplicate, duplicate], activeContentBlock: nil)
+
+        #expect(result.transcript.rows.map(\.id) == [
+            .notice(ChatTranscriptNoticeID(rawValue: "notice-1")),
+            .notice(ChatTranscriptNoticeID(rawValue: "notice-1")),
+        ])
+        #expect(result.anomalies.contains(.duplicateInputRowID(.notice(ChatTranscriptNoticeID(rawValue: "notice-1")))))
+    }
+
+    @Test func permissionResolutionIntentUsesNamespacedOptionID() {
+        let optionID = PermissionOptionID(rawValue: "allow-once")
+        let intent = ChatPermissionResolutionIntent.approve(optionID: optionID)
+
+        #expect(intent.optionID == optionID)
+        #expect(intent.isApproval)
+    }
+
+    @Test func failuresRetainTheirTypedCategoryAndOutlineUsesDurableTarget() throws {
+        let turnID = ChatTurnID(rawValue: "turn-1")
+        let result = ChatDisplayProjection.project(items: [
+            userMessage(id: "message-1", turn: turnID.rawValue, text: "Question"),
+            assistantMessage(id: "message-2", turn: turnID.rawValue, text: "Answer"),
+            .turnFailure(.init(
+                failureID: ChatTranscriptFailureID(rawValue: "failure-1"),
+                turnID: turnID,
+                category: .transportError,
+                message: "Connection lost",
+                createdAt: .distantPast
+            )),
+        ], activeContentBlock: nil)
+
+        let failure = try #require(result.transcript.rows.last)
+        guard case .failure(_, _, let category, _, _) = failure else {
+            Issue.record("Expected a failure row.")
+            return
+        }
+        let outline = ChatDetailPresentation.buildOutlineEntries(displayTranscript: result.transcript)
+        #expect(category == .transportError)
+        #expect(outline.first?.id == .turn(
+            turnID: turnID,
+            promptRowID: .message(ChatMessageID(rawValue: "message-1"))
+        ))
+    }
+
+    private func userMessage(id: String, turn: String, text: String) -> ChatTranscriptItem {
+        .message(.init(
+            messageID: ChatMessageID(rawValue: id),
+            turnID: ChatTurnID(rawValue: turn),
+            role: .user,
+            text: text,
+            createdAt: .distantPast
+        ))
+    }
+
+    private func assistantMessage(id: String, turn: String, text: String) -> ChatTranscriptItem {
+        .message(.init(
+            messageID: ChatMessageID(rawValue: id),
+            turnID: ChatTurnID(rawValue: turn),
+            role: .assistant,
+            text: text,
+            createdAt: .distantPast
+        ))
+    }
+
+    private func toolCall(id: String, turn: String) -> ChatTranscriptItem {
+        .toolCall(.init(
+            toolCallID: ToolCallID(rawValue: id),
+            turnID: ChatTurnID(rawValue: turn),
+            toolName: "read",
+            status: .completed,
+            detail: nil,
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        ))
+    }
+
+    private func notice(id: String, turn: String?) -> ChatTranscriptItem {
+        .systemNotice(.init(
+            noticeID: ChatTranscriptNoticeID(rawValue: id),
+            turnID: turn.map(ChatTurnID.init(rawValue:)),
+            kind: .session,
+            title: "Notice",
+            message: "Message",
+            createdAt: .distantPast
+        ))
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
+++ b/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
@@ -1,0 +1,50 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+
+struct ChatPresentationAPIManifestTests {
+    @Test func presentationContractCannotRegressToEventsOrTimestampArrays() throws {
+        let presentation = try source(named: "ChatDetailPresentation.swift")
+        let sync = try source(named: "ChatClientSync.swift", directory: "Sources/WikiFSEngine")
+        let remoteSession = try source(named: "RemoteChatSession.swift")
+
+        #expect(presentation.contains("AgentEvent") == false)
+        #expect(presentation.contains("displayEvents") == false)
+        #expect(presentation.contains("eventTimestamps") == false)
+        #expect(sync.contains("displayEvents") == false)
+        #expect(sync.contains("displayEventTimestamps") == false)
+        #expect(remoteSession.contains("var events:") == false)
+        #expect(remoteSession.contains("var eventTimestamps:") == false)
+        #expect(remoteSession.contains("var isRunning:") == false)
+        #expect(remoteSession.contains("var isGenerating:") == false)
+        #expect(remoteSession.contains("var isAwaitingGenerationSlot:") == false)
+        #expect(remoteSession.contains("var isInteractiveSession:") == false)
+        #expect(remoteSession.contains("var activeChatID:") == false)
+    }
+
+    @Test func projectionAndPermissionBoundaryUseTypedIDsAndIntent() throws {
+        let projection = try source(named: "ChatDisplayProjection.swift")
+        let pane = try source(named: "ChatTranscriptPaneView.swift")
+
+        #expect(projection.contains("enum ChatDisplayRowID") == true)
+        #expect(projection.contains("case message(ChatMessageID)") == true)
+        #expect(projection.contains("case toolCall(ToolCallID)") == true)
+        #expect(projection.contains("case notice(ChatTranscriptNoticeID)") == true)
+        #expect(projection.contains("case failure(ChatTranscriptFailureID)") == true)
+        #expect(projection.contains("enum ChatPermissionResolutionIntent") == true)
+        #expect(pane.contains("(String, Bool)") == false)
+    }
+
+    private func source(named file: String, directory: String = "Sources/WikiFS/Chats") throws -> String {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: repositoryRoot.appending(path: directory).appending(path: file),
+            encoding: .utf8
+        )
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
+++ b/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
@@ -23,6 +23,15 @@ struct ChatPresentationAPIManifestTests {
         #expect(remoteSession.contains("var activeChatID:") == false)
     }
 
+    @Test func rendererCompatibilityAdapterRemainsTheOnlyPresentationAgentEventBoundary() throws {
+        let projection = try source(named: "ChatDisplayProjection.swift")
+        let rendererAdapter = try source(named: "ChatTranscriptView.swift")
+
+        #expect(projection.contains("AgentEvent") == false)
+        #expect(rendererAdapter.contains("struct ChatTranscriptRenderingInput"))
+        #expect(rendererAdapter.contains("AgentEvent"))
+    }
+
     @Test func projectionAndPermissionBoundaryUseTypedIDsAndIntent() throws {
         let projection = try source(named: "ChatDisplayProjection.swift")
         let pane = try source(named: "ChatTranscriptPaneView.swift")

--- a/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
+++ b/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
@@ -23,13 +23,23 @@ struct ChatPresentationAPIManifestTests {
         #expect(remoteSession.contains("var activeChatID:") == false)
     }
 
-    @Test func rendererCompatibilityAdapterRemainsTheOnlyPresentationAgentEventBoundary() throws {
-        let projection = try source(named: "ChatDisplayProjection.swift")
+    @Test func onlyAllowlistedCompatibilityAdaptersMayExposeAgentEventRows() throws {
+        let displaySources = [
+            try source(named: "ChatDetailPresentation.swift"),
+            try source(named: "ChatDetailView.swift"),
+            try source(named: "ChatDisplayProjection.swift"),
+            try source(named: "ChatTranscriptPaneView.swift"),
+        ]
         let rendererAdapter = try source(named: "ChatTranscriptView.swift")
+        let remoteSession = try source(named: "RemoteChatSession.swift")
 
-        #expect(projection.contains("AgentEvent") == false)
+        #expect(displaySources.allSatisfy { $0.contains("AgentEvent") == false })
         #expect(rendererAdapter.contains("struct ChatTranscriptRenderingInput"))
         #expect(rendererAdapter.contains("AgentEvent"))
+        // The queue/activity surface intentionally adapts legacy agent rows;
+        // it is not part of the display transcript API.
+        #expect(remoteSession.contains("activityFeedEvents"))
+        #expect(remoteSession.contains("AgentEvent"))
     }
 
     @Test func projectionAndPermissionBoundaryUseTypedIDsAndIntent() throws {

--- a/Tests/WikiFSAppTests/ChatViewD2Tests.swift
+++ b/Tests/WikiFSAppTests/ChatViewD2Tests.swift
@@ -316,9 +316,7 @@ struct ChatViewD2Tests {
     @Test func canSendPredicateTrueWithDraftTextAndIdleAgent() {
         #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
-            canType: true,
-            isGenerating: false,
-            isAwaitingSlot: false,
+            runState: .idle,
             hasDraftText: true,
             isChatOperationConfigured: true) == true)
     }
@@ -328,9 +326,7 @@ struct ChatViewD2Tests {
     @Test func canSendPredicateTrueWithoutMount() {
         #expect(ChatDetailView.canSendPredicate(
             hasMount: false,
-            canType: true,
-            isGenerating: false,
-            isAwaitingSlot: false,
+            runState: .idle,
             hasDraftText: true,
             isChatOperationConfigured: true) == true)
     }
@@ -339,20 +335,17 @@ struct ChatViewD2Tests {
     @Test func canSendPredicateFalseWhileGenerating() {
         #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
-            canType: true,
-            isGenerating: true,
-            isAwaitingSlot: false,
+            runState: .answering,
             hasDraftText: true,
             isChatOperationConfigured: true) == false)
     }
 
-    /// `canSendPredicate` returns false when the composer is disabled.
-    @Test func canSendPredicateFalseWhenCannotType() {
+    /// `canSendPredicate` returns false while a turn is queued for the
+    /// generation gate.
+    @Test func canSendPredicateFalseWhileQueued() {
         #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
-            canType: false,
-            isGenerating: false,
-            isAwaitingSlot: false,
+            runState: .queued,
             hasDraftText: true,
             isChatOperationConfigured: true) == false)
     }
@@ -361,9 +354,7 @@ struct ChatViewD2Tests {
     @Test func canSendPredicateFalseWithNoDraftText() {
         #expect(ChatDetailView.canSendPredicate(
             hasMount: true,
-            canType: true,
-            isGenerating: false,
-            isAwaitingSlot: false,
+            runState: .idle,
             hasDraftText: false,
             isChatOperationConfigured: true) == false)
     }

--- a/Tests/WikiFSAppTests/Issue235IngestExtractionLockTests.swift
+++ b/Tests/WikiFSAppTests/Issue235IngestExtractionLockTests.swift
@@ -66,8 +66,8 @@ struct Issue235IngestExtractionLockTests {
         // The core #235 UI fix: waiting for the generation gate shows VISIBLE
         // text (was previously only a hidden .help() tooltip).
         let caption = ChatDetailView.composerCaptionText(
-            isAwaitingGenerationSlot: true,
-            hasChatID: true, isLiveChat: true, isGenerating: false,
+            runState: .queued,
+            hasChatID: true, isLiveChat: true,
             isChatOperationConfigured: true)
         #expect(caption == "Waiting for the other session to finish before sending…")
     }
@@ -75,16 +75,16 @@ struct Issue235IngestExtractionLockTests {
     @Test func captionVisibleWhenAwaitingSlotDraftState() {
         // Even in draft state (chatID == nil), the waiting caption shows.
         let caption = ChatDetailView.composerCaptionText(
-            isAwaitingGenerationSlot: true,
-            hasChatID: false, isLiveChat: false, isGenerating: false,
+            runState: .queued,
+            hasChatID: false, isLiveChat: false,
             isChatOperationConfigured: true)
         #expect(caption == "Waiting for the other session to finish before sending…")
     }
 
     @Test func captionNilWhenIdle() {
         let caption = ChatDetailView.composerCaptionText(
-            isAwaitingGenerationSlot: false,
-            hasChatID: true, isLiveChat: true, isGenerating: false,
+            runState: .idle,
+            hasChatID: true, isLiveChat: true,
             isChatOperationConfigured: true)
         #expect(caption == nil)
     }
@@ -93,8 +93,8 @@ struct Issue235IngestExtractionLockTests {
         // A persisted (non-live) chat whose launcher is generating a different
         // chat shows the "Another chat is responding" caption.
         let caption = ChatDetailView.composerCaptionText(
-            isAwaitingGenerationSlot: false,
-            hasChatID: true, isLiveChat: false, isGenerating: true,
+            runState: .answering,
+            hasChatID: true, isLiveChat: false,
             isChatOperationConfigured: true)
         #expect(caption == "Another chat is responding — wait or stop it.")
     }
@@ -103,18 +103,18 @@ struct Issue235IngestExtractionLockTests {
         // A live chat that is actively generating shows a subtle "Agent is
         // responding…" caption (replaces the old orange banner).
         let caption = ChatDetailView.composerCaptionText(
-            isAwaitingGenerationSlot: false,
-            hasChatID: true, isLiveChat: true, isGenerating: true,
+            runState: .answering,
+            hasChatID: true, isLiveChat: true,
             isChatOperationConfigured: true)
         #expect(caption == "Agent is responding…")
     }
 
     @Test func awaitingSlotOverridesPersistedBusy() {
-        // When both isAwaitingGenerationSlot and isGenerating are true, the gate
-        // wait message takes priority (it's the more actionable state).
+        // Queued is its own state, so the gate wait message remains the most
+        // actionable outcome without contradictory Boolean inputs.
         let caption = ChatDetailView.composerCaptionText(
-            isAwaitingGenerationSlot: true,
-            hasChatID: true, isLiveChat: false, isGenerating: true,
+            runState: .queued,
+            hasChatID: true, isLiveChat: false,
             isChatOperationConfigured: true)
         #expect(caption == "Waiting for the other session to finish before sending…")
     }

--- a/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
+++ b/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
@@ -46,10 +46,10 @@ struct RemoteChatSessionTests {
             )
         ))
 
-        #expect(session.events == [.userText("question"), .assistantText("answer")])
-        #expect(session.isRunning)
-        #expect(session.isGenerating)
-        #expect(session.activeChatID == ChatID(rawValue: "chat-1"))
+        #expect(session.displayTranscript.rows.count == 2)
+        #expect(session.runState.isLive)
+        #expect(session.runState.isAnswering)
+        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
         #expect(session.runStartedAt?.timeIntervalSince1970 == 50)
         #expect(session.preflightError == "preflight")
         #expect(session.thinkingOption?.currentValue == "high")
@@ -93,9 +93,9 @@ struct RemoteChatSessionTests {
         )
         session.optimisticSubmit(submission)
 
-        #expect(session.events == [.userText("hello")])
+        #expect(session.displayTranscript.rows.count == 1)
         #expect(session.runState == .queued)
-        #expect(session.activeChatID == ChatID(rawValue: "chat-1"))
+        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
     }
 
     @Test func optimisticSubmitFailedPreservesAuthoritativeReadyLifecycle() {
@@ -114,10 +114,10 @@ struct RemoteChatSessionTests {
         )
         session.optimisticSubmitFailed(turnID: turnID)
 
-        #expect(session.events.isEmpty)
+        #expect(session.displayTranscript.rows.isEmpty)
         #expect(session.runState == .warm)
-        #expect(session.activeChatID == ChatID(rawValue: "chat-1"))
-        #expect(session.isRunning)
+        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
+        #expect(session.runState.isLive)
     }
 
     @Test func committedHistoryPagingUsesSuccessiveAfterCursorsUntilTargetReached() async {
@@ -310,7 +310,7 @@ struct RemoteChatSessionTests {
 
         await expectEventually((session.syncState?.committedItems.count ?? 0) == 1)
         let syncState = try #require(session.syncState)
-        #expect(session.events == [.userText("hello")])
+        #expect(session.displayTranscript.rows.count == 1)
         #expect(syncState.committedItems.count == 1)
         #expect(syncState.projection?.transcriptOverlay.isEmpty == true)
     }
@@ -318,13 +318,13 @@ struct RemoteChatSessionTests {
     @Test func markNotLiveRelinquishesLivenessClaim() {
         let session = makeSession()
         session.hydrate(from: makeSnapshot(lifecycle: .ready))
-        #expect(session.activeChatID == ChatID(rawValue: "chat-1"))
+        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
 
         session.markNotLive()
 
-        #expect(session.activeChatID == nil)
         #expect(session.runState == .idle)
-        #expect(!session.isRunning)
+        #expect(session.runState == .idle)
+        #expect(!session.runState.isLive)
     }
 
     @Test func resetClearsAllProjectedState() {
@@ -337,10 +337,10 @@ struct RemoteChatSessionTests {
 
         session.reset()
 
-        #expect(session.events.isEmpty)
+        #expect(session.displayTranscript.rows.isEmpty)
         #expect(session.preflightError == nil)
         #expect(session.runState == .idle)
-        #expect(session.activeChatID == nil)
+        #expect(session.runState == .idle)
     }
 
     @Test func resetCancelsPendingHistoryLoadBeforeStalePageApplies() async {

--- a/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
+++ b/Tests/WikiFSAppTests/RemoteChatSessionTests.swift
@@ -46,10 +46,13 @@ struct RemoteChatSessionTests {
             )
         ))
 
-        #expect(session.displayTranscript.rows.count == 2)
+        #expect(session.displayTranscript.rows.map(\.id) == [
+            .message(ChatMessageID(rawValue: "user-turn-1-question")),
+            .message(ChatMessageID(rawValue: "assistant-turn-1-answer")),
+        ])
+        #expect(session.displayTranscript.rows.map(\.textForSearch) == ["question", "answer"])
         #expect(session.runState.isLive)
         #expect(session.runState.isAnswering)
-        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
         #expect(session.runStartedAt?.timeIntervalSince1970 == 50)
         #expect(session.preflightError == "preflight")
         #expect(session.thinkingOption?.currentValue == "high")
@@ -93,9 +96,11 @@ struct RemoteChatSessionTests {
         )
         session.optimisticSubmit(submission)
 
-        #expect(session.displayTranscript.rows.count == 1)
+        #expect(session.displayTranscript.rows.map(\.id) == [
+            .message(ChatMessageID(rawValue: "optimistic-turn-1"))
+        ])
+        #expect(session.displayTranscript.rows.map(\.textForSearch) == ["hello"])
         #expect(session.runState == .queued)
-        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
     }
 
     @Test func optimisticSubmitFailedPreservesAuthoritativeReadyLifecycle() {
@@ -116,7 +121,6 @@ struct RemoteChatSessionTests {
 
         #expect(session.displayTranscript.rows.isEmpty)
         #expect(session.runState == .warm)
-        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
         #expect(session.runState.isLive)
     }
 
@@ -310,7 +314,10 @@ struct RemoteChatSessionTests {
 
         await expectEventually((session.syncState?.committedItems.count ?? 0) == 1)
         let syncState = try #require(session.syncState)
-        #expect(session.displayTranscript.rows.count == 1)
+        #expect(session.displayTranscript.rows.map(\.id) == [
+            .message(ChatMessageID(rawValue: "user-\(turnID.rawValue)-hello"))
+        ])
+        #expect(session.displayTranscript.rows.map(\.textForSearch) == ["hello"])
         #expect(syncState.committedItems.count == 1)
         #expect(syncState.projection?.transcriptOverlay.isEmpty == true)
     }
@@ -318,11 +325,8 @@ struct RemoteChatSessionTests {
     @Test func markNotLiveRelinquishesLivenessClaim() {
         let session = makeSession()
         session.hydrate(from: makeSnapshot(lifecycle: .ready))
-        #expect(session.chatID.chatID == ChatID(rawValue: "chat-1"))
-
         session.markNotLive()
 
-        #expect(session.runState == .idle)
         #expect(session.runState == .idle)
         #expect(!session.runState.isLive)
     }
@@ -340,7 +344,7 @@ struct RemoteChatSessionTests {
         #expect(session.displayTranscript.rows.isEmpty)
         #expect(session.preflightError == nil)
         #expect(session.runState == .idle)
-        #expect(session.runState == .idle)
+        #expect(session.pendingPermissions.isEmpty)
     }
 
     @Test func resetCancelsPendingHistoryLoadBeforeStalePageApplies() async {

--- a/Tests/WikiFSTests/Fixtures/ChatAPISignatures.txt
+++ b/Tests/WikiFSTests/Fixtures/ChatAPISignatures.txt
@@ -62,7 +62,7 @@ Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	    func stopChat(_ chatID: Cha
 Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	    func chatSessionState(_ chatID: ChatID) async throws -> ChatSyncSnapshot
 Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	public func submitTurn(_ request: ChatSubmitRequest) async throws -> ChatID
 Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	public func stop(chatID: ChatID) async {
-Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	public func resolvePermission(chatID: ChatID, optionId: String, approve: Bool) async {
+Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	func resolvePermission(chatID: ChatID, intent: ChatPermissionResolutionIntent) async {
 Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	public func setThinkingEffort(chatID: ChatID, value: String) async {
 Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	public func rehydrate(chatID: ChatID) async {
 Sources/WikiFS/Chats/ChatDaemonCoordinator.swift	public func session(for chatID: ChatID?) -> RemoteChatSession {

--- a/progress/2026-07-30T135649Z-chat-presentation-phase3.md
+++ b/progress/2026-07-30T135649Z-chat-presentation-phase3.md
@@ -39,43 +39,63 @@ terminal calls remain suppressed by the established transcript filter. Notices
 remain typed unattributed sections and cross the renderer boundary as visible
 assistant text.
 
-Persisted model summaries are again preferred for outline responses. The detail
-view derives a `ChatMessageID`-keyed lookup from persisted `ChatMessage.summary`
-metadata and passes it only to the non-live presentation path; outline fallback
-continues to use `ChatSummary.summaryExtract` when the cache is absent.
+Persisted model summaries are again preferred for outline responses, but now
+cross the real transcript boundary rather than an unrelated identifier
+namespace. `readChatTranscriptPage` joins the compatibility `chat_messages`
+row by its maintained `seq == cursor - 1` relationship and returns the cached
+summary with that transcript item. The presentation derives its lookup key from
+the same item's transcript `ChatMessageID`, never by converting the separately
+generated `chat_messages.id` `PageID`. A store round-trip test persists a
+distinctive model summary, verifies those two raw IDs differ and that
+`seq == cursor - 1`, reads the actual transcript page, and proves the outline
+uses the persisted summary rather than the 200-character extraction fallback.
+The write path rejects an out-of-sync legacy compatibility projection instead
+of silently creating an offset that could misattach a summary.
 
 The noncontiguous-turn anomaly now compares a reopened turn against the most
 recently closed turn, so a notice splitting one turn is not anomalous, while a
 turn that reappears after a different turn still is. Direct renderer-boundary
 tests cover failed read-only, completed, cancelled, pending/running tool calls
 and visible notices. The API manifest explicitly permits `AgentEvent` only in
-the final `ChatTranscriptRenderingInput` compatibility adapter.
+the final `ChatTranscriptRenderingInput` compatibility adapter and the
+intentional `RemoteChatSession.activityFeedEvents` queue/activity adapter; it
+continues to reject `AgentEvent` from display-facing sources. Remote session
+tests again assert displayed row identities, content, and order instead of
+only row counts, with duplicate idle and vacuous chat-ID assertions removed.
 
 ## Verification
 
+Passed `swift package clean && WIKIFS_APP_TESTS=1 swift test --filter
+'ChatDetailPresentationTests.persistedOutlineUsesModelSummaryReturnedByTranscriptPage'`:
+the new clean-build store-to-transcript-to-outline round-trip test. Log:
+`tmp/phase3-summary-roundtrip-final.log`.
+
 Passed `WIKIFS_APP_TESTS=1 swift test --filter
-'ChatDisplayProjectionTests|ChatTranscriptRenderingInputTests|ChatDetailPresentationTests|ChatPresentationAPIManifestTests|ChatTranscriptFilterTests'`:
-44 tests in 5 suites. Log:
-`tmp/phase3-corrective-focused.log`.
+'ChatDetailPresentationTests|RemoteChatSessionTests|ChatPresentationAPIManifestTests|ChatDisplayProjectionTests'`:
+40 tests in 5 suites. This includes the new store round-trip presentation test,
+the restored RemoteChatSession assertions, and the narrowed manifest guard.
+Log: `tmp/phase3-summary-wiring-focused-final.log`.
 
 Ran the required full hosted command, `WIKIFS_APP_TESTS=1 swift test`, with
 `HostedAppKitTestGate` enabled. It passed multiple hosted suites, including
 `PageDetailViewHostedTests` and `YouTubeEmbedWebViewTests`, then stopped making
-progress after starting `QuoteHighlightWebViewTests.coordinatorAppliesQuoteHighlightOnceLoaded`.
+progress in the autocomplete-hosted test wave (the final log's last start line
+was truncated as `Test debouncedQu`).
 After more than 90 seconds with the Swift test helper still live and no new log
 output, the locally started test process was terminated. This is a concrete
 hosted-environment limitation, not an inapplicability claim. Full-run log:
-`tmp/phase3-corrective-hosted-app-gate.log`.
+`tmp/phase3-summary-wiring-full-app-final.log`.
 
 Passed the targeted hosted gate command, `WIKIFS_APP_TESTS=1 swift test --filter
 PageDetailViewHostedTests`: 2 tests in 1 suite. It mounts real AppKit/WebKit
 views under `HostedAppKitTestGate`. Log:
-`tmp/phase3-corrective-hosted-gate-targeted.log`.
+`tmp/phase3-summary-wiring-hosted-gate-final.log`.
 
-Passed `make test`: 2,712 tests in 218 suites.
+Passed `make test`: 2,712 tests in 218 suites. Log:
+`tmp/phase3-summary-wiring-make-test-final.log`.
 
 Passed `make build` after the final source edits; it produced a signed local
-`Self Driving Wiki.app` with the File Provider enabled.
+`Self Driving Wiki.app` with the File Provider enabled. Log:
+`tmp/phase3-summary-wiring-make-build-final.log`.
 
-`git diff --check` passed before the final documentation update and is rerun
-immediately before commit.
+`git diff --check` passed after the final documentation update.

--- a/progress/2026-07-30T135649Z-chat-presentation-phase3.md
+++ b/progress/2026-07-30T135649Z-chat-presentation-phase3.md
@@ -1,0 +1,45 @@
+---
+timestamp: 2026-07-30T13:56:49Z
+title: Chat presentation Phase 3 typed app projection
+branch: chat-presentation-diagnostics-phase3
+status: complete
+---
+
+# Chat presentation Phase 3 typed app projection
+
+## Progress
+
+Added app-only typed display rows, sections, turns, unattributed sections, and
+namespaced row identities. `ChatDisplayProjection` consumes reconciled typed
+transcript items and validated active-block metadata. It preserves input order
+and row identities, keeps paged turns promptless, reports duplicate and
+noncontiguous-turn anomalies, and rejects malformed or orphaned active blocks.
+
+Migrated the app chat surface from `AgentEvent` and parallel timestamps to the
+typed display transcript. The WebKit renderer is now an adapter from typed rows
+at the final rendering boundary. Queue/activity-feed compatibility remains
+separate from chat presentation.
+
+Replaced RemoteChatSession launcher-era presentation booleans with
+`ChatRunState` at app call sites. Outline entries now use durable turn and row
+identities. Permission callbacks carry `ChatPermissionResolutionIntent` and
+`PermissionOptionID`; raw option text and approval Boolean are constructed only
+for the XPC request.
+
+## Verification
+
+Passed `WIKIFS_APP_TESTS=1 swift test --filter
+'ChatDisplayProjectionTests|ChatPresentationAPIManifestTests|ChatDetailPresentationTests|RemoteChatSessionTests|ChatDaemonCoordinatorTests|Issue235IngestExtractionLockTests|ChatViewD2Tests'`:
+71 tests in 7 suites.
+
+Passed `make test`: 2,712 tests in 218 suites.
+
+Passed `make build` after the final source edits; it produced a signed local
+`Self Driving Wiki.app` with the File Provider enabled.
+
+Passed `git diff --check` after the final source edits.
+
+The hosted AppKit/WebKit gate did not run. This slice changes the typed
+presentation contract and the renderer input adapter, not hosted interaction or
+visual behavior; the applicable app target compiled and the projection/adapter
+contracts are covered by the focused app-target suites.

--- a/progress/2026-07-30T135649Z-chat-presentation-phase3.md
+++ b/progress/2026-07-30T135649Z-chat-presentation-phase3.md
@@ -13,7 +13,8 @@ Added app-only typed display rows, sections, turns, unattributed sections, and
 namespaced row identities. `ChatDisplayProjection` consumes reconciled typed
 transcript items and validated active-block metadata. It preserves input order
 and row identities, keeps paged turns promptless, reports duplicate and
-noncontiguous-turn anomalies, and rejects malformed or orphaned active blocks.
+noncontiguous-turn anomalies only after another turn intervenes, and rejects
+malformed or orphaned active blocks.
 
 Migrated the app chat surface from `AgentEvent` and parallel timestamps to the
 typed display transcript. The WebKit renderer is now an adapter from typed rows
@@ -26,20 +27,55 @@ identities. Permission callbacks carry `ChatPermissionResolutionIntent` and
 `PermissionOptionID`; raw option text and approval Boolean are constructed only
 for the XPC request.
 
+## Audit corrections
+
+The exact-head audit found that the final renderer adapter discarded tool-call
+status and converted system notices to filtered raw events. The adapter now
+mirrors the existing compatibility projection: pending/running calls use
+tool-use events; completed calls use non-error tool results; failed/cancelled
+calls use error tool results. Consequently, a failed read-only `Read`/`Bash`/
+`Glob`/`Grep` call reaches the renderer with error semantics while successful
+terminal calls remain suppressed by the established transcript filter. Notices
+remain typed unattributed sections and cross the renderer boundary as visible
+assistant text.
+
+Persisted model summaries are again preferred for outline responses. The detail
+view derives a `ChatMessageID`-keyed lookup from persisted `ChatMessage.summary`
+metadata and passes it only to the non-live presentation path; outline fallback
+continues to use `ChatSummary.summaryExtract` when the cache is absent.
+
+The noncontiguous-turn anomaly now compares a reopened turn against the most
+recently closed turn, so a notice splitting one turn is not anomalous, while a
+turn that reappears after a different turn still is. Direct renderer-boundary
+tests cover failed read-only, completed, cancelled, pending/running tool calls
+and visible notices. The API manifest explicitly permits `AgentEvent` only in
+the final `ChatTranscriptRenderingInput` compatibility adapter.
+
 ## Verification
 
 Passed `WIKIFS_APP_TESTS=1 swift test --filter
-'ChatDisplayProjectionTests|ChatPresentationAPIManifestTests|ChatDetailPresentationTests|RemoteChatSessionTests|ChatDaemonCoordinatorTests|Issue235IngestExtractionLockTests|ChatViewD2Tests'`:
-71 tests in 7 suites.
+'ChatDisplayProjectionTests|ChatTranscriptRenderingInputTests|ChatDetailPresentationTests|ChatPresentationAPIManifestTests|ChatTranscriptFilterTests'`:
+44 tests in 5 suites. Log:
+`tmp/phase3-corrective-focused.log`.
+
+Ran the required full hosted command, `WIKIFS_APP_TESTS=1 swift test`, with
+`HostedAppKitTestGate` enabled. It passed multiple hosted suites, including
+`PageDetailViewHostedTests` and `YouTubeEmbedWebViewTests`, then stopped making
+progress after starting `QuoteHighlightWebViewTests.coordinatorAppliesQuoteHighlightOnceLoaded`.
+After more than 90 seconds with the Swift test helper still live and no new log
+output, the locally started test process was terminated. This is a concrete
+hosted-environment limitation, not an inapplicability claim. Full-run log:
+`tmp/phase3-corrective-hosted-app-gate.log`.
+
+Passed the targeted hosted gate command, `WIKIFS_APP_TESTS=1 swift test --filter
+PageDetailViewHostedTests`: 2 tests in 1 suite. It mounts real AppKit/WebKit
+views under `HostedAppKitTestGate`. Log:
+`tmp/phase3-corrective-hosted-gate-targeted.log`.
 
 Passed `make test`: 2,712 tests in 218 suites.
 
 Passed `make build` after the final source edits; it produced a signed local
 `Self Driving Wiki.app` with the File Provider enabled.
 
-Passed `git diff --check` after the final source edits.
-
-The hosted AppKit/WebKit gate did not run. This slice changes the typed
-presentation contract and the renderer input adapter, not hosted interaction or
-visual behavior; the applicable app target compiled and the projection/adapter
-contracts are covered by the focused app-target suites.
+`git diff --check` passed before the final documentation update and is rerun
+immediately before commit.


### PR DESCRIPTION
## Phase 3: typed chat presentation projection

Implements Phase 3 of `plans/chat-presentation-and-diagnostics.md` only.

- Adds app-only typed display rows, sections, stable row IDs, pure projection, active-block validation, and projection anomalies.
- Migrates the app chat surface and outline to typed transcript sections; keeps the legacy WebKit event conversion at the final renderer boundary only.
- Replaces RemoteChatSession lifecycle presentation booleans with `ChatRunState` app callers.
- Replaces raw permission callback pairs with `ChatPermissionResolutionIntent` and `PermissionOptionID`.
- Adds projection and API-manifest coverage plus a dated progress record.

Verification:

- `WIKIFS_APP_TESTS=1 swift test --filter 'ChatDisplayProjectionTests|ChatPresentationAPIManifestTests|ChatDetailPresentationTests|RemoteChatSessionTests|ChatDaemonCoordinatorTests|Issue235IngestExtractionLockTests|ChatViewD2Tests'` — 71 tests in 7 suites passed.
- `make build` — passed; signed local app built with File Provider enabled.
- `make test` — 2,712 tests in 218 suites passed.
- `git diff --check` — passed.

Hosted AppKit/WebKit was not run: this slice changes the presentation contract and renderer adapter, not hosted interaction or visual behavior.
