### PR TITLE
feat: allow agent defaults and add queue preflight validation

### DIFF
--- a/Sources/WikiFS/Queue/XPCQueueEngineProxy.swift
+++ b/Sources/WikiFS/Queue/XPCQueueEngineProxy.swift
@@ -38,7 +38,10 @@ final class XPCQueueEngineProxy: QueueEngineClient {
 
     @discardableResult
     func enqueue(_ request: QueueItemRequest) async throws -> QueueItem.ID {
-        try await workloadClient.enqueue(request)
+        DebugLog.ingest("Queue trace=pending stage=xpc.client event=submitted queue=\(request.queue.rawValue) wiki=\(request.wikiID.rawValue) sources=\(request.payload.sourceIDs.count)")
+        let itemID = try await workloadClient.enqueue(request)
+        DebugLog.ingest("Queue trace=\(itemID.rawValue) stage=xpc.client event=accepted queue=\(request.queue.rawValue) wiki=\(request.wikiID.rawValue)")
+        return itemID
     }
 
     func cancelItem(_ id: QueueItem.ID) async {

--- a/Sources/WikiFS/Repositories/RepositoriesContainerView.swift
+++ b/Sources/WikiFS/Repositories/RepositoriesContainerView.swift
@@ -26,9 +26,13 @@ struct RepositoriesContainerView: View {
                 }
             } else {
                 List(store.trackedRepositories) { repository in
-                    RepositoryRow(repository: repository) { action in
-                        enqueue(action, for: repository)
-                    }
+                    RepositoryRow(
+                        repository: repository,
+                        enqueue: { action in
+                            enqueue(action, for: repository)
+                        },
+                        updateConfigurationError: updateConfigurationError
+                    )
                 }
                 .listStyle(.sidebar)
                 .toolbar {
@@ -50,6 +54,11 @@ struct RepositoriesContainerView: View {
     }
 
     private func enqueue(_ action: RepositoryWorkAction, for repository: TrackedRepo) {
+        DebugLog.ingest("Repository action tapped action=\(action.rawValue) repo=\(repository.id.rawValue) canUpdate=\(repository.canRequestUpdate) drifted=\(repository.isDrifted)")
+        if action == .update, let error = updateConfigurationError {
+            DebugLog.ingest("RepositoriesContainerView refused update for \(repository.id.rawValue): \(error)")
+            return
+        }
         Task {
             do {
                 let request = QueueItemRequest(
@@ -64,11 +73,21 @@ struct RepositoriesContainerView: View {
             }
         }
     }
+
+    private var updateConfigurationError: String? {
+        let directory = DebugLog.trying("resolve app group container", operation: {
+            try DatabaseLocation.appGroupContainerDirectory()
+        }) ?? FileManager.default.temporaryDirectory
+        let config = AgentProvidersConfig.loadOrSeed(from: directory)
+        return config.isRepositoryUpdateConfigured() ? nil : config.agentOperationConfigurationError(
+            forStages: [ACPIngestStage.planner.rawValue])
+    }
 }
 
 private struct RepositoryRow: View {
     let repository: TrackedRepo
     let enqueue: (RepositoryWorkAction) -> Void
+    let updateConfigurationError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -87,11 +106,15 @@ private struct RepositoryRow: View {
                     enqueue(.update)
                 }
                 .buttonStyle(.borderless)
-                .disabled(!repository.isDrifted)
+                .disabled(!repository.canRequestUpdate || updateConfigurationError != nil)
+                .help(updateConfigurationError ?? "Update this wiki from the repository")
             }
             .controlSize(.small)
         }
         .padding(.vertical, 2)
+        .onAppear {
+            DebugLog.ingest("Repository row displayed repo=\(repository.id.rawValue) canUpdate=\(repository.canRequestUpdate) drifted=\(repository.isDrifted) configurationError=\(updateConfigurationError ?? "nil")")
+        }
     }
 
     private var repositoryStatus: String {

--- a/Sources/WikiFS/Settings/StageProviderModelPicker.swift
+++ b/Sources/WikiFS/Settings/StageProviderModelPicker.swift
@@ -31,6 +31,30 @@ enum StageProviderSelectionState: Equatable {
     }
 }
 
+/// The effective meaning of the model-picker inheritance option. Kept pure so
+/// the UI cannot accidentally label an agent-default choice as a missing model.
+enum StageModelInheritanceState: Equatable {
+    case selectedModel(ModelID)
+    case agentDefault
+
+    static func resolve(config: AgentProvidersConfig, stageKey: String) -> StageModelInheritanceState {
+        let provider = config.provider(forStage: stageKey)
+        if let modelID = config.selectedModelId(forProvider: provider.id) {
+            return .selectedModel(modelID)
+        }
+        return .agentDefault
+    }
+
+    var optionLabel: String {
+        switch self {
+        case .selectedModel(let modelID):
+            return "Same as provider (\(modelID.rawValue))"
+        case .agentDefault:
+            return "Same as provider (agent default)"
+        }
+    }
+}
+
 /// A provider + model picker for a single agent stage/operation
 /// (`plans/agent-settings-tabs.md` §2.2/§6). Reused for the Chat Model,
 /// Planner/Executor/Finalizer Models, and Lint Model rows in the nested
@@ -87,11 +111,8 @@ struct StageProviderModelPicker: View {
         config.cachedModels(forProvider: resolvedProvider.id)
     }
 
-    /// Friendly name for the "Same as provider" option — shows the concrete
-    /// model id the stage will actually use, so the user can see the effective
-    /// resolution at a glance.
-    private var fallbackLabel: String {
-        config.selectedModelId(forProvider: resolvedProvider.id)?.rawValue ?? "default"
+    private var modelInheritanceState: StageModelInheritanceState {
+        StageModelInheritanceState.resolve(config: config, stageKey: stageKey)
     }
 
     /// The Summary tab's provider pin is load-bearing: a non-empty but
@@ -170,7 +191,7 @@ struct StageProviderModelPicker: View {
                     if shouldDisableModelPickerForUnavailablePin || resolvedModels.isEmpty {
                         Text(modelPickerPlaceholder).tag("")
                     } else {
-                        Text("Same as provider (\(fallbackLabel))").tag("")
+                        Text(modelInheritanceState.optionLabel).tag("")
                         ForEach(resolvedModels, id: \.modelId) { model in
                             Text(model.displayLabel).tag(model.modelId.rawValue)
                         }

--- a/Sources/WikiFS/Window/SidebarView.swift
+++ b/Sources/WikiFS/Window/SidebarView.swift
@@ -74,6 +74,9 @@ struct SidebarView: View {
             Divider()
             bookmarksOrList
         }
+        // The repositories empty state has only an intrinsic height. Claim the
+        // full sidebar column so NavigationSplitView does not center this stack.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .navigationTitle(activeWikiName)
         .navigationSplitViewColumnWidth(min: PageEditorMetrics.sidebarMinWidth,
                                          ideal: PageEditorMetrics.sidebarIdealWidth)

--- a/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
@@ -302,9 +302,8 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
     }
 
     /// The chat composer may enable submission only when the same resolved
-    /// provider/model pair that the launcher validates is available. This keeps
-    /// an all-disabled provider list or a missing selected model from reaching
-    /// the daemon as a preflight failure.
+    /// provider is available. A nil model inherits the provider's agent
+    /// default, so only provider availability is required.
     public func isChatOperationConfigured(
         chatOverrideProviderId: ProviderID? = nil,
         chatOverrideModelId: ModelID? = nil
@@ -315,14 +314,31 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
             chatOverrideProviderId: chatOverrideProviderId
         )
         guard provider.enabled else { return false }
-        guard let modelID = modelId(
-            forStage: "chat",
-            chatOverrideProviderId: chatOverrideProviderId,
-            chatOverrideModelId: chatOverrideModelId
-        ) else {
-            return false
+        return true
+    }
+
+    /// Whether a repository update can start. Repository updates use the same
+    /// planner-stage provider and model as normal ingestion.
+    public func isRepositoryUpdateConfigured() -> Bool {
+        agentOperationConfigurationError(forStages: [ACPIngestStage.planner.rawValue]) == nil
+    }
+
+    /// Returns the user-facing reason an agent operation cannot start, or nil
+    /// when every required stage resolves to an enabled provider. A nil model
+    /// inherits the provider's agent default.
+    public func agentOperationConfigurationError(forStages stages: [String]) -> String? {
+        guard enabledProviders.isEmpty == false else {
+            return "Agent is not available — no enabled agent provider. Re-enable the agent in Settings → Providers to retry."
         }
-        return modelID.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+
+        for stage in stages {
+            let provider = provider(forStage: stage)
+            guard provider.enabled else {
+                let stageLabel = ACPIngestStage(rawValue: stage)?.label ?? stage.capitalized
+                return "Agent is not available for the \(stageLabel) stage because provider ‘\(provider.label)’ is disabled. Re-enable it in Settings → Providers to retry."
+            }
+        }
+        return nil
     }
 
     // MARK: - Per-stage model selection (per-stage-model-selection plan)

--- a/Sources/WikiFSCore/ReaderFanoutProgress.swift
+++ b/Sources/WikiFSCore/ReaderFanoutProgress.swift
@@ -1,0 +1,25 @@
+// pattern: Functional Core
+
+import Foundation
+
+/// Pure, side-effect-free progress-message formatting for the repository
+/// reader fan-out. The daemon's `runReaderFanout` calls these from the parent
+/// task-group completion loop — never from child tasks — and feeds the result
+/// to the queue `onProgress` callback so the UI updates as each reader finishes.
+public enum ReaderFanoutProgress {
+    /// Message emitted before the first reader starts: "(0/total)".
+    public static func start(repositoryName: String, total: Int) -> String {
+        "Reading \(repositoryName) with \(total) readers (0/\(total))…"
+    }
+
+    /// Message emitted after a reader digest completes: "(completed/total)".
+    public static func readerCompleted(repositoryName: String, completed: Int, total: Int) -> String {
+        "Reading \(repositoryName) with \(total) readers (\(completed)/\(total))…"
+    }
+
+    /// Message emitted after all readers finish, just before the curator
+    /// handoff.
+    public static func curatorHandoff(repositoryName: String, total: Int) -> String {
+        "All \(total) readers finished for \(repositoryName), starting curator…"
+    }
+}

--- a/Sources/WikiFSCore/TrackedRepo.swift
+++ b/Sources/WikiFSCore/TrackedRepo.swift
@@ -88,6 +88,14 @@ public struct TrackedRepo: Identifiable, Hashable, Sendable {
     return headCommit != lastIngestedCommit
   }
 
+  /// Whether an Update request can run. Update always fetches first, so a
+  /// cloned repository remains updateable even when its last fetch found no
+  /// drift; the daemon will report that it is already up to date.
+  public var canRequestUpdate: Bool {
+    guard let headCommit else { return false }
+    return !headCommit.isEmpty
+  }
+
   /// The first 7 characters of `headCommit`, for compact display. Empty when the
   /// repo has not been cloned yet.
   public var shortHead: String {

--- a/Sources/WikiFSEngine/QueueEngine.swift
+++ b/Sources/WikiFSEngine/QueueEngine.swift
@@ -162,6 +162,9 @@ public actor QueueEngine {
             throw QueueStoreError.invalidRequest("wikiID must not be empty")
         }
         let item = try store.enqueue(request)
+        if item.queue == .ingestion {
+            DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=engine event=enqueued queue=ingestion wiki=\(item.wikiID.rawValue) attempt=\(item.attempt) sources=\(item.payload.sourceIDs.count)")
+        }
         emit(.enqueued(item))
         await dispatchScan()
         return item.id
@@ -682,8 +685,14 @@ public actor QueueEngine {
                 continue
             }
             for item in active where item.state == .queued {
+                if item.queue == .ingestion {
+                    DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=dispatch event=scan queue=ingestion wiki=\(item.wikiID.rawValue) attempt=\(item.attempt)")
+                }
                 // The ONE await — resolve the provider up front.
                 guard let providerID = await workerFactory.providerID(for: item) else {
+                    if item.queue == .ingestion {
+                        DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=dispatch event=blocked queue=ingestion wiki=\(item.wikiID.rawValue) reason=no-provider")
+                    }
                     continue  // No provider available; item stays queued.
                 }
 
@@ -703,11 +712,19 @@ public actor QueueEngine {
 
                 // Per-provider capacity check.
                 let currentCount = providerActiveCounts[providerID] ?? 0
-                guard currentCount < limit else { continue }
+                guard currentCount < limit else {
+                    if item.queue == .ingestion {
+                        DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=dispatch event=blocked queue=ingestion wiki=\(item.wikiID.rawValue) reason=provider-capacity provider=\(providerID.rawValue) active=\(currentCount) limit=\(limit)")
+                    }
+                    continue
+                }
 
                 // Per-wiki ingestion invariant: at most one ingestion per wiki.
                 if item.queue == .ingestion {
-                    guard !activeIngestionWikis.contains(item.wikiID) else { continue }
+                    guard !activeIngestionWikis.contains(item.wikiID) else {
+                        DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=dispatch event=blocked queue=ingestion wiki=\(item.wikiID.rawValue) reason=wiki-active")
+                        continue
+                    }
                 }
 
                 // Claim the item: mark running (synchronous store call).
@@ -733,6 +750,7 @@ public actor QueueEngine {
                 incrementProviderCount(providerID)
                 if item.queue == .ingestion {
                     activeIngestionWikis.insert(item.wikiID)
+                    DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=dispatch event=claimed queue=ingestion wiki=\(item.wikiID.rawValue) attempt=\(item.attempt) provider=\(providerID.rawValue)")
                 }
 
                 // Emit the started event.
@@ -758,10 +776,16 @@ public actor QueueEngine {
     private func runWorker(_ item: QueueItem) async {
         let attemptID = QueueAttemptID(itemID: item.id, attempt: item.attempt)
         transcriptState.begin(attemptID)
+        if item.queue == .ingestion {
+            DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=worker event=started queue=ingestion wiki=\(item.wikiID.rawValue) attempt=\(item.attempt)")
+        }
         let worker: any QueueWorker
         do {
             worker = try await workerFactory.worker(for: item)
         } catch {
+            if item.queue == .ingestion {
+                DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=worker event=failed queue=ingestion wiki=\(item.wikiID.rawValue) reason=worker-factory error=\(error.localizedDescription)")
+            }
             // Factory failed to produce a worker — mark the item failed.
             await handleWorkerFinished(item, result: .failure(error))
             transcriptState.finish(attemptID)
@@ -774,10 +798,19 @@ public actor QueueEngine {
         do {
             try await worker.execute(item)
             result = .success(())
+            if item.queue == .ingestion {
+                DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=worker event=finished queue=ingestion wiki=\(item.wikiID.rawValue) attempt=\(item.attempt)")
+            }
         } catch is CancellationError {
             result = .failure(CancellationError())
+            if item.queue == .ingestion {
+                DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=worker event=cancelled queue=ingestion wiki=\(item.wikiID.rawValue) attempt=\(item.attempt)")
+            }
         } catch {
             result = .failure(error)
+            if item.queue == .ingestion {
+                DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=worker event=failed queue=ingestion wiki=\(item.wikiID.rawValue) attempt=\(item.attempt) error=\(error.localizedDescription)")
+            }
         }
 
         await handleWorkerFinished(item, result: result)

--- a/Sources/WikiFSEngine/QueueIngestionProvider.swift
+++ b/Sources/WikiFSEngine/QueueIngestionProvider.swift
@@ -238,6 +238,7 @@ struct QueueIngestionWorker: QueueWorker {
     let emitPendingPermission: @Sendable (QueueItem.ID, PendingPermission?) -> Void
 
     func execute(_ item: QueueItem) async throws {
+        DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=ingestion-worker event=entered wiki=\(item.wikiID.rawValue) attempt=\(item.attempt) sources=\(item.payload.sourceIDs.count)")
         // Pre-dispatch readiness gate (#440): check the agent provider's binary
         // is on PATH BEFORE running the full pipeline. If the binary is missing,
         // fail the item with a clear, user-facing message instead of a cryptic
@@ -246,6 +247,7 @@ struct QueueIngestionWorker: QueueWorker {
         let needsAgent = item.payload.repositoryWork?.action == .update
             || item.payload.repositoryWork == nil
         if needsAgent, let message = await provider.readiness() {
+            DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=ingestion-worker event=blocked wiki=\(item.wikiID.rawValue) reason=not-ready error=\(message)")
             throw QueueIngestionError.notReady(message)
         }
 
@@ -317,8 +319,10 @@ struct QueueIngestionWorker: QueueWorker {
             // Normal ingestion.
             let sourceIDs = item.payload.sourceIDs
             guard !sourceIDs.isEmpty else {
+                DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=ingestion-worker event=failed wiki=\(item.wikiID.rawValue) reason=no-sources")
                 throw QueueIngestionError.noSources
             }
+            DebugLog.ingest("Queue trace=\(item.id.rawValue) stage=ingestion-worker event=handoff wiki=\(item.wikiID.rawValue) target=provider sources=\(sourceIDs.count)")
             try await provider.runIngestion(
                 wikiID: item.wikiID,
                 sourceIDs: sourceIDs,

--- a/Sources/WikiFSEngine/SpawnModelGuard.swift
+++ b/Sources/WikiFSEngine/SpawnModelGuard.swift
@@ -2,15 +2,11 @@
 import Foundation
 import WikiFSCore
 
-/// Pure validation that a provider has an explicitly selected model before the
-/// launcher will spawn an ACP subprocess on its behalf.
+/// Pure model-selection validation at the ACP launch seam.
 ///
-/// Background: without an explicit `selectedModelId`, the launcher passed `nil`
-/// to `providerHints`, and the ACP subprocess picked its own first-listed
-/// upstream model. For OpenCode that was `opencode/big-pickle` (a free model) —
-/// silently, with no UI signal. This guard refuses to spawn instead, setting
-/// `AgentLauncher.preflightError` to an actionable message that points the user
-/// at Agents settings. See `tmp/ingestion-stall-diagnosis.md` (2026-07-18).
+/// A nil selection is deliberate: it inherits the provider's agent default,
+/// so ACP starts without `session/set_model`. An explicit non-empty model still
+/// pins that model for the run.
 ///
 /// PURE — no actor, no I/O. Unit-tested directly. Called from two launch sites:
 /// - `AgentLauncher.runACPIngestPlannerExecutors` (ingest — validates each of
@@ -18,27 +14,18 @@ import WikiFSCore
 ///   `plans/per-stage-model-selection.md` §6)
 /// - `AgentLauncher.startInteractiveQuery` (interactive chat)
 enum SpawnModelGuard {
-    /// Returns `nil` when spawning is allowed (a non-empty `modelId` is set for
-    /// `provider`); otherwise a human-readable preflight error message that
-    /// names the provider and points the user at Settings → Providers.
-    ///
-    /// When `stageName` is provided (the per-stage ingest path), the message
-    /// names the stage too — e.g. "No model selected for the Planner stage of
-    /// provider ‘Claude’." — so a missing *executor*-stage model (with
-    /// planner/finalizer set) is diagnosed specifically rather than as a
-    /// generic "no model" refusal.
+    /// A stage may either pin a model or inherit the provider's agent default;
+    /// both are valid ACP launch configurations. Provider availability is
+    /// validated independently before this seam.
     static func validate(
         provider: AgentProvider,
         modelId: String?,
         stageName: String? = nil
     ) -> String? {
-        if let modelId, !modelId.isEmpty { return nil }
-        if let stageName, !stageName.isEmpty {
-            return "No model selected for the \(stageName) stage of provider ‘\(provider.label)’. "
-                 + "Open Settings → Providers and pick a model before running."
-        }
-        return "No model selected for provider ‘\(provider.label)’. "
-             + "Open Settings → Providers and pick a model before running."
+        _ = provider
+        _ = modelId
+        _ = stageName
+        return nil
     }
 }
 #endif

--- a/Sources/wikid/DaemonQueueIngestionProvider.swift
+++ b/Sources/wikid/DaemonQueueIngestionProvider.swift
@@ -79,7 +79,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
             throw QueueIngestionError.noSources
         }
 
-        DebugLog.ingest("DaemonQueueIngestionProvider.runIngestion: begin count=\(sourceIDs.count)")
+        DebugLog.ingest("Queue trace=\(queueItemID.rawValue) stage=daemon-provider event=started wiki=\(wikiID.rawValue) sources=\(sourceIDs.count)")
 
         let launcher = await makeLauncher()
 
@@ -117,7 +117,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
             throw QueueIngestionError.noSources
         }
 
-        DebugLog.ingest("DaemonQueueIngestionProvider: handing off \(sources.count) source(s)")
+        DebugLog.ingest("Queue trace=\(queueItemID.rawValue) stage=daemon-provider event=handoff wiki=\(wikiID.rawValue) target=launcher sources=\(sources.count)")
 
         let providerLabel = resolveSelectedProvider().label
 
@@ -139,7 +139,8 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
             onUnlock: { DarwinNotifier.postChange(forWikiID: wikiID.rawValue) }
         )
 
-        let results = await launcherResults(launcher)
+        let results = try await completedLauncherResults(launcher)
+        DebugLog.ingest("Queue trace=\(queueItemID.rawValue) stage=daemon-provider event=launcher-returned wiki=\(wikiID.rawValue) exitStatus=\(results.exitStatus.map(String.init) ?? "nil") turnFailed=\(results.hadTurnFailure)")
         onUsage?(results.usage)
         onLogPaths?(results.logURL, results.debugURL)
         if let status = results.exitStatus, status != 0, results.hadTurnFailure {
@@ -179,7 +180,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
             onTranscript: onTranscript,
             onLiveUsage: onLiveUsage,
             onPendingPermission: onPendingPermission)
-        let results = await launcherResults(launcher)
+        let results = try await completedLauncherResults(launcher)
         onUsage?(results.usage)
         onLogPaths?(results.logURL, results.debugURL)
         if let status = results.exitStatus, status != 0, results.hadTurnFailure {
@@ -228,7 +229,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
             onTranscript: onTranscript,
             onLiveUsage: onLiveUsage,
             onPendingPermission: onPendingPermission)
-        let results = await launcherResults(launcher)
+        let results = try await completedLauncherResults(launcher)
         onUsage?(results.usage)
         onLogPaths?(results.logURL, results.debugURL)
         if let status = results.exitStatus, status != 0, results.hadTurnFailure {
@@ -252,6 +253,12 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
     ) async throws {
         guard let store = storeResolver(wikiID) else {
             throw QueueIngestionError.spawnFailed("No store for wikiID=\(wikiID.rawValue)")
+        }
+
+        if request.action == .update,
+           let error = resolveProviderConfig().agentOperationConfigurationError(
+               forStages: [ACPIngestStage.planner.rawValue]) {
+            throw QueueIngestionError.notReady(error)
         }
 
         switch request.action {
@@ -462,7 +469,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
             providerLabel: resolveSelectedProvider().label,
             onLock: { },
             onUnlock: { DarwinNotifier.postChange(forWikiID: wikiID.rawValue) })
-        let results = await launcherResults(launcher)
+        let results = try await completedLauncherResults(launcher)
         onUsage?(results.usage)
         onLogPaths?(results.logURL, results.debugURL)
         if let status = results.exitStatus, status != 0, results.hadTurnFailure {
@@ -511,7 +518,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
                         }
                     }
                     try Task.checkCancellation()
-                    let results = await launcherResults(launcher)
+                    let results = try await completedLauncherResults(launcher)
                     if let status = results.exitStatus, status != 0 {
                         throw QueueIngestionError.spawnFailed(
                             "Repository reader \(assignment.ordinal) failed (exit status \(status)).")
@@ -567,6 +574,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
         let debugURL: URL?
         let exitStatus: Int32?
         let hadTurnFailure: Bool
+        let preflightError: String?
     }
 
     private func launcherResults(_ launcher: AgentLauncher) async -> LauncherResults {
@@ -576,8 +584,19 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
                 logURL: launcher.logFileURL,
                 debugURL: launcher.debugFolderURL,
                 exitStatus: launcher.exitStatus,
-                hadTurnFailure: launcher.runHadTurnFailure)
+                hadTurnFailure: launcher.runHadTurnFailure,
+                preflightError: launcher.preflightError)
         }
+    }
+
+    /// Queue items must not report completion when the launcher refused to
+    /// start. Preflight failures are configuration errors the user can fix.
+    private func completedLauncherResults(_ launcher: AgentLauncher) async throws -> LauncherResults {
+        let results = await launcherResults(launcher)
+        if let preflightError = results.preflightError, !preflightError.isEmpty {
+            throw QueueIngestionError.notReady(preflightError)
+        }
+        return results
     }
 
     private func runLintAgent(

--- a/Sources/wikid/DaemonQueueIngestionProvider.swift
+++ b/Sources/wikid/DaemonQueueIngestionProvider.swift
@@ -435,6 +435,7 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
                 wikiID: wikiID,
                 repoStateMarkdown: snapshot.renderStateFile(),
                 workPlan: readerWorkPlan,
+                onProgress: onProgress,
                 onTranscript: onTranscript)
         } else {
             readerDigests = nil
@@ -476,12 +477,16 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
         wikiID: WikiID,
         repoStateMarkdown: String,
         workPlan: RepoReaderWorkPlan,
+        onProgress: @escaping @Sendable (String) -> Void,
         onTranscript: (@Sendable (AgentEvent) -> Void)?
     ) async throws -> String {
         guard workPlan.isEligibleForReaderFanout else {
             throw QueueIngestionError.spawnFailed(
                 "Repository fan-out requires two or more nonempty reader allowlists")
         }
+
+        let total = workPlan.assignments.count
+        onProgress(ReaderFanoutProgress.start(repositoryName: repository.name, total: total))
 
         let digests = try await withThrowingTaskGroup(of: (Int, String).self) { group in
             for assignment in workPlan.assignments {
@@ -539,9 +544,17 @@ final class DaemonQueueIngestionProvider: QueueIngestionProvider {
                     description: "\(repository.name) reader \(digest.0)",
                     isCompletion: true))
                 result.append(digest)
+                onProgress(ReaderFanoutProgress.readerCompleted(
+                    repositoryName: repository.name,
+                    completed: result.count,
+                    total: total))
             }
             return result
         }
+
+        onProgress(ReaderFanoutProgress.curatorHandoff(
+            repositoryName: repository.name, total: total))
+
         return digests.sorted { $0.0 < $1.0 }.map { ordinal, digest in
             "## Reader \(ordinal)\n\n\(digest)"
         }.joined(separator: "\n\n")

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -551,6 +551,27 @@ final class WikiDaemon: @unchecked Sendable {
         }
     }
 
+    /// Reject user-submitted agent work before it becomes a durable queue item.
+    /// Fetch and clone use Git only, so they do not need a model.
+    func queueRequestPreflightError(_ request: QueueItemRequest) -> String? {
+        guard request.queue == .ingestion else { return nil }
+
+        let requiredStages: [String]
+        if let repositoryWork = request.payload.repositoryWork {
+            guard repositoryWork.action == .update else { return nil }
+            requiredStages = [ACPIngestStage.planner.rawValue]
+        } else if request.payload.lintPageIDs != nil {
+            requiredStages = ["lint"]
+        } else if request.payload.sourceIDs.isEmpty == false {
+            requiredStages = ACPIngestStage.allCases.map(\.rawValue)
+        } else {
+            return nil
+        }
+
+        let config = AgentProvidersConfig.loadOrSeed(from: containerDirectory)
+        return config.agentOperationConfigurationError(forStages: requiredStages)
+    }
+
     /// Serve a queue snapshot as JSON `Data` for the XPC `queueSnapshot` method.
     /// The engine's `snapshot()` is async (it's an actor method), so this is
     /// async too — the exporter wraps it in a `Task` and replies when it

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -138,14 +138,21 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
         let sendableReply = SendableDataReply(reply: reply)
         Task { [daemon] in
             do {
-                let engine = try await daemon.ensureQueueEngine()
                 let req = try JSONDecoder().decode(QueueItemRequest.self, from: request)
+                DebugLog.ingest("Queue trace=pending stage=xpc.daemon event=received queue=\(req.queue.rawValue) wiki=\(req.wikiID.rawValue) sources=\(req.payload.sourceIDs.count)")
+                if let error = daemon.queueRequestPreflightError(req) {
+                    DebugLog.ingest("Queue trace=pending stage=xpc.daemon event=rejected queue=\(req.queue.rawValue) wiki=\(req.wikiID.rawValue) error=\(error)")
+                    throw QueueStoreError.invalidRequest(error)
+                }
+                let engine = try await daemon.ensureQueueEngine()
                 let id = try await engine.enqueue(req)
+                DebugLog.ingest("Queue trace=\(id.rawValue) stage=xpc.daemon event=accepted queue=\(req.queue.rawValue) wiki=\(req.wikiID.rawValue)")
                 // XPC wire boundary: the engine returns a QueueItemID; the reply dict serializes the raw String.
                 let envelope: [String: String?] = ["id": id.rawValue, "error": nil]
                 let data = (DebugLog.trying("JSONEncoder.encode", operation: { try JSONEncoder().encode(envelope) })) ?? Data()
                 sendableReply.reply(data)
             } catch {
+                DebugLog.ingest("Queue trace=pending stage=xpc.daemon event=failed error=\(error.localizedDescription)")
                 let envelope: [String: String?] = ["id": nil, "error": error.localizedDescription]
                 let data = (DebugLog.trying("JSONEncoder.encode", operation: { try JSONEncoder().encode(envelope) })) ?? Data()
                 sendableReply.reply(data)

--- a/Tests/WikiFSAppTests/StageProviderModelPickerTests.swift
+++ b/Tests/WikiFSAppTests/StageProviderModelPickerTests.swift
@@ -5,6 +5,17 @@ import WikiFSCore
 
 struct StageProviderModelPickerTests {
 
+    @Test func inheritedModelUsesAgentDefaultWhenProviderHasNoSelectedModel() {
+        let config = AgentProvidersConfig(providers: [
+            AgentProvider(id: ProviderID(rawValue: "codex-acp"), label: "Codex", enabled: true, isDefault: true),
+        ])
+
+        let state = StageModelInheritanceState.resolve(config: config, stageKey: "planner")
+
+        #expect(state == .agentDefault)
+        #expect(state.optionLabel == "Same as provider (agent default)")
+    }
+
     @Test func selectionStateUsesInheritedWhenNoPinExists() {
         let config = AgentProvidersConfig(providers: [
             AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", enabled: true, isDefault: true),

--- a/Tests/WikiFSTests/AgentProvidersConfigPerStageModelTests.swift
+++ b/Tests/WikiFSTests/AgentProvidersConfigPerStageModelTests.swift
@@ -82,6 +82,21 @@ struct AgentProvidersConfigPerStageModelTests {
         #expect(config.modelId(forStage: "executor", fallbackProvider: ProviderID(rawValue: "p")) == nil)
     }
 
+    @Test func repositoryUpdateAllowsThePlannerToUseItsProvidersAgentDefault() {
+        let providerID = ProviderID(rawValue: "configured")
+        let agentDefaultPlanner = AgentProvidersConfig(providers: [
+            AgentProvider(id: providerID, label: "Configured", enabled: true, isDefault: true),
+        ])
+        let plannerOnly = AgentProvidersConfig(
+            providers: [
+                AgentProvider(id: providerID, label: "Configured", enabled: true, isDefault: true),
+            ],
+            ingestStageModelIds: [ACPIngestStage.planner.rawValue: ModelID(rawValue: "planner-model")]
+        )
+        #expect(agentDefaultPlanner.isRepositoryUpdateConfigured())
+        #expect(plannerOnly.isRepositoryUpdateConfigured())
+    }
+
     // MARK: - Resolution: per-stage override wins
 
     @Test func modelForStageReturnsOverrideWhenSet() {

--- a/Tests/WikiFSTests/ReaderFanoutProgressTests.swift
+++ b/Tests/WikiFSTests/ReaderFanoutProgressTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import WikiFSCore
+
+/// Locks the pure progress-message contract for the repository reader
+/// fan-out. The daemon emits these from the parent task-group completion loop
+/// — never from child tasks — so the helper must be deterministic and free of
+/// side effects.
+struct ReaderFanoutProgressTests {
+    @Test func startMessageShowsZeroOfTotal() {
+        let message = ReaderFanoutProgress.start(repositoryName: "swift-markdown", total: 3)
+
+        #expect(message == "Reading swift-markdown with 3 readers (0/3)…")
+    }
+
+    @Test func readerCompletedMessageShowsCountOfTotal() {
+        let message = ReaderFanoutProgress.readerCompleted(
+            repositoryName: "swift-markdown", completed: 2, total: 5)
+
+        #expect(message == "Reading swift-markdown with 5 readers (2/5)…")
+    }
+
+    @Test func readerCompletedAtFullCountStillShowsIntermediate() {
+        let message = ReaderFanoutProgress.readerCompleted(
+            repositoryName: "swift-markdown", completed: 5, total: 5)
+
+        #expect(message == "Reading swift-markdown with 5 readers (5/5)…")
+    }
+
+    @Test func curatorHandoffMessageAnnouncesCurator() {
+        let message = ReaderFanoutProgress.curatorHandoff(
+            repositoryName: "swift-markdown", total: 19)
+
+        #expect(message == "All 19 readers finished for swift-markdown, starting curator…")
+    }
+
+    @Test func startWithSingleReaderStillFormats() {
+        let message = ReaderFanoutProgress.start(repositoryName: "mono", total: 2)
+
+        #expect(message == "Reading mono with 2 readers (0/2)…")
+    }
+
+    @Test func allMessagesIncludeRepositoryName() {
+        let name = "my-repo"
+        #expect(ReaderFanoutProgress.start(repositoryName: name, total: 3).contains(name))
+        #expect(ReaderFanoutProgress.readerCompleted(repositoryName: name, completed: 1, total: 3).contains(name))
+        #expect(ReaderFanoutProgress.curatorHandoff(repositoryName: name, total: 3).contains(name))
+    }
+}

--- a/Tests/WikiFSTests/SpawnModelGuardTests.swift
+++ b/Tests/WikiFSTests/SpawnModelGuardTests.swift
@@ -39,69 +39,26 @@ struct SpawnModelGuardTests {
         #expect(SpawnModelGuard.validate(provider: claude, modelId: "x") == nil)
     }
 
-    @Test func returnsErrorMessageWhenModelIdIsNil() {
-        let msg = SpawnModelGuard.validate(provider: claude, modelId: nil)
-        #expect(msg != nil)
-        // Three required message fragments per AC.1/AC.2 — actionable
-        // ("No model selected"), identifies the provider (its label), and
-        // points the user where to fix it ("Settings → Providers").
-        #expect(msg?.contains("No model selected") == true)
-        #expect(msg?.contains(claude.label) == true)
-        #expect(msg?.contains("Settings → Providers") == true)
+    @Test func allowsTheAgentsDefaultWhenModelIdIsNil() {
+        #expect(SpawnModelGuard.validate(provider: claude, modelId: nil) == nil)
     }
 
-    @Test func returnsErrorMessageWhenModelIdIsEmptyString() {
+    @Test func allowsTheAgentsDefaultWhenModelIdIsEmptyString() {
         // An empty string is treated identically to nil (the same shape
         // `AgentProvidersConfig.selectedModelId(forProvider:)` collapses to nil).
-        #expect(SpawnModelGuard.validate(provider: claude, modelId: "") != nil)
-        let msg = SpawnModelGuard.validate(provider: claude, modelId: "")
-        #expect(msg?.contains(claude.label) == true)
-    }
-
-    @Test func errorMessageIncludesProviderLabelForActionability() {
-        // The provider label is what the user sees in Settings → Providers, so the
-        // error message must use it (not the internal `id`) to be actionable.
-        let opencode = AgentProvider(
-            id: ProviderID(rawValue: "opencode"),
-            label: "OpenCode",
-            command: ["opencode", "acp"],
-            env: [:],
-            enabled: true,
-            isDefault: true)
-        let msg = SpawnModelGuard.validate(provider: opencode, modelId: nil)
-        #expect(msg?.contains("OpenCode") == true)
-        // And the internal id should NOT leak (the user doesn't know it).
-        #expect(msg?.contains("provider id") == false)
-    }
-
-    @Test func messageIsStableAcrossProvidersForSnapshotStability() {
-        // The wording is templated by label only — two providers with the same
-        // label produce identical messages, so a snapshot/regression test can
-        // pin the format.
-        let a = AgentProvider(id: ProviderID(rawValue: "x"), label: "Hermes", command: ["hermes", "acp"])
-        let b = AgentProvider(id: ProviderID(rawValue: "y"), label: "Hermes", command: ["hermes2", "acp"])
-        #expect(
-            SpawnModelGuard.validate(provider: a, modelId: nil)
-            == SpawnModelGuard.validate(provider: b, modelId: nil))
+        #expect(SpawnModelGuard.validate(provider: claude, modelId: "") == nil)
     }
 
     // MARK: - Per-stage validation (per-stage-model-selection plan §6)
 
-    @Test func returnsStageNamedRefusalWhenStageProvided() {
+    @Test func allowsTheAgentsDefaultWhenStageNameIsProvided() {
         // per-stage-model-selection plan §6: a missing *executor*-stage model
         // (with planner/finalizer set) must produce a phase-named refusal, not
         // a silent spawn — the orchestrator runs the guard three times (once
         // per stage) and the message must name the failing stage so the user
         // knows which picker to fix.
-        let msg = SpawnModelGuard.validate(
-            provider: claude, modelId: nil, stageName: "Executor")
-        #expect(msg != nil)
-        #expect(msg?.contains("Executor") == true)
-        #expect(msg?.contains("stage") == true)
-        // Actionable + provider identification preserved.
-        #expect(msg?.contains("No model selected") == true)
-        #expect(msg?.contains(claude.label) == true)
-        #expect(msg?.contains("Settings → Providers") == true)
+        #expect(SpawnModelGuard.validate(
+            provider: claude, modelId: nil, stageName: "Executor") == nil)
     }
 
     @Test func stageNameIsIgnoredWhenModelIsPresent() {
@@ -111,13 +68,5 @@ struct SpawnModelGuardTests {
             provider: claude, modelId: "sonnet", stageName: "Planner") == nil)
     }
 
-    @Test func stageNameNilFallsBackToNonStageMessage() {
-        // When stageName is nil OR empty, the message uses the legacy
-        // non-stage form. Mirrors `startInteractiveQuery`'s chat-path call
-        // (no stageName arg — chat is not a per-stage ingest kind).
-        #expect(SpawnModelGuard.validate(provider: claude, modelId: nil)?.contains("stage") == false)
-        #expect(SpawnModelGuard.validate(
-            provider: claude, modelId: nil, stageName: "")?.contains("stage") == false)
-    }
 }
 #endif // os(macOS)

--- a/Tests/WikiFSTests/TrackedRepoStoreTests.swift
+++ b/Tests/WikiFSTests/TrackedRepoStoreTests.swift
@@ -37,6 +37,17 @@ struct TrackedRepoStoreTests {
         #expect(persisted.lastIngestedCommit == "abc123")
         #expect(persisted.lastFetchedAt == Date(timeIntervalSince1970: 42))
         #expect(!persisted.isDrifted)
+        #expect(persisted.canRequestUpdate)
+    }
+
+    @Test func repositoryWithoutAnInitialCloneCannotRequestUpdate() throws {
+        let store = try TestStoreFactory.inMemory()
+        let repository = try store.addRepo(
+            name: "example/project",
+            remoteURL: "https://github.com/example/project.git",
+            branch: nil)
+
+        #expect(repository.canRequestUpdate == false)
     }
 
     @Test func v48UpgradeCreatesTrackedRepositoriesTable() throws {


### PR DESCRIPTION
## Summary

Relaxes model selection semantics to allow nil values (inheriting provider agent defaults) instead of requiring explicit selection. Adds repository update support with configuration validation, queue preflight checks, and comprehensive debug logging throughout the ingestion pipeline.

## Changes

### Model Selection Semantics
- Modified `SpawnModelGuard` to allow nil model IDs—agents inherit their provider's default instead of failing
- Added `StageModelInheritanceState` enum to clearly distinguish selected models from agent defaults in the UI
- Updated `isChatOperationConfigured()` to validate only provider availability, not model presence
- Nil model selection is now valid; provider availability is the only hard requirement

### Repository Update Support
- Added `canRequestUpdate` property to `TrackedRepo` to enable update button when repository is cloned
- Added `isRepositoryUpdateConfigured()` and `agentOperationConfigurationError()` methods to `AgentProvidersConfig` for staged validation
- Integrated configuration error checking into `RepositoriesContainerView` with user-facing error messages
- Added preflight validation in `WikiDaemon.queueRequestPreflightError()` to reject misconfigured requests before enqueueing

### Reader Fan-Out Progress
- Added `ReaderFanoutProgress` (pure functions) to format progress messages during parallel repository reader execution
- Integrated progress callbacks through `DaemonQueueIngestionProvider.runReaderFanout()` to emit intermediate completion counts
- Messages track "(completed/total)" as each reader finishes

### Observability
- Added structured debug logging throughout the queue pipeline:
  - XPC client/daemon boundaries (submitted, accepted, rejected, failed)
  - Dispatch stage (scan, blocked reasons: no-provider, provider-capacity, wiki-active)
  - Worker lifecycle (started, finished, cancelled, failed)
  - Ingestion worker entry and handoff points
- All queue trace logs include item ID, wiki ID, queue type, and contextual details

### Validation
- Added `queueRequestPreflightError()` to validate ingestion requests before they become durable queue items
- Validates required stages based on request type (update, lint, or normal ingestion)
- Throws `QueueIngestionError.notReady()` with user-facing error message on configuration issues
- Prevents launcher preflight errors from marking items as completed

### UI/UX Improvements
- Repository update button now disabled with helpful text when configuration is missing
- Sidebar frame now claims full height to avoid centering empty states
- Settings → Providers link provided in error messages for user remediation

## Testing
- Added `ReaderFanoutProgressTests` for deterministic message formatting
- Added `StageModelInheritanceState` resolution test
- Updated `SpawnModelGuardTests` to reflect new allow-nil semantics
- Added `canRequestUpdate` property tests in `TrackedRepoStoreTests`
- Added repository update configuration test in `AgentProvidersConfigPerStageModelTests`