### PR TITLE
Add typed queue transcript storage

### DIFF
--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -23,6 +23,10 @@ public enum QueueStoreError: Error, CustomStringConvertible, LocalizedError {
     case invalidStateTransition(from: QueueItemState, to: QueueItemState)
     /// The request was malformed (e.g. empty wikiID — AC4.2).
     case invalidRequest(String)
+    /// A typed transcript item did not provide a usable case-specific identity.
+    case invalidTranscriptIdentity(String)
+    /// A transcript batch was produced by a queue worker from an earlier retry.
+    case staleAttempt(QueueAttemptID, currentAttempt: Int)
 
     public var description: String {
         switch self {
@@ -32,6 +36,10 @@ public enum QueueStoreError: Error, CustomStringConvertible, LocalizedError {
         case .invalidStateTransition(let from, let to):
             return "Invalid queue state transition: \(from.rawValue) → \(to.rawValue)"
         case .invalidRequest(let m): return "Invalid request: \(m)"
+        case .invalidTranscriptIdentity(let kind):
+            return "Invalid transcript identity for \(kind)"
+        case .staleAttempt(let rejected, let currentAttempt):
+            return "Stale queue attempt \(rejected.attempt) for \(rejected.itemID.rawValue); current attempt is \(currentAttempt)"
         }
     }
 
@@ -177,6 +185,8 @@ public final class QueueStore: @unchecked Sendable {
     ///   `"queue-running"` to disambiguate from `QueueItemState.running` (#508).
     /// - v4: `queue_item_activity` table — per-item usage JSON, log/debug URLs,
     ///   and progress-log text (persisted Activity-window metadata).
+    /// - v5: `queue_item_transcript_items` table — additive typed transcript
+    ///   storage. The legacy `queue_item_events` table remains for old callers.
     private static let migrator: DatabaseMigrator = {
         var m = DatabaseMigrator()
 
@@ -285,6 +295,27 @@ public final class QueueStore: @unchecked Sendable {
             """)
         }
 
+        // v5: additive typed queue transcript storage. The separately planned
+        // cutover migration drops `queue_item_events`; do not combine that data
+        // reset with this independently deployable storage API phase.
+        m.registerMigration("v5_add_typed_transcript_items") { db in
+            try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS queue_item_transcript_items (
+                item_id        TEXT NOT NULL REFERENCES queue_items(id) ON DELETE CASCADE,
+                attempt        INTEGER NOT NULL,
+                seq            INTEGER NOT NULL,
+                item_kind      TEXT NOT NULL,
+                identity       TEXT NOT NULL,
+                item_json      TEXT NOT NULL,
+                projected_text TEXT NOT NULL DEFAULT '',
+                created_at     INTEGER NOT NULL,
+                updated_at     INTEGER NOT NULL,
+                PRIMARY KEY (item_id, attempt, seq),
+                UNIQUE (item_id, attempt, item_kind, identity)
+            ) WITHOUT ROWID;
+            """)
+        }
+
         return m
     }()
 
@@ -311,6 +342,63 @@ public final class QueueStore: @unchecked Sendable {
             throw QueueStoreError.sqlite(code: -1, message: "payload is not valid UTF-8")
         }
         return try JSONDecoder().decode(QueueItemPayload.self, from: data)
+    }
+
+    // MARK: - Typed transcript storage helpers
+
+    /// The case tag is part of the durable identity. A provider can reuse one
+    /// raw ID in multiple transcript namespaces, so the raw value alone is not
+    /// safe for lookups or uniqueness.
+    private enum TypedTranscriptItemKind: String {
+        case message
+        case toolCall
+        case systemNotice
+        case turnFailure
+    }
+
+    private struct TypedTranscriptIdentity {
+        let kind: TypedTranscriptItemKind
+        let rawValue: String
+
+        init(item: ChatTranscriptItem) throws {
+            switch item {
+            case .message(let message):
+                self.kind = .message
+                self.rawValue = message.messageID.rawValue
+            case .toolCall(let toolCall):
+                self.kind = .toolCall
+                self.rawValue = toolCall.toolCallID.rawValue
+            case .systemNotice(let notice):
+                self.kind = .systemNotice
+                self.rawValue = notice.noticeID.rawValue
+            case .turnFailure(let failure):
+                self.kind = .turnFailure
+                self.rawValue = failure.failureID.rawValue
+            }
+
+            guard rawValue.isEmpty == false else {
+                throw QueueStoreError.invalidTranscriptIdentity(kind.rawValue)
+            }
+        }
+    }
+
+    private struct EncodedTypedTranscriptItem {
+        let identity: TypedTranscriptIdentity
+        let itemJSON: String
+        let projectedText: String
+    }
+
+    private static func encodeTypedTranscriptItem(_ item: ChatTranscriptItem) throws -> EncodedTypedTranscriptItem {
+        let identity = try TypedTranscriptIdentity(item: item)
+        let data = try JSONEncoder().encode(item)
+        guard let itemJSON = String(data: data, encoding: .utf8) else {
+            throw QueueStoreError.invalidRequest("Transcript item JSON is not UTF-8")
+        }
+        return EncodedTypedTranscriptItem(
+            identity: identity,
+            itemJSON: itemJSON,
+            projectedText: LegacyChatTranscriptPersistenceProjection.project(item).plainText
+        )
     }
 
     // MARK: - GRDB error wrapping
@@ -867,6 +955,123 @@ public final class QueueStore: @unchecked Sendable {
                 try db.execute(
                     sql: "DELETE FROM queue_item_events WHERE item_id = ?;",
                     arguments: [itemID.rawValue])
+            }
+        }
+    }
+
+    // MARK: - Public API: Typed transcript items
+
+    /// Atomically persist changed typed transcript items for one immutable queue
+    /// attempt. The store validates the attempt inside the same write
+    /// transaction that allocates sequence numbers and upserts the batch.
+    ///
+    /// A matching tagged identity updates content in place. Its original
+    /// sequence and creation time remain stable, so streamed replacements do
+    /// not move a row in the transcript.
+    public func upsertTranscriptItems(
+        attemptID: QueueAttemptID,
+        items: [ChatTranscriptItem]
+    ) throws {
+        let encodedItems = try items.map(Self.encodeTypedTranscriptItem)
+        let now = Self.nowMillis()
+
+        try Self.wrap {
+            let queue = try self.queue()
+            try queue.write { db in
+                let currentAttempt = try Int.fetchOne(
+                    db,
+                    sql: "SELECT attempt FROM queue_items WHERE id = ?;",
+                    arguments: [attemptID.itemID.rawValue]
+                )
+                guard let currentAttempt else {
+                    throw QueueStoreError.notFound(attemptID.itemID)
+                }
+                guard currentAttempt == attemptID.attempt else {
+                    throw QueueStoreError.staleAttempt(attemptID, currentAttempt: currentAttempt)
+                }
+
+                for item in encodedItems {
+                    try db.execute(sql: """
+                    INSERT INTO queue_item_transcript_items (
+                        item_id, attempt, seq, item_kind, identity, item_json,
+                        projected_text, created_at, updated_at
+                    ) VALUES (
+                        ?, ?,
+                        COALESCE((
+                            SELECT MAX(seq) + 1
+                            FROM queue_item_transcript_items
+                            WHERE item_id = ? AND attempt = ?
+                        ), 0),
+                        ?, ?, ?, ?, ?, ?
+                    )
+                    ON CONFLICT(item_id, attempt, item_kind, identity) DO UPDATE SET
+                        item_json = excluded.item_json,
+                        projected_text = excluded.projected_text,
+                        updated_at = excluded.updated_at;
+                    """, arguments: [
+                        attemptID.itemID.rawValue,
+                        attemptID.attempt,
+                        attemptID.itemID.rawValue,
+                        attemptID.attempt,
+                        item.identity.kind.rawValue,
+                        item.identity.rawValue,
+                        item.itemJSON,
+                        item.projectedText,
+                        now,
+                        now,
+                    ])
+                }
+            }
+        }
+    }
+
+    /// Load all typed transcript items for an item in durable sequence order.
+    /// Invalid rows are logged and skipped so one corrupt row does not hide the
+    /// rest of the item transcript.
+    public func loadTranscriptItems(itemID: QueueItem.ID) throws -> [ChatTranscriptItem] {
+        try Self.wrap {
+            let queue = try self.queue()
+            return try queue.read { db in
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                    SELECT item_json
+                    FROM queue_item_transcript_items
+                    WHERE item_id = ?
+                    ORDER BY seq ASC;
+                    """,
+                    arguments: [itemID.rawValue]
+                )
+                var items: [ChatTranscriptItem] = []
+                items.reserveCapacity(rows.count)
+                for row in rows {
+                    let itemJSON: String = row["item_json"]
+                    guard let data = itemJSON.data(using: .utf8) else {
+                        DebugLog.store("QueueStore.loadTranscriptItems: item JSON is not UTF-8 for \(itemID.rawValue)")
+                        continue
+                    }
+                    do {
+                        items.append(try JSONDecoder().decode(ChatTranscriptItem.self, from: data))
+                    } catch {
+                        DebugLog.store("QueueStore.loadTranscriptItems: decode failed for \(itemID.rawValue): \(error)")
+                    }
+                }
+                return items
+            }
+        }
+    }
+
+    /// Delete typed transcript rows for one selected queue item. Phase 2 keeps
+    /// legacy event-store callers unchanged, so this method is intentionally not
+    /// wired into the existing retry path until the typed cutover.
+    public func deleteTranscriptItems(itemID: QueueItem.ID) throws {
+        try Self.wrap {
+            let queue = try self.queue()
+            try queue.write { db in
+                try db.execute(
+                    sql: "DELETE FROM queue_item_transcript_items WHERE item_id = ?;",
+                    arguments: [itemID.rawValue]
+                )
             }
         }
     }

--- a/Sources/WikiFSCore/Core/QueueTypes.swift
+++ b/Sources/WikiFSCore/Core/QueueTypes.swift
@@ -67,6 +67,19 @@ public enum QueueRunState: String, Codable, Sendable {
     case paused
 }
 
+/// Immutable identity for one claimed queue-item attempt. A queue retry creates
+/// a new attempt, so callbacks from an earlier worker cannot target current
+/// transcript rows by item ID alone.
+public struct QueueAttemptID: Hashable, Codable, Sendable {
+    public let itemID: QueueItem.ID
+    public let attempt: Int
+
+    public init(itemID: QueueItem.ID, attempt: Int) {
+        self.itemID = itemID
+        self.attempt = attempt
+    }
+}
+
 // MARK: - Payload
 
 /// The work description for a queue item — what the worker should process.

--- a/Tests/WikiFSTests/QueueStoreTypedTranscriptMigrationTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTypedTranscriptMigrationTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+#if canImport(CSQLite)
+import CSQLite
+#else
+import SQLite3
+#endif
+import Testing
+@testable import WikiFSCore
+
+struct QueueStoreTypedTranscriptMigrationTests {
+    @Test func additiveMigrationCreatesTypedTranscriptTableAndKeepsLegacyEventTable() throws {
+        let url = try temporaryDatabaseURL()
+        let store = try QueueStore(databaseURL: url)
+        store.close()
+
+        #expect(try tableExists(named: "queue_item_transcript_items", in: url))
+        #expect(try tableExists(named: "queue_item_events", in: url))
+    }
+
+    private func temporaryDatabaseURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-typed-migration-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("queue.sqlite")
+    }
+
+    private func tableExists(named tableName: String, in url: URL) throws -> Bool {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not open migration test database")
+        }
+        defer { sqlite3_close(database) }
+
+        let sql = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1;"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not prepare table lookup")
+        }
+        defer { sqlite3_finalize(statement) }
+
+        return try tableName.withCString { tableNamePointer in
+            guard sqlite3_bind_text(statement, 1, tableNamePointer, -1, nil) == SQLITE_OK else {
+                throw QueueStoreError.sqlite(code: -1, message: "Could not bind table name")
+            }
+            return sqlite3_step(statement) == SQLITE_ROW
+        }
+    }
+}

--- a/Tests/WikiFSTests/QueueStoreTypedTranscriptTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTypedTranscriptTests.swift
@@ -1,0 +1,250 @@
+import Foundation
+#if canImport(CSQLite)
+import CSQLite
+#else
+import SQLite3
+#endif
+import Testing
+@testable import WikiFSCore
+
+struct QueueStoreTypedTranscriptTests {
+    @Test func upsertPreservesSequenceForEachTaggedIdentityKind() throws {
+        let store = try QueueStore(databaseURL: try temporaryDatabaseURL())
+        let item = try enqueueItem(in: store)
+        let attemptID = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let initialItems = transcriptItems(rawID: "all-kinds", text: "initial")
+
+        try store.upsertTranscriptItems(attemptID: attemptID, items: initialItems)
+
+        let replacements = transcriptItems(rawID: "all-kinds", text: "replacement").reversed()
+        try store.upsertTranscriptItems(attemptID: attemptID, items: Array(replacements))
+
+        #expect(try store.loadTranscriptItems(itemID: item.id) == transcriptItems(rawID: "all-kinds", text: "replacement"))
+    }
+
+    @Test func identicalRawIDsInDifferentKindsDoNotCollide() throws {
+        let store = try QueueStore(databaseURL: try temporaryDatabaseURL())
+        let item = try enqueueItem(in: store)
+        let attemptID = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let sharedRawID = "shared-provider-id"
+        let items = transcriptItems(rawID: sharedRawID, text: "first")
+
+        try store.upsertTranscriptItems(attemptID: attemptID, items: items)
+
+        #expect(try store.loadTranscriptItems(itemID: item.id) == items)
+    }
+
+    @Test func typedTranscriptOrderSurvivesDatabaseReopen() throws {
+        let url = try temporaryDatabaseURL()
+        let itemID: QueueItem.ID
+        let expected = transcriptItems(rawID: "reopen", text: "stored")
+
+        do {
+            let store = try QueueStore(databaseURL: url)
+            let item = try enqueueItem(in: store)
+            itemID = item.id
+            try store.upsertTranscriptItems(
+                attemptID: QueueAttemptID(itemID: item.id, attempt: item.attempt),
+                items: expected
+            )
+            store.close()
+        }
+
+        let reopened = try QueueStore(databaseURL: url)
+        #expect(try reopened.loadTranscriptItems(itemID: itemID) == expected)
+    }
+
+    @Test func retryClearRemovesOnlyTheSelectedItemTranscript() throws {
+        let store = try QueueStore(databaseURL: try temporaryDatabaseURL())
+        let selectedItem = try enqueueItem(in: store)
+        let preservedItem = try enqueueItem(in: store)
+        let selectedItems = transcriptItems(rawID: "selected", text: "selected")
+        let preservedItems = transcriptItems(rawID: "preserved", text: "preserved")
+
+        try store.upsertTranscriptItems(
+            attemptID: QueueAttemptID(itemID: selectedItem.id, attempt: selectedItem.attempt),
+            items: selectedItems
+        )
+        try store.upsertTranscriptItems(
+            attemptID: QueueAttemptID(itemID: preservedItem.id, attempt: preservedItem.attempt),
+            items: preservedItems
+        )
+        try store.appendItemEvent(itemID: selectedItem.id, event: .assistantText("legacy event"))
+        try store.markRunning(id: selectedItem.id, providerID: ProviderID(rawValue: "test-provider"))
+        try store.markFailed(id: selectedItem.id, error: "retry test")
+        try store.retryItem(id: selectedItem.id)
+        let retriedItem = try #require(try store.getItem(selectedItem.id))
+        try store.upsertTranscriptItems(
+            attemptID: QueueAttemptID(itemID: retriedItem.id, attempt: retriedItem.attempt),
+            items: transcriptItems(rawID: "selected-retry", text: "selected retry")
+        )
+
+        try store.deleteTranscriptItems(itemID: selectedItem.id)
+
+        #expect(try store.loadTranscriptItems(itemID: selectedItem.id).isEmpty)
+        #expect(try store.loadTranscriptItems(itemID: preservedItem.id) == preservedItems)
+        #expect(try store.loadItemEvents(itemID: selectedItem.id) == [.assistantText("legacy event")])
+    }
+
+    @Test func historyPruneCascadesTypedTranscriptRows() throws {
+        let store = try QueueStore(databaseURL: try temporaryDatabaseURL())
+        let item = try enqueueItem(in: store)
+        try store.upsertTranscriptItems(
+            attemptID: QueueAttemptID(itemID: item.id, attempt: item.attempt),
+            items: transcriptItems(rawID: "prune", text: "prune")
+        )
+        try store.markRunning(id: item.id, providerID: ProviderID(rawValue: "test-provider"))
+        try store.markCompleted(id: item.id)
+
+        try store.pruneHistory(maxPerQueue: 0)
+
+        #expect(try store.loadTranscriptItems(itemID: item.id).isEmpty)
+    }
+
+    @Test func staleAttemptBatchIsRejectedAtomically() throws {
+        let store = try QueueStore(databaseURL: try temporaryDatabaseURL())
+        let item = try enqueueItem(in: store)
+        let currentAttempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let persistedItems = transcriptItems(rawID: "persisted", text: "persisted")
+        try store.upsertTranscriptItems(attemptID: currentAttempt, items: persistedItems)
+        try store.markRunning(id: item.id, providerID: ProviderID(rawValue: "test-provider"))
+        try store.markFailed(id: item.id, error: "test failure")
+        try store.retryItem(id: item.id)
+
+        do {
+            try store.upsertTranscriptItems(
+                attemptID: currentAttempt,
+                items: transcriptItems(rawID: "stale", text: "stale")
+            )
+            Issue.record("Expected stale attempt transcript batch to fail.")
+        } catch QueueStoreError.staleAttempt(let rejectedAttempt, let currentAttempt) {
+            #expect(rejectedAttempt.itemID == item.id)
+            #expect(rejectedAttempt.attempt == item.attempt)
+            #expect(currentAttempt == item.attempt + 1)
+        }
+
+        #expect(try store.loadTranscriptItems(itemID: item.id) == persistedItems)
+    }
+
+    @Test func emptyTaggedIdentityIsRejectedBeforeWriting() throws {
+        let store = try QueueStore(databaseURL: try temporaryDatabaseURL())
+        let item = try enqueueItem(in: store)
+        let invalidItem = ChatTranscriptItem.message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: ""),
+            turnID: ChatTurnID(rawValue: "invalid-identity-turn"),
+            role: .assistant,
+            text: "invalid",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        ))
+
+        do {
+            try store.upsertTranscriptItems(
+                attemptID: QueueAttemptID(itemID: item.id, attempt: item.attempt),
+                items: [invalidItem]
+            )
+            Issue.record("Expected an empty tagged identity to fail.")
+        } catch QueueStoreError.invalidTranscriptIdentity(let kind) {
+            #expect(kind == "message")
+        }
+
+        #expect(try store.loadTranscriptItems(itemID: item.id).isEmpty)
+    }
+
+    @Test func malformedStoredTypedItemIsLoggedAndSkipped() throws {
+        let url = try temporaryDatabaseURL()
+        let itemID: QueueItem.ID
+        do {
+            let store = try QueueStore(databaseURL: url)
+            let item = try enqueueItem(in: store)
+            itemID = item.id
+            try store.upsertTranscriptItems(
+                attemptID: QueueAttemptID(itemID: item.id, attempt: item.attempt),
+                items: [transcriptItems(rawID: "malformed", text: "stored")[0]]
+            )
+            store.close()
+        }
+        try execute(
+            sql: "UPDATE queue_item_transcript_items SET item_json = 'not-json' WHERE item_id = '\(itemID.rawValue)';",
+            in: url
+        )
+
+        let reopened = try QueueStore(databaseURL: url)
+        #expect(try reopened.loadTranscriptItems(itemID: itemID).isEmpty)
+    }
+
+    private func temporaryDatabaseURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-typed-transcript-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("queue.sqlite")
+    }
+
+    private func enqueueItem(in store: QueueStore) throws -> QueueItem {
+        try store.enqueue(
+            QueueItemRequest(
+                queue: .extraction,
+                wikiID: WikiID(rawValue: "typed-transcript-wiki"),
+                payload: QueueItemPayload(sourceIDs: [SourceID(rawValue: "typed-transcript-source")])
+            )
+        )
+    }
+
+    private func transcriptItems(rawID: String, text: String) -> [ChatTranscriptItem] {
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let turnID = ChatTurnID(rawValue: "turn-\(rawID)")
+        return [
+            .message(ChatTranscriptMessageItem(
+                messageID: ChatMessageID(rawValue: rawID),
+                turnID: turnID,
+                role: .assistant,
+                text: "message \(text)",
+                createdAt: createdAt
+            )),
+            .toolCall(ChatTranscriptToolCallItem(
+                toolCallID: ToolCallID(rawValue: rawID),
+                turnID: turnID,
+                toolName: "Bash",
+                status: .completed,
+                detail: "detail \(text)",
+                output: "output \(text)",
+                permissionRequestID: nil,
+                updatedAt: createdAt
+            )),
+            .systemNotice(ChatTranscriptSystemNoticeItem(
+                noticeID: ChatTranscriptNoticeID(rawValue: rawID),
+                turnID: turnID,
+                kind: .queue,
+                title: "Notice \(text)",
+                message: "notice \(text)",
+                createdAt: createdAt
+            )),
+            .turnFailure(ChatTranscriptTurnFailureItem(
+                failureID: ChatTranscriptFailureID(rawValue: rawID),
+                turnID: turnID,
+                category: .runtimeError,
+                message: "failure \(text)",
+                createdAt: createdAt
+            )),
+        ]
+    }
+
+    private func execute(sql: String, in url: URL) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not open typed transcript test database")
+        }
+        defer { sqlite3_close(database) }
+
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
+        defer {
+            if let errorMessage {
+                sqlite3_free(errorMessage)
+            }
+        }
+        guard result == SQLITE_OK else {
+            let message = errorMessage.map { String(cString: $0) } ?? "Unknown SQLite error"
+            throw QueueStoreError.sqlite(code: result, message: message)
+        }
+    }
+}

--- a/progress/2026-08-01T112236Z-typed-queue-transcripts-phase2.md
+++ b/progress/2026-08-01T112236Z-typed-queue-transcripts-phase2.md
@@ -1,0 +1,44 @@
+---
+timestamp: 2026-08-01T112236Z
+title: Typed Queue Transcripts Phase 2
+branch: feature/typed-queue-transcripts-phase2
+status: complete
+---
+
+# Typed Queue Transcripts Phase 2
+
+Phase 2 adds durable typed queue transcript storage. It keeps the legacy event
+table and all old callers unchanged.
+
+## Progress
+
+- Added `QueueAttemptID` for an item and its immutable retry attempt.
+- Added the additive v5 `queue_item_transcript_items` migration.
+- Added atomic typed upsert, ordered read, and item-scoped clear APIs.
+- Stored a case tag with every message, tool call, notice, and failure ID.
+- Rejected stale batches inside the same store transaction as each upsert.
+- Added typed storage and migration coverage. The tests cover replacements,
+  shared raw IDs across item kinds, reopen order, item-scoped clear, foreign-key
+  pruning, stale batches, invalid identities, and malformed stored JSON.
+
+This phase does not change the legacy `queue_item_events` table, queue/XPC
+contracts, queue engine callers, Activity-window rendering, or the final
+cutover migration. Phase 3 will depend on this branch head for those changes.
+
+## Verification
+
+- `swift test --filter QueueStoreTypedTranscriptTests` passed with 8 tests.
+- `swift test --filter QueueStoreTypedTranscriptMigrationTests` passed with 1 test.
+- `swift test --filter QueueStoreTests` passed with 31 tests.
+- `make build` passed.
+- `make test` passed with 2,996 tests in 245 suites.
+- `make lint` passed with 0 violations.
+- `git diff --check` passed.
+
+## Review
+
+The concurrency review found no new tasks, actors, locks, streams, or mutable
+shared state. `DatabaseQueue.write` remains the transaction boundary.
+
+The Swift Testing review found isolated test databases and no test ordering
+dependency. The SwiftUI and macOS reviews found no UI code in this phase.


### PR DESCRIPTION
## Summary

Add additive typed queue transcript storage for `QueueStore`.

- Add `QueueAttemptID` and atomic typed transcript upsert, read, and clear APIs.
- Add the v5 `queue_item_transcript_items` migration.
- Keep `queue_item_events` and all legacy callers unchanged.
- Add storage and migration tests for identity, ordering, stale attempts, clear, and cascade behavior.

## Stack

- Stack order: Phase 2, bottom layer.
- Parent branch: `main`.
- PR base: `main`.
- Exact head SHA: `1657ce4b8a5084338c0bc82def5ed8e45ec137d4`.
- Dependency status: Phase 1 merged to `main` at `bfa297cf48ccb2d8ec0243edf81f607c5dc6a595`.
- Phase 3 will depend on this exact head and use `feature/typed-queue-transcripts-phase2` as its PR base.

## Scope

This PR adds typed storage only. It does not change queue engine callers, XPC,
protocols, Activity-window UI, or the legacy event renderer. The final `DROP
TABLE queue_item_events` migration and the queue/XPC/UI cutover are deferred to
Phase 3.

## Verification

- `swift test --filter QueueStoreTypedTranscriptTests` passed with 8 tests.
- `swift test --filter QueueStoreTypedTranscriptMigrationTests` passed with 1 test.
- `swift test --filter QueueStoreTests` passed with 31 tests.
- `make build` passed.
- `make test` passed with 2,996 tests in 245 suites.
- `make lint` passed with 0 violations.
- `git diff --check` passed.
- The commit pre-commit guard passed.

## Review

The Swift concurrency review found no new tasks, actors, locks, streams, or
shared mutable state. The Swift Testing review found isolated databases and no
test ordering dependency. The SwiftUI and macOS reviews found no UI code in this
phase.
