### PR TITLE
fix(extraction): resolve bundled pdf2md via HelpersLocation

### DIFF
--- a/Sources/WikiFSEngine/PdfExtractionService.swift
+++ b/Sources/WikiFSEngine/PdfExtractionService.swift
@@ -478,12 +478,15 @@ public enum PdfExtractionService {
     private static func candidateLocations() -> [URL] {
         var dirs: [URL] = []
 
-        // 1. Bundled in the signed app (Contents/Helpers/pdf2md).
-        dirs.append(
-            Bundle.main.bundleURL
-                .appendingPathComponent("Contents", isDirectory: true)
-                .appendingPathComponent("Helpers", isDirectory: true)
-        )
+        // 1. Bundled in the signed app (Contents/Helpers/pdf2md). Resolved via
+        //    `HelpersLocation` rather than `Bundle.main` directly: in the bundled
+        //    `wikid` XPC service `Bundle.main` is `wikid.xpc`, so a naive
+        //    `bundleURL/Contents/Helpers` pointed inside the `.xpc` (no pdf2md
+        //    there) and `checkReady()` reported the ~2 GB deps as "not installed"
+        //    even on a fully provisioned machine. Same #887 nesting bug that #889
+        //    fixed for bun/wikictl — `HelpersLocation` walks up to the enclosing
+        //    `.app` so the app and the daemon share one Helpers dir.
+        dirs.append(URL(fileURLWithPath: HelpersLocation.wikictlDirectory, isDirectory: true))
 
         // 2. Dev build output dir (`build/pdf2md`), relative to cwd.
         dirs.append(URL(fileURLWithPath: "build", isDirectory: true))


### PR DESCRIPTION
`candidateLocations()` built the bundled-helpers path from `Bundle.main.bundleURL`. Inside the bundled `wikid` XPC service `Bundle.main` is `wikid.xpc`, so that resolved to `wikid.xpc/Contents/Helpers`, which holds no `pdf2md`. `checkReady()` then reported the ~2 GB extraction dependencies as "not installed" even on a fully provisioned machine.

## Fix

Resolve through `HelpersLocation.wikictlDirectory` instead, which walks up to the enclosing `.app` so the app and the daemon share one Helpers directory.

Same #887 bundle-nesting bug that #889 fixed for bun and wikictl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
