### PR TITLE
Repair orphaned cascade children in v48 FK gate

### DIFF
--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -1617,8 +1617,27 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             } catch {
                 throw SchemaV48MigrationError.foreignKeyCheckerFailed(underlying: error)
             }
-            guard violations.isEmpty else {
-                throw SchemaV48MigrationError.foreignKeyViolation(violations)
+            if !violations.isEmpty {
+                // Tolerate databases that accumulated orphaned rows while
+                // foreign-key enforcement was off (e.g. a source deleted
+                // through a path that bypassed cascades): complete the
+                // ON DELETE CASCADE cleanup that should have removed the
+                // children, then re-check. Non-cascade orphans (and NOT NULL /
+                // UNIQUE corruption) are left for the re-check to reject, so
+                // genuinely unrepairable damage still aborts the migration.
+                let removed = try Self.reconcileCascadingOrphans(in: db)
+                if removed > 0 {
+                    DebugLog.store("v48 reconcile removed \(removed) orphaned row(s) before foreign-key re-check")
+                }
+                let remaining: [ForeignKeyCheckViolation]
+                do {
+                    remaining = try schemaForeignKeyChecker.check(db)
+                } catch {
+                    throw SchemaV48MigrationError.foreignKeyCheckerFailed(underlying: error)
+                }
+                guard remaining.isEmpty else {
+                    throw SchemaV48MigrationError.foreignKeyViolation(remaining)
+                }
             }
         } catch let error as SchemaV48MigrationError {
             throw error
@@ -1990,6 +2009,85 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         CREATE INDEX IF NOT EXISTS workspace_ref_sources_source
             ON workspace_ref_sources(source_id, workspace_id, owner_id);
         """)
+    }
+
+    /// Best-effort repair of orphaned foreign-key children, restricted to
+    /// `ON DELETE CASCADE` constraints. Such rows are children the schema
+    /// promised to remove when their parent was deleted; deleting them now
+    /// just completes a cascade that never ran because foreign-key
+    /// enforcement was off at the time (e.g. a `sources` row deleted through
+    /// a path that bypassed cascades, leaving `source_chunks` /
+    /// `source_search` / `source_markdown_versions` / `source_versions`
+    /// behind). Those four tables are leaves — nothing references them — so
+    /// the delete is safe even with enforcement on.
+    ///
+    /// Driven entirely by `PRAGMA foreign_key_check` + `foreign_key_list`
+    /// introspection, so it handles composite keys and `WITHOUT ROWID`
+    /// tables without targeting rowids (which `foreign_key_check` reports as
+    /// NULL for `WITHOUT ROWID` children). Non-cascade orphans are
+    /// deliberately left in place for the caller's re-check to reject.
+    /// Returns the number of rows removed.
+    private static func reconcileCascadingOrphans(in db: Database) throws -> Int {
+        // foreign_key_check columns: table | rowid | parent | fkid. It is a
+        // real diagnostic that reports violations regardless of enforcement
+        // state. Only the distinct set of child tables matters here; the
+        // per-row detail comes from foreign_key_list below.
+        let checkRows = try Row.fetchAll(db, sql: "PRAGMA foreign_key_check")
+        let violatedTables = Set(checkRows.compactMap { row -> String? in row["table"] as String? })
+
+        var removed = 0
+        for table in violatedTables {
+            // foreign_key_list columns: id | seq | table(parent) | from | to |
+            // on_update | on_delete | match. A composite key spans several
+            // rows sharing the same `id`; the parent table and on_delete
+            // action are constant across those rows.
+            let fkRows = try Row.fetchAll(
+                db, sql: "PRAGMA foreign_key_list(\(Self.quoteIdentifier(table)));")
+            struct FKGroup {
+                var parent: String
+                var onDelete: String
+                var columns: [(from: String, to: String)] = []
+            }
+            var groups: [Int: FKGroup] = [:]
+            for row in fkRows {
+                let id: Int = row["id"]
+                let parent: String = row["table"]
+                let fromColumn: String = row["from"]
+                let toColumn: String = row["to"]
+                let onDelete = (row["on_delete"] as String?).map { $0.uppercased() } ?? ""
+                if groups[id] != nil {
+                    groups[id]?.columns.append((fromColumn, toColumn))
+                } else {
+                    groups[id] = FKGroup(parent: parent, onDelete: onDelete, columns: [(fromColumn, toColumn)])
+                }
+            }
+
+            let child = Self.quoteIdentifier(table)
+            for group in groups.values where group.onDelete == "CASCADE" {
+                let parent = Self.quoteIdentifier(group.parent)
+                // match-simple semantics: a row violates the FK only when
+                // every FK column is non-null AND no parent row matches.
+                let notNull = group.columns
+                    .map { "\(Self.quoteIdentifier($0.from)) IS NOT NULL" }
+                    .joined(separator: " AND ")
+                let match = group.columns
+                    .map { "\(parent).\(Self.quoteIdentifier($0.to)) = \(child).\(Self.quoteIdentifier($0.from))" }
+                    .joined(separator: " AND ")
+                try db.execute(sql: """
+                DELETE FROM \(child)
+                WHERE \(notNull)
+                  AND NOT EXISTS (SELECT 1 FROM \(parent) WHERE \(match));
+                """)
+                removed += try Int.fetchOne(db, sql: "SELECT changes()") ?? 0
+            }
+        }
+        return removed
+    }
+
+    /// Quote a trusted SQL identifier (table/column name from our own schema
+    /// introspection) for safe interpolation into built SQL.
+    private static func quoteIdentifier(_ name: String) -> String {
+        "\"" + name.replacingOccurrences(of: "\"", with: "\"\"") + "\""
     }
 
     private static func rebuildChatSubsystemV46(in db: Database) throws {

--- a/Tests/WikiFSTests/SchemaV48MigrationTests.swift
+++ b/Tests/WikiFSTests/SchemaV48MigrationTests.swift
@@ -232,6 +232,54 @@ struct SchemaV48MigrationTests {
         try assertV48ObjectsAbsent(at: url)
     }
 
+    @Test func orphanedCascadeChildrenAreRepairedAndMigrationSucceeds() throws {
+        let url = try v47URL()
+        // Mirror the real-world corruption: a `sources` row was deleted while
+        // foreign-key enforcement was off, leaving its ON DELETE CASCADE
+        // children behind. source_chunks is WITHOUT ROWID (exercises the
+        // NULL-rowid reporting path); source_search is a rowid table.
+        try MetadataSQLiteFixtureSupport.execute("""
+        PRAGMA foreign_keys = OFF;
+        INSERT INTO source_chunks (source_id, chunk_idx, embedding) VALUES
+            ('ghost-source', 0, x'00'),
+            ('ghost-source', 1, x'00');
+        INSERT INTO source_search (source_id, title, body) VALUES
+            ('ghost-source', 'ghost', 'body');
+        PRAGMA foreign_keys = ON;
+        """, at: url)
+        #expect(try scalar("SELECT COUNT(*) FROM pragma_foreign_key_check", at: url) == "3")
+
+        // The store must open despite the orphans: the gate repairs the
+        // cascade children, then re-checks clean.
+        let store = try migrationStore(at: url)
+        #expect(store.pragmaValue("user_version") == "48")
+        #expect(try scalar("SELECT COUNT(*) FROM source_chunks WHERE source_id = 'ghost-source'", at: url) == "0")
+        #expect(try scalar("SELECT COUNT(*) FROM source_search WHERE source_id = 'ghost-source'", at: url) == "0")
+        #expect(try scalar("SELECT COUNT(*) FROM pragma_foreign_key_check", at: url) == "0")
+    }
+
+    @Test func nonCascadeOrphanStillAbortsMigration() throws {
+        let url = try v47URL()
+        // page_links references pages with the default NO ACTION — an orphan
+        // there is not something a cascade-cleanup can repair, so the
+        // migration must still abort rather than mask the damage.
+        try MetadataSQLiteFixtureSupport.execute("""
+        PRAGMA foreign_keys = OFF;
+        INSERT INTO page_links (from_page_id, to_page_id, link_text)
+        VALUES ('missing-page', 'missing-page', 'link');
+        PRAGMA foreign_keys = ON;
+        """, at: url)
+        #expect(try scalar("SELECT COUNT(*) FROM pragma_foreign_key_check", at: url) == "2")
+
+        do {
+            _ = try migrationStore(at: url)
+            Issue.record("expected non-cascade orphan to abort")
+        } catch let error as SchemaV48MigrationError {
+            #expect(error.description.contains("foreign-key check returned"))
+        }
+        try assertV48ObjectsAbsent(at: url)
+    }
+
     @Test func productionForeignKeyCheckerRunsRealCleanPragmaWithEnforcementEnabled() throws {
         let store = try migrationStore(at: v47URL())
         #expect(store.pragmaValue("foreign_keys") == "1")

--- a/progress/2026-08-01T035601Z-fk-orphan-tolerance-on-v48-open.md
+++ b/progress/2026-08-01T035601Z-fk-orphan-tolerance-on-v48-open.md
@@ -1,0 +1,38 @@
+---
+timestamp: 2026-08-01T035601Z
+title: Tolerate orphaned cascade rows when opening (v48 FK gate self-heal)
+branch: fk-constraint-tolerance
+status: complete
+---
+
+# Tolerate orphaned cascade rows when opening (v48 FK gate self-heal)
+
+## Progress
+
+A wiki database (`user_version=47`) would not open: the v47→v48 migration
+ends in a hard `PRAGMA foreign_key_check` gate that threw on any orphaned
+row, aborting the open. The operator's DB had 8 violations, all
+`ON DELETE CASCADE` children of one deleted `sources` row (`source_chunks`,
+`source_search`, `source_markdown_versions`, `source_versions`) that survived
+because the parent was deleted while foreign-key enforcement was off.
+
+`GRDBWikiStore.migrateV47ToV48` now does **repair-then-recheck**: when the
+gate reports violations, `reconcileCascadingOrphans(in:)` completes the
+cascade cleanup that should have run — deleting children whose parent row no
+longer exists, restricted to `ON DELETE CASCADE` FKs (driven generically by
+`foreign_key_check` + `foreign_key_list`, so it handles composite keys and
+`WITHOUT ROWID` tables). The gate then re-checks; non-cascade orphans and
+other corruption still abort, so genuinely unrepairable damage is not masked.
+
+This is the only place orphans block opening (post-v48 there is no open-time
+FK check, and cascades run normally), so the fix is necessary and sufficient.
+
+## Verification
+
+- `swift test --filter SchemaV48MigrationTests` — 39 tests pass, including two
+  new ones: `orphanedCascadeChildrenAreRepairedAndMigrationSucceeds` and
+  `nonCascadeOrphanStillAbortsMigration`.
+- `make test` — full suite, 2951 tests pass.
+- Compiled fix verified against a copy of the operator's real v47 DB (8
+  cascade orphans): opened cleanly to `user_version=48` with a 0-row
+  `foreign_key_check`. The live DB will be auto-repaired on next app launch.


### PR DESCRIPTION
When opening a v47 database, the v48 migration enforces foreign-key constraints. Some databases accumulated orphaned ON DELETE CASCADE children — rows whose parent was deleted while foreign-key enforcement was off, leaving cascading deletes incomplete.

This change makes the migration self-heal: when FK violations are detected, `reconcileCascadingOrphans()` completes the cascade cleanup by deleting orphaned children with no matching parent. The FK check is re-run; if it passes, the database opens normally. Non-cascade orphans and other corruption still abort, preventing data damage from being masked.

The repair is generic (driven by PRAGMA introspection) and handles composite keys and WITHOUT ROWID tables.

Fixes the operator's v47 database with 8 orphaned CASCADE children (source_chunks, source_search, etc.) that blocked opening.

Testing:
- New test: orphaned CASCADE children are repaired and migration succeeds
- New test: non-cascade orphans still abort migration (damage detection works)
- Full suite: 2951 tests pass