### PR TITLE
fix(process): refuse to signal unverified process targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,19 +265,22 @@ check-release: deps prompts version keychain
 
 # Run the test suite.
 #
-# Orphan guard: `swift test` runs Swift Testing through a child
-# `swittpm-testing-helper`. If its `swift` parent is killed mid-run (e.g. a
-# timeout), the helper reparents to init and keeps grinding the full suite;
-# left behind, these accumulate and thrash subsequent runs. We pre-sweep any
-# stale helper for THIS repo's build dir before starting, and trap
-# EXIT/TERM/INT to reap it again on exit so a killed run can't leave one
-# behind. `[s]wiftpm-testing-helper` is the bracket trick so the reap never
-# matches its own command line; `$(CURDIR)/.build` scopes it to this repo so
-# it never touches other repos/worktrees.
+# No orphan sweep here, deliberately (#1051).
+#
+# This target used to pre-sweep and trap-reap stale `swiftpm-testing-helper`
+# processes with `pkill -f "[s]wiftpm-testing-helper.*$(CURDIR)/.build"`. A
+# command-line regex is not proof of process identity: it selects by what a
+# process looks like, not by what this Makefile launched. On 2026-08-02 that
+# sweep was credited with terminating 125 PIDs when one hung child was the
+# intended target.
+#
+# A test helper is owned by the `swift test` process that launched it. Only an
+# owner may signal it, and only after re-verifying the child's identity — see
+# `ProcessSignalSafety` for the product-side rule and
+# `scripts/test-with-watchdog.sh` for the timeout path. If a helper is orphaned,
+# reap it by hand; a broad matcher must fail closed rather than pick a stranger.
 test: deps prompts version keychain
-	@trap 'pkill -f "[s]wiftpm-testing-helper.*$(CURDIR)/.build" 2>/dev/null || true' EXIT TERM INT; \
-	 pkill -f "[s]wiftpm-testing-helper.*$(CURDIR)/.build" 2>/dev/null || true; \
-	 swift test --parallel --num-workers $(SWIFT_TEST_NUM_WORKERS)
+	swift test --parallel --num-workers $(SWIFT_TEST_NUM_WORKERS)
 	@echo "✓ tests pass"
 
 # Same full suite as `test`, but with a hard wall-clock timeout and a

--- a/Package.swift
+++ b/Package.swift
@@ -373,6 +373,15 @@ let package = Package(
             exclude: ["Fixtures"],
             swiftSettings: strictSwiftSettings
         ),
+        // Signal-target validation tests compile against the pure validation
+        // target only. They deliberately cannot link the production `kill`
+        // closures in WikiFSCore, so a test can never signal a real process.
+        .testTarget(
+            name: "ProcessSignalSafetySeamTests",
+            dependencies: ["WikiFSTypes"],
+            path: "Tests/ProcessSignalSafetySeamTests",
+            swiftSettings: strictSwiftSettings
+        ),
         // macOS-only integration tests — AppKit/WebKit/FileProvider/SwiftUI-hosted
         // views, Tantivy integration, MLX embedder, PDF extraction, JS linter/
         // validator. Kept out of the default test graph because these suites can

--- a/Sources/WikiFSCore/Core/AsyncProcessRunner.swift
+++ b/Sources/WikiFSCore/Core/AsyncProcessRunner.swift
@@ -105,6 +105,17 @@ public enum AsyncProcessRunner {
         var didTerminate: (@Sendable (Int32, Int32) -> Void)?
         var didRequestCancellation: (@Sendable () -> Void)?
         var runProcess: (@Sendable (Process) throws -> Void)?
+        var requestTermination: @Sendable (Process) -> Void = { process in
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+        var observeProcess: @Sendable (ProcessSignalSafety.PositivePID) -> ProcessSignalSafety.Identity? = {
+            ProcessIdentityObservation.observe(processID: $0)
+        }
+        var sendSignal: @Sendable (Int32, Int32) -> Int32 = { processID, signal in
+            kill(processID, signal)
+        }
 
         static let none = Hooks()
     }
@@ -204,13 +215,21 @@ public enum AsyncProcessRunner {
                         } else {
                             try process.run()
                         }
-                        hooks.didLaunch?(process.processIdentifier)
-                        if let pid = state.recordLaunch(processID: process.processIdentifier) {
+                        let processID = process.processIdentifier
+                        let expectedIdentity = ProcessSignalSafety.PositivePID(rawValue: processID)
+                            .flatMap(hooks.observeProcess)
+                        hooks.didLaunch?(processID)
+                        if let target = state.recordLaunch(
+                            processID: processID,
+                            expectedIdentity: expectedIdentity) {
                             requestCancellation(
                                 of: process,
-                                processID: pid,
+                                target: target,
                                 gracePeriod: request.cancellationGracePeriod,
-                                state: state)
+                                state: state,
+                                requestTermination: hooks.requestTermination,
+                                observeProcess: hooks.observeProcess,
+                                sendSignal: hooks.sendSignal)
                         }
                     } catch {
                         if state.recordLaunchFailure(error.localizedDescription) {
@@ -222,14 +241,17 @@ public enum AsyncProcessRunner {
                 }
             }
         } onCancel: {
-            let pid = state.requestCancellation()
+            let target = state.requestCancellation()
             hooks.didRequestCancellation?()
-            if let pid {
+            if let target {
                 requestCancellation(
                     of: process,
-                    processID: pid,
+                    target: target,
                     gracePeriod: request.cancellationGracePeriod,
-                    state: state)
+                    state: state,
+                    requestTermination: hooks.requestTermination,
+                    observeProcess: hooks.observeProcess,
+                    sendSignal: hooks.sendSignal)
             }
         }
     }
@@ -258,13 +280,37 @@ public enum AsyncProcessRunner {
 
     private static func requestCancellation(
         of process: Process,
-        processID: Int32,
+        target: ExecutionState.CancellationTarget,
         gracePeriod: Duration,
-        state: ExecutionState
+        state: ExecutionState,
+        requestTermination: @escaping @Sendable (Process) -> Void,
+        observeProcess: @escaping @Sendable (ProcessSignalSafety.PositivePID) -> ProcessSignalSafety.Identity?,
+        sendSignal: @escaping @Sendable (Int32, Int32) -> Int32
     ) {
-        if process.isRunning {
-            process.terminate()
+        guard let expectedIdentity = target.expectedIdentity else {
+            DebugLog.agent("AsyncProcessRunner refused cancellation for PID \(target.processID): identity unavailable at launch")
+            return
         }
+        guard let parentProcessID = ProcessSignalSafety.PositivePID(rawValue: getpid()) else {
+            DebugLog.agent("AsyncProcessRunner refused cancellation for PID \(target.processID): invalid parent PID")
+            return
+        }
+        guard process.isRunning, process.processIdentifier == expectedIdentity.processID.rawValue else {
+            DebugLog.agent("AsyncProcessRunner refused cancellation for PID \(target.processID): direct child is no longer live")
+            return
+        }
+        switch ProcessSignalSafety.verify(
+            processID: expectedIdentity.processID,
+            expectedIdentity: expectedIdentity,
+            expectedParentProcessID: parentProcessID,
+            observedIdentity: observeProcess(expectedIdentity.processID)) {
+        case .verified:
+            break
+        case .refused(let refusal):
+            DebugLog.agent("AsyncProcessRunner refused cancellation for PID \(target.processID): \(refusal)")
+            return
+        }
+        requestTermination(process)
 
         state.installEscalationTask(Task {
             do {
@@ -272,8 +318,29 @@ public enum AsyncProcessRunner {
             } catch {
                 return
             }
-            guard state.shouldEscalateKill(for: processID) else { return }
-            _ = kill(processID, SIGKILL)
+            guard state.shouldEscalateKill(for: target.processID) else { return }
+            guard let expectedIdentity = target.expectedIdentity,
+                  let parentProcessID = ProcessSignalSafety.PositivePID(rawValue: getpid())
+            else { return }
+            guard process.isRunning, process.processIdentifier == expectedIdentity.processID.rawValue else {
+                DebugLog.agent("AsyncProcessRunner refused escalation for PID \(target.processID): direct child is no longer live")
+                return
+            }
+            let observedIdentity = observeProcess(expectedIdentity.processID)
+
+            switch ProcessSignalSafety.signal(
+                processID: expectedIdentity.processID,
+                expectedIdentity: expectedIdentity,
+                expectedParentProcessID: parentProcessID,
+                observedIdentity: observedIdentity,
+                signal: sendSignal) {
+            case .sent(let result) where result == 0:
+                break
+            case .sent(let result):
+                DebugLog.agent("AsyncProcessRunner escalation signal failed for verified child PID \(target.processID): result=\(result)")
+            case .refused(let refusal):
+                DebugLog.agent("AsyncProcessRunner refused escalation for PID \(target.processID): \(refusal)")
+            }
         })
     }
 }
@@ -283,6 +350,11 @@ public enum AsyncProcessRunner {
 /// `cancelRequested`, `didResume`, and `escalationTask`.
 // swiftlint:disable:next unchecked_sendable
 private final class ExecutionState: @unchecked Sendable {
+    struct CancellationTarget: Sendable {
+        let processID: Int32
+        let expectedIdentity: ProcessSignalSafety.Identity?
+    }
+
     enum Phase {
         case preparing
         case launching
@@ -304,6 +376,7 @@ private final class ExecutionState: @unchecked Sendable {
     private var launchFailedMessage: String?
     private(set) var terminationStatus: Int32?
     private var cancelRequested = false
+    private var launchedIdentity: ProcessSignalSafety.Identity?
     private var didResume = false
     private var escalationTask: Task<Void, Never>?
 
@@ -323,19 +396,23 @@ private final class ExecutionState: @unchecked Sendable {
         return true
     }
 
-    func recordLaunch(processID: Int32) -> Int32? {
+    func recordLaunch(
+        processID: Int32,
+        expectedIdentity: ProcessSignalSafety.Identity?
+    ) -> CancellationTarget? {
         lock.lock()
         defer { lock.unlock() }
+        launchedIdentity = expectedIdentity
         switch phase {
         case .launching where cancelRequested:
             phase = .cancelling(processID: processID)
-            return processID
+            return CancellationTarget(processID: processID, expectedIdentity: expectedIdentity)
         case .launching:
             phase = .running(processID: processID)
             return nil
         case .cancelling:
             phase = .cancelling(processID: processID)
-            return processID
+            return CancellationTarget(processID: processID, expectedIdentity: expectedIdentity)
         case .running, .terminated, .completed:
             return nil
         case .preparing:
@@ -353,7 +430,7 @@ private final class ExecutionState: @unchecked Sendable {
         return true
     }
 
-    func requestCancellation() -> Int32? {
+    func requestCancellation() -> CancellationTarget? {
         lock.lock()
         defer { lock.unlock() }
         cancelRequested = true
@@ -366,7 +443,7 @@ private final class ExecutionState: @unchecked Sendable {
             return nil
         case .running(let processID):
             phase = .cancelling(processID: processID)
-            return processID
+            return CancellationTarget(processID: processID, expectedIdentity: launchedIdentity)
         case .cancelling, .terminated, .completed:
             return nil
         }

--- a/Sources/WikiFSTypes/ProcessIdentityObservation.swift
+++ b/Sources/WikiFSTypes/ProcessIdentityObservation.swift
@@ -1,0 +1,131 @@
+// pattern: Imperative Shell
+
+import Foundation
+#if os(macOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+/// Reads independent ownership and lifetime evidence from the operating system.
+///
+/// The parent PID and the kernel-recorded creation time together answer the
+/// question a bare PID cannot: "is the process wearing this number still the one
+/// I launched?" Equal PIDs with different creation times are different process
+/// lifetimes, which is how a recycled PID is detected and refused.
+///
+/// Unsupported platforms fail closed by returning `nil`. Callers must treat
+/// `nil` as "refuse to signal", so an unimplemented platform can never signal a
+/// process it has not proven ownership of.
+public enum ProcessIdentityObservation {
+    public static func observe(processID: ProcessSignalSafety.PositivePID) -> ProcessSignalSafety.Identity? {
+        #if os(macOS)
+        importDarwinObservation(processID: processID)
+        #elseif os(Linux)
+        importLinuxObservation(processID: processID)
+        #else
+        nil
+        #endif
+    }
+
+    #if os(macOS)
+    private static func importDarwinObservation(
+        processID: ProcessSignalSafety.PositivePID
+    ) -> ProcessSignalSafety.Identity? {
+        var info = proc_bsdinfo()
+        let expectedSize = MemoryLayout<proc_bsdinfo>.size
+        let resultSize = proc_pidinfo(
+            processID.rawValue,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(expectedSize))
+        guard resultSize == Int32(expectedSize),
+              info.pbi_pid == UInt32(processID.rawValue),
+              let parentProcessID = ProcessSignalSafety.PositivePID(rawValue: Int32(info.pbi_ppid))
+        else {
+            return nil
+        }
+        return ProcessSignalSafety.Identity(
+            processID: processID,
+            parentProcessID: parentProcessID,
+            startTime: .init(seconds: info.pbi_start_tvsec, microseconds: info.pbi_start_tvusec))
+    }
+    #endif
+
+    #if os(Linux)
+    /// Reads `/proc/<pid>/stat`. Field 4 is the parent PID and field 22 is the
+    /// process start time in clock ticks since boot.
+    ///
+    /// Without a Linux observer, `observe` would return `nil` on Linux and every
+    /// cancellation would fail closed — turning subprocess termination into a
+    /// silent no-op rather than a safety guarantee.
+    private static func importLinuxObservation(
+        processID: ProcessSignalSafety.PositivePID
+    ) -> ProcessSignalSafety.Identity? {
+        // `try?` is correct here rather than swallowed error handling: the read
+        // fails exactly when the process is gone (or /proc is unavailable), and
+        // "cannot observe" is already the answer this function must return. The
+        // caller treats nil as "refuse to signal". WikiFSTypes is a leaf module
+        // with no DebugLog dependency, so the refusal is logged by the caller
+        // (see AsyncProcessRunner.requestCancellation).
+        // swiftlint:disable:next silent_try_optional
+        guard let contents = try? String(
+            contentsOfFile: "/proc/\(processID.rawValue)/stat", encoding: .utf8)
+        else {
+            return nil
+        }
+        let ticksPerSecond = UInt64(max(sysconf(Int32(_SC_CLK_TCK)), 1))
+        return parseLinuxStat(
+            contents, processID: processID, ticksPerSecond: ticksPerSecond)
+    }
+    #endif
+
+    /// Split out from the file read, and compiled on every platform, so the
+    /// field arithmetic can be unit-tested without a Linux host. Getting field
+    /// 22 wrong would silently produce a constant start time, which would make
+    /// every PID-reuse check pass.
+    ///
+    /// Field 2 (`comm`) is wrapped in parentheses and may itself contain spaces
+    /// and parentheses, so everything up to the LAST `)` is skipped rather than
+    /// splitting the whole line on whitespace.
+    static func parseLinuxStat(
+        _ contents: String,
+        processID: ProcessSignalSafety.PositivePID,
+        ticksPerSecond: UInt64
+    ) -> ProcessSignalSafety.Identity? {
+        guard let commEnd = contents.lastIndex(of: ")") else { return nil }
+
+        // Field 1 must match the PID we asked about.
+        let beforeComm = contents[contents.startIndex..<(contents.firstIndex(of: "(") ?? commEnd)]
+        guard let reportedPID = Int32(beforeComm.trimmingCharacters(in: .whitespaces)),
+              reportedPID == processID.rawValue
+        else {
+            return nil
+        }
+
+        let remainder = contents[contents.index(after: commEnd)...]
+        // Split on any whitespace, not just " ": the line ends in "\n", which
+        // would otherwise stay attached to field 22 and fail to parse.
+        let fields = remainder.split(omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
+
+        // `fields[0]` is field 3 (state), so field N is at index N - 3.
+        let parentProcessIDIndex = 4 - 3
+        let startTimeIndex = 22 - 3
+        guard fields.count > startTimeIndex,
+              let parentRaw = Int32(fields[parentProcessIDIndex]),
+              let parentProcessID = ProcessSignalSafety.PositivePID(rawValue: parentRaw),
+              let ticks = UInt64(fields[startTimeIndex])
+        else {
+            return nil
+        }
+
+        let divisor = max(ticksPerSecond, 1)
+        return ProcessSignalSafety.Identity(
+            processID: processID,
+            parentProcessID: parentProcessID,
+            startTime: .init(
+                seconds: ticks / divisor,
+                microseconds: (ticks % divisor) * 1_000_000 / divisor))
+    }
+}

--- a/Sources/WikiFSTypes/ProcessSignalSafety.swift
+++ b/Sources/WikiFSTypes/ProcessSignalSafety.swift
@@ -1,0 +1,127 @@
+// pattern: Functional Core
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Validates process signal targets independently of process creation and OS
+/// observation. A numeric PID is never sufficient authority to signal.
+public enum ProcessSignalSafety {
+    public struct PositivePID: Sendable, Equatable {
+        public let rawValue: Int32
+
+        public init?(rawValue: Int32) {
+            guard rawValue > 1 else { return nil }
+            self.rawValue = rawValue
+        }
+
+        public init?(pidFileContents: String) {
+            let trimmed = pidFileContents.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let parsed = Int32(trimmed) else { return nil }
+            self.init(rawValue: parsed)
+        }
+    }
+
+    /// A kernel-observed creation timestamp. Equal PIDs with different start
+    /// times represent different process lifetimes.
+    public struct StartTime: Sendable, Equatable {
+        public let seconds: UInt64
+        public let microseconds: UInt64
+
+        public init(seconds: UInt64, microseconds: UInt64) {
+            self.seconds = seconds
+            self.microseconds = microseconds
+        }
+    }
+
+    /// Process ownership and lifetime evidence obtained from an OS observer.
+    public struct Identity: Sendable, Equatable {
+        public let processID: PositivePID
+        public let parentProcessID: PositivePID
+        public let startTime: StartTime
+
+        public init(processID: PositivePID, parentProcessID: PositivePID, startTime: StartTime) {
+            self.processID = processID
+            self.parentProcessID = parentProcessID
+            self.startTime = startTime
+        }
+    }
+
+    public enum Refusal: Sendable, Equatable {
+        case invalidPIDFileContents
+        case identityUnavailable
+        case identityMismatch
+        case parentMismatch
+    }
+
+    public enum Outcome: Sendable, Equatable {
+        case sent(result: Int32)
+        case refused(Refusal)
+    }
+
+    public enum Verification: Sendable, Equatable {
+        case verified
+        case refused(Refusal)
+    }
+
+    public static func signalFromPIDFile(
+        _ contents: String,
+        expectedIdentity: Identity,
+        expectedParentProcessID: PositivePID,
+        observedIdentity: Identity?,
+        signal: (Int32, Int32) -> Int32
+    ) -> Outcome {
+        guard let processID = PositivePID(pidFileContents: contents) else {
+            return .refused(.invalidPIDFileContents)
+        }
+        return self.signal(
+            processID: processID,
+            expectedIdentity: expectedIdentity,
+            expectedParentProcessID: expectedParentProcessID,
+            observedIdentity: observedIdentity,
+            signal: signal)
+    }
+
+    public static func signal(
+        processID: PositivePID,
+        expectedIdentity: Identity,
+        expectedParentProcessID: PositivePID,
+        observedIdentity: Identity?,
+        signal: (Int32, Int32) -> Int32
+    ) -> Outcome {
+        switch verify(
+            processID: processID,
+            expectedIdentity: expectedIdentity,
+            expectedParentProcessID: expectedParentProcessID,
+            observedIdentity: observedIdentity) {
+        case .verified:
+            return .sent(result: signal(processID.rawValue, SIGKILL))
+        case .refused(let refusal):
+            return .refused(refusal)
+        }
+    }
+
+    public static func verify(
+        processID: PositivePID,
+        expectedIdentity: Identity,
+        expectedParentProcessID: PositivePID,
+        observedIdentity: Identity?
+    ) -> Verification {
+        guard processID == expectedIdentity.processID else {
+            return .refused(.identityMismatch)
+        }
+        guard expectedIdentity.parentProcessID == expectedParentProcessID else {
+            return .refused(.parentMismatch)
+        }
+        guard let observedIdentity else {
+            return .refused(.identityUnavailable)
+        }
+        guard observedIdentity == expectedIdentity else {
+            return .refused(.identityMismatch)
+        }
+        return .verified
+    }
+}

--- a/Tests/ProcessSignalSafetySeamTests/ProcessIdentityObservationTests.swift
+++ b/Tests/ProcessSignalSafetySeamTests/ProcessIdentityObservationTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+@testable import WikiFSTypes
+
+/// Field-offset tests for the Linux `/proc/<pid>/stat` observer.
+///
+/// These run on every platform on purpose. The parser is the only part of the
+/// identity observer that can be wrong *silently*: if field 22 were misread, the
+/// start time would become a constant, every PID-reuse comparison would compare
+/// equal, and the guard would approve signals it should refuse. macOS CI would
+/// never notice, because the Darwin path uses `proc_pidinfo` instead.
+struct ProcessIdentityObservationTests {
+    /// Fields 3 through 22 of a plausible `/proc/<pid>/stat`, where field 22
+    /// (starttime) is 987654 clock ticks.
+    private static let fieldsThreeThroughTwentyTwo = [
+        "S", // 3  state
+        "1200", // 4  ppid
+        "1234", // 5  pgrp
+        "1200", // 6  session
+        "34816", // 7  tty_nr
+        "1234", // 8  tpgid
+        "4194304", // 9  flags
+        "100", // 10 minflt
+        "0", // 11 cminflt
+        "0", // 12 majflt
+        "0", // 13 cmajflt
+        "10", // 14 utime
+        "5", // 15 stime
+        "0", // 16 cutime
+        "0", // 17 cstime
+        "20", // 18 priority
+        "0", // 19 nice
+        "1", // 20 num_threads
+        "0", // 21 itrealvalue
+        "987654", // 22 starttime
+    ]
+
+    private func statLine(pid: Int32 = 1234, comm: String = "bash") -> String {
+        "\(pid) (\(comm)) " + Self.fieldsThreeThroughTwentyTwo.joined(separator: " ") + "\n"
+    }
+
+    private func pid(_ rawValue: Int32) throws -> ProcessSignalSafety.PositivePID {
+        try #require(ProcessSignalSafety.PositivePID(rawValue: rawValue))
+    }
+
+    @Test func readsParentPIDAndStartTimeFromTheCorrectFields() throws {
+        let identity = try #require(ProcessIdentityObservation.parseLinuxStat(
+            statLine(), processID: try pid(1234), ticksPerSecond: 100))
+
+        #expect(identity.processID.rawValue == 1234)
+        #expect(identity.parentProcessID.rawValue == 1200)
+        // 987654 ticks at 100 Hz = 9876.54 s
+        #expect(identity.startTime.seconds == 9876)
+        #expect(identity.startTime.microseconds == 540_000)
+    }
+
+    /// `comm` is unsanitised kernel data: a process can name itself with spaces
+    /// and parentheses. Splitting the whole line on whitespace, or on the FIRST
+    /// `)`, shifts every later field.
+    @Test(arguments: [
+        "bash",
+        "my proc",
+        "weird)name",
+        "(nested)",
+        "a (b) c",
+        ")",
+    ])
+    func toleratesCommContainingSpacesAndParentheses(comm: String) throws {
+        let identity = try #require(ProcessIdentityObservation.parseLinuxStat(
+            statLine(comm: comm), processID: try pid(1234), ticksPerSecond: 100))
+
+        #expect(identity.parentProcessID.rawValue == 1200)
+        #expect(identity.startTime.seconds == 9876)
+    }
+
+    @Test func differentStartTimesProduceDifferentIdentities() throws {
+        let original = try #require(ProcessIdentityObservation.parseLinuxStat(
+            statLine(), processID: try pid(1234), ticksPerSecond: 100))
+        let recycled = try #require(ProcessIdentityObservation.parseLinuxStat(
+            statLine().replacingOccurrences(of: "987654", with: "987655"),
+            processID: try pid(1234),
+            ticksPerSecond: 100))
+
+        // Same PID, same parent, different lifetime: must not compare equal, or
+        // a recycled PID would be accepted as the original child.
+        #expect(original != recycled)
+    }
+
+    @Test func refusesAStatLineForADifferentPID() throws {
+        #expect(ProcessIdentityObservation.parseLinuxStat(
+            statLine(pid: 999), processID: try pid(1234), ticksPerSecond: 100) == nil)
+    }
+
+    @Test func refusesTruncatedOrMalformedInput() throws {
+        let target = try pid(1234)
+        #expect(ProcessIdentityObservation.parseLinuxStat(
+            "", processID: target, ticksPerSecond: 100) == nil)
+        #expect(ProcessIdentityObservation.parseLinuxStat(
+            "1234 (bash) S 1200", processID: target, ticksPerSecond: 100) == nil)
+        #expect(ProcessIdentityObservation.parseLinuxStat(
+            "1234 (bash", processID: target, ticksPerSecond: 100) == nil)
+        #expect(ProcessIdentityObservation.parseLinuxStat(
+            "not-a-pid (bash) S 1200", processID: target, ticksPerSecond: 100) == nil)
+    }
+
+    /// PID 0 and 1 are never valid signal targets, so an init parent must not
+    /// yield an identity that could later authorise a signal.
+    @Test func refusesNonPositiveParentPID() throws {
+        let orphaned = statLine().replacingOccurrences(
+            of: "(bash) S 1200", with: "(bash) S 1")
+        #expect(ProcessIdentityObservation.parseLinuxStat(
+            orphaned, processID: try pid(1234), ticksPerSecond: 100) == nil)
+    }
+
+    @Test func toleratesAZeroTicksPerSecondWithoutDividingByZero() throws {
+        let identity = try #require(ProcessIdentityObservation.parseLinuxStat(
+            statLine(), processID: try pid(1234), ticksPerSecond: 0))
+        #expect(identity.startTime.seconds == 987_654)
+    }
+}

--- a/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetyAuditTests.swift
+++ b/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetyAuditTests.swift
@@ -68,9 +68,11 @@ struct ProcessSignalSafetyAuditTests {
                     + "ProcessSignalSafety.signal on a re-verified direct child"),
             .init(path: "scripts/lib/test-watchdog-process-control.sh",
                   primitive: .shellSignal):
-                (1, "guarded: builtin kill reached only after "
-                    + "watchdog_is_verified_child proves the PID is an un-reaped "
-                    + "running job of this shell, so the PID cannot have been reused"),
+                (1, "guarded: builtin kill is addressed by jobspec (%N), never by a "
+                    + "number. Bash resolves ownership and signals in one step, so "
+                    + "there is no interval in which the PID could be reaped and "
+                    + "recycled. A separately captured jobs snapshot cannot authorise "
+                    + "a signal, because it only proves ownership at snapshot time"),
 
             // --- Owner-terminates-its-own-child, no numeric PID -------------
             // These call terminate() on a Process/client object the same code
@@ -203,8 +205,8 @@ struct ProcessSignalSafetyAuditTests {
 
         #expect(watchdog.contains("swift test -v"), "watchdog must still launch the suite")
         #expect(
-            watchdog.contains("watchdog_signal_verified_child"),
-            "watchdog must signal only through the verified-child boundary")
+            watchdog.contains("watchdog_signal_job"),
+            "watchdog must signal only through the jobspec boundary")
         // Comments stripped: this script documents the `kill -0` it removed.
         #expect(
             strippingCommentsAndLiterals(watchdog, path: "scripts/test-with-watchdog.sh")
@@ -215,9 +217,28 @@ struct ProcessSignalSafetyAuditTests {
             contentsOf: root.appendingPathComponent(
                 "scripts/lib/test-watchdog-process-control.sh"),
             encoding: .utf8)
+        let executableBoundary = strippingCommentsAndLiterals(
+            boundary, path: "scripts/lib/test-watchdog-process-control.sh")
+
+        // The signal must be addressed by jobspec. A `jobs -pr` snapshot proves
+        // ownership only at snapshot time: bash can reap the job between the
+        // check and a later numeric `kill`, after which the kernel may recycle
+        // the number. Signalling `%N` makes the lookup and the signal one step.
         #expect(
-            boundary.contains("jobs -pr"),
-            "verification must rest on this shell's un-reaped job table")
+            executableBoundary.contains("builtin kill \"-$signal_name\" \"$jobspec\""),
+            "the only kill must be addressed by jobspec, not by PID")
+        #expect(
+            executableBoundary.contains("^%[0-9]+$"),
+            "the jobspec must be validated so a numeric PID cannot reach kill")
+        // No `kill` anywhere in the boundary may take a PID variable.
+        for pidAddressedKill in ["kill \"-$signal_name\" \"$pid\"",
+                                 "kill \"-$signal_name\" \"$processID\"",
+                                 "kill -TERM \"$pid\"",
+                                 "kill -KILL \"$pid\""] {
+            #expect(
+                executableBoundary.contains(pidAddressedKill) == false,
+                "signalling a numeric PID reintroduces the check-then-signal race")
+        }
     }
 
     @Test func scannerIgnoresProcessControlTextInCommentsAndLiterals() {

--- a/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetyAuditTests.swift
+++ b/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetyAuditTests.swift
@@ -1,0 +1,369 @@
+import Foundation
+import Testing
+
+/// Inventories every process-control call site in the repository's executable
+/// sources and requires an explicit, rationale-bearing disposition for each one.
+///
+/// Why this guard exists (#1051): a broad `pkill -f "[s]wiftpm-testing-helper…"`
+/// sweep in `make test` selected processes by command-line appearance rather
+/// than by ownership, and was credited with terminating 125 PIDs when one hung
+/// child was the intended target. Nothing in the build would have objected to
+/// that line being added, or to it being added back. This test objects.
+///
+/// It is deliberately shaped like `StoreEmissionExhaustivenessTests`: a
+/// discovered set is compared against a reviewed inventory, so a NEW call site
+/// fails the build until someone writes down why it is safe.
+///
+/// The inventory is keyed by (path, primitive) with an expected count rather
+/// than by line number. Line numbers would make this test fail on every
+/// unrelated edit above a call site, which trains reviewers to update the table
+/// without reading it. Counts still force review when a call site is added.
+struct ProcessSignalSafetyAuditTests {
+    /// A kind of process-control operation, not a specific API.
+    private enum Primitive: String, Hashable, CaseIterable {
+        /// `pkill` / `killall` — selects targets by command-line appearance.
+        case broadMatcher
+        /// `kill(pid, sig)` — POSIX signal to a numeric PID.
+        case posixSignal
+        /// `Process.terminate()` / client `terminate()`.
+        case processTermination
+        /// `kill -SIG` / `builtin kill` in shell.
+        case shellSignal
+
+        var pattern: String {
+            switch self {
+            case .broadMatcher: #"\b(pkill|killall)\b"#
+            case .posixSignal: #"(?<![-\w])kill\s*\("#
+            case .processTermination: #"\.terminate\s*\(\s*\)"#
+            // Shell quotes its signal argument (`kill "-$sig"`) as often as it
+            // writes it bare (`kill -0`), so both forms must be detected.
+            case .shellSignal: #"(\bbuiltin\s+kill\b|\bkill\s+["'-])"#
+            }
+        }
+    }
+
+    private struct Site: Hashable, CustomStringConvertible {
+        let path: String
+        let primitive: Primitive
+
+        var description: String { "\(path) [\(primitive.rawValue)]" }
+    }
+
+    /// Every process-control call site in the repository, with the number of
+    /// occurrences and the reason it is acceptable.
+    ///
+    /// Adding a process-control call anywhere under `Sources/`, `scripts/`, or
+    /// in the `Makefile` will fail `everyProcessControlCallSiteIsReviewed`
+    /// until it is recorded here with a rationale.
+    private var reviewed: [Site: (count: Int, rationale: String)] {
+        [
+            // --- The verified-signal boundary itself -------------------------
+            .init(path: "Sources/WikiFSCore/Core/AsyncProcessRunner.swift",
+                  primitive: .processTermination):
+                (1, "guarded: ProcessSignalSafety.verify confirms PID, parent PID, "
+                    + "and kernel start time against a fresh observation before TERM"),
+            .init(path: "Sources/WikiFSCore/Core/AsyncProcessRunner.swift",
+                  primitive: .posixSignal):
+                (1, "guarded: injected sendSignal seam, reached only via "
+                    + "ProcessSignalSafety.signal on a re-verified direct child"),
+            .init(path: "scripts/lib/test-watchdog-process-control.sh",
+                  primitive: .shellSignal):
+                (1, "guarded: builtin kill reached only after "
+                    + "watchdog_is_verified_child proves the PID is an un-reaped "
+                    + "running job of this shell, so the PID cannot have been reused"),
+
+            // --- Owner-terminates-its-own-child, no numeric PID -------------
+            // These call terminate() on a Process/client object the same code
+            // created and still holds. The object identity is the authority,
+            // so there is no PID-reuse window to close.
+            .init(path: "Sources/WikiFSEngine/PdfExtractionService.swift",
+                  primitive: .processTermination):
+                (3, "owns the Process object it terminates; no numeric PID involved"),
+            .init(path: "Sources/WikiFS/Sources/DefuddleExtractionService.swift",
+                  primitive: .processTermination):
+                (2, "owns the Process object it terminates; no numeric PID involved"),
+            .init(path: "Sources/WikiFSEngine/ACPBackend.swift",
+                  primitive: .processTermination):
+                (3, "terminates a held ACP client object, not a PID"),
+            .init(path: "Sources/WikiFSEngine/ACPProviderModelProbe.swift",
+                  primitive: .processTermination):
+                (1, "terminates a held ACP client object, not a PID"),
+
+            // --- Liveness probe only ----------------------------------------
+            .init(path: "Sources/WikiFSEngine/ACPBackend.swift",
+                  primitive: .posixSignal):
+                (1, "kill(pid, 0) is a liveness probe and delivers no signal"),
+
+            // --- Known-weak, pre-existing, tracked --------------------------
+            // NOT a safety approval. Recorded so it is visible and cannot be
+            // mistaken for a reviewed-safe pattern.
+            .init(path: "Sources/WikiFSCore/Integrations/TranscriptSubprocess.swift",
+                  primitive: .posixSignal):
+                (2, "WEAK, pre-existing: kill(pid, 0) then kill(pid, SIGTERM) on a "
+                    + "PID from a stored snapshot. This is a check-then-signal race "
+                    + "of the same class as #1051 and should migrate to "
+                    + "ProcessSignalSafety; out of scope for this change"),
+
+            .init(path: "scripts/paseo-archive-cleanup.sh", primitive: .shellSignal):
+                (2, "WEAK, pre-existing: operator-run agent-archive cleanup. Selects "
+                    + "PIDs by matching a ps snapshot, then does pid_is_alive followed "
+                    + "by kill — check-then-signal, same class as #1051. It does skip "
+                    + "self, PPID, and PID 1. Not on any build or test path; out of "
+                    + "scope for this change"),
+
+            // --- Developer app lifecycle, not test helpers -------------------
+            // NOT a safety approval. These match by absolute installed-app path
+            // to stop the developer's own app before reinstalling it.
+            .init(path: "Makefile", primitive: .broadMatcher):
+                (4, "WEAK, pre-existing: pkill -f against the absolute installed "
+                    + "app/appex path in run/install targets. Appearance-based, but "
+                    + "scoped to this developer's install path and never used to "
+                    + "reap test helpers. The test-helper sweep was removed in #1051"),
+        ]
+    }
+
+    /// Files whose text talks about process-control tools by name rather than
+    /// invoking them. Excluded for the same reason `DebugLog.swift` is excluded
+    /// from mutation testing: the match is the subject, not a call.
+    private let excludedPaths: Set<String> = [
+        // Asserts that pkill/killall/kill -0 do NOT appear in the watchdog.
+        "scripts/tests/test-test-with-watchdog-process-control.sh",
+    ]
+
+    @Test func everyProcessControlCallSiteIsReviewed() throws {
+        let discovered = try discoveredSites()
+        let reviewed = self.reviewed
+
+        let undocumented = discovered.keys.filter { reviewed[$0] == nil }.sorted { "\($0)" < "\($1)" }
+        #expect(
+            undocumented.isEmpty,
+            """
+            Unreviewed process-control call site(s):
+            \(undocumented.map { "  - \($0) x\(discovered[$0] ?? 0)" }.joined(separator: "\n"))
+
+            A numeric PID is never sufficient authority to signal (#1051). Either
+            route this through ProcessSignalSafety / the watchdog verified-child
+            boundary, or add it to `reviewed` with a rationale explaining why the
+            target's identity is already proven.
+            """)
+
+        let stale = reviewed.keys.filter { discovered[$0] == nil }.sorted { "\($0)" < "\($1)" }
+        #expect(
+            stale.isEmpty,
+            """
+            Reviewed call site(s) no longer found — remove them from `reviewed`:
+            \(stale.map { "  - \($0)" }.joined(separator: "\n"))
+            """)
+
+        for (site, expected) in reviewed {
+            guard let actual = discovered[site] else { continue }
+            #expect(
+                actual == expected.count,
+                """
+                \(site): expected \(expected.count) occurrence(s), found \(actual).
+                A process-control call was added or removed here. Re-read the
+                rationale and update the count deliberately:
+                  \(expected.rationale)
+                """)
+        }
+
+        #expect(
+            reviewed.values.allSatisfy { $0.rationale.isEmpty == false },
+            "every reviewed call site needs a non-empty rationale")
+    }
+
+    /// The specific line that caused the #1051 incident must never come back.
+    @Test func noSweepReapsTestHelpersByCommandLine() throws {
+        let root = repositoryRoot()
+        for relativePath in ["Makefile", "scripts/test-with-watchdog.sh",
+                             "scripts/lib/test-watchdog-process-control.sh"] {
+            let source = try String(
+                contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+            let executable = strippingCommentsAndLiterals(source, path: relativePath)
+            // Match on "testing-helper", not "swiftpm-testing-helper": the
+            // original sweep wrote the pattern as `[s]wiftpm-testing-helper`
+            // (the bracket trick that stops pkill matching its own command
+            // line), which contains no "swiftpm-testing-helper" substring at
+            // all. A naive check passes straight through the exact line that
+            // caused the incident.
+            #expect(
+                executable.contains("testing-helper") == false,
+                "\(relativePath) must not select the SwiftPM test helper by command line (#1051)")
+        }
+    }
+
+    /// The watchdog must still be able to run a suite. The first attempt at this
+    /// fix shipped a production observer that always failed, so the script hit
+    /// its own refusal branch and exited 78 without running a single test.
+    @Test func watchdogRemainsOperableAndVerifiesBeforeSignalling() throws {
+        let root = repositoryRoot()
+        let watchdog = try String(
+            contentsOf: root.appendingPathComponent("scripts/test-with-watchdog.sh"),
+            encoding: .utf8)
+
+        #expect(watchdog.contains("swift test -v"), "watchdog must still launch the suite")
+        #expect(
+            watchdog.contains("watchdog_signal_verified_child"),
+            "watchdog must signal only through the verified-child boundary")
+        // Comments stripped: this script documents the `kill -0` it removed.
+        #expect(
+            strippingCommentsAndLiterals(watchdog, path: "scripts/test-with-watchdog.sh")
+                .contains("kill -0") == false,
+            "kill -0 cannot distinguish a reused PID; use the job table instead")
+
+        let boundary = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/lib/test-watchdog-process-control.sh"),
+            encoding: .utf8)
+        #expect(
+            boundary.contains("jobs -pr"),
+            "verification must rest on this shell's un-reaped job table")
+    }
+
+    @Test func scannerIgnoresProcessControlTextInCommentsAndLiterals() {
+        let swiftSource = """
+        /// the watchdog kill(pgid) a stuck agent after cancel fails
+        // process.terminate()
+        DebugLog.agent("client.terminate()")
+        client.terminate()
+        """
+        let counts = counted(swiftSource, path: "Fake.swift")
+        #expect(counts[.processTermination] == 1)
+        #expect(counts[.posixSignal] == nil)
+
+        let shellSource = """
+        # pkill -f something
+        builtin kill -TERM "$pid"
+        """
+        let shellCounts = counted(shellSource, path: "fake.sh")
+        #expect(shellCounts[.broadMatcher] == nil)
+        #expect(shellCounts[.shellSignal] == 1)
+    }
+
+    @Test func scannerDoesNotMistakeSimilarIdentifiersForSignals() {
+        let source = """
+        overkill(value)
+        self.killCount(3)
+        kill(pid, SIGTERM)
+        """
+        let counts = counted(source, path: "Fake.swift")
+        #expect(counts[.posixSignal] == 1)
+    }
+
+    // MARK: - Scanning
+
+    private func discoveredSites() throws -> [Site: Int] {
+        let root = repositoryRoot()
+        var result: [Site: Int] = [:]
+
+        for relativePath in try scannedSourceFiles(root: root) {
+            let source = try String(
+                contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+            for (primitive, count) in counted(source, path: relativePath) {
+                result[Site(path: relativePath, primitive: primitive), default: 0] += count
+            }
+        }
+        return result
+    }
+
+    private func counted(_ source: String, path: String) -> [Primitive: Int] {
+        let executable = strippingCommentsAndLiterals(source, path: path)
+        var counts: [Primitive: Int] = [:]
+        for primitive in Primitive.allCases {
+            let matches = regex(primitive.pattern).numberOfMatches(
+                in: executable,
+                range: NSRange(executable.startIndex..., in: executable))
+            if matches > 0 { counts[primitive] = matches }
+        }
+        return counts
+    }
+
+    /// Blanks out comments so that documentation mentioning `kill` is not
+    /// counted as a call site.
+    ///
+    /// Quoted spans are stripped for Swift/Obj-C only, where a `kill` mention is
+    /// almost always a log message. Shell keeps its quotes, because shell passes
+    /// real arguments in them — `kill "-$signal_name" "$pid"` is an invocation,
+    /// not prose, and stripping quotes would hide it.
+    private func strippingCommentsAndLiterals(_ source: String, path: String) -> String {
+        let usesHashComments = path.hasSuffix(".sh") || path.hasSuffix("Makefile")
+        var output: [String] = []
+
+        for rawLine in source.components(separatedBy: .newlines) {
+            var line = rawLine
+
+            if usesHashComments {
+                if let hash = line.firstIndex(of: "#") {
+                    line = String(line[line.startIndex..<hash])
+                }
+                output.append(line)
+                continue
+            }
+
+            if let slashes = line.range(of: "//") {
+                line = String(line[line.startIndex..<slashes.lowerBound])
+            }
+            output.append(removingQuotedSpans(line))
+        }
+        return output.joined(separator: "\n")
+    }
+
+    private func removingQuotedSpans(_ line: String) -> String {
+        var result = ""
+        var insideQuotes = false
+        var previous: Character?
+
+        for character in line {
+            if character == "\"", previous != "\\" {
+                insideQuotes.toggle()
+                previous = character
+                continue
+            }
+            if insideQuotes == false { result.append(character) }
+            previous = character
+        }
+        return result
+    }
+
+    private func scannedSourceFiles(root: URL) throws -> [String] {
+        var paths: [String] = ["Makefile"]
+
+        for directory in ["Sources", "scripts"] {
+            let base = root.appendingPathComponent(directory)
+            guard let enumerator = FileManager.default.enumerator(
+                at: base,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles])
+            else { continue }
+
+            for case let url as URL in enumerator {
+                let isRegularFile = try url.resourceValues(
+                    forKeys: [.isRegularFileKey]).isRegularFile ?? false
+                guard isRegularFile else { continue }
+                guard ["swift", "m", "mm", "sh"].contains(url.pathExtension) else { continue }
+
+                let relativePath = url.path.replacingOccurrences(
+                    of: root.path + "/", with: "")
+                guard excludedPaths.contains(relativePath) == false else { continue }
+                // Build products, vendored dependencies, and checkouts are not ours.
+                guard relativePath.contains("/.build/") == false else { continue }
+                paths.append(relativePath)
+            }
+        }
+        return paths.sorted()
+    }
+
+    private func regex(_ pattern: String) -> NSRegularExpression {
+        // Patterns are compile-time constants in this file.
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: pattern)
+    }
+
+    private func repositoryRoot() -> URL {
+        // This file lives at Tests/ProcessSignalSafetySeamTests/<file>.swift.
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}

--- a/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetySeamTests.swift
+++ b/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetySeamTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import WikiFSTypes
+
+/// This target links only WikiFSTypes. Its recorder is the sole signal seam.
+struct ProcessSignalSafetySeamTests {
+    private final class SignalRecorder {
+        private(set) var processIDs: [Int32] = []
+
+        func record(processID: Int32, signal _: Int32) -> Int32 {
+            processIDs.append(processID)
+            return 0
+        }
+    }
+
+    @Test(arguments: ["", " ", "0", "1", "12x", "12\n4"])
+    func invalidPIDFileContentsRefuseWithoutUsingTheSeam(_ contents: String) throws {
+        let recorder = SignalRecorder()
+        let expected = try identity()
+
+        let outcome = ProcessSignalSafety.signalFromPIDFile(
+            contents,
+            expectedIdentity: expected,
+            expectedParentProcessID: expected.parentProcessID,
+            observedIdentity: expected,
+            signal: recorder.record)
+
+        #expect(outcome == .refused(.invalidPIDFileContents))
+        #expect(recorder.processIDs.isEmpty)
+    }
+
+    @Test func sentinelPIDRefusesWithoutUsingTheSeam() throws {
+        let recorder = SignalRecorder()
+        let expected = try identity()
+
+        let outcome = ProcessSignalSafety.signalFromPIDFile(
+            "-1",
+            expectedIdentity: expected,
+            expectedParentProcessID: expected.parentProcessID,
+            observedIdentity: expected,
+            signal: recorder.record)
+
+        #expect(outcome == .refused(.invalidPIDFileContents))
+        #expect(recorder.processIDs.isEmpty)
+    }
+
+    @Test func stalePIDRefusesWithoutUsingTheSeam() throws {
+        let recorder = SignalRecorder()
+        let expected = try identity()
+
+        let outcome = ProcessSignalSafety.signal(
+            processID: expected.processID,
+            expectedIdentity: expected,
+            expectedParentProcessID: expected.parentProcessID,
+            observedIdentity: nil,
+            signal: recorder.record)
+
+        #expect(outcome == .refused(.identityUnavailable))
+        #expect(recorder.processIDs.isEmpty)
+    }
+
+    @Test func reusedPIDRefusesWithoutUsingTheSeam() throws {
+        let recorder = SignalRecorder()
+        let expected = try identity()
+        let reused = try identity(startTime: 101)
+
+        let outcome = ProcessSignalSafety.signal(
+            processID: expected.processID,
+            expectedIdentity: expected,
+            expectedParentProcessID: expected.parentProcessID,
+            observedIdentity: reused,
+            signal: recorder.record)
+
+        #expect(outcome == .refused(.identityMismatch))
+        #expect(recorder.processIDs.isEmpty)
+    }
+
+    @Test func nonChildPIDRefusesWithoutUsingTheSeam() throws {
+        let recorder = SignalRecorder()
+        let expected = try identity()
+        let differentParent = try positivePID(101)
+
+        let outcome = ProcessSignalSafety.signal(
+            processID: expected.processID,
+            expectedIdentity: expected,
+            expectedParentProcessID: differentParent,
+            observedIdentity: expected,
+            signal: recorder.record)
+
+        #expect(outcome == .refused(.parentMismatch))
+        #expect(recorder.processIDs.isEmpty)
+    }
+
+    @Test func verifiedChildUsesOnlyTheInjectedRecorder() throws {
+        let recorder = SignalRecorder()
+        let expected = try identity()
+
+        let outcome = ProcessSignalSafety.signal(
+            processID: expected.processID,
+            expectedIdentity: expected,
+            expectedParentProcessID: expected.parentProcessID,
+            observedIdentity: expected,
+            signal: recorder.record)
+
+        #expect(outcome == .sent(result: 0))
+        #expect(recorder.processIDs == [expected.processID.rawValue])
+    }
+
+    @Test func validationModuleAndFocusedTestTargetHaveNoSyscallPath() throws {
+        let root = repositoryRoot()
+        let validationSource = try String(
+            contentsOf: root.appendingPathComponent("Sources/WikiFSTypes/ProcessSignalSafety.swift"),
+            encoding: .utf8)
+        let manifest = try String(contentsOf: root.appendingPathComponent("Package.swift"), encoding: .utf8)
+        let syscallName = "kil" + "l("
+
+        #expect(validationSource.contains(syscallName) == false)
+        #expect(validationSource.contains("signal: (Int32, Int32) -> Int32") == true)
+
+        let targetStart = try #require(manifest.range(of: "name: \"ProcessSignalSafetySeamTests\""))
+        let targetTail = manifest[targetStart.lowerBound...]
+        let targetEnd = try #require(targetTail.range(of: "        ),"))
+        let target = String(targetTail[..<targetEnd.lowerBound])
+        #expect(target.contains("dependencies: [\"WikiFSTypes\"]") == true)
+        #expect(target.contains("WikiFSCore") == false)
+    }
+
+    private func positivePID(_ rawValue: Int32) throws -> ProcessSignalSafety.PositivePID {
+        try #require(ProcessSignalSafety.PositivePID(rawValue: rawValue))
+    }
+
+    private func identity(
+        processID: Int32 = 42,
+        parentProcessID: Int32 = 100,
+        startTime: UInt64 = 100
+    ) throws -> ProcessSignalSafety.Identity {
+        ProcessSignalSafety.Identity(
+            processID: try positivePID(processID),
+            parentProcessID: try positivePID(parentProcessID),
+            startTime: .init(seconds: startTime, microseconds: 0))
+    }
+
+    private func repositoryRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+    }
+}

--- a/scripts/lib/test-watchdog-process-control.sh
+++ b/scripts/lib/test-watchdog-process-control.sh
@@ -5,17 +5,26 @@
 # only ever signals a PID that bash still lists as one of THIS shell's running
 # jobs.
 #
-# Why `jobs -pr` is sound proof of identity, and `kill -0` is not:
+# Why signalling goes through a JOBSPEC (%1) and never through a number:
 #
 #   `kill -0 $pid` asks "does some process with this number exist?". Between the
 #   timeout decision and the signal, the child can exit and the kernel can
 #   reissue its PID to an unrelated process. The answer stays "yes" and the
 #   signal lands on a stranger.
 #
-#   `jobs -pr` asks "is this still one of MY un-reaped running children?". The
-#   kernel cannot recycle a child's PID until its parent reaps it, so while the
-#   PID appears in this shell's job table it unambiguously denotes the process
-#   this shell launched. No PID-reuse window exists.
+#   Checking `jobs -pr` first is better, but it is still check-then-signal: the
+#   snapshot proves the PID was an un-reaped job at snapshot time only. Bash can
+#   handle SIGCHLD and reap the job between that check and a later
+#   `kill "$pid"`, after which the kernel may recycle the number. A separately
+#   captured snapshot therefore cannot authorise a numeric signal.
+#
+#   `builtin kill -TERM %1` closes this. Bash resolves the jobspec against its
+#   own job table at the moment of the signal, so the proof and the signal are a
+#   single operation and no recyclable number is ever passed. If the job has been
+#   reaped, the builtin fails with "no such job" and delivers nothing.
+#
+# The numeric predicates below remain for the wait loop and for tests, where a
+# stale answer is harmless. They must NOT be used to authorise a signal.
 #
 # This also replaces the previous `pkill -f "[s]wiftpm-testing-helper.*"` sweep,
 # which selected processes by command-line appearance rather than by ownership.
@@ -57,13 +66,19 @@ watchdog_is_verified_child() {
     return 1
 }
 
-# Signals `pid` only if the snapshot proves it is still our running child.
-# Refuses every other signal name so a caller cannot smuggle in a group signal
-# (a negative PID) or a stop signal.
-watchdog_signal_verified_child() {
+# Signals one of THIS shell's background jobs, addressed only by jobspec.
+#
+# There is deliberately no PID parameter and no snapshot parameter: accepting
+# either would reintroduce the check-then-signal race described above. Bash
+# performs the ownership lookup and the signal together, and fails closed with
+# "no such job" if the job has already been reaped.
+#
+# Refuses every signal name outside TERM/KILL so a caller cannot smuggle in a
+# stop signal, and refuses anything that is not a literal jobspec so a numeric
+# PID or a negative process-group number can never reach `kill`.
+watchdog_signal_job() {
     local signal_name="$1"
-    local pid="$2"
-    local snapshot="$3"
+    local jobspec="$2"
 
     case "$signal_name" in
         TERM | KILL) ;;
@@ -73,10 +88,13 @@ watchdog_signal_verified_child() {
             ;;
     esac
 
-    if ! watchdog_is_verified_child "$pid" "$snapshot"; then
-        echo "test watchdog: refused $signal_name for PID $pid — not a verified running child of this shell" >&2
+    if [[ ! "$jobspec" =~ ^%[0-9]+$ ]]; then
+        echo "test watchdog: refused $signal_name for '$jobspec' — not a jobspec" >&2
         return 1
     fi
 
-    builtin kill "-$signal_name" "$pid" 2>/dev/null
+    if ! builtin kill "-$signal_name" "$jobspec" 2>/dev/null; then
+        echo "test watchdog: $signal_name not delivered to $jobspec — no such job (already exited)" >&2
+        return 1
+    fi
 }

--- a/scripts/lib/test-watchdog-process-control.sh
+++ b/scripts/lib/test-watchdog-process-control.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Process-control boundary for test-with-watchdog.sh (#1051).
+#
+# The rule: a numeric PID is never sufficient authority to signal. This library
+# only ever signals a PID that bash still lists as one of THIS shell's running
+# jobs.
+#
+# Why `jobs -pr` is sound proof of identity, and `kill -0` is not:
+#
+#   `kill -0 $pid` asks "does some process with this number exist?". Between the
+#   timeout decision and the signal, the child can exit and the kernel can
+#   reissue its PID to an unrelated process. The answer stays "yes" and the
+#   signal lands on a stranger.
+#
+#   `jobs -pr` asks "is this still one of MY un-reaped running children?". The
+#   kernel cannot recycle a child's PID until its parent reaps it, so while the
+#   PID appears in this shell's job table it unambiguously denotes the process
+#   this shell launched. No PID-reuse window exists.
+#
+# This also replaces the previous `pkill -f "[s]wiftpm-testing-helper.*"` sweep,
+# which selected processes by command-line appearance rather than by ownership.
+#
+# The verification predicates are pure: callers pass in a job-table snapshot,
+# so they can be unit-tested without launching or signalling anything. See
+# scripts/tests/test-test-with-watchdog-process-control.sh.
+
+watchdog_is_positive_pid() {
+    local pid="$1"
+    [[ "$pid" =~ ^[0-9]+$ ]] && ((pid > 1))
+}
+
+# Refuses PIDs that are structurally never a valid target: non-numeric, 0/1,
+# this shell, or this shell's parent.
+watchdog_is_signal_candidate_pid() {
+    local pid="$1"
+    watchdog_is_positive_pid "$pid" && ((pid != $$)) && ((pid != PPID))
+}
+
+# Snapshot of this shell's running (un-reaped) job PIDs, one per line. Must be
+# called from the shell that owns the job, not from a subshell that launched it.
+watchdog_running_child_pids() {
+    jobs -pr
+}
+
+# PURE: is `pid` present in the supplied job-table snapshot?
+# Exact whole-line match, so PID 42 never satisfies a check for PID 4.
+watchdog_is_verified_child() {
+    local pid="$1"
+    local snapshot="$2"
+    local candidate
+
+    watchdog_is_signal_candidate_pid "$pid" || return 1
+    while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        [[ "$candidate" == "$pid" ]] && return 0
+    done <<<"$snapshot"
+    return 1
+}
+
+# Signals `pid` only if the snapshot proves it is still our running child.
+# Refuses every other signal name so a caller cannot smuggle in a group signal
+# (a negative PID) or a stop signal.
+watchdog_signal_verified_child() {
+    local signal_name="$1"
+    local pid="$2"
+    local snapshot="$3"
+
+    case "$signal_name" in
+        TERM | KILL) ;;
+        *)
+            echo "test watchdog: refused unsupported signal $signal_name" >&2
+            return 1
+            ;;
+    esac
+
+    if ! watchdog_is_verified_child "$pid" "$snapshot"; then
+        echo "test watchdog: refused $signal_name for PID $pid — not a verified running child of this shell" >&2
+        return 1
+    fi
+
+    builtin kill "-$signal_name" "$pid" 2>/dev/null
+}

--- a/scripts/test-with-watchdog.sh
+++ b/scripts/test-with-watchdog.sh
@@ -47,6 +47,10 @@ echo "==> timeout: ${TIMEOUT_SECS}s (override with TEST_TIMEOUT=<seconds>)"
 
 swift test -v --parallel --num-workers "$NUM_WORKERS" "$@" >"$LOG_FILE" 2>&1 &
 TEST_PID=$!
+# The only background job this script starts, so it is always %1. Signals are
+# addressed by this jobspec; the PID is used only for the liveness loop and for
+# `wait`, neither of which sends a signal.
+TEST_JOB="%1"
 
 START_TS=$(date +%s)
 TIMED_OUT=0
@@ -65,18 +69,16 @@ done
 if [ "$TIMED_OUT" -eq 1 ]; then
     echo ""
     echo "✗ TIMED OUT after ${TIMEOUT_SECS}s — signaling only the verified swift test child."
-    if ! watchdog_signal_verified_child TERM "$TEST_PID" "$(watchdog_running_child_pids)"; then
-        echo "test watchdog: TERM not delivered; child is no longer a verified running child." >&2
-    fi
+    # Addressed by jobspec, never by PID: bash resolves ownership and signals in
+    # one step, so there is no interval in which the number could be recycled.
+    # This script launches exactly one background job, so %1 is that job.
+    watchdog_signal_job TERM "$TEST_JOB" || true
     sleep 1
-    # Escalate only if the child is still running. A child that exited on TERM is
-    # the expected outcome, not a refusal worth reporting.
-    KILL_SNAPSHOT="$(watchdog_running_child_pids)"
-    if watchdog_is_verified_child "$TEST_PID" "$KILL_SNAPSHOT"; then
+    # Escalate only if the job is still running. A child that exited on TERM is
+    # the expected outcome, not a failure worth reporting.
+    if watchdog_is_verified_child "$TEST_PID" "$(watchdog_running_child_pids)"; then
         echo "==> child survived TERM; escalating to KILL."
-        if ! watchdog_signal_verified_child KILL "$TEST_PID" "$KILL_SNAPSHOT"; then
-            echo "test watchdog: KILL not delivered; child is no longer a verified running child." >&2
-        fi
+        watchdog_signal_job KILL "$TEST_JOB" || true
     else
         echo "==> child exited on TERM; no KILL needed."
     fi

--- a/scripts/test-with-watchdog.sh
+++ b/scripts/test-with-watchdog.sh
@@ -9,13 +9,22 @@
 # by another concurrently-running blocking suite; see #664/#732). That leaves
 # the WHOLE `swift test` process hanging with no diagnostic. This script:
 #   1. Runs the suite with a real timeout (default 900s; override with
-#      TEST_TIMEOUT), tee'd to a timestamped log under tmp/test-logs/.
-#   2. On timeout, kills the swift-test process tree AND its
-#      swiftpm-testing-helper child (same orphan pattern as `make test`'s
-#      trap) and reports exactly which test(s) started but never finished.
+#      TEST_TIMEOUT), logged to a timestamped file under tmp/test-logs/.
+#   2. On timeout, signals ONLY the `swift test` child it launched, and only
+#      while bash still lists that PID as a running job of this shell. It never
+#      sweeps helpers by command line, path, process group, session, or user.
 #   3. On any exit, prints the slowest tests (parsed from Swift Testing's own
 #      "passed/failed after N seconds" lines) so a newly-slow test is visible
 #      as a trend, not just a future hang.
+#
+# Signal safety (#1051): this script previously ran
+# `pkill -f "[s]wiftpm-testing-helper.*$REPO_ROOT/.build"` on every exit and
+# used `kill -0` for liveness. Both select by appearance rather than ownership.
+# The sweep is gone, and every signal now goes through the verified-child
+# boundary in scripts/lib/test-watchdog-process-control.sh.
+#
+# Orphaned helpers are NOT reaped here. A helper belongs to the `swift test`
+# process that launched it; if one is left behind, reap it by hand.
 #
 # Usage: scripts/test-with-watchdog.sh [swift test args...]
 #   TEST_TIMEOUT=1200 scripts/test-with-watchdog.sh --filter QueueEngineTests
@@ -24,6 +33,7 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
+source "$REPO_ROOT/scripts/lib/test-watchdog-process-control.sh"
 
 TIMEOUT_SECS="${TEST_TIMEOUT:-900}"
 NUM_WORKERS="${SWIFT_TEST_NUM_WORKERS:-1}"
@@ -31,23 +41,20 @@ LOG_DIR="tmp/test-logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/swift-test-$(date +%Y%m%d-%H%M%S).log"
 
-reap_helpers() {
-    pkill -f "[s]wiftpm-testing-helper.*$REPO_ROOT/.build" 2>/dev/null || true
-}
-trap reap_helpers EXIT TERM INT
-
 echo "==> swift test -v --parallel --num-workers ${NUM_WORKERS} $* "
 echo "==> log: $LOG_FILE"
 echo "==> timeout: ${TIMEOUT_SECS}s (override with TEST_TIMEOUT=<seconds>)"
 
-reap_helpers
 swift test -v --parallel --num-workers "$NUM_WORKERS" "$@" >"$LOG_FILE" 2>&1 &
 TEST_PID=$!
 
 START_TS=$(date +%s)
 TIMED_OUT=0
-while kill -0 "$TEST_PID" 2>/dev/null; do
-    ELAPSED=$(( $(date +%s) - START_TS ))
+# `watchdog_running_child_pids` must be evaluated in this shell, which owns the
+# job. The loop ends when the child leaves the running-job table, either by
+# finishing or by being signalled.
+while watchdog_is_verified_child "$TEST_PID" "$(watchdog_running_child_pids)"; do
+    ELAPSED=$(($(date +%s) - START_TS))
     if [ "$ELAPSED" -ge "$TIMEOUT_SECS" ]; then
         TIMED_OUT=1
         break
@@ -57,15 +64,31 @@ done
 
 if [ "$TIMED_OUT" -eq 1 ]; then
     echo ""
-    echo "✗ TIMED OUT after ${TIMEOUT_SECS}s — killing swift test and reaping its helper."
-    kill "$TEST_PID" 2>/dev/null
+    echo "✗ TIMED OUT after ${TIMEOUT_SECS}s — signaling only the verified swift test child."
+    if ! watchdog_signal_verified_child TERM "$TEST_PID" "$(watchdog_running_child_pids)"; then
+        echo "test watchdog: TERM not delivered; child is no longer a verified running child." >&2
+    fi
     sleep 1
-    kill -9 "$TEST_PID" 2>/dev/null
-    reap_helpers
+    # Escalate only if the child is still running. A child that exited on TERM is
+    # the expected outcome, not a refusal worth reporting.
+    KILL_SNAPSHOT="$(watchdog_running_child_pids)"
+    if watchdog_is_verified_child "$TEST_PID" "$KILL_SNAPSHOT"; then
+        echo "==> child survived TERM; escalating to KILL."
+        if ! watchdog_signal_verified_child KILL "$TEST_PID" "$KILL_SNAPSHOT"; then
+            echo "test watchdog: KILL not delivered; child is no longer a verified running child." >&2
+        fi
+    else
+        echo "==> child exited on TERM; no KILL needed."
+    fi
     EXIT_CODE=124
-else
-    wait "$TEST_PID"
-    EXIT_CODE=$?
+fi
+
+# `wait` is safe and bounded here: the child has either finished on its own or
+# been signalled above, so it is a terminated-but-unreaped job in both paths.
+wait "$TEST_PID"
+WAIT_STATUS=$?
+if [ "$TIMED_OUT" -ne 1 ]; then
+    EXIT_CODE=$WAIT_STATUS
 fi
 
 perl -ne '

--- a/scripts/tests/test-test-with-watchdog-process-control.sh
+++ b/scripts/tests/test-test-with-watchdog-process-control.sh
@@ -49,35 +49,52 @@ expect_refused "refuses a PID with whitespace padding" " 4242" "$SNAP"
 expect_refused "refuses this shell" "$$" "$(printf '%s\n' "$$")"
 expect_refused "refuses this shell's parent" "$PPID" "$(printf '%s\n' "$PPID")"
 
-echo "watchdog_signal_verified_child — signal-name allowlist:"
-if watchdog_signal_verified_child HUP 4242 "$SNAP" 2>/dev/null; then
-    fail "refuses HUP"
-else
-    pass "refuses HUP"
-fi
-if watchdog_signal_verified_child STOP 4242 "$SNAP" 2>/dev/null; then
-    fail "refuses STOP"
-else
-    pass "refuses STOP"
-fi
-if watchdog_signal_verified_child TERM 9999 "$SNAP" 2>/dev/null; then
-    fail "refuses TERM for an unverified PID"
-else
-    pass "refuses TERM for an unverified PID"
-fi
+echo "watchdog_signal_job — signal-name allowlist:"
+for bad_signal in HUP STOP CONT USR1 9 -9; do
+    if watchdog_signal_job "$bad_signal" "%1" 2>/dev/null; then
+        fail "refuses $bad_signal"
+    else
+        pass "refuses $bad_signal"
+    fi
+done
 
-echo "live child — end to end:"
+echo "watchdog_signal_job — refuses anything that is not a jobspec:"
+# A numeric PID must never reach kill, or the check-then-signal race returns.
+for bad_target in 4242 -4242 "" "abc" "%" "%%1" "% 1" "1%"; do
+    if watchdog_signal_job TERM "$bad_target" 2>/dev/null; then
+        fail "refuses target '$bad_target'"
+    else
+        pass "refuses target '$bad_target'"
+    fi
+done
+
+echo "live job — end to end via jobspec:"
 sleep 30 &
 LIVE_PID=$!
-LIVE_SNAP="$(watchdog_running_child_pids)"
-expect_verified "verifies a live direct child" "$LIVE_PID" "$LIVE_SNAP"
+expect_verified "verifies a live direct child" "$LIVE_PID" "$(watchdog_running_child_pids)"
 
-if watchdog_signal_verified_child TERM "$LIVE_PID" "$LIVE_SNAP"; then
-    pass "delivers TERM to a verified live child"
+if watchdog_signal_job TERM "%1"; then
+    pass "delivers TERM to a live job by jobspec"
 else
-    fail "delivers TERM to a verified live child"
+    fail "delivers TERM to a live job by jobspec"
 fi
-wait "$LIVE_PID" 2>/dev/null
+wait %1 2>/dev/null
+
+echo "the race the reviewer found — target exits AND is reaped after verification:"
+sleep 0.1 &
+RACE_PID=$!
+RACE_SNAP="$(watchdog_running_child_pids)"
+# Verification succeeded against this snapshot...
+expect_verified "snapshot verified the child while it was running" "$RACE_PID" "$RACE_SNAP"
+# ...then the child exits and bash reaps it, freeing the PID for reuse.
+wait %1 2>/dev/null
+# A numeric signal authorised by the now-stale snapshot would land on whatever
+# holds that PID next. The jobspec boundary refuses instead.
+if watchdog_signal_job TERM "%1" 2>/dev/null; then
+    fail "refuses to signal a job reaped after verification"
+else
+    pass "refuses to signal a job reaped after verification"
+fi
 
 echo "reaped child — the PID-reuse window kill -0 would miss:"
 sleep 0.1 &

--- a/scripts/tests/test-test-with-watchdog-process-control.sh
+++ b/scripts/tests/test-test-with-watchdog-process-control.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Unit tests for the watchdog process-control boundary (#1051).
+#
+# These tests never signal a real process except a `sleep` this script launched
+# itself. The verification predicates are pure — they take a job-table snapshot
+# as an argument — so refusal cases need no processes at all.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$REPO_ROOT/scripts/lib/test-watchdog-process-control.sh"
+
+FAILURES=0
+ASSERTIONS=0
+
+pass() {
+    ASSERTIONS=$((ASSERTIONS + 1))
+    echo "  ✓ $1"
+}
+
+fail() {
+    ASSERTIONS=$((ASSERTIONS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "  ✗ $1"
+}
+
+expect_verified() {
+    if watchdog_is_verified_child "$2" "$3"; then pass "$1"; else fail "$1"; fi
+}
+
+expect_refused() {
+    if watchdog_is_verified_child "$2" "$3"; then fail "$1"; else pass "$1"; fi
+}
+
+echo "watchdog_is_verified_child — refusals (pure, no processes):"
+SNAP=$'4242\n4243'
+expect_verified "accepts a PID present in the snapshot" 4242 "$SNAP"
+expect_verified "accepts the second PID in the snapshot" 4243 "$SNAP"
+expect_refused "refuses a PID absent from the snapshot" 9999 "$SNAP"
+expect_refused "refuses a prefix of a listed PID (4 vs 4242)" 4 "$SNAP"
+expect_refused "refuses a numeric extension of a listed PID (42420)" 42420 "$SNAP"
+expect_refused "refuses an empty snapshot" 4242 ""
+expect_refused "refuses PID 0" 0 $'0'
+expect_refused "refuses PID 1 (init)" 1 $'1'
+expect_refused "refuses a negative PID (process group)" -4242 "$SNAP"
+expect_refused "refuses a non-numeric PID" "abc" "$SNAP"
+expect_refused "refuses an empty PID" "" "$SNAP"
+expect_refused "refuses a PID with whitespace padding" " 4242" "$SNAP"
+expect_refused "refuses this shell" "$$" "$(printf '%s\n' "$$")"
+expect_refused "refuses this shell's parent" "$PPID" "$(printf '%s\n' "$PPID")"
+
+echo "watchdog_signal_verified_child — signal-name allowlist:"
+if watchdog_signal_verified_child HUP 4242 "$SNAP" 2>/dev/null; then
+    fail "refuses HUP"
+else
+    pass "refuses HUP"
+fi
+if watchdog_signal_verified_child STOP 4242 "$SNAP" 2>/dev/null; then
+    fail "refuses STOP"
+else
+    pass "refuses STOP"
+fi
+if watchdog_signal_verified_child TERM 9999 "$SNAP" 2>/dev/null; then
+    fail "refuses TERM for an unverified PID"
+else
+    pass "refuses TERM for an unverified PID"
+fi
+
+echo "live child — end to end:"
+sleep 30 &
+LIVE_PID=$!
+LIVE_SNAP="$(watchdog_running_child_pids)"
+expect_verified "verifies a live direct child" "$LIVE_PID" "$LIVE_SNAP"
+
+if watchdog_signal_verified_child TERM "$LIVE_PID" "$LIVE_SNAP"; then
+    pass "delivers TERM to a verified live child"
+else
+    fail "delivers TERM to a verified live child"
+fi
+wait "$LIVE_PID" 2>/dev/null
+
+echo "reaped child — the PID-reuse window kill -0 would miss:"
+sleep 0.1 &
+GONE_PID=$!
+sleep 1
+GONE_SNAP="$(watchdog_running_child_pids)"
+expect_refused "refuses a child that already exited" "$GONE_PID" "$GONE_SNAP"
+wait "$GONE_PID" 2>/dev/null
+
+echo "no broad matchers anywhere in the watchdog:"
+for candidate in "$REPO_ROOT/scripts/test-with-watchdog.sh" \
+    "$REPO_ROOT/scripts/lib/test-watchdog-process-control.sh"; do
+    name="$(basename "$candidate")"
+    # Skip comment lines: these files describe the removed sweep on purpose.
+    body="$(grep -vE '^[[:space:]]*#' "$candidate")"
+    for tool in pkill killall; do
+        if printf '%s' "$body" | grep -q "$tool"; then
+            fail "$name contains no $tool"
+        else
+            pass "$name contains no $tool"
+        fi
+    done
+    if printf '%s' "$body" | grep -q 'kill -0'; then
+        fail "$name contains no 'kill -0' liveness probe"
+    else
+        pass "$name contains no 'kill -0' liveness probe"
+    fi
+done
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo "✓ all $ASSERTIONS assertions passed"
+    exit 0
+fi
+echo "✗ $FAILURES of $ASSERTIONS assertions failed"
+exit 1


### PR DESCRIPTION
Extracts the signal-safety fix from the reverted PR #1035, and leaves the rest behind.

Refs #1051.

## Background

PR #1035 was meant to be step 1 of the dynamic-renderer series. It got derailed by the process-killing bug, accumulated unrelated material, then was merged as `398cc87c` and reverted wholesale by #1054. Current `main` has none of it.

That merge held three separate things. This PR takes one:

| Bucket | Content | This PR |
|---|---|---|
| Renderer contract | `Sources/WikiFSTypes/Renderer/*`, renderer tests, `RendererHashFixture` | left out |
| PR-gate audit machinery | `DynamicRendererPRSeriesAudit` target + tests, 2 JSON schemas, PR-series and test-inventory JSON | dropped |
| Signal safety | `ProcessSignalSafety`, `ProcessIdentityObservation`, `AsyncProcessRunner`, Makefile, watchdog | **extracted** |

47 files and 5011 insertions become 11 files and ~1310 insertions.

## The incident, and the two defects behind it

On 2026-08-02 a test-helper sweep was credited with terminating 125 PIDs when one hung child was the intended target. Two independent defects caused it. Both were live on `main` until this PR.

**1. Selection by appearance.** `make test` and the watchdog both reaped helpers with:

```
pkill -f "[s]wiftpm-testing-helper.*<repo>/.build"
```

A command-line regex describes what a process looks like, not who owns it. It can select processes the sweep never launched. Both sweeps are removed, and orphaned helpers are no longer reaped automatically.

**2. Selection by stale number.** The watchdog used `kill -0` for liveness and then signalled the bare PID. `AsyncProcessRunner` signalled a recorded PID directly. A child can exit between the check and the signal, and the kernel can reissue its number to an unrelated process.

## What replaces them

**Product path — prove identity before every signal.** Termination verifies the PID, the parent PID, and the kernel-recorded start time against a fresh observation. Equal PIDs with different start times are different process lifetimes, so a reused PID is refused. Observation and signalling are injected seams, so tests exercise the decision without signalling anything. Every refusal is logged through `DebugLog`; nothing fails silently.

**Shell path — never pass a recyclable number to `kill`.** The watchdog signals its child by **jobspec** (`builtin kill -TERM %1`). Bash resolves the jobspec against its own job table at the moment of the signal, so the ownership proof and the signal are a single operation. A job that has already been reaped fails closed with `no such job`.

`watchdog_signal_job` accepts no PID and no job-table snapshot, precisely so a caller cannot authorise a signal with stale evidence. It also refuses any target that is not a literal jobspec, which keeps a negative process-group number away from `kill`. The numeric predicates that remain are used only for the wait loop, where a stale answer is harmless.

## Two corrections to the reverted implementation

**The watchdog was bricked.** As merged, `scripts/lib/test-watchdog-process-control.sh` shipped a production observer that always failed:

```bash
watchdog_observe_process() { return 1; }
watchdog_has_precise_identity_observer() { return 1; }
```

and the script gated on it at the top, so `test-with-watchdog.sh` exited 78 before running a single test. The watchdog here stays operable; a regression test asserts it still launches a suite.

**Linux termination would have become a silent no-op.** `proc_pidinfo` is Darwin-only, so `observe` returned nil on Linux, every cancellation failed closed, and subprocess termination stopped working. `AsyncProcessRunnerTests` is entirely `#if os(macOS)`, so CI would not have caught it. This PR adds a `/proc/<pid>/stat` observer. Its field arithmetic is parsed by a platform-independent function so it is unit-tested on macOS — which caught a real bug during development, where field 22 kept its trailing newline and failed to parse.

## Review finding, and the fix

An independent review (GPT-5.6-terra) raised one Critical issue against the first version of this PR, and it was correct.

The original shell boundary took a `jobs -pr` snapshot plus a PID, verified membership, then called `builtin kill "$pid"`. That is still check-then-signal: the snapshot proves only that the PID was an un-reaped job *at snapshot time*. Bash can handle `SIGCHLD` and reap the job between the check and the `kill`, after which the kernel may recycle the number — the very failure class this PR exists to remove. The code also carried a comment asserting "No PID-reuse window exists", which was wrong.

Fixed in `7375def0` by moving to the jobspec form described above, so no numeric PID is ever passed to `kill`. Added the seam test the review asked for: a child verified against a snapshot that then exits and is reaped must not be signalled. The audit guard now also asserts the boundary contains no PID-addressed `kill`, so the race cannot return silently.

## Reintroduction guard

`ProcessSignalSafetyAuditTests` inventories every process-control call site under `Sources/`, `scripts/`, and the `Makefile`, and requires a written rationale for each. Same shape as `StoreEmissionExhaustivenessTests`. Keyed by (path, primitive) with an expected count rather than by line number, so it does not fail on unrelated edits and get rubber-stamped.

Confirmed to fail when the incident line is put back:

```
Makefile [broadMatcher]: expected 4 occurrence(s), found 5.
Makefile must not select the SwiftPM test helper by command line (#1051)
```

Note the second assertion matches on `testing-helper`, not `swiftpm-testing-helper`. The original sweep wrote the pattern as `[s]wiftpm-testing-helper`, which contains no `swiftpm-testing-helper` substring at all, so a naive check passes straight through the exact line that caused the incident. The first version of this guard had that hole.

## Recorded, not fixed

Two pre-existing weak sites are written into the inventory as visible and explicitly unapproved, rather than quietly accepted:

- `TranscriptSubprocess.swift` — `kill(pid, 0)` then `kill(pid, SIGTERM)` on a PID from a stored snapshot. Same check-then-signal class as this issue. Should migrate to `ProcessSignalSafety`.
- `Makefile` run/install targets — `pkill -f` against the absolute installed app path. Appearance-based, but scoped to the developer's own install path and never used to reap test helpers.

## Scope

This does **not** fix the underlying test hang in #1051 that triggers the timeout path. That issue stays open. This PR makes the timeout path safe when it fires.

## Verification

- `make build` clean
- `make test` — 3042 tests in 250 suites pass
- `bash scripts/tests/test-test-with-watchdog-process-control.sh` — 39 assertions pass, including the exit-and-reap-after-verification race
- Watchdog normal path runs a suite and exits 0
- Watchdog timeout path TERMs by jobspec, declines to escalate to a child that already exited, exits 124, leaves no stray processes
