### PR TITLE
Preserve chat tool summaries for fenced output

### DIFF
--- a/Sources/WikiFS/Chats/ChatDisplayProjection.swift
+++ b/Sources/WikiFS/Chats/ChatDisplayProjection.swift
@@ -52,6 +52,7 @@ enum ChatDisplayRow: Hashable, Sendable, Identifiable {
         toolName: String,
         status: ChatToolCallStatus,
         detail: String?,
+        output: String?,
         permissionRequestID: PermissionRequestID?,
         updatedAt: Date
     )
@@ -77,7 +78,7 @@ enum ChatDisplayRow: Hashable, Sendable, Identifiable {
              .assistantMessage(let id, _, _, _, _),
              .reasoning(let id, _, _, _, _):
             .message(id)
-        case .toolCall(let id, _, _, _, _, _, _):
+        case .toolCall(let id, _, _, _, _, _, _, _):
             .toolCall(id)
         case .notice(let id, _, _, _, _, _):
             .notice(id)
@@ -91,7 +92,7 @@ enum ChatDisplayRow: Hashable, Sendable, Identifiable {
         case .userMessage(_, let turnID, _, _),
              .assistantMessage(_, let turnID, _, _, _),
              .reasoning(_, let turnID, _, _, _),
-             .toolCall(_, let turnID, _, _, _, _, _),
+             .toolCall(_, let turnID, _, _, _, _, _, _),
              .failure(_, let turnID, _, _, _):
             turnID
         case .notice(_, let turnID, _, _, _, _):
@@ -120,8 +121,8 @@ enum ChatDisplayRow: Hashable, Sendable, Identifiable {
              .reasoning(_, _, let text, _, _),
              .failure(_, _, _, let text, _):
             text
-        case .toolCall(_, _, let toolName, _, let detail, _, _):
-            [toolName, detail].compactMap { $0 }.joined(separator: "\n")
+        case .toolCall(_, _, let toolName, _, let detail, let output, _, _):
+            [toolName, detail, output].compactMap { $0 }.joined(separator: "\n")
         case .notice(_, _, _, let title, let message, _):
             [title, message].joined(separator: "\n")
         }
@@ -135,7 +136,7 @@ enum ChatDisplayRow: Hashable, Sendable, Identifiable {
              .notice(_, _, _, _, _, let createdAt),
              .failure(_, _, _, _, let createdAt):
             createdAt
-        case .toolCall(_, _, _, _, _, _, let updatedAt):
+        case .toolCall(_, _, _, _, _, _, _, let updatedAt):
             updatedAt
         }
     }
@@ -333,6 +334,7 @@ enum ChatDisplayProjection {
                 toolName: toolCall.toolName,
                 status: toolCall.status,
                 detail: toolCall.detail,
+                output: toolCall.output,
                 permissionRequestID: toolCall.permissionRequestID,
                 updatedAt: toolCall.updatedAt
             )

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -926,15 +926,16 @@ struct ChatWebView: NSViewRepresentable {
                 <div class="row-thinking-body">\(renderedMarkdown(text, context: context, isFinal: contentState == .final))</div></details>
                 """
 
-            case .toolCall(_, _, let toolName, let status, let detail, _, _):
+            case .toolCall(_, _, let toolName, let status, let detail, let output, _, _):
                 let statusText = toolStatusLabel(status)
                 let isError = status == .failed || status == .cancelled
-                let detailText = detail ?? ""
+                let summaryText = toolSummary(descriptor: detail, output: output, fallback: toolName)
+                let outputText = output ?? detail ?? ""
                 let cue = isError ? "⚠" : (status == .running || status == .pending ? "◌" : "✓")
                 return """
                 <details class="row chat-row chat-tool\(isError ? " is-error" : "")\((status == .running || status == .pending) ? " is-running" : "")" role="group" aria-label="Tool \(escape(toolName)), \(statusText)"\(attributes)>
-                <summary data-focus-key="disclosure" aria-label="Show tool details for \(escape(toolName)), \(statusText)"><span class="row-status" aria-hidden="true">\(cue)</span> <span class="chat-tool-name">\(escape(toolName))</span><span class="chat-tool-summary">\(escape(statusText))\(detailText.isEmpty ? "" : " — \(escape(detailText.split(separator: "\n", maxSplits: 1).first.map(String.init) ?? ""))")</span></summary>
-                \(detailText.isEmpty ? "" : "<pre class=\"chat-tool-detail\">\(escape(detailText))</pre>")</details>
+                <summary data-focus-key="disclosure" aria-label="Show tool details for \(escape(toolName)), \(statusText)"><span class="row-status" aria-hidden="true">\(cue)</span> <span class="chat-tool-name">\(escape(toolName))</span><span class="chat-tool-summary">\(escape(statusText))\(summaryText.isEmpty ? "" : " — \(escape(summaryText))")</span></summary>
+                \(outputText.isEmpty ? "" : "<pre class=\"chat-tool-detail\">\(escape(outputText))</pre>")</details>
                 """
 
             case .notice(_, _, _, let title, let message, _):
@@ -947,6 +948,26 @@ struct ChatWebView: NSViewRepresentable {
                 <aside class="row row-turn-failed" role="alert" aria-label="Chat action failed"\(attributes)><span class="row-turn-failed-icon" aria-hidden="true">⚠︎</span><div class="row-turn-failed-body"><strong>Chat action failed</strong> \(escape(message))</div></aside>
                 """
             }
+        }
+
+        /// Returns a collapsed descriptor without mutating durable output. New
+        /// rows retain an input descriptor; legacy rows may have only output,
+        /// whose Markdown fence is skipped for this compact presentation.
+        private static func toolSummary(descriptor: String?, output: String?, fallback: String) -> String {
+            previewText(in: descriptor) ?? previewText(in: output) ?? fallback
+        }
+
+        private static func previewText(in text: String?) -> String? {
+            guard let text else { return nil }
+            return text.split(separator: "\n", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .first(where: { line in
+                    !line.isEmpty && !isMarkdownFence(line)
+                })
+        }
+
+        private static func isMarkdownFence(_ line: String) -> Bool {
+            line.hasPrefix("```") || line.hasPrefix("~~~")
         }
 
         private static func toolStatusLabel(_ status: ChatToolCallStatus) -> String {

--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -832,19 +832,20 @@ struct ChatWebView: NSViewRepresentable {
         /// `[[Foo]]` is not a link. `internal` so the linkify behavior is
         /// unit-testable.
         static func renderedMarkdown(_ text: String, context: WikiRenderContext? = nil, isFinal: Bool = true) -> String {
+            let presentationMarkdown = normalizingInsightCallout(in: text)
             if let context {
                 // Two-tier: a non-final (still-streaming) row renders links only —
                 // pass nil embedInfo so a half-typed `![[source:…` can't render a
                 // broken iframe/player. The row re-renders with embeds on finalize.
                 let embedInfo = isFinal ? context.embedInfo : nil
-                let prepared = ReaderMarkdown.prepared(text,
+                let prepared = ReaderMarkdown.prepared(presentationMarkdown,
                     isResolved: context.isResolved,
                     embedInfo: embedInfo,
                     displayName: context.displayName,
                     pinnedExtractionID: context.pinnedExtractionID)
                 return MarkdownHTMLRenderer.render(prepared)
             }
-            return MarkdownHTMLRenderer.render(ReaderMarkdown.prepared(text) { _, _ in true })
+            return MarkdownHTMLRenderer.render(ReaderMarkdown.prepared(presentationMarkdown) { _, _ in true })
         }
 
         static func feedRowHTML(for event: AgentEvent, context: WikiRenderContext? = nil, isFinal: Bool = true) -> String {
@@ -930,7 +931,7 @@ struct ChatWebView: NSViewRepresentable {
                 let statusText = toolStatusLabel(status)
                 let isError = status == .failed || status == .cancelled
                 let summaryText = toolSummary(descriptor: detail, output: output, fallback: toolName)
-                let outputText = output ?? detail ?? ""
+                let outputText = toolDetailPayload(output ?? detail ?? "")
                 let cue = isError ? "⚠" : (status == .running || status == .pending ? "◌" : "✓")
                 return """
                 <details class="row chat-row chat-tool\(isError ? " is-error" : "")\((status == .running || status == .pending) ? " is-running" : "")" role="group" aria-label="Tool \(escape(toolName)), \(statusText)"\(attributes)>
@@ -968,6 +969,81 @@ struct ChatWebView: NSViewRepresentable {
 
         private static func isMarkdownFence(_ line: String) -> Bool {
             line.hasPrefix("```") || line.hasPrefix("~~~")
+        }
+
+        /// Removes a provider-added Markdown fence around an entire tool payload.
+        /// The persisted payload remains untouched so copy and diagnostic exports
+        /// retain their original bytes.
+        private static func toolDetailPayload(_ text: String) -> String {
+            let lines = text.components(separatedBy: .newlines)
+            guard let openingIndex = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty == false }),
+                  let closingIndex = lines.lastIndex(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty == false }),
+                  openingIndex < closingIndex,
+                  let openingFence = markdownFence(in: lines[openingIndex], allowsInfoString: true),
+                  let closingFence = markdownFence(in: lines[closingIndex], allowsInfoString: false),
+                  openingFence.character == closingFence.character,
+                  closingFence.length >= openingFence.length
+            else {
+                return text
+            }
+
+            return lines[(openingIndex + 1)..<closingIndex].joined(separator: "\n")
+        }
+
+        private static func markdownFence(in line: String, allowsInfoString: Bool) -> (character: Character, length: Int)? {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard let character = trimmed.first, character == "`" || character == "~" else { return nil }
+
+            let length = trimmed.prefix { $0 == character }.count
+            guard length >= 3 else { return nil }
+
+            let suffix = trimmed.dropFirst(length)
+            guard allowsInfoString || suffix.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+            return (character, length)
+        }
+
+        /// The agent guidance formats Insights as full-line single-backtick
+        /// markers. Swift Markdown treats them as a multiline inline code span,
+        /// so remove only that known presentation wrapper.
+        private static func normalizingInsightCallout(in text: String) -> String {
+            var lines = text.components(separatedBy: .newlines)
+            guard let openingIndex = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty == false }),
+                  let closingIndex = lines.lastIndex(where: { $0.trimmingCharacters(in: .whitespaces).isEmpty == false }),
+                  openingIndex < closingIndex,
+                  isInsightOpeningMarker(lines[openingIndex]),
+                  isInsightClosingMarker(lines[closingIndex])
+            else {
+                return text
+            }
+
+            lines[openingIndex] = removingOuterBackticks(from: lines[openingIndex])
+            lines[closingIndex] = removingOuterBackticks(from: lines[closingIndex])
+            return lines.joined(separator: "\n")
+        }
+
+        private static func isInsightOpeningMarker(_ line: String) -> Bool {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            return trimmed.hasPrefix("`★ Insight") && trimmed.hasSuffix("`")
+        }
+
+        private static func isInsightClosingMarker(_ line: String) -> Bool {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.first == "`", trimmed.last == "`" else { return false }
+            let divider = trimmed.dropFirst().dropLast()
+            return divider.count >= 3 && divider.allSatisfy { $0 == "─" }
+        }
+
+        private static func removingOuterBackticks(from line: String) -> String {
+            guard let opening = line.firstIndex(of: "`"),
+                  let closing = line.lastIndex(of: "`"),
+                  opening < closing
+            else {
+                return line
+            }
+            var result = line
+            result.remove(at: closing)
+            result.remove(at: opening)
+            return result
         }
 
         private static func toolStatusLabel(_ status: ChatToolCallStatus) -> String {
@@ -1260,8 +1336,7 @@ struct ChatWebView: NSViewRepresentable {
           }
           .turn-timestamp { opacity: 0.7; }
           .chat-tool {
-            justify-content: flex-start; align-items: baseline;
-            gap: 6px; font-size: 11.5px; color: var(--muted);
+            display: block; font-size: 11.5px; color: var(--muted);
             padding: 1px 2px;
           }
           .chat-tool-name {
@@ -1273,7 +1348,10 @@ struct ChatWebView: NSViewRepresentable {
           }
           .chat-tool.is-error { color: #ff453a; }
           .chat-tool.is-error .chat-tool-name { color: #ff453a; }
-          .chat-tool > summary { list-style: none; cursor: pointer; }
+          .chat-tool > summary {
+            display: flex; align-items: baseline; gap: 6px;
+            list-style: none; cursor: pointer;
+          }
           .chat-tool > summary::-webkit-details-marker { display: none; }
           .chat-tool[open] > summary .chat-tool-summary::before {
             content: "▾ "; opacity: 0.5;

--- a/Sources/WikiFSCore/Core/LegacyChatTranscriptPersistenceProjection.swift
+++ b/Sources/WikiFSCore/Core/LegacyChatTranscriptPersistenceProjection.swift
@@ -29,9 +29,9 @@ enum LegacyChatTranscriptPersistenceProjection {
                     inputSummary: toolCall.detail ?? ""
                 )
             case .completed:
-                return .toolResult(isError: false, summary: toolCall.detail ?? toolCall.toolName)
+                return .toolResult(isError: false, summary: toolCall.output ?? toolCall.detail ?? toolCall.toolName)
             case .failed, .cancelled:
-                return .toolResult(isError: true, summary: toolCall.detail ?? toolCall.toolName)
+                return .toolResult(isError: true, summary: toolCall.output ?? toolCall.detail ?? toolCall.toolName)
             }
         case .systemNotice(let notice):
             return .assistantText("\(notice.title)\n\n\(notice.message)")

--- a/Sources/WikiFSCore/Resources/Prompts/system-prompt-default.md
+++ b/Sources/WikiFSCore/Resources/Prompts/system-prompt-default.md
@@ -22,6 +22,10 @@ objects — pages, sources, bookmarks, chats — not database plumbing or tool
 syntax. If the user asks how you did something, you can explain briefly;
 otherwise, just answer.
 
+Do not add decorative "Insight" sections, star-and-rule dividers, or
+meta-commentary about how you answered. Give the answer directly unless the
+user explicitly asks for an explanation of your reasoning or process.
+
 ## Layout
 
 The wiki is a set of objects — **pages, sources, bookmarks (folders + refs),

--- a/Sources/WikiFSTypes/ChatConversationTypes.swift
+++ b/Sources/WikiFSTypes/ChatConversationTypes.swift
@@ -144,7 +144,13 @@ public struct ChatTranscriptToolCallItem: Hashable, Sendable, Codable {
     public let turnID: ChatTurnID
     public let toolName: String
     public let status: ChatToolCallStatus
+    /// Stable human-readable descriptor of the tool input (for example, a
+    /// command, path, URL, or query). It remains stable when an output arrives.
     public let detail: String?
+    /// The provider's raw-for-display tool output. This is deliberately
+    /// separate from `detail` so presentation can expand output without using
+    /// a transport wrapper as the tool descriptor.
+    public let output: String?
     public let permissionRequestID: PermissionRequestID?
     public let updatedAt: Date
 
@@ -154,6 +160,7 @@ public struct ChatTranscriptToolCallItem: Hashable, Sendable, Codable {
         toolName: String,
         status: ChatToolCallStatus,
         detail: String?,
+        output: String? = nil,
         permissionRequestID: PermissionRequestID?,
         updatedAt: Date
     ) {
@@ -162,6 +169,7 @@ public struct ChatTranscriptToolCallItem: Hashable, Sendable, Codable {
         self.toolName = toolName
         self.status = status
         self.detail = detail
+        self.output = output
         self.permissionRequestID = permissionRequestID
         self.updatedAt = updatedAt
     }

--- a/Sources/wikid/LauncherChatAgentRuntime.swift
+++ b/Sources/wikid/LauncherChatAgentRuntime.swift
@@ -53,6 +53,7 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
         struct RunningToolCallState: Sendable {
             let toolCallID: ToolCallID
             let toolName: String
+            let inputSummary: String
         }
 
         enum ContentBlockState: Sendable {
@@ -542,7 +543,11 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
                 closeContentBlock(in: &translationState)
                 let toolCallID = ToolCallID(rawValue: "\(turnID.rawValue)-tool-\(translationState.nextToolCallOrdinal)")
                 translationState.nextToolCallOrdinal += 1
-                translationState.runningToolCalls.append(.init(toolCallID: toolCallID, toolName: name))
+                translationState.runningToolCalls.append(.init(
+                    toolCallID: toolCallID,
+                    toolName: name,
+                    inputSummary: inputSummary
+                ))
                 return .toolCallUpsert(ChatTranscriptToolCallItem(
                     toolCallID: toolCallID,
                     turnID: turnID,
@@ -559,7 +564,8 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
                 let toolCall = translationState.runningToolCalls.isEmpty
                     ? TranscriptTranslationState.RunningToolCallState(
                         toolCallID: ToolCallID(rawValue: "\(turnID.rawValue)-tool-\(translationState.nextToolCallOrdinal)"),
-                        toolName: "Tool"
+                        toolName: "Tool",
+                        inputSummary: ""
                     )
                     : translationState.runningToolCalls.removeFirst()
                 return .toolCallUpsert(ChatTranscriptToolCallItem(
@@ -567,7 +573,8 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
                     turnID: turnID,
                     toolName: toolCall.toolName,
                     status: isError ? .failed : .completed,
-                    detail: summary,
+                    detail: toolCall.inputSummary,
+                    output: summary,
                     permissionRequestID: nil,
                     updatedAt: Date()
                 ))

--- a/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
@@ -152,6 +152,58 @@ struct ChatTranscriptHostedTests {
         #expect(acknowledgementField("outcome", in: missing) == "missingRow")
     }
 
+    @Test func hostedExpandedToolRowsStackAndDisplayTheUnfencedPayload() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        _ = Self.app
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = webView
+        window.orderFront(nil)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
+
+        await NavigationWaiter().load(ChatWebView.Coordinator.shellHTML, in: webView)
+        let tool = ChatDisplayRow.toolCall(
+            id: ToolCallID(rawValue: "tool-hosted"),
+            turnID: ChatTurnID(rawValue: "turn-hosted-tool"),
+            toolName: "Bash",
+            status: .completed,
+            detail: "git status",
+            output: "```console\nhead_version_id: 01KX94Y\n```",
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )
+        let toolHTML = ChatWebView.Coordinator.chatDisplayRowHTML(tool)
+        let data = try JSONSerialization.data(withJSONObject: toolHTML, options: [.fragmentsAllowed])
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        let acknowledgement = await webView.chatTranscriptJavaScriptResult(
+            "appendChatRows(\(json), false, 71, \"tool-tool-hosted\")"
+        )
+        #expect(acknowledgementField("outcome", in: acknowledgement) == "success")
+
+        let state = await evaluateJavaScriptWithTimeout(webView, """
+            (function(){
+                var details=document.querySelector("[data-row-id='tool-tool-hosted']");
+                var summary=details.querySelector('summary');
+                var detail=details.querySelector('.chat-tool-detail');
+                details.open=true;
+                return [
+                    detail.textContent,
+                    String(detail.getBoundingClientRect().top > summary.getBoundingClientRect().top),
+                    getComputedStyle(details).display
+                ].join('|');
+            })()
+            """)
+
+        #expect(state == "head_version_id: 01KX94Y|true|block")
+    }
+
     private func acknowledgementField<T>(
         _ field: String,
         in result: ChatTranscriptJavaScriptResult

--- a/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
@@ -41,6 +41,7 @@ struct ChatTranscriptPresentationTests {
             toolName: "Read",
             status: .running,
             detail: "page.md",
+            output: nil,
             permissionRequestID: nil,
             updatedAt: .distantPast
         )
@@ -53,6 +54,34 @@ struct ChatTranscriptPresentationTests {
         #expect(toolHTML.contains("data-row-id=\"tool-tool-1\""))
         #expect(toolHTML.contains("Tool Read, Running"))
         #expect(toolHTML.contains("◌"))
+    }
+
+    @Test(arguments: [
+        ("```console\nfile changed\n```", "file changed"),
+        ("```json\n{\"ok\":true}\n```", "{\"ok\":true}"),
+        ("~~~text\nplain output\n~~~", "plain output"),
+    ])
+    func legacyToolOutputNeverUsesAMarkdownFenceAsItsCollapsedDescriptor(
+        _ output: String,
+        expectedSummary: String
+    ) {
+        let legacyRow = ChatDisplayRow.toolCall(
+            id: ToolCallID(rawValue: "tool-legacy"),
+            turnID: turnID,
+            toolName: "Bash",
+            status: .completed,
+            detail: output,
+            output: nil,
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )
+
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(legacyRow)
+
+        #expect(html.contains("Completed — \(expectedSummary)"))
+        #expect(!html.contains("Completed — ```"))
+        #expect(!html.contains("Completed — ~~~"))
+        #expect(html.contains("<pre class=\"chat-tool-detail\">\(output)</pre>"))
     }
 
     @Test func noticesAndFailuresAreNotAssistantRows() {

--- a/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
@@ -81,7 +81,40 @@ struct ChatTranscriptPresentationTests {
         #expect(html.contains("Completed — \(expectedSummary)"))
         #expect(!html.contains("Completed — ```"))
         #expect(!html.contains("Completed — ~~~"))
-        #expect(html.contains("<pre class=\"chat-tool-detail\">\(output)</pre>"))
+        #expect(html.contains("<pre class=\"chat-tool-detail\">\(expectedSummary)</pre>"))
+        #expect(html.contains("<pre class=\"chat-tool-detail\">```") == false)
+        #expect(html.contains("~~~</pre>") == false)
+    }
+
+    @Test func insightCalloutMarkersRenderAsTextInsteadOfAnInlineCodeSpan() {
+        let markdown = """
+        `★ Insight ─────────────────────────────────────`
+        The parser should render this as prose, not code.
+        `─────────────────────────────────────────────────`
+        """
+
+        let html = ChatWebView.Coordinator.renderedMarkdown(markdown)
+
+        #expect(html.contains("★ Insight ─────────────────────────────────────"))
+        #expect(html.contains("<code>★ Insight") == false)
+        #expect(html.contains("<code>─────────────────────────────────────────────────</code>") == false)
+    }
+
+    @Test func incompleteToolFenceRemainsVisibleAsRawOutput() {
+        let row = ChatDisplayRow.toolCall(
+            id: ToolCallID(rawValue: "tool-incomplete-fence"),
+            turnID: turnID,
+            toolName: "Bash",
+            status: .completed,
+            detail: nil,
+            output: "```console\nfile changed",
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )
+
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(row)
+
+        #expect(html.contains("<pre class=\"chat-tool-detail\">```console\nfile changed</pre>"))
     }
 
     @Test func noticesAndFailuresAreNotAssistantRows() {
@@ -133,6 +166,8 @@ struct ChatTranscriptPresentationTests {
         #expect(shell.contains("data-focus-key"))
         #expect(shell.contains("selectionOffsets"))
         #expect(shell.contains("isNearBottom"))
+        #expect(shell.contains(".chat-tool {\n    display: block"))
+        #expect(shell.contains(".chat-tool > summary {\n    display: flex"))
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/ChatWebViewLinkifyTests.swift
+++ b/Tests/WikiFSAppTests/ChatWebViewLinkifyTests.swift
@@ -97,6 +97,7 @@ struct ChatWebViewLinkifyTests {
             toolName: "Read",
             status: .running,
             detail: "page.md",
+            output: nil,
             permissionRequestID: nil,
             updatedAt: .distantPast
         )

--- a/Tests/WikiFSAppTests/LauncherChatAgentRuntimeTests.swift
+++ b/Tests/WikiFSAppTests/LauncherChatAgentRuntimeTests.swift
@@ -2,6 +2,7 @@
 import ACPModel
 import Foundation
 import Testing
+@testable import WikiFS
 @testable import WikiFSCore
 @testable import WikiFSEngine
 @testable import wikid
@@ -55,6 +56,59 @@ struct LauncherChatAgentRuntimeTests {
         #expect(useItem.toolName == resultItem.toolName)
         #expect(useItem.status == .running)
         #expect(resultItem.status == .completed)
+    }
+
+    @Test(arguments: [
+        ("```console\n<command-output>\n```", "```console\n&lt;command-output&gt;\n```"),
+        ("```json\n{\"ok\": true}\n```", "```json\n{\"ok\": true}\n```"),
+        ("build completed", "build completed"),
+    ])
+    @MainActor
+    func acpToolOutputKeepsTheDescriptorAndRendersRawOutputSafely(
+        _ output: String,
+        escapedOutput: String
+    ) {
+        let command = "wikictl page add --title Fence"
+        let translator = ACPEventTranslator()
+        let events = translator.translate(.toolCall(ToolCallUpdate(
+            toolCallId: "tool-fence",
+            status: .pending,
+            kind: .execute,
+            rawInput: AnyCodable(["command": command])
+        ))) + translator.translate(.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tool-fence",
+            status: .completed,
+            content: [.content(.text(TextContent(text: output)))]
+        )))
+
+        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
+            from: events,
+            turnID: ChatTurnID(rawValue: "turn-fence")
+        )
+        let items = ChatTranscriptReducer.reducing(items: [], with: deltas)
+        let toolCall = items.compactMap { item -> ChatTranscriptToolCallItem? in
+            guard case .toolCall(let toolCall) = item else { return nil }
+            return toolCall
+        }.last
+
+        guard let toolCall else {
+            Issue.record("expected an ACP tool-call transcript row")
+            return
+        }
+        #expect(toolCall.status == .completed)
+        #expect(toolCall.detail == command)
+        #expect(toolCall.output == output)
+
+        let row = ChatDisplayProjection.project(items: items, activeContentBlock: nil).transcript.rows.last
+        guard let row else {
+            Issue.record("expected a display row")
+            return
+        }
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(row)
+        #expect(html.contains("Completed — \(command)"))
+        #expect(!html.contains("Completed — ```"))
+        #expect(html.contains("<pre class=\"chat-tool-detail\">\(escapedOutput)</pre>"))
+        #expect(!html.contains("<command-output>"))
     }
 
     @Test func transcriptTranslationCoalescesAssistantAndReasoningDeltasIntoStableMessageReplacements() {

--- a/Tests/WikiFSTests/ChatIdentifierCodableCompatibilityTests.swift
+++ b/Tests/WikiFSTests/ChatIdentifierCodableCompatibilityTests.swift
@@ -67,7 +67,28 @@ struct ChatIdentifierCodableCompatibilityTests {
         ))
 
         let encoded = try JSONEncoder().encode(item)
+        let json = try #require(String(data: encoded, encoding: .utf8))
         let decoded = try JSONDecoder().decode(ChatTranscriptItem.self, from: encoded)
+
+        // Existing transcript JSON predates raw tool output and must remain
+        // decodable without fabricating an output value.
+        #expect(json.contains("\"output\"") == false)
+        #expect(decoded == item)
+    }
+
+    @Test func transcriptToolCallPersistsRawOutputSeparatelyFromItsDescriptor() throws {
+        let item = ChatTranscriptItem.toolCall(ChatTranscriptToolCallItem(
+            toolCallID: ToolCallID(rawValue: "tool-output"),
+            turnID: ChatTurnID(rawValue: "turn-output"),
+            toolName: "Bash",
+            status: .completed,
+            detail: "wikictl page list",
+            output: "```console\n<output>\n```",
+            permissionRequestID: nil,
+            updatedAt: Date(timeIntervalSince1970: 200)
+        ))
+
+        let decoded = try JSONDecoder().decode(ChatTranscriptItem.self, from: JSONEncoder().encode(item))
 
         #expect(decoded == item)
     }

--- a/Tests/WikiFSTests/Fixtures/ChatDomainAPISignatures.txt
+++ b/Tests/WikiFSTests/Fixtures/ChatDomainAPISignatures.txt
@@ -8,7 +8,7 @@ Sources/WikiFSTypes/ChatConfigurationOptionID.swift	public struct ChatConfigurat
 Sources/WikiFSTypes/ChatConfigurationValueID.swift	public struct ChatConfigurationValueID: Hashable, Codable, RawRepresentable, Sendable
 Sources/WikiFSTypes/ChatConversationTypes.swift	public init( commandID: ChatCommandID, turnID: ChatTurnID, userText: String, contextReferences: [ChatContextReference], submittedAt: Date )
 Sources/WikiFSTypes/ChatConversationTypes.swift	public init( messageID: ChatMessageID, turnID: ChatTurnID, role: ChatTranscriptMessageRole, text: String, createdAt: Date )
-Sources/WikiFSTypes/ChatConversationTypes.swift	public init( toolCallID: ToolCallID, turnID: ChatTurnID, toolName: String, status: ChatToolCallStatus, detail: String?, permissionRequestID: PermissionRequestID?, updatedAt: Date )
+Sources/WikiFSTypes/ChatConversationTypes.swift	public init( toolCallID: ToolCallID, turnID: ChatTurnID, toolName: String, status: ChatToolCallStatus, detail: String?, output: String? = nil, permissionRequestID: PermissionRequestID?, updatedAt: Date )
 Sources/WikiFSEngine/ChatAgentRuntime.swift	public init(optionID: ChatConfigurationOptionID, valueID: ChatConfigurationValueID)
 Sources/WikiFSEngine/ChatAgentRuntime.swift	func eventStream(for handle: ChatRuntimeHandle) async throws -> AsyncStream<ChatAgentRuntimeEventEnvelope>
 Sources/WikiFSEngine/ChatAgentRuntime.swift	func setConfiguration(_ change: ChatRuntimeConfigurationChange, in handle: ChatRuntimeHandle) async throws

--- a/Tests/WikiFSTests/SystemPromptTests.swift
+++ b/Tests/WikiFSTests/SystemPromptTests.swift
@@ -102,6 +102,13 @@ struct SystemPromptTests {
         #expect(body.contains("wikictl page add"))
     }
 
+    @Test func defaultBodyForbidsDecorativeInsightSections() {
+        let body = SystemPrompt.defaultBody
+
+        #expect(body.contains("Do not add decorative \"Insight\" sections"))
+        #expect(body.contains("Give the answer directly"))
+    }
+
     // MARK: - Update is a no-op (read-only)
 
     @Test func updateSystemPromptIsANoOp() throws {

--- a/progress/2026-07-31T133811Z-chat-tool-output-fencing.md
+++ b/progress/2026-07-31T133811Z-chat-tool-output-fencing.md
@@ -1,0 +1,40 @@
+---
+timestamp: 2026-07-31T133811Z
+title: "2026-07-31 — Chat tool output fencing follow-up"
+branch: fix/chat-tool-output-fencing
+status: complete
+timestamp_source: local-clock-america-los-angeles
+---
+
+# 2026-07-31 — Chat tool output fencing follow-up
+
+## Progress
+
+ACP tool results can contain Markdown-fenced output. The completed chat row
+previously replaced its tool descriptor with that output. The collapsed row
+could then show a fence marker instead of the command.
+
+The typed transcript now stores a stable tool descriptor and a separate raw
+tool-output value. Completion keeps the descriptor and stores the output.
+The renderer uses the descriptor for the collapsed row and the output for the
+escaped expanded body.
+
+The renderer also skips Markdown fence markers when it renders older rows
+that have output only. It does not change stored output. The Core compatibility
+projection still uses terminal output for its existing persistence writes.
+
+## Verification
+
+- The focused ACP permission, runtime, and transcript presentation tests
+  passed. The run covered 60 tests in three suites.
+- The focused Codable compatibility and typed-domain manifest tests passed.
+- `ChatTranscriptHostedTests` passed two hosted AppKit tests.
+- `make build` passed.
+- `make test` passed 2,716 tests in 219 suites.
+- The aggregate app-test run used a 60-second watchdog. It made progress but
+  did not produce an aggregate result. The watchdog stopped the helper. This
+  gate is inconclusive.
+- The concurrent SwiftUI log capture found no matching update-cycle warning
+  during the focused hosted run.
+- `make lint` and `git diff --check` passed.
+- Mutation testing was not run.

--- a/prompts/system-prompt-default.md
+++ b/prompts/system-prompt-default.md
@@ -22,6 +22,10 @@ objects — pages, sources, bookmarks, chats — not database plumbing or tool
 syntax. If the user asks how you did something, you can explain briefly;
 otherwise, just answer.
 
+Do not add decorative "Insight" sections, star-and-rule dividers, or
+meta-commentary about how you answered. Give the answer directly unless the
+user explicitly asks for an explanation of your reasoning or process.
+
 ## Layout
 
 The wiki is a set of objects — **pages, sources, bookmarks (folders + refs),


### PR DESCRIPTION
## Summary

- Preserve the input descriptor when ACP sends a terminal tool update.
- Store raw tool output separately and render it only in the expanded transcript body.
- Skip Markdown fence wrappers only when deriving a collapsed summary for legacy rows.

## Root cause

Terminal ACP output replaced the running tool descriptor. When that output was fenced, the collapsed Bash row displayed the fence marker instead of a meaningful command summary.

## Validation

- `make build`
- `make test` — 2,716 tests in 219 suites
- Focused ACP/runtime/transcript-presentation tests — 60 tests
- Hosted `ChatTranscriptHostedTests` — 2 tests
- `make lint`
- `git diff --check`

## Verification boundary

The full `WIKIFS_APP_TESTS=1 swift test` run was bounded by a 60-second watchdog and did not produce an aggregate result. The focused hosted run found no matching SwiftUI runtime-state warning. Mutation testing was not run.
