### PR TITLE
fix(chat): keep streamed assistant text when the overlay drops

### DIFF
--- a/Sources/WikiFSEngine/ChatClientSync.swift
+++ b/Sources/WikiFSEngine/ChatClientSync.swift
@@ -112,9 +112,13 @@ public enum ChatClientSyncReducer {
         }
 
         let preservedProjection = validatingActiveContentBlock(
-            in: preservingLoadedHistory(
-            snapshot.projection,
-            loadedCommittedCursor: state.loadedCommittedCursor
+            in: preservingOverlayForStaleCommittedItems(
+                currentOverlay: state.projection?.transcriptOverlay ?? [],
+                incomingProjection: preservingLoadedHistory(
+                    snapshot.projection,
+                    loadedCommittedCursor: state.loadedCommittedCursor
+                ),
+                committedItems: state.committedItems
             ),
             committedItems: state.committedItems
         )
@@ -468,8 +472,50 @@ public enum ChatClientSyncReducer {
             committedItems: committedItems
         )
         return validatingActiveContentBlock(
-            in: terminalNormalized,
+            in: preservingOverlayForStaleCommittedItems(
+                currentOverlay: currentProjection.transcriptOverlay,
+                incomingProjection: terminalNormalized,
+                committedItems: committedItems
+            ),
             committedItems: committedItems
+        )
+    }
+
+    /// A committed transcript row is rewritten IN PLACE while its message
+    /// streams — the same cursor grows from the first chunk to the final text.
+    /// The wire's committed cursor does not advance for such a rewrite, so a
+    /// client that loaded that row mid-stream never reloads it and holds a
+    /// prefix of the final text. While the row is also in the overlay that
+    /// staleness is invisible; the moment an incoming projection drops the
+    /// overlay (turn completion, a re-hydrated snapshot, gap recovery) the
+    /// display would fall back to the prefix and the response would appear cut
+    /// off. Retain such an overlay item until the committed copy the client
+    /// holds agrees with it — `pruningCommittedOverlay` then drops it for real
+    /// once a reloaded page carries the final text.
+    private static func preservingOverlayForStaleCommittedItems(
+        currentOverlay: [ChatTranscriptItem],
+        incomingProjection: ChatSyncProjection,
+        committedItems: [PersistedChatTranscriptItem]
+    ) -> ChatSyncProjection {
+        guard currentOverlay.isEmpty == false else { return incomingProjection }
+
+        let incomingIdentities = Set(incomingProjection.transcriptOverlay.map(transcriptIdentity(for:)))
+        let retained = currentOverlay.filter { overlayItem in
+            let identity = transcriptIdentity(for: overlayItem)
+            guard incomingIdentities.contains(identity) == false else { return false }
+            guard let committedItem = committedItems.last(where: {
+                transcriptIdentity(for: $0.item) == identity
+            })?.item else {
+                // No committed copy is loaded, so nothing stale can surface.
+                return false
+            }
+            return transcriptItemsMatchForDisplay(committedItem, overlayItem) == false
+        }
+        guard retained.isEmpty == false else { return incomingProjection }
+
+        return replacingOverlay(
+            in: incomingProjection,
+            with: mergingOverlay(retained, with: incomingProjection.transcriptOverlay)
         )
     }
 

--- a/Tests/WikiFSAppTests/ChatStreamedTextCommitRefreshTests.swift
+++ b/Tests/WikiFSAppTests/ChatStreamedTextCommitRefreshTests.swift
@@ -1,0 +1,170 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+@testable import WikiFSEngine
+@testable import wikid
+
+/// End-to-end regression for streamed assistant text (daemon → wire → client).
+///
+/// The daemon rewrites a streaming message's committed row IN PLACE (same
+/// transcript cursor), so the committed cursor does not advance between the
+/// first chunk and the final text. A client that loaded that row after the
+/// first chunk therefore holds a prefix, and any projection that drops the live
+/// overlay used to expose it — the response rendered cut off mid-sentence.
+@MainActor
+struct ChatStreamedTextCommitRefreshTests {
+    private static let firstChunk = "Hello! What"
+    private static let secondChunk = " would you like to do with the wiki today?"
+    private static var fullText: String { firstChunk + secondChunk }
+
+    @Test func streamedAssistantTextSurvivesReHydration() async throws {
+        let harness = try StreamingHarness()
+        defer { harness.tearDown() }
+
+        try await harness.streamOneAssistantTurn(
+            commandID: "command-stream",
+            turnID: "turn-stream"
+        )
+        #expect(harness.assistantText == Self.fullText)
+
+        // A re-hydrated snapshot (view re-appear, reconnect, gap recovery)
+        // carries no overlay: the client must not fall back to the committed
+        // copy it loaded mid-stream.
+        harness.session.hydrate(from: try await harness.controller.chatSyncSnapshot())
+        try await harness.drainClientEffects()
+
+        #expect(harness.assistantText == Self.fullText)
+    }
+
+    @Test func earlierTurnKeepsFullStreamedTextWhenTheNextTurnIsSubmitted() async throws {
+        let harness = try StreamingHarness()
+        defer { harness.tearDown() }
+
+        try await harness.streamOneAssistantTurn(
+            commandID: "command-first",
+            turnID: "turn-first"
+        )
+        #expect(harness.assistantText == Self.fullText)
+
+        // The next submission commits a new user row, which advances the
+        // committed cursor and replaces the overlay.
+        _ = try await harness.controller.submit(
+            harness.controllerHarness.makeSubmitRequest(
+                submission: harness.controllerHarness.makeSubmission(
+                    commandID: "command-second",
+                    turnID: "turn-second",
+                    text: "say a full sentence"
+                )
+            )
+        )
+        try await harness.drainClientEffects()
+
+        #expect(harness.assistantText == Self.fullText)
+    }
+
+    /// Wires a real `DaemonChatController` to a real `RemoteChatSession` over
+    /// the same serialized envelope delivery the XPC sink provides.
+    @MainActor
+    private final class StreamingHarness {
+        let controllerHarness: ControllerHarness
+        let controller: DaemonChatController
+        let session: RemoteChatSession
+        private let envelopeContinuation: AsyncStream<QueueEventEnvelope>.Continuation
+        private let router: Task<Void, Never>
+
+        init() throws {
+            let controllerHarness = try ControllerHarness()
+            let store = controllerHarness.store
+            let chatID = controllerHarness.chat.id
+            let session = RemoteChatSession(chatID: .chat(chatID))
+            session.installHistoryLoader { after in
+                try store.readChatTranscriptPage(chatID: chatID, after: after, limit: 200)
+            }
+
+            let (envelopes, continuation) = AsyncStream.makeStream(of: QueueEventEnvelope.self)
+            let controller = try DaemonChatController(
+                chatID: chatID,
+                wikiID: WikiID(rawValue: "wiki-controller"),
+                store: store,
+                runtime: controllerHarness.runtime,
+                pushEvent: { continuation.yield($0) }
+            )
+            session.onRequestAuthoritativeSnapshot = { try await controller.chatSyncSnapshot() }
+
+            self.controllerHarness = controllerHarness
+            self.controller = controller
+            self.session = session
+            self.envelopeContinuation = continuation
+            self.router = Task { @MainActor in
+                for await envelope in envelopes {
+                    session.ingest(envelope)
+                }
+            }
+        }
+
+        func tearDown() {
+            envelopeContinuation.finish()
+            router.cancel()
+        }
+
+        var assistantText: String? {
+            session.displayTranscript.rows.compactMap { row -> String? in
+                guard case .assistantMessage(_, _, let text, _, _) = row else { return nil }
+                return text
+            }.last
+        }
+
+        /// Submits one turn, streams the canned two-chunk reply exactly as the
+        /// provider does, and completes it.
+        func streamOneAssistantTurn(commandID: String, turnID: String) async throws {
+            session.hydrate(from: try await controller.chatSyncSnapshot())
+            let submission = controllerHarness.makeSubmission(commandID: commandID, turnID: turnID)
+            _ = try await controller.submit(controllerHarness.makeSubmitRequest(submission: submission))
+
+            var translator = AgentEventTranscriptTranslator()
+            await controllerHarness.runtime.emit(.transcript(
+                translator.translate([.assistantTextDelta(firstChunk)], turnID: submission.turnID)
+            ))
+            try await waitForAssistantText(firstChunk)
+
+            await controllerHarness.runtime.emit(.transcript(
+                translator.translate([.assistantTextDelta(secondChunk)], turnID: submission.turnID)
+            ))
+            try await waitForAssistantText(firstChunk + secondChunk)
+
+            await controllerHarness.runtime.emit(.turnCompleted(submission.turnID))
+            try await waitForClearedOverlay()
+            try await drainClientEffects()
+        }
+
+        private var firstChunk: String { ChatStreamedTextCommitRefreshTests.firstChunk }
+        private var secondChunk: String { ChatStreamedTextCommitRefreshTests.secondChunk }
+
+        private func waitForAssistantText(_ expected: String) async throws {
+            for _ in 0..<100 {
+                if assistantText == expected { return }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            Issue.record("timed out waiting for streamed text; last=\(String(describing: assistantText))")
+        }
+
+        private func waitForClearedOverlay() async throws {
+            for _ in 0..<100 {
+                if await controller.typedSnapshot().transientTranscriptOverlay.isEmpty { return }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            Issue.record("timed out waiting for the daemon overlay to clear")
+        }
+
+        /// Lets every queued client effect (committed-history paging) finish.
+        func drainClientEffects() async throws {
+            for _ in 0..<20 {
+                await Task.yield()
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
A streaming message's committed transcript row is rewritten in place at the same cursor, so `committedCursor` never advances between the first chunk and the final text. The client only reloads committed rows when that cursor advances, so a row loaded mid-stream keeps a prefix of the reply forever.

The overlay masked this while it held the same message. As soon as an incoming projection dropped the overlay — turn completion, the next submission, a re-hydrated snapshot, gap recovery — the display fell back to the stale prefix and the response rendered cut off mid-sentence, even though the store held the complete text.

## Fix

Retain an overlay item whenever the committed copy the client holds disagrees with it. `pruningCommittedOverlay` still drops it once a reloaded page carries the final text. This also covers tool-call rows, which are upserted in place the same way.

## Tests

Adds an end-to-end regression through the real controller, wire, and client session, streaming the same two chunks the provider sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
