### PR TITLE
Phase 5: Verify typed queue transcripts

### DIFF
--- a/Sources/WikiFSCore/Core/AgentEvent.swift
+++ b/Sources/WikiFSCore/Core/AgentEvent.swift
@@ -114,8 +114,9 @@ public enum AgentEvent: Equatable, Sendable, Codable {
     case toolUse(name: String, inputSummary: String)
 
     /// A tool finished (`user` message → `tool_result` content block). `summary` is
-    /// the (possibly truncated) result text; `isError` flags a failed tool.
-    case toolResult(isError: Bool, summary: String)
+    /// the optional, possibly truncated result text; `isError` flags a failed tool.
+    /// A terminal provider update can intentionally have no renderable output.
+    case toolResult(isError: Bool, summary: String?)
 
     /// A subagent delegation lifecycle event (`{"type":"system",
     /// "subtype":"task_started" | "task_completed"}`), emitted when the Opus curator
@@ -176,6 +177,7 @@ public enum AgentEvent: Equatable, Sendable, Codable {
         case .toolUse(let name, let inputSummary):
             return inputSummary.isEmpty ? name : "\(name)  \(inputSummary)"
         case .toolResult(let isError, let summary):
+            guard let summary else { return "" }
             let body = summary.isEmpty ? (isError ? "(error)" : "(ok)") : summary
             return isError ? "Error: \(body)" : body
         case .subagent(let subagentType, let description, let isCompletion):

--- a/Sources/WikiFSCore/Core/ChatQuoteResolver.swift
+++ b/Sources/WikiFSCore/Core/ChatQuoteResolver.swift
@@ -45,7 +45,7 @@ public enum ChatQuoteResolver {
         case .toolUse(let name, let summary):
             return summary.isEmpty ? name : "\(name) \(summary)"
         case .toolResult(_, let summary):
-            return summary
+            return summary ?? ""
         case .systemInit, .subagent, .assistantTextDelta, .thinking, .thinkingDelta, .messageStop, .raw:
             return ""
         case .turnFailed(let reason):

--- a/Sources/WikiFSCore/Core/ChatTranscriptRenderer.swift
+++ b/Sources/WikiFSCore/Core/ChatTranscriptRenderer.swift
@@ -49,6 +49,7 @@ public enum ChatTranscriptRenderer {
             let body = inputSummary.isEmpty ? name : "\(name) — \(inputSummary)"
             return ("Tool Use", body)
         case .toolResult(let isError, let summary):
+            guard let summary else { return ("", "") }
             let body = summary.isEmpty ? (isError ? "(error)" : "(ok)") : summary
             return ("Tool Result", isError ? "⚠️ \(body)" : body)
         case .subagent(let subagentType, let description, let isCompletion):

--- a/Sources/WikiFSEngine/ACPPermissions.swift
+++ b/Sources/WikiFSEngine/ACPPermissions.swift
@@ -108,7 +108,8 @@ enum ToolCallRendering {
 /// - `toolCall` / `toolCallUpdate` → `.toolUse` (start) / `.toolResult` (done).
 ///   ACP folds a tool's whole lifecycle into status updates (`pending` →
 ///   `in_progress` → `completed`/`failed`); we map the *call* to `.toolUse` and
-///   a `completed`/`failed` status (with output text) to `.toolResult`.
+///   every `completed`/`failed` status to `.toolResult`, carrying output only
+///   when ACP supplied renderable text.
 /// - everything else (`plan`, `usage_update`, `current_mode_update`, …) → `[]`
 ///   (not rendered, same as `AgentEventParser`'s unmodeled types).
 ///
@@ -152,14 +153,14 @@ struct ACPEventTranslator: Sendable {
             return [.toolUse(name: Self.toolName(for: call), inputSummary: Self.toolSummary(for: call))]
 
         case .toolCallUpdate(let details):
-            // A status patch for an existing tool call. Only a terminal status
-            // (completed/failed) with output text is rendered — as `.toolResult`.
-            if let status = details.status, status == .completed || status == .failed,
-               let output = Self.toolOutput(for: details), !output.isEmpty {
-                return [.toolResult(isError: status == .failed, summary: output)]
+            // A terminal status always closes its matching tool row. Renderable
+            // output is optional: absent or whitespace-only provider output
+            // remains nil instead of becoming synthesized transcript text.
+            if let status = details.status, status == .completed || status == .failed {
+                return [.toolResult(isError: status == .failed, summary: Self.toolOutput(for: details))]
             }
-            // Non-terminal / output-less updates: not rendered (a pending or
-            // in_progress status carries nothing new for the transcript).
+            // Non-terminal updates are not transcript rows, even if they carry
+            // output; only completed/failed updates close a tool lifecycle.
             return []
 
         case .plan, .planUpdate, .planRemoved,
@@ -195,13 +196,38 @@ struct ACPEventTranslator: Sendable {
     }
 
     /// Extract a tool's output text (the `.toolResult` body) from a
-    /// `tool_call_update`. ACP tool output lives in `content`
-    /// (`[ToolCallContent]`) — flatten text/diff blocks to a string.
+    /// `tool_call_update`. Prefer rendered ACP `content` (`[ToolCallContent]`),
+    /// then accept only a nonempty string `rawOutput` or approved structured
+    /// output fields from agents that omit it. The exact trimmed provider marker
+    /// `"(no output)"` means semantic absence, not user-visible transcript text.
     private static func toolOutput(for details: ToolCallUpdateDetails) -> String? {
-        guard let content = details.content else { return nil }
-        return content.compactMap { $0.displayText }
+        let renderedContent = details.content?.compactMap { $0.displayText }
             .joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let renderedContent, !renderedContent.isEmpty {
+            return Self.normalizedTerminalOutput(renderedContent)
+        }
+
+        let rawOutput: String?
+        if let value = details.rawOutput?.value as? String {
+            rawOutput = value
+        } else if let value = details.rawOutput?.value as? [String: any Sendable] {
+            rawOutput = (value["formatted_output"] as? String)
+                ?? (value["output"] as? String)
+                ?? ((value["metadata"] as? [String: any Sendable])?["output"] as? String)
+        } else {
+            rawOutput = nil
+        }
+        guard let rawOutput else { return nil }
+        return Self.normalizedTerminalOutput(rawOutput)
+    }
+
+    /// Normalizes only ACP's canonical no-output marker. Other provider text is
+    /// preserved byte-for-byte apart from the established edge trimming.
+    private static func normalizedTerminalOutput(_ output: String) -> String? {
+        let trimmedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedOutput.isEmpty, trimmedOutput != "(no output)" else { return nil }
+        return trimmedOutput
     }
 }
 

--- a/Sources/WikiFSEngine/ACPPermissions.swift
+++ b/Sources/WikiFSEngine/ACPPermissions.swift
@@ -201,25 +201,20 @@ struct ACPEventTranslator: Sendable {
     /// output fields from agents that omit it. The exact trimmed provider marker
     /// `"(no output)"` means semantic absence, not user-visible transcript text.
     private static func toolOutput(for details: ToolCallUpdateDetails) -> String? {
-        let renderedContent = details.content?.compactMap { $0.displayText }
-            .joined(separator: "\n")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if let renderedContent, !renderedContent.isEmpty {
-            return Self.normalizedTerminalOutput(renderedContent)
+        var candidates: [String?] = [
+            details.content?.compactMap { $0.displayText }.joined(separator: "\n"),
+        ]
+        if let value = details.rawOutput?.value as? String {
+            candidates.append(value)
+        } else if let value = details.rawOutput?.value as? [String: any Sendable] {
+            candidates.append(value["formatted_output"] as? String)
+            candidates.append(value["output"] as? String)
+            candidates.append((value["metadata"] as? [String: any Sendable])?["output"] as? String)
         }
 
-        let rawOutput: String?
-        if let value = details.rawOutput?.value as? String {
-            rawOutput = value
-        } else if let value = details.rawOutput?.value as? [String: any Sendable] {
-            rawOutput = (value["formatted_output"] as? String)
-                ?? (value["output"] as? String)
-                ?? ((value["metadata"] as? [String: any Sendable])?["output"] as? String)
-        } else {
-            rawOutput = nil
-        }
-        guard let rawOutput else { return nil }
-        return Self.normalizedTerminalOutput(rawOutput)
+        return candidates.lazy.compactMap { candidate in
+            candidate.flatMap(Self.normalizedTerminalOutput)
+        }.first
     }
 
     /// Normalizes only ACP's canonical no-output marker. Other provider text is

--- a/Tests/WikiFSAppTests/ACPBackendTests.swift
+++ b/Tests/WikiFSAppTests/ACPBackendTests.swift
@@ -150,15 +150,278 @@ import ACPModel
         #expect(events == [.toolResult(isError: true, summary: "permission denied")])
     }
 
-    /// Non-terminal tool statuses (pending/in_progress) carry nothing new for
-    /// the transcript — they produce no event.
-    @Test func pendingToolCallUpdateEmitsNothing() {
+    @Test func completedToolCallUpdateFallsBackToStringRawOutput() {
         let translator = ACPEventTranslator()
         let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
-            toolCallId: "tc1",
-            status: .inProgress
+            toolCallId: "tc-raw-completed",
+            status: .completed,
+            rawOutput: AnyCodable("1 file changed")
         ))
-        #expect(translator.translate(update) == [])
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "1 file changed")])
+    }
+
+    @Test func failedToolCallUpdateFallsBackToStringRawOutput() {
+        let translator = ACPEventTranslator()
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-raw-failed",
+            status: .failed,
+            rawOutput: AnyCodable("permission denied")
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: true, summary: "permission denied")])
+    }
+
+    @Test func completedToolCallUpdateFallsBackToFormattedStructuredRawOutput() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = [
+            "exit_code": 0,
+            "formatted_output": "1 file changed",
+        ]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-structured-completed",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "1 file changed")])
+    }
+
+    @Test func completedToolCallUpdateFallsBackToStructuredOutputField() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = ["output": "1 file changed"]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-structured-output",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "1 file changed")])
+    }
+
+    @Test func failedToolCallUpdateFallsBackToFormattedStructuredRawOutput() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = [
+            "exit_code": 1,
+            "formatted_output": "permission denied",
+        ]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-structured-failed",
+            status: .failed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: true, summary: "permission denied")])
+    }
+
+    @Test func decodedStructuredRawOutputFallsBackToFormattedOutput() throws {
+        let update = try JSONDecoder().decode(SessionUpdate.self, from: Data("""
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-decoded-structured-completed",
+          "status": "completed",
+          "rawOutput": {
+            "exit_code": 0,
+            "formatted_output": "decoded output"
+          }
+        }
+        """.utf8))
+
+        #expect(ACPEventTranslator().translate(update) == [
+            .toolResult(isError: false, summary: "decoded output")
+        ])
+    }
+
+    @Test func toolCallUpdatePrefersRenderedContentOverRawOutput() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = [
+            "exit_code": 0,
+            "formatted_output": "raw output",
+        ]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-content-precedence",
+            status: .completed,
+            content: [.content(.text(TextContent(text: "rendered output")))],
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "rendered output")])
+    }
+
+    @Test func canonicalNoOutputRenderedContentEmitsNilWithoutRawFallback() {
+        let translator = ACPEventTranslator()
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-content-no-output",
+            status: .completed,
+            content: [.content(.text(TextContent(text: " \n(no output)\t")))],
+            rawOutput: AnyCodable("must not replace preferred absence")
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func canonicalNoOutputStringRawOutputEmitsNilResult() {
+        let translator = ACPEventTranslator()
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-string-no-output",
+            status: .failed,
+            rawOutput: AnyCodable(" (no output) \n")
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: true, summary: nil)])
+    }
+
+    @Test func canonicalNoOutputFormattedStructuredRawOutputEmitsNilResult() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = ["formatted_output": "(no output)"]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-formatted-no-output",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func decodedTrueRunWireShapeNormalizesCanonicalNoOutput() throws {
+        let update = try JSONDecoder().decode(SessionUpdate.self, from: Data("""
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "call_J1COgO0IV74GkKvxlETvUl5J",
+          "status": "completed",
+          "title": "true",
+          "content": [{
+            "type": "content",
+            "content": { "type": "text", "text": "(no output)" }
+          }],
+          "rawOutput": {
+            "metadata": { "exit": 0, "output": "(no output)", "truncated": false },
+            "output": "(no output)"
+          }
+        }
+        """.utf8))
+
+        #expect(ACPEventTranslator().translate(update) == [
+            .toolResult(isError: false, summary: nil)
+        ])
+    }
+
+    @Test func canonicalNoOutputMetadataRawOutputEmitsNilResult() {
+        let translator = ACPEventTranslator()
+        let metadata: [String: any Sendable] = ["output": "(no output)"]
+        let rawOutput: [String: any Sendable] = ["metadata": metadata]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-metadata-no-output",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func whitespaceOnlyRenderedContentFallsBackToFormattedRawOutput() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = ["formatted_output": "raw fallback"]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-content-whitespace-fallback",
+            status: .completed,
+            content: [.content(.text(TextContent(text: " \n\t ")))],
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "raw fallback")])
+    }
+
+    @Test func terminalArbitraryRawOutputArrayEmitsNilResult() {
+        let translator = ACPEventTranslator()
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-raw-array",
+            status: .completed,
+            rawOutput: AnyCodable(["not", "rendered"])
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func completedToolCallUpdateWithWhitespaceOnlyRawOutputEmitsNilResult() {
+        let translator = ACPEventTranslator()
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-raw-whitespace",
+            status: .completed,
+            rawOutput: AnyCodable(" \n\t ")
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func completedToolCallUpdateWithMissingFormattedRawOutputEmitsNilResult() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = ["exit_code": 0]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-structured-missing-output",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func completedToolCallUpdateWithWhitespaceOnlyFormattedRawOutputEmitsNilResult() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = [
+            "exit_code": 0,
+            "formatted_output": " \n\t ",
+        ]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-structured-whitespace-output",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func decodedCompletedToolCallUpdateWithoutOutputEmitsNilResult() throws {
+        let update = try JSONDecoder().decode(SessionUpdate.self, from: Data("""
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-decoded-nil-completed",
+          "status": "completed"
+        }
+        """.utf8))
+
+        #expect(ACPEventTranslator().translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func decodedFailedToolCallUpdateWithoutOutputEmitsNilResult() throws {
+        let update = try JSONDecoder().decode(SessionUpdate.self, from: Data("""
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-decoded-nil-failed",
+          "status": "failed"
+        }
+        """.utf8))
+
+        #expect(ACPEventTranslator().translate(update) == [.toolResult(isError: true, summary: nil)])
+    }
+
+    /// Non-terminal tool statuses (pending/in_progress) carry nothing new for
+    /// the transcript — they produce no event.
+    @Test func pendingAndInProgressToolCallUpdatesEmitNothing() {
+        let translator = ACPEventTranslator()
+        let pending = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-pending",
+            status: .pending,
+            rawOutput: AnyCodable("must not terminate a tool")
+        ))
+        let inProgress = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-in-progress",
+            status: .inProgress,
+            rawOutput: AnyCodable("must not terminate a tool")
+        ))
+
+        #expect(translator.translate(pending) == [])
+        #expect(translator.translate(inProgress) == [])
     }
 
     /// Unmodeled update types (plan, usage, mode, …) produce no event — same

--- a/Tests/WikiFSAppTests/ACPBackendTests.swift
+++ b/Tests/WikiFSAppTests/ACPBackendTests.swift
@@ -248,16 +248,16 @@ import ACPModel
         #expect(translator.translate(update) == [.toolResult(isError: false, summary: "rendered output")])
     }
 
-    @Test func canonicalNoOutputRenderedContentEmitsNilWithoutRawFallback() {
+    @Test func canonicalNoOutputRenderedContentFallsBackToRawOutput() {
         let translator = ACPEventTranslator()
         let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
             toolCallId: "tc-content-no-output",
             status: .completed,
             content: [.content(.text(TextContent(text: " \n(no output)\t")))],
-            rawOutput: AnyCodable("must not replace preferred absence")
+            rawOutput: AnyCodable("raw fallback")
         ))
 
-        #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "raw fallback")])
     }
 
     @Test func canonicalNoOutputStringRawOutputEmitsNilResult() {
@@ -379,6 +379,52 @@ import ACPModel
         ))
 
         #expect(translator.translate(update) == [.toolResult(isError: false, summary: nil)])
+    }
+
+    @Test func whitespaceFormattedRawOutputFallsBackToOutput() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = [
+            "formatted_output": " \n\t ",
+            "output": "fallback output",
+        ]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-formatted-whitespace-fallback",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "fallback output")])
+    }
+
+    @Test func emptyStructuredOutputFallsBackToMetadataOutput() {
+        let translator = ACPEventTranslator()
+        let metadata: [String: any Sendable] = ["output": "metadata fallback"]
+        let rawOutput: [String: any Sendable] = [
+            "output": "",
+            "metadata": metadata,
+        ]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-output-empty-fallback",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "metadata fallback")])
+    }
+
+    @Test func canonicalNoOutputFormattedRawOutputFallsBackToOutput() {
+        let translator = ACPEventTranslator()
+        let rawOutput: [String: any Sendable] = [
+            "formatted_output": "(no output)",
+            "output": "fallback output",
+        ]
+        let update = SessionUpdate.toolCallUpdate(ToolCallUpdateDetails(
+            toolCallId: "tc-formatted-marker-fallback",
+            status: .completed,
+            rawOutput: AnyCodable(rawOutput)
+        ))
+
+        #expect(translator.translate(update) == [.toolResult(isError: false, summary: "fallback output")])
     }
 
     @Test func decodedCompletedToolCallUpdateWithoutOutputEmitsNilResult() throws {

--- a/Tests/WikiFSAppTests/AgentEventParserTests.swift
+++ b/Tests/WikiFSAppTests/AgentEventParserTests.swift
@@ -248,8 +248,12 @@ struct AgentEventParserTests {
         #expect(AgentEvent.toolResult(isError: false, summary: "done").plainText == "done")
     }
 
-    @Test func plainTextToolResultError() {
+    @Test func plainTextToolResultErrorPreservesLegacyEmptySummaryRendering() {
         #expect(AgentEvent.toolResult(isError: true, summary: "").plainText == "Error: (error)")
+    }
+
+    @Test func nilToolResultHasNoSyntheticPlainText() {
+        #expect(AgentEvent.toolResult(isError: true, summary: nil).plainText.isEmpty)
     }
 
     @Test func plainTextSubagentStart() {

--- a/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
@@ -56,6 +56,26 @@ struct ChatTranscriptPresentationTests {
         #expect(toolHTML.contains("◌"))
     }
 
+    @Test func completedToolWithoutOutputShowsNoSyntheticResultText() {
+        let tool = ChatDisplayRow.toolCall(
+            id: ToolCallID(rawValue: "tool-no-output"),
+            turnID: turnID,
+            toolName: "Bash",
+            status: .completed,
+            detail: nil,
+            output: nil,
+            permissionRequestID: nil,
+            updatedAt: .distantPast
+        )
+
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(tool)
+
+        #expect(html.contains("Tool Bash, Completed"))
+        #expect(!html.contains("(ok)"))
+        #expect(!html.contains("(error)"))
+        #expect(!html.contains("chat-tool-detail"))
+    }
+
     @Test(arguments: [
         ("```console\nfile changed\n```", "file changed"),
         ("```json\n{\"ok\":true}\n```", "{\"ok\":true}"),

--- a/Tests/WikiFSTests/AgentEventCodableTests.swift
+++ b/Tests/WikiFSTests/AgentEventCodableTests.swift
@@ -55,6 +55,19 @@ import Foundation
         #expect(try roundTrip(event) == event)
     }
 
+    @Test func nilToolResultRoundTripsWithoutSyntheticSummary() throws {
+        let event = AgentEvent.toolResult(isError: false, summary: nil)
+        #expect(try roundTrip(event) == event)
+    }
+
+    @Test func existingNonemptyToolResultPayloadDecodes() throws {
+        let data = Data(#"{"toolResult":{"isError":true,"summary":"command not found"}}"#.utf8)
+        #expect(try JSONDecoder().decode(AgentEvent.self, from: data) == .toolResult(
+            isError: true,
+            summary: "command not found"
+        ))
+    }
+
     @Test func subagentRoundTrips() throws {
         let event = AgentEvent.subagent(
             subagentType: "source-reader", description: "Digest pages 1-20", isCompletion: false)

--- a/Tests/WikiFSTests/AgentEventTranscriptTranslatorTests.swift
+++ b/Tests/WikiFSTests/AgentEventTranscriptTranslatorTests.swift
@@ -79,6 +79,29 @@ struct AgentEventTranscriptTranslatorTests {
         #expect(toolCalls.map(\.status) == [.completed, .failed])
     }
 
+    @Test func nilToolResultsCloseMatchingFIFOCallsWithoutOutput() {
+        let turnID = ChatTurnID(rawValue: "turn-tool-fifo-nil-output")
+        var translator = AgentEventTranscriptTranslator()
+        let deltas = translator.translate([
+            .toolUse(name: "Read", inputSummary: "first.md"),
+            .toolUse(name: "Edit", inputSummary: "second.md"),
+            .toolResult(isError: false, summary: nil),
+            .toolResult(isError: true, summary: nil),
+        ], turnID: turnID)
+        let toolCalls = ChatTranscriptReducer.reducing(items: [], with: deltas).compactMap { item -> ChatTranscriptToolCallItem? in
+            guard case .toolCall(let toolCall) = item else { return nil }
+            return toolCall
+        }
+
+        #expect(toolCalls.map(\.toolCallID) == [
+            ToolCallID(rawValue: "\(turnID.rawValue)-tool-0"),
+            ToolCallID(rawValue: "\(turnID.rawValue)-tool-1"),
+        ])
+        #expect(toolCalls.map(\.detail) == ["first.md", "second.md"])
+        #expect(toolCalls.map(\.status) == [.completed, .failed])
+        #expect(toolCalls.allSatisfy { $0.output == nil })
+    }
+
     @Test func unmatchedToolResultPreservesTheLegacyFallbackIdentity() {
         let turnID = ChatTurnID(rawValue: "turn-tool-fallback")
         var translator = AgentEventTranscriptTranslator()

--- a/Tests/WikiFSTests/ChatQuoteResolverTests.swift
+++ b/Tests/WikiFSTests/ChatQuoteResolverTests.swift
@@ -128,4 +128,8 @@ struct ChatQuoteResolverTests {
         #expect(ChatQuoteResolver.searchableText(.assistantTextDelta("x")).isEmpty)
         #expect(ChatQuoteResolver.searchableText(.messageStop).isEmpty)
     }
+
+    @Test func searchableTextForNilToolResultIsEmpty() {
+        #expect(ChatQuoteResolver.searchableText(.toolResult(isError: false, summary: nil)).isEmpty)
+    }
 }

--- a/Tests/WikiFSTests/ChatTranscriptRendererTests.swift
+++ b/Tests/WikiFSTests/ChatTranscriptRendererTests.swift
@@ -87,6 +87,15 @@ import WikiFSCore
         #expect(rendered.contains("done") == true)
     }
 
+    @Test func skipsNilToolResultWithoutSynthesizingOutput() {
+        let rendered = ChatTranscriptRenderer.render(
+            summary: summary(),
+            messages: [message(.toolResult(isError: false, summary: nil))])
+        #expect(rendered.contains("## Tool Result") == false)
+        #expect(rendered.contains("(ok)") == false)
+        #expect(rendered.contains("(error)") == false)
+    }
+
     @Test func rendersResultSection() {
         let rendered = ChatTranscriptRenderer.render(
             summary: summary(),

--- a/Tests/WikiFSTests/QueueStoreTypedTranscriptTests.swift
+++ b/Tests/WikiFSTests/QueueStoreTypedTranscriptTests.swift
@@ -54,6 +54,35 @@ struct QueueStoreTypedTranscriptTests {
         #expect(try reopened.loadTranscriptItems(itemID: itemID) == expected)
     }
 
+    @Test func nilToolOutputSurvivesDatabaseReopen() throws {
+        let url = try temporaryDatabaseURL()
+        let itemID: QueueItem.ID
+        let expected = ChatTranscriptItem.toolCall(ChatTranscriptToolCallItem(
+            toolCallID: ToolCallID(rawValue: "nil-output-tool"),
+            turnID: ChatTurnID(rawValue: "nil-output-turn"),
+            toolName: "Bash",
+            status: .completed,
+            detail: "echo hello",
+            output: nil,
+            permissionRequestID: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        ))
+
+        do {
+            let store = try QueueStore(databaseURL: url)
+            let item = try enqueueItem(in: store)
+            itemID = item.id
+            try store.upsertTranscriptItems(
+                attemptID: QueueAttemptID(itemID: item.id, attempt: item.attempt),
+                items: [expected]
+            )
+            store.close()
+        }
+
+        let reopened = try QueueStore(databaseURL: url)
+        #expect(try reopened.loadTranscriptItems(itemID: itemID) == [expected])
+    }
+
     @Test func retryClearRemovesOnlyTheSelectedItemTranscript() throws {
         let store = try QueueStore(databaseURL: try temporaryDatabaseURL())
         let selectedItem = try enqueueItem(in: store)

--- a/plans/typed-queue-transcripts.md
+++ b/plans/typed-queue-transcripts.md
@@ -595,6 +595,14 @@ rows; the hosted progress-fallback test covers their presentation path. The
 restarted signed helper listed four existing chats. This is sufficient live
 evidence for the typed queue Activity surface under the operator decision.
 
+**Exact-head audit correction (2026-08-01):** Normalize every ACP terminal
+output candidate before applying precedence. Whitespace-only text and the exact
+canonical `"(no output)"` marker now fall through to later valid candidates in
+this order: rendered content, string `rawOutput`, `formatted_output`, `output`,
+and `metadata.output`. Only string values participate. Focused Swift Testing
+covers whitespace and marker fall-through, existing valid precedence, and
+nil-output quote and transcript rendering without synthetic text.
+
 ## Acceptance Criteria
 
 ### TQT.AC1: Data reset safety

--- a/plans/typed-queue-transcripts.md
+++ b/plans/typed-queue-transcripts.md
@@ -428,6 +428,173 @@ live agent run and one restored transcript in the signed or development app.
 Update this plan with implementation evidence. Add a progress entry after the
 feature passes all gates.
 
+**Verification record (2026-08-01T06:30:17-07:00):** `make build`, all named
+focused suites, and `make test` passed on the Phase 4 parent
+`df9d165d501726941b8b0e773f295ab038e8706f`; the full suite reported 3,013
+tests in 247 suites. `make lint`, `make check`, and `git diff --check` also
+passed. The signed application and its bundled `wikid` service were started
+through `make run`. With the authorized Luna-backed lint-stage model
+(`codex-auto-review[high]`), the Page Detail "Lint" action created and
+completed item `01KYYR9BJ4MP4SWA5X0D2FQ04J`. The Activity window rendered the
+live typed reasoning, assistant, and Bash tool rows; durable typed storage has
+eleven ordered rows with stable tagged identities. Existing chat history
+remained available through `wikictl` (two conversations).
+
+The live transcript scenario is **not yet passed**. The real ACP debug stream
+contains three `tool_call` and four terminal `tool_call_update` events, but its
+terminal updates use `rawOutput` with no `content`. `ACPEventTranslator` only
+maps terminal updates that have nonempty `content`, so every durable tool row
+remains `running` after completion. This prevents an honest pass for tool
+call/result coalescing, restored transcript fidelity, Copy parity, and the
+progress-only fallback. The Activity window close was exercised, but do not add
+a progress entry or claim the remaining live checks pass until the ACP
+translation path handles this valid terminal output shape.
+
+**Follow-up record (2026-08-01T08:02:00-07:00):** The authorized narrow ACP
+correction now prefers nonempty rendered `content`, then accepts only a trimmed
+string `rawOutput` or a trimmed string `rawOutput.formatted_output` from a
+decoded object. It neither stringifies arbitrary objects or arrays nor changes
+terminal status handling. `ACPBackendTests` covers completed and failed
+structured outputs, content precedence, and missing or whitespace-only
+`formatted_output`; the focused and full automated gates passed after the
+change.
+
+The signed app and daemon were restarted from the corrected build. The earlier
+Luna item `01KYYX05PD5PZTEHD81SFB66NE` is `completed` and has 19 durable
+`queue_item_transcript_items` rows, but it predates the correction and contains
+only message and tool-call rows. It therefore cannot demonstrate formatted
+tool-result rendering. With the signed app focused, the documented `Command-I`
+control was sent once. It returned successfully, but exposed only the two main
+app windows; the accessibility provider denied the Activity-window tree with
+`accessibility_permission_denied`. No other user-facing Activity control is
+enumerable in this environment. This prevents starting and inspecting the fresh
+corrected Luna run, reopening Activity after close, copy parity, visible
+restoration, and the progress-only fallback. These live gates remain **not
+passed**. Preserve the workspace; do not add a progress entry, commit, push, or
+open a PR until an operator can provide access to that existing Activity
+control or another supported verification path.
+
+**Follow-up record (2026-08-01T09:24:28-07:00):** The approved terminal-output
+contract is implemented on parent `df9d165d501726941b8b0e773f295ab038e8706f`.
+`AgentEvent.toolResult.summary` is optional and retains synthesized Codable
+compatibility for existing nonempty summaries. Every ACP `completed` or
+`failed` tool update now emits one terminal result. Its summary is, in order,
+nonempty rendered `content`, a nonempty string `rawOutput`, a nonempty string
+`rawOutput.formatted_output`, or `nil`. Pending and in-progress updates remain
+absent. FIFO translation passes `nil` to typed `output` without changing row
+identity, detail, status, ordering, storage, or XPC contracts; nil output has
+no synthetic plain-text or legacy-transcript rendering. Focused Swift Testing
+covers decoded nil completed/failed updates, whitespace, precedence, arbitrary
+array rejection, FIFO identity/detail/status, Codable compatibility,
+persistence/reopen, and presentation. `make build`, all named focused commands
+(the unprefixed `QueueEngineClientConformanceTests` command selected zero tests;
+its required app-enabled equivalent passed four), `make test` (3,017 tests in
+247 suites), `make lint`, `make check`, and `git diff --check` passed.
+
+The signed app and bundled daemon ran fresh Luna lint item
+`01KYZ1S2HC0EVT5ZKG37111WY4`. Activity showed streamed reasoning and assistant
+rows, five stable tool identities, completed tool cards, and the real readonly
+SQLite failure as a failed output. The elevated retry completed and persisted
+the lint record; [issue #1033](https://github.com/tqbf/selfdrivingwiki/issues/1033)
+tracks granting that authorized lint write access on the first attempt. Durable
+storage contains 15 typed rows and five tool rows for this attempt, with one
+row per identity. This run did not emit a terminal ACP update without output,
+so it cannot live-demonstrate the new nil-output transition; the prior
+output-less Luna item remains persisted as `running` because it predates the
+translation correction. Activity close was exercised, but Command-I did not
+reopen it through Accessibility, and the supported restart attempt was
+interrupted before completion. Copy parity and the progress-only fallback were
+not run; existing chat history was previously verified through `wikictl`.
+These live gates remain **not passed**. Do not add a progress entry, commit,
+push, or open a PR until they have concrete evidence.
+
+**Follow-up record (2026-08-01T09:35:00-07:00):** A fresh signed-app chat was
+started after selecting the existing OpenCode Luna operation profile. Its user
+request was: “Run the shell command `true` exactly once. Do not describe the
+command result; complete after it succeeds.” The live Chat view showed one
+existing Bash tool card in `Running` for queue item
+`01KYZ2SAK3RKFJ2TEB0PKXHS6C` and tool-call identity
+`call_J1COgO0IV74GkKvxlETvUl5J`. Its authoritative ACP debug trace then emitted
+one terminal `completed` update, but it was not output-less: `content` was the
+nonempty rendered text `"(no output)"`, and `rawOutput` was an object whose
+`output` and `metadata.output` carried the same text (with exit `0`). This is
+therefore an output-bearing provider response, not the `content`-absent and
+`rawOutput`-null/empty terminal shape required to prove the nil-output path.
+Do not treat it as that evidence. The requested no-output live gate, including
+its typed-row transition, Activity restoration, and copy check, remains **not
+passed**; preserve the workspace and do not publish a partial PR.
+
+**Follow-up record (2026-08-01T09:58:13-07:00):** The operator approved
+normalizing ACP's exact trimmed `"(no output)"` marker as semantic absence. The
+translator now returns `nil` for that marker when it is the preferred rendered
+content, a string `rawOutput`, `rawOutput.formatted_output`,
+`rawOutput.output`, or `rawOutput.metadata.output`; it preserves every other
+nonempty string, does not stringify arbitrary values, and leaves terminal
+status and FIFO identity unchanged. `ACPBackendTests` includes the exact
+decoded `true` wire payload and the approved fallback shapes; 64 tests passed.
+
+After rebuilding and restarting the signed app, fresh Luna chat item
+`01KYZ42XDESR4NRNAR5NXMW3QT` again ran `true`. Its trace emitted terminal
+`completed` update `call_UUpQxIrUWDaMsugSznUU4rsx` with the canonical marker in
+rendered content and both observed structured raw-output fields. The same
+visible Bash card had first appeared as `Running`, but remained `Running` after
+the terminal event and a bounded 30-second observation. This interactive chat
+also has no `queue_item_transcript_items` rows, so it cannot establish the
+queue Activity typed-storage/restoration/copy gates. These live gates remain
+**not passed**; do not add a progress entry, commit, push, or open a PR.
+
+**Automated follow-up (2026-08-01T10:01:25-07:00):** The marker-normalization
+change passed `make build`; `ACPBackendTests` (64),
+`AgentEventTranscriptTranslatorTests` (12), `QueueStoreTypedTranscriptTests`
+(9), `QueueStoreTypedTranscriptMigrationTests` (2),
+`QueueTranscriptConcurrencyTests` (8), `QueueEventEnvelopeTests` (11),
+`WikiDaemonWorkloadHostTests` (12, app-enabled), and
+`ChatPresentationAPIManifestTests` (10, app-enabled). The plan's unprefixed
+`QueueEngineClientConformanceTests` invocation completed successfully but
+selected zero app tests; its app-enabled equivalent passed all four tests.
+`make test` passed 3,017 tests in 247 suites. `make lint` found zero
+violations and zero serious findings in 436 files, `make check` compiled the
+debug target, and `git diff --check` passed. These automated results do not
+replace the unresolved live Activity gate above.
+
+**Queue-path follow-up (2026-08-01T10:08:44-07:00):** The supported Page
+Detail **Lint** control started fresh Luna queue item
+`01KYZ4GJK9MXEJ5M54X1TVJJ06` for `Interface Tour`, and its real Activity
+window showed streamed reasoning and typed Read file, Bash, Editing files, and
+search cards with completed and failed terminal states. Its authoritative ACP
+trace contains 16 terminal `tool_call_update` events, but no occurrence of the
+canonical `"(no output)"` marker in `content` or `rawOutput`; the normal lint
+agent did not invoke a no-output tool. This is not evidence for the marker to
+nil transition, one-row nil persistence, restoration, or copy parity. Per the
+bounded live-verification rule, do not substitute this output-bearing run for
+that evidence, retry another queue item, add a progress entry, commit, push,
+or open a partial Phase 5 PR.
+
+**Final verification decision (2026-08-01T10:14:36-07:00):** The operator
+accepted the real queued lint run as the live Activity evidence and does not
+require Luna to reproduce its rare canonical `"(no output)"` marker on demand.
+The marker-to-`nil` contract remains covered by the captured, decoded real-wire
+fixtures in `ACPBackendTests` and by translation, persistence, and presentation
+tests; this plan does not claim a live nil-output row. The completed queue item
+has 33 durable typed rows: 17 messages and 16 tool rows, with 14 completed and
+two failed terminal states. The Activity view showed those terminal cards, and
+its Copy assistant response command placed 213 bytes on the clipboard,
+including the same visible `Corrected sidebar search guidance to include
+Chats.` and `Added the Chats search-bar detail.` bullets. It did not copy the
+marker.
+
+`make run` rebuilt, signed, copied, and restarted the app and bundled daemon;
+the same 33 durable rows were then read from `queue.sqlite`. Closing Activity
+succeeded. A bounded documented `Command-I` reopening attempt after the close
+and restart did not surface an Activity window through Accessibility, so this
+is recorded as a control-automation limitation rather than a claimed visual
+reopen. The current queue database retains progress-only items
+`01KY6DQGVGGBTEV5P97M2DB0SD` (753-byte progress log) and
+`01KY6D55V3Z56WMHB1A80MWYXN` (84-byte progress log) without typed transcript
+rows; the hosted progress-fallback test covers their presentation path. The
+restarted signed helper listed four existing chats. This is sufficient live
+evidence for the typed queue Activity surface under the operator decision.
+
 ## Acceptance Criteria
 
 ### TQT.AC1: Data reset safety

--- a/progress/2026-08-01T171436Z-typed-queue-transcripts-phase5.md
+++ b/progress/2026-08-01T171436Z-typed-queue-transcripts-phase5.md
@@ -1,0 +1,51 @@
+---
+timestamp: 2026-08-01T10:14:36-07:00
+title: Typed Queue Transcripts Phase 5
+branch: feature/typed-queue-transcripts-phase5
+status: complete
+---
+
+# Typed Queue Transcripts Phase 5
+
+Phase 5 completes verification and documents the terminal ACP output policy.
+ACP terminal tool updates now preserve the provider's status and matching tool
+identity when output is absent. Nonempty rendered content remains preferred;
+the only structured fallback is a string `formatted_output`, `output`, or
+`metadata.output`. The exact trimmed provider marker `(no output)` means no
+output. Other objects and arrays are not serialized.
+
+## Progress
+
+- Made `AgentEvent.toolResult.summary` optional and carried `nil` through the
+  shared translator and typed transcript output without synthetic text.
+- Added ACP, Codable, FIFO translation, persistence/reopen, and presentation
+  coverage for terminal nil output, marker normalization, output precedence,
+  whitespace, and arbitrary structured output rejection.
+- Ran signed Luna lint item `01KYZ4GJK9MXEJ5M54X1TVJJ06` through the supported
+  Page Detail Lint action. Activity rendered its streaming typed rows and 16
+  terminal tool cards; durable storage contains 33 rows with stable identities.
+- The real queue trace contains zero canonical `(no output)` markers. The
+  exact marker-to-nil behavior is verified by decoded real-wire fixtures, not
+  claimed as a live queue observation.
+
+## Verification
+
+- The Activity Copy assistant response command copied the visible assistant
+  bullets exactly; no marker text was copied.
+- `make run` rebuilt, signed, and restarted the application and bundled daemon.
+  The queue's 33 typed rows remained durable. The documented Command-I Activity
+  reopen did not surface a window through Accessibility after close/restart;
+  this is an automation limitation, not a visual-reopen claim.
+- The queue database retains progress-only items without transcript rows; the
+  hosted progress-fallback suite covers that presentation path. `wikictl chat
+  list --json` after restart returned four existing conversations.
+- Full focused, build, test, lint, check, and diff verification is recorded in
+  `plans/typed-queue-transcripts.md` and rerun at the final Phase 5 head.
+
+## Review
+
+The terminal normalization is pure `Sendable` translation with no new shared
+state, tasks, actors, or UI architecture. The SwiftUI and macOS review found no
+new presentation structure: typed rows, copy, and progress fallback keep using
+the existing canonical Activity projection. Swift Testing coverage uses
+deterministic decoded provider updates and explicit output precedence.

--- a/progress/2026-08-01T175513Z-typed-queue-transcripts-phase5.md
+++ b/progress/2026-08-01T175513Z-typed-queue-transcripts-phase5.md
@@ -1,5 +1,5 @@
 ---
-timestamp: 2026-08-01T10:14:36-07:00
+timestamp: 2026-08-01T10:55:13-07:00
 title: Typed Queue Transcripts Phase 5
 branch: feature/typed-queue-transcripts-phase5
 status: complete
@@ -27,6 +27,10 @@ output. Other objects and arrays are not serialized.
 - The real queue trace contains zero canonical `(no output)` markers. The
   exact marker-to-nil behavior is verified by decoded real-wire fixtures, not
   claimed as a live queue observation.
+- Exact-head audit correction: normalize each approved ACP candidate before
+  precedence selection so whitespace and the exact marker fall through to a
+  later valid string. Added direct nil-rendering tests for the quote resolver
+  and transcript renderer.
 
 ## Verification
 
@@ -41,6 +45,11 @@ output. Other objects and arrays are not serialized.
   list --json` after restart returned four existing conversations.
 - Full focused, build, test, lint, check, and diff verification is recorded in
   `plans/typed-queue-transcripts.md` and rerun at the final Phase 5 head.
+- Corrective verification passed: `make build`; ACP (67), translator (12),
+  typed store (9), migration (2), concurrency (8), app-enabled conformance
+  (4), envelope (11), daemon host (12), presentation manifest (10), quote
+  resolver (18), and transcript renderer (12); `make test` passed 3,019 tests
+  in 247 suites; `make lint`, `make check`, and `git diff --check` passed.
 
 ## Review
 


### PR DESCRIPTION
## Stack metadata

- Parent branch: `feature/typed-queue-transcripts-phase4`
- Base branch: `feature/typed-queue-transcripts-phase4`
- Exact parent SHA: `df9d165d501726941b8b0e773f295ab038e8706f`
- Phase 5 head: `f2427e170c21b912057bf4b92f03aa2ab5c27a25`
- Stack order: `Phase5 > Phase4 > Phase3 > Phase2 > main`
- Dependency: Phase 4 PR #1027 is the immediate lower-stack PR. Operators merge
  bottom-up: Phase 2 PR #1024, Phase 3 PR #1025, Phase 4 PR #1027, then this PR.

## Change

Complete the typed queue transcript verification slice and normalize terminal
ACP tool output without synthesizing provider text. Terminal `completed` and
`failed` tool updates now close their matching FIFO tool row even when output
is absent. Rendered content remains preferred, followed by approved string
raw-output fields; the exact trimmed `(no output)` marker becomes nil output.
Arbitrary objects and arrays are not serialized.

Exact-head audit correction: each candidate is normalized before precedence
selection. Whitespace and the exact canonical marker fall through to later
approved string candidates; direct nil quote-rendering tests preserve the
absence-of-synthetic-output contract.

## Verification

- `make build` passed and produced a signed app bundle.
- Focused suites passed: `AgentEventTranscriptTranslatorTests` (12),
  `QueueStoreTypedTranscriptTests` (9),
  `QueueStoreTypedTranscriptMigrationTests` (2),
  `QueueTranscriptConcurrencyTests` (8), `QueueEventEnvelopeTests` (11),
  app-enabled `QueueEngineClientConformanceTests` (4),
  `WikiDaemonWorkloadHostTests` (12),
  `ChatPresentationAPIManifestTests` (10), `ACPBackendTests` (67),
  `ChatQuoteResolverTests` (18), and `ChatTranscriptRendererTests` (12).
  The plan's unprefixed `QueueEngineClientConformanceTests` command passed but
  selected zero app tests; the app-enabled form above supplies the intended
  coverage.
- `make test` passed: 3,019 tests in 247 suites.
- `make lint` found 0 violations and 0 serious findings in 436 files.
- `make check` passed. `git diff --check` passed.

## Live verification

- Signed Luna queue lint item `01KYZ4GJK9MXEJ5M54X1TVJJ06` was started via the
  supported Page Detail Lint action. Activity rendered streaming typed rows and
  16 terminal tool cards (14 completed, 2 failed); durable storage contains 33
  typed rows with stable identities.
- The Activity copy command placed 213 bytes on the clipboard, including the
  visible assistant bullets. No `(no output)` text was copied.
- `make run` rebuilt, signed, and restarted the app and bundled daemon; the 33
  typed rows remained durable. The current database retains progress-only rows,
  and the restarted helper listed four existing chats.
- This fresh queue trace contained zero canonical `(no output)` markers. The
  marker-to-nil contract is covered by decoded real-wire ACP fixtures and
  focused translation/persistence/presentation tests; this PR does not claim a
  live nil-output row. A bounded Command-I Activity-reopen attempt did not
  surface a window through Accessibility after close/restart; this is recorded
  as a control-automation limitation and was not retried.

## Review

Swift concurrency review found no new shared state, task, actor, or SQLite
boundary. SwiftUI/macOS review found no presentation-architecture change.
Swift Testing review found deterministic coverage for terminal status,
precedence, nil output, FIFO identity, persistence, and presentation.
