### PR TITLE
fix(test): update tool output fence-stripping expectations

### DIFF
--- a/Tests/WikiFSAppTests/LauncherChatAgentRuntimeTests.swift
+++ b/Tests/WikiFSAppTests/LauncherChatAgentRuntimeTests.swift
@@ -38,8 +38,8 @@ struct LauncherChatAgentRuntimeTests {
     }
 
     @Test(arguments: [
-        ("```console\n<command-output>\n```", "```console\n&lt;command-output&gt;\n```"),
-        ("```json\n{\"ok\": true}\n```", "```json\n{\"ok\": true}\n```"),
+        ("```console\n<command-output>\n```", "&lt;command-output&gt;"),
+        ("```json\n{\"ok\": true}\n```", "{\"ok\": true}"),
         ("build completed", "build completed"),
     ])
     @MainActor


### PR DESCRIPTION
## Summary

The chat HTML renderer now strips fenced-code markers from tool output before placing content in a `<pre>` tag. The `LauncherChatAgentRuntimeTests` expectations still expected the raw triple-backtick wrappers to appear in the rendered HTML.

## Change

Update two test argument tuples so the expected `escapedOutput` contains only the inner content:

- `` ```json\n{"ok": true}\n``` `` → expected `{"ok": true}` (was the full fenced block)
- `` ```console\n<command-output>\n``` `` → expected `&lt;command-output&gt;` (was the full fenced block)

The third case (`"build completed"`) has no fences and is unchanged.

## Verification

`WIKIFS_APP_TESTS=1 swift test --filter LauncherChatAgentRuntimeTests` — all 3 test cases pass.
