### PR TITLE
Add native typed chat transcript presentation

### DIFF
--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -254,24 +254,34 @@ struct ChatDetailView: View {
 
     private var transcriptContent: some View {
         ChatTranscriptPaneView(
-            chatID: chatID,
-            transcript: presentation.transcript,
-            preflightBannerMessage: presentation.preflightBannerMessage,
-            livePendingPermission: presentation.livePendingPermission,
-            showsThinkingIndicator: presentation.showsThinkingIndicator,
-            runStartedAt: remoteSession.runStartedAt,
-            store: store,
-            chatZoom: chatZoom,
-            outlineScroll: outlineScroll,
-            quoteAnchor: quoteAnchor,
-            hideToolCalls: hideToolCalls
-        ) { intent in
+            presentation: ChatTranscriptPanePresentation(
+                chatID: chatID,
+                transcript: presentation.transcript,
+                preflightBannerMessage: presentation.preflightBannerMessage,
+                livePendingPermission: presentation.livePendingPermission,
+                showsThinkingIndicator: presentation.showsThinkingIndicator,
+                runStartedAt: remoteSession.runStartedAt,
+                chatZoom: chatZoom,
+                outlineScroll: outlineScroll,
+                quoteAnchor: quoteAnchor,
+                hideToolCalls: hideToolCalls
+            ),
+            renderer: ChatTranscriptRendererEnvironment(
+                renderContext: { [weak store] in store?.renderContext() },
+                blobStore: store
+            ),
+            onIntent: handleTranscriptIntent
+        )
+    }
+
+    private func handleTranscriptIntent(_ intent: ChatTranscriptIntent) {
+        switch intent {
+        case .openWikiLink(let url, let inNewTab):
+            WikiReaderView.onWikiLinkHandler(for: store)(url, inNewTab)
+        case .resolvePermission(let resolution):
             guard let chatID else { return }
             Task {
-                await coordinator.resolvePermission(
-                    chatID: chatID,
-                    intent: intent
-                )
+                await coordinator.resolvePermission(chatID: chatID, intent: resolution)
             }
         }
     }

--- a/Sources/WikiFS/Chats/ChatTranscriptFollowState.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptFollowState.swift
@@ -1,0 +1,44 @@
+// pattern: Functional Core
+
+import Foundation
+
+/// The transcript's local follow policy. It deliberately has no view or WebKit
+/// dependency so scrolling behavior can be characterized without a hosted view.
+enum ChatTranscriptFollowState: Equatable, Sendable {
+    /// New streaming content may move the viewport only while the reader is at
+    /// the end of the transcript.
+    case following
+    /// The reader intentionally moved away from the end. Content may update,
+    /// but it must not move selection, focus, or the reading anchor.
+    case readingHistory
+
+    enum Event: Equatable, Sendable {
+        case viewportChanged(distanceFromBottom: Double)
+        case transcriptReset
+    }
+
+    static func reducing(_ state: Self, event: Event) -> Self {
+        switch event {
+        case .transcriptReset:
+            .following
+        case .viewportChanged(let distanceFromBottom):
+            distanceFromBottom <= ChatTranscriptFollowMetrics.nearBottomDistance
+                ? .following
+                : .readingHistory
+        }
+    }
+
+    var followsStreamingContent: Bool {
+        self == .following
+    }
+}
+
+enum ChatTranscriptFollowMetrics {
+    /// Points from the bottom that still count as following. Named here rather
+    /// than repeated in JavaScript and Swift so tuning has one semantic owner.
+    static let nearBottomDistance = 72.0
+}
+
+enum ChatTranscriptPresentationMetrics {
+    static let reasoningPreviewLength = 80
+}

--- a/Sources/WikiFS/Chats/ChatTranscriptPaneView.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptPaneView.swift
@@ -5,54 +5,45 @@ import WikiFSCore
 import WikiFSEngine
 
 struct ChatTranscriptPaneView: View {
-    let chatID: ChatID?
-    let transcript: ChatDetailPresentation.Transcript
-    let preflightBannerMessage: String?
-    let livePendingPermission: PendingPermission?
-    let showsThinkingIndicator: Bool
-    let runStartedAt: Date?
-    let store: WikiStoreModel
-    let chatZoom: Double
-    let outlineScroll: ChatScrollRequest?
-    let quoteAnchor: ChatHighlightRequest?
-    let hideToolCalls: Bool
-    let onResolvePermission: (ChatPermissionResolutionIntent) -> Void
+    let presentation: ChatTranscriptPanePresentation
+    let renderer: ChatTranscriptRendererEnvironment
+    let onIntent: (ChatTranscriptIntent) -> Void
 
     var body: some View {
-        let rendererInput = ChatTranscriptRenderingInput(transcript: transcript.displayTranscript)
+        let rendererInput = ChatTranscriptRenderingInput(transcript: presentation.transcript.displayTranscript)
         VStack(spacing: 0) {
-            if let preflightBannerMessage {
+            if let preflightBannerMessage = presentation.preflightBannerMessage {
                 preflightBanner(preflightBannerMessage)
                     .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
-                    .padding(.top, chatID != nil ? ChatMetrics.sectionSpacing / 2 : ChatMetrics.chatTopInset)
+                    .padding(.top, presentation.chatID != nil ? ChatMetrics.sectionSpacing / 2 : ChatMetrics.chatTopInset)
                     .padding(.bottom, ChatMetrics.sectionSpacing / 2)
             }
             ChatTranscriptView(
                 rendering: rendererInput,
-                transcriptID: chatID.map(TranscriptID.chat),
-                emptyStateMessage: transcript.emptyStateMessage,
-                isStreaming: transcript.isAnswering,
-                onWikiLink: WikiReaderView.onWikiLinkHandler(for: store),
-                renderContext: { [weak store] in store?.renderContext() },
-                blobStore: store,
-                zoom: chatZoom,
-                scrollRequest: rendererInput.webScrollRequest(for: outlineScroll),
-                quoteAnchor: quoteAnchor,
-                hideToolCalls: hideToolCalls
+                transcriptID: presentation.chatID.map(TranscriptID.chat),
+                emptyStateMessage: presentation.transcript.emptyStateMessage,
+                isStreaming: presentation.transcript.isAnswering,
+                onIntent: onIntent,
+                renderContext: renderer.renderContext,
+                blobStore: renderer.blobStore,
+                zoom: presentation.chatZoom,
+                scrollRequest: rendererInput.webScrollRequest(for: presentation.outlineScroll),
+                quoteAnchor: presentation.quoteAnchor,
+                hideToolCalls: presentation.hideToolCalls
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
-            .padding(.top, preflightBannerMessage == nil
-                ? (chatID != nil ? 0 : ChatMetrics.chatTopInset)
+            .padding(.top, presentation.preflightBannerMessage == nil
+                ? (presentation.chatID != nil ? 0 : ChatMetrics.chatTopInset)
                 : 0)
-            if showsThinkingIndicator {
+            if presentation.showsThinkingIndicator {
                 thinkingIndicator
                     .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                     .padding(.bottom, ChatMetrics.sectionSpacing / 2)
             }
-            if let livePendingPermission {
+            if let livePendingPermission = presentation.livePendingPermission {
                 PermissionApprovalView(permission: livePendingPermission) { intent in
-                    onResolvePermission(intent)
+                    onIntent(.resolvePermission(intent))
                 }
                 .padding(.horizontal, PageEditorMetrics.contentInset + ChatMetrics.extraHorizontalMargin)
                 .padding(.bottom, ChatMetrics.sectionSpacing / 2)
@@ -65,7 +56,7 @@ struct ChatTranscriptPaneView: View {
             HStack(spacing: 8) {
                 ProgressView()
                     .controlSize(.small)
-                if let runStartedAt {
+                if let runStartedAt = presentation.runStartedAt {
                     Text("Thinking… \(durationString(context.date.timeIntervalSince(runStartedAt)))")
                         .font(.callout)
                         .foregroundStyle(.secondary)
@@ -122,4 +113,28 @@ struct ChatTranscriptPaneView: View {
         }
         .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
+}
+
+/// Immutable values for the native transcript pane. The composition root builds
+/// this once from display state, so the pane cannot query daemon or store state
+/// while SwiftUI evaluates its body.
+struct ChatTranscriptPanePresentation {
+    let chatID: ChatID?
+    let transcript: ChatDetailPresentation.Transcript
+    let preflightBannerMessage: String?
+    let livePendingPermission: PendingPermission?
+    let showsThinkingIndicator: Bool
+    let runStartedAt: Date?
+    let chatZoom: Double
+    let outlineScroll: ChatScrollRequest?
+    let quoteAnchor: ChatHighlightRequest?
+    let hideToolCalls: Bool
+}
+
+/// Renderer dependencies prepared by `ChatDetailView`. This shell contains no
+/// persistence or daemon operations; it merely carries the already-authorized
+/// values required by the single WebKit surface.
+struct ChatTranscriptRendererEnvironment {
+    let renderContext: () -> WikiRenderContext?
+    let blobStore: WikiStoreModel?
 }

--- a/Sources/WikiFS/Chats/ChatTranscriptView.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptView.swift
@@ -1,78 +1,40 @@
+// pattern: Imperative Shell
+
 import SwiftUI
 import WikiFSCore
 
-/// The reusable chat transcript renderer. Its input is a single renderer-only
-/// bridge from the typed app presentation model, not an app event contract.
+/// The reusable, typed chat transcript renderer. The chat path carries only
+/// `ChatDisplayRow` values; the separate activity feed retains its legacy
+/// event adapter at its own boundary in `ChatWebView`.
 struct ChatTranscriptView: View {
     let rendering: ChatTranscriptRenderingInput
-    /// Identity of the conversation `events` belongs to, forwarded to
-    /// `ChatWebView` so its incremental differ rebuilds instead of splicing
-    /// when this view is reused for a different chat (see
-    /// `ChatWebView.transcriptID`). `nil` for the draft composer, which never
-    /// reaches the web view (it renders the empty-state placeholder).
     var transcriptID: TranscriptID? = nil
-    /// Idle/fallback empty-state message. Overridden by "Waiting for the
-    /// Agent…" while `isStreaming` (the live streaming case).
     var emptyStateMessage: String
-    /// True while a live session is streaming into this transcript. Shows the
-    /// "Waiting for the Agent…" placeholder and the streaming hint; the
-    /// persisted surface passes `false` (it is never the active stream).
     var isStreaming: Bool = false
-    /// Forwards wiki-link clicks in the transcript to the detail column. Built
-    /// where the store lives (the parent `ChatDetailView`) and forwarded unchanged to
-    /// the transcript web view.
-    var onWikiLink: ((URL, Bool) -> Void)? = nil
-    /// Provider of the current `WikiRenderContext` (Phase A.2) — bound to
-    /// `store.renderContext()` by `ChatDetailView`, so chat rows render source
-    /// references exactly as the reader does. Forwarded unchanged to the
-    /// transcript web view.
+    var onIntent: (ChatTranscriptIntent) -> Void
     var renderContext: (() -> WikiRenderContext?)? = nil
-    /// The store backing `wiki-blob://` blob serving for the transcript's
-    /// images/media. Forwarded to the transcript web view.
     var blobStore: WikiStoreModel? = nil
-    /// Page-zoom multiplier forwarded to the transcript web view. Bound to the
-    /// `chat.zoom` AppStorage by the chat surface.
     var zoom: Double = Double(ZoomScale.defaultScale)
-    /// Versioned scroll-to-turn request, forwarded to the transcript web view.
     var scrollRequest: ChatWebScrollRequest? = nil
-    /// Versioned quote-anchor highlight request (`[[chat:Title#"quote"]]`,
-    /// issue #281), forwarded to the transcript web view.
     var quoteAnchor: ChatHighlightRequest? = nil
-    /// When true, tool-call rows are filtered from the transcript (issue #381).
     var hideToolCalls: Bool = false
 
     var body: some View {
-        // Mirror the hideToolCalls filter on both events and timestamps so
-        // they stay parallel. When hideToolCalls is on, remove tool-call
-        // events and their corresponding timestamps.
-        let transcriptIndices = rendering.events.transcriptVisibleIndices
-        let transcriptEvents = transcriptIndices.map { rendering.events[$0] }
-        let transcriptTimestamps = transcriptIndices.map { index in
-            index < rendering.timestamps.count ? rendering.timestamps[index] : nil
-        }
-        let visibleEvents = hideToolCalls ? transcriptEvents.filter { !$0.isToolCall } : transcriptEvents
-        let visibleTimestamps = hideToolCalls
-            ? transcriptEvents.indices.compactMap { idx -> Date? in
-                guard !transcriptEvents[idx].isToolCall else { return nil }
-                return idx < transcriptTimestamps.count ? transcriptTimestamps[idx] : nil
-            }
-            : transcriptTimestamps
-        return Group {
-            if visibleEvents.isEmpty {
+        let visibleRows = rendering.visibleRows(hidingToolCalls: hideToolCalls)
+        Group {
+            if visibleRows.isEmpty {
                 placeholder
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             } else {
                 ChatWebView(
-                    events: visibleEvents,
-                    style: .chat,
+                    chatRows: visibleRows,
                     transcriptID: transcriptID,
-                    onWikiLink: onWikiLink,
+                    onChatIntent: onIntent,
                     renderContext: renderContext,
                     blobStore: blobStore,
                     zoom: zoom,
                     scrollRequest: scrollRequest,
-                    quoteAnchor: quoteAnchor,
-                    timestamps: visibleTimestamps
+                    quoteAnchor: quoteAnchor
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
@@ -80,16 +42,12 @@ struct ChatTranscriptView: View {
     }
 
     private var placeholder: some View {
-        VStack(spacing: 7) {
-            Text(isStreaming ? "Waiting for the Agent..." : emptyStateMessage)
-                .font(.headline)
-                .fontWeight(.medium)
+        VStack(spacing: ChatTranscriptMetrics.placeholderSpacing) {
+            Text(isStreaming ? "Waiting for the Agent…" : emptyStateMessage)
+                .font(.headline.weight(.medium))
                 .foregroundStyle(.primary)
-            // The streaming hint only applies while the agent is actively
-            // working this transcript; a persisted (read-only) empty state shows
-            // just its message.
             if isStreaming {
-                Text("Answers appear here; one-line tool-call summaries show as the agent works. Full detail is available under “Show internals.”")
+                Text("Answers appear here as separate blocks. Tool activity stays attached to the turn that produced it.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
@@ -101,72 +59,39 @@ struct ChatTranscriptView: View {
 
 private enum ChatTranscriptMetrics {
     static let emptyStatePadding: CGFloat = 24
+    static let placeholderSpacing: CGFloat = 7
 }
 
-/// Narrow renderer bridge retained until Phase 4 replaces the existing WebKit
-/// event renderer. Presentation state never stores these compatibility events
-/// or exposes a timestamp-array API.
-struct ChatTranscriptRenderingInput {
+/// A typed UI intent emitted by the transcript. `ChatDetailView` owns the
+/// authority required to resolve it; neither this view nor its pane reaches
+/// into the store or daemon on its own.
+enum ChatTranscriptIntent {
+    case openWikiLink(URL, inNewTab: Bool)
+    case resolvePermission(ChatPermissionResolutionIntent)
+}
+
+/// Narrow renderer bridge over the typed Phase 3 display projection. It keeps
+/// the renderer boundary explicit without converting the app transcript back
+/// into event arrays or parallel timestamp arrays.
+struct ChatTranscriptRenderingInput: Hashable, Sendable {
     let rows: [ChatDisplayRow]
-    let events: [AgentEvent]
-    let timestamps: [Date?]
 
     init(transcript: ChatDisplayTranscript) {
-        self.rows = transcript.rows
-        self.events = rows.map(Self.event)
-        self.timestamps = rows.map { $0.timestamp }
+        rows = transcript.rows
+    }
+
+    func visibleRows(hidingToolCalls: Bool) -> [ChatDisplayRow] {
+        hidingToolCalls ? rows.filter { row in
+            if case .toolCall = row { return false }
+            return true
+        } : rows
     }
 
     func webScrollRequest(for request: ChatScrollRequest?) -> ChatWebScrollRequest? {
         guard let request,
               case .turn(_, let promptRowID) = request.target,
-              let rowIndex = rows.firstIndex(where: { $0.id == promptRowID }) else {
-            return nil
-        }
-        let turnIndex = rows[..<rowIndex].reduce(into: 0) { count, row in
-            if row.isPrompt { count += 1 }
-        }
-        return ChatWebScrollRequest(version: request.version, turnIndex: turnIndex)
-    }
-
-    private static func event(for row: ChatDisplayRow) -> AgentEvent {
-        switch row {
-        case .userMessage(_, _, let text, _):
-            .userText(text)
-        case .assistantMessage(_, _, let text, _, _):
-            .assistantText(text)
-        case .reasoning(_, _, let text, _, _):
-            .thinking(text)
-        case .toolCall(_, _, let toolName, let status, let detail, _, _):
-            switch status {
-            case .pending, .running:
-                .toolUse(name: toolName, inputSummary: detail ?? "")
-            case .completed:
-                .toolResult(isError: false, summary: detail ?? toolName)
-            case .failed, .cancelled:
-                .toolResult(isError: true, summary: detail ?? toolName)
-            }
-        case .notice(_, _, _, let title, let message, _):
-            .assistantText("\(title)\n\n\(message)")
-        case .failure(_, _, _, let message, _):
-            .turnFailed(reason: .agentError(message))
-        }
-    }
-}
-
-extension [AgentEvent] {
-    /// The indices of transcript-visible events (same filtering rule as
-    /// `transcriptVisible`). Returned so callers that carry parallel arrays
-    /// (timestamps, etc.) can filter them in lockstep without duplicating the
-    /// predicate.
-    var transcriptVisibleIndices: [Int] {
-        indices.filter { self[$0].isVisibleInTranscript(in: self) }
-    }
-
-    /// The transcript-visible subset shared by the live chat surface and the
-    /// read-only chat-history view, so a persisted chat re-renders
-    /// exactly like it looked live.
-    var transcriptVisible: [AgentEvent] {
-        transcriptVisibleIndices.map { self[$0] }
+              let prompt = rows.first(where: { $0.id == promptRowID })
+        else { return nil }
+        return ChatWebScrollRequest(version: request.version, rowID: prompt.id)
     }
 }

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -4,6 +4,32 @@ import SwiftUI
 import WebKit
 import WikiFSCore
 
+private extension ChatDisplayRowID {
+    /// Prefixes make the DOM namespace explicit even where raw durable IDs
+    /// happen to share the same string representation.
+    var domValue: String {
+        switch self {
+        case .message(let id): "message-\(id.rawValue)"
+        case .toolCall(let id): "tool-\(id.rawValue)"
+        case .notice(let id): "notice-\(id.rawValue)"
+        case .failure(let id): "failure-\(id.rawValue)"
+        }
+    }
+}
+
+/// Compatibility filtering belongs to the legacy activity-feed renderer, not
+/// the typed chat transcript adapter. Retaining it here preserves the separate
+/// activity/history surface without letting chat presentation use event arrays.
+extension [AgentEvent] {
+    var transcriptVisibleIndices: [Int] {
+        indices.filter { self[$0].isVisibleInTranscript(in: self) }
+    }
+
+    var transcriptVisible: [AgentEvent] {
+        transcriptVisibleIndices.map { self[$0] }
+    }
+}
+
 /// Renders an entire `AgentEvent` transcript as **one** native text surface
 /// inside a single, internally-scrolling `WKWebView` — so mouse drag-selection
 /// (and Cmd+A / copy) spans every row in the feed, not just one message.
@@ -26,11 +52,11 @@ import WikiFSCore
 ///
 /// A versioned request to scroll the chat transcript to a user turn. Mirrors the
 /// reader's anchor-version pattern: `version` bumps to signal a new request;
-/// `turnIndex` is the 0-based index among the `.chat-user` rows the transcript
-/// renders. Consumed in `ChatWebView.updateNSView`.
+/// `rowID` targets the durable prompt row without deriving identity from a
+/// rendered index. Consumed in `ChatWebView.updateNSView`.
 struct ChatWebScrollRequest: Equatable {
     let version: Int
-    let turnIndex: Int
+    let rowID: ChatDisplayRowID
 }
 
 /// A versioned request to highlight a quoted passage in the chat transcript and
@@ -70,7 +96,10 @@ struct ChatWebView: NSViewRepresentable {
         case chat
     }
 
+    /// The legacy activity-feed input. Chat transcripts use `chatRows` so the
+    /// presentation layer does not discard durable row identity.
     let events: [AgentEvent]
+    let chatRows: [ChatDisplayRow]?
     let style: VisualStyle
     /// Identity of the transcript these `events` belong to (a chat ULID, a
     /// queue item id, …). The coordinator renders **incrementally** — it
@@ -138,12 +167,66 @@ struct ChatWebView: NSViewRepresentable {
     /// row. Empty array (default) → no footers at all (activity-feed callers
     /// that don't track timing are unaffected).
     var timestamps: [Date?] = []
+    /// Typed UI callback used only by the chat transcript. The activity-feed
+    /// API retains its existing raw navigation closure for compatibility.
+    var onChatIntent: ((ChatTranscriptIntent) -> Void)? = nil
 
     /// Name of the `WKScriptMessage` channel the per-bubble "Copy" button posts
     /// to (issue #285). The JS click listener calls
     /// `window.webkit.messageHandlers.copyText.postMessage(text)`; the coordinator
     /// writes `text` to `NSPasteboard`.
     static let copyMessageName = "copyText"
+    static let followMessageName = "chatFollowState"
+
+    init(
+        events: [AgentEvent],
+        style: VisualStyle,
+        transcriptID: TranscriptID? = nil,
+        showsInternals: Bool = false,
+        onWikiLink: ((URL, Bool) -> Void)? = nil,
+        renderContext: (() -> WikiRenderContext?)? = nil,
+        blobStore: WikiStoreModel? = nil,
+        zoom: Double = Double(ZoomScale.defaultScale),
+        scrollRequest: ChatWebScrollRequest? = nil,
+        quoteAnchor: ChatHighlightRequest? = nil,
+        timestamps: [Date?] = []
+    ) {
+        self.events = events
+        self.chatRows = nil
+        self.style = style
+        self.transcriptID = transcriptID
+        self.showsInternals = showsInternals
+        self.onWikiLink = onWikiLink
+        self.renderContext = renderContext
+        self.blobStore = blobStore
+        self.zoom = zoom
+        self.scrollRequest = scrollRequest
+        self.quoteAnchor = quoteAnchor
+        self.timestamps = timestamps
+    }
+
+    init(
+        chatRows: [ChatDisplayRow],
+        transcriptID: TranscriptID?,
+        onChatIntent: @escaping (ChatTranscriptIntent) -> Void,
+        renderContext: (() -> WikiRenderContext?)? = nil,
+        blobStore: WikiStoreModel? = nil,
+        zoom: Double = Double(ZoomScale.defaultScale),
+        scrollRequest: ChatWebScrollRequest? = nil,
+        quoteAnchor: ChatHighlightRequest? = nil
+    ) {
+        self.events = []
+        self.chatRows = chatRows
+        self.style = .chat
+        self.transcriptID = transcriptID
+        self.onWikiLink = nil
+        self.renderContext = renderContext
+        self.blobStore = blobStore
+        self.zoom = zoom
+        self.scrollRequest = scrollRequest
+        self.quoteAnchor = quoteAnchor
+        self.onChatIntent = onChatIntent
+    }
 
     func makeNSView(context: Context) -> WKWebView {
         // Register the blob scheme handler BEFORE the first load (same wiring
@@ -158,6 +241,7 @@ struct ChatWebView: NSViewRepresentable {
         // WikiReaderView's LinkHoverMessageHandler).
         let cc = WKUserContentController()
         cc.add(context.coordinator, name: Self.copyMessageName)
+        cc.add(context.coordinator, name: Self.followMessageName)
         config.userContentController = cc
         let blobHandler = BlobSchemeHandler(store: blobStore)
         config.setURLSchemeHandler(blobHandler, forURLScheme: BlobSchemeHandler.scheme)
@@ -170,9 +254,14 @@ struct ChatWebView: NSViewRepresentable {
         context.coordinator.webView = webView
         context.coordinator.style = style
         context.coordinator.onWikiLink = onWikiLink
+        context.coordinator.onChatIntent = onChatIntent
         context.coordinator.renderContext = renderContext
-        context.coordinator.reload(events: events, showsInternals: showsInternals,
-                                   timestamps: timestamps, transcriptID: transcriptID)
+        if let chatRows {
+            context.coordinator.reload(chatRows: chatRows, transcriptID: transcriptID)
+        } else {
+            context.coordinator.reload(events: events, showsInternals: showsInternals,
+                                       timestamps: timestamps, transcriptID: transcriptID)
+        }
         return webView
     }
 
@@ -180,18 +269,24 @@ struct ChatWebView: NSViewRepresentable {
         webView.pageZoom = zoom
         context.coordinator.style = style
         context.coordinator.onWikiLink = onWikiLink
+        context.coordinator.onChatIntent = onChatIntent
         context.coordinator.renderContext = renderContext
         // Keep the blob handler's store fresh (a wiki switch swaps the store).
         if let handler = webView.configuration.urlSchemeHandler(forURLScheme: BlobSchemeHandler.scheme) as? BlobSchemeHandler {
             handler.store = blobStore
         }
-        context.coordinator.apply(events: events, showsInternals: showsInternals,
-                                  timestamps: timestamps, transcriptID: transcriptID)
+        if let chatRows {
+            context.coordinator.apply(chatRows: chatRows, transcriptID: transcriptID)
+        } else {
+            context.coordinator.apply(events: events, showsInternals: showsInternals,
+                                      timestamps: timestamps, transcriptID: transcriptID)
+        }
         // Outline click → scroll the i-th user bubble into view. Only fires when
         // the version advances, so unrelated re-renders (streaming) don't re-scroll.
         if let req = scrollRequest, req.version != context.coordinator.appliedScrollVersion {
             context.coordinator.appliedScrollVersion = req.version
-            let js = "(function(){var u=document.querySelectorAll('.chat-user');var el=u[\(req.turnIndex)];if(el){el.scrollIntoView({block:'start'});}})()"
+            let rowID = ChatWebView.Coordinator.jsEscape(req.rowID.domValue)
+            let js = "(function(){var el=document.querySelector('[data-row-id=\\\"\(rowID)\\\"]');if(el){el.scrollIntoView({block:'start'});}})()"
             webView.evaluateJavaScript(js, completionHandler: nil)
         }
         // Quote-anchor highlight (issue #281): stash the latest quote and ask
@@ -213,6 +308,7 @@ struct ChatWebView: NSViewRepresentable {
         /// Routes a clicked `wiki://` link out to the view's `onWikiLink`
         /// closure (built where the store lives). Refreshed each update.
         var onWikiLink: ((URL, Bool) -> Void)?
+        var onChatIntent: ((ChatTranscriptIntent) -> Void)?
         /// Provider of the current `WikiRenderContext` (Phase A.2). Refreshed
         /// each update. Resolved to a value once per render pass (see
         /// `currentContext`); the value is `Sendable` so it can flow into the
@@ -253,6 +349,10 @@ struct ChatWebView: NSViewRepresentable {
         /// non-final only when it is the LAST row of a still-live event stream —
         /// i.e. it may still grow via `replaceLastRow`). Captured in `apply`.
         private var renderedEvents: [AgentEvent] = []
+        private var renderedChatRows: [ChatDisplayRow] = []
+        private var pendingChatRows: [ChatDisplayRow] = []
+        private var rendersTypedChatRows = false
+        private var followState: ChatTranscriptFollowState = .following
 
         /// Resolve the provider once per render pass on the main actor. Returns
         /// the current `WikiRenderContext` (or nil → constant-true behavior).
@@ -283,6 +383,7 @@ struct ChatWebView: NSViewRepresentable {
 
         func reload(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = [],
                     transcriptID: TranscriptID? = nil) {
+            rendersTypedChatRows = false
             renderedCount = 0
             renderedShowsInternals = showsInternals
             renderedTranscriptID = transcriptID
@@ -293,6 +394,51 @@ struct ChatWebView: NSViewRepresentable {
             pendingEvents = events
             pendingTimestamps = timestamps
             webView?.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
+        }
+
+        /// Chat-only presentation path. This stays intentionally direct: it
+        /// compares the current typed rows with the existing document and calls
+        /// the document's existing append/replace helpers directly.
+        func reload(chatRows: [ChatDisplayRow], transcriptID: TranscriptID?) {
+            rendersTypedChatRows = true
+            renderedCount = 0
+            renderedShowsInternals = false
+            renderedTranscriptID = transcriptID
+            renderedChatRows = []
+            pendingChatRows = chatRows
+            renderedEvents = []
+            renderedLastEvent = nil
+            followState = ChatTranscriptFollowState.reducing(followState, event: .transcriptReset)
+            isLoaded = false
+            webView?.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
+        }
+
+        func apply(chatRows: [ChatDisplayRow], transcriptID: TranscriptID?) {
+            guard rendersTypedChatRows else {
+                reload(chatRows: chatRows, transcriptID: transcriptID)
+                return
+            }
+            guard transcriptID == renderedTranscriptID,
+                  chatRows.count >= renderedChatRows.count,
+                  zip(chatRows, renderedChatRows).allSatisfy({ $0.0.id == $0.1.id })
+            else {
+                reload(chatRows: chatRows, transcriptID: transcriptID)
+                return
+            }
+            guard isLoaded else {
+                pendingChatRows = chatRows
+                return
+            }
+
+            let existingCount = renderedChatRows.count
+            for index in 0..<existingCount where chatRows[index] != renderedChatRows[index] {
+                replaceChatRow(chatRows[index], context: currentContext())
+            }
+            if chatRows.count > existingCount {
+                appendChatRows(Array(chatRows[existingCount...]), context: currentContext())
+            }
+            renderedChatRows = chatRows
+            renderedCount = chatRows.count
         }
 
         func apply(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = [],
@@ -369,6 +515,19 @@ struct ChatWebView: NSViewRepresentable {
             isLoaded = true
             // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8.
             DebugLog.chatLive("8.web.didFinish pending=\(pendingEvents.count)")
+            if rendersTypedChatRows {
+                let toRender = pendingChatRows
+                pendingChatRows = []
+                if !toRender.isEmpty {
+                    appendChatRows(toRender, context: currentContext())
+                }
+                renderedChatRows = toRender
+                renderedCount = toRender.count
+                if pendingHighlightQuote != nil {
+                    applyHighlight()
+                }
+                return
+            }
             let toRender = pendingEvents
             pendingEvents = []
             pendingTimestamps = []
@@ -417,7 +576,11 @@ struct ChatWebView: NSViewRepresentable {
                 if url.scheme == "wiki" {
                     // ⌘-click opens a new tab; plain click navigates in place.
                     let openInNewTab = navigationAction.modifierFlags.contains(.command)
-                    onWikiLink?(url, openInNewTab)
+                    if let onChatIntent {
+                        onChatIntent(.openWikiLink(url, inNewTab: openInNewTab))
+                    } else {
+                        onWikiLink?(url, openInNewTab)
+                    }
                     decisionHandler(.cancel)
                     return
                 }
@@ -469,6 +632,35 @@ struct ChatWebView: NSViewRepresentable {
             webView?.evaluateJavaScript("replaceLastRow(\(jsonString))", completionHandler: nil)
         }
 
+        private func appendChatRows(_ rows: [ChatDisplayRow], context: WikiRenderContext?) {
+            let html = rows.map { Self.chatDisplayRowHTML($0, context: context) }.joined()
+            guard !html.isEmpty,
+                  let jsonString = Self.jsonString(for: html)
+            else { return }
+            let follows = followState.followsStreamingContent ? "true" : "false"
+            webView?.evaluateJavaScript("appendRows(\(jsonString), \(follows))", completionHandler: nil)
+        }
+
+        /// Replace one semantic chat row in the existing one-document surface.
+        /// The JavaScript routine retains an in-row focus target and selection
+        /// offsets, so changing a streaming block or tool status does not turn a
+        /// reader's current interaction into a new focus destination.
+        private func replaceChatRow(_ row: ChatDisplayRow, context: WikiRenderContext?) {
+            let html = Self.chatDisplayRowHTML(row, context: context)
+            guard let rowID = Self.jsonString(for: row.id.domValue),
+                  let rowHTML = Self.jsonString(for: html)
+            else { return }
+            let follows = followState.followsStreamingContent ? "true" : "false"
+            webView?.evaluateJavaScript("replaceChatRow(\(rowID), \(rowHTML), \(follows))", completionHandler: nil)
+        }
+
+        private static func jsonString(for value: String) -> String? {
+            guard let data = DebugLog.trying("serialize chat row", operation: {
+                try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed])
+            }) else { return nil }
+            return String(data: data, encoding: .utf8)
+        }
+
         // MARK: - Copy button (issue #285)
 
         /// Receives the raw markdown text from the JS click listener and writes it
@@ -479,7 +671,17 @@ struct ChatWebView: NSViewRepresentable {
         ) {
             guard message.name == ChatWebView.copyMessageName,
                   let text = message.body as? String
-            else { return }
+            else {
+                if message.name == ChatWebView.followMessageName,
+                   let body = message.body as? [String: Any],
+                   let distance = body["distanceFromBottom"] as? Double {
+                    followState = ChatTranscriptFollowState.reducing(
+                        followState,
+                        event: .viewportChanged(distanceFromBottom: distance)
+                    )
+                }
+                return
+            }
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             pasteboard.setString(text, forType: .string)
@@ -563,6 +765,78 @@ struct ChatWebView: NSViewRepresentable {
                 return turnFailedBannerHTML(reason: reason)
             case .raw(let line):
                 return "<pre class=\"row row-raw\">\(escape(line))</pre>"
+            }
+        }
+
+        /// Direct typed chat markup used by the Phase 4 transcript surface.
+        /// Every durable row becomes one semantic DOM element with a stable
+        /// attribute; that attribute is presentation metadata, not a rendering
+        /// command protocol.
+        static func chatDisplayRowHTML(_ row: ChatDisplayRow, context: WikiRenderContext? = nil) -> String {
+            let rowID = htmlAttributeEscape(row.id.domValue)
+            let turnAttribute = row.turnID.map { " data-turn-id=\"\(htmlAttributeEscape($0.rawValue))\"" } ?? ""
+            let attributes = " data-row-id=\"\(rowID)\"\(turnAttribute)"
+
+            switch row {
+            case .userMessage(_, _, let text, _):
+                return """
+                <article class="row chat-row chat-user" role="article" aria-label="Your message"\(attributes)>
+                <div class="bubble">\(renderedMarkdown(text, context: context))</div></article>
+                """
+
+            case .assistantMessage(_, _, let text, let createdAt, let contentState):
+                let stateLabel = contentState == .streaming ? "Streaming response" : "Assistant response"
+                let status = contentState == .streaming ? "Streaming" : "Completed"
+                let timestamp = formatTimestamp(createdAt)
+                return """
+                <article class="row chat-row chat-assistant\(contentState == .streaming ? " is-streaming" : "")" role="article" aria-label="\(stateLabel)" aria-busy="\(contentState == .streaming ? "true" : "false")"\(attributes)>
+                <div class="bubble">\(renderedMarkdown(text, context: context, isFinal: contentState == .final))</div>
+                <div class="turn-footer"><span class="row-status" aria-label="\(status)">\(contentState == .streaming ? "◌ Streaming" : "✓ Completed")</span><button class="copy-btn" type="button" data-copy="\(htmlAttributeEscape(text))" data-focus-key="copy" aria-label="Copy assistant response" title="Copy assistant response">\(Self.copyIconSVG)</button><span class="turn-meta" aria-label="Completed \(escape(timestamp))"><span class="turn-timestamp">\(escape(timestamp))</span></span></div>
+                </article>
+                """
+
+            case .reasoning(_, _, let text, _, let contentState):
+                let state = contentState == .streaming ? "streaming" : "completed"
+                let preview = String(text.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false).first ?? "")
+                let previewShort = preview.count > ChatTranscriptPresentationMetrics.reasoningPreviewLength
+                    ? String(preview.prefix(ChatTranscriptPresentationMetrics.reasoningPreviewLength)) + "…"
+                    : preview
+                return """
+                <details class="row chat-row row-thinking collapsible\(contentState == .streaming ? " is-streaming" : "")" role="group" aria-label="Reasoning, \(state)"\(attributes)>
+                <summary data-focus-key="disclosure" aria-label="Show reasoning, \(state)"><span class="row-status" aria-hidden="true">\(contentState == .streaming ? "◌" : "✓")</span> <span class="row-thinking-label">Reasoning</span> <span class="row-thinking-preview">\(escape(previewShort))</span></summary>
+                <div class="row-thinking-body">\(renderedMarkdown(text, context: context, isFinal: contentState == .final))</div></details>
+                """
+
+            case .toolCall(_, _, let toolName, let status, let detail, _, _):
+                let statusText = toolStatusLabel(status)
+                let isError = status == .failed || status == .cancelled
+                let detailText = detail ?? ""
+                let cue = isError ? "⚠" : (status == .running || status == .pending ? "◌" : "✓")
+                return """
+                <details class="row chat-row chat-tool\(isError ? " is-error" : "")\((status == .running || status == .pending) ? " is-running" : "")" role="group" aria-label="Tool \(escape(toolName)), \(statusText)"\(attributes)>
+                <summary data-focus-key="disclosure" aria-label="Show tool details for \(escape(toolName)), \(statusText)"><span class="row-status" aria-hidden="true">\(cue)</span> <span class="chat-tool-name">\(escape(toolName))</span><span class="chat-tool-summary">\(escape(statusText))\(detailText.isEmpty ? "" : " — \(escape(detailText.split(separator: "\n", maxSplits: 1).first.map(String.init) ?? ""))")</span></summary>
+                \(detailText.isEmpty ? "" : "<pre class=\"chat-tool-detail\">\(escape(detailText))</pre>")</details>
+                """
+
+            case .notice(_, _, _, let title, let message, _):
+                return """
+                <aside class="row chat-notice" role="status" aria-label="Notice: \(escape(title))"\(attributes)><span class="row-status" aria-hidden="true">ⓘ</span><div><strong>\(escape(title))</strong><div>\(renderedMarkdown(message, context: context))</div></div></aside>
+                """
+
+            case .failure(_, _, _, let message, _):
+                return """
+                <aside class="row row-turn-failed" role="alert" aria-label="Chat action failed"\(attributes)><span class="row-turn-failed-icon" aria-hidden="true">⚠︎</span><div class="row-turn-failed-body"><strong>Chat action failed</strong> \(escape(message))</div></aside>
+                """
+            }
+        }
+
+        private static func toolStatusLabel(_ status: ChatToolCallStatus) -> String {
+            switch status {
+            case .pending: "Pending"
+            case .running: "Running"
+            case .completed: "Completed"
+            case .failed: "Failed"
+            case .cancelled: "Cancelled"
             }
         }
 
@@ -819,7 +1093,7 @@ struct ChatWebView: NSViewRepresentable {
 
         /// Escape a string for safe embedding in a double-quoted JS string
         /// literal. Mirrors `WikiReaderRep.jsString`.
-        private static func jsEscape(_ s: String) -> String {
+        static func jsEscape(_ s: String) -> String {
             s.replacingOccurrences(of: "\\", with: "\\\\")
              .replacingOccurrences(of: "\"", with: "\\\"")
              .replacingOccurrences(of: "\n", with: "\\n")
@@ -863,7 +1137,7 @@ struct ChatWebView: NSViewRepresentable {
           html, body { margin: 0; padding: 0; background: transparent; }
           body {
             font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-            font-size: 13px; line-height: 1.5; color: var(--text);
+            font-size: 13px; line-height: 1.55; color: var(--text);
             /* Right-side padding keeps content clear of the WebView's scrollbar
                so the right margin matches the left (which has no scrollbar). */
             padding: 10px 12px 10px 0; -webkit-font-smoothing: antialiased;
@@ -873,6 +1147,14 @@ struct ChatWebView: NSViewRepresentable {
             overflow-wrap: break-word; word-wrap: break-word;
           }
           .row { margin: 0 0 8px; }
+          article.row, aside.row { max-width: 72ch; }
+          .row-status { font-variant-numeric: tabular-nums; font-size: 11px; }
+          .is-streaming .row-status, .is-running .row-status { font-weight: 600; }
+          .chat-notice {
+            display: flex; gap: 7px; align-items: first baseline; padding: 8px 10px;
+            background: var(--code-bg); border-left: 3px solid var(--border);
+            border-radius: 6px; color: var(--text); font-size: 12px;
+          }
           .row-label { font-size: 11px; font-weight: 600; color: var(--muted); margin-bottom: 2px; }
           .row-body { white-space: pre-wrap; }
           .row-meta, .row-tool, .row-tool-result, .row-subagent {
@@ -956,6 +1238,7 @@ struct ChatWebView: NSViewRepresentable {
             color: var(--muted);
           }
           .chat-assistant:hover .copy-btn { opacity: 0.55; }
+          .chat-assistant:focus-within .copy-btn { opacity: 1; }
           .copy-btn:hover { opacity: 1; color: var(--text); background: var(--code-bg); }
           .copy-btn.copied { opacity: 1; color: #34c759; }
           .copy-btn svg { display: block; }
@@ -1034,12 +1317,29 @@ struct ChatWebView: NSViewRepresentable {
             margin: 0 0 0.6em; padding: 0 0 0 0.8em;
             border-left: 3px solid var(--border); color: var(--muted);
           }
+          .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+          }
+          @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
+          }
         </style>
         </head><body>
         <script>
-          function appendRows(html) {
+          function isNearBottom() {
+            return Math.max(0, document.documentElement.scrollHeight - (window.scrollY + window.innerHeight)) <= 72;
+          }
+          function reportFollowState() {
+            try {
+              window.webkit.messageHandlers.chatFollowState.postMessage({distanceFromBottom: Math.max(0, document.documentElement.scrollHeight - (window.scrollY + window.innerHeight))});
+            } catch (err) { }
+          }
+          function appendRows(html, shouldFollow) {
+            var wasNearBottom = isNearBottom();
             document.body.insertAdjacentHTML('beforeend', html);
-            window.scrollTo(0, document.body.scrollHeight);
+            if (shouldFollow && wasNearBottom) window.scrollTo(0, document.body.scrollHeight);
+            reportFollowState();
           }
           function replaceLastRow(html) {
             if (document.body.lastElementChild) {
@@ -1049,6 +1349,55 @@ struct ChatWebView: NSViewRepresentable {
             }
             window.scrollTo(0, document.body.scrollHeight);
           }
+          function selectionOffsets(root) {
+            var selection = window.getSelection();
+            if (!selection || selection.rangeCount !== 1) return null;
+            var range = selection.getRangeAt(0);
+            if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return null;
+            function offset(node, container, offset) {
+              var walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, null);
+              var count = 0, current;
+              while ((current = walker.nextNode())) {
+                if (current === container) return count + offset;
+                count += current.nodeValue.length;
+              }
+              return count;
+            }
+            return [offset(root, range.startContainer, range.startOffset), offset(root, range.endContainer, range.endOffset)];
+          }
+          function textPoint(root, target) {
+            var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+            var count = 0, current;
+            while ((current = walker.nextNode())) {
+              var next = count + current.nodeValue.length;
+              if (target <= next) return [current, Math.max(0, target - count)];
+              count = next;
+            }
+            return [root, root.childNodes.length];
+          }
+          function replaceChatRow(rowID, html, shouldFollow) {
+            var oldRow = document.querySelector('[data-row-id="' + CSS.escape(rowID) + '"]');
+            if (!oldRow) { appendRows(html, shouldFollow); return; }
+            var wasNearBottom = isNearBottom();
+            var active = document.activeElement;
+            var focusKey = active && oldRow.contains(active) ? active.getAttribute('data-focus-key') : null;
+            var offsets = selectionOffsets(oldRow);
+            oldRow.outerHTML = html;
+            var newRow = document.querySelector('[data-row-id="' + CSS.escape(rowID) + '"]');
+            if (!newRow) return;
+            if (focusKey) {
+              var replacementFocus = newRow.querySelector('[data-focus-key="' + CSS.escape(focusKey) + '"]');
+              if (replacementFocus) replacementFocus.focus({preventScroll:true});
+            }
+            if (offsets) {
+              var start = textPoint(newRow, offsets[0]), end = textPoint(newRow, offsets[1]);
+              var range = document.createRange(); range.setStart(start[0], start[1]); range.setEnd(end[0], end[1]);
+              var selection = window.getSelection(); selection.removeAllRanges(); selection.addRange(range);
+            }
+            if (shouldFollow && wasNearBottom) window.scrollTo(0, document.body.scrollHeight);
+            reportFollowState();
+          }
+          window.addEventListener('scroll', reportFollowState, {passive:true});
           // Delegated click handler for the per-bubble copy icon (issue #285).
           // Works on dynamically-appended rows since it's on `document`. Posts the
           // raw markdown text (from `data-copy`) to the Swift message handler, then

--- a/Tests/WikiFSAppTests/ChatDisplayProjectionTests.swift
+++ b/Tests/WikiFSAppTests/ChatDisplayProjectionTests.swift
@@ -207,7 +207,7 @@ struct ChatDisplayProjectionTests {
 
 @MainActor
 struct ChatTranscriptRenderingInputTests {
-    @Test func failedReadOnlyToolCallSurvivesTheRendererBridgeWithErrorSemantics() {
+    @Test func toolCallKeepsItsTypedIdentityAtTheRendererBoundary() {
         let input = renderingInput(for: .toolCall(.init(
             toolCallID: ToolCallID(rawValue: "tool-read"),
             turnID: ChatTurnID(rawValue: "turn-1"),
@@ -218,15 +218,16 @@ struct ChatTranscriptRenderingInputTests {
             updatedAt: .distantPast
         )))
 
-        #expect(input.events == [.toolResult(isError: true, summary: "permission denied")])
-        #expect(input.events.transcriptVisible == input.events)
-        let html = ChatWebView.Coordinator.chatRowHTML(for: input.events[0])
+        #expect(input.rows.map(\.id) == [.toolCall(ToolCallID(rawValue: "tool-read"))])
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(input.rows[0])
         #expect(html.isEmpty == false)
+        #expect(html.contains("data-row-id=\"tool-tool-read\""))
+        #expect(html.contains("role=\"group\""))
         #expect(html.contains("is-error"))
         #expect(html.contains("permission denied"))
     }
 
-    @Test func completedToolCallUsesTerminalSuccessSemanticsAndRemainsFiltered() {
+    @Test func completedToolCallRemainsVisibleBetweenAssistantBlocks() {
         let input = renderingInput(for: .toolCall(.init(
             toolCallID: ToolCallID(rawValue: "tool-write"),
             turnID: ChatTurnID(rawValue: "turn-1"),
@@ -237,12 +238,15 @@ struct ChatTranscriptRenderingInputTests {
             updatedAt: .distantPast
         )))
 
-        #expect(input.events == [.toolResult(isError: false, summary: "updated page.md")])
-        #expect(input.events.transcriptVisible.isEmpty)
-        #expect(ChatWebView.Coordinator.chatRowHTML(for: input.events[0]).isEmpty)
+        #expect(input.visibleRows(hidingToolCalls: false).map(\.id) == [
+            .toolCall(ToolCallID(rawValue: "tool-write"))
+        ])
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(input.rows[0])
+        #expect(html.contains("Completed"))
+        #expect(html.contains("updated page.md"))
     }
 
-    @Test func cancelledToolCallUsesTerminalErrorSemantics() {
+    @Test func hideToolCallsFiltersRowsWithoutChangingOtherIdentity() {
         let input = renderingInput(for: .toolCall(.init(
             toolCallID: ToolCallID(rawValue: "tool-cancelled"),
             turnID: ChatTurnID(rawValue: "turn-1"),
@@ -253,21 +257,11 @@ struct ChatTranscriptRenderingInputTests {
             updatedAt: .distantPast
         )))
 
-        #expect(input.events == [.toolResult(isError: true, summary: "Write")])
-        #expect(input.events.transcriptVisible == input.events)
+        #expect(input.visibleRows(hidingToolCalls: true).isEmpty)
+        #expect(input.rows.map(\.id) == [.toolCall(ToolCallID(rawValue: "tool-cancelled"))])
     }
 
-    @Test func pendingAndRunningToolCallsRemainVisibleProgressRows() {
-        let pending = renderingInput(for: toolCall(status: .pending))
-        let running = renderingInput(for: toolCall(status: .running))
-
-        #expect(pending.events == [.toolUse(name: "Edit", inputSummary: "page.md")])
-        #expect(running.events == [.toolUse(name: "Edit", inputSummary: "page.md")])
-        #expect(pending.events.transcriptVisible == pending.events)
-        #expect(running.events.transcriptVisible == running.events)
-    }
-
-    @Test func noticeRemainsVisibleAndRenderableAtTheRendererBoundary() {
+    @Test func noticeRemainsDistinctFromAssistantContentAtTheRendererBoundary() {
         let input = renderingInput(for: .systemNotice(.init(
             noticeID: ChatTranscriptNoticeID(rawValue: "notice-1"),
             turnID: nil,
@@ -277,10 +271,10 @@ struct ChatTranscriptRenderingInputTests {
             createdAt: .distantPast
         )))
 
-        #expect(input.events == [.assistantText("Context updated\n\nThe agent resumed the session.")])
-        #expect(input.events.transcriptVisible == input.events)
-        let html = ChatWebView.Coordinator.chatRowHTML(for: input.events[0])
+        #expect(input.rows.map(\.id) == [.notice(ChatTranscriptNoticeID(rawValue: "notice-1"))])
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(input.rows[0])
         #expect(html.isEmpty == false)
+        #expect(html.contains("role=\"status\""))
         #expect(html.contains("Context updated"))
         #expect(html.contains("The agent resumed the session."))
     }

--- a/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
+++ b/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
@@ -23,7 +23,7 @@ struct ChatPresentationAPIManifestTests {
         #expect(remoteSession.contains("var activeChatID:") == false)
     }
 
-    @Test func onlyAllowlistedCompatibilityAdaptersMayExposeAgentEventRows() throws {
+    @Test func typedChatRendererDoesNotReintroduceAgentEventRows() throws {
         let displaySources = [
             try source(named: "ChatDetailPresentation.swift"),
             try source(named: "ChatDetailView.swift"),
@@ -35,7 +35,8 @@ struct ChatPresentationAPIManifestTests {
 
         #expect(displaySources.allSatisfy { $0.contains("AgentEvent") == false })
         #expect(rendererAdapter.contains("struct ChatTranscriptRenderingInput"))
-        #expect(rendererAdapter.contains("AgentEvent"))
+        #expect(rendererAdapter.contains("AgentEvent") == false)
+        #expect(rendererAdapter.contains("ChatDisplayRow"))
         // The queue/activity surface intentionally adapts legacy agent rows;
         // it is not part of the display transcript API.
         #expect(remoteSession.contains("activityFeedEvents"))

--- a/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
@@ -1,0 +1,96 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import Testing
+import WebKit
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSTypes
+
+/// Exercises the Phase 4 transcript markup against a live WebKit document.
+/// It is serialized through the shared gate because SwiftPM has one AppKit host.
+@Suite(.serialized)
+@MainActor
+struct ChatTranscriptHostedTests {
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    @MainActor
+    private final class NavigationWaiter: NSObject, WKNavigationDelegate {
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func load(_ html: String, in webView: WKWebView) async {
+            webView.navigationDelegate = self
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+                webView.loadHTMLString(html, baseURL: URL(string: "about:blank"))
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    @Test func hostedDocumentPreservesSemanticRowsFocusAndSelectionAcrossAnUpdate() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        _ = Self.app
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = webView
+        window.orderFront(nil)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
+
+        await NavigationWaiter().load(ChatWebView.Coordinator.shellHTML, in: webView)
+        let turnID = ChatTurnID(rawValue: "turn-hosted")
+        let initial = ChatDisplayRow.assistantMessage(
+            id: ChatMessageID(rawValue: "assistant-hosted"),
+            turnID: turnID,
+            text: "Initial answer",
+            createdAt: .distantPast,
+            contentState: .streaming
+        )
+        let replacement = ChatDisplayRow.assistantMessage(
+            id: ChatMessageID(rawValue: "assistant-hosted"),
+            turnID: turnID,
+            text: "Initial answer, completed",
+            createdAt: .distantPast,
+            contentState: .final
+        )
+        let initialHTML = ChatWebView.Coordinator.chatDisplayRowHTML(initial)
+        let replacementHTML = ChatWebView.Coordinator.chatDisplayRowHTML(replacement)
+        let initialData = try JSONSerialization.data(
+            withJSONObject: initialHTML,
+            options: [.fragmentsAllowed]
+        )
+        let replacementData = try JSONSerialization.data(
+            withJSONObject: replacementHTML,
+            options: [.fragmentsAllowed]
+        )
+        let initialJSON = try #require(String(data: initialData, encoding: .utf8))
+        let replacementJSON = try #require(String(data: replacementData, encoding: .utf8))
+
+        _ = await evaluateJavaScriptWithTimeout(webView, "appendRows(\(initialJSON), false)")
+        _ = await evaluateJavaScriptWithTimeout(webView, "document.querySelector('[data-focus-key=\\\"copy\\\"]').focus()")
+        _ = await evaluateJavaScriptWithTimeout(webView, "(function(){var root=document.querySelector('[data-row-id=\\\"message-assistant-hosted\\\"] .bubble');var t=document.createTreeWalker(root,NodeFilter.SHOW_TEXT,null).nextNode();var r=document.createRange();r.setStart(t,0);r.setEnd(t,7);var s=getSelection();s.removeAllRanges();s.addRange(r);})()")
+        let before = await evaluateJavaScriptWithTimeout(webView, "getSelection().toString()")
+        #expect(before == "Initial")
+        _ = await evaluateJavaScriptWithTimeout(webView, "replaceChatRow('message-assistant-hosted', \(replacementJSON), false)")
+
+        let state = await evaluateJavaScriptWithTimeout(webView, "(function(){var row=document.querySelector('[data-row-id=\\\"message-assistant-hosted\\\"]');var active=document.activeElement;return [row.getAttribute('role'),row.getAttribute('aria-busy'),active.getAttribute('data-focus-key'),getSelection().toString().trim()].join('|');})()")
+        #expect(state == "article|false|copy|Initial")
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
@@ -1,0 +1,109 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSTypes
+
+@MainActor
+struct ChatTranscriptPresentationTests {
+    private let turnID = ChatTurnID(rawValue: "turn-1")
+
+    @Test func typedRowsExposeStableSemanticMarkupAndAccessibleCopy() {
+        let assistant = ChatDisplayRow.assistantMessage(
+            id: ChatMessageID(rawValue: "assistant-1"),
+            turnID: turnID,
+            text: "Answer",
+            createdAt: .distantPast,
+            contentState: .streaming
+        )
+
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(assistant)
+
+        #expect(html.contains("data-row-id=\"message-assistant-1\""))
+        #expect(html.contains("role=\"article\""))
+        #expect(html.contains("aria-busy=\"true\""))
+        #expect(html.contains("aria-label=\"Copy assistant response\""))
+        #expect(html.contains("◌ Streaming"))
+    }
+
+    @Test func reasoningAndToolRowsGiveTextualStateCues() {
+        let reasoning = ChatDisplayRow.reasoning(
+            id: ChatMessageID(rawValue: "reasoning-1"),
+            turnID: turnID,
+            text: "Checking the available context",
+            createdAt: .distantPast,
+            contentState: .final
+        )
+        let tool = ChatDisplayRow.toolCall(
+            id: ToolCallID(rawValue: "tool-1"),
+            turnID: turnID,
+            toolName: "Read",
+            status: .running,
+            detail: "page.md",
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )
+
+        let reasoningHTML = ChatWebView.Coordinator.chatDisplayRowHTML(reasoning)
+        let toolHTML = ChatWebView.Coordinator.chatDisplayRowHTML(tool)
+
+        #expect(reasoningHTML.contains("<details"))
+        #expect(reasoningHTML.contains("aria-label=\"Show reasoning, completed\""))
+        #expect(toolHTML.contains("data-row-id=\"tool-tool-1\""))
+        #expect(toolHTML.contains("Tool Read, Running"))
+        #expect(toolHTML.contains("◌"))
+    }
+
+    @Test func noticesAndFailuresAreNotAssistantRows() {
+        let notice = ChatDisplayRow.notice(
+            id: ChatTranscriptNoticeID(rawValue: "notice-1"),
+            turnID: nil,
+            kind: .session,
+            title: "Context updated",
+            message: "The agent resumed.",
+            createdAt: .distantPast
+        )
+        let failure = ChatDisplayRow.failure(
+            id: ChatTranscriptFailureID(rawValue: "failure-1"),
+            turnID: turnID,
+            category: .runtimeError,
+            message: "Provider stopped.",
+            createdAt: .distantPast
+        )
+
+        let noticeHTML = ChatWebView.Coordinator.chatDisplayRowHTML(notice)
+        let failureHTML = ChatWebView.Coordinator.chatDisplayRowHTML(failure)
+
+        #expect(noticeHTML.contains("role=\"status\""))
+        #expect(!noticeHTML.contains("chat-assistant"))
+        #expect(failureHTML.contains("role=\"alert\""))
+        #expect(failureHTML.contains("⚠︎"))
+    }
+
+    @Test func followStateOnlyFollowsNearTheBottom() {
+        let away = ChatTranscriptFollowState.reducing(
+            .following,
+            event: .viewportChanged(distanceFromBottom: ChatTranscriptFollowMetrics.nearBottomDistance + 1)
+        )
+        let near = ChatTranscriptFollowState.reducing(
+            away,
+            event: .viewportChanged(distanceFromBottom: ChatTranscriptFollowMetrics.nearBottomDistance)
+        )
+
+        #expect(!away.followsStreamingContent)
+        #expect(near.followsStreamingContent)
+        #expect(ChatTranscriptFollowState.reducing(away, event: .transcriptReset) == .following)
+    }
+
+    @Test func stylesheetPreservesAppearanceMotionAndFocusedRowInteraction() {
+        let shell = ChatWebView.Coordinator.shellHTML
+
+        #expect(shell.contains("prefers-color-scheme: dark"))
+        #expect(shell.contains("prefers-reduced-motion: reduce"))
+        #expect(shell.contains("data-focus-key"))
+        #expect(shell.contains("selectionOffsets"))
+        #expect(shell.contains("isNearBottom"))
+    }
+}
+#endif

--- a/progress/2026-07-30T233754Z-chat-presentation-phase4-native-transcript.md
+++ b/progress/2026-07-30T233754Z-chat-presentation-phase4-native-transcript.md
@@ -1,0 +1,53 @@
+---
+timestamp: 2026-07-30T233754Z
+title: Chat presentation and diagnostics Phase 4 native transcript
+branch: chat-presentation-diagnostics-phase4
+status: complete
+---
+
+# Chat presentation and diagnostics Phase 4 native transcript
+
+## Progress
+
+Phase 4 moves the chat-only transcript rendering path from compatibility event
+arrays to the Phase 3 typed `ChatDisplayRow` projection. `ChatDetailView`
+remains the composition root: it constructs immutable pane presentation values,
+prepares renderer dependencies, and resolves typed transcript intents. The pane
+does not read store or daemon state while rendering.
+
+The single WebKit document remains the only transcript scroll surface. Typed
+rows now retain durable identity as semantic `data-row-id` attributes and render
+user messages, assistant blocks, collapsed reasoning, tools, notices, and
+failures with distinct roles and state labels. Tool rows remain visible between
+assistant blocks, including terminal outcomes. Copy controls carry an accessible
+name, keyboard-native button behavior, and hover/focus reveal. CSS uses the
+system type stack, semantic light/dark values, a prose measure, line spacing,
+and reduced-motion handling while retaining `pageZoom`.
+
+The direct existing WebKit path now restores an in-row focus target and text
+selection when a typed row changes. A small pure follow-state machine permits
+streaming to follow only while the reader is near the bottom; otherwise direct
+updates keep the current reading position. This work intentionally does not add
+the later rendering-command protocol and failure-handling work untouched.
+
+## Verification
+
+- `WIKIFS_APP_TESTS=1 swift test --filter 'ChatTranscriptPresentationTests|ChatTranscriptHostedTests|ChatDisplayProjectionTests|ChatDetailPresentationTests|ChatViewD2Tests|RemoteChatSessionTests|ChatWebViewTranscriptIDTests|ChatWebViewLinkifyTests|ChatPresentationAPIManifestTests'`
+  - passed: 103 tests in 11 suites.
+- `WIKIFS_APP_TESTS=1 swift test --filter ChatTranscriptHostedTests`
+  - passed: hosted WebKit test verifies semantic typed DOM state plus preserved
+    copy-button focus and selection after a direct row update.
+- Concurrent `log stream` and follow-up `log show` using
+  `subsystem == "com.apple.runtime-issues" and category == "SwiftUI"` during
+  the hosted transcript test produced no runtime-issue entries.
+- `make build`
+  - passed; assembled and signed `build/Self Driving Wiki.app`.
+- `make test`
+  - passed.
+- `WIKIFS_APP_TESTS=1 swift test`
+  - not counted as a pass. It reached and passed `ChatTranscriptHostedTests`,
+    then the shared `swiftpm-testing-helper` stopped making output progress with
+    both parent and helper at 0% CPU for more than one minute. The exact command
+    output is retained locally at `tmp/phase4-full-app-tests.log`; the process
+    was terminated after the stall, consistent with the repository's known
+    app-enabled hosted-suite limitation.


### PR DESCRIPTION
## Summary

- Render chat transcripts directly from Phase 3 typed display rows.
- Add stable semantic transcript rows, native copy actions, accessible state cues, and light/dark reduced-motion styling.
- Preserve in-row selection and copy-button focus during live row replacement, with an explicit near-bottom follow-state reducer.

## Validation

- `WIKIFS_APP_TESTS=1 swift test --filter 'ChatTranscriptPresentationTests|ChatTranscriptHostedTests|ChatDisplayProjectionTests|ChatDetailPresentationTests|ChatViewD2Tests|RemoteChatSessionTests|ChatWebViewTranscriptIDTests|ChatWebViewLinkifyTests|ChatPresentationAPIManifestTests'`
- `WIKIFS_APP_TESTS=1 swift test --filter ChatTranscriptHostedTests` with concurrent SwiftUI runtime-issue log capture
- `make build`
- `make test`
- pre-commit hook (`make lint`)

The full `WIKIFS_APP_TESTS=1 swift test` run was not counted as passing: its shared hosted-test helper stalled at 0% CPU after `ChatTranscriptHostedTests`; output is retained locally in `tmp/phase4-full-app-tests.log`.
