### PR TITLE
fix(reader): normalize typographic quotes in quoted text highlighting

### DIFF
--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1509,7 +1509,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
             var p=m.parentNode; while(m.firstChild) p.insertBefore(m.firstChild,m);
             p.removeChild(m); p.normalize();
           });
-          var nq=q.replace(/\\s+/g," ").trim().toLowerCase();
+          // Source extraction can convert straight quotes in a cite anchor to
+          // typographic quotes in the rendered text. Normalize only the
+          // comparison view: each replacement is one character, so `map` still
+          // indexes the original DOM text used to construct the Range.
+          function normalizeQuotes(s){ return s.replace(/[“”]/g,'"'); }
+          var nq=normalizeQuotes(q).replace(/\\s+/g," ").trim().toLowerCase();
           if(!nq){ return; }
           var chars=[], map=[];
           var tw=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -1519,7 +1524,7 @@ internal struct WikiReaderRep: NSViewRepresentable {
               var c=v[i];
               if(/\\s/.test(c)){
                 if(chars.length===0||chars[chars.length-1]!==" "){ chars.push(" "); map.push({n:tw.currentNode,o:i}); }
-              } else { chars.push(c.toLowerCase()); map.push({n:tw.currentNode,o:i}); }
+              } else { chars.push(normalizeQuotes(c).toLowerCase()); map.push({n:tw.currentNode,o:i}); }
             }
           }
           var lo=0, hi=chars.length;

--- a/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
@@ -180,11 +180,12 @@ struct QuoteHighlightWebViewTests {
         let (lease, window, webView) = await makeHostedWebView()
         defer { Self.releaseWindow(window); lease.release() }
         let quote = #"The location for tests is in the "test" folder."#
-        try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML("<p>\(quote)</p>"))
+        let renderedQuote = #"The location for tests is in the “test” folder."#
+        try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML("<p>\(renderedQuote)</p>"))
 
         await run(webView, WikiReaderRep.highlightJS(quote: quote))
 
-        #expect(await markText(in: webView) == quote)
+        #expect(await markText(in: webView) == renderedQuote)
     }
 
     @Test func highlightMatchesAcrossCollapsedWhitespace() async throws {

--- a/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
@@ -175,6 +175,18 @@ struct QuoteHighlightWebViewTests {
         #expect(exact.lowercased() == "clear improvement")
     }
 
+    @Test("#1059 highlight retains quoted text inside a quoted source fragment")
+    func highlightWrapsQuoteContainingInnerQuotationMarks() async throws {
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
+        let quote = #"The location for tests is in the "test" folder."#
+        try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML("<p>\(quote)</p>"))
+
+        await run(webView, WikiReaderRep.highlightJS(quote: quote))
+
+        #expect(await markText(in: webView) == quote)
+    }
+
     @Test func highlightMatchesAcrossCollapsedWhitespace() async throws {
         // The source has extra internal whitespace / a newline; the quote is
         // single-spaced. The index-map fallback must still wrap the match.


### PR DESCRIPTION
## Problem

When source text contains straight quotes that render as typographic (curly) quotes in HTML, quote highlighting fails to match because the algorithm compares straight quotes against typographic quotes.

## Solution

Add a `normalizeQuotes()` function that converts typographic quotes to straight quotes. Apply normalization to:

1. The input query string before whitespace and case normalization
2. Each character when building the character array for text matching

This ensures consistent comparison. The character map remains valid because each typographic quote maps to exactly one straight quote, preserving the DOM position tracking used by the Range construction.

## Testing

Added test case for #1059 verifying that highlighted quoted text correctly matches and wraps when containing inner quotation marks rendered as typographic quotes.