### PR TITLE
test(queue): guard engine merge tests on Linux

### DIFF
--- a/Tests/WikiFSTests/QueueTranscriptCanonicalMergeTests.swift
+++ b/Tests/WikiFSTests/QueueTranscriptCanonicalMergeTests.swift
@@ -1,3 +1,4 @@
+#if canImport(WikiFSEngine)
 import Foundation
 import Testing
 @testable import WikiFSEngine
@@ -59,3 +60,4 @@ struct QueueTranscriptCanonicalMergeTests {
         ))
     }
 }
+#endif

--- a/Tests/WikiFSTests/QueueTranscriptConcurrencyTests.swift
+++ b/Tests/WikiFSTests/QueueTranscriptConcurrencyTests.swift
@@ -1,3 +1,4 @@
+#if canImport(WikiFSEngine)
 import Foundation
 import Testing
 @testable import WikiFSEngine
@@ -282,3 +283,4 @@ private final class AsyncSignal: @unchecked Sendable {
         }
     }
 }
+#endif


### PR DESCRIPTION
## Parent main

`73a41e69192765f68e528195381489b707f25ac8`

## Head

`76dded08ded66454c0acc1a28dfb54b79ec4ddaf`

## Scope

- Guard `QueueTranscriptCanonicalMergeTests` with `#if canImport(WikiFSEngine)`.
- Guard `QueueTranscriptConcurrencyTests` with `#if canImport(WikiFSEngine)`.
- Keep the four macOS engine merge tests unchanged.
- Keep the eight macOS engine concurrency tests unchanged.
- Exclude both engine-dependent test files from the Linux portable target.
- Sweep `Tests/WikiFSTests` for analogous imports. No other unguarded import exists.

## Stack state

- Parent main already contains the typed queue transcript Phase 5 ACP, test, and progress content after the historical SHA rewrite.
- This corrective PR does not replay or change Phase 1 through Phase 5 work.

## Root cause

`WikiFSCoreTests` receives `WikiFSEngine` only on macOS. The unguarded test import caused the Linux portable build to fail.

## Verification

- `swift test --filter QueueTranscriptCanonicalMergeTests` passed with 4 tests.
- `swift test --filter QueueTranscriptConcurrencyTests` passed with 8 tests.
- `make build`, `make test`, `make lint`, `make check`, and `git diff --check` passed.
- `make test` passed 3,019 tests in 247 suites.
- The local Docker daemon was unavailable, so the exact Linux build will run in this PR's `linux-swift` job.

## Required audit

- Require a fresh Terra exact-head audit at `76dded08ded66454c0acc1a28dfb54b79ec4ddaf`.
- The prior Terra audit covered `ff6c89e1c53882185f8123a9988053f7d3312187` only.
