### PR TITLE
Authorize ACP full-access mode for ingest and lint sessions

### DIFF
--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -643,6 +643,10 @@ public actor ACPBackend: AgentBackend {
             baselineCurrentModelId: modelsInfo?.currentModelId,
             advertisedModelIds: modelsInfo?.availableModels.map(\.modelId) ?? [],
             configOptions: configOptions)
+        try await applyExecutionAccessIfNeeded(
+            session: SessionHandle(id: sessionID),
+            access: profile.executionAccess,
+            configOptions: configOptions)
 
         // Rebind onExit so the latest caller's callback fires on process exit.
         // With a warm subprocess, multiple sessions share one permission delegate;
@@ -1249,11 +1253,12 @@ public actor ACPBackend: AgentBackend {
                     cwd: cwd
                 )
                 DebugLog.agent("ACPBackend.resume: resumeSession succeeded models=\(response.models?.availableModels.count ?? 0)")
-                return registerResumedSession(
+                return try await registerResumedSession(
                     acpSessionId: acpSessionId,
                     warm: newWarm,
                     modelsInfo: response.models,
-                    configOptions: response.configOptions
+                    configOptions: response.configOptions,
+                    executionAccess: profile.executionAccess
                 )
             } catch {
                 // Resume failed (session GC'd, protocol error). Fall through to
@@ -1273,11 +1278,12 @@ public actor ACPBackend: AgentBackend {
                 DebugLog.agent("ACPBackend.resume: loadSession succeeded models=\(response.models?.availableModels.count ?? 0)")
                 // loadSession may return a new sessionId (some agents), or nil.
                 let resumedId = response.sessionId ?? acpSessionId
-                return registerResumedSession(
+                return try await registerResumedSession(
                     acpSessionId: resumedId,
                     warm: newWarm,
                     modelsInfo: response.models,
-                    configOptions: response.configOptions
+                    configOptions: response.configOptions,
+                    executionAccess: profile.executionAccess
                 )
             } catch {
                 DebugLog.agent("ACPBackend.resume: loadSession failed: \(error.localizedDescription) — giving up")
@@ -1300,8 +1306,9 @@ public actor ACPBackend: AgentBackend {
         acpSessionId: SessionId,
         warm: WarmProcess,
         modelsInfo: ModelsInfo?,
-        configOptions: [SessionConfigOption]? = nil
-    ) -> SessionHandle {
+        configOptions: [SessionConfigOption]? = nil,
+        executionAccess: AgentExecutionAccess
+    ) async throws -> SessionHandle {
         let sessionID = UUID().uuidString
         sessions[sessionID] = ACPSession(
             client: warm.client,
@@ -1316,9 +1323,34 @@ public actor ACPBackend: AgentBackend {
         )
         // Phase 4: create a usage tracker for this resumed session.
         usageStates[sessionID] = SessionUsageState()
+        try await applyExecutionAccessIfNeeded(
+            session: SessionHandle(id: sessionID),
+            access: executionAccess,
+            configOptions: configOptions)
         resumableSessionId = acpSessionId
         DebugLog.agent("ACPBackend.resume: resumed session \(acpSessionId.value) (handle \(sessionID)) ready")
         return SessionHandle(id: sessionID)
+    }
+
+    /// Apply a provider-advertised full-access mode before the session receives
+    /// its first tool call. A provider without this mode keeps its default.
+    private func applyExecutionAccessIfNeeded(
+        session: SessionHandle,
+        access: AgentExecutionAccess,
+        configOptions: [SessionConfigOption]?
+    ) async throws {
+        guard let configuration = ACPExecutionAccessResolver.configuration(
+            for: access,
+            options: configOptions ?? []
+        ) else {
+            return
+        }
+
+        try await setConfigOption(
+            sessionHandle: session,
+            configId: configuration.configID,
+            value: configuration.value)
+        DebugLog.agent("ACPBackend: applied full-access session mode before first tool call")
     }
 
     /// Phase 2: Check if the subprocess is alive. Used by the orchestrator to

--- a/Sources/WikiFSEngine/ACPExecutionAccessResolver.swift
+++ b/Sources/WikiFSEngine/ACPExecutionAccessResolver.swift
@@ -1,0 +1,35 @@
+// pattern: Functional Core
+
+#if os(macOS)
+import ACPModel
+import WikiFSCore
+
+/// A validated ACP session config-option write.
+struct ACPConfigOptionApplication: Equatable, Sendable {
+    let configID: String
+    let value: String
+}
+
+/// Resolves the provider-advertised mode needed for application-authorized
+/// mutation workflows. This never guesses at provider-specific config values.
+enum ACPExecutionAccessResolver {
+    private static let modeConfigID = "mode"
+    private static let fullAccessValue = "bypassPermissions"
+
+    static func configuration(
+        for access: AgentExecutionAccess,
+        options: [SessionConfigOption]
+    ) -> ACPConfigOptionApplication? {
+        guard access == .fullAccess,
+              let modeOption = options.first(where: { $0.id.value == modeConfigID }),
+              case .select(let select) = modeOption.kind,
+              select.currentValue.value != fullAccessValue,
+              ACPModelSelectionResolver.configOptionValues(from: select.options).contains(fullAccessValue)
+        else {
+            return nil
+        }
+
+        return ACPConfigOptionApplication(configID: modeConfigID, value: fullAccessValue)
+    }
+}
+#endif

--- a/Sources/WikiFSEngine/AgentBackend.swift
+++ b/Sources/WikiFSEngine/AgentBackend.swift
@@ -60,6 +60,18 @@ public protocol AgentBackend: Sendable {
 /// path, log layout) and passes them in here; `ACPBackend` reads `model`/
 /// `providerHints` for routing and `cli` for the env vars it needs to spawn
 /// (`WIKI_DB`/`WIKICTL`/`PATH`) — see `CLIProfile`.
+/// The execution access the application authorizes for an ACP session.
+///
+/// This is distinct from `PermissionPolicy`: it controls an agent's own
+/// advertised session mode, while `PermissionPolicy` records and resolves ACP
+/// tool permission requests.
+public enum AgentExecutionAccess: Sendable, Equatable {
+    /// Keep the ACP agent's default session mode.
+    case standard
+    /// Request the agent's advertised full-access mode before the first tool call.
+    case fullAccess
+}
+
 public struct BackendProfile: Sendable {
     /// The model alias/name to pass to the agent (backend-interpreted).
     public var model: String?
@@ -69,6 +81,8 @@ public struct BackendProfile: Sendable {
     public var scratchDirectory: URL?
     /// Gates Write/Edit tools — read-only interactive sessions pass `false`.
     public var isReadOnly: Bool
+    /// The agent-session access level the application authorizes for this run.
+    public var executionAccess: AgentExecutionAccess
     /// The env-var context `ACPBackend.start` reads to spawn the agent with
     /// `WIKI_DB`/`WIKICTL` visible. nil for sessions that don't
     /// need them (none today — every launcher call site sets it).
@@ -85,6 +99,7 @@ public struct BackendProfile: Sendable {
         providerHints: [String: String] = [:],
         scratchDirectory: URL? = nil,
         isReadOnly: Bool = false,
+        executionAccess: AgentExecutionAccess = .standard,
         cli: CLIProfile? = nil,
         debugLogURL: URL? = nil
     ) {
@@ -92,6 +107,7 @@ public struct BackendProfile: Sendable {
         self.providerHints = providerHints
         self.scratchDirectory = scratchDirectory
         self.isReadOnly = isReadOnly
+        self.executionAccess = executionAccess
         self.cli = cli
         self.debugLogURL = debugLogURL
     }

--- a/Sources/WikiFSEngine/AgentLauncher.swift
+++ b/Sources/WikiFSEngine/AgentLauncher.swift
@@ -1178,6 +1178,10 @@ public final class AgentLauncher {
         // own per-phase resolution in `runACPIngestPlannerExecutors`.
         let stageKey = Self.stageKey(for: request)
         let policy: PermissionPolicy = resolvePermissionMode(permissionKind)
+        let executionAccess: AgentExecutionAccess = switch permissionKind {
+        case .ingest, .lint: .fullAccess
+        case .chat: .standard
+        }
         // #606: chat is interactive (unbounded — the UI chip is the release
         // valve); ingest/lint are unattended and MUST auto-reject so a stuck
         // permission can't burn the 1800s ceiling.
@@ -1274,6 +1278,7 @@ public final class AgentLauncher {
                     providerHints: [:],
                     scratchDirectory: scratch,
                     isReadOnly: false,
+                    executionAccess: executionAccess,
                     cli: CLIProfile(
                         operation: operation,
                         wikiRoot: wikiRoot,
@@ -1394,6 +1399,7 @@ public final class AgentLauncher {
             providerHints: providerHints,
             scratchDirectory: scratch,
             isReadOnly: false,
+            executionAccess: executionAccess,
             cli: cli,
             debugLogURL: debugFolderURL)
 
@@ -1789,6 +1795,7 @@ public final class AgentLauncher {
             providerHints: executorHints,
             scratchDirectory: scratch,
             isReadOnly: false,
+            executionAccess: .fullAccess,
             cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
         let maxConcurrent = await (backend as? ACPBackend)?.maxConcurrentExecutorCount() ?? 1
 
@@ -2283,6 +2290,7 @@ public final class AgentLauncher {
                 providerHints: hints,
                 scratchDirectory: phaseScratch,
                 isReadOnly: false,
+                executionAccess: .fullAccess,
                 cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
 
             let prompt = buildPrompt(provider)
@@ -2517,6 +2525,7 @@ public final class AgentLauncher {
             providerHints: providerHints,
             scratchDirectory: scratch,
             isReadOnly: false,
+            executionAccess: .fullAccess,
             cli: makeCLIProfile(operation), debugLogURL: debugFolderURL)
         var promptText = operation.prompt(wikiRoot: wikiRoot)
         promptText += "\n\nIMPORTANT: Do NOT dispatch sub-agents, background tasks, or async agents. Do NOT use sleep or ScheduleWakeup. Read all sources, process them, and write all wiki pages directly in THIS session — everything must complete before you stop."

--- a/Tests/WikiFSAppTests/ACPBackendTests.swift
+++ b/Tests/WikiFSAppTests/ACPBackendTests.swift
@@ -22,6 +22,69 @@ import ACPModel
 /// `session/prompt` completion — ACP has no turn-end *notification*).
 @Suite struct ACPBackendTests {
 
+    // MARK: - Execution access
+
+    /// Queued mutation workflows must request the ACP agent's advertised
+    /// full-access mode before their first tool call. This is separate from
+    /// the app's ACP permission policy, which keeps its own audit trail.
+    @Test func fullAccessSelectsAdvertisedBypassPermissionsMode() {
+        let options = [
+            SessionConfigOption(
+                id: SessionConfigId("mode"),
+                name: "Mode",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("default"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("default"), name: "Default"),
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("bypassPermissions"), name: "Full access"),
+                    ]))))
+        ]
+
+        #expect(
+            ACPExecutionAccessResolver.configuration(
+                for: .fullAccess,
+                options: options
+            ) == ACPConfigOptionApplication(
+                configID: "mode",
+                value: "bypassPermissions"
+            )
+        )
+    }
+
+    @Test func standardAccessDoesNotChangeAgentMode() {
+        let options = [
+            SessionConfigOption(
+                id: SessionConfigId("mode"),
+                name: "Mode",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("default"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("bypassPermissions"), name: "Full access"),
+                    ]))))
+        ]
+
+        #expect(ACPExecutionAccessResolver.configuration(for: .standard, options: options) == nil)
+    }
+
+    @Test func fullAccessDoesNotGuessAnUnsupportedAgentMode() {
+        let options = [
+            SessionConfigOption(
+                id: SessionConfigId("mode"),
+                name: "Mode",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("default"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("default"), name: "Default"),
+                    ]))))
+        ]
+
+        #expect(ACPExecutionAccessResolver.configuration(for: .fullAccess, options: options) == nil)
+    }
+
     // MARK: - Event translator
 
     /// A streamed agent prose chunk maps to `.assistantTextDelta` (the launcher

--- a/Tests/WikiFSAppTests/ACPIngestPlanTests.swift
+++ b/Tests/WikiFSAppTests/ACPIngestPlanTests.swift
@@ -609,6 +609,7 @@ struct ACPIngestCollapsedRoutingTests {
 
         let profiles = await fake.startedProfiles
         #expect(profiles.count == 4)
+        #expect(profiles.allSatisfy { $0.executionAccess == .fullAccess })
         let firstExecutor = try #require(ACPBackend.resolveSpawnConfig(from: profiles[1]))
         let secondExecutor = try #require(ACPBackend.resolveSpawnConfig(from: profiles[2]))
         #expect(firstExecutor.environment["WIKI_INGEST_SOURCE_IDS"] == "a,b")


### PR DESCRIPTION
Fixes https://github.com/tqbf/selfdrivingwiki/issues/1033

## What changed
- Added `AgentExecutionAccess` to `BackendProfile` so the launcher can distinguish standard chat sessions from mutation-style workflows that are allowed to run with the agent's advertised full-access mode.
- Wired `AgentLauncher` to request `.fullAccess` for ingest and lint flows, while keeping chat sessions on `.standard`.
- Added `ACPExecutionAccessResolver` to safely map that intent onto a provider-advertised ACP session config option only when the backend exposes a supported `mode=bypassPermissions` choice.
- Updated `ACPBackend` so resumed or newly created ACP sessions apply the access mode before the first tool call.
- Added tests covering the resolver behavior and verifying ingest executor profiles are launched with full access.

## Why
Some workflows need the ACP agent to operate with its advertised bypass-permissions mode before any tools run, but we should only do that when the provider explicitly supports it. This keeps the access change deliberate, avoids guessing at provider-specific config values, and preserves the existing separation between app-side permission policy and the agent's own session mode.