### PR TITLE
feat(renderers): restore portable renderer contract

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -380,7 +380,6 @@ let package = Package(
             name: "WikiFSTypesRendererTests",
             dependencies: ["WikiFSTypes"],
             path: "Tests/WikiFSTypesRendererTests",
-            exclude: ["Fixtures"],
             swiftSettings: strictSwiftSettings
         ),
         // Signal-target validation tests compile against the pure validation

--- a/Package.swift
+++ b/Package.swift
@@ -373,6 +373,16 @@ let package = Package(
             exclude: ["Fixtures"],
             swiftSettings: strictSwiftSettings
         ),
+        // Renderer contract tests depend on the portable leaf target alone.
+        // This makes an accidental WikiFSTypes -> WikiFSCore dependency a
+        // package-graph failure on every supported platform.
+        .testTarget(
+            name: "WikiFSTypesRendererTests",
+            dependencies: ["WikiFSTypes"],
+            path: "Tests/WikiFSTypesRendererTests",
+            exclude: ["Fixtures"],
+            swiftSettings: strictSwiftSettings
+        ),
         // Signal-target validation tests compile against the pure validation
         // target only. They deliberately cannot link the production `kill`
         // closures in WikiFSCore, so a test can never signal a real process.

--- a/Sources/WikiFSCore/Core/PortableHash.swift
+++ b/Sources/WikiFSCore/Core/PortableHash.swift
@@ -1,24 +1,9 @@
-// Portable SHA-256 wrapper.
-//
-// On macOS, `CryptoKit` (system framework) provides `SHA256.hash(data:)`.
-// On Linux, `swift-crypto` (already a transitive dependency via GRDB)
-// provides the identical API under the `Crypto` module.
-//
-// This shim exposes a single `portableSHA256(_:)` function so callers don't
-// need to worry about which module resolved `SHA256`.
+// Compatibility adapter for existing Core callers. The portable typed SHA-256
+// primitive lives in WikiFSTypes/Renderer/RendererSHA256.swift.
 
 import Foundation
-
-#if canImport(CryptoKit)
-import CryptoKit
+import WikiFSTypes
 
 func portableSHA256(_ data: Data) -> [UInt8] {
-    Array(SHA256.hash(data: data))
+    RendererSHA256.digest(data).bytes
 }
-#elseif canImport(Crypto)
-import Crypto
-
-func portableSHA256(_ data: Data) -> [UInt8] {
-    Array(SHA256.hash(data: data))
-}
-#endif

--- a/Sources/WikiFSTypes/Renderer/RendererConstraints.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererConstraints.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+// pattern: Functional Core
+
+public struct RendererRelativePath: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        let segments = rawValue.split(separator: "/", omittingEmptySubsequences: false)
+        guard rawValue.isEmpty == false,
+              rawValue.hasPrefix("/") == false,
+              rawValue.contains("\\") == false,
+              segments.allSatisfy({ $0.isEmpty == false && $0 != "." && $0 != ".." && $0.contains("\0") == false })
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else { throw RendererValidationError.invalidRelativePath(rawValue) }
+        self = value
+    }
+
+    public init(from decoder: any Decoder) throws { try self.init(validating: String(from: decoder)) }
+    public func encode(to encoder: any Encoder) throws { var container = encoder.singleValueContainer(); try container.encode(rawValue) }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+public struct RendererMIMEType: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard rawValue == rawValue.lowercased(),
+              rawValue.range(of: "^[a-z0-9][a-z0-9!#$&^_.+-]*/[a-z0-9][a-z0-9!#$&^_.+-]*$", options: .regularExpression) != nil
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else { throw RendererValidationError.invalidMIMEType(rawValue) }
+        self = value
+    }
+
+    public init(from decoder: any Decoder) throws { try self.init(validating: String(from: decoder)) }
+    public func encode(to encoder: any Encoder) throws { var container = encoder.singleValueContainer(); try container.encode(rawValue) }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+public struct RendererFileExtension: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard rawValue == rawValue.lowercased(), rawValue.hasPrefix(".") == false,
+              rawValue.isEmpty == false, rawValue.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) })
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else { throw RendererValidationError.invalidExtension(rawValue) }
+        self = value
+    }
+
+    public init(from decoder: any Decoder) throws { try self.init(validating: String(from: decoder)) }
+    public func encode(to encoder: any Encoder) throws { var container = encoder.singleValueContainer(); try container.encode(rawValue) }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+public enum RendererArtifactKind: String, Codable, CaseIterable, Hashable, Sendable {
+    case source
+    case markdown
+    case image
+    case binary
+}
+
+/// The named upper bound for all in-memory source sniffing in renderer matching.
+public enum RendererMatchingLimits {
+    public static let maximumSniffByteCount = 4_096
+}
+
+public struct RendererSizeLimits: Codable, Hashable, Sendable {
+    public let maximumInputByteCount: Int
+    public let maximumDecodedByteCount: Int
+
+    public init(maximumInputByteCount: Int, maximumDecodedByteCount: Int) throws {
+        guard maximumInputByteCount > 0, maximumDecodedByteCount > 0,
+              maximumDecodedByteCount >= maximumInputByteCount else {
+            throw RendererValidationError.invalidSizeLimit("input=\(maximumInputByteCount), decoded=\(maximumDecodedByteCount)")
+        }
+        self.maximumInputByteCount = maximumInputByteCount
+        self.maximumDecodedByteCount = maximumDecodedByteCount
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(maximumInputByteCount: container.decode(Int.self, forKey: .maximumInputByteCount), maximumDecodedByteCount: container.decode(Int.self, forKey: .maximumDecodedByteCount))
+    }
+}
+
+public struct RendererCompatibility: Codable, Hashable, Sendable {
+    public let minimumProtocolRevision: Int
+    public let maximumProtocolRevision: Int
+
+    public init(minimumProtocolRevision: Int, maximumProtocolRevision: Int) throws {
+        guard minimumProtocolRevision > 0, maximumProtocolRevision >= minimumProtocolRevision else {
+            throw RendererValidationError.invalidCompatibilityRange
+        }
+        self.minimumProtocolRevision = minimumProtocolRevision
+        self.maximumProtocolRevision = maximumProtocolRevision
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(minimumProtocolRevision: container.decode(Int.self, forKey: .minimumProtocolRevision), maximumProtocolRevision: container.decode(Int.self, forKey: .maximumProtocolRevision))
+    }
+
+    public func supports(hostProtocolRevision: Int) -> Bool {
+        hostProtocolRevision >= minimumProtocolRevision && hostProtocolRevision <= maximumProtocolRevision
+    }
+}
+
+public enum RendererPresentation: String, Codable, CaseIterable, Hashable, Sendable {
+    case native
+    case web
+}
+
+public enum RendererLinkPolicy: String, Codable, Hashable, Sendable {
+    case none
+    case userActivatedExternal
+}
+
+public struct RendererAccessibility: Codable, Hashable, Sendable {
+    public let supportsVoiceOver: Bool
+    public let supportsKeyboardNavigation: Bool
+
+    public init(supportsVoiceOver: Bool, supportsKeyboardNavigation: Bool) {
+        self.supportsVoiceOver = supportsVoiceOver
+        self.supportsKeyboardNavigation = supportsKeyboardNavigation
+    }
+}
+
+/// Capability names parsed from package metadata. Validation admits only the
+/// two read-only host operations in this phase.
+public enum RendererCapability: String, Codable, CaseIterable, Hashable, Sendable {
+    case inputRead
+    case externalLink
+    case network
+    case credentials
+    case worker
+    case contentWrite
+}

--- a/Sources/WikiFSTypes/Renderer/RendererDescriptor.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererDescriptor.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+// pattern: Functional Core
+
+public struct RendererWebEntryPoint: Codable, Hashable, Sendable {
+    public let path: RendererRelativePath
+
+    public init(path: RendererRelativePath) {
+        self.path = path
+    }
+}
+
+public enum RendererImplementation: Codable, Hashable, Sendable {
+    case builtIn(BuiltInRendererID)
+    case webPackage(RendererWebEntryPoint)
+}
+
+public struct RendererAsset: Codable, Hashable, Sendable, Comparable {
+    public let path: RendererRelativePath
+    public let digest: RendererSHA256Digest
+
+    public init(path: RendererRelativePath, digest: RendererSHA256Digest) {
+        self.path = path
+        self.digest = digest
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.path < rhs.path }
+}
+
+/// One immutable renderer registration. Its reference is also its stable tie-break key.
+public struct RendererDescriptor: Codable, Hashable, Sendable {
+    public let reference: RendererReference
+    public let displayName: String
+    public let implementation: RendererImplementation
+    public let matchers: [RendererMatcher]
+    public let presentations: Set<RendererPresentation>
+    public let approvedAssets: [RendererAsset]
+    public let capabilities: Set<RendererCapability>
+    public let sizeLimits: RendererSizeLimits
+    public let linkPolicy: RendererLinkPolicy
+    public let accessibility: RendererAccessibility
+    public let compatibility: RendererCompatibility
+    public let priority: Int
+
+    public init(
+        reference: RendererReference,
+        displayName: String,
+        implementation: RendererImplementation,
+        matchers: [RendererMatcher],
+        presentations: Set<RendererPresentation>,
+        approvedAssets: [RendererAsset],
+        capabilities: Set<RendererCapability>,
+        sizeLimits: RendererSizeLimits,
+        linkPolicy: RendererLinkPolicy,
+        accessibility: RendererAccessibility,
+        compatibility: RendererCompatibility,
+        priority: Int
+    ) throws {
+        guard displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
+              matchers.isEmpty == false,
+              presentations.isEmpty == false else {
+            throw RendererValidationError.invalidPresentation
+        }
+        guard capabilities.contains(.inputRead) else {
+            throw RendererValidationError.missingRequiredCapability(.inputRead)
+        }
+        for capability in capabilities where capability != .inputRead && capability != .externalLink {
+            throw RendererValidationError.forbiddenCapability(capability)
+        }
+        if linkPolicy == .userActivatedExternal && capabilities.contains(.externalLink) == false {
+            throw RendererValidationError.missingRequiredCapability(.externalLink)
+        }
+        if linkPolicy == .none && capabilities.contains(.externalLink) {
+            throw RendererValidationError.forbiddenCapability(.externalLink)
+        }
+        let assets = approvedAssets.sorted()
+        guard Set(assets.map(\.path)).count == assets.count else {
+            guard let duplicate = RendererDescriptor.firstDuplicatePath(in: assets) else {
+                throw RendererValidationError.invalidRelativePath("duplicate asset validation")
+            }
+            throw RendererValidationError.duplicateAsset(duplicate)
+        }
+        switch implementation {
+        case .builtIn:
+            guard presentations == [.native], assets.isEmpty else { throw RendererValidationError.invalidPresentation }
+        case let .webPackage(entryPoint):
+            guard presentations == [.web], assets.contains(where: { $0.path == entryPoint.path }) else {
+                throw RendererValidationError.invalidPresentation
+            }
+        }
+        self.reference = reference
+        self.displayName = displayName
+        self.implementation = implementation
+        self.matchers = matchers
+        self.presentations = presentations
+        self.approvedAssets = assets
+        self.capabilities = capabilities
+        self.sizeLimits = sizeLimits
+        self.linkPolicy = linkPolicy
+        self.accessibility = accessibility
+        self.compatibility = compatibility
+        self.priority = priority
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            reference: container.decode(RendererReference.self, forKey: .reference),
+            displayName: container.decode(String.self, forKey: .displayName),
+            implementation: container.decode(RendererImplementation.self, forKey: .implementation),
+            matchers: container.decode([RendererMatcher].self, forKey: .matchers),
+            presentations: container.decode(Set<RendererPresentation>.self, forKey: .presentations),
+            approvedAssets: container.decode([RendererAsset].self, forKey: .approvedAssets),
+            capabilities: container.decode(Set<RendererCapability>.self, forKey: .capabilities),
+            sizeLimits: container.decode(RendererSizeLimits.self, forKey: .sizeLimits),
+            linkPolicy: container.decode(RendererLinkPolicy.self, forKey: .linkPolicy),
+            accessibility: container.decode(RendererAccessibility.self, forKey: .accessibility),
+            compatibility: container.decode(RendererCompatibility.self, forKey: .compatibility),
+            priority: container.decode(Int.self, forKey: .priority)
+        )
+    }
+
+    public var logicalReference: LogicalRendererReference {
+        .init(packageID: reference.packageID, registrationID: reference.registrationID)
+    }
+
+    /// Match MIME, signature, and artifact matchers first. Extensions are used only
+    /// when no stronger matcher from any descriptor succeeds.
+    public func matchTier(for input: RendererMatchInput) -> RendererMatchTier? {
+        if matchers.contains(where: { $0.isExtensionFallback == false && $0.matches(input) }) {
+            return .strong
+        }
+        if matchers.contains(where: { $0.isExtensionFallback && $0.matches(input) }) {
+            return .extensionFallback
+        }
+        return nil
+    }
+
+    /// Higher priority wins. Equal priorities sort by package ID, then package
+    /// version, then registration ID, all ascending. This key never uses install order.
+    public var stableTieBreakKey: RendererStableTieBreakKey {
+        .init(priority: priority, reference: reference)
+    }
+
+    private static func firstDuplicatePath(in assets: [RendererAsset]) -> RendererRelativePath? {
+        zip(assets, assets.dropFirst()).first(where: { $0.path == $1.path })?.0.path
+    }
+}
+
+public enum RendererMatchTier: Int, Comparable, Sendable {
+    case extensionFallback
+    case strong
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+public struct RendererStableTieBreakKey: Comparable, Hashable, Sendable {
+    public let priority: Int
+    public let reference: RendererReference
+
+    public init(priority: Int, reference: RendererReference) {
+        self.priority = priority
+        self.reference = reference
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        if lhs.priority != rhs.priority { return lhs.priority > rhs.priority }
+        return lhs.reference < rhs.reference
+    }
+}

--- a/Sources/WikiFSTypes/Renderer/RendererIdentifier.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererIdentifier.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+// pattern: Functional Core
+
+/// Stable identity of one installed renderer package. The canonical form is a
+/// lowercase reverse-DNS name with at least two labels.
+public struct RendererPackageID: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard RendererIdentifierRules.isPackageID(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else {
+            throw RendererValidationError.invalidIdentifier(kind: "renderer package ID", value: rawValue)
+        }
+        self = value
+    }
+
+    public init(from decoder: any Decoder) throws { try self.init(validating: String(from: decoder)) }
+    public func encode(to encoder: any Encoder) throws { var container = encoder.singleValueContainer(); try container.encode(rawValue) }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+/// Immutable semantic version of a renderer package.
+public struct RendererPackageVersion: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+    public let major: UInt
+    public let minor: UInt
+    public let patch: UInt
+    public let prerelease: String?
+    public let buildMetadata: String?
+
+    public init?(rawValue: String) {
+        let components = rawValue.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false)
+        let versionAndPrerelease = components[0].split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+        let numbers = versionAndPrerelease[0].split(separator: ".", omittingEmptySubsequences: false)
+        guard numbers.count == 3,
+              let major = RendererIdentifierRules.strictUInt(numbers[0]),
+              let minor = RendererIdentifierRules.strictUInt(numbers[1]),
+              let patch = RendererIdentifierRules.strictUInt(numbers[2]),
+              components.count <= 2,
+              (components.count == 1 || RendererIdentifierRules.isBuildMetadata(String(components[1]))),
+              (versionAndPrerelease.count == 1 || RendererIdentifierRules.isPrerelease(String(versionAndPrerelease[1])))
+        else { return nil }
+        self.rawValue = rawValue
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.prerelease = versionAndPrerelease.count == 2 ? String(versionAndPrerelease[1]) : nil
+        self.buildMetadata = components.count == 2 ? String(components[1]) : nil
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else { throw RendererValidationError.invalidVersion(rawValue) }
+        self = value
+    }
+
+    public init(from decoder: any Decoder) throws { try self.init(validating: String(from: decoder)) }
+    public func encode(to encoder: any Encoder) throws { var container = encoder.singleValueContainer(); try container.encode(rawValue) }
+
+    /// Compares SemVer precedence. Build metadata deliberately has no effect.
+    public func semanticPrecedence(comparedTo other: Self) -> ComparisonResult {
+        if major != other.major { return major < other.major ? .orderedAscending : .orderedDescending }
+        if minor != other.minor { return minor < other.minor ? .orderedAscending : .orderedDescending }
+        if patch != other.patch { return patch < other.patch ? .orderedAscending : .orderedDescending }
+        switch (prerelease, other.prerelease) {
+        case (nil, nil): return .orderedSame
+        case (nil, .some): return .orderedDescending
+        case (.some, nil): return .orderedAscending
+        case let (.some(left), .some(right)):
+            return RendererIdentifierRules.comparePrerelease(left, right)
+        }
+    }
+
+    /// A total ordering for stable collection keys. Call
+    /// ``semanticPrecedence(comparedTo:)`` when SemVer precedence is required.
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        let precedence = lhs.semanticPrecedence(comparedTo: rhs)
+        return precedence == .orderedSame ? lhs.rawValue < rhs.rawValue : precedence == .orderedAscending
+    }
+}
+
+/// Identity of one renderer registration within a package version.
+public struct RendererRegistrationID: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard RendererIdentifierRules.isRegistrationID(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else {
+            throw RendererValidationError.invalidIdentifier(kind: "renderer registration ID", value: rawValue)
+        }
+        self = value
+    }
+
+    public init(from decoder: any Decoder) throws { try self.init(validating: String(from: decoder)) }
+    public func encode(to encoder: any Encoder) throws { var container = encoder.singleValueContainer(); try container.encode(rawValue) }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+/// Closed host-owned identity for a native renderer. Installable package input
+/// cannot add a case to this enum.
+public enum BuiltInRendererID: String, Codable, CaseIterable, Hashable, Sendable, Comparable {
+    case pdf
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+/// Pin to one immutable renderer registration.
+public struct RendererReference: Codable, Hashable, Sendable, Comparable {
+    public let packageID: RendererPackageID
+    public let version: RendererPackageVersion
+    public let registrationID: RendererRegistrationID
+
+    public init(packageID: RendererPackageID, version: RendererPackageVersion, registrationID: RendererRegistrationID) {
+        self.packageID = packageID
+        self.version = version
+        self.registrationID = registrationID
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        (lhs.packageID, lhs.version, lhs.registrationID) < (rhs.packageID, rhs.version, rhs.registrationID)
+    }
+}
+
+/// A preference that can resolve to a compatible package version.
+public struct LogicalRendererReference: Codable, Hashable, Sendable, Comparable {
+    public let packageID: RendererPackageID
+    public let registrationID: RendererRegistrationID
+
+    public init(packageID: RendererPackageID, registrationID: RendererRegistrationID) {
+        self.packageID = packageID
+        self.registrationID = registrationID
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        (lhs.packageID, lhs.registrationID) < (rhs.packageID, rhs.registrationID)
+    }
+}
+
+/// The identifier validation used by every public string boundary in this module.
+enum RendererIdentifierRules {
+    static func isPackageID(_ value: String) -> Bool {
+        let labels = value.split(separator: ".", omittingEmptySubsequences: false)
+        return labels.count >= 2 && labels.allSatisfy(isPackageLabel)
+    }
+
+    static func isPackageLabel(_ label: Substring) -> Bool {
+        guard let first = label.first, first.isASCII, first.isLetter, first.isLowercase,
+              label.count <= 63 else { return false }
+        return label.allSatisfy { character in
+            character.isASCII && (character.isLowercase || character.isNumber || character == "-")
+        } && label.last != "-"
+    }
+
+    static func isRegistrationID(_ value: String) -> Bool {
+        guard let first = value.first, first.isASCII, first.isLetter, first.isLowercase,
+              value.count <= 64, value.last != "-" else { return false }
+        return value.allSatisfy { character in
+            character.isASCII && (character.isLowercase || character.isNumber || character == "-")
+        }
+    }
+
+    static func strictUInt(_ value: Substring) -> UInt? {
+        guard value.isEmpty == false, value.allSatisfy(\.isNumber), value.count == 1 || value.first != "0" else {
+            return nil
+        }
+        return UInt(value)
+    }
+
+    static func isBuildMetadata(_ value: String) -> Bool {
+        isVersionIdentifierList(value)
+    }
+
+    static func isPrerelease(_ value: String) -> Bool {
+        isVersionIdentifierList(value) && value.split(separator: ".", omittingEmptySubsequences: false).allSatisfy { part in
+            part.allSatisfy(\.isNumber) == false || part.count == 1 || part.first != "0"
+        }
+    }
+
+    static func comparePrerelease(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let left = lhs.split(separator: ".", omittingEmptySubsequences: false)
+        let right = rhs.split(separator: ".", omittingEmptySubsequences: false)
+        for (leftIdentifier, rightIdentifier) in zip(left, right) {
+            let identifierComparison = comparePrereleaseIdentifier(leftIdentifier, rightIdentifier)
+            if identifierComparison != .orderedSame { return identifierComparison }
+        }
+        if left.count != right.count { return left.count < right.count ? .orderedAscending : .orderedDescending }
+        return .orderedSame
+    }
+
+    private static func isVersionIdentifierList(_ value: String) -> Bool {
+        value.isEmpty == false && value.split(separator: ".", omittingEmptySubsequences: false).allSatisfy { part in
+            part.isEmpty == false && part.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
+        }
+    }
+
+    private static func comparePrereleaseIdentifier(_ lhs: Substring, _ rhs: Substring) -> ComparisonResult {
+        let leftIsNumeric = lhs.allSatisfy(\.isNumber)
+        let rightIsNumeric = rhs.allSatisfy(\.isNumber)
+        switch (leftIsNumeric, rightIsNumeric) {
+        case (true, true):
+            if lhs.count != rhs.count { return lhs.count < rhs.count ? .orderedAscending : .orderedDescending }
+            return lhs == rhs ? .orderedSame : (lhs < rhs ? .orderedAscending : .orderedDescending)
+        case (true, false): return .orderedAscending
+        case (false, true): return .orderedDescending
+        case (false, false): return lhs == rhs ? .orderedSame : (lhs < rhs ? .orderedAscending : .orderedDescending)
+        }
+    }
+}

--- a/Sources/WikiFSTypes/Renderer/RendererManifest.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererManifest.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+// pattern: Functional Core
+
+public enum RendererManifestRevision {
+    public static let current = 1
+}
+
+/// The normalized package document. It contains metadata only and no package
+/// installation or filesystem behavior.
+public struct RendererManifest: Codable, Hashable, Sendable {
+    public let revision: Int
+    public let packageID: RendererPackageID
+    public let version: RendererPackageVersion
+    public let descriptors: [RendererDescriptor]
+    public let assets: [RendererAsset]
+
+    public init(revision: Int, packageID: RendererPackageID, version: RendererPackageVersion, descriptors: [RendererDescriptor], assets: [RendererAsset]) throws {
+        guard revision == RendererManifestRevision.current else {
+            throw RendererValidationError.unsupportedManifestRevision(revision)
+        }
+        let sortedDescriptors = descriptors.sorted { $0.reference.registrationID < $1.reference.registrationID }
+        guard sortedDescriptors.isEmpty == false else {
+            throw RendererValidationError.emptyManifest
+        }
+        guard Set(sortedDescriptors.map(\.reference.registrationID)).count == sortedDescriptors.count else {
+            guard let duplicate = zip(sortedDescriptors, sortedDescriptors.dropFirst()).first(where: {
+                $0.reference.registrationID == $1.reference.registrationID
+            })?.0.reference.registrationID else { throw RendererValidationError.manifestIdentityMismatch }
+            throw RendererValidationError.duplicateRegistration(duplicate)
+        }
+        let sortedAssets = assets.sorted()
+        guard Set(sortedAssets.map(\.path)).count == sortedAssets.count else {
+            guard let duplicate = zip(sortedAssets, sortedAssets.dropFirst()).first(where: { $0.path == $1.path })?.0.path else {
+                throw RendererValidationError.manifestIdentityMismatch
+            }
+            throw RendererValidationError.duplicatePath(duplicate)
+        }
+        for descriptor in sortedDescriptors {
+            guard descriptor.reference.packageID == packageID, descriptor.reference.version == version else {
+                throw RendererValidationError.manifestIdentityMismatch
+            }
+            if case let .builtIn(identifier) = descriptor.implementation {
+                throw RendererValidationError.packageManifestContainsBuiltIn(identifier)
+            }
+            let packageAssets = Set(sortedAssets)
+            for asset in descriptor.approvedAssets where packageAssets.contains(asset) == false {
+                throw RendererValidationError.manifestAssetNotApproved(asset.path)
+            }
+        }
+        self.revision = revision
+        self.packageID = packageID
+        self.version = version
+        self.descriptors = sortedDescriptors
+        self.assets = sortedAssets
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            revision: container.decode(Int.self, forKey: .revision),
+            packageID: container.decode(RendererPackageID.self, forKey: .packageID),
+            version: container.decode(RendererPackageVersion.self, forKey: .version),
+            descriptors: container.decode([RendererDescriptor].self, forKey: .descriptors),
+            assets: container.decode([RendererAsset].self, forKey: .assets)
+        )
+    }
+
+    /// JSON with Foundation's sorted-key encoder. This uses an explicit
+    /// canonical DTO because synthesized Codable does not impose an order on
+    /// `Set` members nested inside a descriptor.
+    public func canonicalJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(CanonicalManifest(self))
+    }
+
+    /// SHA-256 of a versioned envelope that embeds normalized manifest JSON and
+    /// every asset's canonical lowercase digest. The format label prevents a
+    /// future envelope revision from sharing this hash namespace.
+    public func packageHash() throws -> RendererSHA256Digest {
+        let manifestObject = try JSONSerialization.jsonObject(with: canonicalJSON(), options: [.fragmentsAllowed])
+        let envelope: [String: Any] = [
+            "format": "selfdrivingwiki.renderer-package-hash",
+            "revision": RendererManifestRevision.current,
+            "manifest": manifestObject,
+            "assets": assets.map { ["path": $0.path.rawValue, "sha256": $0.digest.hex] },
+        ]
+        let data = try JSONSerialization.data(withJSONObject: envelope, options: [.sortedKeys, .withoutEscapingSlashes])
+        return RendererSHA256.digest(data)
+    }
+}
+
+private struct CanonicalManifest: Encodable {
+    let revision: Int
+    let packageID: RendererPackageID
+    let version: RendererPackageVersion
+    let descriptors: [CanonicalRendererDescriptor]
+    let assets: [RendererAsset]
+
+    init(_ manifest: RendererManifest) throws {
+        revision = manifest.revision
+        packageID = manifest.packageID
+        version = manifest.version
+        descriptors = try manifest.descriptors.map(CanonicalRendererDescriptor.init)
+        assets = manifest.assets.sorted()
+    }
+}
+
+private struct CanonicalRendererDescriptor: Encodable {
+    let reference: RendererReference
+    let displayName: String
+    let implementation: RendererImplementation
+    let matchers: [RendererMatcher]
+    let presentations: [RendererPresentation]
+    let approvedAssets: [RendererAsset]
+    let capabilities: [RendererCapability]
+    let sizeLimits: RendererSizeLimits
+    let linkPolicy: RendererLinkPolicy
+    let accessibility: RendererAccessibility
+    let compatibility: RendererCompatibility
+    let priority: Int
+
+    init(_ descriptor: RendererDescriptor) throws {
+        reference = descriptor.reference
+        displayName = descriptor.displayName
+        implementation = descriptor.implementation
+        matchers = try CanonicalRendererDescriptor.sortedCodable(descriptor.matchers)
+        presentations = descriptor.presentations.sorted { $0.rawValue < $1.rawValue }
+        approvedAssets = descriptor.approvedAssets.sorted()
+        capabilities = descriptor.capabilities.sorted { $0.rawValue < $1.rawValue }
+        sizeLimits = descriptor.sizeLimits
+        linkPolicy = descriptor.linkPolicy
+        accessibility = descriptor.accessibility
+        compatibility = descriptor.compatibility
+        priority = descriptor.priority
+    }
+
+    private static func sortedCodable<T: Encodable>(_ values: [T]) throws -> [T] {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try values.map { (value: $0, key: try encoder.encode($0)) }
+            .sorted { $0.key.lexicographicallyPrecedes($1.key) }
+            .map(\.value)
+    }
+}

--- a/Sources/WikiFSTypes/Renderer/RendererMatcher.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererMatcher.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// pattern: Functional Core
+
+public struct RendererSignature: Codable, Hashable, Sendable {
+    public let offset: Int
+    public let bytes: [UInt8]
+
+    public init(offset: Int, bytes: [UInt8]) throws {
+        guard offset >= 0, bytes.isEmpty == false,
+              offset <= RendererMatchingLimits.maximumSniffByteCount,
+              bytes.count <= RendererMatchingLimits.maximumSniffByteCount - offset else {
+            throw RendererValidationError.invalidSignature
+        }
+        self.offset = offset
+        self.bytes = bytes
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(offset: container.decode(Int.self, forKey: .offset), bytes: container.decode([UInt8].self, forKey: .bytes))
+    }
+}
+
+public enum RendererMatcher: Codable, Hashable, Sendable {
+    case normalizedMIME(RendererMIMEType)
+    case extensionFallback(RendererFileExtension)
+    case boundedSignature(RendererSignature)
+    case artifactKind(RendererArtifactKind)
+
+    public func matches(_ input: RendererMatchInput) -> Bool {
+        switch self {
+        case let .normalizedMIME(mime): input.mimeType == mime
+        case let .extensionFallback(fileExtension): input.fileExtension == fileExtension
+        case let .boundedSignature(signature): input.sniffedBytes.matches(signature)
+        case let .artifactKind(kind): input.artifactKind == kind
+        }
+    }
+
+    public var isExtensionFallback: Bool {
+        if case .extensionFallback = self { return true }
+        return false
+    }
+}
+
+public struct RendererMatchInput: Hashable, Sendable {
+    public let mimeType: RendererMIMEType?
+    public let fileExtension: RendererFileExtension?
+    public let sniffedBytes: Data
+    public let artifactKind: RendererArtifactKind?
+
+    public init(mimeType: RendererMIMEType?, fileExtension: RendererFileExtension?, sniffedBytes: Data, artifactKind: RendererArtifactKind?) throws {
+        guard sniffedBytes.count <= RendererMatchingLimits.maximumSniffByteCount else {
+            throw RendererValidationError.invalidSizeLimit("sniff byte count \(sniffedBytes.count)")
+        }
+        self.mimeType = mimeType
+        self.fileExtension = fileExtension
+        self.sniffedBytes = sniffedBytes
+        self.artifactKind = artifactKind
+    }
+}
+
+private extension Data {
+    func matches(_ signature: RendererSignature) -> Bool {
+        let end = signature.offset + signature.bytes.count
+        guard count >= end else { return false }
+        return Array(self[signature.offset..<end]) == signature.bytes
+    }
+}

--- a/Sources/WikiFSTypes/Renderer/RendererResolution.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererResolution.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+// pattern: Functional Core
+
+public enum RendererPreferenceReference: Codable, Hashable, Sendable {
+    case exact(RendererReference)
+    case logical(LogicalRendererReference)
+}
+
+/// A persisted preference can retain a logical choice while a user temporarily
+/// pins one exact version. Resolution falls through when that exact version is
+/// unavailable or incompatible.
+public struct RendererPreference: Codable, Hashable, Sendable {
+    public let exact: RendererReference?
+    public let logical: LogicalRendererReference?
+
+    public init(exact: RendererReference?, logical: LogicalRendererReference?) throws {
+        guard exact != nil || logical != nil else { throw RendererValidationError.emptyPreference }
+        if let exact, let logical {
+            guard exact.packageID == logical.packageID, exact.registrationID == logical.registrationID else {
+                throw RendererValidationError.mismatchedPreferenceIdentity
+            }
+        }
+        self.exact = exact
+        self.logical = logical
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            exact: container.decodeIfPresent(RendererReference.self, forKey: .exact),
+            logical: container.decodeIfPresent(LogicalRendererReference.self, forKey: .logical)
+        )
+    }
+}
+
+/// Pure deterministic resolver shared by future registry snapshots.
+public enum RendererResolution {
+    public static func matching(
+        descriptors: [RendererDescriptor],
+        input: RendererMatchInput,
+        hostProtocolRevision: Int
+    ) -> [RendererDescriptor] {
+        let compatible = descriptors.filter { $0.compatibility.supports(hostProtocolRevision: hostProtocolRevision) }
+        let strong = compatible.filter { $0.matchTier(for: input) == .strong }
+        let candidates = strong.isEmpty ? compatible.filter { $0.matchTier(for: input) == .extensionFallback } : strong
+        return candidates.sorted { $0.stableTieBreakKey < $1.stableTieBreakKey }
+    }
+
+    /// Exact pins win when compatible and installed. Logical preferences choose the
+    /// greatest compatible semantic version and then the documented stable key.
+    public static func preferred(
+        descriptors: [RendererDescriptor],
+        preference: RendererPreferenceReference?,
+        input: RendererMatchInput,
+        hostProtocolRevision: Int
+    ) -> RendererDescriptor? {
+        let matches = matching(descriptors: descriptors, input: input, hostProtocolRevision: hostProtocolRevision)
+        guard let preference else { return matches.first }
+        switch preference {
+        case let .exact(reference):
+            return matches.first(where: { $0.reference == reference })
+        case let .logical(reference):
+            let logical = matches.filter { $0.logicalReference == reference }
+            return logical.sorted(by: logicalOrdering).first
+        }
+    }
+
+    public static func preferred(
+        descriptors: [RendererDescriptor],
+        preference: RendererPreference?,
+        input: RendererMatchInput,
+        hostProtocolRevision: Int
+    ) -> RendererDescriptor? {
+        let matches = matching(descriptors: descriptors, input: input, hostProtocolRevision: hostProtocolRevision)
+        guard let preference else { return matches.first }
+        if let exact = preference.exact, let descriptor = matches.first(where: { $0.reference == exact }) {
+            return descriptor
+        }
+        guard let logical = preference.logical else { return nil }
+        return matches.filter { $0.logicalReference == logical }.sorted(by: logicalOrdering).first
+    }
+
+    private static func logicalOrdering(_ lhs: RendererDescriptor, _ rhs: RendererDescriptor) -> Bool {
+        let precedence = lhs.reference.version.semanticPrecedence(comparedTo: rhs.reference.version)
+        if precedence != .orderedSame { return precedence == .orderedDescending }
+        return lhs.stableTieBreakKey < rhs.stableTieBreakKey
+    }
+}

--- a/Sources/WikiFSTypes/Renderer/RendererSHA256.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererSHA256.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+// pattern: Functional Core
+
+#if canImport(CryptoKit)
+import CryptoKit
+#elseif canImport(Crypto)
+import Crypto
+#endif
+
+// pattern: Functional Core
+
+/// SHA-256 digest with exactly 32 bytes and a canonical lowercase-hex codec.
+public struct RendererSHA256Digest: Codable, Hashable, Sendable {
+    public static let byteCount = 32
+    public let bytes: [UInt8]
+
+    public init(bytes: [UInt8]) throws {
+        guard bytes.count == Self.byteCount else { throw RendererDigestError.invalidByteCount(bytes.count) }
+        self.bytes = bytes
+    }
+
+    public init(hex: String) throws {
+        guard hex.count == Self.byteCount * 2 else { throw RendererDigestError.invalidHex(hex) }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(Self.byteCount)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            let pair = hex[index..<next]
+            guard pair.allSatisfy({ $0.isASCII && ($0.isNumber || ("a"..."f").contains($0)) }),
+                  let byte = UInt8(pair, radix: 16) else {
+                throw RendererDigestError.invalidHex(hex)
+            }
+            bytes.append(byte)
+            index = next
+        }
+        try self.init(bytes: bytes)
+    }
+
+    public var hex: String { bytes.map { String(format: "%02x", $0) }.joined() }
+
+    public init(from decoder: any Decoder) throws {
+        try self.init(hex: try String(from: decoder))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(hex)
+    }
+}
+
+public enum RendererDigestError: Error, Equatable, Sendable {
+    case invalidByteCount(Int)
+    case invalidHex(String)
+}
+
+/// Cross-platform SHA-256 entry point. macOS uses CryptoKit and Linux uses
+/// the compatible Crypto module supplied by swift-crypto.
+public enum RendererSHA256 {
+    public static func digest(_ data: Data) -> RendererSHA256Digest {
+        let bytes: [UInt8]
+        #if canImport(CryptoKit)
+        bytes = Array(SHA256.hash(data: data))
+        #elseif canImport(Crypto)
+        bytes = Array(SHA256.hash(data: data))
+        #else
+        #error("RendererSHA256 requires CryptoKit or Crypto")
+        #endif
+        // SHA-256 has a fixed output width. This is a programming invariant,
+        // not caller input, so fail loudly if the platform implementation breaks it.
+        do {
+            return try RendererSHA256Digest(bytes: bytes)
+        } catch {
+            preconditionFailure("SHA-256 platform primitive produced an invalid digest: \(error)")
+        }
+    }
+}

--- a/Sources/WikiFSTypes/Renderer/RendererValidationError.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererValidationError.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// pattern: Functional Core
+
+/// Rejection reason at a renderer contract boundary.
+public enum RendererValidationError: Error, Equatable, Sendable, CustomStringConvertible {
+    case invalidIdentifier(kind: String, value: String)
+    case invalidVersion(String)
+    case invalidRelativePath(String)
+    case invalidMIMEType(String)
+    case invalidExtension(String)
+    case invalidSignature
+    case invalidSizeLimit(String)
+    case invalidCompatibilityRange
+    case invalidPresentation
+    case forbiddenCapability(RendererCapability)
+    case missingRequiredCapability(RendererCapability)
+    case duplicateRegistration(RendererRegistrationID)
+    case duplicatePath(RendererRelativePath)
+    case duplicateAsset(RendererRelativePath)
+    case unsupportedManifestRevision(Int)
+    case manifestIdentityMismatch
+    case manifestAssetNotApproved(RendererRelativePath)
+    case emptyManifest
+    case packageManifestContainsBuiltIn(BuiltInRendererID)
+    case emptyPreference
+    case mismatchedPreferenceIdentity
+
+    public var description: String {
+        switch self {
+        case let .invalidIdentifier(kind, value): "invalid \(kind): \(value)"
+        case let .invalidVersion(value): "invalid renderer package version: \(value)"
+        case let .invalidRelativePath(value): "invalid renderer relative path: \(value)"
+        case let .invalidMIMEType(value): "invalid MIME type: \(value)"
+        case let .invalidExtension(value): "invalid extension: \(value)"
+        case .invalidSignature: "invalid bounded signature"
+        case let .invalidSizeLimit(value): "invalid renderer size limit: \(value)"
+        case .invalidCompatibilityRange: "invalid compatibility revision range"
+        case .invalidPresentation: "invalid renderer presentation for implementation"
+        case let .forbiddenCapability(capability): "forbidden renderer capability: \(capability.rawValue)"
+        case let .missingRequiredCapability(capability): "missing required renderer capability: \(capability.rawValue)"
+        case let .duplicateRegistration(id): "duplicate renderer registration: \(id.rawValue)"
+        case let .duplicatePath(path): "duplicate renderer path: \(path.rawValue)"
+        case let .duplicateAsset(path): "duplicate renderer asset: \(path.rawValue)"
+        case let .unsupportedManifestRevision(revision): "unsupported renderer manifest revision: \(revision)"
+        case .manifestIdentityMismatch: "renderer descriptor does not match manifest identity"
+        case let .manifestAssetNotApproved(path): "renderer descriptor does not approve manifest asset: \(path.rawValue)"
+        case .emptyManifest: "renderer manifest must register at least one renderer"
+        case let .packageManifestContainsBuiltIn(id): "renderer package manifest cannot contain built-in renderer: \(id.rawValue)"
+        case .emptyPreference: "renderer preference has no exact or logical reference"
+        case .mismatchedPreferenceIdentity: "renderer preference exact and logical identities differ"
+        }
+    }
+}

--- a/Tests/WikiFSTests/WikiLinkStoreTests.swift
+++ b/Tests/WikiFSTests/WikiLinkStoreTests.swift
@@ -113,13 +113,19 @@ struct WikiLinkStoreTests {
         // the same millisecond order by their random bits, so derive the expected
         // order from the actual ids rather than assuming creation order == lexical
         // order. The three links are a→b, a→c, c→a.
-        let expected = [
-            (a.id.rawValue, b.id.rawValue),
-            (a.id.rawValue, c.id.rawValue),
-            (c.id.rawValue, a.id.rawValue),
+        let unorderedExpected: [(from: String, to: String)] = [
+            (from: a.id.rawValue, to: b.id.rawValue),
+            (from: a.id.rawValue, to: c.id.rawValue),
+            (from: c.id.rawValue, to: a.id.rawValue),
         ]
-        .sorted { $0.0 != $1.0 ? $0.0 < $1.0 : $0.1 < $1.1 }
-        .map { "\($0.0)->\($0.1)" }
+        let expected = unorderedExpected
+            .sorted { lhs, rhs in
+                if lhs.from != rhs.from {
+                    return lhs.from < rhs.from
+                }
+                return lhs.to < rhs.to
+            }
+            .map { "\($0.from)->\($0.to)" }
         #expect(links.map { "\($0.from)->\($0.to)" } == expected)
     }
 

--- a/Tests/WikiFSTypesRendererTests/RendererContractTests.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererContractTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+import WikiFSTypes
+
+struct RendererSHA256Tests {
+    @Test func testDigestBytes() throws {
+        let digest = RendererSHA256.digest(Data("abc".utf8))
+        #expect(digest.bytes == [
+            0xBA, 0x78, 0x16, 0xBF, 0x8F, 0x01, 0xCF, 0xEA,
+            0x41, 0x41, 0x40, 0xDE, 0x5D, 0xAE, 0x22, 0x23,
+            0xB0, 0x03, 0x61, 0xA3, 0x96, 0x17, 0x7A, 0x9C,
+            0xB4, 0x10, 0xFF, 0x61, 0xF2, 0x00, 0x15, 0xAD,
+        ])
+    }
+}
+
+struct RendererDigestHexCodecTests {
+    @Test func testCanonicalLowercaseHex() throws {
+        let digest = try RendererSHA256Digest(hex: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        #expect(digest.hex == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+    }
+
+    @Test func testRejectsMalformedDigests() {
+        #expect(throws: RendererDigestError.self) {
+            _ = try RendererSHA256Digest(hex: "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD")
+        }
+        #expect(throws: RendererDigestError.self) {
+            _ = try RendererSHA256Digest(hex: "1234")
+        }
+        #expect(throws: RendererDigestError.self) {
+            _ = try RendererSHA256Digest(hex: String(repeating: "g", count: 64))
+        }
+    }
+}
+
+struct RendererPortableHashImportTests {
+    @Test func testSupportedPlatformImports() {
+        #if os(macOS) || os(Linux)
+        let digest = RendererSHA256.digest(Data())
+        #expect(digest.bytes.count == RendererSHA256Digest.byteCount)
+        #else
+        Issue.record("WikiFSTypes must compile only on declared supported platforms")
+        #endif
+    }
+}
+
+struct RendererReferenceShapeTests {
+    @Test func exactAndLogicalReferencesShareOnlyPackageAndRegistrationIdentity() throws {
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+        let version = try RendererPackageVersion(validating: "1.2.3")
+        let registrationID = try RendererRegistrationID(validating: "viewer")
+        let exact = RendererReference(packageID: packageID, version: version, registrationID: registrationID)
+        let logical = LogicalRendererReference(packageID: packageID, registrationID: registrationID)
+        #expect(exact.packageID == logical.packageID)
+        #expect(exact.registrationID == logical.registrationID)
+    }
+}

--- a/Tests/WikiFSTypesRendererTests/RendererFixtures.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererFixtures.swift
@@ -1,0 +1,67 @@
+import Foundation
+@testable import WikiFSTypes
+
+enum RendererFixtures {
+    static let packageID = try! RendererPackageID(validating: "org.example.viewer")
+    static let version = try! RendererPackageVersion(validating: "1.2.3")
+    static let registrationID = try! RendererRegistrationID(validating: "viewer")
+
+    static func nativeDescriptor(
+        version: RendererPackageVersion = version,
+        registrationID: RendererRegistrationID = registrationID,
+        matchers: [RendererMatcher] = [.normalizedMIME(try! RendererMIMEType(validating: "application/pdf"))],
+        compatibility: RendererCompatibility? = nil,
+        priority: Int = 0
+    ) throws -> RendererDescriptor {
+        try RendererDescriptor(
+            reference: .init(packageID: packageID, version: version, registrationID: registrationID),
+            displayName: "Example Viewer",
+            implementation: .builtIn(.pdf),
+            matchers: matchers,
+            presentations: [.native],
+            approvedAssets: [],
+            capabilities: [.inputRead],
+            sizeLimits: try .init(maximumInputByteCount: 1_024, maximumDecodedByteCount: 2_048),
+            linkPolicy: .none,
+            accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true),
+            compatibility: try compatibility ?? .init(minimumProtocolRevision: 1, maximumProtocolRevision: 1),
+            priority: priority
+        )
+    }
+
+    static func webDescriptor(
+        assets: [RendererAsset],
+        registrationID: RendererRegistrationID = registrationID,
+        matchers: [RendererMatcher] = [.artifactKind(.source)]
+    ) throws -> RendererDescriptor {
+        guard let entry = assets.first else { throw RendererValidationError.invalidPresentation }
+        return try RendererDescriptor(
+            reference: .init(packageID: packageID, version: version, registrationID: registrationID),
+            displayName: "Example Web Viewer",
+            implementation: .webPackage(.init(path: entry.path)),
+            matchers: matchers,
+            presentations: [.web],
+            approvedAssets: assets,
+            capabilities: [.inputRead],
+            sizeLimits: try .init(maximumInputByteCount: 1_024, maximumDecodedByteCount: 2_048),
+            linkPolicy: .none,
+            accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true),
+            compatibility: try .init(minimumProtocolRevision: 1, maximumProtocolRevision: 1),
+            priority: 0
+        )
+    }
+
+    static func input(
+        mime: String? = "application/pdf",
+        fileExtension: String? = "pdf",
+        bytes: Data = Data("%PDF".utf8),
+        artifact: RendererArtifactKind? = .source
+    ) throws -> RendererMatchInput {
+        try .init(
+            mimeType: try mime.map(RendererMIMEType.init(validating:)),
+            fileExtension: try fileExtension.map(RendererFileExtension.init(validating:)),
+            sniffedBytes: bytes,
+            artifactKind: artifact
+        )
+    }
+}

--- a/Tests/WikiFSTypesRendererTests/RendererModelTests.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererModelTests.swift
@@ -1,0 +1,362 @@
+import Foundation
+import Testing
+import WikiFSTypes
+
+struct RendererIdentifierTests {
+    @Test(arguments: ["org.example.viewer", "com.example.renderer-v2"])
+    func acceptsCanonicalPackageID(_ rawValue: String) throws {
+        #expect(try RendererPackageID(validating: rawValue).rawValue == rawValue)
+    }
+
+    @Test(arguments: ["Example.viewer", "org..viewer", "viewer", "org.example."])
+    func rejectsMalformedPackageID(_ rawValue: String) {
+        #expect(RendererPackageID(rawValue: rawValue) == nil)
+    }
+
+    @Test(arguments: ["1.2.3", "1.2.3-beta.1", "2.0.0+build.8"])
+    func ordersSemanticVersions(_ rawValue: String) throws {
+        #expect(try RendererPackageVersion(validating: rawValue).rawValue == rawValue)
+    }
+
+    @Test func ordersPrereleaseIdentifiersBySemanticVersionPrecedence() throws {
+        let beta2 = try RendererPackageVersion(validating: "1.0.0-beta.2")
+        let beta10 = try RendererPackageVersion(validating: "1.0.0-beta.10")
+        let alpha = try RendererPackageVersion(validating: "1.0.0-alpha")
+        let alpha1 = try RendererPackageVersion(validating: "1.0.0-alpha.1")
+        let alphaBeta = try RendererPackageVersion(validating: "1.0.0-alpha.beta")
+        let stable = try RendererPackageVersion(validating: "1.0.0")
+
+        #expect(beta2 < beta10)
+        #expect(alpha < alpha1)
+        #expect(alpha1 < alphaBeta)
+        #expect(alphaBeta < stable)
+    }
+
+    @Test func buildMetadataDoesNotChangeSemanticPrecedence() throws {
+        let first = try RendererPackageVersion(validating: "1.0.0+build.1")
+        let second = try RendererPackageVersion(validating: "1.0.0+build.2")
+
+        #expect(first.semanticPrecedence(comparedTo: second) == .orderedSame)
+        #expect(first != second)
+    }
+
+    @Test func rejectsLeadingZeroNumericPrereleaseButAcceptsBuildMetadata() {
+        #expect(RendererPackageVersion(rawValue: "1.0.0-01") == nil)
+        #expect(RendererPackageVersion(rawValue: "1.0.0+01") != nil)
+    }
+
+    @Test func rejectsInvalidIdentifierWhenDecoding() throws {
+        let data = Data("\"BAD\"".utf8)
+        #expect(throws: Error.self) { _ = try JSONDecoder().decode(RendererRegistrationID.self, from: data) }
+    }
+}
+
+struct RendererMatcherTests {
+    @Test(arguments: ["/absolute", "assets/../viewer.js", "assets//viewer.js", "assets\\viewer.js", "./viewer.js"])
+    func rejectsInvalidRelativePaths(_ rawValue: String) {
+        #expect(RendererRelativePath(rawValue: rawValue) == nil)
+    }
+
+    @Test(arguments: ["Application/PDF", "application", "application/", "application/pdf; charset=utf-8"])
+    func rejectsMalformedMIMETypes(_ rawValue: String) {
+        #expect(RendererMIMEType(rawValue: rawValue) == nil)
+    }
+
+    @Test(arguments: [".pdf", "PDF", "pdf-x", ""])
+    func rejectsMalformedFileExtensions(_ rawValue: String) {
+        #expect(RendererFileExtension(rawValue: rawValue) == nil)
+    }
+
+    @Test func matchesMIMEAndSignatureWithinNamedBound() throws {
+        let descriptor = try RendererFixtures.nativeDescriptor(matchers: [
+            .normalizedMIME(try .init(validating: "application/pdf")),
+            .boundedSignature(try .init(offset: 0, bytes: Array("%PDF".utf8))),
+        ])
+        #expect(descriptor.matchTier(for: try RendererFixtures.input()) == .strong)
+    }
+
+    @Test func usesExtensionOnlyWhenNoStrongMatcherExists() throws {
+        let strong = try RendererFixtures.nativeDescriptor(priority: 0)
+        let extensionID = try RendererRegistrationID(validating: "fallback")
+        let fallback = try RendererFixtures.nativeDescriptor(
+            registrationID: extensionID,
+            matchers: [.extensionFallback(try .init(validating: "pdf"))],
+            priority: 100
+        )
+        let input = try RendererFixtures.input()
+        #expect(RendererResolution.matching(descriptors: [fallback, strong], input: input, hostProtocolRevision: 1).map(\.reference) == [strong.reference])
+    }
+
+    @Test func rejectsUnboundedSniffAndSignature() throws {
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererMatchInput(mimeType: nil, fileExtension: nil, sniffedBytes: Data(repeating: 0, count: RendererMatchingLimits.maximumSniffByteCount + 1), artifactKind: nil)
+        }
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererSignature(offset: RendererMatchingLimits.maximumSniffByteCount, bytes: [0])
+        }
+    }
+
+    @Test func distinguishesSignatureOffsetFallbackAndNoMatchTiers() throws {
+        let signature = try RendererFixtures.nativeDescriptor(matchers: [.boundedSignature(try .init(offset: 1, bytes: [0x50]))])
+        let fallback = try RendererFixtures.nativeDescriptor(registrationID: try .init(validating: "fallback-tier"), matchers: [.extensionFallback(try .init(validating: "pdf"))])
+        let signedInput = try RendererMatchInput(mimeType: nil, fileExtension: nil, sniffedBytes: Data([0x00, 0x50]), artifactKind: nil)
+        let fallbackInput = try RendererMatchInput(mimeType: nil, fileExtension: try .init(validating: "pdf"), sniffedBytes: Data(), artifactKind: nil)
+        let noMatchInput = try RendererMatchInput(mimeType: nil, fileExtension: nil, sniffedBytes: Data(), artifactKind: nil)
+        #expect(signature.matchTier(for: signedInput) == .strong)
+        #expect(fallback.matchTier(for: fallbackInput) == .extensionFallback)
+        #expect(signature.matchTier(for: noMatchInput) == nil)
+    }
+}
+
+struct RendererResolutionTests {
+    @Test func rejectsEmptyPreference() {
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererPreference(exact: nil, logical: nil)
+        }
+    }
+
+    @Test func sortsByPriorityThenStableReferenceWithoutInputOrder() throws {
+        let first = try RendererFixtures.nativeDescriptor(priority: 10)
+        let second = try RendererFixtures.nativeDescriptor(registrationID: try .init(validating: "second"), priority: 10)
+        let input = try RendererFixtures.input()
+        let forward = RendererResolution.matching(descriptors: [second, first], input: input, hostProtocolRevision: 1)
+        let reverse = RendererResolution.matching(descriptors: [first, second], input: input, hostProtocolRevision: 1)
+        #expect(forward == reverse)
+        #expect(forward.map(\.reference) == [second.reference, first.reference])
+    }
+
+    @Test func resolvesExactThenLogicalCompatiblePreference() throws {
+        let old = try RendererFixtures.nativeDescriptor(version: try .init(validating: "1.0.0"))
+        let new = try RendererFixtures.nativeDescriptor(version: try .init(validating: "2.0.0"))
+        let input = try RendererFixtures.input()
+        let exact = RendererResolution.preferred(descriptors: [new, old], preference: .exact(old.reference), input: input, hostProtocolRevision: 1)
+        let logical = RendererResolution.preferred(descriptors: [old, new], preference: .logical(new.logicalReference), input: input, hostProtocolRevision: 1)
+        #expect(exact == old)
+        #expect(logical == new)
+    }
+
+    @Test func resolvesEqualSemanticVersionsWithStableDescriptorTieBreak() throws {
+        let first = try RendererFixtures.nativeDescriptor(version: try .init(validating: "1.0.0+build.1"))
+        let second = try RendererFixtures.nativeDescriptor(version: try .init(validating: "1.0.0+build.2"))
+        let input = try RendererFixtures.input()
+        let preference = RendererPreferenceReference.logical(first.logicalReference)
+
+        let forward = RendererResolution.preferred(descriptors: [second, first], preference: preference, input: input, hostProtocolRevision: 1)
+        let reverse = RendererResolution.preferred(descriptors: [first, second], preference: preference, input: input, hostProtocolRevision: 1)
+
+        #expect(first.reference.version.semanticPrecedence(comparedTo: second.reference.version) == .orderedSame)
+        #expect(forward == first)
+        #expect(reverse == first)
+    }
+
+    @Test func ignoresIncompatibleExactPreference() throws {
+        let incompatible = try RendererFixtures.nativeDescriptor(
+            compatibility: try .init(minimumProtocolRevision: 2, maximumProtocolRevision: 2)
+        )
+        let input = try RendererFixtures.input()
+        #expect(RendererResolution.preferred(descriptors: [incompatible], preference: .exact(incompatible.reference), input: input, hostProtocolRevision: 1) == nil)
+    }
+
+    @Test func fallsBackFromUnavailableExactToLogicalPreference() throws {
+        let old = try RendererFixtures.nativeDescriptor(version: try .init(validating: "1.0.0"))
+        let new = try RendererFixtures.nativeDescriptor(version: try .init(validating: "2.0.0"))
+        let unavailable = RendererReference(packageID: RendererFixtures.packageID, version: try .init(validating: "3.0.0"), registrationID: RendererFixtures.registrationID)
+        let preference = try RendererPreference(exact: unavailable, logical: new.logicalReference)
+        let input = try RendererFixtures.input()
+        #expect(RendererResolution.preferred(descriptors: [old, new], preference: preference, input: input, hostProtocolRevision: 1) == new)
+    }
+
+    @Test func rejectsCompoundPreferenceWithDifferentPackageOrRegistrationIdentity() throws {
+        let exact = RendererReference(packageID: RendererFixtures.packageID, version: RendererFixtures.version, registrationID: RendererFixtures.registrationID)
+        let otherPackage = try RendererPackageID(validating: "org.example.other")
+        let otherRegistration = try RendererRegistrationID(validating: "other")
+        #expect(throws: RendererValidationError.mismatchedPreferenceIdentity) {
+            _ = try RendererPreference(exact: exact, logical: .init(packageID: otherPackage, registrationID: exact.registrationID))
+        }
+        #expect(throws: RendererValidationError.mismatchedPreferenceIdentity) {
+            _ = try RendererPreference(exact: exact, logical: .init(packageID: exact.packageID, registrationID: otherRegistration))
+        }
+    }
+}
+
+struct RendererDescriptorValidationTests {
+    @Test func rejectsNonpositiveInputSizeLimit() {
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererSizeLimits(maximumInputByteCount: 0, maximumDecodedByteCount: 1)
+        }
+    }
+
+    @Test func rejectsDecodedSizeBelowInputSizeLimit() {
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererSizeLimits(maximumInputByteCount: 2, maximumDecodedByteCount: 1)
+        }
+    }
+
+    @Test func rejectsInvalidCompatibilityBounds() throws {
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererCompatibility(minimumProtocolRevision: 0, maximumProtocolRevision: 1)
+        }
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererCompatibility(minimumProtocolRevision: 2, maximumProtocolRevision: 1)
+        }
+        let compatibility = try RendererCompatibility(minimumProtocolRevision: 2, maximumProtocolRevision: 4)
+        #expect(compatibility.supports(hostProtocolRevision: 2))
+        #expect(compatibility.supports(hostProtocolRevision: 4))
+        #expect(compatibility.supports(hostProtocolRevision: 1) == false)
+        #expect(compatibility.supports(hostProtocolRevision: 5) == false)
+    }
+
+    @Test func enforcesLinkPolicyCapabilityPairs() throws {
+        let reference = RendererReference(packageID: RendererFixtures.packageID, version: RendererFixtures.version, registrationID: RendererFixtures.registrationID)
+        let limits = try RendererSizeLimits(maximumInputByteCount: 1, maximumDecodedByteCount: 1)
+        let compatibility = try RendererCompatibility(minimumProtocolRevision: 1, maximumProtocolRevision: 1)
+
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererDescriptor(reference: reference, displayName: "Links", implementation: .builtIn(.pdf), matchers: [.artifactKind(.source)], presentations: [.native], approvedAssets: [], capabilities: [.inputRead], sizeLimits: limits, linkPolicy: .userActivatedExternal, accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true), compatibility: compatibility, priority: 0)
+        }
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererDescriptor(reference: reference, displayName: "No links", implementation: .builtIn(.pdf), matchers: [.artifactKind(.source)], presentations: [.native], approvedAssets: [], capabilities: [.inputRead, .externalLink], sizeLimits: limits, linkPolicy: .none, accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true), compatibility: compatibility, priority: 0)
+        }
+    }
+
+    @Test func rejectsNativeDescriptorWithWebPresentation() throws {
+        let reference = RendererReference(packageID: RendererFixtures.packageID, version: RendererFixtures.version, registrationID: RendererFixtures.registrationID)
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererDescriptor(reference: reference, displayName: "Native", implementation: .builtIn(.pdf), matchers: [.artifactKind(.source)], presentations: [.web], approvedAssets: [], capabilities: [.inputRead], sizeLimits: try .init(maximumInputByteCount: 1, maximumDecodedByteCount: 1), linkPolicy: .none, accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true), compatibility: try .init(minimumProtocolRevision: 1, maximumProtocolRevision: 1), priority: 0)
+        }
+    }
+
+    @Test func rejectsForbiddenNetworkCapability() throws {
+        let reference = RendererReference(packageID: RendererFixtures.packageID, version: RendererFixtures.version, registrationID: RendererFixtures.registrationID)
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererDescriptor(reference: reference, displayName: "Network", implementation: .builtIn(.pdf), matchers: [.artifactKind(.source)], presentations: [.native], approvedAssets: [], capabilities: [.inputRead, .network], sizeLimits: try .init(maximumInputByteCount: 1, maximumDecodedByteCount: 1), linkPolicy: .none, accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true), compatibility: try .init(minimumProtocolRevision: 1, maximumProtocolRevision: 1), priority: 0)
+        }
+    }
+
+    @Test func rejectsDuplicateDescriptorAssetPath() throws {
+        let asset = RendererAsset(path: try .init(validating: "assets/index.html"), digest: try .init(hex: String(repeating: "1", count: 64)))
+        #expect(throws: RendererValidationError.duplicateAsset(asset.path)) {
+            _ = try RendererFixtures.webDescriptor(assets: [asset, asset])
+        }
+    }
+
+    @Test func preservesWebImplementationAssetsAccessibilityAndConstraintEnums() throws {
+        let index = RendererAsset(path: try .init(validating: "assets/index.html"), digest: try .init(hex: String(repeating: "3", count: 64)))
+        let script = RendererAsset(path: try .init(validating: "assets/viewer.js"), digest: try .init(hex: String(repeating: "4", count: 64)))
+        let implementation = RendererImplementation.webPackage(.init(path: index.path))
+        let accessibility = RendererAccessibility(supportsVoiceOver: true, supportsKeyboardNavigation: false)
+        let decoded = try JSONDecoder().decode(RendererImplementation.self, from: JSONEncoder().encode(implementation))
+        #expect(decoded == implementation)
+        #expect(index < script)
+        #expect(try JSONDecoder().decode(RendererAccessibility.self, from: JSONEncoder().encode(accessibility)) == accessibility)
+        #expect(RendererArtifactKind.allCases == [.source, .markdown, .image, .binary])
+        #expect(RendererPresentation.allCases == [.native, .web])
+        #expect(RendererCapability.allCases.contains(.externalLink))
+        #expect(RendererLinkPolicy.userActivatedExternal != .none)
+    }
+}
+
+struct RendererPackageHashTests {
+    @Test func canonicalEnvelopeGoldenDigestAndOrderIndependence() throws {
+        let packageID = RendererFixtures.packageID
+        let version = RendererFixtures.version
+        let registrationID = RendererFixtures.registrationID
+        let index = RendererAsset(
+            path: try .init(validating: "assets/index.html"),
+            digest: try .init(hex: String(repeating: "1", count: 64))
+        )
+        let script = RendererAsset(
+            path: try .init(validating: "assets/viewer.js"),
+            digest: try .init(hex: String(repeating: "2", count: 64))
+        )
+        let descriptor = try RendererDescriptor(
+            reference: .init(packageID: packageID, version: version, registrationID: registrationID),
+            displayName: "Web Viewer",
+            implementation: .webPackage(.init(path: index.path)),
+            matchers: [.artifactKind(.source)],
+            presentations: [.web],
+            approvedAssets: [script, index],
+            capabilities: [.inputRead, .externalLink],
+            sizeLimits: try .init(maximumInputByteCount: 1_024, maximumDecodedByteCount: 2_048),
+            linkPolicy: .userActivatedExternal,
+            accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true),
+            compatibility: try .init(minimumProtocolRevision: 1, maximumProtocolRevision: 1),
+            priority: 1
+        )
+        let first = try RendererManifest(revision: 1, packageID: packageID, version: version, descriptors: [descriptor], assets: [script, index])
+        let second = try RendererManifest(revision: 1, packageID: packageID, version: version, descriptors: [descriptor], assets: [index, script])
+        let firstHash = try first.packageHash()
+        let secondHash = try second.packageHash()
+        #expect(firstHash == secondHash)
+        #expect(firstHash.hex == "84457b45f850cb5e6347b026c8c1135c27d32af329fb17f0d5d7b09afdc80fc6")
+    }
+
+    @Test func canonicalHashIsIndependentOfMultiMemberSetConstructionOrder() throws {
+        let index = RendererAsset(path: try .init(validating: "assets/index.html"), digest: try .init(hex: String(repeating: "a", count: 64)))
+        let first = try RendererFixtures.webDescriptor(assets: [index], matchers: [.artifactKind(.source), .normalizedMIME(try .init(validating: "application/pdf")), .extensionFallback(try .init(validating: "pdf"))])
+        let second = try RendererDescriptor(reference: first.reference, displayName: first.displayName, implementation: first.implementation, matchers: Array(first.matchers.reversed()), presentations: Set([.web]), approvedAssets: first.approvedAssets, capabilities: Set([.inputRead]), sizeLimits: first.sizeLimits, linkPolicy: first.linkPolicy, accessibility: first.accessibility, compatibility: first.compatibility, priority: first.priority)
+        let firstManifest = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [first], assets: [index])
+        let secondManifest = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [second], assets: [index])
+        #expect(try firstManifest.packageHash() == secondManifest.packageHash())
+        #expect(try firstManifest.canonicalJSON() == secondManifest.canonicalJSON())
+    }
+
+}
+
+struct RendererManifestValidationTests {
+    @Test func rejectsEmptyPackageRegistrationList() throws {
+        #expect(throws: RendererValidationError.emptyManifest) {
+            _ = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [], assets: [])
+        }
+    }
+
+    @Test func rejectsBuiltInDescriptorInPackageManifest() throws {
+        #expect(throws: RendererValidationError.packageManifestContainsBuiltIn(.pdf)) {
+            _ = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [try RendererFixtures.nativeDescriptor()], assets: [])
+        }
+    }
+
+    @Test func rejectsUnknownBuiltInIdentity() throws {
+        #expect(BuiltInRendererID(rawValue: "untrusted") == nil)
+        #expect(throws: Error.self) { _ = try JSONDecoder().decode(BuiltInRendererID.self, from: Data("\"untrusted\"".utf8)) }
+    }
+
+    @Test func rejectsDuplicateManifestAssetPath() throws {
+        let asset = RendererAsset(path: try .init(validating: "assets/index.html"), digest: try .init(hex: String(repeating: "1", count: 64)))
+        let descriptor = try RendererFixtures.webDescriptor(assets: [asset])
+        #expect(throws: RendererValidationError.duplicatePath(asset.path)) {
+            _ = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [descriptor], assets: [asset, asset])
+        }
+    }
+
+    @Test func rejectsDescriptorAssetOutsideManifestAssets() throws {
+        let descriptorAsset = RendererAsset(path: try .init(validating: "assets/index.html"), digest: try .init(hex: String(repeating: "1", count: 64)))
+        let manifestAsset = RendererAsset(path: try .init(validating: "assets/viewer.js"), digest: try .init(hex: String(repeating: "2", count: 64)))
+        let descriptor = try RendererFixtures.webDescriptor(assets: [descriptorAsset])
+        #expect(throws: RendererValidationError.manifestAssetNotApproved(descriptorAsset.path)) {
+            _ = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [descriptor], assets: [manifestAsset])
+        }
+    }
+
+    @Test func rejectsDuplicateRegistrationUnsupportedRevisionAndIdentityMismatch() throws {
+        let descriptor = try RendererFixtures.nativeDescriptor()
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererManifest(revision: 2, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [descriptor], assets: [])
+        }
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: RendererFixtures.version, descriptors: [descriptor, descriptor], assets: [])
+        }
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererManifest(revision: 1, packageID: RendererFixtures.packageID, version: try .init(validating: "2.0.0"), descriptors: [descriptor], assets: [])
+        }
+    }
+}
+
+struct RendererStableOrderingTests {
+    @Test func ordersPriorityBeforeCanonicalStableTieBreakKey() throws {
+        let high = try RendererFixtures.nativeDescriptor(registrationID: try .init(validating: "high"), priority: 10)
+        let low = try RendererFixtures.nativeDescriptor(registrationID: try .init(validating: "low"), priority: 1)
+        #expect(high.stableTieBreakKey < low.stableTieBreakKey)
+        #expect(RendererMatchTier.extensionFallback < .strong)
+    }
+}

--- a/plans/dynamic-renderers-pr1-test-inventory.json
+++ b/plans/dynamic-renderers-pr1-test-inventory.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "issue": 1026,
+  "pr": 1,
+  "scope": "portable renderer contract only",
+  "productionSources": [
+    "Sources/WikiFSTypes/Renderer/RendererConstraints.swift",
+    "Sources/WikiFSTypes/Renderer/RendererDescriptor.swift",
+    "Sources/WikiFSTypes/Renderer/RendererIdentifier.swift",
+    "Sources/WikiFSTypes/Renderer/RendererManifest.swift",
+    "Sources/WikiFSTypes/Renderer/RendererMatcher.swift",
+    "Sources/WikiFSTypes/Renderer/RendererResolution.swift",
+    "Sources/WikiFSTypes/Renderer/RendererSHA256.swift",
+    "Sources/WikiFSTypes/Renderer/RendererValidationError.swift",
+    "Sources/WikiFSCore/Core/PortableHash.swift"
+  ],
+  "requiredTests": [
+    "RendererSHA256Tests.testDigestBytes",
+    "RendererDigestHexCodecTests.testCanonicalLowercaseHex",
+    "RendererDigestHexCodecTests.testRejectsMalformedDigests",
+    "RendererPortableHashImportTests.testSupportedPlatformImports",
+    "RendererPackageHashTests.canonicalEnvelopeGoldenDigestAndOrderIndependence",
+    "RendererMatcherTests.usesExtensionOnlyWhenNoStrongMatcherExists",
+    "RendererResolutionTests.sortsByPriorityThenStableReferenceWithoutInputOrder",
+    "RendererResolutionTests.resolvesExactThenLogicalCompatiblePreference",
+    "RendererDescriptorValidationTests.rejectsForbiddenNetworkCapability",
+    "RendererManifestValidationTests.rejectsDuplicateRegistrationUnsupportedRevisionAndIdentityMismatch"
+  ],
+  "decisionBranches": [
+    "identifier validation and namespace separation",
+    "semantic-version precedence",
+    "bounded matcher input and extension fallback",
+    "descriptor capability, presentation, and size-limit validation",
+    "manifest identity, registration, and asset validation",
+    "deterministic priority and preference resolution",
+    "strict lowercase digest codec",
+    "canonical package-hash envelope order independence"
+  ],
+  "notApplicable": [
+    "package filesystem installation",
+    "persistence",
+    "network",
+    "UI",
+    "compiler-boundary negative typechecking",
+    "cross-process hash determinism"
+  ],
+  "mutationScope": "Sources/WikiFSTypes/Renderer",
+  "mutationEvidence": "Run and classify the documented scoped mutation report separately; optional mutation-evidence schema and audit enforcement are intentionally excluded from this recovery.",
+  "gateLimitations": [
+    "The compile-boundary negative namespace fixture test is deferred because this recovery may not add subprocess waiting or process-safety harness code.",
+    "The fresh-process package-hash determinism test is deferred for the same reason; the pure construction-order test remains."
+  ]
+}


### PR DESCRIPTION
## Summary

Recover the portable Dynamic Renderer Phase 1 contract from reverted PR #1035.

This PR adds typed renderer identifiers, descriptors, manifests, matchers, deterministic selection, validation errors, and canonical SHA-256 package hashing. It keeps the contract in the portable `WikiFSTypes` target and uses only the minimal Core hash compatibility adapter.

The PR excludes the operator-owned watchdog, cooperative-pool, process-safety, unrelated test, audit executable, mutation-schema, WebView, persistence, settings, Excalidraw, and JSON Canvas changes from PR #1035.

## Validation

- `swift test --filter WikiFSTypesRendererTests` — 43 tests passed in 11 suites.
- `make build` — passed.
- `git diff --check` — passed.
- Exclusion audit — passed. No watchdog, process-control, wait API, audit executable, mutation schema, or specified unrelated test files are included.

## Deferred gates

`Tests/WikiFSTests/PortableHashTests.swift` remains excluded. `Sources/WikiFSCore/Core/PortableHash.swift` is the minimal in-scope compatibility adapter. This recovery does not add fixture files or a subprocess test harness. The optional mutation-evidence schema and audit enforcement remain excluded.

Refs #1026
