### PR TITLE
chore(ci): enforce conventional commits and validate skill metadata

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Validate the first non-comment line of every manually written commit message.
+# Git-generated merge and revert messages keep their normal workflow.
+# Bypass for a genuine emergency: git commit --no-verify.
+
+message_file=$1
+first_line=$(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$message_file" | sed -n '1p')
+
+case "$first_line" in
+  Merge\ *|Revert\ *)
+    exit 0
+    ;;
+esac
+
+if printf '%s\n' "$first_line" | grep -Eq '^(feat|fix|refactor|perf|docs|test|build|ci|chore)(\([[:alnum:]][[:alnum:]./_-]*\))?!?: [^[:space:]].*'; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+✗ invalid commit message
+
+Use: <type>[optional scope][!]: <description>
+
+Allowed types: feat, fix, refactor, perf, docs, test, build, ci, chore
+Examples:
+  feat(search): add source title matching
+  fix!: preserve page identifiers during migration
+EOF
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,19 @@ jobs:
         # annotation on the PR diff instead of burying it in the log.
         run: swiftlint lint --strict --reporter github-actions-logging
 
+  skills:
+    # Validate skill metadata independently from the Swift and Python jobs.
+    # The script declares its PyYAML dependency with PEP 723 inline metadata.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Validate skill metadata
+        run: uv run tools/validate_skills.py
+
   swift:
     # Full `swift test` — no skip, no tier split. The in-memory SQLite
     # fixtures (#658) reduced the full suite from 30+ min to ~1.5 min, so the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ agents, NOT Polytoken):
 - **swiftui-ui-patterns** — https://github.com/Dimillian/Skills
 - **swiftui-performance-audit** — https://github.com/Dimillian/Skills
 - **macos-spm-app-packaging** — https://github.com/Dimillian/Skills
+- **conventional-commits** — https://www.conventionalcommits.org/en/v1.0.0/
 
 > Same caveat: these target recent iOS/macOS toolchains. Filter
 > version-gated guidance to macOS 15 / Swift 6.0. The `macos-spm-app-packaging`
@@ -137,6 +138,11 @@ agents, NOT Polytoken):
   [`docs/skills/swift-testing-pro/SKILL.md`](docs/skills/swift-testing-pro/SKILL.md)
   (core-rules, async-tests, migrating-from-xctest). Prefer Swift Testing over
   XCTest for new tests.
+
+* When creating or reviewing Git commits, follow
+  [`docs/skills/conventional-commits/SKILL.md`](docs/skills/conventional-commits/SKILL.md)
+  for the commit type, scope, description, body, footer, and breaking-change
+  format.
 
 * When a SwiftUI view is slow, janky, or you suspect unnecessary diffing /
   re-rendering, run the audit in

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ help:
 	@echo "  lint              SwiftLint: fail on NEW bare try? in Sources/ + tools/"
 	@echo "  lint-baseline     Re-snapshot .swiftlint-baseline.json (run after fixing try?s)"
 	@echo "  lint-analyze      SwiftLint analyzer: unused decls/imports (advisory, slow, not in CI)"
-	@echo "  hooks             Install .githooks (pre-commit try? guard + git-lfs shims)"
+	@echo "  hooks             Install .githooks (commit-msg + pre-commit + git-lfs shims)"
 	@echo "  mutate            Run swift-mutation-testing (full — see .swift-mutation-testing.yml)"
 	@echo "  mutate-scope      Scoped mutation run: make mutate-scope SOURCES_PATH=Sources/Foo"
 	@echo "  prompts           Regenerate Sources/WikiFSCore/GeneratedPrompts.swift from prompts/*.md"
@@ -453,7 +453,7 @@ lint-analyze:
 hooks:
 	@git config core.hooksPath .githooks
 	@chmod +x .githooks/*
-	@echo "✓ core.hooksPath = .githooks (pre-commit try? guard active; git-lfs shims preserved)"
+	@echo "✓ core.hooksPath = .githooks (commit-msg + pre-commit guards active; git-lfs shims preserved)"
 
 # ---------------------------------------------------------------------------
 # Agent prompts (prompts/*.md → Sources/WikiFSCore/GeneratedPrompts.swift)

--- a/docs/skills/conventional-commits/SKILL.md
+++ b/docs/skills/conventional-commits/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: conventional-commits
+description: Use when creating, reviewing, or correcting Git commit messages - applies the Conventional Commits 1.0.0 format and helps select an accurate type, scope, and breaking-change marker
+---
+
+# Conventional Commits
+
+Use this skill for commits and commit-message reviews. A structured commit message makes the change clear to people and tools such as changelog generators and release automation.
+
+## Format
+
+Write the header in this form:
+
+```text
+<type>[optional scope][!]: <description>
+```
+
+Add an optional body after one blank line. Add one or more optional footers after another blank line.
+
+```text
+feat(search): add source title matching
+
+Include source titles in the lexical search index.
+
+Closes: #123
+```
+
+Use a noun for the type and describe the affected area in the scope. Use lowercase types and scopes. Write a short, imperative description that states the user-visible or repository-level change.
+
+## Type selection
+
+Choose the type that best describes the change:
+
+- `feat`: add a feature. This maps to a SemVer minor release.
+- `fix`: correct a bug. This maps to a SemVer patch release.
+- `refactor`: change structure without changing behavior.
+- `perf`: improve performance without changing behavior.
+- `docs`: change documentation only.
+- `test`: add or change tests.
+- `build`: change build tools, dependencies, or packaging.
+- `ci`: change continuous integration configuration.
+- `chore`: make maintenance changes that do not fit another type.
+
+Use the repository's established type when its history or release tooling defines a narrower convention. Do not use `chore` when a more precise type applies.
+
+## Breaking changes
+
+Mark a breaking change with `!` before the colon:
+
+```text
+feat(api)!: replace the page identifier format
+```
+
+Also add a footer when the reason or migration path needs explanation:
+
+```text
+BREAKING CHANGE: clients must send PageID values instead of raw strings.
+```
+
+Use the exact uppercase footer token `BREAKING CHANGE:`. A breaking change can use any type.
+
+## Validation
+
+Before committing, inspect the staged diff and write one commit for one coherent change. Check that:
+
+1. The type matches the primary purpose.
+2. The scope names a real area of the repository when a scope helps.
+3. The description is specific, concise, and does not end with a period.
+4. The body explains why when the header does not provide enough context.
+5. The footer records issue references or breaking-change details in the format required by the repository.
+
+Use `git diff --cached` to confirm that the message describes the staged change. Follow the repository rule to work on a feature branch and open a pull request. Do not commit directly to `main`.
+
+## Reference
+
+This skill follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/docs/skills/debugging-with-lldb/SKILL.md
+++ b/docs/skills/debugging-with-lldb/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: debugging-with-lldb
 description: When and how to use lldb to debug macOS app deaths that leave no crash report — silent exits, uncatchable C++/abort paths, LaunchServices-only failures. Use before log-grepping yourself into a hole.
 ---
 

--- a/docs/skills/reproducing-live-ui-bugs/SKILL.md
+++ b/docs/skills/reproducing-live-ui-bugs/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: reproducing-live-ui-bugs
 description: Steps for debugging a live UI bug that passes all unit tests but fails in the running app, when you cannot see the screen. Also covers SwiftUI runtime issues that only Xcode displays — "Modifying state during view update", purple runtime warnings, Hang Risk — including how to capture them from the CLI via `log stream` and bisect a view body to find the real source.
 ---
 

--- a/docs/skills/sqlite-concurrency/SKILL.md
+++ b/docs/skills/sqlite-concurrency/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: sqlite-concurrency
 description: This app's SQLite concurrency discipline — the store is method-atomic (internal recursive lock + savepoint transactions); writes flow through the main-actor model, off-main reads go through WikiReadPool, and connection state must never cross a call boundary. Read before adding anything that touches the store off the main actor or composes transactions.
 ---
 

--- a/paseo.json
+++ b/paseo.json
@@ -2,5 +2,10 @@
   "worktree": {
     "setup": "cp -R \"$PASEO_SOURCE_CHECKOUT_PATH/signing\" \"$PASEO_WORKTREE_PATH\"",
     "teardown": "scripts/paseo-archive-cleanup.sh"
+  },
+  "metadataGeneration": {
+    "commitMessage": {
+      "instructions": "Use a Conventional Commit header: <type>[optional scope][!]: <description>. Use one lowercase type from feat, fix, refactor, perf, docs, test, build, ci, or chore. Use a lowercase scope when useful. Use ! for breaking changes. Keep the message to one concise imperative line with no trailing period. Return only the commit message."
+    }
   }
 }

--- a/tools/validate_skills.py
+++ b/tools/validate_skills.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# pattern: Imperative Shell
+
+"""Validate the metadata in every repository skill."""
+
+# /// script
+# dependencies = ["pyyaml"]
+# ///
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+MAX_SKILL_NAME_LENGTH = 64
+ALLOWED_FRONTMATTER_KEYS = {
+    "name",
+    "description",
+    "license",
+    "allowed-tools",
+    "metadata",
+}
+
+
+def validate_skill(skill_path: Path) -> str | None:
+    skill_file = skill_path / "SKILL.md"
+    if not skill_file.exists():
+        return "SKILL.md not found"
+
+    content = skill_file.read_text()
+    if not content.startswith("---"):
+        return "no YAML frontmatter found"
+
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return "invalid frontmatter format"
+
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as error:
+        return f"invalid YAML in frontmatter: {error}"
+
+    if not isinstance(frontmatter, dict):
+        return "frontmatter must be a YAML dictionary"
+
+    unexpected_keys = set(frontmatter) - ALLOWED_FRONTMATTER_KEYS
+    if unexpected_keys:
+        return f"unexpected frontmatter keys: {', '.join(sorted(unexpected_keys))}"
+
+    name = frontmatter.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return "missing or invalid 'name'"
+    name = name.strip()
+    if not re.fullmatch(r"[a-z0-9-]+", name):
+        return "name must use lowercase letters, digits, and hyphens"
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return "name cannot start or end with a hyphen or contain consecutive hyphens"
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return f"name exceeds {MAX_SKILL_NAME_LENGTH} characters"
+
+    description = frontmatter.get("description")
+    if not isinstance(description, str) or not description.strip():
+        return "missing or invalid 'description'"
+    if "<" in description or ">" in description:
+        return "description cannot contain angle brackets"
+    if len(description.strip()) > 1024:
+        return "description exceeds 1024 characters"
+
+    return None
+
+
+def main() -> int:
+    skill_files = sorted(Path("docs/skills").glob("*/SKILL.md"))
+    if not skill_files:
+        print("No skills found", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for skill_file in skill_files:
+        error = validate_skill(skill_file.parent)
+        if error:
+            print(f"{skill_file}: {error}", file=sys.stderr)
+            failures += 1
+        else:
+            print(f"{skill_file}: valid")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a commit-msg hook that enforces Conventional Commits for manually written commit messages
- add CI validation for skill frontmatter metadata with `tools/validate_skills.py`
- document the commit-message convention in AGENTS and a dedicated skill
- update hook install messaging and metadata-generation instructions to match the new workflow
- add missing `name` frontmatter to existing skills

## Why
This makes two repo conventions enforceable instead of informal: commit messages now follow a consistent, machine-readable format, and skill metadata is checked in CI so malformed frontmatter is caught early.

## What changed
- `.githooks/commit-msg` now rejects non-conforming commit headers while still allowing merge and revert commits.
- `tools/validate_skills.py` walks `docs/skills/*/SKILL.md` and validates frontmatter structure, allowed keys, and basic `name`/`description` rules.
- `.github/workflows/ci.yml` now runs the skill validator as its own job.
- `docs/skills/conventional-commits/SKILL.md` captures the commit-message format and type selection guidance.
- `AGENTS.md` now points at the Conventional Commits skill for commit authoring and review.
- `Makefile` hook output now reflects that the installed hooks include both `commit-msg` and `pre-commit` checks.
- `paseo.json` now tells metadata generation to emit Conventional Commit headers.
- Existing skills gained missing `name` frontmatter so they pass the new validator.

## Notes
- The commit hook can still be bypassed with `git commit --no-verify` in an emergency.
- The validator is intentionally narrow: it checks the metadata contract we rely on, not the full skill content.