### PR TITLE
fix(identifiers): append .value to daemonServiceID

### DIFF
--- a/Sources/WikiFSCore/Core/WikiIdentifiers.swift
+++ b/Sources/WikiFSCore/Core/WikiIdentifiers.swift
@@ -115,7 +115,7 @@ public enum WikiIdentifiers {
         env: "WIKI_DAEMON_SERVICE_ID",
         infoKey: "WIKIDaemonServiceID",
         localConfigKey: "DAEMON_BUNDLE_ID",
-        default: derivedDaemonServiceID)
+        default: derivedDaemonServiceID).value
 
     /// `<app bundle id>.wikid` — the fallback used when nothing sets the daemon
     /// id explicitly. Mirrors `DAEMON_BUNDLE_ID="${BUNDLE_ID}.wikid"` in


### PR DESCRIPTION
## Problem

`WikiIdentifiers.resolve()` returns `(value: String, source: ResolutionSource)`, but `daemonServiceID` (Sources/WikiFSCore/Core/WikiIdentifiers.swift:114) does not unwrap it. It is the only String-typed id that misses `.value` — the sibling `fileProviderID` has it, and `appGroupResolution` keeps the tuple on purpose so the fail-fast error can report the source.

As a result `daemonServiceID` is a tuple, and every consumer that treats it as a `String` fails to type-check:

- `Sources/WikiCtlCore/WikiDaemonConnection.swift:65` — `serviceName` infers to the tuple, then `NSXPCConnection(serviceName:)` at line 94 gets a tuple instead of a `String`
- `Sources/wikid/main.swift:17` — same, for `WikiDaemonServiceName`
- `Tests/WikiFSAppTests/DaemonHealthMonitorTests.swift:320,321,339` — `.isEmpty`, `.contains(".")`, `.hasSuffix(".wikid")` on a tuple

This came in with the resolve-signature change in #1101; the follow-up fix did not make it into the squash merge. The Linux CI checks are diagnostic-only as of a2672e01, which is likely why it landed unnoticed.

## Fix

One line — unwrap the tuple, matching `fileProviderID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)