### PR TITLE
feat(renderers): add phase 3 settings journal foundation

### DIFF
--- a/Sources/WikiFSCore/Core/DarwinNotifier.swift
+++ b/Sources/WikiFSCore/Core/DarwinNotifier.swift
@@ -14,12 +14,30 @@ import Foundation
 public enum DarwinNotifier {
     public static func postChange(forWikiID id: String) {
         #if os(macOS)
-        let center = CFNotificationCenterGetDarwinNotifyCenter()
-        let name = CFNotificationName(WikiChangeNotification.name(forWikiID: id) as CFString)
-        CFNotificationCenterPostNotification(center, name, nil, nil, true)
+        post(name: WikiChangeNotification.name(forWikiID: id))
         #else
         // Darwin notifications are macOS-only; on Linux the cross-process
         // change-notification path is unused.
         #endif
     }
+
+    public static func postRendererWikiWake(forWikiID id: WikiID) {
+        #if os(macOS)
+        post(name: RendererChangeNotification.wikiName(forWikiID: id))
+        #endif
+    }
+
+    public static func postRendererMachineWake(for scopeID: RendererMachineScopeID) {
+        #if os(macOS)
+        post(name: RendererChangeNotification.machineName(for: scopeID))
+        #endif
+    }
+
+    #if os(macOS)
+    private static func post(name rawName: String) {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let name = CFNotificationName(rawName as CFString)
+        CFNotificationCenterPostNotification(center, name, nil, nil, true)
+    }
+    #endif
 }

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -196,6 +196,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     private let appendDerivedMarkdownHooks: AppendDerivedMarkdownHooks
     private let rendererEventIDGenerator: any RendererEventIDGenerating
     private let rendererEventClock: any RendererEventClock
+    private let rendererWikiWakePoster: @Sendable (WikiID) -> Void
 
     /// Guards against double-close (`close()` then `deinit`).
     private let closeLock = NSLock()
@@ -234,6 +235,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         appendDerivedMarkdownHooks: AppendDerivedMarkdownHooks = .productionDefault,
         rendererEventIDGenerator: any RendererEventIDGenerating = UUIDRendererEventIDGenerator(),
         rendererEventClock: any RendererEventClock = WallRendererEventClock(),
+        rendererWikiWakePoster: @escaping @Sendable (WikiID) -> Void = { DarwinNotifier.postRendererWikiWake(forWikiID: $0) },
         foreignKeysEnabled: Bool = true
     ) throws {
         self.schemaV48MigrationHooks = schemaV48MigrationHooks
@@ -241,6 +243,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         self.appendDerivedMarkdownHooks = appendDerivedMarkdownHooks
         self.rendererEventIDGenerator = rendererEventIDGenerator
         self.rendererEventClock = rendererEventClock
+        self.rendererWikiWakePoster = rendererWikiWakePoster
         var config = Configuration()
         config.foreignKeysEnabled = foreignKeysEnabled
         config.busyMode = .timeout(5)
@@ -316,6 +319,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         appendDerivedMarkdownHooks = .productionDefault
         rendererEventIDGenerator = UUIDRendererEventIDGenerator()
         rendererEventClock = WallRendererEventClock()
+        rendererWikiWakePoster = { DarwinNotifier.postRendererWikiWake(forWikiID: $0) }
         var config = Configuration()
         config.foreignKeysEnabled = true
         config.busyMode = .timeout(5)
@@ -371,6 +375,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         appendDerivedMarkdownHooks = .productionDefault
         rendererEventIDGenerator = UUIDRendererEventIDGenerator()
         rendererEventClock = WallRendererEventClock()
+        rendererWikiWakePoster = { DarwinNotifier.postRendererWikiWake(forWikiID: $0) }
         var config = Configuration()
         config.foreignKeysEnabled = true
         config.busyMode = .timeout(5)
@@ -3537,6 +3542,12 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
     }
 
+    func corruptRendererJournalEventIDForTesting(_ rawEventID: String) throws {
+        try dbWriter.write { db in
+            try db.execute(sql: "UPDATE renderer_event_journal SET event_id = ?;", arguments: [rawEventID])
+        }
+    }
+
     private func mutateRendererSettings(
         event: RendererSettingsChangeEvent,
         _ body: (Database, RFC3339Timestamp) throws -> Void
@@ -3553,6 +3564,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         }
         if let pending {
             eventBus?.emitRendererSettings(pending)
+            rendererWikiWakePoster(wikiID)
         }
     }
 
@@ -3619,8 +3631,12 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         let payloadJSON: String = row["payload_json"]
         let payloadData = Data(payloadJSON.utf8)
         let payload = try JSONDecoder().decode(WikiStoreChangeEvent.self, from: payloadData)
+        let rawEventID: String = row["event_id"]
+        guard let eventID = UUID(uuidString: rawEventID) else {
+            throw WikiStoreError.invalidRendererEventID(rawEventID)
+        }
         return try PersistedWikiStoreChangeRecord(
-            eventID: UUID(uuidString: row["event_id"]) ?? UUID(),
+            eventID: eventID,
             sequence: UInt64(row["sequence"] as Int64),
             scope: .wiki(WikiID(rawValue: row["scope_id"])),
             payload: payload,

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -145,7 +145,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// databases produced by that store carry `PRAGMA user_version` up to 37, and
     /// this store must recognize them as already-current so the ladder is a no-op
     /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 48
+    private static let currentSchemaVersion = 49
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -194,6 +194,8 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     private let schemaV48MigrationHooks: SchemaV48MigrationHooks
     private let schemaForeignKeyChecker: SchemaForeignKeyChecker
     private let appendDerivedMarkdownHooks: AppendDerivedMarkdownHooks
+    private let rendererEventIDGenerator: any RendererEventIDGenerating
+    private let rendererEventClock: any RendererEventClock
 
     /// Guards against double-close (`close()` then `deinit`).
     private let closeLock = NSLock()
@@ -230,11 +232,15 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         schemaV48MigrationHooks: SchemaV48MigrationHooks,
         schemaForeignKeyChecker: SchemaForeignKeyChecker,
         appendDerivedMarkdownHooks: AppendDerivedMarkdownHooks = .productionDefault,
+        rendererEventIDGenerator: any RendererEventIDGenerating = UUIDRendererEventIDGenerator(),
+        rendererEventClock: any RendererEventClock = WallRendererEventClock(),
         foreignKeysEnabled: Bool = true
     ) throws {
         self.schemaV48MigrationHooks = schemaV48MigrationHooks
         self.schemaForeignKeyChecker = schemaForeignKeyChecker
         self.appendDerivedMarkdownHooks = appendDerivedMarkdownHooks
+        self.rendererEventIDGenerator = rendererEventIDGenerator
+        self.rendererEventClock = rendererEventClock
         var config = Configuration()
         config.foreignKeysEnabled = foreignKeysEnabled
         config.busyMode = .timeout(5)
@@ -308,6 +314,8 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         schemaV48MigrationHooks = .productionDefault
         schemaForeignKeyChecker = .productionDefault()
         appendDerivedMarkdownHooks = .productionDefault
+        rendererEventIDGenerator = UUIDRendererEventIDGenerator()
+        rendererEventClock = WallRendererEventClock()
         var config = Configuration()
         config.foreignKeysEnabled = true
         config.busyMode = .timeout(5)
@@ -361,6 +369,8 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         schemaV48MigrationHooks = .productionDefault
         schemaForeignKeyChecker = .productionDefault()
         appendDerivedMarkdownHooks = .productionDefault
+        rendererEventIDGenerator = UUIDRendererEventIDGenerator()
+        rendererEventClock = WallRendererEventClock()
         var config = Configuration()
         config.foreignKeysEnabled = true
         config.busyMode = .timeout(5)
@@ -1447,6 +1457,18 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
             version = 48
         }
 
+        // v48→v49: dynamic renderer wiki settings and wiki-scoped renderer
+        // event journal foundation. This step must stay before the catch-all
+        // fallback so existing v48 databases get the dedicated tables.
+        if version < 49 {
+            try db.inTransaction(.immediate) {
+                try Self.createRendererSettingsTablesV49(in: db)
+                try db.execute(sql: "PRAGMA user_version = 49;")
+                return .commit
+            }
+            version = 49
+        }
+
         // Catch-all fallback: any DB older than `currentSchemaVersion` whose
         // per-step work has not been added above (the steady-state guard for a
         // genuine currentSchemaVersion bump). Drops FTS5 + stamps
@@ -1512,6 +1534,90 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
     /// scalar text value (e.g. `SELECT sql FROM sqlite_master …`).
     private static func queryScalarText(_ sql: String, in db: Database) throws -> String {
         try String.fetchOne(db, sql: sql) ?? ""
+    }
+
+    private static func createRendererSettingsTablesV49(in db: Database) throws {
+        try db.execute(sql: """
+        CREATE TABLE IF NOT EXISTS renderer_wiki_enablement (
+            package_id TEXT PRIMARY KEY,
+            is_enabled INTEGER NOT NULL CHECK (is_enabled IN (0, 1)),
+            updated_at TEXT NOT NULL CHECK (
+                length(updated_at) >= 25 AND
+                substr(updated_at, -6, 1) IN ('+', '-') AND
+                substr(updated_at, -3, 1) = ':'
+            )
+        );
+        """)
+        try db.execute(sql: """
+        CREATE TABLE IF NOT EXISTS renderer_source_preferences (
+            source_id TEXT PRIMARY KEY REFERENCES sources(id) ON DELETE CASCADE,
+            reference_kind TEXT NOT NULL CHECK (reference_kind IN ('exact', 'logical')),
+            package_id TEXT NOT NULL,
+            package_version TEXT,
+            registration_id TEXT NOT NULL,
+            updated_at TEXT NOT NULL CHECK (
+                length(updated_at) >= 25 AND
+                substr(updated_at, -6, 1) IN ('+', '-') AND
+                substr(updated_at, -3, 1) = ':'
+            ),
+            CHECK ((reference_kind = 'exact' AND package_version IS NOT NULL) OR
+                   (reference_kind = 'logical' AND package_version IS NULL))
+        );
+        """)
+        try db.execute(sql: "CREATE INDEX IF NOT EXISTS renderer_source_preferences_package ON renderer_source_preferences(package_id, registration_id);")
+        try db.execute(sql: """
+        CREATE TABLE IF NOT EXISTS renderer_event_sequence (
+            scope TEXT PRIMARY KEY CHECK (scope = 'wiki'),
+            next_sequence INTEGER NOT NULL CHECK (next_sequence >= 1)
+        );
+        """)
+        try db.execute(sql: "INSERT OR IGNORE INTO renderer_event_sequence(scope, next_sequence) VALUES ('wiki', 1);")
+        try db.execute(sql: """
+        CREATE TABLE IF NOT EXISTS renderer_event_journal (
+            sequence INTEGER PRIMARY KEY CHECK (sequence >= 1),
+            event_id TEXT NOT NULL UNIQUE,
+            scope_kind TEXT NOT NULL CHECK (scope_kind = 'wiki'),
+            scope_id TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            committed_at TEXT NOT NULL CHECK (
+                length(committed_at) >= 25 AND
+                substr(committed_at, -6, 1) IN ('+', '-') AND
+                substr(committed_at, -3, 1) = ':'
+            )
+        );
+        """)
+        try db.execute(sql: "CREATE UNIQUE INDEX IF NOT EXISTS renderer_event_journal_scope_sequence ON renderer_event_journal(scope_kind, scope_id, sequence);")
+        try db.execute(sql: """
+        CREATE TABLE IF NOT EXISTS renderer_event_process_leases (
+            lease_id TEXT PRIMARY KEY,
+            subsystem_id TEXT NOT NULL,
+            process_id INTEGER NOT NULL,
+            executable_identity TEXT NOT NULL,
+            host_identity TEXT,
+            started_at TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            last_heartbeat_at TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('active', 'retired', 'expired')),
+            retired_at TEXT
+        );
+        """)
+        try db.execute(sql: "CREATE INDEX IF NOT EXISTS renderer_event_process_leases_subsystem ON renderer_event_process_leases(subsystem_id, status);")
+        try db.execute(sql: """
+        CREATE TABLE IF NOT EXISTS renderer_event_cursors (
+            subsystem_id TEXT NOT NULL,
+            lease_id TEXT NOT NULL REFERENCES renderer_event_process_leases(lease_id) ON DELETE CASCADE,
+            sequence INTEGER NOT NULL CHECK (sequence >= 0),
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (subsystem_id, lease_id)
+        );
+        """)
+        try db.execute(sql: """
+        CREATE TABLE IF NOT EXISTS renderer_event_checkpoints (
+            subsystem_id TEXT PRIMARY KEY,
+            sequence INTEGER NOT NULL CHECK (sequence >= 0),
+            updated_at TEXT NOT NULL
+        );
+        """)
     }
 
     /// Classification deliberately combines exact column namespaces with the
@@ -3217,6 +3323,7 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
         );
         """)
         try createMetadataProvenanceTablesV48(in: db)
+        try createRendererSettingsTablesV49(in: db)
     }
 
     // MARK: - Internal helpers (mirrors of SQLiteWikiStore privates)
@@ -3326,6 +3433,240 @@ public final class GRDBWikiStore: WikiStore, @unchecked Sendable {
                 token.apply(try contributor.fold(in: self, on: db))
             }
             return token
+        }
+    }
+
+    // MARK: - Renderer settings (dynamic renderers Phase 3)
+
+    public func listRendererWikiEnablement() throws -> [RendererWikiEnablement] {
+        try dbWriter.read { db in
+            try Row.fetchAll(db, sql: """
+            SELECT package_id, is_enabled, updated_at
+            FROM renderer_wiki_enablement
+            ORDER BY package_id;
+            """).map(Self.rendererWikiEnablement(from:))
+        }
+    }
+
+    public func rendererWikiEnablement(packageID: RendererPackageID) throws -> RendererWikiEnablement? {
+        try dbWriter.read { db in
+            try Row.fetchOne(
+                db,
+                sql: "SELECT package_id, is_enabled, updated_at FROM renderer_wiki_enablement WHERE package_id = ?;",
+                arguments: [packageID.rawValue]
+            ).map(Self.rendererWikiEnablement(from:))
+        }
+    }
+
+    public func setRendererWikiEnablement(packageID: RendererPackageID, isEnabled: Bool) throws {
+        let event = RendererSettingsChangeEvent.wikiEnablementSet(packageID: packageID, isEnabled: isEnabled)
+        try mutateRendererSettings(event: event) { db, committedAt in
+            try db.execute(sql: """
+            INSERT INTO renderer_wiki_enablement (package_id, is_enabled, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(package_id) DO UPDATE SET
+                is_enabled = excluded.is_enabled,
+                updated_at = excluded.updated_at;
+            """, arguments: [packageID.rawValue, isEnabled ? 1 : 0, committedAt.rawValue])
+        }
+    }
+
+    public func listRendererSourcePreferences() throws -> [RendererSourcePreference] {
+        try dbWriter.read { db in
+            try Row.fetchAll(db, sql: """
+            SELECT source_id, reference_kind, package_id, package_version, registration_id, updated_at
+            FROM renderer_source_preferences
+            ORDER BY source_id;
+            """).map(Self.rendererSourcePreference(from:))
+        }
+    }
+
+    public func rendererSourcePreference(sourceID: SourceID) throws -> RendererSourcePreference? {
+        try dbWriter.read { db in
+            try Row.fetchOne(
+                db,
+                sql: """
+                SELECT source_id, reference_kind, package_id, package_version, registration_id, updated_at
+                FROM renderer_source_preferences
+                WHERE source_id = ?;
+                """,
+                arguments: [sourceID.rawValue]
+            ).map(Self.rendererSourcePreference(from:))
+        }
+    }
+
+    public func setRendererSourcePreference(sourceID: SourceID, preference: RendererPreferenceReference) throws {
+        let event = RendererSettingsChangeEvent.sourcePreferenceSet(sourceID: sourceID, preference: preference)
+        try mutateRendererSettings(event: event) { db, committedAt in
+            let persisted = Self.persistedPreferenceColumns(preference)
+            try db.execute(sql: """
+            INSERT INTO renderer_source_preferences (
+                source_id, reference_kind, package_id, package_version, registration_id, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_id) DO UPDATE SET
+                reference_kind = excluded.reference_kind,
+                package_id = excluded.package_id,
+                package_version = excluded.package_version,
+                registration_id = excluded.registration_id,
+                updated_at = excluded.updated_at;
+            """, arguments: [
+                sourceID.rawValue,
+                persisted.kind,
+                persisted.packageID,
+                persisted.packageVersion,
+                persisted.registrationID,
+                committedAt.rawValue,
+            ])
+        }
+    }
+
+    public func removeRendererSourcePreference(sourceID: SourceID) throws {
+        let event = RendererSettingsChangeEvent.sourcePreferenceRemoved(sourceID: sourceID)
+        try mutateRendererSettings(event: event) { db, _ in
+            try db.execute(sql: "DELETE FROM renderer_source_preferences WHERE source_id = ?;", arguments: [sourceID.rawValue])
+        }
+    }
+
+    public func rendererSettingsJournalRecords() throws -> [PersistedWikiStoreChangeRecord] {
+        try dbWriter.read { db in
+            try Row.fetchAll(db, sql: """
+            SELECT sequence, event_id, scope_id, payload_json, committed_at
+            FROM renderer_event_journal
+            ORDER BY sequence;
+            """).map(Self.rendererJournalRecord(from:))
+        }
+    }
+
+    private func mutateRendererSettings(
+        event: RendererSettingsChangeEvent,
+        _ body: (Database, RFC3339Timestamp) throws -> Void
+    ) throws {
+        var pending: RendererSettingsChangeEvent?
+        try dbWriter.unsafeReentrantWrite { db in
+            try db.inSavepoint {
+                let committedAt = rendererEventClock.now()
+                try body(db, committedAt)
+                try appendRendererJournalRecord(event: event, committedAt: committedAt, on: db)
+                pending = event
+                return .commit
+            }
+        }
+        if let pending {
+            eventBus?.emitRendererSettings(pending)
+        }
+    }
+
+    private func appendRendererJournalRecord(
+        event: RendererSettingsChangeEvent,
+        committedAt: RFC3339Timestamp,
+        on db: Database
+    ) throws {
+        let sequence = try Self.nextRendererSequence(on: db)
+        let eventID = rendererEventIDGenerator.nextEventID()
+        let record = try PersistedWikiStoreChangeRecord(
+            eventID: eventID,
+            sequence: sequence,
+            scope: .wiki(wikiID),
+            payload: .rendererSettings(event),
+            committedAt: committedAt
+        )
+        let payloadData = try JSONEncoder().encode(record.payload)
+        guard let payloadJSON = String(data: payloadData, encoding: .utf8) else {
+            throw WikiStoreError.unexpected("Renderer event payload was not valid UTF-8 JSON")
+        }
+        try db.execute(sql: """
+        INSERT INTO renderer_event_journal (
+            sequence, event_id, scope_kind, scope_id, payload_json, committed_at
+        ) VALUES (?, ?, 'wiki', ?, ?, ?);
+        """, arguments: [
+            Int64(sequence),
+            eventID.uuidString,
+            wikiID.rawValue,
+            payloadJSON,
+            committedAt.rawValue,
+        ])
+    }
+
+    private static func nextRendererSequence(on db: Database) throws -> UInt64 {
+        let next = try Int64.fetchOne(
+            db,
+            sql: "SELECT next_sequence FROM renderer_event_sequence WHERE scope = 'wiki';"
+        ) ?? 1
+        try db.execute(
+            sql: "UPDATE renderer_event_sequence SET next_sequence = ? WHERE scope = 'wiki';",
+            arguments: [next + 1]
+        )
+        return UInt64(next)
+    }
+
+    private static func rendererWikiEnablement(from row: Row) throws -> RendererWikiEnablement {
+        try RendererWikiEnablement(
+            packageID: RendererPackageID(validating: row["package_id"]),
+            isEnabled: (row["is_enabled"] as Int64) != 0,
+            updatedAt: RFC3339Timestamp(validating: row["updated_at"])
+        )
+    }
+
+    private static func rendererSourcePreference(from row: Row) throws -> RendererSourcePreference {
+        try RendererSourcePreference(
+            sourceID: SourceID(rawValue: row["source_id"]),
+            preference: rendererPreferenceReference(from: row),
+            updatedAt: RFC3339Timestamp(validating: row["updated_at"])
+        )
+    }
+
+    private static func rendererJournalRecord(from row: Row) throws -> PersistedWikiStoreChangeRecord {
+        let payloadJSON: String = row["payload_json"]
+        let payloadData = Data(payloadJSON.utf8)
+        let payload = try JSONDecoder().decode(WikiStoreChangeEvent.self, from: payloadData)
+        return try PersistedWikiStoreChangeRecord(
+            eventID: UUID(uuidString: row["event_id"]) ?? UUID(),
+            sequence: UInt64(row["sequence"] as Int64),
+            scope: .wiki(WikiID(rawValue: row["scope_id"])),
+            payload: payload,
+            committedAt: RFC3339Timestamp(validating: row["committed_at"])
+        )
+    }
+
+    private static func rendererPreferenceReference(from row: Row) throws -> RendererPreferenceReference {
+        let packageID = try RendererPackageID(validating: row["package_id"])
+        let registrationID = try RendererRegistrationID(validating: row["registration_id"])
+        let kind: String = row["reference_kind"]
+        switch kind {
+        case "exact":
+            guard let versionRaw: String = row["package_version"] else {
+                throw WikiStoreError.unexpected("Exact renderer preference is missing package version")
+            }
+            return .exact(RendererReference(
+                packageID: packageID,
+                version: try RendererPackageVersion(validating: versionRaw),
+                registrationID: registrationID
+            ))
+        case "logical":
+            return .logical(LogicalRendererReference(packageID: packageID, registrationID: registrationID))
+        default:
+            throw WikiStoreError.unexpected("Unknown renderer preference kind: \(kind)")
+        }
+    }
+
+    private static func persistedPreferenceColumns(
+        _ preference: RendererPreferenceReference
+    ) -> (kind: String, packageID: String, packageVersion: String?, registrationID: String) {
+        switch preference {
+        case let .exact(reference):
+            return (
+                "exact",
+                reference.packageID.rawValue,
+                reference.version.rawValue,
+                reference.registrationID.rawValue
+            )
+        case let .logical(reference):
+            return (
+                "logical",
+                reference.packageID.rawValue,
+                nil,
+                reference.registrationID.rawValue
+            )
         }
     }
 

--- a/Sources/WikiFSCore/Store/WikiChangeNotification.swift
+++ b/Sources/WikiFSCore/Store/WikiChangeNotification.swift
@@ -34,3 +34,16 @@ public enum WikiChangeNotification {
         "\(baseName).\(id)"
     }
 }
+
+public enum RendererChangeNotification {
+    public static let wikiBaseName = "org.sockpuppet.wiki.renderers.wiki.changed"
+    public static let machineBaseName = "org.sockpuppet.wiki.renderers.machine.changed"
+
+    public static func wikiName(forWikiID id: WikiID) -> String {
+        "\(wikiBaseName).\(id.rawValue)"
+    }
+
+    public static func machineName(for scopeID: RendererMachineScopeID) -> String {
+        "\(machineBaseName).\(scopeID.rawValue)"
+    }
+}

--- a/Sources/WikiFSCore/Store/WikiEventBus.swift
+++ b/Sources/WikiFSCore/Store/WikiEventBus.swift
@@ -4,53 +4,6 @@ import Foundation
 // now live in `Resource.swift` (slice 2b) next to the access layer that owns
 // them; the bus is a consumer of kinds, not their home.
 
-/// How a resource changed.
-public enum ChangeKind: String, Sendable {
-    case created, updated, deleted
-}
-
-/// A thin, serializable description of one resource change. Emitted by the
-/// store at the method-atomic write seam (`mutate()`), and by the cross-process
-/// bridge as a coarse "reload everything" event. Events are *hints*:
-/// subscribers (the File Provider signaler, the model's reload path) react to
-/// them, but the authoritative change-detection token is still
-/// `GRDBWikiStore.changeToken()`.
-///
-/// `kind` is optional: a `nil` kind means a coarse, whole-wiki change (the
-/// Darwin notification carries no per-resource detail), which only matches
-/// all-events (nil-filtered) subscribers. A concrete kind matches its own
-/// kind-filtered subscribers plus all-events subscribers.
-///
-/// `seq` is a bus-stamped, monotonically increasing sequence number owned by
-/// `WikiEventBus.emit` (callers pass `0`; the bus overwrites it on delivery).
-/// It is present but unconsumed (reserved for the future daemon resync
-/// handshake — §3 decision 2).
-///
-/// **Phase E:** the `origin` field (`.local` / `.external`) is removed. The
-/// model now subscribes to ALL events and reloads through the bus for both
-/// in-app writes and cross-process (`wikictl`) writes — one path, not two.
-public struct ResourceChangeEvent: Sendable, Equatable {
-    public let wikiID: WikiID
-    public let kind: ResourceKind?
-    public let id: String
-    public let change: ChangeKind
-    public let seq: UInt64
-
-    public init(
-        wikiID: WikiID,
-        kind: ResourceKind?,
-        id: String,
-        change: ChangeKind,
-        seq: UInt64 = 0
-    ) {
-        self.wikiID = wikiID
-        self.kind = kind
-        self.id = id
-        self.change = change
-        self.seq = seq
-    }
-}
-
 /// Opaque handle returned by ``WikiEventBus/subscribe(_:_:)``; pass it to
 /// ``WikiEventBus/unsubscribe(_:)`` to stop delivery. Unique per subscription.
 public struct SubscriptionToken: Sendable, Hashable {

--- a/Sources/WikiFSCore/Store/WikiEventBus.swift
+++ b/Sources/WikiFSCore/Store/WikiEventBus.swift
@@ -87,15 +87,24 @@ public final class WikiEventBus: @unchecked Sendable {
     /// when building events.
     public let wikiID: WikiID
 
-    private typealias Handler = @MainActor @Sendable (ResourceChangeEvent) -> Void
+    public enum StoreChangeEvent: Sendable, Equatable {
+        case resource(ResourceChangeEvent)
+        case rendererSettings(RendererSettingsChangeEvent)
+    }
+
+    private typealias ResourceHandler = @MainActor @Sendable (ResourceChangeEvent) -> Void
+    private typealias RendererSettingsHandler = @MainActor @Sendable (RendererSettingsChangeEvent) -> Void
 
     private let lock = NSLock()
     /// Subscriber registry: `id → (kindFilter, handler)`. A `nil` kindFilter
     /// means "all kinds" (also the only subscribers that receive coarse,
     /// `kind == nil` events). Guarded by `lock`.
-    private var subscribers: [UUID: (ResourceKind?, Handler)] = [:]
-    /// Monotone per-emit counter, stamped onto each delivered event's `seq`.
-    /// Guarded by `lock`.
+    private var resourceSubscribers: [UUID: (ResourceKind?, ResourceHandler)] = [:]
+    /// Renderer-settings subscribers are separate from resource subscribers, but
+    /// share this bus so the app has one per-wiki in-process event path.
+    private var rendererSettingsSubscribers: [UUID: RendererSettingsHandler] = [:]
+    /// Monotone per-emit counter, stamped onto each delivered resource event's
+    /// `seq`. Guarded by `lock`.
     private var seqCounter: UInt64 = 0
 
     public init(wikiID: WikiID) {
@@ -113,7 +122,18 @@ public final class WikiEventBus: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         let token = SubscriptionToken()
-        subscribers[token.id] = (kind, handler)
+        resourceSubscribers[token.id] = (kind, handler)
+        return token
+    }
+
+    @discardableResult
+    public func subscribeRendererSettings(
+        _ handler: @escaping @MainActor (RendererSettingsChangeEvent) -> Void
+    ) -> SubscriptionToken {
+        lock.lock()
+        defer { lock.unlock() }
+        let token = SubscriptionToken()
+        rendererSettingsSubscribers[token.id] = handler
         return token
     }
 
@@ -122,7 +142,8 @@ public final class WikiEventBus: @unchecked Sendable {
     public func unsubscribe(_ token: SubscriptionToken) {
         lock.lock()
         defer { lock.unlock() }
-        subscribers[token.id] = nil
+        resourceSubscribers[token.id] = nil
+        rendererSettingsSubscribers[token.id] = nil
     }
 
     /// Stamp `seq`, snapshot the matching handlers, then dispatch each to the
@@ -141,7 +162,7 @@ public final class WikiEventBus: @unchecked Sendable {
             change: event.change,
             seq: seqCounter
         )
-        let snapshot = Array(subscribers.values)
+        let snapshot = Array(resourceSubscribers.values)
         lock.unlock()
 
         for (kindFilter, handler) in snapshot {
@@ -150,6 +171,16 @@ public final class WikiEventBus: @unchecked Sendable {
             // nil-filter (all-events) subscribers.
             if let kindFilter, kindFilter != stamped.kind { continue }
             Task { @MainActor in handler(stamped) }
+        }
+    }
+
+    public func emitRendererSettings(_ event: RendererSettingsChangeEvent) {
+        lock.lock()
+        let snapshot = Array(rendererSettingsSubscribers.values)
+        lock.unlock()
+
+        for handler in snapshot {
+            Task { @MainActor in handler(event) }
         }
     }
 }

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -274,6 +274,17 @@ public protocol WikiStore: Sendable {
     /// Source summaries (no content blob), most-recent-first.
     func listSources() throws -> [SourceSummary]
 
+    // MARK: - Renderer settings (dynamic renderers Phase 3)
+
+    func listRendererWikiEnablement() throws -> [RendererWikiEnablement]
+    func rendererWikiEnablement(packageID: RendererPackageID) throws -> RendererWikiEnablement?
+    func setRendererWikiEnablement(packageID: RendererPackageID, isEnabled: Bool) throws
+    func listRendererSourcePreferences() throws -> [RendererSourcePreference]
+    func rendererSourcePreference(sourceID: SourceID) throws -> RendererSourcePreference?
+    func setRendererSourcePreference(sourceID: SourceID, preference: RendererPreferenceReference) throws
+    func removeRendererSourcePreference(sourceID: SourceID) throws
+    func rendererSettingsJournalRecords() throws -> [PersistedWikiStoreChangeRecord]
+
     /// The verbatim content bytes for one source, fetched on demand. On the
     /// protocol so `WikiStoreModel` can STAGE the source into the agent's scratch
     /// dir (reading from SQLite, not the laggy mount) without downcasting. Throws

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -13,6 +13,7 @@ public enum WikiStoreError: Error, CustomStringConvertible {
     case sourceMarkdownVersionNotFound(SourceMarkdownVersionID)
     case deletionRestricted(ResourceDeletionRestriction)
     case invalidBookmarkRow(id: String, reason: String)
+    case invalidRendererEventID(String)
     case unexpected(String)
     /// Thrown by `addSource` when the incoming bytes are byte-identical to an
     /// already-stored source (matched by `content_hash`). Carries the existing
@@ -36,6 +37,7 @@ public enum WikiStoreError: Error, CustomStringConvertible {
         case .deletionRestricted(.provenance(let blockers)):
             return "Source deletion restricted by \(blockers.values.count) page version provenance reference(s)"
         case .invalidBookmarkRow(let id, let reason): return "Invalid bookmark row \(id): \(reason)"
+        case .invalidRendererEventID(let raw): return "Invalid renderer event ID: \(raw)"
         case .unexpected(let m): return "Unexpected: \(m)"
         case .duplicateContent(let existing):
             return "Duplicate content: already stored as \(existing.effectiveName) (\(existing.id.rawValue))"

--- a/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
@@ -173,6 +173,7 @@ public enum RendererSettingsChangeEvent: Codable, Hashable, Sendable {
 }
 
 public enum WikiStoreChangeEvent: Codable, Hashable, Sendable {
+    case resource(ResourceChangeEvent)
     case rendererSettings(RendererSettingsChangeEvent)
 }
 

--- a/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+// pattern: Functional Core
+
+/// Machine-scoped renderer store identity. This is separate from wiki identity
+/// and renderer package identity.
+public struct RendererMachineScopeID: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard rawValue.isEmpty == false,
+              rawValue.count <= 128,
+              rawValue.allSatisfy({ character in
+                  character.isASCII && (character.isLetter || character.isNumber || character == "." || character == "-" || character == "_")
+              }) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else {
+            throw RendererValidationError.invalidIdentifier(kind: "renderer machine scope ID", value: rawValue)
+        }
+        self = value
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+public struct RendererEventSubsystemID: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard RendererIdentifierRules.isRegistrationID(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else {
+            throw RendererValidationError.invalidIdentifier(kind: "renderer event subsystem ID", value: rawValue)
+        }
+        self = value
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+public struct RendererEventProcessLeaseID: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: UUID
+
+    public init(rawValue: UUID) { self.rawValue = rawValue }
+    public init() { self.rawValue = UUID() }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue.uuidString < rhs.rawValue.uuidString }
+}
+
+public struct RendererEventPolicy: Equatable, Sendable {
+    public let heartbeatInterval: TimeInterval
+    public let leaseExpiry: TimeInterval
+    public let clockSkewSafetyMargin: TimeInterval
+    public let cleanRetirementSafetyInterval: TimeInterval
+    public let lockAcquisitionTimeout: TimeInterval
+    public let orderedDrainBatchLimit: Int
+
+    public init(
+        heartbeatInterval: TimeInterval,
+        leaseExpiry: TimeInterval,
+        clockSkewSafetyMargin: TimeInterval,
+        cleanRetirementSafetyInterval: TimeInterval,
+        lockAcquisitionTimeout: TimeInterval,
+        orderedDrainBatchLimit: Int
+    ) {
+        self.heartbeatInterval = heartbeatInterval
+        self.leaseExpiry = leaseExpiry
+        self.clockSkewSafetyMargin = clockSkewSafetyMargin
+        self.cleanRetirementSafetyInterval = cleanRetirementSafetyInterval
+        self.lockAcquisitionTimeout = lockAcquisitionTimeout
+        self.orderedDrainBatchLimit = orderedDrainBatchLimit
+    }
+
+    public static let phase3Default = RendererEventPolicy(
+        heartbeatInterval: 10,
+        leaseExpiry: 45,
+        clockSkewSafetyMargin: 15,
+        cleanRetirementSafetyInterval: 5 * 60,
+        lockAcquisitionTimeout: 30,
+        orderedDrainBatchLimit: 256
+    )
+}
+
+/// RFC 3339 timestamp that requires an explicit numeric UTC offset.
+public struct RFC3339Timestamp: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard Self.isOffsetBearingRFC3339(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else {
+            throw RendererValidationError.invalidIdentifier(kind: "offset-bearing RFC3339 timestamp", value: rawValue)
+        }
+        self = value
+    }
+
+    public init(date: Date, timeZone: TimeZone = TimeZone(secondsFromGMT: 0)!) {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds, .withColonSeparatorInTimeZone]
+        formatter.timeZone = timeZone
+        var encoded = formatter.string(from: date)
+        if encoded.hasSuffix("Z") {
+            encoded.removeLast()
+            encoded.append("+00:00")
+        }
+        self.rawValue = encoded
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+
+    private static func isOffsetBearingRFC3339(_ value: String) -> Bool {
+        guard value.contains("T"), value.count >= 25 else { return false }
+        let suffix = value.suffix(6)
+        guard suffix.first == "+" || suffix.first == "-" else { return false }
+        let hourStart = suffix.index(after: suffix.startIndex)
+        let colon = suffix.index(hourStart, offsetBy: 2)
+        guard suffix[colon] == ":" else { return false }
+        let hours = suffix[hourStart..<colon]
+        let minutes = suffix[suffix.index(after: colon)..<suffix.endIndex]
+        guard hours.allSatisfy(\.isNumber), minutes.allSatisfy(\.isNumber) else { return false }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds, .withColonSeparatorInTimeZone]
+        if formatter.date(from: value) != nil { return true }
+        formatter.formatOptions = [.withInternetDateTime, .withColonSeparatorInTimeZone]
+        return formatter.date(from: value) != nil
+    }
+}
+
+public enum WikiStoreChangeScope: Codable, Hashable, Sendable {
+    case wiki(WikiID)
+    case machine(RendererMachineScopeID)
+}
+
+public struct RendererWikiEnablement: Codable, Hashable, Sendable {
+    public let packageID: RendererPackageID
+    public let isEnabled: Bool
+    public let updatedAt: RFC3339Timestamp
+
+    public init(packageID: RendererPackageID, isEnabled: Bool, updatedAt: RFC3339Timestamp) {
+        self.packageID = packageID
+        self.isEnabled = isEnabled
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct RendererSourcePreference: Codable, Hashable, Sendable {
+    public let sourceID: SourceID
+    public let preference: RendererPreferenceReference
+    public let updatedAt: RFC3339Timestamp
+
+    public init(sourceID: SourceID, preference: RendererPreferenceReference, updatedAt: RFC3339Timestamp) {
+        self.sourceID = sourceID
+        self.preference = preference
+        self.updatedAt = updatedAt
+    }
+}
+
+public enum RendererSettingsChangeEvent: Codable, Hashable, Sendable {
+    case machineInstallStateChanged(packageID: RendererPackageID, version: RendererPackageVersion)
+    case machineSafeModeChanged(isEnabled: Bool)
+    case wikiEnablementSet(packageID: RendererPackageID, isEnabled: Bool)
+    case sourcePreferenceSet(sourceID: SourceID, preference: RendererPreferenceReference)
+    case sourcePreferenceRemoved(sourceID: SourceID)
+}
+
+public enum WikiStoreChangeEvent: Codable, Hashable, Sendable {
+    case rendererSettings(RendererSettingsChangeEvent)
+}
+
+public struct PersistedWikiStoreChangeRecord: Codable, Hashable, Sendable {
+    public let schemaVersion: Int
+    public let eventID: UUID
+    public let sequence: UInt64
+    public let scope: WikiStoreChangeScope
+    public let payload: WikiStoreChangeEvent
+    public let committedAt: RFC3339Timestamp
+
+    public init(
+        schemaVersion: Int = 1,
+        eventID: UUID,
+        sequence: UInt64,
+        scope: WikiStoreChangeScope,
+        payload: WikiStoreChangeEvent,
+        committedAt: RFC3339Timestamp
+    ) throws {
+        guard schemaVersion == 1 else {
+            throw RendererValidationError.unsupportedManifestRevision(schemaVersion)
+        }
+        self.schemaVersion = schemaVersion
+        self.eventID = eventID
+        self.sequence = sequence
+        self.scope = scope
+        self.payload = payload
+        self.committedAt = committedAt
+    }
+}
+
+public protocol RendererEventIDGenerating: Sendable {
+    func nextEventID() -> UUID
+}
+
+public struct UUIDRendererEventIDGenerator: RendererEventIDGenerating {
+    public init() {}
+    public func nextEventID() -> UUID { UUID() }
+}
+
+public protocol RendererEventClock: Sendable {
+    func now() -> RFC3339Timestamp
+}
+
+public struct WallRendererEventClock: RendererEventClock {
+    public init() {}
+    public func now() -> RFC3339Timestamp { RFC3339Timestamp(date: Date()) }
+}

--- a/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
@@ -103,7 +103,7 @@ public struct RFC3339Timestamp: RawRepresentable, Codable, Hashable, Sendable, C
         self = value
     }
 
-    public init(date: Date, timeZone: TimeZone = TimeZone(secondsFromGMT: 0)!) {
+    public init(date: Date, timeZone: TimeZone = TimeZone(secondsFromGMT: 0) ?? .current) {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds, .withColonSeparatorInTimeZone]
         formatter.timeZone = timeZone

--- a/Sources/WikiFSTypes/ResourceKind.swift
+++ b/Sources/WikiFSTypes/ResourceKind.swift
@@ -12,7 +12,7 @@ import Foundation
 /// Lives in `WikiFSTypes` (the shared leaf target) so both the link cluster
 /// (`ParsedLink.LinkType.resourceKind`) and the store/event-bus can reference it
 /// without a circular dependency (module restructuring Phase 1, #532).
-public enum ResourceKind: String, Sendable, CaseIterable {
+public enum ResourceKind: String, Codable, Sendable, CaseIterable {
     case page, source, systemPrompt, wikiIndex, log, bookmark, chat
 
     /// The SF Symbol name used for this resource kind across every UI surface:
@@ -43,5 +43,36 @@ public enum ResourceKind: String, Sendable, CaseIterable {
         case .page, .source, .chat, .bookmark: return "\(rawValue):"
         case .systemPrompt, .wikiIndex, .log: return nil
         }
+    }
+}
+
+/// How a resource changed.
+public enum ChangeKind: String, Codable, Sendable {
+    case created, updated, deleted
+}
+
+/// A thin, serializable description of one resource change. Store-owned
+/// producers emit it locally through `WikiEventBus`; persisted renderer journals
+/// use the same value in `WikiStoreChangeEvent.resource` when they need to carry
+/// a resource-shaped payload without depending on WikiFSCore.
+public struct ResourceChangeEvent: Codable, Sendable, Equatable, Hashable {
+    public let wikiID: WikiID
+    public let kind: ResourceKind?
+    public let id: String
+    public let change: ChangeKind
+    public let seq: UInt64
+
+    public init(
+        wikiID: WikiID,
+        kind: ResourceKind?,
+        id: String,
+        change: ChangeKind,
+        seq: UInt64 = 0
+    ) {
+        self.wikiID = wikiID
+        self.kind = kind
+        self.id = id
+        self.change = change
+        self.seq = seq
     }
 }

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -637,7 +637,10 @@ private struct FixedRendererEventClock: RendererEventClock {
         return dir.appendingPathComponent("WikiFS.sqlite")
     }
 
-    private func store(url: URL? = nil) throws -> GRDBWikiStore {
+    private func store(
+        url: URL? = nil,
+        rendererWikiWakePoster: @escaping @Sendable (WikiID) -> Void = { _ in }
+    ) throws -> GRDBWikiStore {
         try GRDBWikiStore(
             databaseURL: url ?? (try tempDatabaseURL()),
             schemaV48MigrationHooks: .productionDefault,
@@ -649,7 +652,8 @@ private struct FixedRendererEventClock: RendererEventClock {
             ]),
             rendererEventClock: FixedRendererEventClock(
                 timestamp: try RFC3339Timestamp(validating: "2026-08-04T12:34:56+00:00")
-            )
+            ),
+            rendererWikiWakePoster: rendererWikiWakePoster
         )
     }
 
@@ -708,5 +712,110 @@ private struct FixedRendererEventClock: RendererEventClock {
 
         #expect(try store.rendererSettingsJournalRecords().count == 1)
         #expect(store.scalarText("SELECT COUNT(*) FROM renderer_event_journal WHERE payload_json LIKE '%resource%';") == "0")
+    }
+
+    @Test func successfulRendererSettingsMutationPostsOneWikiWake() throws {
+        final class WakeCollector: @unchecked Sendable {
+            private let lock = NSLock()
+            private var values: [WikiID] = []
+            func append(_ value: WikiID) { lock.withLock { values.append(value) } }
+            var snapshot: [WikiID] { lock.withLock { values } }
+        }
+        let collector = WakeCollector()
+        let store = try store(rendererWikiWakePoster: { collector.append($0) })
+        let wikiID = WikiID(rawValue: "wiki-renderer-wake-test")
+        store.eventBus = WikiEventBus(wikiID: wikiID)
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+
+        try store.setRendererWikiEnablement(packageID: packageID, isEnabled: true)
+
+        #expect(collector.snapshot == [wikiID])
+        #expect(try store.rendererSettingsJournalRecords().count == 1)
+    }
+
+    @Test func failedRendererSettingsTransactionPostsNoWikiWake() throws {
+        final class WakeCounter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var countValue = 0
+            func increment(_: WikiID) { lock.withLock { countValue += 1 } }
+            var count: Int { lock.withLock { countValue } }
+        }
+        let counter = WakeCounter()
+        let store = try store(rendererWikiWakePoster: { counter.increment($0) })
+        store.eventBus = WikiEventBus(wikiID: WikiID(rawValue: "wiki-renderer-rollback-test"))
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+        let missing = SourceID(rawValue: "missing-source")
+        let preference = RendererPreferenceReference.logical(
+            LogicalRendererReference(packageID: packageID, registrationID: try RendererRegistrationID(validating: "canvas"))
+        )
+
+        #expect(throws: Error.self) {
+            try store.setRendererSourcePreference(sourceID: missing, preference: preference)
+        }
+
+        #expect(counter.count == 0)
+        #expect(try store.rendererSettingsJournalRecords().isEmpty)
+    }
+
+    @Test func invalidRendererJournalEventIDFailsClosed() throws {
+        let store = try store()
+        store.eventBus = WikiEventBus(wikiID: WikiID(rawValue: "wiki-invalid-event-id"))
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+        try store.setRendererWikiEnablement(packageID: packageID, isEnabled: true)
+        try store.corruptRendererJournalEventIDForTesting("not-a-uuid")
+
+        do {
+            _ = try store.rendererSettingsJournalRecords()
+            Issue.record("expected invalid renderer event ID")
+        } catch WikiStoreError.invalidRendererEventID(let raw) {
+            #expect(raw == "not-a-uuid")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func v49FreshAndUpgradeRendererSchemasMatch() throws {
+        let freshURL = try MetadataSQLiteFixtureSupport.fileURL(prefix: "fresh-v49-renderer")
+        let fresh = try store(url: freshURL)
+        fresh.close()
+
+        let upgradedURL = try MetadataSQLiteFixtureSupport.fileURL(prefix: "upgrade-v49-renderer")
+        try MetadataSQLiteFixtureSupport.prepareV48(at: upgradedURL)
+        let upgraded = try store(url: upgradedURL)
+        upgraded.close()
+
+        let names = rendererSchemaObjectNamesSQLList
+        for type in ["table", "index"] {
+            let freshSQL = try normalizedMetadataSQL(type: type, names: names, at: freshURL)
+            let upgradedSQL = try normalizedMetadataSQL(type: type, names: names, at: upgradedURL)
+            #expect(freshSQL == upgradedSQL)
+        }
+    }
+
+    @Test func explicitV48UpgradeCreatesRendererSchemaAndReopensAtV49() throws {
+        let url = try MetadataSQLiteFixtureSupport.fileURL(prefix: "explicit-v48-to-v49")
+        try MetadataSQLiteFixtureSupport.prepareV48(at: url)
+        #expect(try MetadataSQLiteFixtureSupport.scalar("PRAGMA user_version", at: url) == "48")
+
+        let upgraded = try store(url: url)
+        #expect(upgraded.pragmaValue("user_version") == "49")
+        #expect(upgraded.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='renderer_wiki_enablement';") == "1")
+        #expect(upgraded.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='renderer_event_journal_scope_sequence';") == "1")
+        upgraded.close()
+
+        let reopened = try store(url: url)
+        #expect(reopened.pragmaValue("user_version") == "49")
+        #expect(try reopened.listRendererWikiEnablement().isEmpty)
+    }
+
+    private var rendererSchemaObjectNamesSQLList: String {
+        "('renderer_wiki_enablement', 'renderer_source_preferences', 'renderer_source_preferences_package', 'renderer_event_sequence', 'renderer_event_journal', 'renderer_event_journal_scope_sequence', 'renderer_event_process_leases', 'renderer_event_process_leases_subsystem', 'renderer_event_cursors', 'renderer_event_checkpoints')"
+    }
+
+    private func normalizedMetadataSQL(type: String, names: String, at url: URL) throws -> String {
+        try MetadataSQLiteFixtureSupport.scalar(
+            "SELECT group_concat(replace(replace(lower(sql), char(10), ' '), '  ', ' '), '|') FROM sqlite_master WHERE type = '\(type)' AND name IN \(names) ORDER BY name",
+            at: url
+        )
     }
 }

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -607,3 +607,106 @@ import SQLite3
         #expect(reloaded.updatedAt == originalUpdatedAt)
     }
 }
+
+private final class DeterministicRendererEventIDGenerator: RendererEventIDGenerating, @unchecked Sendable {
+    let ids: [UUID]
+    private let lock = NSLock()
+    private var index = 0
+
+    init(_ ids: [UUID]) { self.ids = ids }
+
+    func nextEventID() -> UUID {
+        lock.lock()
+        defer { lock.unlock() }
+        let id = ids[min(index, ids.count - 1)]
+        index += 1
+        return id
+    }
+}
+
+private struct FixedRendererEventClock: RendererEventClock {
+    let timestamp: RFC3339Timestamp
+    func now() -> RFC3339Timestamp { timestamp }
+}
+
+@Suite struct RendererSettingsStoreTests {
+    private func tempDatabaseURL() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("renderer-settings-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("WikiFS.sqlite")
+    }
+
+    private func store(url: URL? = nil) throws -> GRDBWikiStore {
+        try GRDBWikiStore(
+            databaseURL: url ?? (try tempDatabaseURL()),
+            schemaV48MigrationHooks: .productionDefault,
+            schemaForeignKeyChecker: .productionDefault(),
+            rendererEventIDGenerator: DeterministicRendererEventIDGenerator([
+                UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+                UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+                UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+            ]),
+            rendererEventClock: FixedRendererEventClock(
+                timestamp: try RFC3339Timestamp(validating: "2026-08-04T12:34:56+00:00")
+            )
+        )
+    }
+
+    @Test func freshSchemaCreatesRendererTablesAndReopensAtV49() throws {
+        let url = try tempDatabaseURL()
+        let first = try store(url: url)
+        #expect(first.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
+        #expect(first.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='renderer_wiki_enablement';") == "1")
+        #expect(first.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='renderer_event_journal';") == "1")
+
+        let reopened = try store(url: url)
+        #expect(reopened.pragmaValue("user_version") == "49")
+        #expect(try reopened.listRendererWikiEnablement().isEmpty)
+    }
+
+    @Test func settingsRoundTripPersistsJournalRecordsInOrder() throws {
+        let store = try store()
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+        let source = try store.addSource(filename: "diagram.canvas", data: Data("{}".utf8))
+        let preference = RendererPreferenceReference.logical(
+            LogicalRendererReference(packageID: packageID, registrationID: try RendererRegistrationID(validating: "canvas"))
+        )
+
+        try store.setRendererWikiEnablement(packageID: packageID, isEnabled: true)
+        try store.setRendererSourcePreference(sourceID: source.id, preference: preference)
+
+        #expect(try store.rendererWikiEnablement(packageID: packageID)?.isEnabled == true)
+        #expect(try store.rendererSourcePreference(sourceID: source.id)?.preference == preference)
+        let records = try store.rendererSettingsJournalRecords()
+        #expect(records.map(\.sequence) == [1, 2])
+        #expect(records.allSatisfy { $0.committedAt.rawValue.hasSuffix("+00:00") })
+    }
+
+    @Test func sourcePreferenceConstraintRollbackPersistsNoJournalRecord() throws {
+        let store = try store()
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+        let missing = SourceID(rawValue: "missing-source")
+        let preference = RendererPreferenceReference.logical(
+            LogicalRendererReference(packageID: packageID, registrationID: try RendererRegistrationID(validating: "canvas"))
+        )
+
+        #expect(throws: Error.self) {
+            try store.setRendererSourcePreference(sourceID: missing, preference: preference)
+        }
+        #expect(try store.rendererSettingsJournalRecords().isEmpty)
+        #expect(try store.rendererSourcePreference(sourceID: missing) == nil)
+    }
+
+    @Test func rendererSettingsJournalDoesNotCreateResourceEventRecord() throws {
+        let store = try store()
+        let bus = WikiEventBus(wikiID: WikiID(rawValue: "wiki-renderer-settings-test"))
+        store.eventBus = bus
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+
+        try store.setRendererWikiEnablement(packageID: packageID, isEnabled: true)
+
+        #expect(try store.rendererSettingsJournalRecords().count == 1)
+        #expect(store.scalarText("SELECT COUNT(*) FROM renderer_event_journal WHERE payload_json LIKE '%resource%';") == "0")
+    }
+}

--- a/Tests/WikiFSTests/ChatStoreTests.swift
+++ b/Tests/WikiFSTests/ChatStoreTests.swift
@@ -229,7 +229,7 @@ import SQLite3
     /// AC.2: a fresh schema has the `acp_session_id` column on the chats table.
     @Test func freshSchemaHasChatAcpSessionIdColumn() throws {
         let store = try tempStore()
-        #expect(GRDBWikiStore.schemaVersion == 48)
+        #expect(GRDBWikiStore.schemaVersion == 49)
         let hasCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='acp_session_id';")
         #expect(hasCol == "1")
@@ -317,7 +317,7 @@ import SQLite3
     /// A fresh schema has the `model_provider_id`/`model_id` columns on `chats`.
     @Test func freshSchemaHasChatModelOverrideColumns() throws {
         let store = try tempStore()
-        #expect(GRDBWikiStore.schemaVersion == 48)
+        #expect(GRDBWikiStore.schemaVersion == 49)
         let hasProviderCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='model_provider_id';")
         #expect(hasProviderCol == "1")

--- a/Tests/WikiFSTests/ChatTurnMetadataStoreTests.swift
+++ b/Tests/WikiFSTests/ChatTurnMetadataStoreTests.swift
@@ -3,8 +3,8 @@ import Testing
 @testable import WikiFSCore
 
 struct ChatTurnMetadataStoreTests {
-    @Test func schemaVersionIs48() {
-        #expect(GRDBWikiStore.schemaVersion == 48)
+    @Test func schemaVersionIs49() {
+        #expect(GRDBWikiStore.schemaVersion == 49)
     }
 
     @Test func usageIsKeyedByChatAndTurn() throws {

--- a/Tests/WikiFSTests/MetadataSQLiteFixtureSupport.swift
+++ b/Tests/WikiFSTests/MetadataSQLiteFixtureSupport.swift
@@ -74,6 +74,24 @@ enum MetadataSQLiteFixtureSupport {
         fresh.close()
         try SchemaV48FixtureFactory.apply(classificationFixture, at: url)
     }
+
+    static func prepareV48(at url: URL) throws {
+        let fresh = try GRDBWikiStore(databaseURL: url)
+        fresh.close()
+        try execute("""
+        DROP TABLE IF EXISTS renderer_event_checkpoints;
+        DROP TABLE IF EXISTS renderer_event_cursors;
+        DROP INDEX IF EXISTS renderer_event_process_leases_subsystem;
+        DROP TABLE IF EXISTS renderer_event_process_leases;
+        DROP INDEX IF EXISTS renderer_event_journal_scope_sequence;
+        DROP TABLE IF EXISTS renderer_event_journal;
+        DROP TABLE IF EXISTS renderer_event_sequence;
+        DROP INDEX IF EXISTS renderer_source_preferences_package;
+        DROP TABLE IF EXISTS renderer_source_preferences;
+        DROP TABLE IF EXISTS renderer_wiki_enablement;
+        PRAGMA user_version = 48;
+        """, at: url)
+    }
 }
 
 enum ChatTurnsSchemaClassificationFixture: CaseIterable {

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -641,15 +641,14 @@ struct PageVersionTests {
     }
 
     /// AC.8 (migration ladder sanity) — a fresh DB must report the current
-    /// `user_version`. The v46 step is the destructive chat-only rebuild and
-    /// v47 adds durable non-message transcript identities.
-    /// issue #982 Phase 2.
-    @Test func v44SchemaVersionAfterMigration() throws {
-        #expect(GRDBWikiStore.schemaVersion == 48,
-                "schemaVersion must report 46 after the Phase 2 chat rebuild")
+    /// `user_version`. The v49 step adds the dynamic renderer wiki settings
+    /// and journal foundation.
+    @Test func v49SchemaVersionAfterMigration() throws {
+        #expect(GRDBWikiStore.schemaVersion == 49,
+                "schemaVersion must report the current migration version")
         let store = try tempStore()
         let v = store.pragmaValue("user_version")
-        #expect(v == "48", "fresh DB stamps user_version = 48 (got \(v))")
+        #expect(v == "49", "fresh DB stamps user_version = 49 (got \(v))")
     }
 
     // MARK: - #817: pageVersionBody (read arbitrary version body)

--- a/Tests/WikiFSTests/SchemaV48MigrationTests.swift
+++ b/Tests/WikiFSTests/SchemaV48MigrationTests.swift
@@ -41,9 +41,9 @@ struct SchemaV48MigrationTests {
         )
     }
 
-    @Test func freshDatabaseHasV48Schema() throws {
+    @Test func freshDatabaseHasCurrentSchema() throws {
         let store = try TestStoreFactory.inMemory()
-        #expect(store.pragmaValue("user_version") == "48")
+        #expect(store.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
         #expect(store.scalarText("SELECT COUNT(*) FROM pragma_table_info('chat_turns') WHERE name = 'input_tokens'") == "1")
         #expect(store.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'page_version_sources'") == "1")
     }
@@ -62,15 +62,15 @@ struct SchemaV48MigrationTests {
 
     @Test func upgradeStampsVersionAfterCommit() throws {
         let store = try migrationStore(at: v47URL())
-        #expect(store.pragmaValue("user_version") == "48")
+        #expect(store.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
-    @Test func reopenV48IsIdempotent() throws {
+    @Test func reopenCurrentSchemaIsIdempotent() throws {
         let url = try v47URL()
         let first = try migrationStore(at: url)
         first.close()
         let reopened = try migrationStore(at: url)
-        #expect(reopened.pragmaValue("user_version") == "48")
+        #expect(reopened.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func rewoundV48SchemaRepairsSafely() throws {
@@ -78,7 +78,7 @@ struct SchemaV48MigrationTests {
         let first = try migrationStore(at: url)
         first.close()
         try MetadataSQLiteFixtureSupport.execute("PRAGMA user_version = 47", at: url)
-        #expect(try migrationStore(at: url).pragmaValue("user_version") == "48")
+        #expect(try migrationStore(at: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func freshAndUpgradeSchemasMatch() throws {
@@ -252,7 +252,7 @@ struct SchemaV48MigrationTests {
         // The store must open despite the orphans: the gate repairs the
         // cascade children, then re-checks clean.
         let store = try migrationStore(at: url)
-        #expect(store.pragmaValue("user_version") == "48")
+        #expect(store.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
         #expect(try scalar("SELECT COUNT(*) FROM source_chunks WHERE source_id = 'ghost-source'", at: url) == "0")
         #expect(try scalar("SELECT COUNT(*) FROM source_search WHERE source_id = 'ghost-source'", at: url) == "0")
         #expect(try scalar("SELECT COUNT(*) FROM pragma_foreign_key_check", at: url) == "0")
@@ -300,7 +300,7 @@ struct SchemaV48MigrationTests {
     @Test func retryAfterEnablingForeignKeyEnforcementSucceeds() throws {
         let url = try v47URL()
         do { _ = try migrationStore(at: url, foreignKeysEnabled: false) } catch { }
-        #expect(try migrationStore(at: url).pragmaValue("user_version") == "48")
+        #expect(try migrationStore(at: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func injectedForeignKeyResultMapsToTypedViolation() throws {
@@ -358,14 +358,14 @@ struct SchemaV48MigrationTests {
         )
         let url = try v47URL()
         do { _ = try migrationStore(at: url, checker: checker) } catch { }
-        #expect(try migrationStore(at: url).pragmaValue("user_version") == "48")
+        #expect(try migrationStore(at: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func retryAfterReplacingThrowingCheckerWithProductionCheckerSucceeds() throws {
         let throwing = SchemaForeignKeyChecker(verifyEnforcement: { _ in }, check: { _ in throw Sentinel() })
         let url = try v47URL()
         do { _ = try migrationStore(at: url, checker: throwing) } catch { }
-        #expect(try migrationStore(at: url).pragmaValue("user_version") == "48")
+        #expect(try migrationStore(at: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func failedUpgradeRollsBackAndRetries() throws {
@@ -375,7 +375,7 @@ struct SchemaV48MigrationTests {
         let url = try v47URL()
         do { _ = try migrationStore(at: url, hooks: hooks) } catch { }
         try assertV48ObjectsAbsent(at: url)
-        #expect(try migrationStore(at: url).pragmaValue("user_version") == "48")
+        #expect(try migrationStore(at: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func injectedForeignKeyCheckerRunsAtExactFinalSchemaCheckpoint() throws {
@@ -400,7 +400,7 @@ struct SchemaV48MigrationTests {
         )
         let store = try migrationStore(at: v47URL(), hooks: hooks, checker: checker)
         #expect(recorder.events == ["verify", "cleanup", "copy", "check"])
-        #expect(store.pragmaValue("user_version") == "48")
+        #expect(store.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func readOnlyV47ReturnsCompatibilityEmptyValues() throws {
@@ -446,14 +446,14 @@ struct SchemaV48MigrationTests {
 
     @Test func migrationHooksAreInternalAndProductionDefaultsAreNoOp() throws {
         let store = try migrationStore(at: v47URL(), hooks: .productionDefault, checker: .productionDefault())
-        #expect(store.pragmaValue("user_version") == "48")
+        #expect(store.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func productionForeignKeyCheckerIsRestoredPerStoreInstance() throws {
         let url = try v47URL()
         let rejecting = SchemaForeignKeyChecker(verifyEnforcement: { _ in throw Sentinel() }, check: { _ in [] })
         do { _ = try migrationStore(at: url, checker: rejecting) } catch { }
-        #expect(try migrationStore(at: url).pragmaValue("user_version") == "48")
+        #expect(try migrationStore(at: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func injectedForeignKeyCheckerStateDoesNotLeakAfterRollbackAndReopen() throws {
@@ -463,12 +463,12 @@ struct SchemaV48MigrationTests {
             check: { _ in [.init(table: "child", rowID: 1, parentTable: "parent", foreignKeyIndex: 0)] }
         )
         do { _ = try migrationStore(at: url, checker: rejecting) } catch { }
-        #expect(try migrationStore(at: url).pragmaValue("user_version") == "48")
+        #expect(try migrationStore(at: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func fixtureFactoryUsesFreshProductionCheckerByDefault() throws {
         let url = try v47URL()
-        #expect(try GRDBWikiStore(databaseURL: url).pragmaValue("user_version") == "48")
+        #expect(try GRDBWikiStore(databaseURL: url).pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
     }
 
     @Test func foreignKeysAreEnabled() throws {

--- a/Tests/WikiFSTests/SourceVersionIDPersistenceTests.swift
+++ b/Tests/WikiFSTests/SourceVersionIDPersistenceTests.swift
@@ -13,7 +13,7 @@ import Testing
 /// `sources.id` and markdown-version `PageID`s.
 struct SourceVersionIDPersistenceTests {
 
-    private let currentSchemaVersion = "48"
+    private let currentSchemaVersion = "49"
     private let legacySourceID = "01JSOURCEVERSIONFIXTURE000001"
     private let legacyVersionV1 = "01JSOURCEVERSION000000000001"
     private let legacyVersionV2 = "01JSOURCEVERSION000000000002"

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -872,6 +872,13 @@ struct WikiCtlCommandTests {
         #expect(name.hasPrefix(WikiChangeNotification.baseName))
     }
 
+    @Test func rendererWakeNamesCarryOnlyScopeIdentity() throws {
+        let wikiID = WikiID(rawValue: "01ABCDEF")
+        let machineID = try RendererMachineScopeID(validating: "machine.example")
+        #expect(RendererChangeNotification.wikiName(forWikiID: wikiID) == "org.sockpuppet.wiki.renderers.wiki.changed.01ABCDEF")
+        #expect(RendererChangeNotification.machineName(for: machineID) == "org.sockpuppet.wiki.renderers.machine.changed.machine.example")
+    }
+
     // MARK: - Markdown auto-fix (wikictl page add)
 
     /// Resolve the committed bundles relative to this test file for injection.

--- a/Tests/WikiFSTypesRendererTests/RendererModelTests.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererModelTests.swift
@@ -256,6 +256,41 @@ struct RendererDescriptorValidationTests {
     }
 }
 
+struct RendererPhase3PortableTests {
+    @Test func offsetBearingTimestampRejectsZAndAcceptsNumericOffset() throws {
+        #expect(RFC3339Timestamp(rawValue: "2026-08-04T12:34:56Z") == nil)
+        let timestamp = try RFC3339Timestamp(validating: "2026-08-04T12:34:56+00:00")
+        #expect(timestamp.rawValue.hasSuffix("+00:00"))
+    }
+
+    @Test func envelopePayloadRoundTrip() throws {
+        let packageID = try RendererPackageID(validating: "org.example.viewer")
+        let version = try RendererPackageVersion(validating: "1.2.3")
+        let payload = WikiStoreChangeEvent.rendererSettings(
+            .machineInstallStateChanged(packageID: packageID, version: version)
+        )
+        let record = try PersistedWikiStoreChangeRecord(
+            eventID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            sequence: 42,
+            scope: .machine(try RendererMachineScopeID(validating: "machine.example")),
+            payload: payload,
+            committedAt: try RFC3339Timestamp(validating: "2026-08-04T12:34:56+00:00")
+        )
+        let decoded = try JSONDecoder().decode(PersistedWikiStoreChangeRecord.self, from: JSONEncoder().encode(record))
+        #expect(decoded == record)
+    }
+
+    @Test func namedPolicyDefaultsMatchApprovedPhase3Timing() {
+        let policy = RendererEventPolicy.phase3Default
+        #expect(policy.heartbeatInterval == 10)
+        #expect(policy.leaseExpiry == 45)
+        #expect(policy.clockSkewSafetyMargin == 15)
+        #expect(policy.cleanRetirementSafetyInterval == 5 * 60)
+        #expect(policy.lockAcquisitionTimeout == 30)
+        #expect(policy.orderedDrainBatchLimit == 256)
+    }
+}
+
 struct RendererPackageHashTests {
     @Test func canonicalEnvelopeGoldenDigestAndOrderIndependence() throws {
         let packageID = RendererFixtures.packageID

--- a/Tests/WikiFSTypesRendererTests/RendererModelTests.swift
+++ b/Tests/WikiFSTypesRendererTests/RendererModelTests.swift
@@ -280,6 +280,27 @@ struct RendererPhase3PortableTests {
         #expect(decoded == record)
     }
 
+    @Test func envelopeResourcePayloadRoundTripUsesSameDiscriminatedEvent() throws {
+        let payload = WikiStoreChangeEvent.resource(ResourceChangeEvent(
+            wikiID: WikiID(rawValue: "wiki-event-contract"),
+            kind: .source,
+            id: "source-1",
+            change: .updated,
+            seq: 7
+        ))
+        let record = try PersistedWikiStoreChangeRecord(
+            eventID: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            sequence: 43,
+            scope: .wiki(WikiID(rawValue: "wiki-event-contract")),
+            payload: payload,
+            committedAt: try RFC3339Timestamp(validating: "2026-08-04T12:34:56+00:00")
+        )
+
+        let decoded = try JSONDecoder().decode(PersistedWikiStoreChangeRecord.self, from: JSONEncoder().encode(record))
+
+        #expect(decoded == record)
+    }
+
     @Test func namedPolicyDefaultsMatchApprovedPhase3Timing() {
         let policy = RendererEventPolicy.phase3Default
         #expect(policy.heartbeatInterval == 10)

--- a/plans/dynamic-renderers-phase3-readiness.md
+++ b/plans/dynamic-renderers-phase3-readiness.md
@@ -22,9 +22,17 @@ Current evidence:
 - [`createFreshSchema(on:)`](../Sources/WikiFSCore/Store/GRDBWikiStore.swift) is the fresh-schema authority.
 - [`StoreBackend`](../Sources/WikiFSCore/Store/StoreBackend.swift) uses GRDB as the sole production backend.
 
-## Bootstrap decisions to make
+## Bootstrap decisions
 
-These are implementation choices for Phase 3 bootstrap. They are not a redesign.
+These implementation choices are approved for Phase 3 bootstrap. They do not redesign the reviewed implementation plan.
+
+- Machine metadata is authoritative in SQLite under the resolved App Group renderers root.
+- The JSON index is derived from SQLite and regenerated atomically.
+- The machine coordinator uses a POSIX `O_CREAT|O_EXCL` lock file with ownership, bounded retry, and stale-owner recovery.
+- Phase 3 timing defaults are: heartbeat 10 seconds, expiry 45 seconds, clock-skew safety margin 15 seconds, clean-retirement safety interval 5 minutes, lock acquisition timeout 30 seconds, and ordered drain batch limit 256.
+- Retention age and count remain deferred.
+
+This bounded first increment implements the portable Phase 3 values and the wiki-scoped v49 settings and journal foundation first. The machine SQLite store, JSON index, and POSIX coordinator remain the next bounded increment.
 
 ### Machine package-store coordination
 


### PR DESCRIPTION
## Summary

Implement the bounded first persistence increment for Dynamic Renderers Phase 3 (#1026).

- Add portable, typed renderer settings and persisted change-event contracts.
- Move resource event payload types to `WikiFSTypes` so one discriminated persisted event supports resource and renderer-settings cases without a `WikiFSTypes` to `WikiFSCore` dependency.
- Add schema v49 renderer enablement, source preference, event-journal, lease, cursor, and checkpoint tables, with fresh-schema and migration parity.
- Add typed `WikiStore`/`GRDBWikiStore` APIs and transactional wiki settings/journal writes.
- Emit one local renderer-settings event and one payload-free Darwin wiki wake only after a successful commit.
- Add fail-closed journal UUID decoding and v49 migration/rollback/wake/event regression coverage.

## Deliberately deferred

This PR does not implement the machine metadata SQLite store, derived JSON index, POSIX lock coordinator, package validation/activation, ordered journal drains, active lease heartbeat/reclamation, compaction, model fan-out, or renderer bridge integration. These remain the next Phase 3 bounded increment as recorded in `plans/dynamic-renderers-phase3-readiness.md`.

## Validation

- `make build`
- `make test` — 3109 tests in 264 suites passed
- `swift build`
- `swift test`
- `swift test --filter RendererPhase3PortableTests --filter RendererSettingsStoreTests`
- `swift test --filter SchemaV48MigrationTests --filter WikiEventBusTests --filter WikiChangeBridgeBusTests`
- `git diff --check origin/main...HEAD`

## Review

Independent final review found no critical, high, medium, or low findings. It also verified transactional post-commit wake behavior, v49 fresh/upgrade schema parity, UUID fail-closed decoding, resource-event compatibility, typed boundaries, and Darwin wake privacy.

Issue: #1026
