### PR TITLE
Issue #1005 Phase 2: persist chat lifecycle usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,15 @@ jobs:
         env:
           SKIP: 'CLITantivyLegResolverTests|TantivySmokeTests|TantivyShadowIndexTests|TantivyBM25LegCutoverTests|TantivyAutocompleteTests|RunAwaitsTurnTests|SourceEmbeddingSearchTests|PdfExtractionServiceTests|YouTubeEmbedWebViewTests|QuoteHighlightWebViewTests|SplitDiffSnapshotTests|BlobSchemeHandlerTests|ReaderRenderPerfTests|TransclusionEmbedTests|PageDetailViewHostedTests|PageVersionTests|EnumeratorDeletionTests|BlobVacuumTests|AgentCASTests|GenerationGateLaneTests|WorkspaceStagingTests|WorkspaceMergeCompletenessTests|IngestIsolationTests|IngestGateTests|ChatSummaryTests|ProjectionTreeTests|SessionManagerTests|SidebarDropBuilderIntegrationTests|MediaEmbedPlayerTests|Phase6PinningModelTests|DropLinkTextViewDropTests|ComposerTextViewTests|EditorAutocompleteHostedTests|ComposerAutocompleteHostedTests|ChatAutocompleteSelectionTests|ChatAutocompletePanelPlacementTests|ActivityPermissionPendingRowTests|AddressBarLayoutHostedTests|BookmarkInsertPositionTests|SidebarDragPasteboardBridgeTests|SidebarSelectAllShortcutTests|SourceDetailWebViewMenuTests|SourceWebAnchorTests|FootnoteAnchorTests|RetryStuckRegressionTests|ExternalWriteBookmarkRefreshTests|ExternalWriteDraftRefreshTests'
         run: xcrun swift test --parallel --filter WikiFSCoreTests --skip "$SKIP"
-      - name: Test chat presentation API manifest
-        # This opt-in app target contains source-contract tests only. It does
-        # not host AppKit or WebKit views, so it avoids the known aggregate
-        # SwiftPM helper wedge while keeping the Phase 7 compatibility guard live.
+      - name: Test opt-in chat lifecycle suites
+        # This opt-in app target contains source-contract and daemon lifecycle
+        # tests only. It does not host AppKit or WebKit views, so it avoids the
+        # known aggregate SwiftPM helper wedge while keeping the Phase 7
+        # compatibility guard and persisted chat lifecycle coverage live.
         timeout-minutes: 15
         env:
           WIKIFS_APP_TESTS: "1"
-        run: xcrun swift test --filter ChatPresentationAPIManifestTests
+        run: xcrun swift test --filter 'ChatPresentationAPIManifestTests|DaemonChatUsageTests|DaemonChatControllerMetadataTests|DaemonChatControllerTests'
 
   # Linux Swift CI (#754) — builds and tests the portable target
   # (WikiFSCoreTests) on ubuntu-latest. Validates the macOS/Linux

--- a/Sources/WikiFSEngine/ACPModelValueTypes.swift
+++ b/Sources/WikiFSEngine/ACPModelValueTypes.swift
@@ -17,7 +17,7 @@ import WikiFSTypes
 
 /// Cumulative token/cost usage for a session. Populated by `ACPBackend` from
 /// ACP `Usage` / `UsageUpdate` events; emitted to the queue system and UI.
-public struct SessionUsage: Sendable, Codable, Equatable {
+public struct SessionUsage: Sendable, Codable, Equatable, Hashable {
     /// Cumulative input tokens across all turns (from `Usage.inputTokens`).
     public let inputTokens: Int
     /// Cumulative output tokens across all turns (from `Usage.outputTokens`).
@@ -26,6 +26,9 @@ public struct SessionUsage: Sendable, Codable, Equatable {
     public let totalTokens: Int
     /// Cumulative cached-read tokens (from `Usage.cachedReadTokens`), if reported.
     public let cachedReadTokens: Int?
+    /// Cumulative cached-write tokens, if the provider reports a separate
+    /// write-side cache counter.
+    public let cachedWriteTokens: Int?
     /// Cumulative thought/reasoning tokens (from `Usage.thoughtTokens`), if reported.
     public let thoughtTokens: Int?
     /// The last reported cost amount (from `UsageUpdate.cost.amount`), if any.
@@ -60,6 +63,7 @@ public struct SessionUsage: Sendable, Codable, Equatable {
         outputTokens: Int,
         totalTokens: Int,
         cachedReadTokens: Int?,
+        cachedWriteTokens: Int? = nil,
         thoughtTokens: Int?,
         cost: Double?,
         currency: String?,
@@ -74,6 +78,7 @@ public struct SessionUsage: Sendable, Codable, Equatable {
         self.outputTokens = outputTokens
         self.totalTokens = totalTokens
         self.cachedReadTokens = cachedReadTokens
+        self.cachedWriteTokens = cachedWriteTokens
         self.thoughtTokens = thoughtTokens
         self.cost = cost
         self.currency = currency
@@ -102,6 +107,7 @@ public struct SessionUsage: Sendable, Codable, Equatable {
             outputTokens: existing.outputTokens + new.outputTokens,
             totalTokens: existing.totalTokens + new.totalTokens,
             cachedReadTokens: (existing.cachedReadTokens ?? 0) + (new.cachedReadTokens ?? 0),
+            cachedWriteTokens: (existing.cachedWriteTokens ?? 0) + (new.cachedWriteTokens ?? 0),
             thoughtTokens: (existing.thoughtTokens ?? 0) + (new.thoughtTokens ?? 0),
             cost: mergedCost,
             currency: new.currency ?? existing.currency,
@@ -143,6 +149,7 @@ public struct SessionUsage: Sendable, Codable, Equatable {
             outputTokens: max(0, new.outputTokens - from.outputTokens),
             totalTokens: max(0, new.totalTokens - from.totalTokens),
             cachedReadTokens: max(0, (new.cachedReadTokens ?? 0) - (from.cachedReadTokens ?? 0)),
+            cachedWriteTokens: max(0, (new.cachedWriteTokens ?? 0) - (from.cachedWriteTokens ?? 0)),
             thoughtTokens: max(0, (new.thoughtTokens ?? 0) - (from.thoughtTokens ?? 0)),
             cost: deltaCost,
             currency: new.currency ?? from.currency,

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -2906,6 +2906,7 @@ public final class AgentLauncher {
         chatOverrideModelId: ModelID? = nil,
         onAcpSessionId: (@MainActor (AcpSessionID?) -> Void)? = nil,
         onEvent: (@Sendable (AgentEvent) -> Void)? = nil,
+        onLiveUsage: (@Sendable (SessionUsage) -> Void)? = nil,
         onPendingPermission: (@Sendable (PendingPermission?) -> Void)? = nil,
         onLock: @escaping @MainActor () -> Void,
         onUnlock: @escaping @MainActor @Sendable () -> Void,
@@ -2994,6 +2995,9 @@ public final class AgentLauncher {
         }
 
         self.backend = resolveBackend(policy, permissionBudget, turnCeiling)
+        self.onLiveUsage = onLiveUsage
+        self.liveUsageProviderLabel = provider.label
+        await installLiveUsageCallback(on: self.backend)
         let loginShellPath = await PathPreflight.loginShellPATH()
 
         // Resolve the provider's spawn command (PATH-resolved) + the

--- a/Sources/WikiFSEngine/ChatAgentRuntime.swift
+++ b/Sources/WikiFSEngine/ChatAgentRuntime.swift
@@ -49,9 +49,10 @@ public enum ChatAgentRuntimeEvent: Hashable, Sendable, Codable {
     case transcript([ChatTranscriptDelta])
     case permissionRequested(ChatPendingPermissionRequest)
     case permissionResolved(ChatPermissionResolution)
-    /// A cumulative usage snapshot for the provider session. The controller,
-    /// rather than the runtime, attributes it to the active durable turn.
-    case usage(SessionUsage)
+    /// A cumulative provider-session snapshot attributed by the runtime to its
+    /// active turn. The controller remains the only lifecycle persistence
+    /// writer and rejects snapshots for a non-current durable claim.
+    case usage(turnID: ChatTurnID, usage: SessionUsage)
     case turnCompleted(ChatTurnID)
     case turnFailed(turnID: ChatTurnID, category: ChatTurnFailureCategory, message: String)
     case turnCancelled(ChatTurnID)

--- a/Sources/WikiFSEngine/ChatAgentRuntime.swift
+++ b/Sources/WikiFSEngine/ChatAgentRuntime.swift
@@ -49,6 +49,9 @@ public enum ChatAgentRuntimeEvent: Hashable, Sendable, Codable {
     case transcript([ChatTranscriptDelta])
     case permissionRequested(ChatPendingPermissionRequest)
     case permissionResolved(ChatPermissionResolution)
+    /// A cumulative usage snapshot for the provider session. The controller,
+    /// rather than the runtime, attributes it to the active durable turn.
+    case usage(SessionUsage)
     case turnCompleted(ChatTurnID)
     case turnFailed(turnID: ChatTurnID, category: ChatTurnFailureCategory, message: String)
     case turnCancelled(ChatTurnID)

--- a/Sources/wikid/ChatTurnUsageAccumulator.swift
+++ b/Sources/wikid/ChatTurnUsageAccumulator.swift
@@ -10,7 +10,10 @@ import WikiFSEngine
 /// claim, so no runtime or provider can author durable lifecycle state.
 struct ChatTurnUsageAccumulator: Sendable {
     private let baseline: SessionUsage
-    private var latestSessionSnapshot: SessionUsage?
+    /// Once provider snapshots disagree about currency, a single turn has no
+    /// meaningful cost unit. Keep that fact latched so a later snapshot cannot
+    /// make an ambiguous cost appear valid again.
+    private var isCostUnavailableAfterCurrencyConflict = false
     private(set) var values = ChatTurnUsageValues()
 
     init(baseline: SessionUsage) {
@@ -22,8 +25,7 @@ struct ChatTurnUsageAccumulator: Sendable {
     /// prior value; a changed currency makes the cost unavailable.
     @discardableResult
     mutating func record(_ snapshot: SessionUsage) -> ChatTurnUsageValues {
-        let priorSession = latestSessionSnapshot
-        latestSessionSnapshot = monotonicSessionSnapshot(previous: priorSession, next: snapshot)
+        let cost = mergedCost(snapshot: snapshot)
 
         values = ChatTurnUsageValues(
             inputTokens: greatestValid(previous: values.inputTokens, baseline: baseline.inputTokens, snapshot: snapshot.inputTokens),
@@ -31,8 +33,8 @@ struct ChatTurnUsageAccumulator: Sendable {
             thoughtTokens: greatestValid(previous: values.thoughtTokens, baseline: baseline.thoughtTokens, snapshot: snapshot.thoughtTokens),
             cacheReadTokens: greatestValid(previous: values.cacheReadTokens, baseline: baseline.cachedReadTokens, snapshot: snapshot.cachedReadTokens),
             cacheWriteTokens: greatestValid(previous: values.cacheWriteTokens, baseline: baseline.cachedWriteTokens, snapshot: snapshot.cachedWriteTokens),
-            cost: mergedCost(snapshot: snapshot),
-            currency: mergedCurrency(snapshot: snapshot)
+            cost: cost.cost,
+            currency: cost.currency
         )
         return values
     }
@@ -49,54 +51,22 @@ struct ChatTurnUsageAccumulator: Sendable {
         return max(previous ?? 0, candidate)
     }
 
-    private func mergedCost(snapshot: SessionUsage) -> Decimal? {
-        guard let cost = snapshot.cost, cost >= 0 else { return values.cost }
-        guard let currency = snapshot.currency else { return values.cost }
-        if let persistedCurrency = values.currency, persistedCurrency != currency {
-            DebugLog.agent("DaemonChatController rejected usage cost after currency changed from \(persistedCurrency) to \(currency).")
-            return nil
+    private mutating func mergedCost(snapshot: SessionUsage) -> (cost: Decimal?, currency: String?) {
+        guard isCostUnavailableAfterCurrencyConflict == false else { return (nil, nil) }
+        guard let currency = snapshot.currency else { return (values.cost, values.currency) }
+
+        let expectedCurrency = values.currency ?? baseline.currency
+        if let expectedCurrency, expectedCurrency != currency {
+            isCostUnavailableAfterCurrencyConflict = true
+            DebugLog.agent("DaemonChatController rejected usage cost after currency changed from \(expectedCurrency) to \(currency).")
+            return (nil, nil)
         }
-        if let baselineCurrency = baseline.currency, baselineCurrency != currency {
-            DebugLog.agent("DaemonChatController rejected usage cost after baseline currency changed from \(baselineCurrency) to \(currency).")
-            return nil
+
+        guard let cost = snapshot.cost, cost >= 0 else {
+            return (values.cost, values.cost == nil ? nil : expectedCurrency ?? currency)
         }
         let delta = max(0, cost - (baseline.cost ?? 0))
-        return Decimal(string: String(delta))
-    }
-
-    private func mergedCurrency(snapshot: SessionUsage) -> String? {
-        guard let currency = snapshot.currency else { return values.currency }
-        if let persistedCurrency = values.currency, persistedCurrency != currency { return nil }
-        if let baselineCurrency = baseline.currency, baselineCurrency != currency { return nil }
-        return currency
-    }
-
-    private func monotonicSessionSnapshot(previous: SessionUsage?, next: SessionUsage) -> SessionUsage {
-        guard let previous else { return next }
-        return SessionUsage(
-            inputTokens: max(previous.inputTokens, next.inputTokens),
-            outputTokens: max(previous.outputTokens, next.outputTokens),
-            totalTokens: max(previous.totalTokens, next.totalTokens),
-            cachedReadTokens: maximum(previous.cachedReadTokens, next.cachedReadTokens),
-            cachedWriteTokens: maximum(previous.cachedWriteTokens, next.cachedWriteTokens),
-            thoughtTokens: maximum(previous.thoughtTokens, next.thoughtTokens),
-            cost: next.cost,
-            currency: next.currency,
-            contextUsed: next.contextUsed,
-            contextSize: next.contextSize,
-            providerLabel: next.providerLabel ?? previous.providerLabel,
-            modelId: next.modelId ?? previous.modelId,
-            modelName: next.modelName ?? previous.modelName,
-            thinkingLevel: next.thinkingLevel ?? previous.thinkingLevel
-        )
-    }
-
-    private func maximum(_ lhs: Int?, _ rhs: Int?) -> Int? {
-        switch (lhs, rhs) {
-        case let (.some(lhs), .some(rhs)): max(lhs, rhs)
-        case let (.some(value), .none), let (.none, .some(value)): value
-        case (.none, .none): nil
-        }
+        return (Decimal(string: String(delta)), currency)
     }
 }
 #endif

--- a/Sources/wikid/ChatTurnUsageAccumulator.swift
+++ b/Sources/wikid/ChatTurnUsageAccumulator.swift
@@ -1,0 +1,102 @@
+// pattern: Functional Core
+
+#if canImport(WikiFSEngine)
+import Foundation
+import WikiFSCore
+import WikiFSEngine
+
+/// Computes one turn's durable usage from cumulative snapshots emitted by one
+/// provider session. The controller owns one accumulator for its current
+/// claim, so no runtime or provider can author durable lifecycle state.
+struct ChatTurnUsageAccumulator: Sendable {
+    private let baseline: SessionUsage
+    private var latestSessionSnapshot: SessionUsage?
+    private(set) var values = ChatTurnUsageValues()
+
+    init(baseline: SessionUsage) {
+        self.baseline = baseline
+    }
+
+    /// Accepts a provider's cumulative session snapshot and retains only
+    /// monotonic, nonnegative per-turn evidence. Missing values never erase a
+    /// prior value; a changed currency makes the cost unavailable.
+    @discardableResult
+    mutating func record(_ snapshot: SessionUsage) -> ChatTurnUsageValues {
+        let priorSession = latestSessionSnapshot
+        latestSessionSnapshot = monotonicSessionSnapshot(previous: priorSession, next: snapshot)
+
+        values = ChatTurnUsageValues(
+            inputTokens: greatestValid(previous: values.inputTokens, baseline: baseline.inputTokens, snapshot: snapshot.inputTokens),
+            outputTokens: greatestValid(previous: values.outputTokens, baseline: baseline.outputTokens, snapshot: snapshot.outputTokens),
+            thoughtTokens: greatestValid(previous: values.thoughtTokens, baseline: baseline.thoughtTokens, snapshot: snapshot.thoughtTokens),
+            cacheReadTokens: greatestValid(previous: values.cacheReadTokens, baseline: baseline.cachedReadTokens, snapshot: snapshot.cachedReadTokens),
+            cacheWriteTokens: greatestValid(previous: values.cacheWriteTokens, baseline: baseline.cachedWriteTokens, snapshot: snapshot.cachedWriteTokens),
+            cost: mergedCost(snapshot: snapshot),
+            currency: mergedCurrency(snapshot: snapshot)
+        )
+        return values
+    }
+
+    private func greatestValid(
+        previous: Int?,
+        baseline: Int?,
+        snapshot: Int?
+    ) -> Int? {
+        guard let snapshot, snapshot >= 0 else { return previous }
+        let baseline = baseline ?? 0
+        guard snapshot >= baseline else { return previous }
+        let candidate = max(0, snapshot - baseline)
+        return max(previous ?? 0, candidate)
+    }
+
+    private func mergedCost(snapshot: SessionUsage) -> Decimal? {
+        guard let cost = snapshot.cost, cost >= 0 else { return values.cost }
+        guard let currency = snapshot.currency else { return values.cost }
+        if let persistedCurrency = values.currency, persistedCurrency != currency {
+            DebugLog.agent("DaemonChatController rejected usage cost after currency changed from \(persistedCurrency) to \(currency).")
+            return nil
+        }
+        if let baselineCurrency = baseline.currency, baselineCurrency != currency {
+            DebugLog.agent("DaemonChatController rejected usage cost after baseline currency changed from \(baselineCurrency) to \(currency).")
+            return nil
+        }
+        let delta = max(0, cost - (baseline.cost ?? 0))
+        return Decimal(string: String(delta))
+    }
+
+    private func mergedCurrency(snapshot: SessionUsage) -> String? {
+        guard let currency = snapshot.currency else { return values.currency }
+        if let persistedCurrency = values.currency, persistedCurrency != currency { return nil }
+        if let baselineCurrency = baseline.currency, baselineCurrency != currency { return nil }
+        return currency
+    }
+
+    private func monotonicSessionSnapshot(previous: SessionUsage?, next: SessionUsage) -> SessionUsage {
+        guard let previous else { return next }
+        return SessionUsage(
+            inputTokens: max(previous.inputTokens, next.inputTokens),
+            outputTokens: max(previous.outputTokens, next.outputTokens),
+            totalTokens: max(previous.totalTokens, next.totalTokens),
+            cachedReadTokens: maximum(previous.cachedReadTokens, next.cachedReadTokens),
+            cachedWriteTokens: maximum(previous.cachedWriteTokens, next.cachedWriteTokens),
+            thoughtTokens: maximum(previous.thoughtTokens, next.thoughtTokens),
+            cost: next.cost,
+            currency: next.currency,
+            contextUsed: next.contextUsed,
+            contextSize: next.contextSize,
+            providerLabel: next.providerLabel ?? previous.providerLabel,
+            modelId: next.modelId ?? previous.modelId,
+            modelName: next.modelName ?? previous.modelName,
+            thinkingLevel: next.thinkingLevel ?? previous.thinkingLevel
+        )
+    }
+
+    private func maximum(_ lhs: Int?, _ rhs: Int?) -> Int? {
+        switch (lhs, rhs) {
+        case let (.some(lhs), .some(rhs)): max(lhs, rhs)
+        case let (.some(value), .none), let (.none, .some(value)): value
+        case (.none, .none): nil
+        }
+    }
+}
+#endif

--- a/Sources/wikid/DaemonChatController.swift
+++ b/Sources/wikid/DaemonChatController.swift
@@ -450,9 +450,9 @@ actor DaemonChatController {
             activePermission = nil
             record(.permissionResolved(resolution.requestID))
 
-        case .usage(let usage):
+        case .usage(let turnID, let usage):
             recordUsageIfCurrent(
-                turnID: currentClaimTurnID,
+                turnID: turnID,
                 generation: envelope.generation,
                 usage: usage
             )
@@ -555,16 +555,17 @@ actor DaemonChatController {
             return false
         }
 
-        if let finalUsage = await finalRuntimeUsage() {
-            guard eventGeneration == generation,
-                  currentClaimTurnID == turnID,
-                  currentClaimID == claimID,
-                  snapshot.activeTurn?.turnID == turnID,
-                  snapshot.activeTurn?.state.isTerminal == false
-            else {
-                DebugLog.agent("DaemonChatController rejected terminal signal after final usage snapshot changed ownership.")
-                return false
-            }
+        let finalUsage = await finalRuntimeUsage()
+        guard eventGeneration == generation,
+              currentClaimTurnID == turnID,
+              currentClaimID == claimID,
+              snapshot.activeTurn?.turnID == turnID,
+              snapshot.activeTurn?.state.isTerminal == false
+        else {
+            DebugLog.agent("DaemonChatController rejected terminal signal after final usage snapshot changed ownership.")
+            return false
+        }
+        if let finalUsage {
             if var accumulator = turnUsageAccumulator {
                 _ = accumulator.record(finalUsage)
                 turnUsageAccumulator = accumulator

--- a/Sources/wikid/DaemonChatController.swift
+++ b/Sources/wikid/DaemonChatController.swift
@@ -21,6 +21,7 @@ actor DaemonChatController {
     private let wikiID: WikiID
     private let store: GRDBWikiStore
     private let runtime: ChatAgentRuntime
+    private let clock: @Sendable () -> Date
     private let pushEvent: @Sendable (QueueEventEnvelope) -> Void
     private let diagnosticTrace: DaemonChatDiagnostics
 
@@ -31,9 +32,12 @@ actor DaemonChatController {
     private var nextSequence = ChatUpdateSequence.initial
     private var committedCursor: ChatTranscriptCursor
     private var runtimeHandle: ChatRuntimeHandle?
+    private var runtimeStartRequest: ChatRuntimeStartRequest?
     private var eventTask: Task<Void, Never>?
     private var currentClaimID: ChatTurnClaimID?
     private var currentClaimTurnID: ChatTurnID?
+    private var turnUsageAccumulator: ChatTurnUsageAccumulator?
+    private var latestSessionUsage: SessionUsage?
     private var pendingCancellationTurnID: ChatTurnID?
     private var activePermission: ChatPendingPermissionRequest?
     private var isProcessingQueue = false
@@ -63,17 +67,24 @@ actor DaemonChatController {
         store: GRDBWikiStore,
         runtime: ChatAgentRuntime,
         pushEvent: @escaping @Sendable (QueueEventEnvelope) -> Void,
-        diagnosticTrace: DaemonChatDiagnostics = DaemonChatDiagnostics()
+        diagnosticTrace: DaemonChatDiagnostics = DaemonChatDiagnostics(),
+        clock: @escaping @Sendable () -> Date = { Date() }
     ) throws {
         self.chatID = chatID
         self.wikiID = wikiID
         self.store = store
         self.runtime = runtime
+        self.clock = clock
         self.pushEvent = pushEvent
         self.diagnosticTrace = diagnosticTrace
         self.generation = ChatSessionGenerationID(rawValue: ULID.generate())
         self.replayBuffer = ChatUpdateReplayBuffer(capacity: Self.replayCapacity)
-        self.snapshot = try Self.bootstrapSnapshot(chatID: chatID, store: store, generation: generation)
+        self.snapshot = try Self.bootstrapSnapshot(
+            chatID: chatID,
+            store: store,
+            generation: generation,
+            bootstrapAt: clock()
+        )
         self.committedCursor = try store.chatTranscriptCheckpoint(chatID: chatID)
         if case .permissionRequired = snapshot.attention {
             self.activePermission = nil
@@ -139,6 +150,12 @@ actor DaemonChatController {
                 DebugLog.agent("DaemonChatController.cancel runtime cancel failed: \(error)")
             }
         }
+        _ = await finishTurnIfCurrent(
+            turnID: resolvedTurnID,
+            generation: generation,
+            outcome: .cancelled,
+            at: clock()
+        )
     }
 
     func stopSession() async {
@@ -281,11 +298,15 @@ actor DaemonChatController {
             break
         }
 
+        let startRequest = try currentRuntimeStartRequest()
         let claimID = ChatTurnClaimID(rawValue: ULID.generate())
+        let startedAt = clock()
         guard let claimed = try store.claimNextPersistedChatTurn(
             chatID: chatID,
             claimID: claimID,
-            claimedAt: Date()
+            claimedAt: startedAt,
+            providerID: startRequest.providerID,
+            modelID: startRequest.modelID
         ) else {
             return
         }
@@ -304,6 +325,9 @@ actor DaemonChatController {
 
         currentClaimID = claimID
         currentClaimTurnID = claimed.submission.turnID
+        turnUsageAccumulator = ChatTurnUsageAccumulator(
+            baseline: runtimeHandle == nil ? Self.zeroUsage : (latestSessionUsage ?? Self.zeroUsage)
+        )
         record(.submitted(turnID: claimed.submission.turnID))
 
         let handle: ChatRuntimeHandle
@@ -311,18 +335,9 @@ actor DaemonChatController {
             if let existingHandle = runtimeHandle {
                 handle = existingHandle
             } else {
-                let chat = try store.getChat(id: chatID)
-                handle = try await runtime.start(
-                    ChatRuntimeStartRequest(
-                        chatID: chatID,
-                        generation: generation,
-                        systemPrompt: try store.getSystemPrompt().body,
-                        providerID: chat.modelProviderId,
-                        modelID: chat.modelId,
-                        existingProviderSessionID: chat.acpSessionId
-                    )
-                )
+                handle = try await runtime.start(startRequest)
                 runtimeHandle = handle
+                runtimeStartRequest = startRequest
                 startEventLoop(handle)
             }
             record(.started(turnID: claimed.submission.turnID))
@@ -333,7 +348,7 @@ actor DaemonChatController {
                 turnID: claimed.submission.turnID,
                 claimID: claimID,
                 providerSessionID: snapshot.providerState.providerSessionID,
-                submittedAt: Date()
+                submittedAt: clock()
             )
             if marked.providerSessionID != snapshot.providerState.providerSessionID {
                 snapshot = ChatRuntimeSnapshot(
@@ -358,9 +373,11 @@ actor DaemonChatController {
             await observeDiagnostic(stage: .persistence, detail: "provider-submitted", turnID: claimed.submission.turnID)
         } catch {
             DebugLog.agent("DaemonChatController.processQueueIfPossible submit failed: \(error)")
-            _ = finishPersistedTurn(
+            _ = await finishTurnIfCurrent(
                 turnID: claimed.submission.turnID,
-                outcome: .failed(category: .runtimeError, message: error.localizedDescription)
+                generation: generation,
+                outcome: .failed(category: .runtimeError, message: error.localizedDescription),
+                at: clock()
             )
             if let runtimeError = error as? LauncherChatAgentRuntime.RuntimeError,
                case .preflight(let message) = runtimeError {
@@ -433,11 +450,18 @@ actor DaemonChatController {
             activePermission = nil
             record(.permissionResolved(resolution.requestID))
 
+        case .usage(let usage):
+            recordUsageIfCurrent(
+                turnID: currentClaimTurnID,
+                generation: envelope.generation,
+                usage: usage
+            )
+
         case .turnCompleted(let turnID):
             if consumePendingCancellation(turnID: turnID) {
-                _ = finishPersistedTurn(turnID: turnID, outcome: .cancelled)
+                _ = await finishTurnIfCurrent(turnID: turnID, generation: envelope.generation, outcome: .cancelled, at: clock())
             } else {
-                _ = finishPersistedTurn(turnID: turnID, outcome: .completed)
+                _ = await finishTurnIfCurrent(turnID: turnID, generation: envelope.generation, outcome: .completed, at: clock())
             }
             do {
                 try await processQueueIfPossible()
@@ -447,9 +471,9 @@ actor DaemonChatController {
 
         case .turnFailed(let turnID, let category, let message):
             if consumePendingCancellation(turnID: turnID) {
-                _ = finishPersistedTurn(turnID: turnID, outcome: .cancelled)
+                _ = await finishTurnIfCurrent(turnID: turnID, generation: envelope.generation, outcome: .cancelled, at: clock())
             } else {
-                _ = finishPersistedTurn(turnID: turnID, outcome: .failed(category: category, message: message))
+                _ = await finishTurnIfCurrent(turnID: turnID, generation: envelope.generation, outcome: .failed(category: category, message: message), at: clock())
             }
             do {
                 try await processQueueIfPossible()
@@ -458,7 +482,7 @@ actor DaemonChatController {
             }
 
         case .turnCancelled(let turnID):
-            _ = finishPersistedTurn(turnID: turnID, outcome: .cancelled)
+            _ = await finishTurnIfCurrent(turnID: turnID, generation: envelope.generation, outcome: .cancelled, at: clock())
             do {
                 try await processQueueIfPossible()
             } catch {
@@ -468,11 +492,13 @@ actor DaemonChatController {
         case .transportClosed:
             if let turnID = currentClaimTurnID {
                 if consumePendingCancellation(turnID: turnID) {
-                    _ = finishPersistedTurn(turnID: turnID, outcome: .cancelled)
+                    _ = await finishTurnIfCurrent(turnID: turnID, generation: envelope.generation, outcome: .cancelled, at: clock())
                 } else {
-                    _ = finishPersistedTurn(
+                    _ = await finishTurnIfCurrent(
                         turnID: turnID,
-                        outcome: .interrupted(message: "The daemon transport exited before the turn completed.")
+                        generation: envelope.generation,
+                        outcome: .interrupted(message: "The daemon transport exited before the turn completed."),
+                        at: clock()
                     )
                 }
             }
@@ -503,16 +529,47 @@ actor DaemonChatController {
     }
 
     @discardableResult
-    private func finishPersistedTurn(
+    private func finishTurnIfCurrent(
         turnID: ChatTurnID,
-        outcome: ChatTurnTerminalOutcome
-    ) -> Bool {
-        guard let claimID = currentClaimID,
-              currentClaimTurnID == turnID,
+        generation eventGeneration: ChatSessionGenerationID,
+        outcome: ChatTurnTerminalOutcome,
+        at finishedAt: Date
+    ) async -> Bool {
+        guard eventGeneration == generation else {
+            DebugLog.agent("DaemonChatController rejected terminal signal for stale generation \(eventGeneration.rawValue).")
+            return false
+        }
+        guard currentClaimTurnID == turnID else {
+            DebugLog.agent("DaemonChatController rejected terminal signal for non-current turn \(turnID.rawValue).")
+            return false
+        }
+        guard let claimID = currentClaimID else {
+            DebugLog.agent("DaemonChatController rejected terminal signal without a current claim.")
+            return false
+        }
+        guard
               let activeTurn = snapshot.activeTurn,
               activeTurn.turnID == turnID,
               activeTurn.state.isTerminal == false else {
+            DebugLog.agent("DaemonChatController rejected terminal signal after terminal snapshot.")
             return false
+        }
+
+        if let finalUsage = await finalRuntimeUsage() {
+            guard eventGeneration == generation,
+                  currentClaimTurnID == turnID,
+                  currentClaimID == claimID,
+                  snapshot.activeTurn?.turnID == turnID,
+                  snapshot.activeTurn?.state.isTerminal == false
+            else {
+                DebugLog.agent("DaemonChatController rejected terminal signal after final usage snapshot changed ownership.")
+                return false
+            }
+            if var accumulator = turnUsageAccumulator {
+                _ = accumulator.record(finalUsage)
+                turnUsageAccumulator = accumulator
+                latestSessionUsage = finalUsage
+            }
         }
 
         let persistenceState: ChatTurnPersistenceState
@@ -535,7 +592,7 @@ actor DaemonChatController {
                 failureID: ChatTranscriptFailureID(rawValue: ULID.generate()),
                 category: category,
                 message: terminalMessage,
-                createdAt: Date()
+                createdAt: finishedAt
             )
         case .interrupted(let terminalMessage):
             persistenceState = .failed
@@ -545,7 +602,7 @@ actor DaemonChatController {
                 failureID: ChatTranscriptFailureID(rawValue: ULID.generate()),
                 category: .interrupted,
                 message: terminalMessage,
-                createdAt: Date()
+                createdAt: finishedAt
             )
         }
 
@@ -555,18 +612,75 @@ actor DaemonChatController {
                 turnID: turnID,
                 claimID: claimID,
                 state: persistenceState,
-                terminalMessage: message
+                terminalMessage: message,
+                finishedAt: finishedAt,
+                usage: turnUsageAccumulator?.values
             )
         } catch {
-            DebugLog.store("DaemonChatController.finishPersistedTurn failed: \(error)")
+            DebugLog.store("DaemonChatController.finishTurnIfCurrent failed: \(error)")
+            return false
         }
 
         currentClaimID = nil
         currentClaimTurnID = nil
+        turnUsageAccumulator = nil
         activePermission = nil
         record(payload)
         liveEvents.removeAll(keepingCapacity: true)
         return true
+    }
+
+    private func finalRuntimeUsage() async -> SessionUsage? {
+        guard let runtimeHandle else { return nil }
+        do {
+            return (try await runtime.snapshot(for: runtimeHandle)).usage
+        } catch {
+            DebugLog.agent("DaemonChatController.finalRuntimeUsage failed: \(error)")
+            return nil
+        }
+    }
+
+    private func recordUsageIfCurrent(
+        turnID: ChatTurnID?,
+        generation eventGeneration: ChatSessionGenerationID,
+        usage: SessionUsage
+    ) {
+        guard eventGeneration == generation else {
+            DebugLog.agent("DaemonChatController rejected usage for stale generation \(eventGeneration.rawValue).")
+            return
+        }
+        guard let turnID, currentClaimTurnID == turnID else {
+            DebugLog.agent("DaemonChatController rejected usage for non-current turn.")
+            return
+        }
+        guard let claimID = currentClaimID else {
+            DebugLog.agent("DaemonChatController rejected usage without a current claim.")
+            return
+        }
+        guard let activeTurn = snapshot.activeTurn,
+              activeTurn.turnID == turnID,
+              activeTurn.state.isTerminal == false else {
+            DebugLog.agent("DaemonChatController rejected usage after terminal snapshot.")
+            return
+        }
+        guard var accumulator = turnUsageAccumulator else {
+            DebugLog.agent("DaemonChatController rejected usage without an accumulator.")
+            return
+        }
+
+        let values = accumulator.record(usage)
+        do {
+            _ = try store.updatePersistedChatTurnUsage(
+                chatID: chatID,
+                turnID: turnID,
+                claimID: claimID,
+                usage: values
+            )
+            turnUsageAccumulator = accumulator
+            latestSessionUsage = usage
+        } catch {
+            DebugLog.store("DaemonChatController.recordUsageIfCurrent rejected usage: \(error)")
+        }
     }
 
     private func consumePendingCancellation(turnID: ChatTurnID) -> Bool {
@@ -737,6 +851,35 @@ actor DaemonChatController {
         )
     }
 
+    /// The configuration used to claim a turn is the exact configuration used
+    /// to start its runtime. Warm turns retain their existing session's
+    /// configuration instead of reading settings that can change mid-session.
+    private func currentRuntimeStartRequest() throws -> ChatRuntimeStartRequest {
+        if let runtimeStartRequest { return runtimeStartRequest }
+        let chat = try store.getChat(id: chatID)
+        return ChatRuntimeStartRequest(
+            chatID: chatID,
+            generation: generation,
+            systemPrompt: try store.getSystemPrompt().body,
+            providerID: chat.modelProviderId,
+            modelID: chat.modelId,
+            existingProviderSessionID: chat.acpSessionId
+        )
+    }
+
+    private static let zeroUsage = SessionUsage(
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        cachedReadTokens: nil,
+        cachedWriteTokens: nil,
+        thoughtTokens: nil,
+        cost: nil,
+        currency: nil,
+        contextUsed: 0,
+        contextSize: 0
+    )
+
     /// Acquires the single close-owner role. A re-entrant lifecycle path can
     /// observe that close but cannot perform teardown or clear its guard.
     @discardableResult
@@ -748,12 +891,15 @@ actor DaemonChatController {
             await runtime.close(handle)
         }
         runtimeHandle = nil
+        runtimeStartRequest = nil
         eventTask?.cancel()
         eventTask = nil
         liveEvents.removeAll(keepingCapacity: true)
         pendingCancellationTurnID = nil
         currentClaimID = nil
         currentClaimTurnID = nil
+        turnUsageAccumulator = nil
+        latestSessionUsage = nil
         generation = ChatSessionGenerationID(rawValue: ULID.generate())
         snapshot = ChatRuntimeSnapshot(
             chatID: snapshot.chatID,
@@ -786,7 +932,8 @@ actor DaemonChatController {
     static func bootstrapSnapshot(
         chatID: ChatID,
         store: GRDBWikiStore,
-        generation: ChatSessionGenerationID
+        generation: ChatSessionGenerationID,
+        bootstrapAt: Date = Date()
     ) throws -> ChatRuntimeSnapshot {
         let chat = try store.getChat(id: chatID)
         let turns = try store.listPersistedChatTurns(chatID: chatID)
@@ -801,7 +948,9 @@ actor DaemonChatController {
                     turnID: turn.submission.turnID,
                     claimID: claimID,
                     state: .failed,
-                    terminalMessage: interruptedMessage
+                    terminalMessage: interruptedMessage,
+                    finishedAt: bootstrapAt,
+                    usage: turn.usage
                 )
             } catch {
                 DebugLog.store("DaemonChatController.bootstrapSnapshot interrupted finish failed: \(error)")

--- a/Sources/wikid/LauncherChatAgentRuntime.swift
+++ b/Sources/wikid/LauncherChatAgentRuntime.swift
@@ -229,7 +229,7 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
                 onLiveUsage: { [weak self] usage in
                     guard let self else { return }
                     Task {
-                        await self.emit(.usage(usage))
+                        await self.emitLiveUsage(usage)
                     }
                 },
                 onPendingPermission: { [weak self] permission in
@@ -474,8 +474,15 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
                 try JSONDecoder().decode(SessionUsage.self, from: data)
             }
         }) {
-            await emit(.usage(usage))
+            if let turnID = state.activeTurnID {
+                await emit(.usage(turnID: turnID, usage: usage))
+            }
         }
+    }
+
+    private func emitLiveUsage(_ usage: SessionUsage) async {
+        guard let turnID = runtimeState?.activeTurnID else { return }
+        await emit(.usage(turnID: turnID, usage: usage))
     }
 
     private func updateLatestProviderSessionID(_ sessionID: AcpSessionID?) {

--- a/Sources/wikid/LauncherChatAgentRuntime.swift
+++ b/Sources/wikid/LauncherChatAgentRuntime.swift
@@ -226,6 +226,12 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
                         await self.handleLiveEvent(event)
                     }
                 },
+                onLiveUsage: { [weak self] usage in
+                    guard let self else { return }
+                    Task {
+                        await self.emit(.usage(usage))
+                    }
+                },
                 onPendingPermission: { [weak self] permission in
                     guard let self else { return }
                     Task {
@@ -463,6 +469,13 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
         state.lastFingerprint = fingerprint
         runtimeState = state
         await onStateUpdate(update)
+        if let usage = update.usageData.flatMap({ data in
+            DebugLog.trying("LauncherChatAgentRuntime.decodeUsage") {
+                try JSONDecoder().decode(SessionUsage.self, from: data)
+            }
+        }) {
+            await emit(.usage(usage))
+        }
     }
 
     private func updateLatestProviderSessionID(_ sessionID: AcpSessionID?) {

--- a/Tests/WikiFSAppTests/DaemonChatControllerMetadataTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatControllerMetadataTests.swift
@@ -37,6 +37,20 @@ struct DaemonChatControllerMetadataTests {
         #expect(turn.state == .completed)
     }
 
+    @Test func failureWinsTerminalRace() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "failure-race-command", turnID: "failure-race-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await harness.runtime.emit(.turnFailed(turnID: submission.turnID, category: .runtimeError, message: "winner"))
+        await harness.runtime.emit(.turnCompleted(submission.turnID))
+
+        let turn = try await terminalTurn(harness, turnID: submission.turnID)
+        #expect(turn.state == .failed)
+        #expect(turn.terminalMessage == "winner")
+    }
+
     @Test func cancelWinsTerminalRace() async throws {
         let harness = try ControllerHarness()
         let controller = try harness.makeController()
@@ -48,6 +62,36 @@ struct DaemonChatControllerMetadataTests {
 
         let turn = try await terminalTurn(harness, turnID: submission.turnID)
         #expect(turn.state == .cancelled)
+    }
+
+    @Test func stopActiveTurnCancelsAndFinishes() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "stop-active-command", turnID: "stop-active-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await controller.stopSession()
+
+        let turn = try await terminalTurn(harness, turnID: submission.turnID)
+        let runtime = await harness.runtime.snapshot()
+        #expect(turn.state == .cancelled)
+        #expect(runtime.cancelCalls == [submission.turnID])
+    }
+
+    @Test func stopIdleSessionDoesNotCreateTerminalWrite() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "stop-idle-command", turnID: "stop-idle-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+        await harness.runtime.emit(.turnCompleted(submission.turnID))
+        let terminal = try await terminalTurn(harness, turnID: submission.turnID)
+
+        await controller.stopSession()
+
+        let afterStop = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        #expect(afterStop.state == terminal.state)
+        #expect(afterStop.finishedAt == terminal.finishedAt)
+        #expect(afterStop.terminalMessage == terminal.terminalMessage)
     }
 
     @Test func transportCloseInterruptsActiveTurn() async throws {
@@ -69,7 +113,7 @@ struct DaemonChatControllerMetadataTests {
         let submission = harness.makeSubmission(commandID: "stale-usage-command", turnID: "stale-usage-turn")
         _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
 
-        await harness.runtime.emit(.usage(usage(input: 8, output: 3)), generation: ChatSessionGenerationID(rawValue: "stale"))
+        await harness.runtime.emit(.usage(turnID: submission.turnID, usage: usage(input: 8, output: 3)), generation: ChatSessionGenerationID(rawValue: "stale"))
         for _ in 0..<10 { await Task.yield() }
 
         let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
@@ -94,18 +138,64 @@ struct DaemonChatControllerMetadataTests {
         let controller = try harness.makeController()
         let submission = harness.makeSubmission(commandID: "terminal-usage-command", turnID: "terminal-usage-turn")
         _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
-        await harness.runtime.emit(.usage(usage(input: 5, output: 2)))
+        await harness.runtime.emit(.usage(turnID: submission.turnID, usage: usage(input: 5, output: 2)))
         for _ in 0..<10 { await Task.yield() }
         let persistedUsage = try #require(try harness.store.chatTurnUsage(chatID: harness.chat.id, turnID: submission.turnID))
         #expect(persistedUsage.inputTokens == 5)
         #expect(persistedUsage.outputTokens == 2)
         await harness.runtime.emit(.turnCompleted(submission.turnID))
         let terminal = try await terminalTurn(harness, turnID: submission.turnID)
-        await harness.runtime.emit(.usage(usage(input: 9, output: 4)))
+        await harness.runtime.emit(.usage(turnID: submission.turnID, usage: usage(input: 9, output: 4)))
         for _ in 0..<10 { await Task.yield() }
 
         let after = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
         #expect(after.usage == terminal.usage)
+    }
+
+    @Test func finalUsageIsMissingStillFinishesCurrentTurn() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "no-final-usage-command", turnID: "no-final-usage-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await harness.runtime.emit(.turnCompleted(submission.turnID))
+
+        let turn = try await terminalTurn(harness, turnID: submission.turnID)
+        #expect(turn.state == .completed)
+        #expect(turn.usage.inputTokens == nil)
+    }
+
+    @Test func wrongTurnEventIsRejected() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "wrong-turn-command", turnID: "wrong-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await harness.runtime.emit(.turnCompleted(ChatTurnID(rawValue: "another-turn")))
+        for _ in 0..<10 { await Task.yield() }
+
+        let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        #expect(turn.state == .providerSubmitted)
+    }
+
+    @Test func oldClaimUsageIsRejected() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let first = harness.makeSubmission(commandID: "old-claim-first-command", turnID: "old-claim-first-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: first))
+        await harness.runtime.emit(.usage(turnID: first.turnID, usage: usage(input: 5, output: 2)))
+        try await usageValues(harness, turnID: first.turnID, input: 5, output: 2)
+        await harness.runtime.emit(.turnCompleted(first.turnID))
+        _ = try await terminalTurn(harness, turnID: first.turnID)
+
+        let second = harness.makeSubmission(commandID: "old-claim-second-command", turnID: "old-claim-second-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: second))
+        await harness.runtime.emit(.usage(turnID: first.turnID, usage: usage(input: 99, output: 99)))
+        for _ in 0..<10 { await Task.yield() }
+
+        let secondUsage = try #require(try harness.store.chatTurnUsage(chatID: harness.chat.id, turnID: second.turnID))
+        #expect(secondUsage.inputTokens == nil)
+        #expect(secondUsage.outputTokens == nil)
     }
 
     @Test func restartUsesInjectedBootstrapClock() throws {
@@ -128,6 +218,48 @@ struct DaemonChatControllerMetadataTests {
         #expect(turn.state == .failed)
     }
 
+    @Test func restartInterruptsProviderSubmittedTurn() throws {
+        let harness = try ControllerHarness()
+        let queued = try harness.store.enqueuePersistedChatTurn(
+            chatID: harness.chat.id,
+            submission: harness.makeSubmission(commandID: "restart-submitted-command", turnID: "restart-submitted-turn")
+        )
+        let claimID = ChatTurnClaimID(rawValue: "restart-submitted-claim")
+        _ = try harness.store.claimNextPersistedChatTurn(chatID: harness.chat.id, claimID: claimID, claimedAt: Date(timeIntervalSince1970: 10))
+        _ = try harness.store.markPersistedChatTurnProviderSubmitted(
+            chatID: harness.chat.id,
+            turnID: queued.submission.turnID,
+            claimID: claimID,
+            providerSessionID: AcpSessionID(rawValue: "restart-submitted-session"),
+            submittedAt: Date(timeIntervalSince1970: 11)
+        )
+
+        _ = try harness.makeController(clock: { Date(timeIntervalSince1970: 12) })
+
+        let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        #expect(turn.state == .failed)
+        #expect(turn.finishedAt == Date(timeIntervalSince1970: 12))
+        #expect(turn.terminalMessage == "This turn was interrupted when the daemon restarted.")
+    }
+
+    @Test func restartPreservesLastUsageSnapshot() throws {
+        let harness = try ControllerHarness()
+        let queued = try harness.store.enqueuePersistedChatTurn(
+            chatID: harness.chat.id,
+            submission: harness.makeSubmission(commandID: "restart-usage-command", turnID: "restart-usage-turn")
+        )
+        let claimID = ChatTurnClaimID(rawValue: "restart-usage-claim")
+        _ = try harness.store.claimNextPersistedChatTurn(chatID: harness.chat.id, claimID: claimID, claimedAt: Date(timeIntervalSince1970: 10))
+        let usage = ChatTurnUsageValues(inputTokens: 8, outputTokens: 3, thoughtTokens: 2, cacheReadTokens: 1, cacheWriteTokens: 4, cost: Decimal(string: "0.75"), currency: "USD")
+        _ = try harness.store.updatePersistedChatTurnUsage(chatID: harness.chat.id, turnID: queued.submission.turnID, claimID: claimID, usage: usage)
+
+        _ = try harness.makeController(clock: { Date(timeIntervalSince1970: 12) })
+
+        let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        #expect(turn.state == .failed)
+        #expect(turn.usage == usage)
+    }
+
     @Test func duplicateCommandReturnsExistingTurn() async throws {
         let harness = try ControllerHarness()
         let controller = try harness.makeController()
@@ -139,19 +271,76 @@ struct DaemonChatControllerMetadataTests {
         #expect(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).count == 1)
     }
 
+    @Test func retryCreatesNewTurnIdentity() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let original = harness.makeSubmission(commandID: "retry-original-command", turnID: "retry-original-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: original))
+        await harness.runtime.emit(.turnFailed(turnID: original.turnID, category: .runtimeError, message: "retry me"))
+        _ = try await terminalTurn(harness, turnID: original.turnID)
+
+        let retry = harness.makeSubmission(commandID: "retry-new-command", turnID: "retry-new-turn", text: "retry")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: retry))
+
+        let turns = try harness.store.listPersistedChatTurns(chatID: harness.chat.id)
+        #expect(turns.map(\.submission.turnID) == [original.turnID, retry.turnID])
+        #expect(turns.map(\.submission.commandID) == [original.commandID, retry.commandID])
+    }
+
+    @Test func retryPreservesOldTerminalRow() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let original = harness.makeSubmission(commandID: "retry-preserve-original-command", turnID: "retry-preserve-original-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: original))
+        await harness.runtime.emit(.turnFailed(turnID: original.turnID, category: .runtimeError, message: "original failure"))
+        let terminal = try await terminalTurn(harness, turnID: original.turnID)
+
+        let retry = harness.makeSubmission(commandID: "retry-preserve-new-command", turnID: "retry-preserve-new-turn", text: "retry")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: retry))
+
+        let oldTurn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first(where: { $0.submission.turnID == original.turnID }))
+        #expect(oldTurn.state == terminal.state)
+        #expect(oldTurn.finishedAt == terminal.finishedAt)
+        #expect(oldTurn.terminalMessage == terminal.terminalMessage)
+    }
+
+    @Test func duplicateTurnCannotCreateSecondUsageRow() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let original = harness.makeSubmission(commandID: "duplicate-turn-original-command", turnID: "duplicate-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: original))
+        await harness.runtime.emit(.usage(turnID: original.turnID, usage: usage(input: 5, output: 2)))
+        try await usageValues(harness, turnID: original.turnID, input: 5, output: 2)
+
+        let duplicateTurn = harness.makeSubmission(commandID: "duplicate-turn-new-command", turnID: original.turnID.rawValue)
+        var rejectedDuplicateTurn = false
+        do {
+            _ = try await controller.submit(harness.makeSubmitRequest(submission: duplicateTurn))
+        } catch {
+            rejectedDuplicateTurn = true
+        }
+
+        let turns = try harness.store.listPersistedChatTurns(chatID: harness.chat.id)
+        let persistedUsage = try #require(try harness.store.chatTurnUsage(chatID: harness.chat.id, turnID: original.turnID))
+        #expect(rejectedDuplicateTurn)
+        #expect(turns.count == 1)
+        #expect(persistedUsage.inputTokens == 5)
+        #expect(persistedUsage.outputTokens == 2)
+    }
+
     @Test func warmSessionSubtractsBaseline() async throws {
         let harness = try ControllerHarness()
         let controller = try harness.makeController()
         let first = harness.makeSubmission(commandID: "warm-first-command", turnID: "warm-first-turn")
         _ = try await controller.submit(harness.makeSubmitRequest(submission: first))
-        await harness.runtime.emit(.usage(usage(input: 10, output: 4)))
+        await harness.runtime.emit(.usage(turnID: first.turnID, usage: usage(input: 10, output: 4)))
         try await usageValues(harness, turnID: first.turnID, input: 10, output: 4)
         await harness.runtime.emit(.turnCompleted(first.turnID))
         _ = try await terminalTurn(harness, turnID: first.turnID)
 
         let second = harness.makeSubmission(commandID: "warm-second-command", turnID: "warm-second-turn")
         _ = try await controller.submit(harness.makeSubmitRequest(submission: second))
-        await harness.runtime.emit(.usage(usage(input: 17, output: 7)))
+        await harness.runtime.emit(.usage(turnID: second.turnID, usage: usage(input: 17, output: 7)))
         try await usageValues(harness, turnID: second.turnID, input: 7, output: 3)
     }
 

--- a/Tests/WikiFSAppTests/DaemonChatControllerMetadataTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatControllerMetadataTests.swift
@@ -1,0 +1,202 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import WikiFSEngine
+@testable import wikid
+
+@MainActor
+struct DaemonChatControllerMetadataTests {
+    @Test func startClaimsAndSnapshotsConfiguration() async throws {
+        let harness = try ControllerHarness()
+        let provider = ProviderID(rawValue: "provider-claim")
+        let model = ModelID(rawValue: "model-claim")
+        try harness.store.updateChatModelOverride(id: harness.chat.id, providerId: provider, modelId: model)
+        let controller = try harness.makeController(clock: { Date(timeIntervalSince1970: 42) })
+        let submission = harness.makeSubmission(commandID: "claim-command", turnID: "claim-turn")
+
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        let request = try #require((await harness.runtime.snapshot()).startRequests.first)
+        #expect(turn.claimedAt == Date(timeIntervalSince1970: 42))
+        #expect(turn.providerID == request.providerID)
+        #expect(turn.modelID == request.modelID)
+    }
+
+    @Test func successWinsTerminalRace() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "success-race-command", turnID: "success-race-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await harness.runtime.emit(.turnCompleted(submission.turnID))
+        await harness.runtime.emit(.turnFailed(turnID: submission.turnID, category: .runtimeError, message: "late"))
+
+        let turn = try await terminalTurn(harness, turnID: submission.turnID)
+        #expect(turn.state == .completed)
+    }
+
+    @Test func cancelWinsTerminalRace() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "cancel-race-command", turnID: "cancel-race-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await controller.cancel(turnID: submission.turnID)
+        await harness.runtime.emit(.turnCompleted(submission.turnID))
+
+        let turn = try await terminalTurn(harness, turnID: submission.turnID)
+        #expect(turn.state == .cancelled)
+    }
+
+    @Test func transportCloseInterruptsActiveTurn() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "close-command", turnID: "close-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await harness.runtime.emit(.transportClosed(status: 9))
+
+        let turn = try await terminalTurn(harness, turnID: submission.turnID)
+        #expect(turn.state == .failed)
+        #expect(turn.terminalMessage == "The daemon transport exited before the turn completed.")
+    }
+
+    @Test func staleGenerationUsageIsRejected() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "stale-usage-command", turnID: "stale-usage-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await harness.runtime.emit(.usage(usage(input: 8, output: 3)), generation: ChatSessionGenerationID(rawValue: "stale"))
+        for _ in 0..<10 { await Task.yield() }
+
+        let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        #expect(turn.usage.inputTokens == nil)
+    }
+
+    @Test func staleGenerationTerminalIsRejected() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "stale-terminal-command", turnID: "stale-terminal-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        await harness.runtime.emit(.turnCompleted(submission.turnID), generation: ChatSessionGenerationID(rawValue: "stale"))
+        for _ in 0..<10 { await Task.yield() }
+
+        let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        #expect(turn.state == .providerSubmitted)
+    }
+
+    @Test func terminalUsageUpdateIsRejected() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "terminal-usage-command", turnID: "terminal-usage-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+        await harness.runtime.emit(.usage(usage(input: 5, output: 2)))
+        for _ in 0..<10 { await Task.yield() }
+        let persistedUsage = try #require(try harness.store.chatTurnUsage(chatID: harness.chat.id, turnID: submission.turnID))
+        #expect(persistedUsage.inputTokens == 5)
+        #expect(persistedUsage.outputTokens == 2)
+        await harness.runtime.emit(.turnCompleted(submission.turnID))
+        let terminal = try await terminalTurn(harness, turnID: submission.turnID)
+        await harness.runtime.emit(.usage(usage(input: 9, output: 4)))
+        for _ in 0..<10 { await Task.yield() }
+
+        let after = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first)
+        #expect(after.usage == terminal.usage)
+    }
+
+    @Test func restartUsesInjectedBootstrapClock() throws {
+        let harness = try ControllerHarness()
+        let queued = try harness.store.enqueuePersistedChatTurn(
+            chatID: harness.chat.id,
+            submission: harness.makeSubmission(commandID: "restart-clock-command", turnID: "restart-clock-turn")
+        )
+        _ = try harness.store.claimNextPersistedChatTurn(
+            chatID: harness.chat.id,
+            claimID: ChatTurnClaimID(rawValue: "restart-clock-claim"),
+            claimedAt: Date(timeIntervalSince1970: 1)
+        )
+        let bootstrapAt = Date(timeIntervalSince1970: 99)
+
+        _ = try harness.makeController(clock: { bootstrapAt })
+
+        let turn = try #require(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).first(where: { $0.submission.turnID == queued.submission.turnID }))
+        #expect(turn.finishedAt == bootstrapAt)
+        #expect(turn.state == .failed)
+    }
+
+    @Test func duplicateCommandReturnsExistingTurn() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let submission = harness.makeSubmission(commandID: "duplicate-command", turnID: "duplicate-turn")
+
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
+
+        #expect(try harness.store.listPersistedChatTurns(chatID: harness.chat.id).count == 1)
+    }
+
+    @Test func warmSessionSubtractsBaseline() async throws {
+        let harness = try ControllerHarness()
+        let controller = try harness.makeController()
+        let first = harness.makeSubmission(commandID: "warm-first-command", turnID: "warm-first-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: first))
+        await harness.runtime.emit(.usage(usage(input: 10, output: 4)))
+        try await usageValues(harness, turnID: first.turnID, input: 10, output: 4)
+        await harness.runtime.emit(.turnCompleted(first.turnID))
+        _ = try await terminalTurn(harness, turnID: first.turnID)
+
+        let second = harness.makeSubmission(commandID: "warm-second-command", turnID: "warm-second-turn")
+        _ = try await controller.submit(harness.makeSubmitRequest(submission: second))
+        await harness.runtime.emit(.usage(usage(input: 17, output: 7)))
+        try await usageValues(harness, turnID: second.turnID, input: 7, output: 3)
+    }
+
+    private func terminalTurn(_ harness: ControllerHarness, turnID: ChatTurnID) async throws -> PersistedChatTurn {
+        for _ in 0..<100 {
+            if let turn = try harness.store.listPersistedChatTurns(chatID: harness.chat.id)
+                .first(where: {
+                    $0.submission.turnID == turnID
+                        && [.completed, .cancelled, .failed].contains($0.state)
+                }) {
+                return turn
+            }
+            await Task.yield()
+        }
+        throw MetadataTestError.terminalTurnDidNotArrive(turnID)
+    }
+
+    private func usageValues(
+        _ harness: ControllerHarness,
+        turnID: ChatTurnID,
+        input: Int,
+        output: Int
+    ) async throws {
+        for _ in 0..<100 {
+            if let usage = try harness.store.chatTurnUsage(chatID: harness.chat.id, turnID: turnID),
+               usage.inputTokens == input,
+               usage.outputTokens == output {
+                return
+            }
+            await Task.yield()
+        }
+        throw MetadataTestError.usageDidNotArrive(turnID)
+    }
+
+    private func usage(input: Int, output: Int) -> SessionUsage {
+        SessionUsage(
+            inputTokens: input, outputTokens: output, totalTokens: input + output,
+            cachedReadTokens: nil, thoughtTokens: nil, cost: nil, currency: nil,
+            contextUsed: 0, contextSize: 0
+        )
+    }
+}
+
+private enum MetadataTestError: Error {
+    case terminalTurnDidNotArrive(ChatTurnID)
+    case usageDidNotArrive(ChatTurnID)
+}
+#endif

--- a/Tests/WikiFSAppTests/DaemonChatControllerTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatControllerTests.swift
@@ -793,7 +793,7 @@ struct DaemonChatControllerTests {
     }
 }
 
-private final class ControllerHarness {
+final class ControllerHarness {
     enum HarnessError: Error {
         case timedOut(String)
     }
@@ -823,7 +823,8 @@ private final class ControllerHarness {
     }
 
     func makeController(
-        diagnosticTrace: DaemonChatDiagnostics = DaemonChatDiagnostics()
+        diagnosticTrace: DaemonChatDiagnostics = DaemonChatDiagnostics(),
+        clock: @escaping @Sendable () -> Date = { Date() }
     ) throws -> DaemonChatController {
         try DaemonChatController(
             chatID: chat.id,
@@ -833,7 +834,8 @@ private final class ControllerHarness {
             pushEvent: { [eventRecorder] envelope in
                 eventRecorder.record(envelope)
             },
-            diagnosticTrace: diagnosticTrace
+            diagnosticTrace: diagnosticTrace,
+            clock: clock
         )
     }
 
@@ -982,7 +984,7 @@ private actor IdleEvictionProbe {
     }
 }
 
-private actor StubControllerRuntime: ChatAgentRuntime {
+actor StubControllerRuntime: ChatAgentRuntime {
     struct Snapshot: Sendable {
         let startRequests: [ChatRuntimeStartRequest]
         let submitCalls: [ChatTurnSubmission]

--- a/Tests/WikiFSAppTests/DaemonChatUsageTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatUsageTests.swift
@@ -1,0 +1,134 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSEngine
+@testable import wikid
+
+@MainActor
+struct DaemonChatUsageTests {
+    @Test func streamedCumulativeUsageProducesTurnDelta() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 10, output: 2))
+
+        let persisted = accumulator.record(usage(input: 17, output: 5))
+
+        #expect(persisted.inputTokens == 7)
+        #expect(persisted.outputTokens == 3)
+    }
+
+    @Test func finalOnlyUsagePersists() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+
+        let persisted = accumulator.record(usage(input: 7, output: 3, thought: 2))
+
+        #expect(persisted.inputTokens == 7)
+        #expect(persisted.outputTokens == 3)
+        #expect(persisted.thoughtTokens == 2)
+    }
+
+    @Test func mixedStreamAndFinalUsesGreatestCounters() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+        _ = accumulator.record(usage(input: 5, output: 2, thought: 1))
+
+        let persisted = accumulator.record(usage(input: 4, output: 4, thought: 1))
+
+        #expect(persisted.inputTokens == 5)
+        #expect(persisted.outputTokens == 4)
+        #expect(persisted.thoughtTokens == 1)
+    }
+
+    @Test func missingUsageLeavesColumnsNil() {
+        let accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+
+        let persisted = accumulator.values
+
+        #expect(persisted.inputTokens == nil)
+        #expect(persisted.outputTokens == nil)
+        #expect(persisted.cost == nil)
+    }
+
+    @Test func counterResetRetainsPriorValue() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+        _ = accumulator.record(usage(input: 8, output: 3))
+
+        let persisted = accumulator.record(usage(input: 2, output: 4))
+
+        #expect(persisted.inputTokens == 8)
+        #expect(persisted.outputTokens == 4)
+    }
+
+    @Test func decreasingCounterIsRejected() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 10, output: 4))
+        _ = accumulator.record(usage(input: 17, output: 7))
+
+        let persisted = accumulator.record(usage(input: 16, output: 6))
+
+        #expect(persisted.inputTokens == 7)
+        #expect(persisted.outputTokens == 3)
+    }
+
+    @Test func currencyChangeClearsCostOnly() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+        _ = accumulator.record(usage(input: 3, output: 2, cost: 1.5, currency: "USD"))
+
+        let persisted = accumulator.record(usage(input: 4, output: 3, cost: 2.0, currency: "EUR"))
+
+        #expect(persisted.inputTokens == 4)
+        #expect(persisted.outputTokens == 3)
+        #expect(persisted.cost == nil)
+        #expect(persisted.currency == nil)
+    }
+
+    @Test func cacheReadAndWritePersist() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+
+        let persisted = accumulator.record(usage(input: 1, output: 2, cacheRead: 5, cacheWrite: 3))
+
+        #expect(persisted.cacheReadTokens == 5)
+        #expect(persisted.cacheWriteTokens == 3)
+    }
+
+    @Test func thoughtTokensPersist() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+
+        let persisted = accumulator.record(usage(input: 1, output: 2, thought: 3))
+
+        #expect(persisted.thoughtTokens == 3)
+    }
+
+    @Test func warmSessionSubtractsBaseline() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 100, output: 50, cacheRead: 20, thought: 10, cost: 4, currency: "USD"))
+
+        let persisted = accumulator.record(usage(input: 108, output: 55, cacheRead: 23, thought: 12, cost: 4.75, currency: "USD"))
+
+        #expect(persisted.inputTokens == 8)
+        #expect(persisted.outputTokens == 5)
+        #expect(persisted.cacheReadTokens == 3)
+        #expect(persisted.thoughtTokens == 2)
+        #expect(persisted.cost == Decimal(string: "0.75"))
+        #expect(persisted.currency == "USD")
+    }
+
+    private func usage(
+        input: Int,
+        output: Int,
+        cacheRead: Int? = nil,
+        cacheWrite: Int? = nil,
+        thought: Int? = nil,
+        cost: Double? = nil,
+        currency: String? = nil
+    ) -> SessionUsage {
+        SessionUsage(
+            inputTokens: input,
+            outputTokens: output,
+            totalTokens: input + output,
+            cachedReadTokens: cacheRead,
+            cachedWriteTokens: cacheWrite,
+            thoughtTokens: thought,
+            cost: cost,
+            currency: currency,
+            contextUsed: 0,
+            contextSize: 0
+        )
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/DaemonChatUsageTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatUsageTests.swift
@@ -78,6 +78,19 @@ struct DaemonChatUsageTests {
         #expect(persisted.currency == nil)
     }
 
+    @Test func currencyConflictStaysUnavailableAfterLaterMatchingCurrency() {
+        var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
+        _ = accumulator.record(usage(input: 3, output: 2, cost: 1.5, currency: "USD"))
+        _ = accumulator.record(usage(input: 4, output: 3, cost: 2.0, currency: "EUR"))
+
+        let persisted = accumulator.record(usage(input: 5, output: 4, cost: 2.5, currency: "USD"))
+
+        #expect(persisted.inputTokens == 5)
+        #expect(persisted.outputTokens == 4)
+        #expect(persisted.cost == nil)
+        #expect(persisted.currency == nil)
+    }
+
     @Test func cacheReadAndWritePersist() {
         var accumulator = ChatTurnUsageAccumulator(baseline: usage(input: 0, output: 0))
 

--- a/Tests/WikiFSTests/ChatTurnMetadataStoreTransitionTests.swift
+++ b/Tests/WikiFSTests/ChatTurnMetadataStoreTransitionTests.swift
@@ -47,6 +47,7 @@ struct ChatTurnMetadataStoreTransitionTests {
 
     @Test func usageUpdateRejectsStaleClaim() throws {
         let (store, chatID, turn) = try claimedStore()
+        let before = turn
         do {
             _ = try store.updatePersistedChatTurnUsage(
                 chatID: chatID, turnID: turn.submission.turnID, claimID: ChatTurnClaimID(rawValue: "stale"),
@@ -56,6 +57,7 @@ struct ChatTurnMetadataStoreTransitionTests {
         } catch let error as MetadataStoreError {
             #expect(error == .staleChatTurnClaim)
         }
+        #expect(try persistedTurn(store, chatID: chatID, turnID: turn.submission.turnID) == before)
     }
 
     @Test func finishClaimedTurnPersistsTerminalOutcomeAndFinalUsageAtomically() throws { try assertFinish(submitted: false) }
@@ -87,6 +89,32 @@ struct ChatTurnMetadataStoreTransitionTests {
         #expect(later.usage == winner.usage)
     }
 
+    @Test func rejectedStoreTransitionWritesNothingAndEmitsNothing() async throws {
+        let (store, chatID, turn) = try claimedStore()
+        let bus = WikiEventBus(wikiID: WikiID(rawValue: "transition-wiki"))
+        store.eventBus = bus
+        let recorder = SignalRecorder()
+        bus.subscribe(nil) { recorder.append($0) }
+        let before = try persistedTurn(store, chatID: chatID, turnID: turn.submission.turnID)
+
+        do {
+            _ = try store.updatePersistedChatTurnUsage(
+                chatID: chatID,
+                turnID: turn.submission.turnID,
+                claimID: ChatTurnClaimID(rawValue: "stale"),
+                usage: .init(inputTokens: 1)
+            )
+            Issue.record("stale claim must not update usage")
+        } catch let error as MetadataStoreError {
+            #expect(error == .staleChatTurnClaim)
+        }
+
+        await flushBusDeliveries()
+        await Task.yield()
+        #expect(recorder.snapshot.isEmpty)
+        #expect(try persistedTurn(store, chatID: chatID, turnID: turn.submission.turnID) == before)
+    }
+
     private func assertTerminalUsageRejected(_ state: ChatTurnPersistenceState) throws {
         let (store, chatID, turn) = try claimedStore()
         _ = try finish(store, chatID: chatID, turn: turn, state: state, finishedAt: 12)
@@ -106,7 +134,11 @@ struct ChatTurnMetadataStoreTransitionTests {
         let finished = try finish(store, chatID: chatID, turn: turn, state: .completed, finishedAt: 12)
         #expect(finished.state == .completed)
         #expect(finished.finishedAt == Date(timeIntervalSince1970: 12))
-        #expect(finished.usage.inputTokens == 4)
+        #expect(finished.terminalMessage == "winner")
+        #expect(finished.providerID == ProviderID(rawValue: "provider"))
+        #expect(finished.modelID == ModelID(rawValue: "model"))
+        #expect(finished.usage == usage())
+        #expect(try persistedTurn(store, chatID: chatID, turnID: turn.submission.turnID) == finished)
     }
 
     private func terminalRace() throws -> (PersistedChatTurn, PersistedChatTurn) {
@@ -123,8 +155,29 @@ struct ChatTurnMetadataStoreTransitionTests {
         try store.finishPersistedChatTurn(
             chatID: chatID, turnID: turn.submission.turnID, claimID: ChatTurnClaimID(rawValue: "claim"),
             state: state, terminalMessage: "winner", finishedAt: Date(timeIntervalSince1970: finishedAt),
-            usage: .init(inputTokens: 4, outputTokens: 5, thoughtTokens: 6, cacheReadTokens: 7,
-                         cacheWriteTokens: 8, cost: Decimal(string: "1.50"), currency: "USD")
+            usage: usage()
         )
+    }
+
+    private func usage() -> ChatTurnUsageValues {
+        .init(
+            inputTokens: 4,
+            outputTokens: 5,
+            thoughtTokens: 6,
+            cacheReadTokens: 7,
+            cacheWriteTokens: 8,
+            cost: Decimal(string: "1.50"),
+            currency: "USD"
+        )
+    }
+
+    private func persistedTurn(
+        _ store: GRDBWikiStore,
+        chatID: ChatID,
+        turnID: ChatTurnID
+    ) throws -> PersistedChatTurn {
+        try #require(try store.listPersistedChatTurns(chatID: chatID).first {
+            $0.submission.turnID == turnID
+        })
     }
 }

--- a/progress/2026-07-31T182700Z-issue-1005-phase2-chat-lifecycle.md
+++ b/progress/2026-07-31T182700Z-issue-1005-phase2-chat-lifecycle.md
@@ -1,0 +1,43 @@
+---
+timestamp: 2026-07-31T182700Z
+title: Issue #1005 Phase 2 chat lifecycle persistence
+branch: issue-1005-phase-2-chat-lifecycle
+status: complete
+---
+
+# Issue #1005 Phase 2 chat lifecycle persistence
+
+## Progress
+
+`DaemonChatController` now owns persistent lifecycle writes for active chat
+turns. It claims a turn with the provider/model from the exact runtime start
+request, records the injected claim time, persists cumulative usage deltas only
+for its active claim, and finishes the row with final usage in the terminal
+transaction.
+
+`ChatTurnUsageAccumulator` converts provider-session totals to one turn's
+usage. It preserves the greatest valid token evidence, does not erase absent
+fields, rejects resets, and clears cost when a currency changes. A warm runtime
+uses the last accepted session snapshot as the next turn's baseline.
+
+Terminal events pass through `finishTurnIfCurrent`. It checks generation, turn,
+claim, and the in-memory terminal state before the conditional store winner.
+Late completion, failure, cancellation, usage, and stale-generation events do
+not replace the winning row. Bootstrap recovery finishes active rows with the
+injected clock and their last persisted usage; queued rows remain queued.
+
+## Scope
+
+This phase changes chat lifecycle persistence only. It does not add page-source
+writers, extraction canonicalization, inspector UI, or metadata hydration.
+
+## Verification
+
+- Focused accumulator tests passed: `DaemonChatUsageTests` (10 tests).
+- Focused lifecycle tests passed: `DaemonChatControllerMetadataTests` (10 tests).
+- Direct store transition tests passed: `ChatTurnMetadataStoreTransitionTests`
+  (14 tests).
+- `make build`, `make test`, `swift build`, and `swift test` passed. The full
+  Swift test gate ran 2,825 tests in 227 suites.
+- `git diff --check`, the typed-ID/raw-string audit, lifecycle-writer audit,
+  and changed-file scope review passed.

--- a/progress/2026-07-31T182700Z-issue-1005-phase2-chat-lifecycle.md
+++ b/progress/2026-07-31T182700Z-issue-1005-phase2-chat-lifecycle.md
@@ -17,8 +17,12 @@ transaction.
 
 `ChatTurnUsageAccumulator` converts provider-session totals to one turn's
 usage. It preserves the greatest valid token evidence, does not erase absent
-fields, rejects resets, and clears cost when a currency changes. A warm runtime
-uses the last accepted session snapshot as the next turn's baseline.
+fields, rejects resets, and clears cost when a currency changes. A currency
+conflict is latched for the turn, so a later matching snapshot cannot restore
+an ambiguous cost. Runtime usage events now carry the active typed turn ID, so
+the controller rejects a late old-turn snapshot instead of attributing it to a
+new claim. A warm runtime uses the last accepted session snapshot as the next
+turn's baseline.
 
 Terminal events pass through `finishTurnIfCurrent`. It checks generation, turn,
 claim, and the in-memory terminal state before the conditional store winner.
@@ -33,11 +37,36 @@ writers, extraction canonicalization, inspector UI, or metadata hydration.
 
 ## Verification
 
-- Focused accumulator tests passed: `DaemonChatUsageTests` (10 tests).
-- Focused lifecycle tests passed: `DaemonChatControllerMetadataTests` (10 tests).
+- The original 46 Phase 2 opt-in `WikiFSAppTests` were separate from the
+  default 2,825-test SwiftPM gate. They were run explicitly with
+  `WIKIFS_APP_TESTS=1`; the corrective selector also includes
+  `ChatPresentationAPIManifestTests`.
+- Focused accumulator tests passed: `DaemonChatUsageTests` (11 tests).
+- Focused lifecycle tests passed: `DaemonChatControllerMetadataTests` (21 tests).
+- The CI-equivalent opt-in selector passed 65 tests in 4 suites:
+  `ChatPresentationAPIManifestTests`, `DaemonChatUsageTests`,
+  `DaemonChatControllerMetadataTests`, and `DaemonChatControllerTests`.
 - Direct store transition tests passed: `ChatTurnMetadataStoreTransitionTests`
   (14 tests).
 - `make build`, `make test`, `swift build`, and `swift test` passed. The full
   Swift test gate ran 2,825 tests in 227 suites.
 - `git diff --check`, the typed-ID/raw-string audit, lifecycle-writer audit,
   and changed-file scope review passed.
+
+## Corrective traceability
+
+The Phase 2 plan names below are covered by existing tests whose names predate
+the reviewed matrix:
+
+- `lateCompletionCannotReplaceCancellation()` maps to
+  `cancelWinsTerminalRace()`.
+- `lateFailureCannotReplaceSuccess()` maps to `successWinsTerminalRace()`.
+- `restartInterruptsClaimedTurn()` maps to
+  `restartUsesInjectedBootstrapClock()`, which seeds a claimed row.
+- `restartPreservesQueuedTurns()` maps to
+  `restartRecoveryPreservesQueuedOrderWithoutAutoResubmit()`.
+
+All other Phase 2 lifecycle names in the reviewed matrix now have direct named
+coverage in `DaemonChatControllerMetadataTests` or
+`DaemonChatUsageTests`. The CI selector runs those suites with
+`ChatPresentationAPIManifestTests`.


### PR DESCRIPTION
## Summary

Implements Issue #1005 Phase 2 only: persistent chat-turn lifecycle ownership
in `DaemonChatController`.

- Claims snapshot the exact typed provider/model start configuration and injected
  claim clock.
- A controller-owned usage accumulator converts cumulative runtime session
  usage into nonnegative per-turn deltas, preserves greatest valid counters,
  supports warm-session baselines, and latches cost unavailable after a
  currency conflict.
- Runtime usage observations now carry their typed active turn ID, allowing the
  controller to reject late old-claim usage instead of assigning it to a new
  turn.
- All terminal signals route through conditional controller/store completion;
  stale generation, turn, claim, and terminal signals cannot overwrite the
  terminal winner.
- The opt-in CI step runs the presentation contract plus all Phase 2 lifecycle
  suites.
- Restart recovery finishes active claimed/provider-submitted rows using the
  injected bootstrap clock and their last persisted usage. Queued rows remain
  queued.

Refs #1005

## Exact head

`f9b369b99722a99597c8e2d70ae2e90ffcd51be2`

## Verification

- `make build` — passed
- `make test` — passed (2,825 tests in 227 suites)
- `swift build` — passed
- `swift test` — passed (2,825 tests in 227 suites)
- `WIKIFS_APP_TESTS=1 swift test --filter 'ChatPresentationAPIManifestTests|DaemonChatUsageTests|DaemonChatControllerMetadataTests|DaemonChatControllerTests'` — passed (65 tests in 4 suites)
- `WIKIFS_APP_TESTS=1 swift test --filter 'DaemonChatUsageTests|DaemonChatControllerMetadataTests'` — passed (32 tests in 2 suites)
- `swift test --filter ChatTurnMetadataStoreTransitionTests` — passed (14)
- `git diff --check` — passed
- Commit hook — passed: strict SwiftLint (0 violations) and no new bare `try?`

## Scope evidence

The corrective range changes only the opt-in lifecycle CI gate, the typed
runtime usage boundary, `DaemonChatController`, its usage accumulator,
lifecycle tests, and the Phase 2 progress note. No Phase 3 page-source
writers, Phase 4 extraction canonicalization, or Phase 5 inspector/metadata
hydration files are touched.

Lifecycle-writer audit: the only production calls to
`claimNextPersistedChatTurn`, `updatePersistedChatTurnUsage`, and
`finishPersistedChatTurn` are in `DaemonChatController`; remaining matches are
the Phase 1 store implementation and protocol declarations.

## Compatibility

Phase 1 typed persistence APIs and schema contracts are used unchanged.
`ChatAgentRuntime.Event.usage` now carries `ChatTurnID` with the cumulative
usage snapshot; this is an in-process attribution contract, not a persistence
writer. The default 2,825-test SwiftPM gate excludes the original 46 opt-in
Phase 2 app tests; the app suites were run explicitly above. Bare Swift
commands were run after repository code-generation prerequisites.

## Traceability

The remaining reviewed-matrix names map exactly to existing tests:

- `lateCompletionCannotReplaceCancellation` → `cancelWinsTerminalRace`
- `lateFailureCannotReplaceSuccess` → `successWinsTerminalRace`
- `restartInterruptsClaimedTurn` → `restartUsesInjectedBootstrapClock`
- `restartPreservesQueuedTurns` → `restartRecoveryPreservesQueuedOrderWithoutAutoResubmit`
