### PR TITLE
Clean up Phase 7 chat presentation compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,14 @@ jobs:
         env:
           SKIP: 'CLITantivyLegResolverTests|TantivySmokeTests|TantivyShadowIndexTests|TantivyBM25LegCutoverTests|TantivyAutocompleteTests|RunAwaitsTurnTests|SourceEmbeddingSearchTests|PdfExtractionServiceTests|YouTubeEmbedWebViewTests|QuoteHighlightWebViewTests|SplitDiffSnapshotTests|BlobSchemeHandlerTests|ReaderRenderPerfTests|TransclusionEmbedTests|PageDetailViewHostedTests|PageVersionTests|EnumeratorDeletionTests|StoreEmissionTests|StoreEmissionReentrancyTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|FullTextSearchTests|ChatSearchTests|SessionManagerTests|SidebarDropBuilderIntegrationTests|MediaEmbedPlayerTests|Phase6PinningModelTests|DropLinkTextViewDropTests|ComposerTextViewTests|EditorAutocompleteHostedTests|ComposerAutocompleteHostedTests|ChatAutocompleteSelectionTests|ChatAutocompletePanelPlacementTests|ActivityPermissionPendingRowTests|AddressBarLayoutHostedTests|BookmarkInsertPositionTests|SidebarDragPasteboardBridgeTests|SidebarSelectAllShortcutTests|SourceDetailWebViewMenuTests|SourceWebAnchorTests|FootnoteAnchorTests|RetryStuckRegressionTests|ExternalWriteBookmarkRefreshTests|ExternalWriteDraftRefreshTests'
         run: xcrun swift test --parallel --filter WikiFSCoreTests --skip "$SKIP"
+      - name: Test chat presentation API manifest
+        # This opt-in app target contains source-contract tests only. It does
+        # not host AppKit or WebKit views, so it avoids the known aggregate
+        # SwiftPM helper wedge while keeping the Phase 7 compatibility guard live.
+        timeout-minutes: 15
+        env:
+          WIKIFS_APP_TESTS: "1"
+        run: xcrun swift test --filter ChatPresentationAPIManifestTests
 
   # Linux Swift CI (#754) — builds and tests the portable target
   # (WikiFSCoreTests) on ubuntu-latest. Validates the macOS/Linux

--- a/Sources/WikiFS/Chats/ChatDetailControlsView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailControlsView.swift
@@ -21,7 +21,7 @@ struct ChatDetailControlsView: View {
                         .controlSize(.small)
                 }
                 Menu {
-                    Toggle("Show internals", isOn: $showsInternals)
+                    Toggle("Show Full Activity", isOn: $showsInternals)
                     Toggle("Hide tool calls", isOn: $hideToolCalls)
                     Button("Copy Diagnostics", systemImage: "doc.on.doc") {
                         copyDiagnostics()
@@ -48,7 +48,7 @@ struct ChatDetailControlsView: View {
                 }
                 .labelStyle(.iconOnly)
                 .menuStyle(.borderlessButton)
-                .help("Show activity and transcript internals")
+                .help("Show activity controls while this chat is running")
             }
         }
     }

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -54,14 +54,14 @@ extension [AgentEvent] {
 /// sibling one — every message was an island. Folding the whole feed into one
 /// document removes that boundary entirely.
 ///
-/// `events` is expected to only grow in length, or have its LAST element mutated
+/// Activity-feed `events` are expected to only grow in length, or have their LAST element mutated
 /// in place (a streamed text delta merged into an in-progress `.assistantText`,
 /// issue #121), except for an explicit reset to `[]` (`AgentLauncher.events`'s
 /// contract): new events are inserted into the live DOM via `appendRows`, and an
 /// in-place growth of the last row is patched via `replaceLastRow`, rather than a
 /// full reload — so an in-progress text selection survives a streaming run. A
 /// count *decrease* (a reset), a `showsInternals` change (which changes which
-/// underlying events are visible), or a `transcriptID` change (the events now
+/// underlying activity events are visible), or a `transcriptID` change (the events now
 /// describe a different conversation entirely) forces a full rebuild.
 ///
 /// A versioned request to scroll the chat transcript to a user turn. Mirrors the
@@ -102,19 +102,10 @@ enum TranscriptID: Hashable, Sendable {
 }
 
 struct ChatWebView: NSViewRepresentable {
-    /// `.activityFeed` is the inspector look (labeled rows, tool calls,
-    /// diagnostics). `.chat` is the Query page look (right-aligned capsule
-    /// for the user, plain prose for the assistant, no row labels).
-    enum VisualStyle {
-        case activityFeed
-        case chat
-    }
-
     /// The legacy activity-feed input. Chat transcripts use `chatRows` so the
     /// presentation layer does not discard durable row identity.
     let events: [AgentEvent]
     let chatRows: [ChatDisplayRow]?
-    let style: VisualStyle
     /// Identity of the transcript these `events` belong to (a chat ULID, a
     /// queue item id, …). The coordinator renders **incrementally** — it
     /// appends only `events[renderedCount...]` — which is only sound while
@@ -134,7 +125,7 @@ struct ChatWebView: NSViewRepresentable {
     var transcriptID: TranscriptID? = nil
     /// A value that, when it changes, forces a full rebuild rather than an
     /// append — for callers whose event→visible-row filtering can change
-    /// retroactively (e.g. `AgentQueueView`'s "Show internals" toggle).
+    /// retroactively (e.g. an activity-feed filtering toggle).
     /// Callers whose filtering never changes mid-stream can ignore this.
     var showsInternals: Bool = false
     /// Invoked when the user clicks a `wiki://` link inside the transcript
@@ -175,12 +166,6 @@ struct ChatWebView: NSViewRepresentable {
     /// load). The coordinator stashes it and applies once rows are rendered.
     var quoteAnchor: ChatHighlightRequest? = nil
 
-    /// Wall-clock timestamps parallel to `events`. Indexed per-row so the
-    /// coordinator can compute a duration ("Worked for Xs") and a completion
-    /// timestamp for each assistant bubble. Entry `nil` → no footer for that
-    /// row. Empty array (default) → no footers at all (activity-feed callers
-    /// that don't track timing are unaffected).
-    var timestamps: [Date?] = []
     /// Typed UI callback used only by the chat transcript. The activity-feed
     /// API retains its existing raw navigation closure for compatibility.
     var onChatIntent: ((ChatTranscriptIntent) -> Void)? = nil
@@ -194,7 +179,6 @@ struct ChatWebView: NSViewRepresentable {
 
     init(
         events: [AgentEvent],
-        style: VisualStyle,
         transcriptID: TranscriptID? = nil,
         showsInternals: Bool = false,
         onWikiLink: ((URL, Bool) -> Void)? = nil,
@@ -202,12 +186,10 @@ struct ChatWebView: NSViewRepresentable {
         blobStore: WikiStoreModel? = nil,
         zoom: Double = Double(ZoomScale.defaultScale),
         scrollRequest: ChatWebScrollRequest? = nil,
-        quoteAnchor: ChatHighlightRequest? = nil,
-        timestamps: [Date?] = []
+        quoteAnchor: ChatHighlightRequest? = nil
     ) {
         self.events = events
         self.chatRows = nil
-        self.style = style
         self.transcriptID = transcriptID
         self.showsInternals = showsInternals
         self.onWikiLink = onWikiLink
@@ -216,7 +198,6 @@ struct ChatWebView: NSViewRepresentable {
         self.zoom = zoom
         self.scrollRequest = scrollRequest
         self.quoteAnchor = quoteAnchor
-        self.timestamps = timestamps
     }
 
     init(
@@ -231,7 +212,6 @@ struct ChatWebView: NSViewRepresentable {
     ) {
         self.events = []
         self.chatRows = chatRows
-        self.style = .chat
         self.transcriptID = transcriptID
         self.onWikiLink = nil
         self.renderContext = renderContext
@@ -266,7 +246,6 @@ struct ChatWebView: NSViewRepresentable {
         webView.pageZoom = zoom
         webView.allowsBackForwardNavigationGestures = false
         context.coordinator.webView = webView
-        context.coordinator.style = style
         context.coordinator.onWikiLink = onWikiLink
         context.coordinator.onChatIntent = onChatIntent
         context.coordinator.renderContext = renderContext
@@ -274,14 +253,13 @@ struct ChatWebView: NSViewRepresentable {
             context.coordinator.reload(chatRows: chatRows, transcriptID: transcriptID)
         } else {
             context.coordinator.reload(events: events, showsInternals: showsInternals,
-                                       timestamps: timestamps, transcriptID: transcriptID)
+                                       transcriptID: transcriptID)
         }
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         webView.pageZoom = zoom
-        context.coordinator.style = style
         context.coordinator.onWikiLink = onWikiLink
         context.coordinator.onChatIntent = onChatIntent
         context.coordinator.renderContext = renderContext
@@ -293,7 +271,7 @@ struct ChatWebView: NSViewRepresentable {
             context.coordinator.apply(chatRows: chatRows, transcriptID: transcriptID)
         } else {
             context.coordinator.apply(events: events, showsInternals: showsInternals,
-                                      timestamps: timestamps, transcriptID: transcriptID)
+                                      transcriptID: transcriptID)
         }
         // Outline click → scroll the i-th user bubble into view. Only fires when
         // the version advances, so unrelated re-renders (streaming) don't re-scroll.
@@ -319,7 +297,6 @@ struct ChatWebView: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
         weak var webView: WKWebView?
-        var style: VisualStyle = .activityFeed
         /// Routes a clicked `wiki://` link out to the view's `onWikiLink`
         /// closure (built where the store lives). Refreshed each update.
         var onWikiLink: ((URL, Bool) -> Void)?
@@ -351,12 +328,6 @@ struct ChatWebView: NSViewRepresentable {
         private var pendingTranscriptID: TranscriptID?
         private var isLoaded = false
         private var pendingEvents: [AgentEvent] = []
-        /// Pending timestamps to render once the page finishes loading (stashed by
-        /// `apply` when the view isn't loaded yet). Parallel to `pendingEvents`.
-        private var pendingTimestamps: [Date?] = []
-        /// The full timestamps array — refreshed each `apply` call. Used to
-        /// compute "Worked for Xs" duration + completion timestamp per row.
-        private var timestamps: [Date?] = []
         /// The last event actually rendered, so `apply` can detect "no new row, but
         /// `AgentLauncher` grew the last one in place" (a streamed `.assistantText`
         /// delta merge, issue #121) and patch that row instead of no-op'ing.
@@ -405,7 +376,7 @@ struct ChatWebView: NSViewRepresentable {
             return eventCount < renderedCount
         }
 
-        func reload(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = [],
+        func reload(events: [AgentEvent], showsInternals: Bool,
                     transcriptID: TranscriptID? = nil) {
             rendersTypedChatRows = false
             renderedCount = 0
@@ -413,11 +384,9 @@ struct ChatWebView: NSViewRepresentable {
             renderedTranscriptID = transcriptID
             renderedLastEvent = nil
             renderedEvents = events
-            self.timestamps = timestamps
             isLoaded = false
             pendingEvents = events
             pendingTranscriptID = transcriptID
-            pendingTimestamps = timestamps
             webView?.loadHTMLString(Self.shellHTML, baseURL: URL(string: "about:blank"))
         }
 
@@ -443,9 +412,8 @@ struct ChatWebView: NSViewRepresentable {
             ))
         }
 
-        func apply(events: [AgentEvent], showsInternals: Bool, timestamps: [Date?] = [],
+        func apply(events: [AgentEvent], showsInternals: Bool,
                    transcriptID: TranscriptID? = nil) {
-            self.timestamps = timestamps
             // Checked BEFORE the `isLoaded` guard, so a transcript switch that
             // lands mid-load also replaces `pendingEvents` — otherwise
             // `didFinish` would render the PREVIOUS transcript's rows and seed
@@ -468,7 +436,7 @@ struct ChatWebView: NSViewRepresentable {
                     detail: "reload; rows=\(events.count); rendered=\(renderedCount)"
                 )
                 reload(events: events, showsInternals: showsInternals,
-                       timestamps: timestamps, transcriptID: transcriptID)
+                       transcriptID: transcriptID)
                 return
             }
             guard isLoaded else {
@@ -479,7 +447,6 @@ struct ChatWebView: NSViewRepresentable {
                     detail: "pending; rows=\(events.count)"
                 )
                 pendingEvents = events
-                pendingTimestamps = timestamps
                 return
             }
             guard events.count > renderedCount else {
@@ -491,7 +458,7 @@ struct ChatWebView: NSViewRepresentable {
                     // The last row of a live stream is still growing → render it
                     // in the streaming (links-only) tier so a half-typed
                     // `![[source:…` never instantiates a broken iframe/player.
-                    replaceLastRow(last, at: events.count - 1, isStreaming: true, allEvents: events)
+                    replaceLastRow(last, isStreaming: true)
                     renderedLastEvent = last
                 }
                 renderedEvents = events
@@ -503,7 +470,7 @@ struct ChatWebView: NSViewRepresentable {
             let context = currentContext()
             if let prevLast = renderedEvents.last, events.count > renderedEvents.count,
                renderedEvents.count > 0 {
-                replaceLastRow(prevLast, at: renderedEvents.count - 1, isStreaming: false, allEvents: events, context: context)
+                replaceLastRow(prevLast, isStreaming: false, context: context)
             }
             ChatDiagnostics.observe(
                 stage: .renderPlanning,
@@ -533,7 +500,6 @@ struct ChatWebView: NSViewRepresentable {
             }
             let toRender = pendingEvents
             pendingEvents = []
-            pendingTimestamps = []
             // Initial load: every row is final (persisted chats load all-at-once;
             // a freshly-opened live view's events are all complete at this point).
             let context = currentContext()
@@ -616,13 +582,8 @@ struct ChatWebView: NSViewRepresentable {
             // `replaceLastRow(..., isStreaming: true)` path — uses the
             // links-only tier.
             var html = ""
-            // Hoist the concatenation above the loop: `renderedEvents + events`
-            // was rebuilt per-row, making the loop O(n²) in array copies (#503 P2).
-            let allEvents = renderedEvents + events
-            for (offset, event) in events.enumerated() {
-                let absoluteIndex = startingIndex + offset
-                let ts = absoluteIndex < timestamps.count ? timestamps[absoluteIndex] : nil
-                html += Self.rowHTML(for: event, style: style, context: context, isFinal: true, timestamp: ts, allEvents: allEvents, allTimestamps: timestamps, index: absoluteIndex)
+            for event in events {
+                html += Self.feedRowHTML(for: event, context: context, isFinal: true)
             }
             guard !html.isEmpty,
                   let data = DebugLog.trying("serialize chat rows", operation: { try JSONSerialization.data(withJSONObject: html, options: [.fragmentsAllowed]) }),
@@ -640,9 +601,8 @@ struct ChatWebView: NSViewRepresentable {
         /// a half-typed `![[source:…` never instantiates a broken iframe/player
         /// that churns per token. When false, the row is being *re-finalized*
         /// (a new event landed = turn boundary) → render the full context.
-        private func replaceLastRow(_ event: AgentEvent, at index: Int, isStreaming: Bool, allEvents: [AgentEvent], context: WikiRenderContext? = nil) {
-            let ts = index < timestamps.count ? timestamps[index] : nil
-            let html = Self.rowHTML(for: event, style: style, context: context, isFinal: !isStreaming, timestamp: ts, allEvents: allEvents, allTimestamps: timestamps, index: index)
+        private func replaceLastRow(_ event: AgentEvent, isStreaming: Bool, context: WikiRenderContext? = nil) {
+            let html = Self.feedRowHTML(for: event, context: context, isFinal: !isStreaming)
             guard let data = DebugLog.trying("serialize replaced row", operation: { try JSONSerialization.data(withJSONObject: html, options: [.fragmentsAllowed]) }),
                   let jsonString = String(data: data, encoding: .utf8)
             else { return }
@@ -855,13 +815,6 @@ struct ChatWebView: NSViewRepresentable {
 
         // MARK: - Row rendering
 
-        private static func rowHTML(for event: AgentEvent, style: VisualStyle, context: WikiRenderContext?, isFinal: Bool, timestamp: Date? = nil, allEvents: [AgentEvent] = [], allTimestamps: [Date?] = [], index: Int = -1) -> String {
-            switch style {
-            case .activityFeed: feedRowHTML(for: event, context: context, isFinal: isFinal)
-            case .chat: chatRowHTML(for: event, context: context, isFinal: isFinal, timestamp: timestamp, allEvents: allEvents, allTimestamps: allTimestamps, index: index)
-            }
-        }
-
         /// Render assistant/result markdown with the shared footnote + wiki-link
         /// pre-pass. With a `WikiRenderContext` (Phase A.2), it threads the
         /// context's pure `isResolved`/`embedInfo`/`displayName`/`pinnedExtractionID`
@@ -957,7 +910,7 @@ struct ChatWebView: NSViewRepresentable {
                 return """
                 <article class="row chat-row chat-assistant\(contentState == .streaming ? " is-streaming" : "")" role="article" aria-label="\(stateLabel)" aria-busy="\(contentState == .streaming ? "true" : "false")"\(attributes)>
                 <div class="bubble">\(renderedMarkdown(text, context: context, isFinal: contentState == .final))</div>
-                <div class="turn-footer"><span class="row-status" aria-label="\(status)">\(contentState == .streaming ? "◌ Streaming" : "✓ Completed")</span><button class="copy-btn" type="button" data-copy="\(htmlAttributeEscape(text))" data-focus-key="copy" aria-label="Copy assistant response" title="Copy assistant response">\(Self.copyIconSVG)</button><span class="turn-meta" aria-label="Completed \(escape(timestamp))"><span class="turn-timestamp">\(escape(timestamp))</span></span></div>
+                <div class="turn-footer"><span class="row-status" aria-label="\(status)">\(contentState == .streaming ? "◌ Streaming" : "✓ Completed")</span><button class="copy-btn" type="button" data-copy="\(htmlAttributeEscape(text))" data-focus-key="copy" aria-label="Copy assistant response" title="Copy assistant response">\(Self.copyIconSVG)</button><span class="turn-meta" aria-label="Response recorded at \(escape(timestamp))"><span class="turn-timestamp">\(escape(timestamp))</span></span></div>
                 </article>
                 """
 
@@ -1006,41 +959,6 @@ struct ChatWebView: NSViewRepresentable {
             }
         }
 
-        /// The Query page chat look: a right-aligned capsule for the user, plain
-        /// prose for the assistant (matching `QueryMessageBubble`'s prior
-        /// SwiftUI rendering), no row labels. Tool calls render as a concise,
-        /// muted one-line progress indicator (issue #173) — independent of the
-        /// "Show internals" toggle, which still gates the full raw feed.
-        static func chatRowHTML(for event: AgentEvent, context: WikiRenderContext? = nil, isFinal: Bool = true, timestamp: Date? = nil, allEvents: [AgentEvent] = [], allTimestamps: [Date?] = [], index: Int = -1) -> String {
-            switch event {
-            case .userText(let text):
-                // Run user text through the markdown renderer so prepended
-                // attachment refs ([[source:Name]]) render as clickable
-                // wikilinks, not raw escaped text (issue #385).
-                return """
-                <div class="row chat-row chat-user"><div class="bubble">\(renderedMarkdown(text, context: context, isFinal: isFinal))</div></div>
-                """
-            case .assistantText(let text):
-                return assistantBubbleHTML(text: text, context: context, isFinal: isFinal, timestamp: timestamp, allEvents: allEvents, allTimestamps: allTimestamps, index: index)
-            case .thinking(let text):
-                return thinkingRowHTML(text: text, context: context, isFinal: isFinal)
-            case .result(_, let text):
-                guard !text.isEmpty else { return "" }
-                return assistantBubbleHTML(text: text, context: context, isFinal: isFinal, timestamp: timestamp, allEvents: allEvents, allTimestamps: allTimestamps, index: index)
-            case .toolUse(let name, let summary):
-                return chatToolRowHTML(name: name, summary: summary, isError: false)
-            case .toolResult(let isError, let summary):
-                // Only error results reach a chat-styled transcript (successes are
-                // filtered out upstream in `ChatTranscriptView.visibleEvents`).
-                guard isError else { return "" }
-                return chatToolRowHTML(name: nil, summary: summary, isError: true)
-            case .systemInit, .subagent, .messageStop, .raw, .assistantTextDelta, .thinkingDelta:
-                return ""
-            case .turnFailed(let reason):
-                return turnFailedBannerHTML(reason: reason)
-            }
-        }
-
         /// Inline SVG for the copy button (lucide `Copy` icon, inner `currentColor`
         /// so CSS controls the tint). Duplicated as a JS string in `shellHTML`
         /// so the click handler can swap between copy↔check without a round-trip.
@@ -1050,24 +968,8 @@ struct ChatWebView: NSViewRepresentable {
         /// ~1.5 s to confirm the clipboard write landed.
         private static let checkIconSVG = #"<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>"#
 
-        /// Format a duration (seconds) as a compact string: "47s", "2m 12s",
-        /// "1h 5m". Mirrors Paseo's `formatDuration` (utils/time.ts).
-        static func formatDuration(_ seconds: TimeInterval) -> String {
-            let s = max(0, Int(seconds.rounded(.down)))
-            if s < 60 { return "\(s)s" }
-            let m = s / 60
-            if m < 60 {
-                let rem = s % 60
-                return rem == 0 ? "\(m)m" : "\(m)m \(rem)s"
-            }
-            let h = m / 60
-            let remMin = m % 60
-            return remMin == 0 ? "\(h)h" : "\(h)h \(remMin)m"
-        }
-
-        /// Format a timestamp for the hover-reveal label — same-day shows just
-        /// the time; older shows the date + time. Mirrors Paseo's
-        /// `formatMessageTimestamp` (utils/time.ts).
+        /// Format a typed row's creation time. Same-day rows show only the time;
+        /// older rows show the date and time.
         static func formatTimestamp(_ date: Date, now: Date = Date()) -> String {
             let timeFmt = DateFormatter()
             timeFmt.timeStyle = .short
@@ -1078,80 +980,6 @@ struct ChatWebView: NSViewRepresentable {
                 return "\(dateFmt.string(from: date)), \(timeStr)"
             }
             return timeStr
-        }
-
-        /// Compute the "Worked for Xs" duration for a row: the gap between
-        /// this row's timestamp and the previous non-nil timestamp in the
-        /// parallel array. If there's no predecessor, returns nil.
-        private static func workDuration(at index: Int, timestamps: [Date?]) -> TimeInterval? {
-            guard index < timestamps.count, let ts = timestamps[index] else { return nil }
-            for i in stride(from: min(index - 1, timestamps.count - 1), through: 0, by: -1) {
-                if let prev = timestamps[i] {
-                    return ts.timeIntervalSince(prev)
-                }
-            }
-            return nil
-        }
-
-        /// A chat-style assistant bubble (markdown prose + a hover-revealed copy
-        /// icon button). Shared by `.assistantText` and `.result` rows (issue #285).
-        /// The button's `data-copy` attribute carries the **raw markdown** (HTML-
-        /// attribute-escaped) — not the rendered HTML — so the clipboard gets the
-        /// plain text the user would have drag-selected. The icon swaps to a green
-        /// checkmark for ~1.5 s after clicking (mirrors Paseo's `TurnCopyButton`).
-        ///
-        /// When `timestamp` is non-nil, a "Worked for Xs" footer is appended below
-        /// the prose. On hover, the duration swaps to the completion timestamp
-        /// (CSS-only, no JS) — mirroring Paseo's `AssistantTurnFooter`.
-        private static func assistantBubbleHTML(text: String, context: WikiRenderContext?, isFinal: Bool, timestamp: Date? = nil, allEvents: [AgentEvent] = [], allTimestamps: [Date?] = [], index: Int = -1) -> String {
-            var html = """
-            <div class="row chat-row chat-assistant"><div class="bubble">\
-            \(renderedMarkdown(text, context: context, isFinal: isFinal))</div>
-            """
-
-            // Footer action bar: sits on its own line directly beneath the bubble
-            // so it reads as attached to the response. Holds the copy button and,
-            // when a timestamp is available, the "Worked for Xs" label (which
-            // hover-swaps to the completion timestamp).
-            var metaHTML = ""
-            if let ts = timestamp {
-                let duration = Self.workDuration(at: index, timestamps: allTimestamps)
-                let durationLabel = duration.map { "Worked for \(Self.formatDuration($0))" } ?? ""
-                let timestampLabel = Self.formatTimestamp(ts)
-                // The meta: a sizer (hidden, reserves width) + the visible
-                // duration label + the timestamp (hidden by default). On hover,
-                // the duration fades out and the timestamp fades in — pure CSS,
-                // width stays stable (sizer reserves the wider of the two).
-                let durationHTML = durationLabel.isEmpty ? "" : #"<span class="turn-duration">\#(escape(durationLabel))</span>"#
-                metaHTML = #"<span class="turn-meta"><span class="turn-sizer">\#(escape(timestampLabel))</span>\#(durationHTML)<span class="turn-timestamp">\#(escape(timestampLabel))</span></span>"#
-            }
-            html += #"<div class="turn-footer"><button class="copy-btn" type="button" data-copy="\#(htmlAttributeEscape(text))" aria-label="Copy">\#(Self.copyIconSVG)</button>\#(metaHTML)</div>"#
-
-            html += "</div>"
-            return html
-        }
-
-        /// A single muted, left-aligned progress line for a tool call — the
-        /// lightweight in-transcript indicator (issue #173). Not a chat bubble:
-        /// it reads like a status line, so it stays subordinate to the prose.
-        private static func chatToolRowHTML(name: String?, summary: String, isError: Bool) -> String {
-            let nameHTML = name.map { "<span class=\"chat-tool-name\">\(escape($0))</span>" } ?? ""
-            let body = summary.isEmpty ? (isError ? "(error)" : "") : summary
-            let summaryHTML = body.isEmpty ? "" : "<span class=\"chat-tool-summary\">\(escape(body))</span>"
-            // Expandable tool row (issue #381): a <details> element so the user
-            // can click to reveal the full summary. Only adds the disclosure if
-            // there's content to expand into; otherwise renders as before.
-            if body.isEmpty {
-                return """
-                <div class="row chat-row chat-tool\(isError ? " is-error" : "")">\
-                \(nameHTML)\(summaryHTML)</div>
-                """
-            }
-            return """
-            <details class="row chat-row chat-tool\(isError ? " is-error" : "")">\
-            <summary>\(nameHTML)\(summaryHTML)</summary>\
-            <pre class="chat-tool-detail\">\(escape(body))</pre></details>
-            """
         }
 
         /// A styled amber banner for a turn failure (timeout, ceiling, agent
@@ -1388,9 +1216,7 @@ struct ChatWebView: NSViewRepresentable {
             padding: 11px 16px; white-space: pre-wrap; font-size: 13.5px;
           }
           .chat-assistant .bubble { position: relative; }
-          /* Footer action bar beneath the response: copy button + "Worked for Xs"
-             label share one line, left-aligned under the bubble so they read as
-             attached to it. */
+          /* Footer actions and completion metadata stay attached to each typed response. */
           .turn-footer {
             display: flex; align-items: center; gap: 4px;
             margin-top: 4px; margin-left: 6px; min-height: 20px;
@@ -1408,27 +1234,10 @@ struct ChatWebView: NSViewRepresentable {
           .copy-btn:hover { opacity: 1; color: var(--text); background: var(--code-bg); }
           .copy-btn.copied { opacity: 1; color: #34c759; }
           .copy-btn svg { display: block; }
-          /* "Worked for Xs" with hover-swap to timestamp. Mirrors Paseo's
-             AssistantTurnFooter — a sizer reserves width so the label doesn't
-             shift when swapping. */
           .turn-meta {
-            position: relative; display: inline-block;
-            min-height: 16px;
+            font-size: 11px; color: var(--muted); white-space: nowrap;
           }
-          .turn-sizer {
-            visibility: hidden; opacity: 0;
-            font-size: 11px; color: var(--muted);
-            white-space: nowrap; height: 0; display: block;
-          }
-          .turn-duration, .turn-timestamp {
-            position: absolute; top: 0; left: 0;
-            font-size: 11px; color: var(--muted);
-            white-space: nowrap; transition: opacity 0.15s ease;
-          }
-          .turn-duration { opacity: 0.6; }
-          .turn-timestamp { opacity: 0; }
-          .chat-assistant:hover .turn-duration { opacity: 0; }
-          .chat-assistant:hover .turn-timestamp { opacity: 0.7; }
+          .turn-timestamp { opacity: 0.7; }
           .chat-tool {
             justify-content: flex-start; align-items: baseline;
             gap: 6px; font-size: 11.5px; color: var(--muted);

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -632,7 +632,6 @@ struct ActivityWindowView: View {
         if !events.isEmpty {
             ChatWebView(
                 events: events,
-                style: .activityFeed,
                 // Selecting a different queue item reuses this representable's
                 // web view + coordinator (same structural identity, different
                 // associated value), so the differ needs the item id to know

--- a/Sources/WikiFSCore/Core/ChatQuoteResolver.swift
+++ b/Sources/WikiFSCore/Core/ChatQuoteResolver.swift
@@ -30,7 +30,7 @@ public enum ChatQuoteResolver {
     }
 
     /// The searchable prose of one transcript event — the text a quote anchor
-    /// can match. Mirrors what `ChatWebView.chatRowHTML` renders in each
+    /// can match. Mirrors what `ChatWebView.chatDisplayRowHTML` renders in each
     /// `.chat-row`: user/assistant/result prose (+ tool-call summaries). Empty
     /// for events that render no searchable row (deltas, messageStop, raw,
     /// empty result), so `messageIndex` naturally skips them.

--- a/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
+++ b/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
@@ -42,6 +42,17 @@ struct ChatPresentationAPIManifestTests {
         #expect(remoteSession.contains("ChatTranscriptProjection") == false)
     }
 
+    @Test func chatWebViewKeepsEventCompatibilityAtTheActivityFeedBoundary() throws {
+        let renderer = try source(named: "ChatWebView.swift")
+
+        #expect(renderer.contains("feedRowHTML") == true)
+        #expect(renderer.contains("chatDisplayRowHTML") == true)
+        #expect(renderer.contains("VisualStyle") == false)
+        #expect(renderer.contains("chatRowHTML") == false)
+        #expect(renderer.contains("assistantBubbleHTML") == false)
+        #expect(renderer.contains("timestamps: [Date?]") == false)
+    }
+
     @Test func legacyProjectionRemainsCoreOnlyPersistenceCompatibility() throws {
         let appSession = try source(named: "RemoteChatSession.swift")
         let appPresentation = try source(named: "ChatDetailPresentation.swift")

--- a/Tests/WikiFSAppTests/ChatWebViewLinkifyTests.swift
+++ b/Tests/WikiFSAppTests/ChatWebViewLinkifyTests.swift
@@ -4,6 +4,7 @@ import Testing
 @testable import WikiFS
 @testable import WikiFSEngine
 @testable import WikiFSCore
+@testable import WikiFSTypes
 
 /// Tests for the agent transcript's wiki-link linkify pre-pass. Assistant/result
 /// rows run their markdown through `ReaderMarkdown.prepared` so `[[wiki-links]]`
@@ -11,15 +12,30 @@ import Testing
 /// the markdown renderer so attachment references from drag-to-chat (#385)
 /// render as clickable links.
 ///
-/// Phase A.2 adds a `WikiRenderContext`-aware variant (`renderedMarkdown(_:context:)`,
-/// `feedRowHTML(for:context:isFinal:)`, `chatRowHTML(for:context:isFinal:)`) so
-/// chat transcripts render source references exactly as the reader does — healed
+/// Phase A.2 adds a `WikiRenderContext`-aware renderer (`renderedMarkdown(_:context:)`,
+/// `feedRowHTML(for:context:isFinal:)`, `chatDisplayRowHTML(_:context:)`) so
+/// chat transcript rows render source references exactly as the reader does — healed
 /// display names, `&pin=` quote links, `![[source:…]]` embeds via `wiki-blob://`,
 /// and ghost styling for broken links. See the "Phase A.2" section below.
 @MainActor
 struct ChatWebViewLinkifyTests {
 
     private typealias Transcript = ChatWebView.Coordinator
+
+    private let turnID = ChatTurnID(rawValue: "turn-linkify")
+
+    private func assistantRow(
+        _ text: String,
+        state: ChatDisplayContentState = .final
+    ) -> ChatDisplayRow {
+        .assistantMessage(
+            id: ChatMessageID(rawValue: "assistant-linkify"),
+            turnID: turnID,
+            text: text,
+            createdAt: .distantPast,
+            contentState: state
+        )
+    }
 
     @Test func renderedMarkdownLinkifiesWikiLinks() {
         let html = Transcript.renderedMarkdown("See [[Page Name]] here.")
@@ -48,94 +64,46 @@ struct ChatWebViewLinkifyTests {
         #expect(html.contains("wiki://"))
     }
 
-    @Test func chatAssistantRowLinkifies() {
-        let html = Transcript.chatRowHTML(for: .assistantText("See [[Page]] here."))
+    @Test func typedAssistantRowLinkifies() {
+        let html = Transcript.chatDisplayRowHTML(assistantRow("See [[Page]] here."))
         #expect(html.contains("wiki://"))
         #expect(html.contains("<a "))
     }
 
-    @Test func chatUserRowLinkifiesWikiLinks() {
-        // User text is now rendered through the markdown renderer so that
-        // attachment references ([[source:Name]]) render as clickable links
-        // (issue #385).
-        let html = Transcript.chatRowHTML(for: .userText("See [[Page]] here."))
+    @Test func typedUserRowLinkifiesWikiLinks() {
+        let row = ChatDisplayRow.userMessage(
+            id: ChatMessageID(rawValue: "user-linkify"),
+            turnID: turnID,
+            text: "See [[Page]] here.",
+            createdAt: .distantPast
+        )
+        let html = Transcript.chatDisplayRowHTML(row)
         #expect(html.contains("<a "))
         #expect(html.contains("wiki://"))
     }
 
-    @Test func chatResultRowLinkifies() {
-        let html = Transcript.chatRowHTML(for: .result(isError: false, text: "See [[Page]] here."))
-        #expect(html.contains("wiki://"))
-    }
-
-    // MARK: - Concise tool-call summaries (issue #173)
-
-    @Test func chatToolUseRowRendersConciseSummary() {
-        let html = Transcript.chatRowHTML(for: .toolUse(name: "Read", inputSummary: "page.md"))
-        #expect(html.contains("chat-tool"))
-        #expect(html.contains("Read"))
-        #expect(html.contains("page.md"))
-        // Not a chat bubble — it's a status line.
-        #expect(!html.contains("bubble"))
-    }
-
-    @Test func chatToolUseRowWithoutSummaryStillShowsName() {
-        let html = Transcript.chatRowHTML(for: .toolUse(name: "Grep", inputSummary: ""))
-        #expect(html.contains("Grep"))
-        #expect(html.contains("chat-tool"))
-    }
-
-    @Test func chatToolResultErrorRowRenders() {
-        let html = Transcript.chatRowHTML(for: .toolResult(isError: true, summary: "file not found"))
-        #expect(html.contains("chat-tool"))
-        #expect(html.contains("is-error"))
-        #expect(html.contains("file not found"))
-    }
-
-    @Test func chatToolResultSuccessRowIsEmpty() {
-        let html = Transcript.chatRowHTML(for: .toolResult(isError: false, summary: "ok"))
-        #expect(html.isEmpty)
-    }
-
-    // MARK: - Copy button (issue #285)
-
-    @Test func chatAssistantRowHasCopyButtonWithRawText() {
-        let html = Transcript.chatRowHTML(for: .assistantText("Hello **world**."))
+    @Test func typedAssistantRowHasEscapedRawCopyText() {
+        let html = Transcript.chatDisplayRowHTML(assistantRow(#"Say "hi" <b> & bye"#))
         #expect(html.contains("copy-btn"))
-        // The raw markdown (not rendered HTML) is in data-copy.
-        #expect(html.contains(#"data-copy="Hello **world**.""#))
-    }
-
-    @Test func chatResultRowHasCopyButtonWithRawText() {
-        let html = Transcript.chatRowHTML(for: .result(isError: false, text: "Done."))
-        #expect(html.contains("copy-btn"))
-        #expect(html.contains(#"data-copy="Done.""#))
-    }
-
-    @Test func chatUserRowHasNoCopyButton() {
-        let html = Transcript.chatRowHTML(for: .userText("Hello"))
-        #expect(!html.contains("copy-btn"))
-    }
-
-    @Test func chatToolRowsHaveNoCopyButton() {
-        let toolUse = Transcript.chatRowHTML(for: .toolUse(name: "Read", inputSummary: "x"))
-        let toolResult = Transcript.chatRowHTML(for: .toolResult(isError: true, summary: "fail"))
-        #expect(!toolUse.contains("copy-btn"))
-        #expect(!toolResult.contains("copy-btn"))
-    }
-
-    @Test func copyDataAttributeEscapesHtmlSpecialChars() {
-        let html = Transcript.chatRowHTML(for: .assistantText(#"Say "hi" <b> & bye"#))
-        #expect(html.contains("data-copy="))
-        // Double quotes → &quot;, < → &lt;, > → &gt;, & → &amp;.
         #expect(html.contains("&quot;hi&quot;"))
         #expect(html.contains("&lt;b&gt;"))
         #expect(html.contains("&amp; bye"))
     }
 
-    @Test func emptyResultRowHasNoCopyButton() {
-        let html = Transcript.chatRowHTML(for: .result(isError: false, text: ""))
-        #expect(html.isEmpty)
+    @Test func typedToolRowUsesDisclosureMarkup() {
+        let row = ChatDisplayRow.toolCall(
+            id: ToolCallID(rawValue: "tool-linkify"),
+            turnID: turnID,
+            toolName: "Read",
+            status: .running,
+            detail: "page.md",
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )
+        let html = Transcript.chatDisplayRowHTML(row)
+        #expect(html.contains("<details"))
+        #expect(html.contains("Read"))
+        #expect(html.contains("page.md"))
     }
 
     // MARK: - Phase A.2: nil-context path is behavior-preserving
@@ -166,7 +134,7 @@ struct ChatWebViewLinkifyTests {
 /// chat containing a canonical `[[source:ULID|old name]]` (heals to the current
 /// name), a `#"quote"` link with `@vN` (emits `&pin=`), an `![[source:…]]`
 /// image embed (inline `wiki-blob://`), and a broken link (ghost `wiki://missing`)
-/// must render through `renderedMarkdown(_:context:)` / `chatRowHTML(for:context:)`
+/// must render through `renderedMarkdown(_:context:)` / `chatDisplayRowHTML(_:context:)`
 /// exactly as the reader does. Also covers the two-tier `isFinal` streaming tier
 /// (links only while streaming → embeds appear on finalize).
 @MainActor
@@ -253,12 +221,19 @@ struct AgentTranscriptRenderContextTests {
         #expect(html.contains("wiki://missing"))
     }
 
-    @Test func chatRowHTMLThreadsContextIntoAssistantBubble() throws {
+    @Test func typedAssistantRowThreadsContextIntoAssistantMarkup() throws {
         let (model, _, paperID, _) = try makeFixture()
         let ctx = WikiRenderContext.build(from: model)
-        let row = Transcript.chatRowHTML(
-            for: .assistantText("See [[source:\(paperID.rawValue)|stale]]."),
-            context: ctx, isFinal: true)
+        let row = Transcript.chatDisplayRowHTML(
+            .assistantMessage(
+                id: ChatMessageID(rawValue: "context-assistant"),
+                turnID: ChatTurnID(rawValue: "context-turn"),
+                text: "See [[source:\(paperID.rawValue)|stale]].",
+                createdAt: .distantPast,
+                contentState: .final
+            ),
+            context: ctx
+        )
         // The healed name appears inside the chat bubble's link; the stale alias
         // does not. Note: the raw text survives in the copy button's `data-copy`
         // attribute (issue #285), so we check the *rendered link* text, not the
@@ -301,8 +276,26 @@ struct AgentTranscriptRenderContextTests {
         // Simulate the coordinator's two-tier sequence: the same assistant row is
         // first rendered streaming (links only), then re-rendered final (embeds).
         let text = "Embedded: ![[source:Paper.pdf]] and [[source:\(paperID.rawValue)|old]]."
-        let streaming = Transcript.chatRowHTML(for: .assistantText(text), context: ctx, isFinal: false)
-        let finalized = Transcript.chatRowHTML(for: .assistantText(text), context: ctx, isFinal: true)
+        let streaming = Transcript.chatDisplayRowHTML(
+            .assistantMessage(
+                id: ChatMessageID(rawValue: "streaming-assistant"),
+                turnID: ChatTurnID(rawValue: "streaming-turn"),
+                text: text,
+                createdAt: .distantPast,
+                contentState: .streaming
+            ),
+            context: ctx
+        )
+        let finalized = Transcript.chatDisplayRowHTML(
+            .assistantMessage(
+                id: ChatMessageID(rawValue: "final-assistant"),
+                turnID: ChatTurnID(rawValue: "streaming-turn"),
+                text: text,
+                createdAt: .distantPast,
+                contentState: .final
+            ),
+            context: ctx
+        )
         // Streaming: no embed; the link still heals.
         #expect(!streaming.contains("wiki-blob://source/\(paperID.rawValue)"))
         #expect(streaming.contains("My Paper"))

--- a/docs/user-guide/chat.md
+++ b/docs/user-guide/chat.md
@@ -23,7 +23,7 @@ preserved in the database.
 
 ## The chat interface
 
-![Chat window: title, tab strip, agent transcript with a collapsed thinking block and timestamped response, and the composer with model and permission-mode chips at the bottom.](images/chat-window.png)
+![Chat window: title, tab strip, agent transcript with a collapsed reasoning block and response state, and the composer with model and permission-mode chips at the bottom.](images/chat-window.png)
 
 ### Message layout
 
@@ -138,29 +138,31 @@ Some models show a collapsed reasoning block:
 - The preview shows the first line.
 - Click the block to read it.
 
-### Duration and timestamps
+### Response state and time
 
-After each agent response completes:
-- A **"Worked for Xs"** footer appears below the response.
-- **Hover** the footer to swap it to the completion timestamp (e.g., "2:34 PM").
+Each response block shows whether it is **Streaming** or **Completed**. Completed
+blocks also show the time when the app recorded the response.
 
 ### While generating
 
 - A **"Thinking… [elapsed]"** indicator pulses below the transcript.
-- The **Activity menu** (⋯ icon) appears with options:
-  - **Show internals** — shows extra activity details.
+- The **Activity menu** (⋯ icon) is available while a query chat is queued or
+  answering. It has options:
+  - **Show Full Activity** — replaces the chat transcript with the full run
+    activity feed.
   - **Hide tool calls** — filters tool-call rows.
   - **Exit status** — shows "Ended" or "Exited N" when the process finishes.
-  - **Reveal Debug Folder** — opens the run's debug trace folder in Finder
-    (ACP messages, permissions, usage, stderr.log).
+  - **Reveal Debug Folder** — opens the run's debug trace folder in Finder,
+    when the run created one.
 
 ### Export diagnostic information
 
-If a chat does not behave as expected, open the Activity menu and use one of
-these debug actions:
+If a query chat is queued or answering, open the Activity menu and use these
+debug actions:
 
 - **Copy Diagnostics** copies a redacted report to the clipboard.
-- **Write Redacted Diagnostics JSONL** saves the same report in the debug folder.
+- **Write Redacted Diagnostics JSONL** is available only after the run has a
+  debug folder. It saves the report there.
 
 The report includes timing, status, and row information. It does not include
 chat message text. Use the debug folder only when a developer asks for the

--- a/progress/2026-07-31T101712Z-chat-presentation-diagnostics-phase7.md
+++ b/progress/2026-07-31T101712Z-chat-presentation-diagnostics-phase7.md
@@ -40,8 +40,8 @@ diagnostics plan.
   `swiftpm-testing-helper` stopped producing output at 30 seconds and remained
   live past two minutes. The run was stopped without an aggregate result. This
   gate is bounded and inconclusive.
-- The SwiftUI runtime log query found no matching state-update warnings during
-  the hosted run.
+- The SwiftUI runtime log query was inconclusive because the hosted run did not
+  complete. It captured no aggregate runtime result.
 - The mutation command had started before this pass. Its log contains only the
   command start, and no mutation process was live. Mutation testing is bounded
   and inconclusive.


### PR DESCRIPTION
## Scope

- Remove the unreachable event-array chat renderer compatibility branch from ChatWebView.
- Keep the event-based adapter only for the Activity feed and retain Core legacy persistence dual writes.
- Add a narrow macOS CI invocation for the opt-in chat presentation API manifest.
- Correct chat help text for typed response state/time, full activity, and diagnostic exports.

## Verification

- WIKIFS_APP_TESTS=1 swift test --filter ChatPresentationAPIManifestTests
- WIKIFS_APP_TESTS=1 swift test --filter ChatWebViewLinkifyTests, AgentTranscriptRenderContextTests, and ChatTranscriptPresentationTests
- WIKIFS_APP_TESTS=1 swift test --filter ChatTranscriptHostedTests
- make build
- make test (2,715 tests in 219 suites)
- git diff --check

## Hosted AppKit note

The bounded aggregate WIKIFS_APP_TESTS=1 swift test run made progress, then stopped emitting output and was terminated at two minutes. It has no aggregate result. A concurrent runtime-log capture had no matching SwiftUI state-update warning during the focused hosted transcript suite.

Mutation testing was not run.
