### PR TITLE
feat(markdown-renderers): add native inline attachments

### DIFF
--- a/Sources/WikiFS/Reader/MarkdownHTMLRenderer.swift
+++ b/Sources/WikiFS/Reader/MarkdownHTMLRenderer.swift
@@ -339,7 +339,8 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
                 input: .inlineArtifact(artifact),
                 capability: admission.capability,
                 generation: admission.generation)
-            admission.register(context: context)
+            let placeholder = RendererAttachmentPlaceholderID.validatedOrNil(plan.placeholderID)
+            admission.register(context: context, attachmentPlaceholderID: placeholder)
             return context
         }()
         let inputAttribute: String

--- a/Sources/WikiFS/Reader/RendererAttachmentCoordinator.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentCoordinator.swift
@@ -98,10 +98,8 @@ enum RendererAttachmentGeometry {
 enum RendererAttachmentState: Equatable {
     case unresolved
     case card
-    case activating
     case active
     case failed
-    case collapsing
     case closed
 }
 
@@ -166,10 +164,8 @@ final class RendererAttachmentCoordinator {
 
     func activate(_ placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentActivationResult {
         guard var record = records[placeholderID], record.state == .card else { return .rejected }
-        let activeCount = records.values.filter { $0.state == .active || $0.state == .activating }.count
+        let activeCount = records.values.filter { $0.state == .active }.count
         guard activeCount < activeLimit else { return .showInFullRenderer }
-        record.state = .activating
-        records[placeholderID] = record
         record.state = .active
         records[placeholderID] = record
         return .activate
@@ -177,8 +173,6 @@ final class RendererAttachmentCoordinator {
 
     func collapse(_ placeholderID: RendererAttachmentPlaceholderID) {
         guard var record = records[placeholderID], record.state == .active else { return }
-        record.state = .collapsing
-        records[placeholderID] = record
         record.state = .card
         records[placeholderID] = record
     }

--- a/Sources/WikiFS/Reader/RendererAttachmentCoordinator.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentCoordinator.swift
@@ -1,0 +1,218 @@
+#if os(macOS)
+import CoreGraphics
+import Foundation
+
+// pattern: Functional Core — bounded attachment state and geometry are deterministic values.
+
+enum RendererAttachmentHostPolicy {
+    static let maximumMessageByteCount = 16 * 1_024
+    static let maximumPlaceholderCount = 64
+    static let maximumUpdatesPerPlaceholder = 1_024
+    static let maximumCoordinateMagnitude = 1_000_000.0
+    static let minimumReservedHeight = 96.0
+    static let maximumReservedHeight = 1_200.0
+    static let maximumActiveAttachments = 1
+}
+
+struct RendererAttachmentPlaceholderID: Hashable, Sendable, Equatable {
+    let rawValue: String
+
+    init(validating rawValue: String) throws {
+        guard rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
+              rawValue.isEmpty == false,
+              rawValue.count <= 160,
+              rawValue.unicodeScalars.allSatisfy({ $0.properties.isWhitespace == false })
+        else { throw RendererAttachmentMessageError.invalidPlaceholderID }
+        self.rawValue = rawValue
+    }
+}
+
+extension RendererAttachmentPlaceholderID {
+    static func validatedOrNil(_ rawValue: String) -> Self? {
+        do {
+            return try Self(validating: rawValue)
+        } catch {
+            return nil
+        }
+    }
+}
+
+struct RendererAttachmentGeometryMessage: Sendable, Equatable {
+    let generation: Int
+    let placeholderID: RendererAttachmentPlaceholderID
+    let cssRect: CGRect
+    let visible: Bool
+    let revision: Int
+
+    init(generation: Int, placeholderID: RendererAttachmentPlaceholderID, cssRect: CGRect, visible: Bool, revision: Int) {
+        self.generation = generation
+        self.placeholderID = placeholderID
+        self.cssRect = cssRect
+        self.visible = visible
+        self.revision = revision
+    }
+
+    init?(body: [String: Any]) {
+        guard let generation = body["generation"] as? Int,
+              let rawPlaceholderID = body["placeholderID"] as? String,
+              let placeholderID = RendererAttachmentPlaceholderID.validatedOrNil(rawPlaceholderID),
+              let x = Self.number(body["x"]), let y = Self.number(body["y"]),
+              let width = Self.number(body["width"]), let height = Self.number(body["height"]),
+              let visible = body["visible"] as? Bool,
+              let revision = body["revision"] as? Int
+        else { return nil }
+        let cssRect = CGRect(x: x, y: y, width: width, height: height)
+        guard cssRect.isFiniteRect else { return nil }
+        self.generation = generation
+        self.placeholderID = placeholderID
+        self.cssRect = cssRect
+        self.visible = visible
+        self.revision = revision
+    }
+
+    private static func number(_ value: Any?) -> CGFloat? {
+        if let value = value as? CGFloat, value.isFinite { return value }
+        if let value = value as? Double, value.isFinite { return CGFloat(value) }
+        if let value = value as? Int { return CGFloat(value) }
+        return nil
+    }
+}
+
+enum RendererAttachmentMessageError: Error, Equatable {
+    case invalidPlaceholderID
+}
+
+enum RendererAttachmentGeometry {
+    static func overlayRect(cssRect: CGRect, pageZoom: CGFloat, readerBounds: CGRect) -> CGRect {
+        guard cssRect.isFiniteRect, pageZoom.isFinite, pageZoom > 0 else { return .zero }
+        let x = cssRect.minX * pageZoom
+        let y = readerBounds.height - cssRect.maxY * pageZoom
+        return CGRect(x: x, y: y, width: cssRect.width * pageZoom, height: cssRect.height * pageZoom)
+    }
+
+    static func clip(rect: CGRect, to readerBounds: CGRect) -> CGRect {
+        rect.intersection(readerBounds)
+    }
+}
+
+enum RendererAttachmentState: Equatable {
+    case unresolved
+    case card
+    case activating
+    case active
+    case failed
+    case collapsing
+    case closed
+}
+
+enum RendererAttachmentActivationResult: Equatable {
+    case activate
+    case showInFullRenderer
+    case rejected
+}
+
+@MainActor
+final class RendererAttachmentCoordinator {
+    private struct Record {
+        var state: RendererAttachmentState = .unresolved
+        var latestRevision = -1
+        var updateCount = 0
+        var reservedHeight = RendererAttachmentHostPolicy.minimumReservedHeight
+    }
+
+    let generation: Int
+    private let activeLimit: Int
+    private var records: [RendererAttachmentPlaceholderID: Record] = [:]
+
+    init(generation: Int, activeLimit: Int = RendererAttachmentHostPolicy.maximumActiveAttachments) {
+        self.generation = generation
+        self.activeLimit = max(0, activeLimit)
+    }
+
+    func state(for placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentState {
+        records[placeholderID]?.state ?? .unresolved
+    }
+
+    @discardableResult
+    func ingest(_ message: RendererAttachmentGeometryMessage) -> Bool {
+        guard message.generation == generation,
+              isValid(message.cssRect),
+              message.revision >= 0,
+              records[message.placeholderID] != nil || records.count < RendererAttachmentHostPolicy.maximumPlaceholderCount
+        else { return false }
+
+        var record = records[message.placeholderID] ?? Record()
+        guard record.state != .closed,
+              message.revision > record.latestRevision,
+              record.updateCount < RendererAttachmentHostPolicy.maximumUpdatesPerPlaceholder
+        else { return false }
+        record.latestRevision = message.revision
+        record.updateCount += 1
+        if record.state == .unresolved { record.state = .card }
+        records[message.placeholderID] = record
+        return true
+    }
+
+    func reserveHeight(_ requested: CGFloat, for placeholderID: RendererAttachmentPlaceholderID) -> CGFloat {
+        let height = min(
+            RendererAttachmentHostPolicy.maximumReservedHeight,
+            max(RendererAttachmentHostPolicy.minimumReservedHeight, requested.isFinite ? requested : RendererAttachmentHostPolicy.minimumReservedHeight))
+        var record = records[placeholderID] ?? Record()
+        guard record.state != .closed else { return record.reservedHeight }
+        record.reservedHeight = height
+        records[placeholderID] = record
+        return height
+    }
+
+    func activate(_ placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentActivationResult {
+        guard var record = records[placeholderID], record.state == .card else { return .rejected }
+        let activeCount = records.values.filter { $0.state == .active || $0.state == .activating }.count
+        guard activeCount < activeLimit else { return .showInFullRenderer }
+        record.state = .activating
+        records[placeholderID] = record
+        record.state = .active
+        records[placeholderID] = record
+        return .activate
+    }
+
+    func collapse(_ placeholderID: RendererAttachmentPlaceholderID) {
+        guard var record = records[placeholderID], record.state == .active else { return }
+        record.state = .collapsing
+        records[placeholderID] = record
+        record.state = .card
+        records[placeholderID] = record
+    }
+
+    func fail(_ placeholderID: RendererAttachmentPlaceholderID) {
+        guard var record = records[placeholderID], record.state != .closed else { return }
+        record.state = .failed
+        records[placeholderID] = record
+    }
+
+    func closeAll() {
+        for key in records.keys {
+            records[key]?.state = .closed
+        }
+    }
+
+    func close(_ placeholderID: RendererAttachmentPlaceholderID) {
+        guard var record = records[placeholderID] else { return }
+        record.state = .closed
+        records[placeholderID] = record
+    }
+
+    private func isValid(_ rect: CGRect) -> Bool {
+        rect.isFiniteRect && rect.width > 0 && rect.height > 0 &&
+            abs(rect.minX) <= RendererAttachmentHostPolicy.maximumCoordinateMagnitude &&
+            abs(rect.minY) <= RendererAttachmentHostPolicy.maximumCoordinateMagnitude &&
+            abs(rect.maxX) <= RendererAttachmentHostPolicy.maximumCoordinateMagnitude &&
+            abs(rect.maxY) <= RendererAttachmentHostPolicy.maximumCoordinateMagnitude
+    }
+}
+
+private extension CGRect {
+    var isFiniteRect: Bool {
+        origin.x.isFinite && origin.y.isFinite && size.width.isFinite && size.height.isFinite
+    }
+}
+#endif

--- a/Sources/WikiFS/Reader/WikiReaderContainerView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderContainerView.swift
@@ -1,0 +1,135 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+// pattern: Imperative Shell — owns AppKit child-view layout, clipping, hit testing, and teardown.
+
+/// The native reader host. The WebView remains the document-layout and scrolling
+/// authority; this sibling overlay is only a clipped projection for trusted
+/// attachment rectangles.
+@MainActor
+final class WikiReaderContainerView: NSView {
+    let webView: WikiReaderWebView
+    private let attachmentOverlay = RendererAttachmentOverlayView()
+    private var attachmentChild: RendererAttachmentNativeChildView?
+
+    init(webView: WikiReaderWebView) {
+        self.webView = webView
+        super.init(frame: .zero)
+        addSubview(webView)
+        addSubview(attachmentOverlay)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+
+    override func layout() {
+        super.layout()
+        webView.frame = bounds
+        attachmentOverlay.frame = bounds
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if attachmentOverlay.attachmentClipRect.contains(point), let attachmentChild {
+            let childPoint = attachmentChild.convert(point, from: self)
+            if let hitView = attachmentChild.hitTest(childPoint) {
+                return hitView
+            }
+        }
+        return webView
+    }
+
+    func updateAttachmentViewport(_ rect: CGRect) {
+        attachmentOverlay.attachmentClipRect = rect.intersection(bounds)
+        attachmentChild?.frame = attachmentOverlay.attachmentClipRect
+    }
+
+    func activateAttachment(named placeholderID: RendererAttachmentPlaceholderID, content: AnyView? = nil) {
+        removeAttachmentChild()
+        let child = RendererAttachmentNativeChildView(placeholderID: placeholderID, content: content) { [weak self] in
+            self?.collapseAttachment()
+        }
+        attachmentOverlay.addSubview(child)
+        attachmentChild = child
+        child.frame = attachmentOverlay.attachmentClipRect
+        window?.makeFirstResponder(child)
+    }
+
+    func collapseAttachment() {
+        removeAttachmentChild()
+        window?.makeFirstResponder(webView)
+    }
+
+    private func removeAttachmentChild() {
+        attachmentChild?.removeFromSuperview()
+        attachmentChild = nil
+    }
+
+    func teardown() {
+        removeAttachmentChild()
+        attachmentOverlay.attachmentClipRect = .zero
+        attachmentOverlay.removeFromSuperview()
+        webView.removeFromSuperview()
+    }
+}
+
+@MainActor
+private final class RendererAttachmentOverlayView: NSView {
+    /// A zero rectangle is fully pass-through. Attachment children added in a
+    /// later renderer factory are constrained to this exact visible rectangle.
+    fileprivate var attachmentClipRect: CGRect = .zero {
+        didSet { needsDisplay = true }
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard attachmentClipRect.contains(point) else { return nil }
+        return super.hitTest(point)
+    }
+}
+
+@MainActor
+private final class RendererAttachmentNativeChildView: NSView {
+    private let placeholderID: RendererAttachmentPlaceholderID
+    private let onExit: () -> Void
+    private let hostedContent: NSHostingView<AnyView>?
+
+    init(
+        placeholderID: RendererAttachmentPlaceholderID,
+        content: AnyView?,
+        onExit: @escaping () -> Void
+    ) {
+        self.placeholderID = placeholderID
+        self.onExit = onExit
+        hostedContent = content.map(NSHostingView.init(rootView:))
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.borderWidth = 2
+        layer?.borderColor = NSColor.keyboardFocusIndicatorColor.cgColor
+        setAccessibilityElement(true)
+        setAccessibilityRole(.group)
+        setAccessibilityLabel("Interactive renderer attachment")
+        setAccessibilityIdentifier("renderer-attachment-\(placeholderID.rawValue)")
+        if let hostedContent {
+            hostedContent.frame = bounds
+            hostedContent.autoresizingMask = [.width, .height]
+            addSubview(hostedContent)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard bounds.contains(point) else { return nil }
+        guard let hostedContent else { return self }
+        return hostedContent.hitTest(hostedContent.convert(point, from: self)) ?? self
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 { onExit() }
+        else { super.keyDown(with: event) }
+    }
+}
+#endif

--- a/Sources/WikiFS/Reader/WikiReaderContainerView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderContainerView.swift
@@ -44,10 +44,15 @@ final class WikiReaderContainerView: NSView {
         attachmentChild?.frame = attachmentOverlay.attachmentClipRect
     }
 
-    func activateAttachment(named placeholderID: RendererAttachmentPlaceholderID, content: AnyView? = nil) {
+    func activateAttachment(
+        named placeholderID: RendererAttachmentPlaceholderID,
+        content: AnyView? = nil,
+        onExit: (() -> Void)? = nil
+    ) {
         removeAttachmentChild()
         let child = RendererAttachmentNativeChildView(placeholderID: placeholderID, content: content) { [weak self] in
-            self?.collapseAttachment()
+            if let onExit { onExit() }
+            else { self?.collapseAttachment() }
         }
         attachmentOverlay.addSubview(child)
         attachmentChild = child

--- a/Sources/WikiFS/Reader/WikiReaderContainerView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderContainerView.swift
@@ -60,6 +60,11 @@ final class WikiReaderContainerView: NSView {
         window?.makeFirstResponder(webView)
     }
 
+    /// The mounted child is the sole native attachment shown by this container.
+    func ownsMountedAttachment(named placeholderID: RendererAttachmentPlaceholderID) -> Bool {
+        attachmentChild?.placeholderID == placeholderID
+    }
+
     private func removeAttachmentChild() {
         attachmentChild?.removeFromSuperview()
         attachmentChild = nil
@@ -89,7 +94,7 @@ private final class RendererAttachmentOverlayView: NSView {
 
 @MainActor
 private final class RendererAttachmentNativeChildView: NSView {
-    private let placeholderID: RendererAttachmentPlaceholderID
+    let placeholderID: RendererAttachmentPlaceholderID
     private let onExit: () -> Void
     private let hostedContent: NSHostingView<AnyView>?
 

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -55,6 +55,7 @@ internal final class RendererEmbedActivationAdmission: @unchecked Sendable {
     let generation: Int
     private let lock = NSLock()
     private var registeredContexts: Set<RendererEmbedActivationContext> = []
+    private var attachmentContexts: [RendererAttachmentPlaceholderID: RendererEmbedActivationContext] = [:]
 
     init(
         pageID: PageID,
@@ -68,7 +69,10 @@ internal final class RendererEmbedActivationAdmission: @unchecked Sendable {
         self.generation = generation
     }
 
-    func register(context: RendererEmbedActivationContext) {
+    func register(
+        context: RendererEmbedActivationContext,
+        attachmentPlaceholderID: RendererAttachmentPlaceholderID? = nil
+    ) {
         guard context.pageID == pageID,
               context.pageVersionID == pageVersionID,
               context.capability == capability,
@@ -76,6 +80,9 @@ internal final class RendererEmbedActivationAdmission: @unchecked Sendable {
         else { return }
         lock.lock()
         registeredContexts.insert(context)
+        if let attachmentPlaceholderID {
+            attachmentContexts[attachmentPlaceholderID] = context
+        }
         lock.unlock()
     }
 
@@ -88,6 +95,15 @@ internal final class RendererEmbedActivationAdmission: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return registeredContexts.contains(context)
+    }
+
+    func attachmentContext(for placeholderID: RendererAttachmentPlaceholderID) -> RendererEmbedActivationContext? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let context = attachmentContexts[placeholderID], registeredContexts.contains(context) else {
+            return nil
+        }
+        return context
     }
 }
 
@@ -629,12 +645,20 @@ final class WikiReaderWebView: WKWebView {
         // references this view, same pattern as the hover handler.
         let embedProxy = EmbedFetchMessageHandler(target: nil)
         cc.add(embedProxy, name: Self.embedFetchName)
+        let attachmentProxy = RendererAttachmentGeometryMessageHandler(target: nil)
+        cc.add(attachmentProxy, name: "rendererAttachmentGeometry")
+        let attachmentActionProxy = RendererAttachmentActionMessageHandler(target: nil)
+        cc.add(attachmentActionProxy, name: "rendererAttachmentAction")
         cc.addUserScript(WKUserScript(
             source: Self.hoverListenerJS,
             injectionTime: .atDocumentEnd,
             forMainFrameOnly: true))
         cc.addUserScript(WKUserScript(
             source: Self.embedBootstrapJS,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true))
+        cc.addUserScript(WKUserScript(
+            source: Self.rendererAttachmentGeometryJS,
             injectionTime: .atDocumentEnd,
             forMainFrameOnly: true))
         config.userContentController = cc
@@ -645,7 +669,22 @@ final class WikiReaderWebView: WKWebView {
         super.init(frame: .zero, configuration: config)
         proxy.target = self
         embedProxy.target = self
+        attachmentProxy.target = self
+        attachmentActionProxy.target = self
     }
+
+    private static let rendererAttachmentGeometryJS = """
+    (function(){
+      var known={}; function report(){ var g=window.__sdwRendererAttachmentGeneration; if(typeof g!=='number')return; var current={};
+        document.querySelectorAll('.sdw-renderer-card[id]').forEach(function(e,i){current[e.id]=true;var r=e.getBoundingClientRect();
+          window.webkit.messageHandlers.rendererAttachmentGeometry.postMessage({generation:g,placeholderID:e.id,x:r.x,y:r.y,width:r.width,height:r.height,visible:r.bottom>0&&r.right>0&&r.top<innerHeight&&r.left<innerWidth,revision:(window.__sdwRendererAttachmentRevision||0)});});
+        Object.keys(known).forEach(function(id){if(!current[id])window.webkit.messageHandlers.rendererAttachmentGeometry.postMessage({kind:'removed',generation:g,placeholderID:id});}); known=current; }
+      window.__sdwRendererAttachmentReport=function(g){window.__sdwRendererAttachmentGeneration=g;window.__sdwRendererAttachmentRevision=(window.__sdwRendererAttachmentRevision||0)+1;report();};
+      window.__sdwRendererAttachmentReserve=function(id,height){var e=document.getElementById(id); if(!e||!Number.isFinite(height))return; e.style.minHeight=height+'px'; window.__sdwRendererAttachmentRevision=(window.__sdwRendererAttachmentRevision||0)+1; report();};
+      document.addEventListener('click',function(event){var control=event.target.closest('.sdw-renderer-card__action,.sdw-renderer-card__collapse');if(!control)return;var card=control.closest('.sdw-renderer-card[id]');if(!card)return;event.preventDefault();var collapse=control.classList.contains('sdw-renderer-card__collapse');window.webkit.messageHandlers.rendererAttachmentAction.postMessage({action:collapse?'collapse':'activate',placeholderID:card.id});if(!collapse&&!card.querySelector('.sdw-renderer-card__collapse')){var b=document.createElement('button');b.className='sdw-renderer-card__collapse';b.type='button';b.textContent='Collapse';b.setAttribute('aria-label','Collapse interactive renderer');card.appendChild(b);}});
+      addEventListener('scroll',report,{passive:true}); addEventListener('resize',report); new MutationObserver(report).observe(document.documentElement,{childList:true,subtree:true,attributes:true});
+    })();
+    """
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -1150,6 +1189,40 @@ internal final class EmbedFetchMessageHandler: NSObject, WKScriptMessageHandler 
     }
 }
 
+@MainActor
+private final class RendererAttachmentGeometryMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var target: WikiReaderWebView?
+    init(target: WikiReaderWebView?) { self.target = target }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == "rendererAttachmentGeometry", let body = message.body as? [String: Any] else { return }
+        if body["kind"] as? String == "removed", let generation = body["generation"] as? Int,
+           let rawID = body["placeholderID"] as? String,
+           let id = RendererAttachmentPlaceholderID.validatedOrNil(rawID) {
+            target?.coordinator?.handleAttachmentRemoval(id, generation: generation); return
+        }
+        guard let geometry = RendererAttachmentGeometryMessage(body: body) else { return }
+        target?.coordinator?.handleAttachmentGeometry(geometry)
+    }
+}
+
+@MainActor
+private final class RendererAttachmentActionMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var target: WikiReaderWebView?
+    init(target: WikiReaderWebView?) { self.target = target }
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let body = message.body as? [String: Any], let action = body["action"] as? String,
+              let rawID = body["placeholderID"] as? String,
+              let placeholderID = RendererAttachmentPlaceholderID.validatedOrNil(rawID)
+        else { return }
+        switch action {
+        case "activate": _ = target?.coordinator?.activateAttachment(placeholderID)
+        case "collapse": target?.coordinator?.collapseAttachment(placeholderID)
+        default: break
+        }
+    }
+}
+
 internal struct WikiReaderRep: NSViewRepresentable {
     let markdown: String
     let store: WikiStoreModel
@@ -1169,8 +1242,9 @@ internal struct WikiReaderRep: NSViewRepresentable {
     let findVersion: Int
     let findOccurrence: Int
 
-    func makeNSView(context: Context) -> WikiReaderWebView {
+    func makeNSView(context: Context) -> WikiReaderContainerView {
         let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
         webView.pageZoom = readerZoom
         webView.store = store
         webView.blobHandler.store = store
@@ -1182,16 +1256,18 @@ internal struct WikiReaderRep: NSViewRepresentable {
         webView.navigationDelegate = context.coordinator
         webView.coordinator = context.coordinator
         context.coordinator.webView = webView
+        context.coordinator.attachmentContainer = container
         context.coordinator.store = store
         context.coordinator.currentSelection = currentSelection
         context.coordinator.startLoad(
             markdown: markdown,
             documentIdentity: documentIdentity,
             isLoading: $isLoading)
-        return webView
+        return container
     }
 
-    func updateNSView(_ webView: WikiReaderWebView, context: Context) {
+    func updateNSView(_ container: WikiReaderContainerView, context: Context) {
+        let webView = container.webView
         webView.pageZoom = readerZoom
         webView.store = store
         webView.blobHandler.store = store
@@ -1225,13 +1301,16 @@ internal struct WikiReaderRep: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    static func dismantleNSView(_ webView: WikiReaderWebView, coordinator: Coordinator) {
+    static func dismantleNSView(_ container: WikiReaderContainerView, coordinator: Coordinator) {
         coordinator.teardown()
+        container.teardown()
     }
 
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate {
         weak var webView: WikiReaderWebView?
+        weak var attachmentContainer: WikiReaderContainerView?
+        private var attachmentCoordinator: RendererAttachmentCoordinator?
         var store: WikiStoreModel?
         var currentSelection: WikiSelection?
         var loadedMarkdown: String?
@@ -1261,6 +1340,9 @@ internal struct WikiReaderRep: NSViewRepresentable {
             convertTask?.cancel()  // drop any in-flight conversion for stale markdown
             loadGeneration += 1
             let generation = loadGeneration
+            attachmentCoordinator?.closeAll()
+            attachmentContainer?.collapseAttachment()
+            attachmentCoordinator = RendererAttachmentCoordinator(generation: generation)
             loadedMarkdown = markdown
             loadedDocumentIdentity = documentIdentity
             pageLoaded = false
@@ -1411,6 +1493,9 @@ internal struct WikiReaderRep: NSViewRepresentable {
             webView?.rendererActivationAdmission = nil
             isLoadingBinding = nil
             renderOptions = nil
+            attachmentCoordinator?.closeAll()
+            attachmentCoordinator = nil
+            attachmentContainer = nil
             webView = nil
             store = nil
             currentSelection = nil
@@ -1540,7 +1625,90 @@ internal struct WikiReaderRep: NSViewRepresentable {
             }
             pageLoaded = true
             isLoadingBinding?.wrappedValue = false
+            webView.evaluateJavaScript("window.__sdwRendererAttachmentReport && window.__sdwRendererAttachmentReport(\(loadGeneration));")
             consumeAndApplyPendingAnchor(in: webView)
+        }
+
+        // WebKit's delegate protocol requires an implicitly unwrapped navigation argument.
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            // A real reload begins a new document generation before didFinish;
+            // no native child may survive while WebKit replaces its DOM.
+            attachmentCoordinator?.closeAll()
+            attachmentContainer?.collapseAttachment()
+        }
+
+        func handleAttachmentGeometry(_ message: RendererAttachmentGeometryMessage) {
+            guard let attachmentCoordinator, attachmentCoordinator.ingest(message),
+                  let webView, let attachmentContainer else { return }
+            if message.revision == 1 {
+                let reservedHeight = attachmentCoordinator.reserveHeight(
+                    RendererAttachmentHostPolicy.minimumReservedHeight, for: message.placeholderID)
+                let identifier = WikiReaderRep.jsString(message.placeholderID.rawValue)
+                webView.evaluateJavaScript("window.__sdwRendererAttachmentReserve && window.__sdwRendererAttachmentReserve(\(identifier), \(reservedHeight));")
+            }
+            let rect = RendererAttachmentGeometry.overlayRect(cssRect: message.cssRect, pageZoom: webView.pageZoom, readerBounds: webView.bounds)
+            attachmentContainer.updateAttachmentViewport(message.visible ? rect : .zero)
+        }
+
+        func handleAttachmentRemoval(_ placeholderID: RendererAttachmentPlaceholderID, generation: Int) {
+            guard let attachmentCoordinator, attachmentCoordinator.generation == generation else { return }
+            attachmentCoordinator.close(placeholderID)
+            attachmentContainer?.collapseAttachment()
+        }
+
+        func activateAttachment(_ placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentActivationResult {
+            guard let attachmentCoordinator, let attachmentContainer else { return .rejected }
+            switch nativeAttachmentContent(for: placeholderID) {
+            case .failed:
+                attachmentCoordinator.fail(placeholderID)
+                attachmentContainer.collapseAttachment()
+                return .rejected
+            case .canvas(let content):
+                let result = attachmentCoordinator.activate(placeholderID)
+                if result == .activate {
+                    attachmentContainer.activateAttachment(named: placeholderID, content: content)
+                }
+                return result
+            case .fallback:
+                break
+            }
+            let result = attachmentCoordinator.activate(placeholderID)
+            if result == .activate { attachmentContainer.activateAttachment(named: placeholderID) }
+            return result
+        }
+
+        private enum NativeAttachmentContent {
+            case fallback
+            case canvas(AnyView)
+            case failed
+        }
+
+        private func nativeAttachmentContent(for placeholderID: RendererAttachmentPlaceholderID) -> NativeAttachmentContent {
+            guard let context = webView?.rendererActivationAdmission?.attachmentContext(for: placeholderID),
+                  context.rendererReference == BuiltInRendererReference.reference(for: .jsonCanvas),
+                  case .inlineArtifact(let artifact) = context.input
+            else { return .fallback }
+            do {
+                let factory = NativeJSONCanvasAttachmentFactory { _ in
+                    throw NativeJSONCanvasAttachmentFailure.invalidSourceIdentity
+                }
+                return .canvas(try factory.makeView(for: .fenced(artifact)))
+            } catch {
+                DebugLog.reader("native JSON Canvas attachment failed for \(placeholderID.rawValue): \(error)")
+                return .failed
+            }
+        }
+
+        func attachmentState(for placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentState {
+            attachmentCoordinator?.state(for: placeholderID) ?? .unresolved
+        }
+
+        var attachmentGeneration: Int? { attachmentCoordinator?.generation }
+
+        func collapseAttachment(_ placeholderID: RendererAttachmentPlaceholderID) {
+            attachmentCoordinator?.collapse(placeholderID)
+            attachmentContainer?.collapseAttachment()
         }
 
         func webView(

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1662,20 +1662,26 @@ internal struct WikiReaderRep: NSViewRepresentable {
             guard let attachmentCoordinator, let attachmentContainer else { return .rejected }
             switch nativeAttachmentContent(for: placeholderID) {
             case .failed:
-                attachmentCoordinator.fail(placeholderID)
-                attachmentContainer.collapseAttachment()
+                failAttachment(placeholderID)
                 return .rejected
             case .canvas(let content):
                 let result = attachmentCoordinator.activate(placeholderID)
                 if result == .activate {
-                    attachmentContainer.activateAttachment(named: placeholderID, content: content)
+                    attachmentContainer.activateAttachment(
+                        named: placeholderID,
+                        content: content,
+                        onExit: { [weak self] in self?.collapseAttachment(placeholderID) })
                 }
                 return result
             case .fallback:
                 break
             }
             let result = attachmentCoordinator.activate(placeholderID)
-            if result == .activate { attachmentContainer.activateAttachment(named: placeholderID) }
+            if result == .activate {
+                attachmentContainer.activateAttachment(
+                    named: placeholderID,
+                    onExit: { [weak self] in self?.collapseAttachment(placeholderID) })
+            }
             return result
         }
 
@@ -1706,7 +1712,18 @@ internal struct WikiReaderRep: NSViewRepresentable {
         var attachmentGeneration: Int? { attachmentCoordinator?.generation }
 
         func collapseAttachment(_ placeholderID: RendererAttachmentPlaceholderID) {
-            attachmentCoordinator?.collapse(placeholderID)
+            guard let attachmentCoordinator,
+                  attachmentCoordinator.state(for: placeholderID) == .active,
+                  let attachmentContainer,
+                  attachmentContainer.ownsMountedAttachment(named: placeholderID)
+            else { return }
+            attachmentCoordinator.collapse(placeholderID)
+            attachmentContainer.collapseAttachment()
+        }
+
+        func failAttachment(_ placeholderID: RendererAttachmentPlaceholderID) {
+            attachmentCoordinator?.fail(placeholderID)
+            guard attachmentContainer?.ownsMountedAttachment(named: placeholderID) == true else { return }
             attachmentContainer?.collapseAttachment()
         }
 

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1653,8 +1653,9 @@ internal struct WikiReaderRep: NSViewRepresentable {
 
         func handleAttachmentRemoval(_ placeholderID: RendererAttachmentPlaceholderID, generation: Int) {
             guard let attachmentCoordinator, attachmentCoordinator.generation == generation else { return }
+            let removedMountedChild = attachmentContainer?.ownsMountedAttachment(named: placeholderID) == true
             attachmentCoordinator.close(placeholderID)
-            attachmentContainer?.collapseAttachment()
+            if removedMountedChild { attachmentContainer?.collapseAttachment() }
         }
 
         func activateAttachment(_ placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentActivationResult {
@@ -1690,9 +1691,7 @@ internal struct WikiReaderRep: NSViewRepresentable {
                   case .inlineArtifact(let artifact) = context.input
             else { return .fallback }
             do {
-                let factory = NativeJSONCanvasAttachmentFactory { _ in
-                    throw NativeJSONCanvasAttachmentFailure.invalidSourceIdentity
-                }
+                let factory = NativeJSONCanvasAttachmentFactory.fencedOnly()
                 return .canvas(try factory.makeView(for: .fenced(artifact)))
             } catch {
                 DebugLog.reader("native JSON Canvas attachment failed for \(placeholderID.rawValue): \(error)")

--- a/Sources/WikiFS/Renderer/JSONCanvasDocument.swift
+++ b/Sources/WikiFS/Renderer/JSONCanvasDocument.swift
@@ -204,10 +204,72 @@ struct JSONCanvasRenderProjection: Sendable, Equatable {
         let id: String
         let start: JSONCanvasPoint
         let end: JSONCanvasPoint
+        let sourceFrame: JSONCanvasRect
+        let destinationFrame: JSONCanvasRect
     }
 
     let nodes: [Node]
     let edges: [Edge]
+}
+
+struct JSONCanvasEdgeGeometry: Sendable, Equatable {
+    let start: JSONCanvasPoint
+    let end: JSONCanvasPoint
+    let arrowBaseLeft: JSONCanvasPoint
+    let arrowBaseRight: JSONCanvasPoint
+
+    static let arrowLength = 14.0
+    static let arrowWidth = 10.0
+
+    init(source: JSONCanvasRect, destination: JSONCanvasRect) {
+        let sourceCenter = source.center
+        let destinationCenter = destination.center
+        let direction = Self.unitVector(from: sourceCenter, to: destinationCenter)
+        let start = Self.intersection(from: sourceCenter, toward: destinationCenter, in: source)
+        let end = Self.intersection(from: destinationCenter, toward: sourceCenter, in: destination)
+        let baseCenter = end - direction * Self.arrowLength
+        let perpendicular = JSONCanvasPoint(x: -direction.y, y: direction.x)
+
+        self.start = start
+        self.end = end
+        arrowBaseLeft = baseCenter + perpendicular * (Self.arrowWidth / 2)
+        arrowBaseRight = baseCenter - perpendicular * (Self.arrowWidth / 2)
+    }
+
+    private static func unitVector(from start: JSONCanvasPoint, to end: JSONCanvasPoint) -> JSONCanvasPoint {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        let length = (dx * dx + dy * dy).squareRoot()
+        guard length > 0, length.isFinite else { return .init(x: 1, y: 0) }
+        return .init(x: dx / length, y: dy / length)
+    }
+
+    private static func intersection(
+        from center: JSONCanvasPoint,
+        toward target: JSONCanvasPoint,
+        in rect: JSONCanvasRect
+    ) -> JSONCanvasPoint {
+        let dx = target.x - center.x
+        let dy = target.y - center.y
+        guard dx != 0 || dy != 0 else { return center }
+
+        let halfWidth = rect.width / 2
+        let halfHeight = rect.height / 2
+        let horizontalScale = dx == 0 ? .infinity : halfWidth / abs(dx)
+        let verticalScale = dy == 0 ? .infinity : halfHeight / abs(dy)
+        let scale = min(horizontalScale, verticalScale)
+        return .init(x: center.x + dx * scale, y: center.y + dy * scale)
+    }
+}
+
+private extension JSONCanvasPoint {
+    static func - (lhs: Self, rhs: Self) -> Self {
+        .init(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+    }
+
+    static func * (lhs: Self, rhs: Double) -> Self {
+        .init(x: lhs.x * rhs, y: lhs.y * rhs)
+    }
 }
 
 struct JSONCanvasDocument: Sendable, Equatable {
@@ -297,7 +359,12 @@ struct JSONCanvasDocument: Sendable, Equatable {
             guard let destination = nodesByID[edge.toNodeID] else {
                 throw JSONCanvasDecodingError.unknownEdgeEndpoint(edge.toNodeID.rawValue)
             }
-            renderEdges.append(.init(id: edge.id, start: source.frame.center, end: destination.frame.center))
+            renderEdges.append(.init(
+                id: edge.id,
+                start: source.frame.center,
+                end: destination.frame.center,
+                sourceFrame: source.frame,
+                destinationFrame: destination.frame))
         }
         renderProjection = .init(nodes: renderNodes, edges: renderEdges)
         outline = renderNodes.map { node in

--- a/Sources/WikiFS/Renderer/JSONCanvasRendererView.swift
+++ b/Sources/WikiFS/Renderer/JSONCanvasRendererView.swift
@@ -17,8 +17,15 @@ struct JSONCanvasInteractionSnapshot: Equatable {
     }
 }
 
+/// Distinguishes the compact inline attachment from the full renderer surface.
+enum JSONCanvasRendererPresentation: Equatable, Sendable {
+    case fullRenderer
+    case inlineAttachment
+}
+
 struct JSONCanvasRendererView: View {
     let document: JSONCanvasDocument
+    let presentation: JSONCanvasRendererPresentation
     private let hostActionDispatcher: JSONCanvasHostActionDispatcher
     private let interactionObserver: (JSONCanvasInteractionSnapshot) -> Void
 
@@ -30,15 +37,65 @@ struct JSONCanvasRendererView: View {
 
     init(
         document: JSONCanvasDocument,
+        presentation: JSONCanvasRendererPresentation = .fullRenderer,
         onHostAction: @escaping (JSONCanvasHostAction) -> Void = { _ in },
         onInteractionChange: @escaping (JSONCanvasInteractionSnapshot) -> Void = { _ in }
     ) {
         self.document = document
+        self.presentation = presentation
         hostActionDispatcher = .init(onHostAction)
         interactionObserver = onInteractionChange
     }
 
     var body: some View {
+        HStack(spacing: 0) {
+            if presentation == .fullRenderer {
+                outline
+                Divider()
+            }
+            canvas
+        }
+        // Pan, zoom, focus, and selection are direct manipulation. This renderer
+        // does not add visual motion and also blocks inherited implicit animation.
+        .transaction { transaction in
+            transaction.animation = nil
+            transaction.disablesAnimations = true
+        }
+    }
+
+    private var outline: some View {
+        List(document.outline) { entry in
+            Button(entry.label) {
+                selectOutlineEntry(entry)
+            }
+            .buttonStyle(.plain)
+            .font(.body)
+            .lineLimit(1)
+            .listRowBackground(viewport.selectedNodeID == entry.nodeID ? Color.accentColor.opacity(0.16) : .clear)
+            .accessibilityLabel("Outline node: \(entry.label)")
+            .accessibilityValue(viewport.selectedNodeID == entry.nodeID ? "Selected" : "Not selected")
+            .accessibilityHint("Press Return to select this read-only canvas node.")
+            .accessibilityAction(named: Text("Select")) {
+                selectOutlineEntry(entry)
+            }
+            .onMoveCommand { handleMoveCommand($0, from: .outline) }
+            .contextMenu {
+                if document.hostAction(for: entry.nodeID) != nil {
+                    Button("Open Internal Link") {
+                        requestHostAction(for: entry.nodeID)
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
+        .focusable()
+        .focused($focusedSurface, equals: .outline)
+        .onMoveCommand { handleMoveCommand($0, from: .outline) }
+        .accessibilityLabel("JSON Canvas outline")
+        .accessibilityHint("Use the Up and Down Arrow keys to select an outline node.")
+    }
+
+    private var canvas: some View {
         GeometryReader { _ in
                 ZStack {
                     Canvas { context, _ in
@@ -119,15 +176,10 @@ struct JSONCanvasRendererView: View {
                 .accessibilityLabel("JSON Canvas nodes")
                 .accessibilityHint("Use the Up and Down Arrow keys to select a canvas node.")
             }
-        // Pan, zoom, focus, and selection are direct manipulation. This renderer
-        // does not add visual motion and also blocks inherited implicit animation.
-        .transaction { transaction in
-            transaction.animation = nil
-            transaction.disablesAnimations = true
-        }
     }
 
     private enum FocusSurface: Hashable {
+        case outline
         case canvas
     }
 
@@ -174,6 +226,12 @@ struct JSONCanvasRendererView: View {
         (point.x * point.x + point.y * point.y).squareRoot()
     }
 
+    private func selectOutlineEntry(_ entry: JSONCanvasOutlineEntry) {
+        viewport.selectOutlineEntry(entry)
+        focusedSurface = .outline
+        reportInteraction()
+    }
+
     private func selectCanvasNode(_ nodeID: JSONCanvasNodeID) {
         viewport.select(nodeID: nodeID)
         focusedSurface = .canvas
@@ -192,7 +250,8 @@ struct JSONCanvasRendererView: View {
         case .down:
             viewport.traverseOutline(.next, in: document)
         case .left, .right:
-            focusedSurface = .canvas
+            guard presentation == .fullRenderer else { return }
+            focusedSurface = surface == .outline ? .canvas : .outline
         default:
             break
         }

--- a/Sources/WikiFS/Renderer/JSONCanvasRendererView.swift
+++ b/Sources/WikiFS/Renderer/JSONCanvasRendererView.swift
@@ -5,9 +5,22 @@ import SwiftUI
 // Reason: This native surface binds SwiftUI gesture state to the functional
 // JSON Canvas document and viewport projection types.
 
+struct JSONCanvasInteractionSnapshot: Equatable {
+    let selectedNodeID: JSONCanvasNodeID?
+    let scale: Double
+    let translation: JSONCanvasPoint
+
+    init(viewport: JSONCanvasViewportState) {
+        selectedNodeID = viewport.selectedNodeID
+        scale = viewport.scale
+        translation = viewport.translation
+    }
+}
+
 struct JSONCanvasRendererView: View {
     let document: JSONCanvasDocument
     private let hostActionDispatcher: JSONCanvasHostActionDispatcher
+    private let interactionObserver: (JSONCanvasInteractionSnapshot) -> Void
 
     @State private var viewport = JSONCanvasViewportState()
     @State private var dragStart: JSONCanvasPoint?
@@ -17,47 +30,16 @@ struct JSONCanvasRendererView: View {
 
     init(
         document: JSONCanvasDocument,
-        onHostAction: @escaping (JSONCanvasHostAction) -> Void = { _ in }
+        onHostAction: @escaping (JSONCanvasHostAction) -> Void = { _ in },
+        onInteractionChange: @escaping (JSONCanvasInteractionSnapshot) -> Void = { _ in }
     ) {
         self.document = document
         hostActionDispatcher = .init(onHostAction)
+        interactionObserver = onInteractionChange
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            List(document.outline) { entry in
-                Button(entry.label) {
-                    selectOutlineEntry(entry)
-                }
-                .buttonStyle(.plain)
-                .font(.body)
-                .lineLimit(1)
-                .listRowBackground(viewport.selectedNodeID == entry.nodeID ? Color.accentColor.opacity(0.16) : .clear)
-                .accessibilityLabel("Outline node: \(entry.label)")
-                .accessibilityValue(viewport.selectedNodeID == entry.nodeID ? "Selected" : "Not selected")
-                .accessibilityHint("Press Return to select this read-only canvas node.")
-                .accessibilityAction(named: Text("Select")) {
-                    selectOutlineEntry(entry)
-                }
-                .onMoveCommand { handleMoveCommand($0, from: .outline) }
-                .contextMenu {
-                    if document.hostAction(for: entry.nodeID) != nil {
-                        Button("Open Internal Link") {
-                            requestHostAction(for: entry.nodeID)
-                        }
-                    }
-                }
-            }
-            .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
-            .focusable()
-            .focused($focusedSurface, equals: .outline)
-            .onMoveCommand { handleMoveCommand($0, from: .outline) }
-            .accessibilityLabel("JSON Canvas outline")
-            .accessibilityHint("Use the Up and Down Arrow keys to select an outline node.")
-
-            Divider()
-
-            GeometryReader { _ in
+        GeometryReader { _ in
                 ZStack {
                     Canvas { context, _ in
                         context.concatenate(CGAffineTransform(
@@ -66,10 +48,20 @@ struct JSONCanvasRendererView: View {
                         context.concatenate(CGAffineTransform(scaleX: viewport.scale, y: viewport.scale))
 
                         for edge in document.renderProjection.edges {
+                            let geometry = JSONCanvasEdgeGeometry(
+                                source: edge.sourceFrame,
+                                destination: edge.destinationFrame)
                             var path = Path()
-                            path.move(to: CGPoint(x: edge.start.x, y: edge.start.y))
-                            path.addLine(to: CGPoint(x: edge.end.x, y: edge.end.y))
+                            path.move(to: CGPoint(x: geometry.start.x, y: geometry.start.y))
+                            path.addLine(to: CGPoint(x: geometry.end.x, y: geometry.end.y))
                             context.stroke(path, with: .color(.secondary), lineWidth: 1)
+
+                            var arrowhead = Path()
+                            arrowhead.move(to: CGPoint(x: geometry.end.x, y: geometry.end.y))
+                            arrowhead.addLine(to: CGPoint(x: geometry.arrowBaseLeft.x, y: geometry.arrowBaseLeft.y))
+                            arrowhead.addLine(to: CGPoint(x: geometry.arrowBaseRight.x, y: geometry.arrowBaseRight.y))
+                            arrowhead.closeSubpath()
+                            context.fill(arrowhead, with: .color(.secondary))
                         }
 
                         for node in document.renderProjection.nodes {
@@ -100,6 +92,7 @@ struct JSONCanvasRendererView: View {
                             width: node.frame.width * viewport.scale,
                             height: node.frame.height * viewport.scale)
                         .position(nodePosition(for: node))
+                        .accessibilityIdentifier("json-canvas-node-\(node.id.rawValue)")
                         .accessibilityLabel("Canvas node: \(accessibilityLabel(for: node))")
                         .accessibilityValue(viewport.selectedNodeID == node.id ? "Selected" : "Not selected")
                         .accessibilityHint("Press Return to select this read-only canvas node.")
@@ -126,7 +119,6 @@ struct JSONCanvasRendererView: View {
                 .accessibilityLabel("JSON Canvas nodes")
                 .accessibilityHint("Use the Up and Down Arrow keys to select a canvas node.")
             }
-        }
         // Pan, zoom, focus, and selection are direct manipulation. This renderer
         // does not add visual motion and also blocks inherited implicit animation.
         .transaction { transaction in
@@ -136,7 +128,6 @@ struct JSONCanvasRendererView: View {
     }
 
     private enum FocusSurface: Hashable {
-        case outline
         case canvas
     }
 
@@ -152,6 +143,7 @@ struct JSONCanvasRendererView: View {
                 let delta = JSONCanvasPoint(x: location.x - dragStart.x, y: location.y - dragStart.y)
                 if Self.dragDistance(delta) >= 4 {
                     viewport.setTranslation(dragInitialTranslation + delta)
+                    reportInteraction()
                 }
             }
             .onEnded { value in
@@ -163,6 +155,7 @@ struct JSONCanvasRendererView: View {
                 let point = viewport.documentPoint(screenX: location.x, screenY: location.y)
                 viewport.selectNode(at: point, in: document)
                 focusedSurface = .canvas
+                reportInteraction()
             }
     }
 
@@ -170,6 +163,7 @@ struct JSONCanvasRendererView: View {
         MagnifyGesture()
             .onChanged { value in
                 viewport.setScale(magnificationBaseline * value.magnification)
+                reportInteraction()
             }
             .onEnded { _ in
                 magnificationBaseline = viewport.scale
@@ -180,14 +174,10 @@ struct JSONCanvasRendererView: View {
         (point.x * point.x + point.y * point.y).squareRoot()
     }
 
-    private func selectOutlineEntry(_ entry: JSONCanvasOutlineEntry) {
-        viewport.selectOutlineEntry(entry)
-        focusedSurface = .outline
-    }
-
     private func selectCanvasNode(_ nodeID: JSONCanvasNodeID) {
         viewport.select(nodeID: nodeID)
         focusedSurface = .canvas
+        reportInteraction()
     }
 
     private func requestHostAction(for nodeID: JSONCanvasNodeID) {
@@ -202,10 +192,15 @@ struct JSONCanvasRendererView: View {
         case .down:
             viewport.traverseOutline(.next, in: document)
         case .left, .right:
-            focusedSurface = surface == .outline ? .canvas : .outline
+            focusedSurface = .canvas
         default:
             break
         }
+        reportInteraction()
+    }
+
+    private func reportInteraction() {
+        interactionObserver(.init(viewport: viewport))
     }
 
     private func nodePosition(for node: JSONCanvasRenderProjection.Node) -> CGPoint {

--- a/Sources/WikiFS/Renderer/NativeJSONCanvasAttachmentFactory.swift
+++ b/Sources/WikiFS/Renderer/NativeJSONCanvasAttachmentFactory.swift
@@ -1,0 +1,152 @@
+#if os(macOS)
+import Foundation
+import SwiftUI
+import WikiFSTypes
+
+// pattern: Mixed (unavoidable)
+// Reason: The pure authorization and decoding core returns a JSONCanvasDocument;
+// the final method is the narrow SwiftUI adapter that constructs its native view.
+
+/// One exact source-version identity authorized for a native JSON Canvas attachment.
+/// This deliberately retains no bytes: only the injected resolver may supply them.
+enum NativeJSONCanvasAttachmentInput: Equatable, Sendable {
+    struct SourcePin: Equatable, Sendable {
+        enum Version: Equatable, Sendable {
+            case content(SourceVersionID)
+            case markdown(SourceMarkdownVersionID)
+        }
+
+        let sourceID: SourceID
+        let version: Version
+        let mimeType: RendererMIMEType
+        let digest: RendererSHA256Digest
+
+        init(validating source: RendererEmbeddedContent.Source) throws {
+            switch (source.sourceVersionID, source.sourceMarkdownVersionID) {
+            case let (.some(versionID), .none):
+                version = .content(versionID)
+            case let (.none, .some(versionID)):
+                version = .markdown(versionID)
+            default:
+                throw NativeJSONCanvasAttachmentFailure.invalidSourceIdentity
+            }
+            sourceID = source.sourceID
+            mimeType = source.mimeType
+            digest = source.digest
+        }
+    }
+
+    case source(SourcePin)
+    case fenced(RendererEmbeddedContent.InlineArtifact)
+}
+
+enum NativeJSONCanvasAttachmentFailure: Error, Equatable {
+    enum SourceReason: Equatable {
+        case invalidMIMEType
+        case resolverUnavailable
+        case digestMismatch
+        case oversizedInput
+        case decoding(JSONCanvasDecodingError)
+    }
+
+    enum FencedReason: Equatable {
+        case invalidFenceKind
+        case invalidMIMEType
+        case invalidArtifact
+        case oversizedInput
+        case decoding(JSONCanvasDecodingError)
+    }
+
+    case invalidSourceIdentity
+    case source(input: NativeJSONCanvasAttachmentInput.SourcePin, reason: SourceReason)
+    case fenced(input: RendererEmbeddedContent.InlineArtifact, reason: FencedReason)
+}
+
+/// Creates a bounded native JSON Canvas document from one typed authorization form.
+/// The source resolver is intentionally keyed by SourcePin rather than a live source.
+struct NativeJSONCanvasAttachmentFactory {
+    typealias SourceResolver = (NativeJSONCanvasAttachmentInput.SourcePin) throws -> Data
+
+    private let resolveSource: SourceResolver
+
+    init(_ resolveSource: @escaping SourceResolver) {
+        self.resolveSource = resolveSource
+    }
+
+    func document(for input: NativeJSONCanvasAttachmentInput) throws -> JSONCanvasDocument {
+        switch input {
+        case .source(let pin):
+            return try document(for: pin)
+        case .fenced(let artifact):
+            return try document(for: artifact)
+        }
+    }
+
+    @MainActor
+    func makeView(
+        for input: NativeJSONCanvasAttachmentInput,
+        onHostAction: @escaping (JSONCanvasHostAction) -> Void = { _ in },
+        onInteractionChange: @escaping (JSONCanvasInteractionSnapshot) -> Void = { _ in }
+    ) throws -> AnyView {
+        AnyView(JSONCanvasRendererView(
+            document: try document(for: input),
+            onHostAction: onHostAction,
+            onInteractionChange: onInteractionChange))
+    }
+
+    private func document(for pin: NativeJSONCanvasAttachmentInput.SourcePin) throws -> JSONCanvasDocument {
+        guard pin.mimeType.rawValue == BuiltInRendererMIME.json else {
+            throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .invalidMIMEType)
+        }
+        let bytes: Data
+        do {
+            bytes = try resolveSource(pin)
+        } catch {
+            throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .resolverUnavailable)
+        }
+        guard bytes.count <= JSONCanvasLimits.maximumInputByteCount else {
+            throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .oversizedInput)
+        }
+        guard RendererSHA256.digest(bytes) == pin.digest else {
+            throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .digestMismatch)
+        }
+        do {
+            return try JSONCanvasDocument.decode(bytes)
+        } catch let error as JSONCanvasDecodingError {
+            throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .decoding(error))
+        } catch {
+            throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .decoding(.malformedDocument))
+        }
+    }
+
+    private func document(for artifact: RendererEmbeddedContent.InlineArtifact) throws -> JSONCanvasDocument {
+        guard artifact.fenceKind == .jsoncanvas else {
+            throw NativeJSONCanvasAttachmentFailure.fenced(input: artifact, reason: .invalidFenceKind)
+        }
+        guard artifact.mimeType.rawValue == BuiltInRendererMIME.json else {
+            throw NativeJSONCanvasAttachmentFailure.fenced(input: artifact, reason: .invalidMIMEType)
+        }
+        do {
+            _ = try RendererEmbeddedContent.InlineArtifact(
+                pageID: artifact.pageID,
+                pageVersionID: artifact.pageVersionID,
+                blockID: artifact.blockID,
+                fenceKind: artifact.fenceKind,
+                mimeType: artifact.mimeType,
+                bytes: artifact.bytes)
+        } catch {
+            throw NativeJSONCanvasAttachmentFailure.fenced(input: artifact, reason: .invalidArtifact)
+        }
+        guard artifact.bytes.count <= JSONCanvasLimits.maximumInputByteCount else {
+            throw NativeJSONCanvasAttachmentFailure.fenced(input: artifact, reason: .oversizedInput)
+        }
+        do {
+            return try JSONCanvasDocument.decode(artifact.bytes)
+        } catch let error as JSONCanvasDecodingError {
+            throw NativeJSONCanvasAttachmentFailure.fenced(input: artifact, reason: .decoding(error))
+        } catch {
+            throw NativeJSONCanvasAttachmentFailure.fenced(input: artifact, reason: .decoding(.malformedDocument))
+        }
+    }
+}
+#endif

--- a/Sources/WikiFS/Renderer/NativeJSONCanvasAttachmentFactory.swift
+++ b/Sources/WikiFS/Renderer/NativeJSONCanvasAttachmentFactory.swift
@@ -63,13 +63,23 @@ enum NativeJSONCanvasAttachmentFailure: Error, Equatable {
 }
 
 /// Creates a bounded native JSON Canvas document from one typed authorization form.
-/// The source resolver is intentionally keyed by SourcePin rather than a live source.
+/// A source-capable factory is keyed by `SourcePin` rather than a live source.
 struct NativeJSONCanvasAttachmentFactory {
     typealias SourceResolver = (NativeJSONCanvasAttachmentInput.SourcePin) throws -> Data
 
-    private let resolveSource: SourceResolver
+    private let resolveSource: SourceResolver?
 
     init(_ resolveSource: @escaping SourceResolver) {
+        self.resolveSource = resolveSource
+    }
+
+    /// Creates a factory for fenced inline artifacts only. It intentionally has
+    /// no source resolver, so future source-pin routing cannot use this path.
+    static func fencedOnly() -> Self {
+        Self(resolveSource: nil)
+    }
+
+    private init(resolveSource: SourceResolver?) {
         self.resolveSource = resolveSource
     }
 
@@ -90,6 +100,7 @@ struct NativeJSONCanvasAttachmentFactory {
     ) throws -> AnyView {
         AnyView(JSONCanvasRendererView(
             document: try document(for: input),
+            presentation: .inlineAttachment,
             onHostAction: onHostAction,
             onInteractionChange: onInteractionChange))
     }
@@ -97,6 +108,9 @@ struct NativeJSONCanvasAttachmentFactory {
     private func document(for pin: NativeJSONCanvasAttachmentInput.SourcePin) throws -> JSONCanvasDocument {
         guard pin.mimeType.rawValue == BuiltInRendererMIME.json else {
             throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .invalidMIMEType)
+        }
+        guard let resolveSource else {
+            throw NativeJSONCanvasAttachmentFailure.source(input: pin, reason: .resolverUnavailable)
         }
         let bytes: Data
         do {

--- a/Tests/WikiFSAppTests/JSONCanvasAttachmentHostedTests.swift
+++ b/Tests/WikiFSAppTests/JSONCanvasAttachmentHostedTests.swift
@@ -1,0 +1,409 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+import WikiFSTypes
+
+@Suite("JSON Canvas native attachment hosted interactions", .serialized, .timeLimit(.minutes(2)))
+@MainActor
+struct JSONCanvasAttachmentHostedTests {
+    @Test("source and fenced native attachments report genuine mouse selection and preserve their authorization forms")
+    func sourceAndFencedAttachmentsMountAndSelect() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
+        Self.prepareApplication()
+
+        let source = try Self.source(bytes: Self.canvas)
+        let pin = try NativeJSONCanvasAttachmentInput.SourcePin(validating: source)
+        let fence = try Self.fence(bytes: Self.canvas)
+        var resolvedPins: [NativeJSONCanvasAttachmentInput.SourcePin] = []
+        let factory = NativeJSONCanvasAttachmentFactory { requestedPin in
+            resolvedPins.append(requestedPin)
+            return Self.canvas
+        }
+        var sourceSnapshots: [JSONCanvasInteractionSnapshot] = []
+        var fencedSnapshots: [JSONCanvasInteractionSnapshot] = []
+        let sourceHost = Self.host(try factory.makeView(for: .source(pin), onInteractionChange: { snapshot in
+            sourceSnapshots.append(snapshot)
+        }))
+        let fencedHost = Self.host(try factory.makeView(for: .fenced(fence), onInteractionChange: { snapshot in
+            fencedSnapshots.append(snapshot)
+        }))
+        defer {
+            Self.release(sourceHost)
+            Self.release(fencedHost)
+        }
+
+        let expectedHostBounds = CGRect(origin: .zero, size: Self.hostedCanvasSize)
+        try await Self.waitFor(description: "source JSON Canvas host layout") {
+            sourceHost.host.view.bounds == expectedHostBounds
+        }
+        try await Self.waitFor(description: "fenced JSON Canvas host layout") {
+            fencedHost.host.view.bounds == expectedHostBounds
+        }
+        try #require(sourceHost.host.view.bounds == expectedHostBounds)
+        try #require(fencedHost.host.view.bounds == expectedHostBounds)
+
+        let sourcePoint = Self.firstNodePoint(in: sourceHost.host.view.bounds)
+        let fencedPoint = Self.firstNodePoint(in: fencedHost.host.view.bounds)
+        Self.sendClick(to: sourceHost.window, at: sourcePoint)
+        Self.sendClick(to: fencedHost.window, at: fencedPoint)
+        do {
+            try await Self.waitFor(description: "source JSON Canvas selection") {
+                sourceSnapshots.last?.selectedNodeID?.rawValue == "first"
+            }
+        } catch {
+            throw Self.interactionDeliveryError(
+                hosted: sourceHost,
+                point: sourcePoint,
+                snapshot: sourceSnapshots.last)
+        }
+        do {
+            try await Self.waitFor(description: "fenced JSON Canvas selection") {
+                fencedSnapshots.last?.selectedNodeID?.rawValue == "first"
+            }
+        } catch {
+            throw Self.interactionDeliveryError(
+                hosted: fencedHost,
+                point: fencedPoint,
+                snapshot: fencedSnapshots.last)
+        }
+
+        #expect(resolvedPins == [pin])
+        let expectedSelection = try JSONCanvasNodeID(validating: "first")
+        for snapshot in [try #require(sourceSnapshots.last), try #require(fencedSnapshots.last)] {
+            #expect(snapshot.selectedNodeID == expectedSelection)
+            #expect(snapshot.scale >= JSONCanvasLimits.minimumScale)
+            #expect(snapshot.scale <= JSONCanvasLimits.maximumScale)
+            #expect(abs(snapshot.translation.x) <= JSONCanvasLimits.maximumTranslationMagnitude)
+            #expect(abs(snapshot.translation.y) <= JSONCanvasLimits.maximumTranslationMagnitude)
+        }
+
+        sourceHost.window.appearance = NSAppearance(named: .aqua)
+        sourceHost.host.view.layoutSubtreeIfNeeded()
+        fencedHost.window.appearance = NSAppearance(named: .darkAqua)
+        fencedHost.host.view.layoutSubtreeIfNeeded()
+
+        let badSourceFactory = NativeJSONCanvasAttachmentFactory { _ in Data("bad".utf8) }
+        do {
+            _ = try badSourceFactory.makeView(for: .source(pin))
+            Issue.record("expected source fallback to preserve a source failure")
+        } catch let failure as NativeJSONCanvasAttachmentFailure {
+            #expect(failure == .source(input: pin, reason: .digestMismatch))
+        }
+        let oversizedFence = try Self.fence(
+            bytes: Data(repeating: 0, count: JSONCanvasLimits.maximumInputByteCount + 1))
+        do {
+            _ = try factory.makeView(for: .fenced(oversizedFence))
+            Issue.record("expected fenced fallback to preserve a fenced failure")
+        } catch let failure as NativeJSONCanvasAttachmentFailure {
+            #expect(failure == .fenced(input: oversizedFence, reason: .oversizedInput))
+        }
+    }
+
+    @Test("hosted source and fenced fallbacks preserve authorization and create no version or provenance activity")
+    func hostedFallbacksAndInteractionsDoNotPersist() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
+        Self.prepareApplication()
+
+        let store = try TestStoreFactory.inMemory()
+        let storedSource = try store.addSource(
+            filename: "hosted.canvas",
+            data: Self.canvas,
+            mimeType: BuiltInRendererMIME.json)
+        let storedVersion = try #require(try store.activeContentVersion(sourceID: storedSource.id))
+        let source = try RendererEmbeddedContent.Source(
+            sourceID: storedSource.id,
+            sourceVersionID: storedVersion.id,
+            mimeType: try RendererMIMEType(validating: BuiltInRendererMIME.json),
+            bytes: Self.canvas)
+        let sourcePin = try NativeJSONCanvasAttachmentInput.SourcePin(validating: source)
+        let page = try store.createPage(
+            title: "Hosted Canvas",
+            body: "Canvas attachment",
+            provenance: [.init(sourceID: storedSource.id, role: .primary)])
+        let pageVersionID = try #require(try store.pageHeadVersionID(pageID: page.id))
+        let fenced = try Self.fence(
+            bytes: Self.canvas,
+            pageID: page.id,
+            pageVersionID: pageVersionID)
+        let before = try Self.persistenceObservation(
+            store: store,
+            sourceID: storedSource.id,
+            pageID: page.id,
+            pageVersionID: pageVersionID)
+
+        var resolvedPins: [NativeJSONCanvasAttachmentInput.SourcePin] = []
+        let factory = NativeJSONCanvasAttachmentFactory { requestedPin in
+            resolvedPins.append(requestedPin)
+            guard requestedPin == sourcePin else { throw HostedJSONCanvasAttachmentError.unexpectedSourcePin }
+            return try store.sourceContent(versionID: storedVersion.id)
+        }
+        var sourceSnapshots: [JSONCanvasInteractionSnapshot] = []
+        var fencedSnapshots: [JSONCanvasInteractionSnapshot] = []
+        let sourceHost = Self.host(try factory.makeView(
+            for: NativeJSONCanvasAttachmentInput.source(sourcePin),
+            onInteractionChange: {
+            sourceSnapshots.append($0)
+        }))
+        let fencedHost = Self.host(try factory.makeView(
+            for: NativeJSONCanvasAttachmentInput.fenced(fenced),
+            onInteractionChange: {
+            fencedSnapshots.append($0)
+        }))
+        defer {
+            Self.release(sourceHost)
+            Self.release(fencedHost)
+        }
+
+        let expectedHostBounds = CGRect(origin: .zero, size: Self.hostedCanvasSize)
+        try await Self.waitFor(description: "source persistence-proof host layout") {
+            sourceHost.host.view.bounds == expectedHostBounds
+        }
+        try await Self.waitFor(description: "fenced persistence-proof host layout") {
+            fencedHost.host.view.bounds == expectedHostBounds
+        }
+        try #require(sourceHost.host.view.bounds == expectedHostBounds)
+        try #require(fencedHost.host.view.bounds == expectedHostBounds)
+
+        let sourcePoint = Self.firstNodePoint(in: sourceHost.host.view.bounds)
+        let fencedPoint = Self.firstNodePoint(in: fencedHost.host.view.bounds)
+        Self.sendClick(to: sourceHost.window, at: sourcePoint)
+        Self.sendClick(to: fencedHost.window, at: fencedPoint)
+        try await Self.waitFor(description: "source persistence-proof selection") {
+            sourceSnapshots.last?.selectedNodeID?.rawValue == "first"
+        }
+        try await Self.waitFor(description: "fenced persistence-proof selection") {
+            fencedSnapshots.last?.selectedNodeID?.rawValue == "first"
+        }
+
+        let badSourceFactory = NativeJSONCanvasAttachmentFactory { _ in Data("mismatched".utf8) }
+        let sourceFailure = try Self.fallbackFailure {
+            _ = try badSourceFactory.makeView(for: NativeJSONCanvasAttachmentInput.source(sourcePin))
+        }
+        #expect(sourceFailure == NativeJSONCanvasAttachmentFailure.source(
+            input: sourcePin,
+            reason: .digestMismatch))
+
+        let oversizedFence = try Self.fence(
+            bytes: Data(repeating: 0, count: JSONCanvasLimits.maximumInputByteCount + 1),
+            pageID: page.id,
+            pageVersionID: pageVersionID)
+        let fencedFailure = try Self.fallbackFailure {
+            _ = try factory.makeView(for: NativeJSONCanvasAttachmentInput.fenced(oversizedFence))
+        }
+        #expect(fencedFailure == NativeJSONCanvasAttachmentFailure.fenced(
+            input: oversizedFence,
+            reason: .oversizedInput))
+        #expect(resolvedPins == [sourcePin])
+        #expect(sourceSnapshots.last?.selectedNodeID?.rawValue == "first")
+        #expect(fencedSnapshots.last?.selectedNodeID?.rawValue == "first")
+        #expect(try Self.persistenceObservation(
+            store: store,
+            sourceID: storedSource.id,
+            pageID: page.id,
+            pageVersionID: pageVersionID) == before)
+    }
+
+    private static func waitFor(description: String, condition: @escaping @MainActor () -> Bool) async throws {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while condition() == false {
+            guard ContinuousClock.now < deadline else { throw HostedJSONCanvasAttachmentError.timeout(description) }
+            try Task.checkCancellation()
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private static let hostedCanvasSize = CGSize(width: 520, height: 260)
+    private static let firstNodeOrigin = CGPoint(x: 20, y: 10)
+    private static let firstNodeSize = CGSize(width: 160, height: 80)
+
+    private static func host(_ rootView: AnyView) -> (host: NSHostingController<AnyView>, window: NSWindow) {
+        let host = NSHostingController(rootView: AnyView(rootView.frame(
+            width: hostedCanvasSize.width,
+            height: hostedCanvasSize.height)))
+        let window = NSWindow(
+            contentRect: .init(origin: .zero, size: hostedCanvasSize),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        window.contentViewController = host
+        window.setContentSize(hostedCanvasSize)
+        host.view.frame = .init(origin: .zero, size: hostedCanvasSize)
+        host.view.layoutSubtreeIfNeeded()
+        window.makeKeyAndOrderFront(nil)
+        return (host, window)
+    }
+
+    private static func release(_ hosted: (host: NSHostingController<AnyView>, window: NSWindow)) {
+        hosted.host.rootView = AnyView(EmptyView())
+        hosted.window.orderOut(nil)
+        hosted.window.contentView = nil
+    }
+
+    private static func firstNodePoint(in bounds: CGRect) -> NSPoint {
+        let firstNodeCenter = CGPoint(
+            x: firstNodeOrigin.x + firstNodeSize.width / 2,
+            y: firstNodeOrigin.y + firstNodeSize.height / 2)
+        return NSPoint(
+            x: firstNodeCenter.x,
+            y: bounds.maxY - firstNodeCenter.y)
+    }
+
+    private static func sendClick(to window: NSWindow, at point: NSPoint) {
+        guard let mouseDown = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: point,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1),
+            let mouseUp = NSEvent.mouseEvent(
+                with: .leftMouseUp,
+                location: point,
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: 0,
+                clickCount: 1,
+                pressure: 0)
+        else {
+            Issue.record("failed to construct hosted JSON Canvas mouse events")
+            return
+        }
+        window.sendEvent(mouseDown)
+        window.sendEvent(mouseUp)
+    }
+
+    private static func interactionDeliveryError(
+        hosted: (host: NSHostingController<AnyView>, window: NSWindow),
+        point: NSPoint,
+        snapshot: JSONCanvasInteractionSnapshot?
+    ) -> HostedJSONCanvasAttachmentError {
+        let hitTestClass = hosted.host.view.hitTest(point).map { String(describing: type(of: $0)) } ?? "nil"
+        let firstResponderClass = hosted.window.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        let application = NSApplication.shared
+        return .interactionDelivery(
+            applicationKeyWindowNumber: application.keyWindow?.windowNumber,
+            applicationCurrentEventType: application.currentEvent.map { String(describing: $0.type) } ?? "nil",
+            applicationCurrentEventWindowNumber: application.currentEvent?.windowNumber,
+            windowFrame: hosted.window.frame,
+            viewBounds: hosted.host.view.bounds,
+            point: point,
+            hitTestClass: hitTestClass,
+            firstResponderClass: firstResponderClass,
+            snapshot: snapshot)
+    }
+
+    private static func prepareApplication() {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.accessory)
+    }
+
+    private static func source(bytes: Data) throws -> RendererEmbeddedContent.Source {
+        try .init(
+            sourceID: .init(rawValue: "01JHOSTEDSOURCE0000000000001"),
+            sourceVersionID: .init(rawValue: "01JHOSTEDVERSION000000000001"),
+            mimeType: try .init(validating: "application/json"),
+            bytes: bytes)
+    }
+
+    private static func fence(bytes: Data) throws -> RendererEmbeddedContent.InlineArtifact {
+        try fence(
+            bytes: bytes,
+            pageID: PageID(rawValue: "01JHOSTEDPAGE000000000000001"),
+            pageVersionID: PageVersionID(rawValue: "01JHOSTEDPAGEVERSION00000001"))
+    }
+
+    private static func fence(
+        bytes: Data,
+        pageID: PageID,
+        pageVersionID: PageVersionID
+    ) throws -> RendererEmbeddedContent.InlineArtifact {
+        let block = try MarkdownFencedBlock(
+            documentIdentity: .init(pageID: pageID, pageVersionID: pageVersionID),
+            parserOrdinal: 0,
+            rawInfoString: "jsoncanvas",
+            bytes: bytes)
+        return try .init(
+            pageID: pageID,
+            pageVersionID: pageVersionID,
+            blockID: try #require(block.blockID),
+            fenceKind: .jsoncanvas,
+            mimeType: try .init(validating: "application/json"),
+            bytes: bytes)
+    }
+
+    private static func fallbackFailure(
+        _ operation: () throws -> Void
+    ) throws -> NativeJSONCanvasAttachmentFailure {
+        do {
+            try operation()
+        } catch let failure as NativeJSONCanvasAttachmentFailure {
+            return failure
+        }
+        throw HostedJSONCanvasAttachmentError.expectedFallbackFailure
+    }
+
+    private static func persistenceObservation(
+        store: GRDBWikiStore,
+        sourceID: SourceID,
+        pageID: PageID,
+        pageVersionID: PageVersionID
+    ) throws -> JSONCanvasAttachmentPersistenceObservation {
+        try .init(
+            sourceVersions: store.contentVersionHistory(sourceID: sourceID),
+            activeSourceVersion: store.activeContentVersion(sourceID: sourceID),
+            sourceOrigin: store.sourceOrigin(sourceID: sourceID),
+            activeExtractionProvenance: store.activeExtractionProvenance(sourceID: sourceID),
+            pageVersions: store.pageVersionHistory(pageID: pageID),
+            activePageVersionID: store.pageHeadVersionID(pageID: pageID),
+            pageOrigin: store.pageOrigin(pageID: pageID),
+            pageVersionSources: store.pageVersionSources(versionID: pageVersionID),
+            sourceReferencingPageVersions: store.sourceReferencingPageVersions(sourceID: sourceID))
+    }
+
+    private static let canvas = Data("""
+    {"nodes":[
+      {"id":"first","type":"text","x":20,"y":10,"width":160,"height":80,"text":"First note"},
+      {"id":"second","type":"text","x":220,"y":10,"width":160,"height":80,"text":"Second note"}
+    ],"edges":[{"id":"edge","fromNode":"first","toNode":"second"}]}
+    """.utf8)
+}
+
+private enum HostedJSONCanvasAttachmentError: Error {
+    case timeout(String)
+    case unexpectedSourcePin
+    case expectedFallbackFailure
+    case interactionDelivery(
+        applicationKeyWindowNumber: Int?,
+        applicationCurrentEventType: String,
+        applicationCurrentEventWindowNumber: Int?,
+        windowFrame: CGRect,
+        viewBounds: CGRect,
+        point: NSPoint,
+        hitTestClass: String,
+        firstResponderClass: String,
+        snapshot: JSONCanvasInteractionSnapshot?)
+}
+
+private struct JSONCanvasAttachmentPersistenceObservation: Equatable {
+    let sourceVersions: [SourceVersion]
+    let activeSourceVersion: SourceVersion?
+    let sourceOrigin: SourceOrigin?
+    let activeExtractionProvenance: ExtractionProvenance?
+    let pageVersions: [PageVersionSummary]
+    let activePageVersionID: PageVersionID?
+    let pageOrigin: PageOrigin?
+    let pageVersionSources: [PageVersionSource]
+    let sourceReferencingPageVersions: [PageVersionID]
+}
+#endif

--- a/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
+++ b/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
@@ -28,17 +28,12 @@ struct JSONCanvasRendererTests {
     @Test("native attachment factory never resolves fenced inline artifact bytes")
     func nativeAttachmentFactoryDoesNotLookUpFencedArtifact() throws {
         let fencedInput = try Self.fencedInput(bytes: Self.validCanvas)
-        var sourceLookupCount = 0
-        let factory = NativeJSONCanvasAttachmentFactory { _ in
-            sourceLookupCount += 1
-            return Self.validCanvas
-        }
+        let factory = NativeJSONCanvasAttachmentFactory.fencedOnly()
 
         let document = try factory.document(for: .fenced(fencedInput))
         let expectedDocument = try JSONCanvasDocument.decode(Self.validCanvas)
 
         #expect(document == expectedDocument)
-        #expect(sourceLookupCount == 0)
     }
 
     @Test("native attachment factory retains the authorized input form in failures")
@@ -283,8 +278,11 @@ struct JSONCanvasRendererTests {
         #expect(source.contains(".transaction { transaction in"))
         #expect(source.contains("transaction.animation = nil"))
         #expect(source.contains("transaction.disablesAnimations = true"))
-        #expect(source.contains("List(document.outline)") == false)
-        #expect(source.contains("Divider()") == false)
+        #expect(source.contains("case fullRenderer"))
+        #expect(source.contains("case inlineAttachment"))
+        #expect(source.contains("if presentation == .fullRenderer"))
+        #expect(source.contains("List(document.outline)"))
+        #expect(source.contains("Divider()"))
         #expect(source.contains("lineWidth: viewport.selectedNodeID == node.id ? 2 : 1"))
         #expect(source.contains("withAnimation") == false)
         #expect(source.contains(".animation(") == false)

--- a/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
+++ b/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
@@ -6,6 +6,69 @@ import WikiFSTypes
 
 @Suite("JSON Canvas native renderer", .serialized, .timeLimit(.minutes(1)))
 struct JSONCanvasRendererTests {
+    @Test("native attachment factory resolves the exact source pin and matches equivalent fenced bytes")
+    func nativeAttachmentFactoryResolvesPinnedSourceAndMatchesFence() throws {
+        let source = try Self.sourceInput(bytes: Self.validCanvas)
+        let sourcePin = try NativeJSONCanvasAttachmentInput.SourcePin(validating: source)
+        let fencedInput = try Self.fencedInput(bytes: Self.validCanvas)
+        var resolvedPins: [NativeJSONCanvasAttachmentInput.SourcePin] = []
+        let factory = NativeJSONCanvasAttachmentFactory { pin in
+            resolvedPins.append(pin)
+            return Self.validCanvas
+        }
+
+        let sourceDocument = try factory.document(for: .source(sourcePin))
+        let fencedDocument = try factory.document(for: .fenced(fencedInput))
+
+        #expect(sourceDocument == fencedDocument)
+        #expect(resolvedPins == [sourcePin])
+        #expect(NativeJSONCanvasAttachmentInput.source(sourcePin) != .fenced(fencedInput))
+    }
+
+    @Test("native attachment factory never resolves fenced inline artifact bytes")
+    func nativeAttachmentFactoryDoesNotLookUpFencedArtifact() throws {
+        let fencedInput = try Self.fencedInput(bytes: Self.validCanvas)
+        var sourceLookupCount = 0
+        let factory = NativeJSONCanvasAttachmentFactory { _ in
+            sourceLookupCount += 1
+            return Self.validCanvas
+        }
+
+        let document = try factory.document(for: .fenced(fencedInput))
+        let expectedDocument = try JSONCanvasDocument.decode(Self.validCanvas)
+
+        #expect(document == expectedDocument)
+        #expect(sourceLookupCount == 0)
+    }
+
+    @Test("native attachment factory retains the authorized input form in failures")
+    func nativeAttachmentFactoryRetainsInputFormInFailures() throws {
+        let source = try Self.sourceInput(bytes: Self.validCanvas)
+        let sourcePin = try NativeJSONCanvasAttachmentInput.SourcePin(validating: source)
+        let sourceFactory = NativeJSONCanvasAttachmentFactory { _ in Data("mismatched".utf8) }
+
+        do {
+            _ = try sourceFactory.document(for: .source(sourcePin))
+            Issue.record("expected the mismatched source response to fail")
+        } catch let failure as NativeJSONCanvasAttachmentFailure {
+            #expect(failure == .source(input: sourcePin, reason: .digestMismatch))
+        }
+
+        let oversizedFence = try Self.fencedInput(
+            bytes: Data(repeating: 0, count: JSONCanvasLimits.maximumInputByteCount + 1))
+        let fencedFactory = NativeJSONCanvasAttachmentFactory { _ in
+            Issue.record("fenced input must not perform source lookup")
+            return Data()
+        }
+
+        do {
+            _ = try fencedFactory.document(for: .fenced(oversizedFence))
+            Issue.record("expected the oversized fenced artifact to fail")
+        } catch let failure as NativeJSONCanvasAttachmentFailure {
+            #expect(failure == .fenced(input: oversizedFence, reason: .oversizedInput))
+        }
+    }
+
     @Test("decoder accepts a bounded text-node Canvas and creates a deterministic projection")
     func decoderCreatesDeterministicProjection() throws {
         let document = try JSONCanvasDocument.decode(Self.validCanvas)
@@ -14,6 +77,18 @@ struct JSONCanvasRendererTests {
         #expect(document.outline.map(\.label) == ["First note", "Second note"])
         #expect(document.renderProjection.edges.map(\.id) == ["edge-1"])
         #expect(document.renderProjection.nodes.map(\.id.rawValue) == ["first", "second"])
+    }
+
+    @Test("edge geometry clips to node boundaries and points its arrow at the destination")
+    func edgeGeometryClipsToNodeBoundaries() throws {
+        let geometry = JSONCanvasEdgeGeometry(
+            source: .init(origin: .init(x: 20, y: 10), width: 180, height: 80),
+            destination: .init(origin: .init(x: 240, y: 10), width: 180, height: 80))
+
+        #expect(geometry.start == .init(x: 200, y: 50))
+        #expect(geometry.end == .init(x: 240, y: 50))
+        #expect(geometry.arrowBaseLeft.x < geometry.end.x)
+        #expect(geometry.arrowBaseRight.x < geometry.end.x)
     }
 
     @Test("decoder models only typed internal file and wiki links")
@@ -198,7 +273,6 @@ struct JSONCanvasRendererTests {
         let source = try Self.rendererViewSource()
 
         for semanticStyle in [
-            "Color.accentColor.opacity(0.16)",
             ".color(.secondary.opacity(0.08))",
             ".color(.secondary)",
             ".background(.background)",
@@ -209,6 +283,8 @@ struct JSONCanvasRendererTests {
         #expect(source.contains(".transaction { transaction in"))
         #expect(source.contains("transaction.animation = nil"))
         #expect(source.contains("transaction.disablesAnimations = true"))
+        #expect(source.contains("List(document.outline)") == false)
+        #expect(source.contains("Divider()") == false)
         #expect(source.contains("lineWidth: viewport.selectedNodeID == node.id ? 2 : 1"))
         #expect(source.contains("withAnimation") == false)
         #expect(source.contains(".animation(") == false)
@@ -224,6 +300,31 @@ struct JSONCanvasRendererTests {
         return try String(
             contentsOf: root.appendingPathComponent("Sources/WikiFS/Renderer/JSONCanvasRendererView.swift"),
             encoding: .utf8)
+    }
+
+    private static func sourceInput(bytes: Data) throws -> RendererEmbeddedContent.Source {
+        try .init(
+            sourceID: SourceID(rawValue: "01J00000000000000000000011"),
+            sourceVersionID: SourceVersionID(rawValue: "01J00000000000000000000012"),
+            mimeType: try RendererMIMEType(validating: "application/json"),
+            bytes: bytes)
+    }
+
+    private static func fencedInput(bytes: Data) throws -> RendererEmbeddedContent.InlineArtifact {
+        let pageID = PageID(rawValue: "01J00000000000000000000021")
+        let pageVersionID = PageVersionID(rawValue: "01J00000000000000000000022")
+        let fence = try MarkdownFencedBlock(
+            documentIdentity: .init(pageID: pageID, pageVersionID: pageVersionID),
+            parserOrdinal: 0,
+            rawInfoString: "jsoncanvas",
+            bytes: bytes)
+        return try .init(
+            pageID: pageID,
+            pageVersionID: pageVersionID,
+            blockID: try #require(fence.blockID),
+            fenceKind: .jsoncanvas,
+            mimeType: try RendererMIMEType(validating: "application/json"),
+            bytes: bytes)
     }
 
     private static func canvasData(

--- a/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
@@ -1,0 +1,384 @@
+#if os(macOS)
+import CoreGraphics
+import AppKit
+import SwiftUI
+import WebKit
+import Testing
+@testable import WikiFS
+import WikiFSCore
+import WikiFSTypes
+
+@Suite("Reader renderer attachment coordinator", .serialized, .timeLimit(.minutes(5)))
+struct RendererAttachmentCoordinatorTests {
+    @Test("Escape exits the hosted native attachment and restores reader focus")
+    @MainActor
+    func escapeExitsNativeAttachment() throws {
+        let webView = WikiReaderWebView(); let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container; window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "escape-canvas")
+        container.updateAttachmentViewport(.init(x: 40, y: 80, width: 160, height: 96))
+        container.activateAttachment(named: placeholder)
+        let child = try #require(container.subviews.flatMap(\.subviews).first { $0.accessibilityIdentifier() == "renderer-attachment-escape-canvas" })
+        #expect(window.firstResponder === child)
+        let escape = try #require(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [], timestamp: 0,
+            windowNumber: window.windowNumber, context: nil,
+            characters: "\u{1B}", charactersIgnoringModifiers: "\u{1B}",
+            isARepeat: false, keyCode: 53))
+        window.sendEvent(escape)
+        #expect(container.subviews.flatMap(\.subviews).contains { $0 === child } == false)
+        #expect(window.firstResponder === webView)
+    }
+    private static let javaScriptTimeout = Duration.seconds(5)
+    @Test("DOM placeholder removal closes its admitted native attachment")
+    @MainActor
+    func domRemovalClosesAttachment() async throws {
+        let webView = WikiReaderWebView(); let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container; window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+        let coordinator = WikiReaderRep.Coordinator(); coordinator.webView = webView; coordinator.attachmentContainer = container; webView.coordinator = coordinator; webView.navigationDelegate = coordinator
+        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        try await Self.waitUntil("reader document") { webView.isLoading == false }
+        try await Self.waitForReporter(in: webView)
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "dom-removal-canvas")
+        let generation = try #require(coordinator.attachmentGeneration)
+        try await Self.runJS("var e=document.createElement('section');e.id='dom-removal-canvas';e.className='sdw-renderer-card';e.style.cssText='width:160px;height:96px';document.body.appendChild(e);window.__sdwRendererAttachmentReport(\(generation));", in: webView)
+        try await Self.waitUntil("placeholder admission") { coordinator.attachmentState(for: placeholder) == .card }
+        #expect(coordinator.activateAttachment(placeholder) == .activate)
+        #expect(coordinator.attachmentState(for: placeholder) == .active)
+        #expect(container.subviews.flatMap(\.subviews).contains { $0.accessibilityIdentifier() == "renderer-attachment-dom-removal-canvas" })
+        try await Self.runJS("document.getElementById('dom-removal-canvas').remove();", in: webView)
+        try await Self.waitUntil("placeholder removal") { coordinator.attachmentState(for: placeholder) == .closed }
+        #expect(container.subviews.flatMap(\.subviews).contains { $0.accessibilityIdentifier() == "renderer-attachment-dom-removal-canvas" } == false)
+        #expect(window.firstResponder === webView)
+    }
+
+    @MainActor private static func runJS(_ source: String, in webView: WKWebView) async throws {
+        _ = try await runJavaScript(source, in: webView) { _ in () }
+    }
+
+    @MainActor private static func javaScriptBoolean(_ source: String, in webView: WKWebView) async throws -> Bool {
+        try await runJavaScript(source, in: webView) { $0 as? Bool ?? false }
+    }
+
+    @MainActor private static func runJavaScript<T: Sendable>(
+        _ source: String,
+        in webView: WKWebView,
+        transform: @escaping @Sendable (Any?) -> T
+    ) async throws -> T {
+        let lock = NSLock()
+        var completed = false
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            var timeout: Task<Void, Never>?
+            func finish(_ result: Result<T, Error>) {
+                lock.lock()
+                guard completed == false else { lock.unlock(); return }
+                completed = true
+                lock.unlock()
+                timeout?.cancel()
+                continuation.resume(with: result)
+            }
+            timeout = Task { @MainActor in
+                do {
+                    try await Task.sleep(for: javaScriptTimeout)
+                    finish(.failure(TimeoutError(description: "JavaScript evaluation")))
+                } catch {
+                    // Cancellation is expected when WebKit completes first.
+                }
+            }
+            webView.evaluateJavaScript(source) { result, error in
+                if let error { finish(.failure(error)) }
+                else { finish(.success(transform(result))) }
+            }
+        }
+    }
+
+    @MainActor private static func waitForReporter(in webView: WKWebView) async throws {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while try await javaScriptBoolean("typeof window.__sdwRendererAttachmentReport === 'function'", in: webView) == false {
+            guard ContinuousClock.now < deadline else { throw TimeoutError(description: "attachment reporter") }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+    @Test("new document generation closes its old attachment and rejects stale geometry")
+    @MainActor
+    func generationChangeRejectsOldGeometry() async throws {
+        let webView = WikiReaderWebView(); let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container; window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+        let coordinator = WikiReaderRep.Coordinator(); coordinator.webView = webView; coordinator.attachmentContainer = container; webView.navigationDelegate = coordinator
+        coordinator.startLoad(markdown: "# First", documentIdentity: nil, isLoading: .constant(true))
+        try await Self.waitUntil("first document") { webView.isLoading == false }
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "generation-canvas")
+        let firstGeneration = try #require(coordinator.attachmentGeneration)
+        coordinator.handleAttachmentGeometry(.init(generation: firstGeneration, placeholderID: placeholder, cssRect: .init(x: 20, y: 20, width: 160, height: 96), visible: true, revision: 1))
+        #expect(coordinator.activateAttachment(placeholder) == .activate)
+        #expect(coordinator.attachmentState(for: placeholder) == .active)
+        #expect(container.subviews.flatMap(\.subviews).contains {
+            $0.accessibilityIdentifier() == "renderer-attachment-generation-canvas"
+        })
+        coordinator.startLoad(markdown: "# Second", documentIdentity: nil, isLoading: .constant(true))
+        try await Self.waitUntil("second document") { webView.isLoading == false }
+        #expect(container.subviews.flatMap(\.subviews).contains { $0.accessibilityIdentifier() == "renderer-attachment-generation-canvas" } == false)
+        #expect(window.firstResponder === webView)
+        coordinator.handleAttachmentGeometry(.init(generation: firstGeneration, placeholderID: placeholder, cssRect: .init(x: 20, y: 20, width: 160, height: 96), visible: true, revision: 2))
+        #expect(coordinator.attachmentState(for: placeholder) == .unresolved)
+    }
+    @Test("real WebKit reload removes an admitted native child")
+    @MainActor
+    func reloadClosesAttachmentAndRestoresReaderFocus() async throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+        let coordinator = WikiReaderRep.Coordinator()
+        coordinator.webView = webView
+        coordinator.attachmentContainer = container
+        webView.navigationDelegate = coordinator
+        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        try await Self.waitUntil("initial reader navigation") { webView.isLoading == false }
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "reload-canvas")
+        coordinator.handleAttachmentGeometry(.init(generation: 1, placeholderID: placeholder, cssRect: .init(x: 20, y: 20, width: 160, height: 96), visible: true, revision: 1))
+        #expect(coordinator.activateAttachment(placeholder) == .activate)
+        #expect(coordinator.attachmentState(for: placeholder) == .active)
+        #expect(container.subviews.flatMap(\.subviews).contains { $0.accessibilityIdentifier() == "renderer-attachment-reload-canvas" })
+        webView.reload()
+        try await Self.waitUntil("reload removed native child") {
+            container.subviews.flatMap(\.subviews).contains {
+                $0.accessibilityIdentifier() == "renderer-attachment-reload-canvas"
+            } == false
+        }
+        #expect(coordinator.attachmentState(for: placeholder) == .closed)
+        #expect(window.firstResponder === webView)
+    }
+
+    @MainActor private static func waitUntil(_ description: String, condition: @escaping () -> Bool) async throws {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while !condition() {
+            guard ContinuousClock.now < deadline else { throw TimeoutError(description: description) }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private struct TimeoutError: Error { let description: String }
+    @Test("hosted native child clips, routes focus, and tears down")
+    @MainActor
+    func hostedNativeChildLifecycle() throws {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "hosted-canvas")
+        let expectedVisibleRect = CGRect(x: 40, y: 80, width: 160, height: 96)
+        container.updateAttachmentViewport(expectedVisibleRect)
+        container.activateAttachment(named: placeholder)
+
+        let child = try #require(container.subviews.flatMap(\.subviews).first {
+            $0.accessibilityIdentifier() == "renderer-attachment-hosted-canvas"
+        })
+        #expect(child.frame == expectedVisibleRect)
+        #expect(child.accessibilityRole() == .group)
+        #expect(child.accessibilityLabel() == "Interactive renderer attachment")
+        #expect(container.hitTest(.init(x: 80, y: 100)) === child)
+        #expect(container.hitTest(.init(x: 300, y: 260)) === webView)
+
+        container.collapseAttachment()
+        #expect(container.subviews.flatMap(\.subviews).contains { $0 === child } == false)
+        #expect(window.firstResponder === webView)
+
+        container.activateAttachment(named: placeholder)
+        #expect(container.subviews.flatMap(\.subviews).contains { $0.accessibilityIdentifier() == "renderer-attachment-hosted-canvas" })
+        container.teardown()
+        #expect(container.subviews.isEmpty)
+    }
+
+    @Test("hosted JSON Canvas attachment mounts the factory's native SwiftUI view")
+    @MainActor
+    func hostedJSONCanvasAttachmentMountsNativeView() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let source = try RendererEmbeddedContent.Source(
+            sourceID: .init(rawValue: "01JATTACHMENTSOURCE0000000001"),
+            sourceVersionID: .init(rawValue: "01JATTACHMENTVERSION000000001"),
+            mimeType: try .init(validating: "application/json"),
+            bytes: Self.jsonCanvasBytes)
+        let input = NativeJSONCanvasAttachmentInput.source(try .init(validating: source))
+        let factory = NativeJSONCanvasAttachmentFactory { _ in Self.jsonCanvasBytes }
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "mounted-json-canvas")
+        container.updateAttachmentViewport(.init(x: 40, y: 80, width: 160, height: 96))
+
+        container.activateAttachment(named: placeholder, content: try factory.makeView(for: input))
+
+        let child = try #require(container.subviews.flatMap(\.subviews).first {
+            $0.accessibilityIdentifier() == "renderer-attachment-mounted-json-canvas"
+        })
+        #expect(Self.containsHostingView(in: child))
+        #expect(window.firstResponder === child)
+    }
+
+    @Test("admitted JSON Canvas fence mounts the native factory view through the reader lifecycle")
+    @MainActor
+    func admittedJSONCanvasFenceMountsThroughReaderLifecycle() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let pageID = PageID(rawValue: "01JATTACHMENTPAGE000000000001")
+        let pageVersionID = PageVersionID(rawValue: "01JATTACHMENTPAGEVERSION00001")
+        let identity = MarkdownDocumentIdentity(pageID: pageID, pageVersionID: pageVersionID)
+        let coordinator = WikiReaderRep.Coordinator()
+        coordinator.webView = webView
+        coordinator.attachmentContainer = container
+        webView.coordinator = coordinator
+        webView.onRendererActivation = { _, _ in }
+        coordinator.startLoad(markdown: "# Reader", documentIdentity: identity, isLoading: .constant(true))
+
+        let generation = try #require(coordinator.attachmentGeneration)
+        let admission = try #require(webView.rendererActivationAdmission)
+        let block = try MarkdownFencedBlock(
+            documentIdentity: identity,
+            parserOrdinal: 0,
+            rawInfoString: "jsoncanvas",
+            bytes: Self.jsonCanvasBytes)
+        let artifact = try RendererEmbeddedContent.InlineArtifact(
+            pageID: pageID,
+            pageVersionID: pageVersionID,
+            blockID: try #require(block.blockID),
+            fenceKind: .jsoncanvas,
+            mimeType: try .init(validating: "application/json"),
+            bytes: Self.jsonCanvasBytes)
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "admitted-json-canvas")
+        admission.register(context: .init(
+            pageID: pageID,
+            pageVersionID: pageVersionID,
+            blockID: artifact.blockID,
+            rendererReference: BuiltInRendererReference.reference(for: .jsonCanvas),
+            input: .inlineArtifact(artifact),
+            capability: admission.capability,
+            generation: generation), attachmentPlaceholderID: placeholder)
+        coordinator.handleAttachmentGeometry(.init(
+            generation: generation,
+            placeholderID: placeholder,
+            cssRect: .init(x: 40, y: 80, width: 240, height: 160),
+            visible: true,
+            revision: 1))
+
+        #expect(coordinator.activateAttachment(placeholder) == .activate)
+        let child = try #require(container.subviews.flatMap(\.subviews).first {
+            $0.accessibilityIdentifier() == "renderer-attachment-admitted-json-canvas"
+        })
+        #expect(Self.containsHostingView(in: child))
+        #expect(window.firstResponder === child)
+    }
+    @Test("geometry bridge accepts only a complete finite typed payload")
+    func geometryBridgeDecodesTrustedShape() throws {
+        let message = try #require(RendererAttachmentGeometryMessage(body: [
+            "generation": 3, "placeholderID": "canvas-1", "x": 8.0, "y": 12.0,
+            "width": 240.0, "height": 120.0, "visible": true, "revision": 4,
+        ]))
+        #expect(message.generation == 3)
+        #expect(message.placeholderID.rawValue == "canvas-1")
+        #expect(message.cssRect == .init(x: 8, y: 12, width: 240, height: 120))
+        #expect(RendererAttachmentGeometryMessage(body: ["generation": 3]) == nil)
+        #expect(RendererAttachmentGeometryMessage(body: [
+            "generation": 3, "placeholderID": "canvas-1", "x": Double.nan, "y": 0,
+            "width": 1, "height": 1, "visible": true, "revision": 1,
+        ]) == nil)
+    }
+
+    @Test("geometry rejects a stale generation and clamps an excessive reserved height")
+    @MainActor
+    func staleGeometryAndHeightPolicy() throws {
+        let coordinator = RendererAttachmentCoordinator(generation: 7)
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "canvas-1")
+
+        #expect(coordinator.ingest(.init(
+            generation: 6,
+            placeholderID: placeholder,
+            cssRect: .init(x: 8, y: 16, width: 320, height: 200),
+            visible: true,
+            revision: 1)) == false)
+        #expect(coordinator.state(for: placeholder) == .unresolved)
+
+        #expect(coordinator.ingest(.init(
+            generation: 7,
+            placeholderID: placeholder,
+            cssRect: .init(x: 8, y: 16, width: 320, height: 200),
+            visible: true,
+            revision: 1)))
+        let reserved = coordinator.reserveHeight(
+            RendererAttachmentHostPolicy.maximumReservedHeight + 1,
+            for: placeholder)
+        #expect(reserved <= RendererAttachmentHostPolicy.maximumReservedHeight)
+        #expect(reserved >= RendererAttachmentHostPolicy.maximumReservedHeight - 0.001)
+    }
+
+    @Test("viewport transform flips DOM geometry and clips it to the reader")
+    func viewportTransform() {
+        let rect = RendererAttachmentGeometry.overlayRect(
+            cssRect: .init(x: 10, y: 20, width: 100, height: 40),
+            pageZoom: 1.25,
+            readerBounds: .init(x: 0, y: 0, width: 400, height: 300))
+
+        #expect(rect == .init(x: 12.5, y: 225, width: 125, height: 50))
+        #expect(RendererAttachmentGeometry.clip(
+            rect: rect,
+            to: .init(x: 0, y: 240, width: 400, height: 60)) == .init(x: 12.5, y: 240, width: 125, height: 35))
+    }
+
+    @Test("activation never silently evicts an existing active attachment")
+    @MainActor
+    func activationLimitPreservesExistingAttachment() throws {
+        let coordinator = RendererAttachmentCoordinator(generation: 1, activeLimit: 1)
+        let first = try RendererAttachmentPlaceholderID(validating: "first")
+        let second = try RendererAttachmentPlaceholderID(validating: "second")
+        let geometry = { (id: RendererAttachmentPlaceholderID) in
+            RendererAttachmentGeometryMessage(
+                generation: 1, placeholderID: id,
+                cssRect: .init(x: 0, y: 0, width: 100, height: 100), visible: true, revision: 1)
+        }
+        #expect(coordinator.ingest(geometry(first)))
+        #expect(coordinator.ingest(geometry(second)))
+        #expect(coordinator.activate(first) == .activate)
+        #expect(coordinator.activate(second) == .showInFullRenderer)
+        #expect(coordinator.state(for: first) == .active)
+        #expect(coordinator.state(for: second) == .card)
+    }
+
+    @MainActor
+    private static func containsHostingView(in view: NSView) -> Bool {
+        String(describing: type(of: view)).contains("NSHostingView") ||
+            view.subviews.contains(where: containsHostingView)
+    }
+
+    private static let jsonCanvasBytes = Data("""
+    {"nodes":[{"id":"first","type":"text","x":0,"y":0,"width":80,"height":40,"text":"First"}],"edges":[]}
+    """.utf8)
+}
+#endif

--- a/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
@@ -58,6 +58,46 @@ struct RendererAttachmentCoordinatorTests {
         #expect(window.firstResponder === webView)
     }
 
+    @Test("removing an inactive placeholder preserves the active native attachment")
+    @MainActor
+    func removingInactivePlaceholderPreservesActiveAttachment() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let coordinator = WikiReaderRep.Coordinator()
+        coordinator.webView = webView
+        coordinator.attachmentContainer = container
+        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        let generation = try #require(coordinator.attachmentGeneration)
+        let active = try RendererAttachmentPlaceholderID(validating: "active-canvas")
+        let inactive = try RendererAttachmentPlaceholderID(validating: "inactive-canvas")
+        let geometry = { (placeholderID: RendererAttachmentPlaceholderID) in
+            RendererAttachmentGeometryMessage(
+                generation: generation,
+                placeholderID: placeholderID,
+                cssRect: .init(x: 20, y: 20, width: 160, height: 96),
+                visible: true,
+                revision: 1)
+        }
+        coordinator.handleAttachmentGeometry(geometry(active))
+        coordinator.handleAttachmentGeometry(geometry(inactive))
+        #expect(coordinator.activateAttachment(active) == .activate)
+
+        coordinator.handleAttachmentRemoval(inactive, generation: generation)
+
+        #expect(coordinator.attachmentState(for: active) == .active)
+        #expect(coordinator.attachmentState(for: inactive) == .closed)
+        #expect(container.subviews.flatMap(\.subviews).contains {
+            $0.accessibilityIdentifier() == "renderer-attachment-active-canvas"
+        })
+        #expect((window.firstResponder as? NSView)?.accessibilityIdentifier() == "renderer-attachment-active-canvas")
+    }
+
     @MainActor private static func runJS(_ source: String, in webView: WKWebView) async throws {
         _ = try await runJavaScript(source, in: webView) { _ in () }
     }
@@ -371,6 +411,14 @@ struct RendererAttachmentCoordinatorTests {
         #expect(coordinator.state(for: second) == .card)
     }
 
+    @Test("attachment FSM does not expose synchronous transient states")
+    func attachmentFSMDropsSynchronousTransientStates() throws {
+        let source = try Self.attachmentCoordinatorSource()
+
+        #expect(source.contains("case activating") == false)
+        #expect(source.contains("case collapsing") == false)
+    }
+
     @MainActor
     private static func containsHostingView(in view: NSView) -> Bool {
         String(describing: type(of: view)).contains("NSHostingView") ||
@@ -380,5 +428,15 @@ struct RendererAttachmentCoordinatorTests {
     private static let jsonCanvasBytes = Data("""
     {"nodes":[{"id":"first","type":"text","x":0,"y":0,"width":80,"height":40,"text":"First"}],"edges":[]}
     """.utf8)
+
+    private static func attachmentCoordinatorSource() throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: root.appendingPathComponent("Sources/WikiFS/Reader/RendererAttachmentCoordinator.swift"),
+            encoding: .utf8)
+    }
 }
 #endif

--- a/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
@@ -32,6 +32,45 @@ struct RendererAttachmentCoordinatorTests {
         #expect(container.subviews.flatMap(\.subviews).contains { $0 === child } == false)
         #expect(window.firstResponder === webView)
     }
+
+    @Test("Escape synchronizes the coordinator before allowing attachment reactivation")
+    @MainActor
+    func escapeSynchronizesCoordinatorBeforeReactivation() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let coordinator = WikiReaderRep.Coordinator()
+        coordinator.webView = webView
+        coordinator.attachmentContainer = container
+        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        let generation = try #require(coordinator.attachmentGeneration)
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "escape-synchronized-canvas")
+        coordinator.handleAttachmentGeometry(.init(
+            generation: generation,
+            placeholderID: placeholder,
+            cssRect: .init(x: 20, y: 20, width: 160, height: 96),
+            visible: true,
+            revision: 1))
+        #expect(coordinator.activateAttachment(placeholder) == .activate)
+
+        let escape = try #require(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [], timestamp: 0,
+            windowNumber: window.windowNumber, context: nil,
+            characters: "\u{1B}", charactersIgnoringModifiers: "\u{1B}",
+            isARepeat: false, keyCode: 53))
+        window.sendEvent(escape)
+
+        #expect(coordinator.attachmentState(for: placeholder) == .card)
+        #expect(coordinator.activateAttachment(placeholder) == .activate)
+        #expect(container.subviews.flatMap(\.subviews).contains {
+            $0.accessibilityIdentifier() == "renderer-attachment-escape-synchronized-canvas"
+        })
+    }
     private static let javaScriptTimeout = Duration.seconds(5)
     @Test("DOM placeholder removal closes its admitted native attachment")
     @MainActor
@@ -96,6 +135,46 @@ struct RendererAttachmentCoordinatorTests {
             $0.accessibilityIdentifier() == "renderer-attachment-active-canvas"
         })
         #expect((window.firstResponder as? NSView)?.accessibilityIdentifier() == "renderer-attachment-active-canvas")
+    }
+
+    @Test("collapse and failure for another placeholder preserve the active native attachment")
+    @MainActor
+    func wrongPlaceholderCollapseAndFailurePreserveActiveAttachment() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let coordinator = WikiReaderRep.Coordinator()
+        coordinator.webView = webView
+        coordinator.attachmentContainer = container
+        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        let generation = try #require(coordinator.attachmentGeneration)
+        let active = try RendererAttachmentPlaceholderID(validating: "active-ownership-canvas")
+        let inactive = try RendererAttachmentPlaceholderID(validating: "inactive-ownership-canvas")
+        let geometry = { (placeholderID: RendererAttachmentPlaceholderID) in
+            RendererAttachmentGeometryMessage(
+                generation: generation,
+                placeholderID: placeholderID,
+                cssRect: .init(x: 20, y: 20, width: 160, height: 96),
+                visible: true,
+                revision: 1)
+        }
+        coordinator.handleAttachmentGeometry(geometry(active))
+        coordinator.handleAttachmentGeometry(geometry(inactive))
+        #expect(coordinator.activateAttachment(active) == .activate)
+
+        coordinator.collapseAttachment(inactive)
+        coordinator.failAttachment(inactive)
+
+        #expect(coordinator.attachmentState(for: active) == .active)
+        #expect(coordinator.attachmentState(for: inactive) == .failed)
+        #expect(container.subviews.flatMap(\.subviews).contains {
+            $0.accessibilityIdentifier() == "renderer-attachment-active-ownership-canvas"
+        })
     }
 
     @MainActor private static func runJS(_ source: String, in webView: WKWebView) async throws {

--- a/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
+++ b/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
@@ -334,8 +334,8 @@ struct WikiAppWebViewTests {
         #expect(model.loadedPageHeadVersionID(for: PageID(rawValue: "01JVERSIONMISSING000000000")) == nil)
     }
 
-    @Test("hosted production root opens a renderer presentation surface from a rich fence card")
-    func productionRootOpensRendererPresentationForRichFenceCards() async throws {
+    @Test("hosted production root opens an inline renderer attachment from a rich fence card")
+    func productionRootOpensInlineRendererForRichFenceCards() async throws {
         let lease = await HostedAppKitTestGate.shared.acquire()
         defer { lease.release() }
         _ = NSApplication.shared
@@ -407,12 +407,9 @@ struct WikiAppWebViewTests {
             timeout: .seconds(5)
         )
 
-        let presentedSheet = try await waitForPresentedSheet(
-            attachedTo: window,
-            baselineSheetCount: sheetCountBeforePresentation,
-            timeout: .seconds(10))
-        #expect(presentedSheet.contentView != nil)
-        #expect(presentedSheet.isVisible)
+        let attachment = try await waitForNativeRendererAttachment(in: hosting.view, timeout: .seconds(10))
+        #expect(attachment.isHidden == false)
+        #expect(window.sheets.count == sheetCountBeforePresentation)
     }
 
     @Test("hosted SwiftUI mount exposes the session WebView and tears it down")
@@ -541,22 +538,30 @@ private func waitForPositiveJavaScriptString(
 }
 
 @MainActor
-private func waitForPresentedSheet(
-    attachedTo window: NSWindow,
-    baselineSheetCount: Int,
+private func waitForNativeRendererAttachment(
+    in view: NSView,
     timeout: Duration = .seconds(15)
-) async throws -> NSWindow {
+) async throws -> NSView {
     let deadline = ContinuousClock.now + timeout
     while ContinuousClock.now < deadline {
-        let sheets = window.sheets
-        if sheets.count > baselineSheetCount,
-           let sheet = sheets.first(where: { $0.contentView != nil }) {
-            return sheet
+        if let attachment = findView(in: view, where: {
+            $0.accessibilityIdentifier().hasPrefix("renderer-attachment-")
+        }) {
+            return attachment
         }
         try Task.checkCancellation()
         try await Task.sleep(for: .milliseconds(25))
     }
-    throw WikiDetailHostedRouteError.timeout("renderer presentation sheet")
+    throw WikiDetailHostedRouteError.timeout("native renderer attachment")
+}
+
+@MainActor
+private func findView(in view: NSView, where predicate: (NSView) -> Bool) -> NSView? {
+    if predicate(view) { return view }
+    for child in view.subviews {
+        if let match = findView(in: child, where: predicate) { return match }
+    }
+    return nil
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

- Add trusted native inline attachment lifecycle support for built-in JSON Canvas content.
- Mount source-pinned and fenced Canvas artifacts in native SwiftUI/AppKit views with bounded geometry, clipping, focus, accessibility, and teardown behavior.
- Render Canvas edges between node boundaries with destination arrowheads and use the full attachment width without a duplicate outline panel.

## Validation

- `make build`
- `make test` (3,272 tests passed)
- `swiftlint lint --strict` (0 violations)
- Focused hosted JSON Canvas and attachment coordinator suites passed.

## Manual verification

- Run `make run` from this branch and open a page containing a JSON Canvas fence or admitted source Canvas.
- Confirm native node selection, edge clipping/arrowheads, collapse/focus restoration, and fallback behavior.

This is a draft PR; merge and queue decisions remain operator-owned.
