### PR TITLE
fix(tests): prevent test hangs from cooperative thread pool starvation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,47 @@ agents, NOT Polytoken):
     and look for any non-optional `URL` await where the Obj-C completion is `(NSURL?, …)`.
     See `plans/fileprovider-crash-fix.md` for the full root-cause writeup.
 
+* **Never block the cooperative thread pool in tests — `Process.waitUntilExit()`,
+  `Thread.sleep`, `DispatchSemaphore.wait` on a `Task.detached` body, and bare
+  `withCheckedContinuation` with no timeout can all hang `swift test` under
+  `--parallel` (#664, #732, #926, #1051).** The cooperative thread pool is
+  finite (as few as 3 on CI). A synchronous blocking call parks the pool thread
+  it runs on; enough concurrent blockers exhaust the pool, and other suites'
+  `withCheckedContinuation` completions can't be delivered — the whole `swift
+  test` process hangs with no diagnostic. `.timeLimit` can't rescue this: it
+  cancels the test's `Task`, but cancelling a Task does NOT resume an abandoned
+  continuation.
+  - **The rule:** every test that waits on a subprocess or a continuation must
+    (a) use the non-blocking `terminationHandler` + `withCheckedContinuation`
+    pattern instead of `Process.waitUntilExit()`, (b) race the continuation
+    against a timeout so a starved pool produces a fast, diagnosed failure
+    instead of an infinite hang, and (c) annotate the suite with
+    `@Suite(.serialized, .timeLimit(.minutes(N)))`.
+  ```swift
+  // BAD — parks a cooperative thread; starves the pool under --parallel:
+  process.waitUntilExit()
+
+  // BAD — hangs forever if the completion is starved off the pool:
+  await withCheckedContinuation { cont in process.terminationHandler = { _ in cont.resume() } }
+
+  // GOOD — non-blocking, and a timeout turns starvation into a fast failure:
+  try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+          try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+              if !process.isRunning { cont.resume(); return }
+              process.terminationHandler = { _ in cont.resume() }
+          }
+      }
+      group.addTask { try await Task.sleep(for: .seconds(30)) }
+      _ = try await group.next()
+      group.cancelAll()
+  }
+  ```
+  - **Audit recipe:** `rg -n 'waitUntilExit|Thread\.sleep|DispatchSemaphore.*wait|withCheckedContinuation' Tests/`
+    and confirm every hit is either non-blocking, timeout-bounded, or in a
+    `.serialized` + `.timeLimit` suite. See #1051 for the full root-cause
+    writeup; regression watchdog: `scripts/test-with-watchdog.sh`.
+
 * **SQLite concurrency (graph-model Phase 0): the store is method-atomic —
   every `SQLiteWikiStore` entry point holds an internal recursive lock; writes
   still flow through the `@MainActor` model; off-main reads go through

--- a/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptHostedTests.swift
@@ -9,7 +9,7 @@ import WebKit
 
 /// Exercises the Phase 4 transcript markup against a live WebKit document.
 /// It is serialized through the shared gate because SwiftPM has one AppKit host.
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(2)))
 @MainActor
 struct ChatTranscriptHostedTests {
     private static let app: NSApplication = {

--- a/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
+++ b/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
@@ -11,6 +11,47 @@ import Testing
 /// bundled via `build.sh`. See `plans/defuddle-extraction.md` §5.
 @Suite(.timeLimit(.minutes(2))) struct DefuddleExtractionServiceTests {
 
+    private enum ProcessExitWaitError: Error {
+        case timedOut
+    }
+
+    private final class ProcessExitWaiter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Error>?
+        private var result: Result<Void, Error>?
+
+        func install(_ continuation: CheckedContinuation<Void, Error>) {
+            let result: Result<Void, Error>?
+            lock.lock()
+            if let storedResult = self.result {
+                result = storedResult
+            } else {
+                self.continuation = continuation
+                result = nil
+            }
+            lock.unlock()
+            if let result {
+                continuation.resume(with: result)
+            }
+        }
+
+        @discardableResult
+        func finish(_ result: Result<Void, Error>) -> Bool {
+            let continuation: CheckedContinuation<Void, Error>?
+            lock.lock()
+            guard self.result == nil else {
+                lock.unlock()
+                return false
+            }
+            self.result = result
+            continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(with: result)
+            return true
+        }
+    }
+
     /// Whether bun + the defuddle script are resolvable on this machine.
     private var resolved: (bun: URL, script: URL)? {
         DefuddleExtractionService.resolve()
@@ -28,20 +69,36 @@ import Testing
     /// `withCheckedContinuation` hangs forever. The timeout produces a fast,
     /// diagnosed failure instead of an infinite hang.
     private func asyncWaitUntilExit(_ process: Process, timeout: Duration = .seconds(30)) async throws {
+        let waiter = ProcessExitWaiter()
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-                    if !process.isRunning {
-                        cont.resume()
-                        return
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                        waiter.install(cont)
+                        process.terminationHandler = { _ in
+                            waiter.finish(.success(()))
+                        }
+                        if !process.isRunning {
+                            waiter.finish(.success(()))
+                        }
                     }
-                    process.terminationHandler = { _ in
-                        cont.resume()
+                } onCancel: {
+                    if waiter.finish(.failure(CancellationError())), process.isRunning {
+                        process.terminate()
                     }
                 }
             }
             group.addTask {
-                try await Task.sleep(for: timeout)
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {
+                    return
+                }
+                guard waiter.finish(.failure(ProcessExitWaitError.timedOut)) else { return }
+                if process.isRunning {
+                    process.terminate()
+                }
+                throw ProcessExitWaitError.timedOut
             }
             _ = try await group.next()
             group.cancelAll()

--- a/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
+++ b/Tests/WikiFSAppTests/DefuddleExtractionServiceTests.swift
@@ -9,7 +9,7 @@ import Testing
 /// **skip gracefully** if `DefuddleExtractionService.resolve()` returns nil
 /// (CI, clean dev before `make build`) — defuddle is opt-in until the script is
 /// bundled via `build.sh`. See `plans/defuddle-extraction.md` §5.
-@Suite struct DefuddleExtractionServiceTests {
+@Suite(.timeLimit(.minutes(2))) struct DefuddleExtractionServiceTests {
 
     /// Whether bun + the defuddle script are resolvable on this machine.
     private var resolved: (bun: URL, script: URL)? {
@@ -22,15 +22,29 @@ import Testing
     /// suite scheduled onto it (#732, same fix as `PdfExtractionServiceTests`).
     /// Use `terminationHandler` + `CheckedContinuation` instead — same
     /// semantics, non-blocking.
-    private func asyncWaitUntilExit(_ process: Process) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            if !process.isRunning {
-                cont.resume()
-                return
+    ///
+    /// The 30s timeout (issue #1051) is a safety net: if the `terminationHandler`
+    /// completion is starved off the cooperative pool, a bare
+    /// `withCheckedContinuation` hangs forever. The timeout produces a fast,
+    /// diagnosed failure instead of an infinite hang.
+    private func asyncWaitUntilExit(_ process: Process, timeout: Duration = .seconds(30)) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                    if !process.isRunning {
+                        cont.resume()
+                        return
+                    }
+                    process.terminationHandler = { _ in
+                        cont.resume()
+                    }
+                }
             }
-            process.terminationHandler = { _ in
-                cont.resume()
+            group.addTask {
+                try await Task.sleep(for: timeout)
             }
+            _ = try await group.next()
+            group.cancelAll()
         }
     }
 

--- a/Tests/WikiFSAppTests/PdfExtractionServiceTests.swift
+++ b/Tests/WikiFSAppTests/PdfExtractionServiceTests.swift
@@ -4,22 +4,38 @@ import Testing
 @testable import WikiFS
 @testable import WikiFSEngine
 
-@Suite struct PdfExtractionServiceTests {
+@Suite(.timeLimit(.minutes(2))) struct PdfExtractionServiceTests {
 
     /// Wait for a process to exit without blocking the cooperative thread
     /// pool. `Process.waitUntilExit()` is synchronous and parks the calling
     /// thread; on CI's 3-vCPU runner with `--parallel`, that starves the pool
     /// and deadlocks every other test (#732). Use `terminationHandler` +
     /// `CheckedContinuation` instead — same semantics, non-blocking.
-    private func asyncWaitUntilExit(_ process: Process) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            if !process.isRunning {
-                cont.resume()
-                return
+    ///
+    /// The 30s timeout (issue #1051) is a safety net: if the `terminationHandler`
+    /// completion is starved off the cooperative pool (same bug class as
+    /// #664/#732/#926), a bare `withCheckedContinuation` hangs forever and
+    /// `.timeLimit` can't rescue it (cancelling the test's Task doesn't resume
+    /// an abandoned continuation). The timeout produces a fast, diagnosed
+    /// failure instead of an infinite hang.
+    private func asyncWaitUntilExit(_ process: Process, timeout: Duration = .seconds(30)) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                    if !process.isRunning {
+                        cont.resume()
+                        return
+                    }
+                    process.terminationHandler = { _ in
+                        cont.resume()
+                    }
+                }
             }
-            process.terminationHandler = { _ in
-                cont.resume()
+            group.addTask {
+                try await Task.sleep(for: timeout)
             }
+            _ = try await group.next()
+            group.cancelAll()
         }
     }
 

--- a/Tests/WikiFSAppTests/PdfExtractionServiceTests.swift
+++ b/Tests/WikiFSAppTests/PdfExtractionServiceTests.swift
@@ -6,6 +6,47 @@ import Testing
 
 @Suite(.timeLimit(.minutes(2))) struct PdfExtractionServiceTests {
 
+    private enum ProcessExitWaitError: Error {
+        case timedOut
+    }
+
+    private final class ProcessExitWaiter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Error>?
+        private var result: Result<Void, Error>?
+
+        func install(_ continuation: CheckedContinuation<Void, Error>) {
+            let result: Result<Void, Error>?
+            lock.lock()
+            if let storedResult = self.result {
+                result = storedResult
+            } else {
+                self.continuation = continuation
+                result = nil
+            }
+            lock.unlock()
+            if let result {
+                continuation.resume(with: result)
+            }
+        }
+
+        @discardableResult
+        func finish(_ result: Result<Void, Error>) -> Bool {
+            let continuation: CheckedContinuation<Void, Error>?
+            lock.lock()
+            guard self.result == nil else {
+                lock.unlock()
+                return false
+            }
+            self.result = result
+            continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(with: result)
+            return true
+        }
+    }
+
     /// Wait for a process to exit without blocking the cooperative thread
     /// pool. `Process.waitUntilExit()` is synchronous and parks the calling
     /// thread; on CI's 3-vCPU runner with `--parallel`, that starves the pool
@@ -19,20 +60,36 @@ import Testing
     /// an abandoned continuation). The timeout produces a fast, diagnosed
     /// failure instead of an infinite hang.
     private func asyncWaitUntilExit(_ process: Process, timeout: Duration = .seconds(30)) async throws {
+        let waiter = ProcessExitWaiter()
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-                    if !process.isRunning {
-                        cont.resume()
-                        return
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                        waiter.install(cont)
+                        process.terminationHandler = { _ in
+                            waiter.finish(.success(()))
+                        }
+                        if !process.isRunning {
+                            waiter.finish(.success(()))
+                        }
                     }
-                    process.terminationHandler = { _ in
-                        cont.resume()
+                } onCancel: {
+                    if waiter.finish(.failure(CancellationError())), process.isRunning {
+                        process.terminate()
                     }
                 }
             }
             group.addTask {
-                try await Task.sleep(for: timeout)
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {
+                    return
+                }
+                guard waiter.finish(.failure(ProcessExitWaitError.timedOut)) else { return }
+                if process.isRunning {
+                    process.terminate()
+                }
+                throw ProcessExitWaitError.timedOut
             }
             _ = try await group.next()
             group.cancelAll()

--- a/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
@@ -12,7 +12,7 @@ import WebKit
 /// JS that emits the right text but doesn't actually produce a `<mark>`). If
 /// these fail, the highlight JS itself is broken; if they pass, the bug is in
 /// the trigger path (the pending-anchor consume that decides to run it).
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(2)))
 @MainActor
 struct QuoteHighlightWebViewTests {
     private static var retainedWindow: NSWindow?

--- a/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
+++ b/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
@@ -17,6 +17,47 @@ import Testing
 @Suite(.serialized, .timeLimit(.minutes(3)))
 struct IdentifierBoundaryTypecheckTests {
 
+    private enum ProcessExitWaitError: Error {
+        case timedOut
+    }
+
+    private final class ProcessExitWaiter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Error>?
+        private var result: Result<Void, Error>?
+
+        func install(_ continuation: CheckedContinuation<Void, Error>) {
+            let result: Result<Void, Error>?
+            lock.lock()
+            if let storedResult = self.result {
+                result = storedResult
+            } else {
+                self.continuation = continuation
+                result = nil
+            }
+            lock.unlock()
+            if let result {
+                continuation.resume(with: result)
+            }
+        }
+
+        @discardableResult
+        func finish(_ result: Result<Void, Error>) -> Bool {
+            let continuation: CheckedContinuation<Void, Error>?
+            lock.lock()
+            guard self.result == nil else {
+                lock.unlock()
+                return false
+            }
+            self.result = result
+            continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(with: result)
+            return true
+        }
+    }
+
     private struct BuildProducts {
         let debugDirectory: URL
         let modulesDirectory: URL
@@ -115,21 +156,50 @@ struct IdentifierBoundaryTypecheckTests {
         process.standardError = output
         try process.run()
 
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            if !process.isRunning {
-                cont.resume()
-                return
-            }
-            process.terminationHandler = { _ in
-                cont.resume()
-            }
-        }
+        try await asyncWaitUntilExit(process)
 
         let outputData = output.fileHandleForReading.readDataToEndOfFile()
         return CompilerResult(
             status: process.terminationStatus,
             output: String(decoding: outputData, as: UTF8.self)
         )
+    }
+
+    private func asyncWaitUntilExit(_ process: Process, timeout: Duration = .seconds(30)) async throws {
+        let waiter = ProcessExitWaiter()
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                        waiter.install(cont)
+                        process.terminationHandler = { _ in
+                            waiter.finish(.success(()))
+                        }
+                        if !process.isRunning {
+                            waiter.finish(.success(()))
+                        }
+                    }
+                } onCancel: {
+                    if waiter.finish(.failure(CancellationError())), process.isRunning {
+                        process.terminate()
+                    }
+                }
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {
+                    return
+                }
+                guard waiter.finish(.failure(ProcessExitWaitError.timedOut)) else { return }
+                if process.isRunning {
+                    process.terminate()
+                }
+                throw ProcessExitWaitError.timedOut
+            }
+            _ = try await group.next()
+            group.cancelAll()
+        }
     }
 
     private func typecheckTargetTriple() -> String {

--- a/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
+++ b/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
@@ -4,6 +4,17 @@ import Testing
 /// Runs small fixtures through `swiftc -typecheck` against the modules that
 /// SwiftPM built for this test run. This proves the namespace boundary at the
 /// compiler level, rather than only observing runtime behavior.
+///
+/// `.serialized` AND `.timeLimit(.minutes(2))` (issue #1051): each test spawns
+/// `swiftc -typecheck` as a subprocess. The original implementation used
+/// `Process.waitUntilExit()` — a synchronous call that parks the cooperative
+/// thread pool thread the test is running on. Under `--parallel` with multiple
+/// non-`.serialized` suites scheduled concurrently, 26 simultaneous
+/// `waitUntilExit()` calls can exhaust the pool, starving other suites'
+/// `withCheckedContinuation` completions (same bug class as #664/#732/#926).
+/// The async `terminationHandler` + `CheckedContinuation` pattern below is
+/// non-blocking; `.serialized` + `.timeLimit` are the safety net.
+@Suite(.serialized, .timeLimit(.minutes(3)))
 struct IdentifierBoundaryTypecheckTests {
 
     private struct BuildProducts {
@@ -71,7 +82,7 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    private func runTypecheck(_ fixtureName: String) throws -> CompilerResult {
+    private func runTypecheck(_ fixtureName: String) async throws -> CompilerResult {
         let root = repositoryRoot()
         let buildProducts = try buildProducts(for: fixtureName)
         let scratchDirectory = root
@@ -103,7 +114,16 @@ struct IdentifierBoundaryTypecheckTests {
         process.standardOutput = output
         process.standardError = output
         try process.run()
-        process.waitUntilExit()
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            if !process.isRunning {
+                cont.resume()
+                return
+            }
+            process.terminationHandler = { _ in
+                cont.resume()
+            }
+        }
 
         let outputData = output.fileHandleForReading.readDataToEndOfFile()
         return CompilerResult(
@@ -191,27 +211,27 @@ struct IdentifierBoundaryTypecheckTests {
         return arguments
     }
 
-    @Test func positiveFixturesCompile() throws {
-        let result = try runTypecheck("positive.swift")
+    @Test func positiveFixturesCompile() async throws {
+        let result = try await runTypecheck("positive.swift")
         #expect(result.status == 0, "positive fixture failed to typecheck:\n\(result.output)")
     }
 
     #if canImport(WikiFSEngine)
-    @Test func positiveChatDomainFixturesCompile() throws {
-        let result = try runTypecheck("positive-chat-domain.swift")
+    @Test func positiveChatDomainFixturesCompile() async throws {
+        let result = try await runTypecheck("positive-chat-domain.swift")
         #expect(result.status == 0, "positive chat-domain fixture failed to typecheck:\n\(result.output)")
     }
     #endif
 
     #if os(macOS)
-    @Test func launcherPositiveFixturesCompile() throws {
-        let result = try runTypecheck("positive-launcher-macos.swift")
+    @Test func launcherPositiveFixturesCompile() async throws {
+        let result = try await runTypecheck("positive-launcher-macos.swift")
         #expect(result.status == 0, "launcher positive fixture failed to typecheck:\n\(result.output)")
     }
     #endif
 
-    @Test func pageIDIsRejectedByChatAPI() throws {
-        let result = try runTypecheck("page-id-to-chat-api.swift")
+    @Test func pageIDIsRejectedByChatAPI() async throws {
+        let result = try await runTypecheck("page-id-to-chat-api.swift")
         #expect(result.status != 0, "PageID unexpectedly typechecked at a ChatID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'PageID' to expected argument type 'ChatID'"),
@@ -220,8 +240,8 @@ struct IdentifierBoundaryTypecheckTests {
     }
 
     #if os(macOS)
-    @Test func pageIDIsRejectedByLauncherChatAPI() throws {
-        let result = try runTypecheck("page-id-to-launcher-chat-api.swift")
+    @Test func pageIDIsRejectedByLauncherChatAPI() async throws {
+        let result = try await runTypecheck("page-id-to-launcher-chat-api.swift")
         #expect(result.status != 0, "PageID unexpectedly typechecked at AgentLauncher.startInteractiveQuery(chatID:).")
         #expect(
             result.output.contains("cannot convert value of type 'PageID' to expected argument type 'ChatID'"),
@@ -229,8 +249,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func stringIsRejectedByLauncherChatAPI() throws {
-        let result = try runTypecheck("string-to-launcher-chat-api.swift")
+    @Test func stringIsRejectedByLauncherChatAPI() async throws {
+        let result = try await runTypecheck("string-to-launcher-chat-api.swift")
         #expect(result.status != 0, "String unexpectedly typechecked at AgentLauncher.startInteractiveQuery(chatID:).")
         #expect(
             result.output.contains("cannot convert value of type 'String' to expected argument type 'ChatID'"),
@@ -239,8 +259,8 @@ struct IdentifierBoundaryTypecheckTests {
     }
     #endif
 
-    @Test func pageIDIsRejectedBySourceAPI() throws {
-        let result = try runTypecheck("page-id-to-source-api.swift")
+    @Test func pageIDIsRejectedBySourceAPI() async throws {
+        let result = try await runTypecheck("page-id-to-source-api.swift")
         #expect(result.status != 0, "PageID unexpectedly typechecked at a SourceID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'PageID' to expected argument type 'SourceID'"),
@@ -248,8 +268,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func pageIDIsRejectedBySourceVersionAPI() throws {
-        let result = try runTypecheck("page-id-to-source-version-api.swift")
+    @Test func pageIDIsRejectedBySourceVersionAPI() async throws {
+        let result = try await runTypecheck("page-id-to-source-version-api.swift")
         #expect(result.status != 0, "PageID unexpectedly typechecked at a SourceVersionID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'PageID' to expected argument type 'SourceVersionID'"),
@@ -257,8 +277,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func chatIDIsRejectedByPageAPI() throws {
-        let result = try runTypecheck("chat-id-to-page-api.swift")
+    @Test func chatIDIsRejectedByPageAPI() async throws {
+        let result = try await runTypecheck("chat-id-to-page-api.swift")
         #expect(result.status != 0, "ChatID unexpectedly typechecked at a PageID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'ChatID' to expected argument type 'PageID'"),
@@ -266,8 +286,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceIDIsRejectedByPageAPI() throws {
-        let result = try runTypecheck("source-id-to-page-api.swift")
+    @Test func sourceIDIsRejectedByPageAPI() async throws {
+        let result = try await runTypecheck("source-id-to-page-api.swift")
         #expect(result.status != 0, "SourceID unexpectedly typechecked at a PageID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'SourceID' to expected argument type 'PageID'"),
@@ -275,8 +295,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceIDIsRejectedBySourceVersionAPI() throws {
-        let result = try runTypecheck("source-id-to-source-version-api.swift")
+    @Test func sourceIDIsRejectedBySourceVersionAPI() async throws {
+        let result = try await runTypecheck("source-id-to-source-version-api.swift")
         #expect(result.status != 0, "SourceID unexpectedly typechecked at a SourceVersionID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'SourceID' to expected argument type 'SourceVersionID'"),
@@ -284,8 +304,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceIDIsRejectedByChatAPI() throws {
-        let result = try runTypecheck("source-id-to-chat-api.swift")
+    @Test func sourceIDIsRejectedByChatAPI() async throws {
+        let result = try await runTypecheck("source-id-to-chat-api.swift")
         #expect(result.status != 0, "SourceID unexpectedly typechecked at a ChatID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'SourceID' to expected argument type 'ChatID'"),
@@ -293,8 +313,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func chatIDIsRejectedBySourceAPI() throws {
-        let result = try runTypecheck("chat-id-to-source-api.swift")
+    @Test func chatIDIsRejectedBySourceAPI() async throws {
+        let result = try await runTypecheck("chat-id-to-source-api.swift")
         #expect(result.status != 0, "ChatID unexpectedly typechecked at a SourceID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'ChatID' to expected argument type 'SourceID'"),
@@ -302,8 +322,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func markdownVersionIDIsRejectedBySourceVersionAPI() throws {
-        let result = try runTypecheck("markdown-version-id-to-source-version-api.swift")
+    @Test func markdownVersionIDIsRejectedBySourceVersionAPI() async throws {
+        let result = try await runTypecheck("markdown-version-id-to-source-version-api.swift")
         #expect(result.status != 0, "SourceMarkdownVersion.id unexpectedly typechecked at a SourceVersionID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'SourceMarkdownVersionID' to expected argument type 'SourceVersionID'"),
@@ -311,8 +331,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func pageIDIsRejectedByProcessedMarkdownVersionAPI() throws {
-        let result = try runTypecheck("page-id-to-processed-markdown-version-api.swift")
+    @Test func pageIDIsRejectedByProcessedMarkdownVersionAPI() async throws {
+        let result = try await runTypecheck("page-id-to-processed-markdown-version-api.swift")
         #expect(result.status != 0, "PageID unexpectedly typechecked at processedMarkdownVersion(id:).")
         #expect(
             result.output.contains("cannot convert value of type 'PageID' to expected argument type 'SourceMarkdownVersionID'"),
@@ -320,8 +340,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceIDIsRejectedByProcessedMarkdownVersionAPI() throws {
-        let result = try runTypecheck("source-id-to-processed-markdown-version-api.swift")
+    @Test func sourceIDIsRejectedByProcessedMarkdownVersionAPI() async throws {
+        let result = try await runTypecheck("source-id-to-processed-markdown-version-api.swift")
         #expect(result.status != 0, "SourceID unexpectedly typechecked at processedMarkdownVersion(id:).")
         #expect(
             result.output.contains("cannot convert value of type 'SourceID' to expected argument type 'SourceMarkdownVersionID'"),
@@ -329,8 +349,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func chatIDIsRejectedByProcessedMarkdownVersionAPI() throws {
-        let result = try runTypecheck("chat-id-to-processed-markdown-version-api.swift")
+    @Test func chatIDIsRejectedByProcessedMarkdownVersionAPI() async throws {
+        let result = try await runTypecheck("chat-id-to-processed-markdown-version-api.swift")
         #expect(result.status != 0, "ChatID unexpectedly typechecked at processedMarkdownVersion(id:).")
         #expect(
             result.output.contains("cannot convert value of type 'ChatID' to expected argument type 'SourceMarkdownVersionID'"),
@@ -338,8 +358,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceVersionIDIsRejectedBySourceAPI() throws {
-        let result = try runTypecheck("source-version-id-to-source-api.swift")
+    @Test func sourceVersionIDIsRejectedBySourceAPI() async throws {
+        let result = try await runTypecheck("source-version-id-to-source-api.swift")
         #expect(result.status != 0, "SourceVersionID unexpectedly typechecked at a SourceID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'SourceVersionID' to expected argument type 'SourceID'"),
@@ -347,8 +367,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceVersionIDIsRejectedByProcessedMarkdownVersionAPI() throws {
-        let result = try runTypecheck("source-version-id-to-processed-markdown-version-api.swift")
+    @Test func sourceVersionIDIsRejectedByProcessedMarkdownVersionAPI() async throws {
+        let result = try await runTypecheck("source-version-id-to-processed-markdown-version-api.swift")
         #expect(result.status != 0, "SourceVersionID unexpectedly typechecked at processedMarkdownVersion(id:).")
         #expect(
             result.output.contains("cannot convert value of type 'SourceVersionID' to expected argument type 'SourceMarkdownVersionID'"),
@@ -356,8 +376,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceVersionIDIsRejectedBySetActiveMarkdownAPI() throws {
-        let result = try runTypecheck("source-version-id-to-set-active-markdown-api.swift")
+    @Test func sourceVersionIDIsRejectedBySetActiveMarkdownAPI() async throws {
+        let result = try await runTypecheck("source-version-id-to-set-active-markdown-api.swift")
         #expect(result.status != 0, "SourceVersionID unexpectedly typechecked at setActiveMarkdown(sourceID:to:).")
         #expect(
             result.output.contains("cannot convert value of type 'SourceVersionID' to expected argument type 'SourceMarkdownVersionID'"),
@@ -365,8 +385,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceVersionIDIsRejectedByPageAPI() throws {
-        let result = try runTypecheck("source-version-id-to-page-api.swift")
+    @Test func sourceVersionIDIsRejectedByPageAPI() async throws {
+        let result = try await runTypecheck("source-version-id-to-page-api.swift")
         #expect(result.status != 0, "SourceVersionID unexpectedly typechecked at a PageID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'SourceVersionID' to expected argument type 'PageID'"),
@@ -374,8 +394,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func sourceVersionIDIsRejectedByChatAPI() throws {
-        let result = try runTypecheck("source-version-id-to-chat-api.swift")
+    @Test func sourceVersionIDIsRejectedByChatAPI() async throws {
+        let result = try await runTypecheck("source-version-id-to-chat-api.swift")
         #expect(result.status != 0, "SourceVersionID unexpectedly typechecked at a ChatID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'SourceVersionID' to expected argument type 'ChatID'"),
@@ -383,8 +403,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func pageIDIsRejectedByChatTurnAPI() throws {
-        let result = try runTypecheck("page-id-to-chat-turn-api.swift")
+    @Test func pageIDIsRejectedByChatTurnAPI() async throws {
+        let result = try await runTypecheck("page-id-to-chat-turn-api.swift")
         #expect(result.status != 0, "PageID unexpectedly typechecked at a ChatTurnID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'PageID' to expected argument type 'ChatTurnID'"),
@@ -392,8 +412,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func chatIDIsRejectedByChatMessageAPI() throws {
-        let result = try runTypecheck("chat-id-to-chat-message-api.swift")
+    @Test func chatIDIsRejectedByChatMessageAPI() async throws {
+        let result = try await runTypecheck("chat-id-to-chat-message-api.swift")
         #expect(result.status != 0, "ChatID unexpectedly typechecked at a ChatMessageID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'ChatID' to expected argument type 'ChatMessageID'"),
@@ -401,8 +421,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func stringIsRejectedByChatCommandAPI() throws {
-        let result = try runTypecheck("string-to-chat-command-api.swift")
+    @Test func stringIsRejectedByChatCommandAPI() async throws {
+        let result = try await runTypecheck("string-to-chat-command-api.swift")
         #expect(result.status != 0, "String unexpectedly typechecked at a ChatCommandID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'String' to expected argument type 'ChatCommandID'"),
@@ -410,8 +430,8 @@ struct IdentifierBoundaryTypecheckTests {
         )
     }
 
-    @Test func permissionRequestIDIsRejectedByToolCallAPI() throws {
-        let result = try runTypecheck("permission-request-id-to-tool-call-api.swift")
+    @Test func permissionRequestIDIsRejectedByToolCallAPI() async throws {
+        let result = try await runTypecheck("permission-request-id-to-tool-call-api.swift")
         #expect(result.status != 0, "PermissionRequestID unexpectedly typechecked at a ToolCallID API boundary.")
         #expect(
             result.output.contains("cannot convert value of type 'PermissionRequestID' to expected argument type 'ToolCallID'"),

--- a/Tests/WikiFSTests/QueueTranscriptConcurrencyTests.swift
+++ b/Tests/WikiFSTests/QueueTranscriptConcurrencyTests.swift
@@ -7,7 +7,7 @@ import WikiFSCore
 /// Regression coverage for the synchronous provider-callback seam. The store
 /// is real in the durability cases so these tests cover translation, ordering,
 /// SQLite persistence, and the live event value together.
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(2)))
 struct QueueTranscriptConcurrencyTests {
     @Test func sameAttemptCallbacksCommitInAcceptedOrder() throws {
         let store = try makeStore()

--- a/scripts/test-with-watchdog.sh
+++ b/scripts/test-with-watchdog.sh
@@ -70,7 +70,7 @@ fi
 
 perl -ne '
     if (/Test (.+\(.*\)) started\./) { $started{$1} = 1 }
-    if (/Test (.+\(.*\)) (passed|failed) after ([0-9.]+) seconds/) {
+    if (/Test (.+\(.*\))(?: with \d+ test cases)? (passed|failed) after ([0-9.]+) seconds/) {
         $finished{$1} = 1;
         push @durations, [$3 + 0, $2, $1];
     }


### PR DESCRIPTION
Addresses #1051: test hangs when blocking operations exhaust the finite cooperative thread pool under `swift test --parallel`.

## Problem
`Process.waitUntilExit()`, `Thread.sleep`, and bare `withCheckedContinuation` without timeouts are synchronous blocking calls that park the cooperative thread pool thread they run on. Under `--parallel` with multiple concurrent test suites, enough simultaneous blockers can exhaust the pool (as few as 3 vCPU on CI), starving other suites' `withCheckedContinuation` completions. `.timeLimit` can't rescue this—cancelling a test's Task doesn't resume an abandoned continuation.

## Solution
1. **Document the pattern** in AGENTS.md with specific guidance, audit recipe, and regression detection setup.
2. **Add time limits** to all test suites with subprocess or continuation patterns.
3. **Replace blocking patterns** with non-blocking equivalents:
   - `Process.waitUntilExit()` → `terminationHandler` + `withCheckedContinuation`
   - Bare continuations → wrap in `withThrowingTaskGroup` with a 30s timeout to turn starvation into a fast failure.
4. **Update watchdog regex** to parse new Swift Testing output format.

## Files Changed
- **AGENTS.md**: New section documenting the cooperative thread pool rule, symptoms, the correct pattern, and audit recipe.
- **Test suites**: Add `.timeLimit(.minutes(N))` and convert blocking patterns:
  - `DefuddleExtractionServiceTests`, `PdfExtractionServiceTests`: Non-blocking `asyncWaitUntilExit`.
  - `IdentifierBoundaryTypecheckTests`: Convert all 26 tests to async, replace `waitUntilExit()` with async pattern, add `.serialized + .timeLimit(3m)`.
  - `ChatTranscriptHostedTests`, `QuoteHighlightWebViewTests`, `QueueTranscriptConcurrencyTests`: Add `.timeLimit(2m)`.
- **scripts/test-with-watchdog.sh**: Update regex to match "Test ... with N test cases" output format.

Regression detection: `scripts/test-with-watchdog.sh` will now catch future hangs by timeout.