### PR TITLE
feat: add conventional branch name validation via pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,3 +1,55 @@
 #!/bin/sh
+
+valid_branch_name() {
+  branch_name=$1
+
+  case "$branch_name" in
+    main|master|develop)
+      return 0
+      ;;
+    feature/*|feat/*|bugfix/*|fix/*|hotfix/*|chore/*)
+      printf '%s\n' "$branch_name" | grep -Eq '^(feature|feat|bugfix|fix|hotfix|chore)/[a-z0-9]+(-[a-z0-9]+)*$'
+      ;;
+    release/*)
+      printf '%s\n' "$branch_name" | grep -Eq '^release/[a-z0-9]+([.-][a-z0-9]+)*$'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+ref_input=$(mktemp "tmp/pre-push-refs.XXXXXX") || exit 1
+trap 'rm -f "$ref_input"' EXIT HUP INT TERM
+cat > "$ref_input"
+
+invalid_branch=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$local_ref" in
+    refs/heads/*)
+      branch_name=${local_ref#refs/heads/}
+      if ! valid_branch_name "$branch_name"; then
+        printf >&2 '✗ invalid branch name: %s\n' "$branch_name"
+        invalid_branch=1
+      fi
+      ;;
+  esac
+done < "$ref_input"
+
+if [ "$invalid_branch" -ne 0 ]; then
+  cat >&2 <<'EOF'
+
+Use a Conventional Branch name:
+  feature/<kebab-case-description>
+  bugfix/<kebab-case-description>
+  hotfix/<kebab-case-description>
+  release/v1.2.0
+  chore/<kebab-case-description>
+
+Trunk branches main, master, and develop are also valid.
+EOF
+  exit 1
+fi
+
 command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs pre-push "$@"
+git lfs pre-push "$@" < "$ref_input"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ agents, NOT Polytoken):
 - **swiftui-performance-audit** — https://github.com/Dimillian/Skills
 - **macos-spm-app-packaging** — https://github.com/Dimillian/Skills
 - **conventional-commits** — https://www.conventionalcommits.org/en/v1.0.0/
+- **conventional-branch** — https://github.com/github/awesome-copilot/blob/main/skills/conventional-branch/SKILL.md
 
 > Same caveat: these target recent iOS/macOS toolchains. Filter
 > version-gated guidance to macOS 15 / Swift 6.0. The `macos-spm-app-packaging`
@@ -271,6 +272,12 @@ agents, NOT Polytoken):
 * Never commit or push directly to `main`. Always work on a feature branch, push
   the branch, and open a PR. You may push PR branches but MUST NOT merge them to
   main yourself.
+
+* When creating or naming a branch, follow
+  [`docs/skills/conventional-branch/SKILL.md`](docs/skills/conventional-branch/SKILL.md).
+  Use `feature/` (or `feat/`), `bugfix/` (or `fix/`), `hotfix/`, `release/`, or
+  `chore/`, followed by a lowercase kebab-case description. The installed
+  `pre-push` hook enforces the machine-checkable naming rules for pushed refs.
 
 * Never pipe literal markdown or multi-line content into `gh pr edit --body` —
   the shell mangles the formatting. Use plain text for the inline body, or write

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ help:
 	@echo "  lint              SwiftLint: fail on NEW bare try? in Sources/ + tools/"
 	@echo "  lint-baseline     Re-snapshot .swiftlint-baseline.json (run after fixing try?s)"
 	@echo "  lint-analyze      SwiftLint analyzer: unused decls/imports (advisory, slow, not in CI)"
-	@echo "  hooks             Install .githooks (commit-msg + pre-commit + git-lfs shims)"
+	@echo "  hooks             Install .githooks (commit-msg + pre-commit + branch-name + git-lfs shims)"
 	@echo "  mutate            Run swift-mutation-testing (full — see .swift-mutation-testing.yml)"
 	@echo "  mutate-scope      Scoped mutation run: make mutate-scope SOURCES_PATH=Sources/Foo"
 	@echo "  prompts           Regenerate Sources/WikiFSCore/GeneratedPrompts.swift from prompts/*.md"
@@ -453,7 +453,7 @@ lint-analyze:
 hooks:
 	@git config core.hooksPath .githooks
 	@chmod +x .githooks/*
-	@echo "✓ core.hooksPath = .githooks (commit-msg + pre-commit guards active; git-lfs shims preserved)"
+	@echo "✓ core.hooksPath = .githooks (commit-msg + pre-commit + branch-name guards active; git-lfs shims preserved)"
 
 # ---------------------------------------------------------------------------
 # Agent prompts (prompts/*.md → Sources/WikiFSCore/GeneratedPrompts.swift)

--- a/docs/skills/conventional-branch/SKILL.md
+++ b/docs/skills/conventional-branch/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: conventional-branch
+description: 'Create Git branches following the Conventional Branch specification (feature/, bugfix/, hotfix/, release/, chore/). Use when creating a new branch, naming a branch, or checking whether a branch name complies with the spec.'
+---
+
+# Conventional Branch
+
+Create Git branches that follow the [Conventional Branch](https://conventional-branch.github.io) specification — a simple, consistent convention for naming Git branches.
+
+## Branch Name Format
+
+```text
+<type>/<description>
+```
+
+### Branch Types
+
+| Type | Alias | Purpose |
+|------|-------|---------|
+| `feature/` | `feat/` | New features or enhancements |
+| `bugfix/` | `fix/` | Bug fixes |
+| `hotfix/` | — | Urgent production fixes |
+| `release/` | — | Release preparation (dots allowed in version: `release/v1.2.0`) |
+| `chore/` | — | Non-code tasks (deps, docs, config) |
+
+### Trunk Branches
+
+`main`, `master`, and `develop` are trunk branches — they do not use a prefix. Never create new branches with the same names as trunk branches; branch off them instead.
+
+## Naming Rules
+
+- **Lowercase only** — no uppercase letters anywhere
+- **Alphanumerics, hyphens, and dots** — `a-z`, `0-9`, `-`, `.`
+- **Dots allowed only** in `release/` version descriptions (e.g., `release/v1.2.0`)
+- **No underscores, spaces, or special characters**
+- **No consecutive hyphens** (`--`), **dots** (`..`), or hyphen-dot adjacency (`-.` or `.-`)
+- **No leading or trailing hyphens or dots** in the description
+
+## Valid Examples
+
+```text
+main
+master
+develop
+feature/add-login-page
+feat/add-login-page
+bugfix/fix-header-bug
+fix/header-bug
+hotfix/security-patch
+release/v1.2.0
+chore/update-dependencies
+feature/issue-123-new-login
+```
+
+## Invalid Examples
+
+| Branch | Problem |
+|--------|---------|
+| `Feature/Add-Login` | Uppercase letters |
+| `feature/new--login` | Consecutive hyphens |
+| `feature/-new-login` | Leading hyphen |
+| `feature/new-login-` | Trailing hyphen |
+| `release/v1.-2.0` | Hyphen adjacent to dot |
+| `fix/header bug` | Space |
+| `fix/header_bug` | Underscore |
+| `unknown/some-task` | Unknown prefix type |
+
+## Description Guidelines
+
+- Use kebab-case with 2-5 words
+- Be descriptive but concise (~50 chars total)
+- Good: `add-oauth-login`, `fix-header-overflow`, `update-ci-config`
+- Bad: `fix-bug`, `new-feature`
+
+## Workflow
+
+1. Determine the branch type; default to `feature` when uncertain.
+2. Write a brief description of the work. Include a ticket or issue number when one exists.
+3. Validate the assembled name against the naming rules. Lowercase it, replace underscores and spaces with hyphens, collapse consecutive hyphens, and strip leading/trailing hyphens when correcting a draft name.
+4. Detect the base branch:
+
+   ```sh
+   git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||'
+   ```
+
+   If that returns nothing, check local `develop`, `main`, then `master`.
+5. Create the branch from the base branch and confirm the resulting name:
+
+   ```sh
+   git checkout <base>
+   git pull origin <base>
+   git checkout -b <type>/<description>
+   ```
+
+6. Remind the user to run `git push -u origin <branch-name>` when ready.
+
+## Relationship with Conventional Commits
+
+Conventional Branch complements [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Align the branch type with commit types where possible: `feature/*` with `feat:`, `bugfix/*` with `fix:`, and `chore/*` with `chore:`.

--- a/paseo.json
+++ b/paseo.json
@@ -6,6 +6,9 @@
   "metadataGeneration": {
     "commitMessage": {
       "instructions": "Use a Conventional Commit header: <type>[optional scope][!]: <description>. Use one lowercase type from feat, fix, refactor, perf, docs, test, build, ci, or chore. Use a lowercase scope when useful. Use ! for breaking changes. Keep the message to one concise imperative line with no trailing period. Return only the commit message."
+    },
+    "branchName": {
+      "instructions": "Use Conventional Branch naming. Return a lowercase branch name in the form <type>/<description>, using feature/ (or feat/), bugfix/ (or fix/), hotfix/, release/, or chore/. Use a concise kebab-case description with alphanumerics and hyphens; use dots only in release versions. Never use uppercase letters, underscores, spaces, consecutive separators, or leading/trailing separators. Keep main, master, and develop as trunk branches."
     }
   }
 }


### PR DESCRIPTION
Enforce branch naming consistency across the project by validating branch names at push time.

## Changes

- **`.githooks/pre-push`**: Added `valid_branch_name()` function that validates branch names against the Conventional Branch specification. Accepts `feature/`, `feat/`, `bugfix/`, `fix/`, `hotfix/`, `release/`, `chore/` prefixes (plus trunk branches: main, master, develop). Enforces kebab-case descriptions with alphanumerics and hyphens only.

- **`docs/skills/conventional-branch/SKILL.md`**: New skill documentation for Conventional Branch specification, including branch types, naming rules, valid/invalid examples, and step-by-step workflow guidance.

- **`AGENTS.md`**: Added reference to the conventional-branch skill and documented branch naming requirements in the working agreement (§Agent responsibilities).

- **`Makefile`**: Updated `make hooks` help text and output message to reflect branch-name validation is now active.

- **`paseo.json`**: Added branchName metadata generation instructions so Paseo can assist with generating compliant branch names.

## Why

Enforcing consistent, machine-checkable branch names improves clarity (standardized names make branch purpose obvious), automation (Paseo can generate names; CI/tools can parse branch type reliably), and developer experience (pre-push validation catches errors immediately). The hook runs at push time, not on create, so local workflows remain flexible while protecting the remote.

Aligns with the existing Conventional Commits practice (`conventional-commits` skill).