### PR TITLE
Fix detail column alignment and sizing constraints

### DIFF
--- a/Sources/WikiFS/Detail/DetailInspectorView.swift
+++ b/Sources/WikiFS/Detail/DetailInspectorView.swift
@@ -1,3 +1,7 @@
+// pattern: Mixed (unavoidable)
+// Reason: a SwiftUI view necessarily combines declarative rendering with local
+// gesture state for the inspector-width divider.
+
 import SwiftUI
 import WikiFSCore
 
@@ -171,6 +175,11 @@ struct DetailInspectorView<Outline: View>: View {
                 }
             }
             .frame(width: effectiveWidth)
+            // The divider claims the full offered height. Claim it here as well
+            // so a compact selected tab (notably a short source outline) stays
+            // pinned to the inspector's top edge instead of being centered next
+            // to that full-height sibling.
+            .frame(maxHeight: .infinity, alignment: .top)
             .background(Color(nsColor: .windowBackgroundColor))
         }
     }

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -1,3 +1,7 @@
+// pattern: Mixed (unavoidable)
+// Reason: this SwiftUI detail surface combines view state, user actions, and
+// store-backed presentation data at the app boundary.
+
 import SwiftUI
 import WikiFSEngine
 import WikiFSCore
@@ -542,6 +546,10 @@ struct SourceDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(nsColor: .textBackgroundColor))
+        // Keep the reader column from collapsing when the window-owned trailing
+        // inspector claims its persisted width. Matches PageDetailView and
+        // ChatDetailView's minimum detail-column contract.
+        .frame(minWidth: PageEditorMetrics.detailMinWidth)
         .onAppear {
             headVersion = store.processedMarkdownHead(for: file)
             origin = store.sourceOrigin(for: file.id)


### PR DESCRIPTION
Add layout modifiers to ensure consistent alignment and sizing in detail views.

## Changes

- **DetailInspectorView**: Pin inspector content to the top edge with `.frame(maxHeight: .infinity, alignment: .top)`. This prevents the inspector from centering vertically when the divider sibling claims full height.
- **SourceDetailView**: Set minimum width constraint with `.frame(minWidth: PageEditorMetrics.detailMinWidth)` to prevent the reader column from collapsing when the trailing inspector claims persisted width, matching the constraint in PageDetailView and ChatDetailView.

Both views include pattern documentation comments for their mixed (declarative + local state) architecture.

## Why

These constraints ensure detail columns maintain predictable layout behavior with varying content sizes and prevent unwanted centering or collapse.