### PR TITLE
Log directory creation errors instead of silently failing

### DIFF
--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -578,9 +578,14 @@ if let argPath = CommandLine.arguments.dropFirst().first(where: { !$0.hasPrefix(
     // Linux default — a conventional XDG-style data directory.
     let home = FileManager.default.homeDirectoryForCurrentUser
     let defaultDir = home.appendingPathComponent(".local/share/selfdrivingwiki", isDirectory: true)
-    // Directory creation is idempotent — failure is acceptable (directory may already exist).
-    // swiftlint:disable:next silent_try_optional
-    try? FileManager.default.createDirectory(at: defaultDir, withIntermediateDirectories: true)
+    // createDirectory(withIntermediateDirectories:) succeeds when the dir
+    // already exists, so a real failure here means permissions/disk — log it
+    // rather than swallow silently (house rule: never bare try?).
+    do {
+        try FileManager.default.createDirectory(at: defaultDir, withIntermediateDirectories: true)
+    } catch {
+        DebugLog.store("wikid: failed to create default data directory \(defaultDir.path): \(error)")
+    }
     containerDirectory = defaultDir
 }
 


### PR DESCRIPTION
Replace silent error suppression (`try?`) with explicit error logging when creating the default data directory.

## Why

The previous implementation swallowed all errors during directory creation via bare `try?`. While the function succeeds idempotently when the directory already exists, real failures (permissions, disk space, filesystem errors) were invisible — making it hard to debug why the application couldn't access its data directory.

This change enforces the house rule: never use bare `try?` for operations that could fail in user-visible ways.

## What changed

- Replaced `try? FileManager.default.createDirectory(...)` with an explicit `do-catch` block
- On error, logs the failure to `DebugLog.store()` with the path and error details
- Removed the `swiftlint:disable` comment that was masking the anti-pattern
- Improved comments to clarify that real errors here indicate permissions or disk issues worth debugging

Functionality is unchanged when the directory exists or can be created successfully.