### PR TITLE
fix(reader): normalize typography variants in quote highlights

### DIFF
--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1509,12 +1509,17 @@ internal struct WikiReaderRep: NSViewRepresentable {
             var p=m.parentNode; while(m.firstChild) p.insertBefore(m.firstChild,m);
             p.removeChild(m); p.normalize();
           });
-          // Source extraction can convert straight quotes in a cite anchor to
-          // typographic quotes in the rendered text. Normalize only the
-          // comparison view: each replacement is one character, so `map` still
-          // indexes the original DOM text used to construct the Range.
-          function normalizeQuotes(s){ return s.replace(/[“”]/g,'"'); }
-          var nq=normalizeQuotes(q).replace(/\\s+/g," ").trim().toLowerCase();
+          // Source extraction can convert citation text into editorial
+          // typography. Normalize only the comparison view. A character may
+          // expand (for example, `…` → `...`), so every normalized character
+          // retains the original DOM node + offset in `map`.
+          function normalizeTypography(s){
+            return s.replace(/[“”]/g,'"').replace(/[‘’]/g,"'")
+              .replace(/[‐‑‒–—―−]/g,"-").replace(/…/g,"...")
+              .replace(/ﬀ/g,"ff").replace(/ﬁ/g,"fi").replace(/ﬂ/g,"fl")
+              .replace(/ﬃ/g,"ffi").replace(/ﬄ/g,"ffl").replace(/[ﬅﬆ]/g,"st");
+          }
+          var nq=normalizeTypography(q).replace(/\\s+/g," ").trim().toLowerCase();
           if(!nq){ return; }
           var chars=[], map=[];
           var tw=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -1524,7 +1529,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
               var c=v[i];
               if(/\\s/.test(c)){
                 if(chars.length===0||chars[chars.length-1]!==" "){ chars.push(" "); map.push({n:tw.currentNode,o:i}); }
-              } else { chars.push(normalizeQuotes(c).toLowerCase()); map.push({n:tw.currentNode,o:i}); }
+              } else {
+                var normalized=normalizeTypography(c).toLowerCase();
+                for(var j=0;j<normalized.length;j++){
+                  chars.push(normalized[j]); map.push({n:tw.currentNode,o:i});
+                }
+              }
             }
           }
           var lo=0, hi=chars.length;

--- a/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
+++ b/Tests/WikiFSAppTests/QuoteHighlightWebViewTests.swift
@@ -188,6 +188,19 @@ struct QuoteHighlightWebViewTests {
         #expect(await markText(in: webView) == renderedQuote)
     }
 
+    @Test("#1059 highlight normalizes source typography without changing its selection")
+    func highlightMatchesRenderedTypographyVariants() async throws {
+        let (lease, window, webView) = await makeHostedWebView()
+        defer { Self.releaseWindow(window); lease.release() }
+        let quote = #""quoted" 'single' office - example ..."#
+        let renderedQuote = #"“quoted” ‘single’ ofﬁce — example …"#
+        try await NavigationWaiter().wait(for: webView, html: WikiReaderView.documentHTML("<p>\(renderedQuote)</p>"))
+
+        await run(webView, WikiReaderRep.highlightJS(quote: quote))
+
+        #expect(await markText(in: webView) == renderedQuote)
+    }
+
     @Test func highlightMatchesAcrossCollapsedWhitespace() async throws {
         // The source has extra internal whitespace / a newline; the quote is
         // single-spaced. The index-map fallback must still wrap the match.


### PR DESCRIPTION
## Summary

Expanded source text normalization in quote highlighting to handle typographic variants beyond curly quotes. The source extraction can produce editorial typography (ligatures, dashes, ellipsis) that differs from the original quote text, causing highlights to fail. Now normalizes a comprehensive set of variants:

- Smart quotes (U+201C, U+201D to straight quotes)
- Single quotes (U+2018, U+2019 to apostrophe)
- Dashes and hyphens (various Unicode dash variants to hyphen-minus)
- Ellipsis (U+2026 to three dots)
- Ligatures (ff, fi, fl, ffi, ffl, st variants)

## Changes

- Renamed normalizeQuotes to normalizeTypography with expanded replacement patterns
- Fixed character-by-character mapping to handle multi-character expansions (e.g., ellipsis becomes three dots), where each expanded character maps to the original DOM position
- Added test case verifying highlight matches when source contains typographic variants

## Test

New test highlightMatchesRenderedTypographyVariants validates that quote highlighting correctly matches rendered text with smart quotes, ligatures, dashes, and ellipsis variants.