### PR TITLE
Add keyed acknowledged chat transcript rendering

### DIFF
--- a/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
@@ -1,0 +1,260 @@
+// pattern: Imperative Shell
+
+import Foundation
+import WebKit
+
+struct ChatTranscriptRenderRevision: Hashable, Sendable {
+    let rawValue: Int
+}
+
+enum ChatTranscriptRenderAcknowledgementOutcome: String, Hashable, Sendable {
+    case success
+    case missingRow
+    case error
+    case undefined
+    case javaScriptException
+    case timeout
+}
+
+struct ChatTranscriptRenderAcknowledgement: Hashable, Sendable {
+    let kind: ChatTranscriptRenderCommandKind
+    let revision: ChatTranscriptRenderRevision
+    let rowID: ChatDisplayRowID?
+    let outcome: ChatTranscriptRenderAcknowledgementOutcome
+}
+
+enum ChatTranscriptRendererAnomaly: Hashable, Sendable {
+    case invalidAcknowledgement(expected: ChatTranscriptRenderCommandKind, received: ChatTranscriptRenderCommandKind)
+    case staleAcknowledgement(expected: ChatTranscriptRenderRevision, received: ChatTranscriptRenderRevision)
+    case rowMismatch(expected: ChatDisplayRowID?, received: ChatDisplayRowID?)
+    case failedAcknowledgement(ChatTranscriptRenderAcknowledgementOutcome)
+}
+
+/// Serializes typed DOM mutations. A command changes the acknowledged snapshot
+/// only after WebKit returns the matching acknowledgement.
+@MainActor
+final class ChatTranscriptRenderExecutor {
+    enum State: Hashable, Sendable {
+        case idle
+        case applying(ChatTranscriptRenderCommand, ChatTranscriptRenderRevision)
+        case awaitingReload
+    }
+
+    typealias Mutation = @MainActor (
+        ChatTranscriptRenderCommand,
+        ChatTranscriptRenderRevision,
+        @escaping @MainActor (ChatTranscriptRenderAcknowledgement) -> Void
+    ) -> Void
+
+    private let mutate: Mutation
+    private let reportAnomaly: @MainActor (ChatTranscriptRendererAnomaly) -> Void
+    private var acknowledgedSnapshot: ChatTranscriptRenderSnapshot?
+    private var desiredSnapshot: ChatTranscriptRenderSnapshot?
+    private var reloadSnapshot: ChatTranscriptRenderSnapshot?
+    private var nextRevision = 0
+    private var reloadRevision: ChatTranscriptRenderRevision?
+    private var recoveryReloadAttempted = false
+    private var requiresRecoveryReload = false
+
+    private(set) var state: State = .idle
+
+    init(
+        mutate: @escaping Mutation,
+        reportAnomaly: @escaping @MainActor (ChatTranscriptRendererAnomaly) -> Void
+    ) {
+        self.mutate = mutate
+        self.reportAnomaly = reportAnomaly
+    }
+
+    func submit(_ snapshot: ChatTranscriptRenderSnapshot) {
+        desiredSnapshot = snapshot
+        drain()
+    }
+
+    /// Called by the WebKit navigation delegate only after a controlled shell
+    /// reload has finished. The returned snapshot is frozen for that mutation.
+    func beginReloadMutation() -> (snapshot: ChatTranscriptRenderSnapshot, revision: ChatTranscriptRenderRevision)? {
+        guard case .awaitingReload = state,
+              let desiredSnapshot,
+              let reloadRevision
+        else { return nil }
+        reloadSnapshot = desiredSnapshot
+        state = .applying(.reload(desiredSnapshot), reloadRevision)
+        return (desiredSnapshot, reloadRevision)
+    }
+
+    func acknowledge(_ acknowledgement: ChatTranscriptRenderAcknowledgement) {
+        let expected: (command: ChatTranscriptRenderCommand, revision: ChatTranscriptRenderRevision)?
+        switch state {
+        case .idle:
+            return
+        case .applying(let command, let revision):
+            expected = (command, revision)
+        case .awaitingReload:
+            guard let reloadRevision else { return }
+            expected = (.reload(reloadSnapshot ?? desiredSnapshot ?? ChatTranscriptRenderSnapshot(
+                context: .init(transcriptID: nil), rows: []
+            )), reloadRevision)
+        }
+        guard let expected else { return }
+        guard acknowledgement.revision == expected.revision else {
+            reportAnomaly(.staleAcknowledgement(expected: expected.revision, received: acknowledgement.revision))
+            return
+        }
+        guard acknowledgement.kind == expected.command.kind else {
+            reportAnomaly(.invalidAcknowledgement(expected: expected.command.kind, received: acknowledgement.kind))
+            scheduleRecovery(after: expected.command)
+            return
+        }
+        guard acknowledgement.rowID == expected.command.rowID else {
+            reportAnomaly(.rowMismatch(expected: expected.command.rowID, received: acknowledgement.rowID))
+            scheduleRecovery(after: expected.command)
+            return
+        }
+        guard acknowledgement.outcome == .success else {
+            reportAnomaly(.failedAcknowledgement(acknowledgement.outcome))
+            scheduleRecovery(after: expected.command)
+            return
+        }
+
+        switch expected.command {
+        case .reload(let snapshot):
+            acknowledgedSnapshot = reloadSnapshot ?? snapshot
+            reloadSnapshot = nil
+        default:
+            acknowledgedSnapshot = applying(expected.command, to: acknowledgedSnapshot)
+        }
+        state = .idle
+        reloadRevision = nil
+        recoveryReloadAttempted = false
+        drain()
+    }
+
+    private func drain() {
+        guard case .idle = state, let desiredSnapshot else { return }
+        let command: ChatTranscriptRenderCommand
+        if requiresRecoveryReload {
+            requiresRecoveryReload = false
+            recoveryReloadAttempted = true
+            command = .reload(desiredSnapshot)
+        } else {
+            guard let first = ChatTranscriptRenderPlanner.commands(
+                previous: acknowledgedSnapshot,
+                desired: desiredSnapshot
+            ).first else { return }
+            command = first
+        }
+        let revision = makeRevision()
+        if case .reload = command {
+            state = .awaitingReload
+            reloadRevision = revision
+        } else {
+            state = .applying(command, revision)
+        }
+        mutate(command, revision) { [weak self] acknowledgement in
+            self?.acknowledge(acknowledgement)
+        }
+    }
+
+    private func scheduleRecovery(after command: ChatTranscriptRenderCommand) {
+        state = .idle
+        reloadRevision = nil
+        reloadSnapshot = nil
+        guard case .reload = command else {
+            if !recoveryReloadAttempted {
+                requiresRecoveryReload = true
+                drain()
+            }
+            return
+        }
+        // One controlled reload already ran. Keep the latest desired snapshot
+        // for a future explicit update, but do not enter a reload loop.
+    }
+
+    private func makeRevision() -> ChatTranscriptRenderRevision {
+        nextRevision += 1
+        return ChatTranscriptRenderRevision(rawValue: nextRevision)
+    }
+
+    private func applying(
+        _ command: ChatTranscriptRenderCommand,
+        to snapshot: ChatTranscriptRenderSnapshot?
+    ) -> ChatTranscriptRenderSnapshot? {
+        guard let snapshot else { return nil }
+        var updatedRows = snapshot.rows
+        switch command {
+        case .reload(let replacement):
+            return replacement
+        case .append(let rows):
+            updatedRows.append(contentsOf: rows)
+        case .insert(let row, let before):
+            guard let index = updatedRows.firstIndex(where: { $0.id == before }) else { return nil }
+            updatedRows.insert(row, at: index)
+        case .replace(let row):
+            guard let index = updatedRows.firstIndex(where: { $0.id == row.id }) else { return nil }
+            updatedRows[index] = row
+        case .remove(let rowID):
+            guard let index = updatedRows.firstIndex(where: { $0.id == rowID }) else { return nil }
+            updatedRows.remove(at: index)
+        }
+        return ChatTranscriptRenderSnapshot(context: snapshot.context, rows: updatedRows)
+    }
+}
+
+/// Result of one bounded WebKit evaluation. `undefined` is distinct from a
+/// JavaScript exception because mutation functions must return an acknowledgement.
+@MainActor
+enum ChatTranscriptJavaScriptResult {
+    case success(Any)
+    case undefined
+    case javaScriptException(String)
+    case timeout
+}
+
+@MainActor
+private final class ChatTranscriptJavaScriptCompletion {
+    private var continuation: CheckedContinuation<ChatTranscriptJavaScriptResult, Never>?
+
+    init(_ continuation: CheckedContinuation<ChatTranscriptJavaScriptResult, Never>) {
+        self.continuation = continuation
+    }
+
+    func resolve(_ result: ChatTranscriptJavaScriptResult) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(returning: result)
+    }
+}
+
+@MainActor
+extension WKWebView {
+    func chatTranscriptJavaScriptResult(
+        _ script: String,
+        timeout: Duration = ChatTranscriptRenderMetrics.javaScriptTimeout
+    ) async -> ChatTranscriptJavaScriptResult {
+        await withCheckedContinuation { continuation in
+            let completion = ChatTranscriptJavaScriptCompletion(continuation)
+            evaluateJavaScript(script) { result, error in
+                if let error {
+                    completion.resolve(.javaScriptException(error.localizedDescription))
+                } else if let result {
+                    completion.resolve(.success(result))
+                } else {
+                    completion.resolve(.undefined)
+                }
+            }
+            Task { @MainActor in
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {
+                    return
+                }
+                completion.resolve(.timeout)
+            }
+        }
+    }
+}
+
+enum ChatTranscriptRenderMetrics {
+    static let javaScriptTimeout: Duration = .seconds(15)
+}

--- a/Sources/WikiFS/Chats/ChatTranscriptRenderPlanner.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptRenderPlanner.swift
@@ -1,0 +1,133 @@
+// pattern: Functional Core
+
+import Foundation
+
+/// Rendering identity outside the durable transcript. A changed value means the
+/// existing DOM cannot safely receive an incremental command.
+struct ChatTranscriptRenderContext: Hashable, Sendable {
+    enum Style: Hashable, Sendable {
+        case chat
+        case activityFeed
+    }
+
+    let transcriptID: TranscriptID?
+    let style: Style
+    /// A caller increments this token for an explicit renderer reset even when
+    /// the transcript identity has not changed.
+    let resetToken: Int
+
+    init(
+        transcriptID: TranscriptID?,
+        style: Style = .chat,
+        resetToken: Int = 0
+    ) {
+        self.transcriptID = transcriptID
+        self.style = style
+        self.resetToken = resetToken
+    }
+}
+
+/// The complete desired state for the one-document transcript surface.
+struct ChatTranscriptRenderSnapshot: Hashable, Sendable {
+    let context: ChatTranscriptRenderContext
+    let rows: [ChatDisplayRow]
+}
+
+enum ChatTranscriptRenderCommand: Hashable, Sendable {
+    case reload(ChatTranscriptRenderSnapshot)
+    case append([ChatDisplayRow])
+    case insert(ChatDisplayRow, before: ChatDisplayRowID)
+    case replace(ChatDisplayRow)
+    case remove(ChatDisplayRowID)
+
+    var kind: ChatTranscriptRenderCommandKind {
+        switch self {
+        case .reload: .reload
+        case .append: .append
+        case .insert: .insert
+        case .replace: .replace
+        case .remove: .remove
+        }
+    }
+
+    var rowID: ChatDisplayRowID? {
+        switch self {
+        case .reload: nil
+        case .append(let rows): rows.last?.id
+        case .insert(let row, _), .replace(let row): row.id
+        case .remove(let rowID): rowID
+        }
+    }
+}
+
+enum ChatTranscriptRenderCommandKind: String, Codable, Hashable, Sendable {
+    case reload
+    case append
+    case insert
+    case replace
+    case remove
+}
+
+/// A pure, identity-based DOM update plan. Array positions exist only while
+/// this planner finds insertion points; WebKit receives durable row identities.
+enum ChatTranscriptRenderPlanner {
+    static func commands(
+        previous: ChatTranscriptRenderSnapshot?,
+        desired: ChatTranscriptRenderSnapshot
+    ) -> [ChatTranscriptRenderCommand] {
+        guard let previous else { return [.reload(desired)] }
+        guard previous.context == desired.context else { return [.reload(desired)] }
+
+        let previousIDs = previous.rows.map(\.id)
+        let desiredIDs = desired.rows.map(\.id)
+        guard Set(previousIDs).count == previousIDs.count,
+              Set(desiredIDs).count == desiredIDs.count,
+              preservesCommonRowOrder(previousIDs: previousIDs, desiredIDs: desiredIDs)
+        else {
+            return [.reload(desired)]
+        }
+        // Equal counts with a changed identity are not a last-row replacement.
+        // A reload makes the identity boundary explicit instead of guessing that
+        // a remove-plus-append was an in-place content change.
+        if previousIDs.count == desiredIDs.count, previousIDs != desiredIDs {
+            return [.reload(desired)]
+        }
+
+        let previousIDSet = Set(previousIDs)
+        let previousRowsByID = Dictionary(uniqueKeysWithValues: previous.rows.map { ($0.id, $0) })
+        // Keep changes to existing rows ahead of structural growth. The executor
+        // may coalesce repeated replacements for this same row, but it must not
+        // move a replacement across an append boundary for a different row.
+        var commands: [ChatTranscriptRenderCommand] = desired.rows.compactMap { row in
+            guard let previousRow = previousRowsByID[row.id], previousRow != row else { return nil }
+            return .replace(row)
+        }
+
+        let desiredIDSet = Set(desiredIDs)
+        commands += previousIDs.reversed().compactMap { rowID in
+            desiredIDSet.contains(rowID) ? nil : ChatTranscriptRenderCommand.remove(rowID)
+        }
+        for (index, row) in desired.rows.enumerated() where !previousIDSet.contains(row.id) {
+            if let nextExistingRow = desired.rows[(index + 1)...].first(where: { previousIDSet.contains($0.id) }) {
+                commands.append(.insert(row, before: nextExistingRow.id))
+            } else {
+                let appendedRows = desired.rows[index...].prefix { !previousIDSet.contains($0.id) }
+                commands.append(.append(Array(appendedRows)))
+                break
+            }
+        }
+
+        return commands
+    }
+
+    private static func preservesCommonRowOrder(
+        previousIDs: [ChatDisplayRowID],
+        desiredIDs: [ChatDisplayRowID]
+    ) -> Bool {
+        let desiredIDSet = Set(desiredIDs)
+        let previousCommon = previousIDs.filter(desiredIDSet.contains)
+        let previousIDSet = Set(previousIDs)
+        let desiredCommon = desiredIDs.filter(previousIDSet.contains)
+        return previousCommon == desiredCommon
+    }
+}

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import WebKit
 import WikiFSCore
 
-private extension ChatDisplayRowID {
+extension ChatDisplayRowID {
     /// Prefixes make the DOM namespace explicit even where raw durable IDs
     /// happen to share the same string representation.
     var domValue: String {
@@ -13,6 +13,20 @@ private extension ChatDisplayRowID {
         case .toolCall(let id): "tool-\(id.rawValue)"
         case .notice(let id): "notice-\(id.rawValue)"
         case .failure(let id): "failure-\(id.rawValue)"
+        }
+    }
+
+    init?(domValue: String) {
+        if domValue.hasPrefix("message-") {
+            self = .message(ChatMessageID(rawValue: String(domValue.dropFirst("message-".count))))
+        } else if domValue.hasPrefix("tool-") {
+            self = .toolCall(ToolCallID(rawValue: String(domValue.dropFirst("tool-".count))))
+        } else if domValue.hasPrefix("notice-") {
+            self = .notice(ChatTranscriptNoticeID(rawValue: String(domValue.dropFirst("notice-".count))))
+        } else if domValue.hasPrefix("failure-") {
+            self = .failure(ChatTranscriptFailureID(rawValue: String(domValue.dropFirst("failure-".count))))
+        } else {
+            return nil
         }
     }
 }
@@ -302,6 +316,7 @@ struct ChatWebView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
+    @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
         weak var webView: WKWebView?
         var style: VisualStyle = .activityFeed
@@ -349,10 +364,18 @@ struct ChatWebView: NSViewRepresentable {
         /// non-final only when it is the LAST row of a still-live event stream —
         /// i.e. it may still grow via `replaceLastRow`). Captured in `apply`.
         private var renderedEvents: [AgentEvent] = []
-        private var renderedChatRows: [ChatDisplayRow] = []
-        private var pendingChatRows: [ChatDisplayRow] = []
         private var rendersTypedChatRows = false
         private var followState: ChatTranscriptFollowState = .following
+        private var pendingChatReloadAcknowledgement: (@MainActor (ChatTranscriptRenderAcknowledgement) -> Void)?
+        private lazy var chatRenderExecutor = ChatTranscriptRenderExecutor(
+            mutate: { [weak self] command, revision, acknowledge in
+                guard let self else { return }
+                self.performChatRenderMutation(command, revision: revision, acknowledge: acknowledge)
+            },
+            reportAnomaly: { anomaly in
+                DebugLog.store("chat transcript renderer anomaly: \(anomaly)")
+            }
+        )
 
         /// Resolve the provider once per render pass on the main actor. Returns
         /// the current `WikiRenderContext` (or nil → constant-true behavior).
@@ -401,16 +424,10 @@ struct ChatWebView: NSViewRepresentable {
         /// the document's existing append/replace helpers directly.
         func reload(chatRows: [ChatDisplayRow], transcriptID: TranscriptID?) {
             rendersTypedChatRows = true
-            renderedCount = 0
-            renderedShowsInternals = false
-            renderedTranscriptID = transcriptID
-            renderedChatRows = []
-            pendingChatRows = chatRows
-            renderedEvents = []
-            renderedLastEvent = nil
-            followState = ChatTranscriptFollowState.reducing(followState, event: .transcriptReset)
-            isLoaded = false
-            webView?.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
+            chatRenderExecutor.submit(ChatTranscriptRenderSnapshot(
+                context: ChatTranscriptRenderContext(transcriptID: transcriptID),
+                rows: chatRows
+            ))
         }
 
         func apply(chatRows: [ChatDisplayRow], transcriptID: TranscriptID?) {
@@ -418,27 +435,10 @@ struct ChatWebView: NSViewRepresentable {
                 reload(chatRows: chatRows, transcriptID: transcriptID)
                 return
             }
-            guard transcriptID == renderedTranscriptID,
-                  chatRows.count >= renderedChatRows.count,
-                  zip(chatRows, renderedChatRows).allSatisfy({ $0.0.id == $0.1.id })
-            else {
-                reload(chatRows: chatRows, transcriptID: transcriptID)
-                return
-            }
-            guard isLoaded else {
-                pendingChatRows = chatRows
-                return
-            }
-
-            let existingCount = renderedChatRows.count
-            for index in 0..<existingCount where chatRows[index] != renderedChatRows[index] {
-                replaceChatRow(chatRows[index], context: currentContext())
-            }
-            if chatRows.count > existingCount {
-                appendChatRows(Array(chatRows[existingCount...]), context: currentContext())
-            }
-            renderedChatRows = chatRows
-            renderedCount = chatRows.count
+            chatRenderExecutor.submit(ChatTranscriptRenderSnapshot(
+                context: ChatTranscriptRenderContext(transcriptID: transcriptID),
+                rows: chatRows
+            ))
         }
 
         func apply(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = [],
@@ -516,16 +516,7 @@ struct ChatWebView: NSViewRepresentable {
             // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8.
             DebugLog.chatLive("8.web.didFinish pending=\(pendingEvents.count)")
             if rendersTypedChatRows {
-                let toRender = pendingChatRows
-                pendingChatRows = []
-                if !toRender.isEmpty {
-                    appendChatRows(toRender, context: currentContext())
-                }
-                renderedChatRows = toRender
-                renderedCount = toRender.count
-                if pendingHighlightQuote != nil {
-                    applyHighlight()
-                }
+                beginControlledChatReloadIfNeeded()
                 return
             }
             let toRender = pendingEvents
@@ -632,26 +623,175 @@ struct ChatWebView: NSViewRepresentable {
             webView?.evaluateJavaScript("replaceLastRow(\(jsonString))", completionHandler: nil)
         }
 
-        private func appendChatRows(_ rows: [ChatDisplayRow], context: WikiRenderContext?) {
-            let html = rows.map { Self.chatDisplayRowHTML($0, context: context) }.joined()
-            guard !html.isEmpty,
-                  let jsonString = Self.jsonString(for: html)
-            else { return }
-            let follows = followState.followsStreamingContent ? "true" : "false"
-            webView?.evaluateJavaScript("appendRows(\(jsonString), \(follows))", completionHandler: nil)
+        private func performChatRenderMutation(
+            _ command: ChatTranscriptRenderCommand,
+            revision: ChatTranscriptRenderRevision,
+            acknowledge: @escaping @MainActor (ChatTranscriptRenderAcknowledgement) -> Void
+        ) {
+            guard let webView else {
+                acknowledge(ChatTranscriptRenderAcknowledgement(
+                    kind: command.kind, revision: revision, rowID: command.rowID, outcome: .error
+                ))
+                return
+            }
+            if case .reload = command {
+                followState = ChatTranscriptFollowState.reducing(followState, event: .transcriptReset)
+                if isLoaded {
+                    guard let reload = chatRenderExecutor.beginReloadMutation() else { return }
+                    runControlledChatReload(reload, acknowledge: acknowledge)
+                    return
+                }
+                pendingChatReloadAcknowledgement = acknowledge
+                isLoaded = false
+                webView.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
+                return
+            }
+            guard let script = chatMutationScript(command, revision: revision, context: currentContext()) else {
+                acknowledge(ChatTranscriptRenderAcknowledgement(
+                    kind: command.kind, revision: revision, rowID: command.rowID, outcome: .error
+                ))
+                return
+            }
+            evaluateChatMutation(
+                script,
+                expectedKind: command.kind,
+                revision: revision,
+                expectedRowID: command.rowID,
+                acknowledge: acknowledge
+            )
         }
 
-        /// Replace one semantic chat row in the existing one-document surface.
-        /// The JavaScript routine retains an in-row focus target and selection
-        /// offsets, so changing a streaming block or tool status does not turn a
-        /// reader's current interaction into a new focus destination.
-        private func replaceChatRow(_ row: ChatDisplayRow, context: WikiRenderContext?) {
-            let html = Self.chatDisplayRowHTML(row, context: context)
-            guard let rowID = Self.jsonString(for: row.id.domValue),
-                  let rowHTML = Self.jsonString(for: html)
+        private func beginControlledChatReloadIfNeeded() {
+            guard let pendingChatReloadAcknowledgement,
+                  let reload = chatRenderExecutor.beginReloadMutation()
             else { return }
+            self.pendingChatReloadAcknowledgement = nil
+            runControlledChatReload(reload, acknowledge: pendingChatReloadAcknowledgement)
+        }
+
+        private func runControlledChatReload(
+            _ reload: (snapshot: ChatTranscriptRenderSnapshot, revision: ChatTranscriptRenderRevision),
+            acknowledge: @escaping @MainActor (ChatTranscriptRenderAcknowledgement) -> Void
+        ) {
+            let html = reload.snapshot.rows.map { Self.chatDisplayRowHTML($0, context: currentContext()) }.joined()
+            guard let htmlJSON = Self.jsonString(for: html)
+            else {
+                acknowledge(ChatTranscriptRenderAcknowledgement(
+                    kind: .reload, revision: reload.revision, rowID: nil, outcome: .error
+                ))
+                return
+            }
             let follows = followState.followsStreamingContent ? "true" : "false"
-            webView?.evaluateJavaScript("replaceChatRow(\(rowID), \(rowHTML), \(follows))", completionHandler: nil)
+            let script = "replaceChatTranscript(\(htmlJSON), \(follows), \(reload.revision.rawValue))"
+            evaluateChatMutation(
+                script,
+                expectedKind: .reload,
+                revision: reload.revision,
+                expectedRowID: nil,
+                acknowledge: acknowledge
+            )
+        }
+
+        private func chatMutationScript(
+            _ command: ChatTranscriptRenderCommand,
+            revision: ChatTranscriptRenderRevision,
+            context: WikiRenderContext?
+        ) -> String? {
+            let follows = followState.followsStreamingContent ? "true" : "false"
+            let revisionValue = revision.rawValue
+            switch command {
+            case .reload:
+                return nil
+            case .append(let rows):
+                let html = rows.map { Self.chatDisplayRowHTML($0, context: context) }.joined()
+                guard let htmlJSON = Self.jsonString(for: html),
+                      let rowIDJSON = Self.jsonString(for: rows.last?.id.domValue ?? "")
+                else { return nil }
+                return "appendChatRows(\(htmlJSON), \(follows), \(revisionValue), \(rowIDJSON))"
+            case .insert(let row, let before):
+                guard let rowIDJSON = Self.jsonString(for: row.id.domValue),
+                      let beforeIDJSON = Self.jsonString(for: before.domValue),
+                      let htmlJSON = Self.jsonString(for: Self.chatDisplayRowHTML(row, context: context))
+                else { return nil }
+                return "insertChatRow(\(rowIDJSON), \(beforeIDJSON), \(htmlJSON), \(follows), \(revisionValue))"
+            case .replace(let row):
+                guard let rowIDJSON = Self.jsonString(for: row.id.domValue),
+                      let htmlJSON = Self.jsonString(for: Self.chatDisplayRowHTML(row, context: context))
+                else { return nil }
+                return "replaceChatRow(\(rowIDJSON), \(htmlJSON), \(follows), \(revisionValue))"
+            case .remove(let rowID):
+                guard let rowIDJSON = Self.jsonString(for: rowID.domValue) else { return nil }
+                return "removeChatRow(\(rowIDJSON), \(revisionValue))"
+            }
+        }
+
+        private func evaluateChatMutation(
+            _ script: String,
+            expectedKind: ChatTranscriptRenderCommandKind,
+            revision: ChatTranscriptRenderRevision,
+            expectedRowID: ChatDisplayRowID?,
+            acknowledge: @escaping @MainActor (ChatTranscriptRenderAcknowledgement) -> Void
+        ) {
+            guard let webView else {
+                acknowledge(ChatTranscriptRenderAcknowledgement(
+                    kind: expectedKind, revision: revision, rowID: expectedRowID, outcome: .error
+                ))
+                return
+            }
+            Task { @MainActor in
+                let result = await webView.chatTranscriptJavaScriptResult(script)
+                acknowledge(Self.acknowledgement(
+                    from: result,
+                    expectedKind: expectedKind,
+                    revision: revision,
+                    expectedRowID: expectedRowID
+                ))
+            }
+        }
+
+        private static func acknowledgement(
+            from result: ChatTranscriptJavaScriptResult,
+            expectedKind: ChatTranscriptRenderCommandKind,
+            revision: ChatTranscriptRenderRevision,
+            expectedRowID: ChatDisplayRowID?
+        ) -> ChatTranscriptRenderAcknowledgement {
+            switch result {
+            case .undefined:
+                return .init(kind: expectedKind, revision: revision, rowID: expectedRowID, outcome: .undefined)
+            case .javaScriptException(let message):
+                DebugLog.store("chat transcript JavaScript exception: \(message)")
+                return .init(kind: expectedKind, revision: revision, rowID: expectedRowID, outcome: .javaScriptException)
+            case .timeout:
+                DebugLog.store("chat transcript JavaScript evaluation timed out")
+                return .init(kind: expectedKind, revision: revision, rowID: expectedRowID, outcome: .timeout)
+            case .success(let value):
+                guard JSONSerialization.isValidJSONObject(value) else {
+                    return .init(kind: expectedKind, revision: revision, rowID: expectedRowID, outcome: .error)
+                }
+                do {
+                    let data = try JSONSerialization.data(withJSONObject: value)
+                    let wire = try JSONDecoder().decode(DOMAcknowledgement.self, from: data)
+                    guard let kind = ChatTranscriptRenderCommandKind(rawValue: wire.kind) else {
+                        return .init(kind: expectedKind, revision: revision, rowID: expectedRowID, outcome: .error)
+                    }
+                    return .init(
+                        kind: kind,
+                        revision: .init(rawValue: wire.revision),
+                        rowID: wire.rowID.flatMap(ChatDisplayRowID.init(domValue:)),
+                        outcome: ChatTranscriptRenderAcknowledgementOutcome(rawValue: wire.outcome) ?? .error
+                    )
+                } catch {
+                    DebugLog.store("decode chat transcript acknowledgement: \(error)")
+                    return .init(kind: expectedKind, revision: revision, rowID: expectedRowID, outcome: .error)
+                }
+            }
+        }
+
+        private struct DOMAcknowledgement: Decodable {
+            let kind: String
+            let revision: Int
+            let rowID: String?
+            let outcome: String
         }
 
         private static func jsonString(for value: String) -> String? {
@@ -1326,7 +1466,12 @@ struct ChatWebView: NSViewRepresentable {
           }
         </style>
         </head><body>
+        <main id="chat-transcript" aria-live="polite"></main>
         <script>
+          function transcriptRoot() { return document.getElementById('chat-transcript'); }
+          function renderAcknowledgement(kind, revision, rowID, outcome) {
+            return {kind: kind, revision: revision, rowID: rowID || null, outcome: outcome};
+          }
           function isNearBottom() {
             return Math.max(0, document.documentElement.scrollHeight - (window.scrollY + window.innerHeight)) <= 72;
           }
@@ -1337,15 +1482,16 @@ struct ChatWebView: NSViewRepresentable {
           }
           function appendRows(html, shouldFollow) {
             var wasNearBottom = isNearBottom();
-            document.body.insertAdjacentHTML('beforeend', html);
+            transcriptRoot().insertAdjacentHTML('beforeend', html);
             if (shouldFollow && wasNearBottom) window.scrollTo(0, document.body.scrollHeight);
             reportFollowState();
           }
           function replaceLastRow(html) {
-            if (document.body.lastElementChild) {
-              document.body.lastElementChild.outerHTML = html;
+            var root = transcriptRoot();
+            if (root.lastElementChild) {
+              root.lastElementChild.outerHTML = html;
             } else {
-              document.body.insertAdjacentHTML('beforeend', html);
+              root.insertAdjacentHTML('beforeend', html);
             }
             window.scrollTo(0, document.body.scrollHeight);
           }
@@ -1375,16 +1521,94 @@ struct ChatWebView: NSViewRepresentable {
             }
             return [root, root.childNodes.length];
           }
-          function replaceChatRow(rowID, html, shouldFollow) {
+          function restoreRowInteraction(state) {
+            if (!state) return;
+            var anchor = state.anchorRowID && document.querySelector('[data-row-id="' + CSS.escape(state.anchorRowID) + '"]');
+            if (anchor && !state.wasNearBottom) window.scrollBy(0, anchor.getBoundingClientRect().top - state.anchorTop);
+            var focusRow = state.focusRowID && document.querySelector('[data-row-id="' + CSS.escape(state.focusRowID) + '"]');
+            if (focusRow && state.focusKey) {
+              var focus = focusRow.querySelector('[data-focus-key="' + CSS.escape(state.focusKey) + '"]');
+              if (focus) focus.focus({preventScroll:true});
+            }
+            var selectionRow = state.selectionRowID && document.querySelector('[data-row-id="' + CSS.escape(state.selectionRowID) + '"]');
+            if (selectionRow && state.offsets) {
+              var start = textPoint(selectionRow, state.offsets[0]), end = textPoint(selectionRow, state.offsets[1]);
+              var range = document.createRange(); range.setStart(start[0], start[1]); range.setEnd(end[0], end[1]);
+              var selection = window.getSelection(); selection.removeAllRanges(); selection.addRange(range);
+            }
+          }
+          function currentRowInteraction() {
+            var root = transcriptRoot();
+            var active = document.activeElement;
+            var activeRow = active && active.closest && active.closest('[data-row-id]');
+            var selection = window.getSelection();
+            var selectionRow = selection && selection.rangeCount === 1 && selection.getRangeAt(0).startContainer.parentElement && selection.getRangeAt(0).startContainer.parentElement.closest('[data-row-id]');
+            var anchorRow = Array.from(root.children).find(function(row) { return row.getBoundingClientRect().bottom >= 0; });
+            return {
+              wasNearBottom: isNearBottom(),
+              focusRowID: activeRow && activeRow.getAttribute('data-row-id'),
+              focusKey: activeRow && active.getAttribute('data-focus-key'),
+              selectionRowID: selectionRow && selectionRow.getAttribute('data-row-id'),
+              offsets: selectionRow && selectionOffsets(selectionRow),
+              anchorRowID: anchorRow && anchorRow.getAttribute('data-row-id'),
+              anchorTop: anchorRow ? anchorRow.getBoundingClientRect().top : 0
+            };
+          }
+          function appendChatRows(html, shouldFollow, revision, rowID) {
+            try {
+              appendRows(html, shouldFollow);
+              var row = rowID && document.querySelector('[data-row-id="' + CSS.escape(rowID) + '"]');
+              return renderAcknowledgement('append', revision, rowID, rowID && !row ? 'missingRow' : 'success');
+            } catch (error) {
+              return renderAcknowledgement('append', revision, rowID, 'error');
+            }
+          }
+          function insertChatRow(rowID, beforeRowID, html, shouldFollow, revision) {
+            try {
+              var before = document.querySelector('[data-row-id="' + CSS.escape(beforeRowID) + '"]');
+              if (!before) return renderAcknowledgement('insert', revision, rowID, 'missingRow');
+              var wasNearBottom = isNearBottom();
+              before.insertAdjacentHTML('beforebegin', html);
+              if (!document.querySelector('[data-row-id="' + CSS.escape(rowID) + '"]')) return renderAcknowledgement('insert', revision, rowID, 'missingRow');
+              if (shouldFollow && wasNearBottom) window.scrollTo(0, document.body.scrollHeight);
+              reportFollowState();
+              return renderAcknowledgement('insert', revision, rowID, 'success');
+            } catch (error) {
+              return renderAcknowledgement('insert', revision, rowID, 'error');
+            }
+          }
+          function removeChatRow(rowID, revision) {
+            try {
+              var row = document.querySelector('[data-row-id="' + CSS.escape(rowID) + '"]');
+              if (!row) return renderAcknowledgement('remove', revision, rowID, 'missingRow');
+              row.remove(); reportFollowState();
+              return renderAcknowledgement('remove', revision, rowID, 'success');
+            } catch (error) {
+              return renderAcknowledgement('remove', revision, rowID, 'error');
+            }
+          }
+          function replaceChatTranscript(html, shouldFollow, revision) {
+            try {
+              var state = currentRowInteraction();
+              transcriptRoot().innerHTML = html;
+              restoreRowInteraction(state);
+              if (shouldFollow && state.wasNearBottom) window.scrollTo(0, document.body.scrollHeight);
+              reportFollowState();
+              return renderAcknowledgement('reload', revision, null, 'success');
+            } catch (error) {
+              return renderAcknowledgement('reload', revision, null, 'error');
+            }
+          }
+          function replaceChatRow(rowID, html, shouldFollow, revision) {
             var oldRow = document.querySelector('[data-row-id="' + CSS.escape(rowID) + '"]');
-            if (!oldRow) { appendRows(html, shouldFollow); return; }
+            if (!oldRow) return renderAcknowledgement('replace', revision, rowID, 'missingRow');
             var wasNearBottom = isNearBottom();
             var active = document.activeElement;
             var focusKey = active && oldRow.contains(active) ? active.getAttribute('data-focus-key') : null;
             var offsets = selectionOffsets(oldRow);
             oldRow.outerHTML = html;
             var newRow = document.querySelector('[data-row-id="' + CSS.escape(rowID) + '"]');
-            if (!newRow) return;
+            if (!newRow) return renderAcknowledgement('replace', revision, rowID, 'missingRow');
             if (focusKey) {
               var replacementFocus = newRow.querySelector('[data-focus-key="' + CSS.escape(focusKey) + '"]');
               if (replacementFocus) replacementFocus.focus({preventScroll:true});
@@ -1396,6 +1620,7 @@ struct ChatWebView: NSViewRepresentable {
             }
             if (shouldFollow && wasNearBottom) window.scrollTo(0, document.body.scrollHeight);
             reportFollowState();
+            return renderAcknowledgement('replace', revision, rowID, 'success');
           }
           window.addEventListener('scroll', reportFollowState, {passive:true});
           // Delegated click handler for the per-bubble copy icon (issue #285).

--- a/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
@@ -82,15 +82,84 @@ struct ChatTranscriptHostedTests {
         let initialJSON = try #require(String(data: initialData, encoding: .utf8))
         let replacementJSON = try #require(String(data: replacementData, encoding: .utf8))
 
-        _ = await evaluateJavaScriptWithTimeout(webView, "appendRows(\(initialJSON), false)")
+        let initialAcknowledgement = await webView.chatTranscriptJavaScriptResult(
+            "appendChatRows(\(initialJSON), false, 41, \"message-assistant-hosted\")"
+        )
+        #expect(acknowledgementField("revision", in: initialAcknowledgement) == 41)
+        #expect(acknowledgementField("outcome", in: initialAcknowledgement) == "success")
         _ = await evaluateJavaScriptWithTimeout(webView, "document.querySelector('[data-focus-key=\\\"copy\\\"]').focus()")
         _ = await evaluateJavaScriptWithTimeout(webView, "(function(){var root=document.querySelector('[data-row-id=\\\"message-assistant-hosted\\\"] .bubble');var t=document.createTreeWalker(root,NodeFilter.SHOW_TEXT,null).nextNode();var r=document.createRange();r.setStart(t,0);r.setEnd(t,7);var s=getSelection();s.removeAllRanges();s.addRange(r);})()")
         let before = await evaluateJavaScriptWithTimeout(webView, "getSelection().toString()")
         #expect(before == "Initial")
-        _ = await evaluateJavaScriptWithTimeout(webView, "replaceChatRow('message-assistant-hosted', \(replacementJSON), false)")
+        let replacementAcknowledgement = await webView.chatTranscriptJavaScriptResult(
+            "replaceChatRow('message-assistant-hosted', \(replacementJSON), false, 42)"
+        )
+        #expect(acknowledgementField("revision", in: replacementAcknowledgement) == 42)
+        #expect(acknowledgementField("rowID", in: replacementAcknowledgement) == "message-assistant-hosted")
+        #expect(acknowledgementField("outcome", in: replacementAcknowledgement) == "success")
 
         let state = await evaluateJavaScriptWithTimeout(webView, "(function(){var row=document.querySelector('[data-row-id=\\\"message-assistant-hosted\\\"]');var active=document.activeElement;return [row.getAttribute('role'),row.getAttribute('aria-busy'),active.getAttribute('data-focus-key'),getSelection().toString().trim()].join('|');})()")
         #expect(state == "article|false|copy|Initial")
+    }
+
+    @Test func hostedCommandsUseStableRowIdentityAndReportMissingRows() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        _ = Self.app
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = webView
+        window.orderFront(nil)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
+
+        await NavigationWaiter().load(ChatWebView.Coordinator.shellHTML, in: webView)
+        let turnID = ChatTurnID(rawValue: "turn-order")
+        let first = ChatDisplayRow.userMessage(
+            id: ChatMessageID(rawValue: "row-first"), turnID: turnID,
+            text: "Question", createdAt: .distantPast
+        )
+        let second = ChatDisplayRow.assistantMessage(
+            id: ChatMessageID(rawValue: "row-second"), turnID: turnID,
+            text: "Answer", createdAt: .distantPast, contentState: .final
+        )
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(first)
+            + ChatWebView.Coordinator.chatDisplayRowHTML(second)
+        let data = try JSONSerialization.data(withJSONObject: html, options: [.fragmentsAllowed])
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        let reload = await webView.chatTranscriptJavaScriptResult(
+            "replaceChatTranscript(\(json), false, 61)"
+        )
+        #expect(acknowledgementField("kind", in: reload) == "reload")
+        #expect(acknowledgementField("revision", in: reload) == 61)
+        #expect(acknowledgementField("outcome", in: reload) == "success")
+        let rowIDs = await evaluateJavaScriptWithTimeout(webView,
+            "Array.from(document.querySelectorAll('[data-row-id]')).map(function(row){return row.getAttribute('data-row-id');}).join('|')"
+        )
+        #expect(rowIDs == "message-row-first|message-row-second")
+
+        let missing = await webView.chatTranscriptJavaScriptResult(
+            "replaceChatRow('message-not-present', '<article></article>', false, 62)"
+        )
+        #expect(acknowledgementField("kind", in: missing) == "replace")
+        #expect(acknowledgementField("revision", in: missing) == 62)
+        #expect(acknowledgementField("rowID", in: missing) == "message-not-present")
+        #expect(acknowledgementField("outcome", in: missing) == "missingRow")
+    }
+
+    private func acknowledgementField<T>(
+        _ field: String,
+        in result: ChatTranscriptJavaScriptResult
+    ) -> T? {
+        guard case .success(let value) = result,
+              let acknowledgement = value as? [String: Any]
+        else { return nil }
+        return acknowledgement[field] as? T
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/ChatTranscriptRenderPlannerTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptRenderPlannerTests.swift
@@ -1,0 +1,255 @@
+#if os(macOS)
+import Testing
+@testable import WikiFS
+@testable import WikiFSTypes
+
+struct ChatTranscriptRenderPlannerTests {
+    private let transcript = TranscriptID.chat(ChatID(rawValue: "chat-render"))
+    private let turn = ChatTurnID(rawValue: "turn-render")
+
+    @Test func firstSnapshotReloadsAndUnchangedSnapshotDoesNothing() {
+        let desired = snapshot(rows: [row("a", text: "One")])
+        #expect(ChatTranscriptRenderPlanner.commands(previous: nil, desired: desired) == [.reload(desired)])
+        #expect(ChatTranscriptRenderPlanner.commands(previous: desired, desired: desired).isEmpty)
+    }
+
+    @Test func sameIdentityWithNewContentReplacesThatRow() {
+        let previous = snapshot(rows: [row("a", text: "Before")])
+        let changed = row("a", text: "After")
+        #expect(ChatTranscriptRenderPlanner.commands(
+            previous: previous,
+            desired: snapshot(rows: [changed])
+        ) == [.replace(changed)])
+    }
+
+    @Test func differentIdentityAtEqualCountReloadsInsteadOfReplacingLastRow() {
+        let previous = snapshot(rows: [row("a", text: "One")])
+        let desired = snapshot(rows: [row("b", text: "Two")])
+        #expect(ChatTranscriptRenderPlanner.commands(previous: previous, desired: desired) == [.reload(desired)])
+    }
+
+    @Test func tailRowsAppendAndMiddleRowsInsertByIdentity() {
+        let a = row("a", text: "A")
+        let b = row("b", text: "B")
+        let c = row("c", text: "C")
+        #expect(ChatTranscriptRenderPlanner.commands(
+            previous: snapshot(rows: [a]), desired: snapshot(rows: [a, b, c])
+        ) == [.append([b, c])])
+        #expect(ChatTranscriptRenderPlanner.commands(
+            previous: snapshot(rows: [a, c]), desired: snapshot(rows: [a, b, c])
+        ) == [.insert(b, before: c.id)])
+    }
+
+    @Test func existingReplacementStaysAheadOfAnAppendBoundary() {
+        let before = row("a", text: "Before")
+        let after = row("a", text: "After")
+        let appended = row("b", text: "New block")
+        #expect(ChatTranscriptRenderPlanner.commands(
+            previous: snapshot(rows: [before]),
+            desired: snapshot(rows: [after, appended])
+        ) == [.replace(after), .append([appended])])
+    }
+
+    @Test func removesByIdentityAndReloadsForReorderOrContextChange() {
+        let a = row("a", text: "A")
+        let b = row("b", text: "B")
+        let c = row("c", text: "C")
+        #expect(ChatTranscriptRenderPlanner.commands(
+            previous: snapshot(rows: [a, b, c]), desired: snapshot(rows: [a, c])
+        ) == [.remove(b.id)])
+
+        let previous = snapshot(rows: [a, b])
+        let reordered = snapshot(rows: [b, a])
+        #expect(ChatTranscriptRenderPlanner.commands(previous: previous, desired: reordered) == [.reload(reordered)])
+
+        let reset = ChatTranscriptRenderSnapshot(
+            context: .init(transcriptID: transcript, resetToken: 1), rows: [a, b]
+        )
+        #expect(ChatTranscriptRenderPlanner.commands(previous: previous, desired: reset) == [.reload(reset)])
+
+        let styleChange = ChatTranscriptRenderSnapshot(
+            context: .init(transcriptID: transcript, style: .activityFeed), rows: [a, b]
+        )
+        #expect(ChatTranscriptRenderPlanner.commands(previous: previous, desired: styleChange) == [.reload(styleChange)])
+    }
+
+    private func snapshot(rows: [ChatDisplayRow]) -> ChatTranscriptRenderSnapshot {
+        .init(context: .init(transcriptID: transcript), rows: rows)
+    }
+
+    private func row(_ id: String, text: String) -> ChatDisplayRow {
+        .assistantMessage(
+            id: ChatMessageID(rawValue: id),
+            turnID: turn,
+            text: text,
+            createdAt: .distantPast,
+            contentState: .final
+        )
+    }
+}
+
+@MainActor
+struct ChatTranscriptRenderExecutorTests {
+    private let transcript = TranscriptID.chat(ChatID(rawValue: "chat-executor"))
+    private let turn = ChatTurnID(rawValue: "turn-executor")
+
+    @Test func serializesCommandsUntilEachRevisionAcknowledges() {
+        let recorder = RenderMutationRecorder()
+        let executor = makeExecutor(recorder)
+        let a = row("a", text: "A")
+        let b = row("b", text: "B")
+
+        executor.submit(snapshot([a]))
+        #expect(recorder.commands.count == 1)
+        #expect(executor.state == .awaitingReload)
+        recorder.succeedCurrent()
+        executor.submit(snapshot([a, b]))
+        #expect(recorder.commands.map(\.command) == [.reload(snapshot([a])), .append([b])])
+        #expect(executor.state == .applying(.append([b]), ChatTranscriptRenderRevision(rawValue: 2)))
+        recorder.succeedCurrent()
+        #expect(executor.state == .idle)
+    }
+
+    @Test func coalescesOnlyPendingReplacementForTheSameRow() {
+        let recorder = RenderMutationRecorder()
+        let executor = makeExecutor(recorder)
+        let original = row("a", text: "A")
+        let first = row("a", text: "AB")
+        let latest = row("a", text: "ABC")
+
+        executor.submit(snapshot([original]))
+        recorder.succeedCurrent()
+        executor.submit(snapshot([first]))
+        executor.submit(snapshot([latest]))
+        #expect(recorder.commands.count == 2)
+        recorder.succeedCurrent()
+        #expect(recorder.commands.map(\.command) == [
+            .reload(snapshot([original])), .replace(first), .replace(latest)
+        ])
+    }
+
+    @Test func failedPatchSchedulesOneReloadFromTheLatestSnapshot() {
+        let recorder = RenderMutationRecorder()
+        let anomalies = RenderAnomalyRecorder()
+        let executor = makeExecutor(recorder, anomalies: anomalies)
+        let original = row("a", text: "A")
+        let changed = row("a", text: "AB")
+        let latest = row("a", text: "ABC")
+
+        executor.submit(snapshot([original]))
+        recorder.succeedCurrent()
+        executor.submit(snapshot([changed]))
+        executor.submit(snapshot([latest]))
+        recorder.finishCurrent(outcome: .missingRow)
+
+        #expect(recorder.commands.map(\.command) == [
+            .reload(snapshot([original])), .replace(changed), .reload(snapshot([latest]))
+        ])
+        #expect(anomalies.items == [.failedAcknowledgement(.missingRow)])
+        recorder.finishCurrent(outcome: .timeout)
+        #expect(recorder.commands.count == 3)
+    }
+
+    @Test func acknowledgementMismatchDoesNotAdvanceStateAndTriggersRecovery() {
+        let recorder = RenderMutationRecorder()
+        let anomalies = RenderAnomalyRecorder()
+        let executor = makeExecutor(recorder, anomalies: anomalies)
+        let original = row("a", text: "A")
+        let changed = row("a", text: "AB")
+
+        executor.submit(snapshot([original]))
+        recorder.succeedCurrent()
+        executor.submit(snapshot([changed]))
+        recorder.finishCurrent(kind: .append, outcome: .success)
+
+        #expect(anomalies.items == [.invalidAcknowledgement(expected: .replace, received: .append)])
+        #expect(recorder.commands.last?.command == .reload(snapshot([changed])))
+    }
+
+    @Test func undefinedAndJavaScriptErrorAcknowledgementsDoNotAdvancePatches() {
+        for outcome in [
+            ChatTranscriptRenderAcknowledgementOutcome.undefined,
+            .javaScriptException,
+            .error,
+            .timeout
+        ] {
+            let recorder = RenderMutationRecorder()
+            let anomalies = RenderAnomalyRecorder()
+            let executor = makeExecutor(recorder, anomalies: anomalies)
+            let original = row("a", text: "A")
+            let changed = row("a", text: "AB")
+
+            executor.submit(snapshot([original]))
+            recorder.succeedCurrent()
+            executor.submit(snapshot([changed]))
+            recorder.finishCurrent(outcome: outcome)
+
+            #expect(anomalies.items == [.failedAcknowledgement(outcome)])
+            #expect(recorder.commands.last?.command == .reload(snapshot([changed])))
+        }
+    }
+
+    private func makeExecutor(
+        _ recorder: RenderMutationRecorder,
+        anomalies: RenderAnomalyRecorder = .init()
+    ) -> ChatTranscriptRenderExecutor {
+        ChatTranscriptRenderExecutor(
+            mutate: recorder.record,
+            reportAnomaly: anomalies.record
+        )
+    }
+
+    private func snapshot(_ rows: [ChatDisplayRow]) -> ChatTranscriptRenderSnapshot {
+        .init(context: .init(transcriptID: transcript), rows: rows)
+    }
+
+    private func row(_ id: String, text: String) -> ChatDisplayRow {
+        .assistantMessage(
+            id: ChatMessageID(rawValue: id), turnID: turn, text: text,
+            createdAt: .distantPast, contentState: .final
+        )
+    }
+}
+
+@MainActor
+private final class RenderMutationRecorder {
+    struct Entry {
+        let command: ChatTranscriptRenderCommand
+        let revision: ChatTranscriptRenderRevision
+        let completion: @MainActor (ChatTranscriptRenderAcknowledgement) -> Void
+    }
+
+    private(set) var commands: [Entry] = []
+
+    func record(
+        command: ChatTranscriptRenderCommand,
+        revision: ChatTranscriptRenderRevision,
+        completion: @escaping @MainActor (ChatTranscriptRenderAcknowledgement) -> Void
+    ) {
+        commands.append(Entry(command: command, revision: revision, completion: completion))
+    }
+
+    func succeedCurrent() {
+        finishCurrent(outcome: .success)
+    }
+
+    func finishCurrent(
+        kind: ChatTranscriptRenderCommandKind? = nil,
+        outcome: ChatTranscriptRenderAcknowledgementOutcome
+    ) {
+        guard let entry = commands.last else { return }
+        entry.completion(.init(
+            kind: kind ?? entry.command.kind,
+            revision: entry.revision,
+            rowID: entry.command.rowID,
+            outcome: outcome
+        ))
+    }
+}
+
+@MainActor
+private final class RenderAnomalyRecorder {
+    private(set) var items: [ChatTranscriptRendererAnomaly] = []
+    func record(_ anomaly: ChatTranscriptRendererAnomaly) { items.append(anomaly) }
+}
+#endif

--- a/progress/2026-07-30T174300Z-chat-presentation-phase5-keyed-renderer.md
+++ b/progress/2026-07-30T174300Z-chat-presentation-phase5-keyed-renderer.md
@@ -1,0 +1,38 @@
+# Chat presentation Phase 5: keyed renderer
+
+Date: 2026-07-30
+
+## Result
+
+The app chat transcript now uses a keyed render plan and an acknowledged WebKit command executor.
+
+`ChatTranscriptRenderPlanner` compares typed display rows by durable row ID.
+It returns reload, append, insert, replace, remove, or no command.
+It reloads for transcript, style, reset, duplicate-ID, reorder, and equal-count identity changes.
+
+`ChatTranscriptRenderExecutor` runs on the main actor.
+It allows one DOM mutation at a time.
+It advances its acknowledged snapshot only after a matching successful acknowledgement.
+It coalesces repeated updates for one row through the latest desired snapshot.
+A failed patch schedules one reload from that snapshot.
+
+The WebKit shell now keeps transcript rows in one named root.
+DOM commands target `data-row-id` values only.
+Commands return kind, revision, row ID, and outcome.
+The shell keeps focus, selection offsets, and a scroll anchor during replacements and controlled reloads.
+
+## Validation
+
+- `make build` passed.
+- `make test` passed with 2,712 Swift Testing tests.
+- Focused planner and executor tests passed with app tests enabled.
+- Focused hosted WebKit tests passed with app tests enabled.
+- The hosted tests passed while a SwiftUI runtime-issues log stream was active.
+- `log show` found no matching update-cycle warning for the focused hosted run.
+- `WIKIFS_APP_TESTS=1 swift test` stalled in the aggregate hosted suite after about three minutes.
+- The stalled helpers ran from this worktree and were terminated.
+
+## Scope
+
+This change is Phase 5 only.
+It does not change other planned phases or the documentation index.

--- a/progress/2026-07-30T174300Z-chat-presentation-phase5-keyed-renderer.md
+++ b/progress/2026-07-30T174300Z-chat-presentation-phase5-keyed-renderer.md
@@ -1,8 +1,13 @@
-# Chat presentation Phase 5: keyed renderer
+---
+timestamp: 2026-07-30T174300Z
+title: Chat presentation Phase 5 keyed renderer
+branch: chat-presentation-diagnostics-phase5
+status: complete
+---
 
-Date: 2026-07-30
+# Chat presentation Phase 5 keyed renderer
 
-## Result
+## Progress
 
 The app chat transcript now uses a keyed render plan and an acknowledged WebKit command executor.
 
@@ -21,7 +26,10 @@ DOM commands target `data-row-id` values only.
 Commands return kind, revision, row ID, and outcome.
 The shell keeps focus, selection offsets, and a scroll anchor during replacements and controlled reloads.
 
-## Validation
+This change is Phase 5 only.
+It does not change other planned phases or the documentation index.
+
+## Verification
 
 - `make build` passed.
 - `make test` passed with 2,712 Swift Testing tests.
@@ -31,8 +39,3 @@ The shell keeps focus, selection offsets, and a scroll anchor during replacement
 - `log show` found no matching update-cycle warning for the focused hosted run.
 - `WIKIFS_APP_TESTS=1 swift test` stalled in the aggregate hosted suite after about three minutes.
 - The stalled helpers ran from this worktree and were terminated.
-
-## Scope
-
-This change is Phase 5 only.
-It does not change other planned phases or the documentation index.


### PR DESCRIPTION
## Summary

- Add a keyed planner for typed chat transcript rows.
- Add a main-actor executor that waits for WebKit acknowledgements.
- Keep focus, selection, and scroll anchors during acknowledged DOM updates.

## Validation

- `make build`
- `make test` with 2,712 tests
- Focused planner, executor, and hosted WebKit suites with `WIKIFS_APP_TESTS=1`
- SwiftUI runtime-issues capture during the focused hosted suite

## Note

`WIKIFS_APP_TESTS=1 swift test` stalls in the aggregate hosted suite. The focused hosted tests pass.
