### PR TITLE
Document /graphify allowance for read-only branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 Last verified: 2026-07-27
 
+* Running `/graphify` is always permitted, including from read-only branches or other read-only repository states, when `tmp/graphify-out` is specified as the output directory.
+
 * **All Swift code must compile via SwiftPM from the command line — prefer
   `make build` / `make test` as the default entrypoints, and ensure bare
   `swift build` / `swift test` also work when used directly. Never rely on


### PR DESCRIPTION
## Summary
- Added an explicit AGENTS.md note that `/graphify` is permitted even in read-only branch states when the output is written to `tmp/graphify-out`.

## Why
- This removes ambiguity for agents operating in restricted or read-only repository states and makes the existing exception easy to discover.
- The note preserves the documented workflow without changing any runtime behavior.