### PR TITLE
Hide Open button for deleted pages in lint results

### DIFF
--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -732,24 +732,27 @@ struct ActivityWindowView: View {
     }
 
     /// A single linted page: title (resolved from the wiki's store) with an
-    /// "Open" button. Pages deleted since the lint ran resolve to a placeholder.
+    /// "Open" button. Pages deleted since the lint ran resolve to a placeholder
+    /// and show no "Open" button (there is nothing to navigate to).
     @ViewBuilder
     private func lintPageRow(pageID: PageID, wikiID: WikiID) -> some View {
-        let title = pageTitle(pageID, wikiID: wikiID) ?? "Deleted page"
+        let title = pageTitle(pageID, wikiID: wikiID)
         HStack(spacing: 6) {
             Image(systemName: "doc.text")
                 .foregroundStyle(.secondary)
-            Text(title)
+            Text(title ?? "Deleted page")
                 .lineLimit(1)
                 .truncationMode(.middle)
-                .help(title)
+                .help(title ?? "Deleted page")
             Spacer(minLength: 4)
-            Button("Open", systemImage: "arrow.up.forward.app") {
-                openPage(pageID, in: wikiID)
+            if title != nil {
+                Button("Open", systemImage: "arrow.up.forward.app") {
+                    openPage(pageID, in: wikiID)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Open this page in the wiki window")
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .help("Open this page in the wiki window")
         }
     }
 


### PR DESCRIPTION
## Summary

When pages are deleted after linting runs, the lint results page now shows them as deleted but doesn't offer an "Open" button, since there's nothing to navigate to.

## Changes

- Updated documentation to clarify that deleted pages don't show an Open button
- Modified `lintPageRow()` to conditionally render the Open button only when the page exists (`title != nil`)
- Moved button styling modifiers inside the conditional to keep related UI code together

## Rationale

Showing an Open button for a deleted page is confusing UX — it would fail or navigate to an empty state. By hiding the button entirely for deleted pages, we make it clear that the page no longer exists and there's no action to take.