### PR TITLE
Warn on deletion of pages and sources with incoming links

### DIFF
--- a/Sources/WikiFS/Pages/PagesContainerView.swift
+++ b/Sources/WikiFS/Pages/PagesContainerView.swift
@@ -20,6 +20,10 @@ struct PagesContainerView: View {
     @State private var renameText = ""
     /// Non-nil while the bookmark-target picker is open for a page selection.
     @State private var addToBookmarksContext: BookmarkTargetPickerContext?
+    /// Non-nil while the incoming-reference delete confirmation is open. Set
+    /// when the user deletes a page that other pages link to or bookmarks point
+    /// at (issue #219).
+    @State private var pendingDeletion: PendingPageDeletion?
 
     private var visible: [WikiPageSummary] {
         store.searchQuery.isEmpty ? store.summaries : store.searchResults
@@ -69,6 +73,16 @@ struct PagesContainerView: View {
                     }
                 }
             )
+        }
+        .confirmationDialog(
+            pendingDeletion.map { deletionDialogTitle(ids: $0.ids) } ?? "",
+            isPresented: deletionDialogPresented,
+            titleVisibility: .visible,
+            presenting: pendingDeletion
+        ) { pending in
+            deletionDialogActions(for: pending)
+        } message: { pending in
+            Text(deletionDialogMessage(for: pending))
         }
     }
 
@@ -176,16 +190,7 @@ struct PagesContainerView: View {
             },
             onRename: { summary in beginRename(summary) },
             onDelete: { ids in
-                for id in ids { store.delete(id) }
-                // If a deleted page was the home page, clear the stale
-                // homePageID so the Home button doesn't linger as dead UI.
-                if let homeID = session.descriptor.homePageID,
-                   ids.contains(homeID) {
-                    registry.setHomePage(id: session.wikiID, pageID: nil)
-                    var d = session.descriptor
-                    d.homePageID = nil
-                    session.updateDescriptor(d)
-                }
+                requestPageDeletion(ids)
             },
             onSetHomePage: { pageID in
                 registry.setHomePage(id: session.wikiID, pageID: pageID)
@@ -219,4 +224,107 @@ struct PagesContainerView: View {
             set: { if !$0 { renameTarget = nil } }
         )
     }
+
+    // MARK: - Delete with incoming-reference warning (issue #219)
+
+    /// Aggregate the incoming links + bookmarks for the selected pages, then
+    /// either delete immediately (nothing references them) or open the
+    /// confirmation dialog so the user can see and choose how to handle them.
+    private func requestPageDeletion(_ ids: [PageID]) {
+        let deletedIDs = Set(ids)
+        var linkingIDs: [PageID] = []
+        var bookmarkFolders: Set<String> = []
+        var bookmarkCount = 0
+        for id in ids {
+            let impact = store.deletionImpact(forPage: id)
+            linkingIDs.append(contentsOf: impact.linkingPageIDs)
+            bookmarkCount += impact.bookmarkLabels.count
+            bookmarkFolders.formUnion(impact.bookmarkLabels)
+        }
+        // Drop pages that are themselves being deleted (they vanish with the
+        // batch), then dedupe for display.
+        let displayTitles = Array(Set(linkingIDs))
+            .filter { !deletedIDs.contains($0) }
+            .compactMap { id in store.summaries.first { $0.id == id }?.title }
+            .sorted()
+
+        if displayTitles.isEmpty && bookmarkCount == 0 {
+            confirmPageDeletion(ids: ids, unlink: false)
+        } else {
+            pendingDeletion = PendingPageDeletion(
+                ids: ids,
+                linkingPageTitles: displayTitles,
+                bookmarkCount: bookmarkCount,
+                bookmarkFolders: bookmarkFolders.sorted())
+        }
+    }
+
+    private func confirmPageDeletion(ids: [PageID], unlink: Bool) {
+        for id in ids { store.delete(id, unlinkIncomingLinks: unlink) }
+        // If a deleted page was the home page, clear the stale homePageID so the
+        // Home button doesn't linger as dead UI.
+        if let homeID = session.descriptor.homePageID, ids.contains(homeID) {
+            registry.setHomePage(id: session.wikiID, pageID: nil)
+            var d = session.descriptor
+            d.homePageID = nil
+            session.updateDescriptor(d)
+        }
+        pendingDeletion = nil
+    }
+
+    private var deletionDialogPresented: Binding<Bool> {
+        Binding(
+            get: { pendingDeletion != nil },
+            set: { if !$0 { pendingDeletion = nil } }
+        )
+    }
+
+    private func deletionDialogTitle(ids: [PageID]) -> String {
+        ids.count == 1 ? "Delete Page?" : "Delete \(ids.count) Pages?"
+    }
+
+    private func deletionDialogMessage(for pending: PendingPageDeletion) -> String {
+        var lines: [String] = []
+        if !pending.linkingPageTitles.isEmpty {
+            let names = pending.linkingPageTitles.joined(separator: ", ")
+            let noun = pending.linkingPageTitles.count == 1 ? "page" : "pages"
+            lines.append("Linked from \(pending.linkingPageTitles.count) \(noun): \(names).")
+        }
+        if pending.bookmarkCount > 0 {
+            let noun = pending.bookmarkCount == 1 ? "bookmark" : "bookmarks"
+            let where_ = pending.bookmarkFolders.joined(separator: ", ")
+            lines.append("\(pending.bookmarkCount) \(noun) point to this and will be removed (\(where_)).")
+        }
+        if !pending.linkingPageTitles.isEmpty {
+            lines.append("Unlink and Delete converts the links to plain text.")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    @ViewBuilder
+    private func deletionDialogActions(for pending: PendingPageDeletion) -> some View {
+        if !pending.linkingPageTitles.isEmpty {
+            Button("Unlink and Delete", role: .destructive) {
+                confirmPageDeletion(ids: pending.ids, unlink: true)
+            }
+            Button("Delete", role: .destructive) {
+                confirmPageDeletion(ids: pending.ids, unlink: false)
+            }
+        } else {
+            Button("Delete", role: .destructive) {
+                confirmPageDeletion(ids: pending.ids, unlink: false)
+            }
+        }
+        Button("Cancel", role: .cancel) { pendingDeletion = nil }
+    }
+}
+
+/// State carried by the incoming-reference delete-confirmation dialog
+/// (issue #219).
+private struct PendingPageDeletion: Identifiable {
+    let id = UUID()
+    let ids: [PageID]
+    let linkingPageTitles: [String]
+    let bookmarkCount: Int
+    let bookmarkFolders: [String]
 }

--- a/Sources/WikiFS/Sources/SourcesContainerView.swift
+++ b/Sources/WikiFS/Sources/SourcesContainerView.swift
@@ -32,6 +32,8 @@ struct SourcesContainerView: View {
     @State private var pendingReingestNames: [String] = []
     /// Non-nil while the bookmark-target picker is open for a source selection.
     @State private var addToBookmarksContext: BookmarkTargetPickerContext?
+    /// Non-nil while the incoming-reference delete confirmation is open (issue #219).
+    @State private var pendingDeletion: PendingSourceDeletion?
 
     enum SourceFilter: String, CaseIterable {
         case all = "All"
@@ -110,6 +112,16 @@ struct SourcesContainerView: View {
                     }
                 }
             )
+        }
+        .confirmationDialog(
+            pendingDeletion.map { deletionDialogTitle(for: $0) } ?? "",
+            isPresented: deletionDialogPresented,
+            titleVisibility: .visible,
+            presenting: pendingDeletion
+        ) { pending in
+            deletionDialogActions(for: pending)
+        } message: { pending in
+            Text(deletionDialogMessage(for: pending))
         }
     }
 
@@ -248,7 +260,7 @@ struct SourcesContainerView: View {
             },
             onRename: { source in beginRename(source) },
             onDelete: { ids in
-                for id in ids { store.deleteSource(id) }
+                requestSourceDeletion(ids)
             },
             onAddToBookmarks: { ids in
                 addToBookmarksContext = BookmarkTargetPickerContext(targets: .sources(ids))
@@ -274,4 +286,108 @@ struct SourcesContainerView: View {
             set: { if !$0 { renameTarget = nil } }
         )
     }
+
+    // MARK: - Delete with incoming-reference warning (issue #219)
+
+    private func requestSourceDeletion(_ ids: [SourceID]) {
+        var linkingIDs: [PageID] = []
+        var bookmarkFolders: Set<String> = []
+        var bookmarkCount = 0
+        var blockedPageIDs = Set<PageID>()
+        for id in ids {
+            let impact = store.deletionImpact(forSource: id)
+            linkingIDs.append(contentsOf: impact.linkingPageIDs)
+            bookmarkCount += impact.bookmarkLabels.count
+            bookmarkFolders.formUnion(impact.bookmarkLabels)
+            blockedPageIDs.formUnion(impact.provenanceBlockers.map(\.pageID))
+        }
+        let displayTitles = Array(Set(linkingIDs))
+            .compactMap { id in store.summaries.first { $0.id == id }?.title }
+            .sorted()
+        let blockedTitles = blockedPageIDs
+            .compactMap { id in store.summaries.first { $0.id == id }?.title }
+            .sorted()
+
+        if blockedTitles.isEmpty && displayTitles.isEmpty && bookmarkCount == 0 {
+            confirmSourceDeletion(ids: ids, unlink: false)
+        } else {
+            pendingDeletion = PendingSourceDeletion(
+                ids: ids,
+                linkingPageTitles: displayTitles,
+                bookmarkCount: bookmarkCount,
+                bookmarkFolders: bookmarkFolders.sorted(),
+                blockedPageTitles: blockedTitles)
+        }
+    }
+
+    private func confirmSourceDeletion(ids: [SourceID], unlink: Bool) {
+        for id in ids { store.deleteSource(id, unlinkIncomingLinks: unlink) }
+        pendingDeletion = nil
+    }
+
+    private var deletionDialogPresented: Binding<Bool> {
+        Binding(
+            get: { pendingDeletion != nil },
+            set: { if !$0 { pendingDeletion = nil } }
+        )
+    }
+
+    private func deletionDialogTitle(for pending: PendingSourceDeletion) -> String {
+        if !pending.blockedPageTitles.isEmpty { return "Can't Delete Source" }
+        return pending.ids.count == 1 ? "Delete Source?" : "Delete \(pending.ids.count) Sources?"
+    }
+
+    private func deletionDialogMessage(for pending: PendingSourceDeletion) -> String {
+        if !pending.blockedPageTitles.isEmpty {
+            let names = pending.blockedPageTitles.joined(separator: ", ")
+            return "This source is referenced as evidence by page versions (\(names)). Remove those references before deleting."
+        }
+        var lines: [String] = []
+        if !pending.linkingPageTitles.isEmpty {
+            let names = pending.linkingPageTitles.joined(separator: ", ")
+            let noun = pending.linkingPageTitles.count == 1 ? "page" : "pages"
+            lines.append("Cited by \(pending.linkingPageTitles.count) \(noun): \(names).")
+        }
+        if pending.bookmarkCount > 0 {
+            let noun = pending.bookmarkCount == 1 ? "bookmark" : "bookmarks"
+            let where_ = pending.bookmarkFolders.joined(separator: ", ")
+            lines.append("\(pending.bookmarkCount) \(noun) point to this and will be removed (\(where_)).")
+        }
+        if !pending.linkingPageTitles.isEmpty {
+            lines.append("Unlink and Delete converts the citations to plain text.")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    @ViewBuilder
+    private func deletionDialogActions(for pending: PendingSourceDeletion) -> some View {
+        if !pending.blockedPageTitles.isEmpty {
+            Button("OK", role: .cancel) { pendingDeletion = nil }
+        } else if !pending.linkingPageTitles.isEmpty {
+            Button("Unlink and Delete", role: .destructive) {
+                confirmSourceDeletion(ids: pending.ids, unlink: true)
+            }
+            Button("Delete", role: .destructive) {
+                confirmSourceDeletion(ids: pending.ids, unlink: false)
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } else {
+            Button("Delete", role: .destructive) {
+                confirmSourceDeletion(ids: pending.ids, unlink: false)
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        }
+    }
+}
+
+/// State carried by the incoming-reference delete-confirmation dialog
+/// (issue #219). When `blockedPageTitles` is non-empty, the source can't be
+/// deleted at all (provenance-restricted) and only an OK button is shown.
+private struct PendingSourceDeletion: Identifiable {
+    let id = UUID()
+    let ids: [SourceID]
+    let linkingPageTitles: [String]
+    let bookmarkCount: Int
+    let bookmarkFolders: [String]
+    let blockedPageTitles: [String]
 }

--- a/Sources/WikiFSCore/Core/DeletionImpact.swift
+++ b/Sources/WikiFSCore/Core/DeletionImpact.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A snapshot of what references a page or source that the user is about to
+/// delete (issue #219). The model computes this before showing the
+/// delete-confirmation dialog so the user can see incoming links, bookmarks,
+/// and (for sources) provenance blockers, then choose how to proceed.
+public struct DeletionImpact: Sendable, Equatable {
+    /// Pages that link to the target (excludes the target itself). The UI maps
+    /// these to titles via `summaries`; the unlink path uses the ids directly.
+    public let linkingPageIDs: [PageID]
+    /// Where each referencing bookmark lives, as a folder display path
+    /// (e.g. `"Research / Papers"`; `"Bookmarks"` for a root-level node).
+    public let bookmarkLabels: [String]
+    /// Page versions whose provenance cites this resource, making deletion
+    /// impossible. Always empty for pages; populated for sources the agent has
+    /// used to author pages (issue #219).
+    public let provenanceBlockers: [ProvenanceDeletionBlocker]
+
+    public init(
+        linkingPageIDs: [PageID],
+        bookmarkLabels: [String],
+        provenanceBlockers: [ProvenanceDeletionBlocker] = []
+    ) {
+        self.linkingPageIDs = linkingPageIDs
+        self.bookmarkLabels = bookmarkLabels
+        self.provenanceBlockers = provenanceBlockers
+    }
+
+    /// True when a provenance edge prevents deletion — the dialog must NOT
+    /// offer to delete (the store would throw).
+    public var isProvenanceBlocked: Bool { !provenanceBlockers.isEmpty }
+
+    /// True when there is at least one incoming link or bookmark.
+    public var hasReferences: Bool {
+        !linkingPageIDs.isEmpty || !bookmarkLabels.isEmpty
+    }
+
+    /// True when the delete-confirmation dialog should be shown at all — any
+    /// incoming reference OR a provenance block.
+    public var showsDialog: Bool { hasReferences || isProvenanceBlocked }
+}

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -3992,6 +3992,16 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    /// The page-version provenance edges that prevent `sourceID` from being
+    /// deleted (issue #219). Read-only wrapper over the private
+    /// `provenanceDeletionBlockers` so the model + UI can show the restriction
+    /// before attempting a delete that would throw.
+    public func sourceProvenanceBlockers(sourceID: SourceID) throws -> [ProvenanceDeletionBlocker] {
+        try dbWriter.read { db in
+            try self.provenanceDeletionBlockers(sourceID: sourceID, on: db)?.values ?? []
+        }
+    }
+
     /// Finds the complete, deterministic provenance impact before source
     /// deletion. Raw ordering remains at this SQLite boundary.
     private func provenanceDeletionBlockers(
@@ -10254,6 +10264,19 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 db,
                 sql: "SELECT DISTINCT from_page_id FROM source_links WHERE to_source_id = ?;",
                 arguments: [sourceID.rawValue]
+            )
+            return rows.map { PageID(rawValue: $0) }
+        }
+    }
+
+    /// Pages whose bodies link to `pageID` via `[[wiki-link]]` — the incoming
+    /// page-link edge set (issue #219). Mirrors `sourceLinkingPages`.
+    public func pageLinkingPages(to pageID: PageID) throws -> [PageID] {
+        try dbWriter.read { db in
+            let rows = try String.fetchAll(
+                db,
+                sql: "SELECT DISTINCT from_page_id FROM page_links WHERE to_page_id = ?;",
+                arguments: [pageID.rawValue]
             )
             return rows.map { PageID(rawValue: $0) }
         }

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -190,6 +190,16 @@ public protocol WikiStore: Sendable {
     /// are omitted (the schema forbids a NULL `to_page_id`). Self-links allowed.
     func replaceLinks(from pageID: PageID, parsedLinks: [ParsedLink]) throws
 
+    /// Pages whose bodies link TO `pageID` via `[[wiki-link]]` — the incoming
+    /// edge set (issue #219). Used to warn before deleting a page that other
+    /// pages still reference, and to rewrite those links to plain text.
+    func pageLinkingPages(to pageID: PageID) throws -> [PageID]
+
+    /// Pages whose bodies link TO `sourceID` via `[[source:…]]` — the incoming
+    /// source-link edge set (issue #219). Used to warn before deleting a source
+    /// that pages still cite, and to rewrite those citations to plain text.
+    func sourceLinkingPages(to sourceID: SourceID) throws -> [PageID]
+
     // MARK: - Ingested files (Phase 5)
     //
     // Only the three methods `WikiStoreModel` actually calls live on the
@@ -266,6 +276,12 @@ public protocol WikiStore: Sendable {
 
     /// Remove a source by id.
     func deleteSource(id: SourceID) throws
+
+    /// The page versions whose provenance cites `sourceID`, making the source
+    /// undeletable (issue #219). Empty when the source is free to delete. The
+    /// delete-confirmation dialog surfaces these so the user sees WHY a source
+    /// can't be removed instead of a silent failure.
+    func sourceProvenanceBlockers(sourceID: SourceID) throws -> [ProvenanceDeletionBlocker]
 
     /// The origin provenance of a source: the provider agent + the activity that
     /// fetched/imported it, joined from the active content version to its activity

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -1878,6 +1878,47 @@ public final class WikiStoreModel {
         }
     }
 
+    /// What references `id` right now — pages that link to it and bookmarks that
+    /// point at it (issue #219). The UI shows this before deleting so the user
+    /// can decide whether to convert the incoming links to plain text.
+    public func deletionImpact(forPage id: PageID) -> DeletionImpact {
+        let linkingIDs = (DebugLog.trying("pageLinkingPages", operation: {
+            try store.pageLinkingPages(to: id)
+        }) ?? []).filter { $0 != id }
+        return DeletionImpact(
+            linkingPageIDs: linkingIDs,
+            bookmarkLabels: bookmarkLabelsReferencing { content in
+                if case .page(let pid) = content { return pid == id }
+                return false
+            })
+    }
+
+    /// Delete a page, optionally converting every incoming `[[link]]` in other
+    /// pages to plain text first. Bookmarks pointing at the page are ALWAYS
+    /// removed — a bookmark to a missing page is invalid (issue #219). Use this
+    /// path when `deletionImpact(forPage:)` reported references; use
+    /// ``delete(_:)`` for the no-ceremony immediate delete.
+    public func delete(_ id: PageID, unlinkIncomingLinks: Bool) {
+        do {
+            if unlinkIncomingLinks {
+                try unlinkIncomingLinksTo(pageIDs: [id], sourceIDs: [])
+            }
+            removeBookmarksReferencingPage(id)
+            try store.deletePage(id: id)
+            removeFromHistory(.page(id))
+            if let tab = tabs.first(where: { $0.selection == .page(id) }) {
+                closeTab(id: tab.id)
+            }
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // delete + bookmark removals + (optional) linking-page rewrites.
+        } catch {
+            DebugLog.store("WikiStoreModel.delete(unlink:) failed: \(error)")
+            storeError = StoreError(
+                title: "Couldn't Delete Page",
+                message: "Could not delete the page: \(error.localizedDescription)")
+        }
+    }
+
     /// Dismiss the current store error (called when the user taps OK on the alert).
     public func dismissStoreError() {
         storeError = nil
@@ -2775,6 +2816,74 @@ public final class WikiStoreModel {
             // delete. History and tab cleanup happen explicitly above.
         } catch {
             DebugLog.store("WikiStoreModel.deleteSource failed: \(error)")
+            storeError = StoreError(
+                title: "Couldn't Delete Source",
+                message: "Could not delete the source: \(error.localizedDescription)")
+        }
+    }
+
+    /// What references `id` right now — pages that cite it and bookmarks that
+    /// point at it (issue #219). The UI shows this before deleting so the user
+    /// can decide whether to convert the incoming citations to plain text.
+    public func deletionImpact(forSource id: SourceID) -> DeletionImpact {
+        let linkingIDs = (DebugLog.trying("sourceLinkingPages", operation: {
+            try store.sourceLinkingPages(to: id)
+        }) ?? [])
+        let blockers = DebugLog.trying("sourceProvenanceBlockers", operation: {
+            try store.sourceProvenanceBlockers(sourceID: id)
+        }) ?? []
+        return DeletionImpact(
+            linkingPageIDs: linkingIDs,
+            bookmarkLabels: bookmarkLabelsReferencing { content in
+                if case .source(let sid) = content { return sid == id }
+                return false
+            },
+            provenanceBlockers: blockers)
+    }
+
+    /// Delete a source, optionally converting every incoming `[[source:…]]`
+    /// citation in other pages to plain text first. Bookmarks pointing at the
+    /// source are ALWAYS removed — a bookmark to a missing source is invalid
+    /// (issue #219). Use this path when `deletionImpact(forSource:)` reported
+    /// references; use ``deleteSource(_:)`` for the no-ceremony immediate
+    /// delete.
+    public func deleteSource(_ id: SourceID, unlinkIncomingLinks: Bool) {
+        // A provenance blocker makes deletion impossible (the store throws).
+        // Bail BEFORE any destructive cleanup so we don't unlink citations or
+        // remove bookmarks for a source that stays in place (issue #219).
+        let blockers = DebugLog.trying("sourceProvenanceBlockers", operation: {
+            try store.sourceProvenanceBlockers(sourceID: id)
+        }) ?? []
+        if !blockers.isEmpty {
+            let titles = Set(blockers.map(\.pageID)).compactMap { pid in
+                summaries.first { $0.id == pid }?.title
+            }.sorted()
+            let noun = blockers.count == 1 ? "page version" : "page versions"
+            var message = "This source is referenced as evidence by \(blockers.count) \(noun)"
+            if !titles.isEmpty {
+                message += " (\(titles.joined(separator: ", ")))"
+            }
+            message += ". Remove those references first."
+            storeError = StoreError(title: "Can't Delete Source", message: message)
+            return
+        }
+        do {
+            if unlinkIncomingLinks {
+                try unlinkIncomingLinksTo(pageIDs: [], sourceIDs: [id])
+            }
+            removeBookmarksReferencingSource(id)
+            try store.deleteSource(id: id)
+            removeFromHistory(.source(id))
+            if let tab = tabs.first(where: { $0.selection == .source(id) }) {
+                closeTab(id: tab.id)
+            }
+            // No manual reload — the bus fires reloadFromStore() async after the
+            // delete + bookmark removals + (optional) linking-page rewrites.
+        } catch {
+            DebugLog.store("WikiStoreModel.deleteSource(unlink:) failed: \(error)")
+            storeError = StoreError(
+                title: "Couldn't Delete Source",
+                message: "Could not delete the source: \(error.localizedDescription)")
         }
     }
 
@@ -4089,6 +4198,78 @@ public final class WikiStoreModel {
             DebugLog.store("WikiStoreModel.moveBookmarkNode failed: \(error)")
             return false
         }
+    }
+
+    // MARK: - Deletion-impact helpers (issue #219)
+
+    /// Folder display paths for bookmarks whose content satisfies `matches`.
+    /// A root-level node is reported as `"Bookmarks"`.
+    private func bookmarkLabelsReferencing(
+        matches: (BookmarkNode.Content) -> Bool
+    ) -> [String] {
+        bookmarkNodes
+            .filter { matches($0.content) }
+            .map { bookmarkDisplayPath(for: $0) }
+    }
+
+    private func bookmarkDisplayPath(for node: BookmarkNode) -> String {
+        guard let parentID = node.parentID else { return "Bookmarks" }
+        let path = BookmarkNode.displayPath(id: parentID, in: bookmarkNodes)
+        return path.isEmpty ? "Bookmarks" : path
+    }
+
+    /// Remove every bookmark leaf pointing at `id`. Called on every page delete
+    /// that goes through the confirmation path — a bookmark to a missing page is
+    /// invalid (issue #219).
+    private func removeBookmarksReferencingPage(_ id: PageID) {
+        let nodes = bookmarkNodes.filter { node in
+            if case .page(let pid) = node.content { return pid == id }
+            return false
+        }
+        for node in nodes { deleteBookmarkNode(id: node.id) }
+    }
+
+    /// Remove every bookmark leaf pointing at `id` (the source-side mirror).
+    private func removeBookmarksReferencingSource(_ id: SourceID) {
+        let nodes = bookmarkNodes.filter { node in
+            if case .source(let sid) = node.content { return sid == id }
+            return false
+        }
+        for node in nodes { deleteBookmarkNode(id: node.id) }
+    }
+
+    /// Rewrite the bodies of every page that links to one of `pageIDs` /
+    /// `sourceIDs`, converting the matching `[[…]]` spans to plain text. Runs
+    /// BEFORE the target rows are deleted so name-based links still resolve to
+    /// the about-to-be-deleted id. Each rewrite routes through `PageUpsert` so
+    /// the link graph (`page_links` / `source_links`) drops the now-removed
+    /// edge in the same write the app and `wikictl` share.
+    private func unlinkIncomingLinksTo(pageIDs: Set<PageID>, sourceIDs: Set<SourceID>) throws {
+        guard !pageIDs.isEmpty || !sourceIDs.isEmpty else { return }
+        var linkingPageIDs = Set<PageID>()
+        for id in pageIDs { linkingPageIDs.formUnion(try store.pageLinkingPages(to: id)) }
+        for id in sourceIDs { linkingPageIDs.formUnion(try store.sourceLinkingPages(to: id)) }
+        // Never rewrite a page that is itself being deleted.
+        linkingPageIDs.subtract(pageIDs)
+        for linkingID in linkingPageIDs {
+            try rewritePageBodyUnlinkingTargets(
+                pageID: linkingID, pageIDs: pageIDs, sourceIDs: sourceIDs)
+        }
+    }
+
+    private func rewritePageBodyUnlinkingTargets(
+        pageID: PageID, pageIDs: Set<PageID>, sourceIDs: Set<SourceID>
+    ) throws {
+        let page = try store.getPage(id: pageID)
+        guard let rewritten = try LinkUnlinker.unlink(
+            in: page.bodyMarkdown,
+            unlinkPageIDs: pageIDs,
+            unlinkSourceIDs: sourceIDs,
+            resolvePageName: { name in try self.store.resolveTitleToID(name) },
+            resolveSourceName: { name in try self.store.resolveSourceByName(name) }
+        ) else { return }
+        try PageUpsert.upsert(in: store, id: pageID, title: page.title, body: rewritten,
+                              author: PageAuthor.agent("unlink").rawValue)
     }
 
     private func pruneHistoryToCurrentStore() {

--- a/Sources/WikiFSLinks/LinkUnlinker.swift
+++ b/Sources/WikiFSLinks/LinkUnlinker.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Pure, dependency-free helper that converts `[[wiki-link]]` spans pointing at
+/// a set of deleted targets into their plain display text (issue #219).
+///
+/// When a page or source is deleted, every other page that links to it is left
+/// with a now-broken `[[…]]` (a "ghost link"). `unlink(in:…)` rewrites those
+/// spans to the visible text the link would have rendered (the `|alias` when one
+/// was authored, otherwise the bare target name), so the body reads naturally
+/// instead of showing dead links.
+///
+/// Structurally a sibling of `WikiLinkRewriter.canonicalize`: it reuses
+/// `WikiLinkSpan` for the regex + code-range detection and `WikiLinkParser` for
+/// classification/fragment/pin handling, walks matches right-to-left so byte
+/// offsets stay valid across splices, and returns `nil` when nothing changed
+/// (so callers skip the re-save). Resolution of a *name* target to an id is
+/// injected, keeping the function pure and unit-testable without a store.
+public enum LinkUnlinker {
+
+    /// Convert every `[[…]]` / `![[…]]` span whose resolved target is one of
+    /// `unlinkPageIDs` / `unlinkSourceIDs` to its plain display text. The
+    /// display text is the authored `|alias` when present (and non-empty),
+    /// otherwise the bare target name — matching `WikiLinkParser`'s `linkText`
+    /// derivation. Embed prefixes (`![[…]]`) are consumed along with the span
+    /// so an embed becomes plain text rather than a stray `!`.
+    ///
+    /// Targets are matched two ways:
+    /// 1. **Canonical ULID** (`[[page:<ULID>…]]`): direct membership test
+    ///    against the id set — no resolution needed (and stable across renames).
+    /// 2. **Name** (`[[Page Title]]`): resolved via the injected closures; the
+    ///    returned id is tested for membership. Name matching only fires while
+    ///    the target still exists, so callers should unlink BEFORE deleting.
+    ///
+    /// Chat links are never touched (they are not in either unlink set). Spans
+    /// inside a code fence or inline code span are left literal. Returns `nil`
+    /// when no span matched, so callers can skip the re-save.
+    ///
+    /// - Parameters:
+    ///   - body: The markdown body to rewrite.
+    ///   - unlinkPageIDs: Page ids whose incoming links should become plain text.
+    ///   - unlinkSourceIDs: Source ids whose incoming links should become plain text.
+    ///   - resolvePageName: Resolves a page *title* to its id (nil if unknown).
+    ///   - resolveSourceName: Resolves a source *name* to its id (nil if unknown).
+    /// - Returns: The rewritten body, or `nil` when nothing changed.
+    public static func unlink(
+        in body: String,
+        unlinkPageIDs: Set<PageID>,
+        unlinkSourceIDs: Set<SourceID>,
+        resolvePageName: (String) throws -> PageID?,
+        resolveSourceName: (String) throws -> SourceID?
+    ) throws -> String? {
+        guard !unlinkPageIDs.isEmpty || !unlinkSourceIDs.isEmpty else { return nil }
+
+        let ns = body as NSString
+        let codeRanges = WikiLinkSpan.protectedCodeRanges(in: body)
+        let matches = WikiLinkSpan.regex.matches(
+            in: body, range: NSRange(location: 0, length: ns.length))
+
+        var result = body
+        var changed = false
+
+        // Walk right-to-left so byte offsets stay valid across splices (same
+        // discipline as `WikiLinkRewriter.canonicalize`).
+        for match in matches.reversed() {
+            let fullRange = match.range
+            guard !WikiLinkSpan.isProtected(fullRange, by: codeRanges) else { continue }
+
+            let targetRange = match.range(at: 1)
+            let aliasRange = match.range(at: 2)
+            let rawTarget = ns.substring(with: targetRange)
+            let rawAlias = aliasRange.location != NSNotFound ? ns.substring(with: aliasRange) : nil
+
+            let fixed = WikiLinkFixer.fix(target: rawTarget, alias: rawAlias)
+            let collapsed = WikiText.normalized(fixed.target)
+            guard !collapsed.isEmpty else { continue }
+
+            // Split on the first "#" before classifying — same as the parser, so
+            // `[[source:X#"quote"]]` yields base "source:X" and a same-page
+            // anchor (`[[#…]]`, empty base) is skipped.
+            let (base, _) = WikiLinkParser.splitFragment(collapsed)
+            guard !base.isEmpty else { continue }
+
+            // Strip a trailing `@vN` version pin before classifying so a pinned
+            // canonical target (`ULID@v3`) still passes the ULID fast-path.
+            let (bareBase, _) = WikiLinkParser.splitVersionPin(base)
+
+            let (kind, bareTarget) = WikiLinkParser.classify(bareBase)
+            guard !bareTarget.isEmpty, !WikiLinkParser.isEmptyPrefix(bareBase) else { continue }
+
+            // Resolve this span's target to an id, then test membership.
+            let matchedID: Bool
+            switch kind {
+            case .page:
+                matchedID = try matchesDeleted(
+                    bareTarget: bareTarget, in: unlinkPageIDs,
+                    resolveName: resolvePageName)
+            case .source:
+                matchedID = try matchesDeleted(
+                    bareTarget: bareTarget, in: unlinkSourceIDs,
+                    resolveName: resolveSourceName)
+            case .chat:
+                continue // chat links are never unlinked here
+            }
+            guard matchedID else { continue }
+
+            // Display text: authored alias (if non-empty), else the bare target
+            // name — mirroring `WikiLinkParser`'s `linkText` derivation.
+            let display: String
+            if let alias = fixed.alias {
+                let collapsedAlias = WikiText.normalized(alias)
+                display = collapsedAlias.isEmpty ? bareTarget : collapsedAlias
+            } else {
+                display = bareTarget
+            }
+
+            // Splice the span. Consume a preceding `!` embed prefix so an embed
+            // (`![[source:X]]`) becomes plain text rather than a stray `!`.
+            let isEmbed = WikiLinkSpan.isEmbedPrefix(ns, fullRange)
+            let spliceRange = isEmbed
+                ? NSRange(location: fullRange.location - 1, length: fullRange.length + 1)
+                : fullRange
+            let mutable = NSMutableString(string: result)
+            mutable.replaceCharacters(in: spliceRange, with: display)
+            result = mutable as String
+            changed = true
+        }
+
+        return changed ? result : nil
+    }
+
+    /// True when `bareTarget` identifies a member of `deletedIDs` — either
+    /// directly (a canonical ULID in the set) or by resolving its name to an id
+    /// that is in the set.
+    private static func matchesDeleted<ID: RawRepresentable>(
+        bareTarget: String,
+        in deletedIDs: Set<ID>,
+        resolveName: (String) throws -> ID?
+    ) throws -> Bool where ID.RawValue == String {
+        if WikiLinkParser.isCanonicalULID(bareTarget),
+           let id = ID(rawValue: bareTarget) {
+            return deletedIDs.contains(id)
+        }
+        // Name-based link: resolve to an id and test membership. Resolution is
+        // only meaningful while the target still exists; callers unlink before
+        // deleting, so a name still resolves to the about-to-be-deleted id.
+        if let resolved = try resolveName(bareTarget) {
+            return deletedIDs.contains(resolved)
+        }
+        return false
+    }
+}

--- a/Tests/WikiFSTests/DeletionIncomingReferenceTests.swift
+++ b/Tests/WikiFSTests/DeletionIncomingReferenceTests.swift
@@ -1,0 +1,189 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Store + model tests for the issue #219 delete-with-incoming-references flow:
+/// `pageLinkingPages`, `deletionImpact`, and `delete(_:unlinkIncomingLinks:)`
+/// for both pages and sources.
+@MainActor
+struct DeletionIncomingReferenceTests {
+
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikifs-delete-refs-\(UUID().uuidString).sqlite")
+    }
+
+    private func makeStore() throws -> GRDBWikiStore {
+        try GRDBWikiStore(databaseURL: tempURL())
+    }
+
+    // MARK: - pageLinkingPages (store)
+
+    @Test func pageLinkingPagesReportsIncomingEdges() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+
+        // A links to B.
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+
+        #expect(try store.pageLinkingPages(to: b.id) == [a.id])
+        #expect(try store.pageLinkingPages(to: a.id).isEmpty)
+    }
+
+    // MARK: - deletionImpact
+
+    @Test func deletionImpactForPageReportsLinksAndBookmarks() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+
+        let model = WikiStoreModel(store: store)
+        model.reloadBookmarkNodes()
+
+        let impact = model.deletionImpact(forPage: b.id)
+        #expect(impact.linkingPageIDs == [a.id])
+        #expect(impact.bookmarkLabels.count == 1)
+        #expect(impact.hasReferences)
+    }
+
+    @Test func deletionImpactForPageWithNoReferencesIsEmpty() throws {
+        let store = try makeStore()
+        let b = try store.createPage(title: "B")
+        let model = WikiStoreModel(store: store)
+
+        let impact = model.deletionImpact(forPage: b.id)
+        #expect(!impact.hasReferences)
+    }
+
+    @Test func deletionImpactForSourceReportsCitations() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "cite [[source:paper]]", author: "user")
+
+        let model = WikiStoreModel(store: store)
+        let impact = model.deletionImpact(forSource: src.id)
+        #expect(impact.linkingPageIDs == [a.id])
+        #expect(impact.hasReferences)
+    }
+
+    // MARK: - delete(_:unlinkIncomingLinks:)
+
+    @Test func deletePageWithUnlinkConvertsIncomingLinksToPlainText() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]] end", author: "user")
+
+        let model = WikiStoreModel(store: store)
+        model.delete(b.id, unlinkIncomingLinks: true)
+
+        // A's link to B is now plain text.
+        #expect(try store.getPage(id: a.id).bodyMarkdown == "see B end")
+        // B is gone.
+        let remainingIDs = Set(try store.listPages(sortBy: .lastUpdated).map(\.id))
+        #expect(!remainingIDs.contains(b.id))
+        // The page_links edge A→B no longer exists.
+        #expect(try store.listAllLinks().isEmpty)
+    }
+
+    @Test func deletePageWithoutUnlinkLeavesGhostLink() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+
+        let model = WikiStoreModel(store: store)
+        model.delete(b.id, unlinkIncomingLinks: false)
+
+        // The body still carries the [[…]] syntax (now a ghost link).
+        let body = try store.getPage(id: a.id).bodyMarkdown
+        #expect(body.contains("[[") && body.contains("]]"))
+        // But the link row is cleaned up by deletePage's FK sweep.
+        #expect(try store.listAllLinks().isEmpty)
+    }
+
+    @Test func deletePageRemovesReferencingBookmarks() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+
+        let model = WikiStoreModel(store: store)
+        model.reloadBookmarkNodes()
+        model.delete(b.id, unlinkIncomingLinks: false)
+
+        // The bookmark to B is gone.
+        #expect(try store.listBookmarkNodes().isEmpty)
+    }
+
+    // MARK: - deleteSource(_:unlinkIncomingLinks:)
+
+    @Test func deleteSourceWithUnlinkConvertsCitationsToPlainText() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "cite [[source:paper]]", author: "user")
+
+        let model = WikiStoreModel(store: store)
+        model.deleteSource(src.id, unlinkIncomingLinks: true)
+
+        // The citation is now plain text.
+        let body = try store.getPage(id: a.id).bodyMarkdown
+        #expect(!body.contains("[["))
+        #expect(body.contains("paper"))
+    }
+
+    @Test func deleteSourceRemovesReferencingBookmarks() throws {
+        let store = try makeStore()
+        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .source(src.id))
+
+        let model = WikiStoreModel(store: store)
+        model.reloadBookmarkNodes()
+        model.deleteSource(src.id, unlinkIncomingLinks: false)
+
+        #expect(try store.listBookmarkNodes().isEmpty)
+    }
+
+    // MARK: - provenance restriction (sources the agent has used)
+
+    @Test func deletionImpactForSourceReportsProvenanceBlockers() throws {
+        let store = try makeStore()
+        let page = try store.createPage(title: "Claim")
+        let src = try store.addSource(filename: "evidence.txt", data: Data("evidence".utf8))
+        try store.updatePage(
+            id: page.id, title: page.title, body: "Claim", lastEditedBy: "user",
+            provenance: [.init(sourceID: src.id, role: .primary)])
+
+        let model = WikiStoreModel(store: store)
+        let impact = model.deletionImpact(forSource: src.id)
+        #expect(impact.isProvenanceBlocked)
+        #expect(impact.provenanceBlockers.count == 1)
+    }
+
+    @Test func provenanceBlockedSourceIsNotDeletedAndCitationsSurvive() throws {
+        let store = try makeStore()
+        let page = try store.createPage(title: "Claim")
+        let src = try store.addSource(filename: "evidence.txt", data: Data("evidence".utf8))
+        try store.updatePage(
+            id: page.id, title: page.title, body: "cite [[source:evidence]]", lastEditedBy: "user",
+            provenance: [.init(sourceID: src.id, role: .primary)])
+
+        let model = WikiStoreModel(store: store)
+        model.deleteSource(src.id, unlinkIncomingLinks: true)
+
+        // The source stays (provenance-restricted) …
+        #expect(try store.getSource(id: src.id).id == src.id)
+        // … and its citation is NOT rewritten (we bailed before unlinking).
+        #expect(try store.getPage(id: page.id).bodyMarkdown.contains("[["))
+        // The restriction is surfaced as a store error.
+        #expect(model.storeError != nil)
+    }
+}
+#endif

--- a/Tests/WikiFSTests/LinkUnlinkerTests.swift
+++ b/Tests/WikiFSTests/LinkUnlinkerTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Pure unit tests for `LinkUnlinker.unlink` (issue #219) — converting incoming
+/// `[[wiki-link]]` spans whose target is being deleted to plain display text.
+struct LinkUnlinkerTests {
+
+    // Valid 26-char Crockford Base32 ids (the confusable I/L/O/U are absent).
+    private let homeID = "01HXXXXXXXXXXXXXXXXXXXXXXX"
+    private let paperID = "01JZZZZZZZZZZZZZZZZZZZZZZZ"
+    private let keepID = "01HYYYYYYYYYYYYYYYYYYYYYYY"
+
+    /// Build resolver closures from name→id maps.
+    private func resolvers(pages: [String: String] = [:], sources: [String: String] = [:])
+        -> (resolvePage: (String) throws -> PageID?, resolveSource: (String) throws -> SourceID?) {
+        let rp: (String) throws -> PageID? = { pages[$0].map { PageID(rawValue: $0) } }
+        let rs: (String) throws -> SourceID? = { sources[$0].map { SourceID(rawValue: $0) } }
+        return (rp, rs)
+    }
+
+    // MARK: - Page links
+
+    @Test func unlinksCanonicalPageLinkByULID() throws {
+        let (rp, rs) = resolvers()
+        let out = try LinkUnlinker.unlink(
+            in: "See [[page:\(homeID)|Home]] now.",
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "See Home now.")
+    }
+
+    @Test func unlinksNameBasedPageLinkViaResolver() throws {
+        let (rp, rs) = resolvers(pages: ["Home": homeID])
+        let out = try LinkUnlinker.unlink(
+            in: "See [[Home]] now.",
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "See Home now.")
+    }
+
+    @Test func preservesAuthoredAliasAsDisplayText() throws {
+        let (rp, rs) = resolvers(pages: ["Home": homeID])
+        let out = try LinkUnlinker.unlink(
+            in: "See [[Home|the home page]] now.",
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "See the home page now.")
+    }
+
+    @Test func leavesUnrelatedPageLinkIntact() throws {
+        let (rp, rs) = resolvers(pages: ["Keep": keepID, "Home": homeID])
+        let out = try LinkUnlinker.unlink(
+            in: "[[Keep]] and [[Home]]",
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "[[Keep]] and Home")
+    }
+
+    // MARK: - Source links
+
+    @Test func unlinksCanonicalSourceLinkByULID() throws {
+        let (rp, rs) = resolvers()
+        let out = try LinkUnlinker.unlink(
+            in: "Cite [[source:\(paperID)|Paper]].",
+            unlinkPageIDs: [],
+            unlinkSourceIDs: [SourceID(rawValue: paperID)],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "Cite Paper.")
+    }
+
+    @Test func unlinksNameBasedSourceLinkViaResolver() throws {
+        let (rp, rs) = resolvers(sources: ["Paper": paperID])
+        let out = try LinkUnlinker.unlink(
+            in: "Cite [[source:Paper]].",
+            unlinkPageIDs: [],
+            unlinkSourceIDs: [SourceID(rawValue: paperID)],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "Cite Paper.")
+    }
+
+    @Test func unlinksSourceCitationWithQuoteAnchor() throws {
+        let (rp, rs) = resolvers(sources: ["Paper": paperID])
+        // Quote anchor is dropped — it can't survive as plain text.
+        let out = try LinkUnlinker.unlink(
+            in: "[[source:Paper#\"a passage\"]]",
+            unlinkPageIDs: [],
+            unlinkSourceIDs: [SourceID(rawValue: paperID)],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "Paper")
+    }
+
+    // MARK: - Embeds
+
+    @Test func unlinksEmbedConsumingBangPrefix() throws {
+        let (rp, rs) = resolvers(sources: ["Paper": paperID])
+        let out = try LinkUnlinker.unlink(
+            in: "See ![[source:Paper|the figure]] here.",
+            unlinkPageIDs: [],
+            unlinkSourceIDs: [SourceID(rawValue: paperID)],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "See the figure here.")
+    }
+
+    @Test func unlinksEmbedWithoutAliasUsesBareName() throws {
+        let (rp, rs) = resolvers(sources: ["Paper": paperID])
+        let out = try LinkUnlinker.unlink(
+            in: "See ![[source:Paper]] here.",
+            unlinkPageIDs: [],
+            unlinkSourceIDs: [SourceID(rawValue: paperID)],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "See Paper here.")
+    }
+
+    // MARK: - Safety / no-op
+
+    @Test func returnsNilWhenNothingMatched() throws {
+        let (rp, rs) = resolvers(pages: ["Keep": keepID])
+        let out = try LinkUnlinker.unlink(
+            in: "[[Keep]] only.",
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == nil)
+    }
+
+    @Test func returnsNilWhenBothIdSetsEmpty() throws {
+        let (rp, rs) = resolvers(pages: ["Home": homeID])
+        let out = try LinkUnlinker.unlink(
+            in: "[[Home]]",
+            unlinkPageIDs: [],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == nil)
+    }
+
+    @Test func leavesCodeFenceUntouched() throws {
+        let (rp, rs) = resolvers(pages: ["Home": homeID])
+        let body = "```\n[[Home]]\n```\nand [[Home]] outside."
+        let out = try LinkUnlinker.unlink(
+            in: body,
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "```\n[[Home]]\n```\nand Home outside.")
+    }
+
+    @Test func leavesChatLinksUntouched() throws {
+        let chatID = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+        let (rp, rs) = resolvers(pages: ["Home": homeID])
+        let out = try LinkUnlinker.unlink(
+            in: "[[chat:\(chatID)]] and [[Home]]",
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "[[chat:\(chatID)]] and Home")
+    }
+
+    @Test func unlinksMultipleOccurrencesInOnePass() throws {
+        let (rp, rs) = resolvers(pages: ["Home": homeID, "Keep": keepID])
+        let out = try LinkUnlinker.unlink(
+            in: "[[Home]] then [[Keep]] then [[Home|alias]]",
+            unlinkPageIDs: [PageID(rawValue: homeID)],
+            unlinkSourceIDs: [],
+            resolvePageName: rp, resolveSourceName: rs)
+        #expect(out == "Home then [[Keep]] then alias")
+    }
+}

--- a/progress/2026-08-01T200000Z-issue-219-deletion-incoming-links.md
+++ b/progress/2026-08-01T200000Z-issue-219-deletion-incoming-links.md
@@ -1,0 +1,77 @@
+---
+timestamp: 2026-08-01T200000Z
+title: Issue #219 deletion incoming-links warning
+branch: deletion-incoming-links
+status: complete
+---
+
+# Issue #219 — deleting a resource warns on incoming links
+
+## Progress
+
+Deleting a page or source that other pages link to or bookmarks point at now
+opens a confirmation dialog instead of deleting silently. The dialog lists the
+incoming links (by page title) and the incoming bookmarks (by folder path), and
+offers two destructive choices plus cancel:
+
+- **Unlink and Delete** — rewrites every incoming `[[wiki-link]]` in the linking
+  pages to its plain display text (the authored alias, else the target name),
+  removes the referencing bookmarks, then deletes the target.
+- **Delete** — removes the referencing bookmarks and deletes the target; the
+  incoming `[[…]]` syntax stays in place as a ghost link (it renders as a
+  missing-link placeholder, consistent with forward links).
+
+Bookmark removal is mandatory in both paths — a bookmark to a missing page or
+source is invalid. When a target has no incoming links and no bookmarks, the
+delete is immediate (no dialog), preserving the prior friction-free common case.
+
+### Layered implementation
+
+- **`LinkUnlinker`** (`Sources/WikiFSLinks/LinkUnlinker.swift`) — a pure,
+  Foundation-only sibling of `WikiLinkRewriter.canonicalize`. It walks `[[…]]`
+  spans right-to-left (code-fence-safe via `WikiLinkSpan`), classifies each via
+  `WikiLinkParser`, and converts a span to plain text when its target is in the
+  deleted-id set. Targets match two ways: a canonical ULID is tested for direct
+  membership, and a name is resolved through injected closures then tested.
+  Embed prefixes (`![[…]]`) are consumed with the span. Returns `nil` when
+  nothing changed so callers skip the re-save. Chat links are never touched.
+- **Store reads** — `pageLinkingPages(to:)` (new) and `sourceLinkingPages(to:)`
+  (promoted from concrete-only to the `WikiStore` protocol) return the incoming
+  page-link / source-link edge sets. Both are single `SELECT DISTINCT` reads.
+- **`WikiStoreModel`** — `deletionImpact(forPage:)` /
+  `deletionImpact(forSource:)` gather the linking page ids, bookmark folder
+  paths, and (for sources) provenance blockers into a `DeletionImpact` snapshot
+  for the UI. `delete(_:unlinkIncomingLinks:)` and
+  `deleteSource(_:unlinkIncomingLinks:)` perform the confirmed delete: they
+  unlink incoming bodies (via `LinkUnlinker` + `PageUpsert.upsert`, which drops
+  the now-removed link edge through `replaceLinks`), remove referencing
+  bookmarks, then delete the target. A source the agent has used to author
+  pages is provenance-restricted (the store throws), so `deleteSource` checks
+  the blockers FIRST and bails with a `storeError` before any destructive
+  cleanup — citations and bookmarks survive, and the UI offers no delete button.
+  This completes the scaffolded `Issue219DeletionAnalysisInput.provenance`
+  design (a new public `sourceProvenanceBlockers(sourceID:)` store read backs
+  it). `deleteSource` now surfaces store errors via `storeError` (previously
+  swallowed) so a restricted source reports why instead of failing silently.
+- **UI** — `PagesContainerView` and `SourcesContainerView` aggregate the
+  per-selected-id impact, dedupe it, and either delete immediately (no
+  references) or present a `.confirmationDialog` carrying the details. A
+  provenance-blocked source batch shows a "Can't Delete Source" dialog (OK only)
+  naming the pages that cite it as evidence.
+
+The unlink rewrite runs BEFORE the target row is deleted, so name-based links
+still resolve to the about-to-be-deleted id. Each rewritten page routes through
+the shared `PageUpsert.upsert` seam, so the link graph (`page_links` /
+`source_links`) stays consistent with the stored bytes exactly as an in-app or
+`wikictl` edit would.
+
+## Verification
+
+- `make build` — full app + File Provider build, signed, green.
+- `make test` — 2974 tests pass, including the 14 new `LinkUnlinkerTests`, the
+  11 new `DeletionIncomingReferenceTests` (store `pageLinkingPages`, model
+  `deletionImpact`, `delete(_:unlinkIncomingLinks:)` for both pages and sources,
+  and the provenance-restriction bail-out), and the existing
+  `StoreEmissionTests` / `SourceAPISignatureManifestTests` (no new public
+  mutator was added to the store; `pageLinkingPages` /
+  `sourceProvenanceBlockers` are reads, so neither guard needed updating).


### PR DESCRIPTION
## Summary

When deleting a page or source that other pages link to or bookmarks point at, users now see a confirmation dialog listing the incoming references. They can choose to:
- **Unlink and Delete** — converts incoming `[[wiki-link]]` spans to plain text (the authored alias or target name), removes referencing bookmarks, then deletes
- **Delete** — removes referencing bookmarks and deletes; incoming links become ghost links

Bookmark removal is mandatory in both paths since a bookmark to a missing page/source is invalid. Resources with no incoming links or bookmarks delete immediately (no dialog) to preserve the common frictionless case.

Sources used as evidence in page versions (provenance-restricted) cannot be deleted at all; the dialog shows which pages cite them and only offers OK.

## Implementation

**LinkUnlinker** — Pure utility that walks `[[…]]` spans right-to-left (code-fence-safe), classifies each via WikiLinkParser, and converts spans to plain text when their target is in the deleted-id set. Targets match by canonical ULID or by name via injected resolvers. Embed prefixes (`![[…]]`) are consumed. Returns nil when nothing changed.

**Store layer** — New `pageLinkingPages(to:)` and promoted `sourceLinkingPages(to:)` return incoming edge sets. New public `sourceProvenanceBlockers(sourceID:)` exposes the evidence restriction.

**WikiStoreModel** — `deletionImpact(forPage/Source:)` gather linking pages, bookmark folders, and (for sources) provenance blockers into a DeletionImpact snapshot. `delete(_:unlinkIncomingLinks:)` and `deleteSource(_:unlinkIncomingLinks:)` unlink via LinkUnlinker + PageUpsert (which drops the link edge), remove bookmarks, then delete. Source deletion checks provenance blockers first and bails with a storeError before any cleanup.

**UI** — PagesContainerView and SourcesContainerView aggregate per-selection impact, dedupe, and either delete immediately or present a confirmation dialog with details.

Unlink rewrites run before deletion so name-based links still resolve to the about-to-be-deleted target. Each rewrite routes through PageUpsert so the link graph stays consistent with stored bytes.

## Testing

- Full build and test suite pass (2974 tests)
- 14 new LinkUnlinkerTests verify span rewriting, alias handling, embed handling, code-fence safety, and chat-link preservation
- 11 new DeletionIncomingReferenceTests verify store pageLinkingPages, model deletionImpact, delete/deleteSource with and without unlinking, bookmark cleanup, and provenance-restriction bail-out
- No new public mutators added to store; pageLinkingPages/sourceProvenanceBlockers are reads