### PR TITLE
Add correlated chat diagnostics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,6 +80,12 @@ let package = Package(
         // reference these foundational types without a circular dependency.
         .target(
             name: "WikiFSTypes",
+            dependencies: [
+                // macOS uses CryptoKit; Linux resolves the matching API from
+                // swift-crypto's Crypto module.
+                .product(name: "Crypto", package: "swift-crypto",
+                         condition: .when(platforms: [.linux])),
+            ],
             path: "Sources/WikiFSTypes",
             swiftSettings: strictSwiftSettings
         ),

--- a/Sources/WikiCtlCore/DaemonWorkloadClient.swift
+++ b/Sources/WikiCtlCore/DaemonWorkloadClient.swift
@@ -407,6 +407,20 @@ public final class DaemonWorkloadClient: @unchecked Sendable {
         }
     }
 
+    /// Acknowledge a successfully persisted/copy-delivered export. The daemon
+    /// validates the same versioned request boundary before rotating its ring.
+    public func resetChatDiagnostics(_ request: ChatDiagnosticResetRequest) async throws {
+        let requestData = try JSONEncoder().encode(request)
+        try await withTimeout {
+            let replyData = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+                self.proxy.resetChatDiagnostics(request: requestData) { data in
+                    cont.resume(returning: data)
+                }
+            }
+            guard replyData.isEmpty == false else { throw DaemonXPCError.unexpectedReply }
+        }
+    }
+
     /// Resolve a pending permission request for a chat.
     public func resolveChatPermission(_ request: ChatPermissionResolveRequest) async throws {
         let requestData = try JSONEncoder().encode(request)

--- a/Sources/WikiCtlCore/DaemonWorkloadClient.swift
+++ b/Sources/WikiCtlCore/DaemonWorkloadClient.swift
@@ -11,6 +11,8 @@ public enum DaemonXPCError: Error, LocalizedError {
     case failure(String)
     case unexpectedReply
     case chatWire(ChatSyncWireError)
+    case diagnosticDecode
+    case diagnosticVersion(ChatDiagnosticVersionError)
 
     public var errorDescription: String? {
         switch self {
@@ -22,6 +24,10 @@ public enum DaemonXPCError: Error, LocalizedError {
             return "Unexpected reply from daemon"
         case .chatWire(let error):
             return error.localizedDescription
+        case .diagnosticDecode:
+            return "Daemon diagnostic snapshot could not be decoded"
+        case .diagnosticVersion(let error):
+            return "Daemon diagnostic snapshot version failure: \(error)"
         }
     }
 }
@@ -370,6 +376,34 @@ public final class DaemonWorkloadClient: @unchecked Sendable {
             } catch {
                 throw DaemonXPCError.unexpectedReply
             }
+        }
+    }
+
+    /// Request a redacted daemon trace. The request is bounded by the same XPC
+    /// timeout as every app-side workload request and validates both envelope
+    /// versions after decoding.
+    public func chatDiagnosticSnapshot(
+        _ request: ChatDiagnosticSnapshotRequest
+    ) async throws -> ChatDiagnosticSnapshotEnvelope {
+        let requestData = try JSONEncoder().encode(request)
+        return try await withTimeout {
+            let replyData = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+                self.proxy.chatDiagnosticSnapshot(request: requestData) { data in
+                    cont.resume(returning: data)
+                }
+            }
+            let snapshot: ChatDiagnosticSnapshotEnvelope
+            do {
+                snapshot = try JSONDecoder().decode(ChatDiagnosticSnapshotEnvelope.self, from: replyData)
+            } catch {
+                throw DaemonXPCError.diagnosticDecode
+            }
+            do {
+                try snapshot.validatingVersion()
+            } catch let error as ChatDiagnosticVersionError {
+                throw DaemonXPCError.diagnosticVersion(error)
+            }
+            return snapshot
         }
     }
 

--- a/Sources/WikiDaemonContract/WikiDaemonProtocol.swift
+++ b/Sources/WikiDaemonContract/WikiDaemonProtocol.swift
@@ -128,6 +128,10 @@ import Foundation
     /// JSON-encoded `ChatSyncSnapshotEnvelope` data.
     func chatSessionState(chatID: String, reply: @escaping (Data) -> Void)
 
+    /// Returns a versioned, redacted diagnostic snapshot. Both request and
+    /// reply are JSON `Data`; protocol versions are validated by the daemon.
+    func chatDiagnosticSnapshot(request: Data, reply: @escaping (Data) -> Void)
+
     /// Resolve a pending permission request for a chat (approve/reject).
     /// `request` is JSON `ChatPermissionResolveRequest`.
     func resolveChatPermission(request: Data, reply: @escaping () -> Void)

--- a/Sources/WikiDaemonContract/WikiDaemonProtocol.swift
+++ b/Sources/WikiDaemonContract/WikiDaemonProtocol.swift
@@ -132,6 +132,10 @@ import Foundation
     /// reply are JSON `Data`; protocol versions are validated by the daemon.
     func chatDiagnosticSnapshot(request: Data, reply: @escaping (Data) -> Void)
 
+    /// Acknowledges a successfully delivered diagnostic export so `wikid` can
+    /// rotate its identity, fingerprint key, and bounded ring.
+    func resetChatDiagnostics(request: Data, reply: @escaping (Data) -> Void)
+
     /// Resolve a pending permission request for a chat (approve/reject).
     /// `request` is JSON `ChatPermissionResolveRequest`.
     func resolveChatPermission(request: Data, reply: @escaping () -> Void)

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -13,6 +13,7 @@ public protocol ChatDaemonCommands: AnyObject, Sendable {
     func submitChatTurn(_ request: ChatSubmitRequest) async throws -> ChatID
     func stopChat(_ chatID: ChatID) async throws
     func chatSessionState(_ chatID: ChatID) async throws -> ChatSyncSnapshot
+    func chatDiagnosticSnapshot(_ request: ChatDiagnosticSnapshotRequest) async throws -> ChatDiagnosticSnapshotEnvelope
     func resolveChatPermission(_ request: ChatPermissionResolveRequest) async throws
     func setChatConfigOption(_ request: ChatConfigOptionRequest) async throws
 }
@@ -93,6 +94,44 @@ public final class ChatDaemonCoordinator {
         wireSessionCallbacks(session)
         sessions[key] = session
         return session
+    }
+
+    /// Builds the redacted app/daemon diagnostic artifact for an existing chat.
+    /// Request failures become an explicit app-side snapshot event so exports
+    /// explain whether the daemon half was unavailable, malformed, or old.
+    func diagnosticSnapshot(for chatID: ChatID?) async -> ChatDiagnosticMergedSnapshot {
+        let correlation = chatID.map { ChatDiagnosticCorrelation.Value(rawValue: $0.rawValue) }
+        let app = await ChatDiagnostics.appTrace.snapshot(
+            chat: correlation,
+            summary: ["sync": "app-coordinator", "chat": correlation?.rawValue ?? "draft"]
+        )
+        guard chatID != nil else { return ChatDiagnosticSnapshotMerge.merge(app: app, daemon: nil) }
+        do {
+            let daemon = try await client.chatDiagnosticSnapshot(.init(chat: correlation))
+            return ChatDiagnosticSnapshotMerge.merge(app: app, daemon: daemon)
+        } catch let error as DaemonXPCError {
+            let outcome: ChatDiagnosticOutcome
+            switch error {
+            case .timeout: outcome = .timeout
+            case .diagnosticDecode: outcome = .decodeFailure
+            case .diagnosticVersion: outcome = .versionFailure
+            default: outcome = .failed
+            }
+            _ = await ChatDiagnostics.appTrace.record(
+                stage: .syncAcceptance,
+                outcome: outcome,
+                payload: .init(correlation: .init(chat: correlation), detail: "daemon-diagnostic-snapshot")
+            )
+            let updated = await ChatDiagnostics.appTrace.snapshot(chat: correlation)
+            return ChatDiagnosticSnapshotMerge.merge(app: updated, daemon: nil)
+        } catch {
+            _ = await ChatDiagnostics.appTrace.record(
+                stage: .syncAcceptance,
+                outcome: .failed,
+                payload: .init(correlation: .init(chat: correlation), detail: "daemon-diagnostic-snapshot")
+            )
+            return ChatDiagnosticSnapshotMerge.merge(app: await ChatDiagnostics.appTrace.snapshot(chat: correlation), daemon: nil)
+        }
     }
 
     /// Drop the cached session for a chat (e.g. when retargeting the tab to a

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -44,6 +44,7 @@ public final class ChatDaemonCoordinator {
 
     private let client: ChatDaemonCommands
     private let eventSink: DaemonQueueEventSink
+    private let diagnosticTrace: ChatDiagnosticTrace
 
     /// chat key → mirror session. The draft (.newChat) state uses `.draft`.
     private var sessions: [ChatSessionKey: RemoteChatSession] = [:]
@@ -74,12 +75,17 @@ public final class ChatDaemonCoordinator {
 
     private var routerTask: Task<Void, Never>?
 
-    init(client: ChatDaemonCommands, eventSink: DaemonQueueEventSink) {
+    init(
+        client: ChatDaemonCommands,
+        eventSink: DaemonQueueEventSink,
+        diagnosticTrace: ChatDiagnosticTrace = ChatDiagnostics.appTrace
+    ) {
         // Intentionally non-`public` — `DaemonQueueEventSink` is internal, so
         // the coordinator can only be constructed from within the WikiFS module
         // (the app wires it in `WikiFSApp`; tests inject a stub `ChatDaemonCommands`).
         self.client = client
         self.eventSink = eventSink
+        self.diagnosticTrace = diagnosticTrace
         startRouting()
     }
 
@@ -101,7 +107,7 @@ public final class ChatDaemonCoordinator {
     /// explain whether the daemon half was unavailable, malformed, or old.
     func diagnosticSnapshot(for chatID: ChatID?) async -> ChatDiagnosticMergedSnapshot {
         let correlation = chatID.map { ChatDiagnosticCorrelation.Value(rawValue: $0.rawValue) }
-        let app = await ChatDiagnostics.appTrace.snapshot(
+        let app = await diagnosticTrace.snapshot(
             chat: correlation,
             summary: ["sync": "app-coordinator", "chat": correlation?.rawValue ?? "draft"]
         )
@@ -117,21 +123,46 @@ public final class ChatDaemonCoordinator {
             case .diagnosticVersion: outcome = .versionFailure
             default: outcome = .failed
             }
-            _ = await ChatDiagnostics.appTrace.record(
+            _ = await diagnosticTrace.record(
                 stage: .syncAcceptance,
                 outcome: outcome,
                 payload: .init(correlation: .init(chat: correlation), detail: "daemon-diagnostic-snapshot")
             )
-            let updated = await ChatDiagnostics.appTrace.snapshot(chat: correlation)
+            let updated = await diagnosticTrace.snapshot(chat: correlation)
             return ChatDiagnosticSnapshotMerge.merge(app: updated, daemon: nil)
         } catch {
-            _ = await ChatDiagnostics.appTrace.record(
+            _ = await diagnosticTrace.record(
                 stage: .syncAcceptance,
                 outcome: .failed,
                 payload: .init(correlation: .init(chat: correlation), detail: "daemon-diagnostic-snapshot")
             )
-            return ChatDiagnosticSnapshotMerge.merge(app: await ChatDiagnostics.appTrace.snapshot(chat: correlation), daemon: nil)
+            return ChatDiagnosticSnapshotMerge.merge(app: await diagnosticTrace.snapshot(chat: correlation), daemon: nil)
         }
+    }
+
+    /// Requests the app/daemon snapshot through the normal coordinator path,
+    /// then writes the redacted artifact to the caller-provided destination.
+    /// The exporter rotates app-local trace material only after that write
+    /// succeeds, preserving retry evidence when a pasteboard write fails.
+    func copyDiagnostics(
+        for chatID: ChatID?,
+        exporter: ChatDiagnosticExporter = .init(),
+        write: (Data) throws -> Void
+    ) async throws {
+        let snapshot = await diagnosticSnapshot(for: chatID)
+        try await exporter.copy(snapshot, write: write)
+    }
+
+    /// Writes the same redacted coordinator snapshot as JSONL for explicit
+    /// diagnostic collection. Full-content ACP artifacts remain the separate
+    /// debug-folder workflow owned by the chat runtime.
+    func writeDiagnosticsJSONL(
+        for chatID: ChatID?,
+        to url: URL,
+        exporter: ChatDiagnosticExporter = .init()
+    ) async throws {
+        let snapshot = await diagnosticSnapshot(for: chatID)
+        try await exporter.writeJSONL(snapshot, to: url)
     }
 
     /// Drop the cached session for a chat (e.g. when retargeting the tab to a

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -14,6 +14,7 @@ public protocol ChatDaemonCommands: AnyObject, Sendable {
     func stopChat(_ chatID: ChatID) async throws
     func chatSessionState(_ chatID: ChatID) async throws -> ChatSyncSnapshot
     func chatDiagnosticSnapshot(_ request: ChatDiagnosticSnapshotRequest) async throws -> ChatDiagnosticSnapshotEnvelope
+    func resetChatDiagnostics(_ request: ChatDiagnosticResetRequest) async throws
     func resolveChatPermission(_ request: ChatPermissionResolveRequest) async throws
     func setChatConfigOption(_ request: ChatConfigOptionRequest) async throws
 }
@@ -107,7 +108,7 @@ public final class ChatDaemonCoordinator {
     /// explain whether the daemon half was unavailable, malformed, or old.
     func diagnosticSnapshot(for chatID: ChatID?) async -> ChatDiagnosticMergedSnapshot {
         let correlation = chatID.map { ChatDiagnosticCorrelation.Value(rawValue: $0.rawValue) }
-        let app = await diagnosticTrace.snapshot(
+        let app = diagnosticTrace.snapshot(
             chat: correlation,
             summary: ["sync": "app-coordinator", "chat": correlation?.rawValue ?? "draft"]
         )
@@ -123,34 +124,38 @@ public final class ChatDaemonCoordinator {
             case .diagnosticVersion: outcome = .versionFailure
             default: outcome = .failed
             }
-            _ = await diagnosticTrace.record(
+            _ = diagnosticTrace.record(
                 stage: .syncAcceptance,
                 outcome: outcome,
                 payload: .init(correlation: .init(chat: correlation), detail: "daemon-diagnostic-snapshot")
             )
-            let updated = await diagnosticTrace.snapshot(chat: correlation)
+            let updated = diagnosticTrace.snapshot(chat: correlation)
             return ChatDiagnosticSnapshotMerge.merge(app: updated, daemon: nil)
         } catch {
-            _ = await diagnosticTrace.record(
+            _ = diagnosticTrace.record(
                 stage: .syncAcceptance,
                 outcome: .failed,
                 payload: .init(correlation: .init(chat: correlation), detail: "daemon-diagnostic-snapshot")
             )
-            return ChatDiagnosticSnapshotMerge.merge(app: await diagnosticTrace.snapshot(chat: correlation), daemon: nil)
+            return ChatDiagnosticSnapshotMerge.merge(app: diagnosticTrace.snapshot(chat: correlation), daemon: nil)
         }
     }
 
     /// Requests the app/daemon snapshot through the normal coordinator path,
     /// then writes the redacted artifact to the caller-provided destination.
-    /// The exporter rotates app-local trace material only after that write
-    /// succeeds, preserving retry evidence when a pasteboard write fails.
+    /// Both app and daemon rings rotate only after every export step succeeds,
+    /// preserving retry evidence when a destination or daemon reset fails.
     func copyDiagnostics(
         for chatID: ChatID?,
-        exporter: ChatDiagnosticExporter = .init(),
         write: (Data) throws -> Void
     ) async throws {
         let snapshot = await diagnosticSnapshot(for: chatID)
+        let exporter = ChatDiagnosticExporter(trace: diagnosticTrace)
         try await exporter.copy(snapshot, write: write)
+        if let chatID {
+            try await client.resetChatDiagnostics(.init(chat: .init(rawValue: chatID.rawValue)))
+        }
+        exporter.resetAfterSuccessfulExport()
     }
 
     /// Writes the same redacted coordinator snapshot as JSONL for explicit
@@ -158,11 +163,15 @@ public final class ChatDaemonCoordinator {
     /// debug-folder workflow owned by the chat runtime.
     func writeDiagnosticsJSONL(
         for chatID: ChatID?,
-        to url: URL,
-        exporter: ChatDiagnosticExporter = .init()
+        to url: URL
     ) async throws {
         let snapshot = await diagnosticSnapshot(for: chatID)
+        let exporter = ChatDiagnosticExporter(trace: diagnosticTrace)
         try await exporter.writeJSONL(snapshot, to: url)
+        if let chatID {
+            try await client.resetChatDiagnostics(.init(chat: .init(rawValue: chatID.rawValue)))
+        }
+        exporter.resetAfterSuccessfulExport()
     }
 
     /// Drop the cached session for a chat (e.g. when retargeting the tab to a

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -143,8 +143,9 @@ public final class ChatDaemonCoordinator {
 
     /// Requests the app/daemon snapshot through the normal coordinator path,
     /// then writes the redacted artifact to the caller-provided destination.
-    /// Both app and daemon rings rotate only after every export step succeeds,
-    /// preserving retry evidence when a destination or daemon reset fails.
+    /// A written artifact immediately retires both fingerprint epochs. The
+    /// daemon reset still drains both rings on success; a failed reset retains
+    /// retry evidence without reusing an exported fingerprint key.
     func copyDiagnostics(
         for chatID: ChatID?,
         write: (Data) throws -> Void
@@ -153,7 +154,12 @@ public final class ChatDaemonCoordinator {
         let exporter = ChatDiagnosticExporter(trace: diagnosticTrace)
         try await exporter.copy(snapshot, write: write)
         if let chatID {
-            try await client.resetChatDiagnostics(.init(chat: .init(rawValue: chatID.rawValue)))
+            do {
+                try await client.resetChatDiagnostics(.init(chat: .init(rawValue: chatID.rawValue)))
+            } catch {
+                exporter.rotateFingerprintKeyPreservingRecords()
+                throw error
+            }
         }
         exporter.resetAfterSuccessfulExport()
     }
@@ -169,7 +175,12 @@ public final class ChatDaemonCoordinator {
         let exporter = ChatDiagnosticExporter(trace: diagnosticTrace)
         try await exporter.writeJSONL(snapshot, to: url)
         if let chatID {
-            try await client.resetChatDiagnostics(.init(chat: .init(rawValue: chatID.rawValue)))
+            do {
+                try await client.resetChatDiagnostics(.init(chat: .init(rawValue: chatID.rawValue)))
+            } catch {
+                exporter.rotateFingerprintKeyPreservingRecords()
+                throw error
+            }
         }
         exporter.resetAfterSuccessfulExport()
     }

--- a/Sources/WikiFS/Chats/ChatDetailControlsView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailControlsView.swift
@@ -10,6 +10,8 @@ struct ChatDetailControlsView: View {
     @Binding var hideToolCalls: Bool
     let exitStatus: Int32?
     let debugFolderURL: URL?
+    let copyDiagnostics: () -> Void
+    let writeDiagnosticsJSONL: (URL) -> Void
 
     var body: some View {
         HStack(spacing: 8) {
@@ -21,6 +23,10 @@ struct ChatDetailControlsView: View {
                 Menu {
                     Toggle("Show internals", isOn: $showsInternals)
                     Toggle("Hide tool calls", isOn: $hideToolCalls)
+                    Button("Copy Diagnostics", systemImage: "doc.on.doc") {
+                        copyDiagnostics()
+                    }
+                    .help("Copy a redacted app and daemon diagnostic snapshot")
                     if let exitStatus {
                         Label(
                             exitStatus == 0 ? "Ended" : "Exited \(exitStatus)",
@@ -28,6 +34,10 @@ struct ChatDetailControlsView: View {
                         )
                     }
                     if let debugFolderURL {
+                        Button("Write Redacted Diagnostics JSONL", systemImage: "doc.text") {
+                            writeDiagnosticsJSONL(debugFolderURL.appendingPathComponent("chat-diagnostics.jsonl"))
+                        }
+                        .help("Append redacted trace records to the debug folder")
                         Button("Reveal Debug Folder", systemImage: "folder.badge.gearshape") {
                             NSWorkspace.shared.activateFileViewerSelecting([debugFolderURL])
                         }

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -164,7 +164,11 @@ struct ChatDetailView: View {
             updateRightSidebarRegistration()
         }
         .onChange(of: liveDebugKey, initial: true) { _, key in
-            DebugLog.chatLive("7.detail \(key)")
+            ChatDiagnostics.observe(
+                stage: .displayProjection,
+                correlation: .init(eventKind: .init(rawValue: "chat-detail")),
+                detail: "presentation-change-\(key)"
+            )
         }
         .onChange(of: store.messageVersion) { _, _ in
             if let chatID, !isLiveChat {

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -31,6 +31,7 @@ struct ChatDetailView: View {
     @State private var outlineScroll: ChatScrollRequest? = nil
     @State private var quoteAnchor: ChatHighlightRequest? = nil
     @State private var queuedMessages: [PendingQueuedMessage] = []
+    @State private var diagnosticExportError: String?
     @AppStorage(AgentLauncher.PermissionModeKey.chat) private var permissionModeRaw = PermissionPolicy.bypass.rawValue
 
     private var isLiveChat: Bool {
@@ -168,9 +169,20 @@ struct ChatDetailView: View {
         .onChange(of: liveDebugKey, initial: true) { _, key in
             ChatDiagnostics.observe(
                 stage: .displayProjection,
-                correlation: .init(eventKind: .init(rawValue: "chat-detail")),
-                detail: "presentation-change-\(key)"
+                correlation: .init(
+                    chat: chatID.map { .init(rawValue: $0.rawValue) },
+                    eventKind: .init(rawValue: "chat-detail")
+                ),
+                detail: "presentation-change"
             )
+        }
+        .alert("Diagnostics Export Failed", isPresented: Binding(
+            get: { diagnosticExportError != nil },
+            set: { if !$0 { diagnosticExportError = nil } }
+        )) {
+            Button("OK", role: .cancel) { diagnosticExportError = nil }
+        } message: {
+            Text(diagnosticExportError ?? "Unknown diagnostic export failure.")
         }
         .onChange(of: store.messageVersion) { _, _ in
             if let chatID, !isLiveChat {
@@ -210,6 +222,7 @@ struct ChatDetailView: View {
                 }
             } catch {
                 DebugLog.store("chat diagnostic copy failed: \(error)")
+                diagnosticExportError = error.localizedDescription
             }
         }
     }
@@ -220,6 +233,7 @@ struct ChatDetailView: View {
                 try await coordinator.writeDiagnosticsJSONL(for: chatID, to: url)
             } catch {
                 DebugLog.store("chat diagnostic JSONL export failed: \(error)")
+                diagnosticExportError = error.localizedDescription
             }
         }
     }

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -104,7 +104,9 @@ struct ChatDetailView: View {
                     showsInternals: $showsInternals,
                     hideToolCalls: $hideToolCalls,
                     exitStatus: remoteSession.exitStatus,
-                    debugFolderURL: remoteSession.debugFolderURL
+                    debugFolderURL: remoteSession.debugFolderURL,
+                    copyDiagnostics: copyDiagnostics,
+                    writeDiagnosticsJSONL: writeDiagnosticsJSONL
                 )
                 .padding(.top, ChatMetrics.debugTopInset)
                 .padding(.trailing, ChatMetrics.contentInset)
@@ -190,6 +192,35 @@ struct ChatDetailView: View {
                 version: (quoteAnchor?.version ?? 0) + 1,
                 quote: quote
             )
+        }
+    }
+
+    private func copyDiagnostics() {
+        Task { @MainActor in
+            do {
+                try await coordinator.copyDiagnostics(for: chatID) { data in
+                    guard let text = String(data: data, encoding: .utf8) else {
+                        throw ChatDiagnosticExportError.invalidUTF8
+                    }
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    guard pasteboard.setString(text, forType: .string) else {
+                        throw ChatDiagnosticExportError.pasteboardWriteFailed
+                    }
+                }
+            } catch {
+                DebugLog.store("chat diagnostic copy failed: \(error)")
+            }
+        }
+    }
+
+    private func writeDiagnosticsJSONL(to url: URL) {
+        Task { @MainActor in
+            do {
+                try await coordinator.writeDiagnosticsJSONL(for: chatID, to: url)
+            } catch {
+                DebugLog.store("chat diagnostic JSONL export failed: \(error)")
+            }
         }
     }
 

--- a/Sources/WikiFS/Chats/ChatDiagnostics.swift
+++ b/Sources/WikiFS/Chats/ChatDiagnostics.swift
@@ -32,28 +32,25 @@ struct ChatDiagnosticMergedRetention: Codable, Sendable, Hashable {
 }
 
 enum ChatDiagnosticSnapshotMerge {
-    /// Event sequence is authoritative only inside one process. Source and
-    /// sequence form the deterministic merge key; time merely breaks ties for
-    /// human readability.
+    /// Source, process identity, and per-process sequence are the deterministic
+    /// merge order. Timestamps remain exported capture metadata, but never
+    /// reorder one process's causal sequence.
     static func merge(
         app: ChatDiagnosticSnapshotEnvelope,
         daemon: ChatDiagnosticSnapshotEnvelope?
     ) -> ChatDiagnosticMergedSnapshot {
         let snapshots = [app] + (daemon.map { [$0] } ?? [])
         let events = snapshots.flatMap(\.events).sorted { lhs, rhs in
-            // This is deliberately a single lexicographic key. Mixing a
-            // per-source sequence comparison with a cross-source timestamp
-            // comparison is non-transitive and makes Swift's sort unspecified.
-            if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
             if lhs.process.source != rhs.process.source { return lhs.process.source.rawValue < rhs.process.source.rawValue }
             if lhs.process.instanceID != rhs.process.instanceID { return lhs.process.instanceID.uuidString < rhs.process.instanceID.uuidString }
-            return lhs.sequence < rhs.sequence
+            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
+            return lhs.timestamp < rhs.timestamp
         }
         return ChatDiagnosticMergedSnapshot(
             version: ChatDiagnosticTypes.currentVersion,
             sources: snapshots.map(\.process.source),
             events: events,
-            mergeOrder: "per-process-sequence; timestamp-approximate-across-sources",
+            mergeOrder: "source-instance-sequence; timestamps-informational",
             appSummary: app.summary,
             daemonSummary: daemon?.summary ?? [:],
             retention: snapshots.map {
@@ -109,8 +106,12 @@ final class ChatDiagnosticTrace {
     ) -> ChatDiagnosticEventEnvelope {
         nextSequence &+= 1
         let bucket = payload.correlation.chat.map(Bucket.chat) ?? .process
-        let didCoalesce = shouldCoalesce(stage: stage, correlation: payload.correlation)
-            && recordsByBucket[bucket]?.last.map { coalescingKey(for: $0.event) == coalescingKey(stage: stage, correlation: payload.correlation) } == true
+        let key = coalescingKey(stage: stage, correlation: payload.correlation)
+        let didCoalesce = key.map { key in
+            recordsByBucket[bucket, default: []].contains {
+                coalescingKey(for: $0.event) == key
+            }
+        } ?? false
         let event = ChatDiagnosticEventEnvelope(
             process: identity,
             sequence: ChatDiagnosticSequence(nextSequence),
@@ -147,6 +148,13 @@ final class ChatDiagnosticTrace {
         droppedBytesByBucket.removeAll()
     }
 
+    /// Retires the content-fingerprint epoch while retaining the bounded ring.
+    /// This is used after an artifact reaches its destination but before a
+    /// daemon reset failure can be returned to the UI.
+    func rotateFingerprintKeyPreservingRecords() {
+        fingerprintKey = ChatDiagnosticFingerprintKey()
+    }
+
     private func append(_ event: ChatDiagnosticEventEnvelope, for bucket: Bucket) {
         let encoded: Data
         do {
@@ -157,8 +165,9 @@ final class ChatDiagnosticTrace {
         }
         let record = StoredRecord(event: event, byteCount: encoded.count)
         var records = recordsByBucket[bucket, default: []]
-        if shouldCoalesce(event), let last = records.last, coalescingKey(for: last.event) == coalescingKey(for: event) {
-            records.removeLast()
+        if let key = coalescingKey(for: event),
+           let index = records.lastIndex(where: { coalescingKey(for: $0.event) == key }) {
+            records.remove(at: index)
         }
         records.append(record)
         var bytes = records.reduce(0) { $0 + $1.byteCount }
@@ -285,6 +294,11 @@ struct ChatDiagnosticExporter {
     /// Commit a completed app/daemon diagnostic export.
     func resetAfterSuccessfulExport() {
         trace.resetAfterSuccessfulExport()
+    }
+
+    /// Retires the local fingerprint epoch without draining retry evidence.
+    func rotateFingerprintKeyPreservingRecords() {
+        trace.rotateFingerprintKeyPreservingRecords()
     }
 }
 

--- a/Sources/WikiFS/Chats/ChatDiagnostics.swift
+++ b/Sources/WikiFS/Chats/ChatDiagnostics.swift
@@ -1,0 +1,218 @@
+import Foundation
+import WikiFSEngine
+import WikiFSCore
+
+/// Named limits make trace retention predictable and keep diagnostic exports
+/// bounded even during a noisy streamed response.
+enum ChatDiagnosticPolicy {
+    static let maximumRecordsPerChat = 256
+    static let maximumBytesPerChat = 256 * 1_024
+    static let maximumJSONLRecordBytes = 8 * 1_024
+    static let maximumJSONLFileBytes = 512 * 1_024
+}
+
+struct ChatDiagnosticMergedSnapshot: Codable, Sendable {
+    let version: Int
+    let sources: [ChatDiagnosticSource]
+    let events: [ChatDiagnosticEventEnvelope]
+    let mergeOrder: String
+    let appSummary: [String: String]
+    let daemonSummary: [String: String]
+}
+
+enum ChatDiagnosticSnapshotMerge {
+    /// Event sequence is authoritative only inside one process. Source and
+    /// sequence form the deterministic merge key; time merely breaks ties for
+    /// human readability.
+    static func merge(
+        app: ChatDiagnosticSnapshotEnvelope,
+        daemon: ChatDiagnosticSnapshotEnvelope?
+    ) -> ChatDiagnosticMergedSnapshot {
+        let snapshots = [app] + (daemon.map { [$0] } ?? [])
+        let events = snapshots.flatMap(\.events).sorted { lhs, rhs in
+            if lhs.process.source == rhs.process.source {
+                return lhs.sequence < rhs.sequence
+            }
+            if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
+            return lhs.process.source.rawValue < rhs.process.source.rawValue
+        }
+        return ChatDiagnosticMergedSnapshot(
+            version: ChatDiagnosticTypes.currentVersion,
+            sources: snapshots.map(\.process.source),
+            events: events,
+            mergeOrder: "per-process-sequence; timestamp-approximate-across-sources",
+            appSummary: app.summary,
+            daemonSummary: daemon?.summary ?? [:]
+        )
+    }
+}
+
+/// App-owned serialized, redacted trace store. It intentionally has no app
+/// display-type dependency; UI correlation is supplied as opaque diagnostic
+/// values at the call site.
+actor ChatDiagnosticTrace {
+    private struct StoredRecord: Sendable {
+        let event: ChatDiagnosticEventEnvelope
+        let byteCount: Int
+    }
+
+    private let source: ChatDiagnosticSource
+    private var identity: ChatDiagnosticProcessIdentity
+    private var fingerprintKey = ChatDiagnosticFingerprintKey()
+    private var nextSequence: UInt64 = 0
+    private var recordsByChat: [ChatDiagnosticCorrelation.Value: [StoredRecord]] = [:]
+    private var droppedRecordsByChat: [ChatDiagnosticCorrelation.Value: Int] = [:]
+    private var droppedBytesByChat: [ChatDiagnosticCorrelation.Value: Int] = [:]
+
+    init(source: ChatDiagnosticSource) {
+        self.source = source
+        self.identity = ChatDiagnosticProcessIdentity(source: source)
+    }
+
+    func fingerprint(_ text: String) -> ChatDiagnosticContentFingerprint {
+        fingerprintKey.fingerprint(for: text)
+    }
+
+    @discardableResult
+    func record(
+        stage: ChatDiagnosticStage,
+        outcome: ChatDiagnosticOutcome,
+        payload: ChatDiagnosticPayload = .init()
+    ) -> ChatDiagnosticEventEnvelope {
+        nextSequence &+= 1
+        let event = ChatDiagnosticEventEnvelope(
+            process: identity,
+            sequence: ChatDiagnosticSequence(nextSequence),
+            stage: stage,
+            payload: payload,
+            outcome: outcome
+        )
+        let chat = payload.correlation.chat ?? .init(rawValue: "process")
+        append(event, for: chat)
+        emit(event)
+        return event
+    }
+
+    func snapshot(chat: ChatDiagnosticCorrelation.Value? = nil, summary: [String: String] = [:]) -> ChatDiagnosticSnapshotEnvelope {
+        let selected = chat.map { recordsByChat[$0] ?? [] } ?? recordsByChat.values.flatMap { $0 }
+        let droppedRecords = chat.flatMap { droppedRecordsByChat[$0] } ?? droppedRecordsByChat.values.reduce(0, +)
+        let droppedBytes = chat.flatMap { droppedBytesByChat[$0] } ?? droppedBytesByChat.values.reduce(0, +)
+        return ChatDiagnosticSnapshotEnvelope(
+            process: identity,
+            events: selected.map(\.event),
+            droppedRecordCount: droppedRecords,
+            droppedByteCount: droppedBytes,
+            summary: summary
+        )
+    }
+
+    /// Successful export resets all local correlation material, including the
+    /// ring. Callers must only invoke this after their output write succeeds.
+    func resetAfterSuccessfulExport() {
+        identity = ChatDiagnosticProcessIdentity(source: source)
+        fingerprintKey = ChatDiagnosticFingerprintKey()
+        nextSequence = 0
+        recordsByChat.removeAll()
+        droppedRecordsByChat.removeAll()
+        droppedBytesByChat.removeAll()
+    }
+
+    private func append(_ event: ChatDiagnosticEventEnvelope, for chat: ChatDiagnosticCorrelation.Value) {
+        let encoded: Data
+        do {
+            encoded = try JSONEncoder().encode(event)
+        } catch {
+            DebugLog.store("chat diagnostics event encoding failed: \(error)")
+            return
+        }
+        let record = StoredRecord(event: event, byteCount: encoded.count)
+        var records = recordsByChat[chat, default: []]
+        records.append(record)
+        var bytes = records.reduce(0) { $0 + $1.byteCount }
+        while records.count > ChatDiagnosticPolicy.maximumRecordsPerChat || bytes > ChatDiagnosticPolicy.maximumBytesPerChat {
+            let removed = records.removeFirst()
+            bytes -= removed.byteCount
+            droppedRecordsByChat[chat, default: 0] += 1
+            droppedBytesByChat[chat, default: 0] += removed.byteCount
+        }
+        recordsByChat[chat] = records
+    }
+
+    private func emit(_ event: ChatDiagnosticEventEnvelope) {
+        let message = "chat diagnostic stage=\(event.stage.rawValue) outcome=\(event.outcome.rawValue) source=\(event.process.source.rawValue) sequence=\(event.sequence.rawValue)"
+        switch event.outcome {
+        case .failed, .timeout, .decodeFailure, .versionFailure:
+            DebugLog.chatDiagnostics(message, verbose: false)
+        default:
+            DebugLog.chatDiagnostics(message, verbose: true)
+        }
+    }
+}
+
+/// The process-wide app trace. AppKit-facing callers are on the main actor,
+/// while the actor keeps ring writes serial even when callbacks arrive from XPC.
+enum ChatDiagnostics {
+    static let appTrace = ChatDiagnosticTrace(source: .app)
+
+    /// The UI bridges are synchronous callbacks. The record itself is isolated
+    /// in the trace actor, so this short task only crosses that boundary and
+    /// never mutates SwiftUI state during an update pass.
+    static func observe(
+        stage: ChatDiagnosticStage,
+        outcome: ChatDiagnosticOutcome = .accepted,
+        correlation: ChatDiagnosticCorrelation = .init(),
+        detail: String? = nil
+    ) {
+        Task {
+            _ = await appTrace.record(
+                stage: stage,
+                outcome: outcome,
+                payload: .init(correlation: correlation, detail: detail)
+            )
+        }
+    }
+}
+
+actor ChatDiagnosticJSONLWriter {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) { self.fileManager = fileManager }
+
+    func append(_ event: ChatDiagnosticEventEnvelope, to url: URL) throws -> URL {
+        let encoded = try JSONEncoder().encode(event)
+        guard encoded.count <= ChatDiagnosticPolicy.maximumJSONLRecordBytes else {
+            throw ChatDiagnosticJSONLError.recordTooLarge(encoded.count)
+        }
+        let newline = Data("\n".utf8)
+        let target = try rotatedURLIfNeeded(forAdditionalBytes: encoded.count + newline.count, url: url)
+        if !fileManager.fileExists(atPath: target.path) { fileManager.createFile(atPath: target.path, contents: nil) }
+        let handle = try FileHandle(forWritingTo: target)
+        defer {
+            do { try handle.close() }
+            catch { DebugLog.store("chat diagnostics JSONL close failed: \(error)") }
+        }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: encoded)
+        try handle.write(contentsOf: newline)
+        return target
+    }
+
+    private func rotatedURLIfNeeded(forAdditionalBytes additional: Int, url: URL) throws -> URL {
+        let current: Int
+        do {
+            current = (try fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.intValue ?? 0
+        } catch {
+            DebugLog.store("chat diagnostics JSONL size inspection failed: \(error)")
+            throw error
+        }
+        guard current + additional > ChatDiagnosticPolicy.maximumJSONLFileBytes else { return url }
+        let rotated = url.deletingPathExtension().appendingPathExtension("previous.jsonl")
+        if fileManager.fileExists(atPath: rotated.path) { try fileManager.removeItem(at: rotated) }
+        if fileManager.fileExists(atPath: url.path) { try fileManager.moveItem(at: url, to: rotated) }
+        return url
+    }
+}
+
+enum ChatDiagnosticJSONLError: Error, Equatable {
+    case recordTooLarge(Int)
+}

--- a/Sources/WikiFS/Chats/ChatDiagnostics.swift
+++ b/Sources/WikiFS/Chats/ChatDiagnostics.swift
@@ -95,8 +95,8 @@ actor ChatDiagnosticTrace {
 
     func snapshot(chat: ChatDiagnosticCorrelation.Value? = nil, summary: [String: String] = [:]) -> ChatDiagnosticSnapshotEnvelope {
         let selected = chat.map { recordsByChat[$0] ?? [] } ?? recordsByChat.values.flatMap { $0 }
-        let droppedRecords = chat.flatMap { droppedRecordsByChat[$0] } ?? droppedRecordsByChat.values.reduce(0, +)
-        let droppedBytes = chat.flatMap { droppedBytesByChat[$0] } ?? droppedBytesByChat.values.reduce(0, +)
+        let droppedRecords = chat.map { droppedRecordsByChat[$0] ?? 0 } ?? droppedRecordsByChat.values.reduce(0, +)
+        let droppedBytes = chat.map { droppedBytesByChat[$0] ?? 0 } ?? droppedBytesByChat.values.reduce(0, +)
         return ChatDiagnosticSnapshotEnvelope(
             process: identity,
             events: selected.map(\.event),
@@ -173,6 +173,46 @@ enum ChatDiagnostics {
     }
 }
 
+/// App-side export boundary for the redacted diagnostic artifact. The caller
+/// supplies the destination so AppKit pasteboard access stays at the UI edge
+/// and tests can exercise real coordinator snapshots without a hosted view.
+@MainActor
+struct ChatDiagnosticExporter {
+    private let trace: ChatDiagnosticTrace
+    private let jsonlWriter: ChatDiagnosticJSONLWriter
+
+    init(
+        trace: ChatDiagnosticTrace = ChatDiagnostics.appTrace,
+        jsonlWriter: ChatDiagnosticJSONLWriter = ChatDiagnosticJSONLWriter()
+    ) {
+        self.trace = trace
+        self.jsonlWriter = jsonlWriter
+    }
+
+    /// Copies one complete redacted merged snapshot. Trace material rotates
+    /// strictly after the destination confirms the write succeeded.
+    func copy(
+        _ snapshot: ChatDiagnosticMergedSnapshot,
+        write: (Data) throws -> Void
+    ) async throws {
+        let data = try JSONEncoder().encode(snapshot)
+        try write(data)
+        await trace.resetAfterSuccessfulExport()
+    }
+
+    /// Appends the merged trace records to a redacted JSONL artifact. This is
+    /// deliberately separate from the full-content debug-folder workflow.
+    func writeJSONL(
+        _ snapshot: ChatDiagnosticMergedSnapshot,
+        to url: URL
+    ) async throws {
+        for event in snapshot.events {
+            _ = try await jsonlWriter.append(event, to: url)
+        }
+        await trace.resetAfterSuccessfulExport()
+    }
+}
+
 actor ChatDiagnosticJSONLWriter {
     private let fileManager: FileManager
 
@@ -185,7 +225,9 @@ actor ChatDiagnosticJSONLWriter {
         }
         let newline = Data("\n".utf8)
         let target = try rotatedURLIfNeeded(forAdditionalBytes: encoded.count + newline.count, url: url)
-        if !fileManager.fileExists(atPath: target.path) { fileManager.createFile(atPath: target.path, contents: nil) }
+        if !fileManager.fileExists(atPath: target.path) {
+            try Data().write(to: target, options: .withoutOverwriting)
+        }
         let handle = try FileHandle(forWritingTo: target)
         defer {
             do { try handle.close() }
@@ -198,6 +240,7 @@ actor ChatDiagnosticJSONLWriter {
     }
 
     private func rotatedURLIfNeeded(forAdditionalBytes additional: Int, url: URL) throws -> URL {
+        guard fileManager.fileExists(atPath: url.path) else { return url }
         let current: Int
         do {
             current = (try fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.intValue ?? 0
@@ -215,4 +258,9 @@ actor ChatDiagnosticJSONLWriter {
 
 enum ChatDiagnosticJSONLError: Error, Equatable {
     case recordTooLarge(Int)
+}
+
+enum ChatDiagnosticExportError: Error, Equatable {
+    case invalidUTF8
+    case pasteboardWriteFailed
 }

--- a/Sources/WikiFS/Chats/ChatDiagnostics.swift
+++ b/Sources/WikiFS/Chats/ChatDiagnostics.swift
@@ -18,6 +18,17 @@ struct ChatDiagnosticMergedSnapshot: Codable, Sendable {
     let mergeOrder: String
     let appSummary: [String: String]
     let daemonSummary: [String: String]
+    let retention: [ChatDiagnosticMergedRetention]
+}
+
+/// Exported retention accounting. Keeping it adjacent to the merged event list
+/// prevents a bounded ring from being mistaken for a complete history.
+struct ChatDiagnosticMergedRetention: Codable, Sendable, Hashable {
+    let source: ChatDiagnosticSource
+    let instanceID: UUID
+    let droppedRecordCount: Int
+    let droppedByteCount: Int
+    let summary: [String: String]
 }
 
 enum ChatDiagnosticSnapshotMerge {
@@ -30,11 +41,13 @@ enum ChatDiagnosticSnapshotMerge {
     ) -> ChatDiagnosticMergedSnapshot {
         let snapshots = [app] + (daemon.map { [$0] } ?? [])
         let events = snapshots.flatMap(\.events).sorted { lhs, rhs in
-            if lhs.process.source == rhs.process.source {
-                return lhs.sequence < rhs.sequence
-            }
+            // This is deliberately a single lexicographic key. Mixing a
+            // per-source sequence comparison with a cross-source timestamp
+            // comparison is non-transitive and makes Swift's sort unspecified.
             if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
-            return lhs.process.source.rawValue < rhs.process.source.rawValue
+            if lhs.process.source != rhs.process.source { return lhs.process.source.rawValue < rhs.process.source.rawValue }
+            if lhs.process.instanceID != rhs.process.instanceID { return lhs.process.instanceID.uuidString < rhs.process.instanceID.uuidString }
+            return lhs.sequence < rhs.sequence
         }
         return ChatDiagnosticMergedSnapshot(
             version: ChatDiagnosticTypes.currentVersion,
@@ -42,7 +55,16 @@ enum ChatDiagnosticSnapshotMerge {
             events: events,
             mergeOrder: "per-process-sequence; timestamp-approximate-across-sources",
             appSummary: app.summary,
-            daemonSummary: daemon?.summary ?? [:]
+            daemonSummary: daemon?.summary ?? [:],
+            retention: snapshots.map {
+                ChatDiagnosticMergedRetention(
+                    source: $0.process.source,
+                    instanceID: $0.process.instanceID,
+                    droppedRecordCount: $0.droppedRecordCount,
+                    droppedByteCount: $0.droppedByteCount,
+                    summary: $0.summary
+                )
+            }
         )
     }
 }
@@ -50,7 +72,8 @@ enum ChatDiagnosticSnapshotMerge {
 /// App-owned serialized, redacted trace store. It intentionally has no app
 /// display-type dependency; UI correlation is supplied as opaque diagnostic
 /// values at the call site.
-actor ChatDiagnosticTrace {
+@MainActor
+final class ChatDiagnosticTrace {
     private struct StoredRecord: Sendable {
         let event: ChatDiagnosticEventEnvelope
         let byteCount: Int
@@ -60,9 +83,14 @@ actor ChatDiagnosticTrace {
     private var identity: ChatDiagnosticProcessIdentity
     private var fingerprintKey = ChatDiagnosticFingerprintKey()
     private var nextSequence: UInt64 = 0
-    private var recordsByChat: [ChatDiagnosticCorrelation.Value: [StoredRecord]] = [:]
-    private var droppedRecordsByChat: [ChatDiagnosticCorrelation.Value: Int] = [:]
-    private var droppedBytesByChat: [ChatDiagnosticCorrelation.Value: Int] = [:]
+    private enum Bucket: Hashable {
+        case chat(ChatDiagnosticCorrelation.Value)
+        case process
+    }
+
+    private var recordsByBucket: [Bucket: [StoredRecord]] = [:]
+    private var droppedRecordsByBucket: [Bucket: Int] = [:]
+    private var droppedBytesByBucket: [Bucket: Int] = [:]
 
     init(source: ChatDiagnosticSource) {
         self.source = source
@@ -80,23 +108,25 @@ actor ChatDiagnosticTrace {
         payload: ChatDiagnosticPayload = .init()
     ) -> ChatDiagnosticEventEnvelope {
         nextSequence &+= 1
+        let bucket = payload.correlation.chat.map(Bucket.chat) ?? .process
+        let didCoalesce = shouldCoalesce(stage: stage, correlation: payload.correlation)
+            && recordsByBucket[bucket]?.last.map { coalescingKey(for: $0.event) == coalescingKey(stage: stage, correlation: payload.correlation) } == true
         let event = ChatDiagnosticEventEnvelope(
             process: identity,
             sequence: ChatDiagnosticSequence(nextSequence),
             stage: stage,
             payload: payload,
-            outcome: outcome
+            outcome: didCoalesce ? .coalesced : outcome
         )
-        let chat = payload.correlation.chat ?? .init(rawValue: "process")
-        append(event, for: chat)
+        append(event, for: bucket)
         emit(event)
         return event
     }
 
     func snapshot(chat: ChatDiagnosticCorrelation.Value? = nil, summary: [String: String] = [:]) -> ChatDiagnosticSnapshotEnvelope {
-        let selected = chat.map { recordsByChat[$0] ?? [] } ?? recordsByChat.values.flatMap { $0 }
-        let droppedRecords = chat.map { droppedRecordsByChat[$0] ?? 0 } ?? droppedRecordsByChat.values.reduce(0, +)
-        let droppedBytes = chat.map { droppedBytesByChat[$0] ?? 0 } ?? droppedBytesByChat.values.reduce(0, +)
+        let selected = chat.map { recordsByBucket[.chat($0)] ?? [] } ?? recordsByBucket.values.flatMap { $0 }
+        let droppedRecords = chat.map { droppedRecordsByBucket[.chat($0)] ?? 0 } ?? droppedRecordsByBucket.values.reduce(0, +)
+        let droppedBytes = chat.map { droppedBytesByBucket[.chat($0)] ?? 0 } ?? droppedBytesByBucket.values.reduce(0, +)
         return ChatDiagnosticSnapshotEnvelope(
             process: identity,
             events: selected.map(\.event),
@@ -112,12 +142,12 @@ actor ChatDiagnosticTrace {
         identity = ChatDiagnosticProcessIdentity(source: source)
         fingerprintKey = ChatDiagnosticFingerprintKey()
         nextSequence = 0
-        recordsByChat.removeAll()
-        droppedRecordsByChat.removeAll()
-        droppedBytesByChat.removeAll()
+        recordsByBucket.removeAll()
+        droppedRecordsByBucket.removeAll()
+        droppedBytesByBucket.removeAll()
     }
 
-    private func append(_ event: ChatDiagnosticEventEnvelope, for chat: ChatDiagnosticCorrelation.Value) {
+    private func append(_ event: ChatDiagnosticEventEnvelope, for bucket: Bucket) {
         let encoded: Data
         do {
             encoded = try JSONEncoder().encode(event)
@@ -126,16 +156,54 @@ actor ChatDiagnosticTrace {
             return
         }
         let record = StoredRecord(event: event, byteCount: encoded.count)
-        var records = recordsByChat[chat, default: []]
+        var records = recordsByBucket[bucket, default: []]
+        if shouldCoalesce(event), let last = records.last, coalescingKey(for: last.event) == coalescingKey(for: event) {
+            records.removeLast()
+        }
         records.append(record)
         var bytes = records.reduce(0) { $0 + $1.byteCount }
         while records.count > ChatDiagnosticPolicy.maximumRecordsPerChat || bytes > ChatDiagnosticPolicy.maximumBytesPerChat {
             let removed = records.removeFirst()
             bytes -= removed.byteCount
-            droppedRecordsByChat[chat, default: 0] += 1
-            droppedBytesByChat[chat, default: 0] += removed.byteCount
+            droppedRecordsByBucket[bucket, default: 0] += 1
+            droppedBytesByBucket[bucket, default: 0] += removed.byteCount
         }
-        recordsByChat[chat] = records
+        recordsByBucket[bucket] = records
+    }
+
+    private func shouldCoalesce(_ event: ChatDiagnosticEventEnvelope) -> Bool {
+        shouldCoalesce(stage: event.stage, correlation: event.payload.correlation)
+    }
+
+    private func shouldCoalesce(stage: ChatDiagnosticStage, correlation: ChatDiagnosticCorrelation) -> Bool {
+        switch stage {
+        case .syncReconciliation, .renderPlanning, .displayProjection:
+            return correlation.updateSequence != nil || correlation.rendererRevision != nil || correlation.displayRow != nil
+        default:
+            return false
+        }
+    }
+
+    private func coalescingKey(for event: ChatDiagnosticEventEnvelope) -> String? {
+        coalescingKey(stage: event.stage, correlation: event.payload.correlation)
+    }
+
+    private func coalescingKey(stage: ChatDiagnosticStage, correlation: ChatDiagnosticCorrelation) -> String? {
+        guard shouldCoalesce(stage: stage, correlation: correlation) else { return nil }
+        let subject = correlation.durableItem?.rawValue ?? correlation.displayRow?.rawValue
+        // A display row or durable item identifies the streamed message. Keep
+        // its newest revision rather than only collapsing duplicate callbacks
+        // for one revision. When no item is known, a revision is the narrowest
+        // safe coalescing boundary.
+        let revision = subject == nil
+            ? correlation.rendererRevision.map { String($0.rawValue) } ?? correlation.updateSequence.map { String($0.rawValue) } ?? ""
+            : "message"
+        return [
+            stage.rawValue,
+            correlation.chat?.rawValue ?? "",
+            subject ?? "",
+            revision
+        ].joined(separator: "|")
     }
 
     private func emit(_ event: ChatDiagnosticEventEnvelope) {
@@ -149,28 +217,32 @@ actor ChatDiagnosticTrace {
     }
 }
 
-/// The process-wide app trace. AppKit-facing callers are on the main actor,
-/// while the actor keeps ring writes serial even when callbacks arrive from XPC.
+/// The process-wide app trace. AppKit-facing callers serialize observation on
+/// the main actor, preserving the order in which UI and XPC callbacks arrive.
+@MainActor
 enum ChatDiagnostics {
     static let appTrace = ChatDiagnosticTrace(source: .app)
 
-    /// The UI bridges are synchronous callbacks. The record itself is isolated
-    /// in the trace actor, so this short task only crosses that boundary and
-    /// never mutates SwiftUI state during an update pass.
+    static func fingerprint(_ text: String) -> ChatDiagnosticContentFingerprint {
+        appTrace.fingerprint(text)
+    }
+
+    /// AppKit and SwiftUI callbacks run on the main actor. Recording directly
+    /// here preserves producer order instead of scheduling independent tasks
+    /// that can arrive at the trace actor out of order.
     static func observe(
         stage: ChatDiagnosticStage,
         outcome: ChatDiagnosticOutcome = .accepted,
         correlation: ChatDiagnosticCorrelation = .init(),
         detail: String? = nil
     ) {
-        Task {
-            _ = await appTrace.record(
-                stage: stage,
-                outcome: outcome,
-                payload: .init(correlation: correlation, detail: detail)
-            )
-        }
+        _ = appTrace.record(
+            stage: stage,
+            outcome: outcome,
+            payload: .init(correlation: correlation, detail: detail)
+        )
     }
+
 }
 
 /// App-side export boundary for the redacted diagnostic artifact. The caller
@@ -189,15 +261,16 @@ struct ChatDiagnosticExporter {
         self.jsonlWriter = jsonlWriter
     }
 
-    /// Copies one complete redacted merged snapshot. Trace material rotates
-    /// strictly after the destination confirms the write succeeded.
+    /// Copies one complete redacted merged snapshot.
+    ///
+    /// The coordinator commits ring rotation after both the destination and
+    /// the daemon reset acknowledge success.
     func copy(
         _ snapshot: ChatDiagnosticMergedSnapshot,
         write: (Data) throws -> Void
     ) async throws {
         let data = try JSONEncoder().encode(snapshot)
         try write(data)
-        await trace.resetAfterSuccessfulExport()
     }
 
     /// Appends the merged trace records to a redacted JSONL artifact. This is
@@ -206,10 +279,12 @@ struct ChatDiagnosticExporter {
         _ snapshot: ChatDiagnosticMergedSnapshot,
         to url: URL
     ) async throws {
-        for event in snapshot.events {
-            _ = try await jsonlWriter.append(event, to: url)
-        }
-        await trace.resetAfterSuccessfulExport()
+        try await jsonlWriter.appendSnapshotAtomically(snapshot, to: url)
+    }
+
+    /// Commit a completed app/daemon diagnostic export.
+    func resetAfterSuccessfulExport() {
+        trace.resetAfterSuccessfulExport()
     }
 }
 
@@ -237,6 +312,39 @@ actor ChatDiagnosticJSONLWriter {
         try handle.write(contentsOf: encoded)
         try handle.write(contentsOf: newline)
         return target
+    }
+
+    /// A whole exported snapshot is one JSONL record. The file is replaced
+    /// atomically only after the complete next contents are durable, so retrying
+    /// a failed export cannot duplicate a partial prefix.
+    func appendSnapshotAtomically(_ snapshot: ChatDiagnosticMergedSnapshot, to url: URL) throws {
+        let encoded = try JSONEncoder().encode(snapshot)
+        let newline = Data("\n".utf8)
+        let target = try rotatedURLIfNeeded(forAdditionalBytes: encoded.count + newline.count, url: url)
+        let existing: Data
+        if fileManager.fileExists(atPath: target.path) {
+            existing = try Data(contentsOf: target)
+        } else {
+            existing = Data()
+        }
+        var next = existing
+        next.append(encoded)
+        next.append(newline)
+        let temporary = target.deletingLastPathComponent().appendingPathComponent(".\(target.lastPathComponent).\(UUID().uuidString).tmp")
+        do {
+            try next.write(to: temporary, options: .atomic)
+            if fileManager.fileExists(atPath: target.path) {
+                _ = try fileManager.replaceItemAt(target, withItemAt: temporary)
+            } else {
+                try fileManager.moveItem(at: temporary, to: target)
+            }
+        } catch {
+            if fileManager.fileExists(atPath: temporary.path) {
+                do { try fileManager.removeItem(at: temporary) }
+                catch { DebugLog.store("chat diagnostics JSONL rollback cleanup failed: \(error)") }
+            }
+            throw error
+        }
     }
 
     private func rotatedURLIfNeeded(forAdditionalBytes additional: Int, url: URL) throws -> URL {

--- a/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
@@ -49,6 +49,7 @@ final class ChatTranscriptRenderExecutor {
 
     private let mutate: Mutation
     private let reportAnomaly: @MainActor (ChatTranscriptRendererAnomaly) -> Void
+    private let diagnosticTrace: ChatDiagnosticTrace
     private var acknowledgedSnapshot: ChatTranscriptRenderSnapshot?
     private var desiredSnapshot: ChatTranscriptRenderSnapshot?
     private var reloadSnapshot: ChatTranscriptRenderSnapshot?
@@ -61,10 +62,12 @@ final class ChatTranscriptRenderExecutor {
 
     init(
         mutate: @escaping Mutation,
-        reportAnomaly: @escaping @MainActor (ChatTranscriptRendererAnomaly) -> Void
+        reportAnomaly: @escaping @MainActor (ChatTranscriptRendererAnomaly) -> Void,
+        diagnosticTrace: ChatDiagnosticTrace = ChatDiagnostics.appTrace
     ) {
         self.mutate = mutate
         self.reportAnomaly = reportAnomaly
+        self.diagnosticTrace = diagnosticTrace
     }
 
     func submit(_ snapshot: ChatTranscriptRenderSnapshot) {
@@ -190,14 +193,23 @@ final class ChatTranscriptRenderExecutor {
         revision: ChatTranscriptRenderRevision?,
         rowID: ChatDisplayRowID?
     ) {
-        ChatDiagnostics.observe(
+        let chat: ChatDiagnosticCorrelation.Value?
+        if case .chat(let chatID)? = desiredSnapshot?.context.transcriptID {
+            chat = .init(rawValue: chatID.rawValue)
+        } else {
+            chat = nil
+        }
+        _ = diagnosticTrace.record(
             stage: stage,
             outcome: outcome,
-            correlation: .init(
-                displayRow: rowID.map { .init(rawValue: $0.domValue) },
-                rendererRevision: revision.map { .init(UInt64($0.rawValue)) }
-            ),
-            detail: "renderer"
+            payload: .init(
+                correlation: .init(
+                    chat: chat,
+                    displayRow: rowID.map { .init(rawValue: $0.domValue) },
+                    rendererRevision: revision.map { .init(UInt64($0.rawValue)) }
+                ),
+                detail: "renderer"
+            )
         )
     }
 

--- a/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import WebKit
+import WikiFSCore
 
 struct ChatTranscriptRenderRevision: Hashable, Sendable {
     let rawValue: Int
@@ -98,20 +99,24 @@ final class ChatTranscriptRenderExecutor {
         }
         guard let expected else { return }
         guard acknowledgement.revision == expected.revision else {
+            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
             reportAnomaly(.staleAcknowledgement(expected: expected.revision, received: acknowledgement.revision))
             return
         }
         guard acknowledgement.kind == expected.command.kind else {
+            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
             reportAnomaly(.invalidAcknowledgement(expected: expected.command.kind, received: acknowledgement.kind))
             scheduleRecovery(after: expected.command)
             return
         }
         guard acknowledgement.rowID == expected.command.rowID else {
+            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
             reportAnomaly(.rowMismatch(expected: expected.command.rowID, received: acknowledgement.rowID))
             scheduleRecovery(after: expected.command)
             return
         }
         guard acknowledgement.outcome == .success else {
+            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
             reportAnomaly(.failedAcknowledgement(acknowledgement.outcome))
             scheduleRecovery(after: expected.command)
             return
@@ -125,6 +130,7 @@ final class ChatTranscriptRenderExecutor {
             acknowledgedSnapshot = applying(expected.command, to: acknowledgedSnapshot)
         }
         state = .idle
+        observe(stage: .domAcknowledgement, outcome: .accepted, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
         reloadRevision = nil
         recoveryReloadAttempted = false
         drain()
@@ -145,6 +151,7 @@ final class ChatTranscriptRenderExecutor {
             command = first
         }
         let revision = makeRevision()
+        observe(stage: .renderPlanning, outcome: .accepted, revision: revision, rowID: command.rowID)
         if case .reload = command {
             state = .awaitingReload
             reloadRevision = revision
@@ -162,6 +169,7 @@ final class ChatTranscriptRenderExecutor {
         reloadSnapshot = nil
         guard case .reload = command else {
             if !recoveryReloadAttempted {
+                observe(stage: .recoveryReload, outcome: .recovered, revision: nil, rowID: command.rowID)
                 requiresRecoveryReload = true
                 drain()
             }
@@ -174,6 +182,23 @@ final class ChatTranscriptRenderExecutor {
     private func makeRevision() -> ChatTranscriptRenderRevision {
         nextRevision += 1
         return ChatTranscriptRenderRevision(rawValue: nextRevision)
+    }
+
+    private func observe(
+        stage: ChatDiagnosticStage,
+        outcome: ChatDiagnosticOutcome,
+        revision: ChatTranscriptRenderRevision?,
+        rowID: ChatDisplayRowID?
+    ) {
+        ChatDiagnostics.observe(
+            stage: stage,
+            outcome: outcome,
+            correlation: .init(
+                displayRow: rowID.map { .init(rawValue: $0.domValue) },
+                rendererRevision: revision.map { .init(UInt64($0.rawValue)) }
+            ),
+            detail: "renderer"
+        )
     }
 
     private func applying(

--- a/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
+++ b/Sources/WikiFS/Chats/ChatTranscriptRenderExecutor.swift
@@ -55,6 +55,7 @@ final class ChatTranscriptRenderExecutor {
     private var reloadSnapshot: ChatTranscriptRenderSnapshot?
     private var nextRevision = 0
     private var reloadRevision: ChatTranscriptRenderRevision?
+    private var inFlightDiagnosticCorrelation: ChatDiagnosticCorrelation?
     private var recoveryReloadAttempted = false
     private var requiresRecoveryReload = false
 
@@ -101,27 +102,32 @@ final class ChatTranscriptRenderExecutor {
             )), reloadRevision)
         }
         guard let expected else { return }
+        let correlation = inFlightDiagnosticCorrelation ?? diagnosticCorrelation(
+            snapshot: desiredSnapshot,
+            revision: acknowledgement.revision,
+            rowID: acknowledgement.rowID
+        )
         guard acknowledgement.revision == expected.revision else {
-            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
+            observe(stage: .domFailure, outcome: .failed, correlation: correlation)
             reportAnomaly(.staleAcknowledgement(expected: expected.revision, received: acknowledgement.revision))
             return
         }
         guard acknowledgement.kind == expected.command.kind else {
-            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
+            observe(stage: .domFailure, outcome: .failed, correlation: correlation)
             reportAnomaly(.invalidAcknowledgement(expected: expected.command.kind, received: acknowledgement.kind))
-            scheduleRecovery(after: expected.command)
+            scheduleRecovery(after: expected.command, correlation: correlation)
             return
         }
         guard acknowledgement.rowID == expected.command.rowID else {
-            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
+            observe(stage: .domFailure, outcome: .failed, correlation: correlation)
             reportAnomaly(.rowMismatch(expected: expected.command.rowID, received: acknowledgement.rowID))
-            scheduleRecovery(after: expected.command)
+            scheduleRecovery(after: expected.command, correlation: correlation)
             return
         }
         guard acknowledgement.outcome == .success else {
-            observe(stage: .domFailure, outcome: .failed, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
+            observe(stage: .domFailure, outcome: .failed, correlation: correlation)
             reportAnomaly(.failedAcknowledgement(acknowledgement.outcome))
-            scheduleRecovery(after: expected.command)
+            scheduleRecovery(after: expected.command, correlation: correlation)
             return
         }
 
@@ -133,7 +139,8 @@ final class ChatTranscriptRenderExecutor {
             acknowledgedSnapshot = applying(expected.command, to: acknowledgedSnapshot)
         }
         state = .idle
-        observe(stage: .domAcknowledgement, outcome: .accepted, revision: acknowledgement.revision, rowID: acknowledgement.rowID)
+        observe(stage: .domAcknowledgement, outcome: .accepted, correlation: correlation)
+        inFlightDiagnosticCorrelation = nil
         reloadRevision = nil
         recoveryReloadAttempted = false
         drain()
@@ -154,7 +161,9 @@ final class ChatTranscriptRenderExecutor {
             command = first
         }
         let revision = makeRevision()
-        observe(stage: .renderPlanning, outcome: .accepted, revision: revision, rowID: command.rowID)
+        let correlation = diagnosticCorrelation(snapshot: desiredSnapshot, revision: revision, rowID: command.rowID)
+        observe(stage: .renderPlanning, outcome: .accepted, correlation: correlation)
+        inFlightDiagnosticCorrelation = correlation
         if case .reload = command {
             state = .awaitingReload
             reloadRevision = revision
@@ -166,13 +175,17 @@ final class ChatTranscriptRenderExecutor {
         }
     }
 
-    private func scheduleRecovery(after command: ChatTranscriptRenderCommand) {
+    private func scheduleRecovery(
+        after command: ChatTranscriptRenderCommand,
+        correlation: ChatDiagnosticCorrelation
+    ) {
         state = .idle
         reloadRevision = nil
         reloadSnapshot = nil
+        inFlightDiagnosticCorrelation = nil
         guard case .reload = command else {
             if !recoveryReloadAttempted {
-                observe(stage: .recoveryReload, outcome: .recovered, revision: nil, rowID: command.rowID)
+                observe(stage: .recoveryReload, outcome: .recovered, correlation: correlation)
                 requiresRecoveryReload = true
                 drain()
             }
@@ -190,26 +203,30 @@ final class ChatTranscriptRenderExecutor {
     private func observe(
         stage: ChatDiagnosticStage,
         outcome: ChatDiagnosticOutcome,
+        correlation: ChatDiagnosticCorrelation
+    ) {
+        _ = diagnosticTrace.record(
+            stage: stage,
+            outcome: outcome,
+            payload: .init(correlation: correlation, detail: "renderer")
+        )
+    }
+
+    private func diagnosticCorrelation(
+        snapshot: ChatTranscriptRenderSnapshot?,
         revision: ChatTranscriptRenderRevision?,
         rowID: ChatDisplayRowID?
-    ) {
+    ) -> ChatDiagnosticCorrelation {
         let chat: ChatDiagnosticCorrelation.Value?
-        if case .chat(let chatID)? = desiredSnapshot?.context.transcriptID {
+        if case .chat(let chatID)? = snapshot?.context.transcriptID {
             chat = .init(rawValue: chatID.rawValue)
         } else {
             chat = nil
         }
-        _ = diagnosticTrace.record(
-            stage: stage,
-            outcome: outcome,
-            payload: .init(
-                correlation: .init(
-                    chat: chat,
-                    displayRow: rowID.map { .init(rawValue: $0.domValue) },
-                    rendererRevision: revision.map { .init(UInt64($0.rawValue)) }
-                ),
-                detail: "renderer"
-            )
+        return .init(
+            chat: chat,
+            displayRow: rowID.map { .init(rawValue: $0.domValue) },
+            rendererRevision: revision.map { .init(UInt64($0.rawValue)) }
         )
     }
 

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -348,6 +348,7 @@ struct ChatWebView: NSViewRepresentable {
         /// *different* transcript and must not be used — see
         /// `ChatWebView.transcriptID`.
         private var renderedTranscriptID: TranscriptID?
+        private var pendingTranscriptID: TranscriptID?
         private var isLoaded = false
         private var pendingEvents: [AgentEvent] = []
         /// Pending timestamps to render once the page finishes loading (stashed by
@@ -415,6 +416,7 @@ struct ChatWebView: NSViewRepresentable {
             self.timestamps = timestamps
             isLoaded = false
             pendingEvents = events
+            pendingTranscriptID = transcriptID
             pendingTimestamps = timestamps
             webView?.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
         }
@@ -462,7 +464,7 @@ struct ChatWebView: NSViewRepresentable {
                 eventCount: events.count, renderedCount: renderedCount) {
                 ChatDiagnostics.observe(
                     stage: .recoveryReload,
-                    correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                    correlation: .init(chat: diagnosticChat(transcriptID), eventKind: .init(rawValue: "legacy-web")),
                     detail: "reload; rows=\(events.count); rendered=\(renderedCount)"
                 )
                 reload(events: events, showsInternals: showsInternals,
@@ -473,7 +475,7 @@ struct ChatWebView: NSViewRepresentable {
                 ChatDiagnostics.observe(
                     stage: .renderPlanning,
                     outcome: .coalesced,
-                    correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                    correlation: .init(chat: diagnosticChat(transcriptID), eventKind: .init(rawValue: "legacy-web")),
                     detail: "pending; rows=\(events.count)"
                 )
                 pendingEvents = events
@@ -505,7 +507,11 @@ struct ChatWebView: NSViewRepresentable {
             }
             ChatDiagnostics.observe(
                 stage: .renderPlanning,
-                correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                correlation: .init(
+                    chat: diagnosticChat(transcriptID),
+                    eventKind: .init(rawValue: "legacy-web"),
+                    content: events.last.flatMap(diagnosticContent)
+                ),
                 detail: "append; from=\(renderedCount); to=\(events.count)"
             )
             appendRows(Array(events[renderedCount...]), startingIndex: renderedCount, context: context)
@@ -518,7 +524,7 @@ struct ChatWebView: NSViewRepresentable {
             isLoaded = true
             ChatDiagnostics.observe(
                 stage: .domAcknowledgement,
-                correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                correlation: .init(chat: diagnosticChat(pendingTranscriptID ?? renderedTranscriptID), eventKind: .init(rawValue: "legacy-web")),
                 detail: "shell-finished; pending=\(pendingEvents.count)"
             )
             if rendersTypedChatRows {
@@ -541,6 +547,20 @@ struct ChatWebView: NSViewRepresentable {
             // rows are in the DOM (issue #281).
             if pendingHighlightQuote != nil {
                 applyHighlight()
+            }
+        }
+
+        private func diagnosticChat(_ transcriptID: TranscriptID?) -> ChatDiagnosticCorrelation.Value? {
+            guard case .chat(let chatID)? = transcriptID else { return nil }
+            return .init(rawValue: chatID.rawValue)
+        }
+
+        private func diagnosticContent(_ event: AgentEvent) -> ChatDiagnosticContentFingerprint? {
+            switch event {
+            case .userText(let text), .assistantText(let text), .thinking(let text), .thinkingDelta(let text), .assistantTextDelta(let text), .result(_, let text):
+                return ChatDiagnostics.fingerprint(text)
+            default:
+                return nil
             }
         }
 

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -460,18 +460,22 @@ struct ChatWebView: NSViewRepresentable {
                 transcriptID: transcriptID, renderedTranscriptID: renderedTranscriptID,
                 showsInternals: showsInternals, renderedShowsInternals: renderedShowsInternals,
                 eventCount: events.count, renderedCount: renderedCount) {
-                // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8.
-                DebugLog.chatLive(
-                    "8.web.reload count=\(events.count) renderedCount=\(renderedCount)")
+                ChatDiagnostics.observe(
+                    stage: .recoveryReload,
+                    correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                    detail: "reload; rows=\(events.count); rendered=\(renderedCount)"
+                )
                 reload(events: events, showsInternals: showsInternals,
                        timestamps: timestamps, transcriptID: transcriptID)
                 return
             }
             guard isLoaded else {
-                // TEMPORARY: rows arriving before the shell finishes loading are
-                // stashed, not drawn. A run of these with no `8.web.didFinish`
-                // after them means the shell load never completed.
-                DebugLog.chatLive("8.web.pending count=\(events.count)")
+                ChatDiagnostics.observe(
+                    stage: .renderPlanning,
+                    outcome: .coalesced,
+                    correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                    detail: "pending; rows=\(events.count)"
+                )
                 pendingEvents = events
                 pendingTimestamps = timestamps
                 return
@@ -499,12 +503,11 @@ struct ChatWebView: NSViewRepresentable {
                renderedEvents.count > 0 {
                 replaceLastRow(prevLast, at: renderedEvents.count - 1, isStreaming: false, allEvents: events, context: context)
             }
-            // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8. The
-            // `from` index is the tell — a non-zero `from` on a chat's FIRST
-            // append means rows 0..<from were never drawn (the missing
-            // "thinking" rows before "read").
-            DebugLog.chatLive(
-                "8.web.append from=\(renderedCount) to=\(events.count)")
+            ChatDiagnostics.observe(
+                stage: .renderPlanning,
+                correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                detail: "append; from=\(renderedCount); to=\(events.count)"
+            )
             appendRows(Array(events[renderedCount...]), startingIndex: renderedCount, context: context)
             renderedCount = events.count
             renderedLastEvent = events.last
@@ -513,8 +516,11 @@ struct ChatWebView: NSViewRepresentable {
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             isLoaded = true
-            // TEMPORARY (chat transcript freezes mid-stream): seam 8 of 8.
-            DebugLog.chatLive("8.web.didFinish pending=\(pendingEvents.count)")
+            ChatDiagnostics.observe(
+                stage: .domAcknowledgement,
+                correlation: .init(eventKind: .init(rawValue: "legacy-web")),
+                detail: "shell-finished; pending=\(pendingEvents.count)"
+            )
             if rendersTypedChatRows {
                 beginControlledChatReloadIfNeeded()
                 return

--- a/Sources/WikiFS/Chats/ChatsListView.swift
+++ b/Sources/WikiFS/Chats/ChatsListView.swift
@@ -35,11 +35,6 @@ struct ChatsListView: NSViewControllerRepresentable {
         let visible = store.chatSearchQuery.isEmpty ? store.chats : store.chatSearchResults
         let needs = vc.needsReload(visible)
         DebugLog.tabs("ChatsListView.updateNSVC: count=\(visible.count) needsReload=\(needs)")
-        ChatDiagnostics.observe(
-            stage: .displayProjection,
-            correlation: .init(eventKind: .init(rawValue: "sidebar")),
-            detail: "\(needs ? "reload" : "reconfigure"); rows=\(visible.count)"
-        )
         if needs {
             vc.reloadData(from: visible)
         } else {
@@ -178,12 +173,15 @@ final class ChatsListViewController: NSViewController {
     private func logLiveState(_ reason: String, reconfigured: Int, candidates: Int) {
         let live = Set(items.map(\.id).filter { chatDaemon?.isChatGenerating($0) ?? false })
         guard live != loggedLiveIDs else { return }
+        let previousLive = loggedLiveIDs
         loggedLiveIDs = live
-        ChatDiagnostics.observe(
-            stage: .displayProjection,
-            correlation: .init(eventKind: .init(rawValue: "sidebar-\(reason)")),
-            detail: "live-count=\(live.count); reconfigured=\(reconfigured)/\(candidates)"
-        )
+        for chatID in live.symmetricDifference(previousLive) {
+            ChatDiagnostics.observe(
+                stage: .displayProjection,
+                correlation: .init(chat: .init(rawValue: chatID.rawValue), eventKind: .init(rawValue: "sidebar-\(reason)")),
+                detail: "live-transition; reconfigured=\(reconfigured)/\(candidates)"
+            )
+        }
     }
 
     private func signature(_ rows: [ChatSummary]) -> String {

--- a/Sources/WikiFS/Chats/ChatsListView.swift
+++ b/Sources/WikiFS/Chats/ChatsListView.swift
@@ -35,10 +35,11 @@ struct ChatsListView: NSViewControllerRepresentable {
         let visible = store.chatSearchQuery.isEmpty ? store.chats : store.chatSearchResults
         let needs = vc.needsReload(visible)
         DebugLog.tabs("ChatsListView.updateNSVC: count=\(visible.count) needsReload=\(needs)")
-        // TEMPORARY (stuck "responding…" badge): seam 5 of 6. Seam 4 firing
-        // without this one means `AgentToolsView`'s re-render did not reach the
-        // representable (an unchanged-input short-circuit above us).
-        DebugLog.chatLive("5.sidebar.updateNSVC rows=\(visible.count) needsReload=\(needs)")
+        ChatDiagnostics.observe(
+            stage: .displayProjection,
+            correlation: .init(eventKind: .init(rawValue: "sidebar")),
+            detail: "\(needs ? "reload" : "reconfigure"); rows=\(visible.count)"
+        )
         if needs {
             vc.reloadData(from: visible)
         } else {
@@ -178,9 +179,11 @@ final class ChatsListViewController: NSViewController {
         let live = Set(items.map(\.id).filter { chatDaemon?.isChatGenerating($0) ?? false })
         guard live != loggedLiveIDs else { return }
         loggedLiveIDs = live
-        DebugLog.chatLive(
-            "6.sidebar.\(reason) live=[\(live.map(\.rawValue).sorted().joined(separator: ","))] "
-            + "reconfigured=\(reconfigured)/\(candidates)")
+        ChatDiagnostics.observe(
+            stage: .displayProjection,
+            correlation: .init(eventKind: .init(rawValue: "sidebar-\(reason)")),
+            detail: "live-count=\(live.count); reconfigured=\(reconfigured)/\(candidates)"
+        )
     }
 
     private func signature(_ rows: [ChatSummary]) -> String {

--- a/Sources/WikiFS/Chats/RemoteChatSession.swift
+++ b/Sources/WikiFS/Chats/RemoteChatSession.swift
@@ -87,6 +87,15 @@ public final class RemoteChatSession {
 
     func ingest(_ update: ChatSyncUpdate) {
         guard update.projection.chatID == chatID.chatID else { return }
+        ChatDiagnostics.observe(
+            stage: .syncAcceptance,
+            correlation: .init(
+                chat: .init(rawValue: update.projection.chatID.rawValue),
+                generation: .init(rawValue: update.projection.generation.rawValue),
+                updateSequence: .init(UInt64(max(0, update.projection.lastIncludedSequence.rawValue)))
+            ),
+            detail: "live-update"
+        )
         apply(.applyUpdate(update))
     }
 
@@ -115,6 +124,12 @@ public final class RemoteChatSession {
     private func apply(_ action: ChatClientSyncAction) {
         guard let state = syncState else { return }
         let reduction = ChatClientSyncReducer.reduce(state, action)
+        ChatDiagnostics.observe(
+            stage: .syncReconciliation,
+            outcome: reduction.state.syncStatus == .synchronized ? .accepted : .recovered,
+            correlation: .init(chat: .init(rawValue: state.chatID.rawValue)),
+            detail: "client-sync"
+        )
         syncState = reduction.state
         if reduction.state.syncStatus == .synchronized {
             clearAuthoritativeSnapshotRetryBackoff()

--- a/Sources/WikiFS/Settings/AgentToolsView.swift
+++ b/Sources/WikiFS/Settings/AgentToolsView.swift
@@ -28,13 +28,6 @@ struct AgentToolsView: View {
         // because `isChatGenerating(_:)` is called from the NSTableView data
         // source, which SwiftUI can't observe.
         let _ = chatDaemon?.runningStateToken
-        // Debug-only observation of the sidebar's tracked generation token.
-        // It contains no chat content and is retained only in the redacted trace.
-        let _ = ChatDiagnostics.observe(
-            stage: .displayProjection,
-            correlation: .init(updateSequence: .init(UInt64(chatDaemon?.runningStateToken ?? 0))),
-            detail: "sidebar-body"
-        )
         VStack(spacing: 0) {
             chatsHeader
             chatSearchBar

--- a/Sources/WikiFS/Settings/AgentToolsView.swift
+++ b/Sources/WikiFS/Settings/AgentToolsView.swift
@@ -28,10 +28,13 @@ struct AgentToolsView: View {
         // because `isChatGenerating(_:)` is called from the NSTableView data
         // source, which SwiftUI can't observe.
         let _ = chatDaemon?.runningStateToken
-        // TEMPORARY (stuck "responding…" badge): seam 4 of 6. A token bump at
-        // seam 3 with no matching line here means the read above did not
-        // register with Observation, so the sidebar is never invalidated.
-        let _ = DebugLog.chatLive("4.sidebar.body token=\(chatDaemon?.runningStateToken ?? -1)")
+        // Debug-only observation of the sidebar's tracked generation token.
+        // It contains no chat content and is retained only in the redacted trace.
+        let _ = ChatDiagnostics.observe(
+            stage: .displayProjection,
+            correlation: .init(updateSequence: .init(UInt64(chatDaemon?.runningStateToken ?? 0))),
+            detail: "sidebar-body"
+        )
         VStack(spacing: 0) {
             chatsHeader
             chatSearchBar

--- a/Sources/WikiFSTypes/ChatDiagnosticTypes.swift
+++ b/Sources/WikiFSTypes/ChatDiagnosticTypes.swift
@@ -1,0 +1,257 @@
+import Foundation
+
+/// Foundation-only, versioned diagnostic data shared by the app and `wikid`.
+///
+/// These values deliberately use diagnostic-specific identifiers rather than
+/// importing presentation or runtime types. They are transport and log values,
+/// never persistence identity or user-visible copy.
+public enum ChatDiagnosticTypes {
+    public static let currentVersion = 1
+}
+
+public enum ChatDiagnosticSource: String, Codable, Sendable, CaseIterable {
+    case app
+    case daemon
+}
+
+public struct ChatDiagnosticProcessIdentity: Codable, Hashable, Sendable {
+    public let source: ChatDiagnosticSource
+    public let instanceID: UUID
+
+    public init(source: ChatDiagnosticSource, instanceID: UUID = UUID()) {
+        self.source = source
+        self.instanceID = instanceID
+    }
+}
+
+public struct ChatDiagnosticSequence: Codable, Hashable, Sendable, Comparable {
+    public let rawValue: UInt64
+
+    public init(_ rawValue: UInt64) { self.rawValue = rawValue }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+/// Opaque, namespaced correlation values. Raw values are stable identifiers or
+/// numeric values already present at a boundary; they must never contain text.
+public struct ChatDiagnosticCorrelation: Codable, Hashable, Sendable {
+    public struct Value: Codable, Hashable, Sendable, RawRepresentable {
+        public let rawValue: String
+        public init(rawValue: String) { self.rawValue = rawValue }
+    }
+
+    public let chat: Value?
+    public let generation: Value?
+    public let updateSequence: ChatDiagnosticSequence?
+    public let turn: Value?
+    public let durableItem: Value?
+    public let displayRow: Value?
+    public let tool: Value?
+    public let cursor: Value?
+    public let rendererRevision: ChatDiagnosticSequence?
+    public let eventKind: Value?
+    public let content: ChatDiagnosticContentFingerprint?
+
+    public init(
+        chat: Value? = nil,
+        generation: Value? = nil,
+        updateSequence: ChatDiagnosticSequence? = nil,
+        turn: Value? = nil,
+        durableItem: Value? = nil,
+        displayRow: Value? = nil,
+        tool: Value? = nil,
+        cursor: Value? = nil,
+        rendererRevision: ChatDiagnosticSequence? = nil,
+        eventKind: Value? = nil,
+        content: ChatDiagnosticContentFingerprint? = nil
+    ) {
+        self.chat = chat
+        self.generation = generation
+        self.updateSequence = updateSequence
+        self.turn = turn
+        self.durableItem = durableItem
+        self.displayRow = displayRow
+        self.tool = tool
+        self.cursor = cursor
+        self.rendererRevision = rendererRevision
+        self.eventKind = eventKind
+        self.content = content
+    }
+}
+
+public struct ChatDiagnosticContentFingerprint: Codable, Hashable, Sendable {
+    public static let currentAlgorithm = "keyed-fnv1a64-v1"
+
+    public let algorithm: String
+    public let digest: String
+    public let length: Int
+
+    public init(algorithm: String = Self.currentAlgorithm, digest: String, length: Int) {
+        self.algorithm = algorithm
+        self.digest = digest
+        self.length = length
+    }
+}
+
+/// A local random key used only to produce non-reusable content fingerprints.
+/// It is intentionally not Codable, so it can never be exported with a trace.
+public struct ChatDiagnosticFingerprintKey: Hashable, Sendable {
+    private let bytes: [UInt8]
+
+    public init() {
+        let parts = [UUID().uuid, UUID().uuid]
+        self.bytes = parts.flatMap { tuple in
+            withUnsafeBytes(of: tuple) { Array($0) }
+        }
+    }
+
+    public func fingerprint(for text: String) -> ChatDiagnosticContentFingerprint {
+        // FNV-1a is a compact keyed *fingerprint*, not a password hash or a
+        // secrecy primitive. The random local key prevents correlating text
+        // across a trace or deriving a reusable plaintext token from exports.
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in bytes + Array(text.utf8) {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return ChatDiagnosticContentFingerprint(
+            digest: String(hash, radix: 16, uppercase: false),
+            length: text.utf8.count
+        )
+    }
+}
+
+public enum ChatDiagnosticRedaction: String, Codable, Sendable {
+    case identifiersAndKeyedFingerprintOnly
+}
+
+public enum ChatDiagnosticStage: String, Codable, Sendable, CaseIterable {
+    case providerReceipt
+    case providerTranslation
+    case reduction
+    case persistence
+    case syncAcceptance
+    case syncReconciliation
+    case displayProjection
+    case renderPlanning
+    case domAcknowledgement
+    case domFailure
+    case recoveryReload
+}
+
+public enum ChatDiagnosticOutcome: String, Codable, Sendable {
+    case accepted
+    case coalesced
+    case ignored
+    case recovered
+    case failed
+    case timeout
+    case decodeFailure
+    case versionFailure
+}
+
+/// A compact typed payload: the stage gives meaning to correlation values;
+/// details contain only fixed diagnostic labels, never user content.
+public struct ChatDiagnosticPayload: Codable, Hashable, Sendable {
+    public let correlation: ChatDiagnosticCorrelation
+    public let detail: String?
+
+    public init(correlation: ChatDiagnosticCorrelation = .init(), detail: String? = nil) {
+        self.correlation = correlation
+        self.detail = detail
+    }
+}
+
+public struct ChatDiagnosticEventEnvelope: Codable, Hashable, Sendable {
+    public let version: Int
+    public let process: ChatDiagnosticProcessIdentity
+    public let sequence: ChatDiagnosticSequence
+    public let timestamp: Date
+    public let redaction: ChatDiagnosticRedaction
+    public let stage: ChatDiagnosticStage
+    public let payload: ChatDiagnosticPayload
+    public let outcome: ChatDiagnosticOutcome
+
+    public init(
+        version: Int = ChatDiagnosticTypes.currentVersion,
+        process: ChatDiagnosticProcessIdentity,
+        sequence: ChatDiagnosticSequence,
+        timestamp: Date = Date(),
+        redaction: ChatDiagnosticRedaction = .identifiersAndKeyedFingerprintOnly,
+        stage: ChatDiagnosticStage,
+        payload: ChatDiagnosticPayload = .init(),
+        outcome: ChatDiagnosticOutcome
+    ) {
+        self.version = version
+        self.process = process
+        self.sequence = sequence
+        self.timestamp = timestamp
+        self.redaction = redaction
+        self.stage = stage
+        self.payload = payload
+        self.outcome = outcome
+    }
+
+    public func validatingVersion() throws {
+        guard version == ChatDiagnosticTypes.currentVersion else {
+            throw ChatDiagnosticVersionError.unsupported(version)
+        }
+    }
+}
+
+public struct ChatDiagnosticSnapshotEnvelope: Codable, Hashable, Sendable {
+    public let version: Int
+    public let process: ChatDiagnosticProcessIdentity
+    public let generatedAt: Date
+    public let events: [ChatDiagnosticEventEnvelope]
+    public let droppedRecordCount: Int
+    public let droppedByteCount: Int
+    public let summary: [String: String]
+
+    public init(
+        version: Int = ChatDiagnosticTypes.currentVersion,
+        process: ChatDiagnosticProcessIdentity,
+        generatedAt: Date = Date(),
+        events: [ChatDiagnosticEventEnvelope],
+        droppedRecordCount: Int = 0,
+        droppedByteCount: Int = 0,
+        summary: [String: String] = [:]
+    ) {
+        self.version = version
+        self.process = process
+        self.generatedAt = generatedAt
+        self.events = events
+        self.droppedRecordCount = droppedRecordCount
+        self.droppedByteCount = droppedByteCount
+        self.summary = summary
+    }
+
+    public func validatingVersion() throws {
+        guard version == ChatDiagnosticTypes.currentVersion else {
+            throw ChatDiagnosticVersionError.unsupported(version)
+        }
+        try events.forEach { try $0.validatingVersion() }
+    }
+}
+
+public enum ChatDiagnosticVersionError: Error, Equatable, Sendable {
+    case unsupported(Int)
+}
+
+/// The explicit XPC request boundary. `chat` is optional so a daemon can
+/// provide process-wide diagnostics when no individual session is selected.
+public struct ChatDiagnosticSnapshotRequest: Codable, Hashable, Sendable {
+    public let version: Int
+    public let chat: ChatDiagnosticCorrelation.Value?
+
+    public init(version: Int = ChatDiagnosticTypes.currentVersion, chat: ChatDiagnosticCorrelation.Value? = nil) {
+        self.version = version
+        self.chat = chat
+    }
+
+    public func validatingVersion() throws {
+        guard version == ChatDiagnosticTypes.currentVersion else {
+            throw ChatDiagnosticVersionError.unsupported(version)
+        }
+    }
+}

--- a/Sources/WikiFSTypes/ChatDiagnosticTypes.swift
+++ b/Sources/WikiFSTypes/ChatDiagnosticTypes.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#elseif canImport(Crypto)
+import Crypto
+#endif
 
 /// Foundation-only, versioned diagnostic data shared by the app and `wikid`.
 ///
@@ -80,7 +85,7 @@ public struct ChatDiagnosticCorrelation: Codable, Hashable, Sendable {
 }
 
 public struct ChatDiagnosticContentFingerprint: Codable, Hashable, Sendable {
-    public static let currentAlgorithm = "keyed-fnv1a64-v1"
+    public static let currentAlgorithm = "hmac-sha256-v1"
 
     public let algorithm: String
     public let digest: String
@@ -93,29 +98,35 @@ public struct ChatDiagnosticContentFingerprint: Codable, Hashable, Sendable {
     }
 }
 
-/// A local random key used only to produce non-reusable content fingerprints.
-/// It is intentionally not Codable, so it can never be exported with a trace.
+/// A local random HMAC key used only to produce non-reusable content
+/// fingerprints. It is intentionally not Codable, so it can never be exported
+/// with a trace.
+///
+/// HMAC-SHA-256 is a cryptographic message authentication code: unlike the
+/// former prefix-FNV construction, a known plaintext/digest pair does not
+/// reveal a reusable state for deriving fingerprints of other plaintexts.
 public struct ChatDiagnosticFingerprintKey: Hashable, Sendable {
-    private let bytes: [UInt8]
+    private let key: SymmetricKey
+    /// Preserves value identity for callers without exposing secret key bytes.
+    private let identity: UUID
 
     public init() {
-        let parts = [UUID().uuid, UUID().uuid]
-        self.bytes = parts.flatMap { tuple in
-            withUnsafeBytes(of: tuple) { Array($0) }
-        }
+        self.key = SymmetricKey(size: .bits256)
+        self.identity = UUID()
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.identity == rhs.identity
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(identity)
     }
 
     public func fingerprint(for text: String) -> ChatDiagnosticContentFingerprint {
-        // FNV-1a is a compact keyed *fingerprint*, not a password hash or a
-        // secrecy primitive. The random local key prevents correlating text
-        // across a trace or deriving a reusable plaintext token from exports.
-        var hash: UInt64 = 0xcbf29ce484222325
-        for byte in bytes + Array(text.utf8) {
-            hash ^= UInt64(byte)
-            hash &*= 0x100000001b3
-        }
+        let code = HMAC<SHA256>.authenticationCode(for: Data(text.utf8), using: key)
         return ChatDiagnosticContentFingerprint(
-            digest: String(hash, radix: 16, uppercase: false),
+            digest: Data(code).base64EncodedString(),
             length: text.utf8.count
         )
     }

--- a/Sources/WikiFSTypes/ChatDiagnosticTypes.swift
+++ b/Sources/WikiFSTypes/ChatDiagnosticTypes.swift
@@ -255,3 +255,22 @@ public struct ChatDiagnosticSnapshotRequest: Codable, Hashable, Sendable {
         }
     }
 }
+
+/// Acknowledges that a redacted export reached its destination. It is a
+/// separate XPC operation so a failed pasteboard/file write never drains the
+/// daemon ring that a retry needs.
+public struct ChatDiagnosticResetRequest: Codable, Hashable, Sendable {
+    public let version: Int
+    public let chat: ChatDiagnosticCorrelation.Value?
+
+    public init(version: Int = ChatDiagnosticTypes.currentVersion, chat: ChatDiagnosticCorrelation.Value? = nil) {
+        self.version = version
+        self.chat = chat
+    }
+
+    public func validatingVersion() throws {
+        guard version == ChatDiagnosticTypes.currentVersion else {
+            throw ChatDiagnosticVersionError.unsupported(version)
+        }
+    }
+}

--- a/Sources/WikiFSTypes/DebugLog.swift
+++ b/Sources/WikiFSTypes/DebugLog.swift
@@ -37,6 +37,21 @@ public enum DebugLog {
     ///     log show --predicate 'subsystem == "com.selfdrivingwiki.debug" AND category == "chatlive"' \
     ///              --style compact --info --last 10m
     public static func chatLive(_ message: @autoclosure () -> String) { emit("chatlive", message()) }
+    /// Stable redacted chat diagnostic predicate:
+    ///
+    ///     log show --predicate 'subsystem == "com.selfdrivingwiki.debug" AND category == "chatdiagnostics"' --style compact --info --debug --last 10m
+    public static func chatDiagnostics(_ message: @autoclosure () -> String, verbose: Bool) {
+        if verbose {
+            guard verboseLogging else { return }
+            #if canImport(os)
+            emit("chatdiagnostics", message(), level: .debug)
+            #else
+            emit("chatdiagnostics", message())
+            #endif
+        } else {
+            emit("chatdiagnostics", message())
+        }
+    }
 
     // MARK: - try? replacement
 
@@ -142,6 +157,7 @@ public enum DebugLog {
         "reader": Logger(subsystem: subsystem, category: "reader"),
         "editor": Logger(subsystem: subsystem, category: "editor"),
         "chatlive": Logger(subsystem: subsystem, category: "chatlive"),
+        "chatdiagnostics": Logger(subsystem: subsystem, category: "chatdiagnostics"),
     ]
 
     // `.default` is the "notice" level (persisted by `log show`); `.debug` is

--- a/Sources/wikid/DaemonChatController.swift
+++ b/Sources/wikid/DaemonChatController.swift
@@ -22,6 +22,7 @@ actor DaemonChatController {
     private let store: GRDBWikiStore
     private let runtime: ChatAgentRuntime
     private let pushEvent: @Sendable (QueueEventEnvelope) -> Void
+    private let diagnosticTrace: DaemonChatDiagnostics
 
     private var generation: ChatSessionGenerationID
     private var snapshot: ChatRuntimeSnapshot
@@ -61,13 +62,15 @@ actor DaemonChatController {
         wikiID: WikiID,
         store: GRDBWikiStore,
         runtime: ChatAgentRuntime,
-        pushEvent: @escaping @Sendable (QueueEventEnvelope) -> Void
+        pushEvent: @escaping @Sendable (QueueEventEnvelope) -> Void,
+        diagnosticTrace: DaemonChatDiagnostics = DaemonChatDiagnostics()
     ) throws {
         self.chatID = chatID
         self.wikiID = wikiID
         self.store = store
         self.runtime = runtime
         self.pushEvent = pushEvent
+        self.diagnosticTrace = diagnosticTrace
         self.generation = ChatSessionGenerationID(rawValue: ULID.generate())
         self.replayBuffer = ChatUpdateReplayBuffer(capacity: Self.replayCapacity)
         self.snapshot = try Self.bootstrapSnapshot(chatID: chatID, store: store, generation: generation)
@@ -90,6 +93,13 @@ actor DaemonChatController {
             return chatID
         }
 
+        await observeDiagnostic(
+            stage: .providerReceipt,
+            detail: "turn-received",
+            turnID: request.submission.turnID,
+            content: request.submission.userText
+        )
+
         let persistedTurn = try store.enqueuePersistedChatTurn(chatID: chatID, submission: request.submission)
         try appendTranscriptItems([
             .message(ChatTranscriptMessageItem(
@@ -100,6 +110,7 @@ actor DaemonChatController {
                 createdAt: request.submission.submittedAt
             ))
         ])
+        await observeDiagnostic(stage: .persistence, detail: "turn-enqueued", turnID: request.submission.turnID)
         record(.queued(ChatQueuedTurn(
             ordinal: persistedTurn.ordinal,
             submission: persistedTurn.submission,
@@ -315,6 +326,7 @@ actor DaemonChatController {
                 startEventLoop(handle)
             }
             record(.started(turnID: claimed.submission.turnID))
+            await observeDiagnostic(stage: .providerTranslation, detail: "provider-submit", turnID: claimed.submission.turnID)
             try await runtime.submitTurn(claimed.submission, in: handle)
             let marked = try store.markPersistedChatTurnProviderSubmitted(
                 chatID: chatID,
@@ -343,6 +355,7 @@ actor DaemonChatController {
                     lastIncludedSequence: snapshot.lastIncludedSequence
                 )
             }
+            await observeDiagnostic(stage: .persistence, detail: "provider-submitted", turnID: claimed.submission.turnID)
         } catch {
             DebugLog.agent("DaemonChatController.processQueueIfPossible submit failed: \(error)")
             _ = finishPersistedTurn(
@@ -373,6 +386,7 @@ actor DaemonChatController {
 
     private func handleRuntimeEvent(_ envelope: ChatAgentRuntimeEventEnvelope) async {
         guard envelope.generation == generation else { return }
+        await observeDiagnostic(stage: .providerReceipt, detail: "runtime-event")
         // The runtime supplies this transition with the same envelope as the
         // transcript delta. Clearing it first prevents a closed block from
         // remaining live across a semantic boundary.
@@ -388,6 +402,8 @@ actor DaemonChatController {
             } catch {
                 DebugLog.store("DaemonChatController transcript persistence failed: \(error)")
             }
+            await observeDiagnostic(stage: .reduction, detail: "transcript-reduced")
+            await observeDiagnostic(stage: .persistence, detail: "transcript-persisted")
             record(.transcriptChanged(deltas))
 
         case .permissionRequested(let request):
@@ -563,6 +579,26 @@ actor DaemonChatController {
         case .rejected(let rejection):
             DebugLog.agent("DaemonChatController rejected update \(payload): \(rejection)")
         }
+    }
+
+    private func observeDiagnostic(
+        stage: ChatDiagnosticStage,
+        detail: String,
+        turnID: ChatTurnID? = nil,
+        content: String? = nil
+    ) async {
+        await diagnosticTrace.record(
+            stage: stage,
+            outcome: .accepted,
+            correlation: .init(
+                chat: .init(rawValue: chatID.rawValue),
+                generation: .init(rawValue: generation.rawValue),
+                updateSequence: .init(UInt64(max(0, nextSequence.rawValue))),
+                turn: turnID.map { .init(rawValue: $0.rawValue) }
+            ),
+            detail: detail,
+            content: content
+        )
     }
 
     private func pushSyncUpdate(reason: ChatSyncUpdateReason) {

--- a/Sources/wikid/DaemonChatController.swift
+++ b/Sources/wikid/DaemonChatController.swift
@@ -386,7 +386,14 @@ actor DaemonChatController {
 
     private func handleRuntimeEvent(_ envelope: ChatAgentRuntimeEventEnvelope) async {
         guard envelope.generation == generation else { return }
-        await observeDiagnostic(stage: .providerReceipt, detail: "runtime-event")
+        let diagnosticContext = Self.diagnosticContext(for: envelope.event)
+        await observeDiagnostic(
+            stage: .providerReceipt,
+            detail: "runtime-event",
+            turnID: diagnosticContext?.turnID,
+            durableItem: diagnosticContext?.durableItem,
+            content: diagnosticContext?.content
+        )
         // The runtime supplies this transition with the same envelope as the
         // transcript delta. Clearing it first prevents a closed block from
         // remaining live across a semantic boundary.
@@ -402,8 +409,20 @@ actor DaemonChatController {
             } catch {
                 DebugLog.store("DaemonChatController transcript persistence failed: \(error)")
             }
-            await observeDiagnostic(stage: .reduction, detail: "transcript-reduced")
-            await observeDiagnostic(stage: .persistence, detail: "transcript-persisted")
+            await observeDiagnostic(
+                stage: .reduction,
+                detail: "transcript-reduced",
+                turnID: diagnosticContext?.turnID,
+                durableItem: diagnosticContext?.durableItem,
+                content: diagnosticContext?.content
+            )
+            await observeDiagnostic(
+                stage: .persistence,
+                detail: "transcript-persisted",
+                turnID: diagnosticContext?.turnID,
+                durableItem: diagnosticContext?.durableItem,
+                content: diagnosticContext?.content
+            )
             record(.transcriptChanged(deltas))
 
         case .permissionRequested(let request):
@@ -585,6 +604,7 @@ actor DaemonChatController {
         stage: ChatDiagnosticStage,
         detail: String,
         turnID: ChatTurnID? = nil,
+        durableItem: ChatDiagnosticCorrelation.Value? = nil,
         content: String? = nil
     ) async {
         await diagnosticTrace.record(
@@ -594,7 +614,8 @@ actor DaemonChatController {
                 chat: .init(rawValue: chatID.rawValue),
                 generation: .init(rawValue: generation.rawValue),
                 updateSequence: .init(UInt64(max(0, nextSequence.rawValue))),
-                turn: turnID.map { .init(rawValue: $0.rawValue) }
+                turn: turnID.map { .init(rawValue: $0.rawValue) },
+                durableItem: durableItem
             ),
             detail: detail,
             content: content
@@ -863,6 +884,54 @@ actor DaemonChatController {
                     createdAt: createdAt
                 ))
             }
+        }
+    }
+
+    private struct DiagnosticTranscriptContext {
+        let durableItem: ChatDiagnosticCorrelation.Value
+        let turnID: ChatTurnID
+        let content: String?
+    }
+
+    /// Returns a stable identity only when the runtime envelope changes one
+    /// durable item. Mixed batches deliberately stay uncoalesced so unrelated
+    /// transcript changes cannot overwrite one another in the diagnostic ring.
+    private static func diagnosticContext(
+        for event: ChatAgentRuntimeEvent
+    ) -> DiagnosticTranscriptContext? {
+        guard case .transcript(let deltas) = event else { return nil }
+        let contexts = deltas.compactMap(diagnosticContext(for:))
+        guard let first = contexts.first,
+              contexts.count == deltas.count,
+              contexts.allSatisfy({ $0.durableItem == first.durableItem })
+        else { return nil }
+        return contexts.last
+    }
+
+    private static func diagnosticContext(
+        for delta: ChatTranscriptDelta
+    ) -> DiagnosticTranscriptContext? {
+        switch delta {
+        case .messageDelta(let messageID, let turnID, _, let text, _),
+             .messageReplacement(let messageID, let turnID, _, let text, _):
+            return .init(
+                durableItem: .init(rawValue: messageID.rawValue),
+                turnID: turnID,
+                content: text
+            )
+        case .toolCallUpsert(let toolCall):
+            return .init(
+                durableItem: .init(rawValue: toolCall.toolCallID.rawValue),
+                turnID: toolCall.turnID,
+                content: nil
+            )
+        case .append(let item):
+            guard case .message(let message) = item else { return nil }
+            return .init(
+                durableItem: .init(rawValue: message.messageID.rawValue),
+                turnID: message.turnID,
+                content: message.text
+            )
         }
     }
 }

--- a/Sources/wikid/DaemonChatDiagnostics.swift
+++ b/Sources/wikid/DaemonChatDiagnostics.swift
@@ -1,0 +1,61 @@
+import Foundation
+import WikiFSCore
+
+/// Daemon-only trace ownership. The daemon never imports app display types;
+/// it receives only diagnostic correlation values through the shared DTO.
+actor DaemonChatDiagnostics {
+    private let identity = ChatDiagnosticProcessIdentity(source: .daemon)
+    private var sequence: UInt64 = 0
+    private var events: [ChatDiagnosticEventEnvelope] = []
+
+    func record(
+        stage: ChatDiagnosticStage,
+        outcome: ChatDiagnosticOutcome,
+        payload: ChatDiagnosticPayload = .init()
+    ) {
+        sequence &+= 1
+        let event = ChatDiagnosticEventEnvelope(
+            process: identity,
+            sequence: ChatDiagnosticSequence(sequence),
+            stage: stage,
+            payload: payload,
+            outcome: outcome
+        )
+        events.append(event)
+        while events.count > ChatDiagnosticPolicyDaemon.maximumRecords { events.removeFirst() }
+        switch outcome {
+        case .failed, .timeout, .decodeFailure, .versionFailure:
+            DebugLog.chatDiagnostics("chat diagnostic stage=\(stage.rawValue) outcome=\(outcome.rawValue)", verbose: false)
+        default:
+            DebugLog.chatDiagnostics("chat diagnostic stage=\(stage.rawValue) outcome=\(outcome.rawValue)", verbose: true)
+        }
+    }
+
+    func snapshot(chat: ChatDiagnosticCorrelation.Value?) -> ChatDiagnosticSnapshotEnvelope {
+        let filtered = events.filter { event in
+            guard let chat else { return true }
+            return event.payload.correlation.chat == chat
+        }
+        return ChatDiagnosticSnapshotEnvelope(
+            process: identity,
+            events: filtered,
+            summary: ["retention": "daemon-run-log-jsonl"]
+        )
+    }
+
+    func versionFailureSnapshot() -> ChatDiagnosticSnapshotEnvelope {
+        sequence &+= 1
+        let event = ChatDiagnosticEventEnvelope(
+            process: identity,
+            sequence: ChatDiagnosticSequence(sequence),
+            stage: .syncAcceptance,
+            payload: .init(detail: "diagnostic-request-version"),
+            outcome: .versionFailure
+        )
+        return ChatDiagnosticSnapshotEnvelope(process: identity, events: [event])
+    }
+}
+
+private enum ChatDiagnosticPolicyDaemon {
+    static let maximumRecords = 256
+}

--- a/Sources/wikid/DaemonChatDiagnostics.swift
+++ b/Sources/wikid/DaemonChatDiagnostics.swift
@@ -1,61 +1,158 @@
 import Foundation
 import WikiFSCore
 
-/// Daemon-only trace ownership. The daemon never imports app display types;
-/// it receives only diagnostic correlation values through the shared DTO.
+/// Daemon-only, per-chat redacted ring. The actor serializes observations from
+/// controller lifecycles and the XPC boundary, preserving their causal order.
 actor DaemonChatDiagnostics {
-    private let identity = ChatDiagnosticProcessIdentity(source: .daemon)
+    private struct StoredRecord: Sendable {
+        let event: ChatDiagnosticEventEnvelope
+        let byteCount: Int
+    }
+
+    private enum Bucket: Hashable {
+        case chat(ChatDiagnosticCorrelation.Value)
+        case process
+    }
+
+    private var identity = ChatDiagnosticProcessIdentity(source: .daemon)
+    private var fingerprintKey = ChatDiagnosticFingerprintKey()
     private var sequence: UInt64 = 0
-    private var events: [ChatDiagnosticEventEnvelope] = []
+    private var recordsByBucket: [Bucket: [StoredRecord]] = [:]
+    private var droppedRecordsByBucket: [Bucket: Int] = [:]
+    private var droppedBytesByBucket: [Bucket: Int] = [:]
 
     func record(
         stage: ChatDiagnosticStage,
         outcome: ChatDiagnosticOutcome,
-        payload: ChatDiagnosticPayload = .init()
+        correlation: ChatDiagnosticCorrelation = .init(),
+        detail: String? = nil,
+        content: String? = nil
     ) {
         sequence &+= 1
+        let populated = correlationWithFingerprint(correlation, content: content)
+        let bucket = populated.chat.map(Bucket.chat) ?? .process
+        let didCoalesce = shouldCoalesce(stage: stage, correlation: populated)
+            && recordsByBucket[bucket]?.last.map { coalescingKey(for: $0.event) == coalescingKey(stage: stage, correlation: populated) } == true
         let event = ChatDiagnosticEventEnvelope(
             process: identity,
-            sequence: ChatDiagnosticSequence(sequence),
+            sequence: .init(sequence),
             stage: stage,
-            payload: payload,
-            outcome: outcome
+            payload: .init(correlation: populated, detail: detail),
+            outcome: didCoalesce ? .coalesced : outcome
         )
-        events.append(event)
-        while events.count > ChatDiagnosticPolicyDaemon.maximumRecords { events.removeFirst() }
-        switch outcome {
-        case .failed, .timeout, .decodeFailure, .versionFailure:
-            DebugLog.chatDiagnostics("chat diagnostic stage=\(stage.rawValue) outcome=\(outcome.rawValue)", verbose: false)
-        default:
-            DebugLog.chatDiagnostics("chat diagnostic stage=\(stage.rawValue) outcome=\(outcome.rawValue)", verbose: true)
-        }
+        append(event, bucket: bucket)
+        emit(event)
     }
 
     func snapshot(chat: ChatDiagnosticCorrelation.Value?) -> ChatDiagnosticSnapshotEnvelope {
-        let filtered = events.filter { event in
-            guard let chat else { return true }
-            return event.payload.correlation.chat == chat
-        }
+        let bucket = chat.map(Bucket.chat)
+        let records = bucket.map { recordsByBucket[$0] ?? [] } ?? recordsByBucket.values.flatMap { $0 }
+        let droppedRecords = bucket.map { droppedRecordsByBucket[$0] ?? 0 } ?? droppedRecordsByBucket.values.reduce(0, +)
+        let droppedBytes = bucket.map { droppedBytesByBucket[$0] ?? 0 } ?? droppedBytesByBucket.values.reduce(0, +)
         return ChatDiagnosticSnapshotEnvelope(
             process: identity,
-            events: filtered,
-            summary: ["retention": "daemon-run-log-jsonl"]
+            events: records.map(\.event),
+            droppedRecordCount: droppedRecords,
+            droppedByteCount: droppedBytes,
+            summary: ["retention": "daemon-redacted-ring"]
         )
+    }
+
+    func resetAfterSuccessfulExport() {
+        identity = ChatDiagnosticProcessIdentity(source: .daemon)
+        fingerprintKey = ChatDiagnosticFingerprintKey()
+        sequence = 0
+        recordsByBucket.removeAll()
+        droppedRecordsByBucket.removeAll()
+        droppedBytesByBucket.removeAll()
     }
 
     func versionFailureSnapshot() -> ChatDiagnosticSnapshotEnvelope {
         sequence &+= 1
         let event = ChatDiagnosticEventEnvelope(
             process: identity,
-            sequence: ChatDiagnosticSequence(sequence),
+            sequence: .init(sequence),
             stage: .syncAcceptance,
             payload: .init(detail: "diagnostic-request-version"),
             outcome: .versionFailure
         )
         return ChatDiagnosticSnapshotEnvelope(process: identity, events: [event])
     }
+
+    private func correlationWithFingerprint(_ correlation: ChatDiagnosticCorrelation, content: String?) -> ChatDiagnosticCorrelation {
+        ChatDiagnosticCorrelation(
+            chat: correlation.chat,
+            generation: correlation.generation,
+            updateSequence: correlation.updateSequence,
+            turn: correlation.turn,
+            durableItem: correlation.durableItem,
+            displayRow: correlation.displayRow,
+            tool: correlation.tool,
+            cursor: correlation.cursor,
+            rendererRevision: correlation.rendererRevision,
+            eventKind: correlation.eventKind,
+            content: content.map { fingerprintKey.fingerprint(for: $0) } ?? correlation.content
+        )
+    }
+
+    private func append(_ event: ChatDiagnosticEventEnvelope, bucket: Bucket) {
+        let encoded: Data
+        do { encoded = try JSONEncoder().encode(event) }
+        catch {
+            DebugLog.store("daemon chat diagnostic event encoding failed: \(error)")
+            return
+        }
+        var records = recordsByBucket[bucket, default: []]
+        if shouldCoalesce(event), let last = records.last, coalescingKey(for: last.event) == coalescingKey(for: event) {
+            records.removeLast()
+        }
+        records.append(.init(event: event, byteCount: encoded.count))
+        var bytes = records.reduce(0) { $0 + $1.byteCount }
+        while records.count > ChatDiagnosticPolicyDaemon.maximumRecordsPerChat || bytes > ChatDiagnosticPolicyDaemon.maximumBytesPerChat {
+            let removed = records.removeFirst()
+            bytes -= removed.byteCount
+            droppedRecordsByBucket[bucket, default: 0] += 1
+            droppedBytesByBucket[bucket, default: 0] += removed.byteCount
+        }
+        recordsByBucket[bucket] = records
+    }
+
+    private func shouldCoalesce(_ event: ChatDiagnosticEventEnvelope) -> Bool {
+        shouldCoalesce(stage: event.stage, correlation: event.payload.correlation)
+    }
+
+    private func shouldCoalesce(stage: ChatDiagnosticStage, correlation: ChatDiagnosticCorrelation) -> Bool {
+        switch stage {
+        case .providerReceipt, .providerTranslation, .reduction:
+            return correlation.updateSequence != nil || correlation.durableItem != nil
+        default:
+            return false
+        }
+    }
+
+    private func coalescingKey(for event: ChatDiagnosticEventEnvelope) -> String? {
+        coalescingKey(stage: event.stage, correlation: event.payload.correlation)
+    }
+
+    private func coalescingKey(stage: ChatDiagnosticStage, correlation: ChatDiagnosticCorrelation) -> String? {
+        guard shouldCoalesce(stage: stage, correlation: correlation) else { return nil }
+        let subject = correlation.durableItem?.rawValue ?? correlation.turn?.rawValue
+        // An item or turn identifies the high-frequency provider stream; keep
+        // only its newest update. Without that identity, retain the revision
+        // boundary so unrelated daemon observations cannot collapse together.
+        let revision = subject == nil ? correlation.updateSequence.map { String($0.rawValue) } ?? "" : "item"
+        return [stage.rawValue, correlation.chat?.rawValue ?? "", subject ?? "", revision].joined(separator: "|")
+    }
+
+    private func emit(_ event: ChatDiagnosticEventEnvelope) {
+        DebugLog.chatDiagnostics(
+            "daemon chat diagnostic stage=\(event.stage.rawValue) outcome=\(event.outcome.rawValue) sequence=\(event.sequence.rawValue)",
+            verbose: event.outcome != .failed
+        )
+    }
 }
 
 private enum ChatDiagnosticPolicyDaemon {
-    static let maximumRecords = 256
+    static let maximumRecordsPerChat = 256
+    static let maximumBytesPerChat = 256 * 1_024
 }

--- a/Sources/wikid/DaemonChatDiagnostics.swift
+++ b/Sources/wikid/DaemonChatDiagnostics.swift
@@ -31,8 +31,12 @@ actor DaemonChatDiagnostics {
         sequence &+= 1
         let populated = correlationWithFingerprint(correlation, content: content)
         let bucket = populated.chat.map(Bucket.chat) ?? .process
-        let didCoalesce = shouldCoalesce(stage: stage, correlation: populated)
-            && recordsByBucket[bucket]?.last.map { coalescingKey(for: $0.event) == coalescingKey(stage: stage, correlation: populated) } == true
+        let key = coalescingKey(stage: stage, correlation: populated)
+        let didCoalesce = key.map { key in
+            recordsByBucket[bucket, default: []].contains {
+                coalescingKey(for: $0.event) == key
+            }
+        } ?? false
         let event = ChatDiagnosticEventEnvelope(
             process: identity,
             sequence: .init(sequence),
@@ -65,6 +69,12 @@ actor DaemonChatDiagnostics {
         recordsByBucket.removeAll()
         droppedRecordsByBucket.removeAll()
         droppedBytesByBucket.removeAll()
+    }
+
+    /// Retires content-fingerprint material after a snapshot is handed to the
+    /// export path while retaining the ring until a reset acknowledgement.
+    func rotateFingerprintKeyPreservingRecords() {
+        fingerprintKey = ChatDiagnosticFingerprintKey()
     }
 
     func versionFailureSnapshot() -> ChatDiagnosticSnapshotEnvelope {
@@ -103,8 +113,9 @@ actor DaemonChatDiagnostics {
             return
         }
         var records = recordsByBucket[bucket, default: []]
-        if shouldCoalesce(event), let last = records.last, coalescingKey(for: last.event) == coalescingKey(for: event) {
-            records.removeLast()
+        if let key = coalescingKey(for: event),
+           let index = records.lastIndex(where: { coalescingKey(for: $0.event) == key }) {
+            records.remove(at: index)
         }
         records.append(.init(event: event, byteCount: encoded.count))
         var bytes = records.reduce(0) { $0 + $1.byteCount }
@@ -123,7 +134,10 @@ actor DaemonChatDiagnostics {
 
     private func shouldCoalesce(stage: ChatDiagnosticStage, correlation: ChatDiagnosticCorrelation) -> Bool {
         switch stage {
-        case .providerReceipt, .providerTranslation, .reduction:
+        // These stages are emitted once for each runtime transcript update.
+        // The durable item is the stable stream identity that lets interleaved
+        // receipt, reduction, and persistence observations coalesce safely.
+        case .providerReceipt, .providerTranslation, .reduction, .persistence:
             return correlation.updateSequence != nil || correlation.durableItem != nil
         default:
             return false

--- a/Sources/wikid/DaemonChatHost.swift
+++ b/Sources/wikid/DaemonChatHost.swift
@@ -21,6 +21,7 @@ final class DaemonChatHost: @unchecked Sendable {
     private let extractionCoordinator: ExtractionCoordinator
     private let storeResolver: @Sendable (WikiID) -> GRDBWikiStore?
     private let pushEvent: @Sendable (QueueEventEnvelope) -> Void
+    private let diagnosticTrace: DaemonChatDiagnostics
 
     private let sharedGate: GenerationGate
     private let registry = ControllerRegistry()
@@ -37,6 +38,7 @@ final class DaemonChatHost: @unchecked Sendable {
         generationGate: GenerationGate,
         storeResolver: @escaping @Sendable (WikiID) -> GRDBWikiStore?,
         pushEvent: @escaping @Sendable (QueueEventEnvelope) -> Void,
+        diagnosticTrace: DaemonChatDiagnostics = DaemonChatDiagnostics(),
         idleEvictionDelay: Duration = DaemonChatHost.defaultIdleEvictionDelay
     ) {
         self.containerDirectory = containerDirectory
@@ -44,6 +46,7 @@ final class DaemonChatHost: @unchecked Sendable {
         self.sharedGate = generationGate
         self.storeResolver = storeResolver
         self.pushEvent = pushEvent
+        self.diagnosticTrace = diagnosticTrace
         self.idleEvictionDelay = idleEvictionDelay
     }
 
@@ -301,7 +304,8 @@ final class DaemonChatHost: @unchecked Sendable {
             wikiID: wikiID,
             store: store,
             runtime: runtime,
-            pushEvent: pushEvent
+            pushEvent: pushEvent,
+            diagnosticTrace: diagnosticTrace
         )
         let resolvedController = await registry.insertIfAbsent(
             controller,

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -18,6 +18,7 @@ final class WikiDaemon: @unchecked Sendable {
 
     private let containerDirectory: URL
     private let makeStore: (URL) throws -> WikiStore
+    private let daemonChatDiagnostics = DaemonChatDiagnostics()
 
     // MARK: - State (accessed on `queue`)
 
@@ -716,6 +717,33 @@ final class WikiDaemon: @unchecked Sendable {
         #else
         return Data()
         #endif
+    }
+
+    /// Validates the version at the daemon's XPC boundary before handing out a
+    /// redacted, process-local trace. Invalid requests still receive a typed
+    /// version-failure snapshot rather than an ambiguous empty `Data` reply.
+    func chatDiagnosticSnapshotData(request: Data) async -> Data {
+        do {
+            let decoded = try JSONDecoder().decode(ChatDiagnosticSnapshotRequest.self, from: request)
+            try decoded.validatingVersion()
+            let chat = decoded.chat
+            await daemonChatDiagnostics.record(
+                stage: .syncAcceptance,
+                outcome: .accepted,
+                payload: .init(correlation: .init(chat: chat), detail: "diagnostic-snapshot-request")
+            )
+            let snapshot = await daemonChatDiagnostics.snapshot(chat: chat)
+            return try JSONEncoder().encode(snapshot)
+        } catch {
+            DebugLog.agent("WikiDaemon.chatDiagnosticSnapshotData rejected request: \(error)")
+            let snapshot = await daemonChatDiagnostics.versionFailureSnapshot()
+            do {
+                return try JSONEncoder().encode(snapshot)
+            } catch {
+                DebugLog.agent("WikiDaemon.chatDiagnosticSnapshotData failed to encode version failure: \(error)")
+                return Data()
+            }
+        }
     }
 
     /// Resolve a chat permission.

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -599,7 +599,8 @@ final class WikiDaemon: @unchecked Sendable {
             storeResolver: storeResolver,
             pushEvent: { [weak self] envelope in
                 self?.pushChatEnvelope(envelope)
-            })
+            },
+            diagnosticTrace: daemonChatDiagnostics)
 
         return queue.sync {
             if let existing = _chatHost {
@@ -730,7 +731,8 @@ final class WikiDaemon: @unchecked Sendable {
             await daemonChatDiagnostics.record(
                 stage: .syncAcceptance,
                 outcome: .accepted,
-                payload: .init(correlation: .init(chat: chat), detail: "diagnostic-snapshot-request")
+                correlation: .init(chat: chat),
+                detail: "diagnostic-snapshot-request"
             )
             let snapshot = await daemonChatDiagnostics.snapshot(chat: chat)
             return try JSONEncoder().encode(snapshot)
@@ -743,6 +745,18 @@ final class WikiDaemon: @unchecked Sendable {
                 DebugLog.agent("WikiDaemon.chatDiagnosticSnapshotData failed to encode version failure: \(error)")
                 return Data()
             }
+        }
+    }
+
+    func resetChatDiagnosticsData(request: Data) async -> Data {
+        do {
+            let decoded = try JSONDecoder().decode(ChatDiagnosticResetRequest.self, from: request)
+            try decoded.validatingVersion()
+            await daemonChatDiagnostics.resetAfterSuccessfulExport()
+            return Data("{\"ok\":true}".utf8)
+        } catch {
+            DebugLog.agent("WikiDaemon.resetChatDiagnosticsData rejected request: \(error)")
+            return Data()
         }
     }
 

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -735,6 +735,10 @@ final class WikiDaemon: @unchecked Sendable {
                 detail: "diagnostic-snapshot-request"
             )
             let snapshot = await daemonChatDiagnostics.snapshot(chat: chat)
+            // The caller may successfully copy this artifact but fail before
+            // the reset acknowledgement returns. Retire the key now while the
+            // ring remains available for that retry.
+            await daemonChatDiagnostics.rotateFingerprintKeyPreservingRecords()
             return try JSONEncoder().encode(snapshot)
         } catch {
             DebugLog.agent("WikiDaemon.chatDiagnosticSnapshotData rejected request: \(error)")

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -366,6 +366,14 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
         }
     }
 
+    func resetChatDiagnostics(request: Data, reply: @escaping (Data) -> Void) {
+        let sendableReply = SendableDataReply(reply: reply)
+        Task { [daemon] in
+            let data = await daemon.resetChatDiagnosticsData(request: request)
+            sendableReply.reply(data)
+        }
+    }
+
     func resolveChatPermission(request: Data, reply: @escaping () -> Void) {
         let sendableReply = SendableVoidReply(reply: reply)
         Task { [daemon] in
@@ -435,6 +443,7 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
     func stopChat(chatID: String, reply: @escaping () -> Void) { reply() }
     func chatSessionState(chatID: String, reply: @escaping (Data) -> Void) { reply(Data()) }
     func chatDiagnosticSnapshot(request: Data, reply: @escaping (Data) -> Void) { reply(Data()) }
+    func resetChatDiagnostics(request: Data, reply: @escaping (Data) -> Void) { reply(Data()) }
     func resolveChatPermission(request: Data, reply: @escaping () -> Void) { reply() }
     func setChatConfigOption(request: Data, reply: @escaping (Data) -> Void) {
         let envelope: [String: String?] = ["error": "chat unavailable on Linux"]

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -358,6 +358,14 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
         }
     }
 
+    func chatDiagnosticSnapshot(request: Data, reply: @escaping (Data) -> Void) {
+        let sendableReply = SendableDataReply(reply: reply)
+        Task { [daemon] in
+            let data = await daemon.chatDiagnosticSnapshotData(request: request)
+            sendableReply.reply(data)
+        }
+    }
+
     func resolveChatPermission(request: Data, reply: @escaping () -> Void) {
         let sendableReply = SendableVoidReply(reply: reply)
         Task { [daemon] in
@@ -426,6 +434,7 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
     }
     func stopChat(chatID: String, reply: @escaping () -> Void) { reply() }
     func chatSessionState(chatID: String, reply: @escaping (Data) -> Void) { reply(Data()) }
+    func chatDiagnosticSnapshot(request: Data, reply: @escaping (Data) -> Void) { reply(Data()) }
     func resolveChatPermission(request: Data, reply: @escaping () -> Void) { reply() }
     func setChatConfigOption(request: Data, reply: @escaping (Data) -> Void) {
         let envelope: [String: String?] = ["error": "chat unavailable on Linux"]

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -339,6 +339,14 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
         )
     }
 
+    func chatDiagnosticSnapshot(_ request: ChatDiagnosticSnapshotRequest) async throws -> ChatDiagnosticSnapshotEnvelope {
+        try request.validatingVersion()
+        return ChatDiagnosticSnapshotEnvelope(
+            process: .init(source: .daemon),
+            events: []
+        )
+    }
+
     func resolveChatPermission(_ request: ChatPermissionResolveRequest) async throws {
         resolveCalls.append(request)
         if shouldThrow { throw StubError.throwing }

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -182,7 +182,7 @@ struct ChatDaemonCoordinatorTests {
         #expect(snapshot.events.map(\.stage).contains(.renderPlanning))
         #expect(snapshot.events.map(\.stage).contains(.domAcknowledgement))
         #expect(snapshot.daemonSummary["runtime"] == "daemon")
-        #expect(snapshot.mergeOrder.contains("per-process-sequence"))
+        #expect(snapshot.mergeOrder == "source-instance-sequence; timestamps-informational")
         let daemonRetention = snapshot.retention.first { $0.source == .daemon }
         #expect(daemonRetention?.droppedRecordCount == 3)
         #expect(daemonRetention?.droppedByteCount == 144)
@@ -230,6 +230,40 @@ struct ChatDaemonCoordinatorTests {
         #expect(after.events == before.events)
         #expect(trace.fingerprint("same content") == fingerprint)
         #expect(stub.diagnosticResetRequests.isEmpty)
+    }
+
+    @Test func failedDaemonDiagnosticResetRetiresAppFingerprintEpochButKeepsRetryRing() async {
+        let chatID = ChatID(rawValue: "diagnostic-reset-failure")
+        let correlation = ChatDiagnosticCorrelation.Value(rawValue: chatID.rawValue)
+        let trace = ChatDiagnosticTrace(source: .app)
+        _ = trace.record(
+            stage: .displayProjection,
+            outcome: .accepted,
+            payload: .init(correlation: .init(chat: correlation), detail: "app-display")
+        )
+        let fingerprint = trace.fingerprint("same content")
+        let before = trace.snapshot(chat: correlation)
+        let stub = StubChatDaemonCommands()
+        stub.shouldThrowDiagnosticReset = true
+        let coordinator = ChatDaemonCoordinator(
+            client: stub,
+            eventSink: DaemonQueueEventSink(),
+            diagnosticTrace: trace
+        )
+
+        do {
+            try await coordinator.copyDiagnostics(for: chatID) { _ in }
+            Issue.record("Expected daemon diagnostic reset failure.")
+        } catch StubError.throwing {
+            // The artifact was written, so the key must not remain reusable.
+        } catch {
+            Issue.record("Unexpected reset failure: \(error)")
+        }
+
+        let after = trace.snapshot(chat: correlation)
+        #expect(after.events == before.events)
+        #expect(after.process.instanceID == before.process.instanceID)
+        #expect(trace.fingerprint("same content") != fingerprint)
     }
 
     @Test func jsonlDiagnosticsExportUsesCoordinatorSnapshotAndRotatesAfterWrite() async throws {
@@ -465,6 +499,7 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
     var sessionState: ChatSyncSnapshot?
     var diagnosticSnapshot: ChatDiagnosticSnapshotEnvelope?
     var shouldThrow = false
+    var shouldThrowDiagnosticReset = false
 
     func submitChatTurn(_ request: ChatSubmitRequest) async throws -> ChatID {
         submitTurnCalls.append(request)
@@ -514,6 +549,7 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
     func resetChatDiagnostics(_ request: ChatDiagnosticResetRequest) async throws {
         diagnosticResetRequests.append(request)
         try request.validatingVersion()
+        if shouldThrowDiagnosticReset { throw StubError.throwing }
         if shouldThrow { throw StubError.throwing }
     }
 

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -118,13 +118,35 @@ struct ChatDaemonCoordinatorTests {
         let chatID = ChatID(rawValue: "diagnostic-chat")
         let correlation = ChatDiagnosticCorrelation.Value(rawValue: chatID.rawValue)
         let trace = ChatDiagnosticTrace(source: .app)
-        let fingerprint = await trace.fingerprint("same content")
-        _ = await trace.record(
+        let fingerprint = trace.fingerprint("same content")
+        _ = trace.record(
             stage: .displayProjection,
             outcome: .accepted,
             payload: .init(correlation: .init(chat: correlation), detail: "app-display")
         )
-        let before = await trace.snapshot(chat: correlation)
+        let renderer = ChatTranscriptRenderExecutor(
+            mutate: { command, revision, acknowledgement in
+                acknowledgement(.init(
+                    kind: command.kind,
+                    revision: revision,
+                    rowID: command.rowID,
+                    outcome: .success
+                ))
+            },
+            reportAnomaly: { _ in Issue.record("Unexpected renderer anomaly.") },
+            diagnosticTrace: trace
+        )
+        renderer.submit(.init(
+            context: .init(transcriptID: .chat(chatID)),
+            rows: [.assistantMessage(
+                id: ChatMessageID(rawValue: "diagnostic-message"),
+                turnID: ChatTurnID(rawValue: "diagnostic-turn"),
+                text: "redacted from the diagnostic payload",
+                createdAt: .distantPast,
+                contentState: .final
+            )]
+        ))
+        let before = trace.snapshot(chat: correlation)
         let stub = StubChatDaemonCommands()
         stub.diagnosticSnapshot = ChatDiagnosticSnapshotEnvelope(
             process: .init(source: .daemon),
@@ -137,6 +159,8 @@ struct ChatDaemonCoordinatorTests {
                     outcome: .accepted
                 )
             ],
+            droppedRecordCount: 3,
+            droppedByteCount: 144,
             summary: ["runtime": "daemon"]
         )
         let coordinator = ChatDaemonCoordinator(
@@ -144,39 +168,46 @@ struct ChatDaemonCoordinatorTests {
             eventSink: DaemonQueueEventSink(),
             diagnosticTrace: trace
         )
-        let exporter = ChatDiagnosticExporter(trace: trace)
         var copied: Data?
 
-        try await coordinator.copyDiagnostics(for: chatID, exporter: exporter) { copied = $0 }
+        try await coordinator.copyDiagnostics(for: chatID) { copied = $0 }
 
         let data = try #require(copied)
         let snapshot = try JSONDecoder().decode(ChatDiagnosticMergedSnapshot.self, from: data)
+        #expect(!String(decoding: data, as: UTF8.self).contains("redacted from the diagnostic payload"))
         #expect(stub.diagnosticSnapshotRequests == [.init(chat: correlation)])
         #expect(Set(snapshot.sources) == [.app, .daemon])
         #expect(snapshot.events.map(\.payload.detail).contains("app-display"))
         #expect(snapshot.events.map(\.payload.detail).contains("daemon-sync"))
+        #expect(snapshot.events.map(\.stage).contains(.renderPlanning))
+        #expect(snapshot.events.map(\.stage).contains(.domAcknowledgement))
         #expect(snapshot.daemonSummary["runtime"] == "daemon")
         #expect(snapshot.mergeOrder.contains("per-process-sequence"))
+        let daemonRetention = snapshot.retention.first { $0.source == .daemon }
+        #expect(daemonRetention?.droppedRecordCount == 3)
+        #expect(daemonRetention?.droppedByteCount == 144)
+        #expect(stub.diagnosticResetRequests == [.init(chat: correlation)])
 
-        let after = await trace.snapshot(chat: correlation)
+        let after = trace.snapshot(chat: correlation)
         #expect(after.events.isEmpty)
         #expect(after.process.instanceID != before.process.instanceID)
-        #expect(await trace.fingerprint("same content") != fingerprint)
+        #expect(trace.fingerprint("same content") != fingerprint)
     }
 
     @Test func failedDiagnosticCopyPreservesTraceForRetry() async {
         let chatID = ChatID(rawValue: "diagnostic-chat")
         let correlation = ChatDiagnosticCorrelation.Value(rawValue: chatID.rawValue)
         let trace = ChatDiagnosticTrace(source: .app)
-        let fingerprint = await trace.fingerprint("same content")
-        _ = await trace.record(
+        let fingerprint = trace.fingerprint("same content")
+        _ = trace.record(
             stage: .displayProjection,
             outcome: .accepted,
             payload: .init(correlation: .init(chat: correlation), detail: "app-display")
         )
-        let before = await trace.snapshot(chat: correlation)
+        let before = trace.snapshot(chat: correlation)
+        let stub = StubChatDaemonCommands()
         let coordinator = ChatDaemonCoordinator(
-            client: StubChatDaemonCommands(),
+            client: stub,
             eventSink: DaemonQueueEventSink(),
             diagnosticTrace: trace
         )
@@ -184,7 +215,6 @@ struct ChatDaemonCoordinatorTests {
         do {
             try await coordinator.copyDiagnostics(
                 for: chatID,
-                exporter: ChatDiagnosticExporter(trace: trace)
             ) { _ in
                 throw StubError.throwing
             }
@@ -195,17 +225,18 @@ struct ChatDaemonCoordinatorTests {
             Issue.record("Unexpected diagnostic copy failure: \(error)")
         }
 
-        let after = await trace.snapshot(chat: correlation)
+        let after = trace.snapshot(chat: correlation)
         #expect(after.process.instanceID == before.process.instanceID)
         #expect(after.events == before.events)
-        #expect(await trace.fingerprint("same content") == fingerprint)
+        #expect(trace.fingerprint("same content") == fingerprint)
+        #expect(stub.diagnosticResetRequests.isEmpty)
     }
 
     @Test func jsonlDiagnosticsExportUsesCoordinatorSnapshotAndRotatesAfterWrite() async throws {
         let chatID = ChatID(rawValue: "jsonl-chat")
         let correlation = ChatDiagnosticCorrelation.Value(rawValue: chatID.rawValue)
         let trace = ChatDiagnosticTrace(source: .app)
-        _ = await trace.record(
+        _ = trace.record(
             stage: .displayProjection,
             outcome: .accepted,
             payload: .init(correlation: .init(chat: correlation), detail: "app-display")
@@ -231,14 +262,15 @@ struct ChatDaemonCoordinatorTests {
 
         try await coordinator.writeDiagnosticsJSONL(
             for: chatID,
-            to: url,
-            exporter: ChatDiagnosticExporter(trace: trace)
+            to: url
         )
 
         let line = try #require(String(data: try Data(contentsOf: url), encoding: .utf8))
         #expect(line.contains("app-display"))
+        #expect(line.contains("retention"))
         #expect(stub.diagnosticSnapshotRequests == [.init(chat: correlation)])
-        #expect((await trace.snapshot(chat: correlation)).events.isEmpty)
+        #expect(stub.diagnosticResetRequests == [.init(chat: correlation)])
+        #expect(trace.snapshot(chat: correlation).events.isEmpty)
     }
 
     @Test func rehydrateUsesAuthoritativeSnapshot() async {
@@ -427,6 +459,7 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
     var sessionStateRequests: [ChatID] = []
     var configOptionCalls: [ChatConfigOptionRequest] = []
     var diagnosticSnapshotRequests: [ChatDiagnosticSnapshotRequest] = []
+    var diagnosticResetRequests: [ChatDiagnosticResetRequest] = []
 
     var nextSubmitChatID = ChatID(rawValue: "stub-submit-chat-id")
     var sessionState: ChatSyncSnapshot?
@@ -476,6 +509,12 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
             process: .init(source: .daemon),
             events: []
         )
+    }
+
+    func resetChatDiagnostics(_ request: ChatDiagnosticResetRequest) async throws {
+        diagnosticResetRequests.append(request)
+        try request.validatingVersion()
+        if shouldThrow { throw StubError.throwing }
     }
 
     func resolveChatPermission(_ request: ChatPermissionResolveRequest) async throws {

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -114,6 +114,133 @@ struct ChatDaemonCoordinatorTests {
         #expect(stub.stopCalls == [ChatID(rawValue: "chat-1")])
     }
 
+    @Test func copyDiagnosticsUsesCoordinatorSnapshotAndRotatesOnlyAfterCopySucceeds() async throws {
+        let chatID = ChatID(rawValue: "diagnostic-chat")
+        let correlation = ChatDiagnosticCorrelation.Value(rawValue: chatID.rawValue)
+        let trace = ChatDiagnosticTrace(source: .app)
+        let fingerprint = await trace.fingerprint("same content")
+        _ = await trace.record(
+            stage: .displayProjection,
+            outcome: .accepted,
+            payload: .init(correlation: .init(chat: correlation), detail: "app-display")
+        )
+        let before = await trace.snapshot(chat: correlation)
+        let stub = StubChatDaemonCommands()
+        stub.diagnosticSnapshot = ChatDiagnosticSnapshotEnvelope(
+            process: .init(source: .daemon),
+            events: [
+                .init(
+                    process: .init(source: .daemon),
+                    sequence: .init(1),
+                    stage: .syncAcceptance,
+                    payload: .init(correlation: .init(chat: correlation), detail: "daemon-sync"),
+                    outcome: .accepted
+                )
+            ],
+            summary: ["runtime": "daemon"]
+        )
+        let coordinator = ChatDaemonCoordinator(
+            client: stub,
+            eventSink: DaemonQueueEventSink(),
+            diagnosticTrace: trace
+        )
+        let exporter = ChatDiagnosticExporter(trace: trace)
+        var copied: Data?
+
+        try await coordinator.copyDiagnostics(for: chatID, exporter: exporter) { copied = $0 }
+
+        let data = try #require(copied)
+        let snapshot = try JSONDecoder().decode(ChatDiagnosticMergedSnapshot.self, from: data)
+        #expect(stub.diagnosticSnapshotRequests == [.init(chat: correlation)])
+        #expect(Set(snapshot.sources) == [.app, .daemon])
+        #expect(snapshot.events.map(\.payload.detail).contains("app-display"))
+        #expect(snapshot.events.map(\.payload.detail).contains("daemon-sync"))
+        #expect(snapshot.daemonSummary["runtime"] == "daemon")
+        #expect(snapshot.mergeOrder.contains("per-process-sequence"))
+
+        let after = await trace.snapshot(chat: correlation)
+        #expect(after.events.isEmpty)
+        #expect(after.process.instanceID != before.process.instanceID)
+        #expect(await trace.fingerprint("same content") != fingerprint)
+    }
+
+    @Test func failedDiagnosticCopyPreservesTraceForRetry() async {
+        let chatID = ChatID(rawValue: "diagnostic-chat")
+        let correlation = ChatDiagnosticCorrelation.Value(rawValue: chatID.rawValue)
+        let trace = ChatDiagnosticTrace(source: .app)
+        let fingerprint = await trace.fingerprint("same content")
+        _ = await trace.record(
+            stage: .displayProjection,
+            outcome: .accepted,
+            payload: .init(correlation: .init(chat: correlation), detail: "app-display")
+        )
+        let before = await trace.snapshot(chat: correlation)
+        let coordinator = ChatDaemonCoordinator(
+            client: StubChatDaemonCommands(),
+            eventSink: DaemonQueueEventSink(),
+            diagnosticTrace: trace
+        )
+
+        do {
+            try await coordinator.copyDiagnostics(
+                for: chatID,
+                exporter: ChatDiagnosticExporter(trace: trace)
+            ) { _ in
+                throw StubError.throwing
+            }
+            Issue.record("Expected the diagnostic destination to fail.")
+        } catch StubError.throwing {
+            // Expected: the trace remains available for a retry.
+        } catch {
+            Issue.record("Unexpected diagnostic copy failure: \(error)")
+        }
+
+        let after = await trace.snapshot(chat: correlation)
+        #expect(after.process.instanceID == before.process.instanceID)
+        #expect(after.events == before.events)
+        #expect(await trace.fingerprint("same content") == fingerprint)
+    }
+
+    @Test func jsonlDiagnosticsExportUsesCoordinatorSnapshotAndRotatesAfterWrite() async throws {
+        let chatID = ChatID(rawValue: "jsonl-chat")
+        let correlation = ChatDiagnosticCorrelation.Value(rawValue: chatID.rawValue)
+        let trace = ChatDiagnosticTrace(source: .app)
+        _ = await trace.record(
+            stage: .displayProjection,
+            outcome: .accepted,
+            payload: .init(correlation: .init(chat: correlation), detail: "app-display")
+        )
+        let fileManager = FileManager.default
+        let directory = URL(fileURLWithPath: fileManager.currentDirectoryPath)
+            .appendingPathComponent("tmp/chat-diagnostics-export-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            do {
+                try fileManager.removeItem(at: directory)
+            } catch {
+                DebugLog.store("chat diagnostics export test cleanup failed: \(error)")
+            }
+        }
+        let url = directory.appendingPathComponent("chat-diagnostics.jsonl")
+        let stub = StubChatDaemonCommands()
+        let coordinator = ChatDaemonCoordinator(
+            client: stub,
+            eventSink: DaemonQueueEventSink(),
+            diagnosticTrace: trace
+        )
+
+        try await coordinator.writeDiagnosticsJSONL(
+            for: chatID,
+            to: url,
+            exporter: ChatDiagnosticExporter(trace: trace)
+        )
+
+        let line = try #require(String(data: try Data(contentsOf: url), encoding: .utf8))
+        #expect(line.contains("app-display"))
+        #expect(stub.diagnosticSnapshotRequests == [.init(chat: correlation)])
+        #expect((await trace.snapshot(chat: correlation)).events.isEmpty)
+    }
+
     @Test func rehydrateUsesAuthoritativeSnapshot() async {
         let stub = StubChatDaemonCommands()
         stub.sessionState = makeSnapshot(
@@ -299,9 +426,11 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
     var resolveCalls: [ChatPermissionResolveRequest] = []
     var sessionStateRequests: [ChatID] = []
     var configOptionCalls: [ChatConfigOptionRequest] = []
+    var diagnosticSnapshotRequests: [ChatDiagnosticSnapshotRequest] = []
 
     var nextSubmitChatID = ChatID(rawValue: "stub-submit-chat-id")
     var sessionState: ChatSyncSnapshot?
+    var diagnosticSnapshot: ChatDiagnosticSnapshotEnvelope?
     var shouldThrow = false
 
     func submitChatTurn(_ request: ChatSubmitRequest) async throws -> ChatID {
@@ -340,8 +469,10 @@ final class StubChatDaemonCommands: ChatDaemonCommands, @unchecked Sendable {
     }
 
     func chatDiagnosticSnapshot(_ request: ChatDiagnosticSnapshotRequest) async throws -> ChatDiagnosticSnapshotEnvelope {
+        diagnosticSnapshotRequests.append(request)
         try request.validatingVersion()
-        return ChatDiagnosticSnapshotEnvelope(
+        if shouldThrow { throw StubError.throwing }
+        return diagnosticSnapshot ?? ChatDiagnosticSnapshotEnvelope(
             process: .init(source: .daemon),
             events: []
         )

--- a/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
+++ b/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+
+struct ChatDiagnosticsTests {
+    @Test func traceEvictsOldestRecordsAndRotatesFingerprintKey() async {
+        let trace = ChatDiagnosticTrace(source: .app)
+        let fingerprint = await trace.fingerprint("same content")
+        for index in 0...(ChatDiagnosticPolicy.maximumRecordsPerChat) {
+            _ = await trace.record(
+                stage: .syncAcceptance,
+                outcome: .accepted,
+                payload: .init(correlation: .init(chat: .init(rawValue: "chat")), detail: "event-\(index)")
+            )
+        }
+        let before = await trace.snapshot(chat: .init(rawValue: "chat"))
+        #expect(before.events.count == ChatDiagnosticPolicy.maximumRecordsPerChat)
+        #expect(before.droppedRecordCount == 1)
+        await trace.resetAfterSuccessfulExport()
+        let after = await trace.snapshot(chat: .init(rawValue: "chat"))
+        #expect(after.events.isEmpty)
+        #expect(after.process.instanceID != before.process.instanceID)
+        let rotatedFingerprint = await trace.fingerprint("same content")
+        #expect(rotatedFingerprint != fingerprint)
+    }
+
+    @Test func mergeUsesSequenceWithinSourceAndTimestampAcrossSources() {
+        let app = ChatDiagnosticSnapshotEnvelope(
+            process: .init(source: .app, instanceID: UUID()),
+            events: [
+                .init(process: .init(source: .app, instanceID: UUID()), sequence: .init(2), timestamp: Date(timeIntervalSince1970: 2), stage: .displayProjection, outcome: .accepted),
+                .init(process: .init(source: .app, instanceID: UUID()), sequence: .init(1), timestamp: Date(timeIntervalSince1970: 1), stage: .syncAcceptance, outcome: .accepted),
+            ]
+        )
+        let daemon = ChatDiagnosticSnapshotEnvelope(
+            process: .init(source: .daemon, instanceID: UUID()),
+            events: [.init(process: .init(source: .daemon, instanceID: UUID()), sequence: .init(1), timestamp: Date(timeIntervalSince1970: 1.5), stage: .providerReceipt, outcome: .accepted)]
+        )
+        let merged = ChatDiagnosticSnapshotMerge.merge(app: app, daemon: daemon)
+        #expect(merged.events.filter { $0.process.source == .app }.map(\.sequence.rawValue) == [1, 2])
+        #expect(merged.mergeOrder.contains("per-process-sequence"))
+    }
+}

--- a/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
+++ b/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
@@ -41,4 +41,65 @@ struct ChatDiagnosticsTests {
         #expect(merged.events.filter { $0.process.source == .app }.map(\.sequence.rawValue) == [1, 2])
         #expect(merged.mergeOrder.contains("per-process-sequence"))
     }
+
+    @Test func selectedChatWithoutDropsDoesNotReportAnotherChatsEvictions() async {
+        let trace = ChatDiagnosticTrace(source: .app)
+        let evictedChat = ChatDiagnosticCorrelation.Value(rawValue: "evicted-chat")
+        let retainedChat = ChatDiagnosticCorrelation.Value(rawValue: "retained-chat")
+
+        for index in 0...ChatDiagnosticPolicy.maximumRecordsPerChat {
+            _ = await trace.record(
+                stage: .syncAcceptance,
+                outcome: .accepted,
+                payload: .init(correlation: .init(chat: evictedChat), detail: "event-\(index)")
+            )
+        }
+        _ = await trace.record(
+            stage: .displayProjection,
+            outcome: .accepted,
+            payload: .init(correlation: .init(chat: retainedChat), detail: "retained")
+        )
+
+        let snapshot = await trace.snapshot(chat: retainedChat)
+        #expect(snapshot.events.count == 1)
+        #expect(snapshot.droppedRecordCount == 0)
+        #expect(snapshot.droppedByteCount == 0)
+    }
+
+    @Test func jsonlWriterRotatesBoundedRedactedRecords() async throws {
+        let fileManager = FileManager.default
+        let directory = URL(fileURLWithPath: fileManager.currentDirectoryPath)
+            .appendingPathComponent("tmp/chat-diagnostics-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            do {
+                try fileManager.removeItem(at: directory)
+            } catch {
+                DebugLog.store("chat diagnostics test cleanup failed: \(error)")
+            }
+        }
+
+        let url = directory.appendingPathComponent("chat-diagnostics.jsonl")
+        let writer = ChatDiagnosticJSONLWriter()
+        let identity = ChatDiagnosticProcessIdentity(source: .app)
+        let detail = String(repeating: "x", count: 7_000)
+        for sequence in 1...75 {
+            _ = try await writer.append(
+                .init(
+                    process: identity,
+                    sequence: .init(UInt64(sequence)),
+                    stage: .displayProjection,
+                    payload: .init(detail: detail),
+                    outcome: .accepted
+                ),
+                to: url
+            )
+        }
+
+        let rotated = url.deletingPathExtension().appendingPathExtension("previous.jsonl")
+        #expect(fileManager.fileExists(atPath: url.path))
+        #expect(fileManager.fileExists(atPath: rotated.path))
+        #expect(try Data(contentsOf: url).isEmpty == false)
+        #expect(try Data(contentsOf: rotated).isEmpty == false)
+    }
 }

--- a/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
+++ b/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
@@ -26,21 +26,24 @@ struct ChatDiagnosticsTests {
         #expect(rotatedFingerprint != fingerprint)
     }
 
-    @Test func mergeUsesSequenceWithinSourceAndTimestampAcrossSources() {
+    @Test func mergeUsesDeclaredSourceInstanceSequenceOrder() {
+        let appProcess = ChatDiagnosticProcessIdentity(source: .app, instanceID: UUID())
+        let daemonProcess = ChatDiagnosticProcessIdentity(source: .daemon, instanceID: UUID())
         let app = ChatDiagnosticSnapshotEnvelope(
-            process: .init(source: .app, instanceID: UUID()),
+            process: appProcess,
             events: [
-                .init(process: .init(source: .app, instanceID: UUID()), sequence: .init(2), timestamp: Date(timeIntervalSince1970: 2), stage: .displayProjection, outcome: .accepted),
-                .init(process: .init(source: .app, instanceID: UUID()), sequence: .init(1), timestamp: Date(timeIntervalSince1970: 1), stage: .syncAcceptance, outcome: .accepted),
+                .init(process: appProcess, sequence: .init(2), timestamp: Date(timeIntervalSince1970: 1), stage: .displayProjection, outcome: .accepted),
+                .init(process: appProcess, sequence: .init(1), timestamp: Date(timeIntervalSince1970: 2), stage: .syncAcceptance, outcome: .accepted),
             ]
         )
         let daemon = ChatDiagnosticSnapshotEnvelope(
-            process: .init(source: .daemon, instanceID: UUID()),
-            events: [.init(process: .init(source: .daemon, instanceID: UUID()), sequence: .init(1), timestamp: Date(timeIntervalSince1970: 1.5), stage: .providerReceipt, outcome: .accepted)]
+            process: daemonProcess,
+            events: [.init(process: daemonProcess, sequence: .init(1), timestamp: Date(timeIntervalSince1970: 0), stage: .providerReceipt, outcome: .accepted)]
         )
         let merged = ChatDiagnosticSnapshotMerge.merge(app: app, daemon: daemon)
         #expect(merged.events.filter { $0.process.source == .app }.map(\.sequence.rawValue) == [1, 2])
-        #expect(merged.mergeOrder.contains("per-process-sequence"))
+        #expect(merged.events.map(\.process.source) == [.app, .app, .daemon])
+        #expect(merged.mergeOrder == "source-instance-sequence; timestamps-informational")
     }
 
     @Test func selectedChatWithoutDropsDoesNotReportAnotherChatsEvictions() async {

--- a/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
+++ b/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
@@ -3,25 +3,26 @@ import Testing
 @testable import WikiFS
 @testable import WikiFSCore
 
+@MainActor
 struct ChatDiagnosticsTests {
     @Test func traceEvictsOldestRecordsAndRotatesFingerprintKey() async {
         let trace = ChatDiagnosticTrace(source: .app)
-        let fingerprint = await trace.fingerprint("same content")
+        let fingerprint = trace.fingerprint("same content")
         for index in 0...(ChatDiagnosticPolicy.maximumRecordsPerChat) {
-            _ = await trace.record(
+            _ = trace.record(
                 stage: .syncAcceptance,
                 outcome: .accepted,
                 payload: .init(correlation: .init(chat: .init(rawValue: "chat")), detail: "event-\(index)")
             )
         }
-        let before = await trace.snapshot(chat: .init(rawValue: "chat"))
+        let before = trace.snapshot(chat: .init(rawValue: "chat"))
         #expect(before.events.count == ChatDiagnosticPolicy.maximumRecordsPerChat)
         #expect(before.droppedRecordCount == 1)
-        await trace.resetAfterSuccessfulExport()
-        let after = await trace.snapshot(chat: .init(rawValue: "chat"))
+        trace.resetAfterSuccessfulExport()
+        let after = trace.snapshot(chat: .init(rawValue: "chat"))
         #expect(after.events.isEmpty)
         #expect(after.process.instanceID != before.process.instanceID)
-        let rotatedFingerprint = await trace.fingerprint("same content")
+        let rotatedFingerprint = trace.fingerprint("same content")
         #expect(rotatedFingerprint != fingerprint)
     }
 
@@ -48,22 +49,42 @@ struct ChatDiagnosticsTests {
         let retainedChat = ChatDiagnosticCorrelation.Value(rawValue: "retained-chat")
 
         for index in 0...ChatDiagnosticPolicy.maximumRecordsPerChat {
-            _ = await trace.record(
+            _ = trace.record(
                 stage: .syncAcceptance,
                 outcome: .accepted,
                 payload: .init(correlation: .init(chat: evictedChat), detail: "event-\(index)")
             )
         }
-        _ = await trace.record(
+        _ = trace.record(
             stage: .displayProjection,
             outcome: .accepted,
             payload: .init(correlation: .init(chat: retainedChat), detail: "retained")
         )
 
-        let snapshot = await trace.snapshot(chat: retainedChat)
+        let snapshot = trace.snapshot(chat: retainedChat)
         #expect(snapshot.events.count == 1)
         #expect(snapshot.droppedRecordCount == 0)
         #expect(snapshot.droppedByteCount == 0)
+    }
+
+    @Test func traceCoalescesRepeatedRevisionWithoutChangingChatScope() {
+        let trace = ChatDiagnosticTrace(source: .app)
+        let chat = ChatDiagnosticCorrelation.Value(rawValue: "coalesced-chat")
+        for revision in 4...6 {
+            _ = trace.record(
+                stage: .renderPlanning,
+                outcome: .accepted,
+                payload: .init(correlation: .init(
+                    chat: chat,
+                    displayRow: .init(rawValue: "row-1"),
+                    rendererRevision: .init(UInt64(revision))
+                ), detail: "renderer")
+            )
+        }
+        let snapshot = trace.snapshot(chat: chat)
+        #expect(snapshot.events.count == 1)
+        #expect(snapshot.events[0].outcome == .coalesced)
+        #expect(snapshot.events[0].payload.correlation.rendererRevision == .init(6))
     }
 
     @Test func jsonlWriterRotatesBoundedRedactedRecords() async throws {

--- a/Tests/WikiFSAppTests/ChatTranscriptRenderPlannerTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptRenderPlannerTests.swift
@@ -110,6 +110,21 @@ struct ChatTranscriptRenderExecutorTests {
         #expect(executor.state == .idle)
     }
 
+    @Test func rendererTraceCarriesTypedChatThroughPlanningAndDOMAcknowledgement() {
+        let recorder = RenderMutationRecorder()
+        let trace = ChatDiagnosticTrace(source: .app)
+        let executor = makeExecutor(recorder, diagnosticTrace: trace)
+
+        executor.submit(snapshot([row("a", text: "A")]))
+        recorder.succeedCurrent()
+
+        let correlation = ChatDiagnosticCorrelation.Value(rawValue: "chat-executor")
+        let events = trace.snapshot(chat: correlation).events
+        #expect(events.map(\.stage).contains(.renderPlanning))
+        #expect(events.map(\.stage).contains(.domAcknowledgement))
+        #expect(events.allSatisfy { $0.payload.correlation.chat == correlation })
+    }
+
     @Test func coalescesOnlyPendingReplacementForTheSameRow() {
         let recorder = RenderMutationRecorder()
         let executor = makeExecutor(recorder)
@@ -191,11 +206,13 @@ struct ChatTranscriptRenderExecutorTests {
 
     private func makeExecutor(
         _ recorder: RenderMutationRecorder,
-        anomalies: RenderAnomalyRecorder = .init()
+        anomalies: RenderAnomalyRecorder = .init(),
+        diagnosticTrace: ChatDiagnosticTrace = ChatDiagnostics.appTrace
     ) -> ChatTranscriptRenderExecutor {
         ChatTranscriptRenderExecutor(
             mutate: recorder.record,
-            reportAnomaly: anomalies.record
+            reportAnomaly: anomalies.record,
+            diagnosticTrace: diagnosticTrace
         )
     }
 

--- a/Tests/WikiFSAppTests/ChatTranscriptRenderPlannerTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptRenderPlannerTests.swift
@@ -125,6 +125,52 @@ struct ChatTranscriptRenderExecutorTests {
         #expect(events.allSatisfy { $0.payload.correlation.chat == correlation })
     }
 
+    @Test func rendererTraceCoalescesReplacementPlanningAcrossDOMAcknowledgements() {
+        let recorder = RenderMutationRecorder()
+        let trace = ChatDiagnosticTrace(source: .app)
+        let executor = makeExecutor(recorder, diagnosticTrace: trace)
+        let original = row("a", text: "A")
+        let firstReplacement = row("a", text: "AB")
+        let latestReplacement = row("a", text: "ABC")
+
+        executor.submit(snapshot([original]))
+        recorder.succeedCurrent()
+        executor.submit(snapshot([firstReplacement]))
+        recorder.succeedCurrent()
+        executor.submit(snapshot([latestReplacement]))
+        recorder.succeedCurrent()
+
+        let chat = ChatDiagnosticCorrelation.Value(rawValue: "chat-executor")
+        let row = ChatDiagnosticCorrelation.Value(rawValue: original.id.domValue)
+        let planning = trace.snapshot(chat: chat).events.filter {
+            $0.stage == .renderPlanning && $0.payload.correlation.displayRow == row
+        }
+        #expect(planning.count == 1)
+        #expect(planning[0].outcome == .coalesced)
+        #expect(planning[0].payload.correlation.rendererRevision == .init(3))
+    }
+
+    @Test func acknowledgementKeepsTheOriginatingChatAfterDesiredChatSwitches() {
+        let recorder = RenderMutationRecorder()
+        let trace = ChatDiagnosticTrace(source: .app)
+        let executor = makeExecutor(recorder, diagnosticTrace: trace)
+        let chatA = TranscriptID.chat(ChatID(rawValue: "chat-a"))
+        let chatB = TranscriptID.chat(ChatID(rawValue: "chat-b"))
+
+        executor.submit(.init(context: .init(transcriptID: chatA), rows: [row("a", text: "A")]))
+        executor.submit(.init(context: .init(transcriptID: chatB), rows: [row("b", text: "B")]))
+        recorder.succeedCurrent()
+
+        let acknowledgedA = trace.snapshot(chat: .init(rawValue: "chat-a")).events.filter {
+            $0.stage == .domAcknowledgement
+        }
+        let acknowledgedB = trace.snapshot(chat: .init(rawValue: "chat-b")).events.filter {
+            $0.stage == .domAcknowledgement
+        }
+        #expect(acknowledgedA.count == 1)
+        #expect(acknowledgedB.isEmpty)
+    }
+
     @Test func coalescesOnlyPendingReplacementForTheSameRow() {
         let recorder = RenderMutationRecorder()
         let executor = makeExecutor(recorder)

--- a/Tests/WikiFSAppTests/DaemonChatControllerTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatControllerTests.swift
@@ -721,6 +721,47 @@ struct DaemonChatControllerTests {
         #expect(persistedTools.first?.status == .completed)
     }
 
+    @Test func runtimeTranscriptBurstCoalescesDiagnosticsByRealDurableMessageID() async throws {
+        let harness = try ControllerHarness()
+        let trace = DaemonChatDiagnostics()
+        let controller = try harness.makeController(diagnosticTrace: trace)
+        let submission = harness.makeSubmission(commandID: "command-diagnostic-burst", turnID: "turn-diagnostic-burst")
+        let messageID = ChatMessageID(rawValue: "assistant-diagnostic-burst")
+
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+        for text in ["A", "B", "C"] {
+            await harness.runtime.emit(.transcript([.messageDelta(
+                messageID: messageID,
+                turnID: submission.turnID,
+                role: .assistant,
+                delta: text,
+                createdAt: .distantPast
+            )]))
+        }
+        try await harness.waitUntilOverlay(
+            controller,
+            matches: { items in
+                items.contains {
+                    guard case .message(let message) = $0 else { return false }
+                    return message.messageID == messageID && message.text == "ABC"
+                }
+            },
+            failureMessage: "expected the real runtime burst to reach the transcript overlay"
+        )
+
+        let chat = ChatDiagnosticCorrelation.Value(rawValue: harness.chat.id.rawValue)
+        let item = ChatDiagnosticCorrelation.Value(rawValue: messageID.rawValue)
+        let events = await trace.snapshot(chat: chat).events
+        for stage in [ChatDiagnosticStage.providerReceipt, .reduction, .persistence] {
+            let matching = events.filter {
+                $0.stage == stage && $0.payload.correlation.durableItem == item
+            }
+            #expect(matching.count == 1)
+            #expect(matching[0].outcome == .coalesced)
+            #expect(matching[0].payload.correlation.content?.length == 1)
+        }
+    }
+
     @Test func completedTurnClearsTransientTranscriptOverlay() async throws {
         let harness = try ControllerHarness()
         let controller = try harness.makeController()
@@ -781,7 +822,9 @@ private final class ControllerHarness {
         try? FileManager.default.removeItem(at: rootDirectory)
     }
 
-    func makeController() throws -> DaemonChatController {
+    func makeController(
+        diagnosticTrace: DaemonChatDiagnostics = DaemonChatDiagnostics()
+    ) throws -> DaemonChatController {
         try DaemonChatController(
             chatID: chat.id,
             wikiID: WikiID(rawValue: "wiki-controller"),
@@ -789,7 +832,8 @@ private final class ControllerHarness {
             runtime: runtime,
             pushEvent: { [eventRecorder] envelope in
                 eventRecorder.record(envelope)
-            }
+            },
+            diagnosticTrace: diagnosticTrace
         )
     }
 

--- a/Tests/WikiFSAppTests/DaemonChatHostTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatHostTests.swift
@@ -19,6 +19,51 @@ import WikiDaemonContract
 /// - The adaptive preamble + takeover logic are tested via AgentOperationRunner.
 struct DaemonChatHostTests {
 
+    @Test func daemonDiagnosticRingEvictsOldestAndRotatesAfterAcknowledgedExport() async {
+        let trace = DaemonChatDiagnostics()
+        let chat = ChatDiagnosticCorrelation.Value(rawValue: "daemon-ring-chat")
+        for index in 0...256 {
+            await trace.record(
+                stage: .persistence,
+                outcome: .accepted,
+                correlation: .init(chat: chat, updateSequence: .init(UInt64(index))),
+                detail: "persisted"
+            )
+        }
+        let before = await trace.snapshot(chat: chat)
+        #expect(before.events.count == 256)
+        #expect(before.droppedRecordCount == 1)
+        #expect(before.droppedByteCount > 0)
+
+        await trace.resetAfterSuccessfulExport()
+        let after = await trace.snapshot(chat: chat)
+        #expect(after.events.isEmpty)
+        #expect(after.process.instanceID != before.process.instanceID)
+    }
+
+    @Test func daemonDiagnosticsCoalesceProviderUpdatesForTheSameDurableItem() async {
+        let trace = DaemonChatDiagnostics()
+        let chat = ChatDiagnosticCorrelation.Value(rawValue: "coalesced-daemon-chat")
+        let item = ChatDiagnosticCorrelation.Value(rawValue: "coalesced-item")
+        for update in 1...3 {
+            await trace.record(
+                stage: .providerReceipt,
+                outcome: .accepted,
+                correlation: .init(
+                    chat: chat,
+                    updateSequence: .init(UInt64(update)),
+                    durableItem: item
+                ),
+                detail: "provider-delta"
+            )
+        }
+
+        let snapshot = await trace.snapshot(chat: chat)
+        #expect(snapshot.events.count == 1)
+        #expect(snapshot.events[0].outcome == .coalesced)
+        #expect(snapshot.events[0].payload.correlation.updateSequence == .init(3))
+    }
+
     private func makeTempDir() -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("wikid-chat-tests-\(UUID().uuidString)", isDirectory: true)
@@ -317,6 +362,53 @@ struct DaemonChatHostTests {
         #expect(decoded.projection.chatID == chat.id)
         #expect(decoded.projection.lastIncludedSequence == .initial)
         #expect(decoded.projection.committedCursor == .zero)
+    }
+
+    @Test func xpcChatDiagnosticSnapshotRoundTripsVersionedRedactedEnvelope() async throws {
+        let dir = makeTempDir()
+        let daemon = makeDaemon(dir: dir)
+        let exporter = WikiDaemonExporter(daemon: daemon)
+        let listener = NSXPCListener.anonymous()
+        let delegate = ChatTestListenerDelegate(exporter: exporter)
+        listener.delegate = delegate
+        listener.resume()
+        defer { listener.invalidate() }
+
+        let connection = NSXPCConnection(listenerEndpoint: listener.endpoint)
+        connection.remoteObjectInterface = NSXPCInterface(with: WikiDaemonProtocol.self)
+        connection.resume()
+        defer { connection.invalidate() }
+
+        let proxy = connection.remoteObjectProxyWithErrorHandler { _ in } as! WikiDaemonProtocol
+        let request = try JSONEncoder().encode(ChatDiagnosticSnapshotRequest(chat: .init(rawValue: "chat-xpc")))
+        let replyData = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
+            proxy.chatDiagnosticSnapshot(request: request) { data in
+                continuation.resume(returning: data)
+            }
+        }
+
+        let snapshot = try JSONDecoder().decode(ChatDiagnosticSnapshotEnvelope.self, from: replyData)
+        try snapshot.validatingVersion()
+        #expect(snapshot.process.source == .daemon)
+        #expect(snapshot.events.allSatisfy { $0.payload.correlation.chat == .init(rawValue: "chat-xpc") })
+
+        let resetRequest = try JSONEncoder().encode(
+            ChatDiagnosticResetRequest(chat: .init(rawValue: "chat-xpc"))
+        )
+        let resetReply = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
+            proxy.resetChatDiagnostics(request: resetRequest) { data in
+                continuation.resume(returning: data)
+            }
+        }
+        #expect(resetReply == Data("{\"ok\":true}".utf8))
+
+        let afterResetReply = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
+            proxy.chatDiagnosticSnapshot(request: request) { data in
+                continuation.resume(returning: data)
+            }
+        }
+        let afterReset = try JSONDecoder().decode(ChatDiagnosticSnapshotEnvelope.self, from: afterResetReply)
+        #expect(afterReset.process.instanceID != snapshot.process.instanceID)
     }
 
     @Test func xpcChatSessionStateMissingChatReturnsEmptyData() async throws {

--- a/Tests/WikiFSTests/ChatDiagnosticTypesTests.swift
+++ b/Tests/WikiFSTests/ChatDiagnosticTypesTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+struct ChatDiagnosticTypesTests {
+    @Test func envelopeRoundTripsWithTypedCorrelationAndRedaction() throws {
+        let event = ChatDiagnosticEventEnvelope(
+            process: .init(source: .daemon, instanceID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!),
+            sequence: .init(7),
+            timestamp: Date(timeIntervalSince1970: 100),
+            stage: .providerTranslation,
+            payload: .init(correlation: .init(
+                chat: .init(rawValue: "chat-1"),
+                generation: .init(rawValue: "generation-1"),
+                updateSequence: .init(3),
+                turn: .init(rawValue: "turn-1"),
+                durableItem: .init(rawValue: "message-1"),
+                displayRow: .init(rawValue: "message-1"),
+                tool: .init(rawValue: "tool-1"),
+                cursor: .init(rawValue: "4"),
+                rendererRevision: .init(2),
+                eventKind: .init(rawValue: "assistant"),
+                content: .init(digest: "deadbeef", length: 12)
+            )),
+            outcome: .accepted
+        )
+        let decoded = try JSONDecoder().decode(ChatDiagnosticEventEnvelope.self, from: JSONEncoder().encode(event))
+        #expect(decoded == event)
+        #expect(decoded.redaction == .identifiersAndKeyedFingerprintOnly)
+    }
+
+    @Test func keyedFingerprintsCorrelateOnlyInsideOneTraceKey() {
+        let first = ChatDiagnosticFingerprintKey()
+        let second = ChatDiagnosticFingerprintKey()
+        let text = "sensitive message text"
+        let a = first.fingerprint(for: text)
+        #expect(a == first.fingerprint(for: text))
+        #expect(a != second.fingerprint(for: text))
+        #expect(a.length == text.utf8.count)
+        #expect(a.digest != text)
+    }
+
+    @Test func versionValidationRejectsUnsupportedRequestAndSnapshot() {
+        #expect(throws: ChatDiagnosticVersionError.unsupported(99)) {
+            try ChatDiagnosticSnapshotRequest(version: 99).validatingVersion()
+        }
+        #expect(throws: ChatDiagnosticVersionError.unsupported(99)) {
+            try ChatDiagnosticSnapshotEnvelope(
+                version: 99,
+                process: .init(source: .app),
+                events: []
+            ).validatingVersion()
+        }
+    }
+}

--- a/Tests/WikiFSTests/ChatDiagnosticTypesTests.swift
+++ b/Tests/WikiFSTests/ChatDiagnosticTypesTests.swift
@@ -34,10 +34,16 @@ struct ChatDiagnosticTypesTests {
         let second = ChatDiagnosticFingerprintKey()
         let text = "sensitive message text"
         let a = first.fingerprint(for: text)
+        #expect(first == first)
+        #expect(first != second)
         #expect(a == first.fingerprint(for: text))
         #expect(a != second.fingerprint(for: text))
         #expect(a.length == text.utf8.count)
         #expect(a.digest != text)
+        #expect(a.algorithm == "hmac-sha256-v1")
+        #expect(a.algorithm != "keyed-fnv1a64-v1")
+        let digestBytes = Data(base64Encoded: a.digest)
+        #expect(digestBytes?.count == 32)
     }
 
     @Test func versionValidationRejectsUnsupportedRequestAndSnapshot() {

--- a/progress/2026-07-30T182810Z-chat-presentation-diagnostics-phase6.md
+++ b/progress/2026-07-30T182810Z-chat-presentation-diagnostics-phase6.md
@@ -1,0 +1,39 @@
+---
+timestamp: 2026-07-30T182810Z
+title: "2026-07-30 — Chat presentation diagnostics Phase 6"
+branch: chat-presentation-diagnostics-phase6
+status: implemented
+timestamp_source: local-clock-america-los-angeles
+---
+
+# 2026-07-30 — Chat presentation diagnostics Phase 6
+
+## Progress
+
+Implemented the Phase 6 correlated diagnostics slice without Phase 7
+compatibility cleanup or plan-index migration work.
+
+- Added Foundation-only, versioned diagnostic envelopes and correlation DTOs.
+- Added keyed, trace-local content fingerprints; app trace ring eviction,
+  rotation, JSONL caps, and app/daemon snapshot merge support.
+- Added the versioned `Data` XPC diagnostic snapshot endpoint through the
+  daemon exporter, daemon service, app client, and coordinator seam.
+- Replaced numbered live-observation seams with typed redacted events and
+  added renderer acknowledgement/recovery observations.
+
+## Verification
+
+- `swift build` — passed.
+- `make build` — passed.
+- `swift build --product wikid` — passed.
+- `swift test --filter ChatDiagnosticTypesTests` — passed (3 tests).
+- `WIKIFS_APP_TESTS=1 swift test --filter ChatDiagnosticsTests` — passed (2 tests).
+- `make test` — passed (2,715 tests in 219 suites).
+- `WIKIFS_APP_TESTS=1 swift test` — passed; the hosted aggregate did not
+  stall in this run. A concurrent SwiftUI runtime-warning log capture found no
+  matching state-update warnings.
+- `git diff --check` — passed before handoff.
+
+`make mutate-scope SOURCES_PATH=Sources/WikiFSEngine` was started with local
+`swift-mutation-testing` 1.3.0; it remains a long-running, separately reported
+mutation gate at this record's timestamp.

--- a/progress/2026-07-30T203500Z-chat-presentation-diagnostics-phase6-corrective-round2.md
+++ b/progress/2026-07-30T203500Z-chat-presentation-diagnostics-phase6-corrective-round2.md
@@ -1,0 +1,64 @@
+---
+timestamp: 2026-07-30T20:35:00Z
+title: "2026-07-30 — Chat presentation diagnostics Phase 6 corrective round 2"
+branch: chat-presentation-diagnostics-phase6
+status: implemented
+timestamp_source: local-clock-america-los-angeles
+---
+
+# 2026-07-30 — Chat presentation diagnostics Phase 6 corrective round 2
+
+## Progress
+
+Completed the second Phase 6 corrective pass for the redacted chat diagnostic
+export on PR #1002. This record does not add Phase 7 compatibility work or a
+plan-index change.
+
+- Threaded typed chat correlation through render planning, DOM outcomes,
+  legacy web events, chat-list projection, chat-detail presentation, and
+  daemon provider/persistence/reduction observations. Exported payloads keep
+  only redacted metadata; content is represented by a rotating keyed
+  fingerprint where source text is available.
+- Wired the daemon snapshot/reset XPC contract and bounded per-chat daemon
+  rings. Both app and daemon rings expose dropped record/byte counts in the
+  merged JSON and JSONL exports, evict oldest records first, and rotate their
+  identity and fingerprint key after a fully successful export.
+- Made high-frequency sync, display, renderer, and daemon provider updates
+  coalesce by typed item/revision correlation. App-side observation is
+  main-actor ordered rather than one unstructured task per event.
+- Made Copy Diagnostics and JSONL export failure-visible in the existing
+  debug controls, while retaining `DebugLog` detail. JSONL snapshot appends
+  are temp-file/replace based so a failed write does not leave a duplicate
+  partial retry artifact.
+- Added real producer, coordinator/export, daemon-ring, and anonymous NSXPC
+  regression coverage. The export test exercises render planning and DOM
+  acknowledgement through `ChatTranscriptRenderExecutor`, verifies typed chat
+  scoping, and confirms display content is absent from the copied artifact.
+
+## Verification
+
+- `WIKIFS_APP_TESTS=1 swift test --filter
+  'ChatDiagnosticsTests|ChatDaemonCoordinatorTests|ChatTranscriptRenderExecutorTests|DaemonChatHostTests.(xpcChatDiagnosticSnapshotRoundTripsVersionedRedactedEnvelope|daemonDiagnosticRingEvictsOldestAndRotatesAfterAcknowledgedExport)'`
+  — passed: 27 tests in 4 suites.
+- `make build` — passed; assembled and signed `Self Driving Wiki.app`.
+- `make test` — passed: 2,715 tests in 219 suites.
+- `swift test --filter DocumentationContractTests` — passed: 7 tests in 1
+  suite.
+- `WIKIFS_APP_TESTS=1 swift test` under `HostedAppKitTestGate` — started and
+  made substantial progress, then produced no output for 30 seconds. Stopped
+  and classified as stalled/inconclusive; it is not claimed as a pass. A
+  final-source repeat also began and made progress, but ended without a
+  terminal test result before the interactive session could poll it; it is
+  likewise inconclusive.
+- Concurrent `/usr/bin/log stream` filtering the SwiftUI runtime-issues
+  subsystem produced no entries during the active hosted-test portion.
+- `git diff --check` — passed. The scope review contains Phase 6 diagnostics,
+  chat presentation/daemon wiring, tests, and this required progress record;
+  it contains no Phase 7 compatibility cleanup or plan-index change.
+
+## Remaining limitation
+
+The full app-enabled hosted aggregate remains inconclusive in this environment
+because it stalls after progressing through the suite. The focused app-enabled
+diagnostic, renderer, coordinator/export, daemon-ring, and XPC seam tests
+passed.

--- a/progress/2026-07-31T024103Z-chat-presentation-diagnostics-phase6-corrective-export.md
+++ b/progress/2026-07-31T024103Z-chat-presentation-diagnostics-phase6-corrective-export.md
@@ -1,0 +1,46 @@
+---
+timestamp: 2026-07-31T024103Z
+title: "2026-07-31 — Chat presentation diagnostics Phase 6 corrective export"
+branch: chat-presentation-diagnostics-phase6
+status: implemented
+timestamp_source: local-clock-america-los-angeles
+---
+
+# 2026-07-31 — Chat presentation diagnostics Phase 6 corrective export
+
+## Progress
+
+Completed the remaining Phase 6 diagnostic-export corrective scope without
+Phase 7 compatibility cleanup or plan-index work.
+
+- Added the debug-only Activity menu's redacted Copy Diagnostics action. It
+  requests the app/daemon snapshot through `ChatDaemonCoordinator`, writes the
+  merged JSON to the pasteboard, and rotates app-local trace material only
+  after that write succeeds.
+- Added an explicit redacted JSONL action beside the existing full-content
+  debug-folder reveal workflow. The JSONL writer is now production-wired,
+  covered for first write and bounded-file rotation, and handles an absent
+  target file before checking its size.
+- Made the coordinator's app trace default-injectable so export tests exercise
+  its real snapshot/XPC seam with isolated trace state.
+- Corrected selected-chat drop totals: a chat with no evictions now reports
+  zero rather than another chat's global drop count.
+
+## Verification
+
+- `swift test --filter ChatDiagnosticTypesTests` — passed (3 tests).
+- `WIKIFS_APP_TESTS=1 swift test --filter
+  'ChatDiagnosticsTests|ChatDaemonCoordinatorTests'` — passed (17 tests).
+  The coverage includes coordinator snapshot → copy/write → rotation, failed
+  copy preserving the retry trace, JSONL export, JSONL rotation, and the
+  multiple-chat dropped-count regression.
+- `make build` — passed; assembled and signed `Self Driving Wiki.app`.
+- `make test` — passed (2,715 tests in 219 suites).
+- `WIKIFS_APP_TESTS=1 swift test` — started under the hosted AppKit test
+  configuration, then stalled in the known `swiftpm-testing-helper` state for
+  about six minutes. The exact workspace's parent and orphaned helper were
+  stopped. This aggregate run is inconclusive and is not claimed as a pass.
+- A concurrent `/usr/bin/log stream` capture during the active hosted portion
+  found no `Modifying state during view update` warnings.
+- `git diff --check` — passed. Scope review found only the Phase 6 export,
+  diagnostics, and tests changes; no Phase 7 compatibility cleanup was added.

--- a/progress/2026-07-31T042607Z-chat-presentation-diagnostics-phase6-corrective-round3.md
+++ b/progress/2026-07-31T042607Z-chat-presentation-diagnostics-phase6-corrective-round3.md
@@ -1,0 +1,54 @@
+---
+timestamp: 2026-07-31T04:26:07Z
+title: "2026-07-30 — Chat presentation diagnostics Phase 6 corrective round 3"
+branch: chat-presentation-diagnostics-phase6
+status: implemented
+timestamp_source: local-clock-america-los-angeles
+---
+
+# 2026-07-30 — Chat presentation diagnostics Phase 6 corrective round 3
+
+## Progress
+
+Completed the Phase 6 correction for the two high-severity audit findings on
+PR #1002. This record does not add Phase 7 compatibility work or change a
+plan index.
+
+- Coalescing now uses a stable producer identity across interleaved records.
+  Renderer planning uses the captured display-row context, while daemon runtime
+  transcript observations carry the real durable message or tool identity.
+  Receipt, reduction, and persistence observations for one runtime item now
+  coalesce without collapsing a mixed batch.
+- Renderer acknowledgements and recovery diagnostics retain the chat captured
+  when their command was dispatched, rather than consulting a later selected
+  transcript.
+- Content fingerprints now use an ephemeral 256-bit HMAC-SHA-256 key. The key
+  is not exported. A successful reset rotates and drains the ring; if an
+  artifact was written but its daemon reset fails, the app and daemon retire
+  their fingerprint epochs while retaining retry evidence.
+- The exported merge contract is explicitly
+  `source-instance-sequence; timestamps-informational`, with an exact
+  coordinator assertion to prevent accidental reversion to the old label or
+  ordering policy.
+
+## Verification
+
+- Focused hosted suites passed: `ChatDiagnosticsTests` (5),
+  `ChatDaemonCoordinatorTests` (14), `ChatTranscriptRenderExecutorTests` (8),
+  `DaemonChatControllerTests` (26), `DaemonChatHostTests` (27), and
+  `ChatDiagnosticTypesTests` (3).
+- `make build` — passed; assembled and signed `Self Driving Wiki.app`.
+- `make test` — passed: 2,715 tests in 219 suites.
+- `WIKIFS_APP_TESTS=1 swift test` — the full hosted aggregate was
+  inconclusive: its test helper remained active for more than three minutes
+  after the launcher returned and was stopped. The focused hosted diagnostics,
+  renderer, coordinator, controller, and daemon-host suites above passed.
+- `/usr/bin/log show` scoped to the project debug subsystem found no matching
+  SwiftUI "Modifying state during view update" or "undefined behavior"
+  warnings during the run.
+- `git diff --check` — passed.
+
+## Remaining gate
+
+An independent exact-head audit and green PR CI are still required before any
+merge-readiness decision.


### PR DESCRIPTION
## Summary

Implements Phase 6 of `chat-presentation-and-diagnostics` only.

- Adds Foundation-only, versioned and redacted chat diagnostic DTOs with typed correlation, process identity, sequence, and outcomes.
- Adds bounded app/daemon diagnostic traces, keyed content fingerprints, JSONL cap/rotation support, typed renderer observations, and app/daemon snapshot merge.
- Adds the versioned `Data` diagnostic snapshot XPC endpoint and timeout/decode/version handling in the app client/coordinator.

Phase 7 compatibility cleanup and plan-index migration work are intentionally excluded.

## Verification

- `make build`
- `swift build --product wikid`
- `swift test --filter ChatDiagnosticTypesTests`
- `WIKIFS_APP_TESTS=1 swift test --filter ChatDiagnosticsTests`
- `make test` (2,715 tests / 219 suites)
- `WIKIFS_APP_TESTS=1 swift test` with runtime-warning log capture (no matching SwiftUI state-update warnings)
- `git diff --check`

`make mutate-scope SOURCES_PATH=Sources/WikiFSEngine` was started separately with the local mutation tool and is long-running.
