### PR TITLE
Harden subprocess termination against PID reuse

### DIFF
--- a/Sources/WikiFS/Sources/DefuddleExtractionService.swift
+++ b/Sources/WikiFS/Sources/DefuddleExtractionService.swift
@@ -175,7 +175,10 @@ enum DefuddleExtractionService {
 
             defer {
                 group.cancelAll()
-                if process.isRunning { process.terminate() }
+                if process.isRunning,
+                   ProcessSignalSafety.PositivePID(rawValue: process.processIdentifier) != nil {
+                    process.terminate()
+                }
             }
 
             let result = await group.next() ?? nil
@@ -358,7 +361,8 @@ enum DefuddleExtractionService {
             lock.lock()
             let snapshot = procs
             lock.unlock()
-            for p in snapshot where p.isRunning {
+            for p in snapshot where p.isRunning
+                && ProcessSignalSafety.PositivePID(rawValue: p.processIdentifier) != nil {
                 p.terminate()
             }
         }

--- a/Sources/WikiFSCore/Core/AsyncProcessRunner.swift
+++ b/Sources/WikiFSCore/Core/AsyncProcessRunner.swift
@@ -102,11 +102,13 @@ public enum AsyncProcessRunner {
     struct Hooks: Sendable {
         var beforeLaunch: (@Sendable () async -> Void)?
         var didLaunch: (@Sendable (Int32) -> Void)?
+        var didLaunchIdentity: (@Sendable (ProcessSignalSafety.Identity?) -> Void)?
         var didTerminate: (@Sendable (Int32, Int32) -> Void)?
         var didRequestCancellation: (@Sendable () -> Void)?
         var runProcess: (@Sendable (Process) throws -> Void)?
         var requestTermination: @Sendable (Process) -> Void = { process in
-            if process.isRunning {
+            if process.isRunning,
+               ProcessSignalSafety.PositivePID(rawValue: process.processIdentifier) != nil {
                 process.terminate()
             }
         }
@@ -219,6 +221,7 @@ public enum AsyncProcessRunner {
                         let expectedIdentity = ProcessSignalSafety.PositivePID(rawValue: processID)
                             .flatMap(hooks.observeProcess)
                         hooks.didLaunch?(processID)
+                        hooks.didLaunchIdentity?(expectedIdentity)
                         if let target = state.recordLaunch(
                             processID: processID,
                             expectedIdentity: expectedIdentity) {

--- a/Sources/WikiFSCore/Integrations/TranscriptSubprocess.swift
+++ b/Sources/WikiFSCore/Integrations/TranscriptSubprocess.swift
@@ -20,10 +20,10 @@ enum TranscriptSubprocess {
 
     // MARK: - ProcessRegistry
 
-    /// Tracks live subprocess ids so `NSApplication.willTerminate` kills
-    /// orphans without needing to own the `Process` instances directly.
+    /// Tracks launch identities so `NSApplication.willTerminate` can clean up
+    /// orphans without relying on a recyclable numeric PID.
     final class ProcessRegistry: @unchecked Sendable {
-        private var processIDs = Set<Int32>()
+        private var identities = [ProcessSignalSafety.PositivePID: ProcessSignalSafety.Identity]()
         private var registered = false
         private let lock = NSLock()
 
@@ -46,26 +46,64 @@ enum TranscriptSubprocess {
             #endif
         }
 
-        func track(_ processID: Int32) {
+        func track(_ identity: ProcessSignalSafety.Identity) {
             registerIfNeeded()
             lock.lock()
-            processIDs.insert(processID)
+            identities[identity.processID] = identity
             lock.unlock()
         }
 
         func untrack(_ processID: Int32) {
+            guard let processID = ProcessSignalSafety.PositivePID(rawValue: processID) else { return }
             lock.lock()
-            processIDs.remove(processID)
+            identities.removeValue(forKey: processID)
             lock.unlock()
         }
 
-        func terminateAllForTesting() { terminateAll() }
+        func terminateAllForTesting(
+            observeProcess: @escaping (ProcessSignalSafety.PositivePID) -> ProcessSignalSafety.Identity?,
+            sendSignal: @escaping (Int32, Int32) -> Int32
+        ) {
+            terminateAll(observeProcess: observeProcess, sendSignal: sendSignal)
+        }
+
         private func terminateAll() {
+            terminateAll(
+                observeProcess: { ProcessIdentityObservation.observe(processID: $0) },
+                sendSignal: { processID, signal in kill(processID, signal) })
+        }
+
+        private func terminateAll(
+            observeProcess: (ProcessSignalSafety.PositivePID) -> ProcessSignalSafety.Identity?,
+            sendSignal: (Int32, Int32) -> Int32
+        ) {
             lock.lock()
-            let snapshot = processIDs
+            let snapshot = Array(identities.values)
             lock.unlock()
-            for processID in snapshot where kill(processID, 0) == 0 {
-                _ = kill(processID, SIGTERM)
+
+            guard let expectedParentProcessID = ProcessSignalSafety.PositivePID(
+                rawValue: ProcessInfo.processInfo.processIdentifier)
+            else {
+                DebugLog.extraction("[transcript] refused orphan cleanup: invalid parent process ID")
+                return
+            }
+
+            for identity in snapshot {
+                switch ProcessSignalSafety.signal(
+                    processID: identity.processID,
+                    expectedIdentity: identity,
+                    expectedParentProcessID: expectedParentProcessID,
+                    observedIdentity: observeProcess(identity.processID),
+                    signal: sendSignal) {
+                case .sent(let result) where result == 0:
+                    break
+                case .sent(let result):
+                    DebugLog.extraction(
+                        "[transcript] orphan cleanup signal failed for PID \(identity.processID.rawValue): result=\(result)")
+                case .refused(let refusal):
+                    DebugLog.extraction(
+                        "[transcript] refused orphan cleanup for PID \(identity.processID.rawValue): \(refusal)")
+                }
             }
         }
     }
@@ -121,8 +159,10 @@ enum TranscriptSubprocess {
             let result = try await AsyncProcessRunner.run(
                 request,
                 hooks: .init(
-                    didLaunch: { processID in
-                        processRegistry.track(processID)
+                    didLaunchIdentity: { identity in
+                        if let identity {
+                            processRegistry.track(identity)
+                        }
                     },
                     didTerminate: { processID, _ in
                         processRegistry.untrack(processID)

--- a/Sources/WikiFSEngine/PdfExtractionService.swift
+++ b/Sources/WikiFSEngine/PdfExtractionService.swift
@@ -53,7 +53,8 @@ public enum PdfExtractionService {
             lock.lock()
             let snapshot = procs
             lock.unlock()
-            for p in snapshot where p.isRunning {
+            for p in snapshot where p.isRunning
+                && ProcessSignalSafety.PositivePID(rawValue: p.processIdentifier) != nil {
                 p.terminate()
             }
         }
@@ -178,7 +179,10 @@ public enum PdfExtractionService {
             }
             defer {
                 group.cancelAll()
-                if process.isRunning { process.terminate() }
+                if process.isRunning,
+                   ProcessSignalSafety.PositivePID(rawValue: process.processIdentifier) != nil {
+                    process.terminate()
+                }
             }
             return await group.next() ?? false
         }
@@ -471,7 +475,10 @@ public enum PdfExtractionService {
                 }
             }
         } onCancel: {
-            if process.isRunning { process.terminate() }
+            if process.isRunning,
+               ProcessSignalSafety.PositivePID(rawValue: process.processIdentifier) != nil {
+                process.terminate()
+            }
         }
     }
 

--- a/Sources/WikiFSTypes/ProcessSignalSafety.swift
+++ b/Sources/WikiFSTypes/ProcessSignalSafety.swift
@@ -10,7 +10,7 @@ import Glibc
 /// Validates process signal targets independently of process creation and OS
 /// observation. A numeric PID is never sufficient authority to signal.
 public enum ProcessSignalSafety {
-    public struct PositivePID: Sendable, Equatable {
+    public struct PositivePID: Sendable, Equatable, Hashable {
         public let rawValue: Int32
 
         public init?(rawValue: Int32) {

--- a/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetyAuditTests.swift
+++ b/Tests/ProcessSignalSafetySeamTests/ProcessSignalSafetyAuditTests.swift
@@ -61,11 +61,16 @@ struct ProcessSignalSafetyAuditTests {
             .init(path: "Sources/WikiFSCore/Core/AsyncProcessRunner.swift",
                   primitive: .processTermination):
                 (1, "guarded: ProcessSignalSafety.verify confirms PID, parent PID, "
-                    + "and kernel start time against a fresh observation before TERM"),
+                    + "and kernel start time against a fresh observation before TERM; "
+                    + "the termination closure also rejects invalid process IDs"),
             .init(path: "Sources/WikiFSCore/Core/AsyncProcessRunner.swift",
                   primitive: .posixSignal):
                 (1, "guarded: injected sendSignal seam, reached only via "
                     + "ProcessSignalSafety.signal on a re-verified direct child"),
+            .init(path: "Sources/WikiFSCore/Integrations/TranscriptSubprocess.swift",
+                  primitive: .posixSignal):
+                (1, "guarded: injected sendSignal seam, reached only via "
+                    + "ProcessSignalSafety.signal on a re-verified tracked identity"),
             .init(path: "scripts/lib/test-watchdog-process-control.sh",
                   primitive: .shellSignal):
                 (1, "guarded: builtin kill is addressed by jobspec (%N), never by a "
@@ -80,10 +85,10 @@ struct ProcessSignalSafetyAuditTests {
             // so there is no PID-reuse window to close.
             .init(path: "Sources/WikiFSEngine/PdfExtractionService.swift",
                   primitive: .processTermination):
-                (3, "owns the Process object it terminates; no numeric PID involved"),
+                (3, "owns the Process object it terminates and rejects invalid process IDs"),
             .init(path: "Sources/WikiFS/Sources/DefuddleExtractionService.swift",
                   primitive: .processTermination):
-                (2, "owns the Process object it terminates; no numeric PID involved"),
+                (2, "owns the Process object it terminates and rejects invalid process IDs"),
             .init(path: "Sources/WikiFSEngine/ACPBackend.swift",
                   primitive: .processTermination):
                 (3, "terminates a held ACP client object, not a PID"),
@@ -95,16 +100,6 @@ struct ProcessSignalSafetyAuditTests {
             .init(path: "Sources/WikiFSEngine/ACPBackend.swift",
                   primitive: .posixSignal):
                 (1, "kill(pid, 0) is a liveness probe and delivers no signal"),
-
-            // --- Known-weak, pre-existing, tracked --------------------------
-            // NOT a safety approval. Recorded so it is visible and cannot be
-            // mistaken for a reviewed-safe pattern.
-            .init(path: "Sources/WikiFSCore/Integrations/TranscriptSubprocess.swift",
-                  primitive: .posixSignal):
-                (2, "WEAK, pre-existing: kill(pid, 0) then kill(pid, SIGTERM) on a "
-                    + "PID from a stored snapshot. This is a check-then-signal race "
-                    + "of the same class as #1051 and should migrate to "
-                    + "ProcessSignalSafety; out of scope for this change"),
 
             .init(path: "scripts/paseo-archive-cleanup.sh", primitive: .shellSignal):
                 (2, "WEAK, pre-existing: operator-run agent-archive cleanup. Selects "
@@ -238,6 +233,27 @@ struct ProcessSignalSafetyAuditTests {
             #expect(
                 executableBoundary.contains(pidAddressedKill) == false,
                 "signalling a numeric PID reintroduces the check-then-signal race")
+        }
+    }
+
+    @Test func processTerminationRequiresAValidProcessIdentifier() throws {
+        let root = repositoryRoot()
+        let expectedGuardCounts = [
+            "Sources/WikiFSCore/Core/AsyncProcessRunner.swift": 1,
+            "Sources/WikiFSEngine/PdfExtractionService.swift": 3,
+            "Sources/WikiFS/Sources/DefuddleExtractionService.swift": 2,
+        ]
+
+        for (relativePath, expectedCount) in expectedGuardCounts {
+            let source = try String(
+                contentsOf: root.appendingPathComponent(relativePath),
+                encoding: .utf8)
+            let executable = strippingCommentsAndLiterals(source, path: relativePath)
+            let guardCount = executable.components(separatedBy: "processIdentifier) != nil").count - 1
+
+            #expect(
+                guardCount == expectedCount,
+                "every Process.terminate() in \(relativePath) must reject invalid process IDs")
         }
     }
 

--- a/Tests/WikiFSTests/TranscriptSubprocessTests.swift
+++ b/Tests/WikiFSTests/TranscriptSubprocessTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+struct TranscriptSubprocessTests {
+    private final class SignalRecorder {
+        private(set) var processIDs: [Int32] = []
+
+        func record(processID: Int32, signal _: Int32) -> Int32 {
+            processIDs.append(processID)
+            return 0
+        }
+    }
+
+    @Test func staleIdentityIsRefusedWithoutSignalling() throws {
+        let registry = TranscriptSubprocess.ProcessRegistry()
+        let expected = try identity(startTime: 100)
+        let reused = try identity(startTime: 101)
+        let recorder = SignalRecorder()
+
+        registry.track(expected)
+        registry.terminateAllForTesting(
+            observeProcess: { _ in reused },
+            sendSignal: recorder.record)
+
+        #expect(recorder.processIDs.isEmpty)
+    }
+
+    @Test func verifiedIdentityIsSignalled() throws {
+        let registry = TranscriptSubprocess.ProcessRegistry()
+        let expected = try identity(startTime: 100)
+        let recorder = SignalRecorder()
+
+        registry.track(expected)
+        registry.terminateAllForTesting(
+            observeProcess: { _ in expected },
+            sendSignal: recorder.record)
+
+        #expect(recorder.processIDs == [expected.processID.rawValue])
+    }
+
+    private func identity(startTime: UInt64) throws -> ProcessSignalSafety.Identity {
+        let processID = try #require(ProcessSignalSafety.PositivePID(rawValue: 42))
+        let parentProcessID = try #require(
+            ProcessSignalSafety.PositivePID(rawValue: ProcessInfo.processInfo.processIdentifier))
+        return ProcessSignalSafety.Identity(
+            processID: processID,
+            parentProcessID: parentProcessID,
+            startTime: .init(seconds: startTime, microseconds: 0))
+    }
+}


### PR DESCRIPTION
## Summary
- Verify tracked transcript subprocess identities before sending termination signals.
- Reject invalid process IDs before calling `Process.terminate()` across extraction services.
- Expose launch identities through `AsyncProcessRunner` and make process IDs hashable for registry tracking.
- Add audit coverage and tests for stale-identity refusal and verified signaling.

## Why
Prevents termination of an unrelated process when a tracked PID is recycled, while preserving cleanup of verified child processes.