### PR TITLE
Extract agent event transcript translator

### DIFF
--- a/Sources/WikiFSEngine/AgentEventTranscriptTranslator.swift
+++ b/Sources/WikiFSEngine/AgentEventTranscriptTranslator.swift
@@ -1,0 +1,200 @@
+// pattern: Functional Core
+
+import Foundation
+import WikiFSCore
+
+/// Translates one provider event stream into typed chat transcript deltas.
+///
+/// Keep one value per turn or queue attempt. The value owns only translation
+/// state and has no synchronization, persistence, or presentation concerns.
+public struct AgentEventTranscriptTranslator: Sendable {
+    private struct OpenContentBlock: Sendable {
+        let messageID: ChatMessageID
+        let turnID: ChatTurnID
+        let role: ChatTranscriptMessageRole
+        let createdAt: Date
+        var text: String
+    }
+
+    private struct RunningToolCallState: Sendable {
+        let toolCallID: ToolCallID
+        let toolName: String
+        let inputSummary: String
+    }
+
+    private enum ContentBlockState: Sendable {
+        case none
+        case open(OpenContentBlock)
+    }
+
+    private var contentBlock: ContentBlockState = .none
+    private var nextContentBlockOrdinal = 0
+    private var nextToolCallOrdinal = 0
+    private var runningToolCalls: [RunningToolCallState] = []
+
+    public init() {}
+
+    public var activeContentBlock: ChatActiveContentBlock? {
+        guard case .open(let block) = contentBlock else { return nil }
+        return ChatActiveContentBlock(
+            messageID: block.messageID,
+            turnID: block.turnID,
+            role: block.role
+        )
+    }
+
+    public mutating func translate(
+        _ events: [AgentEvent],
+        turnID: ChatTurnID
+    ) -> [ChatTranscriptDelta] {
+        events.compactMap { event in
+            switch event {
+            case .userText(let text):
+                closeContentBlock()
+                return .append(.message(ChatTranscriptMessageItem(
+                    messageID: ChatMessageID(rawValue: ULID.generate()),
+                    turnID: turnID,
+                    role: .user,
+                    text: text,
+                    createdAt: Date()
+                )))
+            case .assistantText(let text):
+                let delta = replacement(text, role: .assistant, turnID: turnID)
+                closeContentBlock()
+                return delta
+            case .thinking(let text):
+                let delta = replacement(text, role: .reasoning, turnID: turnID)
+                closeContentBlock()
+                return delta
+            case .assistantTextDelta(let delta):
+                return appending(delta, role: .assistant, turnID: turnID)
+            case .thinkingDelta(let delta):
+                return appending(delta, role: .reasoning, turnID: turnID)
+            case .toolUse(let name, let inputSummary):
+                closeContentBlock()
+                let toolCallID = ToolCallID(rawValue: "\(turnID.rawValue)-tool-\(nextToolCallOrdinal)")
+                nextToolCallOrdinal += 1
+                runningToolCalls.append(.init(
+                    toolCallID: toolCallID,
+                    toolName: name,
+                    inputSummary: inputSummary
+                ))
+                return .toolCallUpsert(ChatTranscriptToolCallItem(
+                    toolCallID: toolCallID,
+                    turnID: turnID,
+                    toolName: name,
+                    status: .running,
+                    detail: inputSummary,
+                    permissionRequestID: nil,
+                    updatedAt: Date()
+                ))
+            case .toolResult(let isError, let summary):
+                closeContentBlock()
+                // Compatibility fallback: provider events do not expose the
+                // result-to-use call ID, so pair unmatched results FIFO.
+                let toolCall = runningToolCalls.isEmpty
+                    ? RunningToolCallState(
+                        toolCallID: ToolCallID(rawValue: "\(turnID.rawValue)-tool-\(nextToolCallOrdinal)"),
+                        toolName: "Tool",
+                        inputSummary: ""
+                    )
+                    : runningToolCalls.removeFirst()
+                return .toolCallUpsert(ChatTranscriptToolCallItem(
+                    toolCallID: toolCall.toolCallID,
+                    turnID: turnID,
+                    toolName: toolCall.toolName,
+                    status: isError ? .failed : .completed,
+                    detail: toolCall.inputSummary,
+                    output: summary,
+                    permissionRequestID: nil,
+                    updatedAt: Date()
+                ))
+            case .turnFailed(let reason):
+                closeContentBlock()
+                return .append(.turnFailure(ChatTranscriptTurnFailureItem(
+                    failureID: ChatTranscriptFailureID(rawValue: ULID.generate()),
+                    turnID: turnID,
+                    category: Self.failureCategory(for: reason),
+                    message: reason.description,
+                    createdAt: Date()
+                )))
+            case .systemInit, .subagent, .result, .messageStop, .raw:
+                closeContentBlock()
+                return nil
+            }
+        }
+    }
+
+    public static func failureCategory(for reason: TurnFailureReason) -> ChatTurnFailureCategory {
+        switch reason {
+        case .stalled, .ceilingExceeded:
+            .interrupted
+        case .agentError:
+            .runtimeError
+        case .quotaExhausted:
+            .transportError
+        }
+    }
+
+    private mutating func appending(
+        _ delta: String,
+        role: ChatTranscriptMessageRole,
+        turnID: ChatTurnID
+    ) -> ChatTranscriptDelta {
+        var block = compatibleOpenBlock(role: role, turnID: turnID)
+        block.text += delta
+        contentBlock = .open(block)
+        return .messageReplacement(
+            messageID: block.messageID,
+            turnID: turnID,
+            role: role,
+            text: block.text,
+            createdAt: block.createdAt
+        )
+    }
+
+    private mutating func replacement(
+        _ text: String,
+        role: ChatTranscriptMessageRole,
+        turnID: ChatTurnID
+    ) -> ChatTranscriptDelta {
+        var block = compatibleOpenBlock(role: role, turnID: turnID)
+        block.text = text
+        contentBlock = .open(block)
+        return .messageReplacement(
+            messageID: block.messageID,
+            turnID: turnID,
+            role: role,
+            text: text,
+            createdAt: block.createdAt
+        )
+    }
+
+    private mutating func compatibleOpenBlock(
+        role: ChatTranscriptMessageRole,
+        turnID: ChatTurnID
+    ) -> OpenContentBlock {
+        if case .open(let block) = contentBlock, block.role == role {
+            return block
+        }
+        closeContentBlock()
+        // Compatibility fallback: provider events do not expose a durable
+        // content-block identity, so derive one from role, turn, and ordinal.
+        let block = OpenContentBlock(
+            messageID: ChatMessageID(
+                rawValue: "\(role.rawValue)-\(turnID.rawValue)-block-\(nextContentBlockOrdinal)"
+            ),
+            turnID: turnID,
+            role: role,
+            createdAt: Date(),
+            text: ""
+        )
+        nextContentBlockOrdinal += 1
+        contentBlock = .open(block)
+        return block
+    }
+
+    private mutating func closeContentBlock() {
+        contentBlock = .none
+    }
+}

--- a/Sources/wikid/LauncherChatAgentRuntime.swift
+++ b/Sources/wikid/LauncherChatAgentRuntime.swift
@@ -38,33 +38,7 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
         var activeTurnID: ChatTurnID?
         var latestProviderSessionID: AcpSessionID?
         var lastFingerprint: StateFingerprint?
-        var translationStateByTurn: [ChatTurnID: TranscriptTranslationState] = [:]
-    }
-
-    private struct TranscriptTranslationState: Sendable {
-        struct OpenContentBlock: Sendable {
-            let messageID: ChatMessageID
-            let turnID: ChatTurnID
-            let role: ChatTranscriptMessageRole
-            let createdAt: Date
-            var text: String
-        }
-
-        struct RunningToolCallState: Sendable {
-            let toolCallID: ToolCallID
-            let toolName: String
-            let inputSummary: String
-        }
-
-        enum ContentBlockState: Sendable {
-            case none
-            case open(OpenContentBlock)
-        }
-
-        var contentBlock: ContentBlockState = .none
-        var nextContentBlockOrdinal = 0
-        var nextToolCallOrdinal = 0
-        var runningToolCalls: [RunningToolCallState] = []
+        var translationStateByTurn: [ChatTurnID: AgentEventTranscriptTranslator] = [:]
     }
 
     private struct StateFingerprint: Equatable, Sendable {
@@ -423,24 +397,20 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
         guard var state = runtimeState,
               let turnID = state.activeTurnID else { return }
         await onLiveEvents([event])
-        var translationState = state.translationStateByTurn[turnID] ?? TranscriptTranslationState()
-        let deltas = Self.transcriptDeltas(
-            from: [event],
-            turnID: turnID,
-            translationState: &translationState
-        )
-        state.translationStateByTurn[turnID] = translationState
+        var translator = state.translationStateByTurn[turnID] ?? AgentEventTranscriptTranslator()
+        let deltas = translator.translate([event], turnID: turnID)
+        state.translationStateByTurn[turnID] = translator
         runtimeState = state
         if deltas.isEmpty == false {
             await emit(
                 .transcript(deltas),
-                activeContentBlock: Self.activeContentBlock(in: translationState)
+                activeContentBlock: translator.activeContentBlock
             )
         }
 
         switch event {
         case .turnFailed(let reason):
-            let category = Self.failureCategory(for: reason)
+            let category = AgentEventTranscriptTranslator.failureCategory(for: reason)
             await emit(.turnFailed(turnID: turnID, category: category, message: reason.description))
         default:
             if AgentEvent.endsGeneration(event) {
@@ -511,198 +481,6 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
         ))
     }
 
-    private static func transcriptDeltas(
-        from events: [AgentEvent],
-        turnID: ChatTurnID,
-        translationState: inout TranscriptTranslationState
-    ) -> [ChatTranscriptDelta] {
-        events.compactMap { event in
-            switch event {
-            case .userText(let text):
-                closeContentBlock(in: &translationState)
-                return .append(.message(ChatTranscriptMessageItem(
-                    messageID: ChatMessageID(rawValue: ULID.generate()),
-                    turnID: turnID,
-                    role: .user,
-                    text: text,
-                    createdAt: Date()
-                )))
-            case .assistantText(let text):
-                let delta = replacement(
-                    text,
-                    role: .assistant,
-                    turnID: turnID,
-                    translationState: &translationState
-                )
-                closeContentBlock(in: &translationState)
-                return delta
-            case .thinking(let text):
-                let delta = replacement(
-                    text,
-                    role: .reasoning,
-                    turnID: turnID,
-                    translationState: &translationState
-                )
-                closeContentBlock(in: &translationState)
-                return delta
-            case .assistantTextDelta(let delta):
-                return appending(
-                    delta,
-                    role: .assistant,
-                    turnID: turnID,
-                    translationState: &translationState
-                )
-            case .thinkingDelta(let delta):
-                return appending(
-                    delta,
-                    role: .reasoning,
-                    turnID: turnID,
-                    translationState: &translationState
-                )
-            case .toolUse(let name, let inputSummary):
-                closeContentBlock(in: &translationState)
-                let toolCallID = ToolCallID(rawValue: "\(turnID.rawValue)-tool-\(translationState.nextToolCallOrdinal)")
-                translationState.nextToolCallOrdinal += 1
-                translationState.runningToolCalls.append(.init(
-                    toolCallID: toolCallID,
-                    toolName: name,
-                    inputSummary: inputSummary
-                ))
-                return .toolCallUpsert(ChatTranscriptToolCallItem(
-                    toolCallID: toolCallID,
-                    turnID: turnID,
-                    toolName: name,
-                    status: .running,
-                    detail: inputSummary,
-                    permissionRequestID: nil,
-                    updatedAt: Date()
-                ))
-            case .toolResult(let isError, let summary):
-                closeContentBlock(in: &translationState)
-                // Compatibility fallback: provider events do not expose the
-                // result-to-use call ID, so pair unmatched results FIFO.
-                let toolCall = translationState.runningToolCalls.isEmpty
-                    ? TranscriptTranslationState.RunningToolCallState(
-                        toolCallID: ToolCallID(rawValue: "\(turnID.rawValue)-tool-\(translationState.nextToolCallOrdinal)"),
-                        toolName: "Tool",
-                        inputSummary: ""
-                    )
-                    : translationState.runningToolCalls.removeFirst()
-                return .toolCallUpsert(ChatTranscriptToolCallItem(
-                    toolCallID: toolCall.toolCallID,
-                    turnID: turnID,
-                    toolName: toolCall.toolName,
-                    status: isError ? .failed : .completed,
-                    detail: toolCall.inputSummary,
-                    output: summary,
-                    permissionRequestID: nil,
-                    updatedAt: Date()
-                ))
-            case .turnFailed(let reason):
-                closeContentBlock(in: &translationState)
-                return .append(.turnFailure(ChatTranscriptTurnFailureItem(
-                    failureID: ChatTranscriptFailureID(rawValue: ULID.generate()),
-                    turnID: turnID,
-                    category: failureCategory(for: reason),
-                    message: reason.description,
-                    createdAt: Date()
-                )))
-            case .systemInit, .subagent, .result, .messageStop, .raw:
-                closeContentBlock(in: &translationState)
-                return nil
-            }
-        }
-    }
-
-    private static func appending(
-        _ delta: String,
-        role: ChatTranscriptMessageRole,
-        turnID: ChatTurnID,
-        translationState: inout TranscriptTranslationState
-    ) -> ChatTranscriptDelta {
-        var block = compatibleOpenBlock(
-            role: role,
-            turnID: turnID,
-            translationState: &translationState
-        )
-        block.text += delta
-        translationState.contentBlock = .open(block)
-        return .messageReplacement(
-            messageID: block.messageID,
-            turnID: turnID,
-            role: role,
-            text: block.text,
-            createdAt: block.createdAt
-        )
-    }
-
-    private static func replacement(
-        _ text: String,
-        role: ChatTranscriptMessageRole,
-        turnID: ChatTurnID,
-        translationState: inout TranscriptTranslationState
-    ) -> ChatTranscriptDelta {
-        var block = compatibleOpenBlock(
-            role: role,
-            turnID: turnID,
-            translationState: &translationState
-        )
-        block.text = text
-        translationState.contentBlock = .open(block)
-        return .messageReplacement(
-            messageID: block.messageID,
-            turnID: turnID,
-            role: role,
-            text: text,
-            createdAt: block.createdAt
-        )
-    }
-
-    private static func compatibleOpenBlock(
-        role: ChatTranscriptMessageRole,
-        turnID: ChatTurnID,
-        translationState: inout TranscriptTranslationState
-    ) -> TranscriptTranslationState.OpenContentBlock {
-        if case .open(let block) = translationState.contentBlock, block.role == role {
-            return block
-        }
-        closeContentBlock(in: &translationState)
-        // Compatibility fallback: provider events do not expose a durable
-        // content-block identity, so derive one from role, turn, and ordinal.
-        let block = TranscriptTranslationState.OpenContentBlock(
-            messageID: ChatMessageID(
-                rawValue: "\(role.rawValue)-\(turnID.rawValue)-block-\(translationState.nextContentBlockOrdinal)"
-            ),
-            turnID: turnID,
-            role: role,
-            createdAt: Date(),
-            text: ""
-        )
-        translationState.nextContentBlockOrdinal += 1
-        translationState.contentBlock = .open(block)
-        return block
-    }
-
-    private static func closeContentBlock(in translationState: inout TranscriptTranslationState) {
-        translationState.contentBlock = .none
-    }
-
-    private static func activeContentBlock(
-        in translationState: TranscriptTranslationState
-    ) -> ChatActiveContentBlock? {
-        guard case .open(let block) = translationState.contentBlock else { return nil }
-        return ChatActiveContentBlock(
-            messageID: block.messageID,
-            turnID: block.turnID,
-            role: block.role
-        )
-    }
-
-    static func transcriptDeltasForTesting(from events: [AgentEvent], turnID: ChatTurnID) -> [ChatTranscriptDelta] {
-        var translationState = TranscriptTranslationState()
-        return transcriptDeltas(from: events, turnID: turnID, translationState: &translationState)
-    }
-
     static func permissionRequest(from permission: PendingPermission, turnID: ChatTurnID) -> ChatPendingPermissionRequest {
         ChatPendingPermissionRequest(
             requestID: PermissionRequestID(rawValue: "permission-\(permission.toolCallId.rawValue)"),
@@ -720,17 +498,6 @@ actor LauncherChatAgentRuntime: ChatAgentRuntime {
                 )
             }
         )
-    }
-
-    private static func failureCategory(for reason: TurnFailureReason) -> ChatTurnFailureCategory {
-        switch reason {
-        case .stalled, .ceilingExceeded:
-            return .interrupted
-        case .agentError:
-            return .runtimeError
-        case .quotaExhausted:
-            return .transportError
-        }
     }
 
     private static func permissionBehavior(for rawKind: String) -> ChatPermissionOptionBehavior {

--- a/Tests/WikiFSAppTests/DaemonChatControllerTests.swift
+++ b/Tests/WikiFSAppTests/DaemonChatControllerTests.swift
@@ -665,20 +665,19 @@ struct DaemonChatControllerTests {
         let submission = harness.makeSubmission(commandID: "command-runtime-deltas", turnID: "turn-runtime-deltas")
 
         _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .assistantTextDelta("Hello"),
-                .assistantTextDelta(" world"),
-                .thinkingDelta("Need"),
-                .thinking("Need context"),
-                .toolUse(name: "Edit", inputSummary: "/tmp/file.md"),
-                .toolResult(isError: false, summary: "updated file"),
-            ],
-            turnID: submission.turnID
-        )
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([
+            .assistantTextDelta("Hello"),
+            .assistantTextDelta(" world"),
+            .thinkingDelta("Need"),
+            .thinking("Need context"),
+            .toolUse(name: "Edit", inputSummary: "/tmp/file.md"),
+            .toolResult(isError: false, summary: "updated file"),
+        ], turnID: submission.turnID)
 
         await harness.runtime.emit(.transcript(deltas))
         await harness.runtime.emit(.turnCompleted(submission.turnID))
+        try await harness.waitUntilPersistedTurnState(submission.turnID, equals: .completed)
 
         let messages = try harness.store.chatMessages(chatID: harness.chat.id)
         let assistantRows = messages.filter { $0.event == .assistantText("Hello world") }
@@ -768,15 +767,11 @@ struct DaemonChatControllerTests {
         let submission = harness.makeSubmission(commandID: "command-overlay", turnID: "turn-overlay")
 
         _ = try await controller.submit(harness.makeSubmitRequest(submission: submission))
-        await harness.runtime.emit(.transcript(
-            LauncherChatAgentRuntime.transcriptDeltasForTesting(
-                from: [
-                    .assistantTextDelta("Hello"),
-                    .assistantText("Hello"),
-                ],
-                turnID: submission.turnID
-            )
-        ))
+        var translator = AgentEventTranscriptTranslator()
+        await harness.runtime.emit(.transcript(translator.translate([
+            .assistantTextDelta("Hello"),
+            .assistantText("Hello"),
+        ], turnID: submission.turnID)))
         try await harness.waitUntilOverlay(
             controller,
             matches: { $0.isEmpty == false },

--- a/Tests/WikiFSAppTests/LauncherChatAgentRuntimeTests.swift
+++ b/Tests/WikiFSAppTests/LauncherChatAgentRuntimeTests.swift
@@ -37,27 +37,6 @@ struct LauncherChatAgentRuntimeTests {
         #expect(request.options.map(\.isDefault) == [true, false, false])
     }
 
-    @Test func transcriptTranslationPreservesToolIdentityAcrossUseAndResult() {
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .toolUse(name: "Edit", inputSummary: "/tmp/file.md"),
-                .toolResult(isError: false, summary: "updated file"),
-            ],
-            turnID: ChatTurnID(rawValue: "turn-2")
-        )
-
-        guard case .toolCallUpsert(let useItem) = deltas.first,
-              case .toolCallUpsert(let resultItem) = deltas.last else {
-            Issue.record("expected tool-call upserts for start and result")
-            return
-        }
-
-        #expect(useItem.toolCallID == resultItem.toolCallID)
-        #expect(useItem.toolName == resultItem.toolName)
-        #expect(useItem.status == .running)
-        #expect(resultItem.status == .completed)
-    }
-
     @Test(arguments: [
         ("```console\n<command-output>\n```", "```console\n&lt;command-output&gt;\n```"),
         ("```json\n{\"ok\": true}\n```", "```json\n{\"ok\": true}\n```"),
@@ -81,8 +60,9 @@ struct LauncherChatAgentRuntimeTests {
             content: [.content(.text(TextContent(text: output)))]
         )))
 
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: events,
+        var transcriptTranslator = AgentEventTranscriptTranslator()
+        let deltas = transcriptTranslator.translate(
+            events,
             turnID: ChatTurnID(rawValue: "turn-fence")
         )
         let items = ChatTranscriptReducer.reducing(items: [], with: deltas)
@@ -106,142 +86,24 @@ struct LauncherChatAgentRuntimeTests {
         }
         let html = ChatWebView.Coordinator.chatDisplayRowHTML(row)
         #expect(html.contains("Completed — \(command)"))
-        #expect(!html.contains("Completed — ```"))
+        #expect(html.contains("Completed — ```") == false)
         #expect(html.contains("<pre class=\"chat-tool-detail\">\(escapedOutput)</pre>"))
-        #expect(!html.contains("<command-output>"))
+        #expect(html.contains("<command-output>") == false)
     }
 
-    @Test func transcriptTranslationCoalescesAssistantAndReasoningDeltasIntoStableMessageReplacements() {
-        let turnID = ChatTurnID(rawValue: "turn-3")
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .assistantTextDelta("Hello"),
-                .assistantTextDelta(" world"),
-                .assistantText("Hello world"),
-                .thinkingDelta("Need"),
-                .thinkingDelta(" context"),
-                .thinking("Need context"),
-            ],
-            turnID: turnID
-        )
+    @Test func launcherRuntimeUsesSharedTranslator() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = repositoryRoot.appendingPathComponent("Sources/wikid/LauncherChatAgentRuntime.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
 
-        let reduced = ChatTranscriptReducer.reducing(items: [], with: deltas)
-        let messages = reduced.compactMap { item -> ChatTranscriptMessageItem? in
-            guard case .message(let message) = item else { return nil }
-            return message
-        }
-
-        #expect(messages.count == 2)
-        #expect(messages[0].messageID == ChatMessageID(rawValue: "assistant-\(turnID.rawValue)-block-0"))
-        #expect(messages[0].role == .assistant)
-        #expect(messages[0].text == "Hello world")
-        #expect(messages[1].messageID == ChatMessageID(rawValue: "reasoning-\(turnID.rawValue)-block-1"))
-        #expect(messages[1].role == .reasoning)
-        #expect(messages[1].text == "Need context")
-    }
-
-    @Test func assistantToolAssistantProducesDistinctMessageBlocks() {
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .assistantTextDelta("I will inspect the page."),
-                .toolUse(name: "Read", inputSummary: "README.md"),
-                .toolResult(isError: false, summary: "read complete"),
-                .assistantTextDelta("The page is ready."),
-            ],
-            turnID: ChatTurnID(rawValue: "turn-block-boundary")
-        )
-
-        let messages = ChatTranscriptReducer.reducing(items: [], with: deltas).compactMap { item -> ChatTranscriptMessageItem? in
-            guard case .message(let message) = item else { return nil }
-            return message
-        }
-
-        #expect(messages.count == 2)
-        #expect(messages.map(\.role) == [.assistant, .assistant])
-        #expect(messages[0].messageID != messages[1].messageID)
-        #expect(messages.map(\.text) == ["I will inspect the page.", "The page is ready."])
-    }
-
-    @Test func reasoningAssistantReasoningProducesThreeOrderedContentBlocks() {
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .thinkingDelta("Need context."),
-                .assistantTextDelta("Here is the answer."),
-                .thinkingDelta("Check the cited source."),
-            ],
-            turnID: ChatTurnID(rawValue: "turn-role-boundary")
-        )
-
-        let messages = ChatTranscriptReducer.reducing(items: [], with: deltas).compactMap { item -> ChatTranscriptMessageItem? in
-            guard case .message(let message) = item else { return nil }
-            return message
-        }
-
-        #expect(messages.map(\.role) == [.reasoning, .assistant, .reasoning])
-        #expect(Set(messages.map(\.messageID)).count == 3)
-        #expect(messages.map(\.text) == ["Need context.", "Here is the answer.", "Check the cited source."])
-    }
-
-    @Test func deltaAfterFinalReplacementStartsANewContentBlock() {
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .assistantTextDelta("Partial"),
-                .assistantText("Complete first block."),
-                .assistantTextDelta("Second block."),
-            ],
-            turnID: ChatTurnID(rawValue: "turn-finalized-block")
-        )
-
-        let messages = ChatTranscriptReducer.reducing(items: [], with: deltas).compactMap { item -> ChatTranscriptMessageItem? in
-            guard case .message(let message) = item else { return nil }
-            return message
-        }
-
-        #expect(messages.map(\.text) == ["Complete first block.", "Second block."])
-        #expect(messages[0].messageID != messages[1].messageID)
-    }
-
-    @Test func terminalProviderAssistantBlocksInOneTurnReceiveDistinctMessageIDs() {
-        let turnID = ChatTurnID(rawValue: "turn-terminal-provider-blocks")
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .assistantText("First provider block."),
-                .assistantText("Second provider block."),
-            ],
-            turnID: turnID
-        )
-
-        let messages = ChatTranscriptReducer.reducing(items: [], with: deltas).compactMap { item -> ChatTranscriptMessageItem? in
-            guard case .message(let message) = item else { return nil }
-            return message
-        }
-
-        #expect(messages.map(\.messageID) == [
-            ChatMessageID(rawValue: "assistant-\(turnID.rawValue)-block-0"),
-            ChatMessageID(rawValue: "assistant-\(turnID.rawValue)-block-1"),
-        ])
-        #expect(messages.map(\.text) == ["First provider block.", "Second provider block."])
-    }
-
-    @Test func duplicateTerminalEventsDoNotReopenAFinalizedContentBlock() {
-        let deltas = LauncherChatAgentRuntime.transcriptDeltasForTesting(
-            from: [
-                .assistantTextDelta("Partial"),
-                .assistantText("Final block."),
-                .messageStop,
-                .messageStop,
-            ],
-            turnID: ChatTurnID(rawValue: "turn-duplicate-terminal")
-        )
-
-        let messages = ChatTranscriptReducer.reducing(items: [], with: deltas).compactMap { item -> ChatTranscriptMessageItem? in
-            guard case .message(let message) = item else { return nil }
-            return message
-        }
-
-        #expect(messages.count == 1)
-        #expect(messages.first?.text == "Final block.")
-        #expect(messages.first?.messageID == ChatMessageID(rawValue: "assistant-turn-duplicate-terminal-block-0"))
+        #expect(source.contains("[ChatTurnID: AgentEventTranscriptTranslator]"))
+        #expect(source.contains("translator.translate([event], turnID: turnID)"))
+        #expect(source.contains("translator.activeContentBlock"))
+        #expect(source.contains("TranscriptTranslationState") == false)
+        #expect(source.contains("transcriptDeltasForTesting") == false)
     }
 }
 #endif

--- a/Tests/WikiFSTests/AgentEventTranscriptTranslatorTests.swift
+++ b/Tests/WikiFSTests/AgentEventTranscriptTranslatorTests.swift
@@ -1,0 +1,206 @@
+#if canImport(WikiFSEngine)
+import Testing
+import WikiFSCore
+import WikiFSEngine
+
+struct AgentEventTranscriptTranslatorTests {
+    @Test func assistantStreamUpdatesOneStableMessage() {
+        let turnID = ChatTurnID(rawValue: "turn-assistant-stream")
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([.assistantTextDelta("Hello")], turnID: turnID)
+            + translator.translate([.assistantTextDelta(" world")], turnID: turnID)
+        let items = ChatTranscriptReducer.reducing(items: [], with: deltas)
+
+        guard items.count == 1, case .message(let message)? = items.first else {
+            Issue.record("expected one assistant message")
+            return
+        }
+        #expect(message.messageID == ChatMessageID(rawValue: "assistant-\(turnID.rawValue)-block-0"))
+        #expect(message.role == .assistant)
+        #expect(message.text == "Hello world")
+        #expect(translator.activeContentBlock?.messageID == message.messageID)
+    }
+
+    @Test func reasoningStreamUpdatesOneStableMessage() {
+        let turnID = ChatTurnID(rawValue: "turn-reasoning-stream")
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([.thinkingDelta("Need")], turnID: turnID)
+            + translator.translate([.thinkingDelta(" context")], turnID: turnID)
+        let items = ChatTranscriptReducer.reducing(items: [], with: deltas)
+
+        guard items.count == 1, case .message(let message)? = items.first else {
+            Issue.record("expected one reasoning message")
+            return
+        }
+        #expect(message.messageID == ChatMessageID(rawValue: "reasoning-\(turnID.rawValue)-block-0"))
+        #expect(message.role == .reasoning)
+        #expect(message.text == "Need context")
+        #expect(translator.activeContentBlock?.messageID == message.messageID)
+    }
+
+    @Test func fullReplacementPreservesMessageIdentity() {
+        let turnID = ChatTurnID(rawValue: "turn-replacement")
+        var translator = AgentEventTranscriptTranslator()
+        let initial = translator.translate([.assistantTextDelta("Partial")], turnID: turnID)
+        let replacement = translator.translate([.assistantText("Final")], turnID: turnID)
+        let items = ChatTranscriptReducer.reducing(items: [], with: initial + replacement)
+
+        guard items.count == 1, case .message(let message)? = items.first else {
+            Issue.record("expected one replaced assistant message")
+            return
+        }
+        #expect(message.messageID == ChatMessageID(rawValue: "assistant-\(turnID.rawValue)-block-0"))
+        #expect(message.text == "Final")
+        #expect(translator.activeContentBlock == nil)
+    }
+
+    @Test func toolResultUpdatesTheMatchingFIFOCall() {
+        let turnID = ChatTurnID(rawValue: "turn-tool-fifo")
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([
+            .toolUse(name: "Read", inputSummary: "first.md"),
+            .toolUse(name: "Edit", inputSummary: "second.md"),
+            .toolResult(isError: false, summary: "first result"),
+            .toolResult(isError: true, summary: "second result"),
+        ], turnID: turnID)
+        let items = ChatTranscriptReducer.reducing(items: [], with: deltas)
+        let toolCalls = items.compactMap { item -> ChatTranscriptToolCallItem? in
+            guard case .toolCall(let toolCall) = item else { return nil }
+            return toolCall
+        }
+
+        #expect(toolCalls.map(\.toolCallID) == [
+            ToolCallID(rawValue: "\(turnID.rawValue)-tool-0"),
+            ToolCallID(rawValue: "\(turnID.rawValue)-tool-1"),
+        ])
+        #expect(toolCalls.map(\.toolName) == ["Read", "Edit"])
+        #expect(toolCalls.map(\.detail) == ["first.md", "second.md"])
+        #expect(toolCalls.map(\.output) == ["first result", "second result"])
+        #expect(toolCalls.map(\.status) == [.completed, .failed])
+    }
+
+    @Test func unmatchedToolResultPreservesTheLegacyFallbackIdentity() {
+        let turnID = ChatTurnID(rawValue: "turn-tool-fallback")
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([
+            .toolResult(isError: false, summary: "orphaned result"),
+            .toolUse(name: "Read", inputSummary: "later.md"),
+        ], turnID: turnID)
+
+        guard deltas.count == 2,
+              case .toolCallUpsert(let fallback) = deltas[0],
+              case .toolCallUpsert(let nextUse) = deltas[1] else {
+            Issue.record("expected fallback and later tool upserts")
+            return
+        }
+        #expect(fallback.toolCallID == ToolCallID(rawValue: "\(turnID.rawValue)-tool-0"))
+        #expect(fallback.toolName == "Tool")
+        #expect(fallback.status == .completed)
+        #expect(nextUse.toolCallID == fallback.toolCallID)
+        #expect(nextUse.toolName == "Read")
+        #expect(nextUse.status == .running)
+    }
+
+    @Test func userTextAppendsATypedUserMessage() {
+        let turnID = ChatTurnID(rawValue: "turn-user")
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([.userText("Hello")], turnID: turnID)
+        let items = ChatTranscriptReducer.reducing(items: [], with: deltas)
+
+        guard items.count == 1, case .message(let message)? = items.first else {
+            Issue.record("expected one user message")
+            return
+        }
+        #expect(message.turnID == turnID)
+        #expect(message.role == .user)
+        #expect(message.text == "Hello")
+        #expect(translator.activeContentBlock == nil)
+    }
+
+    @Test func turnFailureProducesTypedFailure() {
+        let turnID = ChatTurnID(rawValue: "turn-failure")
+        var translator = AgentEventTranscriptTranslator()
+        let reason = TurnFailureReason.quotaExhausted(
+            provider: ProviderID(rawValue: "provider-failure"),
+            resetTime: nil
+        )
+        let deltas = translator.translate([.turnFailed(reason: reason)], turnID: turnID)
+        let items = ChatTranscriptReducer.reducing(items: [], with: deltas)
+
+        guard items.count == 1, case .turnFailure(let failure)? = items.first else {
+            Issue.record("expected one turn failure")
+            return
+        }
+        #expect(failure.turnID == turnID)
+        #expect(failure.category == .transportError)
+        #expect(failure.message == reason.description)
+        #expect(translator.activeContentBlock == nil)
+    }
+
+    @Test func failureCategoriesPreserveExistingMappings() {
+        #expect(AgentEventTranscriptTranslator.failureCategory(for: .stalled(idleSeconds: 1)) == .interrupted)
+        #expect(AgentEventTranscriptTranslator.failureCategory(for: .ceilingExceeded(totalSeconds: 1)) == .interrupted)
+        #expect(AgentEventTranscriptTranslator.failureCategory(for: .agentError("failure")) == .runtimeError)
+        #expect(AgentEventTranscriptTranslator.failureCategory(for: .quotaExhausted(
+            provider: ProviderID(rawValue: "provider-failure"),
+            resetTime: nil
+        )) == .transportError)
+    }
+
+    @Test func ignoredEventsProduceNoDelta() {
+        let turnID = ChatTurnID(rawValue: "turn-ignored")
+        var translator = AgentEventTranscriptTranslator()
+        _ = translator.translate([.assistantTextDelta("partial")], turnID: turnID)
+        let deltas = translator.translate([
+            .systemInit(model: "model"),
+            .subagent(subagentType: "worker", description: "work", isCompletion: false),
+            .result(isError: false, text: "complete"),
+            .messageStop,
+            .raw("wire"),
+        ], turnID: turnID)
+
+        #expect(deltas.isEmpty)
+        #expect(translator.activeContentBlock == nil)
+    }
+
+    @Test func queueAttemptCreatesDeterministicDistinctIdentities() {
+        let firstAttempt = ChatTurnID(rawValue: "queue:item-1:attempt:1")
+        let secondAttempt = ChatTurnID(rawValue: "queue:item-1:attempt:2")
+        var firstTranslator = AgentEventTranscriptTranslator()
+        var secondTranslator = AgentEventTranscriptTranslator()
+        let first = firstTranslator.translate([.assistantTextDelta("first")], turnID: firstAttempt)
+        let second = secondTranslator.translate([.assistantTextDelta("second")], turnID: secondAttempt)
+
+        guard first.count == 1,
+              second.count == 1,
+              case .messageReplacement(let firstID, _, _, _, _)? = first.first,
+              case .messageReplacement(let secondID, _, _, _, _)? = second.first else {
+            Issue.record("expected deterministic message replacements")
+            return
+        }
+        #expect(firstID == ChatMessageID(rawValue: "assistant-\(firstAttempt.rawValue)-block-0"))
+        #expect(secondID == ChatMessageID(rawValue: "assistant-\(secondAttempt.rawValue)-block-0"))
+        #expect(firstID != secondID)
+    }
+
+    @Test func terminalEventsStartNewContentBlocks() {
+        let turnID = ChatTurnID(rawValue: "turn-content-boundary")
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([
+            .assistantTextDelta("Partial"),
+            .assistantText("First block"),
+            .assistantTextDelta("Second block"),
+        ], turnID: turnID)
+        let messages = ChatTranscriptReducer.reducing(items: [], with: deltas).compactMap { item -> ChatTranscriptMessageItem? in
+            guard case .message(let message) = item else { return nil }
+            return message
+        }
+
+        #expect(messages.map(\.text) == ["First block", "Second block"])
+        #expect(messages.map(\.messageID) == [
+            ChatMessageID(rawValue: "assistant-\(turnID.rawValue)-block-0"),
+            ChatMessageID(rawValue: "assistant-\(turnID.rawValue)-block-1"),
+        ])
+    }
+}
+#endif

--- a/progress/2026-07-31T225900Z-typed-queue-transcripts-phase1.md
+++ b/progress/2026-07-31T225900Z-typed-queue-transcripts-phase1.md
@@ -1,9 +1,16 @@
+---
+timestamp: 2026-07-31T225900Z
+title: Typed Queue Transcripts Phase 1
+branch: feature/typed-queue-transcripts-phase1
+status: complete
+---
+
 # Typed Queue Transcripts Phase 1
 
 Phase 1 moves the `AgentEvent` transcript translator from `wikid` to
 `WikiFSEngine`. The move keeps the existing event mapping and identities.
 
-## Scope
+## Progress
 
 - Added `AgentEventTranscriptTranslator` as a `Sendable` value type.
 - Moved content-block state, ordinals, FIFO tool-call pairing, failure mapping,

--- a/progress/2026-07-31T225900Z-typed-queue-transcripts-phase1.md
+++ b/progress/2026-07-31T225900Z-typed-queue-transcripts-phase1.md
@@ -1,0 +1,32 @@
+# Typed Queue Transcripts Phase 1
+
+Phase 1 moves the `AgentEvent` transcript translator from `wikid` to
+`WikiFSEngine`. The move keeps the existing event mapping and identities.
+
+## Scope
+
+- Added `AgentEventTranscriptTranslator` as a `Sendable` value type.
+- Moved content-block state, ordinals, FIFO tool-call pairing, failure mapping,
+  ignored-event rules, and active-block projection into the translator.
+- Updated `LauncherChatAgentRuntime` to keep one translator for each turn.
+- Removed the launcher-private translator and its test hook.
+- Added dedicated translator tests and updated launcher/controller tests to use
+  the shared type.
+
+This phase does not change queue storage, queue/XPC contracts, Activity-window
+rendering, prompt resources, or legacy-renderer removal.
+
+## Verification
+
+- `make build` passed.
+- `swift build` passed after generated build prerequisites.
+- `swift test --filter AgentEventTranscriptTranslatorTests` passed with 11 tests.
+- `WIKIFS_APP_TESTS=1 swift test --filter 'LauncherChatAgentRuntimeTests.launcherRuntimeUsesSharedTranslator'` passed.
+- `WIKIFS_APP_TESTS=1 swift test --filter 'DaemonChatControllerTests.productionTranslatedDeltasPersistAssistantReasoningAndToolRowsWithoutDuplicates'` passed.
+- `make test` passed with 2,987 tests in 243 suites.
+
+## Review
+
+The concurrency review found no new shared mutable state. The translator has no
+actor, lock, persistence, task, or UI reference. The SwiftUI review found no
+view code in this phase.


### PR DESCRIPTION
## Phase 1 only

This PR extracts the shared `AgentEvent` transcript translator. It does not
implement typed queue storage, queue/XPC cutover, Activity-window rendering, or
legacy renderer removal.

## Scope

- Add `AgentEventTranscriptTranslator` in `WikiFSEngine`.
- Move translator state, content-block ordinals, FIFO tool pairing, failure
  mapping, ignored-event rules, and active-block projection into that type.
- Update `LauncherChatAgentRuntime` to use one translator per turn.
- Remove the launcher-private translator and test hook.
- Move pure tests to `AgentEventTranscriptTranslatorTests`.
- Update related launcher and controller tests to call the shared translator.
- Record Phase 1 evidence in `progress/`.

## Verification

- `make build` passed.
- `swift build` passed.
- `swift test --filter AgentEventTranscriptTranslatorTests` passed with 11 tests.
- `WIKIFS_APP_TESTS=1 swift test --filter 'LauncherChatAgentRuntimeTests.launcherRuntimeUsesSharedTranslator'` passed.
- `WIKIFS_APP_TESTS=1 swift test --filter 'DaemonChatControllerTests.productionTranslatedDeltasPersistAssistantReasoningAndToolRowsWithoutDuplicates'` passed.
- `make test` passed with 2,987 tests in 243 suites.

## Follow-up gates

Phases 2 through 4 remain out of scope. They will add typed queue storage,
perform the atomic protocol and queue cutover, and remove the legacy renderer.
This PR keeps `AgentEvent` at the provider-to-translator boundary.
