### PR TITLE
Open configured home page when a wiki launches

### DIFF
--- a/Sources/WikiFS/Window/RootScene.swift
+++ b/Sources/WikiFS/Window/RootScene.swift
@@ -249,6 +249,9 @@ struct RootScene: View {
                 return
             }
             session = resolved
+            if resolved.store.openHomePageIfConfigured(homePageID: descriptor.homePageID) {
+                DebugLog.tabs("RootScene [Opening wiki]: opened configured home page for wikiID=\(wikiID.rawValue)")
+            }
             // Wire the File Provider bus subscription for this wiki's session.
             fileProvider.subscribeBus(for: wikiID, bus: resolved.store.eventBus)
             Task { await fileProvider.activate(id: descriptor.id, displayName: descriptor.displayName) }

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -593,6 +593,14 @@ public final class WikiStoreModel {
         return true
     }
 
+    /// Opens the configured home page when it still exists in this wiki.
+    /// Returns `false` for an unset or stale home-page ID.
+    @discardableResult
+    public func openHomePageIfConfigured(homePageID: PageID?) -> Bool {
+        guard let homePageID else { return false }
+        return selectPage(byID: homePageID)
+    }
+
     // MARK: - Source link resolution
 
     /// Existence check for `[[source:…]]` linkification: returns `true` when a

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -24,6 +24,23 @@ struct EditorTabTests {
         #expect(model.recentlyClosedTabs.isEmpty)
     }
 
+    @Test func openingConfiguredHomePageCreatesTheHomeTab() throws {
+        let (model, store) = try tempModel()
+        let home = try store.createPage(title: "Home")
+        model.reloadFromStore()
+
+        #expect(model.openHomePageIfConfigured(homePageID: home.id))
+        #expect(model.activeTab?.selection == .page(home.id))
+    }
+
+    @Test func openingMissingConfiguredHomePageDoesNothing() throws {
+        let (model, _) = try tempModel()
+        let missingHomeID = PageID(rawValue: ULID.generate())
+
+        #expect(!model.openHomePageIfConfigured(homePageID: missingHomeID))
+        #expect(model.tabs.isEmpty)
+    }
+
     // MARK: - Sidebar-driven selection creates tabs
 
     @Test func firstSidebarSelectionCreatesInitialTab() throws {


### PR DESCRIPTION
## Summary
- Open each wiki’s configured home page when its session is resolved.
- Add `openHomePageIfConfigured` to safely handle unset or stale home-page IDs.
- Add tests covering successful home-page tab creation and missing-page behavior.

## Why
Ensures users land on their configured home page when opening a wiki, while avoiding changes when the configuration is unset or references a deleted page.