### PR TITLE
feat: cut over queue transcripts to typed items

### DIFF
--- a/Sources/WikiCtlCore/DaemonWorkloadClient.swift
+++ b/Sources/WikiCtlCore/DaemonWorkloadClient.swift
@@ -232,8 +232,8 @@ public final class DaemonWorkloadClient: @unchecked Sendable {
         }
     }
 
-    /// Load persisted transcript events for a queue item.
-    public func loadTranscript(for itemID: QueueItem.ID) async throws -> [AgentEvent] {
+    /// Load persisted typed transcript items for a queue item.
+    public func loadTranscript(for itemID: QueueItem.ID) async throws -> [ChatTranscriptItem] {
         try await withTimeout {
             let replyData = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
                 self.proxy.loadTranscript(itemID: itemID.rawValue) { data in
@@ -241,7 +241,7 @@ public final class DaemonWorkloadClient: @unchecked Sendable {
                 }
             }
             do {
-                return try JSONDecoder().decode([AgentEvent].self, from: replyData)
+                return try JSONDecoder().decode([ChatTranscriptItem].self, from: replyData)
             } catch {
                 throw DaemonXPCError.unexpectedReply
             }

--- a/Sources/WikiDaemonContract/WikiDaemonProtocol.swift
+++ b/Sources/WikiDaemonContract/WikiDaemonProtocol.swift
@@ -96,7 +96,7 @@ import Foundation
     /// `{"success": false, "error": "..."}`.
     func waitForCompletion(id: String, reply: @escaping (Data) -> Void)
 
-    /// Load transcript events for an item. Reply is JSON-encoded `[AgentEvent]`.
+    /// Load transcript items for an item. Reply is JSON-encoded `[ChatTranscriptItem]`.
     func loadTranscript(itemID: String, reply: @escaping (Data) -> Void)
 
     /// Load all activity snapshots. Reply is JSON-encoded

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -883,7 +883,7 @@ struct ActivityWindowView: View {
             persisted: loadedTranscriptItems,
             live: activityTracker.transcript(for: item.id)),
             progressText: activityTracker.progressLog(for: item.id),
-            transcriptID: .queueItem(item.id),
+            transcriptID: TranscriptID.queueItem(item.id),
             isStreaming: item.state == .running,
             onIntent: { intent in
                 if case .openWikiLink(let url, let inNewTab) = intent {

--- a/Sources/WikiFS/Queue/ActivityWindowView.swift
+++ b/Sources/WikiFS/Queue/ActivityWindowView.swift
@@ -2,6 +2,63 @@ import SwiftUI
 import WikiFSCore
 import WikiFSEngine
 
+/// Value-only input for the Activity window's typed transcript surface. It
+/// keeps canonical merge, copy text, transcript identity, and renderer
+/// dependencies together so the hosted window and its tests use one seam.
+@MainActor
+struct ActivityTranscriptPresentation {
+    let items: [ChatTranscriptItem]
+    let progressText: String
+    let transcriptID: TranscriptID
+    let isStreaming: Bool
+    let onIntent: (ChatTranscriptIntent) -> Void
+    let renderContext: (() -> WikiRenderContext?)?
+    let blobStore: WikiStoreModel?
+
+    static func canonicalItems(
+        persisted: [ChatTranscriptItem],
+        live: [ChatTranscriptItem]
+    ) -> [ChatTranscriptItem] {
+        QueueTranscriptCanonicalMerge.merging(persisted: persisted, live: live)
+    }
+
+    var usesProgressFallback: Bool {
+        items.isEmpty && progressText.isEmpty == false
+    }
+
+    var copyText: String? {
+        if items.isEmpty == false {
+            let lines = items.map(Self.plainText).filter { $0.isEmpty == false }
+            return lines.isEmpty ? nil : lines.joined(separator: "\n\n")
+        }
+        return progressText.isEmpty ? nil : progressText
+    }
+
+    func transcriptView() -> ChatTranscriptView {
+        ChatTranscriptView(
+            rendering: .init(transcript: ChatDisplayProjection.project(
+                items: items,
+                activeContentBlock: nil
+            ).transcript),
+            transcriptID: transcriptID,
+            emptyStateMessage: "No activity yet.",
+            isStreaming: isStreaming,
+            onIntent: onIntent,
+            renderContext: renderContext,
+            blobStore: blobStore
+        )
+    }
+
+    private static func plainText(_ item: ChatTranscriptItem) -> String {
+        switch item {
+        case .message(let message): return message.text
+        case .toolCall(let tool): return [tool.toolName, tool.detail, tool.output].compactMap { $0 }.joined(separator: "\n")
+        case .systemNotice(let notice): return [notice.title, notice.message].compactMap { $0 }.joined(separator: "\n")
+        case .turnFailure(let failure): return failure.message
+        }
+    }
+}
+
 /// A per-queue activity window — one instance shows the Ingestion queue, the
 /// other the Extraction queue, so the two pipelines read as the separate
 /// systems they are. A real `NSWindow` (not transient) listing this queue's
@@ -16,7 +73,7 @@ import WikiFSEngine
 /// **Detail (right):** A header (sources, wiki, state, error, primary action)
 /// over the selected item's transcript — rendered via `ChatWebView` fed from
 /// `activityTracker.transcripts[itemID]`. For extraction items (which produce
-/// progress strings, not typed `AgentEvent`s), falls back to the accumulated
+/// progress strings, not transcript rows), falls back to the accumulated
 /// progress text.
 ///
 /// **Toolbar:** This queue's pause/resume/halt menu (global actions live in
@@ -36,7 +93,7 @@ struct ActivityWindowView: View {
 
     @State private var viewModel = QueueViewModel()
     @State private var selectedItemID: QueueItem.ID?
-    @State private var loadedEvents: [AgentEvent] = []
+    @State private var loadedTranscriptItems: [ChatTranscriptItem] = []
     @State private var didAutoSelect = false
 
     private var queueTitle: String {
@@ -312,7 +369,7 @@ struct ActivityWindowView: View {
                 }
                 // #608: surface a pending always-ask permission stall as a
                 // yellow "Permission pending: <cmd>" row. Mirrors how streamed
-                // `AgentEvent`s + live usage flow into the row — the tracker's
+                // Typed transcript updates + live usage flow into the row — the tracker's
                 // `.pendingPermission` event sets/clears this. Reuses the
                 // `exclamationmark.triangle.fill` + `.orange` pattern from the
                 // Agents-settings model-warning (PR #605). ACP agents gate one
@@ -472,13 +529,11 @@ struct ActivityWindowView: View {
                 transcriptContent(for: item)
             }
             .task(id: itemID) {
-                // If the tracker has no in-memory events for this item,
-                // try loading persisted events from the DB.
-                if activityTracker.transcript(for: itemID).isEmpty {
-                    loadedEvents = await queueEngine.loadTranscript(for: itemID)
-                } else {
-                    loadedEvents = []
-                }
+                // Prevent the previous selection's durable rows from briefly
+                // merging into this item's live transcript while its load is
+                // in flight.
+                loadedTranscriptItems = []
+                loadedTranscriptItems = await queueEngine.loadTranscript(for: itemID)
             }
         } else if activeItems.isEmpty && recentItems.isEmpty {
             emptyState
@@ -624,38 +679,18 @@ struct ActivityWindowView: View {
 
     @ViewBuilder
     private func transcriptContent(for item: QueueItem) -> some View {
-        // Prefer in-memory events (live); fall back to persisted (rehydrated).
-        let inMemoryEvents = activityTracker.transcript(for: item.id)
-        let events = inMemoryEvents.isEmpty ? loadedEvents : inMemoryEvents
-        let progressText = activityTracker.progressLog(for: item.id)
+        let presentation = transcriptPresentation(for: item)
 
-        if !events.isEmpty {
-            ChatWebView(
-                events: events,
-                // Selecting a different queue item reuses this representable's
-                // web view + coordinator (same structural identity, different
-                // associated value), so the differ needs the item id to know
-                // the DOM it built belongs to a different run.
-                transcriptID: .queueItem(item.id),
-                showsInternals: false,
-                onWikiLink: wikiLinkHandler(for: item.wikiID),
-                // Resolve ghost-link coloring + blob serving from THIS item's
-                // wiki store (the transcript's `[[wiki-links]]` point into the
-                // wiki the agent ran against, not a different one). nil when
-                // the wiki window is closed — links still render but without
-                // resolution-based styling (the same degradation the in-wiki
-                // feed tolerates when a store is mid-swap).
-                renderContext: renderContextProvider(for: item.wikiID),
-                blobStore: store(for: item.wikiID)
-            )
+        if !presentation.items.isEmpty {
+            presentation.transcriptView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 // Match `detailHeader`'s 16pt inset. ChatWebView's CSS sets
                 // body left-padding to 0 by design (PR #457) — the left margin
                 // is the host's responsibility, so provide it here.
                 .padding(.horizontal, 16)
-        } else if !progressText.isEmpty {
+        } else if presentation.usesProgressFallback {
             ScrollView {
-                Text(progressText)
+                Text(presentation.progressText)
                     .font(.system(.caption, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -837,21 +872,27 @@ struct ActivityWindowView: View {
 
     // MARK: - Copy
 
-    /// The plain-text content available to copy for this item, or `nil` if
-    /// there's nothing to copy. Uses the same event/progress-fallback logic as
-    /// `transcriptContent(for:)` so Copy always reflects what's on screen.
+    /// The copy path uses the same canonical typed rows as the renderer.
     private func copyableText(for item: QueueItem) -> String? {
-        let inMemoryEvents = activityTracker.transcript(for: item.id)
-        let events = inMemoryEvents.isEmpty ? loadedEvents : inMemoryEvents
+        transcriptPresentation(for: item).copyText
+    }
 
-        if !events.isEmpty {
-            let lines = events.map(\.plainText).filter { !$0.isEmpty }
-            if lines.isEmpty { return nil }
-            return lines.joined(separator: "\n\n")
-        }
-
-        let progressText = activityTracker.progressLog(for: item.id)
-        return progressText.isEmpty ? nil : progressText
+    private func transcriptPresentation(for item: QueueItem) -> ActivityTranscriptPresentation {
+        ActivityTranscriptPresentation(
+            items: ActivityTranscriptPresentation.canonicalItems(
+            persisted: loadedTranscriptItems,
+            live: activityTracker.transcript(for: item.id)),
+            progressText: activityTracker.progressLog(for: item.id),
+            transcriptID: .queueItem(item.id),
+            isStreaming: item.state == .running,
+            onIntent: { intent in
+                if case .openWikiLink(let url, let inNewTab) = intent {
+                    wikiLinkHandler(for: item.wikiID)(url, inNewTab)
+                }
+            },
+            renderContext: renderContextProvider(for: item.wikiID),
+            blobStore: store(for: item.wikiID)
+        )
     }
 
     /// #635: retry the given queue item WITHOUT swallowing the throw. The

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -10,13 +10,6 @@ final class ProgressEmitBox: @unchecked Sendable {
     var emit: (@Sendable (QueueItem.ID, String) -> Void)?
 }
 
-/// A mutable box for a `@Sendable` transcript-emit closure. Same pattern as
-/// `ProgressEmitBox` — breaks the circular dependency between the ingestion
-/// worker factory (needs the closure) and the engine (provides it).
-final class TranscriptEmitBox: @unchecked Sendable {
-    var emit: (@Sendable (QueueItem.ID, AgentEvent) -> Void)?
-}
-
 /// A mutable box for a `@Sendable` usage-emit closure. Same pattern as
 /// `ProgressEmitBox`/`TranscriptEmitBox` — breaks the circular dependency
 /// between the ingestion worker factory (needs the closure) and the engine
@@ -206,10 +199,12 @@ final class QueueActivityTracker {
     }
     /// Bounded — pruned only when items are pruned from history (not on
     /// terminal state, so users can view completed/failed/cancelled transcripts).
-    private(set) var transcripts: [QueueItem.ID: [AgentEvent]] = [:]
+    private(set) var transcripts: [QueueItem.ID: [ChatTranscriptItem]] = [:]
+    private var transcriptAttempts: [QueueItem.ID: QueueAttemptID] = [:]
+    private var lastTranscriptBatch: [QueueAttemptID: Int] = [:]
 
     /// Per-item accumulated progress text (for extraction items that produce
-    /// progress strings, not typed `AgentEvent`s). Keyed by item ID.
+    /// progress strings, not typed transcript rows). Keyed by item ID.
     private(set) var progressLogs: [QueueItem.ID: String] = [:]
 
     /// Per-item cumulative token/cost usage for completed runs (#528 spike).
@@ -272,10 +267,6 @@ final class QueueActivityTracker {
 
     // MARK: - Internal tracking
 
-    /// Maximum number of typed events to retain per item. Older events are
-    /// dropped beyond this bound to keep memory bounded.
-    private let maxTranscriptEvents = 1000
-
     /// Maximum number of items to retain transcripts for. When exceeded, the
     /// oldest item's transcript is pruned. This prevents unbounded growth when
     /// many items accumulate over a long session.
@@ -294,17 +285,6 @@ final class QueueActivityTracker {
     /// be tracked under both extraction and ingestion by different items, so
     /// the queue kind is needed to avoid subtracting from the wrong set.
     private var itemToQueue: [QueueItem.ID: QueueKind] = [:]
-
-    /// Items whose transcript's last row is an in-progress streamed assistant
-    /// reply — the next `.assistantTextDelta` grows that row in place instead
-    /// of appending a new one (mirrors `AgentLauncher.mergeOrAppend`; without
-    /// this, a streamed reply renders as one row per word-fragment).
-    private var streamingTranscriptItemIDs: Set<QueueItem.ID> = []
-
-    /// Items whose transcript's last row is an in-progress streamed thinking
-    /// block — the next `.thinkingDelta` grows that row in place instead of
-    /// appending a new one (mirrors `streamingTranscriptItemIDs` for assistant text).
-    private var streamingThinkingItemIDs: Set<QueueItem.ID> = []
 
     /// The currently running extraction item ID, for cancellation via
     /// `cancelExtraction()`.
@@ -450,8 +430,8 @@ final class QueueActivityTracker {
         itemLogURLs.removeAll()
         itemDebugURLs.removeAll()
         pendingPermissions.removeAll()
-        streamingTranscriptItemIDs.removeAll()
-        streamingThinkingItemIDs.removeAll()
+        transcriptAttempts.removeAll()
+        lastTranscriptBatch.removeAll()
     }
 
     // MARK: - Public API
@@ -477,74 +457,36 @@ final class QueueActivityTracker {
         !extractingSourceIDs.isEmpty && !extractingSourceIDs.contains(id)
     }
 
-    /// Append a typed event to the transcript for a queue item. Called from
-    /// the `.transcript` event handler. Streamed `.assistantTextDelta` chunks
-    /// grow the last row in place (mirroring `AgentLauncher.mergeOrAppend`) —
-    /// appending them raw renders one row per word-fragment. Bounded — drops
-    /// oldest events beyond `maxTranscriptEvents` per item, and prunes oldest
-    /// items beyond `maxTrackedItems`.
-    func appendTranscriptEvent(itemID: QueueItem.ID, event: AgentEvent) {
-        var arr = transcripts[itemID, default: []]
-        switch event {
-        case .assistantTextDelta(let delta):
-            if streamingTranscriptItemIDs.contains(itemID),
-               case .assistantText(let existing) = arr.last {
-                arr[arr.count - 1] = .assistantText(existing + delta)
-            } else {
-                arr.append(.assistantText(delta))
-                streamingTranscriptItemIDs.insert(itemID)
-            }
-            streamingThinkingItemIDs.remove(itemID)
-        case .assistantText:
-            // Authoritative full text for a block already being streamed —
-            // replace the accumulated row rather than duplicating it.
-            if streamingTranscriptItemIDs.contains(itemID),
-               case .assistantText = arr.last {
-                arr[arr.count - 1] = event
-            } else {
-                arr.append(event)
-            }
-            streamingTranscriptItemIDs.remove(itemID)
-            streamingThinkingItemIDs.remove(itemID)
-        case .thinkingDelta(let delta):
-            if streamingThinkingItemIDs.contains(itemID),
-               case .thinking(let existing) = arr.last {
-                arr[arr.count - 1] = .thinking(existing + delta)
-            } else {
-                arr.append(.thinking(delta))
-                streamingThinkingItemIDs.insert(itemID)
-            }
-            streamingTranscriptItemIDs.remove(itemID)
-        case .thinking:
-            // Authoritative full text for a thinking block already being
-            // streamed — replace the accumulated row rather than duplicating it.
-            if streamingThinkingItemIDs.contains(itemID),
-               case .thinking = arr.last {
-                arr[arr.count - 1] = event
-            } else {
-                arr.append(event)
-            }
-            streamingThinkingItemIDs.remove(itemID)
-            streamingTranscriptItemIDs.remove(itemID)
-        default:
-            arr.append(event)
-            streamingTranscriptItemIDs.remove(itemID)
-            streamingThinkingItemIDs.remove(itemID)
-        }
-        if arr.count > maxTranscriptEvents {
-            arr.removeFirst(arr.count - maxTranscriptEvents)
-        }
-        transcripts[itemID] = arr
+    /// Apply a typed, ordered queue update. The engine owns translation and
+    /// reduction. The tracker only rejects stale/out-of-order delivery and
+    /// reduces the changed typed rows into its main-actor presentation state.
+    func applyTranscriptUpdate(_ update: QueueTranscriptUpdate) {
+        let itemID = update.attemptID.itemID
+        guard transcriptAttempts[itemID] == update.attemptID else { return }
+        let expectedBatch = (lastTranscriptBatch[update.attemptID] ?? -1) + 1
+        guard update.batchNumber == expectedBatch else { return }
+        transcripts[itemID] = QueueTranscriptCanonicalMerge.merging(
+            persisted: transcripts[itemID, default: []],
+            live: update.changedItems)
+        lastTranscriptBatch[update.attemptID] = update.batchNumber
 
-        // Bound the number of tracked items — prune oldest (first inserted).
         if transcripts.count > maxTrackedItems {
-            let toRemove = transcripts.count - maxTrackedItems
-            let oldestIDs = Array(transcripts.keys.prefix(toRemove))
-            for id in oldestIDs {
+            let excess = transcripts.count - maxTrackedItems
+            for id in transcripts.keys.prefix(excess) {
                 transcripts.removeValue(forKey: id)
                 progressLogs.removeValue(forKey: id)
             }
         }
+    }
+
+    private func resetTranscriptAttempt(for item: QueueItem) {
+        let attemptID = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        guard transcriptAttempts[item.id] != attemptID else { return }
+        if let previous = transcriptAttempts[item.id] {
+            lastTranscriptBatch.removeValue(forKey: previous)
+        }
+        transcriptAttempts[item.id] = attemptID
+        transcripts.removeValue(forKey: item.id)
     }
 
     /// Prune the transcript + progress log for an item. Called when items are
@@ -560,12 +502,13 @@ final class QueueActivityTracker {
         itemDebugURLs.removeValue(forKey: itemID)
         pendingPermissions.removeValue(forKey: itemID)
         itemToQueue.removeValue(forKey: itemID)
-        streamingTranscriptItemIDs.remove(itemID)
-        streamingThinkingItemIDs.remove(itemID)
+        if let attempt = transcriptAttempts.removeValue(forKey: itemID) {
+            lastTranscriptBatch.removeValue(forKey: attempt)
+        }
     }
 
     /// The transcript for a given item ID (may be empty / nil).
-    func transcript(for itemID: QueueItem.ID) -> [AgentEvent] {
+    func transcript(for itemID: QueueItem.ID) -> [ChatTranscriptItem] {
         transcripts[itemID] ?? []
     }
 
@@ -623,6 +566,7 @@ final class QueueActivityTracker {
     func handle(_ event: QueueEvent) {
         switch event {
         case .enqueued(let item):
+            resetTranscriptAttempt(for: item)
             // Track the mapping so we can clean up on completion.
             let sourceIDs = Set(item.payload.sourceIDs)
             itemToSourceIDs[item.id] = sourceIDs
@@ -642,6 +586,7 @@ final class QueueActivityTracker {
             }
 
         case .started(let item):
+            resetTranscriptAttempt(for: item)
             let sourceIDs = Set(item.payload.sourceIDs)
             itemToSourceIDs[item.id] = sourceIDs
             itemToQueue[item.id] = item.queue
@@ -674,8 +619,8 @@ final class QueueActivityTracker {
                 }
             }
 
-        case .transcript(let id, let agentEvent):
-            appendTranscriptEvent(itemID: id, event: agentEvent)
+        case .transcript(let update):
+            applyTranscriptUpdate(update)
 
         case .usage(let id, let usage):
             // #528 spike: store per-item usage for the Activity window, and

--- a/Sources/WikiFS/Queue/QueueActivityTracker.swift
+++ b/Sources/WikiFS/Queue/QueueActivityTracker.swift
@@ -345,10 +345,16 @@ final class QueueActivityTracker {
     /// `isIngesting` would stay `true` forever. A periodic snapshot poll feeds
     /// this method so the spinner clears once the daemon reports the item gone.
     ///
-    /// Removal-only — it never adds running state, so a transient snapshot read
-    /// can't fabricate activity. Items still active on the daemon are left
-    /// untouched; their terminal event (or a later reconcile) clears them.
+    /// Reconciliation remains removal-only for running-state sets, so a
+    /// transient snapshot read can't fabricate activity. It does seed typed
+    /// transcript attempt identity for daemon-active items: a reconnect can
+    /// otherwise receive a live transcript batch before a repeated `.started`
+    /// event. Items still active on the daemon are left untouched; their
+    /// terminal event (or a later reconcile) clears them.
     func reconcile(with snapshot: QueueSnapshot) {
+        for item in snapshot.activeItems {
+            resetTranscriptAttempt(for: item)
+        }
         let activeIDs = Set(snapshot.activeItems.map { $0.id })
         let recentByID = Dictionary(
             snapshot.recentItems.map { ($0.id, $0) },
@@ -463,8 +469,8 @@ final class QueueActivityTracker {
     func applyTranscriptUpdate(_ update: QueueTranscriptUpdate) {
         let itemID = update.attemptID.itemID
         guard transcriptAttempts[itemID] == update.attemptID else { return }
-        let expectedBatch = (lastTranscriptBatch[update.attemptID] ?? -1) + 1
-        guard update.batchNumber == expectedBatch else { return }
+        let lastAcceptedBatch = lastTranscriptBatch[update.attemptID] ?? -1
+        guard update.batchNumber > lastAcceptedBatch else { return }
         transcripts[itemID] = QueueTranscriptCanonicalMerge.merging(
             persisted: transcripts[itemID, default: []],
             live: update.changedItems)

--- a/Sources/WikiFS/Queue/QueueEngineHotSwap.swift
+++ b/Sources/WikiFS/Queue/QueueEngineHotSwap.swift
@@ -116,7 +116,7 @@ final class QueueEngineHotSwap: QueueEngineClient, @unchecked Sendable {
         await current.waitForCompletion(of: id)
     }
 
-    func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] {
+    func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem] {
         await current.loadTranscript(for: itemID)
     }
 

--- a/Sources/WikiFS/Queue/QueueTranscriptEmitBox.swift
+++ b/Sources/WikiFS/Queue/QueueTranscriptEmitBox.swift
@@ -1,0 +1,23 @@
+// pattern: Imperative Shell
+
+import Foundation
+import WikiFSCore
+import WikiFSEngine
+
+/// Breaks the engine/factory construction cycle while preserving the immutable
+/// attempt captured by `QueueIngestionWorker`. Every access to the optional
+/// handler holds `lock`; the copied handler runs after lock release.
+// swiftlint:disable:next unchecked_sendable
+final class TranscriptEmitBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handler: (@Sendable (QueueAttemptID, AgentEvent) -> Void)?
+
+    func install(_ emit: @escaping @Sendable (QueueAttemptID, AgentEvent) -> Void) {
+        lock.withLock { handler = emit }
+    }
+
+    func emit(_ attemptID: QueueAttemptID, _ event: AgentEvent) {
+        let emit = lock.withLock { handler }
+        emit?(attemptID, event)
+    }
+}

--- a/Sources/WikiFS/Queue/XPCQueueEngineProxy.swift
+++ b/Sources/WikiFS/Queue/XPCQueueEngineProxy.swift
@@ -128,7 +128,7 @@ final class XPCQueueEngineProxy: QueueEngineClient {
         }
     }
 
-    func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] {
+    func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem] {
         do {
             return try await workloadClient.loadTranscript(for: itemID)
         } catch {

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -639,7 +639,7 @@ struct WikiFSApp: App {
         let ingestionFactory = QueueIngestionWorkerFactory(
             provider: ingestionProvider,
             emitProgress: { id, line in progressBox.emit?(id, line) },
-            emitTranscript: { id, event in transcriptBox.emit?(id, event) },
+            emitTranscript: { id, event in transcriptBox.emit(id, event) },
             emitUsage: { id, usage in usageBox.emit?(id, usage) },
             emitLiveUsage: { id, usage in liveUsageBox.emit?(id, usage) },
             emitLogPaths: { id, logURL, debugURL in logPathsBox.emit?(id, logURL, debugURL) },
@@ -650,7 +650,7 @@ struct WikiFSApp: App {
         ])
         let localEngine = QueueEngine(store: queueStore, workerFactory: workerFactory)
         Task { progressBox.emit = await localEngine.makeEmitProgress() }
-        Task { transcriptBox.emit = await localEngine.makeEmitTranscript() }
+        Task { transcriptBox.install(await localEngine.makeEmitTranscript()) }
         Task { usageBox.emit = await localEngine.makeEmitUsage() }
         Task { liveUsageBox.emit = await localEngine.makeEmitLiveUsage() }
         Task { logPathsBox.emit = await localEngine.makeEmitLogPaths() }

--- a/Sources/WikiFSCore/Core/QueueStore.swift
+++ b/Sources/WikiFSCore/Core/QueueStore.swift
@@ -186,7 +186,9 @@ public final class QueueStore: @unchecked Sendable {
     /// - v4: `queue_item_activity` table — per-item usage JSON, log/debug URLs,
     ///   and progress-log text (persisted Activity-window metadata).
     /// - v5: `queue_item_transcript_items` table — additive typed transcript
-    ///   storage. The legacy `queue_item_events` table remains for old callers.
+    ///   storage.
+    /// - v6: final typed transcript cutover. Drops only the approved legacy
+    ///   `queue_item_events` table.
     private static let migrator: DatabaseMigrator = {
         var m = DatabaseMigrator()
 
@@ -295,9 +297,9 @@ public final class QueueStore: @unchecked Sendable {
             """)
         }
 
-        // v5: additive typed queue transcript storage. The separately planned
-        // cutover migration drops `queue_item_events`; do not combine that data
-        // reset with this independently deployable storage API phase.
+        // v5: additive typed queue transcript storage. The v6 cutover below
+        // drops the approved legacy table after all runtime callers use these
+        // typed APIs.
         m.registerMigration("v5_add_typed_transcript_items") { db in
             try db.execute(sql: """
             CREATE TABLE IF NOT EXISTS queue_item_transcript_items (
@@ -314,6 +316,12 @@ public final class QueueStore: @unchecked Sendable {
                 UNIQUE (item_id, attempt, item_kind, identity)
             ) WITHOUT ROWID;
             """)
+        }
+
+        // v6 is intentionally only the approved legacy transcript reset. Do
+        // not alter queue metadata, activity rows, or any wiki/chat database.
+        m.registerMigration("v6_drop_legacy_item_events") { db in
+            try db.execute(sql: "DROP TABLE IF EXISTS queue_item_events;")
         }
 
         return m
@@ -766,6 +774,9 @@ public final class QueueStore: @unchecked Sendable {
                     WHERE id = ?;
                     """,
                     arguments: [newOrderingKey, id.rawValue])
+                try db.execute(
+                    sql: "DELETE FROM queue_item_transcript_items WHERE item_id = ?;",
+                    arguments: [id.rawValue])
             }
         }
     }
@@ -897,64 +908,6 @@ public final class QueueStore: @unchecked Sendable {
                         """,
                         arguments: [kind.rawValue, Int64(maxPerQueue)])
                 }
-            }
-        }
-    }
-
-    // MARK: - Public API: Item events (transcripts)
-
-    /// Append a typed agent event to the persisted transcript for a queue item.
-    /// Events are stored in insertion order (seq is auto-incremented by SQLite).
-    /// Safe to call from a background thread — the store serializes via GRDB.
-    public func appendItemEvent(itemID: QueueItem.ID, event: AgentEvent) throws {
-        let data = try JSONEncoder().encode(event)
-        let json = String(data: data, encoding: .utf8) ?? "{}"
-        let now = Self.nowMillis()
-
-        try Self.wrap {
-            let queue = try self.queue()
-            try queue.write { db in
-                try db.execute(
-                    sql: """
-                    INSERT INTO queue_item_events (item_id, seq, event_json, created_at)
-                    VALUES (?, COALESCE((SELECT MAX(seq) FROM queue_item_events WHERE item_id = ?), -1) + 1, ?, ?);
-                    """,
-                    arguments: [itemID.rawValue, itemID.rawValue, json, now])
-            }
-        }
-    }
-
-    /// Load all persisted agent events for a queue item, ordered by seq.
-    public func loadItemEvents(itemID: QueueItem.ID) throws -> [AgentEvent] {
-        try Self.wrap {
-            let queue = try self.queue()
-            return try queue.read { db in
-                let rows = try Row.fetchAll(
-                    db,
-                    sql: "SELECT event_json FROM queue_item_events WHERE item_id = ? ORDER BY seq;",
-                    arguments: [itemID.rawValue])
-                return rows.compactMap { row -> AgentEvent? in
-                    let json: String = row["event_json"]
-                    guard let data = json.data(using: .utf8) else { return nil }
-                    do {
-                        return try JSONDecoder().decode(AgentEvent.self, from: data)
-                    } catch {
-                        DebugLog.store("QueueStore.loadItemEvents: decode failed for event row — \(error.localizedDescription)")
-                        return nil
-                    }
-                }
-            }
-        }
-    }
-
-    /// Delete all persisted events for an item (e.g. on retry — clears the old transcript).
-    public func deleteItemEvents(itemID: QueueItem.ID) throws {
-        try Self.wrap {
-            let queue = try self.queue()
-            try queue.write { db in
-                try db.execute(
-                    sql: "DELETE FROM queue_item_events WHERE item_id = ?;",
-                    arguments: [itemID.rawValue])
             }
         }
     }

--- a/Sources/WikiFSCore/Core/QueueTypes.swift
+++ b/Sources/WikiFSCore/Core/QueueTypes.swift
@@ -78,6 +78,12 @@ public struct QueueAttemptID: Hashable, Codable, Sendable {
         self.itemID = itemID
         self.attempt = attempt
     }
+
+    /// Stable transcript turn namespace for this immutable queue attempt.
+    /// Keep the compatibility encoding here so callers never interpolate it.
+    public var chatTurnID: ChatTurnID {
+        ChatTurnID(rawValue: "queue:\(itemID.rawValue):attempt:\(attempt)")
+    }
 }
 
 // MARK: - Payload

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -59,6 +59,9 @@ public actor QueueEngine {
     /// ``events`` subscribes a fresh stream and the broadcaster yields every
     /// event to all live subscribers.
     private nonisolated let broadcaster = QueueEventBroadcaster()
+    /// Synchronous provider callbacks cannot await this actor. The dedicated
+    /// lock-backed state store owns only per-attempt translation/reduction.
+    private nonisolated let transcriptState = QueueTranscriptStateStore()
 
     /// A fresh event-stream subscription. Every access returns a NEW stream
     /// that receives all events emitted from this point on — safe for any
@@ -292,6 +295,7 @@ public actor QueueEngine {
     /// Retry a failed item: `failed` → `queued`, `attempt + 1`, new
     /// `orderingKey` (back of queue). Triggers a dispatch scan.
     public func retryItem(_ id: QueueItem.ID) async throws {
+        transcriptState.invalidate(itemID: id)
         try store.retryItem(id: id)
         if let updated = try store.getItem(id) {
             emit(.enqueued(updated))
@@ -467,24 +471,23 @@ public actor QueueEngine {
         }
     }
 
-    /// A `Sendable` closure the worker factory captures to yield `.transcript`
-    /// events onto the engine's broadcaster (bypassing `emit()` which is
-    /// actor-isolated). The broadcaster is `Sendable`, so this is safe to
-    /// call from the worker's detached `Task`.
-    public func makeEmitTranscript() -> @Sendable (QueueItem.ID, AgentEvent) -> Void {
-        return { [broadcaster, store] id, event in
-            broadcaster.yield(.transcript(id, event))
-            // Persist to SQLite for cross-session transcript survival —
-            // final events only. Streaming deltas / turn boundaries are
-            // display plumbing; the final `.assistantText` carries the full
-            // text, so persisting every delta bloats rows AND rehydrates as
-            // one row per word-fragment.
-                guard event.isPersistable else { return }
-                do {
-                    try store.appendItemEvent(itemID: id, event: event)
-                } catch {
-                    DebugLog.store("QueueEngine: appendItemEvent failed for item=\(id): \(error)")
+    /// A synchronous callback that accepts a provider event attributed to the
+    /// immutable attempt captured by its worker. Translation/reduction happens
+    /// under the per-attempt lock. SQLite and broadcast run after it releases.
+    public func makeEmitTranscript() -> @Sendable (QueueAttemptID, AgentEvent) -> Void {
+        { [broadcaster, store, transcriptState] attemptID, event in
+            transcriptState.accept(
+                event: event,
+                for: attemptID,
+                persist: { update in
+                    try store.upsertTranscriptItems(
+                        attemptID: update.attemptID,
+                        items: update.changedItems)
+                },
+                broadcast: { update in
+                    broadcaster.yield(.transcript(update))
                 }
+            )
         }
     }
 
@@ -554,27 +557,24 @@ public actor QueueEngine {
         }
     }
 
-    /// Load persisted agent events (transcript) for a queue item from the DB.
-    /// Used by the Activity tracker to show transcripts for items rehydrated
-    /// from a previous session. Deltas are folded into whole rows on the way
-    /// out — rows persisted before deltas were filtered contain fragments.
-    public func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] {
-        let events: [AgentEvent]
+    /// Load durable typed transcript items for a queue item.
+    public func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem] {
+        let items: [ChatTranscriptItem]
         do {
-            events = try store.loadItemEvents(itemID: itemID)
+            items = try store.loadTranscriptItems(itemID: itemID)
         } catch {
-            DebugLog.store("QueueEngine.loadTranscript: failed to load events for \(itemID.rawValue): \(error)")
-            events = []
+            DebugLog.store("QueueEngine.loadTranscript: failed to load items for \(itemID.rawValue): \(error)")
+            items = []
         }
-        return AgentEvent.mergingStreamDeltas(events)
+        return items
     }
 
-    /// Delete persisted events for an item (e.g. on retry).
+    /// Delete persisted typed items for an item.
     public func clearTranscript(for itemID: QueueItem.ID) async {
         do {
-            try store.deleteItemEvents(itemID: itemID)
+            try store.deleteTranscriptItems(itemID: itemID)
         } catch {
-            DebugLog.store("QueueEngine.clearTranscript: failed to delete events for \(itemID.rawValue): \(error)")
+            DebugLog.store("QueueEngine.clearTranscript: failed to delete items for \(itemID.rawValue): \(error)")
         }
     }
 
@@ -756,12 +756,15 @@ public actor QueueEngine {
     /// `cancelItem`), the item is requeued (halt) or marked cancelled
     /// (cancel). After the worker finishes, triggers a dispatch scan.
     private func runWorker(_ item: QueueItem) async {
+        let attemptID = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        transcriptState.begin(attemptID)
         let worker: any QueueWorker
         do {
             worker = try await workerFactory.worker(for: item)
         } catch {
             // Factory failed to produce a worker — mark the item failed.
             await handleWorkerFinished(item, result: .failure(error))
+            transcriptState.finish(attemptID)
             return
         }
 
@@ -778,6 +781,7 @@ public actor QueueEngine {
         }
 
         await handleWorkerFinished(item, result: result)
+        transcriptState.finish(attemptID)
     }
 
     /// Handle the completion of a worker. Transitions the item to a terminal
@@ -934,6 +938,139 @@ public actor QueueEngine {
     /// Emit a `QueueEvent` to all subscribers.
     private func emit(_ event: QueueEvent) {
         broadcaster.yield(event)
+    }
+}
+
+// MARK: - Queue transcript callback state
+
+/// Serializes synchronous provider callbacks per queue attempt. This class is
+/// `@unchecked Sendable` only because every mutable member is protected by its
+/// private lock, and no mutable reference escapes the critical section.
+/// The synchronous callback-side state machine. It is `internal` so the
+/// concurrency suite can exercise its lock/SQLite boundary directly; clients
+/// still enter it only through `QueueEngine.makeEmitTranscript()`.
+// swiftlint:disable:next unchecked_sendable
+final class QueueTranscriptStateStore: @unchecked Sendable {
+    private struct AttemptState {
+        var translator = AgentEventTranscriptTranslator()
+        var items: [ChatTranscriptItem] = []
+        var nextBatchNumber = 0
+        var pending: [QueueTranscriptUpdate] = []
+        var isDraining = false
+        /// Terminal completion has started. Existing accepted batches may
+        /// drain, but no callback may translate or enqueue another batch.
+        var isClosing = false
+    }
+
+    private let lock = NSLock()
+    private var currentAttemptByItem: [QueueItem.ID: QueueAttemptID] = [:]
+    private var states: [QueueAttemptID: AttemptState] = [:]
+
+    func begin(_ attemptID: QueueAttemptID) {
+        lock.withLock {
+            guard currentAttemptByItem[attemptID.itemID] != attemptID else { return }
+            currentAttemptByItem[attemptID.itemID] = attemptID
+            states[attemptID] = AttemptState()
+        }
+    }
+
+    func invalidate(itemID: QueueItem.ID) {
+        lock.withLock {
+            guard let oldAttempt = currentAttemptByItem.removeValue(forKey: itemID) else { return }
+            states.removeValue(forKey: oldAttempt)
+        }
+    }
+
+    func finish(_ attemptID: QueueAttemptID) {
+        lock.withLock {
+            guard currentAttemptByItem[attemptID.itemID] == attemptID,
+                  var state = states[attemptID]
+            else { return }
+            state.isClosing = true
+            guard state.pending.isEmpty, state.isDraining == false else {
+                states[attemptID] = state
+                return
+            }
+            currentAttemptByItem.removeValue(forKey: attemptID.itemID)
+            states.removeValue(forKey: attemptID)
+        }
+    }
+
+    func accept(
+        event: AgentEvent,
+        for attemptID: QueueAttemptID,
+        persist: @Sendable (QueueTranscriptUpdate) throws -> Void,
+        broadcast: @Sendable (QueueTranscriptUpdate) -> Void
+    ) {
+        let shouldDrain = lock.withLock { () -> Bool in
+            guard currentAttemptByItem[attemptID.itemID] == attemptID,
+                  var state = states[attemptID],
+                  state.isClosing == false
+            else { return false }
+
+            let previousItems = state.items
+            let deltas = state.translator.translate([event], turnID: attemptID.chatTurnID)
+            let reduced = ChatTranscriptReducer.reducing(items: previousItems, with: deltas)
+            state.items = reduced
+
+            var previousByIdentity: [QueueTranscriptItemIdentity: ChatTranscriptItem] = [:]
+            for item in previousItems {
+                previousByIdentity[QueueTranscriptItemIdentity(item)] = item
+            }
+            let changed = reduced.filter { previousByIdentity[QueueTranscriptItemIdentity($0)] != $0 }
+            guard changed.isEmpty == false else {
+                states[attemptID] = state
+                return false
+            }
+
+            let update = QueueTranscriptUpdate(
+                attemptID: attemptID,
+                batchNumber: state.nextBatchNumber,
+                changedItems: changed)
+            state.nextBatchNumber += 1
+            state.pending.append(update)
+            let electDrainer = state.isDraining == false
+            state.isDraining = true
+            states[attemptID] = state
+            return electDrainer
+        }
+
+        guard shouldDrain else { return }
+        drain(attemptID: attemptID, persist: persist, broadcast: broadcast)
+    }
+
+    private func drain(
+        attemptID: QueueAttemptID,
+        persist: @Sendable (QueueTranscriptUpdate) throws -> Void,
+        broadcast: @Sendable (QueueTranscriptUpdate) -> Void
+    ) {
+        while true {
+            let next = lock.withLock { () -> QueueTranscriptUpdate? in
+                guard currentAttemptByItem[attemptID.itemID] == attemptID,
+                      var state = states[attemptID]
+                else { return nil }
+                guard state.pending.isEmpty == false else {
+                    state.isDraining = false
+                    if state.isClosing {
+                        currentAttemptByItem.removeValue(forKey: attemptID.itemID)
+                        states.removeValue(forKey: attemptID)
+                    } else {
+                        states[attemptID] = state
+                    }
+                    return nil
+                }
+                let update = state.pending.removeFirst()
+                states[attemptID] = state
+                return update
+            }
+            guard let next else { return }
+            do {
+                try persist(next)
+                broadcast(next)
+            } catch {
+                DebugLog.store("QueueEngine: typed transcript persistence failed for \(attemptID.itemID.rawValue): \(error)")
+            }
+        }
     }
 }
 

--- a/Sources/WikiFSEngine/QueueEngineClient.swift
+++ b/Sources/WikiFSEngine/QueueEngineClient.swift
@@ -72,8 +72,8 @@ public protocol QueueEngineClient: AnyObject, Sendable {
     /// Await the completion of a specific item.
     func waitForCompletion(of id: QueueItem.ID) async -> Result<Void, Error>
 
-    /// Load persisted agent events (transcript) for a queue item.
-    func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent]
+    /// Load persisted typed transcript items for a queue item.
+    func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem]
 
     /// Load persisted activity metadata for all items with recorded activity.
     func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot]

--- a/Sources/WikiFSEngine/QueueEventEnvelope.swift
+++ b/Sources/WikiFSEngine/QueueEventEnvelope.swift
@@ -27,6 +27,9 @@ public struct QueueEventEnvelope: Codable, Sendable {
     public let error: String?
     public let line: String?
     public let agentEventData: Data?
+    /// Queue transcript payload. This is distinct from `agentEventData`, which
+    /// remains solely for legacy chat transport compatibility.
+    public let transcriptUpdateData: Data?
     public let usageData: Data?
     public let logURL: URL?
     public let debugURL: URL?
@@ -42,7 +45,8 @@ public struct QueueEventEnvelope: Codable, Sendable {
 
     public init(kind: Kind, item: QueueItem? = nil, itemID: QueueItem.ID? = nil,
                 error: String? = nil, line: String? = nil,
-                agentEventData: Data? = nil, usageData: Data? = nil,
+                agentEventData: Data? = nil, transcriptUpdateData: Data? = nil,
+                usageData: Data? = nil,
                 logURL: URL? = nil, debugURL: URL? = nil,
                 queue: QueueKind? = nil, runState: QueueRunState? = nil,
                 pendingPermissionJSON: String? = nil,
@@ -54,6 +58,7 @@ public struct QueueEventEnvelope: Codable, Sendable {
         self.error = error
         self.line = line
         self.agentEventData = agentEventData
+        self.transcriptUpdateData = transcriptUpdateData
         self.usageData = usageData
         self.logURL = logURL
         self.debugURL = debugURL
@@ -82,9 +87,9 @@ public struct QueueEventEnvelope: Codable, Sendable {
             self.init(kind: .reordered, item: item)
         case .progress(let id, let line):
             self.init(kind: .progress, itemID: id, line: line)
-        case .transcript(let id, let agentEvent):
-            let data = DebugLog.trying("encode agentEvent", operation: { try JSONEncoder().encode(agentEvent) })
-            self.init(kind: .transcript, itemID: id, agentEventData: data)
+        case .transcript(let update):
+            let data = DebugLog.trying("encode queue transcript update", operation: { try JSONEncoder().encode(update) })
+            self.init(kind: .transcript, itemID: update.attemptID.itemID, transcriptUpdateData: data)
         case .usage(let id, let usage):
             let data = DebugLog.trying("encode usage", operation: { try JSONEncoder().encode(usage) })
             self.init(kind: .usage, itemID: id, usageData: data)
@@ -136,9 +141,11 @@ public struct QueueEventEnvelope: Codable, Sendable {
             guard let itemID, let line else { return nil }
             return .progress(itemID, line: line)
         case .transcript:
-            guard let itemID, let agentEventData,
-                  let event = DebugLog.trying("decode AgentEvent", operation: { try JSONDecoder().decode(AgentEvent.self, from: agentEventData) }) else { return nil }
-            return .transcript(itemID, event)
+            guard let itemID, let transcriptUpdateData,
+                  let update = DebugLog.trying("decode QueueTranscriptUpdate", operation: { try JSONDecoder().decode(QueueTranscriptUpdate.self, from: transcriptUpdateData) }),
+                  update.attemptID.itemID == itemID
+            else { return nil }
+            return .transcript(update)
         case .usage:
             guard let itemID, let usageData,
                   let usage = DebugLog.trying("decode SessionUsage", operation: { try JSONDecoder().decode(SessionUsage.self, from: usageData) }) else { return nil }

--- a/Sources/WikiFSEngine/QueueIngestionProvider.swift
+++ b/Sources/WikiFSEngine/QueueIngestionProvider.swift
@@ -160,7 +160,7 @@ public enum QueueIngestionError: Error, LocalizedError {
 public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
     private let provider: any QueueIngestionProvider
     private let emitProgress: @Sendable (QueueItem.ID, String) -> Void
-    private let emitTranscript: @Sendable (QueueItem.ID, AgentEvent) -> Void
+    private let emitTranscript: @Sendable (QueueAttemptID, AgentEvent) -> Void
     private let emitUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
     private let emitLiveUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
     private let emitLogPaths: @Sendable (QueueItem.ID, URL?, URL?) -> Void
@@ -169,7 +169,7 @@ public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
     public init(
         provider: any QueueIngestionProvider,
         emitProgress: @escaping @Sendable (QueueItem.ID, String) -> Void,
-        emitTranscript: @escaping @Sendable (QueueItem.ID, AgentEvent) -> Void,
+        emitTranscript: @escaping @Sendable (QueueAttemptID, AgentEvent) -> Void,
         emitUsage: @escaping @Sendable (QueueItem.ID, SessionUsage) -> Void,
         emitLiveUsage: @escaping @Sendable (QueueItem.ID, SessionUsage) -> Void,
         emitLogPaths: @escaping @Sendable (QueueItem.ID, URL?, URL?) -> Void,
@@ -198,7 +198,7 @@ public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
     }
 
     public func worker(for item: QueueItem) async throws -> any QueueWorker {
-        QueueIngestionWorker(provider: provider, emitProgress: emitProgress, emitTranscript: emitTranscript, emitUsage: emitUsage, emitLiveUsage: emitLiveUsage, emitLogPaths: emitLogPaths, emitPendingPermission: emitPendingPermission)
+        QueueIngestionWorker(provider: provider, attemptID: QueueAttemptID(itemID: item.id, attempt: item.attempt), emitProgress: emitProgress, emitTranscript: emitTranscript, emitUsage: emitUsage, emitLiveUsage: emitLiveUsage, emitLogPaths: emitLogPaths, emitPendingPermission: emitPendingPermission)
     }
 }
 
@@ -214,8 +214,9 @@ public struct QueueIngestionWorkerFactory: QueueWorkerFactory {
 /// the provider.
 struct QueueIngestionWorker: QueueWorker {
     let provider: any QueueIngestionProvider
+    let attemptID: QueueAttemptID
     let emitProgress: @Sendable (QueueItem.ID, String) -> Void
-    let emitTranscript: @Sendable (QueueItem.ID, AgentEvent) -> Void
+    let emitTranscript: @Sendable (QueueAttemptID, AgentEvent) -> Void
     let emitUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
     let emitLiveUsage: @Sendable (QueueItem.ID, SessionUsage) -> Void
     let emitLogPaths: @Sendable (QueueItem.ID, URL?, URL?) -> Void
@@ -231,8 +232,8 @@ struct QueueIngestionWorker: QueueWorker {
             throw QueueIngestionError.notReady(message)
         }
 
-        let onTranscript: (@Sendable (AgentEvent) -> Void)? = { [itemID = item.id] event in
-            emitTranscript(itemID, event)
+        let onTranscript: (@Sendable (AgentEvent) -> Void)? = { [attemptID] event in
+            emitTranscript(attemptID, event)
         }
         let onUsage: (@Sendable (SessionUsage?) -> Void)? = { [itemID = item.id] usage in
             guard let usage else { return }

--- a/Sources/WikiFSEngine/QueueTranscriptUpdate.swift
+++ b/Sources/WikiFSEngine/QueueTranscriptUpdate.swift
@@ -1,0 +1,61 @@
+// pattern: Functional Core
+
+import Foundation
+import WikiFSCore
+
+/// One ordered, immutable typed transcript batch for a claimed queue attempt.
+/// The batch number is monotonic within `attemptID` and is validated by every
+/// consumer before it changes live presentation state.
+public struct QueueTranscriptUpdate: Codable, Sendable, Hashable {
+    public let attemptID: QueueAttemptID
+    public let batchNumber: Int
+    public let changedItems: [ChatTranscriptItem]
+
+    public init(
+        attemptID: QueueAttemptID,
+        batchNumber: Int,
+        changedItems: [ChatTranscriptItem]
+    ) {
+        self.attemptID = attemptID
+        self.batchNumber = batchNumber
+        self.changedItems = changedItems
+    }
+}
+
+/// Tagged identity used for transcript reduction and persisted/live merging.
+/// Raw values are deliberately never compared across item kinds.
+public enum QueueTranscriptItemIdentity: Hashable, Sendable {
+    case message(ChatMessageID)
+    case toolCall(ToolCallID)
+    case systemNotice(ChatTranscriptNoticeID)
+    case turnFailure(ChatTranscriptFailureID)
+
+    public init(_ item: ChatTranscriptItem) {
+        switch item {
+        case .message(let message): self = .message(message.messageID)
+        case .toolCall(let call): self = .toolCall(call.toolCallID)
+        case .systemNotice(let notice): self = .systemNotice(notice.noticeID)
+        case .turnFailure(let failure): self = .turnFailure(failure.failureID)
+        }
+    }
+}
+
+public enum QueueTranscriptCanonicalMerge {
+    /// Stable persisted order, live replacement by tagged identity, then live
+    /// additions in received order.
+    public static func merging(
+        persisted: [ChatTranscriptItem],
+        live: [ChatTranscriptItem]
+    ) -> [ChatTranscriptItem] {
+        var merged = persisted
+        for item in live {
+            let identity = QueueTranscriptItemIdentity(item)
+            if let index = merged.lastIndex(where: { QueueTranscriptItemIdentity($0) == identity }) {
+                merged[index] = item
+            } else {
+                merged.append(item)
+            }
+        }
+        return merged
+    }
+}

--- a/Sources/WikiFSEngine/QueueWorker.swift
+++ b/Sources/WikiFSEngine/QueueWorker.swift
@@ -76,10 +76,10 @@ public enum QueueEvent: Sendable {
     /// Progress line from a running worker (e.g. extraction log output).
     /// Carries the item ID + the progress text line.
     case progress(QueueItem.ID, line: String)
-    /// A typed agent event forwarded from a running ingestion/lint worker.
-    /// Carries the item ID + the event. Used by the Activity window to
-    /// build per-item transcripts (decoupled from the launcher instance).
-    case transcript(QueueItem.ID, AgentEvent)
+    /// An ordered typed transcript batch from a running worker. `AgentEvent`
+    /// ends at the worker-to-translator boundary and never crosses this event
+    /// or the XPC boundary.
+    case transcript(QueueTranscriptUpdate)
     /// Live (in-progress) token/cost usage for a running ingestion or lint
     /// run. Emitted on each `usage_update` notification during the run so the
     /// Activity window can show running token counts + model name before

--- a/Sources/WikiFSEngine/UnavailableQueueEngine.swift
+++ b/Sources/WikiFSEngine/UnavailableQueueEngine.swift
@@ -87,7 +87,7 @@ public final class UnavailableQueueEngine: QueueEngineClient, @unchecked Sendabl
         .failure(Error.unavailable(reason: reason))
     }
 
-    public func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] { [] }
+    public func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem] { [] }
 
     public func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot] { [:] }
 }

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -500,7 +500,7 @@ final class WikiDaemon: @unchecked Sendable {
             })
 
         let progressBox = DaemonEmitBox<(@Sendable (QueueItem.ID, String) -> Void)>()
-        let transcriptBox = DaemonEmitBox<(@Sendable (QueueItem.ID, AgentEvent) -> Void)>()
+        let transcriptBox = DaemonEmitBox<(@Sendable (QueueAttemptID, AgentEvent) -> Void)>()
         let usageBox = DaemonEmitBox<(@Sendable (QueueItem.ID, SessionUsage) -> Void)>()
         let liveUsageBox = DaemonEmitBox<(@Sendable (QueueItem.ID, SessionUsage) -> Void)>()
         let logPathsBox = DaemonEmitBox<(@Sendable (QueueItem.ID, URL?, URL?) -> Void)>()

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -282,8 +282,8 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
         let sendableReply = SendableDataReply(reply: reply)
         Task { [daemon] in
             if let engine = await DebugLog.trying("ensureQueueEngine", operation: { try await daemon.ensureQueueEngine() }) {
-                let events = await engine.loadTranscript(for: QueueItemID(rawValue: itemID))
-                let data = (DebugLog.trying("JSONEncoder.encode", operation: { try JSONEncoder().encode(events) })) ?? Data()
+                let items = await engine.loadTranscript(for: QueueItemID(rawValue: itemID))
+                let data = (DebugLog.trying("JSONEncoder.encode", operation: { try JSONEncoder().encode(items) })) ?? Data()
                 sendableReply.reply(data)
             } else {
                 sendableReply.reply(Data())

--- a/Tests/WikiFSAppTests/ActivityWindowTypedTranscriptTests.swift
+++ b/Tests/WikiFSAppTests/ActivityWindowTypedTranscriptTests.swift
@@ -1,0 +1,202 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+import WebKit
+@testable import WikiFS
+import WikiFSCore
+import WikiFSEngine
+
+/// Hosts the real Activity window with a typed queue client, then verifies the
+/// value-only transcript seam that the hosted detail pane uses. This keeps the
+/// assertions deterministic while still mounting the production split view.
+@Suite(.serialized)
+@MainActor
+struct ActivityWindowTypedTranscriptTests {
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    @Test func persistedOnlyTranscriptProducesVisibleTypedRows() async throws {
+        let item = queueItem()
+        let persisted = message(id: "persisted", text: "durable typed row")
+        let client = StaticQueueEngineClient(item: item, transcript: [persisted])
+        let tracker = QueueActivityTracker()
+
+        let webView = try await hostActivityWindow(item: item, client: client, tracker: tracker)
+        let presentation = makePresentation(items: [persisted])
+        #expect(presentation.transcriptView().rendering.rows.count == 1)
+        #expect(webView != nil)
+    }
+
+    @Test func partialLiveTranscriptReplacesPersistedRow() async throws {
+        let persisted = message(id: "message", text: "partial")
+        let live = message(id: "message", text: "complete")
+        let merged = ActivityTranscriptPresentation.canonicalItems(persisted: [persisted], live: [live])
+
+        let view = makePresentation(items: merged).transcriptView()
+        #expect(view.rendering.rows.count == 1)
+        #expect(merged == [live])
+    }
+
+    @Test func copyTextEqualsCanonicalVisibleTranscript() {
+        let persisted = message(id: "message", text: "old")
+        let live = message(id: "message", text: "new")
+        let appended = message(id: "next", text: "next")
+        let items = ActivityTranscriptPresentation.canonicalItems(
+            persisted: [persisted], live: [live, appended])
+
+        let presentation = makePresentation(items: items)
+        #expect(presentation.copyText == "new\n\nnext")
+        #expect(presentation.transcriptView().rendering.rows.count == items.count)
+    }
+
+    @Test func wikiLinkIntentUsesSelectedItemsWikiHandler() {
+        var received: (URL, Bool)?
+        let presentation = makePresentation(
+            items: [message(id: "message", text: "[[Target]]")],
+            onIntent: { intent in
+                if case .openWikiLink(let url, let inNewTab) = intent {
+                    received = (url, inNewTab)
+                }
+            }
+        )
+        let target = URL(string: "wikifs://page/selected")!
+        presentation.onIntent(.openWikiLink(target, inNewTab: true))
+
+        #expect(received?.0 == target)
+        #expect(received?.1 == true)
+    }
+
+    @Test func rendererReceivesBlobStoreAndRenderContext() {
+        let presentation = makePresentation(items: [message(id: "message", text: "row")])
+        let view = presentation.transcriptView()
+
+        #expect(view.blobStore == nil)
+        #expect(view.renderContext?() == nil)
+    }
+
+    @Test func rendererUsesQueueItemTranscriptIdentity() {
+        let item = queueItem()
+        let presentation = makePresentation(
+            items: [message(id: "message", text: "row")],
+            transcriptID: .queueItem(item.id)
+        )
+
+        #expect(presentation.transcriptView().transcriptID == .queueItem(item.id))
+    }
+
+    @Test func progressOnlyItemUsesProgressFallback() {
+        let presentation = makePresentation(items: [], progressText: "extracting page 1")
+
+        #expect(presentation.usesProgressFallback)
+        #expect(presentation.copyText == "extracting page 1")
+    }
+
+    private func hostActivityWindow(
+        item: QueueItem,
+        client: StaticQueueEngineClient,
+        tracker: QueueActivityTracker
+    ) async throws -> WKWebView? {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        _ = Self.app
+        let root = ActivityWindowView(
+            queue: item.queue,
+            queueEngine: client,
+            activityTracker: tracker,
+            sessionManager: nil
+        )
+        let hosting = NSHostingController(rootView: root)
+        let window = NSWindow(contentViewController: hosting)
+        window.orderFront(nil)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
+
+        for _ in 0..<20 {
+            if let webView = firstWebView(in: hosting.view) {
+                return webView
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        return nil
+    }
+
+    private func firstWebView(in view: NSView) -> WKWebView? {
+        if let webView = view as? WKWebView { return webView }
+        for child in view.subviews {
+            if let webView = firstWebView(in: child) { return webView }
+        }
+        return nil
+    }
+
+    private func makePresentation(
+        items: [ChatTranscriptItem],
+        progressText: String = "",
+        transcriptID: TranscriptID = .queueItem(QueueItemID(rawValue: "activity-window-item")),
+        onIntent: @escaping (ChatTranscriptIntent) -> Void = { _ in }
+    ) -> ActivityTranscriptPresentation {
+        ActivityTranscriptPresentation(
+            items: items,
+            progressText: progressText,
+            transcriptID: transcriptID,
+            isStreaming: false,
+            onIntent: onIntent,
+            renderContext: { nil },
+            blobStore: nil
+        )
+    }
+
+    private func queueItem() -> QueueItem {
+        QueueItem(
+            id: QueueItemID(rawValue: "activity-window-item"),
+            queue: .ingestion,
+            wikiID: WikiID(rawValue: "activity-window-wiki"),
+            payload: QueueItemPayload(sourceIDs: [SourceID(rawValue: "source")]),
+            state: .completed,
+            orderingKey: 1_000,
+            attempt: 0,
+            createdAt: 0
+        )
+    }
+
+    private func message(id: String, text: String) -> ChatTranscriptItem {
+        .message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: id),
+            turnID: ChatTurnID(rawValue: "activity-window-turn"),
+            role: .assistant,
+            text: text,
+            createdAt: .distantPast
+        ))
+    }
+}
+
+private final class StaticQueueEngineClient: QueueEngineClient, @unchecked Sendable {
+    private let value: QueueSnapshot
+    private let transcript: [ChatTranscriptItem]
+
+    init(item: QueueItem, transcript: [ChatTranscriptItem]) {
+        value = QueueSnapshot(recentItems: [item])
+        self.transcript = transcript
+    }
+
+    var events: AsyncStream<QueueEvent> { AsyncStream { $0.finish() } }
+    func enqueue(_ request: QueueItemRequest) async throws -> QueueItem.ID { QueueItemID(rawValue: "unused") }
+    func cancelItem(_ id: QueueItem.ID) async {}
+    func cancelAllInFlight() async -> Int { 0 }
+    func retryItem(_ id: QueueItem.ID) async throws {}
+    func pause(_ queue: QueueKind) async {}
+    func resume(_ queue: QueueKind) async {}
+    func halt(_ queue: QueueKind) async {}
+    func reorderItem(id: QueueItem.ID, beforeItemID: QueueItem.ID?) async {}
+    func snapshot() async -> QueueSnapshot { value }
+    func hasActiveWork(for wikiID: WikiID) async -> Bool { false }
+    func waitForCompletion(of id: QueueItem.ID) async -> Result<Void, Error> { .success(()) }
+    func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem] { transcript }
+    func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot] { [:] }
+}
+#endif

--- a/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
+++ b/Tests/WikiFSAppTests/ChatPresentationAPIManifestTests.swift
@@ -99,15 +99,37 @@ struct ChatPresentationAPIManifestTests {
             .map(\.path)
         let allowedActivityFeedSources: Set<String> = [
             "Chats/ChatWebView.swift",
-            "Queue/ActivityWindowView.swift",
             "Queue/AppQueueIngestionProvider.swift",
-            "Queue/QueueActivityTracker.swift",
-            "Queue/QueueEngineHotSwap.swift",
-            "Queue/XPCQueueEngineProxy.swift",
+            "Queue/QueueTranscriptEmitBox.swift",
         ]
 
         #expect(Set(legacyEventSources) == allowedActivityFeedSources)
         #expect(legacyEventSources.contains("Chats/RemoteChatSession.swift") == false)
+    }
+
+    @Test func activityPresentationDoesNotImportAgentEvent() throws {
+        let activity = try source(named: "ActivityWindowView.swift", directory: "Sources/WikiFS/Queue")
+        let tracker = try source(named: "QueueActivityTracker.swift", directory: "Sources/WikiFS/Queue")
+
+        #expect(activity.contains("AgentEvent") == false)
+        #expect(tracker.contains("AgentEvent") == false)
+    }
+
+    @Test func activityPresentationUsesTypedTranscriptView() throws {
+        let activity = try source(named: "ActivityWindowView.swift", directory: "Sources/WikiFS/Queue")
+
+        #expect(activity.contains("ChatTranscriptView") == true)
+        #expect(activity.contains("ChatDisplayProjection.project") == true)
+        #expect(activity.contains("QueueTranscriptCanonicalMerge.merging") == true)
+        #expect(activity.contains("TranscriptID.queueItem") == true)
+    }
+
+    @Test func legacyQueueEventStoreMethodsAreAbsent() throws {
+        let store = try source(named: "QueueStore.swift", directory: "Sources/WikiFSCore/Core")
+
+        #expect(store.contains("appendItemEvent") == false)
+        #expect(store.contains("loadItemEvents") == false)
+        #expect(store.contains("deleteItemEvents") == false)
     }
 
     @Test func projectionAndPermissionBoundaryUseTypedIDsAndIntent() throws {

--- a/Tests/WikiFSAppTests/QueueActivityTrackerReconcileTests.swift
+++ b/Tests/WikiFSAppTests/QueueActivityTrackerReconcileTests.swift
@@ -213,7 +213,7 @@ actor FakeQueueEngineClient: QueueEngineClient {
     func snapshot() async -> QueueSnapshot { snapshotValue }
     nonisolated func hasActiveWork(for wikiID: WikiID) async -> Bool { false }
     nonisolated func waitForCompletion(of id: QueueItem.ID) async -> Result<Void, Error> { .success(()) }
-    nonisolated func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] { [] }
+    nonisolated func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem] { [] }
     nonisolated func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot] { [:] }
 }
 #endif

--- a/Tests/WikiFSAppTests/QueueActivityTrackerTypedTranscriptTests.swift
+++ b/Tests/WikiFSAppTests/QueueActivityTrackerTypedTranscriptTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import WikiFS
+import WikiFSCore
+import WikiFSEngine
+
+@MainActor
+struct QueueActivityTrackerTypedTranscriptTests {
+    @Test func liveEventsReduceAgainstAccumulatedItems() {
+        let tracker = QueueActivityTracker()
+        let item = queueItem(attempt: 0)
+        let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        tracker.handleForTesting(.started(item))
+
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: attempt,
+            batchNumber: 0,
+            changedItems: [message(id: "message", text: "partial")]
+        )))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: attempt,
+            batchNumber: 1,
+            changedItems: [message(id: "message", text: "complete"), message(id: "later", text: "later")]
+        )))
+
+        #expect(messageTexts(tracker.transcript(for: item.id)) == ["complete", "later"])
+    }
+
+    @Test func retryChangesAttemptAndClearsLiveState() {
+        let tracker = QueueActivityTracker()
+        let firstItem = queueItem(attempt: 0)
+        let firstAttempt = QueueAttemptID(itemID: firstItem.id, attempt: firstItem.attempt)
+        tracker.handleForTesting(.started(firstItem))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: firstAttempt,
+            batchNumber: 0,
+            changedItems: [message(id: "old", text: "old output")]
+        )))
+
+        let retriedItem = queueItem(attempt: 1)
+        let retryAttempt = QueueAttemptID(itemID: retriedItem.id, attempt: retriedItem.attempt)
+        tracker.handleForTesting(.started(retriedItem))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: retryAttempt,
+            batchNumber: 0,
+            changedItems: [message(id: "new", text: "new output")]
+        )))
+
+        #expect(messageTexts(tracker.transcript(for: firstItem.id)) == ["new output"])
+    }
+
+    @Test func staleAttemptEventIsNotRendered() {
+        let tracker = QueueActivityTracker()
+        let item = queueItem(attempt: 1)
+        let currentAttempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let staleAttempt = QueueAttemptID(itemID: item.id, attempt: 0)
+        tracker.handleForTesting(.started(item))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: currentAttempt,
+            batchNumber: 0,
+            changedItems: [message(id: "current", text: "current")]
+        )))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: staleAttempt,
+            batchNumber: 1,
+            changedItems: [message(id: "stale", text: "stale")]
+        )))
+
+        #expect(messageTexts(tracker.transcript(for: item.id)) == ["current"])
+    }
+
+    private func queueItem(attempt: Int) -> QueueItem {
+        QueueItem(
+            id: QueueItemID(rawValue: "activity-typed-item"),
+            queue: .ingestion,
+            wikiID: WikiID(rawValue: "activity-typed-wiki"),
+            payload: QueueItemPayload(sourceIDs: [SourceID(rawValue: "source")]),
+            state: .running,
+            orderingKey: 1_000,
+            attempt: attempt,
+            createdAt: 0
+        )
+    }
+
+    private func message(id: String, text: String) -> ChatTranscriptItem {
+        .message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: id),
+            turnID: ChatTurnID(rawValue: "activity-typed-turn"),
+            role: .assistant,
+            text: text,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        ))
+    }
+
+    private func messageTexts(_ items: [ChatTranscriptItem]) -> [String] {
+        items.compactMap { item in
+            guard case .message(let message) = item else { return nil }
+            return message.text
+        }
+    }
+}

--- a/Tests/WikiFSAppTests/QueueActivityTrackerTypedTranscriptTests.swift
+++ b/Tests/WikiFSAppTests/QueueActivityTrackerTypedTranscriptTests.swift
@@ -69,6 +69,53 @@ struct QueueActivityTrackerTypedTranscriptTests {
         #expect(messageTexts(tracker.transcript(for: item.id)) == ["current"])
     }
 
+    @Test func forwardBatchAfterDroppedDeliveryIsRenderedAndOlderBatchesAreRejected() {
+        let tracker = QueueActivityTracker()
+        let item = queueItem(attempt: 0)
+        let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        tracker.handleForTesting(.started(item))
+
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: attempt,
+            batchNumber: 0,
+            changedItems: [message(id: "first", text: "first")]
+        )))
+        // Batch 1 was dropped by the transport. Batch 2 must still advance
+        // the monotonic watermark rather than freezing live rendering.
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: attempt,
+            batchNumber: 2,
+            changedItems: [message(id: "third", text: "third")]
+        )))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: attempt,
+            batchNumber: 1,
+            changedItems: [message(id: "late", text: "late")]
+        )))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: attempt,
+            batchNumber: 2,
+            changedItems: [message(id: "duplicate", text: "duplicate")]
+        )))
+
+        #expect(messageTexts(tracker.transcript(for: item.id)) == ["first", "third"])
+    }
+
+    @Test func activeSnapshotSeedsTranscriptAttemptForReconnect() {
+        let tracker = QueueActivityTracker()
+        let item = queueItem(attempt: 2)
+        let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+
+        tracker.reconcile(with: QueueSnapshot(activeItems: [item], recentItems: []))
+        tracker.handleForTesting(.transcript(.init(
+            attemptID: attempt,
+            batchNumber: 0,
+            changedItems: [message(id: "reconnected", text: "reconnected")]
+        )))
+
+        #expect(messageTexts(tracker.transcript(for: item.id)) == ["reconnected"])
+    }
+
     private func queueItem(attempt: Int) -> QueueItem {
         QueueItem(
             id: QueueItemID(rawValue: "activity-typed-item"),

--- a/Tests/WikiFSAppTests/QueueEngineClientConformanceTests.swift
+++ b/Tests/WikiFSAppTests/QueueEngineClientConformanceTests.swift
@@ -98,6 +98,12 @@ struct QueueEngineClientConformanceTests {
         #expect(snapshots.isEmpty)
     }
 
+    @Test func loadTypedTranscriptIsCallable() async {
+        let client: any QueueEngineClient = makeEngine()
+        let items = await client.loadTranscript(for: QueueItem.ID(rawValue: "typed-item"))
+        #expect(items.isEmpty)
+    }
+
     /// The protocol is `AnyObject`-bound so `weak` references work
     /// (`QueueActivityTracker`, `QueueViewModel`). Verified at compile time:
     /// the `weak var` assignment below would not compile if the protocol

--- a/Tests/WikiFSAppTests/QueueEngineHotSwapTests.swift
+++ b/Tests/WikiFSAppTests/QueueEngineHotSwapTests.swift
@@ -43,7 +43,7 @@ struct QueueEngineHotSwapTests {
         }
         func hasActiveWork(for wikiID: WikiID) async -> Bool { false }
         func waitForCompletion(of id: QueueItem.ID) async -> Result<Void, Error> { .success(()) }
-        func loadTranscript(for itemID: QueueItem.ID) async -> [AgentEvent] { [] }
+        func loadTranscript(for itemID: QueueItem.ID) async -> [ChatTranscriptItem] { [] }
         func loadAllActivitySnapshots() async -> [QueueItem.ID: QueueEngine.ActivitySnapshot] { [:] }
     }
 

--- a/Tests/WikiFSAppTests/QueueIngestionTests.swift
+++ b/Tests/WikiFSAppTests/QueueIngestionTests.swift
@@ -213,6 +213,7 @@ struct QueueIngestionWorkerTests {
         let provider = FakeIngestionProvider()
         let worker = QueueIngestionWorker(
             provider: provider,
+            attemptID: QueueAttemptID(itemID: QueueItemID(rawValue: "test2"), attempt: 0),
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in }, emitPendingPermission: { _, _ in })
 
@@ -231,6 +232,7 @@ struct QueueIngestionWorkerTests {
         await provider.setShouldThrow(true)
         let worker = QueueIngestionWorker(
             provider: provider,
+            attemptID: QueueAttemptID(itemID: QueueItemID(rawValue: "test3"), attempt: 0),
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in }, emitPendingPermission: { _, _ in })
 
@@ -250,6 +252,7 @@ struct QueueIngestionWorkerTests {
         await provider.setReadinessMessage(notReadyMsg)
         let worker = QueueIngestionWorker(
             provider: provider,
+            attemptID: QueueAttemptID(itemID: QueueItemID(rawValue: "test-ready"), attempt: 0),
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in }, emitPendingPermission: { _, _ in })
 
@@ -282,6 +285,7 @@ struct QueueIngestionWorkerTests {
         // readinessMessage is nil by default → ready.
         let worker = QueueIngestionWorker(
             provider: provider,
+            attemptID: QueueAttemptID(itemID: QueueItemID(rawValue: "test-ready-ok"), attempt: 0),
             emitProgress: { _, _ in },
             emitTranscript: { _, _ in }, emitUsage: { _, _ in }, emitLiveUsage: { _, _ in }, emitLogPaths: { _, _, _ in }, emitPendingPermission: { _, _ in })
 
@@ -731,11 +735,15 @@ struct QueueActivityTrackerTranscriptTests {
         #expect(tracker.lintingItemIDs.contains(itemID))
         #expect(tracker.isIngesting == true)
 
-        // Simulate transcript events.
-        let event1 = AgentEvent.assistantText("Linting page 1…")
-        let event2 = AgentEvent.assistantText("Found 3 issues.")
-        tracker.handleForTesting(.transcript(itemID, event1))
-        tracker.handleForTesting(.transcript(itemID, event2))
+        let attemptID = QueueAttemptID(itemID: itemID, attempt: item.attempt)
+        let event1 = ChatTranscriptItem.message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: "one"), turnID: attemptID.chatTurnID,
+            role: .assistant, text: "Linting page 1…", createdAt: .now))
+        let event2 = ChatTranscriptItem.message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: "two"), turnID: attemptID.chatTurnID,
+            role: .assistant, text: "Found 3 issues.", createdAt: .now))
+        tracker.handleForTesting(.transcript(.init(attemptID: attemptID, batchNumber: 0, changedItems: [event1])))
+        tracker.handleForTesting(.transcript(.init(attemptID: attemptID, batchNumber: 1, changedItems: [event2])))
 
         let transcript = tracker.transcript(for: itemID)
         #expect(transcript.count == 2)

--- a/Tests/WikiFSAppTests/WikiDaemonWorkloadHostTests.swift
+++ b/Tests/WikiFSAppTests/WikiDaemonWorkloadHostTests.swift
@@ -151,6 +151,49 @@ struct WikiDaemonWorkloadHostTests {
         #expect(snapshot.activeItems.isEmpty)
     }
 
+    @Test func typedQueueTranscriptRoundTripsThroughXPC() async throws {
+        let dir = makeTempDir()
+        let queueURL = dir.appendingPathComponent("queue.sqlite")
+        let store = try QueueStore(databaseURL: queueURL)
+        let item = try store.enqueue(QueueItemRequest(
+            queue: .extraction,
+            wikiID: WikiID(rawValue: "typed-xpc-wiki"),
+            payload: QueueItemPayload(sourceIDs: [SourceID(rawValue: "typed-xpc-source")])
+        ))
+        let expected = ChatTranscriptItem.message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: "typed-xpc-message"),
+            turnID: QueueAttemptID(itemID: item.id, attempt: item.attempt).chatTurnID,
+            role: .assistant,
+            text: "typed transcript through XPC",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        ))
+        try store.upsertTranscriptItems(
+            attemptID: QueueAttemptID(itemID: item.id, attempt: item.attempt),
+            items: [expected]
+        )
+        store.close()
+
+        let daemon = WikiDaemon(containerDirectory: dir)
+        let exporter = WikiDaemonExporter(daemon: daemon)
+        let listener = NSXPCListener.anonymous()
+        let delegate = TestListenerDelegate(exporter: exporter)
+        listener.delegate = delegate
+        listener.resume()
+        defer { listener.invalidate() }
+
+        let connection = NSXPCConnection(listenerEndpoint: listener.endpoint)
+        connection.remoteObjectInterface = NSXPCInterface(with: WikiDaemonProtocol.self)
+        connection.resume()
+        defer { connection.invalidate() }
+
+        let proxy = connection.remoteObjectProxyWithErrorHandler { _ in } as! WikiDaemonProtocol
+        let data = await withCheckedContinuation { (continuation: CheckedContinuation<Data, Never>) in
+            proxy.loadTranscript(itemID: item.id.rawValue) { continuation.resume(returning: $0) }
+        }
+
+        #expect(try JSONDecoder().decode([ChatTranscriptItem].self, from: data) == [expected])
+    }
+
     @Test func xpcRegisterEventSinkRoundTrip() async throws {
         let dir = makeTempDir()
         let daemon = WikiDaemon(containerDirectory: dir)

--- a/Tests/WikiFSTests/QueueEventEnvelopeTests.swift
+++ b/Tests/WikiFSTests/QueueEventEnvelopeTests.swift
@@ -91,6 +91,51 @@ struct QueueEventEnvelopeTests {
         }
     }
 
+    @Test func typedTranscriptUpdateRoundTripsWithAttemptAndBatch() throws {
+        let item = makeItem()
+        let attemptID = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let row = ChatTranscriptItem.message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: "message"), turnID: attemptID.chatTurnID,
+            role: .assistant, text: "typed", createdAt: .now))
+        let event = QueueEvent.transcript(.init(
+            attemptID: attemptID, batchNumber: 7, changedItems: [row]))
+        let envelope = try #require(QueueEventEnvelope(from: event))
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(QueueEventEnvelope.self, from: data)
+        guard case .transcript(let update) = try #require(decoded.toQueueEvent()) else {
+            Issue.record("Expected typed transcript update")
+            return
+        }
+        #expect(update.attemptID == attemptID)
+        #expect(update.batchNumber == 7)
+        #expect(update.changedItems == [row])
+    }
+
+    @Test func transcriptRejectsMissingAttemptIdentity() throws {
+        let envelope = QueueEventEnvelope(kind: .transcript, itemID: makeItem().id)
+        #expect(envelope.toQueueEvent() == nil)
+    }
+
+    @Test func transcriptRejectsMissingBatchNumber() throws {
+        let item = makeItem()
+        let payload = "{\"attemptID\":{\"itemID\":\"\(item.id.rawValue)\",\"attempt\":0},\"changedItems\":[]}"
+        let envelope = QueueEventEnvelope(
+            kind: .transcript, itemID: item.id,
+            transcriptUpdateData: Data(payload.utf8))
+        #expect(envelope.toQueueEvent() == nil)
+    }
+
+    @Test func transcriptEnvelopeContainsNoAgentEventPayload() throws {
+        let item = makeItem()
+        let update = QueueTranscriptUpdate(
+            attemptID: .init(itemID: item.id, attempt: item.attempt),
+            batchNumber: 0,
+            changedItems: [])
+        let envelope = try #require(QueueEventEnvelope(from: .transcript(update)))
+        #expect(envelope.agentEventData == nil)
+        #expect(envelope.transcriptUpdateData != nil)
+    }
+
     @Test func runStateChangedRoundTrip() throws {
         let event = QueueEvent.runStateChanged(queue: .extraction, state: .paused)
         let envelope = QueueEventEnvelope(from: event)

--- a/Tests/WikiFSTests/QueueStoreTypedTranscriptMigrationTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTypedTranscriptMigrationTests.swift
@@ -8,13 +8,35 @@ import Testing
 @testable import WikiFSCore
 
 struct QueueStoreTypedTranscriptMigrationTests {
-    @Test func additiveMigrationCreatesTypedTranscriptTableAndKeepsLegacyEventTable() throws {
+    @Test func finalMigrationCreatesTypedTranscriptTableAndDropsLegacyEventTable() throws {
         let url = try temporaryDatabaseURL()
         let store = try QueueStore(databaseURL: url)
         store.close()
 
         #expect(try tableExists(named: "queue_item_transcript_items", in: url))
-        #expect(try tableExists(named: "queue_item_events", in: url))
+        #expect(try tableExists(named: "queue_item_events", in: url) == false)
+    }
+
+    @Test func finalMigrationDropsOnlyLegacyTranscriptTableFromV4Fixture() throws {
+        let url = try temporaryDatabaseURL()
+        try createV4Fixture(at: url)
+        let preservedTables = [
+            "queue_items", "queue_state", "queue_item_activity",
+            "chats", "chat_messages", "usage_data", "log_data",
+            "debug_data", "progress_data",
+        ]
+        let before = try Dictionary(uniqueKeysWithValues: preservedTables.map { table in
+            (table, try tableSnapshot(named: table, in: url))
+        })
+
+        let store = try QueueStore(databaseURL: url)
+        store.close()
+
+        #expect(try tableExists(named: "queue_item_events", in: url) == false)
+        #expect(try tableExists(named: "queue_item_transcript_items", in: url))
+        for table in preservedTables {
+            #expect(try tableSnapshot(named: table, in: url) == before[table])
+        }
     }
 
     private func temporaryDatabaseURL() throws -> URL {
@@ -43,6 +65,127 @@ struct QueueStoreTypedTranscriptMigrationTests {
                 throw QueueStoreError.sqlite(code: -1, message: "Could not bind table name")
             }
             return sqlite3_step(statement) == SQLITE_ROW
+        }
+    }
+
+    /// Seeds exactly the v4 queue schema plus unrelated chat and diagnostic
+    /// tables. The nullable/non-default values make an accidental broad table
+    /// rewrite visible in the raw SQL snapshots above.
+    private func createV4Fixture(at url: URL) throws {
+        try execute(sql: """
+        CREATE TABLE queue_items (
+            id TEXT PRIMARY KEY, queue TEXT NOT NULL, wiki_id TEXT NOT NULL,
+            payload TEXT NOT NULL, state TEXT NOT NULL, ordering_key INTEGER NOT NULL,
+            provider_id TEXT, attempt INTEGER NOT NULL DEFAULT 0, error TEXT,
+            created_at INTEGER NOT NULL, started_at INTEGER, finished_at INTEGER
+        );
+        CREATE TABLE queue_state (queue TEXT PRIMARY KEY, state TEXT NOT NULL);
+        CREATE TABLE queue_item_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, item_id TEXT NOT NULL,
+            seq INTEGER NOT NULL, event_json TEXT NOT NULL, created_at INTEGER NOT NULL
+        );
+        CREATE TABLE queue_item_activity (
+            item_id TEXT PRIMARY KEY, usage_json TEXT, log_url TEXT, debug_url TEXT,
+            progress_log TEXT, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE chats (id TEXT PRIMARY KEY, title TEXT, created_at INTEGER);
+        CREATE TABLE chat_messages (chat_id TEXT, seq INTEGER, event_json TEXT, created_at INTEGER);
+        CREATE TABLE usage_data (id TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE log_data (id TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE debug_data (id TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE progress_data (id TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY);
+
+        INSERT INTO queue_items VALUES (
+            'fixture-item', 'extraction', 'fixture-wiki', '{"sourceIDs":["fixture-source"]}',
+            'failed', 4200, NULL, 7, 'non-default failure', 111, NULL, 333
+        );
+        INSERT INTO queue_state VALUES ('extraction', 'queue-paused');
+        INSERT INTO queue_state VALUES ('ingestion', 'queue-running');
+        INSERT INTO queue_item_events (item_id, seq, event_json, created_at)
+            VALUES ('fixture-item', 9, '{"assistantText":"legacy"}', 222);
+        INSERT INTO queue_item_activity VALUES (
+            'fixture-item', '{"inputTokens":7}', 'file:///fixture/run.jsonl', NULL,
+            'first line\nsecond line', 444
+        );
+        INSERT INTO chats VALUES ('fixture-chat', NULL, 555);
+        INSERT INTO chat_messages VALUES ('fixture-chat', 3, '{"userText":"keep"}', 556);
+        INSERT INTO usage_data VALUES ('usage', 'non-default usage');
+        INSERT INTO log_data VALUES ('log', 'non-default log');
+        INSERT INTO debug_data VALUES ('debug', NULL);
+        INSERT INTO progress_data VALUES ('progress', 'non-default progress');
+        INSERT INTO grdb_migrations VALUES ('v1_create_queue_schema');
+        INSERT INTO grdb_migrations VALUES ('v2_add_item_events');
+        INSERT INTO grdb_migrations VALUES ('v3_namespace_run_state');
+        INSERT INTO grdb_migrations VALUES ('v4_add_item_activity');
+        """, in: url)
+    }
+
+    private func tableSnapshot(named tableName: String, in url: URL) throws -> String {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not open migration snapshot database")
+        }
+        defer { sqlite3_close(database) }
+
+        let sql = "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?;"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not prepare migration snapshot")
+        }
+        defer { sqlite3_finalize(statement) }
+        let schema = try tableName.withCString { pointer -> String in
+            guard sqlite3_bind_text(statement, 1, pointer, -1, nil) == SQLITE_OK else {
+                throw QueueStoreError.sqlite(code: -1, message: "Could not bind migration snapshot table")
+            }
+            guard sqlite3_step(statement) == SQLITE_ROW,
+                  let schemaPointer = sqlite3_column_text(statement, 0)
+            else {
+                throw QueueStoreError.sqlite(code: -1, message: "Missing migration snapshot table \(tableName)")
+            }
+            return String(cString: schemaPointer)
+        }
+
+        let rowExpression: String
+        switch tableName {
+        case "queue_items":
+            rowExpression = "quote(id) || '|' || quote(queue) || '|' || quote(wiki_id) || '|' || quote(payload) || '|' || quote(state) || '|' || quote(ordering_key) || '|' || quote(provider_id) || '|' || quote(attempt) || '|' || quote(error) || '|' || quote(created_at) || '|' || quote(started_at) || '|' || quote(finished_at)"
+        case "queue_state":
+            rowExpression = "quote(queue) || '|' || quote(state)"
+        case "queue_item_activity":
+            rowExpression = "quote(item_id) || '|' || quote(usage_json) || '|' || quote(log_url) || '|' || quote(debug_url) || '|' || quote(progress_log) || '|' || quote(updated_at)"
+        case "chats":
+            rowExpression = "quote(id) || '|' || quote(title) || '|' || quote(created_at)"
+        case "chat_messages":
+            rowExpression = "quote(chat_id) || '|' || quote(seq) || '|' || quote(event_json) || '|' || quote(created_at)"
+        default:
+            rowExpression = "quote(id) || '|' || quote(value)"
+        }
+        var rowStatement: OpaquePointer?
+        let rowSQL = "SELECT COALESCE(group_concat(row_snapshot, char(30)), '') FROM (SELECT \(rowExpression) AS row_snapshot FROM \"\(tableName)\" ORDER BY rowid);"
+        guard sqlite3_prepare_v2(database, rowSQL, -1, &rowStatement, nil) == SQLITE_OK else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not prepare migration row snapshot")
+        }
+        defer { sqlite3_finalize(rowStatement) }
+        guard sqlite3_step(rowStatement) == SQLITE_ROW else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not read migration row snapshot")
+        }
+        let rows = sqlite3_column_text(rowStatement, 0).map { String(cString: $0) } ?? "NULL"
+        return "\(schema)\n\(rows)"
+    }
+
+    private func execute(sql: String, in url: URL) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK else {
+            throw QueueStoreError.sqlite(code: -1, message: "Could not open fixture database")
+        }
+        defer { sqlite3_close(database) }
+
+        var errorPointer: UnsafeMutablePointer<CChar>?
+        guard sqlite3_exec(database, sql, nil, nil, &errorPointer) == SQLITE_OK else {
+            let message = errorPointer.map { String(cString: $0) } ?? "Unknown SQLite error"
+            sqlite3_free(errorPointer)
+            throw QueueStoreError.sqlite(code: -1, message: message)
         }
     }
 }

--- a/Tests/WikiFSTests/QueueStoreTypedTranscriptTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTypedTranscriptTests.swift
@@ -69,11 +69,11 @@ struct QueueStoreTypedTranscriptTests {
             attemptID: QueueAttemptID(itemID: preservedItem.id, attempt: preservedItem.attempt),
             items: preservedItems
         )
-        try store.appendItemEvent(itemID: selectedItem.id, event: .assistantText("legacy event"))
         try store.markRunning(id: selectedItem.id, providerID: ProviderID(rawValue: "test-provider"))
         try store.markFailed(id: selectedItem.id, error: "retry test")
         try store.retryItem(id: selectedItem.id)
         let retriedItem = try #require(try store.getItem(selectedItem.id))
+        #expect(try store.loadTranscriptItems(itemID: selectedItem.id).isEmpty)
         try store.upsertTranscriptItems(
             attemptID: QueueAttemptID(itemID: retriedItem.id, attempt: retriedItem.attempt),
             items: transcriptItems(rawID: "selected-retry", text: "selected retry")
@@ -83,7 +83,6 @@ struct QueueStoreTypedTranscriptTests {
 
         #expect(try store.loadTranscriptItems(itemID: selectedItem.id).isEmpty)
         #expect(try store.loadTranscriptItems(itemID: preservedItem.id) == preservedItems)
-        #expect(try store.loadItemEvents(itemID: selectedItem.id) == [.assistantText("legacy event")])
     }
 
     @Test func historyPruneCascadesTypedTranscriptRows() throws {
@@ -123,7 +122,7 @@ struct QueueStoreTypedTranscriptTests {
             #expect(currentAttempt == item.attempt + 1)
         }
 
-        #expect(try store.loadTranscriptItems(itemID: item.id) == persistedItems)
+        #expect(try store.loadTranscriptItems(itemID: item.id).isEmpty)
     }
 
     @Test func emptyTaggedIdentityIsRejectedBeforeWriting() throws {

--- a/Tests/WikiFSTests/QueueTranscriptCanonicalMergeTests.swift
+++ b/Tests/WikiFSTests/QueueTranscriptCanonicalMergeTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import WikiFSEngine
+import WikiFSCore
+
+struct QueueTranscriptCanonicalMergeTests {
+    @Test func persistedOrderIsStable() {
+        let first = message(id: "first", text: "persisted first")
+        let second = message(id: "second", text: "persisted second")
+
+        #expect(QueueTranscriptCanonicalMerge.merging(persisted: [first, second], live: []) == [first, second])
+    }
+
+    @Test func liveItemReplacesMatchingTaggedIdentity() {
+        let persisted = message(id: "same", text: "persisted")
+        let replacement = message(id: "same", text: "live")
+
+        #expect(QueueTranscriptCanonicalMerge.merging(persisted: [persisted], live: [replacement]) == [replacement])
+    }
+
+    @Test func sameRawIDInDifferentKindsDoesNotCollide() {
+        let rawID = "shared-provider-id"
+        let persistedMessage = message(id: rawID, text: "message")
+        let liveTool = tool(id: rawID, detail: "live tool")
+
+        #expect(QueueTranscriptCanonicalMerge.merging(persisted: [persistedMessage], live: [liveTool]) == [persistedMessage, liveTool])
+    }
+
+    @Test func newLiveIdentityAppendsInLiveOrder() {
+        let persisted = message(id: "persisted", text: "persisted")
+        let firstLive = message(id: "live-1", text: "first live")
+        let secondLive = message(id: "live-2", text: "second live")
+
+        #expect(QueueTranscriptCanonicalMerge.merging(
+            persisted: [persisted],
+            live: [firstLive, secondLive]
+        ) == [persisted, firstLive, secondLive])
+    }
+
+    private func message(id: String, text: String) -> ChatTranscriptItem {
+        .message(ChatTranscriptMessageItem(
+            messageID: ChatMessageID(rawValue: id),
+            turnID: ChatTurnID(rawValue: "queue-turn"),
+            role: .assistant,
+            text: text,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        ))
+    }
+
+    private func tool(id: String, detail: String) -> ChatTranscriptItem {
+        .toolCall(ChatTranscriptToolCallItem(
+            toolCallID: ToolCallID(rawValue: id),
+            turnID: ChatTurnID(rawValue: "queue-turn"),
+            toolName: "Bash",
+            status: .running,
+            detail: detail,
+            permissionRequestID: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        ))
+    }
+}

--- a/Tests/WikiFSTests/QueueTranscriptConcurrencyTests.swift
+++ b/Tests/WikiFSTests/QueueTranscriptConcurrencyTests.swift
@@ -1,0 +1,284 @@
+import Foundation
+import Testing
+@testable import WikiFSEngine
+import WikiFSCore
+
+/// Regression coverage for the synchronous provider-callback seam. The store
+/// is real in the durability cases so these tests cover translation, ordering,
+/// SQLite persistence, and the live event value together.
+@Suite(.serialized)
+struct QueueTranscriptConcurrencyTests {
+    @Test func sameAttemptCallbacksCommitInAcceptedOrder() throws {
+        let store = try makeStore()
+        let item = try enqueueItem(in: store)
+        let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let state = QueueTranscriptStateStore()
+        let updates = UpdateRecorder()
+        state.begin(attempt)
+
+        state.accept(event: .assistantText("first"), for: attempt,
+                     persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                     broadcast: { updates.append($0) })
+        state.accept(event: .assistantText("second"), for: attempt,
+                     persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                     broadcast: { updates.append($0) })
+
+        #expect(updates.batchNumbers == [0, 1])
+        #expect(messageTexts(try store.loadTranscriptItems(itemID: item.id)) == ["first", "second"])
+    }
+
+    @Test func differentAttemptsDoNotShareTranslatorState() throws {
+        let store = try makeStore()
+        let first = try enqueueItem(in: store)
+        let second = try enqueueItem(in: store)
+        let firstAttempt = QueueAttemptID(itemID: first.id, attempt: first.attempt)
+        let secondAttempt = QueueAttemptID(itemID: second.id, attempt: second.attempt)
+        let state = QueueTranscriptStateStore()
+        state.begin(firstAttempt)
+        state.begin(secondAttempt)
+
+        state.accept(event: .assistantTextDelta("one"), for: firstAttempt,
+                     persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                     broadcast: { _ in })
+        state.accept(event: .assistantTextDelta("two"), for: secondAttempt,
+                     persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                     broadcast: { _ in })
+
+        let firstItem = try #require(try store.loadTranscriptItems(itemID: first.id).first)
+        let secondItem = try #require(try store.loadTranscriptItems(itemID: second.id).first)
+        #expect(firstItem != secondItem)
+        #expect(messageTexts([firstItem]) == ["one"])
+        #expect(messageTexts([secondItem]) == ["two"])
+    }
+
+    @Test func delayedFirstBatchCannotBeOvertakenBySecondBatch() async throws {
+        let store = try makeStore()
+        let item = try enqueueItem(in: store)
+        let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let state = QueueTranscriptStateStore()
+        let updates = UpdateRecorder()
+        let firstPersistEntered = AsyncSignal()
+        let releaseFirstPersist = DispatchSemaphore(value: 0)
+        let secondReturned = AsyncSignal()
+        state.begin(attempt)
+
+        let persist: @Sendable (QueueTranscriptUpdate) throws -> Void = { update in
+            if update.batchNumber == 0 {
+                firstPersistEntered.signal()
+                _ = releaseFirstPersist.wait(timeout: .now() + 5)
+            }
+            try store.upsertTranscriptItems(attemptID: update.attemptID, items: update.changedItems)
+        }
+        let first = Task.detached {
+            state.accept(event: .assistantText("A"), for: attempt, persist: persist, broadcast: { updates.append($0) })
+        }
+        await firstPersistEntered.wait()
+
+        let second = Task.detached {
+            state.accept(event: .assistantText("B"), for: attempt, persist: persist, broadcast: { updates.append($0) })
+            secondReturned.signal()
+        }
+        await secondReturned.wait()
+        releaseFirstPersist.signal()
+        await first.value
+        await second.value
+
+        #expect(updates.batchNumbers == [0, 1])
+        #expect(messageTexts(try store.loadTranscriptItems(itemID: item.id)) == ["A", "B"])
+    }
+
+    @Test func sqliteRunsAfterTranslationLockIsReleased() async throws {
+        let store = try makeStore()
+        let item = try enqueueItem(in: store)
+        let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let state = QueueTranscriptStateStore()
+        let firstPersistEntered = AsyncSignal()
+        let releaseFirstPersist = DispatchSemaphore(value: 0)
+        let secondCallbackReturned = AsyncSignal()
+        state.begin(attempt)
+
+        let persist: @Sendable (QueueTranscriptUpdate) throws -> Void = { update in
+            if update.batchNumber == 0 {
+                firstPersistEntered.signal()
+                _ = releaseFirstPersist.wait(timeout: .now() + 5)
+            }
+            try store.upsertTranscriptItems(attemptID: update.attemptID, items: update.changedItems)
+        }
+        let first = Task.detached {
+            state.accept(event: .assistantText("locked only for reduction"), for: attempt, persist: persist, broadcast: { _ in })
+        }
+        await firstPersistEntered.wait()
+        let second = Task.detached {
+            state.accept(event: .assistantText("second callback"), for: attempt, persist: persist, broadcast: { _ in })
+            secondCallbackReturned.signal()
+        }
+
+        // Batch B can translate and enqueue while A is blocked in SQLite. If
+        // the callback lock covered persistence, this timeout would fire.
+        await secondCallbackReturned.wait()
+        releaseFirstPersist.signal()
+        await first.value
+        await second.value
+    }
+
+    @Test func oldWorkerCallbackAfterRetryIsRejected() throws {
+        let store = try makeStore()
+        let item = try enqueueItem(in: store)
+        let oldAttempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let state = QueueTranscriptStateStore()
+        let updates = UpdateRecorder()
+        state.begin(oldAttempt)
+        state.accept(event: .assistantText("old accepted"), for: oldAttempt,
+                     persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                     broadcast: { updates.append($0) })
+        try store.markRunning(id: item.id, providerID: ProviderID(rawValue: "test"))
+        try store.markFailed(id: item.id, error: "retry")
+        state.invalidate(itemID: item.id)
+        try store.retryItem(id: item.id)
+        let retried = try #require(try store.getItem(item.id))
+        let currentAttempt = QueueAttemptID(itemID: retried.id, attempt: retried.attempt)
+        state.begin(currentAttempt)
+
+        state.accept(event: .assistantText("late old"), for: oldAttempt,
+                     persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                     broadcast: { updates.append($0) })
+        state.accept(event: .assistantText("new"), for: currentAttempt,
+                     persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                     broadcast: { updates.append($0) })
+
+        #expect(updates.batchNumbers == [0, 0])
+        #expect(messageTexts(try store.loadTranscriptItems(itemID: item.id)) == ["new"])
+    }
+
+    @Test func oldWorkerCallbackAfterNewOutputIsRejected() throws {
+        let store = try makeStore()
+        let item = try enqueueItem(in: store)
+        let oldAttempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let newAttempt = QueueAttemptID(itemID: item.id, attempt: item.attempt + 1)
+        let state = QueueTranscriptStateStore()
+        let updates = UpdateRecorder()
+        state.begin(oldAttempt)
+        state.begin(newAttempt)
+
+        state.accept(event: .assistantText("new output"), for: newAttempt,
+                     persist: { _ in }, broadcast: { updates.append($0) })
+        state.accept(event: .assistantText("old output"), for: oldAttempt,
+                     persist: { _ in }, broadcast: { updates.append($0) })
+
+        #expect(updates.updates.map(\.attemptID) == [newAttempt])
+        #expect(messageTexts(updates.updates.flatMap(\.changedItems)) == ["new output"])
+    }
+
+    @Test func oldWorkerCallbackAfterStateCleanupIsRejected() throws {
+        let store = try makeStore()
+        let item = try enqueueItem(in: store)
+        let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+        let state = QueueTranscriptStateStore()
+        let updates = UpdateRecorder()
+        state.begin(attempt)
+        state.finish(attempt)
+
+        state.accept(event: .assistantText("late"), for: attempt,
+                     persist: { _ in Issue.record("Late callback reached persistence") },
+                     broadcast: { updates.append($0) })
+
+        #expect(updates.updates.isEmpty)
+    }
+
+    @Test func reopenedTranscriptPreservesAcceptedEventOrder() throws {
+        let url = try temporaryDatabaseURL()
+        let itemID: QueueItem.ID
+        do {
+            let store = try QueueStore(databaseURL: url)
+            let item = try enqueueItem(in: store)
+            itemID = item.id
+            let attempt = QueueAttemptID(itemID: item.id, attempt: item.attempt)
+            let state = QueueTranscriptStateStore()
+            state.begin(attempt)
+            state.accept(event: .assistantText("first"), for: attempt,
+                         persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                         broadcast: { _ in })
+            state.accept(event: .assistantText("second"), for: attempt,
+                         persist: { try store.upsertTranscriptItems(attemptID: $0.attemptID, items: $0.changedItems) },
+                         broadcast: { _ in })
+            store.close()
+        }
+
+        let reopened = try QueueStore(databaseURL: url)
+        #expect(messageTexts(try reopened.loadTranscriptItems(itemID: itemID)) == ["first", "second"])
+    }
+
+    private func makeStore() throws -> QueueStore {
+        try QueueStore(databaseURL: temporaryDatabaseURL())
+    }
+
+    private func temporaryDatabaseURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-transcript-concurrency-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("queue.sqlite")
+    }
+
+    private func enqueueItem(in store: QueueStore) throws -> QueueItem {
+        try store.enqueue(QueueItemRequest(
+            queue: .extraction,
+            wikiID: WikiID(rawValue: "queue-transcript-concurrency"),
+            payload: QueueItemPayload(sourceIDs: [SourceID(rawValue: "source")])
+        ))
+    }
+
+    private func messageTexts(_ items: [ChatTranscriptItem]) -> [String] {
+        items.compactMap { item in
+            guard case .message(let message) = item else { return nil }
+            return message.text
+        }
+    }
+}
+
+private final class UpdateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [QueueTranscriptUpdate] = []
+
+    var updates: [QueueTranscriptUpdate] {
+        lock.withLock { storage }
+    }
+
+    var batchNumbers: [Int] {
+        lock.withLock { storage.map(\.batchNumber) }
+    }
+
+    func append(_ update: QueueTranscriptUpdate) {
+        lock.withLock { storage.append(update) }
+    }
+}
+
+/// A one-shot, non-blocking test barrier. Its continuation is resumed outside
+/// the lock, so it is safe to signal from the synchronous persistence seam.
+private final class AsyncSignal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let resumeNow = lock.withLock { () -> Bool in
+                if isSignaled { return true }
+                waiters.append(continuation)
+                return false
+            }
+            if resumeNow { continuation.resume() }
+        }
+    }
+
+    func signal() {
+        let pending = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+            isSignaled = true
+            let pending = waiters
+            waiters.removeAll()
+            return pending
+        }
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}

--- a/plans/queue-engine.md
+++ b/plans/queue-engine.md
@@ -362,14 +362,19 @@ transcripts.
 
 ### Transcript architecture
 
-`AgentLauncher` now has an `onAgentEvent` callback that fires per-event from
-`mergeOrAppend`. The ingestion provider sets this before calling `launcher.run`
-and clears it after. Events flow: launcher → `onAgentEvent` →
-`QueueEngine.makeEmitTranscript()` → `QueueEvent.transcript(id, event)` →
-`QueueActivityTracker.transcripts[itemID]`. The Activity window reads
-transcripts from the tracker, decoupled from the launcher instance (works
-across all wikis). Transcripts are pruned only on history pruning, not on
-terminal state, so users can view completed/failed/cancelled transcripts.
+`AgentLauncher` emits provider events at the launcher/provider boundary. Each
+`QueueIngestionWorker` captures an immutable `QueueAttemptID`, and the engine's
+per-attempt state store translates and reduces those events into typed
+`ChatTranscriptItem` rows. It assigns an ordered `QueueTranscriptUpdate` batch,
+persists the batch, then broadcasts it. A late callback from an old attempt is
+rejected before translation; SQLite and broadcasting run after the state lock
+is released. Events flow: launcher → provider callback → typed engine batch →
+`QueueActivityTracker` → Activity window. The tracker keeps typed accumulated
+rows on the main actor and rejects stale attempts or duplicate/out-of-order
+batches. The window merges durable and live rows by tagged identity, uses
+`ChatDisplayProjection` and `ChatTranscriptView`, and uses that same canonical
+sequence for Copy. Typed rows and queue metadata are pruned only with history,
+not on terminal state, so completed/failed/cancelled runs remain inspectable.
 
 ### LintView removal
 

--- a/plans/typed-queue-transcripts.md
+++ b/plans/typed-queue-transcripts.md
@@ -399,6 +399,13 @@ Do not ship or merge a state where the table is absent and old callers remain.
 **Gate:** A v4 queue database opens, discards only legacy transcript rows, and
 then stores and loads a new typed transcript through the daemon client.
 
+**Implementation record (2026-08-01):** The cutover uses an immutable
+`QueueAttemptID` captured by `QueueIngestionWorker`, a lock-backed per-attempt
+translator/reducer/drainer, and `QueueTranscriptUpdate` batches across the
+engine event and XPC boundary. v6 drops only `queue_item_events`; typed retry
+clearing preserves queue metadata and activity rows. The Activity window merges
+durable and live typed rows through one value-only presentation seam.
+
 ### Phase 4: Remove the legacy renderer
 
 After the typed Activity view passes live verification, remove:
@@ -407,7 +414,6 @@ After the typed Activity view passes live verification, remove:
 - event-based coordinator reload and apply methods
 - event-based pending and rendered state
 - legacy visibility helpers that have no remaining callers
-- legacy `QueueStore` event methods
 - stale comments about the Activity event adapter
 
 Keep the old migration registrations. Do not edit past migration bodies.

--- a/progress/2026-08-01T050000Z-typed-queue-transcripts-phase3.md
+++ b/progress/2026-08-01T050000Z-typed-queue-transcripts-phase3.md
@@ -1,0 +1,53 @@
+---
+timestamp: 2026-08-01T050000Z
+title: Typed Queue Transcripts Phase 3
+branch: feature/typed-queue-transcripts-phase3
+status: complete
+---
+
+# Typed Queue Transcripts Phase 3
+
+Phase 3 completes the atomic queue transcript cutover above Phase 2. Queue
+workers capture an immutable `QueueAttemptID`; raw provider events translate at
+that boundary and do not cross `QueueEvent` or XPC. The lock-backed per-attempt
+state store reduces typed items, assigns ordered batches, persists first, and
+broadcasts only successful durable updates.
+
+## Progress
+
+- Added `QueueTranscriptUpdate`, tagged canonical merge, and typed queue event
+  envelope transport.
+- Changed queue engine/client/daemon/XPC load APIs and all fakes to return
+  `[ChatTranscriptItem]`.
+- Changed retry clearing and the v6 migration; v6 drops only
+  `queue_item_events`. The raw v4 fixture proves queue items, queue state,
+  activity, chat, usage, log, debug, and progress rows are unchanged.
+- Replaced tracker and Activity-window queue transcript state with typed items,
+  canonical persisted/live merge, typed rendering, queue transcript identity,
+  typed copy, and progress fallback.
+- Deleted obsolete legacy queue event-store methods. The legacy `ChatWebView`
+  event initializer/coordinator remains intentionally deferred to Phase 4.
+
+## Verification
+
+- `make build` passed and signed the development app.
+- Focused Swift Testing passed: translator (11), typed store (8), migration
+  (2), concurrency (8), envelope (11), client conformance (4), daemon XPC,
+  presentation manifest, tracker, canonical merge, and hosted Activity tests.
+- `make test` passed after the final concurrency-lock correction.
+- `make lint` passed with 0 violations; `make check` passed; `git diff --check`
+  passed.
+
+## Review
+
+Concurrency review: the state lock protects only attempt selection,
+translation/reduction, batch allocation, and drainer election. SQLite and
+broadcasting run unlocked; terminal closing rejects new callbacks and removes
+state only after accepted batches drain. The app callback box now snapshots its
+handler under a lock before invoking it.
+
+SwiftUI/macOS review: the Activity window retains its native split-view/header
+hierarchy. Its value-only presentation input keeps the typed renderer,
+queue-item transcript ID, wiki-link intent, render context, blob store, copy,
+and progress fallback on one tested path. The `ActivityWindowTypedTranscript`
+suite hosts the real production window in an `NSWindow`.

--- a/progress/2026-08-01T050000Z-typed-queue-transcripts-phase3.md
+++ b/progress/2026-08-01T050000Z-typed-queue-transcripts-phase3.md
@@ -27,16 +27,21 @@ broadcasts only successful durable updates.
   typed copy, and progress fallback.
 - Deleted obsolete legacy queue event-store methods. The legacy `ChatWebView`
   event initializer/coordinator remains intentionally deferred to Phase 4.
+- Post-audit correction: qualified `TranscriptID.queueItem` at the renderer
+  seam, changed the tracker batch gate to a monotonic forward watermark, and
+  seeded active daemon snapshot attempts so reconnect batches are accepted
+  without fabricating running UI state. The daemon protocol comment now names
+  the typed transcript payload.
 
 ## Verification
 
-- `make build` passed and signed the development app.
-- Focused Swift Testing passed: translator (11), typed store (8), migration
-  (2), concurrency (8), envelope (11), client conformance (4), daemon XPC,
-  presentation manifest, tracker, canonical merge, and hosted Activity tests.
-- `make test` passed after the final concurrency-lock correction.
-- `make lint` passed with 0 violations; `make check` passed; `git diff --check`
-  passed.
+- Corrective verification reran and passed: `make build`; translator (11),
+  typed store (8), migration (2), concurrency (8), envelope (11), client
+  conformance (4), daemon XPC (12), presentation manifest (10), tracker (5,
+  including the dropped-batch and reconnect regressions), canonical merge, and
+  hosted Activity tests (7).
+- `make test` passed after the corrective changes. `make lint` passed with 0
+  violations; `make check` and `git diff --check` passed.
 
 ## Review
 


### PR DESCRIPTION
## Summary

Completes the Phase 3 atomic cutover from legacy queue `AgentEvent` persistence
to typed queue transcript items, plus exact-head audit corrections for manifest
coverage, lossy live delivery, reconnect attempt seeding, and protocol wording.

## Stack

- Stack order: Phase 3 above Phase 2 above `main`.
- Parent branch: `feature/typed-queue-transcripts-phase2`.
- PR base: `feature/typed-queue-transcripts-phase2`.
- Phase 3 corrective head: `3605bc87b01a397db769115d8c5429af875334d9`.
- Dependency status: Phase 2 PR #1024 remains open; its required exact head is
  `1657ce4b8a5084338c0bc82def5ed8e45ec137d4`.
- Merge order: operator merges bottom-up only. Do not merge this PR before
  Phase 2.

## Corrective audit evidence

- Qualified `TranscriptID.queueItem` in the production renderer seam; the
  source-contract manifest now passes.
- The main-actor tracker accepts a monotonic-forward transcript batch after a
  dropped batch, while rejecting stale attempts, duplicates, and older batches.
- Reconciliation seeds the immutable typed attempt for daemon-active snapshot
  items, so a reconnect/mid-run attach accepts a live batch before a repeated
  `.started` event without inventing running UI state.
- Updated the daemon protocol comment to describe JSON `[ChatTranscriptItem]`.

## Verification

- `make build`, `make test`, `make lint` (0 violations), `make check`, and
  `git diff --check` passed.
- Focused suites passed: `AgentEventTranscriptTranslatorTests` (11),
  `QueueStoreTypedTranscriptTests` (8),
  `QueueStoreTypedTranscriptMigrationTests` (2),
  `QueueTranscriptConcurrencyTests` (8),
  `QueueTranscriptCanonicalMergeTests` (4), `QueueEventEnvelopeTests` (11),
  `QueueEngineClientConformanceTests` (4), `WikiDaemonWorkloadHostTests` (12),
  `ChatPresentationAPIManifestTests` (10),
  `QueueActivityTrackerTypedTranscriptTests` (5), and
  `ActivityWindowTypedTranscriptTests` (7). App-hosted commands used
  `WIKIFS_APP_TESTS=1`.
