### PR TITLE
Add duplicate URL detection for source intake

### DIFF
--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -114,6 +114,8 @@ public enum ArgumentParser {
                                               rewrite the curated index.md body;
                                               --workspace W stages into workspace W
       source list [--json]                    list sources (TSV, or JSON lines)
+      source add --url URL [--allow-duplicate]
+                                              fetch and add a URL source
       source cat  (--id X | --name N) [--markdown]
                                               write raw source bytes (or extracted markdown
                                               with --markdown) to stdout
@@ -320,9 +322,14 @@ public enum ArgumentParser {
         let rest = Array(args.dropFirst())
         // `--markdown` applies to `cat` and `export`; include it here so the
         // outer parse doesn't reject it as a value flag needing an argument.
-        let options = try Options(rest, booleanFlags: ["--json", "--markdown"])
+        let options = try Options(rest, booleanFlags: ["--json", "--markdown", "--allow-duplicate"])
 
         switch sub {
+        case "add":
+            guard let url = options.value("--url") else {
+                throw Failure.usage("source add: --url is required")
+            }
+            return .source(.addURL(url, allowDuplicateURL: options.flag("--allow-duplicate")))
         case "list":
             return .source(.list(json: options.flag("--json")))
 

--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -38,6 +38,7 @@ public enum SourceCommand {
     }
 
     public enum Action: Equatable {
+        case addURL(String, allowDuplicateURL: Bool)
         case list(json: Bool)
         case cat(Selector, markdown: Bool)
         case export(Selector, out: String?, markdown: Bool)
@@ -75,6 +76,8 @@ public enum SourceCommand {
         bm25Leg: [SourceSummary]? = nil
     ) throws -> Result {
         switch action {
+        case .addURL:
+            throw Failure.message("source add requires async execution")
         case .list(let json):
             return try list(in: store, json: json)
         case .cat(let selector, let markdown):
@@ -97,6 +100,35 @@ public enum SourceCommand {
             // This case is unreachable through the sync `run` path.
             throw Failure.message("source refresh requires async execution")
         }
+    }
+
+    /// Add a website source from a URL for non-interactive callers. The URL
+    /// identity check happens before materialization so a duplicate performs no
+    /// network request unless the caller explicitly supplies --allow-duplicate.
+    public static func runAddURL(
+        _ rawInput: String,
+        allowDuplicateURL: Bool,
+        in store: WikiStore,
+        fetcher: any URLFetchService.URLResourceFetcher
+    ) async throws -> Result {
+        guard let identity = URLFetchService.urlIdentity(rawInput) else {
+            throw Failure.message("invalid URL: \(rawInput)")
+        }
+        if !allowDuplicateURL, let existing = try store.sourceMatchingURLIdentity(identity) {
+            throw Failure.message(
+                "URL already added as \(existing.effectiveName) (\(existing.id.rawValue)); use --allow-duplicate to add another source")
+        }
+        let (material, _) = try await WebsiteMaterializer(rawInput: rawInput, fetcher: fetcher)
+            .materializeWithPlan()
+        let summary = try store.addSource(
+            filename: material.filename, data: material.data,
+            zoteroItemKey: material.zoteroItemKey, zoteroItemTitle: material.zoteroItemTitle,
+            mimeType: material.mimeType, provenance: material.provenance,
+            role: .primary, originalPath: nil, activityID: nil,
+            resolvedDisplayName: nil)
+        return Result(
+            payload: .text("Added \(summary.effectiveName) (\(summary.id.rawValue))."),
+            didCommit: true)
     }
 
     // MARK: - list

--- a/Sources/WikiFS/Sources/AddFromURLSheet.swift
+++ b/Sources/WikiFS/Sources/AddFromURLSheet.swift
@@ -35,6 +35,7 @@ struct AddFromURLSheet: View {
         case idle
         case fetching
         case failed(String)
+        case duplicate(SourceSummary)
     }
 
     var body: some View {
@@ -75,6 +76,7 @@ struct AddFromURLSheet: View {
             .onChange(of: urlText) {
                 // Clear a stale error as soon as the user edits the URL.
                 if case .failed = phase { phase = .idle }
+                if case .duplicate = phase { phase = .idle }
             }
     }
 
@@ -95,6 +97,15 @@ struct AddFromURLSheet: View {
                     .font(.callout)
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
+            case .duplicate(let source):
+                VStack(alignment: .leading, spacing: 6) {
+                    Label("Already added as \(source.effectiveName)", systemImage: "exclamationmark.triangle.fill")
+                        .font(.callout)
+                        .foregroundStyle(.orange)
+                    Text("Open the existing source, cancel, or explicitly add another copy.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             case .idle:
                 Color.clear.frame(height: 0)
             }
@@ -112,6 +123,7 @@ struct AddFromURLSheet: View {
         case .idle: return 0
         case .fetching: return Metrics.statusRowHeight
         case .failed: return Metrics.errorRowHeight
+        case .duplicate: return Metrics.duplicateRowHeight
         }
     }
 
@@ -123,10 +135,19 @@ struct AddFromURLSheet: View {
             Button("Cancel") { dismiss() }
                 .keyboardShortcut(.cancelAction)
                 .disabled(isFetching)
+            if case .duplicate(let source) = phase {
+                Button("Open Existing") {
+                    store.openTab(.source(source.id), title: source.effectiveName)
+                    dismiss()
+                }
+                Button("Add Anyway") { fetch(allowDuplicateURL: true) }
+                    .buttonStyle(.borderedProminent)
+            } else {
             Button("Fetch") { fetch() }
                 .keyboardShortcut(.defaultAction)
                 .buttonStyle(.borderedProminent)
                 .disabled(!canFetch)
+            }
         }
     }
 
@@ -150,15 +171,17 @@ struct AddFromURLSheet: View {
 
     // MARK: - Action
 
-    private func fetch() {
+    private func fetch(allowDuplicateURL: Bool = false) {
         // Read the field fresh at click time (§3.5), not a captured-early copy.
         let input = urlText
         guard URLFetchService.normalizeURL(input) != nil else { return }
         phase = .fetching
         Task {
             do {
-                _ = try await store.addURL(input)
+                _ = try await store.addURL(input, allowDuplicateURL: allowDuplicateURL)
                 dismiss()  // success: the new file is already in store.sources
+            } catch WikiStoreError.duplicateURL(let existing) {
+                phase = .duplicate(existing)
             } catch {
                 let message = (error as? URLFetchService.FetchError)?.errorDescription
                     ?? error.localizedDescription
@@ -174,5 +197,6 @@ struct AddFromURLSheet: View {
         static let sectionSpacing: CGFloat = 14
         static let statusRowHeight: CGFloat = 22
         static let errorRowHeight: CGFloat = 44
+        static let duplicateRowHeight: CGFloat = 54
     }
 }

--- a/Sources/WikiFSCore/Integrations/URLFetchService.swift
+++ b/Sources/WikiFSCore/Integrations/URLFetchService.swift
@@ -117,10 +117,26 @@ public struct URLFetchService {
             withScheme = "https://" + trimmed
         }
         guard let url = URL(string: withScheme),
-              let scheme = url.scheme, scheme == "http" || scheme == "https",
+              let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https",
               url.host?.isEmpty == false
         else { return nil }
         return url
+    }
+
+    /// A stable identity for URL-source provenance. This deliberately preserves
+    /// paths, query strings, ports, and trailing slashes: those can identify
+    /// different resources. Fragments are client-side navigation only and are
+    /// therefore ignored. Use this for duplicate-source checks, not for fetches.
+    public static func urlIdentity(_ raw: String) -> String? {
+        guard let normalizedURL = normalizeURL(raw),
+              var components = URLComponents(url: normalizedURL, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host?.lowercased()
+        else { return nil }
+        components.scheme = scheme
+        components.host = host
+        components.fragment = nil
+        return components.url?.absoluteString
     }
 
     /// Fetch `rawInput`, dispatch by content type, and store the result in the

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -4187,6 +4187,31 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    public func sourceMatchingURLIdentity(_ identity: String) throws -> SourceSummary? {
+        try dbWriter.read { db in
+            let rows = try Row.fetchAll(db, sql: """
+            SELECT s.id, s.filename, s.ext, s.mime_type, s.byte_size,
+                   s.created_at, s.updated_at, s.version,
+                   s.zotero_item_key, s.zotero_item_title, s.display_name, s.role,
+                   a.plan, a.external_ref, sv.external_identity
+            FROM sources s
+            JOIN refs r ON r.kind = 'source-content' AND r.owner_id = s.id
+            JOIN source_versions sv ON sv.id = r.version_id
+            LEFT JOIN activities a ON a.id = sv.activity_id
+            ORDER BY s.updated_at DESC;
+            """)
+            for row in rows {
+                let candidates: [String?] = [
+                    row["plan"], row["external_ref"], row["external_identity"],
+                ]
+                if candidates.contains(where: { URLFetchService.urlIdentity($0 ?? "") == identity }) {
+                    return try Self.readSourceSummary(from: row)
+                }
+            }
+            return nil
+        }
+    }
+
     /// The full edit history for a source — every `source_versions` row joined
     /// to its `activities` → `agents` (the source-side mirror of
     /// `pageEditHistory`). Ordered NEWEST-FIRST (the provenance panel renders

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -19,6 +19,10 @@ public enum WikiStoreError: Error, CustomStringConvertible {
     /// row so callers can reference it (e.g. "already added as <name>") instead
     /// of just reporting a bare failure.
     case duplicateContent(existing: SourceSummary)
+    /// Thrown before URL materialization when an active source already records
+    /// the same normalized URL provenance. This remains distinct from content
+    /// hash deduplication, which happens only after bytes are available.
+    case duplicateURL(existing: SourceSummary)
 
     public var description: String {
         switch self {
@@ -35,6 +39,8 @@ public enum WikiStoreError: Error, CustomStringConvertible {
         case .unexpected(let m): return "Unexpected: \(m)"
         case .duplicateContent(let existing):
             return "Duplicate content: already stored as \(existing.effectiveName) (\(existing.id.rawValue))"
+        case .duplicateURL(let existing):
+            return "Duplicate URL: already stored as \(existing.effectiveName) (\(existing.id.rawValue))"
         }
     }
 }
@@ -290,6 +296,10 @@ public protocol WikiStore: Sendable {
     /// website sources with different URLs each return their own URL); `agentName`
     /// from the **agent** row.
     func sourceOrigin(sourceID: SourceID) throws -> SourceOrigin?
+
+    /// Find an active source whose URL provenance has the given canonical
+    /// identity. The identity is produced by `URLFetchService.urlIdentity(_:)`.
+    func sourceMatchingURLIdentity(_ identity: String) throws -> SourceSummary?
 
     /// The full edit history for a source — every `source_versions` row joined
     /// to its `activities` → `agents` (the source-side mirror of

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2211,14 +2211,17 @@ public final class WikiStoreModel {
     public func addURL(
         _ rawInput: String,
         fetcher: any URLFetchService.URLResourceFetcher = URLSessionFetcher(),
-        youtubeFetcher: (any YouTubeTranscriptFetching)?? = nil
+        youtubeFetcher: (any YouTubeTranscriptFetching)?? = nil,
+        allowDuplicateURL: Bool = false
     ) async throws -> URLFetchService.FetchOutcome {
+        try rejectExistingURL(rawInput, allowDuplicateURL: allowDuplicateURL)
         #if PODCAST_TRANSCRIPTS
         // Delegate to the podcast-aware overload so routing is in one place.
         return try await addURL(
             rawInput, fetcher: fetcher,
             podcastFetcher: ApplePodcastTranscriptService.bundled(),
-            youtubeFetcher: youtubeFetcher ?? YouTubeTranscriptService())
+            youtubeFetcher: youtubeFetcher ?? YouTubeTranscriptService(),
+            allowDuplicateURL: true)
         #else
         // Phase 5b: byteless external-embed media (YouTube/Vimeo/Spotify/
         // SoundCloud/remote-media) routes uniformly through `bytelessMediaOutcome`,
@@ -2251,8 +2254,10 @@ public final class WikiStoreModel {
         _ rawInput: String,
         fetcher: any URLFetchService.URLResourceFetcher,
         podcastFetcher: (any PodcastTranscriptFetching)?,
-        youtubeFetcher: (any YouTubeTranscriptFetching)? = nil
+        youtubeFetcher: (any YouTubeTranscriptFetching)? = nil,
+        allowDuplicateURL: Bool = false
     ) async throws -> URLFetchService.FetchOutcome {
+        try rejectExistingURL(rawInput, allowDuplicateURL: allowDuplicateURL)
         // An Apple Podcasts EPISODE link is recognized before the generic web
         // fetch: its HTML is the useless player page, so we route to the
         // byteless-embed pipeline instead. The pageURL is re-normalized from
@@ -2326,6 +2331,17 @@ public final class WikiStoreModel {
         return try await addURLViaWebsite(rawInput, fetcher: fetcher)
     }
     #endif
+
+    /// Guard URL intake before any provider routing or network work. Invalid
+    /// input remains the fetch service's responsibility so callers retain its
+    /// existing user-facing validation error.
+    private func rejectExistingURL(_ rawInput: String, allowDuplicateURL: Bool) throws {
+        guard !allowDuplicateURL,
+              let identity = URLFetchService.urlIdentity(rawInput),
+              let existing = try store.sourceMatchingURLIdentity(identity)
+        else { return }
+        throw WikiStoreError.duplicateURL(existing: existing)
+    }
 
     /// **Generic RSS-feed podcast intake** (podcast-generalize, M3): a dedicated
     /// entry point for pasting a direct RSS feed URL. Bypasses the generic

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -178,6 +178,11 @@ func execute(
         let r = try LogIndexCommand.run(.indexSet(body: body, workspace: workspace), in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
     case .source(let action):
+        if case .addURL(let rawInput, let allowDuplicateURL) = action {
+            return try await SourceCommand.runAddURL(
+                rawInput, allowDuplicateURL: allowDuplicateURL,
+                in: store, fetcher: URLSessionFetcher())
+        }
         if case .refresh(let selector) = action {
             return try await SourceCommand.runRefresh(
                 selector,

--- a/Tests/WikiFSTests/URLFetchServiceTests.swift
+++ b/Tests/WikiFSTests/URLFetchServiceTests.swift
@@ -307,6 +307,17 @@ struct URLFetchServiceTests {
         #expect(URLFetchService.normalizeURL("ftp://a.com") == nil)  // unsupported scheme
     }
 
+    @Test func urlIdentityNormalizesAuthorityAndDropsFragmentOnly() {
+        #expect(URLFetchService.urlIdentity(" HTTPS://EXAMPLE.com/Path?x=1#section ")
+            == "https://example.com/Path?x=1")
+        #expect(URLFetchService.urlIdentity("example.com/Path?x=1")
+            == "https://example.com/Path?x=1")
+        #expect(URLFetchService.urlIdentity("https://example.com/Path/")
+            != URLFetchService.urlIdentity("https://example.com/Path"))
+        #expect(URLFetchService.urlIdentity("https://example.com/Path?x=1")
+            != URLFetchService.urlIdentity("https://example.com/Path?x=2"))
+    }
+
     // MARK: - Pure helpers
 
     @Test func normalizedMIMEStripsCharset() {

--- a/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
+++ b/Tests/WikiFSTests/WikiStoreModelAddURLTests.swift
@@ -8,9 +8,23 @@ import Testing
 @MainActor
 struct WikiStoreModelAddURLTests {
 
+    actor FetchCallCounter {
+        private(set) var count = 0
+        func record() { count += 1 }
+    }
+
     struct FakeFetcher: URLFetchService.URLResourceFetcher {
         let response: URLFetchService.FetchResponse
         func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse { response }
+    }
+
+    struct CountingFetcher: URLFetchService.URLResourceFetcher {
+        let response: URLFetchService.FetchResponse
+        let counter: FetchCallCounter
+        func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse {
+            await counter.record()
+            return response
+        }
     }
 
     private func tempStore() throws -> GRDBWikiStore {
@@ -94,5 +108,34 @@ struct WikiStoreModelAddURLTests {
             try await model.addURL("https://example.com", fetcher: fetcher)
         }
         #expect(model.sources.isEmpty)
+    }
+
+    @Test func duplicateURLIsRejectedBeforeFetchingAndCanBeExplicitlyOverridden() async throws {
+        let store = try tempStore()
+        let existing = try store.addSource(
+            filename: "existing.html", data: Data("first".utf8),
+            zoteroItemKey: nil, zoteroItemTitle: nil, mimeType: "text/html",
+            provenance: SourceProvenance(
+                agentName: "website", activityKind: "fetch",
+                plan: "https://example.com/article", externalRef: "https://example.com/article#saved"))
+        let model = WikiStoreModel(store: store)
+        let counter = FetchCallCounter()
+        let fetcher = CountingFetcher(response: URLFetchService.FetchResponse(
+            data: Data("changed content".utf8), contentType: "text/plain",
+            finalURL: URL(string: "https://example.com/article")!), counter: counter)
+
+        do {
+            _ = try await model.addURL("HTTPS://EXAMPLE.com/article#new", fetcher: fetcher)
+            Issue.record("expected a URL duplicate")
+        } catch WikiStoreError.duplicateURL(let matched) {
+            #expect(matched.id == existing.id)
+        }
+        #expect(await counter.count == 0)
+        #expect(try store.listSources().count == 1)
+
+        _ = try await model.addURL(
+            "https://example.com/article", fetcher: fetcher, allowDuplicateURL: true)
+        #expect(await counter.count == 1)
+        #expect(try store.listSources().count == 2)
     }
 }

--- a/progress/2026-08-02T162100Z-issue-1047-url-source-duplicate-warning.md
+++ b/progress/2026-08-02T162100Z-issue-1047-url-source-duplicate-warning.md
@@ -1,0 +1,26 @@
+---
+timestamp: 2026-08-02T162100Z
+title: Issue 1047 URL source duplicate warning
+branch: lethal-chipmunk
+status: complete
+---
+
+# Issue 1047 URL source duplicate warning
+
+## Progress
+
+The URL source flow now checks stored URL provenance before it fetches data.
+
+The check lowercases the scheme and host. It ignores URL fragments. It keeps query parameters and trailing slashes.
+
+The Add from URL sheet shows the matched source name. The user can open that source, cancel, or add another source explicitly.
+
+`wikictl source add --url URL` now reports the matched source and does not fetch it. Use `--allow-duplicate` to add another source.
+
+Content-hash duplicate detection remains separate from this URL check.
+
+## Verification
+
+`make build` passed.
+
+`swift test --filter 'URLFetchServiceTests|WikiStoreModelAddURLTests'` passed. The tests cover URL identity and verify that a duplicate URL does not call the fetcher.


### PR DESCRIPTION
Fixes https://github.com/tqbf/selfdrivingwiki/issues/1047

## Summary
- Add a `source add --url` CLI command and wire it through the async source-add path.
- Detect duplicate URL sources before fetching by comparing canonical URL provenance.
- Surface duplicates in the Add from URL sheet with options to open the existing source or add another copy explicitly.
- Preserve content-hash deduplication as a separate check after bytes are fetched.

## What changed
- Added URL identity normalization that lowercases scheme/host and ignores fragments while preserving path, query, port, and trailing slash semantics.
- Added store support to look up an existing source by URL provenance.
- Introduced `WikiStoreError.duplicateURL` so callers can distinguish URL provenance conflicts from content duplicates.
- Updated `WikiStoreModel.addURL` to reject duplicates before any network work unless `allowDuplicateURL` is set.
- Added `--allow-duplicate` to `wikictl source add --url` so non-interactive callers can intentionally create another source.
- Updated the Add from URL sheet to show a duplicate warning state with an `Open Existing` action and an explicit `Add Anyway` path.

## Tests
- Added coverage for URL identity normalization.
- Added coverage that duplicate URL intake does not call the fetcher unless duplication is explicitly allowed.

## Notes
- A progress note was added for issue 1047 documenting the behavior and verification.