### PR TITLE
Bundle prompt resources into the wikid XPC service

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -338,10 +338,9 @@ fi
 
 # SwiftPM module resources — the prompt .md files loaded at runtime via
 # GeneratedPrompts in PromptLoader. Without these, the File Provider extension
-# CRASHES on changeToken() → systemPromptVersion → SystemPrompt.defaultBody →
-# Bundle.module → fatalError, which kills the extension process, breaks ALL
-# getUserVisibleURL calls ("Couldn't communicate with a helper application"),
-# and silently disables Share / Reveal in Finder.
+# CRASHES on changeToken() / a daemon prompt request → SystemPrompt.defaultBody
+# → Bundle.module → fatalError. That kills the File Provider extension or the
+# wikid XPC service, breaking Finder actions or queue work respectively.
 #
 # We copy the Prompts/ directory directly into Contents/Resources/ (NOT the
 # .bundle at the bundle root) because codesign rejects unsealed contents at
@@ -350,10 +349,11 @@ fi
 # (which works in the SwiftPM .build context).
 SPM_RESOURCE_BUNDLE="${BIN_DIR}/WikiFS_WikiFSCore.bundle"
 if [ -d "${SPM_RESOURCE_BUNDLE}/Prompts" ]; then
-  mkdir -p "${APPEX_CONTENTS}/Resources"
+  mkdir -p "${APPEX_CONTENTS}/Resources" "${DAEMON_XPC_CONTENTS}/Resources"
   cp -R "${SPM_RESOURCE_BUNDLE}/Prompts" "${RESOURCES_DIR}/"
   cp -R "${SPM_RESOURCE_BUNDLE}/Prompts" "${APPEX_CONTENTS}/Resources/"
-  echo "  ✓ bundled prompt resources into app + extension"
+  cp -R "${SPM_RESOURCE_BUNDLE}/Prompts" "${DAEMON_XPC_CONTENTS}/Resources/"
+  echo "  ✓ bundled prompt resources into app + extension + wikid XPC service"
 else
   echo "  ⚠ SwiftPM resource bundle not found at ${SPM_RESOURCE_BUNDLE}" >&2
   echo "    Run 'make prompts' then rebuild. Prompt loading will crash at runtime." >&2


### PR DESCRIPTION
## Summary
- Copy SwiftPM prompt resources into the wikid XPC service bundle during `build.sh`
- Expand the build log message and comments to reflect all three runtime consumers: the app, File Provider extension, and wikid XPC service

## Why
Prompt loading currently depends on `Bundle.module` at runtime. If the prompt resources are missing, the File Provider extension or the daemon can crash when resolving the default system prompt, which in turn breaks Finder actions or queue processing. Bundling the prompts into the wikid XPC service closes that gap so all prompt-backed runtimes have the resources they need.

## Details
- Ensure `Contents/Resources` exists for both the extension and the XPC service
- Copy `Prompts/` into the app bundle resources, the extension bundle resources, and the wikid XPC service resources
- Update the build output text to match the broader packaging behavior