### PR TITLE
Add authorized renderer input boundary

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -190,6 +190,8 @@ struct SourceDetailView: View {
             readerZoom: $readerZoom)
     }
 
+    private var rendererAuthorizedInputResolver: any RendererAuthorizedInputResolving { store }
+
     private var showsSourceOutlineTab: Bool {
         isOutlineApplicable && currentMarkdownContent != nil
     }
@@ -1194,7 +1196,7 @@ struct SourceDetailView: View {
         return installedRendererFactory.makeView(
             for: descriptor,
             inputs: installedRendererFactoryInputs,
-            inputReader: store.rendererAuthorizedInputReader(for: file.id)) { _ in
+            inputReader: rendererAuthorizedInputResolver.rendererAuthorizedInputReader(for: file.id)) { _ in
                 // The representable already deferred this callback out of its
                 // AppKit/WebKit stack. Keep the detail-state mutation deferred
                 // as well because the rendered closure can run in an update pass.

--- a/Sources/WikiFSCore/Renderer/RendererAuthorizedInputResolving.swift
+++ b/Sources/WikiFSCore/Renderer/RendererAuthorizedInputResolving.swift
@@ -1,10 +1,10 @@
 import Foundation
 import WikiFSTypes
 
-// pattern: Functional Core
-
-/// Composition seam for the exact, version-pinned input reader used by an
-/// installed renderer session.
+// pattern: Mixed (unavoidable)
+// Reason: this main-actor protocol is a narrow boundary between the SwiftUI
+// host and the concrete store model; it keeps the exact authorized-reader
+// lookup typed without introducing another storage or bridge path.
 @MainActor
 public protocol RendererAuthorizedInputResolving {
     func rendererAuthorizedInputReader(for sourceID: SourceID) -> RendererAuthorizedInputReader?

--- a/Sources/WikiFSCore/Renderer/RendererAuthorizedInputResolving.swift
+++ b/Sources/WikiFSCore/Renderer/RendererAuthorizedInputResolving.swift
@@ -1,0 +1,11 @@
+import Foundation
+import WikiFSTypes
+
+// pattern: Functional Core
+
+/// Composition seam for the exact, version-pinned input reader used by an
+/// installed renderer session.
+@MainActor
+public protocol RendererAuthorizedInputResolving {
+    func rendererAuthorizedInputReader(for sourceID: SourceID) -> RendererAuthorizedInputReader?
+}

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -4657,3 +4657,5 @@ public enum ZoteroFetchError: LocalizedError, Equatable {
         }
     }
 }
+
+extension WikiStoreModel: RendererAuthorizedInputResolving {}

--- a/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
+++ b/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
@@ -263,7 +263,7 @@ struct WikiAppWebViewTests {
 
         #expect(source.contains("BuiltInRendererFactoryMap.makeView"))
         #expect(source.contains("installedRendererFactory.makeView"))
-        #expect(source.contains("rendererAuthorizedInputReader(for: file.id)"))
+        #expect(source.contains("rendererAuthorizedInputResolver.rendererAuthorizedInputReader(for: file.id)"))
         #expect(source.contains("failedInstalledRendererReference"))
     }
 

--- a/Tests/WikiFSTests/DocumentationContractTests.swift
+++ b/Tests/WikiFSTests/DocumentationContractTests.swift
@@ -146,14 +146,14 @@ struct DocumentationContractTests {
             try JSONSerialization.jsonObject(with: data) as? [String: Any],
             "inventory must be a JSON object"
         )
-        let productionPaths = try #require(inventory["productionPaths"] as? [[String: Any]])
-        let testPaths = try #require(inventory["testPaths"] as? [String])
-
         #expect(inventory["baseSHA"] as? String == "660264209f95a545b823fdb6f459d02239ba96cb")
         #expect(inventory["headSHA"] as? String == "63657e10b8a278e6c476119eddb2964f0bee75c2")
+        #expect((inventory["headSHASemantics"] as? String)?.contains("documentation-only evidence commit") == true)
+        #expect((inventory["headSHASemantics"] as? String)?.contains("protocol boundary") == true)
         #expect((inventory["scope"] as? String)?.contains("RendererAuthorizedInputResolving") == true)
         #expect((inventory["scope"] as? String)?.contains("SourceDetailView") == true)
 
+        let productionPaths = try #require(inventory["productionPaths"] as? [[String: Any]])
         let productionSymbols = productionPaths.flatMap { $0["symbols"] as? [String] ?? [] }
         let productionTests = productionPaths.flatMap { $0["tests"] as? [String] ?? [] }
 
@@ -161,11 +161,12 @@ struct DocumentationContractTests {
         #expect(productionSymbols.contains("WikiStoreModel.rendererAuthorizedInputReader"))
         #expect(productionSymbols.contains("SourceDetailView.rendererAuthorizedInputResolver"))
         #expect(productionTests.contains("RendererAuthorizedInputReaderTests.resolverSeamReturnsTheExactPinnedReader"))
-        #expect(productionTests.contains("RendererAuthorizedInputReaderTests.storeBackedMarkdownReadUsesPinnedBlobBytes"))
-        #expect(productionTests.contains("WikiAppWebViewTests.factoryWiresPinnedInputAndLifecycleContracts"))
-        #expect(testPaths.contains("Tests/WikiFSTests/RendererAuthorizedInputReaderTests.swift"))
-        #expect(testPaths.contains("Tests/WikiFSAppTests/WikiAppWebViewTests.swift"))
-        #expect(testPaths.contains("Tests/WikiFSTests/DocumentationContractTests.swift"))
+        #expect(productionTests.contains("WikiAppWebViewTests.sourceDetailKeepsInstalledFactoryOutsideBuiltInMap"))
+        try Self.assertInventoryBidirectionalResolution(
+            inventory: inventory,
+            root: root,
+            inventoryPath: Self.markdownRendererPhase5InventoryPath
+        )
     }
 
     @Test func dynamicRendererBridgeContractIsVersionPinnedAndNavigationScoped() throws {
@@ -271,33 +272,11 @@ struct DocumentationContractTests {
             try JSONSerialization.jsonObject(with: data) as? [String: Any],
             "inventory must be a JSON object"
         )
-        let productionPaths = try #require(inventory["productionPaths"] as? [[String: Any]])
-        let testPaths = try #require(inventory["testPaths"] as? [String])
-        try #require(productionPaths.isEmpty == false)
-        try #require(testPaths.isEmpty == false)
-
-        let testURLs = try testPaths.map { path in
-            let url = root.appendingPathComponent(path)
-            try #require(FileManager.default.fileExists(atPath: url.path), "missing listed test path: \(path)")
-            return url
-        }
-
-        for productionPath in productionPaths {
-            let path = try #require(productionPath["path"] as? String)
-            #expect(FileManager.default.fileExists(atPath: root.appendingPathComponent(path).path), "missing listed production path: \(path)")
-            let symbols = try #require(productionPath["symbols"] as? [String])
-            let tests = try #require(productionPath["tests"] as? [String])
-            try #require(symbols.isEmpty == false, "production path has no symbols: \(path)")
-            try #require(tests.isEmpty == false, "production path has no tests: \(path)")
-
-            for testName in tests {
-                let functionName = try #require(testName.split(separator: ".").last)
-                let matches = testURLs.filter { url in
-                    (try? String(contentsOf: url, encoding: .utf8))?.contains("func \(functionName)(") == true
-                }
-                #expect(matches.count == 1, "inventory test must resolve exactly once: \(testName)")
-            }
-        }
+        try Self.assertInventoryBidirectionalResolution(
+            inventory: inventory,
+            root: root,
+            inventoryPath: Self.dynamicRendererInventoryPath
+        )
     }
 
     @Test func rendererBridgeWebKitBoundaryIsExplicitlyScoped() throws {
@@ -399,6 +378,46 @@ struct DocumentationContractTests {
         return try markdownEntries
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
             .map { ProgressEntry(url: $0, contents: try String(contentsOf: $0, encoding: .utf8)) }
+    }
+
+    private static func assertInventoryBidirectionalResolution(
+        inventory: [String: Any],
+        root: URL,
+        inventoryPath: String
+    ) throws {
+        let productionPaths = try #require(inventory["productionPaths"] as? [[String: Any]])
+        let testPaths = try #require(inventory["testPaths"] as? [String])
+        try #require(productionPaths.isEmpty == false, "inventory has no production paths: \(inventoryPath)")
+        try #require(testPaths.isEmpty == false, "inventory has no test paths: \(inventoryPath)")
+
+        let testContentsByPath = try Dictionary(uniqueKeysWithValues: testPaths.map { path in
+            let url = root.appendingPathComponent(path)
+            try #require(
+                FileManager.default.fileExists(atPath: url.path),
+                "missing listed test path in \(inventoryPath): \(path)"
+            )
+            return (path, try String(contentsOf: url, encoding: .utf8))
+        })
+
+        for productionPath in productionPaths {
+            let path = try #require(productionPath["path"] as? String)
+            #expect(
+                FileManager.default.fileExists(atPath: root.appendingPathComponent(path).path),
+                "missing listed production path in \(inventoryPath): \(path)"
+            )
+            let symbols = try #require(productionPath["symbols"] as? [String])
+            let tests = try #require(productionPath["tests"] as? [String])
+            try #require(symbols.isEmpty == false, "production path has no symbols in \(inventoryPath): \(path)")
+            try #require(tests.isEmpty == false, "production path has no tests in \(inventoryPath): \(path)")
+
+            for testName in tests {
+                let functionName = try #require(testName.split(separator: ".").last)
+                let matches = testContentsByPath.values.filter {
+                    $0.contains("func \(functionName)(")
+                }
+                #expect(matches.count == 1, "inventory test must resolve exactly once: \(testName)")
+            }
+        }
     }
 
     private struct ProgressEntry {

--- a/Tests/WikiFSTests/DocumentationContractTests.swift
+++ b/Tests/WikiFSTests/DocumentationContractTests.swift
@@ -39,6 +39,8 @@ struct DocumentationContractTests {
         "Polymorphic refs and source-link pins:",
         "Rejected cross-namespace calls:",
     ]
+    private static let markdownRendererPhase5InventoryPath = "plans/markdown-renderer-phase5-package-inline-test-inventory.json"
+    private static let markdownRendererPhase5ProgressHeading = "# Markdown renderer Phase 5 package-inline seam and evidence"
 
     @Test func pageSourceIDPlanIsIndexedAndComplete() throws {
         let root = try #require(Self.locateRepositoryRoot())
@@ -126,6 +128,44 @@ struct DocumentationContractTests {
         #expect(progress.contains(Self.sourceMarkdownVersionProgressHeading))
         #expect(progress.contains("SourceMarkdownVersionAPISignatureManifestTests"))
         #expect(progress.contains("SourceMarkdownVersionIDPersistenceTests"))
+    }
+
+    @Test func markdownRendererPhase5DocumentationIsIndexedAndRecorded() throws {
+        let root = try #require(Self.locateRepositoryRoot())
+        let plan = try String(contentsOf: root.appendingPathComponent("PLAN.md"), encoding: .utf8)
+        let progress = try Self.readProgressEntries(from: root)
+
+        #expect(plan.contains("[`plans/markdown-renderer-embeds.md`](plans/markdown-renderer-embeds.md)"))
+        #expect(progress.contains(Self.markdownRendererPhase5ProgressHeading))
+    }
+
+    @Test func markdownRendererPhase5InventoryMapsExactHeadSeamCoverage() throws {
+        let root = try #require(Self.locateRepositoryRoot())
+        let data = try Data(contentsOf: root.appendingPathComponent(Self.markdownRendererPhase5InventoryPath))
+        let inventory = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            "inventory must be a JSON object"
+        )
+        let productionPaths = try #require(inventory["productionPaths"] as? [[String: Any]])
+        let testPaths = try #require(inventory["testPaths"] as? [String])
+
+        #expect(inventory["baseSHA"] as? String == "660264209f95a545b823fdb6f459d02239ba96cb")
+        #expect(inventory["headSHA"] as? String == "63657e10b8a278e6c476119eddb2964f0bee75c2")
+        #expect((inventory["scope"] as? String)?.contains("RendererAuthorizedInputResolving") == true)
+        #expect((inventory["scope"] as? String)?.contains("SourceDetailView") == true)
+
+        let productionSymbols = productionPaths.flatMap { $0["symbols"] as? [String] ?? [] }
+        let productionTests = productionPaths.flatMap { $0["tests"] as? [String] ?? [] }
+
+        #expect(productionSymbols.contains("RendererAuthorizedInputResolving"))
+        #expect(productionSymbols.contains("WikiStoreModel.rendererAuthorizedInputReader"))
+        #expect(productionSymbols.contains("SourceDetailView.rendererAuthorizedInputResolver"))
+        #expect(productionTests.contains("RendererAuthorizedInputReaderTests.resolverSeamReturnsTheExactPinnedReader"))
+        #expect(productionTests.contains("RendererAuthorizedInputReaderTests.storeBackedMarkdownReadUsesPinnedBlobBytes"))
+        #expect(productionTests.contains("WikiAppWebViewTests.factoryWiresPinnedInputAndLifecycleContracts"))
+        #expect(testPaths.contains("Tests/WikiFSTests/RendererAuthorizedInputReaderTests.swift"))
+        #expect(testPaths.contains("Tests/WikiFSAppTests/WikiAppWebViewTests.swift"))
+        #expect(testPaths.contains("Tests/WikiFSTests/DocumentationContractTests.swift"))
     }
 
     @Test func dynamicRendererBridgeContractIsVersionPinnedAndNavigationScoped() throws {

--- a/Tests/WikiFSTests/RendererAuthorizedInputReaderTests.swift
+++ b/Tests/WikiFSTests/RendererAuthorizedInputReaderTests.swift
@@ -95,7 +95,7 @@ struct RendererAuthorizedInputReaderTests {
     func resolverSeamReturnsTheExactPinnedReader() throws {
         let store = try GRDBWikiStore()
         let source = try store.addSource(filename: "reader-seam.md", data: Data("# seam".utf8))
-        let resolver = WikiStoreModel(store: store) as RendererAuthorizedInputResolving
+        let resolver: any RendererAuthorizedInputResolving = WikiStoreModel(store: store)
         let reader = try #require(resolver.rendererAuthorizedInputReader(for: source.id))
         let version = try #require(try store.activeContentVersion(sourceID: source.id))
 

--- a/Tests/WikiFSTests/RendererAuthorizedInputReaderTests.swift
+++ b/Tests/WikiFSTests/RendererAuthorizedInputReaderTests.swift
@@ -89,4 +89,16 @@ struct RendererAuthorizedInputReaderTests {
             try reader.read(input)
         }
     }
+
+    @MainActor
+    @Test("composition seam resolves the exact pinned reader for the requested source")
+    func resolverSeamReturnsTheExactPinnedReader() throws {
+        let store = try GRDBWikiStore()
+        let source = try store.addSource(filename: "reader-seam.md", data: Data("# seam".utf8))
+        let resolver = WikiStoreModel(store: store) as RendererAuthorizedInputResolving
+        let reader = try #require(resolver.rendererAuthorizedInputReader(for: source.id))
+        let version = try #require(try store.activeContentVersion(sourceID: source.id))
+
+        #expect(reader.authorizedInput == RendererBridgeInput.source(versionID: version.id))
+    }
 }

--- a/plans/markdown-renderer-phase5-package-inline-test-inventory.json
+++ b/plans/markdown-renderer-phase5-package-inline-test-inventory.json
@@ -3,8 +3,8 @@
   "branch": "feature/markdown-renderers-05-package-inline",
   "baseSHA": "660264209f95a545b823fdb6f459d02239ba96cb",
   "headSHA": "63657e10b8a278e6c476119eddb2964f0bee75c2",
-  "headSHASemantics": "This is the exact implementation head for the package-inline seam work. The retained documentation entry and inventory record the branch evidence without changing production or test code.",
-  "scope": "RendererAuthorizedInputResolving adds a main-actor composition seam for the exact version-pinned reader, WikiStoreModel resolves the authorized input through the seam, and SourceDetailView routes its installed-renderer lookup through the seam instead of the concrete model method.",
+  "headSHASemantics": "This is the exact implementation head for the package-inline protocol boundary work. The retained documentation entry and inventory record the branch evidence from the post-head documentation-only evidence commit without changing production or test code.",
+  "scope": "RendererAuthorizedInputResolving adds a main-actor protocol boundary for the exact version-pinned reader, WikiStoreModel resolves the authorized input through that boundary, and SourceDetailView routes its installed-renderer lookup through the boundary instead of the concrete model method.",
   "ciCoverage": "The focused seam test runs alongside the repository build/test/lint gates already verified on this branch. This inventory records the exact pinned-reader seam and the SourceDetailView wiring that consumes it.",
   "productionPaths": [
     {
@@ -23,8 +23,7 @@
         "WikiStoreModel:RendererAuthorizedInputResolving"
       ],
       "tests": [
-        "RendererAuthorizedInputReaderTests.resolverSeamReturnsTheExactPinnedReader",
-        "RendererAuthorizedInputReaderTests.storeBackedMarkdownReadUsesPinnedBlobBytes"
+        "RendererAuthorizedInputReaderTests.resolverSeamReturnsTheExactPinnedReader"
       ]
     },
     {
@@ -34,8 +33,7 @@
         "SourceDetailView.renderedContent"
       ],
       "tests": [
-        "WikiAppWebViewTests.sourceDetailKeepsInstalledFactoryOutsideBuiltInMap",
-        "WikiAppWebViewTests.factoryWiresPinnedInputAndLifecycleContracts"
+        "WikiAppWebViewTests.sourceDetailKeepsInstalledFactoryOutsideBuiltInMap"
       ]
     }
   ],

--- a/plans/markdown-renderer-phase5-package-inline-test-inventory.json
+++ b/plans/markdown-renderer-phase5-package-inline-test-inventory.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "branch": "feature/markdown-renderers-05-package-inline",
+  "baseSHA": "660264209f95a545b823fdb6f459d02239ba96cb",
+  "headSHA": "63657e10b8a278e6c476119eddb2964f0bee75c2",
+  "headSHASemantics": "This is the exact implementation head for the package-inline seam work. The retained documentation entry and inventory record the branch evidence without changing production or test code.",
+  "scope": "RendererAuthorizedInputResolving adds a main-actor composition seam for the exact version-pinned reader, WikiStoreModel resolves the authorized input through the seam, and SourceDetailView routes its installed-renderer lookup through the seam instead of the concrete model method.",
+  "ciCoverage": "The focused seam test runs alongside the repository build/test/lint gates already verified on this branch. This inventory records the exact pinned-reader seam and the SourceDetailView wiring that consumes it.",
+  "productionPaths": [
+    {
+      "path": "Sources/WikiFSCore/Renderer/RendererAuthorizedInputResolving.swift",
+      "symbols": [
+        "RendererAuthorizedInputResolving"
+      ],
+      "tests": [
+        "RendererAuthorizedInputReaderTests.resolverSeamReturnsTheExactPinnedReader"
+      ]
+    },
+    {
+      "path": "Sources/WikiFSCore/Store/WikiStoreModel.swift",
+      "symbols": [
+        "WikiStoreModel.rendererAuthorizedInputReader",
+        "WikiStoreModel:RendererAuthorizedInputResolving"
+      ],
+      "tests": [
+        "RendererAuthorizedInputReaderTests.resolverSeamReturnsTheExactPinnedReader",
+        "RendererAuthorizedInputReaderTests.storeBackedMarkdownReadUsesPinnedBlobBytes"
+      ]
+    },
+    {
+      "path": "Sources/WikiFS/Sources/SourceDetailView.swift",
+      "symbols": [
+        "SourceDetailView.rendererAuthorizedInputResolver",
+        "SourceDetailView.renderedContent"
+      ],
+      "tests": [
+        "WikiAppWebViewTests.sourceDetailKeepsInstalledFactoryOutsideBuiltInMap",
+        "WikiAppWebViewTests.factoryWiresPinnedInputAndLifecycleContracts"
+      ]
+    }
+  ],
+  "testPaths": [
+    "Tests/WikiFSTests/RendererAuthorizedInputReaderTests.swift",
+    "Tests/WikiFSAppTests/WikiAppWebViewTests.swift",
+    "Tests/WikiFSTests/DocumentationContractTests.swift"
+  ]
+}

--- a/progress/2026-08-17T040553Z-markdown-renderer-phase5-package-inline.md
+++ b/progress/2026-08-17T040553Z-markdown-renderer-phase5-package-inline.md
@@ -1,0 +1,39 @@
+---
+timestamp: 2026-08-17T040553Z
+title: Markdown renderer Phase 5 package-inline seam and evidence
+branch: feature/markdown-renderers-05-package-inline
+status: complete
+---
+
+# Markdown renderer Phase 5 package-inline seam and evidence
+
+## Progress
+
+Added the `RendererAuthorizedInputResolving` composition seam and wired
+`SourceDetailView` through it so installed renderers resolve the exact
+version-pinned source reader through the main-actor model boundary instead of
+calling the concrete store method directly.
+
+The new seam is covered by `RendererAuthorizedInputReaderTests` with a
+main-actor test that proves the resolver returns the exact pinned reader for
+the requested source. The retained inventory records the implementation head,
+the source-detail wiring, and the exact tests that cover the seam and the
+store-backed reader path.
+
+The branch kept unrelated signing-file work untouched. No extra renderer
+registry, bridge, package store, or security path was added.
+
+## Verification
+
+Passed:
+
+- `swift test --filter RendererAuthorizedInputReaderTests/resolverSeamReturnsTheExactPinnedReader --jobs 4`
+- `make build`
+- `make test`
+- `WIKIFS_APP_TESTS=1 swift test`
+- `swift build`
+- `swift test`
+- `swiftlint lint --strict`
+- `git diff --check`
+
+The code commit for the implementation head is `63657e10b8a278e6c476119eddb2964f0bee75c2`.


### PR DESCRIPTION
This stacked Phase 5 change routes renderer input through a typed, main-actor protocol boundary. It adds focused regression tests and retained test-inventory checks. The full SwiftPM, app-gated, lint, and diff gates passed. An independent Anthropic review passed the corrected exact head. Three low-risk test and documentation cleanups remain as optional follow-up work.