### PR TITLE
ci: enable checks for stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   # Enforces the AGENTS.md "no bare try?" rule via a SwiftLint custom rule.


### PR DESCRIPTION
Enables GitHub Actions for pull requests whose base is another feature branch, such as feature/dynamic-renderers-01-model. The push-to-main trigger and all jobs remain unchanged.