### PR TITLE
Fix footnote navigation in the page reader

### DIFF
--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1278,6 +1278,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
                     decisionHandler(.cancel)
                     return
                 }
+                // A fragment-only link resolves against the synthetic reader origin.
+                // Allow it so WKWebView scrolls to the target within this document.
+                if WikiReaderOrigin.isSameDocumentFragment(url) {
+                    decisionHandler(.allow)
+                    return
+                }
                 // Relative links in source markdown (e.g. `[Back to README](../README.md)`)
                 // are not `[[wikilinks]]`, so `RelativeLinkRewriter` leaves them as raw
                 // `<a href>`. WKWebView resolves them against the synthetic reader origin

--- a/Sources/WikiFSCore/Integrations/ExternalEmbed.swift
+++ b/Sources/WikiFSCore/Integrations/ExternalEmbed.swift
@@ -78,6 +78,22 @@ public enum WikiReaderOrigin {
     public static let string = "https://reader.wikifs.invalid"
     /// The same origin as a `URL`, for `loadHTMLString(baseURL:)`.
     public static var url: URL? { URL(string: string) }
+
+    /// Returns `true` for a fragment link within the reader document.
+    ///
+    /// `WKWebView` resolves `href="#target"` against `url`. The resulting URL
+    /// must bypass relative source-link routing so WebKit can scroll to the target.
+    public static func isSameDocumentFragment(_ url: URL) -> Bool {
+        guard let origin = Self.url,
+              url.scheme == origin.scheme,
+              url.host == origin.host,
+              url.port == origin.port,
+              url.fragment != nil,
+              url.query == nil else {
+            return false
+        }
+        return url.path.isEmpty || url.path == "/"
+    }
 }
 
 // MARK: - ExternalEmbed (pure dispatch table)

--- a/Tests/WikiFSAppTests/WikiReaderRoutingTests.swift
+++ b/Tests/WikiFSAppTests/WikiReaderRoutingTests.swift
@@ -56,6 +56,16 @@ struct WikiReaderRoutingTests {
         #expect(WikiReaderView.linkRoute(for: url) == .inert)
     }
 
+    @Test func syntheticOriginFootnoteFragmentIsSameDocument() {
+        let url = URL(string: "https://reader.wikifs.invalid/#wiki-fn-n10")!
+        #expect(WikiReaderOrigin.isSameDocumentFragment(url))
+    }
+
+    @Test func syntheticOriginRelativeSourceLinkIsNotSameDocumentFragment() {
+        let url = URL(string: "https://reader.wikifs.invalid/docs/README.md#install")!
+        #expect(!WikiReaderOrigin.isSameDocumentFragment(url))
+    }
+
     // MARK: - Phase 5 canonical `?id=` routing (AC.7)
 
     @Test func canonicalPageLinkCarriesId() {


### PR DESCRIPTION
## Summary

- Allow same-document footnote fragments at the synthetic reader origin.
- Keep relative Markdown source links on the existing source-navigation path.
- Add routing regression tests for both URL forms.

## Cause

WKWebView resolves a footnote link such as `#wiki-fn-n10` to the synthetic reader URL. The reader treated that URL as a relative source link and canceled it before WebKit could scroll to the anchor.

## Verification

- `WIKIFS_APP_TESTS=1 swift test --filter WikiReaderRoutingTests`
- `make build`
