### PR TITLE
Fix reasoning row layout in chat transcript web view

### DIFF
--- a/Sources/WikiFS/Chats/ChatWebView.swift
+++ b/Sources/WikiFS/Chats/ChatWebView.swift
@@ -859,7 +859,9 @@ struct ChatWebView: NSViewRepresentable {
           }
           /* Thinking rows: dimmed + italic, visually subordinate to the
              conversation (issue #391). */
-          .row-thinking { font-size: 11.5px; color: var(--muted); margin: 0 0 8px; }
+          .chat-row.row-thinking {
+            display: block; font-size: 11.5px; color: var(--muted); margin: 0 0 8px;
+          }
           .row-thinking > summary { font-style: italic; }
           .row-thinking-label { font-weight: 600; color: var(--muted); }
           .row-thinking-preview { opacity: 0.7; }

--- a/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
@@ -204,6 +204,53 @@ struct ChatTranscriptHostedTests {
         #expect(state == "head_version_id: 01KX94Y|true|block")
     }
 
+    @Test func hostedExpandedReasoningRowsPlaceTheirBodyBelowTheSummary() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        _ = Self.app
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = webView
+        window.orderFront(nil)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
+
+        await NavigationWaiter().load(ChatWebView.Coordinator.shellHTML, in: webView)
+        let reasoning = ChatDisplayRow.reasoning(
+            id: ChatMessageID(rawValue: "reasoning-hosted"),
+            turnID: ChatTurnID(rawValue: "turn-hosted-reasoning"),
+            text: "Read file '/tmp/WIKI_STATE.md'", createdAt: .distantPast,
+            contentState: .final
+        )
+        let html = ChatWebView.Coordinator.chatDisplayRowHTML(reasoning)
+        let data = try JSONSerialization.data(withJSONObject: html, options: [.fragmentsAllowed])
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        let acknowledgement = await webView.chatTranscriptJavaScriptResult(
+            "appendChatRows(\(json), false, 72, \"message-reasoning-hosted\")"
+        )
+        #expect(acknowledgementField("outcome", in: acknowledgement) == "success")
+
+        let state = await evaluateJavaScriptWithTimeout(webView, """
+            (function(){
+                var details=document.querySelector("[data-row-id='message-reasoning-hosted']");
+                var summary=details.querySelector('summary');
+                var body=details.querySelector('.row-thinking-body');
+                details.open=true;
+                return [
+                    String(body.getBoundingClientRect().top > summary.getBoundingClientRect().top),
+                    getComputedStyle(details).display
+                ].join('|');
+            })()
+            """)
+
+        #expect(state == "true|block")
+    }
+
     private func acknowledgementField<T>(
         _ field: String,
         in result: ChatTranscriptJavaScriptResult

--- a/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptPresentationTests.swift
@@ -187,6 +187,7 @@ struct ChatTranscriptPresentationTests {
         #expect(shell.contains("selectionOffsets"))
         #expect(shell.contains("isNearBottom"))
         #expect(shell.contains(".chat-tool {\n    display: block"))
+        #expect(shell.contains(".chat-row.row-thinking {\n    display: block"))
         #expect(shell.contains(".chat-tool > summary {\n    display: flex"))
     }
 }


### PR DESCRIPTION
## What changed
- Updated the chat transcript CSS so expanded thinking/reasoning rows use the full `.chat-row.row-thinking` selector and render as block-level elements.
- Added hosted integration coverage to verify that an expanded reasoning row places its body below the summary when rendered in `WKWebView`.
- Extended the presentation test to assert that the generated shell HTML includes the new thinking-row rule.

## Why
- The previous selector only targeted `.row-thinking`, which was too broad and did not reliably enforce the intended layout for chat rows.
- Using the more specific selector makes the thinking rows behave consistently with the rest of the transcript structure, preventing the body from collapsing into the summary layout.
- The new tests lock in both the generated HTML and the live hosted rendering so this regression is caught at both layers.