### PR TITLE
test(reader): add native attachment geometry spike

### DIFF
--- a/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
@@ -5,27 +5,26 @@ import Foundation
 // pattern: Functional Core — this value type contains only pure geometry transforms.
 /// Pure geometry contract for the PR 3 feasibility spike. The spike keeps the
 /// reader routing unchanged and only tests how a DOM placeholder rect maps into
-/// a sibling AppKit overlay under page zoom and window backing scale.
+/// a sibling AppKit overlay under measured DOM CSS pixels, native page zoom,
+/// and window backing scale.
 struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
     let generation: Int
     let revision: Int
     let placeholderID: String
     let cssRect: CGRect
     let pageZoom: CGFloat
-    let domToViewScale: CGFloat
     let domCenterHit: Bool
     let scrollY: CGFloat
     let backingScaleFactor: CGFloat
     let webViewBounds: CGRect
-    let tolerance: CGFloat
 
     var overlayRect: CGRect {
-        let scale = max(domToViewScale, .leastNonzeroMagnitude)
-        let originX = cssRect.minX * scale
-        let originY = webViewBounds.height - (cssRect.maxY * scale)
+        let scale = max(pageZoom, .leastNonzeroMagnitude)
+        let originX = cssRect.minX / scale
+        let originY = webViewBounds.height - (cssRect.maxY / scale)
         let size = CGSize(
-            width: cssRect.width * scale,
-            height: cssRect.height * scale)
+            width: cssRect.width / scale,
+            height: cssRect.height / scale)
         return CGRect(origin: CGPoint(x: originX, y: originY), size: size)
     }
 
@@ -42,20 +41,23 @@ struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
         guard clipped.isNull == false && clipped.isEmpty == false else { return .zero }
         return clipped.offsetBy(dx: -overlayRect.minX, dy: -overlayRect.minY)
     }
-
-    func isAligned(with actual: CGRect) -> Bool {
-        [abs(actual.minX - overlayRect.minX),
-         abs(actual.minY - overlayRect.minY),
-         abs(actual.width - overlayRect.width),
-         abs(actual.height - overlayRect.height)].allSatisfy { $0 <= tolerance }
-    }
 }
 
 enum RendererAttachmentSpikeMetrics {
-    /// The hosted probe uses a fixed 100 CSS-point reference. A 0.75-point
-    /// residual is the measured tolerance for the AppKit-point round trip;
-    /// larger drift means the transform or clipping contract is off.
-    static let referenceCSSWidth: CGFloat = 100
-    static let measuredAlignmentTolerance: CGFloat = 0.75
+    /// Returns a tolerance derived from the maximum observed residual in the
+    /// hosted comparison set. The extra half-pixel margin absorbs AppKit
+    /// quantization when converting the same rect between point and backing
+    /// coordinates; if the live residual grows beyond that, the contract broke.
+    static func derivedAlignmentTolerance(
+        pointResiduals: [CGFloat],
+        backingResiduals: [CGFloat],
+        backingScaleFactor: CGFloat
+    ) -> CGFloat {
+        let pointResidual = pointResiduals.max() ?? 0
+        let backingResidualPoints = (backingResiduals.max() ?? 0)
+            / max(backingScaleFactor, .leastNonzeroMagnitude)
+        let quantizationMargin = 0.5 / max(backingScaleFactor, .leastNonzeroMagnitude)
+        return max(pointResidual, backingResidualPoints) + quantizationMargin
+    }
 }
 #endif

--- a/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
@@ -3,10 +3,12 @@ import CoreGraphics
 import Foundation
 
 // pattern: Functional Core — this value type contains only pure geometry transforms.
-/// Pure geometry contract for the PR 3 feasibility spike. The spike keeps the
-/// reader routing unchanged and only tests how a DOM placeholder rect maps into
-/// a sibling AppKit overlay under measured DOM CSS pixels, native page zoom,
-/// and window backing scale.
+/// Pure geometry contract for the PR 3 feasibility spike. `cssRect` is a DOM
+/// client rectangle in CSS pixels. `overlayRect` is in AppKit points in an
+/// unflipped overlay superview whose origin coincides with the WebView bounds
+/// origin. The mapping therefore flips Y within the shared bounds and assumes
+/// no additional WebView frame offset. `physicalOverlayRect` is in backing
+/// pixels. Phase 4 owns any non-coincident or transformed container contract.
 struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
     let generation: Int
     let revision: Int

--- a/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
@@ -20,11 +20,11 @@ struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
 
     var overlayRect: CGRect {
         let scale = max(pageZoom, .leastNonzeroMagnitude)
-        let originX = cssRect.minX / scale
-        let originY = webViewBounds.height - (cssRect.maxY / scale)
+        let originX = cssRect.minX * scale
+        let originY = webViewBounds.height - (cssRect.maxY * scale)
         let size = CGSize(
-            width: cssRect.width / scale,
-            height: cssRect.height / scale)
+            width: cssRect.width * scale,
+            height: cssRect.height * scale)
         return CGRect(origin: CGPoint(x: originX, y: originY), size: size)
     }
 
@@ -43,21 +43,4 @@ struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
     }
 }
 
-enum RendererAttachmentSpikeMetrics {
-    /// Returns a tolerance derived from the maximum observed residual in the
-    /// hosted comparison set. The extra half-pixel margin absorbs AppKit
-    /// quantization when converting the same rect between point and backing
-    /// coordinates; if the live residual grows beyond that, the contract broke.
-    static func derivedAlignmentTolerance(
-        pointResiduals: [CGFloat],
-        backingResiduals: [CGFloat],
-        backingScaleFactor: CGFloat
-    ) -> CGFloat {
-        let pointResidual = pointResiduals.max() ?? 0
-        let backingResidualPoints = (backingResiduals.max() ?? 0)
-            / max(backingScaleFactor, .leastNonzeroMagnitude)
-        let quantizationMargin = 0.5 / max(backingScaleFactor, .leastNonzeroMagnitude)
-        return max(pointResidual, backingResidualPoints) + quantizationMargin
-    }
-}
 #endif

--- a/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
@@ -1,0 +1,55 @@
+#if os(macOS)
+import CoreGraphics
+import Foundation
+
+/// Pure geometry contract for the PR 3 feasibility spike. The spike keeps the
+/// reader routing unchanged and only tests how a DOM placeholder rect maps into
+/// a sibling AppKit overlay under page zoom and window backing scale.
+struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
+    let generation: Int
+    let placeholderID: String
+    let cssRect: CGRect
+    let pageZoom: CGFloat
+    let backingScaleFactor: CGFloat
+    let webViewBounds: CGRect
+    let tolerance: CGFloat
+
+    var overlayRect: CGRect {
+        let scale = max(pageZoom, .leastNonzeroMagnitude)
+        let originX = cssRect.minX / scale
+        let originY = webViewBounds.height - (cssRect.maxY / scale)
+        let size = CGSize(
+            width: cssRect.width / scale,
+            height: cssRect.height / scale)
+        return CGRect(origin: CGPoint(x: originX, y: originY), size: size)
+    }
+
+    var physicalOverlayRect: CGRect {
+        overlayRect.applying(.init(scaleX: backingScaleFactor, y: backingScaleFactor))
+    }
+
+    var clipRect: CGRect {
+        overlayRect.intersection(webViewBounds)
+    }
+
+    var localClipRect: CGRect {
+        let clipped = clipRect
+        guard clipped.isNull == false && clipped.isEmpty == false else { return .zero }
+        return clipped.offsetBy(dx: -overlayRect.minX, dy: -overlayRect.minY)
+    }
+
+    func isAligned(with actual: CGRect) -> Bool {
+        [abs(actual.minX - overlayRect.minX),
+         abs(actual.minY - overlayRect.minY),
+         abs(actual.width - overlayRect.width),
+         abs(actual.height - overlayRect.height)].allSatisfy { $0 <= tolerance }
+    }
+}
+
+enum RendererAttachmentSpikeMetrics {
+    /// Measured hosted tolerance for the composite-reader proof. The live tests
+    /// compare in AppKit points, so sub-point drift is acceptable but anything
+    /// larger means the transform or clipping contract is off.
+    static let measuredAlignmentTolerance: CGFloat = 0.75
+}
+#endif

--- a/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentSpikeGeometry.swift
@@ -2,25 +2,30 @@
 import CoreGraphics
 import Foundation
 
+// pattern: Functional Core — this value type contains only pure geometry transforms.
 /// Pure geometry contract for the PR 3 feasibility spike. The spike keeps the
 /// reader routing unchanged and only tests how a DOM placeholder rect maps into
 /// a sibling AppKit overlay under page zoom and window backing scale.
 struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
     let generation: Int
+    let revision: Int
     let placeholderID: String
     let cssRect: CGRect
     let pageZoom: CGFloat
+    let domToViewScale: CGFloat
+    let domCenterHit: Bool
+    let scrollY: CGFloat
     let backingScaleFactor: CGFloat
     let webViewBounds: CGRect
     let tolerance: CGFloat
 
     var overlayRect: CGRect {
-        let scale = max(pageZoom, .leastNonzeroMagnitude)
-        let originX = cssRect.minX / scale
-        let originY = webViewBounds.height - (cssRect.maxY / scale)
+        let scale = max(domToViewScale, .leastNonzeroMagnitude)
+        let originX = cssRect.minX * scale
+        let originY = webViewBounds.height - (cssRect.maxY * scale)
         let size = CGSize(
-            width: cssRect.width / scale,
-            height: cssRect.height / scale)
+            width: cssRect.width * scale,
+            height: cssRect.height * scale)
         return CGRect(origin: CGPoint(x: originX, y: originY), size: size)
     }
 
@@ -47,9 +52,10 @@ struct RendererAttachmentSpikeGeometry: Sendable, Equatable {
 }
 
 enum RendererAttachmentSpikeMetrics {
-    /// Measured hosted tolerance for the composite-reader proof. The live tests
-    /// compare in AppKit points, so sub-point drift is acceptable but anything
-    /// larger means the transform or clipping contract is off.
+    /// The hosted probe uses a fixed 100 CSS-point reference. A 0.75-point
+    /// residual is the measured tolerance for the AppKit-point round trip;
+    /// larger drift means the transform or clipping contract is off.
+    static let referenceCSSWidth: CGFloat = 100
     static let measuredAlignmentTolerance: CGFloat = 0.75
 }
 #endif

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -516,12 +516,10 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           var card = document.querySelector('\(Self.cardSelector)');
           var scrollY = window.scrollY || document.documentElement.scrollTop || 0;
           var viewport = (function(){
-            var visual = window.visualViewport;
-            var left = visual ? visual.offsetLeft : 0;
-            var top = visual ? visual.offsetTop : 0;
-            var width = visual ? visual.width : (window.innerWidth || document.documentElement.clientWidth || 0);
-            var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
-            return { left: left, top: top, right: left + width, bottom: top + height };
+            var docEl = document.documentElement;
+            var width = (docEl && docEl.clientWidth) || window.innerWidth || 0;
+            var height = (docEl && docEl.clientHeight) || window.innerHeight || 0;
+            return { left: 0, top: 0, right: width, bottom: height };
           })();
           function visibleCardRect() {
             if(!card){ return null; }
@@ -674,12 +672,10 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             return { x: r.left, y: r.top, width: r.width, height: r.height };
           }
           function viewportBounds(){
-            var visual = window.visualViewport;
-            var left = visual ? visual.offsetLeft : 0;
-            var top = visual ? visual.offsetTop : 0;
-            var width = visual ? visual.width : (window.innerWidth || document.documentElement.clientWidth || 0);
-            var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
-            return { left: left, top: top, right: left + width, bottom: top + height };
+            var docEl = document.documentElement;
+            var width = (docEl && docEl.clientWidth) || window.innerWidth || 0;
+            var height = (docEl && docEl.clientHeight) || window.innerHeight || 0;
+            return { left: 0, top: 0, right: width, bottom: height };
           }
           function visibleCardRect(card){
             var viewport = viewportBounds();

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -10,12 +10,6 @@ import WebKit
 @Suite("Renderer attachment spike hosted tests", .serialized, .timeLimit(.minutes(5)))
 @MainActor
 struct RendererAttachmentSpikeHostedTests {
-    private static let app: NSApplication = {
-        let app = NSApplication.shared
-        app.setActivationPolicy(.accessory)
-        return app
-    }()
-
     @Test
     func testScrollZoomResizeAndHeightMutationStayAligned() async throws {
         for _ in 0..<20 {
@@ -37,18 +31,29 @@ struct RendererAttachmentSpikeHostedTests {
             try await harness.publishGeometry()
             let initial = try harness.requireGeometry()
             Self.assertAligned(harness.overlay.frame, expected: initial)
+            Self.assertIndependentDOM(harness.currentSnapshot)
             #expect(initial.backingScaleFactor == (window.backingScaleFactor))
+
+            let centeredScroll = max(0, initial.cssRect.minY - (harness.webView.bounds.height * 0.45))
+            try await harness.scrollTo(y: centeredScroll)
+            try await harness.publishGeometry()
+            let centered = try harness.requireGeometry()
+            Self.assertAligned(harness.overlay.frame, expected: centered)
+            Self.assertIndependentDOM(harness.currentSnapshot)
+            #expect(centered.domCenterHit)
 
             try await harness.scrollTo(y: 220)
             try await harness.publishGeometry()
             let scrolled = try harness.requireGeometry()
             Self.assertAligned(harness.overlay.frame, expected: scrolled)
+            Self.assertIndependentDOM(harness.currentSnapshot)
 
             harness.webView.pageZoom = 1.25
             try await harness.updateRuntimeState()
             try await harness.publishGeometry()
             let zoomed = try harness.requireGeometry()
             Self.assertAligned(harness.overlay.frame, expected: zoomed)
+            Self.assertIndependentDOM(harness.currentSnapshot)
 
             window.setContentSize(NSSize(width: 920, height: 580))
             harness.containerView.layoutSubtreeIfNeeded()
@@ -60,12 +65,17 @@ struct RendererAttachmentSpikeHostedTests {
             try await harness.publishGeometry()
             let mutated = try harness.requireGeometry()
             Self.assertAligned(harness.overlay.frame, expected: mutated)
+            Self.assertIndependentDOM(harness.currentSnapshot)
 
             let seam = RendererAttachmentSpikeGeometry(
                 generation: mutated.generation,
+                revision: mutated.revision,
                 placeholderID: mutated.placeholderID,
                 cssRect: mutated.cssRect,
                 pageZoom: mutated.pageZoom,
+                domToViewScale: mutated.domToViewScale,
+                domCenterHit: mutated.domCenterHit,
+                scrollY: mutated.scrollY,
                 backingScaleFactor: 2,
                 webViewBounds: harness.webView.bounds,
                 tolerance: RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
@@ -82,7 +92,7 @@ struct RendererAttachmentSpikeHostedTests {
 
             let harness = RendererAttachmentSpikeHarness(
                 windowSize: NSSize(width: 760, height: 420),
-                markdown: Self.scenarioMarkdown(includeBottomSpacer: false))
+                markdown: Self.scenarioMarkdown(includeBottomSpacer: true))
             let window = harness.window
             window.orderFrontRegardless()
             defer {
@@ -101,6 +111,7 @@ struct RendererAttachmentSpikeHostedTests {
             #expect(geometry.clipRect.isEmpty == false)
             #expect(geometry.clipRect != geometry.overlayRect)
             #expect(harness.overlay.visibleClipRect == geometry.localClipRect)
+            Self.assertIndependentDOM(harness.currentSnapshot)
 
             let visible = geometry.localClipRect
             let insidePoint = NSPoint(x: visible.midX, y: visible.midY)
@@ -115,6 +126,15 @@ struct RendererAttachmentSpikeHostedTests {
             let outsideWindowPoint = harness.overlay.convert(outsidePoint, to: harness.containerView)
             let routedView = harness.containerView.hitTest(outsideWindowPoint)
             #expect(routedView !== harness.overlay)
+
+            let offscreenScroll = max(0, geometry.scrollY + geometry.cssRect.maxY + 80)
+            try await harness.scrollTo(y: offscreenScroll)
+            try await harness.publishGeometry()
+            let offscreen = try harness.requireGeometry()
+            #expect(offscreen.clipRect.isEmpty)
+            #expect(offscreen.domCenterHit == false)
+            #expect(harness.overlay.visibleClipRect.isEmpty)
+            #expect(harness.overlay.hitTest(NSPoint(x: 1, y: 1)) == nil)
         }
     }
 
@@ -151,8 +171,13 @@ struct RendererAttachmentSpikeHostedTests {
             try await harness.publishGeometry()
             let generation3 = try harness.requireGeometry()
 
+            let frameBeforeStaleResize = harness.overlay.frame
+            let revisionBeforeStaleResize = try #require(harness.currentSnapshot).revision
             harness.ingest(Self.snapshot(from: generation2))
             #expect(harness.currentGeometry?.generation == generation3.generation)
+            let currentAfterStaleResize = try #require(harness.currentSnapshot)
+            #expect(currentAfterStaleResize.revision == revisionBeforeStaleResize)
+            #expect(harness.overlay.frame == frameBeforeStaleResize)
 
             try await harness.reload(markdown: Self.scenarioMarkdown(includePlaceholder: false, includeBottomSpacer: false))
             try await harness.publishGeometry()
@@ -208,13 +233,34 @@ struct RendererAttachmentSpikeHostedTests {
         #expect(abs(actual.height - geometry.overlayRect.height) <= geometry.tolerance)
     }
 
+    private static func assertIndependentDOM(_ snapshot: RendererAttachmentSpikeSnapshot?) {
+        guard let snapshot else {
+            Issue.record("missing independent DOM snapshot")
+            return
+        }
+        let expectedPhysicalWidth = RendererAttachmentSpikeMetrics.referenceCSSWidth * snapshot.pageZoom
+        let measuredPhysicalWidth = snapshot.referenceRect.width * snapshot.domToViewScale
+        #expect(snapshot.domToViewScale > 0)
+        #expect(abs(measuredPhysicalWidth - expectedPhysicalWidth)
+            <= RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
+    }
+
     private static func snapshot(from geometry: RendererAttachmentSpikeGeometry) -> RendererAttachmentSpikeSnapshot {
         RendererAttachmentSpikeSnapshot(
             generation: geometry.generation,
+            revision: geometry.revision,
             placeholderID: geometry.placeholderID,
             present: true,
             cssRect: geometry.cssRect,
-            pageZoom: geometry.pageZoom)
+            pageZoom: geometry.pageZoom,
+            domToViewScale: geometry.domToViewScale,
+            centerHit: true,
+            scrollY: 0,
+            referenceRect: CGRect(
+                x: -1000,
+                y: -1000,
+                width: RendererAttachmentSpikeMetrics.referenceCSSWidth / max(geometry.pageZoom, .leastNonzeroMagnitude),
+                height: 1))
     }
 
     private static func outsidePoint(overlayBounds: CGRect, visibleClip: CGRect) -> NSPoint {
@@ -317,9 +363,10 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     }
 
     func publishGeometry() async throws {
+        let minimumRevision = (currentSnapshot?.revision ?? 0) + 1
         _ = await evaluateJavaScriptWithTimeout(webView, "window.__rendererAttachmentSpikeReport ? window.__rendererAttachmentSpikeReport() : 'missing'")
         try await Self.waitFor(description: "renderer attachment geometry") { [weak self] in
-            self?.currentGeometry != nil || self?.currentSnapshot?.present == false
+            (self?.currentSnapshot?.revision ?? 0) >= minimumRevision
         }
     }
 
@@ -351,6 +398,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     func ingest(_ snapshot: RendererAttachmentSpikeSnapshot) {
         guard !isTornDown else { return }
         guard snapshot.generation == generation else { return }
+        guard snapshot.revision > (currentSnapshot?.revision ?? 0) else { return }
         currentSnapshot = snapshot
         guard snapshot.present else {
             currentGeometry = nil
@@ -361,9 +409,13 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         }
         let geometry = RendererAttachmentSpikeGeometry(
             generation: snapshot.generation,
+            revision: snapshot.revision,
             placeholderID: snapshot.placeholderID,
             cssRect: snapshot.cssRect,
             pageZoom: snapshot.pageZoom,
+            domToViewScale: snapshot.domToViewScale,
+            domCenterHit: snapshot.centerHit,
+            scrollY: snapshot.scrollY,
             backingScaleFactor: window.backingScaleFactor,
             webViewBounds: webView.bounds,
             tolerance: RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
@@ -376,9 +428,10 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     func updateRuntimeState() async throws {
         _ = await evaluateJavaScriptWithTimeout(webView, """
         (function(generation, zoom){
-          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1 };
+          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1, revision: 0 };
           window.__rendererAttachmentSpikeState.generation = generation;
           window.__rendererAttachmentSpikeState.pageZoom = zoom;
+          window.__rendererAttachmentSpikeState.revision = window.__rendererAttachmentSpikeState.revision || 0;
           return 'updated';
         })(\(generation), \(Self.posix(webView.pageZoom)))
         """)
@@ -401,7 +454,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         window.contentView = nil
     }
 
-    func requireGeometry(timeout: Duration = .seconds(10)) throws -> RendererAttachmentSpikeGeometry {
+    func requireGeometry() throws -> RendererAttachmentSpikeGeometry {
         guard let geometry = currentGeometry else {
             throw RendererAttachmentSpikeHarnessError.missingGeometry
         }
@@ -426,29 +479,56 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         (function(){
           if(window.__rendererAttachmentSpikeProbeInstalled){ return; }
           window.__rendererAttachmentSpikeProbeInstalled = true;
-          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1 };
+          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1, revision: 0 };
           function rectFor(el){
             var r = el.getBoundingClientRect();
             return { x: r.left, y: r.top, width: r.width, height: r.height };
           }
+          function referenceRect(){
+            var probe = document.createElement('div');
+            probe.style.cssText = 'position:fixed;left:-10000px;top:-10000px;width:100px;height:1px;visibility:hidden;pointer-events:none;';
+            document.documentElement.appendChild(probe);
+            var rect = rectFor(probe);
+            probe.remove();
+            return rect;
+          }
           function report(){
-            var state = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1 };
+            var state = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1, revision: 0 };
+            state.revision = Number(state.revision || 0) + 1;
+            var zoom = Number(state.pageZoom || 1);
+            var reference = referenceRect();
+            var domToViewScale = reference.width > 0 ? (\(Self.posix(RendererAttachmentSpikeMetrics.referenceCSSWidth)) * zoom) / reference.width : 1;
             var card = document.querySelector('\(Self.cardSelector)');
             if(!card){
               window.webkit.messageHandlers.\(Self.messageName).postMessage({
                 generation: state.generation,
+                revision: state.revision,
                 placeholderID: "",
                 present: false,
-                pageZoom: state.pageZoom || 1
+                pageZoom: zoom,
+                domToViewScale: domToViewScale,
+                centerHit: false,
+                scrollY: window.scrollY || document.documentElement.scrollTop || 0,
+                referenceRect: reference
               });
               return "missing";
             }
+            var cardRect = rectFor(card);
+            var centerNode = document.elementFromPoint(
+              cardRect.x + cardRect.width / 2,
+              cardRect.y + cardRect.height / 2);
+            var centerHit = centerNode === card || (!!centerNode && card.contains(centerNode));
             window.webkit.messageHandlers.\(Self.messageName).postMessage({
               generation: state.generation,
+              revision: state.revision,
               placeholderID: card.id || "",
               present: true,
-              cssRect: rectFor(card),
-              pageZoom: state.pageZoom || 1
+              cssRect: cardRect,
+              pageZoom: zoom,
+              domToViewScale: domToViewScale,
+              centerHit: centerHit,
+              scrollY: window.scrollY || document.documentElement.scrollTop || 0,
+              referenceRect: reference
             });
             return "posted";
           }
@@ -512,33 +592,53 @@ private final class RendererAttachmentSpikeOverlayView: NSView {
 
 private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
     let generation: Int
+    let revision: Int
     let placeholderID: String
     let present: Bool
     let cssRect: CGRect
     let pageZoom: CGFloat
+    let domToViewScale: CGFloat
+    let centerHit: Bool
+    let scrollY: CGFloat
+    let referenceRect: CGRect
 
     init(
         generation: Int,
+        revision: Int,
         placeholderID: String,
         present: Bool,
         cssRect: CGRect,
-        pageZoom: CGFloat
+        pageZoom: CGFloat,
+        domToViewScale: CGFloat,
+        centerHit: Bool,
+        scrollY: CGFloat,
+        referenceRect: CGRect
     ) {
         self.generation = generation
+        self.revision = revision
         self.placeholderID = placeholderID
         self.present = present
         self.cssRect = cssRect
         self.pageZoom = pageZoom
+        self.domToViewScale = domToViewScale
+        self.centerHit = centerHit
+        self.scrollY = scrollY
+        self.referenceRect = referenceRect
     }
 
     init?(body: Any) {
         guard let dict = body as? [String: Any] else { return nil }
         guard let generation = Self.int(dict["generation"]),
+              let revision = Self.int(dict["revision"]),
               let present = dict["present"] as? Bool,
               let placeholderID = dict["placeholderID"] as? String else {
             return nil
         }
         let pageZoom = Self.cgFloat(dict["pageZoom"]) ?? 1
+        let domToViewScale = Self.cgFloat(dict["domToViewScale"]) ?? 1
+        let centerHit = dict["centerHit"] as? Bool ?? false
+        let scrollY = Self.cgFloat(dict["scrollY"]) ?? 0
+        let referenceRect = Self.rect(dict["referenceRect"]) ?? .zero
         let rect: CGRect
         if present {
             guard let cssRect = Self.rect(dict["cssRect"]) else { return nil }
@@ -547,10 +647,15 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
             rect = .zero
         }
         self.generation = generation
+        self.revision = revision
         self.placeholderID = placeholderID
         self.present = present
         self.cssRect = rect
         self.pageZoom = pageZoom
+        self.domToViewScale = domToViewScale
+        self.centerHit = centerHit
+        self.scrollY = scrollY
+        self.referenceRect = referenceRect
     }
 
     private static func rect(_ value: Any?) -> CGRect? {

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -484,13 +484,13 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             var r = el.getBoundingClientRect();
             return { x: r.left, y: r.top, width: r.width, height: r.height };
           }
+          var referenceProbe = document.createElement('div');
+          referenceProbe.id = 'renderer-attachment-spike-reference';
+          referenceProbe.setAttribute('aria-hidden', 'true');
+          referenceProbe.style.cssText = 'position:fixed;left:-10000px;top:-10000px;width:100px;height:1px;visibility:hidden;pointer-events:none;';
+          document.documentElement.appendChild(referenceProbe);
           function referenceRect(){
-            var probe = document.createElement('div');
-            probe.style.cssText = 'position:fixed;left:-10000px;top:-10000px;width:100px;height:1px;visibility:hidden;pointer-events:none;';
-            document.documentElement.appendChild(probe);
-            var rect = rectFor(probe);
-            probe.remove();
-            return rect;
+            return rectFor(referenceProbe);
           }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1, revision: 0 };

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -101,7 +101,7 @@ struct RendererAttachmentSpikeHostedTests {
             harness.containerView.layoutSubtreeIfNeeded()
             try await harness.publishGeometry()
             let resized = try harness.requireGeometry()
-            let resizedSnapshot = try #require(harness.currentSnapshot)
+            _ = try #require(harness.currentSnapshot)
             let resizedMeasurement = try await harness.measureDOMGeometry()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -516,24 +516,24 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           var card = document.querySelector('\(Self.cardSelector)');
           var scrollY = window.scrollY || document.documentElement.scrollTop || 0;
           if(!card){
-            return {
+            return JSON.stringify({
               present: false,
               placeholderID: "",
               centerHit: false,
               scrollY: scrollY
-            };
+            });
           }
           var rect = card.getBoundingClientRect();
           var centerNode = document.elementFromPoint(
             rect.left + rect.width / 2,
             rect.top + rect.height / 2);
-          return {
+          return JSON.stringify({
             present: true,
             placeholderID: card.id || "",
             cssRect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
             centerHit: centerNode === card || (!!centerNode && card.contains(centerNode)),
             scrollY: scrollY
-          };
+          });
         })()
         """)
         guard let measurement = RendererAttachmentSpikeDOMMeasurement(body: body) else {
@@ -853,7 +853,7 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
     }
 
     init?(body: Any?) {
-        guard let dict = body as? [String: Any],
+        guard let dict = Self.dictionary(body),
               let present = dict["present"] as? Bool,
               let placeholderID = dict["placeholderID"] as? String else {
             return nil
@@ -872,6 +872,21 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
         self.cssRect = rect
         self.centerHit = centerHit
         self.scrollY = scrollY
+    }
+
+    private static func dictionary(_ value: Any?) -> [String: Any]? {
+        if let dict = value as? [String: Any] {
+            return dict
+        }
+        guard let string = value as? String,
+              let data = string.data(using: .utf8) else {
+            return nil
+        }
+        do {
+            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        } catch {
+            return nil
+        }
     }
 
     private static func rect(_ value: Any?) -> CGRect? {

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -524,15 +524,8 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             return { left: left, top: top, right: left + width, bottom: top + height };
           })();
           function hitAt(x, y) {
-            var position = document.caretPositionFromPoint
-              ? document.caretPositionFromPoint(x, y)
-              : (document.caretRangeFromPoint ? document.caretRangeFromPoint(x, y) : null);
-            var node = position && position.offsetNode
-              ? position.offsetNode
-              : (position && position.startContainer ? position.startContainer : null);
-            if(!node){ return false; }
-            if(node.nodeType === Node.TEXT_NODE){ node = node.parentNode; }
-            return !!node && (node === card || card.contains(node));
+            var rect = paintedTextRect();
+            return !!rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
           }
           function paintedTextRect() {
             if(!card){ return null; }
@@ -563,9 +556,10 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             if(!textRect){
               return false;
             }
-            var x = Math.max(viewport.left, Math.min(textRect.left + textRect.width / 2, viewport.right - 0.5));
-            var y = Math.max(viewport.top, Math.min(textRect.top + textRect.height / 2, viewport.bottom - 0.5));
-            return hitAt(x, y);
+            return textRect.right > viewport.left &&
+                   textRect.left < viewport.right &&
+                   textRect.bottom > viewport.top &&
+                   textRect.top < viewport.bottom;
           }
           if(!card){
             return JSON.stringify({
@@ -711,15 +705,8 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             return { left: left, top: top, right: left + width, bottom: top + height };
           }
           function cardHitAt(card, x, y){
-            var position = document.caretPositionFromPoint
-              ? document.caretPositionFromPoint(x, y)
-              : (document.caretRangeFromPoint ? document.caretRangeFromPoint(x, y) : null);
-            var node = position && position.offsetNode
-              ? position.offsetNode
-              : (position && position.startContainer ? position.startContainer : null);
-            if(!node){ return false; }
-            if(node.nodeType === Node.TEXT_NODE){ node = node.parentNode; }
-            return !!node && (node === card || card.contains(node));
+            var rect = paintedTextRect(card);
+            return !!rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
           }
           function paintedTextRect(card){
             var viewport = viewportBounds();
@@ -751,9 +738,10 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             if(!textRect){
               return false;
             }
-            var x = Math.max(viewport.left, Math.min(textRect.left + textRect.width / 2, viewport.right - 0.5));
-            var y = Math.max(viewport.top, Math.min(textRect.top + textRect.height / 2, viewport.bottom - 0.5));
-            return cardHitAt(card, x, y);
+            return textRect.right > viewport.left &&
+                   textRect.left < viewport.right &&
+                   textRect.bottom > viewport.top &&
+                   textRect.top < viewport.bottom;
           }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -524,42 +524,53 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             return { left: left, top: top, right: left + width, bottom: top + height };
           })();
           function hitAt(x, y) {
-            var rect = paintedTextRect();
-            return !!rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+            return hasLiveChildHit(card, x, y);
           }
-          function paintedTextRect() {
+          function visibleChildRect() {
             if(!card){ return null; }
-            var walker = document.createTreeWalker(card, NodeFilter.SHOW_TEXT);
-            while(walker.nextNode()){
-              var textNode = walker.currentNode;
-              if(!textNode || !textNode.textContent || !textNode.textContent.trim()){
-                continue;
-              }
-              var range = document.createRange();
-              range.selectNodeContents(textNode);
-              var rects = range.getClientRects();
-              for(var i = 0; i < rects.length; i++){
-                var rect = rects[i];
-                var left = Math.max(rect.left, viewport.left);
-                var top = Math.max(rect.top, viewport.top);
-                var right = Math.min(rect.right, viewport.right);
-                var bottom = Math.min(rect.bottom, viewport.bottom);
-                if(right > left && bottom > top){
-                  return rect;
-                }
+            var children = card.children || [];
+            for(var i = 0; i < children.length; i++){
+              var rect = children[i].getBoundingClientRect();
+              var left = Math.max(rect.left, viewport.left);
+              var top = Math.max(rect.top, viewport.top);
+              var right = Math.min(rect.right, viewport.right);
+              var bottom = Math.min(rect.bottom, viewport.bottom);
+              if(right > left && bottom > top){
+                return rect;
               }
             }
             return null;
           }
+          function hasLiveChildHit(card, x, y) {
+            var nodes = document.elementsFromPoint(x, y) || [];
+            for(var i = 0; i < nodes.length; i++){
+              var node = nodes[i];
+              if(node === card){
+                return true;
+              }
+              if(node && card.contains(node) && node !== card){
+                return true;
+              }
+            }
+            return false;
+          }
           function visibleHit() {
-            var textRect = paintedTextRect();
-            if(!textRect){
+            var rect = visibleChildRect();
+            if(!rect){
               return false;
             }
-            return textRect.right > viewport.left &&
-                   textRect.left < viewport.right &&
-                   textRect.bottom > viewport.top &&
-                   textRect.top < viewport.bottom;
+            var xCandidates = [rect.left + 4, rect.left + 12, rect.left + rect.width / 2];
+            var yCandidates = [rect.top + 4, rect.top + 12, rect.top + rect.height / 2];
+            for(var yi = 0; yi < yCandidates.length; yi++){
+              for(var xi = 0; xi < xCandidates.length; xi++){
+                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
+                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
+                if(hasLiveChildHit(card, x, y)){
+                  return true;
+                }
+              }
+            }
+            return false;
           }
           if(!card){
             return JSON.stringify({
@@ -705,43 +716,54 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             return { left: left, top: top, right: left + width, bottom: top + height };
           }
           function cardHitAt(card, x, y){
-            var rect = paintedTextRect(card);
-            return !!rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+            return hasLiveChildHit(card, x, y);
           }
-          function paintedTextRect(card){
+          function visibleChildRect(card){
             var viewport = viewportBounds();
-            var walker = document.createTreeWalker(card, NodeFilter.SHOW_TEXT);
-            while(walker.nextNode()){
-              var textNode = walker.currentNode;
-              if(!textNode || !textNode.textContent || !textNode.textContent.trim()){
-                continue;
-              }
-              var range = document.createRange();
-              range.selectNodeContents(textNode);
-              var rects = range.getClientRects();
-              for(var i = 0; i < rects.length; i++){
-                var rect = rects[i];
-                var left = Math.max(rect.left, viewport.left);
-                var top = Math.max(rect.top, viewport.top);
-                var right = Math.min(rect.right, viewport.right);
-                var bottom = Math.min(rect.bottom, viewport.bottom);
-                if(right > left && bottom > top){
-                  return rect;
-                }
+            var children = card ? card.children : [];
+            for(var i = 0; i < children.length; i++){
+              var rect = children[i].getBoundingClientRect();
+              var left = Math.max(rect.left, viewport.left);
+              var top = Math.max(rect.top, viewport.top);
+              var right = Math.min(rect.right, viewport.right);
+              var bottom = Math.min(rect.bottom, viewport.bottom);
+              if(right > left && bottom > top){
+                return rect;
               }
             }
             return null;
           }
+          function hasLiveChildHit(card, x, y) {
+            var nodes = document.elementsFromPoint(x, y) || [];
+            for(var i = 0; i < nodes.length; i++){
+              var node = nodes[i];
+              if(node === card){
+                return true;
+              }
+              if(node && card.contains(node) && node !== card){
+                return true;
+              }
+            }
+            return false;
+          }
           function visibleCardHit(card){
             var viewport = viewportBounds();
-            var textRect = paintedTextRect(card);
-            if(!textRect){
+            var rect = visibleChildRect(card);
+            if(!rect){
               return false;
             }
-            return textRect.right > viewport.left &&
-                   textRect.left < viewport.right &&
-                   textRect.bottom > viewport.top &&
-                   textRect.top < viewport.bottom;
+            var xCandidates = [rect.left + 4, rect.left + 12, rect.left + rect.width / 2];
+            var yCandidates = [rect.top + 4, rect.top + 12, rect.top + rect.height / 2];
+            for(var yi = 0; yi < yCandidates.length; yi++){
+              for(var xi = 0; xi < xCandidates.length; xi++){
+                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
+                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
+                if(hasLiveChildHit(card, x, y)){
+                  return true;
+                }
+              }
+            }
+            return false;
           }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -533,34 +533,29 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             }
             return false;
           }
-          function visibleHit(rect) {
-            var left = Math.max(rect.left, viewport.left);
-            var top = Math.max(rect.top, viewport.top);
-            var right = Math.min(rect.right, viewport.right);
-            var bottom = Math.min(rect.bottom, viewport.bottom);
-            if(!(right > left && bottom > top)){
-              return false;
-            }
-            var xCandidates = [
-              left + (right - left) / 2,
-              left + 1,
-              right - 1
-            ];
-            var yCandidates = [
-              top + (bottom - top) / 2,
-              top + 1,
-              bottom - 1
-            ];
-            for(var yi = 0; yi < yCandidates.length; yi++){
-              for(var xi = 0; xi < xCandidates.length; xi++){
-                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
-                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
-                if(hitAt(x, y)){
-                  return true;
-                }
+          function visibleChildRect() {
+            if(!card){ return null; }
+            var children = card.children || [];
+            for(var i = 0; i < children.length; i++){
+              var childRect = children[i].getBoundingClientRect();
+              var left = Math.max(childRect.left, viewport.left);
+              var top = Math.max(childRect.top, viewport.top);
+              var right = Math.min(childRect.right, viewport.right);
+              var bottom = Math.min(childRect.bottom, viewport.bottom);
+              if(right > left && bottom > top){
+                return childRect;
               }
             }
-            return false;
+            return null;
+          }
+          function visibleHit() {
+            var childRect = visibleChildRect();
+            if(!childRect){
+              return false;
+            }
+            var x = Math.max(viewport.left, Math.min(childRect.left + childRect.width / 2, viewport.right - 0.5));
+            var y = Math.max(viewport.top, Math.min(childRect.top + childRect.height / 2, viewport.bottom - 0.5));
+            return hitAt(x, y);
           }
           if(!card){
             return JSON.stringify({
@@ -575,7 +570,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             present: true,
             placeholderID: card.id || "",
             cssRect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
-            centerHit: visibleHit(rect),
+            centerHit: visibleHit(),
             scrollY: scrollY
           });
         })()
@@ -715,27 +710,30 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             }
             return false;
           }
-          function visibleCardHit(card, rect){
+          function visibleChildRect(card){
             var viewport = viewportBounds();
-            var left = Math.max(rect.left, viewport.left);
-            var top = Math.max(rect.top, viewport.top);
-            var right = Math.min(rect.right, viewport.right);
-            var bottom = Math.min(rect.bottom, viewport.bottom);
-            if(!(right > left && bottom > top)){
-              return false;
-            }
-            var xCandidates = [left + (right - left) / 2, left + 1, right - 1];
-            var yCandidates = [top + (bottom - top) / 2, top + 1, bottom - 1];
-            for(var yi = 0; yi < yCandidates.length; yi++){
-              for(var xi = 0; xi < xCandidates.length; xi++){
-                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
-                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
-                if(cardHitAt(card, x, y)){
-                  return true;
-                }
+            var children = card ? card.children : [];
+            for(var i = 0; i < children.length; i++){
+              var childRect = children[i].getBoundingClientRect();
+              var left = Math.max(childRect.left, viewport.left);
+              var top = Math.max(childRect.top, viewport.top);
+              var right = Math.min(childRect.right, viewport.right);
+              var bottom = Math.min(childRect.bottom, viewport.bottom);
+              if(right > left && bottom > top){
+                return childRect;
               }
             }
-            return false;
+            return null;
+          }
+          function visibleCardHit(card){
+            var viewport = viewportBounds();
+            var childRect = visibleChildRect(card);
+            if(!childRect){
+              return false;
+            }
+            var x = Math.max(viewport.left, Math.min(childRect.left + childRect.width / 2, viewport.right - 0.5));
+            var y = Math.max(viewport.top, Math.min(childRect.top + childRect.height / 2, viewport.bottom - 0.5));
+            return cardHitAt(card, x, y);
           }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };
@@ -760,7 +758,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
                 placeholderID: card.id || "",
                 present: true,
                 cssRect: cardRect,
-                centerHit: visibleCardHit(card, cardRect),
+                centerHit: visibleCardHit(card),
                 scrollY: window.scrollY || document.documentElement.scrollTop || 0
             });
             return "posted";

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -515,6 +515,12 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         (function(){
           var card = document.querySelector('\(Self.cardSelector)');
           var scrollY = window.scrollY || document.documentElement.scrollTop || 0;
+          var viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+          var viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+          function hitAt(x, y) {
+            var node = document.elementFromPoint(x, y);
+            return !!node && (node === card || card.contains(node));
+          }
           if(!card){
             return JSON.stringify({
               present: false,
@@ -524,14 +530,19 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             });
           }
           var rect = card.getBoundingClientRect();
-          var centerNode = document.elementFromPoint(
-            rect.left + rect.width / 2,
-            rect.top + rect.height / 2);
+          var left = Math.max(rect.left, 0);
+          var top = Math.max(rect.top, 0);
+          var right = Math.min(rect.right, viewportWidth);
+          var bottom = Math.min(rect.bottom, viewportHeight);
+          var centerHit = false;
+          if(right > left && bottom > top){
+            centerHit = hitAt(left + (right - left) / 2, top + (bottom - top) / 2);
+          }
           return JSON.stringify({
             present: true,
             placeholderID: card.id || "",
             cssRect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
-            centerHit: centerNode === card || (!!centerNode && card.contains(centerNode)),
+            centerHit: centerHit,
             scrollY: scrollY
           });
         })()

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -524,37 +524,47 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             return { left: left, top: top, right: left + width, bottom: top + height };
           })();
           function hitAt(x, y) {
-            var nodes = document.elementsFromPoint(x, y) || [];
-            for(var i = 0; i < nodes.length; i++){
-              var node = nodes[i];
-              if(node === card || card.contains(node)){
-                return true;
-              }
-            }
-            return false;
+            var position = document.caretPositionFromPoint
+              ? document.caretPositionFromPoint(x, y)
+              : (document.caretRangeFromPoint ? document.caretRangeFromPoint(x, y) : null);
+            var node = position && position.offsetNode
+              ? position.offsetNode
+              : (position && position.startContainer ? position.startContainer : null);
+            if(!node){ return false; }
+            if(node.nodeType === Node.TEXT_NODE){ node = node.parentNode; }
+            return !!node && (node === card || card.contains(node));
           }
-          function visibleChildRect() {
+          function paintedTextRect() {
             if(!card){ return null; }
-            var children = card.children || [];
-            for(var i = 0; i < children.length; i++){
-              var childRect = children[i].getBoundingClientRect();
-              var left = Math.max(childRect.left, viewport.left);
-              var top = Math.max(childRect.top, viewport.top);
-              var right = Math.min(childRect.right, viewport.right);
-              var bottom = Math.min(childRect.bottom, viewport.bottom);
-              if(right > left && bottom > top){
-                return childRect;
+            var walker = document.createTreeWalker(card, NodeFilter.SHOW_TEXT);
+            while(walker.nextNode()){
+              var textNode = walker.currentNode;
+              if(!textNode || !textNode.textContent || !textNode.textContent.trim()){
+                continue;
+              }
+              var range = document.createRange();
+              range.selectNodeContents(textNode);
+              var rects = range.getClientRects();
+              for(var i = 0; i < rects.length; i++){
+                var rect = rects[i];
+                var left = Math.max(rect.left, viewport.left);
+                var top = Math.max(rect.top, viewport.top);
+                var right = Math.min(rect.right, viewport.right);
+                var bottom = Math.min(rect.bottom, viewport.bottom);
+                if(right > left && bottom > top){
+                  return rect;
+                }
               }
             }
             return null;
           }
           function visibleHit() {
-            var childRect = visibleChildRect();
-            if(!childRect){
+            var textRect = paintedTextRect();
+            if(!textRect){
               return false;
             }
-            var x = Math.max(viewport.left, Math.min(childRect.left + childRect.width / 2, viewport.right - 0.5));
-            var y = Math.max(viewport.top, Math.min(childRect.top + childRect.height / 2, viewport.bottom - 0.5));
+            var x = Math.max(viewport.left, Math.min(textRect.left + textRect.width / 2, viewport.right - 0.5));
+            var y = Math.max(viewport.top, Math.min(textRect.top + textRect.height / 2, viewport.bottom - 0.5));
             return hitAt(x, y);
           }
           if(!card){
@@ -701,38 +711,48 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             return { left: left, top: top, right: left + width, bottom: top + height };
           }
           function cardHitAt(card, x, y){
-            var nodes = document.elementsFromPoint(x, y) || [];
-            for(var i = 0; i < nodes.length; i++){
-              var node = nodes[i];
-              if(node === card || card.contains(node)){
-                return true;
-              }
-            }
-            return false;
+            var position = document.caretPositionFromPoint
+              ? document.caretPositionFromPoint(x, y)
+              : (document.caretRangeFromPoint ? document.caretRangeFromPoint(x, y) : null);
+            var node = position && position.offsetNode
+              ? position.offsetNode
+              : (position && position.startContainer ? position.startContainer : null);
+            if(!node){ return false; }
+            if(node.nodeType === Node.TEXT_NODE){ node = node.parentNode; }
+            return !!node && (node === card || card.contains(node));
           }
-          function visibleChildRect(card){
+          function paintedTextRect(card){
             var viewport = viewportBounds();
-            var children = card ? card.children : [];
-            for(var i = 0; i < children.length; i++){
-              var childRect = children[i].getBoundingClientRect();
-              var left = Math.max(childRect.left, viewport.left);
-              var top = Math.max(childRect.top, viewport.top);
-              var right = Math.min(childRect.right, viewport.right);
-              var bottom = Math.min(childRect.bottom, viewport.bottom);
-              if(right > left && bottom > top){
-                return childRect;
+            var walker = document.createTreeWalker(card, NodeFilter.SHOW_TEXT);
+            while(walker.nextNode()){
+              var textNode = walker.currentNode;
+              if(!textNode || !textNode.textContent || !textNode.textContent.trim()){
+                continue;
+              }
+              var range = document.createRange();
+              range.selectNodeContents(textNode);
+              var rects = range.getClientRects();
+              for(var i = 0; i < rects.length; i++){
+                var rect = rects[i];
+                var left = Math.max(rect.left, viewport.left);
+                var top = Math.max(rect.top, viewport.top);
+                var right = Math.min(rect.right, viewport.right);
+                var bottom = Math.min(rect.bottom, viewport.bottom);
+                if(right > left && bottom > top){
+                  return rect;
+                }
               }
             }
             return null;
           }
           function visibleCardHit(card){
             var viewport = viewportBounds();
-            var childRect = visibleChildRect(card);
-            if(!childRect){
+            var textRect = paintedTextRect(card);
+            if(!textRect){
               return false;
             }
-            var x = Math.max(viewport.left, Math.min(childRect.left + childRect.width / 2, viewport.right - 0.5));
-            var y = Math.max(viewport.top, Math.min(childRect.top + childRect.height / 2, viewport.bottom - 0.5));
+            var x = Math.max(viewport.left, Math.min(textRect.left + textRect.width / 2, viewport.right - 0.5));
+            var y = Math.max(viewport.top, Math.min(textRect.top + textRect.height / 2, viewport.bottom - 0.5));
             return cardHitAt(card, x, y);
           }
           function report(){

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -74,6 +74,17 @@ struct RendererAttachmentSpikeHostedTests {
                 expectedCenterHit: true,
                 expectedFullyInsideLayoutViewport: true,
                 stage: "initial iteration \(iteration)")
+            #expect(initialMeasurement.centerHit)
+            let occluderResult = try await harness.installDOMOccluder()
+            #expect(occluderResult == "installed")
+            try await harness.publishGeometry()
+            let occludedMeasurement = try await harness.measureDOMGeometry()
+            #expect(occludedMeasurement.centerHit == false)
+            let removalResult = try await harness.removeDOMOccluder()
+            #expect(removalResult == "removed")
+            try await harness.publishGeometry()
+            let restoredMeasurement = try await harness.measureDOMGeometry()
+            #expect(restoredMeasurement.centerHit)
             let initialAccessibility = try await harness.measureDOMAccessibility()
             Self.assertAutomatedAccessibilityEvidence(
                 overlay: harness.overlay,
@@ -264,15 +275,10 @@ struct RendererAttachmentSpikeHostedTests {
             let insideWindowPoint = harness.overlay.convert(insidePoint, to: harness.containerView)
             let outsideWindowPoint = harness.overlay.convert(outsidePoint, to: harness.containerView)
 
-            let occluderResult = try await harness.installDOMOccluder()
-            #expect(occluderResult == "installed")
-            try await harness.publishGeometry()
-            let occludedMeasurement = try await harness.measureDOMGeometry()
-            #expect(occludedMeasurement.centerHit == false)
+            // Phase 3 demonstrates clip-based hit relinquishment. Phase 4 owns
+            // the policy that maps DOM occlusion into an overlay clip.
             harness.overlay.visibleClipRect = .zero
             #expect(harness.overlay.hitTest(insideWindowPoint) == nil)
-            let removalResult = try await harness.removeDOMOccluder()
-            #expect(removalResult == "removed")
             try await harness.publishGeometry()
 
             let routedInside = harness.containerView.hitTest(insideWindowPoint)
@@ -538,7 +544,7 @@ struct RendererAttachmentSpikeHostedTests {
         #expect(overlay.isAccessibilityElement())
         #expect(overlay.accessibilityRole() == .group)
         #expect(overlay.accessibilityLabel() == expectedOverlayLabel)
-        #expect(overlay.accessibilityIdentifier() == RendererAttachmentSpikeOverlayView.accessibilityIdentifier(for: placeholderID))
+        #expect(overlay.accessibilityIdentifier() == "renderer-attachment-overlay-\(placeholderID)")
         #expect(dom.present)
         #expect(dom.role == "group")
         #expect(dom.label.isEmpty == false)

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -10,6 +10,8 @@ import WebKit
 @Suite("Renderer attachment spike hosted tests", .serialized, .timeLimit(.minutes(5)))
 @MainActor
 struct RendererAttachmentSpikeHostedTests {
+    private static let bottomSpacerParagraphCount = 24
+
     @Test
     func testScrollZoomResizeAndHeightMutationStayAligned() async throws {
         for _ in 0..<20 {
@@ -205,7 +207,9 @@ struct RendererAttachmentSpikeHostedTests {
             "Paragraph \(index): " + String(repeating: "This keeps the document tall enough for scroll alignment. ", count: 2)
         }.joined(separator: "\n\n")
         let bottom = includeBottomSpacer
-            ? String(repeating: "Trailing content keeps the placeholder in flow.\n\n", count: 8)
+            ? String(
+                repeating: "Trailing content keeps the placeholder in flow.\n\n",
+                count: bottomSpacerParagraphCount)
             : ""
         let placeholder = includePlaceholder
             ? """

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -10,6 +10,9 @@ import WebKit
 @Suite("Renderer attachment spike hosted tests", .serialized, .timeLimit(.minutes(5)))
 @MainActor
 struct RendererAttachmentSpikeHostedTests {
+    private static let positiveLeadingParagraphCount = 3
+    private static let defaultLeadingParagraphCount = 28
+    private static let positiveScrollY: CGFloat = 220
     private static let bottomSpacerParagraphCount = 24
 
     @Test
@@ -22,7 +25,9 @@ struct RendererAttachmentSpikeHostedTests {
 
             let harness = RendererAttachmentSpikeHarness(
                 windowSize: NSSize(width: 820, height: 520),
-                markdown: Self.scenarioMarkdown(includeBottomSpacer: true))
+                markdown: Self.scenarioMarkdown(
+                    includeBottomSpacer: true,
+                    leadingParagraphCount: Self.positiveLeadingParagraphCount))
             let window = harness.window
             window.orderFrontRegardless()
             defer {
@@ -43,28 +48,15 @@ struct RendererAttachmentSpikeHostedTests {
                 backingScaleFactor: window.backingScaleFactor,
                 webViewBounds: harness.webView.bounds)
             )
-            Self.assertIndependentDOM(initialSnapshot, measurement: initialMeasurement, expectedCenterHit: true)
+            Self.assertIndependentDOM(
+                initialSnapshot,
+                measurement: initialMeasurement,
+                expectedCenterHit: true,
+                expectedFullyInsideLayoutViewport: true,
+                stage: "initial")
             #expect(initial.revision == initialSnapshot.revision)
 
-            let centeredScroll = max(0, initial.cssRect.minY - (harness.webView.bounds.height * 0.45))
-            try await harness.scrollTo(y: centeredScroll)
-            try await harness.publishGeometry()
-            let centered = try harness.requireGeometry()
-            let centeredSnapshot = try #require(harness.currentSnapshot)
-            let centeredMeasurement = try await harness.measureDOMGeometry()
-            alignmentEvidences.append(Self.alignmentEvidence(
-                harness.overlay.frame,
-                measurement: centeredMeasurement,
-                pageZoom: harness.webView.pageZoom,
-                containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds)
-            )
-            Self.assertIndependentDOM(centeredSnapshot, measurement: centeredMeasurement, expectedCenterHit: true)
-            #expect(centered.domCenterHit)
-            #expect(centered.revision > initial.revision)
-
-            try await harness.scrollTo(y: 220)
+            try await harness.scrollTo(y: Self.positiveScrollY)
             try await harness.publishGeometry()
             let scrolled = try harness.requireGeometry()
             let scrolledSnapshot = try #require(harness.currentSnapshot)
@@ -77,11 +69,18 @@ struct RendererAttachmentSpikeHostedTests {
                 backingScaleFactor: window.backingScaleFactor,
                 webViewBounds: harness.webView.bounds)
             )
-            Self.assertIndependentDOM(scrolledSnapshot, measurement: scrolledMeasurement, expectedCenterHit: true)
-            #expect(scrolled.revision > centered.revision)
+            Self.assertIndependentDOM(
+                scrolledSnapshot,
+                measurement: scrolledMeasurement,
+                expectedCenterHit: true,
+                expectedFullyInsideLayoutViewport: true,
+                stage: "scroll")
+            #expect(scrolled.domCenterHit)
+            #expect(scrolled.revision > initial.revision)
 
             harness.webView.pageZoom = 1.25
             try await harness.updateRuntimeState()
+            try await harness.scrollTo(y: Self.positiveScrollY)
             try await harness.publishGeometry()
             let zoomed = try harness.requireGeometry()
             let zoomedSnapshot = try #require(harness.currentSnapshot)
@@ -94,14 +93,20 @@ struct RendererAttachmentSpikeHostedTests {
                 backingScaleFactor: window.backingScaleFactor,
                 webViewBounds: harness.webView.bounds)
             )
-            Self.assertIndependentDOM(zoomedSnapshot, measurement: zoomedMeasurement, expectedCenterHit: true)
+            Self.assertIndependentDOM(
+                zoomedSnapshot,
+                measurement: zoomedMeasurement,
+                expectedCenterHit: true,
+                expectedFullyInsideLayoutViewport: true,
+                stage: "zoomed")
             #expect(zoomed.revision > scrolled.revision)
 
             window.setContentSize(NSSize(width: 920, height: 580))
             harness.containerView.layoutSubtreeIfNeeded()
+            try await harness.scrollTo(y: Self.positiveScrollY)
             try await harness.publishGeometry()
             let resized = try harness.requireGeometry()
-            _ = try #require(harness.currentSnapshot)
+            let resizedSnapshot = try #require(harness.currentSnapshot)
             let resizedMeasurement = try await harness.measureDOMGeometry()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,
@@ -111,9 +116,16 @@ struct RendererAttachmentSpikeHostedTests {
                 backingScaleFactor: window.backingScaleFactor,
                 webViewBounds: harness.webView.bounds)
             )
+            Self.assertIndependentDOM(
+                resizedSnapshot,
+                measurement: resizedMeasurement,
+                expectedCenterHit: true,
+                expectedFullyInsideLayoutViewport: true,
+                stage: "resized")
             #expect(resized.revision > zoomed.revision)
 
             try await harness.insertSpacerBeforePlaceholder(height: 96)
+            try await harness.scrollTo(y: Self.positiveScrollY)
             try await harness.publishGeometry()
             let mutated = try harness.requireGeometry()
             let mutatedSnapshot = try #require(harness.currentSnapshot)
@@ -126,7 +138,12 @@ struct RendererAttachmentSpikeHostedTests {
                 backingScaleFactor: window.backingScaleFactor,
                 webViewBounds: harness.webView.bounds)
             )
-            Self.assertIndependentDOM(mutatedSnapshot, measurement: mutatedMeasurement, expectedCenterHit: true)
+            Self.assertIndependentDOM(
+                mutatedSnapshot,
+                measurement: mutatedMeasurement,
+                expectedCenterHit: true,
+                expectedFullyInsideLayoutViewport: true,
+                stage: "height-mutation")
             #expect(mutated.revision == mutatedSnapshot.revision)
             #expect(mutated.revision > resized.revision)
 
@@ -179,7 +196,11 @@ struct RendererAttachmentSpikeHostedTests {
             #expect(geometry.clipRect.isEmpty == false)
             #expect(geometry.clipRect != geometry.overlayRect)
             #expect(harness.overlay.visibleClipRect == geometry.localClipRect)
-            Self.assertIndependentDOM(geometrySnapshot, measurement: geometryMeasurement, expectedCenterHit: true)
+            Self.assertIndependentDOM(
+                geometrySnapshot,
+                measurement: geometryMeasurement,
+                expectedCenterHit: true,
+                stage: "geometry-visible")
 
             let visible = geometry.localClipRect
             let insidePoint = NSPoint(x: visible.midX, y: visible.midY)
@@ -219,7 +240,8 @@ struct RendererAttachmentSpikeHostedTests {
             Self.assertIndependentDOM(
                 offscreenSnapshot,
                 measurement: offscreenMeasurement,
-                expectedCenterHit: false)
+                expectedCenterHit: false,
+                stage: "geometry-offscreen")
 
             let tolerance = RendererAttachmentSpikeMetrics.derivedAlignmentTolerance(
                 pointResiduals: alignmentEvidences.flatMap { $0.pointResiduals },
@@ -294,9 +316,10 @@ struct RendererAttachmentSpikeHostedTests {
 
     private static func scenarioMarkdown(
         includePlaceholder: Bool = true,
-        includeBottomSpacer: Bool
+        includeBottomSpacer: Bool,
+        leadingParagraphCount: Int = defaultLeadingParagraphCount
     ) -> String {
-        let top = (0..<28).map { index in
+        let top = (0..<leadingParagraphCount).map { index in
             "Paragraph \(index): " + String(repeating: "This keeps the document tall enough for scroll alignment. ", count: 2)
         }.joined(separator: "\n\n")
         let bottom = includeBottomSpacer
@@ -326,7 +349,9 @@ struct RendererAttachmentSpikeHostedTests {
         _ snapshot: RendererAttachmentSpikeSnapshot?,
         measurement: RendererAttachmentSpikeDOMMeasurement,
         expectedCenterHit: Bool,
-        expectedPresent: Bool = true
+        expectedPresent: Bool = true,
+        expectedFullyInsideLayoutViewport: Bool = false,
+        stage: String
     ) {
         guard let snapshot else {
             Issue.record("missing independent DOM snapshot")
@@ -334,10 +359,21 @@ struct RendererAttachmentSpikeHostedTests {
         }
         #expect(snapshot.revision > 0)
         #expect(measurement.present == expectedPresent)
+        if measurement.centerHit != expectedCenterHit {
+            Issue.record("DOM measurement mismatch [\(stage)]: \(measurement.diagnostics)")
+        }
         #expect(measurement.centerHit == expectedCenterHit)
         #expect(measurement.scrollY >= 0)
         if expectedPresent {
             #expect(measurement.placeholderID == snapshot.placeholderID)
+            if expectedFullyInsideLayoutViewport {
+                #expect(measurement.layoutViewportClientWidth > 0)
+                #expect(measurement.layoutViewportClientHeight > 0)
+                #expect(measurement.cssRect.minX >= 0)
+                #expect(measurement.cssRect.minY >= 0)
+                #expect(measurement.cssRect.maxX <= measurement.layoutViewportClientWidth)
+                #expect(measurement.cssRect.maxY <= measurement.layoutViewportClientHeight)
+            }
         } else {
             #expect(measurement.placeholderID.isEmpty)
         }
@@ -503,59 +539,91 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     }
 
     func publishGeometry() async throws {
-        let minimumRevision = currentRevision + 1
-        _ = await evaluateJavaScriptWithTimeout(webView, "window.__rendererAttachmentSpikeReport ? window.__rendererAttachmentSpikeReport() : 'missing'")
+        let body = await evaluateJavaScriptWithTimeout(
+            webView,
+            "window.__rendererAttachmentSpikeReport ? window.__rendererAttachmentSpikeReport() : 'missing'")
+        guard let body, let publishedRevision = Int(body) else {
+            throw RendererAttachmentSpikeHarnessError.missingPublishedRevision(body: String(describing: body))
+        }
         try await Self.waitFor(description: "renderer attachment geometry") { [weak self] in
-            (self?.currentSnapshot?.revision ?? 0) >= minimumRevision
+            (self?.currentSnapshot?.revision ?? 0) >= publishedRevision
         }
     }
 
     func measureDOMGeometry() async throws -> RendererAttachmentSpikeDOMMeasurement {
         let body = await evaluateJavaScriptWithTimeout(webView, """
         (function(){
-          var card = document.querySelector('\(Self.cardSelector)');
           var scrollY = window.scrollY || document.documentElement.scrollTop || 0;
-          var viewport = (function(){
-            var docEl = document.documentElement;
+          var docEl = document.documentElement;
+          var body = document.body;
+          var visual = window.visualViewport;
+          var cards = document.querySelectorAll('\(Self.cardSelector)');
+          var card = cards.length ? cards[0] : null;
+          function viewportBounds(){
             var width = (docEl && docEl.clientWidth) || window.innerWidth || 0;
             var height = (docEl && docEl.clientHeight) || window.innerHeight || 0;
-            return { left: 0, top: 0, right: width, bottom: height };
-          })();
-          function visibleCardRect() {
-            if(!card){ return null; }
-            var rect = card.getBoundingClientRect();
-            var left = Math.max(rect.left, viewport.left);
-            var top = Math.max(rect.top, viewport.top);
-            var right = Math.min(rect.right, viewport.right);
-            var bottom = Math.min(rect.bottom, viewport.bottom);
+            return { left: 0, top: 0, right: width, bottom: height, width: width, height: height };
+          }
+          function rectFor(el){
+            var r = el.getBoundingClientRect();
+            return { left: r.left, top: r.top, right: r.right, bottom: r.bottom, width: r.width, height: r.height };
+          }
+          function intersectRects(a, b){
+            if(!a || !b){ return null; }
+            var left = Math.max(a.left, b.left);
+            var top = Math.max(a.top, b.top);
+            var right = Math.min(a.right, b.right);
+            var bottom = Math.min(a.bottom, b.bottom);
             if(right > left && bottom > top){
-              return rect;
+              return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
             }
             return null;
           }
-          function visibleHit() {
-            return visibleCardRect() !== null;
-          }
-          if(!card){
-            return JSON.stringify({
-              present: false,
-              placeholderID: "",
-              centerHit: false,
-              scrollY: scrollY
-            });
-          }
-          var rect = card.getBoundingClientRect();
+          var layoutViewport = viewportBounds();
+          var cardRect = card ? rectFor(card) : null;
+          var visibleIntersection = cardRect ? intersectRects(cardRect, layoutViewport) : null;
+          var selectedCardClass = card ? (typeof card.className === 'string' ? card.className : String(card.className || '')) : "";
           return JSON.stringify({
-            present: true,
-            placeholderID: card.id || "",
-            cssRect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
-            centerHit: visibleHit(),
-            scrollY: scrollY
+            present: !!card,
+            placeholderID: card ? (card.id || "") : "",
+            cssRect: cardRect ? { x: cardRect.left, y: cardRect.top, width: cardRect.width, height: cardRect.height } : { x: 0, y: 0, width: 0, height: 0 },
+            centerHit: visibleIntersection !== null,
+            scrollY: scrollY,
+            matchingCardCount: cards.length,
+            selectedCardTag: card ? (card.tagName || "") : "",
+            selectedCardClass: selectedCardClass,
+            selectedCardID: card ? (card.id || "") : "",
+            selectedCardConnected: !!(card && card.isConnected),
+            selectedCardRect: cardRect,
+            layoutViewportClientWidth: layoutViewport.width,
+            layoutViewportClientHeight: layoutViewport.height,
+            windowInnerWidth: window.innerWidth || 0,
+            windowInnerHeight: window.innerHeight || 0,
+            documentElementClientWidth: docEl ? docEl.clientWidth || 0 : 0,
+            documentElementClientHeight: docEl ? docEl.clientHeight || 0 : 0,
+            documentElementScrollWidth: docEl ? docEl.scrollWidth || 0 : 0,
+            documentElementScrollHeight: docEl ? docEl.scrollHeight || 0 : 0,
+            documentElementScrollLeft: docEl ? docEl.scrollLeft || 0 : 0,
+            documentElementScrollTop: docEl ? docEl.scrollTop || 0 : 0,
+            bodyClientWidth: body ? body.clientWidth || 0 : 0,
+            bodyClientHeight: body ? body.clientHeight || 0 : 0,
+            bodyScrollWidth: body ? body.scrollWidth || 0 : 0,
+            bodyScrollHeight: body ? body.scrollHeight || 0 : 0,
+            bodyScrollLeft: body ? body.scrollLeft || 0 : 0,
+            bodyScrollTop: body ? body.scrollTop || 0 : 0,
+            windowScrollX: window.scrollX || window.pageXOffset || 0,
+            windowScrollY: window.scrollY || window.pageYOffset || 0,
+            readyState: document.readyState || "",
+            visualViewportOffsetLeft: visual ? visual.offsetLeft : null,
+            visualViewportOffsetTop: visual ? visual.offsetTop : null,
+            visualViewportWidth: visual ? visual.width : null,
+            visualViewportHeight: visual ? visual.height : null,
+            visibleIntersection: visibleIntersection
           });
         })()
         """)
         guard let measurement = RendererAttachmentSpikeDOMMeasurement(body: body) else {
-            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: String(describing: body))
         }
         return measurement
     }
@@ -564,7 +632,6 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         _ = await evaluateJavaScriptWithTimeout(webView, """
         (function(y){ window.scrollTo(0, y); return 'scrolled'; })(\(Self.posix(y)))
         """)
-        try await publishGeometry()
     }
 
     func insertSpacerBeforePlaceholder(height: CGFloat) async throws {
@@ -582,7 +649,6 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           return 'inserted';
         })(\(Self.posix(height)))
         """)
-        try await publishGeometry()
     }
 
     func ingest(_ snapshot: RendererAttachmentSpikeSnapshot) {
@@ -669,35 +735,38 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };
           function rectFor(el){
             var r = el.getBoundingClientRect();
-            return { x: r.left, y: r.top, width: r.width, height: r.height };
+            return { left: r.left, top: r.top, right: r.right, bottom: r.bottom, width: r.width, height: r.height };
           }
           function viewportBounds(){
             var docEl = document.documentElement;
             var width = (docEl && docEl.clientWidth) || window.innerWidth || 0;
             var height = (docEl && docEl.clientHeight) || window.innerHeight || 0;
-            return { left: 0, top: 0, right: width, bottom: height };
+            return { left: 0, top: 0, right: width, bottom: height, width: width, height: height };
           }
-          function visibleCardRect(card){
-            var viewport = viewportBounds();
-            if(!card){ return null; }
-            var rect = card.getBoundingClientRect();
-            var left = Math.max(rect.left, viewport.left);
-            var top = Math.max(rect.top, viewport.top);
-            var right = Math.min(rect.right, viewport.right);
-            var bottom = Math.min(rect.bottom, viewport.bottom);
+          function intersectRects(a, b){
+            if(!a || !b){ return null; }
+            var left = Math.max(a.left, b.left);
+            var top = Math.max(a.top, b.top);
+            var right = Math.min(a.right, b.right);
+            var bottom = Math.min(a.bottom, b.bottom);
             if(right > left && bottom > top){
-              return rect;
+              return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
             }
             return null;
-          }
-          function visibleCardHit(card){
-            return visibleCardRect(card) !== null;
           }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };
             state.revision = Number(state.revision || 0) + 1;
             window.__rendererAttachmentSpikeState = state;
-            var card = document.querySelector('\(Self.cardSelector)');
+            var docEl = document.documentElement;
+            var body = document.body;
+            var visual = window.visualViewport;
+            var cards = document.querySelectorAll('\(Self.cardSelector)');
+            var card = cards.length ? cards[0] : null;
+            var viewport = viewportBounds();
+            var cardRect = card ? rectFor(card) : null;
+            var visibleIntersection = cardRect ? intersectRects(cardRect, viewport) : null;
+            var selectedCardClass = card ? (typeof card.className === 'string' ? card.className : String(card.className || '')) : "";
             if(!card){
               window.webkit.messageHandlers.\(Self.messageName).postMessage({
                 generation: state.generation,
@@ -705,21 +774,80 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
                 placeholderID: "",
                 present: false,
                 centerHit: false,
-                scrollY: window.scrollY || document.documentElement.scrollTop || 0
+                scrollY: window.scrollY || document.documentElement.scrollTop || 0,
+                matchingCardCount: cards.length,
+                selectedCardTag: "",
+                selectedCardClass: "",
+                selectedCardID: "",
+                selectedCardConnected: false,
+                selectedCardRect: null,
+                layoutViewportClientWidth: viewport.width,
+                layoutViewportClientHeight: viewport.height,
+                windowInnerWidth: window.innerWidth || 0,
+                windowInnerHeight: window.innerHeight || 0,
+                documentElementClientWidth: docEl ? docEl.clientWidth || 0 : 0,
+                documentElementClientHeight: docEl ? docEl.clientHeight || 0 : 0,
+                documentElementScrollWidth: docEl ? docEl.scrollWidth || 0 : 0,
+                documentElementScrollHeight: docEl ? docEl.scrollHeight || 0 : 0,
+                documentElementScrollLeft: docEl ? docEl.scrollLeft || 0 : 0,
+                documentElementScrollTop: docEl ? docEl.scrollTop || 0 : 0,
+                bodyClientWidth: body ? body.clientWidth || 0 : 0,
+                bodyClientHeight: body ? body.clientHeight || 0 : 0,
+                bodyScrollWidth: body ? body.scrollWidth || 0 : 0,
+                bodyScrollHeight: body ? body.scrollHeight || 0 : 0,
+                bodyScrollLeft: body ? body.scrollLeft || 0 : 0,
+                bodyScrollTop: body ? body.scrollTop || 0 : 0,
+                windowScrollX: window.scrollX || window.pageXOffset || 0,
+                windowScrollY: window.scrollY || window.pageYOffset || 0,
+                readyState: document.readyState || "",
+                visualViewportOffsetLeft: visual ? visual.offsetLeft : null,
+                visualViewportOffsetTop: visual ? visual.offsetTop : null,
+                visualViewportWidth: visual ? visual.width : null,
+                visualViewportHeight: visual ? visual.height : null,
+                visibleIntersection: null
               });
-              return "missing";
+              return String(state.revision);
             }
-            var cardRect = rectFor(card);
             window.webkit.messageHandlers.\(Self.messageName).postMessage({
                 generation: state.generation,
                 revision: state.revision,
                 placeholderID: card.id || "",
                 present: true,
-                cssRect: cardRect,
-                centerHit: visibleCardHit(card),
-                scrollY: window.scrollY || document.documentElement.scrollTop || 0
+                cssRect: cardRect ? { x: cardRect.left, y: cardRect.top, width: cardRect.width, height: cardRect.height } : { x: 0, y: 0, width: 0, height: 0 },
+                centerHit: visibleIntersection !== null,
+                scrollY: window.scrollY || document.documentElement.scrollTop || 0,
+                matchingCardCount: cards.length,
+                selectedCardTag: card.tagName || "",
+                selectedCardClass: selectedCardClass,
+                selectedCardID: card.id || "",
+                selectedCardConnected: !!card.isConnected,
+                selectedCardRect: cardRect,
+                layoutViewportClientWidth: viewport.width,
+                layoutViewportClientHeight: viewport.height,
+                windowInnerWidth: window.innerWidth || 0,
+                windowInnerHeight: window.innerHeight || 0,
+                documentElementClientWidth: docEl ? docEl.clientWidth || 0 : 0,
+                documentElementClientHeight: docEl ? docEl.clientHeight || 0 : 0,
+                documentElementScrollWidth: docEl ? docEl.scrollWidth || 0 : 0,
+                documentElementScrollHeight: docEl ? docEl.scrollHeight || 0 : 0,
+                documentElementScrollLeft: docEl ? docEl.scrollLeft || 0 : 0,
+                documentElementScrollTop: docEl ? docEl.scrollTop || 0 : 0,
+                bodyClientWidth: body ? body.clientWidth || 0 : 0,
+                bodyClientHeight: body ? body.clientHeight || 0 : 0,
+                bodyScrollWidth: body ? body.scrollWidth || 0 : 0,
+                bodyScrollHeight: body ? body.scrollHeight || 0 : 0,
+                bodyScrollLeft: body ? body.scrollLeft || 0 : 0,
+                bodyScrollTop: body ? body.scrollTop || 0 : 0,
+                windowScrollX: window.scrollX || window.pageXOffset || 0,
+                windowScrollY: window.scrollY || window.pageYOffset || 0,
+                readyState: document.readyState || "",
+                visualViewportOffsetLeft: visual ? visual.offsetLeft : null,
+                visualViewportOffsetTop: visual ? visual.offsetTop : null,
+                visualViewportWidth: visual ? visual.width : null,
+                visualViewportHeight: visual ? visual.height : null,
+                visibleIntersection: visibleIntersection
             });
-            return "posted";
+            return String(state.revision);
           }
           window.__rendererAttachmentSpikeReport = report;
           window.addEventListener('scroll', report, { passive: true });
@@ -873,19 +1001,28 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
     let cssRect: CGRect
     let centerHit: Bool
     let scrollY: CGFloat
+    let diagnostics: String
+    let layoutViewportClientWidth: CGFloat
+    let layoutViewportClientHeight: CGFloat
 
     init(
         present: Bool,
         placeholderID: String,
         cssRect: CGRect,
         centerHit: Bool,
-        scrollY: CGFloat
+        scrollY: CGFloat,
+        diagnostics: String = "",
+        layoutViewportClientWidth: CGFloat = 0,
+        layoutViewportClientHeight: CGFloat = 0
     ) {
         self.present = present
         self.placeholderID = placeholderID
         self.cssRect = cssRect
         self.centerHit = centerHit
         self.scrollY = scrollY
+        self.diagnostics = diagnostics
+        self.layoutViewportClientWidth = layoutViewportClientWidth
+        self.layoutViewportClientHeight = layoutViewportClientHeight
     }
 
     init?(body: Any?) {
@@ -908,6 +1045,15 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
         self.cssRect = rect
         self.centerHit = centerHit
         self.scrollY = scrollY
+        self.layoutViewportClientWidth = Self.cgFloat(dict["layoutViewportClientWidth"]) ?? 0
+        self.layoutViewportClientHeight = Self.cgFloat(dict["layoutViewportClientHeight"]) ?? 0
+        self.diagnostics = Self.debugSummary(
+            dict: dict,
+            present: present,
+            placeholderID: placeholderID,
+            rect: rect,
+            centerHit: centerHit,
+            scrollY: scrollY)
     }
 
     private static func dictionary(_ value: Any?) -> [String: Any]? {
@@ -946,6 +1092,108 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
             return nil
         }
     }
+
+    private static func cgFloatOptional(_ value: Any?) -> CGFloat? {
+        guard let value, !(value is NSNull) else { return nil }
+        return cgFloat(value)
+    }
+
+    private static func int(_ value: Any?) -> Int? {
+        switch value {
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func bool(_ value: Any?) -> Bool {
+        value as? Bool ?? false
+    }
+
+    private static func string(_ value: Any?) -> String {
+        value as? String ?? ""
+    }
+
+    private static func rectOptional(_ value: Any?) -> CGRect? {
+        guard let value, !(value is NSNull) else { return nil }
+        return rect(value)
+    }
+
+    private static func debugSummary(
+        dict: [String: Any],
+        present: Bool,
+        placeholderID: String,
+        rect: CGRect,
+        centerHit: Bool,
+        scrollY: CGFloat
+    ) -> String {
+        let matchingCardCount = int(dict["matchingCardCount"]) ?? 0
+        let selectedCardTag = string(dict["selectedCardTag"])
+        let selectedCardClass = string(dict["selectedCardClass"])
+        let selectedCardID = string(dict["selectedCardID"])
+        let selectedCardConnected = bool(dict["selectedCardConnected"])
+        let selectedCardRect = rectOptional(dict["selectedCardRect"])
+        let layoutViewportClientWidth = cgFloat(dict["layoutViewportClientWidth"]) ?? 0
+        let layoutViewportClientHeight = cgFloat(dict["layoutViewportClientHeight"]) ?? 0
+        let windowInnerWidth = cgFloat(dict["windowInnerWidth"]) ?? 0
+        let windowInnerHeight = cgFloat(dict["windowInnerHeight"]) ?? 0
+        let documentElementClientWidth = cgFloat(dict["documentElementClientWidth"]) ?? 0
+        let documentElementClientHeight = cgFloat(dict["documentElementClientHeight"]) ?? 0
+        let documentElementScrollWidth = cgFloat(dict["documentElementScrollWidth"]) ?? 0
+        let documentElementScrollHeight = cgFloat(dict["documentElementScrollHeight"]) ?? 0
+        let documentElementScrollLeft = cgFloat(dict["documentElementScrollLeft"]) ?? 0
+        let documentElementScrollTop = cgFloat(dict["documentElementScrollTop"]) ?? 0
+        let bodyClientWidth = cgFloat(dict["bodyClientWidth"]) ?? 0
+        let bodyClientHeight = cgFloat(dict["bodyClientHeight"]) ?? 0
+        let bodyScrollWidth = cgFloat(dict["bodyScrollWidth"]) ?? 0
+        let bodyScrollHeight = cgFloat(dict["bodyScrollHeight"]) ?? 0
+        let bodyScrollLeft = cgFloat(dict["bodyScrollLeft"]) ?? 0
+        let bodyScrollTop = cgFloat(dict["bodyScrollTop"]) ?? 0
+        let windowScrollX = cgFloat(dict["windowScrollX"]) ?? 0
+        let windowScrollY = cgFloat(dict["windowScrollY"]) ?? 0
+        let readyState = string(dict["readyState"])
+        let visualViewportOffsetLeft = cgFloatOptional(dict["visualViewportOffsetLeft"])
+        let visualViewportOffsetTop = cgFloatOptional(dict["visualViewportOffsetTop"])
+        let visualViewportWidth = cgFloatOptional(dict["visualViewportWidth"])
+        let visualViewportHeight = cgFloatOptional(dict["visualViewportHeight"])
+        let visibleIntersection = rectOptional(dict["visibleIntersection"])
+        return [
+            "present=\(present)",
+            "placeholderID=\(placeholderID)",
+            "centerHit=\(centerHit)",
+            "scrollY=\(scrollY)",
+            "matchingCardCount=\(matchingCardCount)",
+            "selectedCardTag=\(selectedCardTag)",
+            "selectedCardClass=\(selectedCardClass)",
+            "selectedCardID=\(selectedCardID)",
+            "selectedCardConnected=\(selectedCardConnected)",
+            "cardRect=\(describe(rect))",
+            "selectedCardRect=\(describe(selectedCardRect))",
+            "visibleIntersection=\(describe(visibleIntersection))",
+            "layoutViewport=(\(layoutViewportClientWidth),\(layoutViewportClientHeight))",
+            "windowInner=(\(windowInnerWidth),\(windowInnerHeight))",
+            "documentElementClient=(\(documentElementClientWidth),\(documentElementClientHeight))",
+            "documentElementScroll=(\(documentElementScrollLeft),\(documentElementScrollTop),\(documentElementScrollWidth),\(documentElementScrollHeight))",
+            "bodyClient=(\(bodyClientWidth),\(bodyClientHeight))",
+            "bodyScroll=(\(bodyScrollLeft),\(bodyScrollTop),\(bodyScrollWidth),\(bodyScrollHeight))",
+            "windowScroll=(\(windowScrollX),\(windowScrollY))",
+            "readyState=\(readyState)",
+            "visualViewport=(\(describe(value: visualViewportOffsetLeft)),\(describe(value: visualViewportOffsetTop)),\(describe(value: visualViewportWidth)),\(describe(value: visualViewportHeight)))"
+        ].joined(separator: " ")
+    }
+
+    private static func describe(_ rect: CGRect?) -> String {
+        guard let rect else { return "nil" }
+        return "(\(rect.minX),\(rect.minY),\(rect.width),\(rect.height))"
+    }
+
+    private static func describe(value: CGFloat?) -> String {
+        guard let value else { return "nil" }
+        return "\(value)"
+    }
 }
 
 private struct RendererAttachmentSpikeAlignmentEvidence {
@@ -964,7 +1212,8 @@ private struct RendererAttachmentSpikeAlignmentEvidence {
 private enum RendererAttachmentSpikeHarnessError: LocalizedError {
     case timeout(description: String)
     case missingGeometry
-    case missingDOMMeasurement
+    case missingDOMMeasurement(body: String)
+    case missingPublishedRevision(body: String)
 
     var errorDescription: String? {
         switch self {
@@ -972,8 +1221,10 @@ private enum RendererAttachmentSpikeHarnessError: LocalizedError {
             return "timed out waiting for \(description)"
         case .missingGeometry:
             return "missing attachment geometry"
-        case .missingDOMMeasurement:
-            return "missing independent DOM measurement"
+        case let .missingDOMMeasurement(body):
+            return "missing independent DOM measurement: \(body)"
+        case let .missingPublishedRevision(body):
+            return "missing published renderer attachment revision: \(body)"
         }
     }
 }

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -19,6 +19,22 @@ struct RendererAttachmentSpikeHostedTests {
     private static let fixedAlignmentTolerancePoints: CGFloat = 1
 
     @Test
+    func testPhysicalOverlayRectUsesBackingScale() {
+        let geometry = RendererAttachmentSpikeGeometry(
+            generation: 1,
+            revision: 1,
+            placeholderID: "placeholder",
+            cssRect: CGRect(x: 10, y: 20, width: 30, height: 40),
+            pageZoom: 1,
+            domCenterHit: true,
+            scrollY: 0,
+            backingScaleFactor: 2,
+            webViewBounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+        #expect(geometry.overlayRect == CGRect(x: 10, y: 40, width: 30, height: 40))
+        #expect(geometry.physicalOverlayRect == CGRect(x: 20, y: 80, width: 60, height: 80))
+    }
+
+    @Test
     func testScrollZoomResizeAndHeightMutationStayAligned() async throws {
         for iteration in 1...20 {
             var alignmentEvidences: [RendererAttachmentSpikeAlignmentEvidence] = []
@@ -48,7 +64,9 @@ struct RendererAttachmentSpikeHostedTests {
                 harness.overlay.frame,
                 renderedRect: try #require(initialRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor)
+                backingScaleFactor: window.backingScaleFactor,
+                stage: "initial",
+                iteration: iteration)
             )
             Self.assertIndependentDOM(
                 initialSnapshot,
@@ -72,7 +90,9 @@ struct RendererAttachmentSpikeHostedTests {
                 harness.overlay.frame,
                 renderedRect: try #require(scrolledRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor)
+                backingScaleFactor: window.backingScaleFactor,
+                stage: "scroll",
+                iteration: iteration)
             )
             Self.assertIndependentDOM(
                 scrolledSnapshot,
@@ -95,7 +115,9 @@ struct RendererAttachmentSpikeHostedTests {
                 harness.overlay.frame,
                 renderedRect: try #require(zoomedRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor)
+                backingScaleFactor: window.backingScaleFactor,
+                stage: "zoomed",
+                iteration: iteration)
             )
             Self.assertIndependentDOM(
                 zoomedSnapshot,
@@ -119,7 +141,9 @@ struct RendererAttachmentSpikeHostedTests {
                 harness.overlay.frame,
                 renderedRect: try #require(resizedRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor)
+                backingScaleFactor: window.backingScaleFactor,
+                stage: "resized",
+                iteration: iteration)
             )
             Self.assertIndependentDOM(
                 resizedSnapshot,
@@ -129,26 +153,54 @@ struct RendererAttachmentSpikeHostedTests {
                 stage: "resized iteration \(iteration)")
             #expect(resized.revision > zoomed.revision)
 
-            try await harness.insertSpacerBeforePlaceholder(height: 96)
+            let spacerInsertion = try await harness.insertSpacerBeforePlaceholder(height: 96)
+            #expect(spacerInsertion == "inserted")
             try await harness.scrollTo(y: Self.positiveScrollY)
             try await harness.publishGeometry()
-            let mutated = try harness.requireGeometry()
-            let mutatedSnapshot = try #require(harness.currentSnapshot)
-            let mutatedMeasurement = try await harness.measureDOMGeometry()
-            let mutatedRenderedRect = try await harness.captureSentinelRect()
+            let spacerMutated = try harness.requireGeometry()
+            let spacerSnapshot = try #require(harness.currentSnapshot)
+            let spacerMeasurement = try await harness.measureDOMGeometry()
+            let spacerRenderedRect = try await harness.captureSentinelRect()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,
-                renderedRect: try #require(mutatedRenderedRect),
+                renderedRect: try #require(spacerRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor)
+                backingScaleFactor: window.backingScaleFactor,
+                stage: "spacer-mutation",
+                iteration: iteration)
             )
             Self.assertIndependentDOM(
-                mutatedSnapshot,
-                measurement: mutatedMeasurement,
+                spacerSnapshot,
+                measurement: spacerMeasurement,
                 expectedCenterHit: true,
                 expectedFullyInsideLayoutViewport: true,
-                stage: "height-mutation iteration \(iteration)")
-            #expect(mutated.revision > resized.revision)
+                stage: "spacer-mutation iteration \(iteration)")
+            #expect(spacerMeasurement.cssRect.minY > resizedMeasurement.cssRect.minY)
+            #expect(spacerMutated.revision > resized.revision)
+
+            let reservedHeightMutation = try await harness.increasePlaceholderReservedHeight(by: 96)
+            #expect(reservedHeightMutation == "mutated")
+            try await harness.publishGeometry()
+            let reservedHeightMutated = try harness.requireGeometry()
+            let reservedHeightSnapshot = try #require(harness.currentSnapshot)
+            let reservedHeightMeasurement = try await harness.measureDOMGeometry()
+            let reservedHeightRenderedRect = try await harness.captureSentinelRect()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                renderedRect: try #require(reservedHeightRenderedRect),
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                stage: "reserved-height-mutation",
+                iteration: iteration)
+            )
+            Self.assertIndependentDOM(
+                reservedHeightSnapshot,
+                measurement: reservedHeightMeasurement,
+                expectedCenterHit: true,
+                expectedFullyInsideLayoutViewport: true,
+                stage: "reserved-height-mutation iteration \(iteration)")
+            #expect(reservedHeightMeasurement.cssRect.height > spacerMeasurement.cssRect.height)
+            #expect(reservedHeightMutated.revision > spacerMutated.revision)
 
             Self.assertAlignmentEvidence(
                 alignmentEvidences,
@@ -189,7 +241,9 @@ struct RendererAttachmentSpikeHostedTests {
                 harness.overlay.frame.intersection(harness.webView.bounds),
                 renderedRect: try #require(geometryRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor))
+                backingScaleFactor: window.backingScaleFactor,
+                stage: "visible-clipping",
+                iteration: iteration))
 
             #expect(geometry.clipRect.isEmpty == false)
             #expect(geometry.clipRect != geometry.overlayRect)
@@ -209,6 +263,17 @@ struct RendererAttachmentSpikeHostedTests {
             #expect(visible.contains(outsidePoint) == false)
             let insideWindowPoint = harness.overlay.convert(insidePoint, to: harness.containerView)
             let outsideWindowPoint = harness.overlay.convert(outsidePoint, to: harness.containerView)
+
+            let occluderResult = try await harness.installDOMOccluder()
+            #expect(occluderResult == "installed")
+            try await harness.publishGeometry()
+            let occludedMeasurement = try await harness.measureDOMGeometry()
+            #expect(occludedMeasurement.centerHit == false)
+            harness.overlay.visibleClipRect = .zero
+            #expect(harness.overlay.hitTest(insideWindowPoint) == nil)
+            let removalResult = try await harness.removeDOMOccluder()
+            #expect(removalResult == "removed")
+            try await harness.publishGeometry()
 
             let routedInside = harness.containerView.hitTest(insideWindowPoint)
             #expect(routedInside === harness.overlay)
@@ -359,6 +424,7 @@ struct RendererAttachmentSpikeHostedTests {
         }
         #expect(snapshot.revision > 0)
         #expect(measurement.present == expectedPresent)
+        #expect(measurement.matchingCardCount == (expectedPresent ? 1 : 0))
         if measurement.centerHit != expectedCenterHit {
             Issue.record("DOM measurement mismatch [\(stage)]: \(measurement.diagnostics)")
         }
@@ -383,11 +449,17 @@ struct RendererAttachmentSpikeHostedTests {
         _ actual: CGRect,
         renderedRect: CGRect,
         containerView: NSView,
-        backingScaleFactor: CGFloat
+        backingScaleFactor: CGFloat,
+        stage: String,
+        iteration: Int
     ) -> RendererAttachmentSpikeAlignmentEvidence {
         let expectedBacking = containerView.convertToBacking(renderedRect)
         let actualBacking = containerView.convertToBacking(actual)
         return RendererAttachmentSpikeAlignmentEvidence(
+            stage: stage,
+            iteration: iteration,
+            actualRect: actual,
+            renderedRect: renderedRect,
             pointResiduals: [
                 abs(actual.minX - renderedRect.minX),
                 abs(actual.minY - renderedRect.minY),
@@ -408,7 +480,13 @@ struct RendererAttachmentSpikeHostedTests {
         backingScaleFactor: CGFloat
     ) {
         for evidence in evidences {
+            if evidence.maxPointResidual > tolerance {
+                Issue.record(RendererAttachmentSpikeEvidenceError.diagnostic(evidence.diagnostics))
+            }
             #expect(evidence.maxPointResidual <= tolerance)
+            if evidence.maxBackingResidual / max(backingScaleFactor, .leastNonzeroMagnitude) > tolerance {
+                Issue.record(RendererAttachmentSpikeEvidenceError.diagnostic(evidence.diagnostics))
+            }
             #expect(evidence.maxBackingResidual / max(backingScaleFactor, .leastNonzeroMagnitude) <= tolerance)
         }
     }
@@ -456,7 +534,7 @@ struct RendererAttachmentSpikeHostedTests {
         placeholderID: String,
         dom: RendererAttachmentSpikeDOMAccessibility
     ) {
-        let expectedOverlayLabel = RendererAttachmentSpikeOverlayView.accessibilityLabel(for: placeholderID)
+        let expectedOverlayLabel = "Renderer attachment overlay \(placeholderID)"
         #expect(overlay.isAccessibilityElement())
         #expect(overlay.accessibilityRole() == .group)
         #expect(overlay.accessibilityLabel() == expectedOverlayLabel)
@@ -481,12 +559,12 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     static let messageName = "rendererAttachmentSpike"
     private static let cardSelector = "section.sdw-renderer-card"
     private static let sentinelColor = "rgb(1, 2, 3)"
+    private static let sentinelColorSpace = NSColorSpace.genericRGB
     private static let snapshotTimeout: Duration = .seconds(15)
     private static let probeScript = makeProbeScript()
 
     let containerView: NSView
     let webView: WikiReaderWebView
-    private let readerRouteProbe = RendererAttachmentSpikeReaderRouteProbe(frame: .zero)
     let overlay = RendererAttachmentSpikeOverlayView(frame: .zero)
     private let bridge = RendererAttachmentSpikeBridge()
     let window: NSWindow
@@ -524,12 +602,9 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         webView.navigationDelegate = self
         webView.pageZoom = Double(ZoomScale.defaultScale)
         webView.autoresizingMask = [.width, .height]
-        readerRouteProbe.autoresizingMask = [.width, .height]
         overlay.autoresizingMask = []
         overlay.isHidden = true
         containerView.addSubview(webView)
-        readerRouteProbe.frame = webView.bounds
-        webView.addSubview(readerRouteProbe)
         containerView.addSubview(overlay)
         webView.frame = containerView.bounds
         overlay.frame = containerView.bounds
@@ -586,7 +661,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           var body = document.body;
           var visual = window.visualViewport;
           var card = document.getElementById('\(placeholderID)');
-          var cards = card ? [card] : [];
+          var cards = document.querySelectorAll('\(Self.cardSelector)');
           function viewportBounds(){
             var width = (docEl && docEl.clientWidth) || window.innerWidth || 0;
             var height = (docEl && docEl.clientHeight) || window.innerHeight || 0;
@@ -724,8 +799,8 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         """)
     }
 
-    func insertSpacerBeforePlaceholder(height: CGFloat) async throws {
-        _ = await evaluateJavaScriptWithTimeout(webView, """
+    func insertSpacerBeforePlaceholder(height: CGFloat) async throws -> String {
+        guard let result = await evaluateJavaScriptWithTimeout(webView, """
         (function(h){
           var card=document.querySelector('\(Self.cardSelector)');
           if(!card){ return 'missing'; }
@@ -738,7 +813,61 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           card.parentNode.insertBefore(spacer, card);
           return 'inserted';
         })(\(Self.posix(height)))
-        """)
+        """) else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: "spacer insertion timed out")
+        }
+        return result
+    }
+
+    func increasePlaceholderReservedHeight(by height: CGFloat) async throws -> String {
+        let placeholderID = try requiredPlaceholderID()
+        guard let result = await evaluateJavaScriptWithTimeout(webView, """
+        (function(delta){
+          var card=document.getElementById(\(Self.javaScriptString(placeholderID)));
+          if(!card){ return 'missing'; }
+          var rect=card.getBoundingClientRect();
+          card.style.minHeight=(rect.height + delta)+'px';
+          return 'mutated';
+        })(\(Self.posix(height)))
+        """) else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: "reserved-height mutation timed out")
+        }
+        return result
+    }
+
+    func installDOMOccluder() async throws -> String {
+        let placeholderID = try requiredPlaceholderID()
+        guard let result = await evaluateJavaScriptWithTimeout(webView, """
+        (function(){
+          var card=document.getElementById(\(Self.javaScriptString(placeholderID)));
+          if(!card){ return 'missing'; }
+          var existing=document.getElementById('renderer-attachment-spike-occluder');
+          if(existing){ existing.remove(); }
+          var rect=card.getBoundingClientRect();
+          var occluder=document.createElement('div');
+          occluder.id='renderer-attachment-spike-occluder';
+          occluder.style.cssText='position:fixed;left:'+rect.left+'px;top:'+rect.top+'px;width:'+rect.width+'px;height:'+rect.height+'px;z-index:2147483647;background:rgb(9, 9, 9);pointer-events:auto';
+          document.body.appendChild(occluder);
+          return 'installed';
+        })()
+        """) else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: "occluder installation timed out")
+        }
+        return result
+    }
+
+    func removeDOMOccluder() async throws -> String {
+        guard let result = await evaluateJavaScriptWithTimeout(webView, """
+        (function(){
+          var occluder=document.getElementById('renderer-attachment-spike-occluder');
+          if(!occluder){ return 'missing'; }
+          occluder.remove();
+          return 'removed';
+        })()
+        """) else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: "occluder removal timed out")
+        }
+        return result
     }
 
     func ingest(_ snapshot: RendererAttachmentSpikeSnapshot) {
@@ -831,23 +960,24 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         configuration.afterScreenUpdates = true
         let once = Once()
         return try await withCheckedThrowingContinuation { continuation in
-            webView.takeSnapshot(with: configuration) { image, error in
-                once.fire {
-                    if let image {
-                        continuation.resume(returning: image)
-                    } else {
-                        continuation.resume(throwing: error ?? RendererAttachmentSpikeHarnessError.missingSnapshot)
-                    }
-                }
-            }
-            Task { @MainActor in
+            let timeoutTask = Task { @MainActor in
                 do {
                     try await Task.sleep(for: timeout)
                     once.fire {
                         continuation.resume(throwing: RendererAttachmentSpikeHarnessError.snapshotTimeout)
                     }
                 } catch {
-                    // The enclosing test owns cancellation. The WebKit completion can still finish safely.
+                    // The WebKit completion cancelled this timer after winning the one-shot race.
+                }
+            }
+            webView.takeSnapshot(with: configuration) { image, error in
+                once.fire {
+                    timeoutTask.cancel()
+                    if let image {
+                        continuation.resume(returning: image)
+                    } else {
+                        continuation.resume(throwing: error ?? RendererAttachmentSpikeHarnessError.missingSnapshot)
+                    }
                 }
             }
         }
@@ -869,7 +999,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         var maxY = -1
         for y in 0..<bitmap.pixelsHigh {
             for x in 0..<bitmap.pixelsWide {
-                guard let color = bitmap.colorAt(x: x, y: y) else { continue }
+                guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(Self.sentinelColorSpace) else { continue }
                 let red = Int((color.redComponent * 255).rounded())
                 let green = Int((color.greenComponent * 255).rounded())
                 let blue = Int((color.blueComponent * 255).rounded())
@@ -1113,13 +1243,6 @@ private final class RendererAttachmentSpikeOverlayView: NSView {
     }
 }
 
-/// Test-only transparent reader descendant. It makes AppKit's route target
-/// observable without adding production event-routing behavior.
-@MainActor
-private final class RendererAttachmentSpikeReaderRouteProbe: NSView {
-    override var isOpaque: Bool { false }
-}
-
 private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
     let generation: Int
     let revision: Int
@@ -1128,6 +1251,7 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
     let cssRect: CGRect
     let centerHit: Bool
     let scrollY: CGFloat
+    let matchingCardCount: Int
 
     init(
         generation: Int,
@@ -1136,7 +1260,8 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
         present: Bool,
         cssRect: CGRect,
         centerHit: Bool,
-        scrollY: CGFloat
+        scrollY: CGFloat,
+        matchingCardCount: Int = 1
     ) {
         self.generation = generation
         self.revision = revision
@@ -1145,6 +1270,7 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
         self.cssRect = cssRect
         self.centerHit = centerHit
         self.scrollY = scrollY
+        self.matchingCardCount = matchingCardCount
     }
 
     init?(body: Any?) {
@@ -1157,6 +1283,7 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
         }
         let centerHit = dict["centerHit"] as? Bool ?? false
         let scrollY = Self.cgFloat(dict["scrollY"]) ?? 0
+        let matchingCardCount = Self.int(dict["matchingCardCount"]) ?? 0
         let rect: CGRect
         if present {
             guard let cssRect = Self.rect(dict["cssRect"]) else { return nil }
@@ -1171,6 +1298,7 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
         self.cssRect = rect
         self.centerHit = centerHit
         self.scrollY = scrollY
+        self.matchingCardCount = matchingCardCount
     }
 
     private static func rect(_ value: Any?) -> CGRect? {
@@ -1213,6 +1341,7 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
     let cssRect: CGRect
     let centerHit: Bool
     let scrollY: CGFloat
+    let matchingCardCount: Int
     let diagnostics: String
     let layoutViewportClientWidth: CGFloat
     let layoutViewportClientHeight: CGFloat
@@ -1223,6 +1352,7 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
         cssRect: CGRect,
         centerHit: Bool,
         scrollY: CGFloat,
+        matchingCardCount: Int = 0,
         diagnostics: String = "",
         layoutViewportClientWidth: CGFloat = 0,
         layoutViewportClientHeight: CGFloat = 0
@@ -1232,6 +1362,7 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
         self.cssRect = cssRect
         self.centerHit = centerHit
         self.scrollY = scrollY
+        self.matchingCardCount = matchingCardCount
         self.diagnostics = diagnostics
         self.layoutViewportClientWidth = layoutViewportClientWidth
         self.layoutViewportClientHeight = layoutViewportClientHeight
@@ -1245,6 +1376,7 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
         }
         let centerHit = dict["centerHit"] as? Bool ?? false
         let scrollY = Self.cgFloat(dict["scrollY"]) ?? 0
+        let matchingCardCount = Self.int(dict["matchingCardCount"]) ?? 0
         let rect: CGRect
         if present {
             guard let cssRect = Self.rect(dict["cssRect"]) else { return nil }
@@ -1257,6 +1389,7 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
         self.cssRect = rect
         self.centerHit = centerHit
         self.scrollY = scrollY
+        self.matchingCardCount = matchingCardCount
         self.layoutViewportClientWidth = Self.cgFloat(dict["layoutViewportClientWidth"]) ?? 0
         self.layoutViewportClientHeight = Self.cgFloat(dict["layoutViewportClientHeight"]) ?? 0
         self.diagnostics = Self.debugSummary(
@@ -1409,6 +1542,10 @@ private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
 }
 
 private struct RendererAttachmentSpikeAlignmentEvidence {
+    let stage: String
+    let iteration: Int
+    let actualRect: CGRect
+    let renderedRect: CGRect
     let pointResiduals: [CGFloat]
     let backingResiduals: [CGFloat]
 
@@ -1418,6 +1555,20 @@ private struct RendererAttachmentSpikeAlignmentEvidence {
 
     var maxBackingResidual: CGFloat {
         backingResiduals.max() ?? 0
+    }
+
+    var diagnostics: String {
+        "alignment stage=\(stage) iteration=\(iteration) actual=\(actualRect) rendered=\(renderedRect) pointResiduals=\(pointResiduals) backingResiduals=\(backingResiduals)"
+    }
+}
+
+private enum RendererAttachmentSpikeEvidenceError: LocalizedError {
+    case diagnostic(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .diagnostic(message): message
+        }
     }
 }
 

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -523,23 +523,20 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
             return { left: left, top: top, right: left + width, bottom: top + height };
           })();
-          function visibleChildRect() {
+          function visibleCardRect() {
             if(!card){ return null; }
-            var children = card.children || [];
-            for(var i = 0; i < children.length; i++){
-              var rect = children[i].getBoundingClientRect();
-              var left = Math.max(rect.left, viewport.left);
-              var top = Math.max(rect.top, viewport.top);
-              var right = Math.min(rect.right, viewport.right);
-              var bottom = Math.min(rect.bottom, viewport.bottom);
-              if(right > left && bottom > top){
-                return rect;
-              }
+            var rect = card.getBoundingClientRect();
+            var left = Math.max(rect.left, viewport.left);
+            var top = Math.max(rect.top, viewport.top);
+            var right = Math.min(rect.right, viewport.right);
+            var bottom = Math.min(rect.bottom, viewport.bottom);
+            if(right > left && bottom > top){
+              return rect;
             }
             return null;
           }
           function visibleHit() {
-            return visibleChildRect() !== null;
+            return visibleCardRect() !== null;
           }
           if(!card){
             return JSON.stringify({
@@ -684,23 +681,21 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
             return { left: left, top: top, right: left + width, bottom: top + height };
           }
-          function visibleChildRect(card){
+          function visibleCardRect(card){
             var viewport = viewportBounds();
-            var children = card ? card.children : [];
-            for(var i = 0; i < children.length; i++){
-              var rect = children[i].getBoundingClientRect();
-              var left = Math.max(rect.left, viewport.left);
-              var top = Math.max(rect.top, viewport.top);
-              var right = Math.min(rect.right, viewport.right);
-              var bottom = Math.min(rect.bottom, viewport.bottom);
-              if(right > left && bottom > top){
-                return rect;
-              }
+            if(!card){ return null; }
+            var rect = card.getBoundingClientRect();
+            var left = Math.max(rect.left, viewport.left);
+            var top = Math.max(rect.top, viewport.top);
+            var right = Math.min(rect.right, viewport.right);
+            var bottom = Math.min(rect.bottom, viewport.bottom);
+            if(right > left && bottom > top){
+              return rect;
             }
             return null;
           }
           function visibleCardHit(card){
-            return visibleChildRect(card) !== null;
+            return visibleCardRect(card) !== null;
           }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -15,6 +15,7 @@ struct RendererAttachmentSpikeHostedTests {
     @Test
     func testScrollZoomResizeAndHeightMutationStayAligned() async throws {
         for _ in 0..<20 {
+            var alignmentEvidences: [RendererAttachmentSpikeAlignmentEvidence] = []
             let lease = await HostedAppKitTestGate.shared.acquire()
             defer { lease.release() }
             Self.prepareApplication()
@@ -32,62 +33,118 @@ struct RendererAttachmentSpikeHostedTests {
             try await harness.load()
             try await harness.publishGeometry()
             let initial = try harness.requireGeometry()
-            Self.assertAligned(harness.overlay.frame, expected: initial)
-            Self.assertIndependentDOM(harness.currentSnapshot)
-            #expect(initial.backingScaleFactor == (window.backingScaleFactor))
+            let initialSnapshot = try #require(harness.currentSnapshot)
+            let initialMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: initialMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds)
+            )
+            Self.assertIndependentDOM(initialSnapshot, measurement: initialMeasurement, expectedCenterHit: true)
+            #expect(initial.revision == initialSnapshot.revision)
 
             let centeredScroll = max(0, initial.cssRect.minY - (harness.webView.bounds.height * 0.45))
             try await harness.scrollTo(y: centeredScroll)
             try await harness.publishGeometry()
             let centered = try harness.requireGeometry()
-            Self.assertAligned(harness.overlay.frame, expected: centered)
-            Self.assertIndependentDOM(harness.currentSnapshot)
+            let centeredSnapshot = try #require(harness.currentSnapshot)
+            let centeredMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: centeredMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds)
+            )
+            Self.assertIndependentDOM(centeredSnapshot, measurement: centeredMeasurement, expectedCenterHit: true)
             #expect(centered.domCenterHit)
+            #expect(centered.revision > initial.revision)
 
             try await harness.scrollTo(y: 220)
             try await harness.publishGeometry()
             let scrolled = try harness.requireGeometry()
-            Self.assertAligned(harness.overlay.frame, expected: scrolled)
-            Self.assertIndependentDOM(harness.currentSnapshot)
+            let scrolledSnapshot = try #require(harness.currentSnapshot)
+            let scrolledMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: scrolledMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds)
+            )
+            Self.assertIndependentDOM(scrolledSnapshot, measurement: scrolledMeasurement, expectedCenterHit: true)
+            #expect(scrolled.revision > centered.revision)
 
             harness.webView.pageZoom = 1.25
             try await harness.updateRuntimeState()
             try await harness.publishGeometry()
             let zoomed = try harness.requireGeometry()
-            Self.assertAligned(harness.overlay.frame, expected: zoomed)
-            Self.assertIndependentDOM(harness.currentSnapshot)
+            let zoomedSnapshot = try #require(harness.currentSnapshot)
+            let zoomedMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: zoomedMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds)
+            )
+            Self.assertIndependentDOM(zoomedSnapshot, measurement: zoomedMeasurement, expectedCenterHit: true)
+            #expect(zoomed.revision > scrolled.revision)
 
             window.setContentSize(NSSize(width: 920, height: 580))
             harness.containerView.layoutSubtreeIfNeeded()
             try await harness.publishGeometry()
             let resized = try harness.requireGeometry()
-            Self.assertAligned(harness.overlay.frame, expected: resized)
+            let resizedSnapshot = try #require(harness.currentSnapshot)
+            let resizedMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: resizedMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds)
+            )
+            #expect(resized.revision > zoomed.revision)
 
             try await harness.insertSpacerBeforePlaceholder(height: 96)
             try await harness.publishGeometry()
             let mutated = try harness.requireGeometry()
-            Self.assertAligned(harness.overlay.frame, expected: mutated)
-            Self.assertIndependentDOM(harness.currentSnapshot)
+            let mutatedSnapshot = try #require(harness.currentSnapshot)
+            let mutatedMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: mutatedMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds)
+            )
+            Self.assertIndependentDOM(mutatedSnapshot, measurement: mutatedMeasurement, expectedCenterHit: true)
+            #expect(mutated.revision == mutatedSnapshot.revision)
+            #expect(mutated.revision > resized.revision)
 
-            let seam = RendererAttachmentSpikeGeometry(
-                generation: mutated.generation,
-                revision: mutated.revision,
-                placeholderID: mutated.placeholderID,
-                cssRect: mutated.cssRect,
-                pageZoom: mutated.pageZoom,
-                domToViewScale: mutated.domToViewScale,
-                domCenterHit: mutated.domCenterHit,
-                scrollY: mutated.scrollY,
-                backingScaleFactor: 2,
-                webViewBounds: harness.webView.bounds,
-                tolerance: RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
-            #expect(abs(seam.physicalOverlayRect.width - (seam.overlayRect.width * 2)) <= 0.01)
+            let tolerance = RendererAttachmentSpikeMetrics.derivedAlignmentTolerance(
+                pointResiduals: alignmentEvidences.flatMap { $0.pointResiduals },
+                backingResiduals: alignmentEvidences.flatMap { $0.backingResiduals },
+                backingScaleFactor: window.backingScaleFactor)
+            Self.assertAlignmentEvidence(
+                alignmentEvidences,
+                tolerance: tolerance,
+                backingScaleFactor: window.backingScaleFactor)
         }
     }
 
     @Test
     func testClippingAndHitTestingRespectVisiblePlaceholder() async throws {
         for _ in 0..<20 {
+            var alignmentEvidences: [RendererAttachmentSpikeAlignmentEvidence] = []
             let lease = await HostedAppKitTestGate.shared.acquire()
             defer { lease.release() }
             Self.prepareApplication()
@@ -109,23 +166,35 @@ struct RendererAttachmentSpikeHostedTests {
             try await harness.scrollTo(y: targetScroll)
             try await harness.publishGeometry()
             let geometry = try harness.requireGeometry()
+            let geometrySnapshot = try #require(harness.currentSnapshot)
+            let geometryMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: geometryMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds))
 
             #expect(geometry.clipRect.isEmpty == false)
             #expect(geometry.clipRect != geometry.overlayRect)
             #expect(harness.overlay.visibleClipRect == geometry.localClipRect)
-            Self.assertIndependentDOM(harness.currentSnapshot)
+            Self.assertIndependentDOM(geometrySnapshot, measurement: geometryMeasurement, expectedCenterHit: true)
 
             let visible = geometry.localClipRect
             let insidePoint = NSPoint(x: visible.midX, y: visible.midY)
             let outsidePoint = RendererAttachmentSpikeHostedTests.outsidePoint(
                 overlayBounds: harness.overlay.bounds,
                 visibleClip: visible)
-
-            let insideHit = harness.overlay.hitTest(insidePoint)
-            #expect(insideHit === harness.overlay)
-            #expect(harness.overlay.hitTest(outsidePoint) == nil)
-
+            let insideWindowPoint = harness.overlay.convert(insidePoint, to: harness.containerView)
             let outsideWindowPoint = harness.overlay.convert(outsidePoint, to: harness.containerView)
+
+            let routedInside = harness.containerView.hitTest(insideWindowPoint)
+            #expect(routedInside === harness.overlay)
+            let insideHit = harness.overlay.hitTest(insideWindowPoint)
+            #expect(insideHit === harness.overlay)
+            #expect(harness.overlay.hitTest(outsideWindowPoint) == nil)
+
             let routedView = harness.containerView.hitTest(outsideWindowPoint)
             #expect(routedView !== harness.overlay)
 
@@ -133,10 +202,33 @@ struct RendererAttachmentSpikeHostedTests {
             try await harness.scrollTo(y: offscreenScroll)
             try await harness.publishGeometry()
             let offscreen = try harness.requireGeometry()
+            let offscreenSnapshot = try #require(harness.currentSnapshot)
+            let offscreenMeasurement = try await harness.measureDOMGeometry()
+            alignmentEvidences.append(Self.alignmentEvidence(
+                harness.overlay.frame,
+                measurement: offscreenMeasurement,
+                pageZoom: harness.webView.pageZoom,
+                containerView: harness.containerView,
+                backingScaleFactor: window.backingScaleFactor,
+                webViewBounds: harness.webView.bounds))
             #expect(offscreen.clipRect.isEmpty)
             #expect(offscreen.domCenterHit == false)
             #expect(harness.overlay.visibleClipRect.isEmpty)
             #expect(harness.overlay.hitTest(NSPoint(x: 1, y: 1)) == nil)
+            #expect(offscreenSnapshot.scrollY > geometry.scrollY)
+            Self.assertIndependentDOM(
+                offscreenSnapshot,
+                measurement: offscreenMeasurement,
+                expectedCenterHit: false)
+
+            let tolerance = RendererAttachmentSpikeMetrics.derivedAlignmentTolerance(
+                pointResiduals: alignmentEvidences.flatMap { $0.pointResiduals },
+                backingResiduals: alignmentEvidences.flatMap { $0.backingResiduals },
+                backingScaleFactor: window.backingScaleFactor)
+            Self.assertAlignmentEvidence(
+                alignmentEvidences,
+                tolerance: tolerance,
+                backingScaleFactor: window.backingScaleFactor)
         }
     }
 
@@ -175,6 +267,7 @@ struct RendererAttachmentSpikeHostedTests {
 
             let frameBeforeStaleResize = harness.overlay.frame
             let revisionBeforeStaleResize = try #require(harness.currentSnapshot).revision
+            #expect(generation2.revision < generation3.revision)
             harness.ingest(Self.snapshot(from: generation2))
             #expect(harness.currentGeometry?.generation == generation3.generation)
             let currentAfterStaleResize = try #require(harness.currentSnapshot)
@@ -229,24 +322,71 @@ struct RendererAttachmentSpikeHostedTests {
         """
     }
 
-    private static func assertAligned(_ actual: CGRect, expected geometry: RendererAttachmentSpikeGeometry) {
-        #expect(geometry.isAligned(with: actual))
-        #expect(abs(actual.minX - geometry.overlayRect.minX) <= geometry.tolerance)
-        #expect(abs(actual.minY - geometry.overlayRect.minY) <= geometry.tolerance)
-        #expect(abs(actual.width - geometry.overlayRect.width) <= geometry.tolerance)
-        #expect(abs(actual.height - geometry.overlayRect.height) <= geometry.tolerance)
-    }
-
-    private static func assertIndependentDOM(_ snapshot: RendererAttachmentSpikeSnapshot?) {
+    private static func assertIndependentDOM(
+        _ snapshot: RendererAttachmentSpikeSnapshot?,
+        measurement: RendererAttachmentSpikeDOMMeasurement,
+        expectedCenterHit: Bool,
+        expectedPresent: Bool = true
+    ) {
         guard let snapshot else {
             Issue.record("missing independent DOM snapshot")
             return
         }
-        let expectedPhysicalWidth = RendererAttachmentSpikeMetrics.referenceCSSWidth * snapshot.pageZoom
-        let measuredPhysicalWidth = snapshot.referenceRect.width * snapshot.domToViewScale
-        #expect(snapshot.domToViewScale > 0)
-        #expect(abs(measuredPhysicalWidth - expectedPhysicalWidth)
-            <= RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
+        #expect(snapshot.revision > 0)
+        #expect(measurement.present == expectedPresent)
+        #expect(measurement.centerHit == expectedCenterHit)
+        #expect(measurement.scrollY >= 0)
+        if expectedPresent {
+            #expect(measurement.placeholderID == snapshot.placeholderID)
+        } else {
+            #expect(measurement.placeholderID.isEmpty)
+        }
+    }
+
+    private static func alignmentEvidence(
+        _ actual: CGRect,
+        measurement: RendererAttachmentSpikeDOMMeasurement,
+        pageZoom: CGFloat,
+        containerView: NSView,
+        backingScaleFactor: CGFloat,
+        webViewBounds: CGRect
+    ) -> RendererAttachmentSpikeAlignmentEvidence {
+        let expected = RendererAttachmentSpikeGeometry(
+            generation: 0,
+            revision: 0,
+            placeholderID: measurement.placeholderID,
+            cssRect: measurement.cssRect,
+            pageZoom: pageZoom,
+            domCenterHit: measurement.centerHit,
+            scrollY: measurement.scrollY,
+            backingScaleFactor: backingScaleFactor,
+            webViewBounds: webViewBounds)
+        let expectedBacking = containerView.convertToBacking(expected.overlayRect)
+        let actualBacking = containerView.convertToBacking(actual)
+        return RendererAttachmentSpikeAlignmentEvidence(
+            pointResiduals: [
+                abs(actual.minX - expected.overlayRect.minX),
+                abs(actual.minY - expected.overlayRect.minY),
+                abs(actual.width - expected.overlayRect.width),
+                abs(actual.height - expected.overlayRect.height)
+            ],
+            backingResiduals: [
+                abs(actualBacking.minX - expectedBacking.minX),
+                abs(actualBacking.minY - expectedBacking.minY),
+                abs(actualBacking.width - expectedBacking.width),
+                abs(actualBacking.height - expectedBacking.height)
+            ])
+    }
+
+    private static func assertAlignmentEvidence(
+        _ evidences: [RendererAttachmentSpikeAlignmentEvidence],
+        tolerance: CGFloat,
+        backingScaleFactor: CGFloat
+    ) {
+        for evidence in evidences {
+            #expect(evidence.maxPointResidual <= tolerance)
+            #expect(evidence.maxBackingResidual / max(backingScaleFactor, .leastNonzeroMagnitude) <= tolerance)
+        }
     }
 
     private static func snapshot(from geometry: RendererAttachmentSpikeGeometry) -> RendererAttachmentSpikeSnapshot {
@@ -256,15 +396,8 @@ struct RendererAttachmentSpikeHostedTests {
             placeholderID: geometry.placeholderID,
             present: true,
             cssRect: geometry.cssRect,
-            pageZoom: geometry.pageZoom,
-            domToViewScale: geometry.domToViewScale,
-            centerHit: true,
-            scrollY: 0,
-            referenceRect: CGRect(
-                x: -1000,
-                y: -1000,
-                width: RendererAttachmentSpikeMetrics.referenceCSSWidth / max(geometry.pageZoom, .leastNonzeroMagnitude),
-                height: 1))
+            centerHit: geometry.domCenterHit,
+            scrollY: geometry.scrollY)
     }
 
     private static func outsidePoint(overlayBounds: CGRect, visibleClip: CGRect) -> NSPoint {
@@ -308,6 +441,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     private(set) var currentSnapshot: RendererAttachmentSpikeSnapshot?
     private(set) var didFinishLoad = false
     private(set) var generation = 0
+    private(set) var currentRevision = 0
     private(set) var isTornDown = false
 
     init(windowSize: NSSize, markdown: String) {
@@ -346,6 +480,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         didFinishLoad = false
         currentGeometry = nil
         currentSnapshot = nil
+        currentRevision = 0
         webView.pageZoom = Double(ZoomScale.defaultScale)
         webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderOrigin.url)
         try await Self.waitFor(description: "reader web view load") { [weak self] in
@@ -359,6 +494,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         didFinishLoad = false
         currentGeometry = nil
         currentSnapshot = nil
+        currentRevision = 0
         webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderOrigin.url)
         try await Self.waitFor(description: "reader web view reload") { [weak self] in
             self?.didFinishLoad == true
@@ -367,11 +503,43 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     }
 
     func publishGeometry() async throws {
-        let minimumRevision = (currentSnapshot?.revision ?? 0) + 1
+        let minimumRevision = currentRevision + 1
         _ = await evaluateJavaScriptWithTimeout(webView, "window.__rendererAttachmentSpikeReport ? window.__rendererAttachmentSpikeReport() : 'missing'")
         try await Self.waitFor(description: "renderer attachment geometry") { [weak self] in
             (self?.currentSnapshot?.revision ?? 0) >= minimumRevision
         }
+    }
+
+    func measureDOMGeometry() async throws -> RendererAttachmentSpikeDOMMeasurement {
+        let body = await evaluateJavaScriptWithTimeout(webView, """
+        (function(){
+          var card = document.querySelector('\(Self.cardSelector)');
+          var scrollY = window.scrollY || document.documentElement.scrollTop || 0;
+          if(!card){
+            return {
+              present: false,
+              placeholderID: "",
+              centerHit: false,
+              scrollY: scrollY
+            };
+          }
+          var rect = card.getBoundingClientRect();
+          var centerNode = document.elementFromPoint(
+            rect.left + rect.width / 2,
+            rect.top + rect.height / 2);
+          return {
+            present: true,
+            placeholderID: card.id || "",
+            cssRect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
+            centerHit: centerNode === card || (!!centerNode && card.contains(centerNode)),
+            scrollY: scrollY
+          };
+        })()
+        """)
+        guard let measurement = RendererAttachmentSpikeDOMMeasurement(body: body) else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement
+        }
+        return measurement
     }
 
     func scrollTo(y: CGFloat) async throws {
@@ -402,8 +570,9 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     func ingest(_ snapshot: RendererAttachmentSpikeSnapshot) {
         guard !isTornDown else { return }
         guard snapshot.generation == generation else { return }
-        guard snapshot.revision > (currentSnapshot?.revision ?? 0) else { return }
+        guard snapshot.revision > currentRevision else { return }
         currentSnapshot = snapshot
+        currentRevision = snapshot.revision
         guard snapshot.present else {
             currentGeometry = nil
             overlay.isHidden = true
@@ -416,13 +585,11 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             revision: snapshot.revision,
             placeholderID: snapshot.placeholderID,
             cssRect: snapshot.cssRect,
-            pageZoom: snapshot.pageZoom,
-            domToViewScale: snapshot.domToViewScale,
+            pageZoom: webView.pageZoom,
             domCenterHit: snapshot.centerHit,
             scrollY: snapshot.scrollY,
             backingScaleFactor: window.backingScaleFactor,
-            webViewBounds: webView.bounds,
-            tolerance: RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
+            webViewBounds: webView.bounds)
         currentGeometry = geometry
         overlay.isHidden = false
         overlay.frame = geometry.overlayRect
@@ -431,13 +598,11 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
 
     func updateRuntimeState() async throws {
         _ = await evaluateJavaScriptWithTimeout(webView, """
-        (function(generation, zoom){
-          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1, revision: 0 };
+        (function(generation){
+          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };
           window.__rendererAttachmentSpikeState.generation = generation;
-          window.__rendererAttachmentSpikeState.pageZoom = zoom;
-          window.__rendererAttachmentSpikeState.revision = window.__rendererAttachmentSpikeState.revision || 0;
           return 'updated';
-        })(\(generation), \(Self.posix(webView.pageZoom)))
+        })(\(generation))
         """)
     }
 
@@ -483,25 +648,15 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         (function(){
           if(window.__rendererAttachmentSpikeProbeInstalled){ return; }
           window.__rendererAttachmentSpikeProbeInstalled = true;
-          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1, revision: 0 };
+          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };
           function rectFor(el){
             var r = el.getBoundingClientRect();
             return { x: r.left, y: r.top, width: r.width, height: r.height };
           }
-          var referenceProbe = document.createElement('div');
-          referenceProbe.id = 'renderer-attachment-spike-reference';
-          referenceProbe.setAttribute('aria-hidden', 'true');
-          referenceProbe.style.cssText = 'position:fixed;left:-10000px;top:-10000px;width:100px;height:1px;visibility:hidden;pointer-events:none;';
-          document.documentElement.appendChild(referenceProbe);
-          function referenceRect(){
-            return rectFor(referenceProbe);
-          }
           function report(){
-            var state = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1, revision: 0 };
+            var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };
             state.revision = Number(state.revision || 0) + 1;
-            var zoom = Number(state.pageZoom || 1);
-            var reference = referenceRect();
-            var domToViewScale = reference.width > 0 ? (\(Self.posix(RendererAttachmentSpikeMetrics.referenceCSSWidth)) * zoom) / reference.width : 1;
+            window.__rendererAttachmentSpikeState = state;
             var card = document.querySelector('\(Self.cardSelector)');
             if(!card){
               window.webkit.messageHandlers.\(Self.messageName).postMessage({
@@ -509,11 +664,8 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
                 revision: state.revision,
                 placeholderID: "",
                 present: false,
-                pageZoom: zoom,
-                domToViewScale: domToViewScale,
                 centerHit: false,
-                scrollY: window.scrollY || document.documentElement.scrollTop || 0,
-                referenceRect: reference
+                scrollY: window.scrollY || document.documentElement.scrollTop || 0
               });
               return "missing";
             }
@@ -523,16 +675,13 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
               cardRect.y + cardRect.height / 2);
             var centerHit = centerNode === card || (!!centerNode && card.contains(centerNode));
             window.webkit.messageHandlers.\(Self.messageName).postMessage({
-              generation: state.generation,
-              revision: state.revision,
-              placeholderID: card.id || "",
-              present: true,
-              cssRect: cardRect,
-              pageZoom: zoom,
-              domToViewScale: domToViewScale,
-              centerHit: centerHit,
-              scrollY: window.scrollY || document.documentElement.scrollTop || 0,
-              referenceRect: reference
+                generation: state.generation,
+                revision: state.revision,
+                placeholderID: card.id || "",
+                present: true,
+                cssRect: cardRect,
+                centerHit: centerHit,
+                scrollY: window.scrollY || document.documentElement.scrollTop || 0
             });
             return "posted";
           }
@@ -587,10 +736,11 @@ private final class RendererAttachmentSpikeOverlayView: NSView {
     override var isOpaque: Bool { false }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
-        guard visibleClipRect.isEmpty == false, visibleClipRect.contains(point) else {
+        let localPoint = superview.map { convert(point, from: $0) } ?? point
+        guard visibleClipRect.isEmpty == false, visibleClipRect.contains(localPoint) else {
             return nil
         }
-        return super.hitTest(point) ?? self
+        return super.hitTest(point)
     }
 }
 
@@ -600,11 +750,8 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
     let placeholderID: String
     let present: Bool
     let cssRect: CGRect
-    let pageZoom: CGFloat
-    let domToViewScale: CGFloat
     let centerHit: Bool
     let scrollY: CGFloat
-    let referenceRect: CGRect
 
     init(
         generation: Int,
@@ -612,25 +759,19 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
         placeholderID: String,
         present: Bool,
         cssRect: CGRect,
-        pageZoom: CGFloat,
-        domToViewScale: CGFloat,
         centerHit: Bool,
-        scrollY: CGFloat,
-        referenceRect: CGRect
+        scrollY: CGFloat
     ) {
         self.generation = generation
         self.revision = revision
         self.placeholderID = placeholderID
         self.present = present
         self.cssRect = cssRect
-        self.pageZoom = pageZoom
-        self.domToViewScale = domToViewScale
         self.centerHit = centerHit
         self.scrollY = scrollY
-        self.referenceRect = referenceRect
     }
 
-    init?(body: Any) {
+    init?(body: Any?) {
         guard let dict = body as? [String: Any] else { return nil }
         guard let generation = Self.int(dict["generation"]),
               let revision = Self.int(dict["revision"]),
@@ -638,11 +779,8 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
               let placeholderID = dict["placeholderID"] as? String else {
             return nil
         }
-        let pageZoom = Self.cgFloat(dict["pageZoom"]) ?? 1
-        let domToViewScale = Self.cgFloat(dict["domToViewScale"]) ?? 1
         let centerHit = dict["centerHit"] as? Bool ?? false
         let scrollY = Self.cgFloat(dict["scrollY"]) ?? 0
-        let referenceRect = Self.rect(dict["referenceRect"]) ?? .zero
         let rect: CGRect
         if present {
             guard let cssRect = Self.rect(dict["cssRect"]) else { return nil }
@@ -655,11 +793,8 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
         self.placeholderID = placeholderID
         self.present = present
         self.cssRect = rect
-        self.pageZoom = pageZoom
-        self.domToViewScale = domToViewScale
         self.centerHit = centerHit
         self.scrollY = scrollY
-        self.referenceRect = referenceRect
     }
 
     private static func rect(_ value: Any?) -> CGRect? {
@@ -696,9 +831,89 @@ private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
     }
 }
 
+private struct RendererAttachmentSpikeDOMMeasurement: Sendable, Equatable {
+    let present: Bool
+    let placeholderID: String
+    let cssRect: CGRect
+    let centerHit: Bool
+    let scrollY: CGFloat
+
+    init(
+        present: Bool,
+        placeholderID: String,
+        cssRect: CGRect,
+        centerHit: Bool,
+        scrollY: CGFloat
+    ) {
+        self.present = present
+        self.placeholderID = placeholderID
+        self.cssRect = cssRect
+        self.centerHit = centerHit
+        self.scrollY = scrollY
+    }
+
+    init?(body: Any?) {
+        guard let dict = body as? [String: Any],
+              let present = dict["present"] as? Bool,
+              let placeholderID = dict["placeholderID"] as? String else {
+            return nil
+        }
+        let centerHit = dict["centerHit"] as? Bool ?? false
+        let scrollY = Self.cgFloat(dict["scrollY"]) ?? 0
+        let rect: CGRect
+        if present {
+            guard let cssRect = Self.rect(dict["cssRect"]) else { return nil }
+            rect = cssRect
+        } else {
+            rect = .zero
+        }
+        self.present = present
+        self.placeholderID = placeholderID
+        self.cssRect = rect
+        self.centerHit = centerHit
+        self.scrollY = scrollY
+    }
+
+    private static func rect(_ value: Any?) -> CGRect? {
+        guard let dict = value as? [String: Any],
+              let x = cgFloat(dict["x"]),
+              let y = cgFloat(dict["y"]),
+              let width = cgFloat(dict["width"]),
+              let height = cgFloat(dict["height"]) else {
+            return nil
+        }
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private static func cgFloat(_ value: Any?) -> CGFloat? {
+        switch value {
+        case let number as NSNumber:
+            return CGFloat(number.doubleValue)
+        case let string as String:
+            return CGFloat(Double(string) ?? 0)
+        default:
+            return nil
+        }
+    }
+}
+
+private struct RendererAttachmentSpikeAlignmentEvidence {
+    let pointResiduals: [CGFloat]
+    let backingResiduals: [CGFloat]
+
+    var maxPointResidual: CGFloat {
+        pointResiduals.max() ?? 0
+    }
+
+    var maxBackingResidual: CGFloat {
+        backingResiduals.max() ?? 0
+    }
+}
+
 private enum RendererAttachmentSpikeHarnessError: LocalizedError {
     case timeout(description: String)
     case missingGeometry
+    case missingDOMMeasurement
 
     var errorDescription: String? {
         switch self {
@@ -706,6 +921,8 @@ private enum RendererAttachmentSpikeHarnessError: LocalizedError {
             return "timed out waiting for \(description)"
         case .missingGeometry:
             return "missing attachment geometry"
+        case .missingDOMMeasurement:
+            return "missing independent DOM measurement"
         }
     }
 }

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -14,10 +14,13 @@ struct RendererAttachmentSpikeHostedTests {
     private static let defaultLeadingParagraphCount = 28
     private static let positiveScrollY: CGFloat = 220
     private static let bottomSpacerParagraphCount = 24
+    /// Fixed from the retained exact-head hosted evidence. This is deliberately
+    /// independent of the residuals produced by the run under judgment.
+    private static let fixedAlignmentTolerancePoints: CGFloat = 1
 
     @Test
     func testScrollZoomResizeAndHeightMutationStayAligned() async throws {
-        for _ in 0..<20 {
+        for iteration in 1...20 {
             var alignmentEvidences: [RendererAttachmentSpikeAlignmentEvidence] = []
             let lease = await HostedAppKitTestGate.shared.acquire()
             defer { lease.release() }
@@ -40,41 +43,43 @@ struct RendererAttachmentSpikeHostedTests {
             let initial = try harness.requireGeometry()
             let initialSnapshot = try #require(harness.currentSnapshot)
             let initialMeasurement = try await harness.measureDOMGeometry()
+            let initialRenderedRect = try await harness.captureSentinelRect()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,
-                measurement: initialMeasurement,
-                pageZoom: harness.webView.pageZoom,
+                renderedRect: try #require(initialRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds)
+                backingScaleFactor: window.backingScaleFactor)
             )
             Self.assertIndependentDOM(
                 initialSnapshot,
                 measurement: initialMeasurement,
                 expectedCenterHit: true,
                 expectedFullyInsideLayoutViewport: true,
-                stage: "initial")
-            #expect(initial.revision == initialSnapshot.revision)
+                stage: "initial iteration \(iteration)")
+            let initialAccessibility = try await harness.measureDOMAccessibility()
+            Self.assertAutomatedAccessibilityEvidence(
+                overlay: harness.overlay,
+                placeholderID: initialSnapshot.placeholderID,
+                dom: initialAccessibility)
 
             try await harness.scrollTo(y: Self.positiveScrollY)
             try await harness.publishGeometry()
             let scrolled = try harness.requireGeometry()
             let scrolledSnapshot = try #require(harness.currentSnapshot)
             let scrolledMeasurement = try await harness.measureDOMGeometry()
+            let scrolledRenderedRect = try await harness.captureSentinelRect()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,
-                measurement: scrolledMeasurement,
-                pageZoom: harness.webView.pageZoom,
+                renderedRect: try #require(scrolledRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds)
+                backingScaleFactor: window.backingScaleFactor)
             )
             Self.assertIndependentDOM(
                 scrolledSnapshot,
                 measurement: scrolledMeasurement,
                 expectedCenterHit: true,
                 expectedFullyInsideLayoutViewport: true,
-                stage: "scroll")
+                stage: "scroll iteration \(iteration)")
             #expect(scrolled.domCenterHit)
             #expect(scrolled.revision > initial.revision)
 
@@ -85,20 +90,21 @@ struct RendererAttachmentSpikeHostedTests {
             let zoomed = try harness.requireGeometry()
             let zoomedSnapshot = try #require(harness.currentSnapshot)
             let zoomedMeasurement = try await harness.measureDOMGeometry()
+            let zoomedRenderedRect = try await harness.captureSentinelRect()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,
-                measurement: zoomedMeasurement,
-                pageZoom: harness.webView.pageZoom,
+                renderedRect: try #require(zoomedRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds)
+                backingScaleFactor: window.backingScaleFactor)
             )
             Self.assertIndependentDOM(
                 zoomedSnapshot,
                 measurement: zoomedMeasurement,
                 expectedCenterHit: true,
                 expectedFullyInsideLayoutViewport: true,
-                stage: "zoomed")
+                stage: "zoomed iteration \(iteration)")
+            #expect(zoomedMeasurement.cssRect.width < scrolledMeasurement.cssRect.width,
+                    "pageZoom observation iteration \(iteration): DOM CSS width shrinks at 1.25x")
             #expect(zoomed.revision > scrolled.revision)
 
             window.setContentSize(NSSize(width: 920, height: 580))
@@ -108,20 +114,19 @@ struct RendererAttachmentSpikeHostedTests {
             let resized = try harness.requireGeometry()
             let resizedSnapshot = try #require(harness.currentSnapshot)
             let resizedMeasurement = try await harness.measureDOMGeometry()
+            let resizedRenderedRect = try await harness.captureSentinelRect()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,
-                measurement: resizedMeasurement,
-                pageZoom: harness.webView.pageZoom,
+                renderedRect: try #require(resizedRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds)
+                backingScaleFactor: window.backingScaleFactor)
             )
             Self.assertIndependentDOM(
                 resizedSnapshot,
                 measurement: resizedMeasurement,
                 expectedCenterHit: true,
                 expectedFullyInsideLayoutViewport: true,
-                stage: "resized")
+                stage: "resized iteration \(iteration)")
             #expect(resized.revision > zoomed.revision)
 
             try await harness.insertSpacerBeforePlaceholder(height: 96)
@@ -130,37 +135,31 @@ struct RendererAttachmentSpikeHostedTests {
             let mutated = try harness.requireGeometry()
             let mutatedSnapshot = try #require(harness.currentSnapshot)
             let mutatedMeasurement = try await harness.measureDOMGeometry()
+            let mutatedRenderedRect = try await harness.captureSentinelRect()
             alignmentEvidences.append(Self.alignmentEvidence(
                 harness.overlay.frame,
-                measurement: mutatedMeasurement,
-                pageZoom: harness.webView.pageZoom,
+                renderedRect: try #require(mutatedRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds)
+                backingScaleFactor: window.backingScaleFactor)
             )
             Self.assertIndependentDOM(
                 mutatedSnapshot,
                 measurement: mutatedMeasurement,
                 expectedCenterHit: true,
                 expectedFullyInsideLayoutViewport: true,
-                stage: "height-mutation")
-            #expect(mutated.revision == mutatedSnapshot.revision)
+                stage: "height-mutation iteration \(iteration)")
             #expect(mutated.revision > resized.revision)
 
-            let tolerance = RendererAttachmentSpikeMetrics.derivedAlignmentTolerance(
-                pointResiduals: alignmentEvidences.flatMap { $0.pointResiduals },
-                backingResiduals: alignmentEvidences.flatMap { $0.backingResiduals },
-                backingScaleFactor: window.backingScaleFactor)
             Self.assertAlignmentEvidence(
                 alignmentEvidences,
-                tolerance: tolerance,
+                tolerance: Self.fixedAlignmentTolerancePoints,
                 backingScaleFactor: window.backingScaleFactor)
         }
     }
 
     @Test
     func testClippingAndHitTestingRespectVisiblePlaceholder() async throws {
-        for _ in 0..<20 {
+        for iteration in 1...20 {
             var alignmentEvidences: [RendererAttachmentSpikeAlignmentEvidence] = []
             let lease = await HostedAppKitTestGate.shared.acquire()
             defer { lease.release() }
@@ -185,13 +184,12 @@ struct RendererAttachmentSpikeHostedTests {
             let geometry = try harness.requireGeometry()
             let geometrySnapshot = try #require(harness.currentSnapshot)
             let geometryMeasurement = try await harness.measureDOMGeometry()
+            let geometryRenderedRect = try await harness.captureSentinelRect()
             alignmentEvidences.append(Self.alignmentEvidence(
-                harness.overlay.frame,
-                measurement: geometryMeasurement,
-                pageZoom: harness.webView.pageZoom,
+                harness.overlay.frame.intersection(harness.webView.bounds),
+                renderedRect: try #require(geometryRenderedRect),
                 containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds))
+                backingScaleFactor: window.backingScaleFactor))
 
             #expect(geometry.clipRect.isEmpty == false)
             #expect(geometry.clipRect != geometry.overlayRect)
@@ -199,14 +197,16 @@ struct RendererAttachmentSpikeHostedTests {
             Self.assertIndependentDOM(
                 geometrySnapshot,
                 measurement: geometryMeasurement,
-                expectedCenterHit: true,
-                stage: "geometry-visible")
+                expectedCenterHit: false,
+                stage: "geometry-visible iteration \(iteration)")
 
             let visible = geometry.localClipRect
             let insidePoint = NSPoint(x: visible.midX, y: visible.midY)
-            let outsidePoint = RendererAttachmentSpikeHostedTests.outsidePoint(
+            let outsidePoint = try #require(RendererAttachmentSpikeHostedTests.outsidePoint(
                 overlayBounds: harness.overlay.bounds,
-                visibleClip: visible)
+                visibleClip: visible))
+            #expect(harness.overlay.bounds.contains(outsidePoint))
+            #expect(visible.contains(outsidePoint) == false)
             let insideWindowPoint = harness.overlay.convert(insidePoint, to: harness.containerView)
             let outsideWindowPoint = harness.overlay.convert(outsidePoint, to: harness.containerView)
 
@@ -219,19 +219,21 @@ struct RendererAttachmentSpikeHostedTests {
             let routedView = harness.containerView.hitTest(outsideWindowPoint)
             #expect(routedView !== harness.overlay)
 
+            let containerOutsidePoint = try #require(Self.outsideContainerPoint(
+                webViewBounds: harness.webView.bounds,
+                attachmentClip: geometry.clipRect))
+            let containerRoutedView = harness.containerView.hitTest(containerOutsidePoint)
+            #expect(containerRoutedView !== harness.overlay)
+            #expect(harness.isWebViewOrDescendant(containerRoutedView))
+
             let offscreenScroll = max(0, geometry.scrollY + geometry.cssRect.maxY + 80)
             try await harness.scrollTo(y: offscreenScroll)
             try await harness.publishGeometry()
             let offscreen = try harness.requireGeometry()
             let offscreenSnapshot = try #require(harness.currentSnapshot)
             let offscreenMeasurement = try await harness.measureDOMGeometry()
-            alignmentEvidences.append(Self.alignmentEvidence(
-                harness.overlay.frame,
-                measurement: offscreenMeasurement,
-                pageZoom: harness.webView.pageZoom,
-                containerView: harness.containerView,
-                backingScaleFactor: window.backingScaleFactor,
-                webViewBounds: harness.webView.bounds))
+            let offscreenRenderedRect = try await harness.captureSentinelRect()
+            #expect(offscreenRenderedRect == nil)
             #expect(offscreen.clipRect.isEmpty)
             #expect(offscreen.domCenterHit == false)
             #expect(harness.overlay.visibleClipRect.isEmpty)
@@ -241,22 +243,18 @@ struct RendererAttachmentSpikeHostedTests {
                 offscreenSnapshot,
                 measurement: offscreenMeasurement,
                 expectedCenterHit: false,
-                stage: "geometry-offscreen")
+                stage: "geometry-offscreen iteration \(iteration)")
 
-            let tolerance = RendererAttachmentSpikeMetrics.derivedAlignmentTolerance(
-                pointResiduals: alignmentEvidences.flatMap { $0.pointResiduals },
-                backingResiduals: alignmentEvidences.flatMap { $0.backingResiduals },
-                backingScaleFactor: window.backingScaleFactor)
             Self.assertAlignmentEvidence(
                 alignmentEvidences,
-                tolerance: tolerance,
+                tolerance: Self.fixedAlignmentTolerancePoints,
                 backingScaleFactor: window.backingScaleFactor)
         }
     }
 
     @Test
     func testStaleGenerationAndTeardownCannotReviveAttachment() async throws {
-        for _ in 0..<20 {
+        for iteration in 1...20 {
             let lease = await HostedAppKitTestGate.shared.acquire()
             defer { lease.release() }
             Self.prepareApplication()
@@ -280,7 +278,8 @@ struct RendererAttachmentSpikeHostedTests {
             let generation2 = try harness.requireGeometry()
 
             harness.ingest(Self.snapshot(from: generation1))
-            #expect(harness.currentGeometry?.generation == generation2.generation)
+            #expect(harness.currentGeometry?.generation == generation2.generation,
+                    "stale-generation iteration \(iteration)")
 
             window.setContentSize(NSSize(width: 860, height: 500))
             harness.containerView.layoutSubtreeIfNeeded()
@@ -291,7 +290,8 @@ struct RendererAttachmentSpikeHostedTests {
             let revisionBeforeStaleResize = try #require(harness.currentSnapshot).revision
             #expect(generation2.revision < generation3.revision)
             harness.ingest(Self.snapshot(from: generation2))
-            #expect(harness.currentGeometry?.generation == generation3.generation)
+            #expect(harness.currentGeometry?.generation == generation3.generation,
+                    "stale-resize iteration \(iteration)")
             let currentAfterStaleResize = try #require(harness.currentSnapshot)
             #expect(currentAfterStaleResize.revision == revisionBeforeStaleResize)
             #expect(harness.overlay.frame == frameBeforeStaleResize)
@@ -381,30 +381,18 @@ struct RendererAttachmentSpikeHostedTests {
 
     private static func alignmentEvidence(
         _ actual: CGRect,
-        measurement: RendererAttachmentSpikeDOMMeasurement,
-        pageZoom: CGFloat,
+        renderedRect: CGRect,
         containerView: NSView,
-        backingScaleFactor: CGFloat,
-        webViewBounds: CGRect
+        backingScaleFactor: CGFloat
     ) -> RendererAttachmentSpikeAlignmentEvidence {
-        let expected = RendererAttachmentSpikeGeometry(
-            generation: 0,
-            revision: 0,
-            placeholderID: measurement.placeholderID,
-            cssRect: measurement.cssRect,
-            pageZoom: pageZoom,
-            domCenterHit: measurement.centerHit,
-            scrollY: measurement.scrollY,
-            backingScaleFactor: backingScaleFactor,
-            webViewBounds: webViewBounds)
-        let expectedBacking = containerView.convertToBacking(expected.overlayRect)
+        let expectedBacking = containerView.convertToBacking(renderedRect)
         let actualBacking = containerView.convertToBacking(actual)
         return RendererAttachmentSpikeAlignmentEvidence(
             pointResiduals: [
-                abs(actual.minX - expected.overlayRect.minX),
-                abs(actual.minY - expected.overlayRect.minY),
-                abs(actual.width - expected.overlayRect.width),
-                abs(actual.height - expected.overlayRect.height)
+                abs(actual.minX - renderedRect.minX),
+                abs(actual.minY - renderedRect.minY),
+                abs(actual.width - renderedRect.width),
+                abs(actual.height - renderedRect.height)
             ],
             backingResiduals: [
                 abs(actualBacking.minX - expectedBacking.minX),
@@ -436,7 +424,7 @@ struct RendererAttachmentSpikeHostedTests {
             scrollY: geometry.scrollY)
     }
 
-    private static func outsidePoint(overlayBounds: CGRect, visibleClip: CGRect) -> NSPoint {
+    private static func outsidePoint(overlayBounds: CGRect, visibleClip: CGRect) -> NSPoint? {
         let probes: [NSPoint] = [
             NSPoint(x: visibleClip.midX, y: visibleClip.minY - 2),
             NSPoint(x: visibleClip.midX, y: visibleClip.maxY + 2),
@@ -448,7 +436,38 @@ struct RendererAttachmentSpikeHostedTests {
                 return probe
             }
         }
-        return NSPoint(x: max(0, visibleClip.maxX + 2), y: max(0, visibleClip.minY + 2))
+        return nil
+    }
+
+    private static func outsideContainerPoint(webViewBounds: CGRect, attachmentClip: CGRect) -> NSPoint? {
+        let inset: CGFloat = 8
+        let probes = [
+            NSPoint(x: webViewBounds.minX + inset, y: webViewBounds.minY + inset),
+            NSPoint(x: webViewBounds.maxX - inset, y: webViewBounds.minY + inset),
+            NSPoint(x: webViewBounds.minX + inset, y: webViewBounds.maxY - inset),
+            NSPoint(x: webViewBounds.maxX - inset, y: webViewBounds.maxY - inset)
+        ]
+        return probes.first { webViewBounds.contains($0) && attachmentClip.contains($0) == false }
+    }
+
+    /// This checks automated attributes only. It does not certify spoken VoiceOver output.
+    private static func assertAutomatedAccessibilityEvidence(
+        overlay: RendererAttachmentSpikeOverlayView,
+        placeholderID: String,
+        dom: RendererAttachmentSpikeDOMAccessibility
+    ) {
+        let expectedOverlayLabel = RendererAttachmentSpikeOverlayView.accessibilityLabel(for: placeholderID)
+        #expect(overlay.isAccessibilityElement())
+        #expect(overlay.accessibilityRole() == .group)
+        #expect(overlay.accessibilityLabel() == expectedOverlayLabel)
+        #expect(overlay.accessibilityIdentifier() == RendererAttachmentSpikeOverlayView.accessibilityIdentifier(for: placeholderID))
+        #expect(dom.present)
+        #expect(dom.role == "group")
+        #expect(dom.label.isEmpty == false)
+        #expect(dom.actionRole.isEmpty || dom.actionRole == "link")
+        if dom.actionRole == "link" {
+            #expect(dom.actionName.isEmpty == false)
+        }
     }
 
     private static func prepareApplication() {
@@ -461,10 +480,13 @@ struct RendererAttachmentSpikeHostedTests {
 private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelegate {
     static let messageName = "rendererAttachmentSpike"
     private static let cardSelector = "section.sdw-renderer-card"
+    private static let sentinelColor = "rgb(1, 2, 3)"
+    private static let snapshotTimeout: Duration = .seconds(15)
     private static let probeScript = makeProbeScript()
 
     let containerView: NSView
     let webView: WikiReaderWebView
+    private let readerRouteProbe = RendererAttachmentSpikeReaderRouteProbe(frame: .zero)
     let overlay = RendererAttachmentSpikeOverlayView(frame: .zero)
     private let bridge = RendererAttachmentSpikeBridge()
     let window: NSWindow
@@ -502,9 +524,12 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         webView.navigationDelegate = self
         webView.pageZoom = Double(ZoomScale.defaultScale)
         webView.autoresizingMask = [.width, .height]
-        overlay.autoresizingMask = [.width, .height]
+        readerRouteProbe.autoresizingMask = [.width, .height]
+        overlay.autoresizingMask = []
         overlay.isHidden = true
         containerView.addSubview(webView)
+        readerRouteProbe.frame = webView.bounds
+        webView.addSubview(readerRouteProbe)
         containerView.addSubview(overlay)
         webView.frame = containerView.bounds
         overlay.frame = containerView.bounds
@@ -551,14 +576,17 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
     }
 
     func measureDOMGeometry() async throws -> RendererAttachmentSpikeDOMMeasurement {
+        guard let placeholderID = currentSnapshot?.placeholderID, placeholderID.isEmpty == false else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: "missing stable placeholder ID")
+        }
         let body = await evaluateJavaScriptWithTimeout(webView, """
         (function(){
           var scrollY = window.scrollY || document.documentElement.scrollTop || 0;
           var docEl = document.documentElement;
           var body = document.body;
           var visual = window.visualViewport;
-          var cards = document.querySelectorAll('\(Self.cardSelector)');
-          var card = cards.length ? cards[0] : null;
+          var card = document.getElementById('\(placeholderID)');
+          var cards = card ? [card] : [];
           function viewportBounds(){
             var width = (docEl && docEl.clientWidth) || window.innerWidth || 0;
             var height = (docEl && docEl.clientHeight) || window.innerHeight || 0;
@@ -582,12 +610,14 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           var layoutViewport = viewportBounds();
           var cardRect = card ? rectFor(card) : null;
           var visibleIntersection = cardRect ? intersectRects(cardRect, layoutViewport) : null;
+          var centerTarget = cardRect ? document.elementFromPoint(cardRect.left + (cardRect.width / 2), cardRect.top + (cardRect.height / 2)) : null;
+          var centerHit = !!(card && centerTarget && (centerTarget === card || card.contains(centerTarget)));
           var selectedCardClass = card ? (typeof card.className === 'string' ? card.className : String(card.className || '')) : "";
           return JSON.stringify({
             present: !!card,
             placeholderID: card ? (card.id || "") : "",
             cssRect: cardRect ? { x: cardRect.left, y: cardRect.top, width: cardRect.width, height: cardRect.height } : { x: 0, y: 0, width: 0, height: 0 },
-            centerHit: visibleIntersection !== null,
+            centerHit: centerHit,
             scrollY: scrollY,
             matchingCardCount: cards.length,
             selectedCardTag: card ? (card.tagName || "") : "",
@@ -626,6 +656,66 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: String(describing: body))
         }
         return measurement
+    }
+
+    /// Captures browser pixels after temporarily painting only the selected
+    /// placeholder. This must stay separate from all DOM and production geometry.
+    func captureSentinelRect() async throws -> CGRect? {
+        let placeholderID = try requiredPlaceholderID()
+        let selector = "#\(placeholderID)"
+        let styleID = "renderer-attachment-spike-sentinel-style"
+        let setup = """
+        (function(){
+          var card = document.querySelector(\(Self.javaScriptString(selector)));
+          if (!card) { return 'missing'; }
+          var existing = document.getElementById(\(Self.javaScriptString(styleID)));
+          if (existing) { existing.remove(); }
+          var style = document.createElement('style');
+          style.id = \(Self.javaScriptString(styleID));
+          style.textContent = \(Self.javaScriptString("\(selector) { background: \(Self.sentinelColor) !important; border-radius: 0 !important; } \(selector) * { visibility: hidden !important; }"));
+          document.head.appendChild(style);
+          return 'styled';
+        })()
+        """
+        guard await evaluateJavaScriptWithTimeout(webView, setup) == "styled" else {
+            throw RendererAttachmentSpikeHarnessError.missingSentinelPlaceholder
+        }
+        let removal = "document.getElementById(\(Self.javaScriptString(styleID)))?.remove(); 'restored'"
+        let image: NSImage
+        do {
+            image = try await Self.takeSnapshot(of: webView, timeout: Self.snapshotTimeout)
+        } catch {
+            _ = await evaluateJavaScriptWithTimeout(webView, removal)
+            throw error
+        }
+        _ = await evaluateJavaScriptWithTimeout(webView, removal)
+        return Self.sentinelRect(in: image, webViewBounds: webView.bounds)
+    }
+
+    func measureDOMAccessibility() async throws -> RendererAttachmentSpikeDOMAccessibility {
+        let placeholderID = try requiredPlaceholderID()
+        let body = await evaluateJavaScriptWithTimeout(webView, """
+        (function(){
+          var card = document.getElementById(\(Self.javaScriptString(placeholderID)));
+          var action = card ? card.querySelector('a.sdw-renderer-card__action') : null;
+          return JSON.stringify({
+            present: !!card,
+            role: card ? (card.getAttribute('role') || '') : '',
+            label: card ? (card.getAttribute('aria-label') || '') : '',
+            actionRole: action ? (action.getAttribute('role') || 'link') : '',
+            actionName: action ? (action.getAttribute('aria-label') || action.textContent || '').trim() : ''
+          });
+        })()
+        """)
+        guard let accessibility = RendererAttachmentSpikeDOMAccessibility(body: body) else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMAccessibility(body: String(describing: body))
+        }
+        return accessibility
+    }
+
+    func isWebViewOrDescendant(_ view: NSView?) -> Bool {
+        guard let view else { return false }
+        return view === webView || view.isDescendant(of: webView)
     }
 
     func scrollTo(y: CGFloat) async throws {
@@ -678,6 +768,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         overlay.isHidden = false
         overlay.frame = geometry.overlayRect
         overlay.visibleClipRect = geometry.localClipRect
+        overlay.configureAccessibility(placeholderID: snapshot.placeholderID)
     }
 
     func updateRuntimeState() async throws {
@@ -712,6 +803,103 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             throw RendererAttachmentSpikeHarnessError.missingGeometry
         }
         return geometry
+    }
+
+    private func requiredPlaceholderID() throws -> String {
+        guard let placeholderID = currentSnapshot?.placeholderID, placeholderID.isEmpty == false else {
+            throw RendererAttachmentSpikeHarnessError.missingDOMMeasurement(body: "missing stable placeholder ID")
+        }
+        return placeholderID
+    }
+
+    private static func takeSnapshot(of webView: WKWebView, timeout: Duration) async throws -> NSImage {
+        final class Once: @unchecked Sendable {
+            private var fired = false
+            private let lock = NSLock()
+
+            func fire(_ body: () -> Void) {
+                lock.lock()
+                defer { lock.unlock() }
+                guard fired == false else { return }
+                fired = true
+                body()
+            }
+        }
+
+        let configuration = WKSnapshotConfiguration()
+        configuration.rect = webView.bounds
+        configuration.afterScreenUpdates = true
+        let once = Once()
+        return try await withCheckedThrowingContinuation { continuation in
+            webView.takeSnapshot(with: configuration) { image, error in
+                once.fire {
+                    if let image {
+                        continuation.resume(returning: image)
+                    } else {
+                        continuation.resume(throwing: error ?? RendererAttachmentSpikeHarnessError.missingSnapshot)
+                    }
+                }
+            }
+            Task { @MainActor in
+                do {
+                    try await Task.sleep(for: timeout)
+                    once.fire {
+                        continuation.resume(throwing: RendererAttachmentSpikeHarnessError.snapshotTimeout)
+                    }
+                } catch {
+                    // The enclosing test owns cancellation. The WebKit completion can still finish safely.
+                }
+            }
+        }
+    }
+
+    private static func sentinelRect(in image: NSImage, webViewBounds: CGRect) -> CGRect? {
+        var proposedRect = CGRect(origin: .zero, size: image.size)
+        guard let cgImage = image.cgImage(forProposedRect: &proposedRect, context: nil, hints: nil) else {
+            return nil
+        }
+        let bitmap = NSBitmapImageRep(cgImage: cgImage)
+        guard bitmap.pixelsWide > 0, bitmap.pixelsHigh > 0,
+              webViewBounds.width > 0, webViewBounds.height > 0 else {
+            return nil
+        }
+        var minX = bitmap.pixelsWide
+        var minY = bitmap.pixelsHigh
+        var maxX = -1
+        var maxY = -1
+        for y in 0..<bitmap.pixelsHigh {
+            for x in 0..<bitmap.pixelsWide {
+                guard let color = bitmap.colorAt(x: x, y: y) else { continue }
+                let red = Int((color.redComponent * 255).rounded())
+                let green = Int((color.greenComponent * 255).rounded())
+                let blue = Int((color.blueComponent * 255).rounded())
+                if red == 1, green == 2, blue == 3, color.alphaComponent > 0.99 {
+                    minX = min(minX, x)
+                    minY = min(minY, y)
+                    maxX = max(maxX, x)
+                    maxY = max(maxY, y)
+                }
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return nil }
+        let pixelsPerPointX = CGFloat(bitmap.pixelsWide) / webViewBounds.width
+        let pixelsPerPointY = CGFloat(bitmap.pixelsHigh) / webViewBounds.height
+        let width = CGFloat(maxX - minX + 1) / pixelsPerPointX
+        let height = CGFloat(maxY - minY + 1) / pixelsPerPointY
+        return CGRect(
+            x: CGFloat(minX) / pixelsPerPointX,
+            y: webViewBounds.height - (CGFloat(maxY + 1) / pixelsPerPointY),
+            width: width,
+            height: height)
+    }
+
+    private static func javaScriptString(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+        return "\"" + escaped + "\""
     }
 
     private static func html(for markdown: String, documentIdentity: MarkdownDocumentIdentity) -> String {
@@ -766,6 +954,8 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             var viewport = viewportBounds();
             var cardRect = card ? rectFor(card) : null;
             var visibleIntersection = cardRect ? intersectRects(cardRect, viewport) : null;
+            var centerTarget = cardRect ? document.elementFromPoint(cardRect.left + (cardRect.width / 2), cardRect.top + (cardRect.height / 2)) : null;
+            var centerHit = !!(card && centerTarget && (centerTarget === card || card.contains(centerTarget)));
             var selectedCardClass = card ? (typeof card.className === 'string' ? card.className : String(card.className || '')) : "";
             if(!card){
               window.webkit.messageHandlers.\(Self.messageName).postMessage({
@@ -814,7 +1004,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
                 placeholderID: card.id || "",
                 present: true,
                 cssRect: cardRect ? { x: cardRect.left, y: cardRect.top, width: cardRect.width, height: cardRect.height } : { x: 0, y: 0, width: 0, height: 0 },
-                centerHit: visibleIntersection !== null,
+                centerHit: centerHit,
                 scrollY: window.scrollY || document.documentElement.scrollTop || 0,
                 matchingCardCount: cards.length,
                 selectedCardTag: card.tagName || "",
@@ -906,6 +1096,28 @@ private final class RendererAttachmentSpikeOverlayView: NSView {
         }
         return super.hitTest(point)
     }
+
+    static func accessibilityLabel(for placeholderID: String) -> String {
+        "Renderer attachment overlay \(placeholderID)"
+    }
+
+    static func accessibilityIdentifier(for placeholderID: String) -> String {
+        "renderer-attachment-overlay-\(placeholderID)"
+    }
+
+    func configureAccessibility(placeholderID: String) {
+        setAccessibilityElement(true)
+        setAccessibilityRole(.group)
+        setAccessibilityLabel(Self.accessibilityLabel(for: placeholderID))
+        setAccessibilityIdentifier(Self.accessibilityIdentifier(for: placeholderID))
+    }
+}
+
+/// Test-only transparent reader descendant. It makes AppKit's route target
+/// observable without adding production event-routing behavior.
+@MainActor
+private final class RendererAttachmentSpikeReaderRouteProbe: NSView {
+    override var isOpaque: Bool { false }
 }
 
 private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
@@ -1209,11 +1421,48 @@ private struct RendererAttachmentSpikeAlignmentEvidence {
     }
 }
 
+private struct RendererAttachmentSpikeDOMAccessibility: Sendable, Equatable {
+    let present: Bool
+    let role: String
+    let label: String
+    let actionRole: String
+    let actionName: String
+
+    init?(body: String?) {
+        guard let body, let data = body.data(using: .utf8) else {
+            return nil
+        }
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            return nil
+        }
+        guard let dictionary = object as? [String: Any],
+              let present = dictionary["present"] as? Bool,
+              let role = dictionary["role"] as? String,
+              let label = dictionary["label"] as? String,
+              let actionRole = dictionary["actionRole"] as? String,
+              let actionName = dictionary["actionName"] as? String else {
+            return nil
+        }
+        self.present = present
+        self.role = role
+        self.label = label
+        self.actionRole = actionRole
+        self.actionName = actionName
+    }
+}
+
 private enum RendererAttachmentSpikeHarnessError: LocalizedError {
     case timeout(description: String)
     case missingGeometry
     case missingDOMMeasurement(body: String)
+    case missingDOMAccessibility(body: String)
     case missingPublishedRevision(body: String)
+    case missingSentinelPlaceholder
+    case missingSnapshot
+    case snapshotTimeout
 
     var errorDescription: String? {
         switch self {
@@ -1223,8 +1472,16 @@ private enum RendererAttachmentSpikeHarnessError: LocalizedError {
             return "missing attachment geometry"
         case let .missingDOMMeasurement(body):
             return "missing independent DOM measurement: \(body)"
+        case let .missingDOMAccessibility(body):
+            return "missing independent DOM accessibility evidence: \(body)"
         case let .missingPublishedRevision(body):
             return "missing published renderer attachment revision: \(body)"
+        case .missingSentinelPlaceholder:
+            return "missing sentinel placeholder"
+        case .missingSnapshot:
+            return "missing web view snapshot"
+        case .snapshotTimeout:
+            return "timed out waiting for web view snapshot"
         }
     }
 }

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -515,11 +515,52 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         (function(){
           var card = document.querySelector('\(Self.cardSelector)');
           var scrollY = window.scrollY || document.documentElement.scrollTop || 0;
-          var viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
-          var viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+          var viewport = (function(){
+            var visual = window.visualViewport;
+            var left = visual ? visual.offsetLeft : 0;
+            var top = visual ? visual.offsetTop : 0;
+            var width = visual ? visual.width : (window.innerWidth || document.documentElement.clientWidth || 0);
+            var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
+            return { left: left, top: top, right: left + width, bottom: top + height };
+          })();
           function hitAt(x, y) {
-            var node = document.elementFromPoint(x, y);
-            return !!node && (node === card || card.contains(node));
+            var nodes = document.elementsFromPoint(x, y) || [];
+            for(var i = 0; i < nodes.length; i++){
+              var node = nodes[i];
+              if(node === card || card.contains(node)){
+                return true;
+              }
+            }
+            return false;
+          }
+          function visibleHit(rect) {
+            var left = Math.max(rect.left, viewport.left);
+            var top = Math.max(rect.top, viewport.top);
+            var right = Math.min(rect.right, viewport.right);
+            var bottom = Math.min(rect.bottom, viewport.bottom);
+            if(!(right > left && bottom > top)){
+              return false;
+            }
+            var xCandidates = [
+              left + (right - left) / 2,
+              left + 1,
+              right - 1
+            ];
+            var yCandidates = [
+              top + (bottom - top) / 2,
+              top + 1,
+              bottom - 1
+            ];
+            for(var yi = 0; yi < yCandidates.length; yi++){
+              for(var xi = 0; xi < xCandidates.length; xi++){
+                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
+                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
+                if(hitAt(x, y)){
+                  return true;
+                }
+              }
+            }
+            return false;
           }
           if(!card){
             return JSON.stringify({
@@ -530,19 +571,11 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             });
           }
           var rect = card.getBoundingClientRect();
-          var left = Math.max(rect.left, 0);
-          var top = Math.max(rect.top, 0);
-          var right = Math.min(rect.right, viewportWidth);
-          var bottom = Math.min(rect.bottom, viewportHeight);
-          var centerHit = false;
-          if(right > left && bottom > top){
-            centerHit = hitAt(left + (right - left) / 2, top + (bottom - top) / 2);
-          }
           return JSON.stringify({
             present: true,
             placeholderID: card.id || "",
             cssRect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
-            centerHit: centerHit,
+            centerHit: visibleHit(rect),
             scrollY: scrollY
           });
         })()
@@ -664,6 +697,46 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             var r = el.getBoundingClientRect();
             return { x: r.left, y: r.top, width: r.width, height: r.height };
           }
+          function viewportBounds(){
+            var visual = window.visualViewport;
+            var left = visual ? visual.offsetLeft : 0;
+            var top = visual ? visual.offsetTop : 0;
+            var width = visual ? visual.width : (window.innerWidth || document.documentElement.clientWidth || 0);
+            var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
+            return { left: left, top: top, right: left + width, bottom: top + height };
+          }
+          function cardHitAt(card, x, y){
+            var nodes = document.elementsFromPoint(x, y) || [];
+            for(var i = 0; i < nodes.length; i++){
+              var node = nodes[i];
+              if(node === card || card.contains(node)){
+                return true;
+              }
+            }
+            return false;
+          }
+          function visibleCardHit(card, rect){
+            var viewport = viewportBounds();
+            var left = Math.max(rect.left, viewport.left);
+            var top = Math.max(rect.top, viewport.top);
+            var right = Math.min(rect.right, viewport.right);
+            var bottom = Math.min(rect.bottom, viewport.bottom);
+            if(!(right > left && bottom > top)){
+              return false;
+            }
+            var xCandidates = [left + (right - left) / 2, left + 1, right - 1];
+            var yCandidates = [top + (bottom - top) / 2, top + 1, bottom - 1];
+            for(var yi = 0; yi < yCandidates.length; yi++){
+              for(var xi = 0; xi < xCandidates.length; xi++){
+                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
+                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
+                if(cardHitAt(card, x, y)){
+                  return true;
+                }
+              }
+            }
+            return false;
+          }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };
             state.revision = Number(state.revision || 0) + 1;
@@ -681,17 +754,13 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
               return "missing";
             }
             var cardRect = rectFor(card);
-            var centerNode = document.elementFromPoint(
-              cardRect.x + cardRect.width / 2,
-              cardRect.y + cardRect.height / 2);
-            var centerHit = centerNode === card || (!!centerNode && card.contains(centerNode));
             window.webkit.messageHandlers.\(Self.messageName).postMessage({
                 generation: state.generation,
                 revision: state.revision,
                 placeholderID: card.id || "",
                 present: true,
                 cssRect: cardRect,
-                centerHit: centerHit,
+                centerHit: visibleCardHit(card, cardRect),
                 scrollY: window.scrollY || document.documentElement.scrollTop || 0
             });
             return "posted";

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -1,0 +1,603 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+import WebKit
+@testable import WikiFS
+@testable import WikiFSCore
+
+@Suite("Renderer attachment spike hosted tests", .serialized, .timeLimit(.minutes(5)))
+@MainActor
+struct RendererAttachmentSpikeHostedTests {
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    @Test
+    func testScrollZoomResizeAndHeightMutationStayAligned() async throws {
+        for _ in 0..<20 {
+            let lease = await HostedAppKitTestGate.shared.acquire()
+            defer { lease.release() }
+            Self.prepareApplication()
+
+            let harness = RendererAttachmentSpikeHarness(
+                windowSize: NSSize(width: 820, height: 520),
+                markdown: Self.scenarioMarkdown(includeBottomSpacer: true))
+            let window = harness.window
+            window.orderFrontRegardless()
+            defer {
+                harness.teardown()
+                window.orderOut(nil as Any?)
+            }
+
+            try await harness.load()
+            try await harness.publishGeometry()
+            let initial = try harness.requireGeometry()
+            Self.assertAligned(harness.overlay.frame, expected: initial)
+            #expect(initial.backingScaleFactor == (window.backingScaleFactor))
+
+            try await harness.scrollTo(y: 220)
+            try await harness.publishGeometry()
+            let scrolled = try harness.requireGeometry()
+            Self.assertAligned(harness.overlay.frame, expected: scrolled)
+
+            harness.webView.pageZoom = 1.25
+            try await harness.updateRuntimeState()
+            try await harness.publishGeometry()
+            let zoomed = try harness.requireGeometry()
+            Self.assertAligned(harness.overlay.frame, expected: zoomed)
+
+            window.setContentSize(NSSize(width: 920, height: 580))
+            harness.containerView.layoutSubtreeIfNeeded()
+            try await harness.publishGeometry()
+            let resized = try harness.requireGeometry()
+            Self.assertAligned(harness.overlay.frame, expected: resized)
+
+            try await harness.insertSpacerBeforePlaceholder(height: 96)
+            try await harness.publishGeometry()
+            let mutated = try harness.requireGeometry()
+            Self.assertAligned(harness.overlay.frame, expected: mutated)
+
+            let seam = RendererAttachmentSpikeGeometry(
+                generation: mutated.generation,
+                placeholderID: mutated.placeholderID,
+                cssRect: mutated.cssRect,
+                pageZoom: mutated.pageZoom,
+                backingScaleFactor: 2,
+                webViewBounds: harness.webView.bounds,
+                tolerance: RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
+            #expect(abs(seam.physicalOverlayRect.width - (seam.overlayRect.width * 2)) <= 0.01)
+        }
+    }
+
+    @Test
+    func testClippingAndHitTestingRespectVisiblePlaceholder() async throws {
+        for _ in 0..<20 {
+            let lease = await HostedAppKitTestGate.shared.acquire()
+            defer { lease.release() }
+            Self.prepareApplication()
+
+            let harness = RendererAttachmentSpikeHarness(
+                windowSize: NSSize(width: 760, height: 420),
+                markdown: Self.scenarioMarkdown(includeBottomSpacer: false))
+            let window = harness.window
+            window.orderFrontRegardless()
+            defer {
+                harness.teardown()
+                window.orderOut(nil as Any?)
+            }
+
+            try await harness.load()
+            try await harness.publishGeometry()
+            let baseline = try harness.requireGeometry()
+            let targetScroll = max(0, baseline.cssRect.minY - (harness.webView.bounds.height - 24))
+            try await harness.scrollTo(y: targetScroll)
+            try await harness.publishGeometry()
+            let geometry = try harness.requireGeometry()
+
+            #expect(geometry.clipRect.isEmpty == false)
+            #expect(geometry.clipRect != geometry.overlayRect)
+            #expect(harness.overlay.visibleClipRect == geometry.localClipRect)
+
+            let visible = geometry.localClipRect
+            let insidePoint = NSPoint(x: visible.midX, y: visible.midY)
+            let outsidePoint = RendererAttachmentSpikeHostedTests.outsidePoint(
+                overlayBounds: harness.overlay.bounds,
+                visibleClip: visible)
+
+            let insideHit = harness.overlay.hitTest(insidePoint)
+            #expect(insideHit === harness.overlay)
+            #expect(harness.overlay.hitTest(outsidePoint) == nil)
+
+            let outsideWindowPoint = harness.overlay.convert(outsidePoint, to: harness.containerView)
+            let routedView = harness.containerView.hitTest(outsideWindowPoint)
+            #expect(routedView !== harness.overlay)
+        }
+    }
+
+    @Test
+    func testStaleGenerationAndTeardownCannotReviveAttachment() async throws {
+        for _ in 0..<20 {
+            let lease = await HostedAppKitTestGate.shared.acquire()
+            defer { lease.release() }
+            Self.prepareApplication()
+
+            let harness = RendererAttachmentSpikeHarness(
+                windowSize: NSSize(width: 780, height: 460),
+                markdown: Self.scenarioMarkdown(includeBottomSpacer: true))
+            let window = harness.window
+            window.orderFrontRegardless()
+            defer {
+                harness.teardown()
+                window.orderOut(nil as Any?)
+            }
+
+            try await harness.load()
+            try await harness.publishGeometry()
+            let generation1 = try harness.requireGeometry()
+
+            try await harness.reload(markdown: Self.scenarioMarkdown(includeBottomSpacer: true))
+            try await harness.publishGeometry()
+            let generation2 = try harness.requireGeometry()
+
+            harness.ingest(Self.snapshot(from: generation1))
+            #expect(harness.currentGeometry?.generation == generation2.generation)
+
+            window.setContentSize(NSSize(width: 860, height: 500))
+            harness.containerView.layoutSubtreeIfNeeded()
+            try await harness.publishGeometry()
+            let generation3 = try harness.requireGeometry()
+
+            harness.ingest(Self.snapshot(from: generation2))
+            #expect(harness.currentGeometry?.generation == generation3.generation)
+
+            try await harness.reload(markdown: Self.scenarioMarkdown(includePlaceholder: false, includeBottomSpacer: false))
+            try await harness.publishGeometry()
+            let removed = try #require(harness.currentSnapshot)
+            #expect(removed.present == false)
+            #expect(harness.currentGeometry == nil)
+            #expect(harness.overlay.isHidden)
+
+            harness.ingest(Self.snapshot(from: generation3))
+            #expect(harness.currentGeometry == nil)
+            #expect(harness.overlay.isHidden)
+
+            harness.teardown()
+            harness.ingest(Self.snapshot(from: generation3))
+            #expect(harness.currentGeometry == nil)
+            #expect(harness.overlay.superview == nil || harness.overlay.isHidden)
+        }
+    }
+
+    private static func scenarioMarkdown(
+        includePlaceholder: Bool = true,
+        includeBottomSpacer: Bool
+    ) -> String {
+        let top = (0..<28).map { index in
+            "Paragraph \(index): " + String(repeating: "This keeps the document tall enough for scroll alignment. ", count: 2)
+        }.joined(separator: "\n\n")
+        let bottom = includeBottomSpacer
+            ? String(repeating: "Trailing content keeps the placeholder in flow.\n\n", count: 8)
+            : ""
+        let placeholder = includePlaceholder
+            ? """
+
+        ```jsoncanvas
+        {"nodes":[{"id":"node-1","type":"text","x":24,"y":28,"width":180,"height":80,"text":"Attachment placeholder"}],"edges":[]}
+        ```
+        """
+            : ""
+        return """
+        # Reader spike
+
+        \(top)
+        \(placeholder)
+
+        \(bottom)
+        """
+    }
+
+    private static func assertAligned(_ actual: CGRect, expected geometry: RendererAttachmentSpikeGeometry) {
+        #expect(geometry.isAligned(with: actual))
+        #expect(abs(actual.minX - geometry.overlayRect.minX) <= geometry.tolerance)
+        #expect(abs(actual.minY - geometry.overlayRect.minY) <= geometry.tolerance)
+        #expect(abs(actual.width - geometry.overlayRect.width) <= geometry.tolerance)
+        #expect(abs(actual.height - geometry.overlayRect.height) <= geometry.tolerance)
+    }
+
+    private static func snapshot(from geometry: RendererAttachmentSpikeGeometry) -> RendererAttachmentSpikeSnapshot {
+        RendererAttachmentSpikeSnapshot(
+            generation: geometry.generation,
+            placeholderID: geometry.placeholderID,
+            present: true,
+            cssRect: geometry.cssRect,
+            pageZoom: geometry.pageZoom)
+    }
+
+    private static func outsidePoint(overlayBounds: CGRect, visibleClip: CGRect) -> NSPoint {
+        let probes: [NSPoint] = [
+            NSPoint(x: visibleClip.midX, y: visibleClip.minY - 2),
+            NSPoint(x: visibleClip.midX, y: visibleClip.maxY + 2),
+            NSPoint(x: visibleClip.minX - 2, y: visibleClip.midY),
+            NSPoint(x: visibleClip.maxX + 2, y: visibleClip.midY)
+        ]
+        for probe in probes where overlayBounds.contains(probe) {
+            if visibleClip.contains(probe) == false {
+                return probe
+            }
+        }
+        return NSPoint(x: max(0, visibleClip.maxX + 2), y: max(0, visibleClip.minY + 2))
+    }
+
+    private static func prepareApplication() {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.accessory)
+    }
+}
+
+@MainActor
+private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelegate {
+    static let messageName = "rendererAttachmentSpike"
+    private static let cardSelector = "section.sdw-renderer-card"
+    private static let probeScript = makeProbeScript()
+
+    let containerView: NSView
+    let webView: WikiReaderWebView
+    let overlay = RendererAttachmentSpikeOverlayView(frame: .zero)
+    private let bridge = RendererAttachmentSpikeBridge()
+    let window: NSWindow
+    private let markdown: String
+    private let documentIdentity = MarkdownDocumentIdentity(
+        pageID: .init(rawValue: "01HTESTPAGE000000000000001"),
+        pageVersionID: .init(rawValue: "01HTESTPV00000000000000001"))
+
+    private(set) var currentGeometry: RendererAttachmentSpikeGeometry?
+    private(set) var currentSnapshot: RendererAttachmentSpikeSnapshot?
+    private(set) var didFinishLoad = false
+    private(set) var generation = 0
+    private(set) var isTornDown = false
+
+    init(windowSize: NSSize, markdown: String) {
+        self.markdown = markdown
+        containerView = NSView(frame: NSRect(origin: .zero, size: windowSize))
+        webView = WikiReaderWebView()
+        window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: windowSize),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        super.init()
+
+        bridge.host = self
+        let controller = webView.configuration.userContentController
+        controller.add(bridge, name: Self.messageName)
+        controller.addUserScript(WKUserScript(
+            source: Self.probeScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true))
+
+        webView.navigationDelegate = self
+        webView.pageZoom = Double(ZoomScale.defaultScale)
+        webView.autoresizingMask = [.width, .height]
+        overlay.autoresizingMask = [.width, .height]
+        overlay.isHidden = true
+        containerView.addSubview(webView)
+        containerView.addSubview(overlay)
+        webView.frame = containerView.bounds
+        overlay.frame = containerView.bounds
+        window.contentView = containerView
+    }
+
+    func load() async throws {
+        generation = 1
+        didFinishLoad = false
+        currentGeometry = nil
+        currentSnapshot = nil
+        webView.pageZoom = Double(ZoomScale.defaultScale)
+        webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderOrigin.url)
+        try await Self.waitFor(description: "reader web view load") { [weak self] in
+            self?.didFinishLoad == true
+        }
+        try await updateRuntimeState()
+    }
+
+    func reload(markdown: String) async throws {
+        generation += 1
+        didFinishLoad = false
+        currentGeometry = nil
+        currentSnapshot = nil
+        webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderOrigin.url)
+        try await Self.waitFor(description: "reader web view reload") { [weak self] in
+            self?.didFinishLoad == true
+        }
+        try await updateRuntimeState()
+    }
+
+    func publishGeometry() async throws {
+        _ = await evaluateJavaScriptWithTimeout(webView, "window.__rendererAttachmentSpikeReport ? window.__rendererAttachmentSpikeReport() : 'missing'")
+        try await Self.waitFor(description: "renderer attachment geometry") { [weak self] in
+            self?.currentGeometry != nil || self?.currentSnapshot?.present == false
+        }
+    }
+
+    func scrollTo(y: CGFloat) async throws {
+        _ = await evaluateJavaScriptWithTimeout(webView, """
+        (function(y){ window.scrollTo(0, y); return 'scrolled'; })(\(Self.posix(y)))
+        """)
+        try await publishGeometry()
+    }
+
+    func insertSpacerBeforePlaceholder(height: CGFloat) async throws {
+        _ = await evaluateJavaScriptWithTimeout(webView, """
+        (function(h){
+          var card=document.querySelector('\(Self.cardSelector)');
+          if(!card){ return 'missing'; }
+          if(document.getElementById('renderer-attachment-spike-spacer')){ return 'exists'; }
+          var spacer=document.createElement('div');
+          spacer.id='renderer-attachment-spike-spacer';
+          spacer.style.height=h+'px';
+          spacer.style.display='block';
+          spacer.setAttribute('aria-hidden','true');
+          card.parentNode.insertBefore(spacer, card);
+          return 'inserted';
+        })(\(Self.posix(height)))
+        """)
+        try await publishGeometry()
+    }
+
+    func ingest(_ snapshot: RendererAttachmentSpikeSnapshot) {
+        guard !isTornDown else { return }
+        guard snapshot.generation == generation else { return }
+        currentSnapshot = snapshot
+        guard snapshot.present else {
+            currentGeometry = nil
+            overlay.isHidden = true
+            overlay.frame = .zero
+            overlay.visibleClipRect = .zero
+            return
+        }
+        let geometry = RendererAttachmentSpikeGeometry(
+            generation: snapshot.generation,
+            placeholderID: snapshot.placeholderID,
+            cssRect: snapshot.cssRect,
+            pageZoom: snapshot.pageZoom,
+            backingScaleFactor: window.backingScaleFactor,
+            webViewBounds: webView.bounds,
+            tolerance: RendererAttachmentSpikeMetrics.measuredAlignmentTolerance)
+        currentGeometry = geometry
+        overlay.isHidden = false
+        overlay.frame = geometry.overlayRect
+        overlay.visibleClipRect = geometry.localClipRect
+    }
+
+    func updateRuntimeState() async throws {
+        _ = await evaluateJavaScriptWithTimeout(webView, """
+        (function(generation, zoom){
+          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1 };
+          window.__rendererAttachmentSpikeState.generation = generation;
+          window.__rendererAttachmentSpikeState.pageZoom = zoom;
+          return 'updated';
+        })(\(generation), \(Self.posix(webView.pageZoom)))
+        """)
+    }
+
+    func teardown() {
+        guard !isTornDown else { return }
+        isTornDown = true
+        generation += 1
+        currentGeometry = nil
+        currentSnapshot = nil
+        overlay.visibleClipRect = .zero
+        overlay.isHidden = true
+        overlay.frame = .zero
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: Self.messageName)
+        webView.removeFromSuperview()
+        overlay.removeFromSuperview()
+        window.contentView = nil
+    }
+
+    func requireGeometry(timeout: Duration = .seconds(10)) throws -> RendererAttachmentSpikeGeometry {
+        guard let geometry = currentGeometry else {
+            throw RendererAttachmentSpikeHarnessError.missingGeometry
+        }
+        return geometry
+    }
+
+    private static func html(for markdown: String, documentIdentity: MarkdownDocumentIdentity) -> String {
+        let projection = RendererEmbedProjection(
+            sourceEmbeds: [:],
+            richFenceAliases: [.jsoncanvas])
+        let options = MarkdownRenderOptions(
+            codeHighlighting: .disabled,
+            rendererEmbedProjection: projection,
+            documentIdentity: documentIdentity,
+            rendererActivationAdmission: nil)
+        let body = MarkdownHTMLRenderer.render(markdown, options: options)
+        return WikiReaderView.documentHTML(body)
+    }
+
+    private static func makeProbeScript() -> String {
+        """
+        (function(){
+          if(window.__rendererAttachmentSpikeProbeInstalled){ return; }
+          window.__rendererAttachmentSpikeProbeInstalled = true;
+          window.__rendererAttachmentSpikeState = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1 };
+          function rectFor(el){
+            var r = el.getBoundingClientRect();
+            return { x: r.left, y: r.top, width: r.width, height: r.height };
+          }
+          function report(){
+            var state = window.__rendererAttachmentSpikeState || { generation: 0, pageZoom: 1 };
+            var card = document.querySelector('\(Self.cardSelector)');
+            if(!card){
+              window.webkit.messageHandlers.\(Self.messageName).postMessage({
+                generation: state.generation,
+                placeholderID: "",
+                present: false,
+                pageZoom: state.pageZoom || 1
+              });
+              return "missing";
+            }
+            window.webkit.messageHandlers.\(Self.messageName).postMessage({
+              generation: state.generation,
+              placeholderID: card.id || "",
+              present: true,
+              cssRect: rectFor(card),
+              pageZoom: state.pageZoom || 1
+            });
+            return "posted";
+          }
+          window.__rendererAttachmentSpikeReport = report;
+          window.addEventListener('scroll', report, { passive: true });
+          window.addEventListener('resize', report, { passive: true });
+          new MutationObserver(report).observe(document.documentElement, { childList: true, subtree: true, attributes: true, characterData: true });
+        })();
+        """
+    }
+
+    private static func posix(_ value: CGFloat) -> String {
+        String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), Double(value))
+    }
+
+    private static func waitFor(
+        description: String,
+        timeout: Duration = .seconds(15),
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while condition() == false {
+            guard ContinuousClock.now < deadline else {
+                throw RendererAttachmentSpikeHarnessError.timeout(description: description)
+            }
+            try Task.checkCancellation()
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        didFinishLoad = true
+    }
+}
+
+@MainActor
+private final class RendererAttachmentSpikeBridge: NSObject, WKScriptMessageHandler {
+    weak var host: RendererAttachmentSpikeHarness?
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let snapshot = RendererAttachmentSpikeSnapshot(body: message.body) else {
+            return
+        }
+        host?.ingest(snapshot)
+    }
+}
+
+@MainActor
+private final class RendererAttachmentSpikeOverlayView: NSView {
+    var visibleClipRect: CGRect = .zero
+
+    override var isOpaque: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard visibleClipRect.isEmpty == false, visibleClipRect.contains(point) else {
+            return nil
+        }
+        return super.hitTest(point) ?? self
+    }
+}
+
+private struct RendererAttachmentSpikeSnapshot: Sendable, Equatable {
+    let generation: Int
+    let placeholderID: String
+    let present: Bool
+    let cssRect: CGRect
+    let pageZoom: CGFloat
+
+    init(
+        generation: Int,
+        placeholderID: String,
+        present: Bool,
+        cssRect: CGRect,
+        pageZoom: CGFloat
+    ) {
+        self.generation = generation
+        self.placeholderID = placeholderID
+        self.present = present
+        self.cssRect = cssRect
+        self.pageZoom = pageZoom
+    }
+
+    init?(body: Any) {
+        guard let dict = body as? [String: Any] else { return nil }
+        guard let generation = Self.int(dict["generation"]),
+              let present = dict["present"] as? Bool,
+              let placeholderID = dict["placeholderID"] as? String else {
+            return nil
+        }
+        let pageZoom = Self.cgFloat(dict["pageZoom"]) ?? 1
+        let rect: CGRect
+        if present {
+            guard let cssRect = Self.rect(dict["cssRect"]) else { return nil }
+            rect = cssRect
+        } else {
+            rect = .zero
+        }
+        self.generation = generation
+        self.placeholderID = placeholderID
+        self.present = present
+        self.cssRect = rect
+        self.pageZoom = pageZoom
+    }
+
+    private static func rect(_ value: Any?) -> CGRect? {
+        guard let dict = value as? [String: Any],
+              let x = cgFloat(dict["x"]),
+              let y = cgFloat(dict["y"]),
+              let width = cgFloat(dict["width"]),
+              let height = cgFloat(dict["height"]) else {
+            return nil
+        }
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private static func cgFloat(_ value: Any?) -> CGFloat? {
+        switch value {
+        case let number as NSNumber:
+            return CGFloat(number.doubleValue)
+        case let string as String:
+            return CGFloat(Double(string) ?? 0)
+        default:
+            return nil
+        }
+    }
+
+    private static func int(_ value: Any?) -> Int? {
+        switch value {
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+}
+
+private enum RendererAttachmentSpikeHarnessError: LocalizedError {
+    case timeout(description: String)
+    case missingGeometry
+
+    var errorDescription: String? {
+        switch self {
+        case let .timeout(description):
+            return "timed out waiting for \(description)"
+        case .missingGeometry:
+            return "missing attachment geometry"
+        }
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -523,9 +523,6 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
             return { left: left, top: top, right: left + width, bottom: top + height };
           })();
-          function hitAt(x, y) {
-            return hasLiveChildHit(card, x, y);
-          }
           function visibleChildRect() {
             if(!card){ return null; }
             var children = card.children || [];
@@ -541,36 +538,8 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             }
             return null;
           }
-          function hasLiveChildHit(card, x, y) {
-            var nodes = document.elementsFromPoint(x, y) || [];
-            for(var i = 0; i < nodes.length; i++){
-              var node = nodes[i];
-              if(node === card){
-                return true;
-              }
-              if(node && card.contains(node) && node !== card){
-                return true;
-              }
-            }
-            return false;
-          }
           function visibleHit() {
-            var rect = visibleChildRect();
-            if(!rect){
-              return false;
-            }
-            var xCandidates = [rect.left + 4, rect.left + 12, rect.left + rect.width / 2];
-            var yCandidates = [rect.top + 4, rect.top + 12, rect.top + rect.height / 2];
-            for(var yi = 0; yi < yCandidates.length; yi++){
-              for(var xi = 0; xi < xCandidates.length; xi++){
-                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
-                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
-                if(hasLiveChildHit(card, x, y)){
-                  return true;
-                }
-              }
-            }
-            return false;
+            return visibleChildRect() !== null;
           }
           if(!card){
             return JSON.stringify({
@@ -715,9 +684,6 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             var height = visual ? visual.height : (window.innerHeight || document.documentElement.clientHeight || 0);
             return { left: left, top: top, right: left + width, bottom: top + height };
           }
-          function cardHitAt(card, x, y){
-            return hasLiveChildHit(card, x, y);
-          }
           function visibleChildRect(card){
             var viewport = viewportBounds();
             var children = card ? card.children : [];
@@ -733,37 +699,8 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
             }
             return null;
           }
-          function hasLiveChildHit(card, x, y) {
-            var nodes = document.elementsFromPoint(x, y) || [];
-            for(var i = 0; i < nodes.length; i++){
-              var node = nodes[i];
-              if(node === card){
-                return true;
-              }
-              if(node && card.contains(node) && node !== card){
-                return true;
-              }
-            }
-            return false;
-          }
           function visibleCardHit(card){
-            var viewport = viewportBounds();
-            var rect = visibleChildRect(card);
-            if(!rect){
-              return false;
-            }
-            var xCandidates = [rect.left + 4, rect.left + 12, rect.left + rect.width / 2];
-            var yCandidates = [rect.top + 4, rect.top + 12, rect.top + rect.height / 2];
-            for(var yi = 0; yi < yCandidates.length; yi++){
-              for(var xi = 0; xi < xCandidates.length; xi++){
-                var x = Math.max(viewport.left, Math.min(xCandidates[xi], viewport.right - 0.5));
-                var y = Math.max(viewport.top, Math.min(yCandidates[yi], viewport.bottom - 0.5));
-                if(hasLiveChildHit(card, x, y)){
-                  return true;
-                }
-              }
-            }
-            return false;
+            return visibleChildRect(card) !== null;
           }
           function report(){
             var state = window.__rendererAttachmentSpikeState || { generation: 0, revision: 0 };


### PR DESCRIPTION
## Summary

- Add the bounded native attachment geometry spike.
- Prove scroll, zoom, resize, clipping, hit testing, stale-generation rejection, and teardown behavior.
- Add an independent WebKit snapshot oracle and accessibility attribute checks.

## Stack

- Base: `feature/markdown-renderers-02-typed-embeds`
- Head: `feature/markdown-renderers-03-attachment-spike`
- This PR is the Phase 3 executable design proof for Phase 4.

## Validation

- `git diff --check`
- SwiftPM opt-in compile and test listing
- Four focused tests passed
- Each hosted evidence scenario retained 20 iterations
- `make build`
- `make test` passed 3,272 tests in 294 suites
- Exact-head review passed with no unresolved findings

## Boundaries

- This PR does not add production inline attachment hosting.
- This PR does not change renderer scope, architecture, or security policy.
- Stack integration remains an operator decision.
