### PR TITLE
fix(build): resolve tree-sitter ICU includes to the vendored subset

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -112,6 +112,14 @@ let package = Package(
             ],
             publicHeadersPath: "include",
             cSettings: [
+                // Upstream Tree-sitter compiles its runtime with `-Isrc`, and its
+                // vendored ICU subset relies on it: Runtime/unicode/utf8.h asks for
+                // "unicode/umachine.h" and "unicode/utf.h", which only resolve to
+                // the pinned copies when Runtime/ is a header search root. Without
+                // this the includes fall through to the SDK's system ICU — dragging
+                // in urename.h and the deprecated utf_old.h, and silently swapping
+                // the pinned U8_*/U16_* decoding macros for the platform's.
+                .headerSearchPath("Runtime"),
                 // The pinned Scala scanner has optional stderr diagnostics behind
                 // DEBUG. Keep generated vendor bytes intact and prevent project
                 // build settings from enabling those diagnostics at runtime.


### PR DESCRIPTION
`Runtime/unicode/utf8.h` includes `"unicode/umachine.h"` and `"unicode/utf.h"`. From inside `Runtime/unicode/` those only resolve when `Runtime/` is a header search root, which it was not — so both fell through to the SDK's system ICU, dragging in `urename.h` and the deprecated `utf_old.h` and silently replacing the pinned `U8_*`/`U16_*` decode macros with the platform's.

That defeated the point of vendoring the ICU subset, and produced 7 `-Wambiguous-macro` / `-Wmacro-redefined` warnings per build.

## Fix

Add `.headerSearchPath("Runtime")` — the SwiftPM equivalent of the `-Isrc` upstream tree-sitter compiles its runtime with.

Decode behavior is unchanged: the pinned and system macros return identical offsets and code points over valid, invalid, and truncated UTF-8, including the `U_SENTINEL` error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
