### PR TITLE
Support advertised full-access ACP mode values

### DIFF
--- a/Sources/WikiFSEngine/ACPExecutionAccessResolver.swift
+++ b/Sources/WikiFSEngine/ACPExecutionAccessResolver.swift
@@ -14,7 +14,10 @@ struct ACPConfigOptionApplication: Equatable, Sendable {
 /// mutation workflows. This never guesses at provider-specific config values.
 enum ACPExecutionAccessResolver {
     private static let modeConfigID = "mode"
-    private static let fullAccessValue = "bypassPermissions"
+    /// Exact provider-advertised values that authorize the agent's full-access
+    /// session mode. Providers must advertise one of these IDs; mode labels are
+    /// presentation text and are deliberately never used for authorization.
+    private static let fullAccessValues = ["bypassPermissions", "agent-full-access"]
 
     static func configuration(
         for access: AgentExecutionAccess,
@@ -22,9 +25,14 @@ enum ACPExecutionAccessResolver {
     ) -> ACPConfigOptionApplication? {
         guard access == .fullAccess,
               let modeOption = options.first(where: { $0.id.value == modeConfigID }),
-              case .select(let select) = modeOption.kind,
-              select.currentValue.value != fullAccessValue,
-              ACPModelSelectionResolver.configOptionValues(from: select.options).contains(fullAccessValue)
+              case .select(let select) = modeOption.kind
+        else {
+            return nil
+        }
+
+        let advertisedValues = Set(ACPModelSelectionResolver.configOptionValues(from: select.options))
+        guard let fullAccessValue = fullAccessValues.first(where: { advertisedValues.contains($0) }),
+              select.currentValue.value != fullAccessValue
         else {
             return nil
         }

--- a/Tests/WikiFSAppTests/ACPBackendTests.swift
+++ b/Tests/WikiFSAppTests/ACPBackendTests.swift
@@ -53,6 +53,34 @@ import ACPModel
         )
     }
 
+    @Test func fullAccessSelectsAdvertisedAgentFullAccessMode() {
+        let options = [
+            SessionConfigOption(
+                id: SessionConfigId("mode"),
+                name: "Mode",
+                kind: .select(SessionConfigSelect(
+                    currentValue: SessionConfigValueId("agent"),
+                    options: .ungrouped([
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("read-only"), name: "Read-only"),
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("agent"), name: "Agent"),
+                        SessionConfigSelectOption(
+                            value: SessionConfigValueId("agent-full-access"), name: "Agent (full access)"),
+                    ]))))
+        ]
+
+        #expect(
+            ACPExecutionAccessResolver.configuration(
+                for: .fullAccess,
+                options: options
+            ) == ACPConfigOptionApplication(
+                configID: "mode",
+                value: "agent-full-access"
+            )
+        )
+    }
+
     @Test func standardAccessDoesNotChangeAgentMode() {
         let options = [
             SessionConfigOption(


### PR DESCRIPTION
## Summary
- Update `ACPExecutionAccessResolver` to recognize both provider-advertised full-access mode IDs: `bypassPermissions` and `agent-full-access`.
- Keep authorization tied to the exact advertised value instead of the human-readable mode label.
- Add a regression test covering selection of `agent-full-access` when full access is requested.

## Why
Some ACP backends expose full-access mode under `agent-full-access` rather than `bypassPermissions`. This change makes the resolver accept either provider-defined value while preserving the existing rule that only advertised config values can be used for authorization.

## Testing
- Added a focused backend test for the `agent-full-access` full-access case.