### PR TITLE
feat(renderer): add built-in registry snapshot adapters

### DIFF
--- a/Sources/WikiFS/Renderer/BuiltInRendererDescriptors.swift
+++ b/Sources/WikiFS/Renderer/BuiltInRendererDescriptors.swift
@@ -1,0 +1,172 @@
+#if os(macOS)
+import Foundation
+import SwiftUI
+import WikiFSCore
+import WikiFSTypes
+
+// pattern: Functional Core
+
+/// Host-owned renderer registrations for the presentations SourceDetailView
+/// already supports. These descriptors characterize existing behavior only; the
+/// Source presentation remains a host fallback and is not registered here.
+enum BuiltInRendererDescriptors {
+    static let all: [RendererDescriptor] = BuiltInRendererID.allCases.map { descriptor(for: $0) }
+
+    static func descriptor(for id: BuiltInRendererID) -> RendererDescriptor {
+        switch id {
+        case .pdf:
+            return make(
+                id: .pdf,
+                displayName: "PDF",
+                matchers: [
+                    .normalizedMIME(mime(MimeType.pdf)),
+                    .extensionFallback(fileExtension("pdf")),
+                    .boundedSignature(signature("%PDF")),
+                ],
+                maximumInputByteCount: BuiltInRendererLimits.bytefulMaximumInputByteCount,
+                priority: BuiltInRendererPriority.bytefulDocument)
+        case .html:
+            return make(
+                id: .html,
+                displayName: "HTML",
+                matchers: [
+                    .normalizedMIME(mime(MimeType.html)),
+                    .normalizedMIME(mime(MimeType.xhtml)),
+                    .extensionFallback(fileExtension("html")),
+                    .extensionFallback(fileExtension("htm")),
+                    .extensionFallback(fileExtension("xhtml")),
+                ],
+                maximumInputByteCount: BuiltInRendererLimits.bytefulMaximumInputByteCount,
+                priority: BuiltInRendererPriority.bytefulDocument)
+        case .mermaid:
+            return make(
+                id: .mermaid,
+                displayName: "Mermaid",
+                matchers: [
+                    .normalizedMIME(mime(BuiltInRendererMIME.mermaid)),
+                    .extensionFallback(fileExtension("mmd")),
+                    .artifactKind(.markdown),
+                ],
+                maximumInputByteCount: BuiltInRendererLimits.markdownMaximumInputByteCount,
+                priority: BuiltInRendererPriority.markdownDocument)
+        case .media:
+            return make(
+                id: .media,
+                displayName: "Media",
+                matchers: BuiltInRendererMIME.mediaMIMEs.map { .normalizedMIME(mime($0)) },
+                maximumInputByteCount: BuiltInRendererLimits.bytelessMaximumInputByteCount,
+                priority: BuiltInRendererPriority.media)
+        }
+    }
+
+    private static func make(
+        id: BuiltInRendererID,
+        displayName: String,
+        matchers: [RendererMatcher],
+        maximumInputByteCount: Int,
+        priority: Int
+    ) -> RendererDescriptor {
+        do {
+            return try RendererDescriptor(
+                reference: BuiltInRendererReference.reference(for: id),
+                displayName: displayName,
+                implementation: .builtIn(id),
+                matchers: matchers,
+                presentations: [.native],
+                approvedAssets: [],
+                capabilities: [.inputRead],
+                sizeLimits: try .init(
+                    maximumInputByteCount: maximumInputByteCount,
+                    maximumDecodedByteCount: maximumInputByteCount),
+                linkPolicy: .none,
+                accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true),
+                compatibility: try .init(
+                    minimumProtocolRevision: RendererRegistrySnapshotDefaults.hostProtocolRevision,
+                    maximumProtocolRevision: RendererRegistrySnapshotDefaults.hostProtocolRevision),
+                priority: priority)
+        } catch {
+            preconditionFailure("Invalid built-in renderer descriptor for \\(id.rawValue): \\(error)")
+        }
+    }
+
+    private static func mime(_ rawValue: String) -> RendererMIMEType {
+        do { return try RendererMIMEType(validating: rawValue) }
+        catch { preconditionFailure("Invalid built-in renderer MIME \\(rawValue): \\(error)") }
+    }
+
+    private static func fileExtension(_ rawValue: String) -> RendererFileExtension {
+        do { return try RendererFileExtension(validating: rawValue) }
+        catch { preconditionFailure("Invalid built-in renderer extension \\(rawValue): \\(error)") }
+    }
+
+    private static func signature(_ value: String) -> RendererSignature {
+        do { return try RendererSignature(offset: 0, bytes: Array(value.utf8)) }
+        catch { preconditionFailure("Invalid built-in renderer signature \\(value): \\(error)") }
+    }
+}
+
+enum BuiltInRendererReference {
+    static let packageID: RendererPackageID = {
+        do { return try RendererPackageID(validating: "org.selfdrivingwiki.builtin") }
+        catch { preconditionFailure("Invalid built-in renderer package ID: \\(error)") }
+    }()
+
+    static let version: RendererPackageVersion = {
+        do { return try RendererPackageVersion(validating: "1.0.0") }
+        catch { preconditionFailure("Invalid built-in renderer version: \\(error)") }
+    }()
+
+    static func reference(for id: BuiltInRendererID) -> RendererReference {
+        RendererReference(
+            packageID: packageID,
+            version: version,
+            registrationID: registrationID(for: id))
+    }
+
+    static func registrationID(for id: BuiltInRendererID) -> RendererRegistrationID {
+        do { return try RendererRegistrationID(validating: id.rawValue) }
+        catch { preconditionFailure("Invalid built-in renderer registration ID \\(id.rawValue): \\(error)") }
+    }
+}
+
+enum BuiltInRendererPriority {
+    static let bytefulDocument = 100
+    static let markdownDocument = 90
+    static let media = 80
+}
+
+enum BuiltInRendererLimits {
+    static let bytefulMaximumInputByteCount = 512 * 1_024 * 1_024
+    static let markdownMaximumInputByteCount = 64 * 1_024 * 1_024
+    static let bytelessMaximumInputByteCount = 1
+}
+
+enum BuiltInRendererMIME {
+    static let mermaid = "text/mermaid"
+    static let youtube = "video/youtube"
+    static let vimeo = "video/vimeo"
+    static let applePodcast = "audio/apple-podcast"
+    static let spotify = "audio/spotify"
+    static let soundCloud = "audio/soundcloud"
+
+    static let mediaMIMEs: [String] = [
+        youtube,
+        vimeo,
+        applePodcast,
+        spotify,
+        soundCloud,
+        "audio/mpeg",
+        "audio/mp4",
+        "audio/aac",
+        "audio/wav",
+        "audio/x-wav",
+        "audio/flac",
+        "audio/ogg",
+        "video/mp4",
+        "video/quicktime",
+        "video/x-m4v",
+        "application/vnd.apple.mpegurl",
+        "application/x-mpegurl",
+    ]
+}
+#endif

--- a/Sources/WikiFS/Renderer/BuiltInRendererFactoryMap.swift
+++ b/Sources/WikiFS/Renderer/BuiltInRendererFactoryMap.swift
@@ -1,0 +1,44 @@
+#if os(macOS)
+import Foundation
+import SwiftUI
+import WikiFSTypes
+
+// pattern: Composition Root
+
+/// App-target factory registry for host-owned native renderer views.
+///
+/// PR 2 keeps SourceDetailView on its legacy branches, so these factories are a
+/// closed, typed inventory rather than the active routing path. PR 4 will replace
+/// the token output with renderer-host inputs and call the appropriate existing
+/// view builders from one generic host.
+@MainActor
+enum BuiltInRendererFactoryMap {
+    typealias Factory = @MainActor (BuiltInRendererFactoryContext) -> BuiltInRendererFactoryToken
+
+    static let factories: [BuiltInRendererID: Factory] = [
+        .pdf: { _ in .pdf },
+        .html: { _ in .html },
+        .mermaid: { _ in .mermaid },
+        .media: { _ in .media },
+    ]
+
+    static func factory(for id: BuiltInRendererID) -> Factory? {
+        factories[id]
+    }
+}
+
+struct BuiltInRendererFactoryContext: Sendable, Equatable {
+    let rendererID: BuiltInRendererID
+
+    init(rendererID: BuiltInRendererID) {
+        self.rendererID = rendererID
+    }
+}
+
+enum BuiltInRendererFactoryToken: Sendable, Equatable {
+    case pdf
+    case html
+    case mermaid
+    case media
+}
+#endif

--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -80,9 +80,20 @@ struct SourceRendererPresentationPlanner: Sendable {
         return id
     }
 
+    private enum MediaMIMECandidate: Sendable, Equatable {
+        case notMediaOrigin
+        case rejected
+        case renderable(String)
+    }
+
     private static func normalizedMIME(for source: SourceSummary, origin: SourceOrigin?) throws -> RendererMIMEType? {
-        if let mediaMime = renderableMediaMIME(for: source, origin: origin) {
+        switch mediaMIMECandidate(for: source, origin: origin) {
+        case .renderable(let mediaMime):
             return try RendererMIMEType(validating: mediaMime)
+        case .rejected:
+            return nil
+        case .notMediaOrigin:
+            break
         }
         if let mime = source.mimeType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !mime.isEmpty {
             return RendererMIMEType(rawValue: mime)
@@ -114,16 +125,23 @@ struct SourceRendererPresentationPlanner: Sendable {
     }
 
     private static func renderableMediaMIME(for source: SourceSummary, origin: SourceOrigin?) -> String? {
-        guard let origin else { return nil }
-        let mime = mediaMIME(for: source, provider: origin.provider)
+        guard case .renderable(let mime) = mediaMIMECandidate(for: source, origin: origin) else { return nil }
+        return mime
+    }
+
+    private static func mediaMIMECandidate(for source: SourceSummary, origin: SourceOrigin?) -> MediaMIMECandidate {
+        guard let origin,
+              let mime = mediaMIME(for: source, provider: origin.provider) else {
+            return .notMediaOrigin
+        }
         let descriptor = SourceEmbedDescriptor(
             id: source.id,
             mimeType: mime,
             externalIdentity: origin.externalIdentity,
             agentName: origin.agentName,
             planURL: origin.plan)
-        guard ExternalEmbed.target(for: descriptor) != nil else { return nil }
-        return mime
+        guard ExternalEmbed.target(for: descriptor) != nil else { return .rejected }
+        return .renderable(mime)
     }
 
     private static func mediaMIME(for source: SourceSummary, provider: SourceProvider?) -> String? {

--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -1,0 +1,223 @@
+#if os(macOS)
+import Foundation
+import WikiFSCore
+import WikiFSTypes
+
+// pattern: Functional Core
+
+/// Pure adapter from SourceDetailView's current source facts into renderer
+/// registry input. It intentionally does not choose the Source fallback; callers
+/// keep Source outside renderer matching.
+struct SourceRendererPresentationPlanner: Sendable {
+    let registry: RendererRegistrySnapshot
+
+    init(installedDescriptors: [RendererDescriptor] = []) throws {
+        registry = try RendererRegistrySnapshot(
+            builtInDescriptors: BuiltInRendererDescriptors.all,
+            enabledInstalledDescriptors: installedDescriptors)
+    }
+
+    init(registry: RendererRegistrySnapshot) {
+        self.registry = registry
+    }
+
+    func input(
+        for source: SourceSummary,
+        boundedBytes: Data?,
+        currentMarkdown: String?,
+        origin: SourceOrigin?
+    ) throws -> RendererMatchInput {
+        try Self.registryInput(
+            for: source,
+            boundedBytes: boundedBytes,
+            currentMarkdown: currentMarkdown,
+            origin: origin)
+    }
+
+    func matchingDescriptors(
+        for source: SourceSummary,
+        boundedBytes: Data?,
+        currentMarkdown: String?,
+        origin: SourceOrigin?
+    ) throws -> [RendererDescriptor] {
+        try registry.matching(input(
+            for: source,
+            boundedBytes: boundedBytes,
+            currentMarkdown: currentMarkdown,
+            origin: origin))
+    }
+
+    nonisolated static func registryInput(
+        for source: SourceSummary,
+        boundedBytes: Data?,
+        currentMarkdown: String?,
+        origin: SourceOrigin?
+    ) throws -> RendererMatchInput {
+        let sniffedBytes = Data((boundedBytes ?? Data()).prefix(RendererMatchingLimits.maximumSniffByteCount))
+        let mimeType = try normalizedMIME(for: source, origin: origin)
+        let extensionFallback = try normalizedExtension(source.ext)
+        let artifactKind = artifactKind(for: source, currentMarkdown: currentMarkdown, origin: origin)
+        return try RendererMatchInput(
+            mimeType: mimeType,
+            fileExtension: extensionFallback,
+            sniffedBytes: sniffedBytes,
+            artifactKind: artifactKind)
+    }
+
+    nonisolated static func plannedBuiltInRenderer(
+        for source: SourceSummary,
+        boundedBytes: Data?,
+        currentMarkdown: String?,
+        origin: SourceOrigin?
+    ) throws -> BuiltInRendererID? {
+        let snapshot = try RendererRegistrySnapshot(builtInDescriptors: BuiltInRendererDescriptors.all)
+        let input = try registryInput(
+            for: source,
+            boundedBytes: boundedBytes,
+            currentMarkdown: currentMarkdown,
+            origin: origin)
+        guard case let .builtIn(id)? = snapshot.matching(input).first?.implementation else { return nil }
+        return id
+    }
+
+    private static func normalizedMIME(for source: SourceSummary, origin: SourceOrigin?) throws -> RendererMIMEType? {
+        if let providerMime = syntheticMediaMIME(for: origin?.provider) {
+            return try RendererMIMEType(validating: providerMime)
+        }
+        if let mime = source.mimeType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !mime.isEmpty {
+            return RendererMIMEType(rawValue: mime)
+        }
+        return nil
+    }
+
+    private static func normalizedExtension(_ value: String) throws -> RendererFileExtension? {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return nil }
+        return RendererFileExtension(rawValue: normalized)
+    }
+
+    private static func artifactKind(
+        for source: SourceSummary,
+        currentMarkdown: String?,
+        origin: SourceOrigin?
+    ) -> RendererArtifactKind? {
+        if origin?.provider != nil, syntheticMediaMIME(for: origin?.provider) != nil { return .source }
+        if MermaidSourceDetector.isMermaidSource(
+            mimeType: source.mimeType,
+            filename: source.filename,
+            content: currentMarkdown) {
+            return .markdown
+        }
+        if let mime = source.mimeType?.lowercased(), mime.hasPrefix("image/") { return .image }
+        if source.byteSize > 0 { return .binary }
+        return nil
+    }
+
+    private static func syntheticMediaMIME(for provider: SourceProvider?) -> String? {
+        switch provider {
+        case .youtube?: BuiltInRendererMIME.youtube
+        case .vimeo?: BuiltInRendererMIME.vimeo
+        case .applePodcast?: BuiltInRendererMIME.applePodcast
+        case .spotify?: BuiltInRendererMIME.spotify
+        case .soundcloud?: BuiltInRendererMIME.soundCloud
+        case .remoteMedia?, .localFile?, .website?, .zotero?, .markdownFolder?, .podcast?, .legacyImport?, .none:
+            nil
+        }
+    }
+}
+
+/// Testable golden model for the legacy SourceDetailView presentation branches.
+/// PR 2 uses it to characterize behavior before PR 4 replaces routing.
+enum SourceDetailPresentationCharacterization {
+    enum Presentation: String, Sendable, Equatable {
+        case reader = "Reader"
+        case pdf = "PDF"
+        case html = "HTML"
+        case rendered = "Rendered"
+        case media = "Media"
+        case split = "Split"
+    }
+
+    struct Result: Sendable, Equatable {
+        let contentArea: ContentArea
+        let tabs: [Presentation]
+    }
+
+    enum ContentArea: Sendable, Equatable {
+        case tabbed
+        case pdfOnly
+        case markdown
+        case binaryFallback
+    }
+
+    nonisolated static func characterize(
+        source: SourceSummary,
+        boundedBytes: Data?,
+        currentMarkdown: String?,
+        hasProcessedMarkdown: Bool,
+        origin: SourceOrigin?
+    ) -> Result {
+        let isPDF = MimeType.isPDF(source.mimeType)
+        let isHTMLSource = htmlSource(source)
+        let htmlString = htmlSourceString(isHTMLSource: isHTMLSource, boundedBytes: boundedBytes)
+        let mermaidSource = MermaidSourceDetector.isMermaidSource(
+            mimeType: source.mimeType,
+            filename: source.filename,
+            content: currentMarkdown)
+        let hasMediaPlayer = mediaPlayerAvailable(source: source, origin: origin)
+
+        let tabs: [Presentation]
+        if hasMediaPlayer {
+            tabs = hasProcessedMarkdown ? [.reader, .media, .split] : [.reader, .media]
+        } else if isPDF && hasProcessedMarkdown {
+            tabs = [.reader, .pdf, .split]
+        } else if isHTMLSource && (hasProcessedMarkdown || htmlString != nil) {
+            tabs = hasProcessedMarkdown ? [.reader, .html, .split] : [.html]
+        } else if mermaidSource {
+            tabs = [.reader, .rendered, .split]
+        } else {
+            tabs = []
+        }
+
+        let contentArea: ContentArea
+        if !tabs.isEmpty || hasMediaPlayer {
+            contentArea = .tabbed
+        } else if isPDF {
+            contentArea = .pdfOnly
+        } else if source.mimeType.map(MimeType.isText) == true {
+            contentArea = .markdown
+        } else {
+            contentArea = .binaryFallback
+        }
+        return Result(contentArea: contentArea, tabs: tabs)
+    }
+
+    private static func htmlSource(_ source: SourceSummary) -> Bool {
+        if let mime = source.mimeType {
+            return mime == MimeType.html || mime == MimeType.xhtml
+        }
+        let ext = source.ext.lowercased()
+        return ext == "html" || ext == "htm" || ext == "xhtml"
+    }
+
+    private static func htmlSourceString(isHTMLSource: Bool, boundedBytes: Data?) -> String? {
+        guard isHTMLSource, let boundedBytes else { return nil }
+        return String(data: boundedBytes, encoding: .utf8) ?? String(decoding: boundedBytes, as: UTF8.self)
+    }
+
+    private static func mediaPlayerAvailable(source: SourceSummary, origin: SourceOrigin?) -> Bool {
+        guard let descriptor = embedDescriptor(source: source, origin: origin) else { return false }
+        return ExternalEmbed.target(for: descriptor) != nil
+    }
+
+    private static func embedDescriptor(source: SourceSummary, origin: SourceOrigin?) -> SourceEmbedDescriptor? {
+        guard let mime = source.mimeType, let origin else { return nil }
+        return SourceEmbedDescriptor(
+            id: source.id,
+            mimeType: mime,
+            externalIdentity: origin.externalIdentity,
+            agentName: origin.agentName,
+            planURL: origin.plan)
+    }
+}
+#endif

--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -81,8 +81,8 @@ struct SourceRendererPresentationPlanner: Sendable {
     }
 
     private static func normalizedMIME(for source: SourceSummary, origin: SourceOrigin?) throws -> RendererMIMEType? {
-        if let providerMime = syntheticMediaMIME(for: origin?.provider) {
-            return try RendererMIMEType(validating: providerMime)
+        if let mediaMime = renderableMediaMIME(for: source, origin: origin) {
+            return try RendererMIMEType(validating: mediaMime)
         }
         if let mime = source.mimeType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !mime.isEmpty {
             return RendererMIMEType(rawValue: mime)
@@ -101,7 +101,7 @@ struct SourceRendererPresentationPlanner: Sendable {
         currentMarkdown: String?,
         origin: SourceOrigin?
     ) -> RendererArtifactKind? {
-        if origin?.provider != nil, syntheticMediaMIME(for: origin?.provider) != nil { return .source }
+        if renderableMediaMIME(for: source, origin: origin) != nil { return .source }
         if MermaidSourceDetector.isMermaidSource(
             mimeType: source.mimeType,
             filename: source.filename,
@@ -113,14 +113,28 @@ struct SourceRendererPresentationPlanner: Sendable {
         return nil
     }
 
-    private static func syntheticMediaMIME(for provider: SourceProvider?) -> String? {
+    private static func renderableMediaMIME(for source: SourceSummary, origin: SourceOrigin?) -> String? {
+        guard let origin else { return nil }
+        let mime = mediaMIME(for: source, provider: origin.provider)
+        let descriptor = SourceEmbedDescriptor(
+            id: source.id,
+            mimeType: mime,
+            externalIdentity: origin.externalIdentity,
+            agentName: origin.agentName,
+            planURL: origin.plan)
+        guard ExternalEmbed.target(for: descriptor) != nil else { return nil }
+        return mime
+    }
+
+    private static func mediaMIME(for source: SourceSummary, provider: SourceProvider?) -> String? {
         switch provider {
         case .youtube?: BuiltInRendererMIME.youtube
         case .vimeo?: BuiltInRendererMIME.vimeo
         case .applePodcast?: BuiltInRendererMIME.applePodcast
         case .spotify?: BuiltInRendererMIME.spotify
         case .soundcloud?: BuiltInRendererMIME.soundCloud
-        case .remoteMedia?, .localFile?, .website?, .zotero?, .markdownFolder?, .podcast?, .legacyImport?, .none:
+        case .remoteMedia?: source.mimeType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        case .localFile?, .website?, .zotero?, .markdownFolder?, .podcast?, .legacyImport?, .none:
             nil
         }
     }

--- a/Sources/WikiFSTypes/Renderer/RendererIdentifier.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererIdentifier.swift
@@ -110,6 +110,9 @@ public struct RendererRegistrationID: RawRepresentable, Codable, Hashable, Senda
 /// cannot add a case to this enum.
 public enum BuiltInRendererID: String, Codable, CaseIterable, Hashable, Sendable, Comparable {
     case pdf
+    case html
+    case mermaid
+    case media
 
     public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
 }

--- a/Sources/WikiFSTypes/Renderer/RendererRegistrySnapshot.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererRegistrySnapshot.swift
@@ -20,6 +20,9 @@ public struct RendererRegistrySnapshot: Hashable, Sendable {
         guard hostProtocolRevision > 0 else {
             throw RendererValidationError.invalidCompatibilityRange
         }
+        try Self.validateChannelInvariants(
+            builtInDescriptors: builtInDescriptors,
+            enabledInstalledDescriptors: enabledInstalledDescriptors)
         let combined = builtInDescriptors + enabledInstalledDescriptors
         try Self.validateUniqueReferences(combined)
         self.hostProtocolRevision = hostProtocolRevision
@@ -53,6 +56,22 @@ public struct RendererRegistrySnapshot: Hashable, Sendable {
             preference: preference,
             input: input,
             hostProtocolRevision: hostProtocolRevision)
+    }
+
+    private static func validateChannelInvariants(
+        builtInDescriptors: [RendererDescriptor],
+        enabledInstalledDescriptors: [RendererDescriptor]
+    ) throws {
+        for descriptor in builtInDescriptors {
+            guard case .builtIn = descriptor.implementation else {
+                throw RendererValidationError.builtInRegistryContainsInstalled(descriptor.reference.registrationID)
+            }
+        }
+        for descriptor in enabledInstalledDescriptors {
+            guard case .webPackage = descriptor.implementation else {
+                throw RendererValidationError.installedRegistryContainsBuiltIn(descriptor.reference.registrationID)
+            }
+        }
     }
 
     private static func validateUniqueReferences(_ descriptors: [RendererDescriptor]) throws {

--- a/Sources/WikiFSTypes/Renderer/RendererRegistrySnapshot.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererRegistrySnapshot.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+// pattern: Functional Core
+
+/// Immutable registry contents for one renderer-resolution moment.
+///
+/// The snapshot combines host-owned built-ins with enabled installed package
+/// descriptors in one deterministic initializer. Source remains outside this
+/// registry: callers ask for renderer matches and keep the host Source view as
+/// the permanent fallback when no descriptor matches or resolution fails.
+public struct RendererRegistrySnapshot: Hashable, Sendable {
+    public let hostProtocolRevision: Int
+    public let descriptors: [RendererDescriptor]
+
+    public init(
+        builtInDescriptors: [RendererDescriptor],
+        enabledInstalledDescriptors: [RendererDescriptor] = [],
+        hostProtocolRevision: Int = RendererRegistrySnapshotDefaults.hostProtocolRevision
+    ) throws {
+        guard hostProtocolRevision > 0 else {
+            throw RendererValidationError.invalidCompatibilityRange
+        }
+        let combined = builtInDescriptors + enabledInstalledDescriptors
+        try Self.validateUniqueReferences(combined)
+        self.hostProtocolRevision = hostProtocolRevision
+        self.descriptors = combined.sorted { $0.stableTieBreakKey < $1.stableTieBreakKey }
+    }
+
+    public func matching(_ input: RendererMatchInput) -> [RendererDescriptor] {
+        RendererResolution.matching(
+            descriptors: descriptors,
+            input: input,
+            hostProtocolRevision: hostProtocolRevision)
+    }
+
+    public func preferred(
+        preference: RendererPreferenceReference?,
+        input: RendererMatchInput
+    ) -> RendererDescriptor? {
+        RendererResolution.preferred(
+            descriptors: descriptors,
+            preference: preference,
+            input: input,
+            hostProtocolRevision: hostProtocolRevision)
+    }
+
+    public func preferred(
+        preference: RendererPreference?,
+        input: RendererMatchInput
+    ) -> RendererDescriptor? {
+        RendererResolution.preferred(
+            descriptors: descriptors,
+            preference: preference,
+            input: input,
+            hostProtocolRevision: hostProtocolRevision)
+    }
+
+    private static func validateUniqueReferences(_ descriptors: [RendererDescriptor]) throws {
+        var seen = Set<RendererReference>()
+        for descriptor in descriptors {
+            guard seen.insert(descriptor.reference).inserted else {
+                throw RendererValidationError.duplicateRegistration(descriptor.reference.registrationID)
+            }
+        }
+    }
+}
+
+public enum RendererRegistrySnapshotDefaults {
+    public static let hostProtocolRevision = 1
+}

--- a/Sources/WikiFSTypes/Renderer/RendererValidationError.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererValidationError.swift
@@ -23,6 +23,8 @@ public enum RendererValidationError: Error, Equatable, Sendable, CustomStringCon
     case manifestAssetNotApproved(RendererRelativePath)
     case emptyManifest
     case packageManifestContainsBuiltIn(BuiltInRendererID)
+    case builtInRegistryContainsInstalled(RendererRegistrationID)
+    case installedRegistryContainsBuiltIn(RendererRegistrationID)
     case emptyPreference
     case mismatchedPreferenceIdentity
 
@@ -47,6 +49,8 @@ public enum RendererValidationError: Error, Equatable, Sendable, CustomStringCon
         case let .manifestAssetNotApproved(path): "renderer descriptor does not approve manifest asset: \(path.rawValue)"
         case .emptyManifest: "renderer manifest must register at least one renderer"
         case let .packageManifestContainsBuiltIn(id): "renderer package manifest cannot contain built-in renderer: \(id.rawValue)"
+        case let .builtInRegistryContainsInstalled(id): "built-in renderer registry input contains installed renderer: \(id.rawValue)"
+        case let .installedRegistryContainsBuiltIn(id): "installed renderer registry input contains built-in renderer: \(id.rawValue)"
         case .emptyPreference: "renderer preference has no exact or logical reference"
         case .mismatchedPreferenceIdentity: "renderer preference exact and logical identities differ"
         }

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -78,6 +78,34 @@ import WikiFSTypes
         #expect(id == .media)
     }
 
+    @Test("Planner preserves Source fallback for media origins missing renderable identity or plan")
+    func plannerRejectsMalformedMediaOrigins() throws {
+        let youtube = fixtureSource(filename: "video.url", ext: "", mimeType: "video/youtube", byteSize: 0)
+        let applePodcast = fixtureSource(filename: "episode.md", ext: "md", mimeType: MimeType.markdown, byteSize: 0)
+        let remoteMedia = fixtureSource(filename: "clip.mp4", ext: "mp4", mimeType: "video/mp4", byteSize: 0)
+
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: youtube,
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: nil)) == nil)
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: applePodcast,
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            origin: fixtureOrigin(provider: .applePodcast, plan: nil, externalIdentity: nil)) == nil)
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: applePodcast,
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            origin: fixtureOrigin(provider: .applePodcast, plan: "https://example.com/show", externalIdentity: nil)) == nil)
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: remoteMedia,
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            origin: fixtureOrigin(provider: .remoteMedia, plan: "https://example.com/clip.mp4", externalIdentity: nil)) == nil)
+    }
+
     @Test("Source fallback stays outside matching for plain text, unknown, and missing content")
     func sourceFallbackIsOutsideRegistryMatching() throws {
         let plain = fixtureSource(filename: "note.txt", ext: "txt", mimeType: "text/plain", byteSize: 5)
@@ -147,6 +175,27 @@ import WikiFSTypes
             origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: "dQw4w9WgXcQ"))
         #expect(result.contentArea == .tabbed)
         #expect(result.tabs == [.reader, .media, .split])
+    }
+
+    @Test("Characterization: malformed media metadata keeps fallback with no Media tab")
+    func characterizesMalformedMediaMetadataFallback() {
+        let youtubeResult = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "video", ext: "", mimeType: "video/youtube", byteSize: 0),
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            hasProcessedMarkdown: false,
+            origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: nil))
+        let podcastResult = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "episode.md", ext: "md", mimeType: MimeType.markdown, byteSize: 0),
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            hasProcessedMarkdown: false,
+            origin: fixtureOrigin(provider: .applePodcast, plan: nil, externalIdentity: nil))
+
+        #expect(youtubeResult.contentArea == .binaryFallback)
+        #expect(youtubeResult.tabs == [])
+        #expect(podcastResult.contentArea == .markdown)
+        #expect(podcastResult.tabs == [])
     }
 
     @Test("Characterization: plain text uses markdown content area with no tabs")
@@ -223,13 +272,16 @@ private func testInstalledDescriptor() throws -> RendererDescriptor {
     let packageID = try RendererPackageID(validating: "org.example.installed")
     let version = try RendererPackageVersion(validating: "1.0.0")
     let registrationID = try RendererRegistrationID(validating: "installed")
+    let entryPoint = RendererAsset(
+        path: try .init(validating: "index.html"),
+        digest: try RendererSHA256Digest(bytes: Array(repeating: 0, count: RendererSHA256Digest.byteCount)))
     return try RendererDescriptor(
         reference: RendererReference(packageID: packageID, version: version, registrationID: registrationID),
         displayName: "Installed",
-        implementation: .builtIn(.pdf),
+        implementation: .webPackage(.init(path: entryPoint.path)),
         matchers: [.normalizedMIME(try .init(validating: MimeType.pdf))],
-        presentations: [.native],
-        approvedAssets: [],
+        presentations: [.web],
+        approvedAssets: [entryPoint],
         capabilities: [.inputRead],
         sizeLimits: try .init(maximumInputByteCount: 1, maximumDecodedByteCount: 1),
         linkPolicy: .none,

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -1,0 +1,240 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+import WikiFSTypes
+@testable import WikiFS
+
+@Suite struct BuiltInRendererRegistryTests {
+    @Test("Every BuiltInRendererID has exactly one descriptor and one factory")
+    @MainActor
+    func builtInDescriptorAndFactoryExhaustiveness() throws {
+        let descriptors = BuiltInRendererDescriptors.all
+        let ids = descriptors.compactMap { descriptor -> BuiltInRendererID? in
+            guard case let .builtIn(id) = descriptor.implementation else { return nil }
+            return id
+        }
+
+        #expect(ids.sorted() == BuiltInRendererID.allCases.sorted())
+        for id in BuiltInRendererID.allCases {
+            #expect(ids.filter { $0 == id }.count == 1, "\(id.rawValue) must have one descriptor")
+            #expect(BuiltInRendererFactoryMap.factory(for: id) != nil, "\(id.rawValue) must have one factory")
+        }
+        #expect(BuiltInRendererFactoryMap.factories.keys.sorted() == BuiltInRendererID.allCases.sorted())
+    }
+
+    @Test("Snapshot combines built-ins with injected installed descriptors")
+    func snapshotCombinesBuiltInsAndInstalledInput() throws {
+        let installed = try testInstalledDescriptor()
+        let snapshot = try RendererRegistrySnapshot(
+            builtInDescriptors: BuiltInRendererDescriptors.all,
+            enabledInstalledDescriptors: [installed])
+
+        #expect(snapshot.descriptors.contains(installed))
+        #expect(snapshot.descriptors.count == BuiltInRendererID.allCases.count + 1)
+    }
+
+    @Test("Planner maps PDF bytes to the PDF built-in")
+    func plannerMatchesPDF() throws {
+        let source = fixtureSource(filename: "paper.pdf", ext: "pdf", mimeType: MimeType.pdf, byteSize: 4)
+        let id = try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: source,
+            boundedBytes: Data("%PDF".utf8),
+            currentMarkdown: nil,
+            origin: nil)
+        #expect(id == .pdf)
+    }
+
+    @Test("Planner maps HTML bytes to the HTML built-in")
+    func plannerMatchesHTML() throws {
+        let source = fixtureSource(filename: "page.html", ext: "html", mimeType: MimeType.html, byteSize: 14)
+        let id = try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: source,
+            boundedBytes: Data("<h1>Hello</h1>".utf8),
+            currentMarkdown: nil,
+            origin: nil)
+        #expect(id == .html)
+    }
+
+    @Test("Planner maps Mermaid extension/content to the Mermaid built-in")
+    func plannerMatchesMermaid() throws {
+        let source = fixtureSource(filename: "diagram.mmd", ext: "mmd", mimeType: nil, byteSize: 12)
+        let id = try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: source,
+            boundedBytes: Data("flowchart LR".utf8),
+            currentMarkdown: "flowchart LR",
+            origin: nil)
+        #expect(id == .mermaid)
+    }
+
+    @Test("Planner maps media origin to the Media built-in")
+    func plannerMatchesMediaOrigin() throws {
+        let source = fixtureSource(filename: "video.url", ext: "", mimeType: "video/youtube", byteSize: 0)
+        let id = try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: source,
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: "dQw4w9WgXcQ"))
+        #expect(id == .media)
+    }
+
+    @Test("Source fallback stays outside matching for plain text, unknown, and missing content")
+    func sourceFallbackIsOutsideRegistryMatching() throws {
+        let plain = fixtureSource(filename: "note.txt", ext: "txt", mimeType: "text/plain", byteSize: 5)
+        let unknown = fixtureSource(filename: "blob.bin", ext: "bin", mimeType: nil, byteSize: 5)
+        let missing = fixtureSource(filename: "empty", ext: "", mimeType: nil, byteSize: 0)
+
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(for: plain, boundedBytes: Data("hello".utf8), currentMarkdown: "hello", origin: nil) == nil)
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(for: unknown, boundedBytes: Data([0, 1, 2]), currentMarkdown: nil, origin: nil) == nil)
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(for: missing, boundedBytes: nil, currentMarkdown: nil, origin: nil) == nil)
+    }
+
+    @Test("Characterization: PDF with markdown keeps Reader/PDF/Split tabs")
+    func characterizesPDFWithMarkdown() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "paper.pdf", ext: "pdf", mimeType: MimeType.pdf, byteSize: 4),
+            boundedBytes: Data("%PDF".utf8),
+            currentMarkdown: "# Paper",
+            hasProcessedMarkdown: true,
+            origin: nil)
+        #expect(result.contentArea == .tabbed)
+        #expect(result.tabs == [.reader, .pdf, .split])
+    }
+
+    @Test("Characterization: PDF without markdown renders PDF only")
+    func characterizesPDFWithoutMarkdown() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "paper.pdf", ext: "pdf", mimeType: MimeType.pdf, byteSize: 4),
+            boundedBytes: Data("%PDF".utf8),
+            currentMarkdown: nil,
+            hasProcessedMarkdown: false,
+            origin: nil)
+        #expect(result.contentArea == .pdfOnly)
+        #expect(result.tabs == [])
+    }
+
+    @Test("Characterization: HTML with markdown keeps Reader/HTML/Split tabs")
+    func characterizesHTMLWithMarkdown() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "page.html", ext: "html", mimeType: MimeType.html, byteSize: 14),
+            boundedBytes: Data("<h1>Hello</h1>".utf8),
+            currentMarkdown: "# Hello",
+            hasProcessedMarkdown: true,
+            origin: nil)
+        #expect(result.contentArea == .tabbed)
+        #expect(result.tabs == [.reader, .html, .split])
+    }
+
+    @Test("Characterization: Mermaid keeps Reader/Rendered/Split tabs")
+    func characterizesMermaid() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "diagram.mmd", ext: "mmd", mimeType: nil, byteSize: 12),
+            boundedBytes: Data("flowchart LR".utf8),
+            currentMarkdown: "flowchart LR",
+            hasProcessedMarkdown: false,
+            origin: nil)
+        #expect(result.contentArea == .tabbed)
+        #expect(result.tabs == [.reader, .rendered, .split])
+    }
+
+    @Test("Characterization: media with transcript keeps Reader/Media/Split tabs")
+    func characterizesMediaWithTranscript() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "video", ext: "", mimeType: "video/youtube", byteSize: 0),
+            boundedBytes: nil,
+            currentMarkdown: "Transcript",
+            hasProcessedMarkdown: true,
+            origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: "dQw4w9WgXcQ"))
+        #expect(result.contentArea == .tabbed)
+        #expect(result.tabs == [.reader, .media, .split])
+    }
+
+    @Test("Characterization: plain text uses markdown content area with no tabs")
+    func characterizesPlainText() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "note.txt", ext: "txt", mimeType: "text/plain", byteSize: 5),
+            boundedBytes: Data("hello".utf8),
+            currentMarkdown: "hello",
+            hasProcessedMarkdown: false,
+            origin: nil)
+        #expect(result.contentArea == .markdown)
+        #expect(result.tabs == [])
+    }
+
+    @Test("Characterization: unknown byteful content uses binary fallback")
+    func characterizesUnknownContent() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "blob.bin", ext: "bin", mimeType: nil, byteSize: 3),
+            boundedBytes: Data([0, 1, 2]),
+            currentMarkdown: nil,
+            hasProcessedMarkdown: false,
+            origin: nil)
+        #expect(result.contentArea == .binaryFallback)
+        #expect(result.tabs == [])
+    }
+
+    @Test("Characterization: missing content uses binary fallback")
+    func characterizesMissingContent() {
+        let result = SourceDetailPresentationCharacterization.characterize(
+            source: fixtureSource(filename: "empty", ext: "", mimeType: nil, byteSize: 0),
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            hasProcessedMarkdown: false,
+            origin: nil)
+        #expect(result.contentArea == .binaryFallback)
+        #expect(result.tabs == [])
+    }
+}
+
+private func fixtureSource(
+    filename: String,
+    ext: String,
+    mimeType: String?,
+    byteSize: Int
+) -> SourceSummary {
+    SourceSummary(
+        id: SourceID(rawValue: "01J00000000000000000000000"),
+        filename: filename,
+        ext: ext,
+        mimeType: mimeType,
+        byteSize: byteSize,
+        createdAt: Date(timeIntervalSince1970: 0),
+        updatedAt: Date(timeIntervalSince1970: 0),
+        version: 1)
+}
+
+private func fixtureOrigin(
+    provider: SourceProvider,
+    plan: String?,
+    externalIdentity: String?
+) -> SourceOrigin {
+    SourceOrigin(
+        versionID: SourceVersionID(rawValue: "01J00000000000000000000001"),
+        agentName: provider.rawValue,
+        agentKind: "software",
+        activityKind: "fetch",
+        plan: plan,
+        externalRef: plan,
+        externalIdentity: externalIdentity,
+        fetchedAt: Date(timeIntervalSince1970: 0))
+}
+
+private func testInstalledDescriptor() throws -> RendererDescriptor {
+    let packageID = try RendererPackageID(validating: "org.example.installed")
+    let version = try RendererPackageVersion(validating: "1.0.0")
+    let registrationID = try RendererRegistrationID(validating: "installed")
+    return try RendererDescriptor(
+        reference: RendererReference(packageID: packageID, version: version, registrationID: registrationID),
+        displayName: "Installed",
+        implementation: .builtIn(.pdf),
+        matchers: [.normalizedMIME(try .init(validating: MimeType.pdf))],
+        presentations: [.native],
+        approvedAssets: [],
+        capabilities: [.inputRead],
+        sizeLimits: try .init(maximumInputByteCount: 1, maximumDecodedByteCount: 1),
+        linkPolicy: .none,
+        accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true),
+        compatibility: try .init(minimumProtocolRevision: 1, maximumProtocolRevision: 1),
+        priority: 1)
+}
+#endif

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -81,11 +81,18 @@ import WikiFSTypes
     @Test("Planner preserves Source fallback for media origins missing renderable identity or plan")
     func plannerRejectsMalformedMediaOrigins() throws {
         let youtube = fixtureSource(filename: "video.url", ext: "", mimeType: "video/youtube", byteSize: 0)
+        let youtubeWithRawVideoMIME = fixtureSource(filename: "video.url", ext: "", mimeType: "video/mp4", byteSize: 0)
         let applePodcast = fixtureSource(filename: "episode.md", ext: "md", mimeType: MimeType.markdown, byteSize: 0)
+        let applePodcastWithRawAudioMIME = fixtureSource(filename: "episode.mp3", ext: "mp3", mimeType: "audio/mpeg", byteSize: 0)
         let remoteMedia = fixtureSource(filename: "clip.mp4", ext: "mp4", mimeType: "video/mp4", byteSize: 0)
 
         #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
             for: youtube,
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: nil)) == nil)
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: youtubeWithRawVideoMIME,
             boundedBytes: nil,
             currentMarkdown: nil,
             origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: nil)) == nil)
@@ -96,6 +103,11 @@ import WikiFSTypes
             origin: fixtureOrigin(provider: .applePodcast, plan: nil, externalIdentity: nil)) == nil)
         #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
             for: applePodcast,
+            boundedBytes: nil,
+            currentMarkdown: nil,
+            origin: fixtureOrigin(provider: .applePodcast, plan: "https://example.com/show", externalIdentity: nil)) == nil)
+        #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+            for: applePodcastWithRawAudioMIME,
             boundedBytes: nil,
             currentMarkdown: nil,
             origin: fixtureOrigin(provider: .applePodcast, plan: "https://example.com/show", externalIdentity: nil)) == nil)

--- a/Tests/WikiFSTypesRendererTests/RendererFixtures.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererFixtures.swift
@@ -30,9 +30,12 @@ enum RendererFixtures {
     }
 
     static func webDescriptor(
-        assets: [RendererAsset],
+        assets: [RendererAsset] = [webAsset()],
+        packageID: RendererPackageID = packageID,
+        version: RendererPackageVersion = version,
         registrationID: RendererRegistrationID = registrationID,
-        matchers: [RendererMatcher] = [.artifactKind(.source)]
+        matchers: [RendererMatcher] = [.artifactKind(.source)],
+        priority: Int = 0
     ) throws -> RendererDescriptor {
         guard let entry = assets.first else { throw RendererValidationError.invalidPresentation }
         return try RendererDescriptor(
@@ -47,8 +50,14 @@ enum RendererFixtures {
             linkPolicy: .none,
             accessibility: .init(supportsVoiceOver: true, supportsKeyboardNavigation: true),
             compatibility: try .init(minimumProtocolRevision: 1, maximumProtocolRevision: 1),
-            priority: 0
+            priority: priority
         )
+    }
+
+    static func webAsset(path: String = "index.html") -> RendererAsset {
+        RendererAsset(
+            path: try! .init(validating: path),
+            digest: try! RendererSHA256Digest(bytes: Array(repeating: 0, count: RendererSHA256Digest.byteCount)))
     }
 
     static func input(

--- a/Tests/WikiFSTypesRendererTests/RendererRegistrySnapshotTests.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererRegistrySnapshotTests.swift
@@ -5,27 +5,49 @@ import WikiFSTypes
 struct RendererRegistrySnapshotTests {
     @Test func combinesBuiltInsAndEnabledInstalledDescriptorsDeterministically() throws {
         let builtIn = try RendererFixtures.nativeDescriptor(priority: 10)
-        let installed = try RendererFixtures.nativeDescriptor(
-            registrationID: try .init(validating: "installed"),
+        let installedA = try RendererFixtures.webDescriptor(
+            packageID: try .init(validating: "org.example.alpha"),
+            registrationID: try .init(validating: "installed-a"),
+            priority: 20)
+        let installedB = try RendererFixtures.webDescriptor(
+            packageID: try .init(validating: "org.example.beta"),
+            registrationID: try .init(validating: "installed-b"),
             priority: 20)
 
         let forward = try RendererRegistrySnapshot(
             builtInDescriptors: [builtIn],
-            enabledInstalledDescriptors: [installed])
+            enabledInstalledDescriptors: [installedA, installedB])
         let reverse = try RendererRegistrySnapshot(
             builtInDescriptors: [builtIn],
-            enabledInstalledDescriptors: [installed])
+            enabledInstalledDescriptors: [installedB, installedA])
 
         #expect(forward.descriptors.map(\.reference) == reverse.descriptors.map(\.reference))
-        #expect(forward.descriptors.map(\.reference) == [installed.reference, builtIn.reference])
+        #expect(forward.descriptors.map(\.reference) == [installedA.reference, installedB.reference, builtIn.reference])
     }
 
     @Test func rejectsDuplicateDescriptorReferencesAcrossInputs() throws {
-        let descriptor = try RendererFixtures.nativeDescriptor()
-        #expect(throws: RendererValidationError.self) {
+        let builtIn = try RendererFixtures.nativeDescriptor()
+        let installed = try RendererFixtures.webDescriptor()
+        #expect(throws: RendererValidationError.duplicateRegistration(builtIn.reference.registrationID)) {
             _ = try RendererRegistrySnapshot(
-                builtInDescriptors: [descriptor],
-                enabledInstalledDescriptors: [descriptor])
+                builtInDescriptors: [builtIn],
+                enabledInstalledDescriptors: [installed])
+        }
+    }
+
+    @Test func rejectsInstalledDescriptorsInBuiltInChannel() throws {
+        let installed = try RendererFixtures.webDescriptor()
+        #expect(throws: RendererValidationError.builtInRegistryContainsInstalled(installed.reference.registrationID)) {
+            _ = try RendererRegistrySnapshot(builtInDescriptors: [installed])
+        }
+    }
+
+    @Test func rejectsBuiltInDescriptorsInInstalledChannel() throws {
+        let builtIn = try RendererFixtures.nativeDescriptor()
+        #expect(throws: RendererValidationError.installedRegistryContainsBuiltIn(builtIn.reference.registrationID)) {
+            _ = try RendererRegistrySnapshot(
+                builtInDescriptors: [],
+                enabledInstalledDescriptors: [builtIn])
         }
     }
 

--- a/Tests/WikiFSTypesRendererTests/RendererRegistrySnapshotTests.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererRegistrySnapshotTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+import WikiFSTypes
+
+struct RendererRegistrySnapshotTests {
+    @Test func combinesBuiltInsAndEnabledInstalledDescriptorsDeterministically() throws {
+        let builtIn = try RendererFixtures.nativeDescriptor(priority: 10)
+        let installed = try RendererFixtures.nativeDescriptor(
+            registrationID: try .init(validating: "installed"),
+            priority: 20)
+
+        let forward = try RendererRegistrySnapshot(
+            builtInDescriptors: [builtIn],
+            enabledInstalledDescriptors: [installed])
+        let reverse = try RendererRegistrySnapshot(
+            builtInDescriptors: [builtIn],
+            enabledInstalledDescriptors: [installed])
+
+        #expect(forward.descriptors.map(\.reference) == reverse.descriptors.map(\.reference))
+        #expect(forward.descriptors.map(\.reference) == [installed.reference, builtIn.reference])
+    }
+
+    @Test func rejectsDuplicateDescriptorReferencesAcrossInputs() throws {
+        let descriptor = try RendererFixtures.nativeDescriptor()
+        #expect(throws: RendererValidationError.self) {
+            _ = try RendererRegistrySnapshot(
+                builtInDescriptors: [descriptor],
+                enabledInstalledDescriptors: [descriptor])
+        }
+    }
+
+    @Test func matchingAndPreferenceDelegateThroughSnapshotProtocolRevision() throws {
+        let compatible = try RendererFixtures.nativeDescriptor()
+        let incompatible = try RendererFixtures.nativeDescriptor(
+            registrationID: try .init(validating: "future"),
+            compatibility: try .init(minimumProtocolRevision: 2, maximumProtocolRevision: 2))
+        let snapshot = try RendererRegistrySnapshot(
+            builtInDescriptors: [incompatible, compatible],
+            hostProtocolRevision: 1)
+        let input = try RendererFixtures.input()
+
+        #expect(snapshot.matching(input).map(\.reference) == [compatible.reference])
+        #expect(snapshot.preferred(preference: .exact(incompatible.reference), input: input) == nil)
+        #expect(snapshot.preferred(preference: .logical(compatible.logicalReference), input: input) == compatible)
+    }
+}


### PR DESCRIPTION
## Summary

Implement Phase 2 / PR 2 of issue #1026 as a stacked change on PR #1061.

- Add an immutable `RendererRegistrySnapshot` combining built-in and enabled installed descriptors.
- Add built-in descriptors for PDF, HTML, Mermaid, and media.
- Add typed built-in descriptor and factory inventories.
- Add a source presentation planner without changing `SourceDetailView` routing.
- Add characterization and exhaustiveness tests.
- Enforce built-in versus installed renderer channels.
- Preserve Source fallback for malformed or incomplete media origins.

## Scope

This PR intentionally does not add:

- Generic `SourceDetailView` routing (PR 4).
- Package persistence or settings.
- WebView package loading or isolation.
- Excalidraw or JSON Canvas.
- Package management.

## Validation

- `swift test --filter RendererRegistrySnapshotTests`
- `WIKIFS_APP_TESTS=1 swift test --filter BuiltInRendererRegistryTests`
- `WIKIFS_APP_TESTS=1 swift test`
- `make build`
- `make test`
- `swift build`
- `swift test`

Full suite result: 3095 tests in 262 suites passed.

## Review

Independent final review completed with no critical, high, medium, or low findings.

Base PR: #1061
Issue: #1026
